### PR TITLE
Model Cache Mark and Sweep

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -78,8 +78,10 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 	s.mux = apiserverhttp.NewMux()
 
 	modelCache, err := modelcache.NewWorker(modelcache.Config{
-		Logger:               loggo.GetLogger("test"),
-		StatePool:            s.StatePool,
+		Logger: loggo.GetLogger("test"),
+		WatcherFactory: func() modelcache.BackingWatcher {
+			return s.StatePool.SystemState().WatchAllModels(s.StatePool)
+		},
 		PrometheusRegisterer: noopRegisterer{},
 		Cleanup:              func() {},
 	})

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -39,8 +39,10 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 
 	modelCache, err := modelcache.NewWorker(modelcache.Config{
-		Logger:               loggo.GetLogger("test"),
-		StatePool:            s.StatePool,
+		Logger: loggo.GetLogger("test"),
+		WatcherFactory: func() modelcache.BackingWatcher {
+			return s.StatePool.SystemState().WatchAllModels(s.StatePool)
+		},
 		PrometheusRegisterer: noopRegisterer{},
 		Cleanup:              func() {},
 	})

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -77,7 +77,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Lock()
 
 	// If this is the first receipt of details, set the removal message.
-	if a.details.Name == "" {
+	if a.removalMessage == nil {
 		a.removalMessage = RemoveApplication{
 			ModelUUID: details.ModelUUID,
 			Name:      details.Name,

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -76,7 +76,15 @@ type appCharmUrlChange struct {
 func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Lock()
 
-	a.stale = false
+	// If this is the first receipt of details, set the removal message.
+	if a.details.Name == "" {
+		a.removalMessage = RemoveApplication{
+			ModelUUID: details.ModelUUID,
+			Name:      details.Name,
+		}
+	}
+
+	a.setStale(false)
 
 	if a.details.CharmURL != details.CharmURL {
 		a.hub.Publish(

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -76,6 +76,8 @@ type appCharmUrlChange struct {
 func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Lock()
 
+	a.stale = false
+
 	if a.details.CharmURL != details.CharmURL {
 		a.hub.Publish(
 			a.modelTopic(applicationCharmURLChange),

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -20,10 +20,6 @@ type ApplicationSuite struct {
 
 var _ = gc.Suite(&ApplicationSuite{})
 
-func (s *ApplicationSuite) SetUpTest(c *gc.C) {
-	s.EntitySuite.SetUpTest(c)
-}
-
 func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
 	m := s.NewApplication(appChange)
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(0))

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -43,6 +43,9 @@ func (c *Charm) LXDProfile() lxdprofile.Profile {
 
 func (c *Charm) setDetails(details CharmChange) {
 	c.mu.Lock()
+
+	c.stale = false
 	c.details = details
+
 	c.mu.Unlock()
 }

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -44,7 +44,15 @@ func (c *Charm) LXDProfile() lxdprofile.Profile {
 func (c *Charm) setDetails(details CharmChange) {
 	c.mu.Lock()
 
-	c.stale = false
+	// If this is the first receipt of details, set the removal message.
+	if c.details.CharmURL == "" {
+		c.removalMessage = RemoveCharm{
+			ModelUUID: details.ModelUUID,
+			CharmURL:  details.CharmURL,
+		}
+	}
+
+	c.setStale(false)
 	c.details = details
 
 	c.mu.Unlock()

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -45,7 +45,7 @@ func (c *Charm) setDetails(details CharmChange) {
 	c.mu.Lock()
 
 	// If this is the first receipt of details, set the removal message.
-	if c.details.CharmURL == "" {
+	if c.removalMessage == nil {
 		c.removalMessage = RemoveCharm{
 			ModelUUID: details.ModelUUID,
 			CharmURL:  details.CharmURL,

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -65,6 +65,7 @@ func newController(config ControllerConfig, manager *residentManager) (*Controll
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	c := &Controller{
 		manager: manager,
 		changes: config.Changes,
@@ -76,6 +77,8 @@ func newController(config ControllerConfig, manager *residentManager) (*Controll
 		}),
 		metrics: createControllerGauges(),
 	}
+
+	manager.done = c.tomb.Dying()
 	c.tomb.Go(c.loop)
 	return c, nil
 }
@@ -252,7 +255,7 @@ func (c *Controller) removeResident(modelUUID string, removeFrom func(m *Model) 
 // It is likely that we will receive a change update for the model before we
 // get an update for one of its entities, but the cache needs to be resilient
 // enough to make sure that we can handle when this is not the case.
-// No model retrieved by this method is ever considered to be stale.
+// No model returned by this method is ever considered to be stale.
 func (c *Controller) ensureModel(modelUUID string) *Model {
 	c.mu.Lock()
 

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -171,9 +171,7 @@ func (c *Controller) Model(uuid string) (*Model, error) {
 // updateModel will add or update the model details as
 // described in the ModelChange.
 func (c *Controller) updateModel(ch ModelChange) {
-	c.mu.Lock()
 	c.ensureModel(ch.ModelUUID).setDetails(ch)
-	c.mu.Unlock()
 }
 
 // removeModel removes the model from the cache.
@@ -193,9 +191,7 @@ func (c *Controller) removeModel(ch RemoveModel) error {
 
 // updateApplication adds or updates the application in the specified model.
 func (c *Controller) updateApplication(ch ApplicationChange) {
-	c.mu.Lock()
 	c.ensureModel(ch.ModelUUID).updateApplication(ch, c.manager)
-	c.mu.Unlock()
 }
 
 // removeApplication removes the application for the cached model.
@@ -206,9 +202,7 @@ func (c *Controller) removeApplication(ch RemoveApplication) error {
 }
 
 func (c *Controller) updateCharm(ch CharmChange) {
-	c.mu.Lock()
 	c.ensureModel(ch.ModelUUID).updateCharm(ch, c.manager)
-	c.mu.Unlock()
 }
 
 func (c *Controller) removeCharm(ch RemoveCharm) error {
@@ -217,9 +211,7 @@ func (c *Controller) removeCharm(ch RemoveCharm) error {
 
 // updateUnit adds or updates the unit in the specified model.
 func (c *Controller) updateUnit(ch UnitChange) {
-	c.mu.Lock()
 	c.ensureModel(ch.ModelUUID).updateUnit(ch, c.manager)
-	c.mu.Unlock()
 }
 
 // removeUnit removes the unit from the cached model.
@@ -231,9 +223,7 @@ func (c *Controller) removeUnit(ch RemoveUnit) error {
 
 // updateMachine adds or updates the machine in the specified model.
 func (c *Controller) updateMachine(ch MachineChange) {
-	c.mu.Lock()
 	c.ensureModel(ch.ModelUUID).updateMachine(ch, c.manager)
-	c.mu.Unlock()
 }
 
 // removeMachine removes the machine from the cached model.
@@ -261,10 +251,14 @@ func (c *Controller) removeResident(modelUUID string, removeFrom func(m *Model) 
 // get an update for one of its entities, but the cache needs to be resilient
 // enough to make sure that we can handle when this is not the case.
 func (c *Controller) ensureModel(modelUUID string) *Model {
+	c.mu.Lock()
+
 	model, found := c.models[modelUUID]
 	if !found {
 		model = newModel(c.metrics, c.hub, c.manager.new())
 		c.models[modelUUID] = model
 	}
+
+	c.mu.Unlock()
 	return model
 }

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -143,7 +143,10 @@ func (c *Controller) Marked() bool {
 // cleaning up resources that they are responsible for.
 func (c *Controller) Sweep() {
 	if c.marked {
-		<-c.manager.sweep()
+		select {
+		case <-c.manager.sweep():
+		case <-c.tomb.Dying():
+		}
 	}
 	c.marked = false
 }

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -252,6 +252,7 @@ func (c *Controller) removeResident(modelUUID string, removeFrom func(m *Model) 
 // It is likely that we will receive a change update for the model before we
 // get an update for one of its entities, but the cache needs to be resilient
 // enough to make sure that we can handle when this is not the case.
+// No model retrieved by this method is ever considered to be stale.
 func (c *Controller) ensureModel(modelUUID string) *Model {
 	c.mu.Lock()
 
@@ -259,6 +260,8 @@ func (c *Controller) ensureModel(modelUUID string) *Model {
 	if !found {
 		model = newModel(c.metrics, c.hub, c.manager.new())
 		c.models[modelUUID] = model
+	} else {
+		model.stale = false
 	}
 
 	c.mu.Unlock()

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -125,8 +125,9 @@ func (c *Controller) loop() error {
 }
 
 // Mark updates all cached entities to indicate they are stale.
-func (c *Controller) Mark() {
-	c.manager.mark()
+// Returns true unless there were no entities to mark.
+func (c *Controller) Mark() bool {
+	return c.manager.mark()
 }
 
 // Sweep evicts any stale entities from the cache,

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -42,10 +42,6 @@ type Controller struct {
 	// from a type-agnostic viewpoint.
 	manager *residentManager
 
-	// marked indicates whether a cache mark has been run,
-	// but not yet any corresponding sweep.
-	marked bool
-
 	changes <-chan interface{}
 	notify  func(interface{})
 	models  map[string]*Model
@@ -130,25 +126,16 @@ func (c *Controller) loop() error {
 
 // Mark updates all cached entities to indicate they are stale.
 func (c *Controller) Mark() {
-	c.marked = c.manager.mark()
-}
-
-// Marked indicates that there have been entities in the cache marked stale,
-// and a sweep is required.
-func (c *Controller) Marked() bool {
-	return c.marked
+	c.manager.mark()
 }
 
 // Sweep evicts any stale entities from the cache,
 // cleaning up resources that they are responsible for.
 func (c *Controller) Sweep() {
-	if c.marked {
-		select {
-		case <-c.manager.sweep():
-		case <-c.tomb.Dying():
-		}
+	select {
+	case <-c.manager.sweep():
+	case <-c.tomb.Dying():
 	}
-	c.marked = false
 }
 
 // Report returns information that is used in the dependency engine report.

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -236,9 +236,13 @@ func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 		done <- struct{}{}
 	}()
 
-	c.Assert(controller.Mark(), jc.IsTrue)
+	c.Assert(controller.Marked(), jc.IsFalse)
+	controller.Mark()
+	c.Assert(controller.Marked(), jc.IsTrue)
+
 	controller.Sweep()
 	<-done
+	c.Assert(controller.Marked(), jc.IsFalse)
 
 	s.AssertNoResidents(c)
 }

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -239,6 +239,8 @@ func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 	controller.Mark()
 	controller.Sweep()
 	<-done
+
+	s.AssertNoResidents(c)
 }
 
 func (s *ControllerSuite) new(c *gc.C) (*cache.Controller, <-chan interface{}) {

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -236,7 +236,7 @@ func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 		done <- struct{}{}
 	}()
 
-	controller.Mark()
+	c.Assert(controller.Mark(), jc.IsTrue)
 	controller.Sweep()
 	<-done
 

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -223,13 +223,11 @@ func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 	s.processChange(c, unitChange, events)
 	s.processChange(c, modelChange, events)
 
-	c.Assert(controller.Marked(), jc.IsFalse)
 	controller.Mark()
-	c.Assert(controller.Marked(), jc.IsTrue)
 
 	done := make(chan struct{})
 	go func() {
-		// Removals are congruent with FILO.
+		// Removals are congruent with LIFO.
 		// Model is last because models are added if they do not exist,
 		// when we first get a delta for one of their entities.
 		c.Check(s.nextChange(c, events), gc.FitsTypeOf, cache.RemoveUnit{})
@@ -247,7 +245,6 @@ func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 		c.Fatal("timeout waiting for sweep removal messages")
 	}
 
-	c.Assert(controller.Marked(), jc.IsFalse)
 	s.AssertNoResidents(c)
 }
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -151,6 +151,8 @@ func (m *Machine) modelTopic(suffix string) string {
 func (m *Machine) setDetails(details MachineChange) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	m.stale = false
 	m.details = details
 
 	configHash, err := hash(details.Config)

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -153,7 +153,7 @@ func (m *Machine) setDetails(details MachineChange) {
 	defer m.mu.Unlock()
 
 	// If this is the first receipt of details, set the removal message.
-	if m.details.Id == "" {
+	if m.removalMessage == nil {
 		m.removalMessage = RemoveMachine{
 			ModelUUID: details.ModelUUID,
 			Id:        details.Id,

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -152,7 +152,15 @@ func (m *Machine) setDetails(details MachineChange) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.stale = false
+	// If this is the first receipt of details, set the removal message.
+	if m.details.Id == "" {
+		m.removalMessage = RemoveMachine{
+			ModelUUID: details.ModelUUID,
+			Id:        details.Id,
+		}
+	}
+
+	m.setStale(false)
 	m.details = details
 
 	configHash, err := hash(details.Config)

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -327,7 +327,9 @@ func modelTopic(modelUUID, suffix string) string {
 func (m *Model) setDetails(details ModelChange) {
 	m.mu.Lock()
 
+	m.stale = false
 	m.details = details
+
 	hashCache, configHash := newHashCache(details.Config, m.metrics.ModelHashCacheHit, m.metrics.ModelHashCacheMiss)
 	if configHash != m.configHash {
 		m.configHash = configHash

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -328,7 +328,7 @@ func (m *Model) setDetails(details ModelChange) {
 	m.mu.Lock()
 
 	// If this is the first receipt of details, set the removal message.
-	if m.details.ModelUUID == "" {
+	if m.removalMessage == nil {
 		m.removalMessage = RemoveModel{
 			ModelUUID: details.ModelUUID,
 		}

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -327,7 +327,14 @@ func modelTopic(modelUUID, suffix string) string {
 func (m *Model) setDetails(details ModelChange) {
 	m.mu.Lock()
 
-	m.stale = false
+	// If this is the first receipt of details, set the removal message.
+	if m.details.ModelUUID == "" {
+		m.removalMessage = RemoveModel{
+			ModelUUID: details.ModelUUID,
+		}
+	}
+
+	m.setStale(false)
 	m.details = details
 
 	hashCache, configHash := newHashCache(details.Config, m.metrics.ModelHashCacheHit, m.metrics.ModelHashCacheMiss)

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -21,10 +21,6 @@ type ModelSuite struct {
 
 var _ = gc.Suite(&ModelSuite{})
 
-func (s *ModelSuite) SetUpTest(c *gc.C) {
-	s.EntitySuite.SetUpTest(c)
-}
-
 func (s *ModelSuite) TestReport(c *gc.C) {
 	m := s.NewModel(modelChange)
 	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{
@@ -279,7 +275,7 @@ func (s *ControllerSuite) TestWatchMachineGatherMachines(c *gc.C) {
 
 func (s *ControllerSuite) newWithMachine(c *gc.C) (*cache.Controller, <-chan interface{}) {
 	events := s.captureEvents(c)
-	controller, err := cache.NewController(s.config)
+	controller, err := s.NewController()
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
 	s.processChange(c, modelChange, events)

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -23,17 +23,21 @@ func TestPackage(t *testing.T) {
 type BaseSuite struct {
 	jujutesting.IsolationSuite
 
+	Changes chan interface{}
+	Config  ControllerConfig
 	Manager *residentManager
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
-	s.Manager = newResidentManager()
+	s.Changes = make(chan interface{})
+	s.Config = ControllerConfig{Changes: s.Changes}
+	s.Manager = newResidentManager(s.Changes)
 }
 
-func (s *BaseSuite) NewController(config ControllerConfig) (*Controller, error) {
-	return newController(config, s.Manager)
+func (s *BaseSuite) NewController() (*Controller, error) {
+	return newController(s.Config, s.Manager)
 }
 
 func (s *BaseSuite) NewResident() *Resident {

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -49,6 +49,10 @@ func (s *BaseSuite) AssertResident(c *gc.C, id uint64, expectPresent bool) {
 	c.Assert(present, gc.Equals, expectPresent)
 }
 
+func (s *BaseSuite) AssertNoResidents(c *gc.C) {
+	c.Assert(s.Manager.residents, gc.HasLen, 0)
+}
+
 // entitySuite is the base suite for testing cached entities
 // (models, applications, machines).
 type EntitySuite struct {

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -96,10 +96,12 @@ func (m *residentManager) new() *Resident {
 }
 
 // mark sets all of the manager's residents to be stale.
-func (m *residentManager) mark() {
+// The boolean return indicates if there were any residents to mark.
+func (m *residentManager) mark() bool {
 	for _, r := range m.residents {
 		r.setStale(true)
 	}
+	return len(m.residents) > 0
 }
 
 // sweep removes stale cache residents in descending order of ID.

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -98,9 +98,12 @@ func (m *residentManager) new() *Resident {
 // mark sets all of the manager's residents to be stale.
 // The boolean return indicates if there were any residents to mark.
 func (m *residentManager) mark() bool {
+	m.mu.Lock()
 	for _, r := range m.residents {
 		r.setStale(true)
 	}
+	m.mu.Unlock()
+
 	return len(m.residents) > 0
 }
 

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -50,7 +50,7 @@ type residentManager struct {
 	resourceCount *counter
 
 	// residents are all the residents of the cache indexed by ID.
-	// Access to this map should be Goroutine-safe.
+	// Access to this map should be protected by the Mutex below.
 	residents map[uint64]*Resident
 	mu        sync.Mutex
 
@@ -187,7 +187,7 @@ type Resident struct {
 	// workers are resources that must be cleaned up when a resident is to be
 	// evicted from the cache.
 	// Obvious examples are watchers created by the resident.
-	// Access to this map should be Goroutine-safe.
+	// Access to this map should be protected with the Mutex below.
 	workers map[uint64]worker.Worker
 	mu      sync.Mutex
 }

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
@@ -101,7 +102,7 @@ func (m *residentManager) sweep() error {
 
 			select {
 			case m.removals <- r.removalMessage:
-			default:
+			case <-time.After(10 * time.Second):
 				return errors.New("unable to progress cache sweep")
 			}
 		}

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -80,7 +80,7 @@ func (s *residentSuite) TestManagerMarkAndSweepSendsRemovalMessagesForStaleResid
 		}
 	}()
 
-	c.Assert(s.Manager.sweep(), jc.ErrorIsNil)
+	s.Manager.sweep()
 	close(s.Changes)
 	<-done
 

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -59,7 +59,7 @@ func (s *residentSuite) TestManagerMarkAndSweepSendsRemovalMessagesForStaleResid
 
 	// Sets all 4 to be stale, but we freshen up one.
 	s.Manager.mark()
-	r1.stale = false
+	r1.setStale(false)
 
 	// Consume all the messages from the manager's removals channel.
 	var removals []interface{}
@@ -80,7 +80,7 @@ func (s *residentSuite) TestManagerMarkAndSweepSendsRemovalMessagesForStaleResid
 		}
 	}()
 
-	s.Manager.sweep()
+	<-s.Manager.sweep()
 	close(s.Changes)
 	<-done
 

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -58,7 +58,7 @@ func (s *residentSuite) TestManagerMarkAndSweepSendsRemovalMessagesForStaleResid
 	r4.removalMessage = 4
 
 	// Sets all 4 to be stale, but we freshen up one.
-	s.Manager.mark()
+	c.Assert(s.Manager.mark(), jc.IsTrue)
 	r1.setStale(false)
 
 	// Consume all the messages from the manager's removals channel.

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -8,15 +8,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/testing"
-
-	"github.com/juju/errors"
-
 	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/worker.v1"
 
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/mocks"
 )
 

--- a/core/cache/resident_test.go
+++ b/core/cache/resident_test.go
@@ -56,12 +56,14 @@ func (s *residentSuite) TestManagerMarkAndSweepSendsRemovalMessagesForStaleResid
 	r4.removalMessage = 4
 
 	// Sets all 4 to be stale, but we freshen up one.
-	c.Assert(s.Manager.mark(), jc.IsTrue)
+	c.Assert(s.Manager.isMarked(), jc.IsFalse)
+	s.Manager.mark()
+	c.Assert(s.Manager.isMarked(), jc.IsTrue)
 	r1.setStale(false)
 
 	// Consume all the messages from the manager's removals channel.
 	var removals []interface{}
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		timeout := time.After(testing.LongWait)
 		for {
@@ -92,6 +94,7 @@ func (s *residentSuite) TestManagerMarkAndSweepSendsRemovalMessagesForStaleResid
 
 	// Stale resident messages were received in descending order.
 	c.Assert(removals, gc.DeepEquals, []interface{}{4, 3, 2})
+	c.Assert(s.Manager.isMarked(), jc.IsFalse)
 }
 
 func (s *residentSuite) TestResidentWorkerConcurrentRegisterCleanup(c *gc.C) {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -78,7 +78,7 @@ func (u *Unit) setDetails(details UnitChange) {
 	u.mu.Lock()
 
 	// If this is the first receipt of details, set the removal message.
-	if u.details.Name == "" {
+	if u.removalMessage == nil {
 		u.removalMessage = RemoveUnit{
 			ModelUUID: details.ModelUUID,
 			Name:      details.Name,

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -77,6 +77,8 @@ func (u *Unit) CharmURL() string {
 func (u *Unit) setDetails(details UnitChange) {
 	u.mu.Lock()
 
+	u.stale = false
+
 	machineChange := u.details.MachineId != details.MachineId
 	u.details = details
 	if machineChange || u.details.Subordinate {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -77,7 +77,15 @@ func (u *Unit) CharmURL() string {
 func (u *Unit) setDetails(details UnitChange) {
 	u.mu.Lock()
 
-	u.stale = false
+	// If this is the first receipt of details, set the removal message.
+	if u.details.Name == "" {
+		u.removalMessage = RemoveUnit{
+			ModelUUID: details.ModelUUID,
+			Name:      details.Name,
+		}
+	}
+
+	u.setStale(false)
 
 	machineChange := u.details.MachineId != details.MachineId
 	u.details = details

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -15,10 +15,6 @@ type UnitSuite struct {
 
 var _ = gc.Suite(&UnitSuite{})
 
-func (s *UnitSuite) SetUpTest(c *gc.C) {
-	s.EntitySuite.SetUpTest(c)
-}
-
 var unitChange = cache.UnitChange{
 	ModelUUID:      "model-uuid",
 	Name:           "application-name/0",

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -66,13 +66,14 @@ func (w *notifyWatcherBase) Changes() <-chan struct{} {
 // Kill is part of the worker.Worker interface.
 func (w *notifyWatcherBase) Kill() {
 	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if w.closed {
-		w.mu.Unlock()
 		return
 	}
+
 	w.closed = true
 	close(w.changes)
-	w.mu.Unlock()
 	w.tomb.Kill(nil)
 }
 
@@ -196,13 +197,14 @@ func (w *stringsWatcherBase) Changes() <-chan []string {
 // Kill is part of the worker.Worker interface.
 func (w *stringsWatcherBase) Kill() {
 	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if w.closed {
-		w.mu.Unlock()
 		return
 	}
+
 	w.closed = true
 	close(w.changes)
-	w.mu.Unlock()
 	w.tomb.Kill(nil)
 }
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -926,8 +926,10 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			}
 
 			modelCache, err := modelcache.NewWorker(modelcache.Config{
-				Logger:               loggo.GetLogger("dummy"),
-				StatePool:            statePool,
+				Logger: loggo.GetLogger("dummy"),
+				WatcherFactory: func() modelcache.BackingWatcher {
+					return statePool.SystemState().WatchAllModels(statePool)
+				},
 				PrometheusRegisterer: noopRegisterer{},
 				Cleanup:              func() {},
 			})

--- a/worker/modelcache/manifold_test.go
+++ b/worker/modelcache/manifold_test.go
@@ -83,8 +83,8 @@ func (s *ManifoldSuite) TestConfigValidationMissingNewWorker(c *gc.C) {
 func (s *ManifoldSuite) TestManifoldCallsValidate(c *gc.C) {
 	context := dt.StubContext(nil, map[string]interface{}{})
 	s.config.Logger = nil
-	worker, err := s.manifold().Start(context)
-	c.Check(worker, gc.IsNil)
+	w, err := s.manifold().Start(context)
+	c.Check(w, gc.IsNil)
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `missing Logger not valid`)
 }
@@ -94,8 +94,8 @@ func (s *ManifoldSuite) TestAgentMissing(c *gc.C) {
 		"state": dependency.ErrMissing,
 	})
 
-	worker, err := s.manifold().Start(context)
-	c.Check(worker, gc.IsNil)
+	w, err := s.manifold().Start(context)
+	c.Check(w, gc.IsNil)
 	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
 }
 
@@ -111,12 +111,12 @@ func (s *ManifoldSuite) TestNewWorkerArgs(c *gc.C) {
 		"state": tracker,
 	})
 
-	worker, err := s.manifold().Start(context)
+	w, err := s.manifold().Start(context)
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(worker, gc.NotNil)
+	c.Check(w, gc.NotNil)
 
 	c.Check(config.Validate(), jc.ErrorIsNil)
-	c.Check(config.StatePool, gc.Equals, tracker.pool())
+	c.Check(config.WatcherFactory, gc.NotNil)
 	c.Check(config.Logger, gc.Equals, s.config.Logger)
 	c.Check(config.PrometheusRegisterer, gc.Equals, s.config.PrometheusRegisterer)
 

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -21,16 +21,24 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 )
 
+type BackingWatcher interface {
+	Next() ([]multiwatcher.Delta, error)
+	Stop() error
+}
+
 // Config describes the necessary fields for NewWorker.
 type Config struct {
 	Logger               Logger
-	StatePool            *state.StatePool
 	PrometheusRegisterer prometheus.Registerer
 	Cleanup              func()
+
 	// Notify is used primarily for testing, and is passed through
 	// to the cache.Controller. It is called every time the controller
 	// processes an event.
 	Notify func(interface{})
+
+	// WatchFactory supplies the
+	WatcherFactory func() BackingWatcher
 }
 
 // Validate ensures all the necessary values are specified
@@ -38,8 +46,8 @@ func (c *Config) Validate() error {
 	if c.Logger == nil {
 		return errors.NotValidf("missing logger")
 	}
-	if c.StatePool == nil {
-		return errors.NotValidf("missing state pool")
+	if c.WatcherFactory == nil {
+		return errors.NotValidf("missing watcher factory")
 	}
 	if c.PrometheusRegisterer == nil {
 		return errors.NotValidf("missing prometheus registerer")
@@ -55,7 +63,7 @@ type cacheWorker struct {
 	catacomb   catacomb.Catacomb
 	controller *cache.Controller
 	changes    chan interface{}
-	watcher    *state.Multiwatcher
+	watcher    BackingWatcher
 	mu         sync.Mutex
 }
 
@@ -95,7 +103,6 @@ func (c *cacheWorker) Report() map[string]interface{} {
 
 func (c *cacheWorker) loop() error {
 	defer c.config.Cleanup()
-	pool := c.config.StatePool
 
 	allWatcherStarts := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "juju_worker_modelcache",
@@ -110,18 +117,12 @@ func (c *cacheWorker) loop() error {
 	defer c.config.PrometheusRegisterer.Unregister(collector)
 
 	watcherChanges := make(chan []multiwatcher.Delta)
-	// This worker needs to be robust with respect to the multiwatcher
-	// errors. If we get an unexpected error we should get a new allWatcher.
+	// This worker needs to be robust with respect to the multiwatcher errors.
+	// If we get an unexpected error we should get a new allWatcher.
 	// We don't want a weird error in the multiwatcher taking down the apiserver,
 	// which is what would happen if this worker errors out.
-	// We do need to consider cache invalidation for multiwatcher entities
-	// that may be in our cache but when we restart the watcher, they aren't there.
-	// Cache invalidation is a hard problem, but here at least we should perhaps
-	// be able to do some form of mark and sweep. When we create a new watcher
-	// we should mark entities in the controller, and when we are done with the
-	// first call to Next(), which returns the state of the world, we can issue
-	// a sweep to remove anything that wasn't updated since the Mark.
-	// TODO: This is left for upcoming work.
+	// The cached controller takes care of invalidation
+	// via its own mark/sweep logic.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	defer func() {
@@ -134,6 +135,7 @@ func (c *cacheWorker) loop() error {
 		c.mu.Unlock()
 		wg.Wait()
 	}()
+
 	go func() {
 		// Ensure we don't leave the main loop until the goroutine is done.
 		defer wg.Done()
@@ -146,19 +148,23 @@ func (c *cacheWorker) loop() error {
 			default:
 				// Continue through.
 			}
+
+			// Each time the watcher is restarted,
+			// mark the cache residents as stale.
+			c.controller.Mark()
+
 			allWatcherStarts.Inc()
-			watcher := pool.SystemState().WatchAllModels(pool)
-			c.watcher = watcher
+			c.watcher = c.config.WatcherFactory()
 			c.mu.Unlock()
 
-			err := c.processWatcher(watcher, watcherChanges)
+			err := c.processWatcher(watcherChanges)
 			if err == nil {
 				// We are done, so exit
-				_ = watcher.Stop()
+				_ = c.watcher.Stop()
 				return
 			}
 			c.config.Logger.Errorf("watcher error, %v, getting new watcher", err)
-			_ = watcher.Stop()
+			_ = c.watcher.Stop()
 		}
 	}()
 
@@ -181,13 +187,16 @@ func (c *cacheWorker) loop() error {
 					}
 				}
 			}
+
+			// Evict any stale residents.
+			c.controller.Sweep()
 		}
 	}
 }
 
-func (c *cacheWorker) processWatcher(w *state.Multiwatcher, watcherChanges chan<- []multiwatcher.Delta) error {
+func (c *cacheWorker) processWatcher(watcherChanges chan<- []multiwatcher.Delta) error {
 	for {
-		deltas, err := w.Next()
+		deltas, err := c.watcher.Next()
 		if err != nil {
 			if errors.Cause(err) == state.ErrStopped {
 				return nil

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -21,6 +21,8 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 )
 
+// BackingWatcher describes watcher methods that supply deltas from state to
+// this worker. In-theatre it is satisfied by a state.Multiwatcher.
 type BackingWatcher interface {
 	Next() ([]multiwatcher.Delta, error)
 	Stop() error
@@ -37,7 +39,10 @@ type Config struct {
 	// processes an event.
 	Notify func(interface{})
 
-	// WatchFactory supplies the
+	// WatcherFactory supplies the watcher that supplies deltas from state.
+	// We use a factory because we do not allow the worker loop to be crashed
+	// by a watcher that stops in an error state.
+	// Watcher acquisition my occur multiple times during a worker life-cycle.
 	WatcherFactory func() BackingWatcher
 }
 


### PR DESCRIPTION
## Description of change

This patch adds mark/sweep logic to the cache resident manager.
- Each resident is provided a removal message upon instantiation.
- `Mark` is invoked when the mode cache worker's multi-watcher throws an error and restarts.
- After the first deltas are processed following such a restart, cache `Sweep` is invoked.
- Any residents still stale send their removal messages to the cache controller's change channel causing them to be evicted from the cache.

## QA steps

Unit tests verify the new functionality.

QA for regression is the same as for https://github.com/juju/juju/pull/10062.

## Documentation changes

None.

## Bug reference

N/A
