### PR TITLE
Advise user how to access migrated models

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -164,6 +164,10 @@ type RedirectError struct {
 
 	// CACert holds the certificate of the remote server.
 	CACert string
+
+	// FollowRedirect is set to true for cases like JAAS where the client
+	// needs to automatically follow the redirect to the new controller.
+	FollowRedirect bool
 }
 
 func (e *RedirectError) Error() string {

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -692,8 +692,9 @@ func (s *apiclientSuite) TestOpenWithRedirect(c *gc.C) {
 
 	hps, _ := network.ParseHostPorts(redirectToHosts...)
 	c.Assert(errors.Cause(err), jc.DeepEquals, &api.RedirectError{
-		Servers: [][]network.HostPort{hps},
-		CACert:  redirectToCACert,
+		Servers:        [][]network.HostPort{hps},
+		CACert:         redirectToCACert,
+		FollowRedirect: true,
 	})
 }
 

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -179,14 +179,14 @@ func (s *apiclientSuite) TestVerifyCA(c *gc.C) {
 			// proceeds with the connection to the servers. This
 			// would be the case where we connect to an older juju
 			// controller.
-			expConnCount: 6,
+			expConnCount: 2,
 			errRegex:     `unable to connect to API: .*`,
 		},
 		{
 			descr:      "no VerifyCA provided",
 			serverCert: serverCertWithSelfSignedCA,
 			// Dial connects to all servers
-			expConnCount: 3,
+			expConnCount: 1,
 			errRegex:     `unable to connect to API: .*`,
 		},
 		{
@@ -196,7 +196,7 @@ func (s *apiclientSuite) TestVerifyCA(c *gc.C) {
 				return errors.New("CA not trusted")
 			},
 			// Dial aborts after fetching CAs
-			expConnCount: 3,
+			expConnCount: 1,
 			errRegex:     "CA not trusted",
 		},
 		{
@@ -206,7 +206,7 @@ func (s *apiclientSuite) TestVerifyCA(c *gc.C) {
 				return nil
 			},
 			// Dial fetches CAs and then proceeds with the connection to the servers
-			expConnCount: 6,
+			expConnCount: 2,
 			errRegex:     `unable to connect to API: .*`,
 		},
 	}
