### PR TITLE
Avoid repetition in juju register warnings/errors

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -342,8 +342,7 @@ func (c *registerCommand) updateController(
 			); err != nil {
 				return err
 			}
-			ctx.Warningf(buf.String())
-			return errors.Errorf("controller is already registered as %q", name)
+			return errors.New(buf.String())
 		}
 	}
 	if err := store.AddController(controllerName, controllerDetails); err != nil {
@@ -356,7 +355,7 @@ func (c *registerCommand) updateController(
 }
 
 var alreadyRegisteredMessageT = template.Must(template.New("").Parse(`
-This controller has already been registered on this client as "{{.ControllerName}}."
+This controller has already been registered on this client as "{{.ControllerName}}".
 To login user "{{.UserName}}" run 'juju login -u {{.UserName}} -c {{.ControllerName}}'.
 To update controller details and login as user "{{.UserName}}":
     1. run 'juju unregister {{.UserName}}'

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -644,10 +644,10 @@ var alreadyRegisteredMessageT = template.Must(template.New("").Parse(`
 This controller has already been registered on this client as "{{.ControllerName}}".
 To login user "{{.UserName}}" run 'juju login -u {{.UserName}} -c {{.ControllerName}}'.
 To update controller details and login as user "{{.UserName}}":
-    1. run 'juju unregister {{.UserName}}'
+    1. run 'juju unregister {{.ControllerName}}'
     2. request from your controller admin another registration string, i.e
        output from 'juju change-user-password {{.UserName}} --reset'
-    3. re-run 'juju register' with the registration from (2) above.
+    3. re-run 'juju register' with the registration string from (2) above.
 `[1:]))
 
 func genAlreadyRegisteredError(controller, user string) error {

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -332,10 +332,10 @@ Initial password successfully set for bob.
 	c.Assert(err.Error(), gc.Equals, `This controller has already been registered on this client as "controller-name".
 To login user "bob" run 'juju login -u bob -c controller-name'.
 To update controller details and login as user "bob":
-    1. run 'juju unregister bob'
+    1. run 'juju unregister controller-name'
     2. request from your controller admin another registration string, i.e
        output from 'juju change-user-password bob --reset'
-    3. re-run 'juju register' with the registration from (2) above.
+    3. re-run 'juju register' with the registration string from (2) above.
 `)
 	prompter.CheckDone()
 }
@@ -530,10 +530,10 @@ func (s *RegisterSuite) TestRegisterAlreadyKnownControllerEndpointAndUser(c *gc.
 	c.Assert(err.Error(), gc.Equals, `This controller has already been registered on this client as "foo".
 To login user "bob" run 'juju login -u bob -c foo'.
 To update controller details and login as user "bob":
-    1. run 'juju unregister bob'
+    1. run 'juju unregister foo'
     2. request from your controller admin another registration string, i.e
        output from 'juju change-user-password bob --reset'
-    3. re-run 'juju register' with the registration from (2) above.
+    3. re-run 'juju register' with the registration string from (2) above.
 `)
 }
 

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -328,7 +328,15 @@ Enter a name for this controller: »foo
 Initial password successfully set for bob.
 `[1:])
 	err = s.run(c, prompter, registrationData)
-	c.Assert(err, gc.ErrorMatches, `controller is already registered as "controller-name"`, gc.Commentf("details: %v", errors.Details(err)))
+	c.Assert(err, gc.Not(gc.IsNil))
+	c.Assert(err.Error(), gc.Equals, `This controller has already been registered on this client as "controller-name".
+To login user "bob" run 'juju login -u bob -c controller-name'.
+To update controller details and login as user "bob":
+    1. run 'juju unregister bob'
+    2. request from your controller admin another registration string, i.e
+       output from 'juju change-user-password bob --reset'
+    3. re-run 'juju register' with the registration from (2) above.
+`)
 	prompter.CheckDone()
 }
 

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -618,10 +618,10 @@ func ensureNotKnownEndpoint(store jujuclient.ClientStore, endpoint string) error
 	}
 
 	if accountDetails != nil {
-		return errors.Errorf(`This controller has already been registered on this client as %q
+		return errors.Errorf(`This controller has already been registered on this client as %q.
 To login as user %q run 'juju login -u %s -c %s'.`, existingName, accountDetails.User, accountDetails.User, existingName)
 	}
 
-	return errors.Errorf(`This controller has already been registered on this client as %q
+	return errors.Errorf(`This controller has already been registered on this client as %q.
 To login run 'juju login -c %s'.`, existingName, existingName)
 }

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -370,7 +370,7 @@ func (s *LoginCommandSuite) TestLoginUsingKnownControllerEndpoint(c *gc.C) {
 			descr: "user provides an endpoint as the controller name and has a local account for the controller",
 			cmd:   []string{details.APIEndpoints[0]},
 			expErr: `
-ERROR This controller has already been registered on this client as "` + existingName + `"
+ERROR This controller has already been registered on this client as "` + existingName + `".
 To login as user "current-user" run 'juju login -u current-user -c ` + existingName + `'.
 `,
 		},
@@ -378,7 +378,7 @@ To login as user "current-user" run 'juju login -u current-user -c ` + existingN
 			descr: "user provides an endpoint as the controller name and does not have a local account for the controller",
 			cmd:   []string{"1.1.1.1:12345"},
 			expErr: `
-ERROR This controller has already been registered on this client as "controller-with-no-account"
+ERROR This controller has already been registered on this client as "controller-with-no-account".
 To login run 'juju login -c controller-with-no-account'.
 `,
 		},
