### PR TITLE
Increase default teardown timeout

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -116,7 +116,7 @@ def get_teardown_timeout(client):
     elif client.env.provider == 'gce':
         return 1200
     else:
-        return 600
+        return 900
 
 
 def parse_new_state_server_from_error(error):


### PR DESCRIPTION
## Description of change

A small number of our CI jobs are failing because the machine or controller teardown takes longer than a pre-defined 10 minutes. This commit increases the default limit to 15 minutes. It doesn't affect the global timeout for the job that is set by Jenkins Job Builder.

## QA steps

n/a

## Documentation changes

n/a

## Bug reference

n/a