### PR TITLE
2.5.5 release

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.5.6"
+#define MyAppVersion "2.5.5"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.5.6
+version: 2.5.5
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.5.6"
+const version = "2.5.5"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")


### PR DESCRIPTION
## Description of change

We need a 2.5.5 build for the 2.5.5 release. Because we burned 2.5.5
and then didn't burn it, we moved the version back to 2.5.4, which
meant that aws s3 buckets didn't have the correct version number in
the path of the files. It had 2.5.4 instead of 2.5.5.

The following commit that bumped it to 2.5.6 then meant we never had
a 2.5.5 build in s3, so we could never do a build from it. This
fixes this, but after this we'll need to bump it back to 2.5.6!
