### PR TITLE
For 2.6.1: modelcache worker, multiwatcher and shared state stopped error handling.

### DIFF
--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -657,6 +657,7 @@ func (*storeManagerSuite) TestRunStop(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	d, err := w.Next()
 	c.Assert(err, gc.ErrorMatches, "shared state watcher was stopped")
+	c.Assert(err, jc.Satisfies, IsErrStopped)
 	c.Assert(d, gc.HasLen, 0)
 }
 
@@ -742,7 +743,7 @@ func (*storeManagerSuite) TestMultiwatcherStop(c *gc.C) {
 	w := &Multiwatcher{all: sm}
 	err := w.Stop()
 	c.Assert(err, jc.ErrorIsNil)
-	checkNext(c, w, nil, ErrStopped.Error())
+	checkNext(c, w, nil, NewErrStopped().Error())
 }
 
 func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) {
@@ -759,7 +760,7 @@ func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) 
 	b.setFetchError(errors.New("some error"))
 	c.Logf("updating entity")
 	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
-	checkNext(c, w, nil, `shared state watcher was stopped`)
+	checkNext(c, w, nil, ErrStoppedf("shared state watcher").Error())
 }
 
 func StoreIncRef(a *multiwatcherStore, id interface{}) {

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -203,7 +203,7 @@ func (c *cacheWorker) processWatcher(watcherChanges chan<- []multiwatcher.Delta)
 	for {
 		deltas, err := c.watcher.Next()
 		if err != nil {
-			if errors.Cause(err) == state.ErrStopped {
+			if state.IsErrStopped(err) {
 				return nil
 			} else {
 				return errors.Trace(err)


### PR DESCRIPTION
## Description of change

While testing force destroy model functionality, I have noticed that 70% of my logs become quickly filled with:

```
134864d5-3510-42f9-81ee-a443e96c34ce: machine-0 2019-05-13 02:26:36 ERROR juju.worker.modelcache worker.go:171 watcher error, shared state watcher was stopped, getting new watcher
134864d5-3510-42f9-81ee-a443e96c34ce: machine-0 2019-05-13 02:26:36 ERROR juju.worker.modelcache worker.go:171 watcher error, shared state watcher was stopped, getting new watcher

``` 

Having a look at modelcache worker, it is aware and knowns what to do with state.ErrStopped but multiwatcher besides state.ErrStopped can also emit errors.Errorf("shared state watcher was stopped").

Upon close inspection, the error messages are very similar and they are emitted in  correct circumstances but when modelcache worker receives the error, it can only react to one and goes completely beserk with the other - re-starts continuously, spams logs, etc.

This PR creates a new state error type which is used by multiwatcher to signify that a state watcher was stopped. This allows to still emit messages with exactly the same messages as before but in addition enables error type checking in the model cache worker. With the patch in place, logs do not get flooded and model cache worker behaves correctly.