### PR TITLE
Show redirect errors when running "juju show-model blah"

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -180,8 +180,15 @@ func NewFacadeV7(ctx facade.Context) (*ModelManagerAPI, error) {
 		return nil, err
 	}
 
+	// Since we know this is a user tag (because AuthClient is true),
+	// we just do the type assertion to the UserTag.
+	if !auth.AuthClient() {
+		return nil, common.ErrPerm
+	}
+	apiUser, _ := auth.GetAuthTag().(names.UserTag)
+
 	return NewModelManagerAPI(
-		common.NewModelManagerBackend(model, pool),
+		common.NewUserAwareModelManagerBackend(model, pool, apiUser),
 		common.NewModelManagerBackend(ctrlModel, pool),
 		configGetter,
 		caas.New,

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -548,7 +548,12 @@ func (w *modelCommandWrapper) Run(ctx *cmd.Context) error {
 	if err := w.validateCommandForModelType(true); err != nil {
 		return errors.Trace(err)
 	}
-	return w.ModelCommand.Run(ctx)
+	err := w.ModelCommand.Run(ctx)
+	if redirErr, ok := errors.Cause(err).(*api.RedirectError); ok {
+		modelName, _ := w.ModelCommand.ModelName()
+		return newModelMigratedError(store, modelName, redirErr)
+	}
+	return err
 }
 
 func (w *modelCommandWrapper) SetFlags(f *gnuflag.FlagSet) {


### PR DESCRIPTION
## Description of change

This PR updates the `juju show-model` implementation to cope with RedirectErrors and display user-friendly advisory messages that match the ones emitted when running other CLI commands that target models (e.g `juju status -m blah`).

Contrary to other model-related commands that authenticate to the **model** when establishing API connections, this class of commands authenticates to the **controller** and then perform an RPC call (`ModelInfo` in this case) where a _potentially migrated_ model can be provided.

Currently, the modelmanager facade is initialized with two `ModelManagerBackend` instances (one for the model and one for the controller); in the case of `juju show-model` _both_ instances point to the controller model. The actual implementation for ModelInfo eventually calls the auxiliary method `GetBackend(actual-model-uuid)` on the _model_ backend that was used to initialize the facade to obtain yet another backend that can be used to access model-related info for the model being queried.

The PR updates the `modelManagerStateShim` implementation in `apiserver/common` so it can be optionally made user-aware. This is achieved by introducing another constructor that also takes a user tag argument. The shim's implementation of `GetBackend` will check if a user has been provided and apply the appropriate checks to figure out if the targeted model has been migrated and whether a `RedirectError` should be returned to the user.

The other half of the PR updates the CLI code so it can detect redirect errors in `ModelInfo` RPC responses and emit the appropriate error.

## QA steps

```console
$ juju bootstrap lxd dst
$ juju bootstrap lxd src
$ juju add-model mig
$ juju switch controller

# Make a copy of your $HOME/.local/share/juju/models.yaml as the UUID may 
# removed after the migration. If that happens just copy the relevant model 
# entry from dst to src
$ juju migrate src:mig dst

# Wait a bit for the migration to complete

$ juju show-model mig
ERROR Model "mig" has been migrated to controller "dst".
To access it run 'juju switch dst:mig'.

# Now remove the entry for *dst* from ~/.local/share/juju/controllers.yaml and run the command again
$ juju show-model mig
ERROR Model "mig" has been migrated to another controller.
To access it run one of the following commands (you can replace the -c argument with your own preferred controller name):
  'juju login 10.220.120.99:17070 -c dst'

New controller fingerprint [88:0F:80:6E:EF:D7:98:2D:01:6D:9D:A1:6E:E5:F7:D2:9F:37:0F:A8:F9:E9:4B:AF:2B:40:41:BB:84:91:74:E0]
```