### PR TITLE
Fix dupe k8s model detection

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -529,6 +529,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 			cloudSpec,
 			args,
 			cloudTag,
+			cloudRegionName,
 			cloudCredentialTag,
 			ownerTag)
 	} else {
@@ -550,6 +551,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 func (m *ModelManagerAPI) newCAASModel(cloudSpec environs.CloudSpec,
 	createArgs params.ModelCreateArgs,
 	cloudTag names.CloudTag,
+	cloudRegionName string,
 	cloudCredentialTag names.CloudCredentialTag,
 	ownerTag names.UserTag,
 ) (common.Model, error) {
@@ -592,6 +594,7 @@ Please choose a different model name.
 	model, st, err := m.state.NewModel(state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               cloudTag.Id(),
+		CloudRegion:             cloudRegionName,
 		CloudCredential:         cloudCredentialTag,
 		Config:                  newConfig,
 		Owner:                   ownerTag,

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -196,7 +196,7 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 func (s *ApplicationSuite) TestCAASSetCharm(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "caas-model",
-		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+		Type: state.ModelTypeCAAS,
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
@@ -221,7 +221,7 @@ func (s *ApplicationSuite) TestCAASSetCharm(c *gc.C) {
 func (s *ApplicationSuite) TestCAASSetCharmNewDeploymentFails(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "caas-model",
-		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+		Type: state.ModelTypeCAAS,
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
@@ -2090,7 +2090,7 @@ func (s *ApplicationSuite) TestAddUnitWhenNotAlive(c *gc.C) {
 func (s *ApplicationSuite) TestAddCAASUnit(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "caas-model",
-		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+		Type: state.ModelTypeCAAS,
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
@@ -2139,7 +2139,7 @@ func (s *ApplicationSuite) TestAddCAASUnit(c *gc.C) {
 func (s *ApplicationSuite) TestAgentTools(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "caas-model",
-		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+		Type: state.ModelTypeCAAS,
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
@@ -3929,7 +3929,7 @@ func (s *CAASApplicationSuite) TestWatchScale(c *gc.C) {
 func (s *CAASApplicationSuite) TestRewriteStatusHistory(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "caas-model",
-		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+		Type: state.ModelTypeCAAS,
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
@@ -4032,7 +4032,7 @@ func (s *ApplicationSuite) TestSetOperatorStatusNonCAAS(c *gc.C) {
 func (s *ApplicationSuite) TestSetOperatorStatus(c *gc.C) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "caas-model",
-		Type: state.ModelTypeCAAS, CloudRegion: "<none>",
+		Type: state.ModelTypeCAAS,
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -157,9 +157,9 @@ func (s *CAASModelSuite) TestDestroyModelDestroyStorage(c *gc.C) {
 	c.Assert(fs, gc.HasLen, 0)
 }
 
-func (s *CAASModelSuite) TestCAASModelsCantHaveCloudRegion(c *gc.C) {
+func (s *CAASModelSuite) TestCAASModelWrongCloudRegion(c *gc.C) {
 	cfg, _ := s.createTestModelConfig(c)
-	_, st, err := s.Controller.NewModel(state.ModelArgs{
+	_, _, err := s.Controller.NewModel(state.ModelArgs{
 		Type:                    state.ModelTypeCAAS,
 		CloudName:               "dummy",
 		CloudRegion:             "fork",
@@ -167,8 +167,7 @@ func (s *CAASModelSuite) TestCAASModelsCantHaveCloudRegion(c *gc.C) {
 		Owner:                   names.NewUserTag("test@remote"),
 		StorageProviderRegistry: provider.CommonStorageProviders(),
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	defer st.Close()
+	c.Assert(err, gc.ErrorMatches, `region "fork" not found \(expected one of \["dotty.region" "dummy-region" "nether-region" "unused-region"\]\)`)
 }
 
 func (s *CAASModelSuite) TestDestroyControllerAndHostedCAASModels(c *gc.C) {

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -292,6 +292,7 @@ func (s *CloudSuite) TestRemoveInUseCloudNotAllowed(c *gc.C) {
 
 	otherSt := s.Factory.MakeCAASModel(c, &factory.ModelParams{
 		CloudName:       lowCloud.Name,
+		CloudRegion:     "region1",
 		CloudCredential: credTag,
 		Owner:           otherModelOwner.UserTag,
 		ConfigAttrs: testing.Attrs{
@@ -318,6 +319,7 @@ func (s *CloudSuite) TestRemoveCloudNewModelRace(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State, func() {
 		otherSt := s.Factory.MakeCAASModel(c, &factory.ModelParams{
 			CloudName:       lowCloud.Name,
+			CloudRegion:     "region1",
 			CloudCredential: credTag,
 			Owner:           otherModelOwner.UserTag,
 			ConfigAttrs: testing.Attrs{

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -371,10 +371,6 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 	}
 	// Some values require marshalling before storage.
 	modelCfg = config.CoerceForStorage(modelCfg)
-	qualifier := args.Owner.Id()
-	if args.Type == ModelTypeCAAS {
-		qualifier = args.CloudName
-	}
 	ops = append(ops,
 		createSettingsOp(settingsC, modelGlobalKey, modelCfg),
 		createModelEntityRefsOp(modelUUID),
@@ -387,7 +383,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 			args.MigrationMode,
 			args.EnvironVersion,
 		),
-		createUniqueOwnerModelNameOp(qualifier, args.Config.Name()),
+		createUniqueOwnerModelNameOp(args.Owner, args.Config.Name()),
 	)
 	ops = append(ops, modelUserOps...)
 	return ops, modelStatusDoc, nil

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -524,9 +524,6 @@ func (s *ModelUserSuite) newModelWithOwner(c *gc.C, owner names.UserTag) *state.
 
 func (s *ModelUserSuite) newModelWithUser(c *gc.C, user names.UserTag, modelType state.ModelType) *state.Model {
 	params := &factory.ModelParams{Type: modelType}
-	if modelType == state.ModelTypeCAAS {
-		params.CloudRegion = "<none>"
-	}
 	st := s.Factory.MakeModel(c, params)
 	defer st.Close()
 	newModel, err := st.Model()

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2109,3 +2109,53 @@ func RemoveInstanceCharmProfileDataCollection(pool *StatePool) error {
 	}
 	return nil
 }
+
+// UpdateK8sModelNameIndex migrates k8s model indices to be based
+// on the model owner rather than the cloud name.
+func UpdateK8sModelNameIndex(pool *StatePool) error {
+	st := pool.SystemState()
+
+	models, closer := st.db().GetCollection(modelsC)
+	defer closer()
+	usermodelNames, closer2 := st.db().GetCollection(usermodelnameC)
+	defer closer2()
+
+	var ops []txn.Op
+	var docs []bson.M
+	err := models.Find(bson.D{{"type", ModelTypeCAAS}}).Select(bson.M{"cloud": 1, "name": 1, "owner": 1}).All(&docs)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, m := range docs {
+		owner := m["owner"].(string)
+		name := m["name"].(string)
+		cloudName := m["cloud"].(string)
+		oldId := userModelNameIndex(cloudName, name)
+		expectedId := userModelNameIndex(owner, name)
+
+		n, err := usermodelNames.FindId(expectedId).Count()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if n > 0 {
+			continue
+		}
+
+		ops = append(ops, []txn.Op{{
+			C:      usermodelnameC,
+			Id:     oldId,
+			Assert: txn.DocExists,
+			Remove: true,
+		}, {
+			C:      usermodelnameC,
+			Id:     expectedId,
+			Assert: txn.DocMissing,
+			Insert: bson.M{},
+		}}...)
+	}
+	if len(ops) > 0 {
+		return errors.Trace(st.runRawTransaction(ops))
+	}
+	return nil
+}

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -720,7 +720,7 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 	if params.CloudName == "" {
 		params.CloudName = "dummy"
 	}
-	if params.CloudRegion == "" {
+	if params.CloudRegion == "" && params.CloudName == "dummy" {
 		params.CloudRegion = "dummy-region"
 	}
 	if params.CloudRegion == "<none>" {
@@ -774,7 +774,6 @@ func (factory *Factory) MakeCAASModel(c *gc.C, params *ModelParams) *state.State
 		params = &ModelParams{}
 	}
 	params.Type = state.ModelTypeCAAS
-	params.CloudRegion = "<none>"
 	if params.Owner == nil {
 		origEnv, err := factory.st.Model()
 		c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -63,6 +63,7 @@ type StateBackend interface {
 	EnsureDefaultModificationStatus() error
 	EnsureApplicationDeviceConstraints() error
 	RemoveInstanceCharmProfileDataCollection() error
+	UpdateK8sModelNameIndex() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -243,4 +244,8 @@ func (s stateBackend) EnsureApplicationDeviceConstraints() error {
 
 func (s stateBackend) RemoveInstanceCharmProfileDataCollection() error {
 	return state.RemoveInstanceCharmProfileDataCollection(s.pool)
+}
+
+func (s stateBackend) UpdateK8sModelNameIndex() error {
+	return state.UpdateK8sModelNameIndex(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -36,6 +36,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.5.3"), stateStepsFor253()},
 		upgradeToVersion{version.MustParse("2.5.4"), stateStepsFor254()},
 		upgradeToVersion{version.MustParse("2.6.0"), stateStepsFor26()},
+		upgradeToVersion{version.MustParse("2.6.3"), stateStepsFor263()},
 	}
 	return steps
 }

--- a/upgrades/steps_263.go
+++ b/upgrades/steps_263.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/juju/api/upgradesteps"
 )
 
-// stateStepsFor263 returns upgrade steps for Juju 2.6.3.
+// stepsFor263 returns upgrade steps for Juju 2.6.3.
 func stepsFor263() []Step {
 	return []Step{
 		&upgradeStep{
@@ -29,4 +29,17 @@ func resetKVMMachineModificationStatusIdle(context Context) error {
 	}
 	client := upgradesteps.NewClient(context.APIState())
 	return client.ResetKVMMachineModificationStatusIdle(tag)
+}
+
+// stateStepsFor263 returns upgrade steps for Juju 2.6.3.
+func stateStepsFor263() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "update model name index of k8s models",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().UpdateK8sModelNameIndex()
+			},
+		},
+	}
 }

--- a/upgrades/steps_263_test.go
+++ b/upgrades/steps_263_test.go
@@ -24,3 +24,9 @@ func (s *steps263Suite) TestResetKVMMachineModificationStatusIdle(c *gc.C) {
 	step := findStep(c, v263, "reset kvm machine modification status to idle")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.AllMachines})
 }
+
+func (s *steps263Suite) TestUpdateK8sModelNameIndex(c *gc.C) {
+	step := findStateStep(c, v263, `update model name index of k8s models`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -653,6 +653,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.5.3",
 		"2.5.4",
 		"2.6.0",
+		"2.6.3",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Duplicate model detection for k8s models used to include the cloud name as well as the owner in the selection criteria. This was wrong as it allowed 2 models of the same name in state model.

There was no unit test for the functionality that was removed that used a different cloud name- there's an existing unit test for the standard dupe case.

## QA steps

Add a k8s model with the same name to different clouds and get an error.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1768857
