### PR TITLE
Add --no-wait for remove-application and -unit CLI and api.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -8,6 +8,8 @@
 package application
 
 import (
+	"time"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -453,6 +455,11 @@ type DestroyUnitsParams struct {
 	// Force controls whether or not the removal of applications
 	// will be forced, i.e. ignore removal errors.
 	Force bool
+
+	// MaxWait specifies the amount of time that each step in unit removal
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration
 }
 
 // DestroyUnits decreases the number of units dedicated to one or more
@@ -475,6 +482,7 @@ func (c *Client) DestroyUnits(in DestroyUnitsParams) ([]params.DestroyUnitResult
 			UnitTag:        names.NewUnitTag(name).String(),
 			DestroyStorage: in.DestroyStorage,
 			Force:          in.Force,
+			MaxWait:        in.MaxWait,
 		})
 	}
 	if len(argsV5.Units) == 0 {
@@ -536,6 +544,11 @@ type DestroyApplicationsParams struct {
 	// Force controls whether or not the removal of applications
 	// will be forced, i.e. ignore removal errors.
 	Force bool
+
+	// MaxWait specifies the amount of time that each step in application removal
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration
 }
 
 // DestroyApplications destroys the given applications.
@@ -557,6 +570,7 @@ func (c *Client) DestroyApplications(in DestroyApplicationsParams) ([]params.Des
 			ApplicationTag: names.NewApplicationTag(name).String(),
 			DestroyStorage: in.DestroyStorage,
 			Force:          in.Force,
+			MaxWait:        in.MaxWait,
 		})
 	}
 	if len(argsV5.Applications) == 0 {

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -4,6 +4,8 @@
 package application_test
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -344,12 +346,13 @@ func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
 			DestroyedUnits:   []params.Entity{{Tag: "unit-bar-1"}},
 		},
 	}}
+	delay := 1 * time.Minute
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		c.Assert(request, gc.Equals, "DestroyApplication")
 		c.Assert(a, jc.DeepEquals, params.DestroyApplicationsParams{
 			Applications: []params.DestroyApplicationParams{
-				{ApplicationTag: "application-foo", Force: true},
-				{ApplicationTag: "application-bar", Force: true},
+				{ApplicationTag: "application-foo", Force: true, MaxWait: &delay},
+				{ApplicationTag: "application-bar", Force: true, MaxWait: &delay},
 			},
 		})
 		c.Assert(response, gc.FitsTypeOf, &params.DestroyApplicationResults{})
@@ -360,6 +363,7 @@ func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
 	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
 		Applications: []string{"foo", "bar"},
 		Force:        true,
+		MaxWait:      &delay,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
@@ -462,12 +466,13 @@ func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
 			DetachedStorage:  []params.Entity{{Tag: "storage-pgdata-1"}},
 		},
 	}}
+	delay := 1 * time.Minute
 	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
 		c.Assert(request, gc.Equals, "DestroyUnit")
 		c.Assert(a, jc.DeepEquals, params.DestroyUnitsParams{
 			Units: []params.DestroyUnitParams{
-				{UnitTag: "unit-foo-0", Force: true},
-				{UnitTag: "unit-bar-1", Force: true},
+				{UnitTag: "unit-foo-0", Force: true, MaxWait: &delay},
+				{UnitTag: "unit-bar-1", Force: true, MaxWait: &delay},
 			},
 		})
 		c.Assert(response, gc.FitsTypeOf, &params.DestroyUnitResults{})
