### PR TITLE
Remove unused ReplaceOrAddInstanceProfile from LXDProfiler interface

### DIFF
--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -430,10 +430,6 @@ func (env *minModelWorkersEnviron) LXDProfileNames(containerName string) ([]stri
 	return nil, nil
 }
 
-func (env *minModelWorkersEnviron) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
-	return []string{newProfile}, nil
-}
-
 func (env *minModelWorkersEnviron) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
 	return profilesNames, nil
 }

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -237,15 +237,6 @@ func (broker *lxdBroker) MaybeWriteLXDProfile(pName string, put *charm.LXDProfil
 	return profileMgr.MaybeWriteLXDProfile(pName, put)
 }
 
-// ReplaceOrAddInstanceProfile implements environs.LXDProfiler.
-func (broker *lxdBroker) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
-	profileMgr, ok := broker.manager.(container.LXDProfileManager)
-	if !ok {
-		return []string{}, nil
-	}
-	return profileMgr.ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile, put)
-}
-
 // AssignLXDProfiles implements environs.LXDProfiler.
 func (broker *lxdBroker) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error) {
 	profileMgr, ok := broker.manager.(container.LXDProfileManager)

--- a/container/interface.go
+++ b/container/interface.go
@@ -91,17 +91,6 @@ type LXDProfileManager interface {
 	// MaybeWriteLXDProfile, write given LXDProfile to machine if not already
 	// there.
 	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
-
-	// TODO: HML 2-apr-2019
-	// remove when provisioner_task processProfileChanges() is
-	// removed.
-	//
-	// ReplaceOrAddInstanceProfile replaces, adds, a charm profile to
-	// the given instance and returns a slice of LXD profiles applied
-	// to the instance. Replace happens inplace in the current order of
-	// applied profiles. If the LXDProfile ptr is nil, replace becomes
-	// remove.
-	ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error)
 }
 
 // LXDProfileNameRetriever defines an interface for dealing with lxd profile

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -323,28 +323,6 @@ func (m *containerManager) LXDProfileNames(containerName string) ([]string, erro
 	return m.server.GetContainerProfiles(containerName)
 }
 
-// TODO: HML 2-apr-2019
-// remove when provisioner_task processProfileChanges() is
-// removed.
-// ReplaceOrAddLXDProfile implements environs.LXDProfiler.
-func (m *containerManager) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
-	if put != nil {
-		if err := m.MaybeWriteLXDProfile(newProfile, put); err != nil {
-			return []string{}, errors.Trace(err)
-		}
-	}
-	if err := m.server.ReplaceOrAddContainerProfile(instId, oldProfile, newProfile); err != nil {
-		return []string{}, errors.Trace(err)
-	}
-	if oldProfile != "" {
-		if err := m.server.DeleteProfile(oldProfile); err != nil {
-			// most likely the failure is because the profile is already in use
-			logger.Debugf("failed to delete profile %q: %s", oldProfile, err)
-		}
-	}
-	return m.LXDProfileNames(instId)
-}
-
 // AssignLXDProfiles implements environs.LXDProfiler.
 func (m *containerManager) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
 	report := func(err error) ([]string, error) {

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -536,31 +536,6 @@ func (s *managerSuite) TestMaybeWriteLXDProfile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *managerSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
-	ctrl := s.setup(c)
-	defer ctrl.Finish()
-	s.expectUpdateOp(ctrl, "Updating container", nil)
-
-	old := "old-profile"
-	new := "new-profile"
-	newProfiles := []string{"default", "juju-default", new}
-	put := charm.LXDProfile{
-		Config: map[string]string{
-			"security.nesting": "true",
-		},
-		Description: "test profile",
-	}
-	s.expectUpdateContainerProfiles(old, new, newProfiles, lxdapi.ProfilePut(put))
-
-	s.makeManager(c)
-	proMgr, ok := s.manager.(container.LXDProfileManager)
-	c.Assert(ok, jc.IsTrue)
-
-	obtained, err := proMgr.ReplaceOrAddInstanceProfile("testme", old, new, &put)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtained, gc.DeepEquals, newProfiles)
-}
-
 func (s *managerSuite) TestAssignLXDProfiles(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -181,14 +181,4 @@ type LXDProfiler interface {
 
 	// LXDProfileNames returns all the profiles associated to a container name
 	LXDProfileNames(containerName string) ([]string, error)
-
-	// TODO: HML 2-apr-2019
-	// remove when provisioner_task processProfileChanges() is
-	// removed.
-	// ReplaceOrAddInstanceProfile replaces, adds, a charm profile to
-	// the given instance and returns a slice of LXD profiles applied
-	// to the instance. Replace happens inplace in the current order of
-	// applied profiles. If the LXDProfile ptr is nil, replace becomes
-	// remove.
-	ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error)
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1906,11 +1906,6 @@ func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
 	return nil, nil
 }
 
-// ReplaceOrAddInstanceProfile implements environs.LXDProfiler.
-func (env *environ) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
-	return []string{newProfile}, nil
-}
-
 // AssignLXDProfiles implements environs.LXDProfiler.
 func (env *environ) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
 	return profilesNames, nil

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -356,29 +356,6 @@ func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
 	return env.server().GetContainerProfiles(containerName)
 }
 
