### PR TITLE
AdoptResources deals with all instances.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1153,7 +1153,7 @@ func (e *environ) subnetsForVPC(ctx context.ProviderCallContext) (resp *ec2.Subn
 // AdoptResources is part of the Environ interface.
 func (e *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	// Gather resource ids for instances, volumes and security groups tagged with this model.
-	instances, err := e.AllRunningInstances(ctx)
+	instances, err := e.AllInstances(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -130,7 +130,7 @@ func (env *environ) ControllerInstances(ctx context.ProviderCallContext, control
 
 // AdoptResources is part of the Environ interface.
 func (env *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
-	instances, err := env.AllRunningInstances(ctx)
+	instances, err := env.AllInstances(ctx)
 	if err != nil {
 		return errors.Annotate(err, "all instances")
 	}

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -120,7 +120,7 @@ func (env *environ) ControllerInstances(ctx context.ProviderCallContext, control
 // AdoptResources updates the controller tags on all instances to have the
 // new controller id. It's part of the Environ interface.
 func (env *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
-	instances, err := env.AllRunningInstances(ctx)
+	instances, err := env.AllInstances(ctx)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Annotate(err, "all instances")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2377,7 +2377,7 @@ func (env *maasEnviron) AdoptResources(ctx context.ProviderCallContext, controll
 		return nil
 	}
 
-	instances, err := env.AllRunningInstances(ctx)
+	instances, err := env.AllInstances(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1575,7 +1575,7 @@ func (e *Environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 	var failed []string
 	controllerTag := map[string]string{tags.JujuController: controllerUUID}
 
-	instances, err := e.AllRunningInstances(ctx)
+	instances, err := e.AllInstances(ctx)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)


### PR DESCRIPTION
## Description of change

AdoptResources is a central call that deals with cloud instances when migrating models.

Some providers implement it using a broker to identify needed instances. Such providers need to call AllInstances instead of AllRunningInstances:

* ec2
* maas
* gce
* lxd
* openstack 

The rest of the providers do not use broker.