### PR TITLE
Support Partial Machine Placement for Enable-HA

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -170,11 +170,11 @@ func getReferenceController(st *state.State, machineIds []string) (*state.Machin
 	controllerId := controllerIds[0]
 
 	// Load the controller machine and get its constraints.
-	controller, err := st.Machine(strconv.Itoa(controllerId))
+	cm, err := st.Machine(strconv.Itoa(controllerId))
 	if err != nil {
 		return nil, errors.Annotatef(err, "reading controller id %v", controllerId)
 	}
-	return controller, nil
+	return cm, nil
 }
 
 // validateCurrentControllers checks for a scenario where there is no HA space
@@ -189,11 +189,11 @@ func validateCurrentControllers(st *state.State, cfg controller.Config, machineI
 
 	var badIds []string
 	for _, id := range machineIds {
-		controller, err := st.Machine(id)
+		cm, err := st.Machine(id)
 		if err != nil {
 			return errors.Annotatef(err, "reading controller id %v", id)
 		}
-		addresses := controller.Addresses()
+		addresses := cm.Addresses()
 		if len(addresses) == 0 {
 			// machines without any address are essentially not started yet
 			continue

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -227,7 +227,7 @@ func (c *enableHACommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	defer haClient.Close()
+	defer func() { _ = haClient.Close() }()
 	enableHAResult, err := haClient.EnableHA(
 		c.NumControllers,
 		c.Constraints,


### PR DESCRIPTION
## Description of change

This patch ensures that when new controller machines are being added to make up a HA quorum, machine placement directives are not used for those machines.

## QA steps

Corrected Behaviour:
- Bootstrap.
- `juju add-machine -m controller`.
- `juju enable-ha --to 1`.
- Check that HA settles using the existing machine and one newly created one.

Regression:
- Bootstrap.
- `juju add-machine -m controller`.
- `juju add-machine -m controller`.
- `juju enable-ha --to 1,2`.
- Check that HA settles on the existing machines.

Regression with non-machine placement:
- Bootstrap on a substrate supporting AZs (I used MAAS).
- `juju enable-ha --to <some existing AZ>`.
- Check that HA settles appropriately.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1817564
