### PR TITLE
2.6 - Guard SetApplicationConfig Against Empty Branch Name

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2146,6 +2146,12 @@ func (api *APIBase) setApplicationConfig(arg params.ApplicationConfigSet) error 
 		if err != nil {
 			return errors.Trace(err)
 		}
+
+		// We need a guard on the API server-side for direct API callers such as
+		// python-libjuju. Always default to the master branch.
+		if arg.Generation == "" {
+			arg.Generation = model.GenerationMaster
+		}
 		if err := app.UpdateCharmConfig(arg.Generation, charmConfigChanges); err != nil {
 			return errors.Annotate(err, "updating application charm settings")
 		}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2148,7 +2148,8 @@ func (api *APIBase) setApplicationConfig(arg params.ApplicationConfigSet) error 
 		}
 
 		// We need a guard on the API server-side for direct API callers such as
-		// python-libjuju. Always default to the master branch.
+		// python-libjuju, and for older clients.
+		// Always default to the master branch.
 		if arg.Generation == "" {
 			arg.Generation = model.GenerationMaster
 		}
@@ -2223,7 +2224,8 @@ func (api *APIBase) unsetApplicationConfig(arg params.ApplicationUnset) error {
 
 	if len(charmSettings) > 0 {
 		// We need a guard on the API server-side for direct API callers such as
-		// python-libjuju. Always default to the master branch.
+		// python-libjuju, and for older clients.
+		// Always default to the master branch.
 		if arg.BranchName == "" {
 			arg.BranchName = model.GenerationMaster
 		}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1416,7 +1416,15 @@ func (s *ApplicationSuite) TestRemoteRelationDisAllowedCIDR(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `CIDR "0.0.0.0/0" not allowed`)
 }
 
-func (s *ApplicationSuite) TestSetApplicationConfig(c *gc.C) {
+func (s *ApplicationSuite) TestSetApplicationConfigExplicitMaster(c *gc.C) {
+	s.testSetApplicationConfig(c, model.GenerationMaster)
+}
+
+func (s *ApplicationSuite) TestSetApplicationConfigEmptyUsesMaster(c *gc.C) {
+	s.testSetApplicationConfig(c, "")
+}
+
+func (s *ApplicationSuite) testSetApplicationConfig(c *gc.C, branchName string) {
 	application.SetModelType(s.api, state.ModelTypeCAAS)
 	result, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
 		Args: []params.ApplicationConfigSet{{
@@ -1425,7 +1433,7 @@ func (s *ApplicationSuite) TestSetApplicationConfig(c *gc.C) {
 				"juju-external-hostname": "value",
 				"stringOption":           "stringVal",
 			},
-			Generation: model.GenerationMaster,
+			Generation: branchName,
 		}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

This patch adds logic already present for un-setting configuration values. 

It ensures that when an empty string is supplied for branch/generation name to `SetApplicationConfig`, it is defaulted to "master".

## QA steps

- Build and bootstrap this branch.
- `juju deploy redis`.
- Build or Snap install a 2.5.7 client.
- Use this client to `juju config redis password=pass`.
- Check that the password is set without error. 

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829140
