### PR TITLE
Prevent GCE provider from sending port numbers in ICMP firewall rules

### DIFF
--- a/provider/gce/google/network_test.go
+++ b/provider/gce/google/network_test.go
@@ -59,12 +59,16 @@ func (s ByIPProtocol) Less(i, j int) bool {
 
 func (s *networkSuite) TestFirewallSpec(c *gc.C) {
 	ports := map[string][]corenetwork.PortRange{
-		"tcp": {{FromPort: 80, ToPort: 81}, {FromPort: 8888, ToPort: 8888}},
-		"udp": {{FromPort: 1234, ToPort: 1234}},
+		"tcp":  {{FromPort: 80, ToPort: 81}, {FromPort: 8888, ToPort: 8888}},
+		"udp":  {{FromPort: 1234, ToPort: 1234}},
+		"icmp": {{FromPort: -1, ToPort: -1}},
 	}
 	fw := google.FirewallSpec("spam", "target", []string{"192.168.1.0/24", "10.0.0.0/24"}, ports)
 
 	allowed := []*compute.FirewallAllowed{{
+		IPProtocol: "icmp",
+		Ports:      []string{},
+	}, {
 		IPProtocol: "tcp",
 		Ports:      []string{"80-81", "8888"},
 	}, {

--- a/provider/gce/google/ruleset.go
+++ b/provider/gce/google/ruleset.go
@@ -218,6 +218,11 @@ func (pp protocolPorts) String() string {
 // for the given protocol.
 func (pp protocolPorts) portStrings(protocol string) []string {
 	var result []string
+	// Google doesn't permit a range of ports for the ICMP protocol
+	// https://web.archive.org/web/20190521045119/https://cloud.google.com/vpc/docs/firewalls#protocols_and_ports
+	if protocol == "icmp" {
+		return result
+	}
 	ports := pp[protocol]
 	for _, pr := range ports {
 		portStr := fmt.Sprintf("%d", pr.FromPort)

--- a/provider/gce/google/ruleset_test.go
+++ b/provider/gce/google/ruleset_test.go
@@ -25,7 +25,8 @@ func makeRuleSet() ruleSet {
 	rule2 := network.MustNewIngressRule("tcp", 80, 80)
 	rule3 := network.MustNewIngressRule("tcp", 79, 81)
 	rule4 := network.MustNewIngressRule("udp", 5123, 8099, "192.168.1.0/24")
-	return newRuleSetFromRules(rule1, rule2, rule3, rule4)
+	rule5 := network.MustNewIngressRule("icmp", -1, -1)
+	return newRuleSetFromRules(rule1, rule2, rule3, rule4, rule5)
 }
 
 func (s *RuleSetSuite) TestNewRuleSetFromRules(c *gc.C) {
@@ -34,7 +35,8 @@ func (s *RuleSetSuite) TestNewRuleSetFromRules(c *gc.C) {
 		"b42e18366a": &firewall{
 			SourceCIDRs: []string{"0.0.0.0/0"},
 			AllowedPorts: protocolPorts{
-				"tcp": []corenetwork.PortRange{{8000, 8099, "tcp"}, {80, 80, "tcp"}, {79, 81, "tcp"}},
+				"tcp":  []corenetwork.PortRange{{8000, 8099, "tcp"}, {80, 80, "tcp"}, {79, 81, "tcp"}},
+				"icmp": []corenetwork.PortRange{{-1, -1, "icmp"}},
 			},
 		},
 		"d01a825c13": &firewall{
@@ -171,7 +173,8 @@ func (s *RuleSetSuite) TestMatchSourceCIDRs(c *gc.C) {
 	c.Assert(fw, gc.DeepEquals, &firewall{
 		SourceCIDRs: []string{"0.0.0.0/0"},
 		AllowedPorts: protocolPorts{
-			"tcp": []corenetwork.PortRange{{8000, 8099, "tcp"}, {80, 80, "tcp"}, {79, 81, "tcp"}},
+			"tcp":  []corenetwork.PortRange{{8000, 8099, "tcp"}, {80, 80, "tcp"}, {79, 81, "tcp"}},
+			"icmp": []corenetwork.PortRange{{-1, -1, "icmp"}},
 		},
 	})
 	fw, ok = ruleset.matchSourceCIDRs([]string{"1.2.3.0/24"})


### PR DESCRIPTION
## Description of change

Juju currently breaks the GCE API when it sends a ICMP firewall rule. When creating a ICMP firewall rule, Juju sends the port range [-1, -1]. This breaks Google's validation, which [doesn't allow a port range to be specified for ICMP firewall rules](https://web.archive.org/web/20190521045119/https://cloud.google.com/vpc/docs/firewalls#protocols_and_ports).

## QA steps

* Bootstrap to GCE
* `juju deploy ubuntu`
* `juju run --unit ubuntu/0 open-port icmp`

`juju status` now reports that `icmp` has been made available:

```plain
$ juju status
Model    Controller  Cloud/Region     Version  SLA          Timestamp
default  gce-2       google/us-east1  2.6.3.1  unsupported  17:21:32+12:00

App     Version  Status  Scale  Charm   Store       Rev  OS      Notes
ubuntu  18.04    active      1  ubuntu  jujucharms   12  ubuntu  

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        35.231.252.171  icmp   ready

Machine  State    DNS             Inst id        Series  AZ          Message
0        started  35.231.252.171  juju-ac2961-0  bionic  us-east1-b  RUNNING
```

We can verify that the port was successfully opened by pinging the server:
```plain
$ ping 35.231.252.171
PING 35.231.252.171 (35.231.252.171) 56(84) bytes of data.
64 bytes from 35.231.252.171: icmp_seq=1 ttl=51 time=331 ms
64 bytes from 35.231.252.171: icmp_seq=2 ttl=51 time=262 ms
^C
--- 35.231.252.171 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 2ms
rtt min/avg/max/mdev = 262.318/296.906/331.494/34.588 ms
```

## Documentation changes

None.

## Bug reference

* [lp:1829512](https://bugs.launchpad.net/juju/+bug/1829512)
