### PR TITLE
Remove- and detach- storage force and no/max-wait

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -97,7 +97,7 @@ var facadeVersions = map[string]int{
 	"Spaces":                       3,
 	"SSHClient":                    2,
 	"StatusHistory":                2,
-	"Storage":                      5,
+	"Storage":                      6,
 	"StorageProvisioner":           4,
 	"StringsWatcher":               1,
 	"Subnets":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -286,7 +286,8 @@ func AllFacades() *facade.Registry {
 
 	reg("Storage", 3, storage.NewStorageAPIV3)
 	reg("Storage", 4, storage.NewStorageAPIV4) // changes Destroy() method signature.
-	reg("Storage", 5, storage.NewStorageAPI)   // Update and Delete storage pools and CreatePool bulk calls.
+	reg("Storage", 5, storage.NewStorageAPIV5) // Update and Delete storage pools and CreatePool bulk calls.
+	reg("Storage", 6, storage.NewStorageAPI)   // modify Remove to support force and maxWait; adde DetachStorage to support force and maxWait.
 
 	reg("StorageProvisioner", 3, storageprovisioner.NewFacadeV3)
 	reg("StorageProvisioner", 4, storageprovisioner.NewFacadeV4)

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -86,7 +86,7 @@ type StorageBackend interface {
 	StorageInstanceVolume(names.StorageTag) (state.Volume, error)
 	StorageInstanceFilesystem(names.StorageTag) (state.Filesystem, error)
 	ReleaseStorageInstance(names.StorageTag, bool, bool, time.Duration) error
-	DetachStorage(names.StorageTag, names.UnitTag, bool) error
+	DetachStorage(names.StorageTag, names.UnitTag, bool, time.Duration) error
 
 	Filesystem(names.FilesystemTag) (state.Filesystem, error)
 	FilesystemAttachment(names.Tag, names.FilesystemTag) (state.FilesystemAttachment, error)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -556,10 +556,10 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
 		Application: application,
 	})
-	storage, err := s.storageBackend.AllStorageInstances()
+	testStorage, err := s.storageBackend.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(storage, gc.HasLen, 1)
-	storageVolume, err := s.storageBackend.StorageInstanceVolume(storage[0].StorageTag())
+	c.Assert(testStorage, gc.HasLen, 1)
+	storageVolume, err := s.storageBackend.StorageInstanceVolume(testStorage[0].StorageTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.storageBackend.SetVolumeInfo(storageVolume.VolumeTag(), state.VolumeInfo{
 		VolumeId:   "zing",
@@ -583,9 +583,9 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 	// Make the "data" storage volume Dead, releasing.
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storage[0].StorageTag(), true, false, dontWait)
+	err = s.storageBackend.ReleaseStorageInstance(testStorage[0].StorageTag(), true, false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storage[0].StorageTag(), unit.UnitTag(), false)
+	err = s.storageBackend.DetachStorage(testStorage[0].StorageTag(), unit.UnitTag(), false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
 	unitMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -680,10 +680,10 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
 		Application: application,
 	})
-	storage, err := s.storageBackend.AllStorageInstances()
+	testStorage, err := s.storageBackend.AllStorageInstances()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(storage, gc.HasLen, 1)
-	storageFilesystem, err := s.storageBackend.StorageInstanceFilesystem(storage[0].StorageTag())
+	c.Assert(testStorage, gc.HasLen, 1)
+	storageFilesystem, err := s.storageBackend.StorageInstanceFilesystem(testStorage[0].StorageTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.storageBackend.SetFilesystemInfo(storageFilesystem.FilesystemTag(), state.FilesystemInfo{
 		FilesystemId: "zing",
@@ -706,9 +706,9 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 	// Make the "data" storage filesystem Dead, releasing.
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.ReleaseStorageInstance(storage[0].StorageTag(), true, false, dontWait)
+	err = s.storageBackend.ReleaseStorageInstance(testStorage[0].StorageTag(), true, false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storage[0].StorageTag(), unit.UnitTag(), false)
+	err = s.storageBackend.DetachStorage(testStorage[0].StorageTag(), unit.UnitTag(), false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
 	unitMachineId, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -74,7 +74,9 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	newAPI := storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
 	s.apiv3 = &storage.StorageAPIv3{
 		StorageAPIv4: storage.StorageAPIv4{
-			StorageAPI: *newAPI,
+			StorageAPIv5: storage.StorageAPIv5{
+				StorageAPI: *newAPI,
+			},
 		},
 	}
 }

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -169,7 +169,7 @@ func (st *mockStorageAccessor) AttachStorage(storage names.StorageTag, unit name
 	return st.attachStorage(storage, unit)
 }
 
-func (st *mockStorageAccessor) DetachStorage(storage names.StorageTag, unit names.UnitTag, force bool) error {
+func (st *mockStorageAccessor) DetachStorage(storage names.StorageTag, unit names.UnitTag, force bool, maxWait time.Duration) error {
 	return st.detachStorage(storage, unit, force)
 }
 

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -54,7 +54,7 @@ type storageInterface interface {
 
 	// DetachStorage detaches the storage instance with the
 	// specified tag from the unit with the specified tag.
-	DetachStorage(names.StorageTag, names.UnitTag, bool) error
+	DetachStorage(names.StorageTag, names.UnitTag, bool, time.Duration) error
 
 	// DestroyStorageInstance destroys the storage instance with the specified tag.
 	DestroyStorageInstance(names.StorageTag, bool, bool, time.Duration) error

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -1212,9 +1212,6 @@ func (a *StorageAPI) UpdatePool(p params.StoragePoolArgs) (params.ErrorResults, 
 // code in rpc/rpcreflect/type.go:newMethod skips 2-argument methods,
 // so this removes the method as far as the RPC machinery is concerned.
 
-// Dropped from v6 onwards.
-func (*StorageAPI) Detach(_, _ struct{}) {}
-
 // Added in v6 api version
 func (*StorageAPIv5) DetachStorage(_, _ struct{}) {}
 

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -29,7 +29,7 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 )
 
-// StorageAPI implements the latest version (v5) of the Storage API which adds Update and Delete.
+// StorageAPI implements the latest version (v6) of the Storage API.
 type StorageAPI struct {
 	backend       backend
 	storageAccess storageAccess
@@ -40,9 +40,14 @@ type StorageAPI struct {
 	modelType     state.ModelType
 }
 
+// APIv5 implements the storage v5 API.
+type StorageAPIv5 struct {
+	StorageAPI
+}
+
 // APIv4 implements the storage v4 API adding AddToUnit, Import and Remove (replacing Destroy)
 type StorageAPIv4 struct {
-	StorageAPI
+	StorageAPIv5
 }
 
 // APIv3 implements the storage v3 API.
@@ -98,14 +103,25 @@ func newStorageAPI(
 	}
 }
 
-// NewStorageAPIV4 returns a new storage v4 API facade.
-func NewStorageAPIV4(context facade.Context) (*StorageAPIv4, error) {
+// NewStorageAPIV5 returns a new storage v5 API facade.
+func NewStorageAPIV5(context facade.Context) (*StorageAPIv5, error) {
 	storageAPI, err := NewStorageAPI(context)
 	if err != nil {
 		return nil, err
 	}
-	return &StorageAPIv4{
+	return &StorageAPIv5{
 		StorageAPI: *storageAPI,
+	}, nil
+}
+
+// NewStorageAPIV4 returns a new storage v4 API facade.
+func NewStorageAPIV4(context facade.Context) (*StorageAPIv4, error) {
+	storageAPI, err := NewStorageAPIV5(context)
+	if err != nil {
+		return nil, err
+	}
+	return &StorageAPIv4{
+		StorageAPIv5: *storageAPI,
 	}, nil
 }
 
@@ -257,7 +273,7 @@ func createStorageDetails(
 		}
 		statusEntity = volume
 	}
-	status, err := statusEntity.Status()
+	aStatus, err := statusEntity.Status()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -299,7 +315,7 @@ func createStorageDetails(
 		OwnerTag:    ownerTag,
 		Kind:        params.StorageKind(si.Kind()),
 		Life:        params.Life(si.Life().String()),
-		Status:      common.EntityStatusFromState(status),
+		Status:      common.EntityStatusFromState(aStatus),
 		Persistent:  persistent,
 		Attachments: storageAttachmentDetails,
 	}, nil
@@ -634,11 +650,11 @@ func createVolumeDetails(
 		}
 	}
 
-	status, err := v.Status()
+	aStatus, err := v.Status()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	details.Status = common.EntityStatusFromState(status)
+	details.Status = common.EntityStatusFromState(aStatus)
 
 	if storageTag, err := v.StorageInstance(); err == nil {
 		storageInstance, err := st.StorageInstance(storageTag)
@@ -800,11 +816,11 @@ func createFilesystemDetails(
 		}
 	}
 
-	status, err := f.Status()
+	aStatus, err := f.Status()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	details.Status = common.EntityStatusFromState(status)
+	details.Status = common.EntityStatusFromState(aStatus)
 
 	if storageTag, err := f.Storage(); err == nil {
 		storageInstance, err := st.StorageInstance(storageTag)
@@ -871,14 +887,14 @@ func (a *StorageAPI) addToUnit(args params.StoragesAddParams) (params.AddStorage
 			continue
 		}
 
-		tags, err := a.storageAccess.AddStorageForUnit(
+		storageTags, err := a.storageAccess.AddStorageForUnit(
 			u, one.StorageName, paramsToState(one.Constraints),
 		)
 		if err != nil {
 			result[i].Error = common.ServerError(err)
 		}
-		tagStrings := make([]string, len(tags))
-		for i, tag := range tags {
+		tagStrings := make([]string, len(storageTags))
+		for i, tag := range storageTags {
 			tagStrings[i] = tag.String()
 		}
 		result[i].Result = &params.AddStorageDetails{
@@ -918,19 +934,20 @@ func (a *StorageAPI) remove(args params.RemoveStorage) (params.ErrorResults, err
 		if !arg.DestroyStorage {
 			remove = a.storageAccess.ReleaseStorageInstance
 		}
-		result[i].Error = common.ServerError(
-			// TODO (anastasiamac 2019-04-04) We can now force storage removal
-			// but for now, while we have not an arg passed in, just hardcode.
-			remove(tag, arg.DestroyAttachments, false, time.Duration(0)),
-		)
+		force := arg.Force != nil && *arg.Force
+		result[i].Error = common.ServerError(remove(tag, arg.DestroyAttachments, force, common.MaxWait(arg.MaxWait)))
 	}
 	return params.ErrorResults{result}, nil
 }
 
-// Detach sets the specified storage attachments to Dying, unless they are
+// DetachStorage sets the specified storage attachments to Dying, unless they are
 // already Dying or Dead. Any associated, persistent storage will remain
-// alive.
-func (a *StorageAPI) Detach(args params.StorageAttachmentIds) (params.ErrorResults, error) {
+// alive. This call can be forced.
+func (a *StorageAPI) DetachStorage(args params.StorageDetachmentParams) (params.ErrorResults, error) {
+	return a.internalDetach(args.StorageIds, args.Force, args.MaxWait)
+}
+
+func (a *StorageAPI) internalDetach(args params.StorageAttachmentIds, force *bool, maxWait *time.Duration) (params.ErrorResults, error) {
 	if err := a.checkCanWrite(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
@@ -953,7 +970,7 @@ func (a *StorageAPI) Detach(args params.StorageAttachmentIds) (params.ErrorResul
 				return err
 			}
 		}
-		return a.detachStorage(storageTag, unitTag)
+		return a.detachStorage(storageTag, unitTag, force, maxWait)
 	}
 
 	result := make([]params.ErrorResult, len(args.Ids))
@@ -963,13 +980,19 @@ func (a *StorageAPI) Detach(args params.StorageAttachmentIds) (params.ErrorResul
 	return params.ErrorResults{result}, nil
 }
 
-func (a *StorageAPI) detachStorage(storageTag names.StorageTag, unitTag names.UnitTag) error {
+// Detach sets the specified storage attachments to Dying, unless they are
+// already Dying or Dead. Any associated, persistent storage will remain
+// alive.
+func (a *StorageAPIv5) Detach(args params.StorageAttachmentIds) (params.ErrorResults, error) {
+	return a.internalDetach(args, nil, nil)
+}
+
+func (a *StorageAPI) detachStorage(storageTag names.StorageTag, unitTag names.UnitTag, force *bool, maxWait *time.Duration) error {
+	forcing := force != nil && *force
 	if unitTag != (names.UnitTag{}) {
 		// The caller has specified a unit explicitly. Do
 		// not filter out "not found" errors in this case.
-		// TODO (anastasiamac 2019-04-04) We can now force storage removal
-		// but for now, while we have not an arg passed in, just hardcode.
-		return a.storageAccess.DetachStorage(storageTag, unitTag, false)
+		return a.storageAccess.DetachStorage(storageTag, unitTag, forcing, common.MaxWait(maxWait))
 	}
 	attachments, err := a.storageAccess.StorageAttachments(storageTag)
 	if err != nil {
@@ -985,9 +1008,7 @@ func (a *StorageAPI) detachStorage(storageTag names.StorageTag, unitTag names.Un
 		if att.Life() != state.Alive {
 			continue
 		}
-		// TODO (anastasiamac 2019-04-04) We can now force storage removal
-		// but for now, while we have not an arg passed in, just hardcode.
-		err := a.storageAccess.DetachStorage(storageTag, att.Unit(), false)
+		err := a.storageAccess.DetachStorage(storageTag, att.Unit(), forcing, common.MaxWait(maxWait))
 		if err != nil && !errors.IsNotFound(err) {
 			// We only care about NotFound errors if
 			// the user specified a unit explicitly.
@@ -1191,7 +1212,13 @@ func (a *StorageAPI) UpdatePool(p params.StoragePoolArgs) (params.ErrorResults, 
 // code in rpc/rpcreflect/type.go:newMethod skips 2-argument methods,
 // so this removes the method as far as the RPC machinery is concerned.
 
-// Added in current api version
+// Dropped from v6 onwards.
+func (*StorageAPI) Detach(_, _ struct{}) {}
+
+// Added in v6 api version
+func (*StorageAPIv5) DetachStorage(_, _ struct{}) {}
+
+// Added in v5 api version
 func (*StorageAPIv4) RemovePool(_, _ struct{}) {}
 func (*StorageAPIv4) UpdatePool(_, _ struct{}) {}
 

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -3,7 +3,11 @@
 
 package params
 
-import "github.com/juju/juju/storage"
+import (
+	"time"
+
+	"github.com/juju/juju/storage"
+)
 
 // MachineBlockDevices holds a machine tag and the block devices present
 // on that machine.
@@ -106,6 +110,20 @@ type StorageAttachmentId struct {
 // StorageAttachmentIds holds a set of storage attachment identifiers.
 type StorageAttachmentIds struct {
 	Ids []StorageAttachmentId `json:"ids"`
+}
+
+type StorageDetachmentParams struct {
+	// StorageIds to detach
+	StorageIds StorageAttachmentIds `json:"ids"`
+
+	// Force specifies whether relation destruction will be forced, i.e.
+	// keep going despite operational errors.
+	Force *bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in relation destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // StorageAttachmentIdsResult holds the result of an API call to retrieve the
@@ -862,6 +880,15 @@ type RemoveStorageInstance struct {
 	// is destroyed. If DestroyStorage is true, the cloud storage will be
 	// destroyed; otherwise it will only be released from Juju's control.
 	DestroyStorage bool `json:"destroy-storage,omitempty"`
+
+	// Force specifies whether relation destruction will be forced, i.e.
+	// keep going despite operational errors.
+	Force *bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in relation destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // BulkImportStorageParams contains the parameters for importing a collection

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -63,7 +63,7 @@ that --force will also remove all units of the application, its subordinates
 and, potentially, machines without given them the opportunity to shutdown cleanly.
 
 Application removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished. 
+proceed to a next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -42,7 +42,7 @@ all operational errors. In these rare cases, use --force option but note
 that --force will remove a relation without giving it the opportunity to be removed cleanly.
 
 Relation removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished. 
+proceed to a next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -75,7 +75,7 @@ that --force will remove a unit and, potentially, its machine without
 given them the opportunity to shutdown cleanly.
 
 Unit removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished.
+proceed to a next step until the current step has finished.
 However, when using --force, users can also specify --no-wait to progress through steps
 without delay waiting for each step to complete.
 

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -50,7 +50,7 @@ option; this will also remove those units and containers without giving
 them an opportunity to shut down cleanly.
 
 Machine removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished. 
+proceed to a next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -90,7 +90,7 @@ that --force will also remove all units of the application, its subordinates
 and, potentially, machines without given them the opportunity to shutdown cleanly.
 
 Model destruction is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished. 
+proceed to a next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/storage/detach.go
+++ b/cmd/juju/storage/detach.go
@@ -44,7 +44,7 @@ Detaching storage may fail but under some circumstances, Juju user may need
 to force storage detachment despite operational errors. 
 
 Storage detachment is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished. 
+proceed to a next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/storage/detach.go
+++ b/cmd/juju/storage/detach.go
@@ -43,16 +43,10 @@ removed by an operator.
 Detaching storage may fail but under some circumstances, Juju user may need 
 to force storage detachment despite operational errors. 
 
-Storage detachment is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished. 
-However, when using --force, users can also specify --no-wait to progress through steps 
-without delay waiting for each step to complete.
-
 
 Examples:
     juju detach-storage pgdata/0
     juju detach-storage --force pgdata/0
-    juju detach-storage --force --no-wait pgdata/0
 `
 
 	detachStorageCommandArgs = `<storage> [<storage> ...]`
@@ -83,7 +77,6 @@ func (c *detachStorageCommand) Init(args []string) error {
 func (c *detachStorageCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.StorageCommandBase.SetFlags(f)
 	f.BoolVar(&c.Force, "force", false, "Forcefully detach storage")
-	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through storage detachment without waiting for each individual step to complete")
 	c.fs = f
 }
 

--- a/cmd/juju/storage/detach_test.go
+++ b/cmd/juju/storage/detach_test.go
@@ -40,16 +40,6 @@ detaching bar/1
 `[1:])
 }
 
-func (s *DetachStorageSuite) TestDetachNoWaitNoForce(c *gc.C) {
-	fake := fakeEntityDetacher{results: []params.ErrorResult{
-		{},
-		{},
-	}}
-	command := storage.NewDetachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
-	_, err := cmdtesting.RunCommand(c, command, "--no-wait", "foo/0", "bar/1")
-	c.Assert(err, gc.ErrorMatches, "--no-wait without --force not valid")
-}
-
 func (s *DetachStorageSuite) TestDetachError(c *gc.C) {
 	fake := fakeEntityDetacher{results: []params.ErrorResult{
 		{Error: &params.Error{Message: "foo"}},

--- a/cmd/juju/storage/detach_test.go
+++ b/cmd/juju/storage/detach_test.go
@@ -4,12 +4,13 @@
 package storage_test
 
 import (
+	"time"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"time"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"

--- a/cmd/juju/storage/remove.go
+++ b/cmd/juju/storage/remove.go
@@ -36,7 +36,7 @@ is attached to any units. To override this behaviour,
 you can use "juju remove-storage --force".
 
 Storage removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step finished. 
+proceed to a next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/storage/remove.go
+++ b/cmd/juju/storage/remove.go
@@ -35,18 +35,12 @@ By default, remove-storage will fail if the storage
 is attached to any units. To override this behaviour,
 you can use "juju remove-storage --force".
 
-Storage removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished. 
-However, when using --force, users can also specify --no-wait to progress through steps 
-without delay waiting for each step to complete.
-
 Examples:
     # Remove the detached storage pgdata/0.
     juju remove-storage pgdata/0
 
     # Remove the possibly attached storage pgdata/0.
     juju remove-storage --force pgdata/0
-    juju remove-storage --force --no-wait pgdata/0
 
     # Remove the storage pgdata/0, without destroying
     # the corresponding cloud storage.
@@ -81,7 +75,6 @@ func (c *removeStorageCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.StorageCommandBase.SetFlags(f)
 	f.BoolVar(&c.force, "force", false, "Remove storage even if it is currently attached")
 	f.BoolVar(&c.noDestroy, "no-destroy", false, "Remove the storage without destroying it")
-	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through storage removal without waiting for each individual step to complete")
 	c.fs = f
 }
 

--- a/cmd/juju/storage/remove_test.go
+++ b/cmd/juju/storage/remove_test.go
@@ -52,16 +52,6 @@ func (s *RemoveStorageSuite) TestRemoveStorageForce(c *gc.C) {
 	fake.CheckCall(c, 1, "Remove", []string{"pgdata/0", "pgdata/1"}, true, true, &force, (*time.Duration)(nil))
 }
 
-func (s *RemoveStorageSuite) TestRemoveStorageNoWaitNoForce(c *gc.C) {
-	fake := fakeStorageRemover{results: []params.ErrorResult{
-		{},
-		{},
-	}}
-	command := storage.NewRemoveStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
-	_, err := cmdtesting.RunCommand(c, command, "--no-wait", "pgdata/0", "pgdata/1")
-	c.Assert(err, gc.ErrorMatches, "--no-wait without --force not valid")
-}
-
 func (s *RemoveStorageSuite) TestRemoveStorageNoDestroy(c *gc.C) {
 	fake := fakeStorageRemover{results: []params.ErrorResult{
 		{},

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -745,7 +745,7 @@ func (s *FilesystemIAASModelSuite) TestRemoveStorageInstanceDestroysAndUnassigns
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.storageBackend.DestroyStorageInstance(storageTag, true, false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storageTag, unitTag, false)
+	err = s.storageBackend.DetachStorage(storageTag, unitTag, false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The storage instance and attachment are dying, but not yet
@@ -784,7 +784,7 @@ func (s *FilesystemIAASModelSuite) TestReleaseStorageInstanceFilesystemReleasing
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.storageBackend.ReleaseStorageInstance(storageTag, true, false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false)
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The filesystem should should be dying, and releasing.
@@ -806,7 +806,7 @@ func (s *FilesystemIAASModelSuite) TestReleaseStorageInstanceFilesystemUnreleasa
 	err = s.storageBackend.ReleaseStorageInstance(storageTag, true, false, dontWait)
 	c.Assert(err, gc.ErrorMatches,
 		`cannot release storage "data/0": storage provider "modelscoped-unreleasable" does not support releasing storage`)
-	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false)
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false, dontWait)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The filesystem should should be dying, and releasing.

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -214,7 +214,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplication(c *gc.C) {
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	for _, storageTag := range storageTags {
-		err = sb.DetachStorage(storageTag, unit.UnitTag(), false)
+		err = sb.DetachStorage(storageTag, unit.UnitTag(), false, dontWait)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	for _, volumeTag := range volumeTags {

--- a/state/storage.go
+++ b/state/storage.go
@@ -492,11 +492,11 @@ func (sb *storageBackend) destroyStorageInstanceOps(
 }
 
 func checkStoragePoolReleasable(im *storageBackend, pool string) error {
-	providerType, provider, _, err := poolStorageProvider(im, pool)
+	providerType, aProvider, _, err := poolStorageProvider(im, pool)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if !provider.Releasable() {
+	if !aProvider.Releasable() {
 		return errors.Errorf(
 			"storage provider %q does not support releasing storage",
 			providerType,
@@ -1194,7 +1194,7 @@ func (sb *storageBackend) DestroyUnitStorageAttachments(unit names.UnitTag) (err
 
 // DetachStorage ensures that the storage attachment will be
 // removed at some point.
-func (sb *storageBackend) DetachStorage(storage names.StorageTag, unit names.UnitTag, force bool) (err error) {
+func (sb *storageBackend) DetachStorage(storage names.StorageTag, unit names.UnitTag, force bool, maxWait time.Duration) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot destroy storage attachment %s:%s", storage.Id(), unit.Id())
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		s, err := sb.storageAttachment(storage, unit)
@@ -1841,18 +1841,18 @@ func validateStoragePool(
 	if poolName == "" {
 		return errors.New("pool name is required")
 	}
-	providerType, provider, poolConfig, err := poolStorageProvider(sb, poolName)
+	providerType, aProvider, poolConfig, err := poolStorageProvider(sb, poolName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// Ensure the storage provider supports the specified kind.
-	kindSupported := provider.Supports(kind)
+	kindSupported := aProvider.Supports(kind)
 	if !kindSupported && kind == storage.StorageKindFilesystem {
 		// Filesystems can be created if either filesystem
 		// or block storage are supported. The scope of the
 		// filesystem is the same as the backing volume.
-		kindSupported = provider.Supports(storage.StorageKindBlock)
+		kindSupported = aProvider.Supports(storage.StorageKindBlock)
 	}
 	if !kindSupported {
 		return errors.Errorf("%q provider does not support %q storage", providerType, kind)
@@ -1860,7 +1860,7 @@ func validateStoragePool(
 
 	// Check the storage scope.
 	if machineId != nil {
-		switch provider.Scope() {
+		switch aProvider.Scope() {
 		case storage.ScopeMachine:
 			if *machineId == "" {
 				return errors.Annotate(err, "machine unspecified for machine-scoped storage")
@@ -1890,22 +1890,22 @@ func poolStorageProvider(sb *storageBackend, poolName string) (storage.ProviderT
 		// If there's no pool called poolName, maybe a provider type
 		// has been specified directly.
 		providerType := storage.ProviderType(poolName)
-		provider, err1 := sb.registry.StorageProvider(providerType)
+		aProvider, err1 := sb.registry.StorageProvider(providerType)
 		if err1 != nil {
 			// The name can't be resolved as a storage provider type,
 			// so return the original "pool not found" error.
 			return "", nil, nil, errors.Trace(err)
 		}
-		return providerType, provider, nil, nil
+		return providerType, aProvider, nil, nil
 	} else if err != nil {
 		return "", nil, nil, errors.Trace(err)
 	}
 	providerType := pool.Provider()
-	provider, err := sb.registry.StorageProvider(providerType)
+	aProvider, err := sb.registry.StorageProvider(providerType)
 	if err != nil {
 		return "", nil, nil, errors.Trace(err)
 	}
-	return providerType, provider, pool.Attrs(), nil
+	return providerType, aProvider, pool.Attrs(), nil
 }
 
 // ErrNoDefaultStoragePool is returned when a storage pool is required but none

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -167,10 +167,10 @@ func (ctx *context) apiLogin(c *gc.C) {
 	apiConn := ctx.s.OpenAPIAs(c, ctx.unit.Tag(), password)
 	c.Assert(apiConn, gc.NotNil)
 	c.Logf("API: login as %q successful", ctx.unit.Tag())
-	api, err := apiConn.Uniter()
+	testApi, err := apiConn.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(api, gc.NotNil)
-	ctx.api = api
+	c.Assert(testApi, gc.NotNil)
+	ctx.api = testApi
 	ctx.apiConn = apiConn
 	ctx.leaderTracker = newMockLeaderTracker(ctx)
 	ctx.leaderTracker.setLeader(c, true)
@@ -374,9 +374,9 @@ func (s addCharm) step(c *gc.C, ctx *context) {
 type serveCharm struct{}
 
 func (s serveCharm) step(c *gc.C, ctx *context) {
-	storage := storage.NewStorage(ctx.st.ModelUUID(), ctx.st.MongoSession())
+	testStorage := storage.NewStorage(ctx.st.ModelUUID(), ctx.st.MongoSession())
 	for storagePath, data := range ctx.charms {
-		err := storage.Put(storagePath, bytes.NewReader(data), int64(len(data)))
+		err := testStorage.Put(storagePath, bytes.NewReader(data), int64(len(data)))
 		c.Assert(err, jc.ErrorIsNil)
 		delete(ctx.charms, storagePath)
 	}
@@ -1776,6 +1776,7 @@ func (s destroyStorageAttachment) step(c *gc.C, ctx *context) {
 		storageAttachments[0].StorageInstance(),
 		ctx.unit.UnitTag(),
 		false,
+		time.Duration(0),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
## Description of change

remove-storage and detach-storage commands gain 'force' and 'no-wait' options that are propagated to apiserver.

This Pr includes a facade version bump.

Drive-by: renamed variables that conflicted with imports names.