### PR TITLE
Keep track of migration targets to show to users who need to login

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -168,6 +168,11 @@ type RedirectError struct {
 	// FollowRedirect is set to true for cases like JAAS where the client
 	// needs to automatically follow the redirect to the new controller.
 	FollowRedirect bool
+
+	// An optional alias for the controller the model got redirected to. It
+	// can be used by the client to present the user with a more meaningful
+	// juju login -c XYZ command
+	ControllerAlias string
 }
 
 func (e *RedirectError) Error() string {

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -260,13 +260,14 @@ func (c *Client) ConfigSet(values map[string]interface{}) error {
 // MigrationSpec holds the details required to start the migration of
 // a single model.
 type MigrationSpec struct {
-	ModelUUID            string
-	TargetControllerUUID string
-	TargetAddrs          []string
-	TargetCACert         string
-	TargetUser           string
-	TargetPassword       string
-	TargetMacaroons      []macaroon.Slice
+	ModelUUID             string
+	TargetControllerUUID  string
+	TargetControllerAlias string
+	TargetAddrs           []string
+	TargetCACert          string
+	TargetUser            string
+	TargetPassword        string
+	TargetMacaroons       []macaroon.Slice
 }
 
 // Validate performs sanity checks on the migration configuration it
@@ -310,12 +311,13 @@ func (c *Client) InitiateMigration(spec MigrationSpec) (string, error) {
 		Specs: []params.MigrationSpec{{
 			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
 			TargetInfo: params.MigrationTargetInfo{
-				ControllerTag: names.NewControllerTag(spec.TargetControllerUUID).String(),
-				Addrs:         spec.TargetAddrs,
-				CACert:        spec.TargetCACert,
-				AuthTag:       names.NewUserTag(spec.TargetUser).String(),
-				Password:      spec.TargetPassword,
-				Macaroons:     macsJSON,
+				ControllerTag:   names.NewControllerTag(spec.TargetControllerUUID).String(),
+				ControllerAlias: spec.TargetControllerAlias,
+				Addrs:           spec.TargetAddrs,
+				CACert:          spec.TargetCACert,
+				AuthTag:         names.NewUserTag(spec.TargetUser).String(),
+				Password:        spec.TargetPassword,
+				Macaroons:       macsJSON,
 			},
 		}},
 	}

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -116,12 +116,13 @@ func specToArgs(spec controller.MigrationSpec) params.InitiateMigrationArgs {
 		Specs: []params.MigrationSpec{{
 			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
 			TargetInfo: params.MigrationTargetInfo{
-				ControllerTag: names.NewControllerTag(spec.TargetControllerUUID).String(),
-				Addrs:         spec.TargetAddrs,
-				CACert:        spec.TargetCACert,
-				AuthTag:       names.NewUserTag(spec.TargetUser).String(),
-				Password:      spec.TargetPassword,
-				Macaroons:     string(macsJSON),
+				ControllerTag:   names.NewControllerTag(spec.TargetControllerUUID).String(),
+				ControllerAlias: spec.TargetControllerAlias,
+				Addrs:           spec.TargetAddrs,
+				CACert:          spec.TargetCACert,
+				AuthTag:         names.NewUserTag(spec.TargetUser).String(),
+				Password:        spec.TargetPassword,
+				Macaroons:       string(macsJSON),
 			},
 		}},
 	}
@@ -260,13 +261,14 @@ func makeSpec() controller.MigrationSpec {
 		panic(err)
 	}
 	return controller.MigrationSpec{
-		ModelUUID:            randomUUID(),
-		TargetControllerUUID: randomUUID(),
-		TargetAddrs:          []string{"1.2.3.4:5"},
-		TargetCACert:         "cert",
-		TargetUser:           "someone",
-		TargetPassword:       "secret",
-		TargetMacaroons:      []macaroon.Slice{{mac}},
+		ModelUUID:             randomUUID(),
+		TargetControllerUUID:  randomUUID(),
+		TargetControllerAlias: "target-controller",
+		TargetAddrs:           []string{"1.2.3.4:5"},
+		TargetCACert:          "cert",
+		TargetUser:            "someone",
+		TargetPassword:        "secret",
+		TargetMacaroons:       []macaroon.Slice{{mac}},
 	}
 }
 

--- a/api/state.go
+++ b/api/state.go
@@ -71,9 +71,10 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 			err := rpcErr.UnmarshalInfo(&redirInfo)
 			if err == nil && redirInfo.CACert != "" && len(redirInfo.Servers) != 0 {
 				return &RedirectError{
-					Servers:        redirInfo.Servers,
-					CACert:         redirInfo.CACert,
-					FollowRedirect: false, // user-action required
+					Servers:         redirInfo.Servers,
+					CACert:          redirInfo.CACert,
+					ControllerAlias: redirInfo.ControllerAlias,
+					FollowRedirect:  false, // user-action required
 				}
 			}
 		}

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -359,8 +359,9 @@ func (a *admin) maybeEmitRedirectError(modelUUID string, authTag names.Tag) erro
 		return errors.Trace(err)
 	}
 	return &common.RedirectError{
-		Servers: [][]network.HostPort{hps},
-		CACert:  target.CACert,
+		Servers:         [][]network.HostPort{hps},
+		CACert:          target.CACert,
+		ControllerAlias: target.ControllerAlias,
 	}
 }
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -692,11 +692,12 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 	mig, err := modelState.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
-			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
-			Addrs:         []string{"1.2.3.4:5555"},
-			CACert:        coretesting.CACert,
-			AuthTag:       names.NewUserTag("user2"),
-			Password:      "secret",
+			ControllerTag:   names.NewControllerTag(utils.MustNewUUID().String()),
+			ControllerAlias: "target",
+			Addrs:           []string{"1.2.3.4:5555"},
+			CACert:          coretesting.CACert,
+			AuthTag:         names.NewUserTag("user2"),
+			Password:        "secret",
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -725,6 +726,7 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 	c.Assert(redirErr.Servers, jc.DeepEquals, [][]network.HostPort{nhp})
 	c.Assert(redirErr.CACert, gc.Equals, coretesting.CACert)
 	c.Assert(redirErr.FollowRedirect, gc.Equals, false)
