### PR TITLE
Implement new k8s charm deployment metadata

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1461,7 +1461,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:96b43bfe348be6362e66b0c98dc2fe590d822633da7df13fba644f44e710a57e"
+  digest = "1:f6560765e17f77f08ebd7358a026f4ce6c2829123ce6f81b97e90aee8efb1613"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1469,7 +1469,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "ba56c9482e6c71e9ed79b1551754831bf9af8854"
+  revision = "b4861dc361873d2618454bcfb8656c6cb77fdf69"
 
 [[projects]]
   digest = "1:86df7d2874a5250cf64324e2ce4e88fea552aa1f5c1a3f065599bd1f381ce939"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "ba56c9482e6c71e9ed79b1551754831bf9af8854"
+  revision = "b4861dc361873d2618454bcfb8656c6cb77fdf69"
 
 [[constraint]]
   revision = "7778a447283bd71109671c20818544514e16e9d9"

--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -143,13 +143,20 @@ func (c *Client) WatchPodSpec(application string) (watcher.NotifyWatcher, error)
 	return w, nil
 }
 
+// DeploymentInfo holds deployment info from charm metadata.
+type DeploymentInfo struct {
+	DeploymentType string
+	ServiceType    string
+}
+
 // ProvisioningInfo holds unit provisioning info.
 type ProvisioningInfo struct {
-	PodSpec     string
-	Constraints constraints.Value
-	Filesystems []storage.KubernetesFilesystemParams
-	Devices     []devices.KubernetesDeviceParams
-	Tags        map[string]string
+	DeploymentInfo DeploymentInfo
+	PodSpec        string
+	Constraints    constraints.Value
+	Filesystems    []storage.KubernetesFilesystemParams
+	Devices        []devices.KubernetesDeviceParams
+	Tags           map[string]string
 }
 
 // ErrNoUnits is returned when trying to provision a caas app but
@@ -183,6 +190,12 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 		PodSpec:     result.PodSpec,
 		Constraints: result.Constraints,
 		Tags:        result.Tags,
