### PR TITLE
Add a timeout for lease manager stopping

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -883,6 +883,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			FSM:                  leaseFSM,
 			RequestTopic:         leaseRequestTopic,
 			Logger:               loggo.GetLogger("juju.worker.lease.raft"),
+			LogDir:               agentConfig.LogDir(),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            leasemanager.NewWorker,
 			NewStore:             leasemanager.NewStore,

--- a/state/workers.go
+++ b/state/workers.go
@@ -4,14 +4,17 @@
 package state
 
 import (
+	"path"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/os/series"
 	"github.com/juju/pubsub"
 	"gopkg.in/juju/worker.v1"
 
 	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/state/watcher"
 	jworker "github.com/juju/juju/worker"
@@ -101,6 +104,14 @@ func (st *State) newLeaseManager(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	series, err := series.HostSeries()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logDir, err := paths.LogDir(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	manager, err := lease.NewManager(lease.ManagerConfig{
 		Secretary: func(_ string) (lease.Secretary, error) {
 			return secretary, nil
@@ -110,6 +121,7 @@ func (st *State) newLeaseManager(
 		Logger:     loggo.GetLogger("juju.worker.lease.mongo"),
 		MaxSleep:   time.Minute,
 		EntityUUID: entityUUID,
+		LogDir:     path.Join(logDir, "juju"),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -63,6 +63,10 @@ type ManagerConfig struct {
 	// logging purposes.
 	EntityUUID string
 
+	// LogDir is the directory to write a debugging log file in the
+	// case that the worker times out waiting to shut down.
+	LogDir string
+
 	PrometheusRegisterer prometheus.Registerer
 }
 

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -191,8 +191,9 @@ func (s *AsyncSuite) TestExpiryInterruptedRetry(c *gc.C) {
 		// Stopping the worker should cancel the retry.
 		c.Assert(worker.Stop(manager), jc.ErrorIsNil)
 
-		// Advance the clock to trigger the next expire retry
-		c.Assert(clock.WaitAdvance(50*time.Millisecond, coretesting.ShortWait, 1), jc.ErrorIsNil)
+		// Advance the clock to trigger the next expire retry (second
+		// expected timer is the shutdown timeout check).
+		c.Assert(clock.WaitAdvance(50*time.Millisecond, coretesting.ShortWait, 2), jc.ErrorIsNil)
 
 		// Allow some wallclock time for a non-cancelled retry to
 		// happen if stopping the worker didn't cancel it. This is not

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -59,6 +59,7 @@ type ManifoldConfig struct {
 	FSM                  *raftlease.FSM
 	RequestTopic         string
 	Logger               lease.Logger
+	LogDir               string
 	PrometheusRegisterer prometheus.Registerer
 	NewWorker            func(lease.ManagerConfig) (worker.Worker, error)
 	NewStore             func(raftlease.StoreConfig) *raftlease.Store
@@ -158,6 +159,7 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 		Logger:               s.config.Logger,
 		MaxSleep:             MaxSleep,
 		EntityUUID:           controllerUUID,
+		LogDir:               s.config.LogDir,
 		PrometheusRegisterer: s.config.PrometheusRegisterer,
 	})
 	if err != nil {


### PR DESCRIPTION
## Description of change

Debugging logs generated when the http-server worker times out shutting down suggest that the lease manager is failing to stop in some cases. Add a timeout to the shutdown so we don't wait indefinitely if a background claim or expire doesn't finish in a timely manner.

Track how many outstanding claims and expires there are in flight and report these in a debug log dumped on timeout, as well as in the introspection report. Include goroutines since (if this is the only thing stopping the httpserver from stopping) the httpserver won't dump them when we timeout here.

The chain from httpserver to lease manager is:
* httpserver is waiting for the mux
* the mux is waiting for api-server to call ClientDone
* the api-server is waiting for a request to finish releasing a state
  back to the pool
* the release is stuck because the state in question is waiting for
  its workers to stop
* the state worker goroutine counts indicate that there's one more
  lease manager than all of the other workers (hub watcher, presence
  watcher, ping batcher)

## QA steps

* Bootstrap a controller.
* Running juju_engine_report shows the outstanding claims and expires for each lease manager.
* I don't have a way to induce the shutdown problem (otherwise I'd just fix it rather than adding more specific debugging), but to check the output of the log I commented out the early return leg of the select in `waitForGoroutines` and upgraded twice. The second time dumped the debug logging.

## Documentation changes
 None

## Bug reference
https://bugs.launchpad.net/bugs/1829635
