### PR TITLE
fix bug 1829393

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -53,7 +53,7 @@ var facadeVersions = map[string]int{
 	"ImageManager":                 2,
 	"ImageMetadata":                3,
 	"ImageMetadataManager":         1,
-	"InstanceMutater":              1,
+	"InstanceMutater":              2,
 	"InstancePoller":               3,
 	"KeyManager":                   1,
 	"KeyUpdater":                   1,

--- a/api/instancemutater/machine.go
+++ b/api/instancemutater/machine.go
@@ -29,6 +29,9 @@ type MutaterMachine interface {
 	// CharmProfilingInfo returns info to update lxd profiles on the machine
 	CharmProfilingInfo() (*UnitProfileInfo, error)
 
+	// ContainerType returns the container type for this machine.
+	ContainerType() (instance.ContainerType, error)
+
 	// SetCharmProfiles records the given slice of charm profile names.
 	SetCharmProfiles([]string) error
 
@@ -68,6 +71,20 @@ type Machine struct {
 
 	tag  names.MachineTag
 	life params.Life
+}
+
+// ContainerType implements MutaterMachine.ContainerType.
+func (m *Machine) ContainerType() (instance.ContainerType, error) {
+	var result params.ContainerTypeResult
+	args := params.Entity{Tag: m.tag.String()}
+	err := m.facade.FacadeCall("ContainerType", args, &result)
+	if err != nil {
+		return "", err
+	}
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Type, nil
 }
 
 // InstanceId implements MutaterMachine.InstanceId.

--- a/api/instancemutater/mocks/machinemutater_mock.go
+++ b/api/instancemutater/mocks/machinemutater_mock.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
 	params "github.com/juju/juju/apiserver/params"
+	instance "github.com/juju/juju/core/instance"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v2 "gopkg.in/juju/names.v2"
@@ -48,6 +49,19 @@ func (m *MockMutaterMachine) CharmProfilingInfo() (*instancemutater.UnitProfileI
 // CharmProfilingInfo indicates an expected call of CharmProfilingInfo
 func (mr *MockMutaterMachineMockRecorder) CharmProfilingInfo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfilingInfo", reflect.TypeOf((*MockMutaterMachine)(nil).CharmProfilingInfo))
+}
+
+// ContainerType mocks base method
+func (m *MockMutaterMachine) ContainerType() (instance.ContainerType, error) {
+	ret := m.ctrl.Call(m, "ContainerType")
+	ret0, _ := ret[0].(instance.ContainerType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerType indicates an expected call of ContainerType
+func (mr *MockMutaterMachineMockRecorder) ContainerType() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMutaterMachine)(nil).ContainerType))
 }
 
 // InstanceId mocks base method

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -206,6 +206,7 @@ func AllFacades() *facade.Registry {
 	}
 
 	reg("InstanceMutater", 1, instancemutater.NewFacadeV1)
+	reg("InstanceMutater", 2, instancemutater.NewFacadeV2)
 
 	reg("InstancePoller", 3, instancepoller.NewFacade)
 	reg("KeyManager", 1, keymanager.NewKeyManagerAPI)

--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -35,6 +35,18 @@ type InstanceMutaterV1 interface {
 	WatchLXDProfileVerificationNeeded(args params.Entities) (params.NotifyWatchResults, error)
 }
 
