### PR TITLE
Add Generations to All-Watcher

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1336,11 +1336,19 @@ func (g *backingGeneration) updated(st *State, store *multiwatcherStore, id stri
 		}
 	}
 
+	// Make a copy of the AssignedUnits map.
+	assigned := make(map[string][]string, len(g.AssignedUnits))
+	for k, v := range g.AssignedUnits {
+		units := make([]string, len(v))
+		copy(units, v)
+		assigned[k] = units
+	}
+
 	info := &multiwatcher.GenerationInfo{
 		ModelUUID:     st.ModelUUID(),
 		Id:            st.localID(id),
 		Name:          g.Name,
-		AssignedUnits: g.AssignedUnits,
+		AssignedUnits: assigned,
 		Config:        cfg,
 		Completed:     g.Completed,
 		GenerationId:  g.GenerationId,

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -101,6 +101,8 @@ func makeAllWatcherCollectionInfo(collNames ...string) map[string]allWatcherStat
 			collection.docType = reflect.TypeOf(backingRemoteApplication{})
 		case applicationOffersC:
 			collection.docType = reflect.TypeOf(backingApplicationOffer{})
+		case generationsC:
+			collection.docType = reflect.TypeOf(backingGeneration{})
 		default:
 			panic(errors.Errorf("unknown collection %q", collName))
 		}
@@ -542,25 +544,12 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 		if err != nil {
 			return errors.Annotatef(err, "reading application status for key %s", key)
 		}
-		if err == nil {
-			info.Status = multiwatcher.StatusInfo{
-				Current: applicationStatus.Status,
-				Message: applicationStatus.Message,
-				Data:    normaliseStatusData(applicationStatus.Data),
-				Since:   applicationStatus.Since,
-			}
-		} else {
-			// TODO(wallyworld) - bug http://pad.lv/1451283
-			// return an error here once we figure out what's happening
-			// Not sure how status can even return NotFound as it is created
-			// with the application initially. For now, we'll log the error as per
-			// the above and return Unknown.
-			now := st.clock().Now()
-			info.Status = multiwatcher.StatusInfo{
-				Current: status.Unknown,
-				Since:   &now,
-				Data:    normaliseStatusData(nil),
-			}
+
+		info.Status = multiwatcher.StatusInfo{
+			Current: applicationStatus.Status,
+			Message: applicationStatus.Message,
+			Data:    normaliseStatusData(applicationStatus.Data),
+			Since:   applicationStatus.Since,
 		}
 	} else {
 		// The entry already exists, so preserve the current status.
@@ -959,7 +948,7 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id string) 
 		info0 = &newInfo
 	case *multiwatcher.MachineInfo:
 		newInfo := *info
-		// lets dissambiguate between juju machine agent and provider instance statuses.
+		// lets disambiguate between juju machine agent and provider instance statuses.
 		if strings.HasSuffix(id, "#instance") {
 			newInfo.InstanceStatus = s.toStatusInfo()
 		} else {
@@ -1325,6 +1314,55 @@ func backingEntityIdForGlobalKey(modelUUID, key string) (multiwatcher.EntityId, 
 	}
 }
 
