### PR TITLE
Watcher cleanup

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -70,6 +70,8 @@ var (
 
 type (
 	CharmDoc       charmDoc
+	ApplicationDoc = applicationDoc
+
 	StorageBackend = storageBackend
 	DeviceBackend  = deviceBackend
 )

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1864,6 +1864,11 @@ func watchInstanceCharmProfileCompatibilityData(backend modelBackend, watchDocId
 	return newDocumentFieldWatcher(backend, collection, document, members, initial, filter, extract, transform)
 }
 
+// *Deprecated* Although this watcher seems fairly admirable in terms of what
+// it does, it unfortunately does things at the wrong level. With the
+// consequence of wiring up complex structures on something that wasn't intended
+// from the outset for it to do.
+//
 // documentFieldWatcher notifies about any changes to a document field
 // specifically, the watcher looks for changes to a document field, and records
 // the current document field (known value). If the document doesn't exist an

--- a/state/watcher_profilecharm_test.go
+++ b/state/watcher_profilecharm_test.go
@@ -140,6 +140,7 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) TestFullWatch(c *gc.C) {
 	w := s.workerForScenario(c,
 		s.expectInitialCollectionInstanceField("cs:~user/series/name-0"),
 		s.expectLoopCollectionFilterAndNotify([]watcher.Change{
+			{Revno: -1},
 			{Revno: 0},
 			{Revno: 1},
 		}, done),

--- a/state/watcher_profilecharm_test.go
+++ b/state/watcher_profilecharm_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/workertest"
 	"gopkg.in/mgo.v2/bson"
@@ -192,7 +193,7 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) expectInitialCollectionI
 		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
 		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
-			CharmURL: url,
+			CharmURL: charm.MustParseURL(url),
 		}).Return(nil)
 	}
 }
@@ -217,7 +218,7 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) expectMergeCollectionIns
 		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
 		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
-			CharmURL: url,
+			CharmURL: charm.MustParseURL(url),
 		}).Return(nil)
 	}
 }

--- a/state/watcher_profilecharm_test.go
+++ b/state/watcher_profilecharm_test.go
@@ -190,8 +190,8 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) expectInitialCollectionI
 	return func() {
 		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
-		s.query.EXPECT().One(gomock.Any()).SetArg(0, map[string]interface{}{
-			"charmurl": url,
+		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
+			CharmURL: url,
 		}).Return(nil)
 	}
 }
@@ -215,8 +215,8 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) expectMergeCollectionIns
 	return func() {
 		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
-		s.query.EXPECT().One(gomock.Any()).SetArg(0, map[string]interface{}{
-			"charmurl": url,
+		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
+			CharmURL: url,
 		}).Return(nil)
 	}
 }


### PR DESCRIPTION
## Description of change

Typed extraction

The following changes ensure that we're better typed for extracting
the type rather than falling down to a `map[string]interface{}`. This
should clean up any potential issues when trying to understand the
underlying type.

Example: https://github.com/juju/juju/pull/10081#discussion_r277629465

## QA steps

Tests should pass.
