### PR TITLE
Add --force and --no-wait to juju remove-saas

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  9,
+	"Application":                  10,
 	"ApplicationOffers":            2,
 	"ApplicationScaler":            1,
 	"Backups":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -147,7 +147,8 @@ func AllFacades() *facade.Registry {
 	reg("Application", 6, application.NewFacadeV6)
 	reg("Application", 7, application.NewFacadeV7)
 	reg("Application", 8, application.NewFacadeV8)
-	reg("Application", 9, application.NewFacadeV9) // ApplicationInfo; generational config; Force on App, Relation and Unit Removal.
+	reg("Application", 9, application.NewFacadeV9)   // ApplicationInfo; generational config; Force on App, Relation and Unit Removal.
+	reg("Application", 10, application.NewFacadeV10) // --force and --no-wait parameters
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -50,7 +50,7 @@ type applicationSuite struct {
 	apiservertesting.CharmStoreSuite
 	commontesting.BlockHelper
 
-	applicationAPI *application.APIv9
+	applicationAPI *application.APIv10
 	application    *state.Application
 	authorizer     *apiservertesting.FakeAuthorizer
 }
@@ -87,7 +87,7 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 	s.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv9 {
+func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv10 {
 	resources := common.NewResources()
 	c.Assert(resources.RegisterNamed("dataDir", common.StringResource(c.MkDir())), jc.ErrorIsNil)
 	storageAccess, err := application.GetStorageState(s.State)
@@ -111,7 +111,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv9 {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	return &application.APIv9{api}
+	return &application.APIv10{api}
 }
 
 func (s *applicationSuite) TestCharmConfig(c *gc.C) {
@@ -132,7 +132,11 @@ func (s *applicationSuite) TestCharmConfig(c *gc.C) {
 
 func (s *applicationSuite) TestCharmConfigV8(c *gc.C) {
 	s.setUpConfigTest(c)
-	api := &application.APIv8{APIv9: s.applicationAPI}
+	api := &application.APIv8{
+		APIv9: &application.APIv9{
+			APIv10: s.applicationAPI,
+		},
+	}
 	results, err := api.CharmConfig(params.Entities{
 		Entities: []params.Entity{
 			{"wat"}, {"machine-0"}, {"user-foo"},

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -54,7 +54,7 @@ type ApplicationSuite struct {
 	env              environs.Environ
 	blockChecker     mockBlockChecker
 	authorizer       apiservertesting.FakeAuthorizer
-	api              *application.APIv9
+	api              *application.APIv10
 	deployParams     map[string]application.DeployApplicationParams
 }
 
@@ -84,7 +84,7 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		s.storageValidator,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api = &application.APIv9{api}
+	s.api = &application.APIv10{api}
 }
 
 func (s *ApplicationSuite) SetUpTest(c *gc.C) {
@@ -558,9 +558,45 @@ func (s *ApplicationSuite) TestDestroyConsumedApplication(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{})
 
-	s.backend.CheckCallNames(c, "RemoteApplication")
+	s.backend.CheckCallNames(c, "RemoteApplication", "ApplyOperation")
 	app := s.backend.remoteApplications["hosted-db2"]
-	app.(*mockRemoteApplication).CheckCallNames(c, "Destroy")
+	app.(*mockRemoteApplication).CheckCallNames(c, "DestroyOperation")
+}
+
+func (s *ApplicationSuite) TestForceDestroyConsumedApplication(c *gc.C) {
+	force := true
+	results, err := s.api.DestroyConsumedApplications(params.DestroyConsumedApplicationsParams{
+		Applications: []params.DestroyConsumedApplicationParams{{
+			ApplicationTag: "application-hosted-db2",
+			Force:          &force,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{})
+
+	s.backend.CheckCallNames(c, "RemoteApplication", "ApplyOperation")
+	app := s.backend.remoteApplications["hosted-db2"]
+	app.(*mockRemoteApplication).CheckCallNames(c, "DestroyOperation")
+}
+
+func (s *ApplicationSuite) TestForceDestroyConsumedApplicationNoWait(c *gc.C) {
+	force := true
+	noWait := 0 * time.Minute
+	results, err := s.api.DestroyConsumedApplications(params.DestroyConsumedApplicationsParams{
+		Applications: []params.DestroyConsumedApplicationParams{{
+			ApplicationTag: "application-hosted-db2",
+			Force:          &force,
+			MaxWait:        &noWait,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{})
+
+	s.backend.CheckCallNames(c, "RemoteApplication", "ApplyOperation")
+	app := s.backend.remoteApplications["hosted-db2"]
+	app.(*mockRemoteApplication).CheckCallNames(c, "DestroyOperation")
 }
 
 func (s *ApplicationSuite) TestDestroyConsumedApplicationNotFound(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -264,6 +264,7 @@ type RemoteApplication interface {
 	Bindings() map[string]string
 	Spaces() []state.RemoteSpace
 	Destroy() error
+	DestroyOperation(force bool) *state.DestroyRemoteApplicationOperation
 }
 
 func (s stateShim) RemoteApplication(name string) (RemoteApplication, error) {

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -15,6 +15,6 @@ func GetState(st *state.State) Backend {
 	return stateShim{st}
 }
 
-func SetModelType(api *APIv9, modelType state.ModelType) {
+func SetModelType(api *APIv10, modelType state.ModelType) {
 	api.modelType = modelType
 }

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -28,7 +28,7 @@ import (
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	applicationAPI *application.APIv9
+	applicationAPI *application.APIv10
 	authorizer     apiservertesting.FakeAuthorizer
 }
 
@@ -59,12 +59,12 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.applicationAPI = &application.APIv9{api}
+	s.applicationAPI = &application.APIv10{api}
 }
 
 func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}}
+	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{&application.APIv9{s.applicationAPI}}}}}}
 	results, err := v4.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -84,7 +84,7 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 
 func (s *getSuite) TestClientApplicationGetSmokeTestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{s.applicationAPI}}}}
+	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{&application.APIv9{s.applicationAPI}}}}}
 	results, err := v5.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -201,7 +201,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	apiV8 := &application.APIv8{&application.APIv9{api}}
+	apiV8 := &application.APIv8{&application.APIv9{&application.APIv10{api}}}
 
 	results, err := apiV8.Get(params.ApplicationGet{ApplicationName: "dashboard4miner"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -318,6 +318,13 @@ func (m *mockRemoteApplication) Destroy() error {
 	return nil
 }
 
+func (m *mockRemoteApplication) DestroyOperation(force bool) *state.DestroyRemoteApplicationOperation {
+	m.MethodCall(m, "DestroyOperation")
+	return &state.DestroyRemoteApplicationOperation{
+		ForcedOperation: state.ForcedOperation{Force: force},
+	}
+}
+
 type mockBackend struct {
 	jtesting.Stub
 	application.Backend

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -314,6 +314,15 @@ type DestroyConsumedApplicationsParams struct {
 // RemoteApplication.Destroy call.
 type DestroyConsumedApplicationParams struct {
 	ApplicationTag string `json:"application-tag"`
+
+	// Force controls whether or not the destruction process ignores
+	// operational errors. When true, the process will ignore them.
+	Force *bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in application removal
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // GetApplicationConstraints stores parameters for making the GetApplicationConstraints call.

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -249,15 +249,15 @@ func copyAttributes(values attributeMap) attributeMap {
 	return result
 }
 
-// DestroyRemoteApplicationOperation returns a model operation to destroy remote application.
-func (s *RemoteApplication) DestroyRemoteApplicationOperation(force bool) *DestroyRemoteApplicationOperation {
+// DestroyOperation returns a model operation to destroy remote application.
+func (s *RemoteApplication) DestroyOperation(force bool) *DestroyRemoteApplicationOperation {
 	return &DestroyRemoteApplicationOperation{
 		app:             &RemoteApplication{st: s.st, doc: s.doc},
 		ForcedOperation: ForcedOperation{Force: force},
 	}
 }
 
-// LeaveScopeOperation is a model operation to destroy remote application.
+// DestroyRemoteApplicationOperation is a model operation to destroy a remote application.
 type DestroyRemoteApplicationOperation struct {
 	// ForcedOperation stores needed information to force this operation.
 	ForcedOperation
@@ -314,7 +314,7 @@ func (s *RemoteApplication) DestroyWithForce(force bool, maxWait time.Duration) 
 			s.doc.Life = Dying
 		}
 	}()
-	op := s.DestroyRemoteApplicationOperation(force)
+	op := s.DestroyOperation(force)
 	op.MaxWait = maxWait
 	err = s.st.ApplyOperation(op)
 	return op.Errors, err


### PR DESCRIPTION
## Description of change

This commit adds `--force` and `--no-wait` parameters to the `remove-saas` CLI command. The first prevents the removal process from aborting if there is an error detected during an intermediate step. The second argument instructs Juju to proceed as quickly as possible. By default, Juju does one thing at a time and waits before proceeding to the next step.

## QA steps

- Create a remote/consumed application in accordance with the CMR steps
- Use `juju remove-saas --force`

## Documentation changes

New parameters have been added to the `remove-saas` command.

Error messages are reported when `--no-wait` is provided without `--force` and when either `--force` or `--no-wait` is provided for controllers that do not support those options.

## Bug reference

* [lp:1822050](https://bugs.launchpad.net/juju/+bug/1822050)
* [lp:1813886](https://bugs.launchpad.net/juju/+bug/1813886)
