### PR TITLE
Show effect of credential validity in model status.

### DIFF
--- a/core/status/status.go
+++ b/core/status/status.go
@@ -332,6 +332,7 @@ func ValidModelStatus(status Status) bool {
 		Available,
 		Busy,
 		Destroying,
+		Suspended, // For  model, this means that its cloud credential is invalid and model will not be doing any cloud calls.
 		Error:
 		return true
 	default:

--- a/core/status/status_test.go
+++ b/core/status/status_test.go
@@ -3,6 +3,7 @@
 package status_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/status"
@@ -47,5 +48,53 @@ func (s *StatusSuite) TestModification(c *gc.C) {
 	for k, v := range testcases {
 		c.Logf("Testing modification status %d %s", k, v.name)
 		c.Assert(v.status.KnownModificationStatus(), gc.Equals, v.valid)
+	}
+}
+
+func (s *StatusSuite) TestValidModelStatus(c *gc.C) {
+	for _, v := range []status.Status{
+		status.Available,
+		status.Busy,
+		status.Destroying,
+		status.Error,
+		status.Suspended,
+	} {
+		c.Assert(status.ValidModelStatus(v), jc.IsTrue, gc.Commentf("status %q is not valid for a model", v))
+	}
+}
+
+func (s *StatusSuite) TestInvalidModelStatus(c *gc.C) {
+	for _, v := range []status.Status{
+		status.Active,
+		status.Allocating,
+		status.Applied,
+		status.Attached,
+		status.Attaching,
+		status.Blocked,
+		status.Broken,
+		status.Detached,
+		status.Detaching,
+		status.Down,
+		status.Empty,
+		status.Executing,
+		status.Failed,
+		status.Idle,
+		status.Joined,
+		status.Joining,
+		status.Lost,
+		status.Maintenance,
+		status.Pending,
+		status.Provisioning,
+		status.ProvisioningError,
+		status.Rebooting,
+		status.Running,
+		status.Suspending,
+		status.Started,
+		status.Stopped,
+		status.Terminated,
+		status.Unknown,
+		status.Waiting,
+	} {
+		c.Assert(status.ValidModelStatus(v), jc.IsFalse, gc.Commentf("status %q is valid for a model", v))
 	}
 }

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -13,8 +13,10 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type CloudCredentialsSuite struct {
@@ -110,6 +112,114 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 	expected.Revoked = true
 
 	c.Assert(out, jc.DeepEquals, expected)
+}
+
+func assertCredentialCreated(c *gc.C, testSuite ConnSuite) (string, *state.User, names.CloudCredentialTag) {
+	owner := testSuite.Factory.MakeUser(c, &factory.UserParams{
+		Password: "secret",
+		Name:     "bob",
+	})
+
+	cloudName := "stratus"
+	err := testSuite.State.AddCloud(cloud.Cloud{
+		Name:      cloudName,
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+		Regions:   []cloud.Region{{Name: "dummy-region", Endpoint: "endpoint"}},
+	}, owner.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	tag := names.NewCloudCredentialTag(fmt.Sprintf("%v/%v/foobar", cloudName, owner.Name()))
+	// 1.
+	err = testSuite.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	return cloudName, owner, tag
+}
+
+func assertModelCreated(c *gc.C, testSuite ConnSuite, cloudName string, credentialTag names.CloudCredentialTag, owner names.Tag, modelName string) string {
+	// Test model needs to be on the test cloud for all validation to pass.
+	modelState := testSuite.Factory.MakeModel(c, &factory.ModelParams{
+		Name:            modelName,
+		CloudCredential: credentialTag,
+		Owner:           owner,
+		CloudName:       cloudName,
+	})
+	defer modelState.Close()
+	testModel, err := modelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	assertModelStatus(c, testSuite.StatePool, testModel.UUID(), status.Available)
+	return testModel.UUID()
+}
+
+func assertModelSuspended(c *gc.C, testSuite ConnSuite) (names.CloudCredentialTag, string) {
+	// 1. Create a credential
+	cloudName, credentialOwner, credentialTag := assertCredentialCreated(c, testSuite)
+
+	// 2. Create model on the test cloud with test credential
+	modelUUID := assertModelCreated(c, testSuite, cloudName, credentialTag, credentialOwner.Tag(), "model-for-cloud")
+
+	// 3. update credential to be invalid and check model is suspended
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	cred.Invalid = true
+	cred.InvalidReason = "because it is really really invalid"
+	err := testSuite.State.UpdateCloudCredential(credentialTag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	assertModelStatus(c, testSuite.StatePool, modelUUID, status.Suspended)
+
+	return credentialTag, modelUUID
+}
+
+func assertModelStatus(c *gc.C, pool *state.StatePool, testModelUUID string, expectedStatus status.Status) {
+	aModel, helper, err := pool.GetModel(testModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	defer helper.Release()
+	modelStatus, err := aModel.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(modelStatus.Status, gc.DeepEquals, expectedStatus)
+}
+
+func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsTouchesCredentialModels(c *gc.C) {
+	// This test checks that models are affected when their credential validity is changed...
+	// 1. create a credential
+	// 2. set a model to use it
+	// 3. update credential to be invalid and check model is suspended
+	// 4. update credential bar its validity, check no changes in model state
+	// 5. mark credential as valid and check that model is unsuspended
+
+	// 1.2.3.
+	tag, testModelUUID := assertModelSuspended(c, s.ConnSuite)
+
+	// 4.
+	storedCred, err := s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storedCred.IsValid(), jc.IsFalse)
+
+	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		"user":     "bob's nephew",
+		"password": "simple",
+	})
+	cred.Revoked = true
+	// all other credential attributes remain unchanged
+	cred.Invalid = storedCred.Invalid
+	cred.InvalidReason = storedCred.InvalidReason
+
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	assertModelStatus(c, s.StatePool, testModelUUID, status.Suspended)
+
+	// 5.
+	cred.Invalid = !storedCred.Invalid
+	cred.InvalidReason = ""
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	assertModelStatus(c, s.StatePool, testModelUUID, status.Available)
 }
 
 func (s *CloudCredentialsSuite) assertCredentialInvalidated(c *gc.C, tag names.CloudCredentialTag) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -874,6 +874,26 @@ func NewInstanceCharmProfileDataCompatibilityWatcher(backend ModelBackendShim, m
 	return watchInstanceCharmProfileCompatibilityData(backend, memberId)
 }
 
+func EraseModelStatusHistory(c *gc.C, st *State, uuid string) error {
+	newSt, err := st.newStateNoWorkers(uuid)
+	// We explicitly don't start the workers.
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+		// This model could have been removed.
+		return nil
+	}
+	defer newSt.Close()
+
+	aModel, err := newSt.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return eraseStatusHistory(st, aModel.globalKey())
+}
+
 // ModelBackendShim is required to live here in the export_test.go file because
 // there is issues placing this in the test files themselves. The strangeness
 // exhibits itself from the fact that `clock() clock.Clock` doesn't type