+// InstanceMutaterV2 defines the methods on the instance mutater API facade, version 2.
+type InstanceMutaterV2 interface {
+	Life(args params.Entities) (params.LifeResults, error)
+
+	CharmProfilingInfo(arg params.Entity) (params.CharmProfilingInfoResult, error)
+	ContainerType(arg params.Entity) (params.ContainerTypeResult, error)
+	SetCharmProfiles(args params.SetProfileArgs) (params.ErrorResults, error)
+	SetModificationStatus(args params.SetStatus) (params.ErrorResults, error)
+	WatchMachines() (params.StringsWatchResult, error)
+	WatchLXDProfileVerificationNeeded(args params.Entities) (params.NotifyWatchResults, error)
+}
+
 type InstanceMutaterAPI struct {
 	*common.LifeGetter
 
@@ -45,13 +57,18 @@ type InstanceMutaterAPI struct {
 	getAuthFunc common.GetAuthFunc
 }
 
+type InstanceMutaterAPIV1 struct {
+	*InstanceMutaterAPI
+}
+
 // using apiserver/facades/client/cloud as an example.
 var (
-	_ InstanceMutaterV1 = (*InstanceMutaterAPI)(nil)
+	_ InstanceMutaterV2 = (*InstanceMutaterAPI)(nil)
+	_ InstanceMutaterV1 = (*InstanceMutaterAPIV1)(nil)
 )
 
-// NewFacadeV1 is used for API registration.
-func NewFacadeV1(ctx facade.Context) (*InstanceMutaterAPI, error) {
+// NewFacadeV2 is used for API registration.
+func NewFacadeV2(ctx facade.Context) (*InstanceMutaterAPI, error) {
 	st := &instanceMutaterStateShim{State: ctx.State()}
 
 	model, err := ctx.Controller().Model(st.ModelUUID())
@@ -61,6 +78,15 @@ func NewFacadeV1(ctx facade.Context) (*InstanceMutaterAPI, error) {
 	modelCache := &modelCacheShim{Model: model}
 
 	return NewInstanceMutaterAPI(st, modelCache, ctx.Resources(), ctx.Auth())
+}
+
+// NewFacadeV1 is used for API registration.
+func NewFacadeV1(ctx facade.Context) (*InstanceMutaterAPIV1, error) {
+	v2, err := NewFacadeV2(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &InstanceMutaterAPIV1{v2}, nil
 }
 
 // NewInstanceMutaterAPI creates a new API server endpoint for managing
@@ -118,6 +144,27 @@ func (api *InstanceMutaterAPI) CharmProfilingInfo(arg params.Entity) (params.Cha
 	result.CurrentProfiles = lxdProfileInfo.MachineProfiles
 	result.ProfileChanges = lxdProfileInfo.ProfileUnits
 
+	return result, nil
+}
+
+// ContainerType returns the container type of a machine.
+func (api *InstanceMutaterAPI) ContainerType(arg params.Entity) (params.ContainerTypeResult, error) {
+	result := params.ContainerTypeResult{}
+	canAccess, err := api.getAuthFunc()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	tag, err := names.ParseMachineTag(arg.Tag)
+	if err != nil {
+		result.Error = common.ServerError(common.ErrPerm)
+		return result, nil
+	}
+	m, err := api.getCacheMachine(canAccess, tag)
+	if err != nil {
+		result.Error = common.ServerError(err)
+		return result, nil
+	}
+	result.Type = m.ContainerType()
 	return result, nil
 }
 

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -53,6 +53,7 @@ type ModelCacheApplication interface {
 type ModelCacheMachine interface {
 	InstanceId() (instance.Id, error)
 	CharmProfiles() []string
+	ContainerType() instance.ContainerType
 	WatchLXDProfileVerificationNeeded() (cache.NotifyWatcher, error)
 	WatchContainers() (cache.StringsWatcher, error)
 	Units() ([]ModelCacheUnit, error)

--- a/apiserver/facades/agent/instancemutater/mocks/modelcache_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/modelcache_mock.go
@@ -135,6 +135,18 @@ func (mr *MockModelCacheMachineMockRecorder) CharmProfiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfiles", reflect.TypeOf((*MockModelCacheMachine)(nil).CharmProfiles))
 }
 
+// ContainerType mocks base method
+func (m *MockModelCacheMachine) ContainerType() instance.ContainerType {
+	ret := m.ctrl.Call(m, "ContainerType")
+	ret0, _ := ret[0].(instance.ContainerType)
+	return ret0
+}
+
+// ContainerType indicates an expected call of ContainerType
+func (mr *MockModelCacheMachineMockRecorder) ContainerType() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockModelCacheMachine)(nil).ContainerType))
+}
+
 // InstanceId mocks base method
 func (m *MockModelCacheMachine) InstanceId() (instance.Id, error) {
 	ret := m.ctrl.Call(m, "InstanceId")

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -885,3 +885,9 @@ type GoalState struct {
 	Units     UnitsGoalState            `json:"units"`
 	Relations map[string]UnitsGoalState `json:"relations"`
 }
+
+// ContainerTypeResult holds the result of a machine's ContainerType.
+type ContainerTypeResult struct {
+	Type  instance.ContainerType `json:"container-type"`
+	Error *Error                 `json:"error"`
+}

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -57,7 +57,7 @@ var marshalTestCases = []struct {
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
 		},
 	},
-	json: `["machine","change",{"model-uuid":"uuid","id":"Benji","instance-id":"Shazam","agent-status":{"current":"error","message":"foo","version":""},"instance-status":{"current":"pending","message":"","version":""},"life":"alive","series":"trusty","supported-containers":["lxd"],"supported-containers-known":false,"hardware-characteristics":{},"jobs":["JobManageModel"],"addresses":[],"has-vote":false,"wants-vote":false}]`,
+	json: `["machine","change",{"model-uuid":"uuid","id":"Benji","instance-id":"Shazam","container-type":"","agent-status":{"current":"error","message":"foo","version":""},"instance-status":{"current":"pending","message":"","version":""},"life":"alive","series":"trusty","supported-containers":["lxd"],"supported-containers-known":false,"hardware-characteristics":{},"jobs":["JobManageModel"],"addresses":[],"has-vote":false,"wants-vote":false}]`,
 }, {
 	about: "ApplicationInfo Delta",
 	value: multiwatcher.Delta{

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -106,6 +106,7 @@ type MachineChange struct {
 	Life                     life.Value
 	Config                   map[string]interface{}
 	Series                   string
+	ContainerType            string
 	SupportedContainers      []instance.ContainerType
 	SupportedContainersKnown bool
 	HardwareCharacteristics  *instance.HardwareCharacteristics

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -66,6 +66,13 @@ func (m *Machine) CharmProfiles() []string {
 	return m.details.CharmProfiles
 }
 
+// ContainerType returns the cached container type hosting this machine.
+func (m *Machine) ContainerType() instance.ContainerType {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return instance.ContainerType(m.details.ContainerType)
+}
+
 // Units returns all the units that have been assigned to the machine
 // including subordinates.
 func (m *Machine) Units() ([]*Unit, error) {

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -240,6 +240,7 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string)
 		Id:                       m.Id,
 		Life:                     multiwatcher.Life(m.Life.String()),
 		Series:                   m.Series,
+		ContainerType:            m.ContainerType,
 		Jobs:                     paramsJobsFromJobs(m.Jobs),
 		SupportedContainers:      m.SupportedContainers,
 		SupportedContainersKnown: m.SupportedContainersKnown,

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -138,6 +138,7 @@ type MachineInfo struct {
 	Life                     Life                              `json:"life"`
 	Config                   map[string]interface{}            `json:"config,omitempty"`
 	Series                   string                            `json:"series"`
+	ContainerType            string                            `json:"container-type"`
 	SupportedContainers      []instance.ContainerType          `json:"supported-containers"`
 	SupportedContainersKnown bool                              `json:"supported-containers-known"`
 	HardwareCharacteristics  *instance.HardwareCharacteristics `json:"hardware-characteristics,omitempty"`

--- a/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/worker/instancemutater/mocks/machinemutater_mock.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
 	params "github.com/juju/juju/apiserver/params"
+	instance "github.com/juju/juju/core/instance"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v2 "gopkg.in/juju/names.v2"
@@ -48,6 +49,19 @@ func (m *MockMutaterMachine) CharmProfilingInfo() (*instancemutater.UnitProfileI
 // CharmProfilingInfo indicates an expected call of CharmProfilingInfo
 func (mr *MockMutaterMachineMockRecorder) CharmProfilingInfo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfilingInfo", reflect.TypeOf((*MockMutaterMachine)(nil).CharmProfilingInfo))
+}
+
+// ContainerType mocks base method
+func (m *MockMutaterMachine) ContainerType() (instance.ContainerType, error) {
+	ret := m.ctrl.Call(m, "ContainerType")
+	ret0, _ := ret[0].(instance.ContainerType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerType indicates an expected call of ContainerType
+func (mr *MockMutaterMachineMockRecorder) ContainerType() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMutaterMachine)(nil).ContainerType))
 }
 
 // InstanceId mocks base method

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api/instancemutater"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -69,8 +70,18 @@ func (m *mutater) startMachines(tags []names.MachineTag) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-
 			id := api.Tag().Id()
+
+			// Ensure we do not watch any KVM containers.
+			containerType, err := api.ContainerType()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if containerType == instance.KVM {
+				m.logger.Tracef("ignoring KVM container machine-%s", id)
+				continue
+			}
+
 			c = make(chan struct{})
 			m.machines[tag] = c
 

--- a/worker/instancemutater/mutater_test.go
+++ b/worker/instancemutater/mutater_test.go
@@ -46,7 +46,7 @@ func (s *mutaterSuite) TestProcessMachineProfileChanges(c *gc.C) {
 	startingProfiles := []string{"default", "juju-testme"}
 	finishingProfiles := append(startingProfiles, "juju-testme-lxd-profile-1")
 
-	s.ignoreLogging(c)()
+	s.ignoreLogging(c)
 	s.expectRefreshLifeAliveStatusIdle()
 	s.expectLXDProfileNames(startingProfiles, nil)
 	s.expectAssignLXDProfiles(finishingProfiles, nil)
@@ -63,7 +63,7 @@ func (s *mutaterSuite) TestProcessMachineProfileChangesMachineDead(c *gc.C) {
 
 	startingProfiles := []string{"default", "juju-testme"}
 
-	s.ignoreLogging(c)()
+	s.ignoreLogging(c)
 	s.expectRefreshLifeDead()
 
 	info := s.info(startingProfiles, 1, false)
@@ -77,7 +77,7 @@ func (s *mutaterSuite) TestProcessMachineProfileChangesError(c *gc.C) {
 	startingProfiles := []string{"default", "juju-testme"}
 	finishingProfiles := append(startingProfiles, "juju-testme-lxd-profile-1")
 
-	s.ignoreLogging(c)()
+	s.ignoreLogging(c)
 	s.expectRefreshLifeAliveStatusIdle()
 	s.expectLXDProfileNames(startingProfiles, nil)
 	s.expectAssignLXDProfiles(finishingProfiles, errors.New("fail me"))

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -187,52 +187,49 @@ var _ = gc.Suite(&workerEnvironSuite{})
 func (s *workerEnvironSuite) TestFullWorkflow(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachines([][]string{{"0"}}),
-		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1),
-		s.expectMachineCharmProfilingInfo(0, 3),
-		s.expectLXDProfileNamesTrue,
-		s.expectSetCharmProfiles(0),
-		s.expectAssignLXDProfiles,
-		s.expectAliveAndSetModificationStatusIdle(0),
-		s.expectModificationStatusApplied(0),
-	)
-	s.cleanKill(c, w)
+	s.ignoreLogging(c)
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeMachineTag(0)
+	s.notifyMachineAppLXDProfile(0, 1)
+	s.expectMachineCharmProfilingInfo(0, 3)
+	s.expectLXDProfileNamesTrue()
+	s.expectSetCharmProfiles(0)
+	s.expectAssignLXDProfiles()
+	s.expectAliveAndSetModificationStatusIdle(0)
+	s.expectModificationStatusApplied(0)
+
+	s.cleanKill(c, s.workerForScenario(c))
 }
 
 func (s *workerEnvironSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachines([][]string{{"0"}}),
-		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1),
-		s.expectAliveAndSetModificationStatusIdle(0),
-		s.expectMachineCharmProfilingInfo(0, 2),
-		s.expectLXDProfileNamesTrue,
-		s.expectModificationStatusApplied(0),
-	)
-	s.cleanKill(c, w)
+	s.ignoreLogging(c)
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeMachineTag(0)
+	s.notifyMachineAppLXDProfile(0, 1)
+	s.expectAliveAndSetModificationStatusIdle(0)
+	s.expectMachineCharmProfilingInfo(0, 2)
+	s.expectLXDProfileNamesTrue()
+	s.expectModificationStatusApplied(0)
+
+	s.cleanKill(c, s.workerForScenario(c))
 }
 
 func (s *workerEnvironSuite) TestRemoveAllCharmProfiles(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachines([][]string{{"0"}}),
-		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1),
-		s.expectAliveAndSetModificationStatusIdle(0),
-		s.expectCharmProfilingInfoRemove(0),
-		s.expectLXDProfileNamesTrue,
-		s.expectRemoveAllCharmProfiles(0),
-		s.expectModificationStatusApplied(0),
-	)
-	s.cleanKill(c, w)
+	s.ignoreLogging(c)
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeMachineTag(0)
+	s.notifyMachineAppLXDProfile(0, 1)
+	s.expectAliveAndSetModificationStatusIdle(0)
+	s.expectCharmProfilingInfoRemove(0)
+	s.expectLXDProfileNamesTrue()
+	s.expectRemoveAllCharmProfiles(0)
+	s.expectModificationStatusApplied(0)
+
+	s.cleanKill(c, s.workerForScenario(c))
 }
 
 func (s *workerEnvironSuite) TestMachineNotifyTwice(c *gc.C) {
@@ -242,44 +239,42 @@ func (s *workerEnvironSuite) TestMachineNotifyTwice(c *gc.C) {
 	// machine notifications are sent.  The 2nd group must
 	// be after machine 0 gets Life() == Alive.
 	var group sync.WaitGroup
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachinesWaitGroup([][]string{{"0", "1"}, {"0"}}, &group),
-		s.expectFacadeMachineTag(0),
-		s.expectFacadeMachineTag(1),
-		s.notifyMachineAppLXDProfile(0, 1),
-		s.notifyMachineAppLXDProfile(1, 1),
-		s.expectAliveAndSetModificationStatusIdle(1),
-		s.expectMachineCharmProfilingInfo(0, 2),
-		s.expectMachineCharmProfilingInfo(1, 2),
-		s.expectLXDProfileNamesTrue,
-		s.expectLXDProfileNamesTrue,
-		s.expectMachineAliveStatusIdleMachineDead(0, &group),
-	)
-	s.cleanKill(c, w)
+	s.ignoreLogging(c)
+	s.notifyMachinesWaitGroup([][]string{{"0", "1"}, {"0"}}, &group)
+	s.expectFacadeMachineTag(0)
+	s.expectFacadeMachineTag(1)
+	s.notifyMachineAppLXDProfile(0, 1)
+	s.notifyMachineAppLXDProfile(1, 1)
+	s.expectAliveAndSetModificationStatusIdle(1)
+	s.expectMachineCharmProfilingInfo(0, 2)
+	s.expectMachineCharmProfilingInfo(1, 2)
+	s.expectLXDProfileNamesTrue()
+	s.expectLXDProfileNamesTrue()
+	s.expectMachineAliveStatusIdleMachineDead(0, &group)
+
+	s.cleanKill(c, s.workerForScenario(c))
 }
 
 func (s *workerEnvironSuite) TestNoChangeFoundOne(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachines([][]string{{"0"}}),
-		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1),
-		s.expectCharmProfilingInfoSimpleNoChange(0),
-	)
-	s.cleanKill(c, w)
+	s.ignoreLogging(c)
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeMachineTag(0)
+	s.notifyMachineAppLXDProfile(0, 1)
+	s.expectCharmProfilingInfoSimpleNoChange(0)
+
+	s.cleanKill(c, s.workerForScenario(c))
 }
 
 func (s *workerEnvironSuite) TestNoMachineFound(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	w, err := s.workerErrorForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachines([][]string{{"0"}}),
-		s.expectFacadeReturnsNoMachine,
-	)
+	s.ignoreLogging(c)
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeReturnsNoMachine()
+
+	w, err := s.workerErrorForScenario(c)
 
 	// Since we don't use cleanKill() nor errorKill()
 	// here, but do waitDone() before checking errors.
