### PR TITLE
Remove redundant and incorrect []error.

### DIFF
--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -430,12 +430,6 @@ type DestroyUnitParams struct {
 	// will be forced, i.e. ignore operational errors.
 	Force bool `json:"force"`
 
-	// Errors contains errors encountered while applying this operation.
-	// Generally, these are non-fatal errors that have been encountered
-	// during, say, force. They may not have prevented the operation from being
-	// aborted but the user might still want to know about them.
-	Errors []error `json:"errors,omitempty"`
-
 	// MaxWait specifies the amount of time that each step in unit removal
 	// will wait before forcing the next step to kick-off. This parameter
 	// only makes sense in combination with 'force' set to 'true'.


### PR DESCRIPTION
## Description of change

Some time in recent past []error parameter was introduced in apiserver. Besides the fact that it is unused, it' is also not going to be marshalled correctly over the wire.
This PR removes it.