### PR TITLE
WIP Add nowait/maxwait to remote-application, remove-unit, remove-machine

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -8,6 +8,8 @@
 package application
 
 import (
+	"time"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -453,6 +455,10 @@ type DestroyUnitsParams struct {
 	// Force controls whether or not the removal of applications
 	// will be forced, i.e. ignore removal errors.
 	Force bool
+
+	// MaxWait is the maximum time that Juju will wait at any
+	// given step before proceeding to the next one.
+	MaxWait *time.Duration
 }
 
 // DestroyUnits decreases the number of units dedicated to one or more
@@ -475,6 +481,7 @@ func (c *Client) DestroyUnits(in DestroyUnitsParams) ([]params.DestroyUnitResult
 			UnitTag:        names.NewUnitTag(name).String(),
 			DestroyStorage: in.DestroyStorage,
 			Force:          in.Force,
+			MaxWait:        in.MaxWait,
 		})
 	}
 	if len(argsV5.Units) == 0 {
@@ -536,6 +543,10 @@ type DestroyApplicationsParams struct {
 	// Force controls whether or not the removal of applications
 	// will be forced, i.e. ignore removal errors.
 	Force bool
+
+	// MaxWait is the maximum time that Juju will wait at any
+	// given step before proceeding to the next one.
+	MaxWait *time.Duration
 }
 
 // DestroyApplications destroys the given applications.
@@ -557,6 +568,7 @@ func (c *Client) DestroyApplications(in DestroyApplicationsParams) ([]params.Des
 			ApplicationTag: names.NewApplicationTag(name).String(),
 			DestroyStorage: in.DestroyStorage,
 			Force:          in.Force,
+			MaxWait:        in.MaxWait,
 		})
 	}
 	if len(argsV5.Applications) == 0 {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -62,7 +62,7 @@ var facadeVersions = map[string]int{
 	"LogForwarding":                1,
 	"Logger":                       1,
 	"MachineActions":               1,
-	"MachineManager":               5,
+	"MachineManager":               6,
 	"MachineUndertaker":            1,
 	"Machiner":                     1,
 	"MeterStatus":                  1,

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -4,6 +4,8 @@
 package machinemanager
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
@@ -60,11 +62,14 @@ func (client *Client) ForceDestroyMachines(machines ...string) ([]params.Destroy
 // DestroyMachinesWithParams removes the given set of machines, the semantics of which
 // is determined by the force and keep parameters.
 // TODO(wallyworld) - for Juju 3.0, this should be the preferred api to use.
-func (client *Client) DestroyMachinesWithParams(force, keep bool, machines ...string) ([]params.DestroyMachineResult, error) {
+func (client *Client) DestroyMachinesWithParams(force, keep bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
 	args := params.DestroyMachinesParams{
 		Force:       force,
 		Keep:        keep,
 		MachineTags: make([]string, 0, len(machines)),
+	}
+	if client.BestAPIVersion() > 5 {
+		args.MaxWait = maxWait
 	}
 	allResults := make([]params.DestroyMachineResult, len(machines))
 	index := make([]int, 0, len(machines))

--- a/api/machinemanager/machinemanager_test.go
+++ b/api/machinemanager/machinemanager_test.go
@@ -6,6 +6,7 @@ package machinemanager_test
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -206,7 +207,8 @@ func (s *MachinemanagerSuite) TestDestroyMachinesWithParams(c *gc.C) {
 		*out = params.DestroyMachineResults{Results: expectedResults}
 		return nil
 	})
-	results, err := client.DestroyMachinesWithParams(true, true, "0", "0/lxd/1")
+	var noWait time.Duration
+	results, err := client.DestroyMachinesWithParams(true, true, &noWait, "0", "0/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1512,6 +1512,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 		op := app.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
 		op.Force = arg.Force
+		op.MaxWait = arg.MaxWait
 		if err := api.backend.ApplyOperation(op); err != nil {
 			return nil, err
 		}

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -5,6 +5,7 @@ package machinemanager
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -64,6 +65,14 @@ type MachineManagerAPIV4 struct {
 // Version 5 of Machine Manager API.
 // Adds CreateUpgradeSeriesLock and removes UpdateMachineSeries.
 type MachineManagerAPIV5 struct {
+	*MachineManagerAPIV6
+}
+
+// Version 6 of Machine Manager API.
+//
+// No methods are added or removed. Adds a maxWait field to
+// params.DestroyMachinesParams to work in conjunction with Force
+type MachineManagerAPIV6 struct {
 	*MachineManagerAPI
 }
 
@@ -78,11 +87,20 @@ func NewFacadeV4(ctx facade.Context) (*MachineManagerAPIV4, error) {
 
 // NewFacadeV5 creates a new server-side MachineManager API facade.
 func NewFacadeV5(ctx facade.Context) (*MachineManagerAPIV5, error) {
-	machineManagerAPI, err := NewFacade(ctx)
+	machineManagerAPI, err := NewFacadeV6(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &MachineManagerAPIV5{machineManagerAPI}, nil
+}
+
+// NewFacadeV6 creates a new server-side MachineManager API facade.
+func NewFacadeV6(ctx facade.Context) (*MachineManagerAPIV6, error) {
+	machineManagerAPI, err := NewFacade(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &MachineManagerAPIV6{machineManagerAPI}, nil
 }
 
 // NewMachineManagerAPI creates a new server-side MachineManager API facade.
@@ -247,12 +265,12 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 
 // DestroyMachine removes a set of machines from the model.
 func (mm *MachineManagerAPI) DestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, false, false)
+	return mm.destroyMachine(args, false, false, nil)
 }
 
 // ForceDestroyMachine forcibly removes a set of machines from the model.
 func (mm *MachineManagerAPI) ForceDestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, true, false)
+	return mm.destroyMachine(args, true, false, nil)
 }
 
 // DestroyMachineWithParams removes a set of machines from the model.
@@ -261,16 +279,22 @@ func (mm *MachineManagerAPI) DestroyMachineWithParams(args params.DestroyMachine
 	for i, tag := range args.MachineTags {
 		entities.Entities[i].Tag = tag
 	}
-	return mm.destroyMachine(entities, args.Force, args.Keep)
+	return mm.destroyMachine(entities, args.Force, args.Keep, args.MaxWait)
 }
 
-func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bool) (params.DestroyMachineResults, error) {
+func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bool, maxWait *time.Duration) (params.DestroyMachineResults, error) {
 	if err := mm.checkCanWrite(); err != nil {
 		return params.DestroyMachineResults{}, err
 	}
 	if err := mm.check.RemoveAllowed(); err != nil {
 		return params.DestroyMachineResults{}, err
 	}
+
+	if maxWait == nil {
+		defaultMaxWait := time.Minute
+		maxWait = &defaultMaxWait
+	}
+
 	destroyMachine := func(entity params.Entity) params.DestroyMachineResult {
 		result := params.DestroyMachineResult{}
 		fail := func(e error) params.DestroyMachineResult {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -362,7 +362,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateOK(c *gc.C) {
 	s.setupUpgradeSeries(c)
 	s.st.machines["0"].unitAgentState = status.Idle
 
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
@@ -384,7 +384,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateOK(c *gc.C) {
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateIsControllerError(c *gc.C) {
 	s.setupUpgradeSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("3").String()},
@@ -399,7 +399,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateIsControllerError(c *gc.C
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateNoSeriesError(c *gc.C) {
 	s.setupUpgradeSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
@@ -413,7 +413,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateNoSeriesError(c *gc.C) {
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateNotFromUbuntuError(c *gc.C) {
 	s.setupUpgradeSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("2").String()},
@@ -429,7 +429,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateNotFromUbuntuError(c *gc.
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateNotToUbuntuError(c *gc.C) {
 	s.setupUpgradeSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
@@ -445,7 +445,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateNotToUbuntuError(c *gc.C)
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateAlreadyRunningSeriesError(c *gc.C) {
 	s.setupUpgradeSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
@@ -460,7 +460,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateAlreadyRunningSeriesError
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateOlderSeriesError(c *gc.C) {
 	s.setupUpgradeSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("1").String()},
@@ -479,7 +479,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateUnitNotIdleError(c *gc.C)
 	s.st.machines["0"].unitAgentState = status.Executing
 	s.st.machines["0"].unitState = status.Active
 
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
@@ -497,7 +497,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateUnitStatusError(c *gc.C) 
 	s.st.machines["0"].unitAgentState = status.Idle
 	s.st.machines["0"].unitState = status.Error
 
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	args := params.UpdateSeriesArgs{
 		Args: []params.UpdateSeriesArg{{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
@@ -514,7 +514,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
 	s.setupUpgradeSeries(c)
 	s.st.machines["0"].unitAgentState = status.Idle
 
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	machineTag := names.NewMachineTag("0")
 	result, err := apiV5.UpgradeSeriesPrepare(
 		params.UpdateSeriesArg{
@@ -533,7 +533,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareMachineNotFound(c *gc.C) {
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	machineTag := names.NewMachineTag("76")
 	result, err := apiV5.UpgradeSeriesPrepare(
 		params.UpdateSeriesArg{
@@ -547,7 +547,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareMachineNotFound(c *gc.C) {
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareNotMachineTag(c *gc.C) {
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	unitTag := names.NewUnitTag("mysql/0")
 	result, err := apiV5.UpgradeSeriesPrepare(
 		params.UpdateSeriesArg{
@@ -563,7 +563,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareNotMachineTag(c *gc.C) {
 func (s *MachineManagerSuite) TestUpgradeSeriesPreparePermissionDenied(c *gc.C) {
 	user := names.NewUserTag("fred")
 	s.setAPIUser(c, user)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	machineTag := names.NewMachineTag("0")
 	_, err := apiV5.UpgradeSeriesPrepare(
 		params.UpdateSeriesArg{
@@ -576,7 +576,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPreparePermissionDenied(c *gc.C) 
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareBlockedChanges(c *gc.C) {
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	s.st.blockMsg = "TestUpgradeSeriesPrepareBlockedChanges"
 	s.st.block = state.ChangeBlock
 	_, err := apiV5.UpgradeSeriesPrepare(
@@ -594,7 +594,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareBlockedChanges(c *gc.C) {
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareNoSeries(c *gc.C) {
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	result, err := apiV5.UpgradeSeriesPrepare(
 		params.UpdateSeriesArg{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
@@ -616,7 +616,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 		Series:     "xenial",
 		CharmName:  "TestCharm",
 	})
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	result, err := apiV5.UpgradeSeriesPrepare(
 		params.UpdateSeriesArg{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
@@ -639,7 +639,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareRemoveLockAfterFail(c *gc.
 
 func (s *MachineManagerSuite) TestUpgradeSeriesComplete(c *gc.C) {
 	s.setupUpgradeSeries(c)
-	apiV5 := machinemanager.MachineManagerAPIV5{MachineManagerAPI: s.api}
+	apiV5 := s.machineManagerAPIV5()
 	_, err := apiV5.UpgradeSeriesComplete(
 		params.UpdateSeriesArg{
 			Entity: params.Entity{Tag: names.NewMachineTag("0").String()},
@@ -970,7 +970,12 @@ func (v *mockVolume) Detachable() bool {
 	return v.detachable
 }
 
+func (s *MachineManagerSuite) machineManagerAPIV5() machinemanager.MachineManagerAPIV5 {
+	managerV6 := &machinemanager.MachineManagerAPIV6{s.api}
+	return machinemanager.MachineManagerAPIV5{managerV6}
+}
+
 func (s *MachineManagerSuite) machineManagerAPIV4() machinemanager.MachineManagerAPIV4 {
-	managerV5 := &machinemanager.MachineManagerAPIV5{s.api}
-	return machinemanager.MachineManagerAPIV4{managerV5}
+	managerV5 := s.machineManagerAPIV5()
+	return machinemanager.MachineManagerAPIV4{&managerV5}
 }

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -4,6 +4,8 @@
 package params
 
 import (
+	"time"
+
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -294,7 +296,12 @@ type DestroyApplicationParams struct {
 
 	// Force controls whether or not the destruction of an application
 	// will be forced, i.e. ignore operational errors.
-	Force bool
+	Force bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in application destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // DestroyConsumedApplicationsParams holds bulk parameters for the

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -246,6 +246,11 @@ type DestroyMachinesParams struct {
 	MachineTags []string `json:"machine-tags"`
 	Force       bool     `json:"force,omitempty"`
 	Keep        bool     `json:"keep,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in model destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // UpdateSeriesArg holds the parameters for updating the series for the
@@ -414,7 +419,12 @@ type DestroyUnitParams struct {
 
 	// Force controls whether or not the destruction of an application
 	// will be forced, i.e. ignore operational errors.
-	Force bool
+	Force bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in unit during
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 
 	// Errors contains errors encountered while applying this operation.
 	// Generally, these are non-fatal errors that have been encountered

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -4,6 +4,8 @@
 package machine_test
 
 import (
+	"time"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
@@ -43,6 +45,7 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 		machines    []string
 		force       bool
 		keep        bool
+		noWait      bool
 		errorString string
 	}{
 		{
@@ -66,6 +69,16 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 			machines: []string{"1", "2"},
 			keep:     true,
 		}, {
+			args:     []string{"1", "--force", "--no-wait"},
+			machines: []string{"1"},
+			force:    true,
+			noWait:   true,
+		}, {
+			args:     []string{"1", "2", "--force", "--no-wait"},
+			machines: []string{"1", "2"},
+			force:    true,
+			noWait:   true,
+		}, {
 			args:        []string{"lxd"},
 			errorString: `invalid machine id "lxd"`,
 		}, {
@@ -80,6 +93,7 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(removeCmd.Force, gc.Equals, test.force)
 			c.Check(removeCmd.KeepInstance, gc.Equals, test.keep)
+			c.Check(removeCmd.NoWait, gc.Equals, test.noWait)
 			c.Check(removeCmd.MachineIds, jc.DeepEquals, test.machines)
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errorString)
@@ -186,7 +200,7 @@ func (f *fakeRemoveMachineAPI) ForceDestroyMachines(machines ...string) ([]param
 	return f.destroyMachines(machines)
 }
 
-func (f *fakeRemoveMachineAPI) DestroyMachinesWithParams(force, keep bool, machines ...string) ([]params.DestroyMachineResult, error) {
+func (f *fakeRemoveMachineAPI) DestroyMachinesWithParams(force, keep bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
 	f.forced = force
 	f.keep = keep
 	return f.destroyMachines(machines)

--- a/state/unit.go
+++ b/state/unit.go
@@ -983,7 +983,7 @@ func (u *Unit) RemoveOperation(force bool) *RemoveUnitOperation {
 	}
 }
 
-// ForcedOperation that allowas accumulation of operational errors and
+// ForcedOperation that allows accumulation of operational errors and
 // can be forced.
 type ForcedOperation struct {
 	// Force controls whether or not the removal of a unit
@@ -995,6 +995,10 @@ type ForcedOperation struct {
 	// during, say, force. They may not have prevented the operation from being
 	// aborted but the user might still want to know about them.
 	Errors []error
+
+	// MaxWait indicates how long the operation will wait for a step to
+	// complete before before proceeding to the next one.
+	MaxWait *time.Duration
 }
 
 // AddError adds an error to the collection of errors for this operation.


### PR DESCRIPTION
## Description of change

Add the MaxWait parameter to the machinemanager and application facades to facilitate `--no-wait` for `remove-application`, `remove-unit` and `remove-machine`.

## QA steps

### Remove machine

* `juju bootstrap localhost <controller>`
* `juju add-machine -n 3`
* Test 1: `juju remove-machine --no-wait 1` returns `ERROR --no-wait without --force not valid`
* Test 2: `juju remove-machine --force --no-wait 1` returns `removing machine 1`

## Documentation changes

N/A, no user-facing changes yet. (Should not be far off!)

## Bug reference

Indirectly affects

* [lp#1771792](https://bugs.launchpad.net/juju/+bug/1771792)
* [lp#1814956](https://bugs.launchpad.net/juju/+bug/1814956)
* [lp#1818045](https://bugs.launchpad.net/juju/+bug/1818045)