### PR TITLE
2.6.1: log operational errors

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -165,7 +165,7 @@ func NewFacadeV9(ctx facade.Context) (*APIv9, error) {
 }
 
 func newFacadeBase(ctx facade.Context) (*APIBase, error) {
-	model, err := ctx.State().Model()
+	facadeModel, err := ctx.State().Model()
 	if err != nil {
 		return nil, errors.Annotate(err, "getting model")
 	}
@@ -181,7 +181,7 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		registry           storage.ProviderRegistry
 		storageValidator   caas.Broker
 	)
-	if model.Type() == state.ModelTypeCAAS {
+	if facadeModel.Type() == state.ModelTypeCAAS {
 		storageValidator, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
 		if err != nil {
 			return nil, errors.Annotate(err, "getting caas client")
@@ -197,7 +197,7 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		storageAccess,
 		ctx.Auth(),
 		blockChecker,
-		model,
+		facadeModel,
 		stateCharm,
 		DeployApplication,
 		storagePoolManager,
@@ -271,12 +271,12 @@ func (api *APIBase) SetMetricCredentials(args params.ApplicationMetricCredential
 		return result, nil
 	}
 	for i, a := range args.Creds {
-		application, err := api.backend.Application(a.ApplicationName)
+		oneApplication, err := api.backend.Application(a.ApplicationName)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		err = application.SetMetricCredentials(a.MetricCredentials)
+		err = oneApplication.SetMetricCredentials(a.MetricCredentials)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 		}
@@ -383,11 +383,11 @@ func applicationConfigSchema(modelType state.ModelType) (environschema.Fields, s
 	}
 	// TODO(caas) - get the schema from the provider
 	defaults := caas.ConfigDefaults(k8s.ConfigDefaults())
-	schema, err := caas.ConfigSchema(k8s.ConfigSchema())
+	configSchema, err := caas.ConfigSchema(k8s.ConfigSchema())
 	if err != nil {
 		return nil, nil, err
 	}
-	return AddTrustSchemaAndDefaults(schema, defaults)
+	return AddTrustSchemaAndDefaults(configSchema, defaults)
 }
 
 func splitApplicationAndCharmConfig(modelType state.ModelType, inConfig map[string]string) (
@@ -572,11 +572,11 @@ func deployApplication(
 	}
 
 	var applicationConfig *application.Config
-	schema, defaults, err := applicationConfigSchema(modelType)
+	configSchema, defaults, err := applicationConfigSchema(modelType)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	applicationConfig, err = application.NewConfig(appSettings, schema, defaults)
+	applicationConfig, err = application.NewConfig(appSettings, configSchema, defaults)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -825,11 +825,11 @@ func (api *APIBase) updateCharm(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	charm, err := api.backend.Charm(curl)
+	aCharm, err := api.backend.Charm(curl)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return api.applicationSetCharm(params, charm)
+	return api.applicationSetCharm(params, aCharm)
 }
 
 // UpdateApplicationSeries updates the application series. Series for
@@ -889,7 +889,7 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 			return errors.Trace(err)
 		}
 	}
-	application, err := api.backend.Application(args.ApplicationName)
+	oneApplication, err := api.backend.Application(args.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -897,7 +897,7 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	return api.setCharmWithAgentValidation(
 		setCharmParams{
 			AppName:               args.ApplicationName,
-			Application:           application,
+			Application:           oneApplication,
 			Channel:               channel,
 			ConfigSettingsStrings: args.ConfigSettings,
 			ConfigSettingsYAML:    args.ConfigSettingsYAML,
@@ -934,7 +934,7 @@ func (api *APIBase) setCharmWithAgentValidation(
 		return api.applicationSetCharm(params, newCharm)
 	}
 
-	application := params.Application
+	oneApplication := params.Application
 	// Check if the controller agent tools version is greater than the
 	// version we support for the new LXD profiles.
 	// Then check all the units, to see what their agent tools versions is
@@ -952,13 +952,13 @@ func (api *APIBase) setCharmWithAgentValidation(
 	// machines what profiles they currently have and matching with the
 	// incoming update. This could be very costly when you have lots of
 	// machines.
-	currentCharm, _, err := application.Charm()
+	currentCharm, _, err := oneApplication.Charm()
 	if err != nil {
 		logger.Debugf("Unable to locate current charm: %v", err)
 	}
 	if lxdprofile.NotEmpty(lxdCharmProfiler{Charm: currentCharm}) ||
 		lxdprofile.NotEmpty(lxdCharmProfiler{Charm: newCharm}) {
-		if err := validateAgentVersions(application, api.model); err != nil {
+		if err := validateAgentVersions(oneApplication, api.model); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -1074,11 +1074,11 @@ func (api *APIBase) GetCharmURL(args params.ApplicationGet) (params.StringResult
 	if err := api.checkCanWrite(); err != nil {
 		return params.StringResult{}, errors.Trace(err)
 	}
-	application, err := api.backend.Application(args.ApplicationName)
+	oneApplication, err := api.backend.Application(args.ApplicationName)
 	if err != nil {
 		return params.StringResult{}, errors.Trace(err)
 	}
-	charmURL, _ := application.CharmURL()
+	charmURL, _ := oneApplication.CharmURL()
 	return params.StringResult{Result: charmURL.String()}, nil
 }
 
@@ -1271,12 +1271,12 @@ func addApplicationUnits(backend Backend, modelType state.ModelType, args params
 		}
 		attachStorage[i] = tag
 	}
-	application, err := backend.Application(args.ApplicationName)
+	oneApplication, err := backend.Application(args.ApplicationName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return addUnits(
-		application,
+		oneApplication,
 		args.ApplicationName,
 		args.NumUnits,
 		args.Placement,
@@ -1361,13 +1361,13 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 			return nil, errors.Errorf("unit %q is a subordinate", name)
 		}
 		var info params.DestroyUnitInfo
-		storage, err := storagecommon.UnitStorage(api.storageAccess, unit.UnitTag())
+		unitStorage, err := storagecommon.UnitStorage(api.storageAccess, unit.UnitTag())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
 		if arg.DestroyStorage {
-			for _, s := range storage {
+			for _, s := range unitStorage {
 				info.DestroyedStorage = append(
 					info.DestroyedStorage,
 					params.Entity{Tag: s.StorageTag().String()},
@@ -1375,7 +1375,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 			}
 		} else {
 			info.DestroyedStorage, info.DetachedStorage, err = storagecommon.ClassifyDetachedStorage(
-				api.storageAccess.VolumeAccess(), api.storageAccess.FilesystemAccess(), storage,
+				api.storageAccess.VolumeAccess(), api.storageAccess.FilesystemAccess(), unitStorage,
 			)
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -1477,7 +1477,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 				info.DestroyedUnits,
 				params.Entity{unit.UnitTag().String()},
 			)
-			storage, err := storagecommon.UnitStorage(api.storageAccess, unit.UnitTag())
+			unitStorage, err := storagecommon.UnitStorage(api.storageAccess, unit.UnitTag())
 			if err != nil {
 				return nil, err
 			}
@@ -1485,7 +1485,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 			// Filter out storage we've already seen. Shared
 			// storage may be attached to multiple units.
 			var unseen []state.StorageInstance
-			for _, stor := range storage {
+			for _, stor := range unitStorage {
 				storageTag := stor.StorageTag()
 				if storageSeen.Contains(storageTag) {
 					continue
@@ -1493,10 +1493,10 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 				storageSeen.Add(storageTag)
 				unseen = append(unseen, stor)
 			}
-			storage = unseen
+			unitStorage = unseen
 
 			if arg.DestroyStorage {
-				for _, s := range storage {
+				for _, s := range unitStorage {
 					info.DestroyedStorage = append(
 						info.DestroyedStorage,
 						params.Entity{s.StorageTag().String()},
@@ -1504,7 +1504,7 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 				}
 			} else {
 				destroyed, detached, err := storagecommon.ClassifyDetachedStorage(
-					api.storageAccess.VolumeAccess(), api.storageAccess.FilesystemAccess(), storage,
+					api.storageAccess.VolumeAccess(), api.storageAccess.FilesystemAccess(), unitStorage,
 				)
 				if err != nil {
 					return nil, err
@@ -1757,7 +1757,10 @@ func (api *APIBase) DestroyRelation(args params.DestroyRelation) (err error) {
 		return err
 	}
 	force := args.Force != nil && *args.Force
-	_, err = rel.DestroyWithForce(force, common.MaxWait(args.MaxWait))
+	errs, err := rel.DestroyWithForce(force, common.MaxWait(args.MaxWait))
+	if len(errs) != 0 {
+		logger.Warningf("operational errors destroying relation %v: %v", rel.Tag().Id(), errs)
+	}
 	return err
 }
 
@@ -2122,13 +2125,13 @@ func (api *APIBase) setApplicationConfig(arg params.ApplicationConfigSet) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	schema, defaults, err := applicationConfigSchema(api.modelType)
+	configSchema, defaults, err := applicationConfigSchema(api.modelType)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	if len(appConfigAttrs) > 0 {
-		if err := app.UpdateApplicationConfig(appConfigAttrs, nil, schema, defaults); err != nil {
+		if err := app.UpdateApplicationConfig(appConfigAttrs, nil, configSchema, defaults); err != nil {
 			return errors.Annotate(err, "updating application config values")
 		}
 	}
@@ -2189,11 +2192,11 @@ func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
 		return errors.Trace(err)
 	}
 
-	schema, defaults, err := applicationConfigSchema(api.modelType)
+	configSchema, defaults, err := applicationConfigSchema(api.modelType)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	appConfigFields := application.KnownConfigKeys(schema)
+	appConfigFields := application.KnownConfigKeys(configSchema)
 
 	var appConfigKeys []string
 	charmSettings := make(charm.Settings)
@@ -2206,7 +2209,7 @@ func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
 	}
 
 	if len(appConfigKeys) > 0 {
-		if err := app.UpdateApplicationConfig(nil, appConfigKeys, schema, defaults); err != nil {
+		if err := app.UpdateApplicationConfig(nil, appConfigKeys, configSchema, defaults); err != nil {
 			return errors.Annotate(err, "updating application config values")
 		}
 	}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -408,7 +408,7 @@ func (s *ApplicationSuite) TestDestroyRelation(c *gc.C) {
 	s.blockChecker.CheckCallNames(c, "RemoveAllowed")
 	s.backend.CheckCallNames(c, "InferEndpoints", "EndpointsRelation")
 	s.backend.CheckCall(c, 0, "InferEndpoints", []string{"a", "b"})
-	s.relation.CheckCallNames(c, "Destroy")
+	s.relation.CheckCallNames(c, "DestroyWithForce")
 }
 
 func (s *ApplicationSuite) TestDestroyRelationNoRelationsFound(c *gc.C) {
@@ -438,7 +438,7 @@ func (s *ApplicationSuite) TestDestroyRelationId(c *gc.C) {
 	s.blockChecker.CheckCallNames(c, "RemoveAllowed")
 	s.backend.CheckCallNames(c, "Relation")
 	s.backend.CheckCall(c, 0, "Relation", 123)
-	s.relation.CheckCallNames(c, "Destroy")
+	s.relation.CheckCallNames(c, "DestroyWithForce")
 }
 
 func (s *ApplicationSuite) TestDestroyRelationIdRelationNotFound(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -4,6 +4,8 @@
 package application
 
 import (
+	"time"
+
 	"github.com/juju/schema"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
@@ -117,6 +119,7 @@ type Relation interface {
 	status.StatusSetter
 	Tag() names.Tag
 	Destroy() error
+	DestroyWithForce(bool, time.Duration) ([]error, error)
 	Endpoint(string) (state.Endpoint, error)
 	SetSuspended(bool, string) error
 	Suspended() bool

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -718,6 +719,11 @@ func (r *mockRelation) SuspendedReason() string {
 func (r *mockRelation) Destroy() error {
 	r.MethodCall(r, "Destroy")
 	return r.NextErr()
+}
+
+func (r *mockRelation) DestroyWithForce(force bool, maxWait time.Duration) ([]error, error) {
+	r.MethodCall(r, "DestroyWithForce", force, maxWait)
+	return nil, r.NextErr()
 }
 
 type mockUnit struct {

--- a/state/application.go
+++ b/state/application.go
@@ -212,7 +212,12 @@ func (a *Application) Destroy() (err error) {
 			a.doc.Life = Dying
 		}
 	}()
-	return a.st.ApplyOperation(a.DestroyOperation())
+	op := a.DestroyOperation()
+	err = a.st.ApplyOperation(a.DestroyOperation())
+	if len(op.Errors) != 0 {
+		logger.Warningf("operational errors destroying application %v: %v", a.Name(), op.Errors)
+	}
+	return err
 }
 
 // DestroyOperation returns a model operation that will destroy the application.

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -207,9 +207,9 @@ func (op *RemoveOfferOperation) Done(err error) error {
 func (s *applicationOffers) Remove(offerName string, force bool) error {
 	op := s.RemoveOfferOperation(offerName, force)
 	err := s.st.ApplyOperation(op)
-	// TODO (anastasiamac 2019-04-10) we can surfacing these errors to the user.
-	// These are non-fatal operational errors that occurred during force and are
-	// collected in the operation, op.Errors.
+	if len(op.Errors) != 0 {
+		logger.Warningf("operational errors removing offer %v: %v", offerName, op.Errors)
+	}
 	return err
 }
 

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -422,7 +422,7 @@ func (st *State) cleanupApplication(applicationname string, cleanupArgs []bson.R
 	op.Force = force
 	err = st.ApplyOperation(op)
 	if len(op.Errors) != 0 {
-		logger.Warningf("operational errors cleaning up applicationr %v: %v", applicationname, op.Errors)
+		logger.Warningf("operational errors cleaning up application %v: %v", applicationname, op.Errors)
 	}
 	return err
 }

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -420,7 +420,11 @@ func (st *State) cleanupApplication(applicationname string, cleanupArgs []bson.R
 	op := app.DestroyOperation()
 	op.DestroyStorage = destroyStorage
 	op.Force = force
-	return st.ApplyOperation(op)
+	err = st.ApplyOperation(op)
+	if len(op.Errors) != 0 {
+		logger.Warningf("operational errors cleaning up applicationr %v: %v", applicationname, op.Errors)
+	}
+	return err
 }
 
 // cleanupApplicationsForDyingModel sets all applications to Dying, if they are
@@ -463,7 +467,11 @@ func (st *State) removeApplicationsForDyingModel(args DestroyModelParams) (err e
 		op.RemoveOffers = true
 		op.Force = force
 		op.MaxWait = args.MaxWait
-		if err := st.ApplyOperation(op); err != nil {
+		err := st.ApplyOperation(op)
+		if len(op.Errors) != 0 {
+			logger.Warningf("operational errors removing application %v for dying model %v: %v", application.Name(), st.ModelUUID(), op.Errors)
+		}
+		if err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -539,7 +547,12 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 		op.DestroyStorage = destroyStorage
 		op.Force = force
 		op.MaxWait = maxWait
-		if err := st.ApplyOperation(op); err != nil {
+		err := st.ApplyOperation(op)
+		if len(op.Errors) != 0 {
+			logger.Warningf("operational errors destroying unit %v for dying application %v: %v", unit.Name(), applicationname, op.Errors)
+		}
+
+		if err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/relation.go
+++ b/state/relation.go
@@ -313,16 +313,16 @@ func (r *Relation) DestroyWithForce(force bool, maxWait time.Duration) ([]error,
 	op := r.DestroyOperation(force)
 	op.MaxWait = maxWait
 	err := r.st.ApplyOperation(op)
-	if len(op.Errors) != 0 {
-		logger.Warningf("operational errors removing relation %v: %v", r.Id(), op.Errors)
-	}
 	return op.Errors, err
 }
 
 // Destroy ensures that the relation will be removed at some point; if no units
 // are currently in scope, it will be removed immediately.
 func (r *Relation) Destroy() error {
-	_, err := r.DestroyWithForce(false, time.Duration(0))
+	errs, err := r.DestroyWithForce(false, time.Duration(0))
+	if len(errs) != 0 {
+		logger.Warningf("operational errors removing relation %v: %v", r.Id(), errs)
+	}
 	return err
 }
 

--- a/state/relation.go
+++ b/state/relation.go
@@ -313,6 +313,9 @@ func (r *Relation) DestroyWithForce(force bool, maxWait time.Duration) ([]error,
 	op := r.DestroyOperation(force)
 	op.MaxWait = maxWait
 	err := r.st.ApplyOperation(op)
+	if len(op.Errors) != 0 {
+		logger.Warningf("operational errors removing relation %v: %v", r.Id(), op.Errors)
+	}
 	return op.Errors, err
 }
 

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -346,9 +346,6 @@ func (ru *RelationUnit) LeaveScopeWithForce(force bool, maxWait time.Duration) (
 	op := ru.LeaveScopeOperation(force)
 	op.MaxWait = maxWait
 	err := ru.st.ApplyOperation(op)
-	if len(op.Errors) != 0 {
-		logger.Warningf("operational errors leaving scope for %v: %v", op.Description(), op.Errors)
-	}
 	return op.Errors, err
 }
 
@@ -358,7 +355,10 @@ func (ru *RelationUnit) LeaveScopeWithForce(force bool, maxWait time.Duration) (
 // leaves, it is removed immediately. It is not an error to leave a scope
 // that the unit is not, or never was, a member of.
 func (ru *RelationUnit) LeaveScope() error {
-	_, err := ru.LeaveScopeWithForce(false, time.Duration(0))
+	errs, err := ru.LeaveScopeWithForce(false, time.Duration(0))
+	if len(errs) != 0 {
+		logger.Warningf("operational errors leaving scope for unit %q in relation %q: %v", ru.unitName, ru.relation, errs)
+	}
 	return err
 }
 

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -346,6 +346,9 @@ func (ru *RelationUnit) LeaveScopeWithForce(force bool, maxWait time.Duration) (
 	op := ru.LeaveScopeOperation(force)
 	op.MaxWait = maxWait
 	err := ru.st.ApplyOperation(op)
+	if len(op.Errors) != 0 {
+		logger.Warningf("operational errors leaving scope for %v: %v", op.Description(), op.Errors)
+	}
 	return op.Errors, err
 }
 

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -317,6 +317,9 @@ func (s *RemoteApplication) DestroyWithForce(force bool, maxWait time.Duration) 
 	op := s.DestroyRemoteApplicationOperation(force)
 	op.MaxWait = maxWait
 	err = s.st.ApplyOperation(op)
+	if len(op.Errors) != 0 {
+		logger.Warningf("operational errors destroying remote application %v: %v", s.Name(), op.Errors)
+	}
 	return op.Errors, err
 }
 

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -317,9 +317,6 @@ func (s *RemoteApplication) DestroyWithForce(force bool, maxWait time.Duration) 
 	op := s.DestroyRemoteApplicationOperation(force)
 	op.MaxWait = maxWait
 	err = s.st.ApplyOperation(op)
-	if len(op.Errors) != 0 {
-		logger.Warningf("operational errors destroying remote application %v: %v", s.Name(), op.Errors)
-	}
 	return op.Errors, err
 }
 
@@ -327,7 +324,10 @@ func (s *RemoteApplication) DestroyWithForce(force bool, maxWait time.Duration) 
 // will be removed at some point; if no relation involving the
 // application has any units in scope, they are all removed immediately.
 func (s *RemoteApplication) Destroy() error {
-	_, err := s.DestroyWithForce(false, time.Duration(0))
+	errs, err := s.DestroyWithForce(false, time.Duration(0))
+	if len(errs) != 0 {
+		logger.Warningf("operational errors destroying remote application %v: %v", s.Name(), errs)
+	}
 	return err
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -466,7 +466,10 @@ func (op *UpdateUnitOperation) Done(err error) error {
 // to a provisioned machine is Destroyed, it will be removed from state
 // directly.
 func (u *Unit) Destroy() error {
-	_, err := u.DestroyWithForce(false, time.Duration(0))
+	errs, err := u.DestroyWithForce(false, time.Duration(0))
+	if len(errs) != 0 {
+		logger.Warningf("operational errors destroying unit %v: %v", u.Name(), errs)
+	}
 	return err
 }
 
@@ -483,9 +486,6 @@ func (u *Unit) DestroyWithForce(force bool, maxWait time.Duration) (errs []error
 	op.Force = force
 	op.MaxWait = maxWait
 	err = u.st.ApplyOperation(op)
-	if len(op.Errors) != 0 {
-		logger.Warningf("operational errors destroying unit %v: %v", u.Name(), op.Errors)
-	}
 	return op.Errors, err
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -483,6 +483,9 @@ func (u *Unit) DestroyWithForce(force bool, maxWait time.Duration) (errs []error
 	op.Force = force
 	op.MaxWait = maxWait
 	err = u.st.ApplyOperation(op)
+	if len(op.Errors) != 0 {
+		logger.Warningf("operational errors destroying unit %v: %v", u.Name(), op.Errors)
+	}
 	return op.Errors, err
 }
 


### PR DESCRIPTION
## Description of change

Most of remove and destroy operations now collect operational, non-fatal errors. We have no means of easily exposing these to the user, but we can log them for now. 
