### PR TITLE
Allow manual provider precheck to succeed when placement is empty

### DIFF
--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -324,7 +324,21 @@ exit 0
 	return err
 }
 
-func (*manualEnviron) PrecheckInstance(context.ProviderCallContext, environs.PrecheckInstanceParams) error {
+func (e *manualEnviron) PrecheckInstance(ctx context.ProviderCallContext, params environs.PrecheckInstanceParams) error {
+	validator, err := e.ConstraintsValidator(ctx)
+	if err != nil {
+		return err
+	}
+
+	if _, err = validator.Validate(params.Constraints); err != nil {
+		return err
+	}
+
+	// Fix for #1829559
+	if params.Placement == "" {
+		return nil
+	}
+
 	return errors.New(`use "juju add-machine ssh:[user@]<host>" to provision machines`)
 }
 


### PR DESCRIPTION
## Description of change

The existing implementation of `PrecheckInstance` always returns back an error: `use "juju add-machine ssh:[user@]<host>" to provision machines`. However attempting to deploy a bundle to a manual cloud with the `--map-machines=existing` option currently fails as the state code will invoke 
the pre-check hook.

This PR attempts to workaround the issue by adding the following predicate to the `PrecheckInstance`
implementation: if the provided constraints (if any) are valid AND the placement is empty then return without an error. Otherwise, return the current error.

## QA steps

```console
# Setup a manual cloud. For my tests I used vagrant boxes and amd64 arch but it will be 
# probably easier to spin up a bunch of lxd instances instead.
$ juju add-cloud
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: manual

Enter a name for your manual cloud: manual

Enter the controller's hostname or IP address: ubuntu@192.168.99.10

Cloud "test" successfully added

You will need to add credentials for this cloud (`juju add-credential test`)
before creating a controller (`juju bootstrap test`).

$ juju bootstrap manual test

# Add 5 machines to the cloud
$ juju add-machine ssh:ubuntu@192.168.99.11
$ juju add-machine ssh:ubuntu@192.168.99.12
$ juju add-machine ssh:ubuntu@192.168.99.13
$ juju add-machine ssh:ubuntu@192.168.99.14
$ juju add-machine ssh:ubuntu@192.168.99.15

# Fetch test bundle and deploy it
$ wget -O bundle.yaml https://gist.githubusercontent.com/achilleasa/e5cff2fe18a4f19f262d57a1e0b6f378/raw/429436aada994bae31fa8f6d2c08ad6ef94e1b0a/manual-bundle.yaml
$ juju deploy bundle.yaml --map-machines=existing
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1829559