### PR TITLE
Allow lxd profile test to run on aws

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -166,15 +166,19 @@ class JujuData:
                 provider = self.provider
             except NoProvider:
                 provider = None
+            self.lxd = (self._config.get('container') == 'lxd' or provider == 'lxd')
             self.kvm = (bool(self._config.get('container') == 'kvm'))
             self.maas = bool(provider == 'maas')
             self.joyent = bool(provider == 'joyent')
             self.logging_config = self._config.get('logging-config')
+            self.provider_type = provider
         else:
+            self.lxd = False
             self.kvm = False
             self.maas = False
             self.joyent = False
             self.logging_config = None
+            self.provider_type = None
         self.credentials = {}
         self.clouds = {}
         self._cloud_name = cloud_name
@@ -200,6 +204,7 @@ class JujuData:
             model_name, config, juju_home=self.juju_home,
             controller=self.controller,
             bootstrap_to=self.bootstrap_to)
+        result.lxd = self.lxd
         result.kvm = self.kvm
         result.maas = self.maas
         result.joyent = self.joyent
@@ -208,6 +213,7 @@ class JujuData:
         result.clouds = deepcopy(self.clouds)
         result._cloud_name = self._cloud_name
         result.logging_config = self.logging_config
+        result.provider_type = self.provider_type
         return result
 
     @classmethod

--- a/acceptancetests/jujupy/exceptions.py
+++ b/acceptancetests/jujupy/exceptions.py
@@ -15,9 +15,7 @@
 
 import re
 import subprocess
-
 from datetime import timedelta
-
 
 __metaclass__ = type
 
@@ -131,7 +129,7 @@ class LXDProfileNotAvailable(Exception):
         self.machine = machine
 
     def __str__(self):
-        return self._fmt.format(env=self.profile_name)
+        return self._fmt.format(profile_name=self.profile_name, machine=self.machine)
 
 class LXDProfilesNotAvailable(Exception):
 
@@ -141,7 +139,7 @@ class LXDProfilesNotAvailable(Exception):
         self.profile_names = profile_names
 
     def __str__(self):
-        return self._fmt.format(env=self.profile_names)
+        return self._fmt.format(profile_names=self.profile_names)
 
 class StatusError(Exception):
     """Generic error for Status."""

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -15,23 +15,14 @@
 
 import logging
 from datetime import datetime
-from time import sleep
 from subprocess import CalledProcessError
+from time import sleep
 
-from jujupy.exceptions import (
-    VersionsNotUpdated,
-    AgentsNotStarted,
-    StatusNotMet,
-    LXDProfileNotAvailable,
-    LXDProfilesNotAvailable,
-    )
-from jujupy.status import (
-    Status,
-    )
-from jujupy.utility import (
-    until_timeout,
-    )
-
+from jujupy.exceptions import (AgentsNotStarted, LXDProfileNotAvailable,
+                               LXDProfilesNotAvailable, StatusNotMet,
+                               VersionsNotUpdated)
+from jujupy.status import Status
+from jujupy.utility import until_timeout
 
 log = logging.getLogger(__name__)
 
@@ -488,20 +479,20 @@ class WaitForLXDProfilesConditions(BaseCondition):
     def iter_blocking_state(self, status):
         """Wait until 'profiles' listed in machine lxd-profiles from status.
         """
-        matched = 0
+        profiles_names = self.profile_names(self.profiles)
         for machine_name, status in status.iter_machines(containers=True):
             for profile_name, machines in self.profiles.items():
                 if machine_name in machines:
-                    if not 'lxd-profiles' in status:
-                        yield ('lxd-profile ({})'.format(self.profiles), 'no lxd profile')
-                    if not profile_name in self.profile_names(status['lxd-profiles']):
-                        yield ('lxd-profile ({})'.format(self.profiles), 'missing profile')
-                    matched += 1
-        if matched < self.profile_total():
-            yield ('lxd-profile ({})'.format(self.profiles), 'not matched')
+                    status_profiles = self.profile_names(status.get('lxd-profiles', {}))
+                    if (profile_name in status_profiles) and (profile_name in profiles_names):
+                        profiles_names.remove(profile_name)
+                    if len(profiles_names) == 0:
+                        return
+        if len(profiles_names) > 0:
+            yield ('lxd-profile ({})'.format(profiles_names), 'not matched')
 
     def do_raise(self, model_name, status):
-        raise LXDProfilesNotAvailable(self.profiles)
+        raise LXDProfilesNotAvailable(self.profile_names(self.profiles))
 
     def profile_names(self, profiles):
         """profile names returns all the profile names from applied machines 
@@ -509,14 +500,7 @@ class WaitForLXDProfilesConditions(BaseCondition):
         
         :param profiles: profile configurations applied to machines
         """
-        names = []
+        names = set()
         for name in profiles.keys():
-            names.append(name)
-        return names
-
-    def profile_total(self):
-        """profile total returns the number of profiles to match against"""
-        result = 0
-        for profile_names in self.profiles.values():
-            result += len(profile_names)
-        return result
+            names.add(name)
+        return list(names)


### PR DESCRIPTION
## Description of change

Some of the lxd profile tests will fail because of the assertions
with in the test on what profiles should be where. This PR fixes
this, so that we don't care what profiles land where.

It's a better fix because we use a object for instance removal,
rather than a counter, so we can visually inspect the object to
see what's left to be applied rather than just knowing something
has to be applied.

## QA steps

Setup the acceptance tests correctly for aws, then run the 
following:

```
./assess_deploy_lxd_profile_bundle.py myaws --charm-bundle=cs:~juju-qa/bundle/lxd-profile-bundle-sub-1
```