@@ -300,30 +295,26 @@ func (s *workerEnvironSuite) TestNoMachineFound(c *gc.C) {
 func (s *workerEnvironSuite) TestCharmProfilingInfoNotProvisioned(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachines([][]string{{"0"}}),
-		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1),
-		s.expectCharmProfileInfoNotProvisioned(0),
-	)
+	s.ignoreLogging(c)
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeMachineTag(0)
+	s.notifyMachineAppLXDProfile(0, 1)
+	s.expectCharmProfileInfoNotProvisioned(0)
 
-	err := s.errorKill(c, w)
+	err := s.errorKill(c, s.workerForScenario(c))
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *workerEnvironSuite) TestCharmProfilingInfoError(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyMachines([][]string{{"0"}}),
-		s.expectFacadeMachineTag(0),
-		s.notifyMachineAppLXDProfile(0, 1),
-		s.expectCharmProfileInfoError(0),
-	)
+	s.ignoreLogging(c)
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeMachineTag(0)
+	s.notifyMachineAppLXDProfile(0, 1)
+	s.expectCharmProfileInfoError(0)
 
-	err := s.errorKill(c, w)
+	err := s.errorKill(c, s.workerForScenario(c))
 	c.Assert(err, jc.Satisfies, params.IsCodeNotSupported)
 }
 