@@ -386,7 +386,7 @@ To login run 'juju login -c controller-with-no-account'.
 			descr: "user provides an endpoint and overrides the controller name",
 			cmd:   []string{details.APIEndpoints[0], "-c", "some-controller-name"},
 			expErr: `
-ERROR This controller has already been registered on this client as "` + existingName + `"
+ERROR This controller has already been registered on this client as "` + existingName + `".
 To login as user "current-user" run 'juju login -u current-user -c ` + existingName + `'.
 `,
 		},


### PR DESCRIPTION
## Description of change

When invoking a `juju register` command twice, you would get a warning message advising you that the controller is already known and how to connect to it, followed by an _error_ like `controller is already registered as "blah"`. 

This PR fixes the above stuttering issue and as a drive-by updates the logic behind `juju register $ip` to work similarly to the `juju login $ip` command, i.e when you try to register an endpoint IP for an already locally known controller you will get the same error like calling `juju register` twice.

## QA steps

```console
$ juju bootstrap lxd test --no-gui

# Create a new user and grab the registration command
$ juju add-user bob
User "bob" added
Please send this command to bob:
    juju register MEMTA2JvYjAUExIxMC42NS40Ny4xMTU6MTcwNzAEIP4g-Nnh4plv7E11qLsOPK0bSKlZDkQhy4RHqdIODGTQEwR0ZXN0

"bob" has not been granted access to any models. You can use "juju grant" to grant access.

# Edit ~/.local/share/juju/controllers.yaml and change the controller entry key to "test1"
# Then, run the registration command (when prompted for a controller name use the default value: "test")
$ juju register MEMTA2JvYjAUExIxMC42NS40Ny4xMTU6MTcwNzAEIP4g-Nnh4plv7E11qLsOPK0bSKlZDkQhy4RHqdIODGTQEwR0ZXN0

Enter a new password:
Confirm password:
Enter a name for this controller [test]:
Initial password successfully set for bob.
ERROR This controller has already been registered on this client as "test1".
To login user "bob" run 'juju login -u bob -c test1'.
To update controller details and login as user "bob":
    1. run 'juju unregister bob'
    2. request from your controller admin another registration string, i.e
       output from 'juju change-user-password bob --reset'
    3. re-run 'juju register' with the registration from (2) above.

# Next, try to register the controller using the endpoint of the test controller (see controllers.yaml)
$ juju register 10.65.47.115:17070
ERROR This controller has already been registered on this client as "test1"
To login run 'juju login -c test1'.

# Finally, edit the controllers.yaml file and change the controller key back to "test".
# Then, run the registration command one more time
$ juju register 10.65.47.115:17070
ERROR This controller has already been registered on this client as "test".
To login user "admin" run 'juju login -u admin -c test'.
To update controller details and login as user "admin":
    1. run 'juju unregister admin'
    2. request from your controller admin another registration string, i.e
       output from 'juju change-user-password admin --reset'
    3. re-run 'juju register' with the registration from (2) above.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1825166