### PR TITLE
2.5 - Uniter API Creation - Missing Error Check

### DIFF
--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/meterstatus"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/state"
 )
 
 var (
@@ -35,4 +36,12 @@ func NewStorageAPI(
 
 func SetNewContainerBrokerFunc(api *UniterAPI, newBroker caas.NewContainerBrokerFunc) {
 	api.containerBrokerFunc = newBroker
+}
+
+type patcher interface {
+	PatchValue(interface{}, interface{})
+}
+
+func PatchGetStorageStateError(patcher patcher, err error) {
+	patcher.PatchValue(&getStorageState, func(st *state.State) (storageAccess, error) { return nil, err })
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -232,11 +232,15 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 	}
 
 	storageAccessor, err := getStorageState(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	storageAPI, err := newStorageAPI(
 		stateShim{st}, storageAccessor, resources, accessUnit)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
+
 	msAPI, err := meterstatus.NewMeterStatusAPI(st, resources, authorizer)
 	if err != nil {
 		return nil, errors.Annotate(err, "could not create meter status API handler")


### PR DESCRIPTION
## Description of change

This patch fixes a missing error check when creating a new uniter API.

## QA steps

Unit test verifies change.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1827838
