### PR TITLE
Update goose.v2 sha to fix bug 1817242

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1396,7 +1396,7 @@
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:9a9b8033b631d8cf0d16e71fd815a6e90a8133efc81543784127a1e8d8b4687e"
+  digest = "1:3bc94878ebb5ec72f58047fc1a613de37ba4ef2b0c152480c2b6400fa3a875a8"
   name = "gopkg.in/goose.v2"
   packages = [
     ".",
@@ -1422,7 +1422,7 @@
     "testservices/swiftservice",
   ]
   pruneopts = ""
-  revision = "cf9b64132d71c47930543f2add6ddab0fc402147"
+  revision = "13b769d3462eedac5f8ec2458f8e61a0dfe54d51"
 
 [[projects]]
   digest = "1:445becf3878aa9bd50dfa972bd65f974ed2468c09350ab9ce28b1e4adce464df"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -488,7 +488,7 @@
 
 [[constraint]]
   name = "gopkg.in/goose.v2"
-  revision = "cf9b64132d71c47930543f2add6ddab0fc402147"
+  revision = "13b769d3462eedac5f8ec2458f8e61a0dfe54d51"
 
 [[override]]
   name = "gopkg.in/httprequest.v1"


### PR DESCRIPTION
## Description of change

Update goose.v2 sha to fix bug 1817242

## QA steps

Here are juju cloud and credential setup for my trial account:
https://pastebin.canonical.com/p/ccQChHYj9c/

novarc for openstack trial account:
https://pastebin.canonical.com/p/MsDhYVkvFh/

Create image metadata to bootstrap with:
source novarc
mkdir ~/simplestreams
juju metadata generate-image -d ~/simplestreams  -r $OS_REGION_NAME -u $OS_AUTH_URL -s xenial -i f99bb6f7-658d-4f7c-840d-40228ee22581
juju metadata generate-image -d ~/simplestreams  -r $OS_REGION_NAME -u $OS_AUTH_URL -s bionic -i 02e47341-017f-4cc5-a049-92bbeeb7310f

juju bootstrap  bluvalt --metadata-source ~/simplestreams
juju deploy ubuntu

## Documentation changes

no

## Bug reference

https://bugs.launchpad.net/juju/+bug/1817242