@@ -217,35 +217,32 @@ func (s *apiclientSuite) TestVerifyCA(c *gc.C) {
 
 		// connCount holds the number of times we've accepted a connection.
 		var connCount int32
-		var addrs []string
 		tlsConf := &tls.Config{
 			Certificates: []tls.Certificate{spec.serverCert},
 		}
-		for i := 0; i < 3; i++ {
-			listener, err := tls.Listen("tcp", "127.0.0.1:0", tlsConf)
-			c.Assert(err, jc.ErrorIsNil)
-			defer listener.Close()
-			addrs = append(addrs, listener.Addr().String())
-			go func() {
-				buf := make([]byte, 4)
-				for {
-					client, err := listener.Accept()
-					if err != nil {
-						return
-					}
-					atomic.AddInt32(&connCount, 1)
 
-					// Do a dummy read to prevent the connection from
-					// closing before the client can access the certs.
-					_, _ = client.Read(buf)
-					_ = client.Close()
+		listener, err := tls.Listen("tcp", "127.0.0.1:0", tlsConf)
+		c.Assert(err, jc.ErrorIsNil)
+		defer listener.Close()
+		go func() {
+			buf := make([]byte, 4)
+			for {
+				client, err := listener.Accept()
+				if err != nil {
+					return
 				}
-			}()
-		}
+				atomic.AddInt32(&connCount, 1)
+
+				// Do a dummy read to prevent the connection from
+				// closing before the client can access the certs.
+				_, _ = client.Read(buf)
+				_ = client.Close()
+			}
+		}()
 
 		connCount = 0
-		info.Addrs = addrs
-		_, _, err := api.DialAPI(info, api.DialOpts{
+		info.Addrs = []string{listener.Addr().String()}
+		_, _, err = api.DialAPI(info, api.DialOpts{
 			VerifyCA: spec.verifyCA,
 		})
 		c.Assert(err, gc.ErrorMatches, spec.errRegex)

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/network"
 	"github.com/juju/loggo"
 	"gopkg.in/macaroon.v2-unstable"
 )
@@ -92,6 +93,20 @@ type DischargeRequiredErrorInfo struct {
 
 // AsMap encodes the error info as a map that can be attached to an Error.
 func (e DischargeRequiredErrorInfo) AsMap() map[string]interface{} {
+	return serializeToMap(e)
+}
+
+// RedirectErrorInfo provides additional information for Redirect errors.
+type RedirectErrorInfo struct {
+	// Servers holds the sets of addresses of the redirected servers.
+	Servers [][]network.HostPort `json:"servers"`
+
+	// CACert holds the certificate of the remote server.
+	CACert string `json:"ca-cert"`
+}
+
+// AsMap encodes the error info as a map that can be attached to an Error.
+func (e RedirectErrorInfo) AsMap() map[string]interface{} {
 	return serializeToMap(e)
 }
 

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -255,14 +255,14 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 
 	// Always attempt to get the status at least once, and retry if it fails.
 	status, err := c.getStatus()
-	if err != nil {
+	if err != nil && !modelcmd.IsModelMigratedError(err) {
 		for i := 0; i < c.retryCount; i++ {
 			// fun bit - make sure a new api connection is used for each new call
 			c.SetModelAPI(nil)
 			// Wait for a bit before retries.
 			<-c.clock.After(c.retryDelay)
 			status, err = c.getStatus()
-			if err == nil {
+			if err == nil || modelcmd.IsModelMigratedError(err) {
 				break
 			}
 		}

--- a/juju/api.go
+++ b/juju/api.go
@@ -68,7 +68,7 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 	st, err := args.OpenAPI(apiInfo, args.DialOpts)
 	if err != nil {
 		redirErr, ok := errors.Cause(err).(*api.RedirectError)
-		if !ok {
+		if !ok || !redirErr.FollowRedirect {
 			return nil, errors.Trace(err)
 		}
 		// We've been told to connect to a different API server,

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -187,8 +187,9 @@ func (s *NewAPIClientSuite) TestWithRedirect(c *gc.C) {
 			c.Check(apiInfo.Addrs, jc.DeepEquals, []string{"0.1.2.3:5678"})
 			c.Check(apiInfo.CACert, gc.Equals, "certificate")
 			return nil, errors.Trace(&api.RedirectError{
-				Servers: [][]network.HostPort{mustParseHostPorts(redirHPs)},
-				CACert:  "alternative CA cert",
+				Servers:        [][]network.HostPort{mustParseHostPorts(redirHPs)},
+				CACert:         "alternative CA cert",
+				FollowRedirect: true,
 			})
 		case 2:
 			c.Check(apiInfo.Addrs, jc.DeepEquals, []string{"0.0.9.9:1234", "0.0.9.10:1235"})

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/permission"
 )
 
 // This file contains functionality for managing the state documents
@@ -93,6 +94,10 @@ type ModelMigration interface {
 	// Refresh updates the contents of the ModelMigration from the
 	// underlying state.
 	Refresh() error
+
+	// ModelUserAccess returns the type of access that the given tag had to
+	// the model prior to it being migrated.
+	ModelUserAccess(names.Tag) permission.Access
 }
 
 // MinionReports indicates the sets of agents whose migration minion
@@ -151,6 +156,14 @@ type modelMigDoc struct {
 	// TargetMacaroons holds the macaroons to use with TargetAuthTag
 	// when authenticating.
 	TargetMacaroons string `bson:"target-macaroons,omitempty"`
+
+	// The list of users and their access-level to the model being migrated.
+	ModelUsers []modelMigUserDoc `bson:"model-users,omitempty"`
+}
+
+type modelMigUserDoc struct {
+	UserID string            `bson:"user_id"`
+	Access permission.Access `bson:"access"`
 }
 
 // modelMigStatusDoc tracks the progress of a migration attempt for a
@@ -604,6 +617,18 @@ func (mig *modelMigration) Refresh() error {
 	return nil
 }
 
+// ModelUserAccess implements ModelMigration.
+func (mig *modelMigration) ModelUserAccess(tag names.Tag) permission.Access {
+	id := tag.Id()
+	for _, user := range mig.doc.ModelUsers {
+		if user.UserID == id {
+			return user.Access
+		}
+	}
+
+	return permission.NoAccess
+}
+
 // MigrationSpec holds the information required to create a
 // ModelMigration instance.
 type MigrationSpec struct {
@@ -670,6 +695,11 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 			return nil, errors.Trace(err)
 		}
 
+		userDocs, err := modelUserDocs(model)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
 		id := fmt.Sprintf("%s:%d", modelUUID, attempt)
 		doc = modelMigDoc{
 			Id:               id,
@@ -682,6 +712,7 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 			TargetAuthTag:    spec.TargetInfo.AuthTag.String(),
 			TargetPassword:   spec.TargetInfo.Password,
 			TargetMacaroons:  macsJSON,
+			ModelUsers:       userDocs,
 		}
 
 		statusDoc = modelMigStatusDoc{
@@ -727,6 +758,23 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 		statusDoc: statusDoc,
 		st:        st,
 	}, nil
+}
+
+func modelUserDocs(m *Model) ([]modelMigUserDoc, error) {
+	users, err := m.Users()
+	if err != nil {
+		return nil, err
+	}
+
+	var docs []modelMigUserDoc
+	for _, user := range users {
+		docs = append(docs, modelMigUserDoc{
+			UserID: user.UserTag.Id(),
+			Access: user.Access,
+		})
+	}
+
+	return docs, nil
 }
 
 func macaroonsToJSON(m []macaroon.Slice) (string, error) {


### PR DESCRIPTION
## Description of change

This PR updates both the client and the server code so that clients (with sufficient access) attempting to connect to a model (basically, running any CLI command supporting a `-m` flag) that has been migrated to another controller will get back an error letting them know that the model has been migrated and providing advise on how to access it.

When a model gets successfully migrated to another controller, its relevant documents get deleted from the DB and the only thing that remains is a document that tracks the migration itself and details about the controller the model got migrated to. 

When users attempt to run a model-related command (e.g `juju status -m XXX`) the client attempts to establish a websocket connection and includes the target model UUID in the request URL. As the model document does not exist any more, the connection gets torn down with a NotFound error. Slightly O/T: this is interesting from a security standpoint as the current implementation provides an oracle for finding out if a model with a particular UUID exists or not; however this is probably not an issue as UUIDs don't convey any useful information anyway.

The server can figure out if a model has been migrated by checking whether a migration document exists for that particular model UUID. To make redirects work for our use-case we also need to know whether the user **used to have access** to the model before it got migrated. The first 2 commits from the PR update the migration document code to also track the users and their access levels before initiating the migration. Note that this information cannot be recovered for older controllers so we don't need an upgrade step for the extra field. Also, this information does not get migrated across controllers so presumably no migration step is required either.

With these 2 changes we have the means to detect if we should return a redirect error to the user or not. Unfortunately, we need to wait for the user to login first before we can decide. To make this flow work, the admin route handler has been modified to allow websocket connections to be established **if and only if** we are aware that a particular model has been migrated. This allows the users to invoke the `Login` RPC and to get back either a `RedirectError` or an `Unauthorized` error depending on whether they used to have access to the model or not.

On the client-side, things are also a bit more complicated due to the fact that we already have a codepath that deals with RedirectErrors! However, that path is used to implement **transparent** redirects for the JAAS use-case where JAAS appears as a controller front-end that can potentially dispatch requests to other controllers.

For _this_ particular use-case we **do not** want to transparently redirect users but would rather abort the command with an error advising the users how to connect to the new controller (either via a `juju login $controller_ip` or a `juju switch XXX` if the destination controller is already known). The reason for this is that we always want users to be aware on which controller they are executing commands.

To ensure that both cases work as expected, the client-side `RedirectError` has been augmented with a `FollowRedirect` attribute (set to true for JAAS-like cases) which allows us to provide a user-friendly error message for redirected models in the non-JAAS use-case.

NOTE: The changes from this PR only affect model-related commands (CLI commands using modelcmd/base.go). Commands that login to the controller like `juju show-model XXX` will just get back a `permission denied` error when targeting a migrated model. If we need to support redirects for this type of commands we can do it via a separate PR. 

## QA steps

### Migrate model to locally known controller 

```console
$ juju bootstrap lxd src
$ juju change-user-password 

$ juju bootstrap lxd dst
$ juju change-user-password

$ juju switch src:controller
$ juju add-model migrate

# At this point make a copy of your ~/.local/share/juju/models.yaml
# as the model uuid will probably be removed from src after migrating
$ juju migrate src:migrate dst

# wait a few seconds for the migration to complete and ensure that 
# the source controller in your local models.yaml still contains the 
# uuid for the model that just got migrated 

# Try any model-related command, e.g:
$ juju status -m migrate
ERROR Model "migrate" has been migrated to controller "dst".
To access it run 'juju switch dst:migrate'.
```

### Migrate model to controller not locally known

```console
# Run these steps after trying out the previous QA step
$ juju unregister dst

# Try any model-related command, e.g:
$ juju status -m migrate
ERROR Model "migrate" has been migrated to another controller.
To access it run one of the following commands:
  'juju login 10.65.47.40:17070 -c new-controller'

New controller fingerprint [93:73:88:C9:9A:AA:EC:C8:85:AE:D1:33:E5:92:CE:95:0F:B6:00:82:21:CB:8C:A0:42:16:29:77:CF:6D:B6:D4]
```

### Different client/server versions

```
| client | server | juju status -m $model                         |
|--------|--------|-----------------------------------------------|
| 2.5    | 2.5    | model not found                               |
| 2.5    | 2.6    | cannot get redirect addresses: not redirected |
| 2.6    | 2.5    | model not found                               |
```

## Documentation changes

@pmatulis we probably need to document this work-flow.