### PR TITLE
Register singular of debug-hooks

### DIFF
--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -50,6 +50,7 @@ func (c *debugHooksCommand) Info() *cmd.Info {
 		Args:    "<unit name> [hook or action names]",
 		Purpose: "Launch a tmux session to debug hooks and/or actions.",
 		Doc:     debugHooksDoc,
+		Aliases: []string{"debug-hook"},
 	})
 }
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -448,6 +448,7 @@ var commandNames = []string{
 	"create-storage-pool",
 	"create-wallet",
 	"credentials",
+	"debug-hook",
 	"debug-hooks",
 	"debug-log",
 	"deploy",


### PR DESCRIPTION
## Description of change

This is a feature request from the [community](https://discourse.jujucharms.com/t/feature-request-add-debug-hook-as-alias-for-debug-hooks/1395) and is a very easy
change, so might be worth doing it.

## QA steps

```
juju debug-hook
```
