### PR TITLE
All cloud instances.

### DIFF
--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -130,7 +130,8 @@ func checkMachineInstances(backend PersistentBackend, provider CloudProvider, ca
 		machinesByInstance[string(instanceId)] = machine.Id()
 	}
 
-	// Check can see all machines' instances
+	// Check that we can see all machines' instances regardless of their state as perceived by the cloud, i.e.
+	// this call will return all non-terminated instances.
 	instances, err := provider.AllInstances(callCtx)
 	if err != nil {
 		return fail(errors.Trace(err))

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -130,7 +130,7 @@ func WaitForAgentInitialisation(
 
 // BootstrapEndpointAddresses returns the addresses of the bootstrapped instance.
 func BootstrapEndpointAddresses(environ environs.InstanceBroker, callContext context.ProviderCallContext) ([]network.Address, error) {
-	instances, err := environ.AllInstances(callContext)
+	instances, err := environ.AllRunningInstances(callContext)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -414,7 +414,7 @@ func (e *minModelWorkersEnviron) SetConfig(*config.Config) error {
 	return nil
 }
 
-func (e *minModelWorkersEnviron) AllInstances(context.ProviderCallContext) ([]instances.Instance, error) {
+func (e *minModelWorkersEnviron) AllRunningInstances(context.ProviderCallContext) ([]instances.Instance, error) {
 	return nil, nil
 }
 

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -296,7 +296,7 @@ func instancesFromResults(results ...*environs.StartInstanceResult) []instances.
 }
 
 func assertInstancesStarted(c *gc.C, broker environs.InstanceBroker, results ...*environs.StartInstanceResult) {
-	allInstances, err := broker.AllInstances(context.NewCloudCallContext())
+	allInstances, err := broker.AllRunningInstances(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	instancetest.MatchInstances(c, allInstances, instancesFromResults(results...)...)
 }

--- a/container/broker/kvm-broker.go
+++ b/container/broker/kvm-broker.go
@@ -191,7 +191,12 @@ func (broker *kvmBroker) StopInstances(ctx context.ProviderCallContext, ids ...i
 	return nil
 }
 
-// AllInstances only returns running containers.
+// AllInstances returns all containers.
 func (broker *kvmBroker) AllInstances(ctx context.ProviderCallContext) (result []instances.Instance, err error) {
+	return broker.manager.ListContainers()
+}
+
+// AllRunningInstances only returns running containers.
+func (broker *kvmBroker) AllRunningInstances(ctx context.ProviderCallContext) (result []instances.Instance, err error) {
 	return broker.manager.ListContainers()
 }

--- a/container/broker/kvm-broker_test.go
+++ b/container/broker/kvm-broker_test.go
@@ -172,7 +172,7 @@ func (s *kvmBrokerSuite) TestStopInstance(c *gc.C) {
 	s.assertNoResults(c, broker)
 }
 
-func (s *kvmBrokerSuite) TestAllInstances(c *gc.C) {
+func (s *kvmBrokerSuite) TestAllRunningInstances(c *gc.C) {
 	broker, brokerErr := s.newKVMBroker(c)
 	c.Assert(brokerErr, jc.ErrorIsNil)
 

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -169,8 +169,13 @@ func (broker *lxdBroker) StopInstances(ctx context.ProviderCallContext, ids ...i
 	return nil
 }
 
-// AllInstances only returns running containers.
+// AllInstances returns all containers.
 func (broker *lxdBroker) AllInstances(ctx context.ProviderCallContext) (result []instances.Instance, err error) {
+	return broker.manager.ListContainers()
+}
+
+// AllRunningInstances only returns running containers.
+func (broker *lxdBroker) AllRunningInstances(ctx context.ProviderCallContext) (result []instances.Instance, err error) {
 	return broker.manager.ListContainers()
 }
 

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -162,6 +162,9 @@ type InstanceBroker interface {
 	// AllInstances returns all instances currently known to the broker.
 	AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error)
 
+	// AllRunningInstances returns all running, available instances currently known to the broker.
+	AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error)
+
 	// MaintainInstance is used to run actions on jujud startup for existing
 	// instances. It is currently only used to ensure that LXC hosts have the
 	// correct network configuration.

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -5,22 +5,24 @@
 package testing
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	jsonschema "github.com/juju/jsonschema"
-	cloud "github.com/juju/juju/cloud"
-	constraints "github.com/juju/juju/core/constraints"
-	instance "github.com/juju/juju/core/instance"
-	environs "github.com/juju/juju/environs"
-	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
-	instances "github.com/juju/juju/environs/instances"
-	network "github.com/juju/juju/network"
-	storage "github.com/juju/juju/storage"
-	version "github.com/juju/version"
+	"io"
+	"reflect"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/jsonschema"
+	"github.com/juju/version"
 	environschema_v1 "gopkg.in/juju/environschema.v1"
 	names_v2 "gopkg.in/juju/names.v2"
-	io "io"
-	reflect "reflect"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/storage"
 )
 
 // MockEnvironProvider is a mock of EnvironProvider interface
@@ -726,6 +728,19 @@ func (mr *MockEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockEnviron)(nil).AllInstances), arg0)
 }
 
+// AllRunningInstances mocks base method
+func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
+	ret0, _ := ret[0].([]instances.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRunningInstances indicates an expected call of AllRunningInstances
+func (mr *MockEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockEnviron)(nil).AllRunningInstances), arg0)
+}
+
 // Bootstrap mocks base method
 func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
