### PR TITLE
Fix/operator agentversion never updated

### DIFF
--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/gate"
@@ -58,6 +59,7 @@ type CaasOperatorAgent struct {
 	errReason        error
 	machineLock      machinelock.Lock
 
+	preUpgradeSteps upgrades.PreUpgradeStepsFunc
 	upgradeComplete gate.Lock
 
 	prometheusRegistry *prometheus.Registry
@@ -76,6 +78,7 @@ func NewCaasOperatorAgent(ctx *cmd.Context, bufferedLogger *logsender.BufferedLo
 		dead:               make(chan struct{}),
 		bufferedLogger:     bufferedLogger,
 		prometheusRegistry: prometheusRegistry,
+		preUpgradeSteps:    upgrades.PreUpgradeSteps,
 	}, nil
 }
 
@@ -214,6 +217,7 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		UpdateLoggerConfig:   updateAgentConfLogging,
 		PrometheusRegisterer: op.prometheusRegistry,
 		LeadershipGuarantee:  30 * time.Second,
+		PreUpgradeSteps:      op.preUpgradeSteps,
 		UpgradeStepsLock:     op.upgradeComplete,
 		ValidateMigration:    op.validateMigration,
 		MachineLock:          op.machineLock,

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -50,6 +50,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"migration-inactive-flag",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate",
+		"upgrade-steps-runner",
 		"upgrader",
 		// TODO(caas)
 		//"metric-spool",
@@ -182,10 +183,19 @@ var expectedOperatorManifoldsWithDependencies = map[string][]string{
 
 	"upgrade-steps-gate": {},
 
+	"upgrade-steps-runner": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"upgrade-steps-gate",
+	},
+
 	"upgrader": {
 		"agent",
 		"api-caller",
-		"api-config-watcher"},
+		"api-config-watcher",
+		"upgrade-steps-gate",
+	},
 
 	"clock": {},
 

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -297,7 +297,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		// The uniter installs charms; manages the unit's presence in its
-		// relations; creates suboordinate units; runs all the hooks; sends
+		// relations; creates subordinate units; runs all the hooks; sends
 		// metrics; etc etc etc. We expect to break it up further in the
 		// coming weeks, and to need one per unit in a consolidated agent
 		// (and probably one for each component broken out).

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -417,6 +417,7 @@ func (s *UpgradeSuite) runUpgradeWorker(c *gc.C, jobs ...multiwatcher.MachineJob
 		s.openStateForUpgrade,
 		s.preUpgradeSteps,
 		machineStatus,
+		false,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return worker.Wait(), config, machineStatus.Calls, doneLock


### PR DESCRIPTION

## Description of change

Fix: operators' `upgradedToVersion` in `agent.cfg` is not updated after `uprade-model`;

## QA steps

- prepare caas model;
- deploy workloads;
- upgrade-controller;
- upgrade-model;
- check `upgradedToVersion`;

```bash
$ mkubectl exec gitlab-k8s-operator-0  -n t1 -it cat /var/lib/juju/agents/application-gitlab-k8s/agent.conf | grep upgradedToVersion
```


## Documentation changes

None;

## Bug reference

No, not released yet;