### PR TITLE
Prevent model migrations if users are missing from destination

### DIFF
--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -306,7 +306,7 @@ users do not exist in the target controller. To resolve this issue you need to r
 the following external users from "%s:%s":
   - %s
 
-and either migrate the following list of local users to %q or remove them from "%s:%s":
+and either add the following list of local users to %q or remove them from "%s:%s":
   - %s`,
 				srcControllerName, srcModelName, c.targetController,
 				srcControllerName, srcModelName,
@@ -325,7 +325,7 @@ and either migrate the following list of local users to %q or remove them from "
 	if missing := srcUsers.Difference(dstUsers); missing.Size() != 0 {
 		return errors.Errorf(`cannot initiate migration of model "%s:%s" to controller %q as some of the
 model's users do not exist in the target controller. To resolve this issue you can
-either migrate the following list of users to %q or remove them from "%s:%s":
+either add the following list of users to %q or remove them from "%s:%s":
   - %s`,
 			srcControllerName, srcModelName, c.targetController,
 			c.targetController, srcControllerName, srcModelName,

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -129,7 +129,7 @@ func (c *migrateCommand) Run(ctx *cmd.Context) error {
 	}
 	spec.ModelUUID = uuids[0]
 	if err := c.checkMigrationFeasibility(spec); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	controllerName, err := c.ControllerName()
 	if err != nil {

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -323,7 +323,7 @@ func (s *MigrateSuite) TestUserMissingFromTarget(c *gc.C) {
 			srcModel: "model-with-extra-local-users",
 			expErr: `cannot initiate migration of model "source:model-with-extra-local-users" to controller "target" as some of the
 model's users do not exist in the target controller. To resolve this issue you can
-either migrate the following list of users to "target" or remove them from "source:model-with-extra-local-users":
+either add the following list of users to "target" or remove them from "source:model-with-extra-local-users":
   - foo`,
 		},
 		{
@@ -335,7 +335,7 @@ either migrate the following list of users to "target" or remove them from "sour
 			dstIdentityURL: "https://api.jujucharms.com/identity",
 			expErr: `cannot initiate migration of model "source:model-with-extra-users" to controller "target" as some of the
 model's users do not exist in the target controller. To resolve this issue you can
-either migrate the following list of users to "target" or remove them from "source:model-with-extra-users":
+either add the following list of users to "target" or remove them from "source:model-with-extra-users":
   - bar`,
 		},
 		{
@@ -378,7 +378,7 @@ users do not exist in the target controller. To resolve this issue you need to r
 the following external users from "source:model-with-extra-users":
   - foo@external
 
-and either migrate the following list of local users to "target" or remove them from "source:model-with-extra-users":
+and either add the following list of local users to "target" or remove them from "source:model-with-extra-users":
   - bar`,
 		},
 	}

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -228,7 +228,7 @@ func (s *MigrateSuite) makeCommand() modelcmd.ModelCommand {
 	cmd.SetClientStore(s.store)
 	cmd.SetModelAPI(s.modelAPI)
 	inner := modelcmd.InnerCommand(cmd).(*migrateCommand)
-	inner.api = s.api
+	inner.migAPI = s.api
 	inner.newAPIRoot = func(jujuclient.ClientStore, string, string) (api.Connection, error) {
 		return s.targetControllerAPI, nil
 	}
@@ -242,6 +242,10 @@ type fakeMigrateAPI struct {
 func (a *fakeMigrateAPI) InitiateMigration(spec controller.MigrationSpec) (string, error) {
 	a.specSeen = &spec
 	return "uuid:0", nil
+}
+
+func (*fakeMigrateAPI) Close() error {
+	return nil
 }
 
 type fakeModelAPI struct {

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -108,6 +108,16 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 			UUID:  "extra-local-users-uuid",
 			Type:  model.IAAS,
 			Owner: "sourceuser",
+		}, {
+			Name:  "model-with-extra-external-users",
+			UUID:  "extra-external-users-uuid",
+			Type:  model.IAAS,
+			Owner: "sourceuser",
+		}, {
+			Name:  "model-with-extra-users",
+			UUID:  "extra-users-uuid",
+			Type:  model.IAAS,
+			Owner: "sourceuser",
 		}},
 		modelInfo: []params.ModelInfo{
 			{
@@ -128,11 +138,55 @@ func (s *MigrateSuite) SetUpTest(c *gc.C) {
 			{
 				Name: "model-with-extra-local-users",
 				UUID: "extra-local-users-uuid",
-				Users: append(userList, params.ModelUserInfo{
-					UserName:    "foo",
-					DisplayName: "foo",
-					Access:      params.ModelReadAccess,
-				}),
+				Users: []params.ModelUserInfo{
+					{
+						UserName:    "admin",
+						DisplayName: "admin",
+						Access:      params.ModelAdminAccess,
+					},
+					{
+						UserName:    "foo",
+						DisplayName: "foo",
+						Access:      params.ModelReadAccess,
+					},
+				},
+			},
+			{
+				Name: "model-with-extra-external-users",
+				UUID: "extra-external-users-uuid",
+				Users: []params.ModelUserInfo{
+					{
+						UserName:    "admin",
+						DisplayName: "admin",
+						Access:      params.ModelAdminAccess,
+					},
+					{
+						UserName:    "foo@external",
+						DisplayName: "foo",
+						Access:      params.ModelReadAccess,
+					},
+				},
+			},
+			{
+				Name: "model-with-extra-users",
+				UUID: "extra-users-uuid",
+				Users: []params.ModelUserInfo{
+					{
+						UserName:    "admin",
+						DisplayName: "admin",
+						Access:      params.ModelAdminAccess,
+					},
+					{
+						UserName:    "foo@external",
+						DisplayName: "foo",
+						Access:      params.ModelReadAccess,
+					},
+					{
+						UserName:    "bar",
+						DisplayName: "bar",
+						Access:      params.ModelReadAccess,
+					},
+				},
 			},
 		},
 	}
@@ -256,15 +310,95 @@ func (s *MigrateSuite) TestMultipleModelMatch(c *gc.C) {
 	})
 }
 
