### PR TITLE
Weaving force into model-destroy backend.

### DIFF
--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -110,7 +110,7 @@ func destroyModel(st ModelManagerBackend, args state.DestroyModelParams) error {
 		return errors.Trace(err)
 	}
 	if err := model.Destroy(args); err != nil {
-		if args.Force != nil && !*args.Force {
+		if args.Force == nil || !*args.Force {
 			return errors.Trace(err)
 		}
 		logger.Warningf("failed destroying model %v: %v", model.UUID(), err)

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -55,7 +55,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	controller, err := controller.NewControllerAPIv7(
+	testController, err := controller.NewControllerAPIv7(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,
@@ -63,7 +63,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 			Auth_:      s.authorizer,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.controller = controller
+	s.controller = testController
 
 	s.otherModelOwner = names.NewUserTag("jess@dummy")
 	s.otherState = s.Factory.MakeModel(c, &factory.ModelParams{
@@ -141,7 +141,7 @@ func (s *destroyControllerSuite) TestDestroyControllerLeavesBlocksIfNotKillAll(c
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedModels(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.otherModel.Refresh(), jc.ErrorIsNil)
 	c.Assert(s.otherModel.Life(), gc.Equals, state.Dying)
@@ -157,7 +157,7 @@ func (s *destroyControllerSuite) TestDestroyControllerNoHostedModels(c *gc.C) {
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBlock(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
@@ -171,7 +171,7 @@ func (s *destroyControllerSuite) TestDestroyControllerErrsOnNoHostedModelsWithBl
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerNoHostedModelsWithBlockFail(c *gc.C) {
-	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil)
+	err := common.DestroyModel(common.NewModelManagerBackend(s.otherModel, s.StatePool), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyModel(c, "TestBlockDestroyModel")
@@ -234,7 +234,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageSpecified(c 
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageNotSpecifiedV3(c *gc.C) {
-	controller, err := controller.NewControllerAPIv3(facadetest.Context{
+	testController, err := controller.NewControllerAPIv3(facadetest.Context{
 		State_:     s.State,
 		StatePool_: s.StatePool,
 		Resources_: s.resources,
@@ -254,7 +254,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageNotSpecified
 		}),
 	})
 
-	err = controller.DestroyController(params.DestroyControllerArgs{
+	err = testController.DestroyController(params.DestroyControllerArgs{
 		DestroyModels: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -265,7 +265,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageNotSpecified
 }
 
 func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageSpecifiedV3(c *gc.C) {
-	controller, err := controller.NewControllerAPIv3(facadetest.Context{
+	testController, err := controller.NewControllerAPIv3(facadetest.Context{
 		State_:     s.State,
 		StatePool_: s.StatePool,
 		Resources_: s.resources,
@@ -274,7 +274,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageSpecifiedV3(
 	c.Assert(err, jc.ErrorIsNil)
 
 	destroyStorage := true
-	err = controller.DestroyController(params.DestroyControllerArgs{
+	err = testController.DestroyController(params.DestroyControllerArgs{
 		DestroyModels:  true,
 		DestroyStorage: &destroyStorage,
 	})

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -985,7 +985,7 @@ func (m *ModelManagerAPI) DestroyModels(args params.DestroyModelsParams) (params
 		Results: make([]params.ErrorResult, len(args.Models)),
 	}
 
-	destroyModel := func(modelUUID string, destroyStorage *bool) error {
+	destroyModel := func(modelUUID string, destroyStorage, force *bool, maxWait *time.Duration) error {
 		st, releaseSt, err := m.state.GetBackend(modelUUID)
 		if err != nil {
 			return errors.Trace(err)
@@ -1006,7 +1006,7 @@ func (m *ModelManagerAPI) DestroyModels(args params.DestroyModelsParams) (params
 			}
 		}
 
-		return errors.Trace(common.DestroyModel(st, destroyStorage))
+		return errors.Trace(common.DestroyModel(st, destroyStorage, force, maxWait))
 	}
 
 	for i, arg := range args.Models {
@@ -1015,7 +1015,7 @@ func (m *ModelManagerAPI) DestroyModels(args params.DestroyModelsParams) (params
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if err := destroyModel(tag.Id(), arg.DestroyStorage); err != nil {
+		if err := destroyModel(tag.Id(), arg.DestroyStorage, arg.Force, arg.MaxWait); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -312,10 +312,10 @@ func (st *State) cleanupMachinesForDyingModel(cleanupArgs []bson.Raw) (err error
 		}
 		manual, err := m.IsManual()
 		if err != nil {
-			// TODO (anastasiamac 2019-4-24) we should not break out here but continue with other machines.
+			// TODO (force 2019-4-24) we should not break out here but continue with other machines.
 			return errors.Trace(err)
 		}
-		// TODO (anastasiamac 2019-04-26) Should this always be ForceDestroy or only when
+		// TODO (force 2019-04-26) Should this always be ForceDestroy or only when
 		// 'destroy-model --force' is specified?...
 		destroy := m.ForceDestroy
 		if manual {
@@ -330,11 +330,11 @@ func (st *State) cleanupMachinesForDyingModel(cleanupArgs []bson.Raw) (err error
 		if err := destroy(); err != nil {
 			if manual {
 				// Since we cannot delete a manual machine, we cannot proceed with model destruction even if it is forced.
-				// TODO (anastasiamac 2019-4-24) However, we should not break out here but continue with other machines.
+				// TODO (force 2019-4-24) However, we should not break out here but continue with other machines.
 				return errors.Trace(errors.Annotatef(err, "could not destroy manual machine %v", m.Id()))
 			}
 			err = errors.Annotatef(err, "while destroying machine %v is", m.Id())
-			// TODO (anastasiamac 2019-4-24) we should not break out here but continue with other machines.
+			// TODO (force 2019-4-24) we should not break out here but continue with other machines.
 			if !force {
 				return errors.Trace(err)
 			}
@@ -442,7 +442,7 @@ func (st *State) removeRemoteApplicationsForDyingModel(args DestroyModelParams) 
 
 	force := args.Force != nil && *args.Force
 	for iter.Next(&remoteApp.doc) {
-		// TODO (anastasiamac 2019-4-24) There may be some operational errors.
+		// TODO (force 2019-4-24) There may be some operational errors.
 		// Do something with with them.
 		if _, err := remoteApp.DestroyWithForce(force); err != nil {
 			return errors.Trace(err)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -364,7 +364,7 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 	}
 
 	destroyStorage := sb.DestroyStorageInstance
-	if args.DestroyStorage != nil && !*args.DestroyStorage {
+	if args.DestroyStorage == nil || !*args.DestroyStorage {
 		destroyStorage = sb.ReleaseStorageInstance
 	}
 

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -171,7 +171,7 @@ func (st *State) Cleanup() (err error) {
 		case cleanupRemovedUnit:
 			err = st.cleanupRemovedUnit(doc.Prefix, args)
 		case cleanupApplicationsForDyingModel:
-			err = st.cleanupApplicationsForDyingModel()
+			err = st.cleanupApplicationsForDyingModel(args)
 		case cleanupDyingMachine:
 			err = st.cleanupDyingMachine(doc.Prefix, args)
 		case cleanupForceDestroyedMachine:
@@ -185,7 +185,7 @@ func (st *State) Cleanup() (err error) {
 		case cleanupModelsForDyingController:
 			err = st.cleanupModelsForDyingController(args)
 		case cleanupMachinesForDyingModel: // IAAS models only
-			err = st.cleanupMachinesForDyingModel()
+			err = st.cleanupMachinesForDyingModel(args)
 		case cleanupResourceBlob:
 			err = st.cleanupResourceBlob(doc.Prefix)
 		case cleanupStorageForDyingModel:
@@ -252,7 +252,6 @@ func (st *State) cleanupModelsForDyingController(cleanupArgs []bson.Raw) (err er
 	default:
 		return errors.Errorf("expected 0-1 arguments, got %d", n)
 	}
-
 	modelUUIDs, err := st.AllModelUUIDs()
 	if err != nil {
 		return errors.Trace(err)
@@ -284,7 +283,18 @@ func (st *State) cleanupModelsForDyingController(cleanupArgs []bson.Raw) (err er
 // cleanupMachinesForDyingModel sets all non-manager machines to Dying,
 // if they are not already Dying or Dead. It's expected to be used when
 // a model is destroyed.
-func (st *State) cleanupMachinesForDyingModel() (err error) {
+func (st *State) cleanupMachinesForDyingModel(cleanupArgs []bson.Raw) (err error) {
+	var args DestroyModelParams
+	switch n := len(cleanupArgs); n {
+	case 0:
+	// Old cleanups have no args, so follow the old behaviour.
+	case 1:
+		if err := cleanupArgs[0].Unmarshal(&args); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup 'destroy model' args")
+		}
+	default:
+		return errors.Errorf("expected 0-1 arguments, got %d", n)
+	}
 	// This won't miss machines, because a Dying model cannot have
 	// machines added to it. But we do have to remove the machines themselves
 	// via individual transactions, because they could be in any state at all.
@@ -292,6 +302,7 @@ func (st *State) cleanupMachinesForDyingModel() (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	force := args.Force != nil && *args.Force
 	for _, m := range machines {
 		if m.IsManager() {
 			continue
@@ -301,8 +312,11 @@ func (st *State) cleanupMachinesForDyingModel() (err error) {
 		}
 		manual, err := m.IsManual()
 		if err != nil {
+			// TODO (anastasiamac 2019-4-24) we should not break out here but continue with other machines.
 			return errors.Trace(err)
 		}
+		// TODO (anastasiamac 2019-04-26) Should this always be ForceDestroy or only when
+		// 'destroy-model --force' is specified?...
 		destroy := m.ForceDestroy
 		if manual {
 			// Manually added machines should never be force-
@@ -314,7 +328,17 @@ func (st *State) cleanupMachinesForDyingModel() (err error) {
 			destroy = m.Destroy
 		}
 		if err := destroy(); err != nil {
-			return errors.Trace(err)
+			if manual {
+				// Since we cannot delete a manual machine, we cannot proceed with model destruction even if it is forced.
+				// TODO (anastasiamac 2019-4-24) However, we should not break out here but continue with other machines.
+				return errors.Trace(errors.Annotatef(err, "could not destroy manual machine %v", m.Id()))
+			}
+			err = errors.Annotatef(err, "while destroying machine %v is", m.Id())
+			// TODO (anastasiamac 2019-4-24) we should not break out here but continue with other machines.
+			if !force {
+				return errors.Trace(err)
+			}
+			logger.Warningf("%v", err)
 		}
 	}
 	return nil
@@ -327,39 +351,28 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	destroyStorage := sb.DestroyStorageInstance
-	destroyStorageFromArg := func() error {
-		var destroyStorageFlag bool
-		if err := cleanupArgs[0].Unmarshal(&destroyStorageFlag); err != nil {
-			return errors.Annotate(err, "unmarshalling cleanup arg 'destroyStorage'")
+	var args DestroyModelParams
+	switch n := len(cleanupArgs); n {
+	case 0:
+		// Old cleanups have no args, so follow the old behaviour.
+	case 1:
+		if err := cleanupArgs[0].Unmarshal(&args); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup 'destroy model' args")
 		}
-		if !destroyStorageFlag {
-			destroyStorage = sb.ReleaseStorageInstance
-		}
-		return nil
+	default:
+		return errors.Errorf("expected 0-1 arguments, got %d", n)
 	}
 
-	var force bool
-	// It's valid to have no args: old cleanups have no args, so follow the old behaviour.
-	if n := len(cleanupArgs); n > 0 {
-		if n > 2 {
-			return errors.Errorf("expected 0-2 arguments, got %d", n)
-		}
-		if n >= 1 {
-			if err := destroyStorageFromArg(); err != nil {
-				return err
-			}
-		}
-		if n >= 2 {
-			if err := cleanupArgs[1].Unmarshal(&force); err != nil {
-				return errors.Annotate(err, "unmarshalling cleanup arg 'force'")
-			}
-		}
+	destroyStorage := sb.DestroyStorageInstance
+	if args.DestroyStorage != nil && !*args.DestroyStorage {
+		destroyStorage = sb.ReleaseStorageInstance
 	}
+
 	storage, err := sb.AllStorageInstances()
 	if err != nil {
 		return errors.Trace(err)
 	}
+	force := args.Force != nil && *args.Force
 	for _, s := range storage {
 		const destroyAttached = true
 		err := destroyStorage(s.StorageTag(), destroyAttached, force)
@@ -375,14 +388,25 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 // cleanupApplicationsForDyingModel sets all applications to Dying, if they are
 // not already Dying or Dead. It's expected to be used when a model is
 // destroyed.
-func (st *State) cleanupApplicationsForDyingModel() (err error) {
-	if err := st.removeRemoteApplicationsForDyingModel(); err != nil {
+func (st *State) cleanupApplicationsForDyingModel(cleanupArgs []bson.Raw) (err error) {
+	var args DestroyModelParams
+	switch n := len(cleanupArgs); n {
+	case 0:
+		// Old cleanups have no args, so follow the old behaviour.
+	case 1:
+		if err := cleanupArgs[0].Unmarshal(&args); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup 'destroy model' args")
+		}
+	default:
+		return errors.Errorf("expected 0-1 arguments, got %d", n)
+	}
+	if err := st.removeRemoteApplicationsForDyingModel(args); err != nil {
 		return err
 	}
-	return st.removeApplicationsForDyingModel()
+	return st.removeApplicationsForDyingModel(args)
 }
 
-func (st *State) removeApplicationsForDyingModel() (err error) {
+func (st *State) removeApplicationsForDyingModel(args DestroyModelParams) (err error) {
 	// This won't miss applications, because a Dying model cannot have
 	// applications added to it. But we do have to remove the applications
 	// themselves via individual transactions, because they could be in any
@@ -393,9 +417,11 @@ func (st *State) removeApplicationsForDyingModel() (err error) {
 	sel := bson.D{{"life", Alive}}
 	iter := applications.Find(sel).Iter()
 	defer closeIter(iter, &err, "reading application document")
+	force := args.Force != nil && *args.Force
 	for iter.Next(&application.doc) {
 		op := application.DestroyOperation()
 		op.RemoveOffers = true
+		op.Force = force
 		if err := st.ApplyOperation(op); err != nil {
 			return errors.Trace(err)
 		}
@@ -403,7 +429,7 @@ func (st *State) removeApplicationsForDyingModel() (err error) {
 	return nil
 }
 
-func (st *State) removeRemoteApplicationsForDyingModel() (err error) {
+func (st *State) removeRemoteApplicationsForDyingModel(args DestroyModelParams) (err error) {
 	// This won't miss remote applications, because a Dying model cannot have
 	// applications added to it. But we do have to remove the applications themselves
 	// via individual transactions, because they could be in any state at all.
@@ -413,8 +439,12 @@ func (st *State) removeRemoteApplicationsForDyingModel() (err error) {
 	sel := bson.D{{"life", Alive}}
 	iter := remoteApps.Find(sel).Iter()
 	defer closeIter(iter, &err, "reading remote application document")
+
+	force := args.Force != nil && *args.Force
 	for iter.Next(&remoteApp.doc) {
-		if err := remoteApp.Destroy(); err != nil {
+		// TODO (anastasiamac 2019-4-24) There may be some operational errors.
+		// Do something with with them.
+		if _, err := remoteApp.DestroyWithForce(force); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/model.go
+++ b/state/model.go
@@ -1198,7 +1198,7 @@ func (m *Model) destroyOps(
 				if errors.IsNotFound(err) {
 					continue
 				}
-				// TODO (anastasiamac 2019-4-24) we should not break out here but
+				// TODO (force 2019-4-24) we should not break out here but
 				// continue with other models.
 				return nil, errors.Trace(err)
 			}
@@ -1206,7 +1206,7 @@ func (m *Model) destroyOps(
 
 			model, err := newSt.Model()
 			if err != nil {
-				// TODO (anastasiamac 2019-4-24) we should not break out here but
+				// TODO (force 2019-4-24) we should not break out here but
 				// continue with other models.
 				return nil, errors.Trace(err)
 			}
@@ -1234,7 +1234,7 @@ func (m *Model) destroyOps(
 				aliveEmpty++
 			default:
 				if !IsModelNotEmptyError(err) {
-					// TODO (anastasiamac 2019-4-24) we should not break out here but
+					// TODO (force 2019-4-24) we should not break out here but
 					// continue with other models.
 					return nil, errors.Trace(err)
 				}
@@ -1262,13 +1262,15 @@ func (m *Model) destroyOps(
 		)
 	}
 
+	assert := isAliveDoc
+	if force {
+		assert = bson.D{{"life", m.Life()}}
+	}
 	var ops []txn.Op
 	modelOp := txn.Op{
-		C:  modelsC,
-		Id: modelUUID,
-		// TODO (anastasiamac 2019-4-24) when forcing, we might just consider if the document exists
-		//  instead of checking Life.
-		Assert: isAliveDoc,
+		C:      modelsC,
+		Id:     modelUUID,
+		Assert: assert,
 	}
 	if !destroyingController {
 		modelOp.Update = bson.D{

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -336,7 +336,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 
 	var eventsObserved int
 	observedEvent := func(flag *bool) {
-		if flag != nil && !*flag {
+		if flag == nil || !*flag {
 			*flag = true
 			eventsObserved++
 		}


### PR DESCRIPTION
## Description of change

Force has been added as an option to 'model-destroy' command in previous work. This PR ensures that backend is aware of it.

As a drive-by addressed some var names that collided with import names. 