### PR TITLE
2.6 nil fixes

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -701,7 +701,11 @@ func (p lxdCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 		return nil
 	}
 	if profiler, ok := p.Charm.(charm.LXDProfiler); ok {
-		return profiler.LXDProfile()
+		profile := profiler.LXDProfile()
+		if profile == nil {
+			return nil
+		}
+		return profile
 	}
 	return nil
 }

--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/meterstatus"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/state"
 )
 
 var (
@@ -35,4 +36,12 @@ func NewStorageAPI(
 
 func SetNewContainerBrokerFunc(api *UniterAPI, newBroker caas.NewContainerBrokerFunc) {
 	api.containerBrokerFunc = newBroker
+}
+
+type patcher interface {
+	PatchValue(interface{}, interface{})
+}
+
+func PatchGetStorageStateError(patcher patcher, err error) {
+	patcher.PatchValue(&getStorageState, func(st *state.State) (storageAccess, error) { return nil, err })
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -251,11 +251,15 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 	}
 
 	storageAccessor, err := getStorageState(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	storageAPI, err := newStorageAPI(
 		stateShim{st}, storageAccessor, resources, accessUnit)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
+
 	msAPI, err := meterstatus.NewMeterStatusAPI(st, resources, authorizer)
 	if err != nil {
 		return nil, errors.Annotate(err, "could not create meter status API handler")

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2328,7 +2328,11 @@ func (p lxdCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 		return nil
 	}
 	if profiler, ok := p.Charm.(charm.LXDProfiler); ok {
-		return profiler.LXDProfile()
+		profile := profiler.LXDProfile()
+		if profile == nil {
+			return nil
+		}
+		return profile
 	}
 	return nil
 }

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -454,5 +454,9 @@ func (p lxdCharmArchiveProfiler) LXDProfile() lxdprofile.LXDProfile {
 	if p.CharmArchive == nil {
 		return nil
 	}
-	return p.CharmArchive.LXDProfile()
+	profile := p.CharmArchive.LXDProfile()
+	if profile == nil {
+		return nil
+	}
+	return profile
 }

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1479,5 +1479,9 @@ func (p lxdStateCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 	if p.Charm == nil {
 		return nil
 	}
-	return p.Charm.LXDProfile()
+	profile := p.Charm.LXDProfile()
+	if profile == nil {
+		return nil
+	}
+	return profile
 }

--- a/apiserver/facades/client/client/status_internal_test.go
+++ b/apiserver/facades/client/client/status_internal_test.go
@@ -17,12 +17,12 @@ func (*lxdStateCharmProfilerSuite) TestLXDProfileEmptyCharm(c *gc.C) {
 	wrapper := lxdStateCharmProfiler{
 		Charm: nil,
 	}
-	c.Check(wrapper.LXDProfile(), gc.Equals, nil)
+	c.Check(wrapper.LXDProfile(), gc.IsNil)
 }
 
 func (*lxdStateCharmProfilerSuite) TestLXDProfileCharmNoProfile(c *gc.C) {
 	wrapper := lxdStateCharmProfiler{
 		Charm: &state.Charm{},
 	}
-	c.Check(wrapper.LXDProfile(), gc.Equals, nil)
+	c.Check(wrapper.LXDProfile(), gc.IsNil)
 }

--- a/apiserver/facades/client/client/status_internal_test.go
+++ b/apiserver/facades/client/client/status_internal_test.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+)
+
+type lxdStateCharmProfilerSuite struct{}
+
+var _ = gc.Suite(&lxdStateCharmProfilerSuite{})
+
+func (*lxdStateCharmProfilerSuite) TestLXDProfileEmptyCharm(c *gc.C) {
+	wrapper := lxdStateCharmProfiler{
+		Charm: nil,
+	}
+	c.Check(wrapper.LXDProfile(), gc.Equals, nil)
+}
+
+func (*lxdStateCharmProfilerSuite) TestLXDProfileCharmNoProfile(c *gc.C) {
+	wrapper := lxdStateCharmProfiler{
+		Charm: &state.Charm{},
+	}
+	c.Check(wrapper.LXDProfile(), gc.Equals, nil)
+}

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -250,7 +250,7 @@ func (c *controllerStack) getControllerSecret() (secret *core.Secret, err error)
 
 func (c *controllerStack) getControllerConfigMap() (cm *core.ConfigMap, err error) {
 	defer func() {
-		if cm.Data == nil {
+		if cm != nil && cm.Data == nil {
 			cm.Data = map[string]string{}
 		}
 	}()

--- a/cmd/juju/application/validate.go
+++ b/cmd/juju/application/validate.go
@@ -64,7 +64,11 @@ func (p lxdCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 		return nil
 	}
 	if profiler, ok := p.Charm.(charm.LXDProfiler); ok {
-		return profiler.LXDProfile()
+		profile := profiler.LXDProfile()
+		if profile == nil {
+			return nil
+		}
+		return profile
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

This cherry picks the proposed nil pointer fixes that had landed in the 2.6 branch before being reverted, and adds one for the typed nil LXDProfile interface bug.

## QA steps

For this bug the fix is to
```
$ juju-2.4 bootstrap
$ juju-2.4 deploy cs:~jameinel/ubuntu-lite
$ juju-2.6 upgrade-juju 
$ juju status
```

Without this fix, the 2.4 Juju will create a charm document that doesn't have an LXDProfile attribute. Upgrading it to 2.6 will create a Charm object in memory that has a nil pointer for lxdprofile. And the code that thought it was trapping a nil pointer was failing because of Go's [typed-nil issue](https://dave.cheney.net/2017/08/09/typed-nils-in-go-2).

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829014