+	c.Assert(redirErr.ControllerAlias, gc.Equals, "target")
 
 	// Attempt to open an API connection to the migrated model as a user
 	// that had NO access to the model before it got migrated. The server

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -95,6 +95,9 @@ type RedirectError struct {
 
 	// CACert holds the certificate of the remote server.
 	CACert string `json:"ca-cert"`
+
+	// An optional alias for the controller where the model got redirected to.
+	ControllerAlias string `json:"controller-alias,omitempty"`
 }
 
 // Error implements the error interface.
@@ -283,8 +286,9 @@ func ServerError(err error) *params.Error {
 		redirErr := errors.Cause(err).(*RedirectError)
 		code = params.CodeRedirect
 		info = params.RedirectErrorInfo{
-			Servers: redirErr.Servers,
-			CACert:  redirErr.CACert,
+			Servers:         redirErr.Servers,
+			CACert:          redirErr.CACert,
+			ControllerAlias: redirErr.ControllerAlias,
 		}.AsMap()
 	default:
 		code = params.ErrCode(err)

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -536,12 +536,13 @@ func (c *ControllerAPI) initiateOneMigration(spec params.MigrationSpec) (string,
 		}
 	}
 	targetInfo := coremigration.TargetInfo{
-		ControllerTag: controllerTag,
-		Addrs:         specTarget.Addrs,
-		CACert:        specTarget.CACert,
-		AuthTag:       authTag,
-		Password:      specTarget.Password,
-		Macaroons:     macs,
+		ControllerTag:   controllerTag,
+		ControllerAlias: specTarget.ControllerAlias,
+		Addrs:           specTarget.Addrs,
+		CACert:          specTarget.CACert,
+		AuthTag:         authTag,
+		Password:        specTarget.Password,
+		Macaroons:       macs,
 	}
 
 	// Check if the migration is likely to succeed.

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -397,21 +397,23 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 			{
 				ModelTag: model1.ModelTag().String(),
 				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: randomControllerTag(),
-					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
-					CACert:        "cert1",
-					AuthTag:       names.NewUserTag("admin1").String(),
-					Password:      "secret1",
+					ControllerTag:   randomControllerTag(),
+					ControllerAlias: "", // intentionally left empty; simulates older client
+					Addrs:           []string{"1.1.1.1:1111", "2.2.2.2:2222"},
+					CACert:          "cert1",
+					AuthTag:         names.NewUserTag("admin1").String(),
+					Password:        "secret1",
 				},
 			}, {
 				ModelTag: model2.ModelTag().String(),
 				TargetInfo: params.MigrationTargetInfo{
-					ControllerTag: randomControllerTag(),
-					Addrs:         []string{"3.3.3.3:3333"},
-					CACert:        "cert2",
-					AuthTag:       names.NewUserTag("admin2").String(),
-					Macaroons:     string(macsJSON),
-					Password:      "secret2",
+					ControllerTag:   randomControllerTag(),
+					ControllerAlias: "target-controller",
+					Addrs:           []string{"3.3.3.3:3333"},
+					CACert:          "cert2",
+					AuthTag:         names.NewUserTag("admin2").String(),
+					Macaroons:       string(macsJSON),
+					Password:        "secret2",
 				},
 			},
 		},