### PR DESCRIPTION
## Description of change

Occasionally, cloud credentials used by the model become invalid.
This PR allows user to find out that this happened via 'juju models' or 'juju status'.
We now will tell the user that a model is suspended due to the credential being invalid. Once credential becomes valid again, the model status is reverted to whatever it was beforehand.

Model credential can become valid again if it is either updated with a new content or  a different, new credential is set for the model. 

If we cannot figure out what model status was prior to the model being suspended (for example, if status history for the model has been pruned), we will set model to 'available'.


## QA steps
1. bootstrap
2. add a model with a different credential
[at this stage, juju output would look similar to this]

```
$ juju models
Controller: mycontroller

Model       Cloud/Region   Type  Status     Machines  Cores  Access  Last connection
controller  aws/us-east-1  ec2   available         1      4  admin   just now
default     aws/us-east-1  ec2   available         0      -  admin   12 minutes ago
trial*      aws/us-east-1  ec2   available         0      -  admin   never connected

$ juju status
Model  Controller    Cloud/Region   Version  SLA          Timestamp
trial  mycontroller  aws/us-east-1  2.6.3.1  unsupported  17:01:53+10:00

Model "admin/trial" is empty.
```
3. disable second credential and try to deploy something on the model
[at this stage, juju output will change to something like this]

```
$ juju models
Controller: mycontroller

Model       Cloud/Region   Type  Status     Machines  Cores  Access  Last connection
controller  aws/us-east-1  ec2   available         1      4  admin   just now
default     aws/us-east-1  ec2   available         0      -  admin   6 minutes ago
trial*      aws/us-east-1  ec2   suspended         0      -  admin   8 seconds ago

$ juju status
Model  Controller    Cloud/Region   Version  SLA          Timestamp       Notes
trial  mycontroller  aws/us-east-1  2.6.3.1  unsupported  17:00:31+10:00  suspended since cloud credential is not valid

Model "admin/trial" is empty.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1822117