+	}
+	if result.DeploymentInfo != nil {
+		info.DeploymentInfo = DeploymentInfo{
+			DeploymentType: result.DeploymentInfo.DeploymentType,
+			ServiceType:    result.DeploymentInfo.ServiceType,
+		}
 	}
 
 	for _, fs := range result.Filesystems {

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -49,6 +49,10 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 					PodSpec:     "foo",
 					Tags:        map[string]string{"foo": "bar"},
 					Constraints: constraints.MustParse("mem=4G"),
+					DeploymentInfo: &params.KubernetesDeploymentInfo{
+						DeploymentType: "stateful",
+						ServiceType:    "loadbalancer",
+					},
 					Filesystems: []params.KubernetesFilesystemParams{{
 						StorageName: "database",
 						Size:        uint64(100),
@@ -81,6 +85,10 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 		PodSpec:     "foo",
 		Tags:        map[string]string{"foo": "bar"},
 		Constraints: constraints.MustParse("mem=4G"),
+		DeploymentInfo: caasunitprovisioner.DeploymentInfo{
+			DeploymentType: "stateful",
+			ServiceType:    "loadbalancer",
+		},
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName:  "database",
 			Size:         uint64(100),

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -6,6 +6,7 @@ package caasunitprovisioner_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/facades/controller/caasunitprovisioner"
@@ -125,6 +126,7 @@ type mockApplication struct {
 	ops        *state.UpdateUnitsOperation
 	providerId string
 	addresses  []network.Address
+	charm      *mockCharm
 }
 
 func (*mockApplication) Tag() names.Tag {
@@ -155,6 +157,19 @@ func (a *mockApplication) SetScale(scale int) error {
 	a.MethodCall(a, "SetScale", scale)
 	a.scale = scale
 	return nil
+}
+
+type mockCharm struct {
+	meta charm.Meta
+}
+
+func (m *mockCharm) Meta() *charm.Meta {
+	return &m.meta
+}
+
+func (a *mockApplication) Charm() (caasunitprovisioner.Charm, bool, error) {
+	a.MethodCall(a, "Charm")
+	return a.charm, false, nil
 }
 
 func (a *mockApplication) GetPlacement() string {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -314,13 +314,26 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		modelConfig,
 	)
 
-	return &params.KubernetesProvisioningInfo{
+	ch, _, err := app.Charm()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	info := &params.KubernetesProvisioningInfo{
 		PodSpec:     podSpec,
 		Filesystems: filesystemParams,
 		Devices:     devices,
 		Constraints: mergedCons,
 		Tags:        resourceTags,
-	}, nil
+	}
+	deployInfo := ch.Meta().Deployment
+	if deployInfo != nil {
+		info.DeploymentInfo = &params.KubernetesDeploymentInfo{
+			DeploymentType: string(deployInfo.DeploymentType),
+			ServiceType:    string(deployInfo.ServiceType),
+		}
+	}
+	return info, nil
 }
 
 func filesystemParams(

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/clock/testclock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/juju/worker.v1/workertest"
 
@@ -160,6 +161,14 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 		&mockUnit{name: "gitlab/0", life: state.Dying},
 		&mockUnit{name: "gitlab/1", life: state.Alive},
 	}
+	s.st.application.charm = &mockCharm{
+		meta: charm.Meta{
+			Deployment: &charm.Deployment{
+				DeploymentType: charm.DeploymentStateful,
+				ServiceType:    charm.ServiceLoadBalancer,
+			},
+		},
+	}
 	s.storage.storageFilesystems[names.NewStorageTag("data/0")] = names.NewFilesystemTag("gitlab/1/0")
 	s.storage.storageAttachments[names.NewUnitTag("gitlab/1")] = names.NewStorageTag("data/0")
 
@@ -174,6 +183,10 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 		Results: []params.KubernetesProvisioningInfoResult{{
 			Result: &params.KubernetesProvisioningInfo{
 				PodSpec: "spec(gitlab)",
+				DeploymentInfo: &params.KubernetesDeploymentInfo{
+					DeploymentType: "stateful",
+					ServiceType:    "loadbalancer",
+				},
 				Filesystems: []params.KubernetesFilesystemParams{{
 					StorageName: "data",
 					Provider:    string(provider.K8s_ProviderType),

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -5,6 +5,7 @@ package caasunitprovisioner
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/controller"
@@ -82,6 +83,7 @@ type Application interface {
 	GetPlacement() string
 	SetOperatorStatus(sInfo status.StatusInfo) error
 	SetStatus(statusInfo status.StatusInfo) error
+	Charm() (Charm, bool, error)
 }
 
 type stateShim struct {
@@ -118,6 +120,14 @@ func (a applicationShim) AllUnits() ([]Unit, error) {
 		result[i] = u
 	}
 	return result, nil
+}
+
+func (a applicationShim) Charm() (Charm, bool, error) {
+	return a.Application.Charm()
+}
+
+type Charm interface {
+	Meta() *charm.Meta
 }
 
 type Unit interface {

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -9,14 +9,21 @@ import (
 	"github.com/juju/juju/core/constraints"
 )
 
+// KubernetesDeploymentInfo holds deployment info from charm metadata.
+type KubernetesDeploymentInfo struct {
+	DeploymentType string `json:"deployment-type"`
+	ServiceType    string `json:"service-type"`
+}
+
 // KubernetesProvisioningInfo holds unit provisioning info.
 type KubernetesProvisioningInfo struct {
-	PodSpec     string                       `json:"pod-spec"`
-	Constraints constraints.Value            `json:"constraints"`
-	Tags        map[string]string            `json:"tags,omitempty"`
-	Filesystems []KubernetesFilesystemParams `json:"filesystems,omitempty"`
-	Volumes     []KubernetesVolumeParams     `json:"volumes,omitempty"`
-	Devices     []KubernetesDeviceParams     `json:"devices,omitempty"`
+	DeploymentInfo *KubernetesDeploymentInfo    `json:"deployment-info,omitempty"`
+	PodSpec        string                       `json:"pod-spec"`
+	Constraints    constraints.Value            `json:"constraints"`
+	Tags           map[string]string            `json:"tags,omitempty"`
+	Filesystems    []KubernetesFilesystemParams `json:"filesystems,omitempty"`
+	Volumes        []KubernetesVolumeParams     `json:"volumes,omitempty"`
+	Devices        []KubernetesDeviceParams     `json:"devices,omitempty"`
 }
 
 // KubernetesProvisioningInfoResult holds unit provisioning info or an error.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -72,8 +72,34 @@ type NewContainerBrokerFunc func(args environs.OpenParams) (Broker, error)
 // StatusCallbackFunc represents a function that can be called to report a status.
 type StatusCallbackFunc func(appName string, settableStatus status.Status, info string, data map[string]interface{}) error
 
+// DeploymentType defines a deployment type.
+type DeploymentType string
+
+const (
+	DeploymentStateless DeploymentType = "stateless"
+	DeploymentStateful  DeploymentType = "stateful"
+)
+
+// ServiceType defines a service type.
+type ServiceType string
+
+const (
+	ServiceCluster      ServiceType = "cluster"
+	ServiceLoadBalancer ServiceType = "loadbalancer"
+	ServiceExternal     ServiceType = "external"
+)
+
+// DeploymentParams defines parameters for specifying how a service is deployed.
+type DeploymentParams struct {
+	DeploymentType DeploymentType
+	ServiceType    ServiceType
+}
+
 // ServiceParams defines parameters used to create a service.
 type ServiceParams struct {
+	// Deployment defines how a service is deployed.
+	Deployment DeploymentParams
+
 	// PodSpec is the spec used to configure a pod.
 	PodSpec *PodSpec
 

--- a/caas/kubernetes/provider/config.go
+++ b/caas/kubernetes/provider/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultServiceType           = string(core.ServiceTypeClusterIP)
+	defaultServiceType           = core.ServiceTypeClusterIP
 	defaultIngressClass          = "nginx"
 	defaultIngressSSLRedirect    = false
 	defaultIngressSSLPassthrough = false
@@ -89,7 +89,7 @@ var configFields = environschema.Fields{
 }
 
 var schemaDefaults = schema.Defaults{
-	serviceTypeConfigKey:     defaultServiceType,
+	serviceTypeConfigKey:     schema.Omit,
 	serviceAnnotationsKey:    schema.Omit,
 	ingressClassKey:          defaultIngressClass,
 	ingressSSLRedirectKey:    defaultIngressSSLRedirect,

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1085,6 +1085,76 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", basicPodspec)
+	c.Assert(err, jc.ErrorIsNil)
+	podSpec := provider.PodSpec(unitSpec)
+
+	numUnits := int32(2)
+	statefulSetArg := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "app-name",
+			Annotations: map[string]string{
+				"juju-app-uuid": "appuuid",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &numUnits,
+			Selector: &v1.LabelSelector{
+				MatchLabels: map[string]string{"juju-app": "app-name"},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"juju-app": "app-name"},
+					Annotations: map[string]string{
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+					},
+				},
+				Spec: podSpec,
+			},
+			PodManagementPolicy: apps.ParallelPodManagement,
+		},
+	}
+
+	serviceArg := *basicServiceArg
+	serviceArg.Spec.Type = core.ServiceTypeExternalName
+	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
+			Return(nil, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+			Return(nil, nil),
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Update(&serviceArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Create(&serviceArg).Times(1).
+			Return(nil, nil),
+	)
+
+	params := &caas.ServiceParams{
+		PodSpec: basicPodspec,
+		Deployment: caas.DeploymentParams{
+			DeploymentType: caas.DeploymentStateful,
+			ServiceType:    caas.ServiceExternal,
+		},
+	}
+	err = s.broker.EnsureService("app-name", nil, params, 2, application.ConfigAttributes{
+		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
+		"kubernetes-service-externalname":    "ext-name",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionCreate(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()

--- a/featuretests/cmdjuju_test.go
+++ b/featuretests/cmdjuju_test.go
@@ -219,11 +219,9 @@ application-config:
     source: unset
     type: string
   kubernetes-service-type:
-    default: ClusterIP
     description: determines how the Service is exposed
-    source: default
+    source: unset
     type: string
-    value: ClusterIP
   trust:
     default: false
     description: Does this application have access to trusted credentials

--- a/state/application.go
+++ b/state/application.go
@@ -1167,6 +1167,16 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 	if cfg.Charm.Meta().Subordinate != a.doc.Subordinate {
 		return errors.Errorf("cannot change an application's subordinacy")
 	}
+	currentCharm, err := a.st.Charm(a.doc.CharmURL)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if cfg.Charm.Meta().Deployment != currentCharm.Meta().Deployment {
+		if currentCharm.Meta().Deployment == nil ||
+			cfg.Charm.Meta().Deployment.DeploymentType != currentCharm.Meta().Deployment.DeploymentType {
+			return errors.New("cannot change a charm's deployment type")
+		}
+	}
 	// For old style charms written for only one series, we still retain
 	// this check. Newer charms written for multi-series have a URL
 	// with series = "".

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -164,6 +164,10 @@ func (w *deploymentWorker) loop() error {
 			ResourceTags: info.Tags,
 			Filesystems:  info.Filesystems,
 			Devices:      info.Devices,
+			Deployment: caas.DeploymentParams{
+				DeploymentType: caas.DeploymentType(info.DeploymentInfo.DeploymentType),
+				ServiceType:    caas.ServiceType(info.DeploymentInfo.ServiceType),
+			},
 		}
 		err = w.broker.EnsureService(w.application, w.provisioningStatusSetter.SetOperatorStatus, serviceParams, currentScale, appConfig)
 		if err != nil {

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -89,6 +89,10 @@ containers:
 		PodSpec:      &parsedSpec,
 		ResourceTags: map[string]string{"foo": "bar"},
 		Constraints:  constraints.MustParse("mem=4G"),
+		Deployment: caas.DeploymentParams{
+			DeploymentType: caas.DeploymentStateful,
+			ServiceType:    caas.ServiceLoadBalancer,
+		},
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
 			Size:        100,
@@ -124,6 +128,10 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		PodSpec:     containerSpec,
 		Tags:        map[string]string{"foo": "bar"},
 		Constraints: constraints.MustParse("mem=4G"),
+		DeploymentInfo: apicaasunitprovisioner.DeploymentInfo{
+			DeploymentType: "stateful",
+			ServiceType:    "loadbalancer",
+		},
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
 			Size:        100,


### PR DESCRIPTION
## Description of change

k8s charms have new (optional) deployment metadata for specifying stateful vs stateless deployment as well as service type. This PR adds the juju changes to make use of that metadata. ie a charm like gitlab without storage can still specify that a statefulset be used.

Also, a drive by fix for the error message when creating a duplicate controller.

## QA steps

deploy a k8s mediawiki charm with additional metadata
```yaml
deployment:
  type: stateful
  service: loadbalancer
```
Check that a statefulset is used and that the service type is correct.

## Documentation changes

There will be a discourse post.
