### PR TITLE
Use microk8s label metadata to detect cloud

### DIFF
--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -54,6 +54,11 @@ func init() {
 // cloud provider from node labels.
 func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 	return map[string][]k8slabels.Selector{
+		caas.K8sCloudMicrok8s: {
+			newLabelRequirements(
+				requirementParams{"microk8s.io/cluster", selection.Exists, nil},
+			),
+		},
 		caas.K8sCloudGCE: {
 			// GKE.
 			newLabelRequirements(

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -4,9 +4,6 @@
 package provider
 
 import (
-	"os"
-	"strings"
-
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
@@ -49,19 +46,12 @@ func getCloudRegionFromNodeMeta(node core.Node) (string, string) {
 		for _, checker := range checkers {
 			if checker.Matches(k8slabels.Set(node.GetLabels())) {
 				region := node.Labels[regionLabelName]
+				if region == "" && cloudType == caas.K8sCloudMicrok8s {
+					region = caas.Microk8sRegion
+				}
 				return cloudType, region
 			}
 		}
-	}
-	// TODO - add microk8s node label check when available
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", ""
-	}
-	hostname = strings.ToLower(hostname)
-	hostLabel, _ := node.Labels["kubernetes.io/hostname"]
-	if node.Name == hostname && hostLabel == hostname {
-		return caas.K8sCloudMicrok8s, caas.Microk8sRegion
 	}
 	return "", ""
 }


### PR DESCRIPTION
## Description of change

microk8s now adds the "microk8s.cluster" label to its node, so we use that for detection

## QA steps

microk8s.config | juju add-k8s foo