@@ -476,8 +481,9 @@ func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
 		return nil
 	})
 	results, err := client.DestroyUnits(application.DestroyUnitsParams{
-		Units: []string{"foo/0", "bar/1"},
-		Force: true,
+		Units:   []string{"foo/0", "bar/1"},
+		Force:   true,
+		MaxWait: &delay,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -4,6 +4,8 @@
 package params
 
 import (
+	"time"
+
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -294,7 +296,12 @@ type DestroyApplicationParams struct {
 
 	// Force controls whether or not the destruction of an application
 	// will be forced, i.e. ignore operational errors.
-	Force bool
+	Force bool `json:"force"`
+
+	// MaxWait specifies the amount of time that each step in application removal
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // DestroyConsumedApplicationsParams holds bulk parameters for the
@@ -374,7 +381,7 @@ type ScaleApplicationParams struct {
 
 	// Force controls whether or not scaling of an application
 	// will be forced, i.e. ignore operational errors.
-	Force bool
+	Force bool `json:"force"`
 }
 
 // ScaleApplicationResults contains the results of a ScaleApplication

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -414,13 +414,18 @@ type DestroyUnitParams struct {
 
 	// Force controls whether or not the destruction of an application
 	// will be forced, i.e. ignore operational errors.
-	Force bool
+	Force bool `json:"force"`
 
 	// Errors contains errors encountered while applying this operation.
 	// Generally, these are non-fatal errors that have been encountered
 	// during, say, force. They may not have prevented the operation from being
 	// aborted but the user might still want to know about them.
-	Errors []error
+	Errors []error `json:"errors,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in unit removal
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // Creds holds credentials for identifying an entity.

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -223,9 +223,6 @@ func (c *removeApplicationCommand) removeApplications(
 		if c.NoWait {
 			zeroSec := 0 * time.Second
 			maxWait = &zeroSec
-		} else {
-			oneMin := 1 * time.Minute
-			maxWait = &oneMin
 		}
 	}
 

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -141,6 +141,11 @@ func (s *RemoveApplicationSuite) TestInvalidArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid application name "invalid:name"`)
 }
 
+func (s *RemoveApplicationSuite) TestNoWaitWithoutForce(c *gc.C) {
+	_, err := runRemoveApplication(c, "gargleblaster", "--no-wait")
+	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
+}
+
 type RemoveCharmStoreCharmsSuite struct {
 	legacyCharmStoreSuite
 	ctx *cmd.Context

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -273,9 +273,6 @@ func (c *removeUnitCommand) removeUnits(ctx *cmd.Context, client RemoveApplicati
 		if c.NoWait {
 			zeroSec := 0 * time.Second
 			maxWait = &zeroSec
-		} else {
-			oneMin := 1 * time.Minute
-			maxWait = &oneMin
 		}
 	}
 

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -147,6 +147,11 @@ removing unit unit/2 failed: unit "unit/2" does not exist
 `[1:])
 }
 
+func (s *RemoveUnitSuite) TestRemoveUnitNoWaitWithouForce(c *gc.C) {
+	_, err := s.runRemoveUnit(c, "unit/0", "--no-wait")
+	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
+}
+
 func (s *RemoveUnitSuite) TestBlockRemoveUnit(c *gc.C) {
 	// Block operation
 	s.fake.err = common.OperationBlockedError("TestBlockRemoveUnit")

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -329,9 +329,6 @@ upgrade the controller to version 2.3 or greater.
 		if c.NoWait {
 			zeroSec := 0 * time.Second
 			maxWait = &zeroSec
-		} else {
-			oneMin := 1 * time.Minute
-			maxWait = &oneMin
 		}
 	}
 	modelTag := names.NewModelTag(modelDetails.ModelUUID)

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -217,9 +217,8 @@ func (s *DestroySuite) TestDestroyWithForce(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
 	force := true
-	maxWait := 1 * time.Minute
 	s.stub.CheckCalls(c, []jutesting.StubCall{
-		{"DestroyModel", []interface{}{names.NewModelTag("test2-uuid"), (*bool)(nil), &force, &maxWait}},
+		{"DestroyModel", []interface{}{names.NewModelTag("test2-uuid"), (*bool)(nil), &force, (*time.Duration)(nil)}},
 	})
 }
 


### PR DESCRIPTION
## Description of change

Unit or application removal is a multi-step process. Currently, Juju will not proceed to the next step until a previous step in the process is completed successfully. This may block the removal process - next steps are not called and the removal does not complete. For example, Juju may not be able to contact machine agent to do some unit cleanup jobs and unit removal will seem to hang. 

This PR is part of the change that will support force removal despite operational errors. Force removal will call the next step in the process regardless of where the current step is or if it has succeeded. Generally, we'd wait for a set period of time before calling this next step. However, with 'no-wait' command option specified, Juju will forgo this wait and will call the next step is soon as possible. This means that the whole force removal process will be faster.
