### PR TITLE
Report but don't return k8s pod spec errors

### DIFF
--- a/caas/kubernetes/provider/errors.go
+++ b/caas/kubernetes/provider/errors.go
@@ -3,6 +3,11 @@
 
 package provider
 
+import (
+	"github.com/juju/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
 // ClusterQueryError represents an issue when querying a cluster.
 type ClusterQueryError struct {
 	Message string
@@ -51,5 +56,12 @@ func (e NoRecommendedStorageError) StorageProvider() string {
 // IsNoRecommendedStorageError returns true if err is a NoRecommendedStorageError
 func IsNoRecommendedStorageError(err error) bool {
 	_, ok := err.(NoRecommendedStorageError)
+	return ok
+}
+
+// MaskError is used to signify that an error
+// should not be reported back to the caller.
+func MaskError(err error) bool {
+	_, ok := errors.Cause(err).(*k8serrors.StatusError)
 	return ok
 }

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/caasunitprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -166,6 +167,11 @@ func (w *deploymentWorker) loop() error {
 		}
 		err = w.broker.EnsureService(w.application, w.provisioningStatusSetter.SetOperatorStatus, serviceParams, currentScale, appConfig)
 		if err != nil {
+			// Some errors we don't want to exit the worker.
+			if provider.MaskError(err) {
+				logger.Errorf(err.Error())
+				continue
+			}
 			return errors.Trace(err)
 		}
 		logger.Debugf("created/updated deployment for %s for %v units", w.application, currentScale)


### PR DESCRIPTION
## Description of change

When creating a k8s service during application deploy, if there's an error in the pod spec, k8s will report that. We need to report it to Juju but not exit the worker with an error, to prevent the worker continually restarting over and over.

## QA steps

Deploy a k8s charm with an error in the pod spec.
Check that juju status shows the error, and that the debug-log shows the worker not restarting