### PR TITLE
Add --no-wait for remove-machine CLI and api.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -62,7 +62,7 @@ var facadeVersions = map[string]int{
 	"LogForwarding":                1,
 	"Logger":                       1,
 	"MachineActions":               1,
-	"MachineManager":               5,
+	"MachineManager":               6,
 	"MachineUndertaker":            1,
 	"Machiner":                     1,
 	"MeterStatus":                  1,

--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -50,49 +50,15 @@ func (client *Client) AddMachines(machineParams []params.AddMachineParams) ([]pa
 
 // DestroyMachines removes a given set of machines.
 func (client *Client) DestroyMachines(machines ...string) ([]params.DestroyMachineResult, error) {
-	in, index, results := client.entitiesFromMachines(machines)
-	if len(in.Entities) > 0 {
-		var result params.DestroyMachineResults
-		if err := client.facade.FacadeCall("DestroyMachine", in, &result); err != nil {
-			return nil, errors.Trace(err)
-		}
-		if n := len(result.Results); n != len(in.Entities) {
-			return nil, errors.Errorf("expected %d result(s), got %d", len(in.Entities), n)
-		}
-		for i, result := range result.Results {
-			results[index[i]] = result
-		}
-	}
-	return results, nil
+	return client.destroyMachines("DestroyMachine", machines)
 }
 
 // ForceDestroyMachines removes a given set of machines and all
 // associated units.
-func (client *Client) ForceDestroyMachines(maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
-	entities, index, results := client.entitiesFromMachines(machines)
-	if len(entities.Entities) > 0 {
-		var result params.DestroyMachineResults
-		if client.BestAPIVersion() < 6 {
-			if err := client.facade.FacadeCall("ForceDestroyMachine", entities, &result); err != nil {
-				return nil, errors.Trace(err)
-			}
-		} else {
-			in := params.ForceDestroyMachinesParams{
-				Machines: entities,
-				MaxWait:  maxWait,
-			}
-			if err := client.facade.FacadeCall("ForceDestroyMachine", in, &result); err != nil {
-				return nil, errors.Trace(err)
-			}
-		}
-		if n := len(result.Results); n != len(entities.Entities) {
-			return nil, errors.Errorf("expected %d result(s), got %d", len(entities.Entities), n)
-		}
-		for i, result := range result.Results {
-			results[index[i]] = result
-		}
-	}
-	return results, nil
+// TODO (anastasiamac 2019-4-24) From Juju 3.0 this call will be removed in favour of DestroyMachinesWithParams.
+// Also from ModelManger v6 this call is less useful as it ignores MaxWait customisation.
+func (client *Client) ForceDestroyMachines(machines ...string) ([]params.DestroyMachineResult, error) {
+	return client.destroyMachines("ForceDestroyMachine", machines)
 }
 
 // DestroyMachinesWithParams removes the given set of machines, the semantics of which
@@ -134,7 +100,7 @@ func (client *Client) DestroyMachinesWithParams(force, keep bool, maxWait *time.
 	return allResults, nil
 }
 
-func (client *Client) entitiesFromMachines(machines []string) (params.Entities, []int, []params.DestroyMachineResult) {
+func (client *Client) destroyMachines(method string, machines []string) ([]params.DestroyMachineResult, error) {
 	args := params.Entities{
 		Entities: make([]params.Entity, 0, len(machines)),
 	}
@@ -152,7 +118,19 @@ func (client *Client) entitiesFromMachines(machines []string) (params.Entities, 
 			Tag: names.NewMachineTag(machineId).String(),
 		})
 	}
-	return args, index, allResults
+	if len(args.Entities) > 0 {
+		var result params.DestroyMachineResults
+		if err := client.facade.FacadeCall(method, args, &result); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if n := len(result.Results); n != len(args.Entities) {
+			return nil, errors.Errorf("expected %d result(s), got %d", len(args.Entities), n)
+		}
+		for i, result := range result.Results {
+			allResults[index[i]] = result
+		}
+	}
+	return allResults, nil
 }
 
 // UpgradeSeriesPrepare notifies the controller that a series upgrade is taking

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -224,6 +224,7 @@ func AllFacades() *facade.Registry {
 	reg("MachineManager", 3, machinemanager.NewFacade)   // Adds DestroyMachine and ForceDestroyMachine.
 	reg("MachineManager", 4, machinemanager.NewFacadeV4) // Adds DestroyMachineWithParams.
 	reg("MachineManager", 5, machinemanager.NewFacadeV5) // Adds UpgradeSeriesPrepare, removes UpdateMachineSeries.
+	reg("MachineManager", 6, machinemanager.NewFacadeV6) // ForceRemoveMachine gains maxWait.
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
 	reg("Machiner", 1, machine.NewMachinerAPI)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -224,7 +224,7 @@ func AllFacades() *facade.Registry {
 	reg("MachineManager", 3, machinemanager.NewFacade)   // Adds DestroyMachine and ForceDestroyMachine.
 	reg("MachineManager", 4, machinemanager.NewFacadeV4) // Adds DestroyMachineWithParams.
 	reg("MachineManager", 5, machinemanager.NewFacadeV5) // Adds UpgradeSeriesPrepare, removes UpdateMachineSeries.
-	reg("MachineManager", 6, machinemanager.NewFacadeV6) // ForceRemoveMachine gains maxWait.
+	reg("MachineManager", 6, machinemanager.NewFacadeV6) // DestroyMachinesWithParams gains maxWait.
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
 	reg("Machiner", 1, machine.NewMachinerAPI)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -5,6 +5,7 @@ package machinemanager
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -64,6 +65,12 @@ type MachineManagerAPIV4 struct {
 // Version 5 of Machine Manager API.
 // Adds CreateUpgradeSeriesLock and removes UpdateMachineSeries.
 type MachineManagerAPIV5 struct {
+	*MachineManagerAPIV6
+}
+
+// Version 6 of Machine Manager API.
+// Changes input parameters to DestroyMachineWithParams and ForceDestroyMachine.
+type MachineManagerAPIV6 struct {
 	*MachineManagerAPI
 }
 
@@ -78,11 +85,20 @@ func NewFacadeV4(ctx facade.Context) (*MachineManagerAPIV4, error) {
 
 // NewFacadeV5 creates a new server-side MachineManager API facade.
 func NewFacadeV5(ctx facade.Context) (*MachineManagerAPIV5, error) {
+	machineManagerAPIv6, err := NewFacadeV6(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &MachineManagerAPIV5{machineManagerAPIv6}, nil
+}
+
+// NewFacadeV6 creates a new server-side MachineManager API facade.
+func NewFacadeV6(ctx facade.Context) (*MachineManagerAPIV6, error) {
 	machineManagerAPI, err := NewFacade(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &MachineManagerAPIV5{machineManagerAPI}, nil
+	return &MachineManagerAPIV6{machineManagerAPI}, nil
 }
 
 // NewMachineManagerAPI creates a new server-side MachineManager API facade.
@@ -247,12 +263,28 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 
 // DestroyMachine removes a set of machines from the model.
 func (mm *MachineManagerAPI) DestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, false, false)
+	return mm.destroyMachine(args, false, false, (*time.Duration)(nil))
 }
 
 // ForceDestroyMachine forcibly removes a set of machines from the model.
-func (mm *MachineManagerAPI) ForceDestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, true, false)
+func (mm *MachineManagerAPI) ForceDestroyMachine(in params.ForceDestroyMachinesParams) (params.DestroyMachineResults, error) {
+	return mm.destroyMachine(in.Machines, true, false, in.MaxWait)
+}
+
+// ForceDestroyMachine forcibly removes a set of machines from the model.
+// v5 and prior versions did not support MaxWait.
+func (mm *MachineManagerAPIV5) ForceDestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
+	return mm.destroyMachine(args, true, false, (*time.Duration)(nil))
+}
+
+// DestroyMachineWithParams removes a set of machines from the model.
+// v5 and prior versions did not support MaxWait.
+func (mm *MachineManagerAPIV5) DestroyMachineWithParams(args params.DestroyMachinesParams) (params.DestroyMachineResults, error) {
+	entities := params.Entities{Entities: make([]params.Entity, len(args.MachineTags))}
+	for i, tag := range args.MachineTags {
+		entities.Entities[i].Tag = tag
+	}
+	return mm.destroyMachine(entities, args.Force, args.Keep, (*time.Duration)(nil))
 }
 
 // DestroyMachineWithParams removes a set of machines from the model.
@@ -261,10 +293,10 @@ func (mm *MachineManagerAPI) DestroyMachineWithParams(args params.DestroyMachine
 	for i, tag := range args.MachineTags {
 		entities.Entities[i].Tag = tag
 	}
-	return mm.destroyMachine(entities, args.Force, args.Keep)
+	return mm.destroyMachine(entities, args.Force, args.Keep, args.MaxWait)
 }
 
-func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bool) (params.DestroyMachineResults, error) {
+func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bool, maxWait *time.Duration) (params.DestroyMachineResults, error) {
 	if err := mm.checkCanWrite(); err != nil {
 		return params.DestroyMachineResults{}, err
 	}

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -263,18 +263,14 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 
 // DestroyMachine removes a set of machines from the model.
 func (mm *MachineManagerAPI) DestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, false, false, (*time.Duration)(nil))
+	return mm.destroyMachine(args, false, false, nil)
 }
 
 // ForceDestroyMachine forcibly removes a set of machines from the model.
-func (mm *MachineManagerAPI) ForceDestroyMachine(in params.ForceDestroyMachinesParams) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(in.Machines, true, false, in.MaxWait)
-}
-
-// ForceDestroyMachine forcibly removes a set of machines from the model.
-// v5 and prior versions did not support MaxWait.
-func (mm *MachineManagerAPIV5) ForceDestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
-	return mm.destroyMachine(args, true, false, (*time.Duration)(nil))
+// TODO (anastasiamac 2019-4-24) From Juju 3.0 this call will be removed in favour of DestroyMachinesWithParams.
+// Also from ModelManger v6 this call is less useful as it does not support MaxWait customisation.
+func (mm *MachineManagerAPI) ForceDestroyMachine(args params.Entities) (params.DestroyMachineResults, error) {
+	return mm.destroyMachine(args, true, false, nil)
 }
 
 // DestroyMachineWithParams removes a set of machines from the model.
@@ -284,7 +280,7 @@ func (mm *MachineManagerAPIV5) DestroyMachineWithParams(args params.DestroyMachi
 	for i, tag := range args.MachineTags {
 		entities.Entities[i].Tag = tag
 	}
-	return mm.destroyMachine(entities, args.Force, args.Keep, (*time.Duration)(nil))
+	return mm.destroyMachine(entities, args.Force, args.Keep, nil)
 }
 
 // DestroyMachineWithParams removes a set of machines from the model.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -262,17 +262,6 @@ type DestroyMachinesParams struct {
 	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
-// ForceDestroyMachinesParams holds parameters for the ForceDestroyMachines call.
-type ForceDestroyMachinesParams struct {
-	// Machines holds machines to force destroy.
-	Machines Entities `json:"machines"`
-
-	// MaxWait specifies the amount of time that each step in machine destroy process
-	// will wait before forcing the next step to kick-off. This parameter
-	// only makes sense in combination with 'force' set to 'true'.
-	MaxWait *time.Duration `json:"max-wait,omitempty"`
-}
-
 // UpdateSeriesArg holds the parameters for updating the series for the
 // specified application or machine. For Application, only known by facade
 // version 5 and greater. For MachineManger, only known by facade version

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -255,6 +255,22 @@ type DestroyMachinesParams struct {
 	MachineTags []string `json:"machine-tags"`
 	Force       bool     `json:"force,omitempty"`
 	Keep        bool     `json:"keep,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in machine destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
+}
+
+// ForceDestroyMachinesParams holds parameters for the ForceDestroyMachines call.
+type ForceDestroyMachinesParams struct {
+	// Machines holds machines to force destroy.
+	Machines Entities `json:"machines"`
+
+	// MaxWait specifies the amount of time that each step in machine destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // UpdateSeriesArg holds the parameters for updating the series for the

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -188,11 +188,6 @@ func (f *fakeRemoveMachineAPI) DestroyMachines(machines ...string) ([]params.Des
 	return f.destroyMachines(machines)
 }
 
-func (f *fakeRemoveMachineAPI) ForceDestroyMachines(maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
-	f.forced = true
-	return f.destroyMachines(machines)
-}
-
 func (f *fakeRemoveMachineAPI) DestroyMachinesWithParams(force, keep bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
 	f.forced = force
 	f.keep = keep

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -4,6 +4,8 @@
 package machine_test
 
 import (
+	"time"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
@@ -94,6 +96,11 @@ func (s *RemoveMachineSuite) TestRemove(c *gc.C) {
 	c.Assert(s.fake.machines, jc.DeepEquals, []string{"1", "2/lxd/1"})
 }
 
+func (s *RemoveMachineSuite) TestRemoveNoWaitWithoutForce(c *gc.C) {
+	_, err := s.run(c, "1", "--no-wait")
+	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
+}
+
 func (s *RemoveMachineSuite) TestRemoveOutput(c *gc.C) {
 	s.fake.results = []params.DestroyMachineResult{{
 		Error: &params.Error{
@@ -181,12 +188,12 @@ func (f *fakeRemoveMachineAPI) DestroyMachines(machines ...string) ([]params.Des
 	return f.destroyMachines(machines)
 }
 
-func (f *fakeRemoveMachineAPI) ForceDestroyMachines(machines ...string) ([]params.DestroyMachineResult, error) {
+func (f *fakeRemoveMachineAPI) ForceDestroyMachines(maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
 	f.forced = true
 	return f.destroyMachines(machines)
 }
 
-func (f *fakeRemoveMachineAPI) DestroyMachinesWithParams(force, keep bool, machines ...string) ([]params.DestroyMachineResult, error) {
+func (f *fakeRemoveMachineAPI) DestroyMachinesWithParams(force, keep bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
 	f.forced = force
 	f.keep = keep
 	return f.destroyMachines(machines)


### PR DESCRIPTION
## Description of change

Machine removal is a multi-step process. Currently, Juju will not proceed to the next step until a previous step in the process is completed successfully. This may block the removal process - next steps are not called and the removal does not complete.

Force removal will call the next step in the process regardless of where the current step is or if it has succeeded. Generally, we'd wait for a set period of time before calling this next step. However, with 'no-wait' command option specified, Juju will forgo this wait and will call the next step is soon as possible. This means that the whole force removal process will be faster.

This PR has a MachineManager facade bump.