### PR TITLE
Remove Model UUID for Generation API Calls

### DIFF
--- a/api/modelgeneration/modelgeneration.go
+++ b/api/modelgeneration/modelgeneration.go
@@ -56,8 +56,8 @@ func (c *Client) CommitBranch(branchName string) (int, error) {
 	return result.Result, nil
 }
 
-// TrackBranch sets the input units and/or applications to track changes made
-// under the input branch name.
+// TrackBranch sets the input units and/or applications
+// to track changes made under the input branch name.
 func (c *Client) TrackBranch(branchName string, entities []string) error {
 	var result params.ErrorResults
 	arg := params.BranchTrackArg{
@@ -89,8 +89,8 @@ func (c *Client) TrackBranch(branchName string, entities []string) error {
 	return nil
 }
 
-// HasActiveBranch returns true if the model has an "in-flight" branch with
-// the input name.
+// HasActiveBranch returns true if the model has an
+// "in-flight" branch with the input name.
 func (c *Client) HasActiveBranch(branchName string) (bool, error) {
 	var result params.BoolResult
 	err := c.facade.FacadeCall("HasActiveBranch", argForBranch(branchName), &result)
@@ -104,8 +104,8 @@ func (c *Client) HasActiveBranch(branchName string) (bool, error) {
 }
 
 // BranchInfo returns information about "in-flight" branches.
-// If a non-empty string is supplied for branch name, then only information
-// for that branch is returned.
+// If a non-empty string is supplied for branch name,
+// then only information for that branch is returned.
 // Supplying true for detailed returns extra unit detail for the branch.
 func (c *Client) BranchInfo(
 	branchName string, detailed bool, formatTime func(time.Time) string,

--- a/api/modelgeneration/modelgeneration.go
+++ b/api/modelgeneration/modelgeneration.go
@@ -29,9 +29,9 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // AddBranch adds a new branch to the model.
-func (c *Client) AddBranch(modelUUID, branchName string) error {
+func (c *Client) AddBranch(branchName string) error {
 	var result params.ErrorResult
-	err := c.facade.FacadeCall("AddBranch", argForBranch(modelUUID, branchName), &result)
+	err := c.facade.FacadeCall("AddBranch", argForBranch(branchName), &result)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -44,9 +44,9 @@ func (c *Client) AddBranch(modelUUID, branchName string) error {
 // CommitBranch commits the branch with the input name to the model,
 // effectively completing it and applying all branch changes across the model.
 // The new generation ID of the model is returned.
-func (c *Client) CommitBranch(modelUUID, branchName string) (int, error) {
+func (c *Client) CommitBranch(branchName string) (int, error) {
 	var result params.IntResult
-	err := c.facade.FacadeCall("CommitBranch", argForBranch(modelUUID, branchName), &result)
+	err := c.facade.FacadeCall("CommitBranch", argForBranch(branchName), &result)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
@@ -58,10 +58,9 @@ func (c *Client) CommitBranch(modelUUID, branchName string) (int, error) {
 
 // TrackBranch sets the input units and/or applications to track changes made
 // under the input branch name.
-func (c *Client) TrackBranch(modelUUID, branchName string, entities []string) error {
+func (c *Client) TrackBranch(branchName string, entities []string) error {
 	var result params.ErrorResults
 	arg := params.BranchTrackArg{
-		Model:      argForModel(modelUUID),
 		BranchName: branchName,
 	}
 	if len(entities) == 0 {
@@ -92,9 +91,9 @@ func (c *Client) TrackBranch(modelUUID, branchName string, entities []string) er
 
 // HasActiveBranch returns true if the model has an "in-flight" branch with
 // the input name.
-func (c *Client) HasActiveBranch(modelUUID, branchName string) (bool, error) {
+func (c *Client) HasActiveBranch(branchName string) (bool, error) {
 	var result params.BoolResult
-	err := c.facade.FacadeCall("HasActiveBranch", argForBranch(modelUUID, branchName), &result)
+	err := c.facade.FacadeCall("HasActiveBranch", argForBranch(branchName), &result)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
@@ -109,7 +108,7 @@ func (c *Client) HasActiveBranch(modelUUID, branchName string) (bool, error) {
 // for that branch is returned.
 // Supplying true for detailed returns extra unit detail for the branch.
 func (c *Client) BranchInfo(
-	modelUUID, branchName string, detailed bool, formatTime func(time.Time) string,
+	branchName string, detailed bool, formatTime func(time.Time) string,
 ) (model.GenerationSummaries, error) {
 	arg := params.BranchInfoArgs{Detailed: detailed}
 	if branchName != "" {
@@ -127,15 +126,10 @@ func (c *Client) BranchInfo(
 	return generationInfoFromResult(result, detailed, formatTime), nil
 }
 
-func argForBranch(modelUUID, branchName string) params.BranchArg {
+func argForBranch(branchName string) params.BranchArg {
 	return params.BranchArg{
-		Model:      argForModel(modelUUID),
 		BranchName: branchName,
 	}
-}
-
-func argForModel(modelUUID string) params.Entity {
-	return params.Entity{Tag: names.NewModelTag(modelUUID).String()}
 }
 
 func generationInfoFromResult(

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -44,10 +44,7 @@ func (s *modelGenerationSuite) TearDownTest(c *gc.C) {
 func (s *modelGenerationSuite) TestAddBranchInvalidNameError(c *gc.C) {
 	defer s.setupModelGenerationAPI(c, nil).Finish()
 
-	arg := params.BranchArg{
-		BranchName: model.GenerationMaster,
-		Model:      params.Entity{Tag: names.NewModelTag(s.modelUUID).String()},
-	}
+	arg := params.BranchArg{BranchName: model.GenerationMaster}
 	result, err := s.api.AddBranch(arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.NotNil)
@@ -66,7 +63,6 @@ func (s *modelGenerationSuite) TestAddBranchSuccess(c *gc.C) {
 
 func (s *modelGenerationSuite) TestTrackBranchEntityTypeError(c *gc.C) {
 	arg := params.BranchTrackArg{
-		Model:      params.Entity{Tag: names.NewModelTag(s.modelUUID).String()},
 		BranchName: s.newBranchName,
 		Entities: []params.Entity{
 			{Tag: names.NewUnitTag("mysql/0").String()},
@@ -95,7 +91,6 @@ func (s *modelGenerationSuite) TestTrackBranchEntityTypeError(c *gc.C) {
 
 func (s *modelGenerationSuite) TestTrackBranchSuccess(c *gc.C) {
 	arg := params.BranchTrackArg{
-		Model:      params.Entity{Tag: names.NewModelTag(s.modelUUID).String()},
 		BranchName: s.newBranchName,
 		Entities: []params.Entity{
 			{Tag: names.NewUnitTag("mysql/0").String()},
@@ -258,8 +253,5 @@ func (s *modelGenerationSuite) setupModelGenerationAPI(c *gc.C, fn setupFunc) *g
 }
 
 func (s *modelGenerationSuite) newBranchArg() params.BranchArg {
-	return params.BranchArg{
-		BranchName: s.newBranchName,
-		Model:      params.Entity{Tag: names.NewModelTag(s.modelUUID).String()},
-	}
+	return params.BranchArg{BranchName: s.newBranchName}
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1124,7 +1124,6 @@ type SetProfileUpgradeCompleteArg struct {
 
 // BranchArg represents an in-flight branch via its model and branch name.
 type BranchArg struct {
-	Model      Entity `json:"model"`
 	BranchName string `json:"branch"`
 }
 
@@ -1141,7 +1140,6 @@ type BranchInfoArgs struct {
 // BranchTrackArg identifies an in-flight branch and a collection of
 // entities that should be set to track changes made under the branch.
 type BranchTrackArg struct {
-	Model      Entity   `json:"model"`
 	BranchName string   `json:"branch"`
 	Entities   []Entity `json:"entities"`
 }

--- a/cmd/juju/model/branch.go
+++ b/cmd/juju/model/branch.go
@@ -60,7 +60,7 @@ type branchCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/branch_mock.go github.com/juju/juju/cmd/juju/model BranchCommandAPI
 type BranchCommandAPI interface {
 	Close() error
-	AddBranch(string, string) error
+	AddBranch(string) error
 }
 
 // Info implements part of the cmd.Command interface.
@@ -113,17 +113,11 @@ func (c *branchCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	_, modelDetails, err := c.ModelCommandBase.ModelDetails()
-	if err != nil {
-		return errors.Annotate(err, "getting model details")
-	}
-
-	if err = client.AddBranch(modelDetails.ModelUUID, c.branchName); err != nil {
+	if err = client.AddBranch(c.branchName); err != nil {
 		return err
 	}
 
-	// Now update the model store with the 'next' generation for this
-	// model.
+	// Update the model store with the new active branch for this model.
 	if err = c.SetActiveBranch(c.branchName); err != nil {
 		return err
 	}

--- a/cmd/juju/model/branch.go
+++ b/cmd/juju/model/branch.go
@@ -60,7 +60,9 @@ type branchCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/branch_mock.go github.com/juju/juju/cmd/juju/model BranchCommandAPI
 type BranchCommandAPI interface {
 	Close() error
-	AddBranch(string) error
+
+	// AddBranch adds a new branch to the model.
+	AddBranch(branchName string) error
 }
 
 // Info implements part of the cmd.Command interface.

--- a/cmd/juju/model/branch_test.go
+++ b/cmd/juju/model/branch_test.go
@@ -41,7 +41,7 @@ func (s *branchSuite) TestRunCommand(c *gc.C) {
 	ctrl, api := setUpMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().AddBranch(gomock.Any(), s.branchName).Return(nil)
+	api.EXPECT().AddBranch(s.branchName).Return(nil)
 
 	ctx, err := s.runCommand(c, api)
 	c.Assert(err, jc.ErrorIsNil)
@@ -58,7 +58,7 @@ func (s *branchSuite) TestRunCommandFail(c *gc.C) {
 	ctrl, api := setUpMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().AddBranch(gomock.Any(), s.branchName).Return(errors.Errorf("fail"))
+	api.EXPECT().AddBranch(s.branchName).Return(errors.Errorf("fail"))
 
 	_, err := s.runCommand(c, api)
 	c.Assert(err, gc.ErrorMatches, "fail")

--- a/cmd/juju/model/checkout.go
+++ b/cmd/juju/model/checkout.go
@@ -58,7 +58,7 @@ type checkoutCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/checkout_mock.go github.com/juju/juju/cmd/juju/model CheckoutCommandAPI
 type CheckoutCommandAPI interface {
 	Close() error
-	HasActiveBranch(string, string) (bool, error)
+	HasActiveBranch(string) (bool, error)
 }
 
 // Info implements part of the cmd.Command interface.
@@ -111,11 +111,7 @@ func (c *checkoutCommand) Run(ctx *cmd.Context) error {
 		}
 		defer func() { _ = client.Close() }()
 
-		_, modelDetails, err := c.ModelDetails()
-		if err != nil {
-			return errors.Annotate(err, "getting model details")
-		}
-		hasBranch, err := client.HasActiveBranch(modelDetails.ModelUUID, c.branchName)
+		hasBranch, err := client.HasActiveBranch(c.branchName)
 		if err != nil {
 			return errors.Annotate(err, "checking for active branch")
 		}

--- a/cmd/juju/model/checkout.go
+++ b/cmd/juju/model/checkout.go
@@ -58,7 +58,9 @@ type checkoutCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/checkout_mock.go github.com/juju/juju/cmd/juju/model CheckoutCommandAPI
 type CheckoutCommandAPI interface {
 	Close() error
-	HasActiveBranch(string) (bool, error)
+	// HasActiveBranch returns true if the model has an
+	// "in-flight" branch with the input name.
+	HasActiveBranch(branchName string) (bool, error)
 }
 
 // Info implements part of the cmd.Command interface.

--- a/cmd/juju/model/checkout_test.go
+++ b/cmd/juju/model/checkout_test.go
@@ -46,7 +46,7 @@ func (s *checkoutSuite) TestRunCommandBranchExists(c *gc.C) {
 	ctrl, api := setUpSwitchMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().HasActiveBranch(gomock.Any(), s.branchName).Return(true, nil)
+	api.EXPECT().HasActiveBranch(s.branchName).Return(true, nil)
 
 	ctx, err := s.runCommand(c, api, s.branchName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *checkoutSuite) TestRunCommandNoBranchError(c *gc.C) {
 	ctrl, api := setUpSwitchMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().HasActiveBranch(gomock.Any(), s.branchName).Return(false, nil)
+	api.EXPECT().HasActiveBranch(s.branchName).Return(false, nil)
 
 	_, err := s.runCommand(c, api, s.branchName)
 	c.Assert(err, gc.ErrorMatches, `this model has no active branch "`+s.branchName+`"`)

--- a/cmd/juju/model/commit.go
+++ b/cmd/juju/model/commit.go
@@ -54,7 +54,7 @@ type commitCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/commit_mock.go github.com/juju/juju/cmd/juju/model CommitCommandAPI
 type CommitCommandAPI interface {
 	Close() error
-	CommitBranch(string, string) (int, error)
+	CommitBranch(string) (int, error)
 }
 
 // Info implements part of the cmd.Command interface.
@@ -104,12 +104,7 @@ func (c *commitCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	_, modelDetails, err := c.ModelCommandBase.ModelDetails()
-	if err != nil {
-		return errors.Annotate(err, "getting model details")
-	}
-
-	newGenId, err := client.CommitBranch(modelDetails.ModelUUID, c.branchName)
+	newGenId, err := client.CommitBranch(c.branchName)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/model/commit.go
+++ b/cmd/juju/model/commit.go
@@ -54,7 +54,12 @@ type commitCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/commit_mock.go github.com/juju/juju/cmd/juju/model CommitCommandAPI
 type CommitCommandAPI interface {
 	Close() error
-	CommitBranch(string) (int, error)
+
+	// CommitBranch commits the branch with the input name to the model,
+	// effectively completing it and applying
+	// all branch changes across the model.
+	// The new generation ID of the model is returned.
+	CommitBranch(branchName string) (int, error)
 }
 
 // Info implements part of the cmd.Command interface.

--- a/cmd/juju/model/commit_test.go
+++ b/cmd/juju/model/commit_test.go
@@ -36,7 +36,7 @@ func (s *commitSuite) TestRunCommandAborted(c *gc.C) {
 	ctrl, api := setUpCancelMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().CommitBranch(gomock.Any(), s.branchName).Return(0, nil)
+	api.EXPECT().CommitBranch(s.branchName).Return(0, nil)
 
 	ctx, err := s.runCommand(c, api)
 	c.Assert(err, jc.ErrorIsNil)
@@ -56,7 +56,7 @@ func (s *commitSuite) TestRunCommandCommitted(c *gc.C) {
 	ctrl, api := setUpCancelMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().CommitBranch(gomock.Any(), s.branchName).Return(3, nil)
+	api.EXPECT().CommitBranch(s.branchName).Return(3, nil)
 
 	ctx, err := s.runCommand(c, api)
 	c.Assert(err, jc.ErrorIsNil)
@@ -76,7 +76,7 @@ func (s *commitSuite) TestRunCommandFail(c *gc.C) {
 	ctrl, api := setUpCancelMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().CommitBranch(gomock.Any(), s.branchName).Return(0, errors.Errorf("fail"))
+	api.EXPECT().CommitBranch(s.branchName).Return(0, errors.Errorf("fail"))
 
 	_, err := s.runCommand(c, api)
 	c.Assert(err, gc.ErrorMatches, "fail")

--- a/cmd/juju/model/diff.go
+++ b/cmd/juju/model/diff.go
@@ -51,7 +51,12 @@ See also:
 //go:generate mockgen -package mocks -destination ./mocks/diff_mock.go github.com/juju/juju/cmd/juju/model DiffCommandAPI
 type DiffCommandAPI interface {
 	Close() error
-	BranchInfo(string, bool, func(time.Time) string) (model.GenerationSummaries, error)
+
+	// BranchInfo returns information about "in-flight" branches.
+	// If a non-empty string is supplied for branch name,
+	// then only information for that branch is returned.
+	// Supplying true for detailed returns extra unit detail for the branch.
+	BranchInfo(branchName string, detailed bool, formatTime func(time.Time) string) (model.GenerationSummaries, error)
 }
 
 // diffCommand supplies the "diff" CLI command used to show information about

--- a/cmd/juju/model/diff.go
+++ b/cmd/juju/model/diff.go
@@ -51,7 +51,7 @@ See also:
 //go:generate mockgen -package mocks -destination ./mocks/diff_mock.go github.com/juju/juju/cmd/juju/model DiffCommandAPI
 type DiffCommandAPI interface {
 	Close() error
-	BranchInfo(string, string, bool, func(time.Time) string) (model.GenerationSummaries, error)
+	BranchInfo(string, bool, func(time.Time) string) (model.GenerationSummaries, error)
 }
 
 // diffCommand supplies the "diff" CLI command used to show information about
@@ -136,17 +136,12 @@ func (c *diffCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	_, modelDetails, err := c.ModelCommandBase.ModelDetails()
-	if err != nil {
-		return errors.Annotate(err, "getting model details")
-	}
-
 	// Partially apply our time format
 	formatTime := func(t time.Time) string {
 		return common.FormatTime(&t, c.isoTime)
 	}
 
-	deltas, err := client.BranchInfo(modelDetails.ModelUUID, c.branchName, c.detailed, formatTime)
+	deltas, err := client.BranchInfo(c.branchName, c.detailed, formatTime)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/model/diff_test.go
+++ b/cmd/juju/model/diff_test.go
@@ -57,7 +57,7 @@ func (s *diffSuite) TestRunCommandNextGenExists(c *gc.C) {
 			}},
 		},
 	}
-	s.api.EXPECT().BranchInfo(gomock.Any(), s.branchName, true, gomock.Any()).Return(result, nil)
+	s.api.EXPECT().BranchInfo(s.branchName, true, gomock.Any()).Return(result, nil)
 
 	ctx, err := s.runCommand(c)
 	c.Assert(err, jc.ErrorIsNil)
@@ -81,7 +81,7 @@ new-branch:
 func (s *diffSuite) TestRunCommandAPIError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.api.EXPECT().BranchInfo(gomock.Any(), s.branchName, true, gomock.Any()).Return(nil, errors.New("boom"))
+	s.api.EXPECT().BranchInfo(s.branchName, true, gomock.Any()).Return(nil, errors.New("boom"))
 
 	_, err := s.runCommand(c)
 	c.Assert(err, gc.ErrorMatches, "boom")

--- a/cmd/juju/model/mocks/branch_mock.go
+++ b/cmd/juju/model/mocks/branch_mock.go
@@ -33,15 +33,15 @@ func (m *MockBranchCommandAPI) EXPECT() *MockBranchCommandAPIMockRecorder {
 }
 
 // AddBranch mocks base method
-func (m *MockBranchCommandAPI) AddBranch(arg0, arg1 string) error {
-	ret := m.ctrl.Call(m, "AddBranch", arg0, arg1)
+func (m *MockBranchCommandAPI) AddBranch(arg0 string) error {
+	ret := m.ctrl.Call(m, "AddBranch", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddBranch indicates an expected call of AddBranch
-func (mr *MockBranchCommandAPIMockRecorder) AddBranch(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBranch", reflect.TypeOf((*MockBranchCommandAPI)(nil).AddBranch), arg0, arg1)
+func (mr *MockBranchCommandAPIMockRecorder) AddBranch(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBranch", reflect.TypeOf((*MockBranchCommandAPI)(nil).AddBranch), arg0)
 }
 
 // Close mocks base method

--- a/cmd/juju/model/mocks/checkout_mock.go
+++ b/cmd/juju/model/mocks/checkout_mock.go
@@ -45,14 +45,14 @@ func (mr *MockCheckoutCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // HasActiveBranch mocks base method
-func (m *MockCheckoutCommandAPI) HasActiveBranch(arg0, arg1 string) (bool, error) {
-	ret := m.ctrl.Call(m, "HasActiveBranch", arg0, arg1)
+func (m *MockCheckoutCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
+	ret := m.ctrl.Call(m, "HasActiveBranch", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HasActiveBranch indicates an expected call of HasActiveBranch
-func (mr *MockCheckoutCommandAPIMockRecorder) HasActiveBranch(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasActiveBranch", reflect.TypeOf((*MockCheckoutCommandAPI)(nil).HasActiveBranch), arg0, arg1)
+func (mr *MockCheckoutCommandAPIMockRecorder) HasActiveBranch(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasActiveBranch", reflect.TypeOf((*MockCheckoutCommandAPI)(nil).HasActiveBranch), arg0)
 }

--- a/cmd/juju/model/mocks/commit_mock.go
+++ b/cmd/juju/model/mocks/commit_mock.go
@@ -45,14 +45,14 @@ func (mr *MockCommitCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // CommitBranch mocks base method
-func (m *MockCommitCommandAPI) CommitBranch(arg0, arg1 string) (int, error) {
-	ret := m.ctrl.Call(m, "CommitBranch", arg0, arg1)
+func (m *MockCommitCommandAPI) CommitBranch(arg0 string) (int, error) {
+	ret := m.ctrl.Call(m, "CommitBranch", arg0)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CommitBranch indicates an expected call of CommitBranch
-func (mr *MockCommitCommandAPIMockRecorder) CommitBranch(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitBranch", reflect.TypeOf((*MockCommitCommandAPI)(nil).CommitBranch), arg0, arg1)
+func (mr *MockCommitCommandAPIMockRecorder) CommitBranch(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitBranch", reflect.TypeOf((*MockCommitCommandAPI)(nil).CommitBranch), arg0)
 }

--- a/cmd/juju/model/mocks/diff_mock.go
+++ b/cmd/juju/model/mocks/diff_mock.go
@@ -35,16 +35,16 @@ func (m *MockDiffCommandAPI) EXPECT() *MockDiffCommandAPIMockRecorder {
 }
 
 // BranchInfo mocks base method
-func (m *MockDiffCommandAPI) BranchInfo(arg0, arg1 string, arg2 bool, arg3 func(time.Time) string) (map[string]model.Generation, error) {
-	ret := m.ctrl.Call(m, "BranchInfo", arg0, arg1, arg2, arg3)
+func (m *MockDiffCommandAPI) BranchInfo(arg0 string, arg1 bool, arg2 func(time.Time) string) (map[string]model.Generation, error) {
+	ret := m.ctrl.Call(m, "BranchInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]model.Generation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BranchInfo indicates an expected call of BranchInfo
-func (mr *MockDiffCommandAPIMockRecorder) BranchInfo(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BranchInfo", reflect.TypeOf((*MockDiffCommandAPI)(nil).BranchInfo), arg0, arg1, arg2, arg3)
+func (mr *MockDiffCommandAPIMockRecorder) BranchInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BranchInfo", reflect.TypeOf((*MockDiffCommandAPI)(nil).BranchInfo), arg0, arg1, arg2)
 }
 
 // Close mocks base method

--- a/cmd/juju/model/mocks/trackbranch_mock.go
+++ b/cmd/juju/model/mocks/trackbranch_mock.go
@@ -45,13 +45,13 @@ func (mr *MockTrackBranchCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // TrackBranch mocks base method
-func (m *MockTrackBranchCommandAPI) TrackBranch(arg0, arg1 string, arg2 []string) error {
-	ret := m.ctrl.Call(m, "TrackBranch", arg0, arg1, arg2)
+func (m *MockTrackBranchCommandAPI) TrackBranch(arg0 string, arg1 []string) error {
+	ret := m.ctrl.Call(m, "TrackBranch", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TrackBranch indicates an expected call of TrackBranch
-func (mr *MockTrackBranchCommandAPIMockRecorder) TrackBranch(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).TrackBranch), arg0, arg1, arg2)
+func (mr *MockTrackBranchCommandAPIMockRecorder) TrackBranch(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).TrackBranch), arg0, arg1)
 }

--- a/cmd/juju/model/trackbranch.go
+++ b/cmd/juju/model/trackbranch.go
@@ -57,7 +57,10 @@ type trackBranchCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/trackbranch_mock.go github.com/juju/juju/cmd/juju/model TrackBranchCommandAPI
 type TrackBranchCommandAPI interface {
 	Close() error
-	TrackBranch(string, []string) error
+
+	// TrackBranch sets the input units and/or applications
+	// to track changes made under the input branch name.
+	TrackBranch(branchName string, entities []string) error
 }
 
 // Info implements part of the cmd.Command interface.

--- a/cmd/juju/model/trackbranch.go
+++ b/cmd/juju/model/trackbranch.go
@@ -57,7 +57,7 @@ type trackBranchCommand struct {
 //go:generate mockgen -package mocks -destination ./mocks/trackbranch_mock.go github.com/juju/juju/cmd/juju/model TrackBranchCommandAPI
 type TrackBranchCommandAPI interface {
 	Close() error
-	TrackBranch(string, string, []string) error
+	TrackBranch(string, []string) error
 }
 
 // Info implements part of the cmd.Command interface.
@@ -116,10 +116,5 @@ func (c *trackBranchCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	_, modelDetails, err := c.ModelDetails()
-	if err != nil {
-		return errors.Annotate(err, "getting model details")
-	}
-
-	return errors.Trace(client.TrackBranch(modelDetails.ModelUUID, c.branchName, c.entities))
+	return errors.Trace(client.TrackBranch(c.branchName, c.entities))
 }

--- a/cmd/juju/model/trackbranch_test.go
+++ b/cmd/juju/model/trackbranch_test.go
@@ -59,7 +59,7 @@ func (s *trackBranchSuite) TestRunCommand(c *gc.C) {
 	mockController, api := setUpAdvanceMocks(c)
 	defer mockController.Finish()
 
-	api.EXPECT().TrackBranch(gomock.Any(), s.branchName, []string{"ubuntu/0", "redis"}).Return(nil)
+	api.EXPECT().TrackBranch(s.branchName, []string{"ubuntu/0", "redis"}).Return(nil)
 
 	_, err := s.runCommand(c, api, s.branchName, "ubuntu/0", "redis")
 	c.Assert(err, jc.ErrorIsNil)
@@ -69,7 +69,7 @@ func (s *trackBranchSuite) TestRunCommandFail(c *gc.C) {
 	ctrl, api := setUpAdvanceMocks(c)
 	defer ctrl.Finish()
 
-	api.EXPECT().TrackBranch(gomock.Any(), s.branchName, []string{"ubuntu/0"}).Return(errors.Errorf("fail"))
+	api.EXPECT().TrackBranch(s.branchName, []string{"ubuntu/0"}).Return(errors.Errorf("fail"))
 
 	_, err := s.runCommand(c, api, s.branchName, "ubuntu/0")
 	c.Assert(err, gc.ErrorMatches, "fail")


### PR DESCRIPTION
## Description of change

This patch removes explicit supply of model UUID when making generation-based API calls for CLI commands.

## QA steps

All generation CLI commands still work.

- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- Bootstrap.
- `juju branch test-branch`.
- `juju deploy redis`.
- `juju track test-branch redis/0`.
- `juju config redis password=pass --branch test-branch`.
- `juju diff` should reflect branch changes so far.
- `juju checkout master`.
- `juju checkout test-branch`.
- `juju commit test-branch`.

## Documentation changes

None.

## Bug reference

N/A
