### PR TITLE
Remove package level logger for provisioner and pass one in.

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -876,6 +876,7 @@ func (a *MachineAgent) updateSupportedContainers(
 	}
 	params := provisioner.ContainerSetupParams{
 		Runner:              runner,
+		Logger:              loggo.GetLogger("juju.container-setup"),
 		WorkerName:          watcherName,
 		SupportedContainers: containers,
 		Machine:             machine,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -336,9 +336,11 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// All the rest depend on ifNotMigrating.
 		computeProvisionerName: ifNotMigrating(ifCredentialValid(provisioner.Manifold(provisioner.ManifoldConfig{
-			AgentName:                    agentName,
-			APICallerName:                apiCallerName,
-			EnvironName:                  environTrackerName,
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			Logger:        loggo.GetLogger("juju.worker.provisioner"),
+
 			NewProvisionerFunc:           provisioner.NewEnvironProvisioner,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		}))),

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/pkg/errors"
@@ -153,6 +154,7 @@ func (s *containerSetupSuite) setUpContainerWorker(c *gc.C) (watcher.StringsHand
 
 	args := provisioner.ContainerSetupParams{
 		Runner:              runner,
+		Logger:              loggo.GetLogger("test"),
 		WorkerName:          watcherName,
 		SupportedContainers: instance.ContainerTypes,
 		Machine:             s.machine,

--- a/worker/provisioner/containerprovisioner_test.go
+++ b/worker/provisioner/containerprovisioner_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	gc "gopkg.in/check.v1"
@@ -106,7 +107,9 @@ func (s *kvmProvisionerSuite) newKvmProvisioner(c *gc.C) provisioner.Provisioner
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
 	toolsFinder := (*provisioner.GetToolsFinder)(s.provisioner)
-	w, err := provisioner.NewContainerProvisioner(instance.KVM, s.provisioner, agentConfig, broker,
+	w, err := provisioner.NewContainerProvisioner(
+		instance.KVM, s.provisioner, loggo.GetLogger("test"),
+		agentConfig, broker,
 		toolsFinder, &mockDistributionGroupFinder{}, &credentialAPIForTest{})
 	c.Assert(err, jc.ErrorIsNil)
 	return w

--- a/worker/provisioner/logging.go
+++ b/worker/provisioner/logging.go
@@ -14,7 +14,7 @@ import (
 // stack of the error to be printed out at error severity if and only if the
 // "log-error-stack" feature flag has been specified.  The passed in error
 // is also the return value of this function.
-func loggedErrorStack(err error) error {
+func loggedErrorStack(logger Logger, err error) error {
 	if featureflag.Enabled(feature.LogErrorStack) {
 		logger.Errorf("error stack:\n%s", errors.ErrorStack(err))
 	}

--- a/worker/provisioner/logging_test.go
+++ b/worker/provisioner/logging_test.go
@@ -6,6 +6,7 @@ package provisioner
 import (
 	"errors"
 
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -17,18 +18,20 @@ import (
 type logSuite struct {
 	testing.LoggingSuite
 	jujutesting.JujuOSEnvSuite
+	logger loggo.Logger
 }
 
 func (l *logSuite) SetUpTest(c *gc.C) {
 	l.LoggingSuite.SetUpTest(c)
 	l.JujuOSEnvSuite.SetUpTest(c)
+	l.logger = loggo.GetLogger("juju.provisioner")
 }
 
 var _ = gc.Suite(&logSuite{})
 
-func (*logSuite) TestFlagNotSet(c *gc.C) {
+func (s *logSuite) TestFlagNotSet(c *gc.C) {
 	err := errors.New("test error")
-	err2 := loggedErrorStack(err)
+	err2 := loggedErrorStack(s.logger, err)
 	c.Assert(err, gc.Equals, err2)
 	c.Assert(c.GetTestLog(), gc.Equals, "")
 }
@@ -36,7 +39,7 @@ func (*logSuite) TestFlagNotSet(c *gc.C) {
 func (s *logSuite) TestFlagSet(c *gc.C) {
 	s.SetFeatureFlags(feature.LogErrorStack)
 	err := errors.New("test error")
-	err2 := loggedErrorStack(err)
+	err2 := loggedErrorStack(s.logger, err)
 	c.Assert(err, gc.Equals, err2)
 	expected := "ERROR juju.provisioner error stack:\ntest error"
 	c.Assert(c.GetTestLog(), jc.Contains, expected)

--- a/worker/provisioner/manifold.go
+++ b/worker/provisioner/manifold.go
@@ -15,6 +15,15 @@ import (
 	"github.com/juju/juju/worker/common"
 )
 
+// Logger defines the logging methods that the worker uses.
+type Logger interface {
+	Tracef(string, ...interface{})
+	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
+	Warningf(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
 // ManifoldConfig defines an environment provisioner's dependencies. It's not
 // currently clear whether it'll be easier to extend this type to include all
 // provisioners, or to create separate (Environ|Container)Manifold[Config]s;
@@ -24,8 +33,9 @@ type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
 	EnvironName   string
+	Logger        Logger
 
-	NewProvisionerFunc           func(*apiprovisioner.State, agent.Config, environs.Environ, common.CredentialAPI) (Provisioner, error)
+	NewProvisionerFunc           func(*apiprovisioner.State, agent.Config, Logger, environs.Environ, common.CredentialAPI) (Provisioner, error)
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
 }
 
@@ -62,7 +72,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			w, err := config.NewProvisionerFunc(api, agentConfig, environ, credentialAPI)
+			w, err := config.NewProvisionerFunc(api, agentConfig, config.Logger, environ, credentialAPI)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/worker/provisioner/manifold_test.go
+++ b/worker/provisioner/manifold_test.go
@@ -5,6 +5,7 @@ package provisioner_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -29,10 +30,11 @@ var _ = gc.Suite(&ManifoldSuite{})
 
 func (s *ManifoldSuite) makeManifold() dependency.Manifold {
 	fakeNewProvFunc := func(
-		apiSt *apiprovisioner.State,
-		agentConf agent.Config,
-		environ environs.Environ,
-		credentialAPI common.CredentialAPI,
+		*apiprovisioner.State,
+		agent.Config,
+		provisioner.Logger,
+		environs.Environ,
+		common.CredentialAPI,
 	) (provisioner.Provisioner, error) {
 		s.stub.AddCall("NewProvisionerFunc")
 		return struct{ provisioner.Provisioner }{}, nil
@@ -40,6 +42,7 @@ func (s *ManifoldSuite) makeManifold() dependency.Manifold {
 	return provisioner.Manifold(provisioner.ManifoldConfig{
 		AgentName:                    "agent",
 		APICallerName:                "api-caller",
+		Logger:                       loggo.GetLogger("test"),
 		EnvironName:                  "environ",
 		NewProvisionerFunc:           fakeNewProvFunc,
 		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) { return nil, nil },

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
@@ -410,6 +411,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithRetry(
 	w, err := provisioner.NewProvisionerTask(
 		coretesting.ControllerTag.Id(),
 		names.NewMachineTag("0"),
+		loggo.GetLogger("test"),
 		harvestingMethod,
 		s.machineGetter,
 		distributionGroupFinder,
@@ -432,6 +434,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithBroker(
 	task, err := provisioner.NewProvisionerTask(
 		coretesting.ControllerTag.Id(),
 		names.NewMachineTag("0"),
+		loggo.GetLogger("test"),
 		config.HarvestAll,
 		s.machineGetter,
 		&mockDistributionGroupFinder{groups: distributionGroups},

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -468,7 +469,7 @@ func (s *CommonProvisionerSuite) newEnvironProvisioner(c *gc.C) provisioner.Prov
 	machineTag := names.NewMachineTag("0")
 	agentConfig := s.AgentConfigForTag(c, machineTag)
 	apiState := apiprovisioner.NewState(s.st)
-	w, err := provisioner.NewEnvironProvisioner(apiState, agentConfig, s.Environ, &credentialAPIForTest{})
+	w, err := provisioner.NewEnvironProvisioner(apiState, agentConfig, loggo.GetLogger("test"), s.Environ, &credentialAPIForTest{})
 	c.Assert(err, jc.ErrorIsNil)
 	return w
 }
@@ -990,7 +991,7 @@ func (s *MachineClassifySuite) TestMachineClassification(c *gc.C) {
 
 		c.Logf("%s: %s", id, t.description)
 		machine := MockMachine{t.life, t.status, id, s2e(t.idErr), s2e(t.ensureDeadErr), s2e(t.statusErr)}
-		classification, err := provisioner.ClassifyMachine(&machine)
+		classification, err := provisioner.ClassifyMachine(loggo.GetLogger("test"), &machine)
 		if err != nil {
 			c.Assert(err, gc.ErrorMatches, fmt.Sprintf(t.expectErrFmt, machine.Id()))
 		} else {
@@ -1360,6 +1361,7 @@ func (s *ProvisionerSuite) newProvisionerTaskWithRetryStrategy(
 	w, err := provisioner.NewProvisionerTask(
 		s.ControllerConfig.ControllerUUID(),
 		names.NewMachineTag("0"),
+		loggo.GetLogger("test"),
 		harvestingMethod,
 		machineGetter,
 		distributionGroupFinder,


### PR DESCRIPTION
A precursor to work to have workers run in controllers on behalf of other models go into the model logs. To do this, we need to remove the package level loggers.

Doing the provisioner first as it is one of the most asked for informational pieces for models.

There is currently no change in behaviour (apart from the removal of one call site because I couldn't thread the logger through easily).
