### PR TITLE
2.5 Store Provider Space ID With Addresses in State

### DIFF
--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -282,20 +282,22 @@ type EntitiesPortRanges struct {
 // the API requests/responses. See also network.Address, from/to
 // which this is transformed.
 type Address struct {
-	Value     string `json:"value"`
-	Type      string `json:"type"`
-	Scope     string `json:"scope"`
-	SpaceName string `json:"space-name,omitempty"`
+	Value           string `json:"value"`
+	Type            string `json:"type"`
+	Scope           string `json:"scope"`
+	SpaceName       string `json:"space-name,omitempty"`
+	SpaceProviderId string `json:"space-id,omitempty"`
 }
 
 // FromNetworkAddress is a convenience helper to create a parameter
 // out of the network type, here for Address.
 func FromNetworkAddress(naddr network.Address) Address {
 	return Address{
-		Value:     naddr.Value,
-		Type:      string(naddr.Type),
-		Scope:     string(naddr.Scope),
-		SpaceName: string(naddr.SpaceName),
+		Value:           naddr.Value,
+		Type:            string(naddr.Type),
+		Scope:           string(naddr.Scope),
+		SpaceName:       string(naddr.SpaceName),
+		SpaceProviderId: string(naddr.SpaceProviderId),
 	}
 }
 
@@ -303,10 +305,11 @@ func FromNetworkAddress(naddr network.Address) Address {
 // as network type, here for Address.
 func (addr Address) NetworkAddress() network.Address {
 	return network.Address{
-		Value:     addr.Value,
-		Type:      network.AddressType(addr.Type),
-		Scope:     network.Scope(addr.Scope),
-		SpaceName: network.SpaceName(addr.SpaceName),
+		Value:           addr.Value,
+		Type:            network.AddressType(addr.Type),
+		Scope:           network.Scope(addr.Scope),
+		SpaceName:       network.SpaceName(addr.SpaceName),
+		SpaceProviderId: network.Id(addr.SpaceProviderId),
 	}
 }
 

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -275,6 +275,11 @@ func (s *NetworkSuite) TestAddressConvenience(c *gc.C) {
 	}
 	paramsAddress := params.FromNetworkAddress(networkAddress)
 	c.Assert(networkAddress, jc.DeepEquals, paramsAddress.NetworkAddress())
+
+	networkAddress.SpaceName = "test-space"
+	networkAddress.SpaceProviderId = "666"
+	paramsAddress = params.FromNetworkAddress(networkAddress)
+	c.Assert(networkAddress, jc.DeepEquals, paramsAddress.NetworkAddress())
 }
 
 func (s *NetworkSuite) TestHostPortConvenience(c *gc.C) {

--- a/network/address.go
+++ b/network/address.go
@@ -653,10 +653,10 @@ func IPv4ToDecimal(ipv4Addr net.IP) (uint32, error) {
 // because it can be used both as an IPv4 or IPv6 endpoint (e.g., in
 // IPv6-only networks).
 func ResolvableHostnames(addrs []Address) []Address {
-	resolveableAddrs := make([]Address, 0, len(addrs))
+	resolvableAddrs := make([]Address, 0, len(addrs))
 	for _, addr := range addrs {
 		if addr.Value == "localhost" || net.ParseIP(addr.Value) != nil {
-			resolveableAddrs = append(resolveableAddrs, addr)
+			resolvableAddrs = append(resolvableAddrs, addr)
 			continue
 		}
 		_, err := netLookupIP(addr.Value)
@@ -664,9 +664,9 @@ func ResolvableHostnames(addrs []Address) []Address {
 			logger.Infof("removing unresolvable address %q: %v", addr.Value, err)
 			continue
 		}
-		resolveableAddrs = append(resolveableAddrs, addr)
+		resolvableAddrs = append(resolvableAddrs, addr)
 	}
-	return resolveableAddrs
+	return resolvableAddrs
 }
 
 // MergedAddresses provides a single list of addresses without duplicates

--- a/state/address.go
+++ b/state/address.go
@@ -258,11 +258,12 @@ func (st *State) apiHostPortsForKey(key string) ([][]network.HostPort, error) {
 // stuff at some point. We want to use juju-specific network names
 // that point to existing documents in the networks collection.
 type address struct {
-	Value       string `bson:"value"`
-	AddressType string `bson:"addresstype"`
-	Scope       string `bson:"networkscope,omitempty"`
-	Origin      string `bson:"origin,omitempty"`
-	SpaceName   string `bson:"spacename,omitempty"`
+	Value           string `bson:"value"`
+	AddressType     string `bson:"addresstype"`
+	Scope           string `bson:"networkscope,omitempty"`
+	Origin          string `bson:"origin,omitempty"`
+	SpaceName       string `bson:"spacename,omitempty"`
+	SpaceProviderId string `bson:"spaceid,omitempty"`
 }
 
 // Origin specifies where an address comes from, whether it was reported by a
@@ -282,11 +283,12 @@ const (
 // out of the network type, here for Address with a given Origin.
 func fromNetworkAddress(netAddr network.Address, origin Origin) address {
 	return address{
-		Value:       netAddr.Value,
-		AddressType: string(netAddr.Type),
-		Scope:       string(netAddr.Scope),
-		Origin:      string(origin),
-		SpaceName:   string(netAddr.SpaceName),
+		Value:           netAddr.Value,
+		AddressType:     string(netAddr.Type),
+		Scope:           string(netAddr.Scope),
+		Origin:          string(origin),
+		SpaceName:       string(netAddr.SpaceName),
+		SpaceProviderId: string(netAddr.SpaceProviderId),
 	}
 }
 
@@ -294,10 +296,11 @@ func fromNetworkAddress(netAddr network.Address, origin Origin) address {
 // as network type, here for Address.
 func (addr *address) networkAddress() network.Address {
 	return network.Address{
-		Value:     addr.Value,
-		Type:      network.AddressType(addr.AddressType),
-		Scope:     network.Scope(addr.Scope),
-		SpaceName: network.SpaceName(addr.SpaceName),
+		Value:           addr.Value,
+		Type:            network.AddressType(addr.AddressType),
+		Scope:           network.Scope(addr.Scope),
+		SpaceName:       network.SpaceName(addr.SpaceName),
+		SpaceProviderId: network.Id(addr.SpaceProviderId),
 	}
 }
 

--- a/state/address_internal_test.go
+++ b/state/address_internal_test.go
@@ -121,3 +121,23 @@ func (*AddressEqualitySuite) TestHostPortsEqual(c *gc.C) {
 	}
 	c.Assert(hostsPortsEqual(first, second), jc.IsTrue)
 }
+
+func (s *AddressEqualitySuite) TestAddressConversion(c *gc.C) {
+	machineAddress := network.Address{
+		Value: "foo",
+		Type:  network.IPv4Address,
+		Scope: network.ScopePublic,
+	}
+	stateAddress := fromNetworkAddress(machineAddress, "machine")
+	c.Assert(machineAddress, jc.DeepEquals, stateAddress.networkAddress())
+
+	providerAddress := network.Address{
+		Value:           "bar",
+		Type:            network.IPv4Address,
+		Scope:           network.ScopePublic,
+		SpaceName:       "test-space",
+		SpaceProviderId: "666",
+	}
+	stateAddress = fromNetworkAddress(providerAddress, "provider")
+	c.Assert(providerAddress, jc.DeepEquals, stateAddress.networkAddress())
+}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1944,14 +1944,23 @@ func (s *MachineSuite) TestSetProviderAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
+	addresses := []network.Address{
+		network.NewAddress("127.0.0.1"),
+		{
+			Value:           "8.8.8.8",
+			Type:            network.IPv4Address,
+			Scope:           network.ScopeCloudLocal,
+			SpaceName:       "test-space",
+			SpaceProviderId: "1",
+		},
+	}
 	err = machine.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := network.NewAddresses("8.8.8.8", "127.0.0.1")
-	c.Assert(machine.Addresses(), jc.DeepEquals, expectedAddresses)
+	network.SortAddresses(addresses)
+	c.Assert(machine.Addresses(), jc.DeepEquals, addresses)
 }
 
 func (s *MachineSuite) TestSetProviderAddressesWithContainers(c *gc.C) {

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -46,10 +46,10 @@ func (s *machineSuite) TestSetsInstanceInfoInitially(c *gc.C) {
 	}
 	died := make(chan machine)
 
-	clock := newTestClock()
-	go runMachine(context, m, nil, died, clock)
-	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
-	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	clk := newTestClock()
+	go runMachine(context, m, nil, died, clk)
+	c.Assert(clk.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	c.Assert(clk.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 
 	killMachineLoop(c, m, context.dyingc, died)
 	c.Assert(context.killErr, gc.Equals, nil)
@@ -71,10 +71,10 @@ func (s *machineSuite) TestSetsInstanceInfoDeadMachineInitially(c *gc.C) {
 	}
 	died := make(chan machine)
 
-	clock := newTestClock()
-	go runMachine(context, m, nil, died, clock)
-	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
-	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	clk := newTestClock()
+	go runMachine(context, m, nil, died, clk)
+	c.Assert(clk.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	c.Assert(clk.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 
 	killMachineLoop(c, m, context.dyingc, died)
 	c.Assert(context.killErr, gc.Equals, nil)
@@ -99,15 +99,15 @@ func (s *machineSuite) testShortPoll(
 	instId, instStatus string,
 	machineStatus status.Status,
 ) {
-	clock := newTestClock()
-	testRunMachine(c, addrs, instId, instStatus, machineStatus, clock, func() {
-		c.Assert(clock.WaitAdvance(
+	clk := newTestClock()
+	testRunMachine(c, addrs, instId, instStatus, machineStatus, clk, func() {
+		c.Assert(clk.WaitAdvance(
 			time.Duration(float64(ShortPoll)*ShortPollBackoff), coretesting.ShortWait, 1),
 			jc.ErrorIsNil,
 		)
 	})
-	clock.CheckCall(c, 0, "After", time.Duration(float64(ShortPoll)*ShortPollBackoff))
-	clock.CheckCall(c, 1, "After", time.Duration(float64(ShortPoll)*ShortPollBackoff*ShortPollBackoff))
+	clk.CheckCall(c, 0, "After", time.Duration(float64(ShortPoll)*ShortPollBackoff))
+	clk.CheckCall(c, 1, "After", time.Duration(float64(ShortPoll)*ShortPollBackoff*ShortPollBackoff))
 }
 
 func (s *machineSuite) TestNoPollWhenNotProvisioned(c *gc.C) {
@@ -133,12 +133,12 @@ func (s *machineSuite) TestNoPollWhenNotProvisioned(c *gc.C) {
 	}
 	died := make(chan machine)
 
-	clock := testclock.NewClock(time.Time{})
+	clk := testclock.NewClock(time.Time{})
 	changed := make(chan struct{})
-	go runMachine(context, m, changed, died, clock)
+	go runMachine(context, m, changed, died, clk)
 
 	expectPoll := func() {
-		c.Assert(clock.WaitAdvance(ShortPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+		c.Assert(clk.WaitAdvance(ShortPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 	}
 
 	expectPoll()
@@ -175,23 +175,23 @@ func (s *machineSuite) TestShortPollBackoffLimit(c *gc.C) {
 		900 * time.Second, // limit is 15 minutes (LongPoll)
 	}
 
-	clock := newTestClock()
-	testRunMachine(c, nil, "i1234", "", status.Started, clock, func() {
+	clk := newTestClock()
+	testRunMachine(c, nil, "i1234", "", status.Started, clk, func() {
 		for _, d := range pollDurations {
-			c.Assert(clock.WaitAdvance(time.Duration(d), coretesting.ShortWait, 1), jc.ErrorIsNil)
+			c.Assert(clk.WaitAdvance(time.Duration(d), coretesting.ShortWait, 1), jc.ErrorIsNil)
 		}
 	})
 	for i, d := range pollDurations {
-		clock.CheckCall(c, i, "After", d)
+		clk.CheckCall(c, i, "After", d)
 	}
 }
 
 func (s *machineSuite) TestLongPollIntervalWhenHasAllInstanceInfo(c *gc.C) {
-	clock := newTestClock()
-	testRunMachine(c, testAddrs, "i1234", "running", status.Started, clock, func() {
-		c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	clk := newTestClock()
+	testRunMachine(c, testAddrs, "i1234", "running", status.Started, clk, func() {
+		c.Assert(clk.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 	})
-	clock.CheckCall(c, 0, "After", LongPoll)
+	clk.CheckCall(c, 0, "After", LongPoll)
 }
 
 func testRunMachine(
@@ -248,10 +248,10 @@ func (*machineSuite) TestChangedRefreshes(c *gc.C) {
 	}
 	died := make(chan machine)
 	changed := make(chan struct{})
-	clock := newTestClock()
-	go runMachine(context, m, changed, died, clock)
+	clk := newTestClock()
+	go runMachine(context, m, changed, died, clk)
 
-	c.Assert(clock.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
+	c.Assert(clk.WaitAdvance(LongPoll, coretesting.ShortWait, 1), jc.ErrorIsNil)
 	select {
 	case <-died:
 		c.Fatalf("machine died prematurely")
@@ -496,8 +496,8 @@ type testClock struct {
 }
 
 func newTestClock() *testClock {
-	clock := testclock.NewClock(time.Time{})
-	return &testClock{Clock: clock}
+	clk := testclock.NewClock(time.Time{})
+	return &testClock{Clock: clk}
 }
 
 func (t *testClock) After(d time.Duration) <-chan time.Time {

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -31,7 +31,16 @@ type machineSuite struct {
 	coretesting.BaseSuite
 }
 
-var testAddrs = network.NewAddresses("127.0.0.1")
+var testAddrs = []network.Address{
+	network.NewAddress("127.0.0.1"),
+	{
+		Value:           "10.6.6.6",
+		Type:            network.IPv4Address,
+		Scope:           network.ScopeCloudLocal,
+		SpaceName:       "test-space",
+		SpaceProviderId: "1",
+	},
+}
 
 func (s *machineSuite) TestSetsInstanceInfoInitially(c *gc.C) {
 	context := &testMachineContext{

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -189,17 +189,15 @@ func machineLoop(context machineContext, m machine, lifeChanged <-chan struct{},
 	pollInstance := func() error {
 		instInfo, err := pollInstanceInfo(context, m)
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 
 		machineStatus := status.Pending
-		if err == nil {
-			if statusInfo, err := m.Status(); err != nil {
-				logger.Warningf("cannot get current machine status for machine %v: %v", m.Id(), err)
-			} else {
-				// TODO(perrito666) add status validation.
-				machineStatus = status.Status(statusInfo.Status)
-			}
+		if statusInfo, err := m.Status(); err != nil {
+			logger.Warningf("cannot get current machine status for machine %v: %v", m.Id(), err)
+		} else {
+			// TODO(perrito666) add status validation.
+			machineStatus = status.Status(statusInfo.Status)
 		}
 
 		// the extra condition below (checking allocating/pending) is here to improve user experience
@@ -292,6 +290,7 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 		if err != nil {
 			return instanceInfo{}, err
 		}
+
 		if !addressesEqual(providerAddresses, instInfo.addresses) {
 			logger.Infof("machine %q has new addresses: %v", m.Id(), instInfo.addresses)
 			if err := m.SetProviderAddresses(instInfo.addresses...); err != nil {


### PR DESCRIPTION
## Description of change

This patch includes the provider space ID in address representations and transports, and stores it in state when present.

It prevents the instance-poller from updating provider addresses every 5 seconds for each machine due to comparisons being unequal.

## QA steps

- Bootstrap to MAAS.
- `juju add-machine`.
- `juju debug-log -m controller`.
- Observe that messages like these do not repeat every 5 seconds:
> machine-0: 11:56:23 INFO juju.worker.instancepoller machine "0" has new addresses: [local-cloud:172.16.99.3@space-default(id:1)]

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1828972
