### PR TITLE
Remove default memory constrainst for bootstrap in CI tests.

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1457,24 +1457,19 @@ class ModelClient:
     def _get_substrate_constraints(self):
         if self.env.joyent:
             # Only accept kvm packages by requiring >1 cpu core, see lp:1446264
-            return 'mem=2G cpu-cores=1'
+            return 'cores=1'
         elif self.env.maas and self._maas_spaces_enabled():
             # For now only maas support spaces in a meaningful way.
-            return 'mem=2G spaces={}'.format(','.join(
+            return 'spaces={}'.format(','.join(
                 '^' + space for space in sorted(self.excluded_spaces)))
-        elif self.env.lxd:
-            # LXD should not be constrained via memory
-            return ''
         else:
-            return 'mem=2G'
+            return ''
 
     def quickstart(self, bundle_template, upload_tools=False):
         bundle = self.format_bundle(bundle_template)
-        constraints = 'mem=2G'
-        args = ('--constraints', constraints)
+        args = ('--no-browser', bundle,)
         if upload_tools:
             args = ('--upload-tools',) + args
-        args = args + ('--no-browser', bundle,)
         self.juju('quickstart', args, extra_env={'JUJU': self.full_path})
 
     def status_until(self, timeout, start=None):

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -388,7 +388,7 @@ class TestModelClient(ClientTest):
                     client.bootstrap()
             mock.assert_called_once_with(
                 'bootstrap', (
-                    '--constraints', 'mem=2G cpu-cores=1',
+                    '--constraints', 'cores=1',
                     'joyent/foo', 'joyent',
                     '--config', config_file.name,
                     '--default-model', 'joyent', '--agent-version', '2.0',


### PR DESCRIPTION
## Description of change

CI tests shouldn't have a mem=2G constraint when the default for a juju controller is 3.5G.  A follow on for the same change for LXD controllers.

# QA

Run an acceptance test using a non lxd environment.