### PR TITLE
caas operatorprovisionerinfo should get agent version from model config

### DIFF
--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -96,6 +96,7 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
 	attrs := coretesting.FakeConfig()
 	attrs["operator-storage"] = "k8s-storage"
+	attrs["agent-version"] = "2.6-beta3"
 	return config.New(config.UseDefaults, attrs)
 }
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -4,10 +4,9 @@
 package caasoperatorprovisioner_test
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
@@ -17,7 +16,6 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&CAASProvisionerSuite{})
@@ -123,8 +121,8 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    fmt.Sprintf("jujusolutions/jujud-operator:%s", version.Current.String()),
-		Version:      version.Current,
+		ImagePath:    "jujusolutions/jujud-operator:2.6-beta3",
+		Version:      version.MustParse("2.6-beta3"),
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
 			"juju-model-uuid":      coretesting.ModelTag.Id(),
@@ -149,8 +147,8 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + version.Current.String(),
-		Version:      version.Current,
+		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + "2.6-beta3",
+		Version:      version.MustParse("2.6-beta3"),
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
 			"juju-model-uuid":      coretesting.ModelTag.Id(),
@@ -176,8 +174,8 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C
 	result, err := s.api.OperatorProvisioningInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfo{
-		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + version.Current.String(),
-		Version:      version.Current,
+		ImagePath:    s.st.operatorRepo + "/jujud-operator:" + "2.6-beta3",
+		Version:      version.MustParse("2.6-beta3"),
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags: map[string]string{
 			"juju-model-uuid":      coretesting.ModelTag.Id(),

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -1,0 +1,83 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package podcfg
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/version"
+
+	"github.com/juju/juju/controller"
+)
+
+const (
+	jujudOCINamespace = "jujusolutions"
+	jujudOCIName      = "jujud-operator"
+	jujudbOCIName     = "juju-db"
+)
+
+// GetControllerImagePath returns oci image path of jujud for a controller.
+func (cfg *ControllerPodConfig) GetControllerImagePath() string {
+	return GetJujuOCIImagePath(cfg.Controller.Config, cfg.JujuVersion)
+}
+
+// GetJujuDbOCIImagePath returns the juju-db oci image path.
+func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
+	imageRepo := cfg.Controller.Config.CAASImageRepo()
+	if imageRepo == "" {
+		imageRepo = jujudOCINamespace
+	}
+	v := jujudbVersion
+	return fmt.Sprintf("%s/%s:%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor)
+}
+
+// IsJujuOCIImage returns true if the image path is for a Juju operator.
+func IsJujuOCIImage(imagePath string) bool {
+	return strings.Contains(imagePath, jujudOCIName+":")
+}
+
+// GetJujuOCIImagePath returns the jujud oci image path.
+func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) string {
+	// First check the deprecated "caas-operator-image-path" config.
+	imagePath := rebuildOldOperatorImagePath(
+		controllerCfg.CAASOperatorImagePath(), ver,
+	)
+	if imagePath != "" {
+		return imagePath
+	}
+	return imageRepoToPath(controllerCfg.CAASImageRepo(), ver)
+}
+
+func rebuildOldOperatorImagePath(imagePath string, ver version.Number) string {
+	if imagePath == "" {
+		return ""
+	}
+	return tagImagePath(imagePath, ver)
+}
+
+func tagImagePath(path string, ver version.Number) string {
+	var verString string
+	splittedPath := strings.Split(path, ":")
+	path = splittedPath[0]
+	if len(splittedPath) > 1 {
+		verString = splittedPath[1]
+	}
+	if ver != version.Zero {
+		verString = ver.String()
+	}
+	if verString != "" {
+		// tag with version.
+		path += ":" + verString
+	}
+	return path
+}
+
+func imageRepoToPath(imageRepo string, ver version.Number) string {
+	if imageRepo == "" {
+		imageRepo = jujudOCINamespace
+	}
+	path := fmt.Sprintf("%s/%s", imageRepo, jujudOCIName)
+	return tagImagePath(path, ver)
+}

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package podcfg_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloudconfig/podcfg"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/testing"
+)
+
+type imageSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&imageSuite{})
+
+func (*imageSuite) TestGetJujuOCIImagePath(c *gc.C) {
+	cfg := testing.FakeControllerConfig()
+
+	cfg[controller.CAASImageRepo] = "testing-repo"
+	ver := version.MustParse("2.6-beta3")
+	path := podcfg.GetJujuOCIImagePath(cfg, ver)
+	c.Assert(path, jc.DeepEquals, "testing-repo/jujud-operator:2.6-beta3")
+
+	cfg[controller.CAASOperatorImagePath] = "testing-old-repo/jujud-old-operator:1.6"
+	path = podcfg.GetJujuOCIImagePath(cfg, ver)
+	c.Assert(path, jc.DeepEquals, "testing-old-repo/jujud-old-operator:2.6-beta3")
+}

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -4,11 +4,9 @@
 package podcfg
 
 import (
-	"fmt"
 	"net"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -30,12 +28,6 @@ import (
 )
 
 var logger = loggo.GetLogger("juju.cloudconfig.podcfg")
-
-const (
-	jujudOCINamespace = "jujusolutions"
-	jujudOCIName      = "jujud-operator"
-	jujudbOCIName     = "juju-db"
-)
 
 // jujudbVersion is the version of juju-db to use.
 var jujudbVersion = mongo.Mongo40wt
@@ -210,43 +202,6 @@ func (cfg *ControllerPodConfig) VerifyConfig() (err error) {
 		}
 	}
 	return nil
-}
-
-// GetControllerImagePath returns oci image path of jujud for a controller.
-func (cfg *ControllerPodConfig) GetControllerImagePath() string {
-	return GetJujuOCIImagePath(cfg.Controller.Config, cfg.JujuVersion)
-}
-
-// GetJujuDbOCIImagePath returns the juju-db oci image path.
-func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
-	imageRepo := cfg.Controller.Config.CAASImageRepo()
-	if imageRepo == "" {
-		imageRepo = jujudOCINamespace
-	}
-	v := jujudbVersion
-	return fmt.Sprintf("%s/%s:%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor)
-}
-
-// IsJujuOCIImage returns true if the image path is for a Juju operator.
-func IsJujuOCIImage(imagePath string) bool {
-	return strings.Contains(imagePath, jujudOCIName+":")
-}
-
-// GetJujuOCIImagePath returns the jujud oci image path.
-func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) string {
-	// First check the deprecated "caas-operator-image-path" config.
-	imagePath := controllerCfg.CAASOperatorImagePath()
-	if imagePath != "" {
-		return imagePath
-	}
-	imageRepo := controllerCfg.CAASImageRepo()
-	if imageRepo == "" {
-		imageRepo = jujudOCINamespace
-	}
-	if ver == version.Zero {
-		return fmt.Sprintf("%s/%s", imageRepo, jujudOCIName)
-	}
-	return fmt.Sprintf("%s/%s:%s", imageRepo, jujudOCIName, ver.String())
 }
 
 func (cfg *ControllerPodConfig) verifyBootstrapConfig() (err error) {


### PR DESCRIPTION

## Description of change

fix upgrade caas controller issue (currently, upgrade controller will upgrade caas operators in all models as well)

## QA steps

1. bootstrap to k8s
2. creates a caas model and deploys some workloads
3. upgrade controller
4. monitor only controller is upgraded but not operators

## Documentation changes

None (bug fix)

## Bug reference

bug that has not been released yet.
