### PR TITLE
Capture TPS metric when running webscale tests

### DIFF
--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -117,7 +117,7 @@ def extract_txn_metrics(logs, module):
     }
 
 
-def calc_stats(prefix, values, include_count=False):
+def calc_stats(prefix, values, include_count=False, test_duration=0):
     """ Calculate statistics for a list of float values and return them as an
         object where the keys are prefixed using the provided prefix.
     """
@@ -132,6 +132,9 @@ def calc_stats(prefix, values, include_count=False):
 
     if include_count:
         stats[prefix+'count'] = len(values)
+
+    if test_duration is not 0:
+        stats[prefix+'rate'] = float(len(values)) / float(test_duration)
 
     return stats
 
@@ -150,7 +153,8 @@ def construct_metrics(txn_metrics, test_duration):
     """
 
     return merge_dicts(
-        calc_stats('txn_time_', txn_metrics['timings'], include_count=True),
+        calc_stats('txn_time_', txn_metrics['timings'], include_count=True,
+                   test_duration=test_duration),
         calc_stats('txn_retries_', txn_metrics['retries']),
         {'test_duration': test_duration},
     )


### PR DESCRIPTION
The number of transactions is not constant between runs of the webscale tests. For example, 
when server-side txns are enabled we can perform more status update transactions compared 
to running with server-side txns off. 

For this reason, the transaction count is not a meaningful metric to compare txn-related metrics across runs. Since influxdb does not allow us to query across measurements, this PR updates the webscale metrics python file to also export a transactions per second metric for our dashboards.