### PR TITLE
Ensure unit status get/set uses new leadership

### DIFF
--- a/api/uniter/application_test.go
+++ b/api/uniter/application_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api/leadership"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/status"
@@ -142,11 +143,12 @@ func (s *applicationSuite) TestApplicationStatus(c *gc.C) {
 	s.claimLeadership(c, s.wordpressUnit, s.wordpressApplication)
 	result, err = s.apiApplication.Status(s.wordpressUnit.Name())
 	c.Check(err, jc.ErrorIsNil)
+	c.Check(result.Error, gc.IsNil)
 	c.Check(result.Application.Status, gc.Equals, status.Active.String())
 }
 
 func (s *applicationSuite) claimLeadership(c *gc.C, unit *state.Unit, app *state.Application) {
-	claimer := s.State.LeadershipClaimer()
+	claimer := leadership.NewClient(s.st)
 	err := claimer.ClaimLeadership(app.Name(), unit.Name(), time.Minute)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -6,12 +6,14 @@ package common_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing/factory"
@@ -90,18 +92,18 @@ func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
 	c.Assert(unitStatus.Status, gc.Equals, status.Maintenance.String())
 }
 
-func (s *statusGetterSuite) TestGetServiceStatus(c *gc.C) {
-	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
+func (s *statusGetterSuite) TestGetApplicationStatus(c *gc.C) {
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
-		service.Tag().String(),
+		app.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	serviceStatus := result.Results[0]
-	c.Assert(serviceStatus.Error, gc.IsNil)
-	c.Assert(serviceStatus.Status, gc.Equals, status.Maintenance.String())
+	appStatus := result.Results[0]
+	c.Assert(appStatus.Error, gc.IsNil)
+	c.Assert(appStatus.Status, gc.Equals, status.Maintenance.String())
 }
 
 func (s *statusGetterSuite) TestBulk(c *gc.C) {
@@ -122,22 +124,22 @@ func (s *statusGetterSuite) TestBulk(c *gc.C) {
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
 }
 
-type serviceStatusGetterSuite struct {
+type applicationStatusGetterSuite struct {
 	statusBaseSuite
 	getter *common.ApplicationStatusGetter
 }
 
-var _ = gc.Suite(&serviceStatusGetterSuite{})
+var _ = gc.Suite(&applicationStatusGetterSuite{})
 
-func (s *serviceStatusGetterSuite) SetUpTest(c *gc.C) {
+func (s *applicationStatusGetterSuite) SetUpTest(c *gc.C) {
 	s.statusBaseSuite.SetUpTest(c)
 
 	s.getter = common.NewApplicationStatusGetter(s.State, func() (common.AuthFunc, error) {
 		return s.authFunc, nil
-	})
+	}, s.leadershipChecker)
 }
 
-func (s *serviceStatusGetterSuite) TestUnauthorized(c *gc.C) {
+func (s *applicationStatusGetterSuite) TestUnauthorized(c *gc.C) {
 	// Machines are unauthorized since they are not units
 	tag := names.NewUnitTag("foo/0")
 	s.badTag = tag
@@ -149,7 +151,7 @@ func (s *serviceStatusGetterSuite) TestUnauthorized(c *gc.C) {
 	c.Assert(result.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
-func (s *serviceStatusGetterSuite) TestNotATag(c *gc.C) {
+func (s *applicationStatusGetterSuite) TestNotATag(c *gc.C) {
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		"not a tag",
 	}}})
@@ -158,7 +160,7 @@ func (s *serviceStatusGetterSuite) TestNotATag(c *gc.C) {
 	c.Assert(result.Results[0].Error, gc.ErrorMatches, `"not a tag" is not a valid tag`)
 }
 
-func (s *serviceStatusGetterSuite) TestNotFound(c *gc.C) {
+func (s *applicationStatusGetterSuite) TestNotFound(c *gc.C) {
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		names.NewUnitTag("foo/0").String(),
 	}}})
@@ -167,32 +169,33 @@ func (s *serviceStatusGetterSuite) TestNotFound(c *gc.C) {
 	c.Assert(result.Results[0].Error, jc.Satisfies, params.IsCodeNotFound)
 }
 
-func (s *serviceStatusGetterSuite) TestGetMachineStatus(c *gc.C) {
+func (s *applicationStatusGetterSuite) TestGetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		machine.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	// Can't call service status on a machine.
+	// Can't call application status on a machine.
 	c.Assert(result.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
-func (s *serviceStatusGetterSuite) TestGetServiceStatus(c *gc.C) {
-	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
+func (s *applicationStatusGetterSuite) TestGetApplicationStatus(c *gc.C) {
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
-		service.Tag().String(),
+		app.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	// Can't call service status on a service.
+	// Can't call unit status on an application.
 	c.Assert(result.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
-func (s *serviceStatusGetterSuite) TestGetUnitStatusNotLeader(c *gc.C) {
+func (s *applicationStatusGetterSuite) TestGetUnitStatusNotLeader(c *gc.C) {
 	// If the unit isn't the leader, it can't get it.
+	s.leadershipChecker.isLeader = false
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
@@ -202,20 +205,21 @@ func (s *serviceStatusGetterSuite) TestGetUnitStatusNotLeader(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	status := result.Results[0]
-	c.Assert(status.Error, gc.ErrorMatches, ".* is not leader of .*")
+	c.Assert(status.Error, gc.ErrorMatches, "not leader")
 }
 
-func (s *serviceStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
+func (s *applicationStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
 	// If the unit isn't the leader, it can't get it.
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
-	service, err := unit.Application()
+	app, err := unit.Application()
 	c.Assert(err, jc.ErrorIsNil)
-	s.State.LeadershipClaimer().ClaimLeadership(
-		service.Name(),
+	err = s.State.LeadershipClaimer().ClaimLeadership(
+		app.Name(),
 		unit.Name(),
 		time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		unit.Tag().String(),
 	}}})
@@ -233,7 +237,7 @@ func (s *serviceStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
 	c.Assert(unitStatus.Status, gc.Equals, status.Maintenance.String())
 }
 
-func (s *serviceStatusGetterSuite) TestBulk(c *gc.C) {
+func (s *applicationStatusGetterSuite) TestBulk(c *gc.C) {
 	s.badTag = names.NewMachineTag("42")
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
@@ -250,14 +254,35 @@ func (s *serviceStatusGetterSuite) TestBulk(c *gc.C) {
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
 }
 
+type fakeLeadershipChecker struct {
+	isLeader bool
+}
+
+type token struct {
+	isLeader bool
+}
+
+func (t *token) Check(attempt int, trapdoorKey interface{}) error {
+	if !t.isLeader {
+		return errors.New("not leader")
+	}
+	return nil
+}
+
+func (f *fakeLeadershipChecker) LeadershipCheck(applicationName, unitName string) leadership.Token {
+	return &token{f.isLeader}
+}
+
 type statusBaseSuite struct {
 	testing.StateSuite
-	badTag names.Tag
+	leadershipChecker *fakeLeadershipChecker
+	badTag            names.Tag
 }
 
 func (s *statusBaseSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 	s.badTag = nil
+	s.leadershipChecker = &fakeLeadershipChecker{true}
 }
 
 func (s *statusBaseSuite) authFunc(tag names.Tag) bool {

--- a/apiserver/facades/agent/uniter/status.go
+++ b/apiserver/facades/agent/uniter/status.go
@@ -14,12 +14,12 @@ import (
 // status from different entities, this particular separation from
 // base is because we have a shim to support unit/agent split.
 type StatusAPI struct {
-	agentSetter   *common.StatusSetter
-	unitSetter    *common.StatusSetter
-	unitGetter    *common.StatusGetter
-	serviceSetter *common.ApplicationStatusSetter
-	serviceGetter *common.ApplicationStatusGetter
-	getCanModify  common.GetAuthFunc
+	agentSetter       *common.StatusSetter
+	unitSetter        *common.StatusSetter
+	unitGetter        *common.StatusGetter
+	applicationSetter *common.ApplicationStatusSetter
+	applicationGetter *common.ApplicationStatusGetter
+	getCanModify      common.GetAuthFunc
 }
 
 // NewStatusAPI creates a new server-side Status setter API facade.
@@ -28,16 +28,16 @@ func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc, leadershipCh
 	// characteristics? I think not.
 	unitSetter := common.NewStatusSetter(st, getCanModify)
 	unitGetter := common.NewStatusGetter(st, getCanModify)
-	serviceSetter := common.NewApplicationStatusSetter(st, getCanModify, leadershipChecker)
-	serviceGetter := common.NewApplicationStatusGetter(st, getCanModify, leadershipChecker)
+	applicationSetter := common.NewApplicationStatusSetter(st, getCanModify, leadershipChecker)
+	applicationGetter := common.NewApplicationStatusGetter(st, getCanModify, leadershipChecker)
 	agentSetter := common.NewStatusSetter(&common.UnitAgentFinder{st}, getCanModify)
 	return &StatusAPI{
-		agentSetter:   agentSetter,
-		unitSetter:    unitSetter,
-		unitGetter:    unitGetter,
-		serviceSetter: serviceSetter,
-		serviceGetter: serviceGetter,
-		getCanModify:  getCanModify,
+		agentSetter:       agentSetter,
+		unitSetter:        unitSetter,
+		unitGetter:        unitGetter,
+		applicationSetter: applicationSetter,
+		applicationGetter: applicationGetter,
+		getCanModify:      getCanModify,
 	}
 }
 
@@ -61,10 +61,10 @@ func (s *StatusAPI) SetUnitStatus(args params.SetStatus) (params.ErrorResults, e
 	return s.unitSetter.SetStatus(args)
 }
 
-// SetApplicationStatus sets the status for all the Services in args if the given Unit is
+// SetApplicationStatus sets the status for all the Applications in args if the given Unit is
 // the leader.
 func (s *StatusAPI) SetApplicationStatus(args params.SetStatus) (params.ErrorResults, error) {
-	return s.serviceSetter.SetStatus(args)
+	return s.applicationSetter.SetStatus(args)
 }
 
 // UnitStatus returns the workload status information for the unit.
@@ -75,5 +75,5 @@ func (s *StatusAPI) UnitStatus(args params.Entities) (params.StatusResults, erro
 // ApplicationStatus returns the status of the Applications and its workloads
 // if the given unit is the leader.
 func (s *StatusAPI) ApplicationStatus(args params.Entities) (params.ApplicationStatusResults, error) {
-	return s.serviceGetter.Status(args)
+	return s.applicationGetter.Status(args)
 }

--- a/apiserver/facades/agent/uniter/status.go
+++ b/apiserver/facades/agent/uniter/status.go
@@ -6,6 +6,7 @@ package uniter
 import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/state"
 )
 
@@ -22,13 +23,13 @@ type StatusAPI struct {
 }
 
 // NewStatusAPI creates a new server-side Status setter API facade.
-func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc) *StatusAPI {
+func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc, leadershipChecker leadership.Checker) *StatusAPI {
 	// TODO(fwereade): so *all* of these have exactly the same auth
 	// characteristics? I think not.
 	unitSetter := common.NewStatusSetter(st, getCanModify)
 	unitGetter := common.NewStatusGetter(st, getCanModify)
-	serviceSetter := common.NewServiceStatusSetter(st, getCanModify)
-	serviceGetter := common.NewApplicationStatusGetter(st, getCanModify)
+	serviceSetter := common.NewApplicationStatusSetter(st, getCanModify, leadershipChecker)
+	serviceGetter := common.NewApplicationStatusGetter(st, getCanModify, leadershipChecker)
 	agentSetter := common.NewStatusSetter(&common.UnitAgentFinder{st}, getCanModify)
 	return &StatusAPI{
 		agentSetter:   agentSetter,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -281,7 +281,7 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 		MeterStatus:                msAPI,
 		// TODO(fwereade): so *every* unit should be allowed to get/set its
 		// own status *and* its application's? This is not a pleasing arrangement.
-		StatusAPI: NewStatusAPI(st, accessUnitOrApplication),
+		StatusAPI: NewStatusAPI(st, accessUnitOrApplication, leadershipChecker),
 
 		st:                st,
 		m:                 m,


### PR DESCRIPTION
## Description of change

The unit agent facade backend was not checking for leadership properly in the status get/set calls.
Update to use the new infrastructure.

## QA steps

Run a k8s model with a bad pod and check the app status is set.

