### PR TITLE
Filter firewalls more aggressively

### DIFF
--- a/provider/gce/google/export_test.go
+++ b/provider/gce/google/export_test.go
@@ -18,6 +18,7 @@ var (
 	FirewallSpec        = firewallSpec
 	ExtractAddresses    = extractAddresses
 	NewRuleSetFromRules = newRuleSetFromRules
+	MatchesPrefix       = matchesPrefix
 )
 
 func SetRawConn(conn *Connection, raw rawConnectionWrapper) {

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -116,6 +116,10 @@ func (rc *rawConn) RemoveInstance(projectID, zone, id string) error {
 	return errors.Trace(err)
 }
 
+func matchesPrefix(firewallName, namePrefix string) bool {
+	return firewallName == namePrefix || strings.HasPrefix(firewallName, namePrefix+"-")
+}
+
 func (rc *rawConn) GetFirewalls(projectID, namePrefix string) ([]*compute.Firewall, error) {
 	call := rc.Firewalls.List(projectID)
 	firewallList, err := call.Do()
@@ -128,7 +132,7 @@ func (rc *rawConn) GetFirewalls(projectID, namePrefix string) ([]*compute.Firewa
 	}
 	var result []*compute.Firewall
 	for _, fw := range firewallList.Items {
-		if strings.HasPrefix(fw.Name, namePrefix) {
+		if matchesPrefix(fw.Name, namePrefix) {
 			result = append(result, fw)
 		}
 	}

--- a/provider/gce/google/raw_test.go
+++ b/provider/gce/google/raw_test.go
@@ -149,3 +149,22 @@ func (s *rawConnSuite) TestConnectionWaitOperationError(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `.* "testing-wait-operation-error" .*`)
 	c.Check(s.callCount, gc.Equals, 1)
 }
+
+type firewallNameSuite struct{}
+
+var _ = gc.Suite(&firewallNameSuite{})
+
+func (s *firewallNameSuite) TestSimplePattern(c *gc.C) {
+	res := MatchesPrefix("juju-3-123", "juju-3")
+	c.Assert(res, gc.Equals, true)
+}
+
+func (s *firewallNameSuite) TestExactMatch(c *gc.C) {
+	res := MatchesPrefix("juju-3", "juju-3")
+	c.Assert(res, gc.Equals, true)
+}
+
+func (s *firewallNameSuite) TestThatJujuMachineIDsDoNotCollide(c *gc.C) {
+	res := MatchesPrefix("juju-30-123", "juju-3")
+	c.Assert(res, gc.Equals, false)
+}


### PR DESCRIPTION
Our firewaller currently gets confused if we have several instances running. We match firewall rules by a prefix, but that prefix test treats `juju-eg-2` and `juju-eg-20`.  

## QA steps

* Bootstrap to GCE
* `juju deploy -n20 ubuntu` 
* `juju run --unit ubuntu/20 -- open-port 100-200/tcp`
* `juju status` should report that the ports are now open

## Documentation changes

None. 

## Bug reference

* [lp:1829750](https://bugs.launchpad.net/juju/+bug/1829750)
