### PR TITLE
Use application tag as the entity in processEntities in debuglog cmd …

### DIFF
--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -45,7 +45,8 @@ The "entity" is the source of the message: a machine or unit. The names for
 machines and units can be seen in the output of `[1:] + "`juju status`" + `.
 
 The '--include' and '--exclude' options filter by entity. The entity can be
-a machine, unit, or application.
+a machine, unit, or application for IAAS model, but can be application only
+for k8s model.
 
 The '--include-module' and '--exclude-module' options filter by (dotted)
 logging module name. The module name can be truncated such that all loggers

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -45,8 +45,8 @@ The "entity" is the source of the message: a machine or unit. The names for
 machines and units can be seen in the output of `[1:] + "`juju status`" + `.
 
 The '--include' and '--exclude' options filter by entity. The entity can be
-a machine, unit, or application for IAAS model, but can be application only
-for k8s model.
+a machine, unit, or application for vm models, but can be application only
+for k8s models.
 
 The '--include-module' and '--exclude-module' options filter by (dotted)
 logging module name. The module name can be truncated such that all loggers
@@ -71,6 +71,10 @@ Include only unit mysql/0 messages; show a maximum of 50 lines; and then
 exit:
 
     juju debug-log -T --include unit-mysql-0 --lines 50
+
+Include only k8s application gitlab-k8s messages:
+
+    juju debug-log --include gitlab-k8s
 
 Show all messages from unit apache2/3 or machine 1 and then exit:
 


### PR DESCRIPTION

## Description of change

fixed juju-debug-log `--include` option for CAAS model;

## QA steps

1. prepare caas model;
2. deploy some caas workloads;
3. test cmd;

```bash
$  juju debug-log -m <controller-name>:<model-name> --color  --include "<application-name>"
```

## Documentation changes

bug fix, no document change;

## Bug reference

https://bugs.launchpad.net/juju/+bug/1825439
