### PR TITLE
Update wording of the success message.

### DIFF
--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -103,7 +103,7 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	if sameCloudInfo {
-		fmt.Fprintln(ctxt.Stderr, "Your list of public clouds is up to date, see `juju clouds`.")
+		fmt.Fprintln(ctxt.Stderr, "This client's list of public clouds is up to date, see `juju clouds --local`.")
 		return nil
 	}
 	if err := jujucloud.WritePublicCloudMetadata(newPublicClouds); err != nil {

--- a/cmd/juju/cloud/updatepublicclouds_test.go
+++ b/cmd/juju/cloud/updatepublicclouds_test.go
@@ -131,7 +131,7 @@ func (s *updatePublicCloudsSuite) TestNoNewData(c *gc.C) {
 	defer ts.Close()
 
 	msg := s.run(c, ts.URL, "")
-	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...Your list of public clouds is up to date, see `juju clouds`.")
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...This client's list of public clouds is up to date, see `juju clouds --local`.")
 }
 
 func (s *updatePublicCloudsSuite) TestFirstRun(c *gc.C) {


### PR DESCRIPTION
## Description of change

Clouds command has been updated to support both local and remote, on the controller, list of clouds.
However, not all wording that guides users to correct usage of the command was updated.

This PR updates the last oversight. I have double checked all other occurrences of references to 'juju clouds' - this is the only place that might benefit form the update.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829929
