### PR TITLE
Pass in logger and logging context to the logger worker.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -584,14 +584,14 @@
   revision = "a0ef8b74ebcffeeff9fc374854deb4af388f037e"
 
 [[projects]]
-  digest = "1:3be464a55a419d4c22383388f1204a9597c6cdc41d67ca4bc08848e688585279"
+  digest = "1:e460f07bec03866640127c47aae303167e9c79ee426c5fab03c180001eb4a39f"
   name = "github.com/juju/loggo"
   packages = [
     ".",
     "loggocolor",
   ]
   pruneopts = ""
-  revision = "8232ab8918d91c72af1a9fb94d3edbe31d88b790"
+  revision = "6e530bcce5d8e1b51b8e5ee7f08a455cd0a8c2e5"
 
 [[projects]]
   digest = "1:8d1ee4a52b3d31b061d381552b5b31aa73f5c8cf96d8ce2322e0715ac47c87f0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -312,7 +312,7 @@
 
 [[constraint]]
   name = "github.com/juju/loggo"
-  revision = "8232ab8918d91c72af1a9fb94d3edbe31d88b790"
+  revision = "6e530bcce5d8e1b51b8e5ee7f08a455cd0a8c2e5"
 
 [[override]]
   name = "github.com/juju/lru"

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -6,6 +6,8 @@ package caasoperator
 import (
 	"time"
 
+	"github.com/juju/loggo"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/utils/voyeur"
@@ -200,6 +202,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
 			AgentName:       agentName,
 			APICallerName:   apiCallerName,
+			LoggingContext:  loggo.DefaultContext(),
+			Logger:          loggo.GetLogger("juju.worker.logger"),
 			UpdateAgentFunc: config.UpdateLoggerConfig,
 		})),
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -566,6 +566,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
 			AgentName:       agentName,
 			APICallerName:   apiCallerName,
+			LoggingContext:  loggo.DefaultContext(),
+			Logger:          loggo.GetLogger("juju.worker.logger"),
 			UpdateAgentFunc: config.UpdateLoggerConfig,
 		})),
 

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -246,6 +246,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
 			AgentName:       agentName,
 			APICallerName:   apiCallerName,
+			LoggingContext:  loggo.DefaultContext(),
+			Logger:          loggo.GetLogger("juju.worker.logger"),
 			UpdateAgentFunc: config.UpdateLoggerConfig,
 		})),
 

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -12,35 +12,56 @@ import (
 	"github.com/juju/juju/core/watcher"
 )
 
-var log = loggo.GetLogger("juju.worker.logger")
-
 // LoggerAPI represents the API calls the logger makes.
 type LoggerAPI interface {
 	LoggingConfig(agentTag names.Tag) (string, error)
 	WatchLoggingConfig(agentTag names.Tag) (watcher.NotifyWatcher, error)
 }
 
-// Logger is responsible for updating the loggo configuration when the
+// WorkerConfig contains the information required for the Logger worker
+// to operate.
+type WorkerConfig struct {
+	Context  *loggo.Context
+	API      LoggerAPI
+	Tag      names.Tag
+	Logger   Logger
+	Override string
+
+	Callback func(string) error
+}
+
+// Validate ensures all the necessary fields have values.
+func (c *WorkerConfig) Validate() error {
+	if c.Context == nil {
+		return errors.NotValidf("missing logging context")
+	}
+	if c.API == nil {
+		return errors.NotValidf("missing api")
+	}
+	if c.Logger == nil {
+		return errors.NotValidf("missing logger")
+	}
+	return nil
+}
+
+// loggerWorker is responsible for updating the loggo configuration when the
 // environment watcher tells the agent that the value has changed.
