### PR TITLE
Tweak status for k8s apps without pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,15 @@ else
 	CHECK_ARGS =
 endif
 
+# Compile with debug flags if requested.
+ifeq ($(DEBUG_JUJU), 1)
+    COMPILE_FLAGS = -gcflags "all=-N -l"
+    LINK_FLAGS =
+else
+    COMPILE_FLAGS =
+    LINK_FLAGS = -ldflags "-s -w"
+endif
+
 define DEPENDENCIES
   ca-certificates
   bzip2
@@ -68,11 +77,11 @@ clean:
 	go clean -n -r --cache --testcache $(PROJECT_PACKAGES)
 
 go-install:
-	@echo 'go install -ldflags "-s -w" -v $$PROJECT_PACKAGES'
-	@go install -ldflags "-s -w" -v $(PROJECT_PACKAGES)
+	@echo 'go install $(COMPILE_FLAGS) $(LINK_FLAGS) -v $$PROJECT_PACKAGES'
+	@go install $(COMPILE_FLAGS) $(LINK_FLAGS) -v $(PROJECT_PACKAGES)
 
 go-build:
-	@go build $(PROJECT_PACKAGES)
+	@go build $(COMPILE_FLAGS) $(PROJECT_PACKAGES)
 
 else # --------------------------------
 

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -107,7 +107,6 @@ var scenarioStatus = &params.FullStatus{
 		Version:     "1.2.3",
 		ModelStatus: params.DetailedStatus{
 			Status: "available",
-			Data:   map[string]interface{}{},
 		},
 		SLA: "unsupported",
 	},
