### PR TITLE
Ensure add-k8s uses existing storage if specified

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/permission"
+	"github.com/juju/juju/rpc"
 )
 
 var logger = loggo.GetLogger("juju.api.modelmanager")
@@ -74,6 +75,10 @@ func (c *Client) CreateModel(
 	var modelInfo params.ModelInfo
 	err := c.facade.FacadeCall("CreateModel", createArgs, &modelInfo)
 	if err != nil {
+		// We don't want the message to contain the "(already exists)" suffix.
+		if rpcErr, ok := errors.Cause(err).(*rpc.RequestError); ok {
+			return result, errors.New(rpcErr.Message)
+		}
 		return result, errors.Trace(err)
 	}
 	return convertParamsModelInfo(modelInfo)

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -383,7 +383,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) error {
 		GetClusterMetadataFunc: c.getClusterMetadataFunc(ctx),
 	}
 
-	storageMsg, err := provider.UpdateKubeCloudWithStorage(&newCloud, credential, storageParams)
+	storageMsg, err := provider.UpdateKubeCloudWithStorage(&newCloud, storageParams)
 	if err != nil {
 		if provider.IsClusterQueryError(err) {
 			if err.Error() == "" {
@@ -410,6 +410,9 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) error {
 
 	if clusterName == "" {
 		clusterName = c.hostCloudRegion
+		if clusterName == "" {
+			clusterName = newCloud.HostCloudRegion
+		}
 	}
 	if c.controllerName == "" {
 		successMsg := fmt.Sprintf("k8s substrate %q added as cloud %q%s", clusterName, c.caasName, storageMsg)

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -134,7 +134,7 @@ func (api *fakeK8sClusterMetadataChecker) CheckDefaultWorkloadStorage(cluster st
 }
 
 func (api *fakeK8sClusterMetadataChecker) EnsureStorageProvisioner(cfg jujucaas.StorageProvisioner) (*jujucaas.StorageProvisioner, error) {
-	results := api.MethodCall(api, "EnsureStorageProvisioner")
+	results := api.MethodCall(api, "EnsureStorageProvisioner", cfg)
 	return results[0].(*jujucaas.StorageProvisioner), jujutesting.TypeAssertError(results[1])
 }
 
@@ -546,7 +546,7 @@ func (s *addCAASSuite) TestGatherClusterRegionMetaRegionMatchesAndPassThrough(c 
 	cmd := s.makeCommand(c, true, false, true)
 	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s"`)
+	c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s".`)
 	s.assertAddCloudResult(c, cloudRegion, "", false)
 }
 
@@ -616,6 +616,28 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRecommendedStorageError(c *gc.
 	c.Assert(err, gc.ErrorMatches, expectedErr)
 }
 
+func (s *addCAASSuite) TestUnknownClusterExistingStorageClass(c *gc.C) {
+	s.fakeCloudAPI.isCloudRegionRequired = true
+	cloudRegion := "gce/us-east1"
+
+	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("cluster"))
+	storageProvisioner := &jujucaas.StorageProvisioner{
+		Name:        "mystorage",
+		Provisioner: "kubernetes.io/gce-pd",
+	}
+	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
+		Name: "mystorage",
+	}).Returns(storageProvisioner, nil)
+
+	cmd := s.makeCommand(c, true, false, true)
+	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
+	c.Assert(err, jc.ErrorIsNil)
+	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
+	result = strings.Replace(result, "\n", " ", -1)
+	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class.`)
+	s.assertAddCloudResult(c, cloudRegion, "mystorage", false)
+}
+
 func (s *addCAASSuite) TestCreateDefaultStorageProvisioner(c *gc.C) {
 	s.fakeCloudAPI.isCloudRegionRequired = true
 	cloudRegion := "gce/us-east1"
@@ -628,14 +650,17 @@ func (s *addCAASSuite) TestCreateDefaultStorageProvisioner(c *gc.C) {
 		Name:        "mystorage",
 		Provisioner: "kubernetes.io/gce-pd",
 	}
-	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner").Returns(storageProvisioner, nil)
+	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
+		Name:        "mystorage",
+		Provisioner: "kubernetes.io/gce-pd",
+	}).Returns(storageProvisioner, nil)
 
 	cmd := s.makeCommand(c, true, false, true)
 	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
-	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class`)
+	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class.`)
 	s.assertAddCloudResult(c, cloudRegion, "mystorage", false)
 }
 
@@ -649,14 +674,16 @@ func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
 		Name:        "my disk",
 		Provisioner: "my disk provisioner",
 	}
-	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner").Returns(storageProvisioner, nil)
+	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
+		Name: "mystorage",
+	}).Returns(storageProvisioner, nil)
 
 	cmd := s.makeCommand(c, true, false, true)
 	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
-	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class`)
+	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class.`)
 	s.assertAddCloudResult(c, cloudRegion, "mystorage", false)
 }
 
@@ -667,7 +694,7 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 	cmd := s.makeCommand(c, true, false, true)
 	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "mrcloud2", "--local")
 	c.Assert(err, jc.ErrorIsNil)
-	expected := `k8s substrate "mrcloud2" added as cloud "myk8s"You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
+	expected := `k8s substrate "mrcloud2" added as cloud "myk8s".You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
 	c.Assert(strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1), gc.Equals, expected)
 	s.assertAddCloudResult(c, cloudRegion, "", true)
 }


### PR DESCRIPTION
## Description of change

When running add-k8s on an unknown cluster with --storage, we should use the specified storage if it exists. We were previously not doing that and printing the wrong error message.

As a drive by, tweak the message when adding a duplicate model.

## QA steps

add-k8s --storage foo --region unknown/foo
should print storage-class "foo" not found