+type backingGeneration generationDoc
+
+func (g *backingGeneration) updated(st *State, store *multiwatcherStore, id string) error {
+	// Convert the state representation of config deltas
+	// to the multiwatcher representation.
+	var cfg map[string][]multiwatcher.ItemChange
+	if len(g.Config) > 0 {
+		cfg = make(map[string][]multiwatcher.ItemChange, len(g.Config))
+		for app, deltas := range g.Config {
+			d := make([]multiwatcher.ItemChange, len(deltas))
+			for i, delta := range deltas {
+				d[i] = multiwatcher.ItemChange{
+					Type:     delta.Type,
+					Key:      delta.Key,
+					OldValue: delta.OldValue,
+					NewValue: delta.NewValue,
+				}
+			}
+			cfg[app] = d
+		}
+	}
+
+	info := &multiwatcher.GenerationInfo{
+		ModelUUID:     st.ModelUUID(),
+		Id:            st.localID(id),
+		Name:          g.Name,
+		AssignedUnits: g.AssignedUnits,
+		Config:        cfg,
+		Completed:     g.Completed,
+		GenerationId:  g.GenerationId,
+	}
+	store.Update(info)
+	return nil
+
+}
+
+func (g *backingGeneration) removed(store *multiwatcherStore, modelUUID, id string, _ *State) error {
+	store.Remove(multiwatcher.EntityId{
+		Kind:      "generation",
+		ModelUUID: modelUUID,
+		Id:        id,
+	})
+	return nil
+}
+
+func (g *backingGeneration) mongoId() string {
+	return g.DocId
+}
+
 // backingEntityDoc is implemented by the documents in
 // collections that the allWatcherStateBacking watches.
 type backingEntityDoc interface {
@@ -1354,6 +1392,7 @@ func newAllWatcherStateBacking(st *State, params WatchParams) Backing {
 		blocksC,
 		charmsC,
 		constraintsC,
+		generationsC,
 		instanceDataC,
 		machinesC,
 		openedPortsC,
@@ -1439,6 +1478,7 @@ func NewAllModelWatcherStateBacking(st *State, pool *StatePool) Backing {
 		applicationsC,
 		charmsC,
 		constraintsC,
+		generationsC,
 		instanceDataC,
 		modelsC,
 		machinesC,
@@ -1527,7 +1567,7 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 		if exists, modelErr := b.st.ModelExists(modelUUID); exists && modelErr == nil {
 			// The entity's model is gone so remove the entity
 			// from the store.
-			doc.removed(all, modelUUID, id, nil)
+			_ = doc.removed(all, modelUUID, id, nil)
 			return nil
 		}
 		return errors.Trace(err) // prioritise getState error

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -4084,7 +4084,7 @@ func testChangeGenerations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
-				about: "generation is removed if not in backing store",
+				about: "generation is removed if not in backing",
 				initialContents: []multiwatcher.EntityInfo{
 					&multiwatcher.GenerationInfo{
 						ModelUUID: st.ModelUUID(),
@@ -4103,7 +4103,7 @@ func testChangeGenerations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
-				about: "generation is added if in backing but not in tore",
+				about: "generation is added if in backing but not in store",
 				change: watcher.Change{
 					C:  "generations",
 					Id: st.docID(branch.doc.DocId),

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -44,6 +44,7 @@ var (
 	_ backingEntityDoc = (*backingOpenedPorts)(nil)
 	_ backingEntityDoc = (*backingAction)(nil)
 	_ backingEntityDoc = (*backingBlock)(nil)
+	_ backingEntityDoc = (*backingGeneration)(nil)
 )
 
 var dottedConfig = `
@@ -630,6 +631,10 @@ func (s *allWatcherStateSuite) TestChangeRemoteApplications(c *gc.C) {
 
 func (s *allWatcherStateSuite) TestChangeApplicationOffers(c *gc.C) {
 	testChangeApplicationOffers(c, s.performChangeTestCases)
+}
+
+func (s *allWatcherStateSuite) TestChangeGenerations(c *gc.C) {
+	testChangeGenerations(c, s.performChangeTestCases)
 }
 
 func (s *allWatcherStateSuite) TestChangeActions(c *gc.C) {
@@ -1793,15 +1798,20 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m10.Id(), gc.Equals, "0")
 
+	// Add a branch.
+	c.Assert(st1.AddBranch("new-branch", "test-user"), jc.ErrorIsNil)
+	br, err := st1.Branch("new-branch")
+	c.Assert(br, gc.NotNil)
+
 	now := st0.clock().Now()
 
 	backing := s.NewAllModelWatcherStateBacking()
 	tw := newTestWatcher(backing, st0, c)
 	defer tw.Stop()
 
-	// Expect to see events for the already created models and
-	// machines first.
-	deltas := tw.All(4)
+	// Expect to see events for the already created models,
+	// machines and branch first.
+	deltas := tw.All(5)
 	checkDeltasEqual(c, deltas, []multiwatcher.Delta{{
 		Entity: &multiwatcher.ModelInfo{
 			ModelUUID:      model0.UUID(),
@@ -1881,6 +1891,13 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Addresses: []multiwatcher.Address{},
 			HasVote:   false,
 			WantsVote: false,
+		},
+	}, {
+		Entity: &multiwatcher.GenerationInfo{
+			ModelUUID:     st1.ModelUUID(),
+			Id:            "0",
+			Name:          "new-branch",
+			AssignedUnits: map[string][]string{},
 		},
 	}})
 
@@ -1966,9 +1983,11 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m20.Id(), gc.Equals, "0")
 
+	c.Assert(br.AssignUnit(wu.Name()), jc.ErrorIsNil)
+
 	// Look for the state changes from the allwatcher.
 	later := st2.clock().Now()
-	deltas = tw.All(9)
+	deltas = tw.All(10)
 
 	expectedRemoveMachineEntity := &multiwatcher.MachineInfo{
 		ModelUUID: st1.ModelUUID(),
@@ -2144,6 +2163,13 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Addresses: []multiwatcher.Address{},
 			HasVote:   false,
 			WantsVote: false,
+		},
+	}, {
+		Entity: &multiwatcher.GenerationInfo{
+			ModelUUID:     st1.ModelUUID(),
+			Id:            "0",
+			Name:          "new-branch",
+			AssignedUnits: map[string][]string{wordpress.Name(): {wu.Name()}},
 		},
 	}}
 
@@ -4040,6 +4066,88 @@ func testChangeApplicationOffers(c *gc.C, runChangeTests func(*gc.C, []changeTes
 					Id: st.docID("remote-wordpress2"),
 				},
 				expectContents: []multiwatcher.EntityInfo{&applicationOfferInfo},
+			}
+		},
+	}
+	runChangeTests(c, changeTestFuncs)
+}
+
+func testChangeGenerations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
+	changeTestFuncs := []changeTestFunc{
+		func(c *gc.C, st *State) changeTestCase {
+			return changeTestCase{
+				about: "no change if generation absent from state and store",
+				change: watcher.Change{
+					C:  "generations",
+					Id: st.docID("does-not-exist"),
+				}}
+		},
+		func(c *gc.C, st *State) changeTestCase {
+			return changeTestCase{
+				about: "generation is removed if not in backing store",
+				initialContents: []multiwatcher.EntityInfo{
+					&multiwatcher.GenerationInfo{
+						ModelUUID: st.ModelUUID(),
+						Id:        "to-be-removed",
+					},
+				},
+				change: watcher.Change{
+					C:  "generations",
+					Id: st.docID("to-be-removed"),
+				},
+			}
+		},
+		func(c *gc.C, st *State) changeTestCase {
+			c.Assert(st.AddBranch("new-branch", "some-user"), jc.ErrorIsNil)
+			branch, err := st.Branch("new-branch")
+			c.Assert(err, jc.ErrorIsNil)
+
+			return changeTestCase{
+				about: "generation is added if in backing but not in tore",
+				change: watcher.Change{
+					C:  "generations",
+					Id: st.docID(branch.doc.DocId),
+				},
+				expectContents: []multiwatcher.EntityInfo{
+					&multiwatcher.GenerationInfo{
+						ModelUUID:     st.ModelUUID(),
+						Id:            st.localID(branch.doc.DocId),
+						Name:          "new-branch",
+						AssignedUnits: map[string][]string{},
+					}},
+			}
+		},
+		func(c *gc.C, st *State) changeTestCase {
+			c.Assert(st.AddBranch("new-branch", "some-user"), jc.ErrorIsNil)
+			branch, err := st.Branch("new-branch")
+			c.Assert(err, jc.ErrorIsNil)
+
+			app := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
+			u, err := app.AddUnit(AddUnitParams{})
+			c.Assert(err, jc.ErrorIsNil)
+
+			c.Assert(branch.AssignUnit(u.Name()), jc.ErrorIsNil)
+
+			return changeTestCase{
+				about: "generation is updated if in backing and in store",
+				change: watcher.Change{
+					C:  "generations",
+					Id: st.docID(branch.doc.DocId),
+				},
+				initialContents: []multiwatcher.EntityInfo{
+					&multiwatcher.GenerationInfo{
+						ModelUUID:     st.ModelUUID(),
+						Id:            st.localID(branch.doc.DocId),
+						Name:          "new-branch",
+						AssignedUnits: map[string][]string{},
+					}},
+				expectContents: []multiwatcher.EntityInfo{
+					&multiwatcher.GenerationInfo{
+						ModelUUID:     st.ModelUUID(),
+						Id:            st.localID(branch.doc.DocId),
+						Name:          "new-branch",
+						AssignedUnits: map[string][]string{app.Name(): {u.Name()}},
+					}},
 			}
 		},
 	}

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -112,6 +112,8 @@ func (d *Delta) UnmarshalJSON(data []byte) error {
 		d.Entity = new(ActionInfo)
 	case "charm":
 		d.Entity = new(CharmInfo)
+	case "generation":
+		d.Entity = new(GenerationInfo)
 	default:
 		return errors.Errorf("Unexpected entity name %q", entityKind)
 	}
@@ -480,7 +482,7 @@ type ModelSLAInfo struct {
 	Owner string `json:"owner"`
 }
 
-// ModelInfo holds the information about an model that is
+// ModelInfo holds the information about a model that is
 // tracked by multiwatcherStore.
 type ModelInfo struct {
 	ModelUUID      string                 `json:"model-uuid"`
@@ -495,11 +497,40 @@ type ModelInfo struct {
 	SLA            ModelSLAInfo           `json:"sla"`
 }
 
-// EntityId returns a unique identifier for an model.
+// EntityId returns a unique identifier for a model.
 func (i *ModelInfo) EntityId() EntityId {
 	return EntityId{
 		Kind:      "model",
 		ModelUUID: i.ModelUUID,
 		Id:        i.ModelUUID,
+	}
+}
+
+// ItemChange is the multiwatcher representation of a core settings ItemChange.
+type ItemChange struct {
+	Type     int         `json:"type"`
+	Key      string      `json:"key"`
+	OldValue interface{} `json:"old,omitempty"`
+	NewValue interface{} `json:"new,omitempty"`
+}
+
+// GenerationInfo holds data about a model generation (branch)
+// that is tracked by multiwatcherStore.
+type GenerationInfo struct {
+	ModelUUID     string                  `json:"model-uuid"`
+	Id            string                  `json:"id"`
+	Name          string                  `json:"name"`
+	AssignedUnits map[string][]string     `json:"assigned-units"`
+	Config        map[string][]ItemChange `json:"charm-config"`
+	Completed     int64                   `json:"completed"`
+	GenerationId  int                     `json:"generation-id"`
+}
+
+// EntityId returns a unique identifier for a generation.
+func (i *GenerationInfo) EntityId() EntityId {
+	return EntityId{
+		Kind:      "generation",
+		ModelUUID: i.ModelUUID,
+		Id:        i.Id,
 	}
 }

--- a/state/multiwatcher/multiwatcher_internal_test.go
+++ b/state/multiwatcher/multiwatcher_internal_test.go
@@ -22,6 +22,7 @@ var (
 	_ EntityInfo = (*BlockInfo)(nil)
 	_ EntityInfo = (*ActionInfo)(nil)
 	_ EntityInfo = (*ModelInfo)(nil)
+	_ EntityInfo = (*GenerationInfo)(nil)
 )
 
 type ConstantsSuite struct{}


### PR DESCRIPTION
## Description of change

This patch adds the _generations_ collection to the `allwatcher`, which now emits deltas when generation documents are changed.

## QA steps

New unit tests verify this change. A following patch will have QA steps to verify realised behaviour.

## Documentation changes

None.

## Bug reference

N/A