@@ -1355,6 +1370,19 @@ func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) (
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockNetworkingEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllInstances), arg0)
+}
+
+// AllRunningInstances mocks base method
+func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
+	ret0, _ := ret[0].([]instances.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRunningInstances indicates an expected call of AllRunningInstances
+func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllRunningInstances), arg0)
 }
 
 // AllocateContainerAddresses mocks base method

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1532,6 +1532,11 @@ func (env *azureEnviron) AllInstances(ctx context.ProviderCallContext) ([]instan
 	return env.allInstances(ctx, env.resourceGroup, true /* refresh addresses */, false /* all instances */)
 }
 
+// AllRunningInstances is specified in the InstanceBroker interface.
+func (env *azureEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	return env.AllInstances(ctx)
+}
+
 // allInstances returns all of the instances in the given resource group,
 // and optionally ensures that each instance's addresses are up-to-date.
 func (env *azureEnviron) allInstances(

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -522,7 +522,7 @@ func (s *environSuite) TestCloudEndpointManagementURI(c *gc.C) {
 	sender.AppendResponse(mocks.NewResponseWithContent("{}"))
 	s.sender = azuretesting.Senders{sender}
 	s.requests = nil
-	env.AllInstances(s.callCtx) // trigger a query
+	env.AllRunningInstances(s.callCtx) // trigger a query
 
 	c.Assert(s.requests, gc.HasLen, 1)
 	c.Assert(s.requests[0].URL.Host, gc.Equals, "api.azurestack.local")
@@ -534,7 +534,7 @@ func (s *environSuite) TestCloudEndpointManagementURIWithCredentialError(c *gc.C
 	s.requests = nil
 
 	c.Assert(s.invalidatedCredential, jc.IsFalse)
-	env.AllInstances(s.callCtx) // trigger a query
+	env.AllRunningInstances(s.callCtx) // trigger a query
 	c.Assert(s.requests, gc.HasLen, 1)
 	c.Assert(s.requests[0].URL.Host, gc.Equals, "api.azurestack.local")
 	c.Assert(s.invalidatedCredential, jc.IsTrue)
@@ -1334,7 +1334,7 @@ func (s *environSuite) TestBootstrapWithAutocert(c *gc.C) {
 	})
 }
 
-func (s *environSuite) TestAllInstancesResourceGroupNotFound(c *gc.C) {
+func (s *environSuite) TestAllRunningInstancesResourceGroupNotFound(c *gc.C) {
 	env := s.openEnviron(c)
 	azure.SetRetries(env)
 	sender := mocks.NewSender()
@@ -1342,11 +1342,11 @@ func (s *environSuite) TestAllInstancesResourceGroupNotFound(c *gc.C) {
 		"resource group not found", http.StatusNotFound,
 	), 2)
 	s.sender = azuretesting.Senders{sender}
-	_, err := env.AllInstances(s.callCtx)
+	_, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *environSuite) TestAllInstancesIgnoresCommonDeployment(c *gc.C) {
+func (s *environSuite) TestAllRunningInstancesIgnoresCommonDeployment(c *gc.C) {
 	env := s.openEnviron(c)
 
 	dependencies := []resources.Dependency{{
@@ -1365,7 +1365,7 @@ func (s *environSuite) TestAllInstancesIgnoresCommonDeployment(c *gc.C) {
 		s.makeSender("/deployments", result),
 	}
 
-	instances, err := env.AllInstances(s.callCtx)
+	instances, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 0)
 }

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -597,6 +597,15 @@ func (s *instanceSuite) TestAllInstances(c *gc.C) {
 	c.Assert(instances[1].Id(), gc.Equals, instance.Id("machine-1"))
 }
 
+func (s *instanceSuite) TestAllRunningInstances(c *gc.C) {
+	s.sender = s.getInstancesSender()
+	instances, err := s.env.AllRunningInstances(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instances, gc.HasLen, 2)
+	c.Assert(instances[0].Id(), gc.Equals, instance.Id("machine-0"))
+	c.Assert(instances[1].Id(), gc.Equals, instance.Id("machine-1"))
+}
+
 func (s *instanceSuite) TestControllerInstances(c *gc.C) {
 	*(*(*s.deployments[0].Properties.Dependencies)[0].DependsOn)[0].ResourceName = "juju-controller"
 	s.sender = s.getInstancesSender()

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -98,15 +98,24 @@ func (env *environ) StartInstance(ctx context.ProviderCallContext, args environs
 
 // AllInstances returns all instances currently known to the broker.
 func (env *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	return env.instancesForMethod(ctx, "AllInstances")
+}
+
+// AllRunningInstances returns all running, available instances currently known to the broker.
+func (env *environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	return env.instancesForMethod(ctx, "AllRunningInstances")
+}
+
+func (env *environ) instancesForMethod(ctx context.ProviderCallContext, method string) ([]instances.Instance, error) {
 	// Please note that this must *not* return instances that have not been
 	// allocated as part of this environment -- if it does, juju will see they
 	// are not tracked in state, assume they're stale/rogue, and shut them down.
 
-	logger.Tracef("environ.AllInstances...")
+	logger.Tracef("environ.%v...", method)
 
 	servers, err := env.client.instances()
 	if err != nil {
-		logger.Tracef("environ.AllInstances failed: %v", err)
+		logger.Tracef("environ.%v failed: %v", method, err)
 		return nil, err
 	}
 
@@ -117,7 +126,7 @@ func (env *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.I
 	}
 
 	if logger.LogLevel() <= loggo.TRACE {
-		logger.Tracef("All instances, len = %d:", len(instances))
+		logger.Tracef("%v, len = %d:", method, len(instances))
 		for _, instance := range instances {
 			logger.Tracef("... id: %q, status: %q", instance.Id(), instance.Status(ctx))
 		}

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -93,7 +93,7 @@ func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) enviro
 func (s *environInstanceSuite) TestInstances(c *gc.C) {
 	env := s.createEnviron(c, nil)
 
-	instances, err := env.AllInstances(s.callCtx)
+	instances, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(instances, gc.NotNil)
 	c.Assert(err, gc.IsNil)
 	c.Check(instances, gc.HasLen, 0)
@@ -103,7 +103,7 @@ func (s *environInstanceSuite) TestInstances(c *gc.C) {
 	addTestClientServer(c, jujuMetaInstanceServer, "other-model")
 	addTestClientServer(c, jujuMetaInstanceController, "other-model")
 
-	instances, err = env.AllInstances(s.callCtx)
+	instances, err = env.AllRunningInstances(s.callCtx)
 	c.Assert(instances, gc.NotNil)
 	c.Assert(err, gc.IsNil)
 	c.Check(instances, gc.HasLen, 2)
@@ -149,7 +149,7 @@ func (s *environInstanceSuite) TestInstancesFail(c *gc.C) {
 
 	environ := s.createEnviron(c, nil)
 
-	instances, err := environ.AllInstances(s.callCtx)
+	instances, err := environ.AllRunningInstances(s.callCtx)
 	c.Assert(instances, gc.IsNil)
 	c.Assert(err, gc.NotNil)
 

--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -84,12 +84,12 @@ func (b byPopulationThenName) Swap(i, j int) {
 // ordered by name.
 //
 // If the specified group is empty, then it will behave as if the result of
-// AllInstances were provided.
+// AllRunningInstances were provided.
 func AvailabilityZoneAllocations(
 	env ZonedEnviron, ctx context.ProviderCallContext, group []instance.Id,
 ) ([]AvailabilityZoneInstances, error) {
 	if len(group) == 0 {
-		instances, err := env.AllInstances(ctx)
+		instances, err := env.AllRunningInstances(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/common/availabilityzones_test.go
+++ b/provider/common/availabilityzones_test.go
@@ -51,7 +51,7 @@ func (s *AvailabilityZoneSuite) SetUpSuite(c *gc.C) {
 	}
 }
 
-func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsAllInstances(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsAllRunningInstances(c *gc.C) {
 	var called int
 	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"inst0", "inst1", "inst2"})
@@ -72,7 +72,7 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsAllInstances(c *g
 	}})
 }
 
-func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsAllInstancesErrors(c *gc.C) {
+func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsAllRunningInstancesErrors(c *gc.C) {
 	resultErr := fmt.Errorf("oh noes")
 	s.PatchValue(&s.env.allInstances, func(context.ProviderCallContext) ([]instances.Instance, error) {
 		return nil, resultErr

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -47,6 +47,10 @@ func (env *mockEnviron) AllInstances(ctx context.ProviderCallContext) ([]instanc
 	return env.allInstances(ctx)
 }
 
+func (env *mockEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	return env.allInstances(ctx)
+}
+
 func (env *mockEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 	return env.instances(ctx, ids)
 }

--- a/provider/common/mocks/zoned_environ.go
+++ b/provider/common/mocks/zoned_environ.go
@@ -5,17 +5,19 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	constraints "github.com/juju/juju/core/constraints"
-	instance "github.com/juju/juju/core/instance"
-	environs "github.com/juju/juju/environs"
-	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
-	instances "github.com/juju/juju/environs/instances"
-	common "github.com/juju/juju/provider/common"
-	storage "github.com/juju/juju/storage"
-	version "github.com/juju/version"
-	reflect "reflect"
+	"reflect"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/storage"
 )
 
 // MockZonedEnviron is a mock of ZonedEnviron interface
@@ -64,6 +66,19 @@ func (m *MockZonedEnviron) AllInstances(arg0 context.ProviderCallContext) ([]ins
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockZonedEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockZonedEnviron)(nil).AllInstances), arg0)
+}
+
+// AllRunningInstances mocks base method
+func (m *MockZonedEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
+	ret0, _ := ret[0].([]instances.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRunningInstances indicates an expected call of AllRunningInstances
+func (mr *MockZonedEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockZonedEnviron)(nil).AllRunningInstances), arg0)
 }
 
 // AvailabilityZones mocks base method

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1601,8 +1601,16 @@ func (env *environ) subnetsForSpaceDiscovery(estate *environState) ([]network.Su
 }
 
 func (e *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	return e.instancesForMethod(ctx, "AllInstances")
+}
+
+func (e *environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	return e.instancesForMethod(ctx, "AllRunningInstances")
+}
+
+func (e *environ) instancesForMethod(ctx context.ProviderCallContext, method string) ([]instances.Instance, error) {
 	defer delay()
-	if err := e.checkBroken("AllInstances"); err != nil {
+	if err := e.checkBroken(method); err != nil {
 		return nil, err
 	}
 	var insts []instances.Instance

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -145,7 +145,7 @@ func (t *LiveTests) TestStartInstanceConstraints(c *gc.C) {
 
 func (t *LiveTests) TestControllerInstances(c *gc.C) {
 	t.BootstrapOnce(c)
-	allInsts, err := t.Env.AllInstances(t.callCtx)
+	allInsts, err := t.Env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allInsts, gc.HasLen, 1) // bootstrap instance
 	bootstrapInstId := allInsts[0].Id()
@@ -163,7 +163,7 @@ func (t *LiveTests) TestControllerInstances(c *gc.C) {
 
 func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 	t.BootstrapOnce(c)
-	allInsts, err := t.Env.AllInstances(t.callCtx)
+	allInsts, err := t.Env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allInsts, gc.HasLen, 1) // bootstrap instance
 	bootstrapInstId := allInsts[0].Id()
@@ -281,7 +281,7 @@ func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 	insts, err := t.Env.Instances(t.callCtx, instIds)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instIds, jc.SameContents, idsFromInsts(insts))
-	allInsts, err = t.Env.AllInstances(t.callCtx)
+	allInsts, err = t.Env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	// ignore the bootstrap instance
 	for i, inst := range allInsts {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -381,7 +381,7 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceIds, gc.HasLen, 1)
 
-	insts, err := env.AllInstances(t.callCtx)
+	insts, err := env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(insts, gc.HasLen, 1)
 	c.Check(insts[0].Id(), gc.Equals, instanceIds[0])
@@ -459,7 +459,7 @@ func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceIds, gc.HasLen, 1)
 
-	insts, err := env.AllInstances(t.callCtx)
+	insts, err := env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(insts, gc.HasLen, 1)
 	c.Check(insts[0].Id(), gc.Equals, instanceIds[0])
@@ -529,7 +529,7 @@ func (t *localServerSuite) TestTerminateInstancesIgnoresNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
-	insts, err := env.AllInstances(t.callCtx)
+	insts, err := env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	idsToStop := make([]instance.Id, len(insts)+1)
 	for i, one := range insts {
@@ -587,7 +587,7 @@ func (t *localServerSuite) TestGetTerminatedInstances(c *gc.C) {
 func (t *localServerSuite) TestInstanceSecurityGroupsWitheInstanceStatusFilter(c *gc.C) {
 	env := t.prepareAndBootstrap(c)
 
-	insts, err := env.AllInstances(t.callCtx)
+	insts, err := env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	ids := make([]instance.Id, len(insts))
 	for i, one := range insts {
@@ -676,7 +676,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 	c.Assert(volumeResults[0].Error, jc.ErrorIsNil)
 
 	assertInstances := func(expect ...instance.Id) {
-		insts, err := env.AllInstances(t.callCtx)
+		insts, err := env.AllRunningInstances(t.callCtx)
 		c.Assert(err, jc.ErrorIsNil)
 		ids := make([]instance.Id, len(insts))
 		for i, inst := range insts {
@@ -1757,7 +1757,7 @@ func (t *localServerSuite) TestSubnetsMissingSubnet(c *gc.C) {
 func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	env := t.prepareAndBootstrap(c)
 
-	instances, err := env.AllInstances(t.callCtx)
+	instances, err := env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 1)
 
@@ -1773,7 +1773,7 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 func (t *localServerSuite) TestRootDiskTags(c *gc.C) {
 	env := t.prepareAndBootstrap(c)
 
-	instances, err := env.AllInstances(t.callCtx)
+	instances, err := env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 1)
 
@@ -1799,7 +1799,7 @@ func (t *localServerSuite) TestRootDiskTags(c *gc.C) {
 
 func (s *localServerSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	env := s.prepareAndBootstrap(c)
-	inst, err := env.AllInstances(s.callCtx)
+	inst, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(inst, gc.HasLen, 1)
 	ec2inst := ec2.InstanceEC2(inst[0])
@@ -1816,7 +1816,7 @@ func makeFilter(key string, values ...string) *amzec2.Filter {
 
 func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 	controllerEnv := s.prepareAndBootstrap(c)
-	controllerInsts, err := controllerEnv.AllInstances(s.callCtx)
+	controllerInsts, err := controllerEnv.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerInsts, gc.HasLen, 1)
 

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -283,10 +283,10 @@ func (s *environBrokerSuite) TestGetHardwareCharacteristics(c *gc.C) {
 	c.Check(*hwc.RootDisk, gc.Equals, uint64(15360))
 }
 
-func (s *environBrokerSuite) TestAllInstances(c *gc.C) {
+func (s *environBrokerSuite) TestAllRunningInstances(c *gc.C) {
 	s.FakeEnviron.Insts = []instances.Instance{s.Instance}
 
-	insts, err := s.Env.AllInstances(s.CallCtx)
+	insts, err := s.Env.AllRunningInstances(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(insts, jc.DeepEquals, []instances.Instance{s.Instance})
 }

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -435,7 +435,7 @@ type fakeEnviron struct {
 	Spec  *instances.InstanceSpec
 }
 
-func (fe *fakeEnviron) GetInstances(env *environ, ctx context.ProviderCallContext) ([]instances.Instance, error) {
+func (fe *fakeEnviron) GetInstances(env *environ, ctx context.ProviderCallContext, statusFilters ...string) ([]instances.Instance, error) {
 	fe.addCall("GetInstances", FakeCallArgs{
 		"switch": env,
 	})

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -328,7 +328,7 @@ func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceIds, gc.HasLen, 1)
 
-	insts, err := env.AllInstances(s.callCtx)
+	insts, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(insts, gc.HasLen, 1)
 	c.Check(instanceIds[0], gc.Equals, insts[0].Id())

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -324,6 +324,12 @@ func (env *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.I
 	return instances, errors.Trace(err)
 }
 
+// AllRunningInstances implements environs.InstanceBroker.
+func (env *environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	// We can only get Alive containers from lxd api which means that "all" is the same as "running".
+	return env.AllInstances(ctx)
+}
+
 // StopInstances implements environs.InstanceBroker.
 func (env *environ) StopInstances(ctx context.ProviderCallContext, instances ...instance.Id) error {
 	prefix := env.namespace.Prefix()

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -120,7 +120,7 @@ func (env *environ) ControllerInstances(ctx context.ProviderCallContext, control
 // AdoptResources updates the controller tags on all instances to have the
 // new controller id. It's part of the Environ interface.
 func (env *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
-	instances, err := env.AllInstances(ctx)
+	instances, err := env.AllRunningInstances(ctx)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Annotate(err, "all instances")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2076,9 +2076,15 @@ func checkNotFound(subnetIdSet map[string]bool) error {
 	return nil
 }
 
-// AllInstances returns all the instances.Instance in this provider.
+// AllInstances implements environs.InstanceBroker.
 func (env *maasEnviron) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
 	return env.acquiredInstances(ctx, nil)
+}
+
+// AllRunningInstances implements environs.InstanceBroker.
+func (env *maasEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	// We always get all instances here, so "all" is the same as "running".
+	return env.AllInstances(ctx)
 }
 
 // Storage is defined by the Environ interface.
@@ -2371,7 +2377,7 @@ func (env *maasEnviron) AdoptResources(ctx context.ProviderCallContext, controll
 		return nil
 	}
 
-	instances, err := env.AllInstances(ctx)
+	instances, err := env.AllRunningInstances(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -101,17 +101,17 @@ func (suite *environSuite) TestInstancesReturnsErrNoInstancesIfNoneFound(c *gc.C
 	c.Check(instances, gc.IsNil)
 }
 
-func (suite *environSuite) TestAllInstances(c *gc.C) {
+func (suite *environSuite) TestAllRunningInstances(c *gc.C) {
 	id := suite.addNode(allocatedNode)
-	instances, err := suite.makeEnviron().AllInstances(suite.callCtx)
+	instances, err := suite.makeEnviron().AllRunningInstances(suite.callCtx)
 
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 1)
 	c.Assert(instances[0].Id(), gc.Equals, id)
 }
 
-func (suite *environSuite) TestAllInstancesReturnsEmptySliceIfNoInstance(c *gc.C) {
-	instances, err := suite.makeEnviron().AllInstances(suite.callCtx)
+func (suite *environSuite) TestAllRunningInstancesReturnsEmptySliceIfNoInstance(c *gc.C) {
+	instances, err := suite.makeEnviron().AllRunningInstances(suite.callCtx)
 
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(instances, gc.HasLen, 0)
@@ -172,7 +172,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 	instanceIds, err := env.ControllerInstances(suite.callCtx, suite.controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceIds, gc.HasLen, 1)
-	insts, err := env.AllInstances(suite.callCtx)
+	insts, err := env.AllRunningInstances(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(insts, gc.HasLen, 1)
 	c.Check(insts[0].Id(), gc.Equals, instanceIds[0])

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -142,7 +142,7 @@ func (suite *EnvironProviderSuite) testMAASServerFromEndpoint(c *gc.C, endpoint 
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.addNode(`{"system_id":"test-allocated"}`)
-	_, err = env.AllInstances(suite.callCtx)
+	_, err = env.AllRunningInstances(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -114,11 +114,11 @@ func (suite *maas2EnvironSuite) makeEnvironWithMachines(c *gc.C, expectedSystemI
 	return env
 }
 
-func (suite *maas2EnvironSuite) TestAllInstances(c *gc.C) {
+func (suite *maas2EnvironSuite) TestAllRunningInstances(c *gc.C) {
 	env := suite.makeEnvironWithMachines(
 		c, []string{}, []string{"tuco", "tio", "gus"},
 	)
-	result, err := env.AllInstances(suite.callCtx)
+	result, err := env.AllRunningInstances(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedMachines := set.NewStrings("tuco", "tio", "gus")
 	actualMachines := set.NewStrings()
@@ -128,10 +128,10 @@ func (suite *maas2EnvironSuite) TestAllInstances(c *gc.C) {
 	c.Assert(actualMachines, gc.DeepEquals, expectedMachines)
 }
 
-func (suite *maas2EnvironSuite) TestAllInstancesError(c *gc.C) {
+func (suite *maas2EnvironSuite) TestAllRunningInstancesError(c *gc.C) {
 	controller := &fakeController{machinesError: errors.New("Something terrible!")}
 	env := suite.makeEnviron(c, controller)
-	_, err := env.AllInstances(suite.callCtx)
+	_, err := env.AllRunningInstances(suite.callCtx)
 	c.Assert(err, gc.ErrorMatches, "Something terrible!")
 }
 
@@ -2250,7 +2250,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	instanceIds, err := env.ControllerInstances(suite.callCtx, suite.controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceIds, gc.HasLen, 1)
-	insts, err := env.AllInstances(suite.callCtx)
+	insts, err := env.AllRunningInstances(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(insts, gc.HasLen, 1)
 	c.Check(insts[0].Id(), gc.Equals, instanceIds[0])

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -74,8 +74,15 @@ func (*manualEnviron) StopInstances(context.ProviderCallContext, ...instance.Id)
 	return errNoStopInstance
 }
 
+// AllInstances implements environs.InstanceBroker.
 func (e *manualEnviron) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
 	return e.Instances(ctx, []instance.Id{BootstrapInstanceId})
+}
+
+// AllRunningInstances implements environs.InstanceBroker.
+func (e *manualEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	// All instances and all running instance is the same for manual.
+	return e.AllInstances(ctx)
 }
 
 func (e *manualEnviron) envConfig() (cfg *environConfig) {

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -752,6 +752,13 @@ func (e *Environ) AllInstances(ctx envcontext.ProviderCallContext) ([]instances.
 	return ret, nil
 }
 
+// AllRunningInstances implements environs.InstanceBroker.
+func (e *Environ) AllRunningInstances(ctx envcontext.ProviderCallContext) ([]instances.Instance, error) {
+	// e.allInstances() returns all but 'terminated' instances already, so
+	// "all instances is the same as "all running" instances here.
+	return e.AllInstances(ctx)
+}
+
 // MaintainInstance implements environs.InstanceBroker.
 func (e *Environ) MaintainInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) error {
 	return nil

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -777,7 +777,7 @@ func (e *environSuite) TestStopInstancesTimeoutTransitioningToTerminated(c *gc.C
 
 }
 
-func (e *environSuite) TestAllInstances(c *gc.C) {
+func (e *environSuite) TestAllRunningInstances(c *gc.C) {
 	ctrl := e.patchEnv(c)
 	defer ctrl.Finish()
 
@@ -785,12 +785,12 @@ func (e *environSuite) TestAllInstances(c *gc.C) {
 		context.Background(), e.listInstancesRequest).Return(
 		e.listInstancesResponse, nil)
 
-	ids, err := e.env.AllInstances(nil)
+	ids, err := e.env.AllRunningInstances(nil)
 	c.Assert(err, gc.IsNil)
 	c.Check(len(ids), gc.Equals, 2)
 }
 
-func (e *environSuite) TestAllInstancesExtraUnrelatedInstance(c *gc.C) {
+func (e *environSuite) TestAllRunningInstancesExtraUnrelatedInstance(c *gc.C) {
 	ctrl := e.patchEnv(c)
 	defer ctrl.Finish()
 
@@ -804,7 +804,7 @@ func (e *environSuite) TestAllInstancesExtraUnrelatedInstance(c *gc.C) {
 		context.Background(), e.listInstancesRequest).Return(
 		e.listInstancesResponse, nil)
 
-	ids, err := e.env.AllInstances(nil)
+	ids, err := e.env.AllRunningInstances(nil)
 	c.Assert(err, gc.IsNil)
 	c.Check(len(ids), gc.Equals, 2)
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -746,7 +746,7 @@ func assertSecurityGroups(c *gc.C, env environs.Environ, expected []string) {
 }
 
 func assertInstanceIds(c *gc.C, env environs.Environ, callCtx context.ProviderCallContext, expected ...instance.Id) {
-	insts, err := env.AllInstances(callCtx)
+	insts, err := env.AllRunningInstances(callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	instIds := make([]instance.Id, len(insts))
 	for i, inst := range insts {
@@ -952,7 +952,7 @@ func (s *localServerSuite) TestInstanceStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *localServerSuite) TestAllInstancesFloatingIP(c *gc.C) {
+func (s *localServerSuite) TestAllRunningInstancesFloatingIP(c *gc.C) {
 	env := s.openEnviron(c, coretesting.Attrs{
 		"network":         "private_999",
 		"use-floating-ip": true,
@@ -965,7 +965,7 @@ func (s *localServerSuite) TestAllInstancesFloatingIP(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}()
 
-	insts, err := env.AllInstances(s.callCtx)
+	insts, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, inst := range insts {
 		c.Assert(*openstack.InstanceFloatingIP(inst), gc.Equals, fmt.Sprintf("10.0.0.%v", inst.Id()))
@@ -1102,7 +1102,7 @@ func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ids, gc.HasLen, 1)
 
-	insts, err := s.env.AllInstances(s.callCtx)
+	insts, err := s.env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(insts, gc.HasLen, 1)
 	c.Check(insts[0].Id(), gc.Equals, ids[0])
@@ -1901,7 +1901,7 @@ func (s *localHTTPSServerSuite) TestSSLVerify(c *gc.C) {
 		Config: cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = env.AllInstances(s.callCtx)
+	_, err = env.AllRunningInstances(s.callCtx)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -1923,7 +1923,7 @@ func (s *localHTTPSServerSuite) TestMustDisableSSLVerify(c *gc.C) {
 		Config: cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = env.AllInstances(s.callCtx)
+	_, err = env.AllRunningInstances(s.callCtx)
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*x509: certificate signed by unknown authority")
 }
 
@@ -2070,17 +2070,17 @@ func (s *localServerSuite) TestRemoveBlankContainer(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot remove "some-file": swift container name is empty`)
 }
 
-func (s *localServerSuite) TestAllInstancesIgnoresOtherMachines(c *gc.C) {
+func (s *localServerSuite) TestAllRunningInstancesIgnoresOtherMachines(c *gc.C) {
 	err := bootstrapEnv(c, s.env)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we see 1 instance in the environment
-	insts, err := s.env.AllInstances(s.callCtx)
+	insts, err := s.env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(insts, gc.HasLen, 1)
 
 	// Now start a machine 'manually' in the same account, with a similar
-	// but not matching name, and ensure it isn't seen by AllInstances
+	// but not matching name, and ensure it isn't seen by AllRunningInstances
 	// See bug #1257481, for how similar names were causing them to get
 	// listed (and thus destroyed) at the wrong time
 	existingModelName := s.TestConfig["name"]
@@ -2103,7 +2103,7 @@ func (s *localServerSuite) TestAllInstancesIgnoresOtherMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(servers, gc.HasLen, 2)
 
-	insts, err = s.env.AllInstances(s.callCtx)
+	insts, err = s.env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(insts, gc.HasLen, 1)
 }
@@ -2388,7 +2388,7 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	err := bootstrapEnv(c, t.env)
 	c.Assert(err, jc.ErrorIsNil)
 
-	instances, err := t.env.AllInstances(t.callCtx)
+	instances, err := t.env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 1)
 
@@ -2409,7 +2409,7 @@ func (t *localServerSuite) TestTagInstance(c *gc.C) {
 
 	assertMetadata := func(extraKey, extraValue string) {
 		// Refresh instance
-		instances, err := t.env.AllInstances(t.callCtx)
+		instances, err := t.env.AllRunningInstances(t.callCtx)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(instances, gc.HasLen, 1)
 		c.Assert(
@@ -2424,7 +2424,7 @@ func (t *localServerSuite) TestTagInstance(c *gc.C) {
 		)
 	}
 
-	instances, err := t.env.AllInstances(t.callCtx)
+	instances, err := t.env.AllRunningInstances(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 1)
 
@@ -2549,7 +2549,7 @@ func addVolume(c *gc.C, env environs.Environ, callCtx context.ProviderCallContex
 }
 
 func (s *localServerSuite) checkInstanceTags(c *gc.C, env environs.Environ, expectedController string) {
-	instances, err := env.AllInstances(s.callCtx)
+	instances, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.Not(gc.HasLen), 0)
 	for _, instance := range instances {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1466,7 +1466,7 @@ func (e *Environ) listServers(ctx context.ProviderCallContext, ids []instance.Id
 		return wantedServers, nil
 	}
 	// List all instances in the environment.
-	instances, err := e.AllInstances(ctx)
+	instances, err := e.AllRunningInstances(ctx)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, err
@@ -1575,7 +1575,7 @@ func (e *Environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 	var failed []string
 	controllerTag := map[string]string{tags.JujuController: controllerUUID}
 
-	instances, err := e.AllInstances(ctx)
+	instances, err := e.AllRunningInstances(ctx)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)
@@ -1660,6 +1660,13 @@ func (e *Environ) AllInstances(ctx context.ProviderCallContext) ([]instances.Ins
 		return instances, err
 	}
 	return instances, nil
+}
+
+// AllRunningInstances returns all running, available instances in this environment.
+func (e *Environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	// e.allInstances(...) already handles all instances irrespective of the state, so
+	// here 'all' is also 'all running'.
+	return e.AllInstances(ctx)
 }
 
 // allControllerManagedInstances returns all instances managed by this

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -606,6 +606,13 @@ func (o *OracleEnviron) AllInstances(ctx context.ProviderCallContext) ([]envinst
 	return ret, nil
 }
 
+// AllRunningInstances is part of the InstanceBroker interface.
+func (o *OracleEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]envinstance.Instance, error) {
+	// o.allInstances(...) already handles all instances irrespective of the state, so
+	// here 'all' is also 'all running'.
+	return o.AllInstances(ctx)
+}
+
 func (o *OracleEnviron) allInstances(tagFilter tagValue) ([]*oracleInstance, error) {
 	filter := []oci.Filter{
 		{

--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -222,8 +222,8 @@ func (e *environSuite) TestStopInstances(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (e *environSuite) TestAllInstances(c *gc.C) {
-	_, err := e.env.AllInstances(e.callCtx)
+func (e *environSuite) TestAllRunningInstances(c *gc.C) {
+	_, err := e.env.AllRunningInstances(e.callCtx)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -222,6 +222,11 @@ func (e *fakeEnviron) AllInstances(callCtx context.ProviderCallContext) ([]insta
 	return nil, nil
 }
 
+func (e *fakeEnviron) AllRunningInstances(callCtx context.ProviderCallContext) ([]instances.Instance, error) {
+	e.Push("AllRunningInstances", callCtx)
+	return nil, nil
+}
+
 func (e *fakeEnviron) MaintainInstance(callCtx context.ProviderCallContext, args environs.StartInstanceParams) error {
 	e.Push("MaintainInstance", callCtx, args)
 	return nil

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -296,6 +296,20 @@ func (env *sessionEnviron) AllInstances(ctx context.ProviderCallContext) ([]inst
 	return results, err
 }
 
+// AllRunningInstances implements environs.InstanceBroker.
+func (env *environ) AllRunningInstances(ctx context.ProviderCallContext) (instances []instances.Instance, err error) {
+	// AllInstances() already handles all instances irrespective of the state, so
+	// here 'all' is also 'all running'.
+	return env.AllInstances(ctx)
+}
+
+// AllRunningInstances implements environs.InstanceBroker.
+func (env *sessionEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+	// AllInstances() already handles all instances irrespective of the state, so
+	// here 'all' is also 'all running'.
+	return env.AllInstances(ctx)
+}
+
 // StopInstances implements environs.InstanceBroker.
 func (env *environ) StopInstances(ctx context.ProviderCallContext, ids ...instance.Id) error {
 	return env.withSession(ctx, func(env *sessionEnviron) error {

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -33,7 +33,7 @@ func (env *sessionEnviron) Instances(ctx context.ProviderCallContext, ids []inst
 		return nil, environs.ErrNoInstances
 	}
 
-	allInstances, err := env.AllInstances(ctx)
+	allInstances, err := env.AllRunningInstances(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to get instances")
 	}
@@ -73,7 +73,7 @@ func (env *environ) ControllerInstances(ctx context.ProviderCallContext, control
 
 // ControllerInstances is part of the environs.Environ interface.
 func (env *sessionEnviron) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
-	instances, err := env.AllInstances(ctx)
+	instances, err := env.AllRunningInstances(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/containerbroker/mocks/environs_mock.go
+++ b/worker/containerbroker/mocks/environs_mock.go
@@ -5,14 +5,16 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	instance "github.com/juju/juju/core/instance"
-	lxdprofile "github.com/juju/juju/core/lxdprofile"
-	environs "github.com/juju/juju/environs"
-	context "github.com/juju/juju/environs/context"
-	instances "github.com/juju/juju/environs/instances"
+	"reflect"
+
+	"github.com/golang/mock/gomock"
 	charm_v6 "gopkg.in/juju/charm.v6"
-	reflect "reflect"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
 )
 
 // MockLXDProfiler is a mock of LXDProfiler interface
@@ -110,6 +112,19 @@ func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]i
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllInstances), arg0)
+}
+
+// AllRunningInstances mocks base method
+func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
+	ret0, _ := ret[0].([]instances.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRunningInstances indicates an expected call of AllRunningInstances
+func (mr *MockInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
 // MaintainInstance mocks base method

--- a/worker/instancemutater/mocks/environs_mock.go
+++ b/worker/instancemutater/mocks/environs_mock.go
@@ -5,18 +5,20 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	constraints "github.com/juju/juju/core/constraints"
-	instance "github.com/juju/juju/core/instance"
-	lxdprofile "github.com/juju/juju/core/lxdprofile"
-	environs "github.com/juju/juju/environs"
-	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
-	instances "github.com/juju/juju/environs/instances"
-	storage "github.com/juju/juju/storage"
-	version "github.com/juju/version"
+	"reflect"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/version"
 	charm_v6 "gopkg.in/juju/charm.v6"
-	reflect "reflect"
+
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/storage"
 )
 
 // MockEnviron is a mock of Environ interface
@@ -65,6 +67,19 @@ func (m *MockEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instance
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockEnviron)(nil).AllInstances), arg0)
+}
+
+// AllRunningInstances mocks base method
+func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
+	ret0, _ := ret[0].([]instances.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRunningInstances indicates an expected call of AllRunningInstances
+func (mr *MockEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockEnviron)(nil).AllRunningInstances), arg0)
 }
 
 // Bootstrap mocks base method
@@ -391,6 +406,19 @@ func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]i
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllInstances), arg0)
+}
+
+// AllRunningInstances mocks base method
+func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
+	ret0, _ := ret[0].([]instances.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRunningInstances indicates an expected call of AllRunningInstances
+func (mr *MockInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
 // MaintainInstance mocks base method

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -337,7 +337,7 @@ func instanceIds(instances []instances.Instance) []string {
 func (task *provisionerTask) populateMachineMaps(ids []string) error {
 	task.instances = make(map[instance.Id]instances.Instance)
 
-	instances, err := task.broker.AllInstances(task.cloudCallCtx)
+	instances, err := task.broker.AllRunningInstances(task.cloudCallCtx)
 	if err != nil {
 		return errors.Annotate(err, "failed to get all instances from broker")
 	}


### PR DESCRIPTION
## Description of change

Each provider has to implement an InstanceBroker interface. One of the major calls of this interface is AllInstances(). The call is made whenever Juju needs to retrieve known cloud instances, be it for provisioning, for adopting resources, for querying instance states, destroying instances, etc.

The original intent was to *always* list all instances. However, it became apparent that some providers had limitations on what a user can do with an instance in a particular state, so the AllInstance method was inconsistently re-defined to mean *all running, usable instances*. This especially affected public clouds like aws. This new definition works for most of cases, except for destroying an instance - Juju does not really care what state the instance is in as long as we knew about and at the time when we want to terminate, we can. In addition, some providers did not need to make this distinction either because their underlying substrate only returned *running* instances or because the substrate dealt with instances in different state itself.

This means that we needed to rename current AllInstances to mean AllRunnningInstances and re-implement new AllInstances to return all instances except the ones that are already terminated.
 This PR does just that.
  
This is a largely mechanical PR. Most of fun is in environ broker where a new AllRunningInstances call is added and in providers that filter on status like ec2 and gce. 
