### PR TITLE
Feature/bootstrap gke

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -125,11 +125,14 @@ def main(argv=None):
     bs_manager = BootstrapManager.from_args(args)
 
     with k8s_provider(bs_manager).substrate_context() as caas_client:
+        # add-k8s --local
         with bs_manager.booted_context(
             args.upload_tools,
             caas_image_repo=args.caas_image_repo,
         ):
-            assess_caas_charm_deployment(caas_client)
+            # add-k8s to controller
+            caas_client.add_k8s()
+            # assess_caas_charm_deployment(caas_client)
         return 0
 
 

--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -112,6 +112,11 @@ def parse_args(argv):
         choices=K8sProviderType.keys(),
         help='Specify K8s cloud provider to use for CAAS tests.'
     )
+    parser.add_argument(
+        '--k8s-controller',
+        action='store_false',
+        help='Bootstrap to k8s cluster or not.'
+    )
 
     add_basic_testing_arguments(parser, existing=False)
     return parser.parse_args(argv)
@@ -126,12 +131,15 @@ def main(argv=None):
 
     with k8s_provider(bs_manager).substrate_context() as caas_client:
         # add-k8s --local
+        if args.k8s_controller:
+            caas_client.add_k8s(True)
         with bs_manager.booted_context(
             args.upload_tools,
             caas_image_repo=args.caas_image_repo,
         ):
-            # add-k8s to controller
-            caas_client.add_k8s()
+            if not args.k8s_controller:
+                # add-k8s to controller
+                caas_client.add_k8s(False)
             # assess_caas_charm_deployment(caas_client)
         return 0
 

--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -16,13 +16,20 @@ from time import sleep
 
 import requests
 
-from deploy_stack import BootstrapManager
+from deploy_stack import (
+    BootstrapManager,
+    # temp_juju_home,
+)
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
     JujuAssertionError,
 )
 
+from jujupy.client import (
+    temp_bootstrap_env,
+    # juju_home_path,
+)
 from jujupy.utility import until_timeout
 from jujupy.k8s_provider import (
     providers,
@@ -114,7 +121,7 @@ def parse_args(argv):
     )
     parser.add_argument(
         '--k8s-controller',
-        action='store_false',
+        action='store_true',
         help='Bootstrap to k8s cluster or not.'
     )
 
@@ -132,6 +139,17 @@ def main(argv=None):
     with k8s_provider(bs_manager).substrate_context() as caas_client:
         # add-k8s --local
         if args.k8s_controller:
