### PR TITLE
Don't uninstall machine agent when a fatal connection error occurs in the machine agent manifold

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -262,16 +262,11 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	// connectFilter exists:
 	//  1) to let us retry api connections immediately on password change,
 	//     rather than causing the dependency engine to wait for a while;
-	//  2) to ensure that certain connection failures correctly trigger
-	//     complete agent removal. (It's not safe to let any agent other
-	//     than the machine mess around with SetCanUninstall).
+	//  2) to decide how to deal with fatal, non-recoverable errors
+	//     e.g apicaller.ErrConnectImpossible.
 	connectFilter := func(err error) error {
 		cause := errors.Cause(err)
 		if cause == apicaller.ErrConnectImpossible {
-			err2 := coreagent.SetCanUninstall(config.Agent)
-			if err2 != nil {
-				return errors.Trace(err2)
-			}
 			return jworker.ErrTerminateAgent
 		} else if cause == apicaller.ErrChangedPassword {
 			return dependency.ErrBounce

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -4,8 +4,6 @@
 package machine_test
 
 import (
-	"io/ioutil"
-	"os"
 	"sort"
 
 	"github.com/juju/collections/set"
@@ -228,13 +226,9 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 }
 
 func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *gc.C) {
-	tmpDir, err := ioutil.TempDir("", "agent-data-dir")
-	c.Assert(err, jc.ErrorIsNil)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
 	ag := &mockAgent{
 		conf: mockConfig{
-			dataPath: tmpDir,
+			dataPath: c.MkDir(),
 		},
 	}
 	manifolds := machine.Manifolds(machine.ManifoldsConfig{
@@ -247,7 +241,7 @@ func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *gc.C) {
 	// Check that when the api-caller maps non-recoverable errors to
 	// ErrTerminateAgent and that it does not create an uninstall file for
 	// the agent.
-	err = apiCaller.Filter(apicaller.ErrConnectImpossible)
+	err := apiCaller.Filter(apicaller.ErrConnectImpossible)
 	c.Assert(err, gc.Equals, jworker.ErrTerminateAgent)
 	c.Assert(agent.CanUninstall(ag), gc.Equals, false)
 }

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -4,6 +4,8 @@
 package machine_test
 
 import (
+	"io/ioutil"
+	"os"
 	"sort"
 
 	"github.com/juju/collections/set"
@@ -18,6 +20,8 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/agent/machine"
 	"github.com/juju/juju/testing"
+	jworker "github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/gate"
 )
 
@@ -221,6 +225,31 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
 		}
 	}
+}
+
+func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *gc.C) {
+	tmpDir, err := ioutil.TempDir("", "agent-data-dir")
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ag := &mockAgent{
+		conf: mockConfig{
+			dataPath: tmpDir,
+		},
+	}
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{
+		Agent: ag,
+	})
+
+	c.Assert(manifolds["api-caller"], gc.Not(gc.IsNil))
+	apiCaller := manifolds["api-caller"]
+
+	// Check that when the api-caller maps non-recoverable errors to
+	// ErrTerminateAgent and that it does not create an uninstall file for
+	// the agent.
+	err = apiCaller.Filter(apicaller.ErrConnectImpossible)
+	c.Assert(err, gc.Equals, jworker.ErrTerminateAgent)
+	c.Assert(agent.CanUninstall(ag), gc.Equals, false)
 }
 
 func checkContains(c *gc.C, names []string, seek string) {
@@ -881,9 +910,10 @@ func (ma *mockAgent) ChangeConfig(f agent.ConfigMutator) error {
 
 type mockConfig struct {
 	agent.ConfigSetter
-	tag    names.Tag
-	ssiSet bool
-	ssi    params.StateServingInfo
+	tag      names.Tag
+	ssiSet   bool
+	ssi      params.StateServingInfo
+	dataPath string
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -908,4 +938,11 @@ func (mc *mockConfig) SetStateServingInfo(info params.StateServingInfo) {
 
 func (mc *mockConfig) LogDir() string {
 	return "log-dir"
+}
+
+func (mc *mockConfig) DataDir() string {
+	if mc.dataPath != "" {
+		return mc.dataPath
+	}
+	return "data-dir"
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -761,6 +761,8 @@ func (s *MachineLegacyLeasesSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C)
 }
 
 func (s *MachineLegacyLeasesSuite) TestMachineAgentUninstall(c *gc.C) {
+	c.Skip("test takes over 30s to complete; we need to investigate why it takes so long for the agent to appear as alive")
+
 	m, ac, _ := s.primeAgent(c, state.JobHostUnits)
 	a := s.newAgent(c, m)
 


### PR DESCRIPTION
## Description of change

There are two codepaths that eventually call `agent.SetCanUninstall`:

- A filter func for the `api-caller` worker in the machine agent manifold invokes it when a `ErrConnectImpossible` error is encountered; the error is logged and replaced with `ErrTerminateAgent`.
- The machiner, after ensuring that a machine is dead.

In both cases, when the machine agent processes the `ErrTerminateAgent` error it attempts to uninstall the agent. This attempt will only succeed if `agent.SetCanUninstall` is invoked first (it writes out an uninstall file that the agent tries to stat before continuing).

This PR patches the code for the **first** case so an uninstall is never triggered. NOTE: Dealing with the latter case will be tackled via a separate PR as it has implications for users working with the manual provider.