### PR TITLE
Invalidate credentials when access has not been configured 

### DIFF
--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -153,8 +153,12 @@ func timerLoop(api APIClient, requestedId string, wait, tick *time.Timer) (param
 		// Block until a tick happens, or the timeout arrives.
 		select {
 		case _ = <-wait.C:
-			return result, nil
-
+			switch result.Status {
+			case params.ActionRunning, params.ActionPending:
+				return result, errors.NewTimeout(err, "timeout reached")
+			default:
+				return result, nil
+			}
 		case _ = <-tick.C:
 			tick.Reset(2 * time.Second)
 		}

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -80,6 +80,7 @@ func (s *ShowOutputSuite) TestRun(c *gc.C) {
 		withClientQueryID: validActionId,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse:   []params.ActionResult{{}},
+		expectedErr:       "timeout reached",
 		expectedOutput: `
 status: pending
 timing:
@@ -183,6 +184,7 @@ timing:
 			Enqueued: time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
 			Started:  time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 		}},
+		expectedErr: "timeout reached",
 		expectedOutput: `
 results:
   foo:
@@ -207,6 +209,7 @@ timing:
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 		}},
+		expectedErr: "timeout reached",
 		expectedOutput: `
 results:
   foo:
@@ -231,6 +234,7 @@ timing:
 			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
+		expectedErr: "timeout reached",
 		expectedOutput: `
 results:
   foo:


### PR DESCRIPTION
## Description of change

When the Compute Engine API  has not been enabled in the GCE console, Google returns a non-standard HTTP 403 error. This custom error confuses our logic for detecting invalid credentials. This commit fixes that.

This is a backport of #10200 into 2.5.

## QA steps

First, open GCE's console. Navigate to "IAM & admin" > "Create service account". Create a role that has "Compute Engine Admin" access. Download the key as a JSON key file.

Now run `juju add-credential google`, pointing to the downloaded JSON key file.

```
$ juju bootstrap --credential=borked google

ERROR googleapi: Error 403: Access Not Configured. Compute Engine API has not been used in project 657072961473 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=657072961473 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
```

## Documentation changes

None.

## Bug reference

* [lp#1829388](https://bugs.launchpad.net/juju/+bug/1829388)


