### PR TITLE
Longer wait for workerSuite.TestRemovePrimaryValidSecondaries.

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -352,7 +352,7 @@ func (f *Facade) applicationFilesystemParams(
 	controllerConfig controller.Config,
 	modelConfig *config.Config,
 ) ([]params.KubernetesFilesystemParams, error) {
-	storage, err := app.StorageConstraints()
+	storageConstraints, err := app.StorageConstraints()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -363,7 +363,14 @@ func (f *Facade) applicationFilesystemParams(
 	}
 
 	var allFilesystemParams []params.KubernetesFilesystemParams
-	for name, cons := range storage {
+	// To always guarantee the same order, sort by names.
+	var sNames []string
+	for name := range storageConstraints {
+		sNames = append(sNames, name)
+	}
+	sort.Strings(sNames)
+	for _, name := range sNames {
+		cons := storageConstraints[name]
 		fsParams, err := filesystemParams(
 			app, cons, name,
 			controllerConfig.ControllerUUID(),

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -190,62 +190,75 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, params.KubernetesProvisioningInfoResults{
-		Results: []params.KubernetesProvisioningInfoResult{{
-			Result: &params.KubernetesProvisioningInfo{
-				PodSpec: "spec(gitlab)",
-				DeploymentInfo: &params.KubernetesDeploymentInfo{
-					DeploymentType: "stateful",
-					ServiceType:    "loadbalancer",
-				},
-				Filesystems: []params.KubernetesFilesystemParams{{
-					StorageName: "data",
-					Provider:    string(provider.K8s_ProviderType),
-					Size:        100,
-					Attributes: map[string]interface{}{
-						"storage-class": "k8s-storage",
-						"foo":           "bar",
-					},
-					Tags: map[string]string{
-						"juju-storage-owner":   "gitlab",
-						"juju-model-uuid":      coretesting.ModelTag.Id(),
-						"juju-controller-uuid": coretesting.ControllerTag.Id()},
-					Attachment: &params.KubernetesFilesystemAttachmentParams{
-						Provider:   string(provider.K8s_ProviderType),
-						MountPoint: "/var/lib/juju/storage/data/0",
-						ReadOnly:   true,
-					},
-				}, {
-					StorageName: "logs",
-					Provider:    string(storageprovider.RootfsProviderType),
-					Size:        200,
-					Attributes:  map[string]interface{}{},
-					Tags: map[string]string{
-						"juju-storage-owner":   "gitlab",
-						"juju-model-uuid":      coretesting.ModelTag.Id(),
-						"juju-controller-uuid": coretesting.ControllerTag.Id()},
-					Attachment: &params.KubernetesFilesystemAttachmentParams{
-						Provider:   string(storageprovider.RootfsProviderType),
-						MountPoint: "/var/lib/juju/storage/logs/0",
-					},
-				}},
-				Devices: []params.KubernetesDeviceParams{
-					{
-						Type:       "nvidia.com/gpu",
-						Count:      3,
-						Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
-					},
-				},
-				Constraints: constraints.MustParse("mem=64G"),
-				Tags: map[string]string{
-					"juju-model-uuid":      coretesting.ModelTag.Id(),
-					"juju-controller-uuid": coretesting.ControllerTag.Id()},
+	// Maps are harder to check...
+	// http://ci.jujucharms.com/job/make-check-juju/4853/testReport/junit/github/com_juju_juju_apiserver_facades_controller_caasunitprovisioner/TestAll/
+	expectedResult := &params.KubernetesProvisioningInfo{
+		PodSpec: "spec(gitlab)",
+		DeploymentInfo: &params.KubernetesDeploymentInfo{
+			DeploymentType: "stateful",
+			ServiceType:    "loadbalancer",
+		},
+		Devices: []params.KubernetesDeviceParams{
+			{
+				Type:       "nvidia.com/gpu",
+				Count:      3,
+				Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
 			},
-		}, {
-			Error: &params.Error{
-				Message: `"unit-gitlab-0" is not a valid application tag`,
+		},
+		Constraints: constraints.MustParse("mem=64G"),
+		Tags: map[string]string{
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ControllerTag.Id()},
+	}
+	expectedFileSystems := map[string]params.KubernetesFilesystemParams{
+		"data": {
+			StorageName: "data",
+			Provider:    string(provider.K8s_ProviderType),
+			Size:        100,
+			Attributes: map[string]interface{}{
+				"storage-class": "k8s-storage",
+				"foo":           "bar",
 			},
-		}},
+			Tags: map[string]string{
+				"juju-storage-owner":   "gitlab",
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ControllerTag.Id()},
+			Attachment: &params.KubernetesFilesystemAttachmentParams{
+				Provider:   string(provider.K8s_ProviderType),
+				MountPoint: "/var/lib/juju/storage/data/0",
+				ReadOnly:   true,
+			},
+		},
+		"logs": {
+			StorageName: "logs",
+			Provider:    string(storageprovider.RootfsProviderType),
+			Size:        200,
+			Attributes:  map[string]interface{}{},
+			Tags: map[string]string{
+				"juju-storage-owner":   "gitlab",
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ControllerTag.Id()},
+			Attachment: &params.KubernetesFilesystemAttachmentParams{
+				Provider:   string(storageprovider.RootfsProviderType),
+				MountPoint: "/var/lib/juju/storage/logs/0",
+			},
+		}}
+	obtained := results.Results[0].Result
+	c.Assert(obtained.PodSpec, jc.DeepEquals, expectedResult.PodSpec)
+	c.Assert(obtained.DeploymentInfo, jc.DeepEquals, expectedResult.DeploymentInfo)
+	c.Assert(len(obtained.Filesystems), gc.Equals, len(expectedFileSystems))
+	for _, fs := range obtained.Filesystems {
+		c.Assert(fs, gc.DeepEquals, expectedFileSystems[fs.StorageName])
+	}
+	c.Assert(obtained.Devices, jc.DeepEquals, expectedResult.Devices)
+	c.Assert(obtained.Constraints, jc.DeepEquals, expectedResult.Constraints)
+	for tagKey := range obtained.Tags {
+		c.Assert(obtained.Tags[tagKey], jc.DeepEquals, expectedResult.Tags[tagKey])
+	}
+	c.Assert(results.Results[1], jc.DeepEquals, params.KubernetesProvisioningInfoResult{
+		Error: &params.Error{
+			Message: `"unit-gitlab-0" is not a valid application tag`,
+		},
 	})
 	s.st.CheckCallNames(c, "Model", "Application", "ControllerConfig", "ResolveConstraints")
 	s.st.CheckCall(c, 3, "ResolveConstraints", constraints.MustParse("mem=64G"))

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -252,9 +252,7 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	}
 	c.Assert(obtained.Devices, jc.DeepEquals, expectedResult.Devices)
 	c.Assert(obtained.Constraints, jc.DeepEquals, expectedResult.Constraints)
-	for tagKey := range obtained.Tags {
-		c.Assert(obtained.Tags[tagKey], jc.DeepEquals, expectedResult.Tags[tagKey])
-	}
+	c.Assert(obtained.Tags, jc.DeepEquals, expectedResult.Tags)
 	c.Assert(results.Results[1], jc.DeepEquals, params.KubernetesProvisioningInfoResult{
 		Error: &params.Error{
 			Message: `"unit-gitlab-0" is not a valid application tag`,


### PR DESCRIPTION
## Description of change

Prior to this PR, this test failed frequently. In fact, locally on my machine, it has failed only after 7 runs under stress.
By increasing the wait from Short to Long, I have not seen a failure locally after 147 runs.

Drive-by: naming collision in test between variable name and an import.  
