### PR TITLE
Fix machine cleanup with manual machines

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -326,7 +326,7 @@ func (st *State) cleanupMachinesForDyingModel(cleanupArgs []bson.Raw) (err error
 				// TODO (force 2019-4-24) However, we should not break out here but continue with other machines.
 				return errors.Trace(errors.Annotatef(err, "could not destroy manual machine %v", m.Id()))
 			}
-			return nil
+			continue
 		}
 		// TODO (force 2019-04-26) Should this always be ForceDestroy or only when
 		// 'destroy-model --force' is specified?...

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -224,7 +224,7 @@ func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
 	s.assertNeedsCleanup(c)
 
 	// Clean up, and check that the unit has been removed...
-	s.assertCleanupCount(c, 3)
+	s.assertCleanupCount(c, 4)
 	assertRemoved(c, pr.u0)
 
 	// ...and the unit has departed relation scope...


### PR DESCRIPTION
## Description of change

Models with manual machines were not being destroyed properly - the loop which iterated over machines to clean up incorrectly skipped any non manual machines once the first manual machine was encountered.

## QA steps

create a model and add a manual machine
deploy an application (creates a non-manual machine)
destroy-model
should complete (previously would have got stuck on machines)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1827285
