### PR TITLE
Fix isController value on model summaries

### DIFF
--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -115,7 +115,7 @@ func newProcessorFromModelDocs(st *State, modelDocs []modelDoc, user names.UserT
 			Life:               doc.Life,
 			Owner:              doc.Owner,
 			ControllerUUID:     doc.ControllerUUID,
-			IsController:       st.IsController(),
+			IsController:       doc.UUID == st.modelTag.Id(),
 			SLALevel:           string(doc.SLA.Level),
 			SLAOwner:           doc.SLA.Owner,
 			CloudTag:           names.NewCloudTag(doc.Cloud).String(),

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -141,9 +141,11 @@ func (s *ModelSummariesSuite) TestModelsForSuperuserWithAll(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	names := make([]string, len(summaries))
 	access := make(map[string]string)
+	isController := make(map[string]bool)
 	for i, summary := range summaries {
 		names[i] = summary.Name
 		access[summary.Name] = string(summary.Access)
+		isController[summary.Name] = summary.IsController
 	}
 	sort.Strings(names)
 	c.Check(names, gc.DeepEquals, []string{"shared", "testmodel", "user1model", "user2model", "user3model"})
@@ -153,6 +155,13 @@ func (s *ModelSummariesSuite) TestModelsForSuperuserWithAll(c *gc.C) {
 		"user1model": "",
 		"user2model": "",
 		"user3model": "",
+	})
+	c.Check(isController, gc.DeepEquals, map[string]bool{
+		"shared":     false,
+		"testmodel":  true,
+		"user1model": false,
+		"user2model": false,
+		"user3model": false,
 	})
 }
 


### PR DESCRIPTION
## Description of change

isController field was being incorrectly set when listing models.

## QA steps

juju list-models --format yaml
check is-controller value

## Bug reference

https://bugs.launchpad.net/bugs/1827447
