### PR TITLE
Use actions for tokens

### DIFF
--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -3,34 +3,23 @@
 
 from __future__ import print_function
 
-from argparse import ArgumentParser
-from contextlib import contextmanager
 import logging
 import re
-from subprocess import CalledProcessError
 import sys
+from argparse import ArgumentParser
+from contextlib import contextmanager
+from subprocess import CalledProcessError
 
-from deploy_stack import (
-    BootstrapManager,
-    deploy_dummy_stack,
-    get_remote_machines,
-    get_token_from_status,
-    wait_for_state_server_to_shutdown,
-)
-from jujupy import (
-    parse_new_state_server_from_error,
-)
-from substrate import (
-    convert_to_azure_ids,
-    terminate_instances,
-)
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
-    JujuAssertionError,
-    LoggedException,
-    until_timeout,
-)
+import yaml
+
+from deploy_stack import (BootstrapManager, deploy_dummy_stack,
+                          get_remote_machines, get_token_from_status,
+                          wait_for_state_server_to_shutdown)
+from jujupy import parse_new_state_server_from_error
+from substrate import convert_to_azure_ids, terminate_instances
+from utility import (JujuAssertionError, LoggedException,
+                     add_basic_testing_arguments, configure_logging,
+                     until_timeout)
 
 __metaclass__ = type
 
@@ -38,20 +27,29 @@ running_instance_pattern = re.compile('\["([^"]+)"\]')
 
 log = logging.getLogger("assess_recovery")
 
-def check_token(client, token):
-    for ignored in until_timeout(300):
-        found = get_token_from_status(client)
-        if found and token in found:
-            return found
+def set_token(client, token):
+    # unfortunately deploying a stack currently requires a token setting, but
+    # in reality the way the charm exposes the token via status means that we
+    # sometimes can't read the token i.e. if the workload-status changes after
+    # or before the token is set multiple times.
+    client.set_config('dummy-source', {'token': token})
+    return client.action_do('dummy-sink/0', 'echo', "value={}".format(token))
+
+def check_token(client, id, token):
+    result = client.action_fetch(id, 'echo', "300s")
+    parsed = yaml.safe_load(result)
+    value = parsed["results"]["echo"]["value"]
+    if value and token in value:
+        return value
     raise JujuAssertionError('Token is not {}: {}'.format(
-                             token, found))
+                             token, value))
 
 def deploy_stack(client, charm_series):
     """"Deploy a simple stack, state-server and ubuntu."""
     deploy_dummy_stack(client, charm_series)
-    client.set_config('dummy-source', {'token': 'One'})
+    id = set_token(client, 'One')
     client.wait_for_workloads()
-    check_token(client, 'One')
+    check_token(client, id, 'One')
     log.info("%s is ready to testing", client.env.environment)
 
 def enable_ha(bs_manager, controller_client):
