### PR TITLE
Merge 2.5 into 2.6

### DIFF
--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/raft"
-	"github.com/hashicorp/raft-boltdb"
+	raftboltdb "github.com/hashicorp/raft-boltdb"
 	"github.com/juju/errors"
 	"github.com/juju/replicaset"
 

--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -405,7 +405,7 @@ func getLastSnapshot(store raft.SnapshotStore) (*raft.SnapshotMeta, error) {
 	for _, snapshot := range snapshots {
 		_, source, err := store.Open(snapshot.ID)
 		if err != nil {
-			logger.Warningf("couldn't open snapshot %q: %v", err)
+			logger.Warningf("couldn't open snapshot %q: %v", snapshot.ID, err)
 			continue
 		}
 		source.Close()

--- a/upgrades/raft_test.go
+++ b/upgrades/raft_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
-	"github.com/hashicorp/raft-boltdb"
+	raftboltdb "github.com/hashicorp/raft-boltdb"
 	"github.com/juju/loggo"
 	"github.com/juju/replicaset"
 	"github.com/juju/testing"


### PR DESCRIPTION
Merge 2.5 into 2.6 bringing patch #10135.

Commits indicate #10100 coming in, but the child commits for that are already present - no file changes result from this.