-type Logger struct {
-	api            LoggerAPI
-	tag            names.Tag
-	updateCallback func(string) error
-	lastConfig     string
-	configOverride string
+type loggerWorker struct {
+	config     WorkerConfig
+	lastConfig string
 }
 
 // NewLogger returns a worker.Worker that uses the notify watcher returned
 // from the setup.
-func NewLogger(api LoggerAPI, tag names.Tag, loggingOverride string, updateCallback func(string) error) (worker.Worker, error) {
-	logger := &Logger{
-		api:            api,
-		tag:            tag,
-		updateCallback: updateCallback,
-		lastConfig:     loggo.LoggerInfo(),
-		configOverride: loggingOverride,
+func NewLogger(config WorkerConfig) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
 	}
-	log.Debugf("initial log config: %q", logger.lastConfig)
+	logger := &loggerWorker{
+		config:     config,
+		lastConfig: config.Context.Config().String(),
+	}
+	config.Logger.Debugf("initial log config: %q", logger.lastConfig)
 
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
 		Handler: logger,
@@ -51,57 +72,65 @@ func NewLogger(api LoggerAPI, tag names.Tag, loggingOverride string, updateCallb
 	return w, nil
 }
 
-func (logger *Logger) setLogging() {
+func (l *loggerWorker) setLogging() {
 	loggingConfig := ""
+	logger := l.config.Logger
 
-	if logger.configOverride != "" {
-		log.Debugf("overriding logging config with override from agent.conf %q", logger.configOverride)
-		loggingConfig = logger.configOverride
+	if override := l.config.Override; override != "" {
+		logger.Debugf("overriding logging config with override from agent.conf %q", override)
+		loggingConfig = override
 	} else {
-		modelLoggingConfig, err := logger.api.LoggingConfig(logger.tag)
+		modelLoggingConfig, err := l.config.API.LoggingConfig(l.config.Tag)
 		if err != nil {
-			log.Errorf("%v", err)
+			logger.Errorf("%v", err)
 			return
 		}
 		loggingConfig = modelLoggingConfig
 	}
 
-	if loggingConfig != logger.lastConfig {
-		log.Debugf("reconfiguring logging from %q to %q", logger.lastConfig, loggingConfig)
-		loggo.DefaultContext().ResetLoggerLevels()
-		if err := loggo.ConfigureLoggers(loggingConfig); err != nil {
+	if loggingConfig != l.lastConfig {
+		logger.Debugf("reconfiguring logging from %q to %q", l.lastConfig, loggingConfig)
+		context := l.config.Context
+		context.ResetLoggerLevels()
+		if err := context.ConfigureLoggers(loggingConfig); err != nil {
 			// This shouldn't occur as the loggingConfig should be
 			// validated by the original Config before it gets here.
-			log.Warningf("configure loggers failed: %v", err)
+			logger.Warningf("configure loggers failed: %v", err)
 			// Try to reset to what we had before
-			loggo.ConfigureLoggers(logger.lastConfig)
+			context.ConfigureLoggers(l.lastConfig)
 			return
 		}
-		logger.lastConfig = loggingConfig
+		l.lastConfig = loggingConfig
 		// Save the logging config in the agent.conf file.
-		if logger.updateCallback != nil {
-			err := logger.updateCallback(loggingConfig)
+		if callback := l.config.Callback; callback != nil {
+			err := callback(loggingConfig)
 			if err != nil {
-				log.Errorf("%v", err)
+				logger.Errorf("%v", err)
 			}
 		}
 	}
 }
 
-func (logger *Logger) SetUp() (watcher.NotifyWatcher, error) {
-	log.Debugf("logger setup")
+// SetUp is called by the NotifyWorker when the worker starts, and it is
+// required to return a notify watcher that is used as the event source
+// for the Handle method.
+func (l *loggerWorker) SetUp() (watcher.NotifyWatcher, error) {
+	l.config.Logger.Infof("logger worker started")
 	// We need to set this up initially as the NotifyWorker sucks up the first
 	// event.
-	logger.setLogging()
-	return logger.api.WatchLoggingConfig(logger.tag)
+	l.setLogging()
+	return l.config.API.WatchLoggingConfig(l.config.Tag)
 }
 
-func (logger *Logger) Handle(_ <-chan struct{}) error {
-	logger.setLogging()
+// Handle is called by the NotifyWorker whenever the notify event is fired.
+func (l *loggerWorker) Handle(_ <-chan struct{}) error {
+	l.setLogging()
 	return nil
 }
 
-func (logger *Logger) TearDown() error {
+// TearDown is called by the NotifyWorker when the worker is being stopped.
+func (l *loggerWorker) TearDown() error {
 	// Nothing to cleanup, only state is the watcher
+	l.config.Logger.Infof("logger worker stopped")
 	return nil
 }


### PR DESCRIPTION
This branch changes the logger worker so the logging context and logger are passed in rather than depending on the package level logger and the default loggo context.

This is needed for the move to logging the workers run by the controller on behalf of a model to the model's log collection rather than the the controller's log collection.

## QA steps

Run a controller, logs still work.

## Documentation changes

No user facing impact.