### PR TITLE
Multi cloud feature flag

### DIFF
--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/credentialcommon"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -31,6 +32,7 @@ type Backend interface {
 	CredentialModelsAndOwnerAccess(tag names.CloudCredentialTag) ([]state.CredentialOwnerModelAccess, error)
 	CredentialModels(tag names.CloudCredentialTag) (map[string]string, error)
 
+	ControllerConfig() (controller.Config, error)
 	ControllerInfo() (*state.ControllerInfo, error)
 	GetCloudAccess(cloud string, user names.UserTag) (permission.Access, error)
 	GetCloudUsers(cloud string) (map[string]permission.Access, error)

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -71,7 +71,8 @@ positional argument:
 When <cloud definition file> is provided with <cloud name>,
 Juju stores that definition in the current controller (after
 validating the contents), or the specified controller if
---controller is used.
+--controller is used. To make use of this multi-cloud feature,
+the controller needs to have the "multi-cloud" feature flag turned on.
 
 If --local is used, Juju stores that definition its internal cache directly.
 
@@ -112,8 +113,11 @@ you can specify which to upload with the --credential option.
 
 Examples:
     juju add-cloud
-    juju add-cloud mycloud ~/mycloud.yaml
     juju add-cloud --local mycloud ~/mycloud.yaml
+
+If the "multi-cloud" feature flag is turned on in the controller:
+
+    juju add-cloud mycloud ~/mycloud.yaml
     juju add-cloud --replace mycloud ~/mycloud2.yaml
     juju add-cloud --controller mycontroller mycloud
     juju add-cloud --controller mycontroller mycloud --credential mycred

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -160,7 +160,11 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	var output interface{}
 	switch c.out.Name() {
 	case "yaml", "json":
-		output = details.all()
+		clouds := details.all()
+		for _, cloud := range clouds {
+			cloud.CloudType = displayCloudType(cloud.CloudType)
+		}
+		output = clouds
 	default:
 		if c.controllerName == "" && !c.Local {
 			ctxt.Infof(
@@ -202,9 +206,7 @@ func (c *cloudList) all() map[string]*CloudDetails {
 	result := make(map[string]*CloudDetails)
 	addAll := func(someClouds map[string]*CloudDetails) {
 		for name, cloud := range someClouds {
-			displayCloud := cloud
-			displayCloud.CloudType = displayCloudType(displayCloud.CloudType)
-			result[name] = displayCloud
+			result[name] = cloud
 		}
 	}
 

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -218,7 +218,7 @@ clouds:
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `Hypervisorhomestack             1  london           openstack   Openstack Cloud`)
+	c.Assert(out, jc.Contains, `homestack             1  london           openstack   Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -57,3 +57,7 @@ const MongoDbSnap = "mongodb-snap"
 // MongoDbSnap tells Juju to use server-side transactions. It does nothing if
 // MongoDbSnap is not also enabled.
 const MongoDbSSTXN = "mongodb-sstxn"
+
+// MultiCloud tells Juju to allow a different IAAS cloud to the one the controller
+// was bootstrapped on to be added to the controller.
+const MultiCloud = "multi-cloud"


### PR DESCRIPTION
## Description of change

Hide the multi-cloud feature behind a feature flag.
Also a driveby fix for formatting kubernetes cloud types when running list-clouds. This was incorrectly changing the cloud type to "k8s" when adding a k8s cloud to the controller.

## QA steps

bootstrap
add a cloud without feature flag -> error message
juju controller-config features="[multi-cloud]"
add a cloud now works
check that juju add-k8s to a controller works