-func (s *MigrateSuite) TestLocalUserMissingFromTarget(c *gc.C) {
-	cmd := s.makeCommand()
-
-	_, err := cmdtesting.RunCommand(c, cmd, "model-with-extra-local-users", "target")
-	c.Assert(err, gc.Not(gc.IsNil))
-	c.Assert(err.Error(), gc.Equals, `cannot initiate migration of model "source:model-with-extra-local-users" to controller "target" as some of the
+func (s *MigrateSuite) TestUserMissingFromTarget(c *gc.C) {
+	specs := []struct {
+		descr          string
+		srcModel       string
+		srcIdentityURL string
+		dstIdentityURL string
+		expErr         string
+	}{
+		{
+			descr:    "local model grants access to users not present in target",
+			srcModel: "model-with-extra-local-users",
+			expErr: `cannot initiate migration of model "source:model-with-extra-local-users" to controller "target" as some of the
 model's users do not exist in the target controller. To resolve this issue you can
 either migrate the following list of users to "target" or remove them from "source:model-with-extra-local-users":
-  - foo`)
+  - foo`,
+		},
+		{
+			// Even though the same external identity provider is used
+			// local users still need to be shared so this should fail.
+			descr:          "both controllers share the same external identity provider but some of the local model users are not present in target",
+			srcModel:       "model-with-extra-users",
+			srcIdentityURL: "https://api.jujucharms.com/identity",
+			dstIdentityURL: "https://api.jujucharms.com/identity",
+			expErr: `cannot initiate migration of model "source:model-with-extra-users" to controller "target" as some of the
+model's users do not exist in the target controller. To resolve this issue you can
+either migrate the following list of users to "target" or remove them from "source:model-with-extra-users":
+  - bar`,
+		},
+		{
+			// This should work as the local users are shared and
+			// the same external identity provider can authenticate
+			// the external users.
+			descr:          "local model grants access to external users not present in target but both controllers use same external identity provider",
+			srcModel:       "model-with-extra-external-users",
+			srcIdentityURL: "https://api.jujucharms.com/identity",
+			dstIdentityURL: "https://api.jujucharms.com/identity",
+		},
+		{
+			// This should fail even though the local users are shared
+			// as different identity providers are used which means
+			// we probably won't be able to auth external users
+			// anyway.
+			descr:          "local model grants access to external users not present in target but both controllers use different external identity provider",
+			srcModel:       "model-with-extra-external-users",
+			srcIdentityURL: "https://api.jujucharms.com/identity",
+			dstIdentityURL: "https://candid.provider/identity",
+			expErr: `cannot initiate migration of model "source:model-with-extra-external-users" to controller "target" as
+external users have been granted access to the model and the two controllers have
+different identity provider configurations. To resolve this issue you can remove
+the following list of external users from "source:model-with-extra-external-users":
+  - foo@external`,
+		},
+		{
+			// This is a more complicated case. The two controllers
+			// use different identity providers which means that we
+			// probably won't be able to auth external users. Also,
+			// some of the local model's users do not exist in the
+			// target.
+			descr:          "controllers use different external identity providers AND local model users are not present in target",
+			srcModel:       "model-with-extra-users",
+			srcIdentityURL: "https://api.jujucharms.com/identity",
+			expErr: `cannot initiate migration of model "source:model-with-extra-users" to controller "target" as
+external users have been granted access to the model and the two controllers have
+different identity provider configurations. Additionally, some of the model's local
+users do not exist in the target controller. To resolve this issue you need to remove
+the following external users from "source:model-with-extra-users":
+  - foo@external
+
+and either migrate the following list of local users to "target" or remove them from "source:model-with-extra-users":
+  - bar`,
+		},
+	}
+
+	for specIndex, spec := range specs {
+		c.Logf("test %d: %s", specIndex, spec.descr)
+
+		cmd := s.makeCommand()
+		inner := modelcmd.InnerCommand(cmd).(*migrateCommand)
+		inner.migAPI["source"].(*fakeMigrateAPI).identityURL = spec.srcIdentityURL
+		inner.migAPI["target"].(*fakeMigrateAPI).identityURL = spec.dstIdentityURL
+		_, err := cmdtesting.RunCommand(c, cmd, spec.srcModel, "target")
+
+		if spec.expErr == "" {
+			c.Assert(err, gc.IsNil)
+		} else {
+			c.Assert(err, gc.Not(gc.IsNil))
+			c.Assert(err.Error(), gc.Equals, spec.expErr)
+		}
+	}
 }
 
 func (s *MigrateSuite) TestSpecifyOwner(c *gc.C) {
@@ -290,7 +424,11 @@ func (s *MigrateSuite) makeCommand() modelcmd.ModelCommand {
 	cmd.SetClientStore(s.store)
 	cmd.SetModelAPI(s.modelAPI)
 	inner := modelcmd.InnerCommand(cmd).(*migrateCommand)
-	inner.migAPI = s.api
+	apiCopy := *s.api
+	inner.migAPI = map[string]migrateAPI{
+		"source": s.api,
+		"target": &apiCopy,
+	}
 	inner.modelAPI = s.modelAPI
 	inner.userAPI = s.userAPI
 	inner.newAPIRoot = func(jujuclient.ClientStore, string, string) (api.Connection, error) {
@@ -307,6 +445,10 @@ type fakeMigrateAPI struct {
 func (a *fakeMigrateAPI) InitiateMigration(spec controller.MigrationSpec) (string, error) {
 	a.specSeen = &spec
 	return "uuid:0", nil
+}
+
+func (a *fakeMigrateAPI) IdentityProviderURL() (string, error) {
+	return a.identityURL, nil
 }
 
 func (*fakeMigrateAPI) Close() error {


### PR DESCRIPTION
## Description of change

This PR updates the juju client so that it will disallow model migrations when the model to be migrated grants access to users that are not present in the target controller.

The following rules are used to decide whether the migration from (src:model -> dst) should be allowed to proceed or not:
1) When the src **does not** use an external identity provider and **all** users granted access to the model  **are present** in dst: **allow the migration**
2) When the src **does not** use an external identity provider and the model grants access to users **not present** in dst: **abort the migration**
3) When **both src & dst** use the **same** identity provider and **all local** model users exist on dst: **allow the migration**. External users are not considered as they are handled by the same provider. Also, if the model does not grant access to external users this rule is identical with **1**.

In all scenarios where the migrations are aborted (see QA steps) an appropriate error message will be presented to the user to let them know how they can resolve the problem and proceed with the migration.

## QA steps

### Happy path 1: shared local users

```console
$ juju bootstrap lxd src
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig

$ juju bootstrap lxd dst
$ juju add-user foo 

$ juju migrate src:mig dst
 Migration started with ID "45967f61-1991-4340-8c14-f3cdf2682d35:0"
```

### Happy path 2: shared local users and same identity providers 

```console
$ juju bootstrap lxd src --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig
$ juju grant me@external write mig

$ juju bootstrap lxd dst --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-user foo 

$ juju migrate src:mig dst
Migration started with ID "fe066fbe-cec4-4efd-8e46-e77465e08c22:0"
```
### Local user missing from target

```console
$ juju bootstrap lxd src
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig

$ juju bootstrap lxd dst

$ juju migrate src:mig dst
ERROR cannot initiate migration of model "src:mig" to controller "dst" as some of the
model's users do not exist in the target controller. To resolve this issue you can
either add the following list of users to "dst" or remove them from "src:mig":
  - foo
```

### Shared local users, different identity providers and granted access to external user

```console
$ juju bootstrap lxd src --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig
$ juju grant me@external write mig

$ juju bootstrap lxd dst --config identity-url=https://candid.provider/identity --config allow-model-access=true
$ juju add-user foo

$ juju migrate src:mig dst
ERROR cannot initiate migration of model "src:mig" to controller "dst" as
external users have been granted access to the model and the two controllers have
different identity provider configurations. To resolve this issue you can remove
the following list of external users from "src:mig":
  - me@external
```

### Not shared local users, different identity providers and granted access to external user

```console
$ juju bootstrap lxd src --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig
$ juju grant me@external write mig

$ juju bootstrap lxd dst --config identity-url=https://candid.provider/identity --config allow-model-access=true

$ juju migrate src:mig dst
ERROR cannot initiate migration of model "src:mig" to controller "dst" as
external users have been granted access to the model and the two controllers have
different identity provider configurations. Additionally, some of the model's local
users do not exist in the target controller. To resolve this issue you need to remove
the following external users from "src:mig":
  - me@external

and either add the following list of local users to "dst" or remove them from "src:mig":
  - foo
```


## Documentation changes

@pmatulis Older CLI versions do not perform any of the checks introduced by this PR before initiating a migration. We should document the change in behavior introduced by this patch-set.