@@ -92,10 +90,10 @@ def restore_backup(bs_manager, client, backup_file,
         client.wait_for_started(600)
     show_controller(bs_manager.client)
     bs_manager.has_controller = True
-    bs_manager.client.set_config('dummy-source', {'token': 'Two'})
+    id = set_token(bs_manager.client, 'Two')
     bs_manager.client.wait_for_started()
     bs_manager.client.wait_for_workloads()
-    check_token(bs_manager.client, 'Two')
+    check_token(bs_manager.client, id, 'Two')
     log.info("%s restored", bs_manager.client.env.environment)
     log.info("PASS")
 
@@ -132,7 +130,7 @@ def assess_recovery(bs_manager, strategy, charm_series):
     log.info("Setting up test.")
     client = bs_manager.client
     deploy_stack(client, charm_series)
-    client.set_config('dummy-source', {'token': ''})
+    set_token(client, 'empty')
     log.info("Setup complete.")
     log.info("Test started.")
     controller_client = client.get_controller_client()

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -857,9 +857,9 @@ class ModelClient:
         """
         options = ()
         if force:
-            options = ('--force',)
+            options = options + ('--force',)
         if controller:
-            options = ('-m', 'controller',)
+            options = options + ('-m', 'controller',)
         self.juju('remove-machine', options + tuple(machine_ids))
         return self.make_remove_machine_condition(machine_ids)
 
@@ -1693,7 +1693,7 @@ class ModelClient:
         """Return the controller-member-status of the machine if it exists."""
         return info_dict.get('controller-member-status')
 
-    def wait_for_ha(self, timeout=1200, start=None):
+    def wait_for_ha(self, timeout=1200, start=None, quorum=3):
         """Wait for voiting to be enabled.
 
         May only be called on a controller client."""
@@ -1710,7 +1710,7 @@ class ModelClient:
                     continue
                 states.setdefault(status, []).append(machine)
             if list(states.keys()) == [desired_state]:
-                if len(states.get(desired_state, [])) >= 3:
+                if len(states.get(desired_state, [])) >= quorum:
                     return None
             return states
 

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1462,6 +1462,10 @@ class ModelClient:
             # For now only maas support spaces in a meaningful way.
             return 'spaces={}'.format(','.join(
                 '^' + space for space in sorted(self.excluded_spaces)))
+        elif self.env.lxd:
+            # LXD should be constrained by memory when running in HA, otherwise
+            # mongo just eats everything.
+            return 'mem=6G'
         else:
             return ''
 

--- a/acceptancetests/jujupy/wait_condition.py
+++ b/acceptancetests/jujupy/wait_condition.py
@@ -217,7 +217,7 @@ class WaitMachineNotPresent(BaseCondition):
             if machine in self.machines:
                 machines.append(machine)
         if len(machines) > 0:
-            yield machine[0], 'still-present'
+            yield machines[0], 'still-present'
 
     def do_raise(self, model_name, status):
         plural = "s"

--- a/acceptancetests/repository/charms/dummy-sink/actions.yaml
+++ b/acceptancetests/repository/charms/dummy-sink/actions.yaml
@@ -1,0 +1,6 @@
+echo:
+  description: Echo takes a string value and echo's it out
+  params:
+    value:
+      type: string
+      description: The value that should be echo'd

--- a/acceptancetests/repository/charms/dummy-sink/actions/echo
+++ b/acceptancetests/repository/charms/dummy-sink/actions/echo
@@ -1,0 +1,12 @@
+#!/bin/bash -eux
+
+value="$(action-get value)"
+
+if [ -z "${value}" ]; then
+    action-set echo.value="${value}"
+    action-set outcome="failure"
+    action-fail "echo value can't be empty"
+fi
+
+action-set echo.value="${value}"
+action-set outcome="success"

--- a/acceptancetests/repository/charms/dummy-source/actions.yaml
+++ b/acceptancetests/repository/charms/dummy-source/actions.yaml
@@ -1,0 +1,6 @@
+echo:
+  description: Echo takes a string value and echo's it out
+  params:
+    value:
+      type: string
+      description: The value that should be echo'd

--- a/acceptancetests/repository/charms/dummy-source/actions/echo
+++ b/acceptancetests/repository/charms/dummy-source/actions/echo
@@ -1,0 +1,12 @@
+#!/bin/bash -eux
+
+value="$(action-get value)"
+
+if [ -z "${value}" ]; then
+    action-set echo.value="${value}"
+    action-set outcome="failure"
+    action-fail "echo value can't be empty"
+fi
+
+action-set echo.value="${value}"
+action-set outcome="success"


### PR DESCRIPTION
## Description of change

The following uses actions on a charm, rather than using config
changes. Although the config changes ensure that a relation is set
and that the token can be read when the relation changes, the way
it sets the status and then read means that it's problematic when
reading the value in the tests. This is more evident when running
against a cloud like aws/gce, where latency comes in.

To improve this, we instead run an action for the charm to ensure
that the charm is still alive and that we can read the value from
the action result. This replicates some of the functionality of
the config setup, but the difference being that it's reliable to
work on the clouds.

## QA steps

Ensure you've setup the acceptance tests as per the readme.

```
cd acceptancetests
./assess_recovery.py myaws
```
