### PR TITLE
Backport "allow manual provider precheck to complete with empty placement" to 2.5

### DIFF
--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -315,7 +315,21 @@ exit 0
 	return err
 }
 
-func (*manualEnviron) PrecheckInstance(context.ProviderCallContext, environs.PrecheckInstanceParams) error {
+func (e *manualEnviron) PrecheckInstance(ctx context.ProviderCallContext, params environs.PrecheckInstanceParams) error {
+	validator, err := e.ConstraintsValidator(ctx)
+	if err != nil {
+		return err
+	}
+
+	if _, err = validator.Validate(params.Constraints); err != nil {
+		return err
+	}
+
+	// Fix for #1829559
+	if params.Placement == "" {
+		return nil
+	}
+
 	return errors.New(`use "juju add-machine ssh:[user@]<host>" to provision machines`)
 }
 


### PR DESCRIPTION
## Description of change

This PR backports the fix from #10209 to the 2.5.

I have confirmed that 2.5.8 exhibits the same problem as described in the bug report 
and applying this patch allows the deployments to the manual cloud to continue.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829559