### PR TITLE
Fix operator version tag for upgrade-juju

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -66,19 +66,6 @@ def assess_caas_charm_deployment(caas_client):
     model_name = caas_client.client.get_controller_uuid() + '-testcaas'
     k8s_model = caas_client.add_model(model_name)
 
-    k8s_model.deploy(
-        charm="cs:~juju/mediawiki-k8s-3",
-        config='juju-external-hostname={}'.format(external_hostname),
-    )
-
-    k8s_model.deploy(
-        charm="cs:~juju/mariadb-k8s-0",
-    )
-
-    k8s_model.juju('relate', ('mediawiki-k8s:db', 'mariadb-k8s:server'))
-    k8s_model.juju('expose', ('mediawiki-k8s',))
-    k8s_model.wait_for_workloads(timeout=600)
-
     def success_hook():
         log.info(caas_client.kubectl('get', 'all', '--all-namespaces'))
 
@@ -87,13 +74,30 @@ def assess_caas_charm_deployment(caas_client):
         log.info(caas_client.kubectl('get', 'pv,pvc', '-n', model_name))
         caas_client.ensure_cleanup()
 
-    url = '{}://{}'.format('http', external_hostname)
-    check_app_healthy(
-        url, timeout=300,
-        success_hook=success_hook,
-        fail_hook=fail_hook,
-    )
-    k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
+    try:
+        k8s_model.deploy(
+            charm="cs:~juju/mediawiki-k8s-3",
+            config='juju-external-hostname={}'.format(external_hostname),
+        )
+
+        k8s_model.deploy(
+            charm="cs:~juju/mariadb-k8s-0",
+        )
+
+        k8s_model.juju('relate', ('mediawiki-k8s:db', 'mariadb-k8s:server'))
+        k8s_model.juju('expose', ('mediawiki-k8s',))
+        k8s_model.wait_for_workloads(timeout=600)
+
+        url = '{}://{}'.format('http', external_hostname)
+        check_app_healthy(
+            url, timeout=300,
+            success_hook=success_hook,
+        )
+        k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
+    except:
+        # run cleanup steps then raise.
+        fail_hook()
+        raise
 
 
 def parse_args(argv):

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1317,8 +1317,7 @@ func (k *kubernetesClient) Upgrade(appName string, vers version.Number) error {
 		if !podcfg.IsJujuOCIImage(c.Image) {
 			continue
 		}
-		tagSep := strings.LastIndex(c.Image, ":")
-		c.Image = fmt.Sprintf("%s:%s", c.Image[:tagSep], vers.String())
+		c.Image = podcfg.RebuildOldOperatorImagePath(c.Image, vers)
 		existingStatefulSet.Spec.Template.Spec.Containers[i] = c
 	}
 	_, err = statefulsets.Update(existingStatefulSet)

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -41,7 +41,7 @@ func IsJujuOCIImage(imagePath string) bool {
 // GetJujuOCIImagePath returns the jujud oci image path.
 func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) string {
 	// First check the deprecated "caas-operator-image-path" config.
-	imagePath := rebuildOldOperatorImagePath(
+	imagePath := RebuildOldOperatorImagePath(
 		controllerCfg.CAASOperatorImagePath(), ver,
 	)
 	if imagePath != "" {
@@ -50,7 +50,8 @@ func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) st
 	return imageRepoToPath(controllerCfg.CAASImageRepo(), ver)
 }
 
-func rebuildOldOperatorImagePath(imagePath string, ver version.Number) string {
+// RebuildOldOperatorImagePath returns a updated image path for the specified juju version.
+func RebuildOldOperatorImagePath(imagePath string, ver version.Number) string {
 	if imagePath == "" {
 		return ""
 	}
@@ -65,6 +66,7 @@ func tagImagePath(path string, ver version.Number) string {
 		verString = splittedPath[1]
 	}
 	if ver != version.Zero {
+		ver.Build = 0
 		verString = ver.String()
 	}
 	if verString != "" {


### PR DESCRIPTION
## Description of change

Fix operator vesion  tag for `upgrade-controller/model`;

Driveby: do cleanup steps if got any errors then raise because `BootstrapManager.ensure_cleanup` is not reliable at all.

## QA steps

- deploy caas workload on `2.6-rc3`;

## Documentation changes

None

## Bug reference

Not released yet
