### PR TITLE
Server-side migration pre-checks to ensure model users are present in destination before migrating

### DIFF
--- a/apiserver/facades/client/controller/controller_internal_test.go
+++ b/apiserver/facades/client/controller/controller_internal_test.go
@@ -1,0 +1,104 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&controllerSuite{})
+
+type controllerSuite struct{}
+
+func (s *controllerSuite) TestUserListCompatibility(c *gc.C) {
+	extProvider1 := "https://api.jujucharms.com/identity"
+	extProvider2 := "http://candid.provider/identity"
+	specs := []struct {
+		descr    string
+		src, dst userList
+		expErr   string
+	}{
+		{
+			descr: `all src users present in dst`,
+			src: userList{
+				users: set.NewStrings("foo", "bar"),
+			},
+			dst: userList{
+				users: set.NewStrings("foo", "bar"),
+			},
+		},
+		{
+			descr: `local src users present in dst, and an external user has been granted access, and src/dst use the same identity provider url`,
+			src: userList{
+				users:       set.NewStrings("foo", "bar@external"),
+				identityURL: extProvider1,
+			},
+			dst: userList{
+				users:       set.NewStrings("foo"),
+				identityURL: extProvider1,
+			},
+		},
+		{
+			descr: `some local src users not present in dst`,
+			src: userList{
+				users: set.NewStrings("foo", "bar"),
+			},
+			dst: userList{
+				users: set.NewStrings("bar"),
+			},
+			expErr: `cannot initiate migration as the users granted access to the model do not exist
+on the destination controller. To resolve this issue you can add the following
+users to the destination controller or remove them from the current model:
+  - foo`,
+		},
+		{
+			descr: `local src users present in dst, and an external user has been granted access, and src/dst use different identity provider URL`,
+			src: userList{
+				users:       set.NewStrings("foo", "bar@external"),
+				identityURL: extProvider1,
+			},
+			dst: userList{
+				users:       set.NewStrings("foo", "bar@external"),
+				identityURL: extProvider2,
+			},
+			expErr: `cannot initiate migration as external users have been granted access to the model
+and the two controllers have different identity provider configurations. To resolve
+this issue you can remove the following users from the current model:
+  - bar@external`,
+		},
+		{
+			descr: `not all local src users present in dst, and an external user has been granted access, and src/dst use different identity provider URL`,
+			src: userList{
+				users:       set.NewStrings("foo", "bar@external"),
+				identityURL: extProvider1,
+			},
+			dst: userList{
+				users:       set.NewStrings("baz", "bar@external"),
+				identityURL: extProvider2,
+			},
+			expErr: `cannot initiate migration as external users have been granted access to the model
+and the two controllers have different identity provider configurations. To resolve
+this issue you need to remove the following users from the current model:
+  - bar@external
+
+and add the following users to the destination controller or remove them from
+the current model:
+  - foo`,
+		},
+	}
+
+	for specIndex, spec := range specs {
+		c.Logf("test %d: %s", specIndex, spec.descr)
+
+		err := spec.src.checkCompatibilityWith(spec.dst)
+		if spec.expErr == "" {
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(err, gc.Not(gc.Equals), nil)
+			c.Assert(err.Error(), gc.Equals, spec.expErr)
+		}
+	}
+}


### PR DESCRIPTION
## Description of change

This PR implements the server-side equivalent of the changes introduced by #10092 because as we all know: _you can never trust the client_.

Side-note: the facade tests for the InitiateMigration RPC tend to patch the pre-check code so it returns a nil value. As the introduced code runs as part of that pre-check and it is also expected to make extra calls to the target controller I have added an internal (in the `controller` package) test-suite so I could just check the user comparison logic without having to set up elaborate multi-controller tests.

## QA steps

**IMPORTANT**: you must bootstrap the controllers with this branch but when running juju commands you need to use an **older** client (e.g 2.5). 

### Happy path 1: shared local users

```console
$ juju bootstrap lxd src
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig

$ juju bootstrap lxd dst
$ juju add-user foo 

$ juju migrate src:mig dst
 Migration started with ID "45967f61-1991-4340-8c14-f3cdf2682d35:0"
```

### Happy path 2: shared local users and same identity providers 

```console
$ juju bootstrap lxd src --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig
$ juju grant me@external write mig

$ juju bootstrap lxd dst --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-user foo 

$ juju migrate src:mig dst
Migration started with ID "fe066fbe-cec4-4efd-8e46-e77465e08c22:0"
```
### Local user missing from target

```console
$ juju bootstrap lxd src
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig

$ juju bootstrap lxd dst

$ juju migrate src:mig dst
ERROR cannot initiate migration as the users granted access to the model do not exist
on the destination controller. To resolve this issue you can add the following
users to the destination controller or remove them from the current model:
  - foo
```

### Shared local users, different identity providers and granted access to external user

```console
$ juju bootstrap lxd src --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig
$ juju grant me@external write mig

$ juju bootstrap lxd dst --config identity-url=https://candid.provider/identity --config allow-model-access=true
$ juju add-user foo

$ juju migrate src:mig dst
ERROR cannot initiate migration as external users have been granted access to the model
and the two controllers have different identity provider configurations. To resolve
this issue you can remove the following users from the current model:
  - me@external
```

### Not shared local users, different identity providers and granted access to external user

```console
$ juju bootstrap lxd src --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju add-model mig
$ juju add-user foo 
$ juju grant foo read mig
$ juju grant me@external write mig

$ juju bootstrap lxd dst --config identity-url=https://candid.provider/identity --config allow-model-access=true

$ juju migrate src:mig dst
ERROR cannot initiate migration as external users have been granted access to the model
and the two controllers have different identity provider configurations. To resolve
this issue you need to remove the following users from the current model:
  - me@external

and add the following users to the destination controller or remove them from
the current model:
  - foo
```