+            # old_home = bs_manager.client.env.juju_home
+            # old_env = bs_manager.client.env.environment
+            # print("old_home ---> ", old_home)
+            # bs_manager.client.env.environment = bs_manager.temp_env_name
+            # print("bs_manager.client.env.environment ---> ", bs_manager.client.env.environment)
+            # with temp_bootstrap_env(bs_manager.client.env.juju_home, bs_manager.client) as tm_h:
+            #     print("tm_h ---> ", tm_h)
+            #     bs_manager.client.env.juju_home = tm_h
+            #     caas_client.refresh_home(bs_manager.client)
+            # bs_manager.client.env.juju_home = old_home
+            # bs_manager.client.env.environment = old_env
             caas_client.add_k8s(True)
         with bs_manager.booted_context(
             args.upload_tools,

--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -45,9 +45,9 @@ def check_app_healthy(url, timeout=300, success_hook=lambda: None, fail_hook=lam
     for remaining in until_timeout(timeout):
         try:
             r = requests.get(url)
-            if r.ok and r.status_code < 400:
-                return success_hook()
             status_code = r.status_code
+            if r.ok and status_code < 400:
+                return success_hook()
         except IOError:
             ...
         finally:
@@ -71,7 +71,7 @@ def get_app_endpoint(caas_client, model_name, app_name, svc_type, timeout=120):
                 if lb_addr:
                     log.info('load balancer addr for %s is %s' % (app_name, lb_addr))
                     return lb_addr
-            except:
+            except:  # noqa: E722
                 ...
         raise JujuAssertionError('No load balancer addr available for %s' % app_name)
         

--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -115,14 +115,19 @@ def assess_caas_charm_deployment(caas_client, caas_provider):
         success_hook()
         log.info(caas_client.kubectl('get', 'pv,pvc', '-n', model_name))
         caas_client.ensure_cleanup()
-
-    endpoint = deploy_test_workloads(caas_client, k8s_model, caas_provider)
-    check_app_healthy(
-        endpoint, timeout=300,
-        success_hook=success_hook,
-        fail_hook=fail_hook,
-    )
-    k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
+        
+    try:
+        endpoint = deploy_test_workloads(caas_client, k8s_model, caas_provider)
+        check_app_healthy(
+            endpoint, timeout=300,
+            success_hook=success_hook,
+            fail_hook=fail_hook,
+        )
+        k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
+    except:  # noqa: E722
+        # run cleanup steps then raise.	
+        fail_hook()	
+        raise
 
 
 def parse_args(argv):

--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -12,24 +12,19 @@ from __future__ import print_function
 import argparse
 import logging
 import sys
+import json
 from time import sleep
 
 import requests
 
-from deploy_stack import (
-    BootstrapManager,
-    # temp_juju_home,
-)
+from deploy_stack import BootstrapManager
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
     JujuAssertionError,
 )
 
-from jujupy.client import (
-    temp_bootstrap_env,
-    # juju_home_path,
-)
+from jujupy.client import temp_bootstrap_env
 from jujupy.utility import until_timeout
 from jujupy.k8s_provider import (
     providers,
@@ -53,8 +48,8 @@ def check_app_healthy(url, timeout=300, success_hook=lambda: None, fail_hook=lam
             if r.ok and r.status_code < 400:
                 return success_hook()
             status_code = r.status_code
-        except IOError as e:
-            log.error(e)
+        except IOError:
+            ...
         finally:
             sleep(3)
             if remaining % 30 == 0:
@@ -64,9 +59,49 @@ def check_app_healthy(url, timeout=300, success_hook=lambda: None, fail_hook=lam
     raise JujuAssertionError('gitlab is not healthy')
 
 
-def assess_caas_charm_deployment(caas_client):
-    external_hostname = caas_client.get_external_hostname()
+def get_app_endpoint(caas_client, model_name, app_name, svc_type, timeout=120):
+    if svc_type == 'LoadBalancer':
+        for remaining in until_timeout(timeout):
+            try:
+                lb_addr = json.loads(
+                    caas_client.kubectl(
+                        '-n', model_name, 'get', 'svc', app_name, '-o', 'json'
+                    )
+                )['status']['loadBalancer']['ingress'][0]['ip']
+                if lb_addr:
+                    log.info('load balancer addr for %s is %s' % (app_name, lb_addr))
+                    return lb_addr
+            except:
+                ...
+        raise JujuAssertionError('No load balancer addr available for %s' % app_name)
+        
+    return caas_client.get_external_hostname()
 
+
+def deploy_test_workloads(caas_client, k8s_model, caas_provider):
+    k8s_model.deploy(
+        charm="cs:~juju/mariadb-k8s-0",
+    )
+    svc_type = None
+    if caas_provider == K8sProviderType.MICROK8S.name:
+        k8s_model.deploy(
+            charm="cs:~juju/mediawiki-k8s-3",
+            config='juju-external-hostname={}'.format(caas_client.get_external_hostname()),
+        )
+        k8s_model.juju('expose', ('mediawiki-k8s',))
+    else:
+        k8s_model.deploy(
+            charm="cs:~juju/mediawiki-k8s-3",
+            config='kubernetes-service-type=LoadBalancer',
+        )
+        svc_type = 'LoadBalancer'
+
+    k8s_model.juju('relate', ('mediawiki-k8s:db', 'mariadb-k8s:server'))
+    k8s_model.wait_for_workloads(timeout=600)
+    return 'http://' + get_app_endpoint(caas_client, k8s_model.model_name, 'mediawiki-k8s', svc_type)
+    
+    
+def assess_caas_charm_deployment(caas_client, caas_provider):
     if not caas_client.check_cluster_healthy(timeout=60):
         raise JujuAssertionError('k8s cluster is not healthy because kubectl is not accessible')
 
@@ -81,30 +116,13 @@ def assess_caas_charm_deployment(caas_client):
         log.info(caas_client.kubectl('get', 'pv,pvc', '-n', model_name))
         caas_client.ensure_cleanup()
 
-    try:
-        k8s_model.deploy(
-            charm="cs:~juju/mediawiki-k8s-3",
-            config='juju-external-hostname={}'.format(external_hostname),
-        )
-
-        k8s_model.deploy(
-            charm="cs:~juju/mariadb-k8s-0",
-        )
-
-        k8s_model.juju('relate', ('mediawiki-k8s:db', 'mariadb-k8s:server'))
-        k8s_model.juju('expose', ('mediawiki-k8s',))
-        k8s_model.wait_for_workloads(timeout=600)
-
-        url = '{}://{}'.format('http', external_hostname)
-        check_app_healthy(
-            url, timeout=300,
-            success_hook=success_hook,
-        )
-        k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
-    except:
-        # run cleanup steps then raise.
-        fail_hook()
-        raise
+    endpoint = deploy_test_workloads(caas_client, k8s_model, caas_provider)
+    check_app_healthy(
+        endpoint, timeout=300,
+        success_hook=success_hook,
+        fail_hook=fail_hook,
+    )
+    k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
 
 
 def parse_args(argv):
@@ -138,27 +156,17 @@ def main(argv=None):
 
     with k8s_provider(bs_manager).substrate_context() as caas_client:
         # add-k8s --local
-        if args.k8s_controller:
-            # old_home = bs_manager.client.env.juju_home
-            # old_env = bs_manager.client.env.environment
-            # print("old_home ---> ", old_home)
-            # bs_manager.client.env.environment = bs_manager.temp_env_name
-            # print("bs_manager.client.env.environment ---> ", bs_manager.client.env.environment)
-            # with temp_bootstrap_env(bs_manager.client.env.juju_home, bs_manager.client) as tm_h:
-            #     print("tm_h ---> ", tm_h)
-            #     bs_manager.client.env.juju_home = tm_h
-            #     caas_client.refresh_home(bs_manager.client)
-            # bs_manager.client.env.juju_home = old_home
-            # bs_manager.client.env.environment = old_env
+        if args.k8s_controller and args.caas_provider != K8sProviderType.MICROK8S.name:
+            # microk8s is built-in cloud, no need run add-k8s for bootstrapping.
             caas_client.add_k8s(True)
-        with bs_manager.booted_context(
+        with bs_manager.existing_booted_context(
             args.upload_tools,
             caas_image_repo=args.caas_image_repo,
         ):
             if not args.k8s_controller:
                 # add-k8s to controller
                 caas_client.add_k8s(False)
-            # assess_caas_charm_deployment(caas_client)
+            assess_caas_charm_deployment(caas_client, args.caas_provider)
         return 0
 
 

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -1004,7 +1004,7 @@ class BootstrapManager:
             # the failed operation.
             with logged_exception(logging):
                 yield
-        except:
+        except:  # noqa: E722
             # If run from a windows machine may not have ssh to get
             # logs
             with self.client.ignore_soft_deadline():
@@ -1032,7 +1032,7 @@ class BootstrapManager:
                 if addable_machines is not None:
                     self.client.add_ssh_machines(addable_machines)
                 yield
-        except:
+        except:  # noqa: E722
             if self.has_controller:
                 safe_print_status(self.client)
             else:

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -1056,9 +1056,12 @@ class BootstrapManager:
                     if not self.keep_env:
                         if self.has_controller:
                             self.collect_resource_details()
-                        self.tear_down()
-                        unclean_resources = self.ensure_cleanup()
-                        error_if_unclean(unclean_resources)
+                        try:
+                            self.tear_down()
+                        finally:
+                            # ensure_cleanup does not reply on controller at all, so always try to do cleanup.
+                            unclean_resources = self.ensure_cleanup()
+                            error_if_unclean(unclean_resources)
 
     # GZ 2016-08-11: Should this method be elsewhere to avoid poking backend?
     def _should_dump(self):

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -445,8 +445,10 @@ class JujuData:
         if self.provider != 'kubernetes':
             raise Exception("cloud type %s has to be kubernetes" % self.provider)
 
+        def f(x):
+            return [x] + x.split('/')
+
         cache_key = 'host-cloud-region'
-        f = lambda x: [x] + x.split('/')
         raw = getattr(self, cache_key, None)
         if raw is not None:
             return f(raw)

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -364,12 +364,19 @@ class JujuData:
         raise LookupError('No such endpoint: {}'.format(endpoint))
 
     def find_cloud_by_host_cloud_region(self, host_cloud_region):
+        if not self.clouds['clouds']:
+            self.load_yaml()
         for cloud, cloud_config in self.clouds['clouds'].items():
             if cloud_config['type'] != 'kubernetes':
                 continue
             if cloud_config['host-cloud-region'] == host_cloud_region:
                 return cloud
-        raise LookupError('No such host cloud region: {}'.format(host_cloud_region))
+        raise LookupError(
+            'No such host cloud region: {host_cloud_region}, clouds: {clouds}'.format(
+                host_cloud_region=host_cloud_region,
+                clouds=self.clouds['clouds'],
+            )
+        )
 
     def set_model_name(self, model_name, set_controller=True):
         if set_controller:

--- a/acceptancetests/jujupy/k8s_provider/__init__.py
+++ b/acceptancetests/jujupy/k8s_provider/__init__.py
@@ -23,3 +23,4 @@ from .factory import providers  # noqa
 # it's not for outside to use, so alias them to _.
 from .kubernetes_core import KubernetesCore as _  # noqa
 from .microk8s import MicroK8s as _  # noqa
+from .gke import GKE as _  # noqa

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -135,7 +135,6 @@ class Base(object):
             self._ensure_kube_dir()
             self.check_cluster_healthy()
             self._ensure_cluster_config()
-            self._add_k8s()
 
             yield self
         finally:
@@ -146,7 +145,7 @@ class Base(object):
         # returns the newly added CAAS model.
         return self.client.add_model(env=self.client.env.clone(model_name), cloud_region=self.cloud_name)
 
-    def _add_k8s(self):
+    def add_k8s(self):
         self.client.controller_juju(
             'add-k8s',
             (self.cloud_name, '--controller', self.client.env.controller.name)

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -81,6 +81,7 @@ class Base(object):
     kube_config_path = None
 
     default_storage_class_name = None
+    kubeconfig_cluster_name = None
 
     def _ensure_cluster_stack(self):
         """ensures or checks if stack/infrastructure is ready to use.
@@ -145,11 +146,17 @@ class Base(object):
         # returns the newly added CAAS model.
         return self.client.add_model(env=self.client.env.clone(model_name), cloud_region=self.cloud_name)
 
-    def add_k8s(self):
-        self.client.controller_juju(
-            'add-k8s',
-            (self.cloud_name, '--controller', self.client.env.controller.name)
-        )
+    def add_k8s(self, is_local=False):
+        if is_local:
+            self.client.controller_juju(
+                'add-k8s',
+                (self.cloud_name, '--local', '--cluster-name', self.kubeconfig_cluster_name)
+            )
+        else:
+            self.client.controller_juju(
+                'add-k8s',
+                (self.cloud_name, '--controller', self.client.env.controller.name)
+            )
         logger.debug('added caas cloud, now all clouds are -> \n%s', self.client.list_clouds(format='yaml'))
 
     def check_cluster_healthy(self, timeout=0):

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -177,7 +177,7 @@ class Base(object):
             self.kubectl('get', '-n', namespace, 'cm', cm_name, '-o', 'json')
         )
         data = cm.get('data', {})
-        data[key] = str(value)
+        data[key] = value if isinstance(value, str) else str(value)
         cm['data'] = data
         self.kubectl_apply(json.dumps(cm))
 

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -172,6 +172,15 @@ class Base(object):
     def kubectl(self, *args):
         return self.sh(*(self._kubectl_bin + args))
 
+    def patch_configmap(self, namespace, cm_name, key, value):
+        cm = json.loads(
+            self.kubectl('get', '-n', namespace, 'cm', cm_name, '-o', 'json')
+        )
+        data = cm.get('data', {})
+        data[key] = str(value)
+        cm['data'] = data
+        self.kubectl_apply(json.dumps(cm))
+
     def sh(self, *args):
         return subprocess.check_output(
             # args should be str.

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -209,9 +209,11 @@ class Base(object):
         self.kubectl_apply(json.dumps(cm))
 
     def sh(self, *args):
+        args = [str(arg) for arg in args]
+        logger.debug('sh -> %s', ' '.join(args))
         return subprocess.check_output(
-            # args should be str.
-            (str(arg) for arg in args),
+            # cmd should be a list of str.
+            args,
             stderr=subprocess.STDOUT,
         ).decode('UTF-8').strip()
 

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -32,7 +32,10 @@ from jujupy.utility import (
     ensure_dir,
     until_timeout,
 )
-from jujupy.client import temp_bootstrap_env
+from jujupy.client import (
+    temp_bootstrap_env,
+    JujuData,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -120,11 +123,11 @@ class Base(object):
 
         self.timeout = timeout
         old_environment = bs_manager.client.env.environment
+    
         bs_manager.client.env.environment = bs_manager.temp_env_name
         with temp_bootstrap_env(bs_manager.client.env.juju_home, bs_manager.client) as tm_h:
             self.client.env.juju_home = tm_h
             self.refresh_home(self.client)
-
         bs_manager.client.env.environment = old_environment
 
     def refresh_home(self, client):
@@ -175,7 +178,6 @@ class Base(object):
             used_feature_flags=self.client.used_feature_flags, juju_home=juju_home,
         )
         logger.debug('added caas cloud, now all clouds are -> \n%s', self.client.list_clouds(format='yaml'))
-        print('add-k8s env',  self.sh('env'))
 
     def check_cluster_healthy(self, timeout=0):
         def check():

--- a/acceptancetests/jujupy/k8s_provider/factory.py
+++ b/acceptancetests/jujupy/k8s_provider/factory.py
@@ -42,7 +42,7 @@ class Factory(object):
             key = K8sProviderType[name]
             return self._providers[key]
         except KeyError:
-            raise ProviderNotAvailable("provider {} is not defined".format(key.name))
+            raise ProviderNotAvailable("provider {} is not defined".format(name))
 
     @property
     def providers(self):

--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -1,0 +1,64 @@
+# This file is part of JujuPy, a library for driving the Juju CLI.
+# Copyright 2013-2019 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the Lesser GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the Lesser
+# GNU General Public License for more details.
+#
+# You should have received a copy of the Lesser GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Functionality for handling installed or other juju binaries
+# (including paths etc.)
+
+
+from __future__ import print_function
+
+import logging
+# import shutil
+
+from .base import (
+    Base,
+    K8sProviderType,
+)
+from .factory import register_provider
+
+
+logger = logging.getLogger(__name__)
+
+
+@register_provider
+class GKE(Base):
+
+    name = K8sProviderType.GKE
+
+    def __init__(self, bs_manager, timeout=1800):
+        super().__init__(bs_manager, timeout)
+        self.default_storage_class_name = '???'
+
+    def _ensure_cluster_stack(self):
+        self.provision_gke()
+
+    def _tear_down_substrate(self):
+        # No need to tear down microk8s.
+        ...
+
+    def _ensure_kube_dir(self):
+        # TODO
+        ...
+
+    def _ensure_cluster_config(self):
+        # TODO
+        ...
+
+    def _node_address_getter(self, node):
+        # TODO
+        ...
+
+    def provision_gke(self):
+        ...

--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -57,7 +57,7 @@ class GKE(Base):
     def __init__(self, bs_manager, timeout=1800):
         super().__init__(bs_manager, timeout)
 
-        self.gke_cluster_name = self.client.env.controller.name  # use controller name as cluster name
+        self.gke_cluster_name = self.client.env.controller.name  # use controller name for cluster name
         self.default_storage_class_name = ''
         self.__init_driver(bs_manager.client.env)
 
@@ -124,7 +124,7 @@ class GKE(Base):
                 cluster_id=self.gke_cluster_name, **self.default_params,
             )
         except exceptions.NotFound:
-            ...
+            pass
 
     def _ensure_kube_dir(self):
         cluster = self._get_cluster(self.gke_cluster_name)
@@ -144,10 +144,10 @@ class GKE(Base):
             self.kubectl_path = kubectl_bin_path
         else:
             self.sh(
-                'curl', '-LO',
-                'https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl',
+                'curl', 'https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl',
                 '-o', self.kubectl_path
             )
+            os.chmod(self.kubectl_path, 0o774)
 
     def _ensure_cluster_config(self):
         ...

--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -112,8 +112,7 @@ class GKE(Base):
         ...
 
     def _node_address_getter(self, node):
-        # TODO
-        print('_node_address_getter node --->', node)
+        return [addr['address'] for addr in node['status']['addresses'] if addr['type'] == 'ExternalIP'][0]
 
     def _get_cluster(self, name):
         return self.driver.get_cluster(

--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -105,7 +105,7 @@ class GKE(Base):
             self.sh(
                 'curl', '-LO',
                 'https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl',
-                '-o', self.self.kubectl_path
+                '-o', self.kubectl_path
             )
 
     def _ensure_cluster_config(self):

--- a/acceptancetests/jujupy/k8s_provider/kubernetes_core.py
+++ b/acceptancetests/jujupy/k8s_provider/kubernetes_core.py
@@ -206,7 +206,7 @@ class KubernetesCore(Base):
 
     def _node_address_getter(self, node):
         # TODO(ycliuhw): implement here once described k8s core node to find the corrent node ip.
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __ensure_lxd_profile(self, profile, model_name):
         profile = profile.format(model_name=model_name)

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -56,7 +56,7 @@ class MicroK8s(Base):
         # choose to use microk8s.kubectl
         mkubectl = shutil.which('microk8s.kubectl')
         if mkubectl is None:
-            raise AssertionError(mkubectl + "is required!")
+            raise AssertionError("microk8s.kubectl is required!")
         self.kubectl_path = mkubectl
 
         # export microk8s.config to kubeconfig file.

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -46,7 +46,7 @@ class MicroK8s(Base):
 
     def _tear_down_substrate(self):
         # No need to tear down microk8s.
-        ...
+        logger.warn('skip tearing down microk8s')
 
     def _ensure_kube_dir(self):
         # choose to use microk8s.kubectl

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -44,6 +44,10 @@ class MicroK8s(Base):
     def _ensure_cluster_stack(self):
         self.__ensure_microk8s_installed()
 
+    def _tear_down_substrate(self):
+        # No need to tear down microk8s.
+        ...
+
     def _ensure_kube_dir(self):
         # choose to use microk8s.kubectl
         mkubectl = shutil.which('microk8s.kubectl')

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 class MicroK8s(Base):
 
     name = K8sProviderType.MICROK8S
+    cloud_name = 'microk8s'  # built-in cloud name
 
     def __init__(self, bs_manager, timeout=1800):
         super().__init__(bs_manager, timeout)

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -68,7 +68,10 @@ class MicroK8s(Base):
 
     def _ensure_cluster_config(self):
         self.__enable_addons()
-        self.__tmp_fix_patch_kubedns()
+        try:
+            self.__tmp_fix_patch_kubedns()
+        except Exception as e:
+            logger.error(e)
 
     def _node_address_getter(self, node):
         # microk8s uses the node's 'InternalIP`.

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import logging
 import shutil
 import os
+import json
 
 import dns.resolver
 
@@ -97,6 +98,5 @@ class MicroK8s(Base):
         nameservers = dns.resolver.Resolver().nameservers
         for ns in nameservers:
             if ping(ns):
-                ns = '8.8.8.8'
-                return self.patch_configmap('kube-system', 'kube-dns', 'upstreamNameservers', [ns])
+                return self.patch_configmap('kube-system', 'kube-dns', 'upstreamNameservers', json.dumps([ns]))
         raise Exception('No working nameservers found from %s to use for patching kubedns' % nameservers)

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -1,4 +1,4 @@
-apache-libcloud>=2.2.1
+apache-libcloud>=2.4.0
 azure>=2.0.0rc3
 azure-batch>=0.30.0rc3
 azure-common>=1.1.3

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -40,3 +40,4 @@ boto3>=1.5.18
 pyaml>=17.12.1
 pycrypto==2.6.1
 dnspython==1.16.0
+google-api-python-client==1.7.8

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -41,3 +41,4 @@ pyaml>=17.12.1
 pycrypto==2.6.1
 dnspython==1.16.0
 google-api-python-client==1.7.8
+google-cloud-container==0.2.1

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -38,3 +38,4 @@ python-novaclient>=6.0.2
 pyOpenSSL>=17.5.0
 boto3>=1.5.18
 pyaml>=17.12.1
+pycrypto==2.6.1

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -39,3 +39,4 @@ pyOpenSSL>=17.5.0
 boto3>=1.5.18
 pyaml>=17.12.1
 pycrypto==2.6.1
+dnspython==1.16.0


### PR DESCRIPTION
## Description of change

Implement bootstrapping to GKE for CI tests;

## QA steps

To run a test locally with lxd and locally complied juju:

  * ```$ mkdir /tmp/test-run```
  * ```$ export JUJU_HOME=/tmp/test-run```
  * ```$ vim $JUJU_HOME/environments.yaml  # copy gke & microk8s environment from cloud-city```
    ```yaml
    environments:
        gke:
            type: kubernetes
            test-mode: true
            ...
        microk8s:
            type: kubernetes
            test-mode: true
            ...
       
    ```
  * ```export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository```
  * ```mkdir /tmp/artifacts```
  * Now you can run the test with:
     * ```$ ./acceptancetests/assess_caas_deploy_charms.py gke $GOPATH/bin/juju /tmp/artifacts nw-caas-deploy-charms-gke --caas-image-repo=jujuqabot --caas-provider=GKE --k8s-controller --debug```
    * ```$ ./acceptancetests/assess_caas_deploy_charms.py microk8s $GOPATH/bin/juju /tmp/artifacts nw-caas-deploy-charms-microk8s --caas-image-repo=jujuqabot --caas-provider=MICROK8S --k8s-controller --debug```


## Documentation changes

None

## Bug reference

None
