### PR TITLE
k8s bundles support local images; hande terminating operators

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -91,6 +91,15 @@ type ServiceParams struct {
 	Devices []devices.KubernetesDeviceParams
 }
 
+// OperatorState is returned by the OperatorExists call.
+type OperatorState struct {
+	// Exists is true if the operator exists in the cluster.
+	Exists bool
+
+	// Terminating is true if the operator is in Terminating state.
+	Terminating bool
+}
+
 // Broker instances interact with the CAAS substrate.
 type Broker interface {
 	// Provider returns the ContainerEnvironProvider that created this Broker.
@@ -103,9 +112,9 @@ type Broker interface {
 	// a charm for the specified application.
 	EnsureOperator(appName, agentPath string, config *OperatorConfig) error
 
-	// OperatorExists returns true if the operator for the specified
-	// application exists.
-	OperatorExists(appName string) (bool, error)
+	// OperatorExists indicates if the operator for the specified
+	// application exists, and whether the operator is terminating.
+	OperatorExists(appName string) (OperatorState, error)
 
 	// DeleteOperator deletes the specified operator.
 	DeleteOperator(appName string) error

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -85,7 +85,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C) {
-	// Set up a CAAS model to replace the IAAS one.
 	unregister := caas.RegisterContainerProvider("kubernetes-test", &fakeProvider{})
 	s.AddCleanup(func(_ *gc.C) { unregister() })
 

--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/charmstore"
-	resources "github.com/juju/juju/core/resources"
+	"github.com/juju/juju/core/resources"
 )
 
 // DeployClient exposes the functionality of the resources API needed

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -449,6 +449,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 				AgentName:     agentName,
 				APICallerName: apiCallerName,
 				BrokerName:    caasBrokerTrackerName,
+				ClockName:     clockName,
 				NewWorker:     caasoperatorprovisioner.NewProvisionerWorker,
 			},
 		)),

--- a/testcharms/charm-repo/bundle/kubernetes-simple/bundle.yaml
+++ b/testcharms/charm-repo/bundle/kubernetes-simple/bundle.yaml
@@ -5,5 +5,7 @@ applications:
         scale: 1
     mariadb:
         charm: mariadb
+        resources:
+            mysql_image: mariadb:latest
 relations:
     - ["gitlab:db", "mariadb:server"]

--- a/worker/caasoperatorprovisioner/manifold_test.go
+++ b/worker/caasoperatorprovisioner/manifold_test.go
@@ -30,6 +30,7 @@ func (s *ManifoldConfigSuite) validConfig() caasoperatorprovisioner.ManifoldConf
 		AgentName:     "agent",
 		APICallerName: "api-caller",
 		BrokerName:    "broker",
+		ClockName:     "clock",
 		NewWorker: func(config caasoperatorprovisioner.Config) (worker.Worker, error) {
 			return nil, nil
 		},
@@ -53,6 +54,11 @@ func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingBrokerName(c *gc.C) {
 	s.config.BrokerName = ""
 	s.checkNotValid(c, "empty BrokerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingClockName(c *gc.C) {
+	s.config.ClockName = ""
+	s.checkNotValid(c, "empty ClockName not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {

--- a/worker/caasoperatorprovisioner/mock_test.go
+++ b/worker/caasoperatorprovisioner/mock_test.go
@@ -120,6 +120,7 @@ type mockBroker struct {
 	testing.Stub
 	caas.Broker
 	operatorExists bool
+	terminating    bool
 }
 
 func (m *mockBroker) EnsureOperator(appName, agentPath string, config *caas.OperatorConfig) error {
@@ -127,9 +128,9 @@ func (m *mockBroker) EnsureOperator(appName, agentPath string, config *caas.Oper
 	return m.NextErr()
 }
 
-func (m *mockBroker) OperatorExists(appName string) (bool, error) {
+func (m *mockBroker) OperatorExists(appName string) (caas.OperatorState, error) {
 	m.MethodCall(m, "OperatorExists", appName)
-	return m.operatorExists, m.NextErr()
+	return caas.OperatorState{Exists: m.operatorExists, Terminating: m.terminating}, m.NextErr()
 }
 
 func (m *mockBroker) DeleteOperator(appName string) error {


### PR DESCRIPTION
## Description of change

Fix 2 k8s issues:
1. bundles support local images as resources
(previously it was being incorrectly interpreted as a file)
2. deploying an app and the operator is terminating from a previous remove now waits

## QA steps

Create a k8s bundle with a resource attribute, deploy
remove the application and immediately redeploy
the deployer waits till the operator has terminated and completes succesfully

