### PR TITLE
Snapcraft: ignore errors, wait for microk8s

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,7 +8,7 @@ if ! which microk8s.kubectl; then
 fi
 
 container_cmd=microk8s.ctr
-image_arg=images
+image_arg="-n k8s.io images"
 if ! which $container_cmd; then
     container_cmd=microk8s.docker
     image_arg=image
@@ -18,14 +18,18 @@ if ! which $container_cmd; then
     fi
 fi
 
+echo "Wait for microk8s to be ready if needed."
+microk8s.status --wait-ready --timeout 30
+
 juju_version=$(/snap/bin/juju version | rev | cut -d- -f3- | rev)
 oci_image="docker.io/jujusolutions/jujud-operator:$juju_version"
 mongo_image="docker.io/jujusolutions/juju-db:4.0"
 
 echo "Going to cache images: $oci_image and $mongo_image."
 
+# It's not an install/refresh blocker if we can't get the images.
 echo "Pulling: $oci_image."
-$container_cmd $image_arg pull $oci_image
+$container_cmd $image_arg pull $oci_image || true
 
 echo "Pulling: $mongo_image."
-$container_cmd $image_arg pull $mongo_image
+$container_cmd $image_arg pull $mongo_image || true


### PR DESCRIPTION
## Description of change

Updates the snap config with the latest changes:
  - Ignore errors when caching images (don't want to block install)
  - Give microk8s a moment to be ready (if it was installed just before Juju etc.)