@@ -350,7 +341,7 @@ func (s *workerSuite) setup(c *gc.C, machineCount int) *gomock.Controller {
 // workerForScenario creates worker config based on the suite's mocks.
 // Any supplied behaviour functions are executed, then a new worker
 // is started successfully and returned.
-func (s *workerSuite) workerForScenario(c *gc.C, behaviours ...func()) worker.Worker {
+func (s *workerSuite) workerForScenario(c *gc.C) worker.Worker {
 	config := instancemutater.Config{
 		Facade:                 s.facade,
 		Logger:                 s.logger,
@@ -358,10 +349,6 @@ func (s *workerSuite) workerForScenario(c *gc.C, behaviours ...func()) worker.Wo
 		AgentConfig:            s.agentConfig,
 		Tag:                    s.machineTag,
 		GetRequiredLXDProfiles: s.getRequiredLXDProfiles,
-	}
-
-	for _, b := range behaviours {
-		b()
 	}
 
 	w, err := s.newWorkerFunc(config)
@@ -372,7 +359,7 @@ func (s *workerSuite) workerForScenario(c *gc.C, behaviours ...func()) worker.Wo
 // workerErrorForScenario creates worker config based on the suite's mocks.
 // Any supplied behaviour functions are executed, then a new worker is
 // started and returned with any error in creation.
-func (s *workerSuite) workerErrorForScenario(c *gc.C, behaviours ...func()) (worker.Worker, error) {
+func (s *workerSuite) workerErrorForScenario(c *gc.C) (worker.Worker, error) {
 	config := instancemutater.Config{
 		Facade:      s.facade,
 		Logger:      s.logger,
@@ -381,19 +368,13 @@ func (s *workerSuite) workerErrorForScenario(c *gc.C, behaviours ...func()) (wor
 		Tag:         s.machineTag,
 	}
 
-	for _, b := range behaviours {
-		b()
-	}
-
 	return s.newWorkerFunc(config)
 }
 
-func (s *workerSuite) expectFacadeMachineTag(machine int) func() {
-	return func() {
-		tag := names.NewMachineTag(strconv.Itoa(machine))
-		s.facade.EXPECT().Machine(tag).Return(s.machine[machine], nil).AnyTimes()
-		s.machine[machine].EXPECT().Tag().Return(tag).AnyTimes()
-	}
+func (s *workerSuite) expectFacadeMachineTag(machine int) {
+	tag := names.NewMachineTag(strconv.Itoa(machine))
+	s.facade.EXPECT().Machine(tag).Return(s.machine[machine], nil).AnyTimes()
+	s.machine[machine].EXPECT().Tag().Return(tag).AnyTimes()
 }
 
 func (s *workerSuite) expectFacadeReturnsNoMachine() {
@@ -407,11 +388,9 @@ func (s *workerSuite) expectContainerTypeNone() {
 	}
 }
 
-func (s *workerSuite) expectCharmProfilingInfoSimpleNoChange(machine int) func() {
-	return func() {
-		do := s.workGroupAddGetDoneFunc()
-		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, nil).Do(do)
-	}
+func (s *workerSuite) expectCharmProfilingInfoSimpleNoChange(machine int) {
+	do := s.workGroupAddGetDoneFunc()
+	s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, nil).Do(do)
 }
 
 func (s *workerSuite) workGroupAddGetDoneFunc() func(_ ...interface{}) {
@@ -423,97 +402,86 @@ func (s *workerSuite) expectLXDProfileNamesTrue() {
 	s.broker.EXPECT().LXDProfileNames("juju-23423-0").Return([]string{"default", "juju-testing", "juju-testing-one-2"}, nil)
 }
 
-func (s *workerSuite) expectMachineCharmProfilingInfo(machine, rev int) func() {
-	return s.expectCharmProfilingInfo(s.machine[machine], rev)
+func (s *workerSuite) expectMachineCharmProfilingInfo(machine, rev int) {
+	s.expectCharmProfilingInfo(s.machine[machine], rev)
 }
 
-func (s *workerSuite) expectCharmProfilingInfo(mock *mocks.MockMutaterMachine, rev int) func() {
-	return func() {
-		mock.EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{
-			CurrentProfiles: []string{"default", "juju-testing", "juju-testing-one-2"},
-			InstanceId:      "juju-23423-0",
-			ModelName:       "testing",
-			ProfileChanges: []apiinstancemutater.UnitProfileChanges{
-				{
-					ApplicationName: "one",
-					Revision:        rev,
-					Profile: lxdprofile.Profile{
-						Config: map[string]string{"hi": "bye"},
-					},
+func (s *workerSuite) expectCharmProfilingInfo(mock *mocks.MockMutaterMachine, rev int) {
+	mock.EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{
+		CurrentProfiles: []string{"default", "juju-testing", "juju-testing-one-2"},
+		InstanceId:      "juju-23423-0",
+		ModelName:       "testing",
+		ProfileChanges: []apiinstancemutater.UnitProfileChanges{
+			{
+				ApplicationName: "one",
+				Revision:        rev,
+				Profile: lxdprofile.Profile{
+					Config: map[string]string{"hi": "bye"},
 				},
 			},
-		}, nil)
-	}
+		},
+	}, nil)
 }
 
-func (s *workerSuite) expectCharmProfilingInfoRemove(machine int) func() {
-	return func() {
-		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{
-			CurrentProfiles: []string{"default", "juju-testing", "juju-testing-one-2"},
-			InstanceId:      "juju-23423-0",
-			ModelName:       "testing",
-			ProfileChanges:  []apiinstancemutater.UnitProfileChanges{},
-		}, nil)
-	}
+func (s *workerSuite) expectCharmProfilingInfoRemove(machine int) {
+	s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{
+		CurrentProfiles: []string{"default", "juju-testing", "juju-testing-one-2"},
+		InstanceId:      "juju-23423-0",
+		ModelName:       "testing",
+		ProfileChanges:  []apiinstancemutater.UnitProfileChanges{},
+	}, nil)
 }
 
-func (s *workerSuite) expectCharmProfileInfoNotProvisioned(machine int) func() {
-	return func() {
-		do := s.workGroupAddGetDoneFunc()
-		err := params.Error{
-			Message: "machine 0 not provisioned",
-			Code:    params.CodeNotProvisioned,
-		}
-		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, err).Do(do)
+func (s *workerSuite) expectCharmProfileInfoNotProvisioned(machine int) {
+	do := s.workGroupAddGetDoneFunc()
+	err := params.Error{
+		Message: "machine 0 not provisioned",
+		Code:    params.CodeNotProvisioned,
 	}
+	s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, err).Do(do)
 }
 
-func (s *workerSuite) expectCharmProfileInfoError(machine int) func() {
-	return func() {
-		do := s.workGroupAddGetDoneFunc()
-		err := params.Error{
-			Message: "machine 0 not supported",
-			Code:    params.CodeNotSupported,
-		}
-		s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, err).Do(do)
+func (s *workerSuite) expectCharmProfileInfoError(machine int) {
+	do := s.workGroupAddGetDoneFunc()
+	err := params.Error{
+		Message: "machine 0 not supported",
+		Code:    params.CodeNotSupported,
 	}
+	s.machine[machine].EXPECT().CharmProfilingInfo().Return(&apiinstancemutater.UnitProfileInfo{}, err).Do(do)
+
 }
 
-func (s *workerSuite) expectAliveAndSetModificationStatusIdle(machine int) func() {
-	return func() {
-		mExp := s.machine[machine].EXPECT()
-		mExp.Refresh().Return(nil)
-		mExp.Life().Return(params.Alive)
-		mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
-	}
+func (s *workerSuite) expectAliveAndSetModificationStatusIdle(machine int) {
+	mExp := s.machine[machine].EXPECT()
+	mExp.Refresh().Return(nil)
+	mExp.Life().Return(params.Alive)
+	mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
+
 }
 
-func (s *workerSuite) expectMachineAliveStatusIdleMachineDead(machine int, group *sync.WaitGroup) func() {
-	return func() {
-		mExp := s.machine[machine].EXPECT()
+func (s *workerSuite) expectMachineAliveStatusIdleMachineDead(machine int, group *sync.WaitGroup) {
+	s.doneWG.Add(1)
+	do := s.workGroupAddGetDoneFunc()
 
-		group.Add(1)
-		notificationSync := func(_ ...interface{}) { group.Done() }
+	mExp := s.machine[machine].EXPECT()
 
-		mExp.Refresh().Return(nil).Times(2)
-		o1 := mExp.Life().Return(params.Alive).Do(notificationSync)
+	group.Add(1)
+	notificationSync := func(_ ...interface{}) { group.Done() }
 
-		mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
+	mExp.Refresh().Return(nil).Times(2)
+	o1 := mExp.Life().Return(params.Alive).Do(notificationSync)
 
-		do := s.workGroupAddGetDoneFunc()
-		s.machine[0].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil)
-		s.machine[1].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
+	mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
 
-		s.doneWG.Add(1)
-		mExp.Life().Return(params.Dead).After(o1).Do(do)
-	}
+	s.machine[0].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil)
+	s.machine[1].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
+
+	mExp.Life().Return(params.Dead).After(o1).Do(do)
 }
 
-func (s *workerSuite) expectModificationStatusApplied(machine int) func() {
-	return func() {
-		do := s.workGroupAddGetDoneFunc()
-		s.machine[machine].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
-	}
+func (s *workerSuite) expectModificationStatusApplied(machine int) {
+	do := s.workGroupAddGetDoneFunc()
+	s.machine[machine].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
 }
 
 func (s *workerSuite) expectAssignLXDProfiles() {
@@ -521,103 +489,90 @@ func (s *workerSuite) expectAssignLXDProfiles() {
 	s.broker.EXPECT().AssignLXDProfiles("juju-23423-0", profiles, gomock.Any()).Return(profiles, nil)
 }
 
-func (s *workerSuite) expectSetCharmProfiles(machine int) func() {
-	return func() {
-		s.machine[machine].EXPECT().SetCharmProfiles([]string{"default", "juju-testing", "juju-testing-one-3"})
-	}
+func (s *workerSuite) expectSetCharmProfiles(machine int) {
+	s.machine[machine].EXPECT().SetCharmProfiles([]string{"default", "juju-testing", "juju-testing-one-3"})
 }
 
-func (s *workerSuite) expectRemoveAllCharmProfiles(machine int) func() {
-	return func() {
-		profiles := []string{"default", "juju-testing"}
-		s.machine[machine].EXPECT().SetCharmProfiles(profiles)
-		s.broker.EXPECT().AssignLXDProfiles("juju-23423-0", profiles, gomock.Any()).Return(profiles, nil)
-	}
+func (s *workerSuite) expectRemoveAllCharmProfiles(machine int) {
+	profiles := []string{"default", "juju-testing"}
+	s.machine[machine].EXPECT().SetCharmProfiles(profiles)
+	s.broker.EXPECT().AssignLXDProfiles("juju-23423-0", profiles, gomock.Any()).Return(profiles, nil)
 }
 
 // notifyMachines returns a suite behaviour that will cause the instance mutator
 // watcher to send a number of notifications equal to the supplied argument.
 // Once notifications have been consumed, we notify via the suite's channel.
-func (s *workerSuite) notifyMachines(values [][]string) func() {
+func (s *workerSuite) notifyMachines(values [][]string) {
 	ch := make(chan []string)
+	s.doneWG.Add(1)
+	go func() {
+		for _, v := range values {
+			ch <- v
+		}
+		s.doneWG.Done()
+	}()
 
-	return func() {
-		s.doneWG.Add(1)
-		go func() {
-			for _, v := range values {
-				ch <- v
-			}
-			s.doneWG.Done()
-		}()
+	s.machinesWorker.EXPECT().Kill().AnyTimes()
+	s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
 
-		s.machinesWorker.EXPECT().Kill().AnyTimes()
-		s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
-
-		s.facade.EXPECT().WatchMachines().Return(
-			&fakeStringsWatcher{
-				Worker: s.machinesWorker,
-				ch:     ch,
-			}, nil)
-	}
+	s.facade.EXPECT().WatchMachines().Return(
+		&fakeStringsWatcher{
+			Worker: s.machinesWorker,
+			ch:     ch,
+		}, nil)
 }
 
-func (s *workerSuite) notifyMachinesWaitGroup(values [][]string, group *sync.WaitGroup) func() {
+func (s *workerSuite) notifyMachinesWaitGroup(values [][]string, group *sync.WaitGroup) {
 	ch := make(chan []string)
+	s.doneWG.Add(1)
+	go func() {
+		for _, v := range values {
+			ch <- v
+			group.Wait()
+		}
+		s.doneWG.Done()
+	}()
 
-	return func() {
-		s.doneWG.Add(1)
-		go func() {
-			for _, v := range values {
-				ch <- v
-				group.Wait()
-			}
-			s.doneWG.Done()
-		}()
+	s.machinesWorker.EXPECT().Kill().AnyTimes()
+	s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
 
-		s.machinesWorker.EXPECT().Kill().AnyTimes()
-		s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
-
-		s.facade.EXPECT().WatchMachines().Return(
-			&fakeStringsWatcher{
-				Worker: s.machinesWorker,
-				ch:     ch,
-			}, nil)
-	}
+	s.facade.EXPECT().WatchMachines().Return(
+		&fakeStringsWatcher{
+			Worker: s.machinesWorker,
+			ch:     ch,
+		}, nil)
 }
 
 // notifyAppLXDProfile returns a suite behaviour that will cause the instance mutator
 // watcher to send a number of notifications equal to the supplied argument.
 // Once notifications have been consumed, we notify via the suite's channel.
-func (s *workerSuite) notifyMachineAppLXDProfile(machine, times int) func() {
-	return s.notifyAppLXDProfile(s.machine[machine], machine, times)
+func (s *workerSuite) notifyMachineAppLXDProfile(machine, times int) {
+	s.notifyAppLXDProfile(s.machine[machine], machine, times)
 }
 
-func (s *workerContainerSuite) notifyContainerAppLXDProfile(times int) func() {
-	return s.notifyAppLXDProfile(s.lxdContainer, 0, times)
+func (s *workerContainerSuite) notifyContainerAppLXDProfile(times int) {
+	s.notifyAppLXDProfile(s.lxdContainer, 0, times)
 }
 
-func (s *workerSuite) notifyAppLXDProfile(mock *mocks.MockMutaterMachine, which, times int) func() {
+func (s *workerSuite) notifyAppLXDProfile(mock *mocks.MockMutaterMachine, which, times int) {
 	ch := make(chan struct{})
+	s.doneWG.Add(1)
+	go func() {
+		for i := 0; i < times; i += 1 {
+			ch <- struct{}{}
+		}
+		s.doneWG.Done()
+	}()
 
-	return func() {
-		s.doneWG.Add(1)
-		go func() {
-			for i := 0; i < times; i += 1 {
-				ch <- struct{}{}
-			}
-			s.doneWG.Done()
-		}()
+	w := s.appLXDProfileWorker[which]
+	w.EXPECT().Kill().AnyTimes()
+	w.EXPECT().Wait().Return(nil).AnyTimes()
 
-		w := s.appLXDProfileWorker[which]
-		w.EXPECT().Kill().AnyTimes()
-		w.EXPECT().Wait().Return(nil).AnyTimes()
-
-		mock.EXPECT().WatchLXDProfileVerificationNeeded().Return(
-			&fakeNotifyWatcher{
-				Worker: w,
-				ch:     ch,
-			}, nil)
-	}
+	mock.EXPECT().WatchLXDProfileVerificationNeeded().Return(
+		&fakeNotifyWatcher{
+			Worker: w,
+			ch:     ch,
+		}, nil)
 }
 
 // cleanKill waits for notifications to be processed, then waits for the input
@@ -659,19 +614,18 @@ var _ = gc.Suite(&loggerSuite{})
 
 // ignoreLogging turns the suite's mock Logger into a sink, with no validation.
 // Logs are still emitted via the test Logger.
-func (s *loggerSuite) ignoreLogging(c *gc.C) func() {
+func (s *loggerSuite) ignoreLogging(c *gc.C) {
 	warnIt := func(message string, args ...interface{}) { logIt(c, loggo.WARNING, message, args) }
 	debugIt := func(message string, args ...interface{}) { logIt(c, loggo.DEBUG, message, args) }
 	errorIt := func(message string, args ...interface{}) { logIt(c, loggo.ERROR, message, args) }
 	traceIt := func(message string, args ...interface{}) { logIt(c, loggo.TRACE, message, args) }
 
-	return func() {
-		e := s.logger.EXPECT()
-		e.Warningf(gomock.Any(), gomock.Any()).AnyTimes().Do(warnIt)
-		e.Debugf(gomock.Any(), gomock.Any()).AnyTimes().Do(debugIt)
-		e.Errorf(gomock.Any(), gomock.Any()).AnyTimes().Do(errorIt)
-		e.Tracef(gomock.Any(), gomock.Any()).AnyTimes().Do(traceIt)
-	}
+	e := s.logger.EXPECT()
+	e.Warningf(gomock.Any(), gomock.Any()).AnyTimes().Do(warnIt)
+	e.Debugf(gomock.Any(), gomock.Any()).AnyTimes().Do(debugIt)
+	e.Errorf(gomock.Any(), gomock.Any()).AnyTimes().Do(errorIt)
+	e.Tracef(gomock.Any(), gomock.Any()).AnyTimes().Do(traceIt)
+
 }
 
 func logIt(c *gc.C, level loggo.Level, message string, args interface{}) {
@@ -714,21 +668,20 @@ func (s *workerContainerSuite) SetUpTest(c *gc.C) {
 func (s *workerContainerSuite) TestFullWorkflow(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	w := s.workerForScenario(c,
-		s.ignoreLogging(c),
-		s.notifyContainers(0, [][]string{{"0/lxd/0", "0/kvm/0"}}),
-		s.expectFacadeMachineTag(0),
-		s.expectFacadeContainerTags,
-		s.expectContainerTypes,
-		s.notifyContainerAppLXDProfile(1),
-		s.expectContainerCharmProfilingInfo(3),
-		s.expectLXDProfileNamesTrue,
-		s.expectContainerSetCharmProfiles,
-		s.expectAssignLXDProfiles,
-		s.expectContainerAliveAndSetModificationStatusIdle,
-		s.expectContainerModificationStatusApplied,
-	)
-	s.cleanKill(c, w)
+	s.ignoreLogging(c)
+	s.notifyContainers(0, [][]string{{"0/lxd/0", "0/kvm/0"}})
+	s.expectFacadeMachineTag(0)
+	s.expectFacadeContainerTags()
+	s.expectContainerTypes()
+	s.notifyContainerAppLXDProfile(1)
+	s.expectContainerCharmProfilingInfo(3)
+	s.expectLXDProfileNamesTrue()
+	s.expectContainerSetCharmProfiles()
+	s.expectAssignLXDProfiles()
+	s.expectContainerAliveAndSetModificationStatusIdle()
+	s.expectContainerModificationStatusApplied()
+
+	s.cleanKill(c, s.workerForScenario(c))
 }
 
 func (s *workerContainerSuite) setup(c *gc.C) *gomock.Controller {
@@ -750,8 +703,8 @@ func (s *workerContainerSuite) expectContainerTypes() {
 	s.kvmContainer.EXPECT().ContainerType().Return(instance.KVM, nil).AnyTimes()
 }
 
-func (s *workerContainerSuite) expectContainerCharmProfilingInfo(rev int) func() {
-	return s.expectCharmProfilingInfo(s.lxdContainer, rev)
+func (s *workerContainerSuite) expectContainerCharmProfilingInfo(rev int) {
+	s.expectCharmProfilingInfo(s.lxdContainer, rev)
 }
 
 func (s *workerContainerSuite) expectContainerAliveAndSetModificationStatusIdle() {
@@ -778,27 +731,24 @@ func (s *workerContainerSuite) expectContainerSetCharmProfiles() {
 // notifyContainers returns a suite behaviour that will cause the instance mutator
 // watcher to send a number of notifications equal to the supplied argument.
 // Once notifications have been consumed, we notify via the suite's channel.
-func (s *workerContainerSuite) notifyContainers(machine int, values [][]string) func() {
+func (s *workerContainerSuite) notifyContainers(machine int, values [][]string) {
 	ch := make(chan []string)
+	s.doneWG.Add(1)
+	go func() {
+		for _, v := range values {
+			ch <- v
+		}
+		s.doneWG.Done()
+	}()
 
-	return func() {
-		s.doneWG.Add(1)
-		go func() {
-			for _, v := range values {
-				ch <- v
-			}
-			s.doneWG.Done()
-		}()
+	s.machinesWorker.EXPECT().Kill().AnyTimes()
+	s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
 
-		s.machinesWorker.EXPECT().Kill().AnyTimes()
-		s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
-
-		s.machine[machine].EXPECT().WatchContainers().Return(
-			&fakeStringsWatcher{
-				Worker: s.machinesWorker,
-				ch:     ch,
-			}, nil)
-	}
+	s.machine[machine].EXPECT().WatchContainers().Return(
+		&fakeStringsWatcher{
+			Worker: s.machinesWorker,
+			ch:     ch,
+		}, nil)
 }
 
 type fakeStringsWatcher struct {

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -285,6 +285,7 @@ func (c *cacheWorker) translate(d multiwatcher.Delta) interface{} {
 			Life:                     life.Value(value.Life),
 			Config:                   value.Config,
 			Series:                   value.Series,
+			ContainerType:            value.ContainerType,
 			SupportedContainers:      value.SupportedContainers,
 			SupportedContainersKnown: value.SupportedContainersKnown,
 			HardwareCharacteristics:  value.HardwareCharacteristics,


### PR DESCRIPTION
## Description of change

The instance-mutater worker should not watch KVM containers.  Most of the change is threading the machine's ContainerType into the allwatcher, model cache, and apiserver.

## QA steps

1. juju bootstrap --config logging-config='<root>=DEBUG;unit=DEBUG;juju.worker.instancemutater=TRACE' <an open stack cloud>
3. juju deploy nova-compute --to kvm
2. juju add-unit nova-computer --to lxd:0
2. juju deploy neutron-openvswitch
3. juju add-relation nova-compute neutron-openvswitch
2. juju debug-log  --include-module juju.worker.instancemutater  

Log messages should indicated that an lxd profile was applied to 0/lxd/0 for neutron-openvswitch and that 0/kvm/0 is being ignored by the instance mutater.

Also test starting with a 2.5.7 controller and deploy units; upgrade to 2.6.2 to see the error messages from the bug; then upgrade to this code to see the error messages resolved.  

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829393