### PR TITLE
remove-unit --force: cleanups to remove a unit if the uniter isn't responding

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -21,8 +21,10 @@ type cleanupKind string
 
 const (
 	// forceTimeout is how far in the future the backstop force
-	// cleanup will be scheduled.
-	forceTimeout = time.Minute
+	// cleanup will be scheduled. This will be hard-coded to 0 for now
+	// until the no-wait flag is wired through, then we can change it
+	// to time.Minute.
+	forceTimeout = time.Duration(0)
 )
 
 var (

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -686,7 +686,7 @@ func (st *State) cleanupForceRemoveUnit(unitId string) error {
 	}
 	opErrs, err := unit.RemoveWithForce(true)
 	if len(opErrs) != 0 {
-		logger.Warningf("errors encountered force-removing unit %q: %v", opErrs)
+		logger.Warningf("errors encountered force-removing unit %q: %v", unitId, opErrs)
 	}
 	return errors.Trace(err)
 }

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1254,6 +1254,17 @@ func (prr *ProReqRelation) watches() []*state.RelationScopeWatcher {
 	}
 }
 
+func (prr *ProReqRelation) allEnterScope(c *gc.C) {
+	err := prr.pru0.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = prr.pru1.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = prr.rru0.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = prr.rru1.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func addRU(c *gc.C, app *state.Application, rel *state.Relation, principal *state.Unit) (*state.Unit, *state.RelationUnit) {
 	// Given the application app in the relation rel, add a unit of app and create
 	// a RelationUnit with rel. If principal is supplied, app is assumed to be

--- a/state/unit.go
+++ b/state/unit.go
@@ -613,10 +613,18 @@ func (op *DestroyUnitOperation) destroyOps() ([]txn.Op, error) {
 	// its own CL.
 	minUnitsOp := minUnitsTriggerOp(op.unit.st, op.unit.ApplicationName())
 	cleanupOp := newCleanupOp(cleanupDyingUnit, op.unit.doc.Name, op.DestroyStorage, op.Force)
+
+	// If we're forcing destruction the assertion shouldn't be that
+	// life is alive, but that it's what we think it is now.
+	assertion := isAliveDoc
+	if op.Force {
+		assertion = bson.D{{"life", op.unit.doc.Life}}
+	}
+
 	setDyingOp := txn.Op{
 		C:      unitsC,
 		Id:     op.unit.doc.DocID,
-		Assert: isAliveDoc,
+		Assert: assertion,
 		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
 	}
 	setDyingOps := func(dyingErr error) ([]txn.Op, error) {


### PR DESCRIPTION
## Description of change

Unit removals can stall if the uniter (in the unit agent) and deployer (in the machine agent) don't respond to the unit's lifecycle changes for some reason - a common example is a charm hook failing with an error.

To handle this we now have the `--force` flag on the `remove-unit` command. If the force flag is set when removing a unit we schedule a fallback cleanup from the dyingUnit cleanup. This cleanup performs the tasks the unit agent normally performs when a unit is dying:
* removing subordinates
* leaving the scope of any relations
* detaching storage
* marking the unit dead

Then there's another cleanup to remove the unit in case the deployer is stuck for some reason.

At the moment the fallback cleanups are scheduled immediately, but once the `--no-wait` flag is fully plumbed through from CLI -> API -> state -> cleanups it will be deferred for a minute (unless `--no-wait` is set) to allow the uniter & deployer to act.

## QA steps

* Deploy the [hook-error](https://private-fileshare.canonical.com/~xtian/hook-error.zip) charm to a model with some storage `juju deploy ~/path/to/hook-error -n 3 --storage pgdata=tmpfs,1G,1`.
* Add subordinates and other relations to it (it has a require-mysql endpoint).
* Once the units are ready, change the config so that the unit has an error processing the hook: `juju config hook-error crash=true`
* Running `juju remove-unit hook-error/0` will work but the unit will stick around.
* Running `juju remove-unit --force hook-error/0` will succeed - the subordinates and storage will be cleaned up, and the db relations will be left.
* The unit will be removed from status.
* Running `remove-application --force hook-error` will also not get blocked by the error units.

## Documentation changes

This doesn't require any docs changes (although it relies on the new `--force` flags to remove-unit, remove-application and destroy-model).

## Bug reference

None.
