### PR TITLE
Pass max-wait to unit/app destroy to state. 

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1375,6 +1375,9 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 		op := unit.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
 		op.Force = arg.Force
+		if arg.Force {
+			op.MaxWait = common.MaxWait(arg.MaxWait)
+		}
 		if err := api.backend.ApplyOperation(op); err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1507,6 +1510,9 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 		op := app.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
 		op.Force = arg.Force
+		if arg.Force {
+			op.MaxWait = common.MaxWait(arg.MaxWait)
+		}
 		if err := api.backend.ApplyOperation(op); err != nil {
 			return nil, err
 		}

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -41,16 +41,10 @@ However, at times, there is a need to remove a relation ignoring
 all operational errors. In these rare cases, use --force option but note 
 that --force will remove a relation without giving it the opportunity to be removed cleanly.
 
-Relation removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished. 
-However, when using --force, users can also specify --no-wait to progress through steps 
-without delay waiting for each step to complete.
-
 Examples:
     juju remove-relation mysql wordpress
     juju remove-relation 4
     juju remove-relation 4 --force
-    juju remove-relation 4 --force --no-wait
 
 In the case of multiple relations, the relation name should be specified
 at least once - the following examples will all have the same effect:
@@ -114,7 +108,6 @@ func (c *removeRelationCommand) Init(args []string) (err error) {
 func (c *removeRelationCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.Force, "force", false, "Force remove a relation")
-	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through relation removal without waiting for each individual step to complete")
 	c.fs = f
 }
 

--- a/cmd/juju/application/removerelation_test.go
+++ b/cmd/juju/application/removerelation_test.go
@@ -52,16 +52,6 @@ func (s *RemoveRelationSuite) TestRemoveRelationWrongNumberOfArguments(c *gc.C) 
 	c.Assert(err, gc.ErrorMatches, "a relation must involve two applications")
 }
 
-func (s *RemoveRelationSuite) TestRemoveRelationNoWaitWithoutForce(c *gc.C) {
-	// with relation id
-	err := s.runRemoveRelation(c, "123", "--no-wait")
-	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
-
-	// with relation applications
-	err = s.runRemoveRelation(c, "application1", "application2", "--no-wait")
-	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
-}
-
 func (s *RemoveRelationSuite) TestRemoveRelationIdOldServer(c *gc.C) {
 	s.mockAPI.version = 4
 	err := s.runRemoveRelation(c, "123")


### PR DESCRIPTION
## Description of change

Max wait has been wired everywhere except not actually passed in into state from apiserver.
This PR adds this last link.

As a drive-by: Hide no-wait in remove-relation CLI.