### PR TITLE
k8s brokers implement SetCloudSpec, respond to update-cloud

### DIFF
--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -100,7 +100,7 @@ func NewProviderCredentials(getter func(CommandRunner) (cloud.Cloud, jujucloud.C
 }
 
 func StorageProvider(k8sClient kubernetes.Interface, namespace string) storage.Provider {
-	return &storageProvider{&kubernetesClient{Interface: k8sClient, namespace: namespace}}
+	return &storageProvider{&kubernetesClient{clientUnlocked: k8sClient, namespace: namespace}}
 }
 
 func GetStorageClass(cfg *storageConfig) string {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -85,8 +85,6 @@ var (
 
 type kubernetesClient struct {
 	clock jujuclock.Clock
-	kubernetes.Interface
-	apiextensionsClient apiextensionsclientset.Interface
 
 	// namespace is the k8s namespace to use when
 	// creating k8s resources.
@@ -94,8 +92,12 @@ type kubernetesClient struct {
 
 	annotations k8sannotations.Annotation
 
-	lock   sync.Mutex
-	envCfg *config.Config
+	lock                        sync.Mutex
+	envCfgUnlocked              *config.Config
+	clientUnlocked              kubernetes.Interface
+	apiextensionsClientUnlocked apiextensionsclientset.Interface
+
+	newClient NewK8sClientFunc
 
 	// modelUUID is the UUID of the model this client acts on.
 	modelUUID string
@@ -142,13 +144,14 @@ func NewK8sBroker(
 		return nil, errors.NotValidf("modelUUID is required")
 	}
 	client := &kubernetesClient{
-		clock:               clock,
-		Interface:           k8sClient,
-		apiextensionsClient: apiextensionsClient,
-		envCfg:              newCfg.Config,
-		namespace:           newCfg.Name(),
-		modelUUID:           modelUUID,
-		newWatcher:          newWatcher,
+		clock:                       clock,
+		clientUnlocked:              k8sClient,
+		apiextensionsClientUnlocked: apiextensionsClient,
+		envCfgUnlocked:              newCfg.Config,
+		namespace:                   newCfg.Name(),
+		modelUUID:                   modelUUID,
+		newWatcher:                  newWatcher,
+		newClient:                   newClient,
 		annotations: k8sannotations.New(nil).
 			Add(annotationModelUUIDKey, modelUUID),
 	}
@@ -170,11 +173,25 @@ func (k *kubernetesClient) addAnnotations(key, value string) k8sannotations.Anno
 	return k.annotations.Add(key, value)
 }
 
+func (k *kubernetesClient) client() kubernetes.Interface {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	client := k.clientUnlocked
+	return client
+}
+
+func (k *kubernetesClient) extendedCient() apiextensionsclientset.Interface {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	client := k.apiextensionsClientUnlocked
+	return client
+}
+
 // Config returns environ config.
 func (k *kubernetesClient) Config() *config.Config {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	cfg := k.envCfg
+	cfg := k.envCfgUnlocked
 	return cfg
 }
 
@@ -186,12 +203,29 @@ func (k *kubernetesClient) SetConfig(cfg *config.Config) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	k.envCfg = newCfg.Config
+	k.envCfgUnlocked = newCfg.Config
+	return nil
+}
+
+// SetCloudSpec is specified in the environs.Environ interface.
+func (k *kubernetesClient) SetCloudSpec(spec environs.CloudSpec) error {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+
+	k8sRestConfig, err := cloudSpecToK8sRestConfig(spec)
+	if err != nil {
+		return errors.Annotate(err, "cannot set cloud spec")
+	}
+
+	k.clientUnlocked, k.apiextensionsClientUnlocked, err = k.newClient(k8sRestConfig)
+	if err != nil {
+		return errors.Annotate(err, "cannot set cloud spec")
+	}
 	return nil
 }
 
 func (k *kubernetesClient) validateOperatorStorage() (string, error) {
-	storageClass, _ := k.envCfg.AllAttrs()[OperatorStorageKey].(string)
+	storageClass, _ := k.Config().AllAttrs()[OperatorStorageKey].(string)
 	if storageClass == "" {
 		return "", errors.NewNotValid(nil, "config without operator-storage value not valid.\nRun juju add-k8s to reimport your k8s cluster.")
 	}
@@ -357,7 +391,7 @@ func (k *kubernetesClient) Destroy(callbacks context.ProviderCallContext) error 
 	// Delete any storage classes created as part of this model.
 	// Storage classes live outside the namespace so need to be deleted separately.
 	modelSelector := fmt.Sprintf("%s==%s", labelModel, k.namespace)
-	err = k.StorageV1().StorageClasses().DeleteCollection(&v1.DeleteOptions{
+	err = k.client().StorageV1().StorageClasses().DeleteCollection(&v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	}, v1.ListOptions{
 		LabelSelector: modelSelector,
@@ -386,7 +420,7 @@ func (k *kubernetesClient) Destroy(callbacks context.ProviderCallContext) error 
 
 // APIVersion returns the version info for the cluster.
 func (k *kubernetesClient) APIVersion() (string, error) {
-	body, err := k.CoreV1().RESTClient().Get().AbsPath("/version").Do().Raw()
+	body, err := k.client().CoreV1().RESTClient().Get().AbsPath("/version").Do().Raw()
 	if err != nil {
 		return "", err
 	}
@@ -431,7 +465,7 @@ func (k *kubernetesClient) ensureOCIImageSecret(
 }
 
 func (k *kubernetesClient) ensureSecret(sec *core.Secret) error {
-	secrets := k.CoreV1().Secrets(k.namespace)
+	secrets := k.client().CoreV1().Secrets(k.namespace)
 	_, err := secrets.Update(sec)
 	if k8serrors.IsNotFound(err) {
 		_, err = secrets.Create(sec)
@@ -441,13 +475,13 @@ func (k *kubernetesClient) ensureSecret(sec *core.Secret) error {
 
 // updateSecret updates a secret resource.
 func (k *kubernetesClient) updateSecret(sec *core.Secret) error {
-	_, err := k.CoreV1().Secrets(k.namespace).Update(sec)
+	_, err := k.client().CoreV1().Secrets(k.namespace).Update(sec)
 	return errors.Trace(err)
 }
 
 // getSecret return a secret resource.
 func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
-	secret, err := k.CoreV1().Secrets(k.namespace).Get(secretName, v1.GetOptions{IncludeUninitialized: true})
+	secret, err := k.client().CoreV1().Secrets(k.namespace).Get(secretName, v1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, errors.NotFoundf("secret %q", secretName)
@@ -459,13 +493,13 @@ func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
 
 // createSecret creates a secret resource.
 func (k *kubernetesClient) createSecret(secret *core.Secret) error {
-	_, err := k.CoreV1().Secrets(k.namespace).Create(secret)
+	_, err := k.client().CoreV1().Secrets(k.namespace).Create(secret)
 	return errors.Trace(err)
 }
 
 // deleteSecret deletes a secret resource.
 func (k *kubernetesClient) deleteSecret(secretName string) error {
-	secrets := k.CoreV1().Secrets(k.namespace)
+	secrets := k.client().CoreV1().Secrets(k.namespace)
 	err := secrets.Delete(secretName, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
@@ -480,7 +514,7 @@ func (k *kubernetesClient) deleteSecret(secretName string) error {
 func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, error) {
 	var result caas.OperatorState
 
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	operator, err := statefulsets.Get(k.operatorName(appName), v1.GetOptions{IncludeUninitialized: true})
 	if k8serrors.IsNotFound(err) {
 		return result, nil
@@ -503,7 +537,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	if config.AgentConf == nil {
 		// We expect that the config map already exists,
 		// so make sure it does.
-		configMaps := k.CoreV1().ConfigMaps(k.namespace)
+		configMaps := k.client().CoreV1().ConfigMaps(k.namespace)
 		_, err := configMaps.Get(operatorConfigMapName(operatorName), v1.GetOptions{IncludeUninitialized: true})
 		if err != nil {
 			return errors.Annotatef(err, "config map for %q should already exist", appName)
@@ -685,7 +719,7 @@ func (k *kubernetesClient) maybeGetVolumeClaimSpec(params volumeParams) (*core.P
 // getStorageClass returns a named storage class, first looking for
 // one which is qualified by the current namespace if it's available.
 func (k *kubernetesClient) getStorageClass(name string) (*k8sstorage.StorageClass, error) {
-	storageClasses := k.StorageV1().StorageClasses()
+	storageClasses := k.client().StorageV1().StorageClasses()
 	qualifiedName := qualifiedStorageClassName(k.namespace, name)
 	sc, err := storageClasses.Get(qualifiedName, v1.GetOptions{})
 	if err == nil {
@@ -725,7 +759,7 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner)
 		policy := core.PersistentVolumeReclaimPolicy(cfg.ReclaimPolicy)
 		reclaimPolicy = &policy
 	}
-	storageClasses := k.StorageV1().StorageClasses()
+	storageClasses := k.client().StorageV1().StorageClasses()
 	sc = &k8sstorage.StorageClass{
 		ObjectMeta: v1.ObjectMeta{
 			Name: qualifiedStorageClassName(cfg.Namespace, cfg.Name),
@@ -756,7 +790,7 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 	legacy := isLegacyName(operatorName)
 
 	// First delete the config map(s).
-	configMaps := k.CoreV1().ConfigMaps(k.namespace)
+	configMaps := k.client().CoreV1().ConfigMaps(k.namespace)
 	configMapName := operatorConfigMapName(operatorName)
 	err = configMaps.Delete(configMapName, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
@@ -781,7 +815,7 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 	if err := k.deleteStatefulSet(operatorName); err != nil {
 		return errors.Trace(err)
 	}
-	pods := k.CoreV1().Pods(k.namespace)
+	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(v1.ListOptions{
 		LabelSelector: operatorSelector(appName),
 	})
@@ -793,7 +827,7 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 	if legacy {
 		deploymentName = "juju-" + appName
 	}
-	pvs := k.CoreV1().PersistentVolumes()
+	pvs := k.client().CoreV1().PersistentVolumes()
 	for _, p := range podsList.Items {
 		// Delete secrets.
 		for _, c := range p.Spec.Containers {
@@ -890,7 +924,7 @@ func getSvcAddresses(svc *core.Service, includeClusterIP bool) []network.Address
 
 // GetService returns the service for the specified application.
 func (k *kubernetesClient) GetService(appName string, includeClusterIP bool) (*caas.Service, error) {
-	services := k.CoreV1().Services(k.namespace)
+	services := k.client().CoreV1().Services(k.namespace)
 	servicesList, err := services.List(v1.ListOptions{
 		LabelSelector:        applicationSelector(appName),
 		IncludeUninitialized: true,
@@ -907,7 +941,7 @@ func (k *kubernetesClient) GetService(appName string, includeClusterIP bool) (*c
 	}
 
 	deploymentName := k.deploymentName(appName)
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	ss, err := statefulsets.Get(deploymentName, v1.GetOptions{})
 	if err == nil {
 		if ss.Spec.Replicas != nil {
@@ -928,7 +962,7 @@ func (k *kubernetesClient) GetService(appName string, includeClusterIP bool) (*c
 		return nil, errors.Trace(err)
 	}
 
-	deployments := k.AppsV1().Deployments(k.namespace)
+	deployments := k.client().AppsV1().Deployments(k.namespace)
 	deployment, err := deployments.Get(deploymentName, v1.GetOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, errors.Trace(err)
@@ -965,7 +999,7 @@ func (k *kubernetesClient) DeleteService(appName string) (err error) {
 	if err := k.deleteDeployment(deploymentName); err != nil {
 		return errors.Trace(err)
 	}
-	secrets := k.CoreV1().Secrets(k.namespace)
+	secrets := k.client().CoreV1().Secrets(k.namespace)
 	secretList, err := secrets.List(v1.ListOptions{
 		LabelSelector: applicationSelector(appName),
 	})
@@ -1001,7 +1035,7 @@ func (k *kubernetesClient) ensureCustomResourceDefinitionTemplate(name string, s
 		},
 		Spec: spec,
 	}
-	apiextensionsV1beta1 := k.apiextensionsClient.ApiextensionsV1beta1()
+	apiextensionsV1beta1 := k.extendedCient().ApiextensionsV1beta1()
 	logger.Debugf("creating crd %#v", crdIn)
 	crd, err = apiextensionsV1beta1.CustomResourceDefinitions().Create(crdIn)
 	if k8serrors.IsAlreadyExists(err) {
@@ -1185,7 +1219,7 @@ func (k *kubernetesClient) EnsureService(
 	} else {
 		useStatefulSet = len(params.Filesystems) > 0
 	}
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	existingStatefulSet, err := statefulsets.Get(deploymentName, v1.GetOptions{IncludeUninitialized: true})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Trace(err)
@@ -1267,7 +1301,7 @@ func (k *kubernetesClient) Upgrade(appName string, vers version.Number) error {
 	}
 	logger.Debugf("Upgrading %q", resourceName)
 
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	existingStatefulSet, err := statefulsets.Get(resourceName, v1.GetOptions{IncludeUninitialized: true})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Trace(err)
@@ -1290,7 +1324,7 @@ func (k *kubernetesClient) Upgrade(appName string, vers version.Number) error {
 
 func (k *kubernetesClient) deleteAllPods(appName, deploymentName string) error {
 	zero := int32(0)
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	statefulSet, err := statefulsets.Get(deploymentName, v1.GetOptions{IncludeUninitialized: true})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Trace(err)
@@ -1301,7 +1335,7 @@ func (k *kubernetesClient) deleteAllPods(appName, deploymentName string) error {
 		return errors.Trace(err)
 	}
 
-	deployments := k.AppsV1().Deployments(k.namespace)
+	deployments := k.client().AppsV1().Deployments(k.namespace)
 	deployment, err := deployments.Get(deploymentName, v1.GetOptions{IncludeUninitialized: true})
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -1519,7 +1553,7 @@ func (k *kubernetesClient) configureDeployment(
 }
 
 func (k *kubernetesClient) ensureDeployment(spec *apps.Deployment) error {
-	deployments := k.AppsV1().Deployments(k.namespace)
+	deployments := k.client().AppsV1().Deployments(k.namespace)
 	_, err := deployments.Update(spec)
 	if k8serrors.IsNotFound(err) {
 		_, err = deployments.Create(spec)
@@ -1528,7 +1562,7 @@ func (k *kubernetesClient) ensureDeployment(spec *apps.Deployment) error {
 }
 
 func (k *kubernetesClient) deleteDeployment(name string) error {
-	deployments := k.AppsV1().Deployments(k.namespace)
+	deployments := k.client().AppsV1().Deployments(k.namespace)
 	err := deployments.Delete(name, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
@@ -1586,7 +1620,7 @@ func (k *kubernetesClient) configureStatefulSet(
 }
 
 func (k *kubernetesClient) ensureStatefulSet(spec *apps.StatefulSet, existingPodSpec core.PodSpec) error {
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	_, err := statefulsets.Update(spec)
 	if k8serrors.IsNotFound(err) {
 		_, err = statefulsets.Create(spec)
@@ -1612,13 +1646,13 @@ func (k *kubernetesClient) ensureStatefulSet(spec *apps.StatefulSet, existingPod
 
 // createStatefulSet deletes a statefulset resource.
 func (k *kubernetesClient) createStatefulSet(spec *apps.StatefulSet) error {
-	_, err := k.AppsV1().StatefulSets(k.namespace).Create(spec)
+	_, err := k.client().AppsV1().StatefulSets(k.namespace).Create(spec)
 	return errors.Trace(err)
 }
 
 // deleteStatefulSet deletes a statefulset resource.
 func (k *kubernetesClient) deleteStatefulSet(name string) error {
-	deployments := k.AppsV1().StatefulSets(k.namespace)
+	deployments := k.client().AppsV1().StatefulSets(k.namespace)
 	err := deployments.Delete(name, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
@@ -1646,7 +1680,7 @@ func (k *kubernetesClient) deleteVolumeClaims(appName string, p *core.Pod) ([]st
 			// Ignore volumes which are not Juju managed filesystems.
 			continue
 		}
-		pvClaims := k.CoreV1().PersistentVolumeClaims(k.namespace)
+		pvClaims := k.client().CoreV1().PersistentVolumeClaims(k.namespace)
 		err := pvClaims.Delete(vol.PersistentVolumeClaim.ClaimName, &v1.DeleteOptions{
 			PropagationPolicy: &defaultPropagationPolicy,
 		})
@@ -1723,7 +1757,7 @@ func (k *kubernetesClient) configureService(
 
 // ensureK8sService ensures a k8s service resource.
 func (k *kubernetesClient) ensureK8sService(spec *core.Service) error {
-	services := k.CoreV1().Services(k.namespace)
+	services := k.client().CoreV1().Services(k.namespace)
 	// Set any immutable fields if the service already exists.
 	existing, err := services.Get(spec.Name, v1.GetOptions{IncludeUninitialized: true})
 	if err == nil {
@@ -1739,7 +1773,7 @@ func (k *kubernetesClient) ensureK8sService(spec *core.Service) error {
 
 // deleteService deletes a service resource.
 func (k *kubernetesClient) deleteService(deploymentName string) error {
-	services := k.CoreV1().Services(k.namespace)
+	services := k.client().CoreV1().Services(k.namespace)
 	err := services.Delete(deploymentName, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
@@ -1770,7 +1804,7 @@ func (k *kubernetesClient) ExposeService(appName string, resourceTags map[string
 	}
 
 	deploymentName := k.deploymentName(appName)
-	svc, err := k.CoreV1().Services(k.namespace).Get(deploymentName, v1.GetOptions{})
+	svc, err := k.client().CoreV1().Services(k.namespace).Get(deploymentName, v1.GetOptions{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1812,7 +1846,7 @@ func (k *kubernetesClient) UnexposeService(appName string) error {
 }
 
 func (k *kubernetesClient) ensureIngress(spec *v1beta1.Ingress) error {
-	ingress := k.ExtensionsV1beta1().Ingresses(k.namespace)
+	ingress := k.client().ExtensionsV1beta1().Ingresses(k.namespace)
 	_, err := ingress.Update(spec)
 	if k8serrors.IsNotFound(err) {
 		_, err = ingress.Create(spec)
@@ -1822,7 +1856,7 @@ func (k *kubernetesClient) ensureIngress(spec *v1beta1.Ingress) error {
 
 func (k *kubernetesClient) deleteIngress(appName string) error {
 	deploymentName := k.deploymentName(appName)
-	ingress := k.ExtensionsV1beta1().Ingresses(k.namespace)
+	ingress := k.client().ExtensionsV1beta1().Ingresses(k.namespace)
 	err := ingress.Delete(deploymentName, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
@@ -1843,7 +1877,7 @@ func applicationSelector(appName string) string {
 // WatchUnits returns a watcher which notifies when there
 // are changes to units of the specified application.
 func (k *kubernetesClient) WatchUnits(appName string) (watcher.NotifyWatcher, error) {
-	pods := k.CoreV1().Pods(k.namespace)
+	pods := k.client().CoreV1().Pods(k.namespace)
 	w, err := pods.Watch(v1.ListOptions{
 		LabelSelector: applicationSelector(appName),
 		Watch:         true,
@@ -1860,7 +1894,7 @@ func (k *kubernetesClient) WatchService(appName string) (watcher.NotifyWatcher, 
 	// Application may be a statefulset or deployment. It may not have
 	// been set up when the watcher is started so we don't know which it
 	// is ahead of time. So use a multi-watcher to cover both cases.
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	sswatcher, err := statefulsets.Watch(v1.ListOptions{
 		LabelSelector: applicationSelector(appName),
 		Watch:         true,
@@ -1873,7 +1907,7 @@ func (k *kubernetesClient) WatchService(appName string) (watcher.NotifyWatcher, 
 		return nil, errors.Trace(err)
 	}
 
-	deployments := k.AppsV1().Deployments(k.namespace)
+	deployments := k.client().AppsV1().Deployments(k.namespace)
 	dwatcher, err := deployments.Watch(v1.ListOptions{
 		LabelSelector: applicationSelector(appName),
 		Watch:         true,
@@ -1892,7 +1926,7 @@ func (k *kubernetesClient) WatchService(appName string) (watcher.NotifyWatcher, 
 // WatchOperator returns a watcher which notifies when there
 // are changes to the operator of the specified application.
 func (k *kubernetesClient) WatchOperator(appName string) (watcher.NotifyWatcher, error) {
-	pods := k.CoreV1().Pods(k.namespace)
+	pods := k.client().CoreV1().Pods(k.namespace)
 	w, err := pods.Watch(v1.ListOptions{
 		LabelSelector: operatorSelector(appName),
 		Watch:         true,
@@ -1914,7 +1948,7 @@ var jujuPVNameRegexp = regexp.MustCompile(`^(?P<storageName>\D+)-\w+$`)
 // Units returns all units and any associated filesystems of the specified application.
 // Filesystems are mounted via volumes bound to the unit.
 func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
-	pods := k.CoreV1().Pods(k.namespace)
+	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(v1.ListOptions{
 		LabelSelector: applicationSelector(appName),
 	})
@@ -2028,7 +2062,7 @@ func (k *kubernetesClient) volumeInfoForEmptyDir(vol core.Volume, volMount core.
 }
 
 func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.VolumeMount, claimName string, now time.Time) (*caas.FilesystemInfo, error) {
-	pvClaims := k.CoreV1().PersistentVolumeClaims(k.namespace)
+	pvClaims := k.client().CoreV1().PersistentVolumeClaims(k.namespace)
 	pvc, err := pvClaims.Get(claimName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		// Ignore claims which don't exist (yet).
@@ -2061,7 +2095,7 @@ func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.Volum
 	if statusMessage == "" {
 		// If there are any events for this pvc we can use the
 		// most recent to set the status.
-		events := k.CoreV1().Events(k.namespace)
+		events := k.client().CoreV1().Events(k.namespace)
 		eventList, err := events.List(v1.ListOptions{
 			IncludeUninitialized: true,
 			FieldSelector:        fields.OneTermEqualSelector("involvedObject.name", pvc.Name).String(),
@@ -2075,7 +2109,7 @@ func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.Volum
 		}
 	}
 
-	pVolumes := k.CoreV1().PersistentVolumes()
+	pVolumes := k.client().CoreV1().PersistentVolumes()
 	pv, err := pVolumes.Get(pvc.Spec.VolumeName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		// Ignore volumes which don't exist (yet).
@@ -2111,7 +2145,7 @@ func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.Volum
 
 // Operator returns an Operator with current status and life details.
 func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
-	pods := k.CoreV1().Pods(k.namespace)
+	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(v1.ListOptions{
 		LabelSelector: operatorSelector(appName),
 	})
@@ -2156,7 +2190,7 @@ func (k *kubernetesClient) getPODStatus(pod core.Pod, now time.Time) (string, st
 	if statusMessage == "" {
 		// If there are any events for this pod we can use the
 		// most recent to set the status.
-		events := k.CoreV1().Events(k.namespace)
+		events := k.client().CoreV1().Events(k.namespace)
 		eventList, err := events.List(v1.ListOptions{
 			IncludeUninitialized: true,
 			FieldSelector:        fields.OneTermEqualSelector("involvedObject.name", pod.Name).String(),
@@ -2198,7 +2232,7 @@ func (k *kubernetesClient) getDeploymentStatus(deployment *apps.Deployment) (str
 }
 
 func (k *kubernetesClient) getStatusFromEvents(parentName string, jujuStatus status.Status) (string, status.Status, error) {
-	events := k.CoreV1().Events(k.namespace)
+	events := k.client().CoreV1().Events(k.namespace)
 	eventList, err := events.List(v1.ListOptions{
 		IncludeUninitialized: true,
 		FieldSelector:        fields.OneTermEqualSelector("involvedObject.name", parentName).String(),
@@ -2281,7 +2315,7 @@ func filesetConfigMap(configMapName string, files *caas.FileSet) *core.ConfigMap
 
 // ensureConfigMap ensures a ConfigMap resource.
 func (k *kubernetesClient) ensureConfigMap(configMap *core.ConfigMap) error {
-	configMaps := k.CoreV1().ConfigMaps(k.namespace)
+	configMaps := k.client().CoreV1().ConfigMaps(k.namespace)
 	_, err := configMaps.Update(configMap)
 	if k8serrors.IsNotFound(err) {
 		_, err = configMaps.Create(configMap)
@@ -2291,7 +2325,7 @@ func (k *kubernetesClient) ensureConfigMap(configMap *core.ConfigMap) error {
 
 // deleteConfigMap deletes a ConfigMap resource.
 func (k *kubernetesClient) deleteConfigMap(configMapName string) error {
-	err := k.CoreV1().ConfigMaps(k.namespace).Delete(configMapName, &v1.DeleteOptions{
+	err := k.client().CoreV1().ConfigMaps(k.namespace).Delete(configMapName, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
 	if k8serrors.IsNotFound(err) {
@@ -2302,13 +2336,13 @@ func (k *kubernetesClient) deleteConfigMap(configMapName string) error {
 
 // createConfigMap creates a ConfigMap resource.
 func (k *kubernetesClient) createConfigMap(configMap *core.ConfigMap) error {
-	_, err := k.CoreV1().ConfigMaps(k.namespace).Create(configMap)
+	_, err := k.client().CoreV1().ConfigMaps(k.namespace).Create(configMap)
 	return errors.Trace(err)
 }
 
 // getConfigMap returns a ConfigMap resource.
 func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) {
-	cm, err := k.CoreV1().ConfigMaps(k.namespace).Get(cmName, v1.GetOptions{IncludeUninitialized: true})
+	cm, err := k.client().CoreV1().ConfigMaps(k.namespace).Get(cmName, v1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, errors.NotFoundf("configmap %q", cmName)
@@ -2546,7 +2580,7 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 // legacyAppName returns true if there are any artifacts for
 // appName which indicate that this deployment was for Juju 2.5.0.
 func (k *kubernetesClient) legacyAppName(appName string) bool {
-	statefulsets := k.AppsV1().StatefulSets(k.namespace)
+	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	legacyName := "juju-operator-" + appName
 	_, err := statefulsets.Get(legacyName, v1.GetOptions{IncludeUninitialized: true})
 	return err == nil

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -87,7 +87,7 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 	}
 
 	if storageClass != "" {
-		sc, err := k.StorageV1().StorageClasses().Get(storageClass, v1.GetOptions{IncludeUninitialized: true})
+		sc, err := k.client().StorageV1().StorageClasses().Get(storageClass, v1.GetOptions{IncludeUninitialized: true})
 		if err != nil && !k8serrors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}
@@ -105,7 +105,7 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 
 	// We may have the workload storage but still need to look for operator storage.
 	preferredOperatorStorage, havePreferredOperatorStorage := jujuPreferredOperatorStorage[result.Cloud]
-	storageClasses, err := k.StorageV1().StorageClasses().List(v1.ListOptions{})
+	storageClasses, err := k.client().StorageV1().StorageClasses().List(v1.ListOptions{})
 	if err != nil {
 		return nil, errors.Annotate(err, "listing storage classes")
 	}
@@ -176,7 +176,7 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 func (k *kubernetesClient) listHostCloudRegions() (string, set.Strings, error) {
 	// we only check 5 worker nodes as of now just run in the one region and
 	// we are just looking for a running worker to sniff its region.
-	nodes, err := k.CoreV1().Nodes().List(v1.ListOptions{Limit: 5})
+	nodes, err := k.client().CoreV1().Nodes().List(v1.ListOptions{Limit: 5})
 	if err != nil {
 		return "", nil, errors.Annotate(err, "listing nodes")
 	}

--- a/caas/kubernetes/provider/namespaces.go
+++ b/caas/kubernetes/provider/namespaces.go
@@ -33,7 +33,7 @@ func checkNamespaceOwnedByJuju(ns *core.Namespace, annotationMap map[string]stri
 
 // Namespaces returns names of the namespaces on the cluster.
 func (k *kubernetesClient) Namespaces() ([]string, error) {
-	namespaces := k.CoreV1().Namespaces()
+	namespaces := k.client().CoreV1().Namespaces()
 	ns, err := namespaces.List(v1.ListOptions{IncludeUninitialized: true})
 	if err != nil {
 		return nil, errors.Annotate(err, "listing namespaces")
@@ -63,7 +63,7 @@ func (k *kubernetesClient) GetNamespace(name string) (*core.Namespace, error) {
 // getNamespaceByName is used internally for bootstrap.
 // Note: it should be never used by something else. "GetNamespace" is what you should use.
 func (k *kubernetesClient) getNamespaceByName(name string) (*core.Namespace, error) {
-	ns, err := k.CoreV1().Namespaces().Get(name, v1.GetOptions{IncludeUninitialized: true})
+	ns, err := k.client().CoreV1().Namespaces().Get(name, v1.GetOptions{IncludeUninitialized: true})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("namespace %q", name)
 	}
@@ -81,7 +81,7 @@ func (k *kubernetesClient) SetNamespace(name string) {
 
 // listNamespacesByAnnotations filters namespaces by annotations.
 func (k *kubernetesClient) listNamespacesByAnnotations(annotations k8sannotations.Annotation) ([]core.Namespace, error) {
-	namespaces, err := k.CoreV1().Namespaces().List(v1.ListOptions{IncludeUninitialized: true})
+	namespaces, err := k.client().CoreV1().Namespaces().List(v1.ListOptions{IncludeUninitialized: true})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -125,7 +125,7 @@ func (k *kubernetesClient) createNamespace(name string) error {
 	if err := k.ensureNamespaceAnnotations(ns); err != nil {
 		return errors.Trace(err)
 	}
-	_, err := k.CoreV1().Namespaces().Create(ns)
+	_, err := k.client().CoreV1().Namespaces().Create(ns)
 	if k8serrors.IsAlreadyExists(err) {
 		return errors.AlreadyExistsf("namespace %q", name)
 	}
@@ -148,7 +148,7 @@ func (k *kubernetesClient) deleteNamespace() error {
 		return errors.Trace(err)
 	}
 
-	err = k.CoreV1().Namespaces().Delete(k.namespace, &v1.DeleteOptions{
+	err = k.client().CoreV1().Namespaces().Delete(k.namespace, &v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
 	if k8serrors.IsNotFound(err) {
@@ -160,7 +160,7 @@ func (k *kubernetesClient) deleteNamespace() error {
 // WatchNamespace returns a watcher which notifies when there
 // are changes to current namespace.
 func (k *kubernetesClient) WatchNamespace() (watcher.NotifyWatcher, error) {
-	w, err := k.CoreV1().Namespaces().Watch(
+	w, err := k.client().CoreV1().Namespaces().Watch(
 		v1.ListOptions{
 			FieldSelector:        fields.OneTermEqualSelector("metadata.name", k.namespace).String(),
 			IncludeUninitialized: true,

--- a/caas/kubernetes/provider/resources.go
+++ b/caas/kubernetes/provider/resources.go
@@ -19,7 +19,7 @@ import (
 func (k *kubernetesClient) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	modelLabel := fmt.Sprintf("%v==%v", tags.JujuModel, k.modelUUID)
 
-	pods := k.CoreV1().Pods(k.namespace)
+	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
@@ -33,7 +33,7 @@ func (k *kubernetesClient) AdoptResources(ctx context.ProviderCallContext, contr
 		}
 	}
 
-	pvcs := k.CoreV1().PersistentVolumeClaims(k.namespace)
+	pvcs := k.client().CoreV1().PersistentVolumeClaims(k.namespace)
 	pvcList, err := pvcs.List(v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
@@ -47,7 +47,7 @@ func (k *kubernetesClient) AdoptResources(ctx context.ProviderCallContext, contr
 		}
 	}
 
-	pvs := k.CoreV1().PersistentVolumes()
+	pvs := k.client().CoreV1().PersistentVolumes()
 	pvList, err := pvs.List(v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
@@ -61,7 +61,7 @@ func (k *kubernetesClient) AdoptResources(ctx context.ProviderCallContext, contr
 		}
 	}
 
-	sSets := k.AppsV1().StatefulSets(k.namespace)
+	sSets := k.client().AppsV1().StatefulSets(k.namespace)
 	ssList, err := sSets.List(v1.ListOptions{
 		LabelSelector: modelLabel,
 	})
@@ -75,7 +75,7 @@ func (k *kubernetesClient) AdoptResources(ctx context.ProviderCallContext, contr
 		}
 	}
 
-	deployments := k.AppsV1().Deployments(k.namespace)
+	deployments := k.client().AppsV1().Deployments(k.namespace)
 	dList, err := deployments.List(v1.ListOptions{
 		LabelSelector: modelLabel,
 	})

--- a/worker/caasbroker/broker.go
+++ b/worker/caasbroker/broker.go
@@ -4,12 +4,15 @@
 package caasbroker
 
 import (
+	"reflect"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1/catacomb"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 )
@@ -22,6 +25,8 @@ type ConfigAPI interface {
 	CloudSpec() (environs.CloudSpec, error)
 	ModelConfig() (*config.Config, error)
 	ControllerConfig() (controller.Config, error)
+	WatchForModelConfigChanges() (watcher.NotifyWatcher, error)
+	WatchCloudSpecChanges() (watcher.NotifyWatcher, error)
 }
 
 // Config describes the dependencies of a Tracker.
@@ -47,9 +52,10 @@ func (config Config) Validate() error {
 // Tracker loads a caas broker, makes it available to clients, and updates
 // the broker in response to config changes until it is killed.
 type Tracker struct {
-	config   Config
-	catacomb catacomb.Catacomb
-	broker   caas.Broker
+	config           Config
+	catacomb         catacomb.Catacomb
+	broker           caas.Broker
+	currentCloudSpec environs.CloudSpec
 }
 
 // NewTracker returns a new Tracker, or an error if anything goes wrong.
@@ -83,8 +89,9 @@ func NewTracker(config Config) (*Tracker, error) {
 	}
 
 	t := &Tracker{
-		config: config,
-		broker: broker,
+		config:           config,
+		broker:           broker,
+		currentCloudSpec: cloudSpec,
 	}
 	err = catacomb.Invoke(catacomb.Plan{
 		Site: &t.catacomb,
@@ -103,12 +110,67 @@ func (t *Tracker) Broker() caas.Broker {
 }
 
 func (t *Tracker) loop() error {
-	// TODO(caas) - watch for config and credential changes
+	modelWatcher, err := t.config.ConfigAPI.WatchForModelConfigChanges()
+	if err != nil {
+		return errors.Annotate(err, "cannot watch model config")
+	}
+	if err := t.catacomb.Add(modelWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Some environs support reacting to changes in the cloud config.
+	// Set up a watcher if that's the case.
+	var (
+		cloudWatcherChanges watcher.NotifyChannel
+		cloudSpecSetter     environs.CloudSpecSetter
+		ok                  bool
+	)
+	if cloudSpecSetter, ok = t.broker.(environs.CloudSpecSetter); !ok {
+		logger.Warningf("cloud type %v doesn't support dynamic changing of cloud spec", t.broker.Config().Type())
+	} else {
+		cloudWatcher, err := t.config.ConfigAPI.WatchCloudSpecChanges()
+		if err != nil {
+			return errors.Annotate(err, "cannot watch environ cloud spec")
+		}
+		if err := t.catacomb.Add(cloudWatcher); err != nil {
+			return errors.Trace(err)
+		}
+		cloudWatcherChanges = cloudWatcher.Changes()
+	}
+
 	for {
 		logger.Debugf("waiting for config and credential notifications")
 		select {
 		case <-t.catacomb.Dying():
 			return t.catacomb.ErrDying()
+		case _, ok := <-modelWatcher.Changes():
+			if !ok {
+				return errors.New("model config watch closed")
+			}
+			logger.Debugf("reloading model config")
+			modelConfig, err := t.config.ConfigAPI.ModelConfig()
+			if err != nil {
+				return errors.Annotate(err, "cannot read model config")
+			}
+			if err = t.broker.SetConfig(modelConfig); err != nil {
+				return errors.Annotate(err, "cannot update model config")
+			}
+		case _, ok := <-cloudWatcherChanges:
+			if !ok {
+				return errors.New("cloud watch closed")
+			}
+			cloudSpec, err := t.config.ConfigAPI.CloudSpec()
+			if err != nil {
+				return errors.Annotate(err, "cannot read model config")
+			}
+			if reflect.DeepEqual(cloudSpec, t.currentCloudSpec) {
+				continue
+			}
+			logger.Debugf("reloading cloud config")
+			if err = cloudSpecSetter.SetCloudSpec(cloudSpec); err != nil {
+				return errors.Annotate(err, "cannot update broker cloud spec")
+			}
+			t.currentCloudSpec = cloudSpec
 		}
 	}
 }

--- a/worker/caasbroker/broker_test.go
+++ b/worker/caasbroker/broker_test.go
@@ -4,6 +4,8 @@
 package caasbroker_test
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -75,7 +77,7 @@ func (s *TrackerSuite) validFixture() *fixture {
 	cfg := coretesting.FakeConfig()
 	cfg["type"] = "kubernetes"
 	cfg["uuid"] = utils.MustNewUUID().String()
-	return &fixture{cloud: cloudSpec, config: cfg}
+	return &fixture{initialSpec: cloudSpec, initialConfig: cfg}
 }
 
 func (s *TrackerSuite) TestSuccess(c *gc.C) {
@@ -99,13 +101,259 @@ func (s *TrackerSuite) TestInitialise(c *gc.C) {
 		tracker, err := caasbroker.NewTracker(caasbroker.Config{
 			ConfigAPI: context,
 			NewContainerBrokerFunc: func(args environs.OpenParams) (caas.Broker, error) {
-				c.Assert(args.Cloud, jc.DeepEquals, fix.cloud)
+				c.Assert(args.Cloud, jc.DeepEquals, fix.initialSpec)
 				c.Assert(args.Config.Name(), jc.DeepEquals, "testmodel")
 				return nil, errors.NotValidf("cloud spec")
 			},
 		})
 		c.Check(err, gc.ErrorMatches, `cannot create caas broker: cloud spec not valid`)
 		c.Check(tracker, gc.IsNil)
-		context.CheckCallNames(c, "CloudSpec", "Model", "ControllerConfig")
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig", "ControllerConfig")
+	})
+}
+
+func (s *TrackerSuite) TestModelConfigFails(c *gc.C) {
+	fix := &fixture{
+		observerErrs: []error{
+			nil,
+			errors.New("no you"),
+		},
+	}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Check(err, gc.ErrorMatches, "no you")
+		c.Check(tracker, gc.IsNil)
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig")
+	})
+}
+
+func (s *TrackerSuite) TestModelConfigInvalid(c *gc.C) {
+	fix := &fixture{}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI: context,
+			NewContainerBrokerFunc: func(environs.OpenParams) (caas.Broker, error) {
+				return nil, errors.NotValidf("config")
+			},
+		})
+		c.Check(err, gc.ErrorMatches, `cannot create caas broker: config not valid`)
+		c.Check(tracker, gc.IsNil)
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig", "ControllerConfig")
+	})
+}
+
+func (s *TrackerSuite) TestModelConfigValid(c *gc.C) {
+	fix := &fixture{
+		initialConfig: coretesting.Attrs{
+			"name": "this-particular-name",
+		},
+	}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		defer workertest.CleanKill(c, tracker)
+
+		gotBroker := tracker.Broker()
+		c.Assert(gotBroker, gc.NotNil)
+		c.Check(gotBroker.Config().Name(), gc.Equals, "this-particular-name")
+	})
+}
+
+func (s *TrackerSuite) TestCloudSpecInvalid(c *gc.C) {
+	cloudSpec := environs.CloudSpec{
+		Name:   "foo",
+		Type:   "bar",
+		Region: "baz",
+	}
+	fix := &fixture{initialSpec: cloudSpec}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI: context,
+			NewContainerBrokerFunc: func(args environs.OpenParams) (caas.Broker, error) {
+				c.Assert(args.Cloud, jc.DeepEquals, cloudSpec)
+				return nil, errors.NotValidf("cloud spec")
+			},
+		})
+		c.Check(err, gc.ErrorMatches, `cannot create caas broker: cloud spec not valid`)
+		c.Check(tracker, gc.IsNil)
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig", "ControllerConfig")
+	})
+}
+
+func (s *TrackerSuite) TestWatchFails(c *gc.C) {
+	fix := &fixture{
+		observerErrs: []error{
+			nil, nil, nil, errors.New("grrk splat"),
+		},
+	}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		defer workertest.DirtyKill(c, tracker)
+
+		err = workertest.CheckKilled(c, tracker)
+		c.Check(err, gc.ErrorMatches, "cannot watch model config: grrk splat")
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig", "ControllerConfig", "WatchForModelConfigChanges")
+	})
+}
+
+func (s *TrackerSuite) TestModelConfigWatchCloses(c *gc.C) {
+	fix := &fixture{}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		defer workertest.DirtyKill(c, tracker)
+
+		context.CloseModelConfigNotify()
+		err = workertest.CheckKilled(c, tracker)
+		c.Check(err, gc.ErrorMatches, "model config watch closed")
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig", "ControllerConfig", "WatchForModelConfigChanges", "WatchCloudSpecChanges")
+	})
+}
+
+func (s *TrackerSuite) TestCloudSpecWatchCloses(c *gc.C) {
+	fix := &fixture{}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		defer workertest.DirtyKill(c, tracker)
+
+		context.CloseCloudSpecNotify()
+		err = workertest.CheckKilled(c, tracker)
+		c.Check(err, gc.ErrorMatches, "cloud watch closed")
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig", "ControllerConfig", "WatchForModelConfigChanges", "WatchCloudSpecChanges")
+	})
+}
+
+func (s *TrackerSuite) TestWatchedModelConfigFails(c *gc.C) {
+	fix := &fixture{
+		observerErrs: []error{
+			nil, nil, nil, nil, nil, errors.New("blam ouch"),
+		},
+	}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Check(err, jc.ErrorIsNil)
+		defer workertest.DirtyKill(c, tracker)
+
+		context.SendModelConfigNotify()
+		context.SendCloudSpecNotify()
+		err = workertest.CheckKilled(c, tracker)
+		c.Check(err, gc.ErrorMatches, "cannot read model config: blam ouch")
+	})
+}
+
+func (s *TrackerSuite) TestWatchedModelConfigIncompatible(c *gc.C) {
+	fix := &fixture{}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI: context,
+			NewContainerBrokerFunc: func(environs.OpenParams) (caas.Broker, error) {
+				broker := &mockBroker{}
+				broker.SetErrors(errors.New("SetConfig is broken"))
+				return broker, nil
+			},
+		})
+		c.Check(err, jc.ErrorIsNil)
+		defer workertest.DirtyKill(c, tracker)
+
+		context.SendModelConfigNotify()
+		err = workertest.CheckKilled(c, tracker)
+		c.Check(err, gc.ErrorMatches, "cannot update model config: SetConfig is broken")
+		context.CheckCallNames(c, "CloudSpec", "ModelConfig", "ControllerConfig", "WatchForModelConfigChanges", "WatchCloudSpecChanges", "ModelConfig")
+	})
+}
+
+func (s *TrackerSuite) TestWatchedModelConfigUpdates(c *gc.C) {
+	fix := &fixture{
+		initialConfig: coretesting.Attrs{
+			"name": "original-name",
+		},
+	}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Check(err, jc.ErrorIsNil)
+		defer workertest.CleanKill(c, tracker)
+
+		context.SetConfig(c, coretesting.Attrs{
+			"name": "updated-name",
+		})
+		gotBroker := tracker.Broker()
+		c.Assert(gotBroker.Config().Name(), gc.Equals, "original-name")
+
+		timeout := time.After(coretesting.LongWait)
+		attempt := time.After(0)
+		context.SendModelConfigNotify()
+		for {
+			select {
+			case <-attempt:
+				name := gotBroker.Config().Name()
+				if name == "original-name" {
+					attempt = time.After(coretesting.ShortWait)
+					continue
+				}
+				c.Check(name, gc.Equals, "updated-name")
+			case <-timeout:
+				c.Fatalf("timed out waiting for broker to be updated")
+			}
+			break
+		}
+	})
+}
+
+func (s *TrackerSuite) TestWatchedCloudSpecUpdates(c *gc.C) {
+	fix := &fixture{
+		initialSpec: environs.CloudSpec{Name: "cloud", Type: "lxd"},
+	}
+	fix.Run(c, func(context *runContext) {
+		tracker, err := caasbroker.NewTracker(caasbroker.Config{
+			ConfigAPI:              context,
+			NewContainerBrokerFunc: newMockBroker,
+		})
+		c.Check(err, jc.ErrorIsNil)
+		defer workertest.CleanKill(c, tracker)
+
+		context.SetCloudSpec(c, environs.CloudSpec{Name: "lxd", Type: "lxd", Endpoint: "http://api"})
+		gotBroker := tracker.Broker().(*mockBroker)
+		c.Assert(gotBroker.CloudSpec(), jc.DeepEquals, fix.initialSpec)
+
+		timeout := time.After(coretesting.LongWait)
+		attempt := time.After(0)
+		context.SendCloudSpecNotify()
+		for {
+			select {
+			case <-attempt:
+				ep := gotBroker.CloudSpec().Endpoint
+				if ep == "" {
+					attempt = time.After(coretesting.ShortWait)
+					continue
+				}
+				c.Check(ep, gc.Equals, "http://api")
+			case <-timeout:
+				c.Fatalf("timed out waiting for environ to be updated")
+			}
+			break
+		}
 	})
 }

--- a/worker/caasbroker/fixture_test.go
+++ b/worker/caasbroker/fixture_test.go
@@ -8,38 +8,68 @@ import (
 
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	coretesting "github.com/juju/juju/testing"
 
 	jujutesting "github.com/juju/juju/testing"
 )
 
 type fixture struct {
-	watcherErr   error
-	observerErrs []error
-	cloud        environs.CloudSpec
-	config       map[string]interface{}
+	watcherErr    error
+	observerErrs  []error
+	cloud         environs.CloudSpec
+	initialConfig map[string]interface{}
+	initialSpec   environs.CloudSpec
 }
 
 func (fix *fixture) Run(c *gc.C, test func(*runContext)) {
+	watcher := newNotifyWatcher(fix.watcherErr)
+	defer workertest.DirtyKill(c, watcher)
+	cloudWatcher := newNotifyWatcher(fix.watcherErr)
+	defer workertest.DirtyKill(c, cloudWatcher)
 	context := &runContext{
-		cloud:  fix.cloud,
-		config: fix.config,
+		cloud:        fix.initialSpec,
+		config:       newModelConfig(c, fix.initialConfig),
+		watcher:      watcher,
+		cloudWatcher: cloudWatcher,
 	}
 	context.stub.SetErrors(fix.observerErrs...)
 	test(context)
 }
 
 type runContext struct {
-	mu     sync.Mutex
-	stub   testing.Stub
-	cloud  environs.CloudSpec
-	config map[string]interface{}
+	mu           sync.Mutex
+	stub         testing.Stub
+	cloud        environs.CloudSpec
+	config       map[string]interface{}
+	watcher      *notifyWatcher
+	cloudWatcher *notifyWatcher
+	credWatcher  *notifyWatcher
 }
 
+// SetConfig updates the configuration returned by ModelConfig.
+func (context *runContext) SetConfig(c *gc.C, extraAttrs coretesting.Attrs) {
+	context.mu.Lock()
+	defer context.mu.Unlock()
+	context.config = newModelConfig(c, extraAttrs)
+}
+
+// SetCloudSpec updates the spec returned by CloudSpec.
+func (context *runContext) SetCloudSpec(c *gc.C, spec environs.CloudSpec) {
+	context.mu.Lock()
+	defer context.mu.Unlock()
+	context.cloud = spec
+}
+
+// CloudSpec is part of the environ.ConfigObserver interface.
 func (context *runContext) CloudSpec() (environs.CloudSpec, error) {
 	context.mu.Lock()
 	defer context.mu.Unlock()
@@ -50,10 +80,11 @@ func (context *runContext) CloudSpec() (environs.CloudSpec, error) {
 	return context.cloud, nil
 }
 
+// ModelConfig is part of the environ.ConfigObserver interface.
 func (context *runContext) ModelConfig() (*config.Config, error) {
 	context.mu.Lock()
 	defer context.mu.Unlock()
-	context.stub.AddCall("Model")
+	context.stub.AddCall("ModelConfig")
 	if err := context.stub.NextErr(); err != nil {
 		return nil, err
 	}
@@ -70,20 +101,165 @@ func (context *runContext) ControllerConfig() (controller.Config, error) {
 	return jujutesting.FakeControllerConfig(), nil
 }
 
+// KillModelConfigNotify kills the watcher returned from WatchForModelConfigChanges with
+// the error configured in the enclosing fixture.
+func (context *runContext) KillModelConfigNotify() {
+	context.watcher.Kill()
+}
+
+// SendModelConfigNotify sends a value on the channel used by WatchForModelConfigChanges
+// results.
+func (context *runContext) SendModelConfigNotify() {
+	context.watcher.changes <- struct{}{}
+}
+
+// CloseModelConfigNotify closes the channel used by WatchForModelConfigChanges results.
+func (context *runContext) CloseModelConfigNotify() {
+	close(context.watcher.changes)
+}
+
+// KillCloudSpecNotify kills the watcher returned from WatchCloudSpecChanges with
+// the error configured in the enclosing fixture.
+func (context *runContext) KillCloudSpecNotify() {
+	context.cloudWatcher.Kill()
+}
+
+// SendCloudSpecNotify sends a value on the channel used by WatchCloudSpecChanges
+// results.
+func (context *runContext) SendCloudSpecNotify() {
+	context.cloudWatcher.changes <- struct{}{}
+}
+
+// CloseCloudSpecNotify closes the channel used by WatchCloudSpecChanges results.
+func (context *runContext) CloseCloudSpecNotify() {
+	close(context.cloudWatcher.changes)
+}
+
+// WatchForModelConfigChanges is part of the environ.ConfigObserver interface.
+func (context *runContext) WatchForModelConfigChanges() (watcher.NotifyWatcher, error) {
+	context.mu.Lock()
+	defer context.mu.Unlock()
+	context.stub.AddCall("WatchForModelConfigChanges")
+	if err := context.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return context.watcher, nil
+}
+
+func (context *runContext) WatchCloudSpecChanges() (watcher.NotifyWatcher, error) {
+	context.mu.Lock()
+	defer context.mu.Unlock()
+	context.stub.AddCall("WatchCloudSpecChanges")
+	if err := context.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return context.cloudWatcher, nil
+}
+
+// KillCredentialNotify kills the watcher returned from WatchCredentialChanges with
+// the error configured in the enclosing fixture.
+func (context *runContext) KillCredentialNotify() {
+	context.credWatcher.Kill()
+}
+
+// SendCredentialNotify sends a value on the channel used by WatchCredentialChanges
+// results.
+func (context *runContext) SendCredentialNotify() {
+	context.credWatcher.changes <- struct{}{}
+}
+
+// CloseCredentialNotify closes the channel used by WatchCredentialChanges results.
+func (context *runContext) CloseCredentialNotify() {
+	close(context.credWatcher.changes)
+}
+
+// WatchCredential is part of the environ.ConfigObserver interface.
+func (context *runContext) WatchCredential(cred names.CloudCredentialTag) (watcher.NotifyWatcher, error) {
+	context.mu.Lock()
+	defer context.mu.Unlock()
+	context.stub.AddCall("WatchCredential")
+	if err := context.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return context.watcher, nil
+}
+
 func (context *runContext) CheckCallNames(c *gc.C, names ...string) {
 	context.mu.Lock()
 	defer context.mu.Unlock()
 	context.stub.CheckCallNames(c, names...)
 }
 
+// newNotifyWatcher returns a watcher.NotifyWatcher that will fail with the
+// supplied error when Kill()ed.
+func newNotifyWatcher(err error) *notifyWatcher {
+	return &notifyWatcher{
+		Worker:  workertest.NewErrorWorker(err),
+		changes: make(chan struct{}, 1000),
+	}
+}
+
+type notifyWatcher struct {
+	worker.Worker
+	changes chan struct{}
+}
+
+// Changes is part of the watcher.NotifyWatcher interface.
+func (w *notifyWatcher) Changes() watcher.NotifyChannel {
+	return w.changes
+}
+
+// newModelConfig returns an environment config map with the supplied attrs
+// (on top of some default set), or fails the test.
+func newModelConfig(c *gc.C, extraAttrs coretesting.Attrs) map[string]interface{} {
+	return coretesting.CustomModelConfig(c, extraAttrs).AllAttrs()
+}
+
 type mockBroker struct {
 	caas.Broker
 	testing.Stub
 	spec      environs.CloudSpec
+	cfg       *config.Config
 	namespace string
 	mu        sync.Mutex
 }
 
 func newMockBroker(args environs.OpenParams) (caas.Broker, error) {
-	return &mockBroker{spec: args.Cloud, namespace: args.Config.Name()}, nil
+	return &mockBroker{spec: args.Cloud, namespace: args.Config.Name(), cfg: args.Config}, nil
+}
+
+func (e *mockBroker) CloudSpec() environs.CloudSpec {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.spec
+}
+
+func (e *mockBroker) SetCloudSpec(spec environs.CloudSpec) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.MethodCall(e, "SetCloudSpec", spec)
+	if err := e.NextErr(); err != nil {
+		return err
+	}
+	e.spec = spec
+	return nil
+}
+
+func (e *mockBroker) Config() *config.Config {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.MethodCall(e, "Config")
+	e.PopNoErr()
+	return e.cfg
+}
+
+func (e *mockBroker) SetConfig(cfg *config.Config) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.MethodCall(e, "SetConfig", cfg)
+	if err := e.NextErr(); err != nil {
+		return err
+	}
+	e.cfg = cfg
+	return nil
 }


### PR DESCRIPTION
## Description of change

The k8s broker implements SetCloudSpec(). This allows it to respond to cloud changes. The fix needed to separate out the actual k8s API client so it could be set via a mutex after initial creation.

Additionally, the broker tracker worker has a bunch of code copied across from the environ tracker worker. The environ tracker already implemented the necessary watchers etc for vm clouds. 

## QA steps

bootstrap k8s
run update-cloud with a changed cloud definition
see that the logs show the tracker worker responding to the change