@@ -441,6 +443,7 @@ func (s *controllerSuite) TestInitiateMigration(c *gc.C) {
 		targetInfo, err := mig.TargetInfo()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(targetInfo.ControllerTag.String(), gc.Equals, spec.TargetInfo.ControllerTag)
+		c.Check(targetInfo.ControllerAlias, gc.Equals, spec.TargetInfo.ControllerAlias)
 		c.Check(targetInfo.Addrs, jc.SameContents, spec.TargetInfo.Addrs)
 		c.Check(targetInfo.CACert, gc.Equals, spec.TargetInfo.CACert)
 		c.Check(targetInfo.AuthTag.String(), gc.Equals, spec.TargetInfo.AuthTag)

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -103,6 +103,9 @@ type RedirectErrorInfo struct {
 
 	// CACert holds the certificate of the remote server.
 	CACert string `json:"ca-cert"`
+
+	// An optional alias for the controller the model migrated to.
+	ControllerAlias string `json:"controller-alias,omitempty"`
 }
 
 // AsMap encodes the error info as a map that can be attached to an Error.

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -30,12 +30,13 @@ type MigrationSpec struct {
 // MigrationTargetInfo holds the details required to connect to and
 // authenticate with a remote controller for model migration.
 type MigrationTargetInfo struct {
-	ControllerTag string   `json:"controller-tag"`
-	Addrs         []string `json:"addrs"`
-	CACert        string   `json:"ca-cert"`
-	AuthTag       string   `json:"auth-tag"`
-	Password      string   `json:"password,omitempty"`
-	Macaroons     string   `json:"macaroons,omitempty"`
+	ControllerTag   string   `json:"controller-tag"`
+	ControllerAlias string   `json:"controller-alias,omitempty"`
+	Addrs           []string `json:"addrs"`
+	CACert          string   `json:"ca-cert"`
+	AuthTag         string   `json:"auth-tag"`
+	Password        string   `json:"password,omitempty"`
+	Macaroons       string   `json:"macaroons,omitempty"`
 }
 
 // InitiateMigrationResults is used to return the result of one or

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -113,12 +113,13 @@ func (c *migrateCommand) getMigrationSpec() (*controller.MigrationSpec, error) {
 	}
 
 	return &controller.MigrationSpec{
-		TargetControllerUUID: controllerInfo.ControllerUUID,
-		TargetAddrs:          controllerInfo.APIEndpoints,
-		TargetCACert:         controllerInfo.CACert,
-		TargetUser:           accountInfo.User,
-		TargetPassword:       accountInfo.Password,
-		TargetMacaroons:      macs,
+		TargetControllerUUID:  controllerInfo.ControllerUUID,
+		TargetControllerAlias: c.targetController,
+		TargetAddrs:           controllerInfo.APIEndpoints,
+		TargetCACert:          controllerInfo.CACert,
+		TargetUser:            accountInfo.User,
+		TargetPassword:        accountInfo.Password,
+		TargetMacaroons:       macs,
 	}, nil
 }
 

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -147,12 +147,13 @@ func (s *MigrateSuite) TestSuccess(c *gc.C) {
 
 	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
 	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
-		ModelUUID:            modelUUID,
-		TargetControllerUUID: targetControllerUUID,
-		TargetAddrs:          []string{"1.2.3.4:5"},
-		TargetCACert:         "cert",
-		TargetUser:           "targetuser",
-		TargetPassword:       "secret",
+		ModelUUID:             modelUUID,
+		TargetControllerUUID:  targetControllerUUID,
+		TargetControllerAlias: "target",
+		TargetAddrs:           []string{"1.2.3.4:5"},
+		TargetCACert:          "cert",
+		TargetUser:            "targetuser",
+		TargetPassword:        "secret",
 	})
 }
 
@@ -173,11 +174,12 @@ func (s *MigrateSuite) TestSuccessMacaroons(c *gc.C) {
 	s.api.specSeen.TargetMacaroons = nil
 	apitesting.MacaroonsEqual(c, macs, s.targetControllerAPI.macaroons)
 	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
-		ModelUUID:            modelUUID,
-		TargetControllerUUID: targetControllerUUID,
-		TargetAddrs:          []string{"1.2.3.4:5"},
-		TargetCACert:         "cert",
-		TargetUser:           "targetuser",
+		ModelUUID:             modelUUID,
+		TargetControllerUUID:  targetControllerUUID,
+		TargetControllerAlias: "target",
+		TargetAddrs:           []string{"1.2.3.4:5"},
+		TargetCACert:          "cert",
+		TargetUser:            "targetuser",
 	})
 }
 