@@ -117,15 +116,12 @@ var scenarioStatus = &params.FullStatus{
 			InstanceId: instance.Id("i-machine-0"),
 			AgentStatus: params.DetailedStatus{
 				Status: "started",
-				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
 				Status: status.Pending.String(),
-				Data:   make(map[string]interface{}),
 			},
 			ModificationStatus: params.DetailedStatus{
 				Status: status.Idle.String(),
-				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",
 			Containers: map[string]params.MachineStatus{},
@@ -138,15 +134,12 @@ var scenarioStatus = &params.FullStatus{
 			InstanceId: instance.Id("i-machine-1"),
 			AgentStatus: params.DetailedStatus{
 				Status: "started",
-				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
 				Status: status.Pending.String(),
-				Data:   make(map[string]interface{}),
 			},
 			ModificationStatus: params.DetailedStatus{
 				Status: status.Idle.String(),
-				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",
 			Containers: map[string]params.MachineStatus{},
@@ -159,15 +152,12 @@ var scenarioStatus = &params.FullStatus{
 			InstanceId: instance.Id("i-machine-2"),
 			AgentStatus: params.DetailedStatus{
 				Status: "started",
-				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
 				Status: status.Pending.String(),
-				Data:   make(map[string]interface{}),
 			},
 			ModificationStatus: params.DetailedStatus{
 				Status: status.Idle.String(),
-				Data:   make(map[string]interface{}),
 			},
 			Series:      "quantal",
 			Constraints: "mem=1024M",
@@ -189,7 +179,6 @@ var scenarioStatus = &params.FullStatus{
 			Relations: map[string][]string{},
 			Status: params.DetailedStatus{
 				Status: status.Unknown.String(),
-				Data:   map[string]interface{}{},
 			},
 		},
 	},
@@ -219,7 +208,6 @@ var scenarioStatus = &params.FullStatus{
 			Status: params.DetailedStatus{
 				Status: "waiting",
 				Info:   "waiting for machine",
-				Data:   map[string]interface{}{},
 			},
 			EndpointBindings: map[string]string{
 				"info":              "",
@@ -236,7 +224,6 @@ var scenarioStatus = &params.FullStatus{
 			Status: params.DetailedStatus{
 				Status: "waiting",
 				Info:   "waiting for machine",
-				Data:   map[string]interface{}{},
 			},
 			EndpointBindings: map[string]string{
 				"server":         "",
@@ -265,7 +252,6 @@ var scenarioStatus = &params.FullStatus{
 					},
 					AgentStatus: params.DetailedStatus{
 						Status: "idle",
-						Data:   make(map[string]interface{}),
 					},
 					Machine: "1",
 					Subordinates: map[string]params.UnitStatus{
@@ -273,11 +259,9 @@ var scenarioStatus = &params.FullStatus{
 							WorkloadStatus: params.DetailedStatus{
 								Status: "waiting",
 								Info:   "waiting for machine",
-								Data:   make(map[string]interface{}),
 							},
 							AgentStatus: params.DetailedStatus{
 								Status: "allocating",
-								Data:   map[string]interface{}{},
 							},
 						},
 					},
@@ -286,12 +270,10 @@ var scenarioStatus = &params.FullStatus{
 					WorkloadStatus: params.DetailedStatus{
 						Status: "waiting",
 						Info:   "waiting for machine",
-						Data:   make(map[string]interface{}),
 					},
 					AgentStatus: params.DetailedStatus{
 						Status: "allocating",
 						Info:   "",
-						Data:   make(map[string]interface{}),
 					},
 
 					Machine: "2",
@@ -300,12 +282,10 @@ var scenarioStatus = &params.FullStatus{
 							WorkloadStatus: params.DetailedStatus{
 								Status: "waiting",
 								Info:   "waiting for machine",
-								Data:   make(map[string]interface{}),
 							},
 							AgentStatus: params.DetailedStatus{
 								Status: "allocating",
 								Info:   "",
-								Data:   make(map[string]interface{}),
 							},
 						},
 					},
@@ -346,7 +326,6 @@ var scenarioStatus = &params.FullStatus{
 			Status: params.DetailedStatus{
 				Status: "joining",
 				Info:   "",
-				Data:   make(map[string]interface{}),
 			},
 		},
 	},

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -535,36 +535,71 @@ var _ = gc.Suite(&clientSuite{})
 
 // clearSinceTimes zeros out the updated timestamps inside status
 // so we can easily check the results.
+// Also set any empty status data maps to nil as there's no
+// practical difference and it's easier to write tests that way.
 func clearSinceTimes(status *params.FullStatus) {
 	for applicationId, application := range status.Applications {
 		for unitId, unit := range application.Units {
 			unit.WorkloadStatus.Since = nil
+			if len(unit.WorkloadStatus.Data) == 0 {
+				unit.WorkloadStatus.Data = nil
+			}
 			unit.AgentStatus.Since = nil
+			if len(unit.AgentStatus.Data) == 0 {
+				unit.AgentStatus.Data = nil
+			}
 			for id, subord := range unit.Subordinates {
 				subord.WorkloadStatus.Since = nil
+				if len(subord.WorkloadStatus.Data) == 0 {
+					subord.WorkloadStatus.Data = nil
+				}
 				subord.AgentStatus.Since = nil
+				if len(subord.AgentStatus.Data) == 0 {
+					subord.AgentStatus.Data = nil
+				}
 				unit.Subordinates[id] = subord
 			}
 			application.Units[unitId] = unit
 		}
 		application.Status.Since = nil
+		if len(application.Status.Data) == 0 {
+			application.Status.Data = nil
+		}
 		status.Applications[applicationId] = application
 	}
 	for applicationId, application := range status.RemoteApplications {
 		application.Status.Since = nil
+		if len(application.Status.Data) == 0 {
+			application.Status.Data = nil
+		}
 		status.RemoteApplications[applicationId] = application
 	}
 	for id, machine := range status.Machines {
 		machine.AgentStatus.Since = nil
+		if len(machine.AgentStatus.Data) == 0 {
+			machine.AgentStatus.Data = nil
+		}
 		machine.InstanceStatus.Since = nil
+		if len(machine.InstanceStatus.Data) == 0 {
+			machine.InstanceStatus.Data = nil
+		}
 		machine.ModificationStatus.Since = nil
+		if len(machine.ModificationStatus.Data) == 0 {
+			machine.ModificationStatus.Data = nil
+		}
 		status.Machines[id] = machine
 	}
 	for id, rel := range status.Relations {
 		rel.Status.Since = nil
+		if len(rel.Status.Data) == 0 {
+			rel.Status.Data = nil
+		}
 		status.Relations[id] = rel
 	}
 	status.Model.ModelStatus.Since = nil
+	if len(status.Model.ModelStatus.Data) == 0 {
+		status.Model.ModelStatus.Data = nil
+	}
 }
 
 // clearContollerTimestamp zeros out the controller timestamps inside

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -214,6 +214,7 @@ func opClientStatus(c *gc.C, st api.Connection, mst *state.State) (func(), error
 		return func() {}, err
 	}
 	clearSinceTimes(status)
+	clearSinceTimes(scenarioStatus)
 	clearContollerTimestamp(status)
 	c.Assert(status, jc.DeepEquals, scenarioStatus)
 	return func() {}, nil

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -133,7 +133,7 @@ type LXDProfile struct {
 
 // ApplicationStatus holds status info about an application.
 type ApplicationStatus struct {
-	Err              error                  `json:"err,omitempty"`
+	Err              *Error                 `json:"err,omitempty"`
 	Charm            string                 `json:"charm"`
 	Series           string                 `json:"series"`
 	Exposed          bool                   `json:"exposed"`
@@ -157,7 +157,7 @@ type ApplicationStatus struct {
 
 // RemoteApplicationStatus holds status info about a remote application.
 type RemoteApplicationStatus struct {
-	Err       error               `json:"err,omitempty"`
+	Err       *Error              `json:"err,omitempty"`
 	OfferURL  string              `json:"offer-url"`
 	OfferName string              `json:"offer-name"`
 	Endpoints []RemoteEndpoint    `json:"endpoints"`
@@ -168,7 +168,7 @@ type RemoteApplicationStatus struct {
 
 // ApplicationOfferStatus holds status info about an application offer.
 type ApplicationOfferStatus struct {
-	Err                  error                     `json:"err,omitempty"`
+	Err                  *Error                    `json:"err,omitempty"`
 	OfferName            string                    `json:"offer-name"`
 	ApplicationName      string                    `json:"application-name"`
 	CharmURL             string                    `json:"charm"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -230,7 +230,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 	}
 
 	out := applicationStatus{
-		Err:              application.Err,
+		Err:              typedNilCheck(application.Err),
 		Charm:            application.Charm,
 		Series:           application.Series,
 		OS:               osInfo,
@@ -266,7 +266,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 
 func (sf *statusFormatter) formatRemoteApplication(name string, application params.RemoteApplicationStatus) remoteApplicationStatus {
 	out := remoteApplicationStatus{
-		Err:        application.Err,
+		Err:        typedNilCheck(application.Err),
 		OfferURL:   application.OfferURL,
 		Life:       application.Life,
 		Relations:  application.Relations,
@@ -354,7 +354,7 @@ func (sf *statusFormatter) getRemoteApplicationStatusInfo(application params.Rem
 
 func (sf *statusFormatter) formatOffer(name string, offer params.ApplicationOfferStatus) offerStatus {
 	out := offerStatus{
-		Err:                  offer.Err,
+		Err:                  typedNilCheck(offer.Err),
 		ApplicationName:      offer.ApplicationName,
 		CharmURL:             offer.CharmURL,
 		ActiveConnectedCount: offer.ActiveConnectedCount,

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2088,7 +2088,7 @@ func (s *ApplicationSuite) TestAddCAASUnit(c *gc.C) {
 	us.Since = nil
 	c.Assert(us, jc.DeepEquals, status.StatusInfo{
 		Status:  status.Waiting,
-		Message: "waiting for container",
+		Message: status.MessageInitializingAgent,
 		Data:    map[string]interface{}{},
 	})
 	as, err := unitZero.AgentStatus()
@@ -3765,7 +3765,7 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	statusInfo, err = u.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, status.Waiting)
-	c.Assert(statusInfo.Message, gc.Equals, "waiting for container")
+	c.Assert(statusInfo.Message, gc.Equals, "agent initializing")
 	statusInfo, err = state.GetCloudContainerStatus(s.caasSt, u.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, status.Running)
@@ -3782,7 +3782,7 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	unitHistory, err = u.StatusHistory(status.StatusHistoryFilter{Size: 10})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unitHistory[0].Status, gc.Equals, status.Waiting)
-	c.Assert(unitHistory[0].Message, gc.Equals, status.MessageWaitForContainer)
+	c.Assert(unitHistory[0].Message, gc.Equals, status.MessageInitializingAgent)
 
 	u, ok = unitsById["add-never-cloud-container"]
 	c.Assert(ok, jc.IsTrue)
@@ -3791,7 +3791,7 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	unitHistory, err = u.StatusHistory(status.StatusHistoryFilter{Size: 10})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unitHistory[0].Status, gc.Equals, status.Waiting)
-	c.Assert(unitHistory[0].Message, gc.Equals, status.MessageWaitForContainer)
+	c.Assert(unitHistory[0].Message, gc.Equals, status.MessageInitializingAgent)
 
 	u, ok = unitsById["new-unit-uuid"]
 	info, ok = containerInfoById["new-unit-uuid"]
@@ -3810,7 +3810,7 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	statusInfo, err = u.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, status.Waiting)
-	c.Assert(statusInfo.Message, gc.Equals, status.MessageWaitForContainer)
+	c.Assert(statusInfo.Message, gc.Equals, status.MessageInitializingAgent)
 	statusInfo, err = state.GetCloudContainerStatus(s.caasSt, u.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Status, gc.Equals, status.Running)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -855,12 +855,12 @@ func GetCloudContainerStatusHistory(st *State, name string, filter status.Status
 	return statusHistory(args)
 }
 
-func CaasUnitDisplayStatus(unitStatus status.StatusInfo, cloudContainerStatus status.StatusInfo) status.StatusInfo {
-	return caasUnitDisplayStatus(unitStatus, cloudContainerStatus)
+func CaasUnitDisplayStatus(unitStatus status.StatusInfo, cloudContainerStatus status.StatusInfo, expectWorkload bool) status.StatusInfo {
+	return caasUnitDisplayStatus(unitStatus, cloudContainerStatus, expectWorkload)
 }
 
-func CaasApplicationDisplayStatus(appStatus status.StatusInfo, operatorStatus status.StatusInfo) status.StatusInfo {
-	return caasApplicationDisplayStatus(appStatus, operatorStatus)
+func CaasApplicationDisplayStatus(appStatus status.StatusInfo, operatorStatus status.StatusInfo, expectWorkload bool) status.StatusInfo {
+	return caasApplicationDisplayStatus(appStatus, operatorStatus, expectWorkload)
 }
 
 func ApplicationOperatorStatus(st *State, appName string) (status.StatusInfo, error) {

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -619,7 +619,7 @@ func (s *MigrationExportSuite) assertMigrateUnits(c *gc.C, st *state.State) {
 	if dbModel.Type() == state.ModelTypeCAAS {
 		// Account for the extra cloud container status history addition.
 		c.Assert(workloadHistory, gc.HasLen, expectedHistoryCount+1)
-		c.Assert(workloadHistory[expectedHistoryCount].Message(), gc.Equals, "waiting for container")
+		c.Assert(workloadHistory[expectedHistoryCount].Message(), gc.Equals, "agent initializing")
 		c.Assert(workloadHistory[expectedHistoryCount].Value(), gc.Equals, "waiting")
 		c.Assert(workloadHistory[expectedHistoryCount-1].Message(), gc.Equals, "cloud container running")
 		c.Assert(workloadHistory[expectedHistoryCount-1].Value(), gc.Equals, "running")

--- a/state/unit.go
+++ b/state/unit.go
@@ -435,7 +435,7 @@ func (op *UpdateUnitOperation) Build(attempt int) ([]txn.Op, error) {
 			return nil, errors.Trace(err)
 		}
 
-		modifiedStatus := caasUnitDisplayStatus(unitStatus, cloudContainerStatus)
+		modifiedStatus := caasUnitDisplayStatus(unitStatus, cloudContainerStatus, true)
 		now := op.unit.st.clock().Now()
 		doc := statusDoc{
 			Status:     modifiedStatus.Status,
@@ -1486,8 +1486,11 @@ func (u *Unit) SetStatus(unitStatus status.StatusInfo) error {
 				return errors.Trace(err)
 			}
 		}
-
-		newHistory, err = caasHistoryRewriteDoc(unitStatus, cloudContainerStatus, caasUnitDisplayStatus, u.st.clock())
+		expectWorkload, err := expectWorkload(u.st, u.ApplicationName())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		newHistory, err = caasHistoryRewriteDoc(unitStatus, cloudContainerStatus, expectWorkload, caasUnitDisplayStatus, u.st.clock())
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

Some k8s charms will not start any pods. So the "waiting for container" status message is misleading. And more so when the charm has set status to Active but Juju still displays it as Waiting because there are no pods yet.
This PR tweaks the k8s unit/app status so that if not pod spec has been set, it instead displays as "agent initializing". If the charm does set a status, that is still preferred.

Writing tests showed up a serious, latent bug in setting the params.ApplicationStatus error. The type was wrong and needed to be params.Error not error.
Also, the test help to clear status times now also clears empty error data to make things easier.

Also a driveby Makefile fix to enable jujud to be compiled with debug info left in.

## QA steps

Deploy a "normal" k8s app and check status history.
Deploy a k8s app which does not set a pod spec and check status history.

