### PR TITLE
Add make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,9 @@ pre-check:
 	@echo running pre-test checks
 	@INCLUDE_GOLINTERS=1 $(PROJECT_DIR)/scripts/verify.bash
 
-check: dep pre-check
+check: pre-check test
+
+test: dep
 	go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
 
 install: dep go-install


### PR DESCRIPTION
## Description of change

Add a new `make test ` target which is like `make check` but does not run the linters.
