### PR TITLE
Fix/set pod spec by leader only

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -319,7 +319,7 @@ func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {
 func microK8sStatus(cmdRunner CommandRunner) (microk8sStatus, error) {
 	var status microk8sStatus
 	result, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: "microk8s.status --yaml",
+		Commands: "microk8s.status --wait-ready --timeout 15 --yaml",
 	})
 	if err != nil {
 		return status, errors.Trace(err)

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -125,7 +125,7 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
 	var ctx mockContext
@@ -160,7 +160,7 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
 	var ctx mockContext
@@ -191,7 +191,7 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), jc.ErrorIsNil)
 }
@@ -199,7 +199,7 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
 func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusStorageDisabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `storage is not enabled for microk8s, run 'microk8s.enable storage'`)
 }
@@ -207,7 +207,7 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
 func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDNSDisabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `dns is not enabled for microk8s, run 'microk8s.enable dns'`)
 }

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -70,13 +70,13 @@ Sometimes, the removal of the unit may fail as Juju encounters errors
 and failures that need to be dealt with before a unit can be removed.
 For example, Juju will not remove a unit if there are hook failures.
 However, at times, there is a need to remove a unit ignoring
-all operational errors. In these rare cases, use --force option but note 
-that --force will remove a unit and, potentially, its machine without 
+all operational errors. In these rare cases, use --force option but note
+that --force will remove a unit and, potentially, its machine without
 given them the opportunity to shutdown cleanly.
 
 Unit removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished. 
-However, when using --force, users can also specify --no-wait to progress through steps 
+proceed to a next step until the current step finished.
+However, when using --force, users can also specify --no-wait to progress through steps
 without delay waiting for each step to complete.
 
 Examples:
@@ -84,7 +84,7 @@ Examples:
     juju remove-unit wordpress/2 wordpress/3 wordpress/4
 
     juju remove-unit wordpress/2 --destroy-storage
- 
+
     juju remove-unit wordpress/2 --force
 
     juju remove-unit wordpress/2 --force --no-wait
