### PR TITLE
RemoveUpgradeCharmProfileData from uniterAPI

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -103,7 +103,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      2,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       11,
+	"Uniter":                       12,
 	"Upgrader":                     1,
 	"UpgradeSeries":                1,
 	"UserManager":                  2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -301,7 +301,8 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 8, uniter.NewUniterAPIV8)
 	reg("Uniter", 9, uniter.NewUniterAPIV9)
 	reg("Uniter", 10, uniter.NewUniterAPIV10)
-	reg("Uniter", 11, uniter.NewUniterAPI)
+	reg("Uniter", 11, uniter.NewUniterAPIV11)
+	reg("Uniter", 12, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UpgradeSeries", 1, upgradeseries.NewAPI)

--- a/apiserver/facades/agent/uniter/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/lxdprofile.go
@@ -121,7 +121,7 @@ func (u *LXDProfileAPI) WatchUnitLXDProfileUpgradeNotifications(args params.Enti
 			result.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		unit, err := u.getUnit(tag)
+		unit, err := u.getLXDProfileUnit(tag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -174,7 +174,7 @@ func (u *LXDProfileAPI) WatchLXDProfileUpgradeNotifications(args params.LXDProfi
 			result.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		machine, err := u.getMachine(tag)
+		machine, err := u.getLXDProfileMachine(tag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -208,14 +208,14 @@ func (u *LXDProfileAPI) watchOneChangeLXDProfileUpgradeNotifications(machine LXD
 // to ensure that we start from a clean slate.
 func (u *LXDProfileAPI) RemoveUpgradeCharmProfileData(args params.Entities) (params.ErrorResults, error) {
 	// This is a canned response for V9 of the API, so that clients will still
-	// be supported and the error for each param entity is nil, along with the
+	// be supported and the error for each params entity is nil, along with the
 	// call.
 	return params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}, nil
 }
 
-func (u *LXDProfileAPI) getMachine(tag names.Tag) (LXDProfileMachine, error) {
+func (u *LXDProfileAPI) getLXDProfileMachine(tag names.Tag) (LXDProfileMachine, error) {
 	var id string
 	if tag.Kind() != names.UnitTagKind {
 		return nil, errors.Errorf("not a unit tag")
@@ -231,6 +231,6 @@ func (u *LXDProfileAPI) getMachine(tag names.Tag) (LXDProfileMachine, error) {
 	return u.backend.Machine(id)
 }
 
-func (u *LXDProfileAPI) getUnit(tag names.Tag) (LXDProfileUnit, error) {
+func (u *LXDProfileAPI) getLXDProfileUnit(tag names.Tag) (LXDProfileUnit, error) {
 	return u.backend.Unit(tag.Id())
 }

--- a/apiserver/facades/agent/uniter/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/lxdprofile.go
@@ -207,36 +207,12 @@ func (u *LXDProfileAPI) watchOneChangeLXDProfileUpgradeNotifications(machine LXD
 // RemoveUpgradeCharmProfileData is intended to clean up the LXDProfile status
 // to ensure that we start from a clean slate.
 func (u *LXDProfileAPI) RemoveUpgradeCharmProfileData(args params.Entities) (params.ErrorResults, error) {
-	u.logger.Tracef("Starting RemoveUpgradeCharmProfileData with %+v", args)
-	result := params.ErrorResults{
+	// This is a canned response for V9 of the API, so that clients will still
+	// be supported and the error for each param entity is nil, along with the
+	// call.
+	return params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
-	}
-	canAccess, err := u.accessUnit()
-	if err != nil {
-		return params.ErrorResults{}, err
-	}
-	for i, entity := range args.Entities {
-		tag, err := names.ParseTag(entity.Tag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-
-		if !canAccess(tag) {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		_, err = u.getMachine(tag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(err)
-			continue
-		}
-		// TODO (hml) 2019-04-19
-		// Removing call to machine.RemoveUpgradeCharmProfileData from
-		// state.  2nd pass is to remove it and other charm profile
-		// functionality from the uniter.
-	}
-	return result, nil
+	}, nil
 }
 
 func (u *LXDProfileAPI) getMachine(tag names.Tag) (LXDProfileMachine, error) {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -68,10 +68,16 @@ type UniterAPI struct {
 	cloudSpec       cloudspec.CloudSpecAPI
 }
 
-// UniterAPI implements the latest version (v11) of the Uniter API,
+// UniterAPIV11 implements the latest version (v12) of the Uniter API,
+// with RemoveUpgradeCharmProfileData as NotSupproted.
+type UniterAPIV11 struct {
+	UniterAPI
+}
+
+// UniterAPIV10 implements the latest version (v11) of the Uniter API,
 // which adds WatchUnitLXDProfileUpgradeNotifications.
 type UniterAPIV10 struct {
-	UniterAPI
+	UniterAPIV11
 }
 
 // UniterAPIV9 adds WatchConfigSettingsHash, WatchTrustConfigSettingsHash,
@@ -280,14 +286,25 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 	}, nil
 }
 
-// NewUniterAPIV10 creates an instance of the V10 uniter API.
-func NewUniterAPIV10(context facade.Context) (*UniterAPIV10, error) {
+// NewUniterAPIV11 creates an instance of the V11 uniter API.
+func NewUniterAPIV11(context facade.Context) (*UniterAPIV11, error) {
 	uniterAPI, err := NewUniterAPI(context)
 	if err != nil {
 		return nil, err
 	}
-	return &UniterAPIV10{
+	return &UniterAPIV11{
 		UniterAPI: *uniterAPI,
+	}, nil
+}
+
+// NewUniterAPIV10 creates an instance of the V10 uniter API.
+func NewUniterAPIV10(context facade.Context) (*UniterAPIV10, error) {
+	uniterAPI, err := NewUniterAPIV11(context)
+	if err != nil {
+		return nil, err
+	}
+	return &UniterAPIV10{
+		UniterAPIV11: *uniterAPI,
 	}, nil
 }
 
@@ -2891,3 +2908,7 @@ func (u *UniterAPI) CloudAPIVersion() (params.StringResult, error) {
 	result.Result = apiVersion
 	return result, err
 }
+
+// RemoveUpgradeCharmProfileData isn't on the v11 API.
+// Note this overwrites the embedded LXDProfileAPI
+func (u *UniterAPI) RemoveUpgradeCharmProfileData(_, _ struct{}) {}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -70,15 +70,13 @@ type UniterAPI struct {
 }
 
 // UniterAPIV11 implements the latest version (v11) of the Uniter API,
-// which adds WatchUnitLXDProfileUpgradeNotifications and adds CloudAPIVersion.
+// which adds CloudAPIVersion.
 type UniterAPIV11 struct {
 	*LXDProfileAPI
 	UniterAPI
 }
 
-// UniterAPIV10 adds WatchConfigSettingsHash, WatchTrustConfigSettingsHash,
-// WatchUnitAddressesHash, WatchLXDProfileUpgradeNotifications, and
-// RemoveUpgradeCharmProfileData.
+// UniterAPIV10 adds WatchUnitLXDProfileUpgradeNotifications and
 type UniterAPIV10 struct {
 	// LXDProfileAPI is removed from a UniterAPI embedded struct to UniterAPIV10
 	// embedded struct removing it completely from future API versions.
@@ -86,7 +84,9 @@ type UniterAPIV10 struct {
 	UniterAPIV11
 }
 
-// UniterAPIV9 adds LXDProfileAPI
+// UniterAPIV9 adds WatchConfigSettingsHash, WatchTrustConfigSettingsHash,
+// WatchUnitAddressesHash and LXDProfileAPI, which includes
+// WatchLXDProfileUpgradeNotifications and RemoveUpgradeCharmProfileData
 type UniterAPIV9 struct {
 	// LXDProfileAPI is removed from a UniterAPI embedded struct to UniterAPIV9
 	// embedded struct removing it completely from future API versions.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -47,7 +47,6 @@ type UniterAPI struct {
 	*common.ModelWatcher
 	*common.RebootRequester
 	*common.UpgradeSeriesAPI
-	*LXDProfileAPI
 	*leadershipapiserver.LeadershipSettingsAccessor
 	meterstatus.MeterStatus
 	m                   *state.Model
@@ -69,7 +68,9 @@ type UniterAPI struct {
 }
 
 // UniterAPIV11 implements the latest version (v12) of the Uniter API,
-// with RemoveUpgradeCharmProfileData as NotSupproted.
+// Removes the embedded LXDProfileAPI, which in turn removes the following;
+// RemoveUpgradeCharmProfileData, WatchUnitLXDProfileUpgradeNotifications
+// and WatchLXDProfileUpgradeNotifications
 type UniterAPIV11 struct {
 	UniterAPI
 }
@@ -77,6 +78,9 @@ type UniterAPIV11 struct {
 // UniterAPIV10 implements the latest version (v11) of the Uniter API,
 // which adds WatchUnitLXDProfileUpgradeNotifications.
 type UniterAPIV10 struct {
+	// LXDProfileAPI is removed from a UniterAPI embedded struct to UniterAPIV10
+	// embedded struct removing it completely from future API versions.
+	*LXDProfileAPI
 	UniterAPIV11
 }
 
@@ -84,6 +88,9 @@ type UniterAPIV10 struct {
 // WatchUnitAddressesHash, WatchLXDProfileUpgradeNotifications, and
 // RemoveUpgradeCharmProfileData.
 type UniterAPIV9 struct {
+	// LXDProfileAPI is removed from a UniterAPI embedded struct to UniterAPIV9
+	// embedded struct removing it completely from future API versions.
+	*LXDProfileAPI
 	UniterAPIV10
 }
 
@@ -118,19 +125,9 @@ type UniterAPIV4 struct {
 	UniterAPIV5
 }
 
-// NewUniterAPI creates a new instance of the core Uniter API.
-func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
-	authorizer := context.Auth()
-	if !authorizer.AuthUnitAgent() && !authorizer.AuthApplicationAgent() {
-		return nil, common.ErrPerm
-	}
-	st := context.State()
-	resources := context.Resources()
-	leadershipChecker, err := context.LeadershipChecker()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	accessUnit := func() (common.AuthFunc, error) {
+// unitAccessor creates a accessUnit function for accessing a unit
+func unitAccessor(authorizer facade.Authorizer, st *state.State) common.GetAuthFunc {
+	return func() (common.AuthFunc, error) {
 		switch tag := authorizer.GetAuthTag().(type) {
 		case names.ApplicationTag:
 			// If called by an application agent, any of the units
@@ -158,6 +155,21 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 		default:
 			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
 		}
+	}
+}
+
+// NewUniterAPI creates a new instance of the core Uniter API.
+func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
+	authorizer := context.Auth()
+	if !authorizer.AuthUnitAgent() && !authorizer.AuthApplicationAgent() {
+		return nil, common.ErrPerm
+	}
+	st := context.State()
+	resources := context.Resources()
+	accessUnit := unitAccessor(authorizer, st)
+	leadershipChecker, err := context.LeadershipChecker()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	accessApplication := func() (common.AuthFunc, error) {
 		switch tag := authorizer.GetAuthTag().(type) {
@@ -265,7 +277,6 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 		ModelWatcher:               common.NewModelWatcher(m, resources, authorizer),
 		RebootRequester:            common.NewRebootRequester(st, accessMachine),
 		UpgradeSeriesAPI:           common.NewExternalUpgradeSeriesAPI(st, resources, authorizer, accessMachine, accessUnit, logger),
-		LXDProfileAPI:              NewExternalLXDProfileAPI(st, resources, authorizer, accessUnit, logger),
 		LeadershipSettingsAccessor: leadershipSettingsAccessorFactory(st, leadershipChecker, resources, authorizer),
 		MeterStatus:                msAPI,
 		// TODO(fwereade): so *every* unit should be allowed to get/set its
@@ -303,8 +314,13 @@ func NewUniterAPIV10(context facade.Context) (*UniterAPIV10, error) {
 	if err != nil {
 		return nil, err
 	}
+	authorizer := context.Auth()
+	st := context.State()
+	resources := context.Resources()
+	accessUnit := unitAccessor(authorizer, st)
 	return &UniterAPIV10{
-		UniterAPIV11: *uniterAPI,
+		LXDProfileAPI: NewExternalLXDProfileAPI(st, resources, authorizer, accessUnit, logger),
+		UniterAPIV11:  *uniterAPI,
 	}, nil
 }
 
@@ -315,7 +331,8 @@ func NewUniterAPIV9(context facade.Context) (*UniterAPIV9, error) {
 		return nil, err
 	}
 	return &UniterAPIV9{
-		UniterAPIV10: *uniterAPI,
+		LXDProfileAPI: uniterAPI.LXDProfileAPI,
+		UniterAPIV10:  *uniterAPI,
 	}, nil
 }
 
@@ -2908,7 +2925,3 @@ func (u *UniterAPI) CloudAPIVersion() (params.StringResult, error) {
 	result.Result = apiVersion
 	return result, err
 }
-
-// RemoveUpgradeCharmProfileData isn't on the v11 API.
-// Note this overwrites the embedded LXDProfileAPI
-func (u *UniterAPI) RemoveUpgradeCharmProfileData(_, _ struct{}) {}


### PR DESCRIPTION
## Description of change

The following removes RemoveUpgradeCharmProfileData from uniterAPI
This hides the RemoveUpgradeCharmProfileData for new APIs, but we
have to do it in a very unlikeable manor as the LXDProfileAPI is
embedded and I'm very unsure how to overwrite it in a nice manor.

## QA steps

Deploy and upgrade charms with and without lxd profiles. Try bundles
with more than 5 machines, subordinates, containers: with and without
the lxd provider, local and charm store charms.

---

if you want to test the upgrade flow directly.

Bootstrap 2.5.4
```
juju bootstrap lxd
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
```

Upgrade the juju controller
```
juju upgrade-juju -m controller --build-agent
```
