### PR TITLE
Add --force and --no-wait for remove-relation CLI and api.

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -790,14 +790,22 @@ func (c *Client) AddRelation(endpoints, viaCIDRs []string) (*params.AddRelationR
 }
 
 // DestroyRelation removes the relation between the specified endpoints.
-func (c *Client) DestroyRelation(endpoints ...string) error {
-	args := params.DestroyRelation{Endpoints: endpoints}
+func (c *Client) DestroyRelation(force *bool, maxWait *time.Duration, endpoints ...string) error {
+	args := params.DestroyRelation{
+		Endpoints: endpoints,
+		Force:     force,
+		MaxWait:   maxWait,
+	}
 	return c.facade.FacadeCall("DestroyRelation", args, nil)
 }
 
 // DestroyRelationId removes the relation with the specified id.
-func (c *Client) DestroyRelationId(relationId int) error {
-	args := params.DestroyRelation{RelationId: relationId}
+func (c *Client) DestroyRelationId(relationId int, force *bool, maxWait *time.Duration) error {
+	args := params.DestroyRelation{
+		RelationId: relationId,
+		Force:      force,
+		MaxWait:    maxWait,
+	}
 	return c.facade.FacadeCall("DestroyRelation", args, nil)
 }
 

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -607,35 +607,70 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDestroyRelation(c *gc.C) {
-	called := false
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		c.Assert(request, gc.Equals, "DestroyRelation")
-		c.Assert(a, jc.DeepEquals, params.DestroyRelation{
-			Endpoints: []string{"ep1", "ep2"},
+	false_ := false
+	true_ := true
+	zero := time.Minute * 1
+	for _, t := range []struct {
+		force   *bool
+		maxWait *time.Duration
+	}{
+		{},
+		{force: &true_},
+		{force: &false_},
+		{maxWait: &zero},
+		{force: &false_, maxWait: &zero},
+		{force: &true_, maxWait: &zero},
+	} {
+		called := false
+		client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
+			c.Assert(request, gc.Equals, "DestroyRelation")
+			c.Assert(a, jc.DeepEquals, params.DestroyRelation{
+				Endpoints: []string{"ep1", "ep2"},
+				Force:     t.force,
+				MaxWait:   t.maxWait,
+			})
+			c.Assert(response, gc.IsNil)
+			called = true
+			return nil
 		})
-		c.Assert(response, gc.IsNil)
-		called = true
-		return nil
-	})
-	err := client.DestroyRelation("ep1", "ep2")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+
+		err := client.DestroyRelation(t.force, t.maxWait, "ep1", "ep2")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(called, jc.IsTrue)
+	}
 }
 
 func (s *applicationSuite) TestDestroyRelationId(c *gc.C) {
-	called := false
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		c.Assert(request, gc.Equals, "DestroyRelation")
-		c.Assert(a, jc.DeepEquals, params.DestroyRelation{
-			RelationId: 123,
+	false_ := false
+	true_ := true
+	zero := time.Minute * 1
+	for _, t := range []struct {
+		force   *bool
+		maxWait *time.Duration
+	}{
+		{},
+		{force: &true_},
+		{force: &false_},
+		{maxWait: &zero},
+		{force: &false_, maxWait: &zero},
+		{force: &true_, maxWait: &zero},
+	} {
+		called := false
+		client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
+			c.Assert(request, gc.Equals, "DestroyRelation")
+			c.Assert(a, jc.DeepEquals, params.DestroyRelation{
+				RelationId: 123,
+				Force:      t.force,
+				MaxWait:    t.maxWait,
+			})
+			c.Assert(response, gc.IsNil)
+			called = true
+			return nil
 		})
-		c.Assert(response, gc.IsNil)
-		called = true
-		return nil
-	})
-	err := client.DestroyRelationId(123)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+		err := client.DestroyRelationId(123, t.force, t.maxWait)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(called, jc.IsTrue)
+	}
 }
 
 func (s *applicationSuite) TestSetRelationSuspended(c *gc.C) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -147,7 +147,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 6, application.NewFacadeV6)
 	reg("Application", 7, application.NewFacadeV7)
 	reg("Application", 8, application.NewFacadeV8)
