### PR TITLE
Feature/add-k8s for cdk on maas openstack

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -348,7 +348,10 @@ func (c *controllerStack) getControllerSvcSpec(cloudType string) (*controllerSer
 
 func (c *controllerStack) createControllerService() error {
 	svcName := c.resourceNameService
-	cloudType, _ := cloud.SplitHostCloudRegion(c.pcfg.Bootstrap.ControllerCloud.HostCloudRegion)
+	cloudType, _, err := cloud.SplitHostCloudRegion(c.pcfg.Bootstrap.ControllerCloud.HostCloudRegion)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	controllerSvcSpec, err := c.getControllerSvcSpec(cloudType)
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -348,10 +348,8 @@ func (c *controllerStack) getControllerSvcSpec(cloudType string) (*controllerSer
 
 func (c *controllerStack) createControllerService() error {
 	svcName := c.resourceNameService
-	cloudType, _, err := cloud.SplitHostCloudRegion(c.pcfg.Bootstrap.ControllerCloud.HostCloudRegion)
-	if err != nil {
-		return errors.Trace(err)
-	}
+
+	cloudType, _, _ := cloud.SplitHostCloudRegion(c.pcfg.Bootstrap.ControllerCloud.HostCloudRegion)
 	controllerSvcSpec, err := c.getControllerSvcSpec(cloudType)
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -337,9 +337,9 @@ func (c *controllerStack) getControllerSvcSpec(cloudType string) (*controllerSer
 	spec, ok := controllerServiceSpecs[cloudType]
 	if !ok {
 		logger.Debugf("fallback to default svc spec for %q", cloudType)
-		spec, _ = controllerServiceSpecs[caas.K8sCloudOther]
+		spec = controllerServiceSpecs[caas.K8sCloudOther]
 	}
-	if spec.ServiceType == "" {
+	if spec == nil || spec.ServiceType == "" {
 		// ServiceType is required.
 		return nil, errors.NotValidf("service type is empty for %q", cloudType)
 	}
@@ -348,8 +348,7 @@ func (c *controllerStack) getControllerSvcSpec(cloudType string) (*controllerSer
 
 func (c *controllerStack) createControllerService() error {
 	svcName := c.resourceNameService
-
-	cloudType := cloud.SplitHostCloudRegion(c.pcfg.Bootstrap.ControllerCloud.HostCloudRegion)[0]
+	cloudType, _ := cloud.SplitHostCloudRegion(c.pcfg.Bootstrap.ControllerCloud.HostCloudRegion)
 	controllerSvcSpec, err := c.getControllerSvcSpec(cloudType)
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -101,7 +101,7 @@ func updateK8sCloud(k8sCloud *cloud.Cloud, clusterMetadata *caas.ClusterMetadata
 		if storageMsg == "" {
 			storageMsg += "\nwith "
 		} else {
-			storageMsg += "\nand"
+			storageMsg += "\nand "
 		}
 		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class.")
 	}

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -182,6 +182,10 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 		if ok {
 			provisioner = nonPreferredStorageErr.Provisioner
 			params = nonPreferredStorageErr.Parameters
+		} else if clusterMetadata.NominatedStorageClass != nil {
+			// no preferred storage class config but user provided an existing storage class name.
+			provisioner = clusterMetadata.NominatedStorageClass.Provisioner
+			params = clusterMetadata.NominatedStorageClass.Parameters
 		}
 		sp, err := storageParams.MetadataChecker.EnsureStorageProvisioner(caas.StorageProvisioner{
 			Name:        storageParams.WorkloadStorage,

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -128,7 +128,7 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 	}}
 
 	// If the user has not specified storage, check that the cluster has Juju's opinionated defaults.
-	cloudType := cloud.SplitHostCloudRegion(storageParams.HostCloudRegion)[0]
+	cloudType, _ := cloud.SplitHostCloudRegion(storageParams.HostCloudRegion)
 	err = storageParams.MetadataChecker.CheckDefaultWorkloadStorage(cloudType, clusterMetadata.NominatedStorageClass)
 
 	if storageParams.WorkloadStorage == "" {

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -161,7 +161,7 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 
 	if err != nil {
 		// Region is optional, but cloudType is required for next step.
-		return "", errors.Trace(err)
+		return "", ClusterQueryError{}
 	}
 
 	// check Juju's opinionated defaults if cloudType is usable.
@@ -208,12 +208,12 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 				storageMsg = fmt.Sprintf("%s provisioned\nby the existing %q storage class", storageMsg, storageParams.WorkloadStorage)
 			}
 		} else {
-			clusterMetadata.NominatedStorageClass = sp
-			clusterMetadata.OperatorStorageClass = sp
 			storageMsg = fmt.Sprintf(" with storage provisioned\nby the existing %q storage class", storageParams.WorkloadStorage)
 		}
+		clusterMetadata.NominatedStorageClass = sp
+		clusterMetadata.OperatorStorageClass = sp
 	}
-	return
+	return storageMsg, nil
 }
 
 // BaseKubeCloudOpenParams provides a basic OpenParams for a cluster

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -40,6 +40,10 @@ func init() {
 			Name:        "EBS Volume",
 			Provisioner: "kubernetes.io/aws-ebs",
 		},
+		caas.K8sCloudOpenStack: {
+			Name:        "Cinder Disk",
+			Provisioner: "csi-cinderplugin",
+		},
 	}
 
 	// jujuPreferredOperatorStorage defines the opinionated storage
@@ -67,7 +71,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on GCE.
 			newLabelRequirements(
-				requirementParams{"juju-io-cloud", selection.Equals, []string{"gce"}},
+				requirementParams{"juju.io/cloud", selection.Equals, []string{"gce"}},
 			),
 		},
 		caas.K8sCloudEC2: {
@@ -77,7 +81,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on AWS.
 			newLabelRequirements(
-				requirementParams{"juju-io-cloud", selection.Equals, []string{"ec2"}},
+				requirementParams{"juju.io/cloud", selection.Equals, []string{"ec2"}},
 			),
 		},
 		caas.K8sCloudAzure: {
@@ -87,7 +91,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on Azure.
 			newLabelRequirements(
-				requirementParams{"juju-io-cloud", selection.Equals, []string{"azure"}},
+				requirementParams{"juju.io/cloud", selection.Equals, []string{"azure"}},
 			),
 		},
 		// format - cloudType: requirements.

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -67,7 +67,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on GCE.
 			newLabelRequirements(
-				requirementParams{"juju.io/cloud", selection.Equals, []string{"gce"}},
+				requirementParams{"juju-io-cloud", selection.Equals, []string{"gce"}},
 			),
 		},
 		caas.K8sCloudEC2: {
@@ -77,7 +77,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on AWS.
 			newLabelRequirements(
-				requirementParams{"juju.io/cloud", selection.Equals, []string{"ec2"}},
+				requirementParams{"juju-io-cloud", selection.Equals, []string{"ec2"}},
 			),
 		},
 		caas.K8sCloudAzure: {
@@ -87,7 +87,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on Azure.
 			newLabelRequirements(
-				requirementParams{"juju.io/cloud", selection.Equals, []string{"azure"}},
+				requirementParams{"juju-io-cloud", selection.Equals, []string{"azure"}},
 			),
 		},
 		// format - cloudType: requirements.

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -167,22 +167,19 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 	}
 
 	if result.OperatorStorageClass == nil && len(possibleOperatorStorage) > 0 {
-		sc := possibleOperatorStorage[0]
-		result.OperatorStorageClass = sc
-		logger.Debugf("Use %q for operator storage class", sc.Name)
+		result.OperatorStorageClass = possibleOperatorStorage[0]
+		logger.Debugf("Use %q for operator storage class", possibleOperatorStorage[0].Name)
 	}
 	// Even if no storage class was marked as default for the cluster, if there's only
 	// one of them, use it for workload storage.
-	if result.NominatedStorageClass == nil && len(possibleWorkloadStorage) > 0 {
-		sc := possibleWorkloadStorage[0]
-		result.NominatedStorageClass = sc
-		logger.Debugf("Use %q for nominated storage class", sc.Name)
+	if result.NominatedStorageClass == nil && len(possibleWorkloadStorage) == 1 {
+		result.NominatedStorageClass = possibleWorkloadStorage[0]
+		logger.Debugf("Use %q for nominated storage class", possibleWorkloadStorage[0].Name)
 	}
-	if result.OperatorStorageClass == nil {
+	if result.OperatorStorageClass == nil && result.NominatedStorageClass != nil {
 		// use workload storage class if no operator storage class preference found.
-		sc := result.NominatedStorageClass
-		result.OperatorStorageClass = sc
-		logger.Debugf("Use nominated storage class %q for operator storage class", sc.Name)
+		result.OperatorStorageClass = result.NominatedStorageClass
+		logger.Debugf("Use nominated storage class %q for operator storage class", result.NominatedStorageClass.Name)
 	}
 	return &result, nil
 }

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -97,21 +97,21 @@ var hostRegionsTestCases = []hostRegionTestcase{
 		expectedCloud:   "gce",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju-io-cloud": "gce",
+			"juju.io/cloud": "gce",
 		}),
 	},
 	{
 		expectedCloud:   "ec2",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju-io-cloud": "ec2",
+			"juju.io/cloud": "ec2",
 		}),
 	},
 	{
 		expectedCloud:   "azure",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju-io-cloud": "azure",
+			"juju.io/cloud": "azure",
 		}),
 	},
 	{

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -97,21 +97,21 @@ var hostRegionsTestCases = []hostRegionTestcase{
 		expectedCloud:   "gce",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju.io/cloud": "gce",
+			"juju-io-cloud": "gce",
 		}),
 	},
 	{
 		expectedCloud:   "ec2",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju.io/cloud": "ec2",
+			"juju-io-cloud": "ec2",
 		}),
 	},
 	{
 		expectedCloud:   "azure",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju.io/cloud": "azure",
+			"juju-io-cloud": "azure",
 		}),
 	},
 	{

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -31,9 +31,6 @@ const (
 	// K8sCloudLXD is the name used for LXD k8s clouds(Kubernetes Core).
 	K8sCloudLXD = "lxd"
 
-	// K8sCloudOracle is the name used for Oracle k8s clouds(CDK).
-	K8sCloudOracle = "oci"
-
 	// K8sCloudRackspace is the name used for Rackspace k8s clouds(CDK).
 	K8sCloudRackspace = "rackspace"
 

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -31,6 +31,12 @@ const (
 	// K8sCloudLXD is the name used for LXD k8s clouds(Kubernetes Core).
 	K8sCloudLXD = "lxd"
 
+	// K8sCloudOracle is the name used for Oracle k8s clouds(CDK).
+	K8sCloudOracle = "oci"
+
+	// K8sCloudRackspace is the name used for Rackspace k8s clouds(CDK).
+	K8sCloudRackspace = "rackspace"
+
 	// K8sCloudOther is the name used for any other k8s cloud is not listed above.
 	K8sCloudOther = "other"
 

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -182,6 +182,9 @@ func SplitHostCloudRegion(hostCloudRegion string) (string, string, error) {
 
 // BuildHostCloudRegion combines cloudType with region to host cloud region.
 func BuildHostCloudRegion(cloudType, region string) string {
+	if region == "" {
+		return cloudType
+	}
 	return cloudType + "/" + region
 }
 

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -168,8 +168,12 @@ type Cloud struct {
 }
 
 // SplitHostCloudRegion splits host cloud region to cloudType and region.
-func SplitHostCloudRegion(hostCloudRegion string) []string {
-	return strings.Split(hostCloudRegion, "/")
+func SplitHostCloudRegion(hostCloudRegion string) (string, string) {
+	r := strings.Split(hostCloudRegion, "/")
+	if len(r) >= 2 {
+		return r[0], r[1]
+	}
+	return r[0], ""
 }
 
 // BuildHostCloudRegion combines cloudType with region to host cloud region.

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -168,12 +168,12 @@ type Cloud struct {
 }
 
 // SplitHostCloudRegion splits host cloud region to cloudType and region.
-func SplitHostCloudRegion(hostCloudRegion string) (string, string) {
-	r := strings.Split(hostCloudRegion, "/")
-	if len(r) >= 2 {
-		return r[0], r[1]
+func SplitHostCloudRegion(hostCloudRegion string) (string, string, error) {
+	fields := strings.SplitN(hostCloudRegion, "/", 2)
+	if len(fields) != 2 || fields[0] == "" || fields[1] == "" {
+		return "", "", errors.NotValidf("cloud region %q", hostCloudRegion)
 	}
-	return r[0], ""
+	return fields[0], fields[1], nil
 }
 
 // BuildHostCloudRegion combines cloudType with region to host cloud region.

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -170,10 +170,14 @@ type Cloud struct {
 // SplitHostCloudRegion splits host cloud region to cloudType and region.
 func SplitHostCloudRegion(hostCloudRegion string) (string, string, error) {
 	fields := strings.SplitN(hostCloudRegion, "/", 2)
-	if len(fields) != 2 || fields[0] == "" || fields[1] == "" {
-		return "", "", errors.NotValidf("cloud region %q", hostCloudRegion)
+	if len(fields) == 0 || fields[0] == "" {
+		return "", "", errors.NotValidf("host cloud region %q", hostCloudRegion)
 	}
-	return fields[0], fields[1], nil
+	region := ""
+	if len(fields) > 1 {
+		region = fields[1]
+	}
+	return fields[0], region, nil
 }
 
 // BuildHostCloudRegion combines cloudType with region to host cloud region.

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -85,7 +85,7 @@ Examples:
     juju add-k8s --context-name mycontext myk8scloud
     juju add-k8s myk8scloud --region <cloudNameOrCloudType>/<someregion>
     juju add-k8s myk8scloud --cloud <cloudNameOrCloudType>
-    juju add-k8s myk8scloud --cloud <cloudNameOrCloudType> --region=someregion
+    juju add-k8s myk8scloud --cloud <cloudNameOrCloudType> --region=<someregion>
 
     KUBECONFIG=path-to-kubuconfig-file juju add-k8s myk8scloud --cluster-name=my_cluster_name
     kubectl config view --raw | juju add-k8s myk8scloud --cluster-name=my_cluster_name
@@ -481,7 +481,7 @@ func getCloudAndRegionFromOptions(cloudOption, regionOption string) (string, str
 		cloudNameOrType = c
 	}
 	if r != "" {
-		return "", "", errors.NewNotValid(nil, "--cloud is cloud name or cloud type with region")
+		return "", "", errors.NewNotValid(nil, "--cloud incorrectly specifies a cloud/region instead of just a cloud")
 	}
 	if cloudNameOrType != "" && region != "" && c != "" && cloudNameOrType != c {
 		return "", "", errors.NotValidf("two different clouds specified: %q, %q", cloudNameOrType, c)
@@ -554,7 +554,9 @@ func (c *AddCAASCommand) validateCloudRegion(ctx *cmd.Context, cloudRegion strin
 			}
 			if len(details.RegionsMap) == 0 {
 				if region != "" {
-					return "", errors.NotValidf("cloud %q does not have a region, but %q provided", cloudType, region)
+					return "", errors.NewNotValid(nil, fmt.Sprintf(
+						"cloud %q does not have a region, but %q provided", cloudType, region,
+					))
 				}
 				return details.CloudType, nil
 			}

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -473,7 +473,7 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 
 func buildCloudAndRegionOption(cloudOption, regionOption string) (string, error) {
 	cloudNameOrType, region, err := jujucloud.SplitHostCloudRegion(regionOption)
-	if err != nil {
+	if err != nil && cloudOption == "" {
 		return "", errors.Annotate(err, "parsing region option")
 	}
 	c, r, _ := jujucloud.SplitHostCloudRegion(cloudOption)
@@ -500,6 +500,7 @@ func (c *AddCAASCommand) tryEnsureCloudTypeForHostRegion(cloudOption, regionOpti
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+	logger.Debugf("cloud option %q region option %q, cloudRegion %q", cloudOption, regionOption, cloudRegion)
 	cloudNameOrType, region, err := jujucloud.SplitHostCloudRegion(cloudRegion)
 	if err != nil {
 		return "", errors.Annotate(err, "parsing cloud region")

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -472,7 +472,10 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 }
 
 func buildCloudAndRegionOption(cloudOption, regionOption string) (string, error) {
-	cloudNameOrType, region, _ := jujucloud.SplitHostCloudRegion(regionOption)
+	cloudNameOrType, region, err := jujucloud.SplitHostCloudRegion(regionOption)
+	if err != nil {
+		return "", errors.Annotate(err, "parsing region option")
+	}
 	c, r, _ := jujucloud.SplitHostCloudRegion(cloudOption)
 	if region == "" && c != "" {
 		// --cloud ec2 --region us-east-1

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -379,7 +379,6 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) error {
 	storageParams := provider.KubeCloudStorageParams{
 		WorkloadStorage:        c.workloadStorage,
 		HostCloudRegion:        c.hostCloudRegion,
-		IsBootstrap:			c.Local,
 		MetadataChecker:        broker,
 		GetClusterMetadataFunc: c.getClusterMetadataFunc(ctx),
 	}
@@ -503,7 +502,7 @@ func (c *AddCAASCommand) validateCloudRegion(cloudRegion string) (_ string, err 
 }
 
 func (c *AddCAASCommand) getClusterMetadataFunc(ctx *cmd.Context) provider.GetClusterMetadataFunc {
-	return func(broker caas.ClusterMetadataChecker) (*caas.ClusterMetadata, error) {
+	return func(storageParams provider.KubeCloudStorageParams) (*caas.ClusterMetadata, error) {
 		interrupted := make(chan os.Signal, 1)
 		defer close(interrupted)
 		ctx.InterruptNotify(interrupted)
@@ -512,7 +511,7 @@ func (c *AddCAASCommand) getClusterMetadataFunc(ctx *cmd.Context) provider.GetCl
 		result := make(chan *caas.ClusterMetadata, 1)
 		errChan := make(chan error, 1)
 		go func() {
-			clusterMetadata, err := broker.GetClusterMetadata(c.workloadStorage)
+			clusterMetadata, err := storageParams.MetadataChecker.GetClusterMetadata(storageParams.WorkloadStorage)
 			if err != nil {
 				errChan <- err
 			} else {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -385,23 +385,16 @@ type regionTestCase struct {
 }
 
 func (s *addCAASSuite) TestRegionFlag(c *gc.C) {
-	errMsg := `
-	Juju needs to query the k8s cluster to ensure that the recommended
-	storage defaults are available and to detect the cluster's cloud/region.
-	This was not possible in this case so run add-k8s again, using
-	--storage=<name> to specify the storage class to use and
-	--region=<cloudType>/<region> to specify the cloud/region.
-`[1:]
 	for _, ts := range []regionTestCase{
 		{
 			title:          "missing cloud",
 			regionStr:      "/region",
-			expectedErrStr: errMsg,
+			expectedErrStr: `parsing region option: host cloud region "/region" not valid`,
 		},
 		{
 			title:          "missing region",
 			regionStr:      "cloud/",
-			expectedErrStr: `validating cloud region "cloud/": cloud region "cloud/" not valid`,
+			expectedErrStr: `validating cloud region "cloud": cloud region "cloud" not valid`,
 		},
 		{
 			title:          "not a known juju cloud",
@@ -691,7 +684,7 @@ func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
 	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class.`)
-	s.assertAddCloudResult(c, cloudRegion,"mystorage" ,"mystorage", false)
+	s.assertAddCloudResult(c, cloudRegion, "mystorage", "mystorage", false)
 }
 
 func (s *addCAASSuite) TestLocalOnly(c *gc.C) {


### PR DESCRIPTION
## Description of change

Storage/hosted-region enhancement for CDK;

## QA steps

test cmd: 
```bash
$ juju add-k8s $NAME [--local] --debug [--storage $CS_NAME] \
    [--region=$BASE_CLOUD_TYPE_WITH_OR_WITHOUT_REGION] \
    [--cloud=$CLOUD_NAME_OR_CLOUD_TYPE]
```

test cases:

1. with an existing sc has annotation as below:

```yaml
metadata:
  annotations:
    juju.io/workload-storage: "true"
```

2. with an existing sc has annotation as below:

```yaml
metadata:
  annotations:
    juju.io/workload-storage: "true"
    juju.io/operator-storage: "true"
```

3. with an existing sc has annotation as below:

```yaml
metadata:
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
```

4. with NO existing sc in the cluster - this will create a prefer sc for you:

```bash
$ juju add-k8s $NAME --local --debug --storage $CS_NAME
```

5. CDK on maas;
```bash
$ juju add-k8s $NAME --local --debug --storage $CS_NAME --region=$MAAS_CLOUD_TYPE
```

## Documentation changes

valid format of `--region` is `<cloudType>/[region]`;
If Juju can not figure out how to ensure the storage class then `--region` is required.
The `cloudType` is required but `region` becomes `optional` now.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829792