### PR TITLE
Ensure inclusivity of LXD containers

### DIFF
--- a/worker/containerbroker/broker.go
+++ b/worker/containerbroker/broker.go
@@ -111,10 +111,15 @@ func NewTracker(config Config) (*Tracker, error) {
 		return nil, dependency.ErrUninstall
 	}
 	// we only work on LXD, so check for that.
+	var found bool
 	for _, containerType := range instanceContainers {
-		if containerType != instance.LXD {
-			return nil, dependency.ErrUninstall
+		if containerType == instance.LXD {
+			found = true
+			break
 		}
+	}
+	if !found {
+		return nil, dependency.ErrUninstall
 	}
 
 	// We guarded against non-LXD types, so lets talk about specific container


### PR DESCRIPTION
## Description of change

Ensure that we don't bail out if we find another container type,
continue on until we can be sure we find a LXD. If no LXD container
is found, then bail out.

This was found by an intermittent test.

## QA steps

```
juju bootstrap lxd test
juju deploy redis
juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt

juju upgrade-charm lxd-profile-alt --path ./testcharms/charm-repo/quantal/lxd-profile-alt
```


