### PR TITLE
Invalidate credentials when access has not been configured

### DIFF
--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -94,9 +94,11 @@ func HasDenialStatusCode(err error) bool {
 	// contains response status code and description in error.Error.
 	// We have to examine the error message to determine whether the error is related to authentication failure.
 	if cause, ok := errors.Cause(err).(*url.Error); ok {
-		for code, desc := range AuthorisationFailureStatusCodes {
-			if strings.Contains(cause.Error(), fmt.Sprintf(": %v %v", code, desc)) {
-				return true
+		for code, descs := range AuthorisationFailureStatusCodes {
+			for _, desc := range descs {
+				if strings.Contains(cause.Error(), fmt.Sprintf(": %v %v", code, desc)) {
+					return true
+				}
 			}
 		}
 	}
@@ -104,13 +106,17 @@ func HasDenialStatusCode(err error) bool {
 
 }
 
-// AuthorisationFailureStatusCodes contains http status code nad description that signify authorisation difficulties.
-var AuthorisationFailureStatusCodes = map[int]string{
-	http.StatusUnauthorized:      "Unauthorized",
-	http.StatusPaymentRequired:   "Payment Required",
-	http.StatusForbidden:         "Forbidden",
-	http.StatusProxyAuthRequired: "Proxy Auth Required",
+// AuthorisationFailureStatusCodes contains http status code and
+// description that signify authorisation difficulties.
+//
+// Google does not always use standard HTTP descriptions, which
+// is why a single status code can map to multiple descriptions.
+var AuthorisationFailureStatusCodes = map[int][]string{
+	http.StatusUnauthorized:      {"Unauthorized"},
+	http.StatusPaymentRequired:   {"Payment Required"},
+	http.StatusForbidden:         {"Forbidden", "Access Not Configured"},
+	http.StatusProxyAuthRequired: {"Proxy Auth Required"},
 	// OAuth 2.0 also implements RFC#6749, so we need to cater for specific BadRequest errors.
 	// https://tools.ietf.org/html/rfc6749#section-5.2
-	http.StatusBadRequest: "Bad Request",
+	http.StatusBadRequest: {"Bad Request"},
 }

--- a/provider/gce/google/errors_test.go
+++ b/provider/gce/google/errors_test.go
@@ -61,11 +61,20 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	google.HandleCredentialError(s.googleError, ctx)
 	c.Assert(called, jc.IsFalse)
 
-	for code, desc := range google.AuthorisationFailureStatusCodes {
-		called = false
-		s.internalError.SetMessage(code, desc)
+	for code, descs := range google.AuthorisationFailureStatusCodes {
+		for _, desc := range descs {
+			called = false
+			s.internalError.SetMessage(code, desc)
+			google.HandleCredentialError(s.googleError, ctx)
+			c.Assert(called, jc.IsTrue)
+		}
+	}
+
+	called = false
+	for code := range google.AuthorisationFailureStatusCodes {
+		s.internalError.SetMessage(code, "Some strange error")
 		google.HandleCredentialError(s.googleError, ctx)
-		c.Assert(called, jc.IsTrue)
+		c.Assert(called, jc.IsFalse)
 	}
 }
 


### PR DESCRIPTION
## Description of change

When the Compute Engine API  has not been enabled in the GCE console, Google returns a non-standard HTTP 403 error. This custom error confuses our logic for detecting invalid credentials. This commit fixes that.

## QA steps

First, open GCE's console. Navigate to "IAM & admin" > "Create service account". Create a role that has "Compute Engine Admin" access. Download the key as a JSON key file.

Now run `juju add-credential google`, pointing to the downloaded JSON key file.

```
$ juju bootstrap --credential=borked google

ERROR googleapi: Error 403: Access Not Configured. Compute Engine API has not been used in project 657072961473 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=657072961473 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
```

## Documentation changes

None.

## Bug reference

* [lp#1829388](https://bugs.launchpad.net/juju/+bug/1829388)