### PR TITLE
Add useful error message when vSphere datastore not specified

### DIFF
--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -192,7 +192,7 @@ func (env *sessionEnviron) newRawInstance(
 		cons.RootDisk = &minRootDisk
 	}
 	defaultDatastore := env.ecfg.datastore()
-	if cons.RootDiskSource == nil || *cons.RootDiskSource == "" {
+	if (cons.RootDiskSource == nil || *cons.RootDiskSource == "") && defaultDatastore != "" {
 		cons.RootDiskSource = &defaultDatastore
 	}
 


### PR DESCRIPTION
We currently produce a confusing error message when we attempt to bootstrap without including a datastore config option. 

> ERROR failed to bootstrap model: cannot start bootstrap instance in any availability zone (aron.internal, aron.internal/Low, aron.internal/High, aron.internal/High/Child)

Looking into the logs, the actual error is attempting to find a datastore that matches an empty string:

> 13:37:15 DEBUG juju.provider.common bootstrap.go:216 failed to start instance in availability zone "aron.internal": could not find datastore ""

## QA steps

Manual bootstrap into vSphere in 3 configurations:

- single datastore (ok)
- multiple datastores available, none selected (error: config required)
- multiple datastores available, one selected (ok)
- multiple datastores available, missing selected (error: unable to find datastore)

## Documentation changes

Business logic to mention during bootstrap process for vSphere:

- when there are no datastores available, `juju bootstrap` fails
- if there's one available, Juju will use that
- when there are multiple datastores,  `--config bootstrap=<datastore>` is required

The error message repeats 4 times, as Juju retries a few times before stopping.

```plain
ERROR no datastore provided, select one from testing, ds1, ds2
ERROR no datastore provided, select one from testing, ds1, ds2
ERROR no datastore provided, select one from testing, ds1, ds2
ERROR no datastore provided, select one from testing, ds1, ds2
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830452
