### PR TITLE
Add index for the mongo metrics collection

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -177,7 +177,12 @@ func allCollections() CollectionSchema {
 
 		// This collection holds workload metrics reported by certain charms
 		// for passing onward to other tools.
-		metricsC: {global: true},
+		metricsC: {
+			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "sent"},
+			}},
+		},
 
 		// This collection holds persistent state for the metrics manager.
 		metricsManagerC: {global: true},


### PR DESCRIPTION
## Description of change

This PR adds an index to the mongo metrics collection to speed up queries (see attached bug report)

## QA steps

``` console 
# Create OR upgrade a controller
$ juju bootstrap lxd test --no-gui

# Run the following queries against mongo db 
# (e.g using https://discourse.jujucharms.com/t/login-into-mongodb/309)

$ juju:PRIMARY> db.metrics.explain().find( { sent: false, "model-uuid": "<uuid>" } ).count()
...
"winningPlan" : {
  "stage" : "COUNT",
    "inputStage" : {
    "stage" : "COUNT_SCAN",
    "keyPattern" : {
      "model-uuid" : 1,
      "sent" : 1
    },
    "indexName" : "model-uuid_1_sent_1",
...


$ juju:PRIMARY> db.metrics.explain().find( { sent: false, "model-uuid": "<uuid>" } )
...
"winningPlan" : {
  "stage" : "FETCH",
  "inputStage" : {
    "stage" : "IXSCAN",
    "keyPattern" : {
      "model-uuid" : 1,
      "sent" : 1
    },
    "indexName" : "model-uuid_1_sent_1",
...
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829086