@@ -138,6 +138,7 @@ func (c *removeUnitCommand) validateArgsByModelType() error {
 
 func (c *removeUnitCommand) validateCAASRemoval() error {
 	if c.DestroyStorage {
+		// TODO(caas): enable --destroy-storage for caas model.
 		return errors.New("Kubernetes models only support --num-units")
 	}
 	if len(c.EntityNames) != 1 {

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -213,7 +213,7 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		LogSource:            op.bufferedLogger.Logs(),
 		UpdateLoggerConfig:   updateAgentConfLogging,
 		PrometheusRegisterer: op.prometheusRegistry,
-		LeadershipGuarantee:  30 * time.Second,
+		LeadershipGuarantee:  15 * time.Second,
 		UpgradeStepsLock:     op.upgradeComplete,
 		ValidateMigration:    op.validateMigration,
 		MachineLock:          op.machineLock,

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
 )
 
 // TODO (manadart 2018-10-05) Add interfaces to the end of this line,
@@ -136,6 +137,12 @@ type Tracker interface {
 	// WaitMinion will return a Ticket which, when Wait()ed for, will block
 	// until the tracker's future leadership can no longer be guaranteed.
 	WaitMinion() Ticket
+}
+
+// TrackerWorker represents a leadership tracker worker.
+type TrackerWorker interface {
+	worker.Worker
+	Tracker
 }
 
 // Reader describes the capability to read the current state of leadership.

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -22,7 +22,6 @@ import (
 	"gopkg.in/juju/worker.v1/catacomb"
 
 	apiuniter "github.com/juju/juju/api/uniter"
-	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
@@ -98,8 +97,8 @@ type Config struct {
 	// VersionSetter is an interface for setting the operator agent version.
 	VersionSetter VersionSetter
 
-	// LeadershipTrackerFunc is a function for getting a leadership tracker.
-	LeadershipTrackerFunc func(unitTag names.UnitTag) leadership.Tracker
+	// LeadershipTrackerFunc is a function for getting a leadership tracker worker.
+	LeadershipTrackerFunc func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker
 
 	// UniterFacadeFunc is a function for making a uniter facade.
 	UniterFacadeFunc func(unitTag names.UnitTag) *apiuniter.State

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/juju/worker.v1/catacomb"
 
 	apiuniter "github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
@@ -98,7 +99,7 @@ type Config struct {
 	VersionSetter VersionSetter
 
 	// LeadershipTrackerFunc is a function for getting a leadership tracker worker.
-	LeadershipTrackerFunc func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker
+	LeadershipTrackerFunc func(unitTag names.UnitTag) leadership.TrackerWorker
 
 	// UniterFacadeFunc is a function for making a uniter facade.
 	UniterFacadeFunc func(unitTag names.UnitTag) *apiuniter.State

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -25,7 +25,6 @@ import (
 
 	agenttools "github.com/juju/juju/agent/tools"
 	apiuniter "github.com/juju/juju/api/uniter"
-	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -52,7 +51,7 @@ type WorkerSuite struct {
 	charmDownloader       fakeDownloader
 	charmSHA256           string
 	uniterParams          *uniter.UniterParams
-	leadershipTrackerFunc func(unitTag names.UnitTag) leadership.Tracker
+	leadershipTrackerFunc func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker
 	uniterFacadeFunc      func(unitTag names.UnitTag) *apiuniter.State
 }
 
@@ -88,7 +87,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.client.watcher = watchertest.NewMockNotifyWatcher(s.appChanges)
 	s.charmDownloader.ResetCalls()
 	s.uniterParams = &uniter.UniterParams{}
-	s.leadershipTrackerFunc = func(unitTag names.UnitTag) leadership.Tracker {
+	s.leadershipTrackerFunc = func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker {
 		return &runnertesting.FakeTracker{}
 	}
 	s.uniterFacadeFunc = func(unitTag names.UnitTag) *apiuniter.State {

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -25,6 +25,7 @@ import (
 
 	agenttools "github.com/juju/juju/agent/tools"
 	apiuniter "github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -51,7 +52,7 @@ type WorkerSuite struct {
 	charmDownloader       fakeDownloader
 	charmSHA256           string
 	uniterParams          *uniter.UniterParams
-	leadershipTrackerFunc func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker
+	leadershipTrackerFunc func(unitTag names.UnitTag) leadership.TrackerWorker
 	uniterFacadeFunc      func(unitTag names.UnitTag) *apiuniter.State
 }
 
@@ -87,7 +88,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.client.watcher = watchertest.NewMockNotifyWatcher(s.appChanges)
 	s.charmDownloader.ResetCalls()
 	s.uniterParams = &uniter.UniterParams{}
-	s.leadershipTrackerFunc = func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker {
+	s.leadershipTrackerFunc = func(unitTag names.UnitTag) leadership.TrackerWorker {
 		return &runnertesting.FakeTracker{}
 	}
 	s.uniterFacadeFunc = func(unitTag names.UnitTag) *apiuniter.State {

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -17,7 +17,6 @@ import (
 	apileadership "github.com/juju/juju/api/leadership"
 	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
-	coreleadership "github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/leadership"
@@ -135,7 +134,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			newUniterFunc := func(unitTag names.UnitTag) *apiuniter.State {
 				return apiuniter.NewState(apiCaller, unitTag)
 			}
-			leadershipTrackerFunc := func(unitTag names.UnitTag) coreleadership.Tracker {
+			leadershipTrackerFunc := func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker {
 				claimer := apileadership.NewClient(apiCaller)
 				return leadership.NewTracker(unitTag, claimer, clock, config.LeadershipGuarantee)
 			}

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -17,6 +17,7 @@ import (
 	apileadership "github.com/juju/juju/api/leadership"
 	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	coreleadership "github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/leadership"
@@ -134,7 +135,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			newUniterFunc := func(unitTag names.UnitTag) *apiuniter.State {
 				return apiuniter.NewState(apiCaller, unitTag)
 			}
-			leadershipTrackerFunc := func(unitTag names.UnitTag) uniter.LeadershipTrackerWorker {
+			leadershipTrackerFunc := func(unitTag names.UnitTag) coreleadership.TrackerWorker {
 				claimer := apileadership.NewClient(apiCaller)
 				return leadership.NewTracker(unitTag, claimer, clock, config.LeadershipGuarantee)
 			}

--- a/worker/leadership/manifold.go
+++ b/worker/leadership/manifold.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/leadership"
-	"github.com/juju/juju/worker/uniter"
+	coreleadership "github.com/juju/juju/core/leadership"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
@@ -73,13 +73,13 @@ var NewManifoldWorker = func(agent agent.Agent, apiCaller base.APICaller, clock 
 	return NewTracker(unitTag, claimer, clock, guarantee), nil
 }
 
-// outputFunc extracts the coreleadership.Tracker from a *Tracker passed in as a Worker.
+// outputFunc extracts the coreleadership.TrackerWorker from a *Tracker passed in as a Worker.
 func outputFunc(in worker.Worker, out interface{}) error {
 	inWorker, _ := in.(*Tracker)
 	if inWorker == nil {
 		return errors.Errorf("expected *Tracker input; got %T", in)
 	}
-	outPointer, _ := out.(*uniter.LeadershipTrackerWorker)
+	outPointer, _ := out.(*coreleadership.TrackerWorker)
 	if outPointer == nil {
 		return errors.Errorf("expected *leadership.Tracker output; got %T", out)
 	}

--- a/worker/leadership/manifold.go
+++ b/worker/leadership/manifold.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/leadership"
-	coreleadership "github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/worker/uniter"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
@@ -79,7 +79,7 @@ func outputFunc(in worker.Worker, out interface{}) error {
 	if inWorker == nil {
 		return errors.Errorf("expected *Tracker input; got %T", in)
 	}
-	outPointer, _ := out.(*coreleadership.Tracker)
+	outPointer, _ := out.(*uniter.LeadershipTrackerWorker)
 	if outPointer == nil {
 		return errors.Errorf("expected *leadership.Tracker output; got %T", out)
 	}

--- a/worker/leadership/manifold_test.go
+++ b/worker/leadership/manifold_test.go
@@ -126,7 +126,7 @@ func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
 }
 
 func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
-	var target coreleadership.Tracker
+	var target coreleadership.TrackerWorker
 	err := s.manifold.Output(&dummyWorker{}, &target)
 	c.Check(target, gc.IsNil)
 	c.Check(err.Error(), gc.Equals, "expected *Tracker input; got *leadership_test.dummyWorker")
@@ -134,7 +134,7 @@ func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
 
 func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
 	source := &leadership.Tracker{}
-	var target coreleadership.Tracker
+	var target coreleadership.TrackerWorker
 	err := s.manifold.Output(source, &target)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(target, gc.Equals, source)

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/fortress"
@@ -65,7 +66,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				// leader-deposed hook -- but that's not done yet.
 				return nil, err
 			}
-			var leadershipTracker LeadershipTrackerWorker
+			var leadershipTracker leadership.TrackerWorker
 			if err := context.Get(config.LeadershipTrackerName, &leadershipTracker); err != nil {
 				return nil, err
 			}

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/fortress"
@@ -66,7 +65,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				// leader-deposed hook -- but that's not done yet.
 				return nil, err
 			}
-			var leadershipTracker leadership.Tracker
+			var leadershipTracker LeadershipTrackerWorker
 			if err := context.Get(config.LeadershipTrackerName, &leadershipTracker); err != nil {
 				return nil, err
 			}

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -519,9 +519,8 @@ func (ctx *HookContext) SetPodSpec(specYaml string) error {
 		return errors.Annotatef(err, "cannot determine leadership")
 	}
 	if !isLeader {
-		// TODO(caas) - race - initial unit is sometimes not recognised as the leader
 		logger.Warningf("%v is not the leader but is setting application pod spec", entityName)
-		//return ErrIsNotLeader
+		return ErrIsNotLeader
 	}
 	entityName = ctx.unit.ApplicationName()
 	return ctx.state.SetPodSpec(entityName, specYaml)

--- a/worker/uniter/runner/testing/utils.go
+++ b/worker/uniter/runner/testing/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/storage"
@@ -118,6 +119,7 @@ func (c *ContextStorage) Location() string {
 
 type FakeTracker struct {
 	leadership.Tracker
+	worker.Worker
 }
 
 func (FakeTracker) ApplicationName() string {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -86,7 +86,7 @@ type Uniter struct {
 	newOperationExecutor NewExecutorFunc
 	translateResolverErr func(error) error
 
-	leadershipTracker LeadershipTrackerWorker
+	leadershipTracker leadership.TrackerWorker
 	charmDirGuard     fortress.Guard
 
 	hookLock machinelock.Lock
@@ -118,18 +118,12 @@ type Uniter struct {
 	downloader charm.Downloader
 }
 
-// LeadershipTrackerWorker represents a leadership tracker worker.
-type LeadershipTrackerWorker interface {
-	worker.Worker
-	leadership.Tracker
-}
-
 // UniterParams hold all the necessary parameters for a new Uniter.
 type UniterParams struct {
 	UniterFacade         *uniter.State
 	UnitTag              names.UnitTag
 	ModelType            model.ModelType
-	LeadershipTracker    LeadershipTrackerWorker
+	LeadershipTracker    leadership.TrackerWorker
 	DataDir              string
 	Downloader           charm.Downloader
 	MachineLock          machinelock.Lock

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1551,6 +1551,14 @@ type mockLeaderTracker struct {
 	waiting  []chan struct{}
 }
 
+func (mock *mockLeaderTracker) Kill() {
+	return
+}
+
+func (mock *mockLeaderTracker) Wait() error {
+	return nil
+}
+
 func (mock *mockLeaderTracker) ApplicationName() string {
 	return mock.ctx.application.Name()
 }


### PR DESCRIPTION
## Description of change

- Make uniter SetPodSpec context method returning ErrIsNotLeader if current unit is not leader;
- Fix: leadership Tracker worker is never killed by uniter - leadership is never changed/re-claimed even the leader unit is gone;

A drive by: Add --wait-ready flag and --timeout 15s option to microk8s.status cmd in caas cloud;

## QA steps

1. prepare caas model;
2. deploy caas workload;

```bash
juju add-model t1 microk8s && \                                                                             
juju deploy cs:~juju/mariadb-k8s-0 --debug && \
juju deploy cs:~juju/gitlab-k8s-0 --debug  --config juju-external-hostname=127.0.0.1.xip.io && \
juju relate mariadb-k8s gitlab-k8s && \
juju expose gitlab-k8s
```

3. add one more unit then delete one unit;

```bash
$ juju add-unit gitlab-k8s -n 1 --debug
$ mkubectl delete -n t1 pod/gitlab-k8s-7669d9d7bc-nzdkj
```

4. monitor leadership change (shortened from `1min` to `30s`);

```bash
$ juju debug-log -m k1:t1 --color  --include "gitlab-k8s" --include-module="juju.worker.leadership" --include-module="juju.worker.caasoperator"
```
**Previous** 60s

```text
application-gitlab-k8s: 16:58:48 TRACE juju.worker.leadership gitlab-k8s/0 confirmed for gitlab-k8s leadership until 2019-04-26 06:59:48.201394665 +0000 UTC m=+91.757356104

```

**Now** 30s
```text
application-gitlab-k8s: 16:46:04 DEBUG juju.worker.caasoperator.remotestate got application change
application-gitlab-k8s: 16:46:09 TRACE juju.worker.leadership gitlab-k8s/0 renewing lease for gitlab-k8s leadership
application-gitlab-k8s: 16:46:09 TRACE juju.worker.leadership checking gitlab-k8s/0 for gitlab-k8s leadership
application-gitlab-k8s: 16:46:09 TRACE juju.worker.leadership gitlab-k8s/0 confirmed for gitlab-k8s leadership until 2019-04-26 06:46:39.05703218 +0000 UTC m=+91.754741606
application-gitlab-k8s: 16:46:09 TRACE juju.worker.leadership gitlab-k8s/0 will renew gitlab-k8s leadership at 2019-04-26 06:46:24.05703218 +0000 UTC m=+76.754741606

application-gitlab-k8s: 16:46:54 INFO juju.worker.leadership gitlab-k8s/1 promoted to leadership of gitlab-k8s
application-gitlab-k8s: 16:46:54 TRACE juju.worker.leadership gitlab-k8s/1 confirmed for gitlab-k8s leadership until 2019-04-26 06:47:24.760599174 +0000 UTC m=+137.458308479
application-gitlab-k8s: 16:46:54 TRACE juju.worker.leadership gitlab-k8s/1 will renew gitlab-k8s leadership at 2019-04-26 06:47:09.760599174 +0000 UTC m=+122.458308479

```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1825440