-// TODO: HML 2-apr-2019
-// remove when provisioner_task processProfileChanges() is
-// removed.
-// ReplaceLXDProfile implements environs.LXDProfiler.
-func (env *environ) ReplaceOrAddInstanceProfile(instId, oldProfile, newProfile string, put *charm.LXDProfile) ([]string, error) {
-	if put != nil {
-		if err := env.MaybeWriteLXDProfile(newProfile, put); err != nil {
-			return []string{}, errors.Trace(err)
-		}
-	}
-	server := env.server()
-	if err := server.ReplaceOrAddContainerProfile(instId, oldProfile, newProfile); err != nil {
-		return []string{}, errors.Trace(err)
-	}
-	if oldProfile != "" {
-		if err := server.DeleteProfile(oldProfile); err != nil {
-			// most likely the failure is because the profile is already in use
-			logger.Debugf("failed to delete profile %q: %s", oldProfile, err)
-		}
-	}
-	return env.LXDProfileNames(instId)
-}
-
 // AssignLXDProfiles implements environs.LXDProfiler.
 func (env *environ) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
 	report := func(err error) ([]string, error) {

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -424,26 +424,6 @@ func (s *environProfileSuite) TestLXDProfileNames(c *gc.C) {
 	})
 }
 
-func (s *environProfileSuite) TestReplaceOrAddInstanceProfile(c *gc.C) {
-	defer s.setup(c).Finish()
-
-	instId := "testme"
-	old := "old-profile"
-	new := "new-profile"
-
-	s.expectReplaceOrAddInstanceProfile(instId, old, new)
-
-	put := &charm.LXDProfile{
-		Config: map[string]string{
-			"security.nesting": "true",
-		},
-		Description: "test profile",
-	}
-	obtained, err := s.lxdEnv.ReplaceOrAddInstanceProfile(instId, old, new, put)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtained, gc.DeepEquals, []string{"default", "juju-default", new})
-}
-
 func (s *environProfileSuite) TestAssignLXDProfiles(c *gc.C) {
 	defer s.setup(c).Finish()
 
@@ -524,14 +504,6 @@ func (s *environProfileSuite) expectMaybeWriteLXDProfile(hasProfile bool, name s
 			},
 		}).Return(nil)
 	}
-}
-
-func (s *environProfileSuite) expectReplaceOrAddInstanceProfile(instId, old, new string) {
-	s.expectMaybeWriteLXDProfile(false, new)
-	exp := s.svr.EXPECT()
-	exp.ReplaceOrAddContainerProfile(instId, old, new)
-	exp.DeleteProfile(old)
-	exp.GetContainerProfiles(instId).Return([]string{"default", "juju-default", new}, nil)
 }
 
 func (s *environProfileSuite) expectAssignLXDProfiles(instId, old, new string, oldProfiles, newProfiles []string, updateErr error) {

--- a/worker/containerbroker/mocks/environs_mock.go
+++ b/worker/containerbroker/mocks/environs_mock.go
@@ -76,19 +76,6 @@ func (mr *MockLXDProfilerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfiler)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
-// ReplaceOrAddInstanceProfile mocks base method
-func (m *MockLXDProfiler) ReplaceOrAddInstanceProfile(arg0, arg1, arg2 string, arg3 *charm_v6.LXDProfile) ([]string, error) {
-	ret := m.ctrl.Call(m, "ReplaceOrAddInstanceProfile", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplaceOrAddInstanceProfile indicates an expected call of ReplaceOrAddInstanceProfile
-func (mr *MockLXDProfilerMockRecorder) ReplaceOrAddInstanceProfile(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceOrAddInstanceProfile", reflect.TypeOf((*MockLXDProfiler)(nil).ReplaceOrAddInstanceProfile), arg0, arg1, arg2, arg3)
-}
-
 // MockInstanceBroker is a mock of InstanceBroker interface
 type MockInstanceBroker struct {
 	ctrl     *gomock.Controller

--- a/worker/instancemutater/mocks/environs_mock.go
+++ b/worker/instancemutater/mocks/environs_mock.go
@@ -357,19 +357,6 @@ func (mr *MockLXDProfilerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfiler)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
-// ReplaceOrAddInstanceProfile mocks base method
-func (m *MockLXDProfiler) ReplaceOrAddInstanceProfile(arg0, arg1, arg2 string, arg3 *charm_v6.LXDProfile) ([]string, error) {
-	ret := m.ctrl.Call(m, "ReplaceOrAddInstanceProfile", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplaceOrAddInstanceProfile indicates an expected call of ReplaceOrAddInstanceProfile
-func (mr *MockLXDProfilerMockRecorder) ReplaceOrAddInstanceProfile(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceOrAddInstanceProfile", reflect.TypeOf((*MockLXDProfiler)(nil).ReplaceOrAddInstanceProfile), arg0, arg1, arg2, arg3)
-}
-
 // MockInstanceBroker is a mock of InstanceBroker interface
 type MockInstanceBroker struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
## Description of change

Remove unused ReplaceOrAddInstanceProfile from LXDProfiler interface.  Last bit of clean up associated with removing the InstanceMutater feature flag.

## QA steps

Unit tests pass.  

