### PR TITLE
Use params.HostPort to encode the payload of API Redirect errors

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -71,7 +71,7 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 			err := rpcErr.UnmarshalInfo(&redirInfo)
 			if err == nil && redirInfo.CACert != "" && len(redirInfo.Servers) != 0 {
 				return &RedirectError{
-					Servers:         redirInfo.Servers,
+					Servers:         params.NetworkHostsPorts(redirInfo.Servers),
 					CACert:          redirInfo.CACert,
 					ControllerAlias: redirInfo.ControllerAlias,
 					FollowRedirect:  false, // user-action required

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -286,7 +286,7 @@ func ServerError(err error) *params.Error {
 		redirErr := errors.Cause(err).(*RedirectError)
 		code = params.CodeRedirect
 		info = params.RedirectErrorInfo{
-			Servers:         redirErr.Servers,
+			Servers:         params.FromNetworkHostsPorts(redirErr.Servers),
 			CACert:          redirErr.CACert,
 			ControllerAlias: redirErr.ControllerAlias,
 		}.AsMap()

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -200,7 +200,10 @@ var errorTransformTests = []struct {
 	code:   params.CodeRedirect,
 	helperFunc: func(err error) bool {
 		err1, ok := err.(*params.Error)
-		exp := asMap(sampleRedirectError)
+		exp := asMap(params.RedirectErrorInfo{
+			Servers: params.FromNetworkHostsPorts(sampleRedirectError.Servers),
+			CACert:  sampleRedirectError.CACert,
+		})
 		if !ok || err1.Info == nil || !reflect.DeepEqual(err1.Info, exp) {
 			return false
 		}

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/network"
 	"github.com/juju/loggo"
 	"gopkg.in/macaroon.v2-unstable"
 )
@@ -99,7 +98,7 @@ func (e DischargeRequiredErrorInfo) AsMap() map[string]interface{} {
 // RedirectErrorInfo provides additional information for Redirect errors.
 type RedirectErrorInfo struct {
 	// Servers holds the sets of addresses of the redirected servers.
-	Servers [][]network.HostPort `json:"servers"`
+	Servers [][]HostPort `json:"servers"`
 
 	// CACert holds the certificate of the remote server.
 	CACert string `json:"ca-cert"`


### PR DESCRIPTION
## Description of change

The changes introduced by #10069 accidentally used `network.HostPort` to encode the payload for server `RedirectErrors` instead of `params.HostPort`. These two types are essentially the same with the difference that the latter generates **lower-cased** names for fields when encoding to json.