### PR TITLE
Follow 4.0 channel in juju-db snap

### DIFF
--- a/feature/flags.go
+++ b/feature/flags.go
@@ -40,7 +40,7 @@ const StrictMigration = "strict-migration"
 
 // OldPresence indicates that the old database presence implementation
 // should be used by the API server to determine agent presence.
-// This value is only checked using the controller config "features" attrubite.
+// This value is only checked using the controller config "features" attribute.
 const OldPresence = "old-presence"
 
 // LegacyLeases will switch all lease management to be handled by the

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -85,7 +85,7 @@ const (
 	Upgrading StorageEngine = "Upgrading"
 
 	// SnapTrack is the track to get the juju-db snap from
-	SnapTrack = "latest"
+	SnapTrack = "4.0"
 
 	// SnapRisk is which juju-db snap to use i.e. stable or edge.
 	SnapRisk = "stable"


### PR DESCRIPTION
## Description of change

Juju requires stability over time. Switching to the 4.0 channel minimises the chances that we'll encounter breaking API changes.  

## QA steps

**`JUJU_DEV_FEATURE_FLAGS=mongodb-snap juju bootstrap localhost s4`**
```
Creating Juju controller "s4" on localhost/localhost
...
Launching controller instance(s) on localhost/localhost...
 - juju-cba768-0 (arch=amd64)
...
Initial model "default" added
```

**`lxc exec juju-cba768-0 snap list juju-db`**
```
Name     Version  Rev  Tracking  Publisher  Notes
juju-db  4.0.9    16   4.0       juju-qa    -
```
From this output, we can determine that we're tracking the 4.0 channel.

## Documentation changes

None.

## Bug reference

- https://bugs.launchpad.net/juju/+bug/1826938