### PR TITLE
Raise error when timeout reached while result pending

### DIFF
--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -153,8 +153,12 @@ func timerLoop(api APIClient, requestedId string, wait, tick *time.Timer) (param
 		// Block until a tick happens, or the timeout arrives.
 		select {
 		case _ = <-wait.C:
-			return result, nil
-
+			switch result.Status {
+			case params.ActionRunning, params.ActionPending:
+				return result, errors.NewTimeout(err, "timeout reached")
+			default:
+				return result, nil
+			}
 		case _ = <-tick.C:
 			tick.Reset(2 * time.Second)
 		}

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -80,6 +80,7 @@ func (s *ShowOutputSuite) TestRun(c *gc.C) {
 		withClientQueryID: validActionId,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse:   []params.ActionResult{{}},
+		expectedErr:       "timeout reached",
 		expectedOutput: `
 status: pending
 timing:
@@ -183,6 +184,7 @@ timing:
 			Enqueued: time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
 			Started:  time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 		}},
+		expectedErr: "timeout reached",
 		expectedOutput: `
 results:
   foo:
@@ -207,6 +209,7 @@ timing:
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 		}},
+		expectedErr: "timeout reached",
 		expectedOutput: `
 results:
   foo:
@@ -231,6 +234,7 @@ timing:
 			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
+		expectedErr: "timeout reached",
 		expectedOutput: `
 results:
   foo:


### PR DESCRIPTION
When users currently run juju show-action-output with the --wait option enabled, and that deadline is reached without output, Juju does not indicate that an error has occurred.

## QA steps

Bootstrap

    $ juju bootstrap localhost testing

Deploy the `postgresql` charm, as it contains several actions.

    $ juju deploy postgresql pg

Run an action that reaches a timeout and try to view output with `show-action-output`.

    $ juju show-action-output --wait 1 $(juju run-action pg/0 wal-e-backup | cut -d' ' -f5)
    ERROR timeout reached
 

## Documentation changes

None. This change should make Juju match the current behaviour.

## Bug reference

* [lp:1827251](https://bugs.launchpad.net/juju/+bug/1827251)