### PR TITLE
Prepush 1.12.x vet fixes

### DIFF
--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -83,14 +83,14 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 			print(
 				info.MachineId, info.UnitId, info.Storage,
 				info.FilesystemId, info.Volume, info.ProviderFilesystemId,
-				info.MountPoint, size,
+				info.FilesystemAttachment.MountPoint, size,
 				string(info.Status.Current), info.Status.Message,
 			)
 		} else {
 			print(
 				info.UnitId, info.Storage,
 				info.FilesystemId, info.ProviderFilesystemId,
-				info.MountPoint, size,
+				info.FilesystemAttachment.MountPoint, size,
 				string(info.Status.Current), info.Status.Message,
 			)
 		}
@@ -103,11 +103,11 @@ type filesystemAttachmentInfo struct {
 	FilesystemId string
 	FilesystemInfo
 
-	MachineId string
-	FilesystemAttachment
+	MachineId            string
+	FilesystemAttachment FilesystemAttachment
 
-	UnitId string
-	UnitStorageAttachment
+	UnitId                string
+	UnitStorageAttachment UnitStorageAttachment
 }
 
 type filesystemAttachmentInfos []filesystemAttachmentInfo

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -83,7 +83,7 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 			print(
 				info.MachineId, info.UnitId, info.Storage,
 				info.VolumeId, info.ProviderVolumeId,
-				info.DeviceName, size,
+				info.VolumeAttachment.DeviceName, size,
 				string(info.Status.Current), info.Status.Message,
 			)
 		} else {
@@ -102,11 +102,11 @@ type volumeAttachmentInfo struct {
 	VolumeId string
 	VolumeInfo
 
-	MachineId string
-	VolumeAttachment
+	MachineId        string
+	VolumeAttachment VolumeAttachment
 
-	UnitId string
-	UnitStorageAttachment
+	UnitId                string
+	UnitStorageAttachment UnitStorageAttachment
 }
 
 type volumeAttachmentInfos []volumeAttachmentInfo


### PR DESCRIPTION
## Description of change

The following fixes ensure that we can run golang 1.12.x vet. The
following changes where previously warning, but are now errors.

The struct fields (life) where causing issues when embedding
multiple structs into one composed struct. This fixes it by
namespacing all the embedded structs that have the Life field.

## QA steps

Unit tests pass.