-	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo, generational config, Force on App and Unit Removal.
+	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo; generational config; Force on App, Relation and Unit Removal.
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -5,6 +5,7 @@ package client_test
 
 import (
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -200,7 +201,7 @@ func opClientAddRelation(c *gc.C, st api.Connection, mst *state.State) (func(), 
 }
 
 func opClientDestroyRelation(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := application.NewClient(st).DestroyRelation("nosuch1", "nosuch2")
+	err := application.NewClient(st).DestroyRelation((*bool)(nil), (*time.Duration)(nil), "nosuch1", "nosuch2")
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -131,6 +131,15 @@ type AddRelationResults struct {
 type DestroyRelation struct {
 	Endpoints  []string `json:"endpoints,omitempty"`
 	RelationId int      `json:"relation-id"`
+
+	// Force specifies whether relation destruction will be forced, i.e.
+	// keep going despite operational errors.
+	Force *bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in relation destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // RelationStatusArgs holds the parameters for updating the status

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -4,7 +4,9 @@
 package application
 
 import (
+	"github.com/juju/gnuflag"
 	"strconv"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -33,9 +35,22 @@ The relation is specified using the relation endpoint names, eg
 It is also possible to specify the relation ID, if known. This is useful to
 terminate a relation originating from a different model, where only the ID is known. 
 
+Sometimes, the removal of the relation may fail as Juju encounters errors
+and failures that need to be dealt with before a relation can be removed.
+However, at times, there is a need to remove a relation ignoring
+all operational errors. In these rare cases, use --force option but note 
+that --force will remove a relation without giving it the opportunity to be removed cleanly.
+
+Relation removal is a multi-step process. Under normal circumstances, Juju will not
+proceed to a next step until the current step finished. 
+However, when using --force, users can also specify --no-wait to progress through steps 
+without delay waiting for each step to complete.
+
 Examples:
     juju remove-relation mysql wordpress
     juju remove-relation 4
+    juju remove-relation 4 --force
+    juju remove-relation 4 --force --no-wait
 
 In the case of multiple relations, the relation name should be specified
 at least once - the following examples will all have the same effect:
@@ -50,16 +65,16 @@ See also:
 
 // NewRemoveRelationCommand returns a command to remove a relation between 2 applications.
 func NewRemoveRelationCommand() cmd.Command {
-	cmd := &removeRelationCommand{}
-	cmd.newAPIFunc = func() (ApplicationDestroyRelationAPI, error) {
-		root, err := cmd.NewAPIRoot()
+	command := &removeRelationCommand{}
+	command.newAPIFunc = func() (ApplicationDestroyRelationAPI, error) {
+		root, err := command.NewAPIRoot()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return application.NewClient(root), nil
 
 	}
-	return modelcmd.Wrap(cmd)
+	return modelcmd.Wrap(command)
 }
 
 // removeRelationCommand causes an existing application relation to be shut down.
@@ -68,6 +83,9 @@ type removeRelationCommand struct {
 	RelationId int
 	Endpoints  []string
 	newAPIFunc func() (ApplicationDestroyRelationAPI, error)
+	Force      bool
+	NoWait     bool
+	fs         *gnuflag.FlagSet
 }
 
 func (c *removeRelationCommand) Info() *cmd.Info {
@@ -93,15 +111,44 @@ func (c *removeRelationCommand) Init(args []string) (err error) {
 	return nil
 }
 
+func (c *removeRelationCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	f.BoolVar(&c.Force, "force", false, "Force remove a relation")
+	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through relation removal without waiting for each individual step to complete")
+	c.fs = f
+}
+
 // ApplicationDestroyRelationAPI defines the API methods that application remove relation command uses.
 type ApplicationDestroyRelationAPI interface {
 	Close() error
 	BestAPIVersion() int
-	DestroyRelation(endpoints ...string) error
-	DestroyRelationId(relationId int) error
+	DestroyRelation(force *bool, maxWait *time.Duration, endpoints ...string) error
+	DestroyRelationId(relationId int, force *bool, maxWait *time.Duration) error
 }
 
 func (c *removeRelationCommand) Run(_ *cmd.Context) error {
+	noWaitSet := false
+	forceSet := false
+	c.fs.Visit(func(flag *gnuflag.Flag) {
+		if flag.Name == "no-wait" {
+			noWaitSet = true
+		} else if flag.Name == "force" {
+			forceSet = true
+		}
+	})
+	if !forceSet && noWaitSet {
+		return errors.NotValidf("--no-wait without --force")
+	}
+	var maxWait *time.Duration
+	var force *bool
+	if c.Force {
+		force = &c.Force
+		if c.NoWait {
+			zeroSec := 0 * time.Second
+			maxWait = &zeroSec
+		}
+	}
+
 	client, err := c.newAPIFunc()
 	if err != nil {
 		return err
@@ -111,9 +158,9 @@ func (c *removeRelationCommand) Run(_ *cmd.Context) error {
 		return errors.New("removing a relation using its ID is not supported by this version of Juju")
 	}
 	if len(c.Endpoints) > 0 {
-		err = client.DestroyRelation(c.Endpoints...)
+		err = client.DestroyRelation(force, maxWait, c.Endpoints...)
 	} else {
-		err = client.DestroyRelationId(c.RelationId)
+		err = client.DestroyRelationId(c.RelationId, force, maxWait)
 	}
 	return block.ProcessBlockedError(err, block.BlockRemove)
 }

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -4,12 +4,12 @@
 package application
 
 import (
-	"github.com/juju/gnuflag"
 	"strconv"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/api/application"
 	jujucmd "github.com/juju/juju/cmd"

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -72,14 +72,14 @@ func (s *RemoveRelationSuite) TestRemoveRelationIdOldServer(c *gc.C) {
 func (s *RemoveRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
 	err := s.runRemoveRelation(c, "application1", "application2")
 	c.Assert(err, jc.ErrorIsNil)
-	s.mockAPI.CheckCall(c, 0, "DestroyRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 0, "DestroyRelation", (*bool)(nil), (*time.Duration)(nil), []string{"application1", "application2"})
 	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
 func (s *RemoveRelationSuite) TestRemoveRelationIdSuccess(c *gc.C) {
 	err := s.runRemoveRelation(c, "123")
 	c.Assert(err, jc.ErrorIsNil)
-	s.mockAPI.CheckCall(c, 0, "DestroyRelationId", 123)
+	s.mockAPI.CheckCall(c, 0, "DestroyRelationId", 123, (*bool)(nil), (*time.Duration)(nil))
 	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
@@ -88,7 +88,7 @@ func (s *RemoveRelationSuite) TestRemoveRelationFail(c *gc.C) {
 	s.mockAPI.SetErrors(errors.New(msg))
 	err := s.runRemoveRelation(c, "application1", "application2")
 	c.Assert(err, gc.ErrorMatches, msg)
-	s.mockAPI.CheckCall(c, 0, "DestroyRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 0, "DestroyRelation", (*bool)(nil), (*time.Duration)(nil), []string{"application1", "application2"})
 	s.mockAPI.CheckCall(c, 1, "Close")
 }
 
@@ -96,7 +96,7 @@ func (s *RemoveRelationSuite) TestRemoveRelationBlocked(c *gc.C) {
 	s.mockAPI.SetErrors(common.OperationBlockedError("TestRemoveRelationBlocked"))
 	err := s.runRemoveRelation(c, "application1", "application2")
 	coretesting.AssertOperationWasBlocked(c, err, ".*TestRemoveRelationBlocked.*")
-	s.mockAPI.CheckCall(c, 0, "DestroyRelation", []string{"application1", "application2"})
+	s.mockAPI.CheckCall(c, 0, "DestroyRelation", (*bool)(nil), (*time.Duration)(nil), []string{"application1", "application2"})
 	s.mockAPI.CheckCall(c, 1, "Close")
 }
 

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -4,12 +4,13 @@
 package application
 
 import (
+	"time"
+
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"time"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -147,7 +147,7 @@ removing unit unit/2 failed: unit "unit/2" does not exist
 `[1:])
 }
 
-func (s *RemoveUnitSuite) TestRemoveUnitNoWaitWithouForce(c *gc.C) {
+func (s *RemoveUnitSuite) TestRemoveUnitNoWaitWithoutForce(c *gc.C) {
 	_, err := s.runRemoveUnit(c, "unit/0", "--no-wait")
 	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
 }


### PR DESCRIPTION
## Description of change

Relation removal is a multi-step process. Currently, Juju will not proceed to the next step until a previous step in the process is completed successfully. This may block the removal process - next steps are not called and the removal does not complete. 

This PR is part of the change that will support force removal despite operational errors. Force removal will call the next step in the process regardless of where the current step is or if it has succeeded. Generally, we'd wait for a set period of time before calling this next step. However, with 'no-wait' command option specified, Juju will forgo this wait and will call the next step is soon as possible. This means that the whole force removal process will be faster.