@@ -196,12 +198,13 @@ func (s *MigrateSuite) TestMultipleModelMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
 	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
-		ModelUUID:            "prod-2-uuid",
-		TargetControllerUUID: targetControllerUUID,
-		TargetAddrs:          []string{"1.2.3.4:5"},
-		TargetCACert:         "cert",
-		TargetUser:           "targetuser",
-		TargetPassword:       "secret",
+		ModelUUID:             "prod-2-uuid",
+		TargetControllerUUID:  targetControllerUUID,
+		TargetControllerAlias: "target",
+		TargetAddrs:           []string{"1.2.3.4:5"},
+		TargetCACert:          "cert",
+		TargetUser:            "targetuser",
+		TargetPassword:        "secret",
 	})
 }
 

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -228,13 +228,18 @@ To access it run 'juju switch %s:%s'.`, modelName, existingName, existingName, m
 	// CACerts are always valid so no error checking is required here.
 	fingerprint, _ := cert.Fingerprint(redirErr.CACert)
 
+	ctrlAlias := "new-controller"
+	if redirErr.ControllerAlias != "" {
+		ctrlAlias = redirErr.ControllerAlias
+	}
+
 	var loginCmds []string
 	for _, endpoint := range allEndpoints {
-		loginCmds = append(loginCmds, fmt.Sprintf("  'juju login %s -c new-controller'", endpoint))
+		loginCmds = append(loginCmds, fmt.Sprintf("  'juju login %s -c %s'", endpoint, ctrlAlias))
 	}
 
 	mErr := fmt.Sprintf(`Model %q has been migrated to another controller.
-To access it run one of the following commands:
+To access it run one of the following commands (you can replace the -c argument with your own preferred controller name):
 %s
 
 New controller fingerprint [%s]`, modelName, strings.Join(loginCmds, "\n"), fingerprint)

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -22,6 +22,9 @@ type TargetInfo struct {
 	// ControllerTag holds tag for the target controller.
 	ControllerTag names.ControllerTag
 
+	// ControllerAlias holds an optional alias for the target controller.
+	ControllerAlias string
+
 	// Addrs holds the addresses and ports of the target controller's
 	// API servers.
 	Addrs []string

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -137,6 +137,9 @@ type modelMigDoc struct {
 	// TargetController holds the UUID of the target controller.
 	TargetController string `bson:"target-controller"`
 
+	// An optional alias for the controller the model got migrated to.
+	TargetControllerAlias string `bson:"target-controller-alias"`
+
 	// TargetAddrs holds the host:port values for the target API
 	// server.
 	TargetAddrs []string `bson:"target-addrs"`
@@ -278,12 +281,13 @@ func (mig *modelMigration) TargetInfo() (*migration.TargetInfo, error) {
 		return nil, errors.Trace(err)
 	}
 	return &migration.TargetInfo{
-		ControllerTag: names.NewControllerTag(mig.doc.TargetController),
-		Addrs:         mig.doc.TargetAddrs,
-		CACert:        mig.doc.TargetCACert,
-		AuthTag:       authTag,
-		Password:      mig.doc.TargetPassword,
-		Macaroons:     macs,
+		ControllerTag:   names.NewControllerTag(mig.doc.TargetController),
+		ControllerAlias: mig.doc.TargetControllerAlias,
+		Addrs:           mig.doc.TargetAddrs,
+		CACert:          mig.doc.TargetCACert,
+		AuthTag:         authTag,
+		Password:        mig.doc.TargetPassword,
+		Macaroons:       macs,
 	}, nil
 }
 
@@ -702,17 +706,18 @@ func (st *State) CreateMigration(spec MigrationSpec) (ModelMigration, error) {
 
 		id := fmt.Sprintf("%s:%d", modelUUID, attempt)
 		doc = modelMigDoc{
-			Id:               id,
-			ModelUUID:        modelUUID,
-			Attempt:          attempt,
-			InitiatedBy:      spec.InitiatedBy.Id(),
-			TargetController: spec.TargetInfo.ControllerTag.Id(),
-			TargetAddrs:      spec.TargetInfo.Addrs,
-			TargetCACert:     spec.TargetInfo.CACert,
-			TargetAuthTag:    spec.TargetInfo.AuthTag.String(),
-			TargetPassword:   spec.TargetInfo.Password,
-			TargetMacaroons:  macsJSON,
-			ModelUsers:       userDocs,
+			Id:                    id,
+			ModelUUID:             modelUUID,
+			Attempt:               attempt,
+			InitiatedBy:           spec.InitiatedBy.Id(),
+			TargetController:      spec.TargetInfo.ControllerTag.Id(),
+			TargetControllerAlias: spec.TargetInfo.ControllerAlias,
+			TargetAddrs:           spec.TargetInfo.Addrs,
+			TargetCACert:          spec.TargetInfo.CACert,
+			TargetAuthTag:         spec.TargetInfo.AuthTag.String(),
+			TargetPassword:        spec.TargetInfo.Password,
+			TargetMacaroons:       macsJSON,
+			ModelUsers:            userDocs,
 		}
 
 		statusDoc = modelMigStatusDoc{

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -46,12 +46,13 @@ func (s *MigrationSuite) SetUpTest(c *gc.C) {
 	s.stdSpec = state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
-			ControllerTag: targetControllerTag,
-			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
-			CACert:        "cert",
-			AuthTag:       names.NewUserTag("user"),
-			Password:      "password",
-			Macaroons:     []macaroon.Slice{{mac}},
+			ControllerTag:   targetControllerTag,
+			ControllerAlias: "target-controller",
+			Addrs:           []string{"1.2.3.4:5555", "4.3.2.1:6666"},
+			CACert:          "cert",
+			AuthTag:         names.NewUserTag("user"),
+			Password:        "password",
+			Macaroons:       []macaroon.Slice{{mac}},
 		},
 	}
 	// Before we get into the tests, ensure that all the creation events have flowed through the system.
@@ -84,6 +85,7 @@ func (s *MigrationSuite) TestCreate(c *gc.C) {
 	apitesting.MacaroonsEqual(c, infoMacs, s.stdSpec.TargetInfo.Macaroons)
 	s.stdSpec.TargetInfo.Macaroons = nil
 	c.Check(*info, jc.DeepEquals, s.stdSpec.TargetInfo)
+	c.Check(info.ControllerAlias, gc.Equals, s.stdSpec.TargetInfo.ControllerAlias)
 
 	assertPhase(c, mig, migration.QUIESCE)
 	c.Check(mig.PhaseChangedTime(), gc.Equals, mig.StartTime())


### PR DESCRIPTION
## Description of change

This PR contributes a UX enhancement to the changes introduced by #10069. When attempting to run any model-related command against a model that has been migrated to a different controller that is **not** locally known, juju would display an error message like `juju login $ip -c new-controller`. 

While this works, it is not the most user-friendly approach. For example, if the user runs the command _as-is_ twice for a different controller IP or they already have a controller named `new-controller` they will get an error.

To improve the UX for this use-case, this PR threads the controller name, the local `alias` used by the user initiating the migration, through the `InitiateMigration` API call and ensures it gets stored in the migration document for the model. When the server emits a `RedirectError` it includes the alias in the error payload which allows the client to display a more sensible value for the `-c` argument to `juju login`.

The alias itself is optional (older controllers do not keep track of it); the redirect error handling code will fall-back to the default `new-controller` value for the controller name if no alias is available. To avoid user confusion, the error wording has been tweaked slightly to indicate that the user is free to swap the `-c` argument value with any other value that makes sense for the user.

One could argue that the controller alias may have different meaning for the user that initiating the model migration vs the user who tries to run a command against the migrated model. However, we already do something similar for the [juju register](https://github.com/juju/juju/blob/develop/jujuclient/registration.go#L23) command.

## QA steps

```console
$ juju bootstrap lxd src
$ juju change-user-password 

$ juju bootstrap lxd dst
$ juju change-user-password

$ juju switch src:controller
$ juju add-model migrate

# At this point make a copy of your ~/.local/share/juju/models.yaml
# as the model uuid will probably be removed from src after migrating
$ juju migrate src:migrate dst

# wait a few seconds for the migration to complete and ensure that 
# the source controller in your local models.yaml still contains the 
# uuid for the model that just got migrated 

$ juju unregister dst

# Try any model-related command, e.g:
$ juju status -m migrate
ERROR Model "migrate" has been migrated to another controller.
To access it run one of the following commands (you can replace the -c argument with your own preferred controller name):
  'juju login 10.65.47.40:17070 -c dst'

New controller fingerprint [93:73:88:C9:9A:AA:EC:C8:85:AE:D1:33:E5:92:CE:95:0F:B6:00:82:21:CB:8C:A0:42:16:29:77:CF:6D:B6:D4]
```

## Documentation changes

@pmatulis there is a slight change in the error output (the bit in parentheses); we should probably update the docs to reflect the change.