### PR TITLE
2.6 - Accept Model UUID for Commands Using the -m Option

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -805,7 +805,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 	if hostedModel != nil {
 		modelNameToSet = c.hostedModelName
 	}
-	if err = c.SetModelName(modelcmd.JoinModelName(c.controllerName, modelNameToSet), false); err != nil {
+	if err = c.SetModelIdentifier(modelcmd.JoinModelName(c.controllerName, modelNameToSet), false); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/commands/list_sshkeys.go
+++ b/cmd/juju/commands/list_sshkeys.go
@@ -90,7 +90,7 @@ func (c *listKeysCommand) Run(context *cmd.Context) error {
 		context.Infof("No keys to display.")
 		return nil
 	}
-	modelName, err := c.ModelName()
+	modelName, err := c.ModelIdentifier()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/list_sshkeys.go
+++ b/cmd/juju/commands/list_sshkeys.go
@@ -69,7 +69,7 @@ func (c *listKeysCommand) Run(context *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	mode := ssh.Fingerprints
 	if c.showFullKey {
@@ -90,11 +90,11 @@ func (c *listKeysCommand) Run(context *cmd.Context) error {
 		context.Infof("No keys to display.")
 		return nil
 	}
-	modelName, err := c.ModelIdentifier()
+	modelIdentifier, err := c.ModelIdentifier()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprintf(context.Stdout, "Keys used in model: %s\n", modelName)
-	fmt.Fprintln(context.Stdout, strings.Join(result.Result, "\n"))
+	_, _ = fmt.Fprintf(context.Stdout, "Keys used in model: %s\n", modelIdentifier)
+	_, _ = fmt.Fprintln(context.Stdout, strings.Join(result.Result, "\n"))
 	return nil
 }

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -108,7 +108,10 @@ func (c *migrateCommand) Init(args []string) error {
 		return errors.New("too many arguments specified")
 	}
 
-	c.SetModelName(args[0], false)
+	if err := c.SetModelIdentifier(args[0], false); err != nil {
+		return errors.Trace(err)
+	}
+
 	c.targetController = args[1]
 	return nil
 }
@@ -119,7 +122,7 @@ func (c *migrateCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	modelName, err := c.ModelName()
+	modelName, err := c.ModelIdentifier()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -278,6 +278,7 @@ func (s *MigrateSuite) TestSuccessMacaroons(c *gc.C) {
 	macs := s.api.specSeen.TargetMacaroons
 	s.api.specSeen.TargetMacaroons = nil
 	apitesting.MacaroonsEqual(c, macs, s.targetControllerAPI.macaroons)
+
 	c.Check(s.api.specSeen, jc.DeepEquals, &controller.MigrationSpec{
 		ModelUUID:             modelUUID,
 		TargetControllerUUID:  targetControllerUUID,
@@ -410,7 +411,7 @@ func (s *MigrateSuite) TestSpecifyOwner(c *gc.C) {
 	c.Check(s.api.specSeen.ModelUUID, gc.Equals, "prod-1-uuid")
 }
 
-func (s *MigrateSuite) TestControllerDoesntExist(c *gc.C) {
+func (s *MigrateSuite) TestControllerDoesNotExist(c *gc.C) {
 	_, err := s.makeAndRun(c, "model", "wat")
 	c.Check(err, gc.ErrorMatches, "controller wat not found")
 	c.Check(s.api.specSeen, gc.IsNil) // API shouldn't have been called

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -272,7 +272,7 @@ func (c *SSHCommon) setProxyCommand(options *ssh.Options) error {
 		return errors.Errorf("failed to get juju executable path: %v", err)
 	}
 
-	modelName, err := c.ModelName()
+	modelName, err := c.ModelIdentifier()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -102,6 +102,19 @@ func (s *ListKeysSuite) TestListKeys(c *gc.C) {
 	c.Assert(output, gc.Matches, "Keys used in model: controller\n.*\\(user@host\\)\n.*\\(another@host\\)")
 }
 
+func (s *ListKeysSuite) TestListKeysWithModelUUID(c *gc.C) {
+	key1 := sshtesting.ValidKeyOne.Key + " user@host"
+	key2 := sshtesting.ValidKeyTwo.Key + " another@host"
+	s.setAuthorizedKeys(c, key1, key2)
+
+	context, err := cmdtesting.RunCommand(c, NewListKeysCommand(), "-m", s.Model.UUID())
+	c.Assert(err, jc.ErrorIsNil)
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(output, gc.Matches,
+		fmt.Sprintf("Keys used in model: %s\n.*\\(user@host\\)\n.*\\(another@host\\)", s.Model.UUID()))
+}
+
 func (s *ListKeysSuite) TestListFullKeys(c *gc.C) {
 	key1 := sshtesting.ValidKeyOne.Key + " user@host"
 	key2 := sshtesting.ValidKeyTwo.Key + " another@host"

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -190,7 +190,7 @@ func (c *guiCommand) openBrowser(ctx *cmd.Context, rawURL string, vers *version.
 		if vers != nil {
 			versInfo = fmt.Sprintf("%v ", vers)
 		}
-		modelName, err := c.ModelName()
+		modelName, err := c.ModelIdentifier()
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -168,7 +168,7 @@ func (c *destroyCommand) Init(args []string) error {
 	case 0:
 		return errors.New("no model specified")
 	case 1:
-		return c.SetModelName(args[0], false)
+		return c.SetModelIdentifier(args[0], false)
 	default:
 		return cmd.CheckEmpty(args[1:])
 	}

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -207,7 +207,19 @@ func (s *DestroySuite) TestDestroy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
 	s.stub.CheckCalls(c, []jutesting.StubCall{
-		{"DestroyModel", []interface{}{names.NewModelTag("test2-uuid"), (*bool)(nil), (*bool)(nil), (*time.Duration)(nil)}},
+		{"DestroyModel",
+			[]interface{}{names.NewModelTag("test2-uuid"), (*bool)(nil), (*bool)(nil), (*time.Duration)(nil)}},
+	})
+}
+
+func (s *DestroySuite) TestDestroyWithPartModelUUID(c *gc.C) {
+	checkModelExistsInStore(c, "test1:admin/test2", s.store)
+	_, err := s.runDestroyCommand(c, "test2-uu", "-y")
+	c.Assert(err, jc.ErrorIsNil)
+	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
+	s.stub.CheckCalls(c, []jutesting.StubCall{
+		{"DestroyModel",
+			[]interface{}{names.NewModelTag("test2-uuid"), (*bool)(nil), (*bool)(nil), (*time.Duration)(nil)}},
 	})
 }
 

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -75,7 +75,7 @@ func (c *showModelCommand) Init(args []string) error {
 		modelName = args[0]
 		args = args[1:]
 	}
-	if err := c.SetModelName(modelName, true); err != nil {
+	if err := c.SetModelIdentifier(modelName, true); err != nil {
 		return errors.Trace(err)
 	}
 	if err := c.ModelCommandBase.Init(args); err != nil {

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -137,6 +137,15 @@ func (s *ShowCommandSuite) TestShow(c *gc.C) {
 	})
 }
 
+func (s *ShowCommandSuite) TestShowWithPartModelUUID(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newShowCommand(), "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+		{"ModelInfo", []interface{}{[]names.ModelTag{testing.ModelTag}}},
+		{"Close", nil},
+	})
+}
+
 func (s *ShowCommandSuite) TestShowUnknownCallsRefresh(c *gc.C) {
 	called := false
 	refresh := func(jujuclient.ClientStore, string) error {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -334,7 +334,7 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		return nil
 	}
 	if len(c.patterns) == 0 {
-		modelName, err := c.ModelName()
+		modelName, err := c.ModelIdentifier()
 		if err != nil {
 			return err
 		}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4943,13 +4943,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 	return ctx
 }
 
-func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
-	ctx := s.prepareTabularData(c)
-	defer s.resetContext(c, ctx)
-	code, stdout, stderr := runStatus(c, "--format", "tabular", "--relations")
-	c.Check(code, gc.Equals, 0)
-	c.Check(string(stderr), gc.Equals, "")
-	expected := `
+var expectedTabularStatus = `
 Model       Controller  Cloud/Region        Version  SLA          Timestamp       Notes
 controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00  upgrade available: 1.2.4
 
@@ -4985,9 +4979,29 @@ wordpress:logging-dir  logging:logging-directory  logging    subordinate
 
 `[1:]
 
+func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
+	ctx := s.prepareTabularData(c)
+	defer s.resetContext(c, ctx)
+	code, stdout, stderr := runStatus(c, "--format", "tabular", "--relations")
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "")
+
 	output := substituteFakeTimestamp(c, stdout, false)
 	output = substituteSpacingBetweenTimestampAndNotes(c, output)
-	c.Assert(string(output), gc.Equals, expected)
+	c.Assert(string(output), gc.Equals, expectedTabularStatus)
+}
+
+func (s *StatusSuite) TestStatusWithFormatTabularValidModelUUID(c *gc.C) {
+	ctx := s.prepareTabularData(c)
+	defer s.resetContext(c, ctx)
+
+	code, stdout, stderr := runStatus(c, "--format", "tabular", "--relations", "-m", s.Model.UUID())
+	c.Check(code, gc.Equals, 0)
+	c.Check(string(stderr), gc.Equals, "")
+
+	output := substituteFakeTimestamp(c, stdout, false)
+	output = substituteSpacingBetweenTimestampAndNotes(c, output)
+	c.Assert(string(output), gc.Equals, expectedTabularStatus)
 }
 
 func (s *StatusSuite) TestStatusWithFormatYaml(c *gc.C) {

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -211,7 +211,6 @@ func (c *CommandBase) NewAPIRoot(
 	if redirErr, ok := errors.Cause(err).(*api.RedirectError); ok {
 		return nil, newModelMigratedError(store, modelName, redirErr)
 	}
-
 	return conn, err
 }
 
@@ -220,7 +219,7 @@ func (c *CommandBase) NewAPIRoot(
 // If this model has also been cached as current, it will be reset if
 // the requesting command can modify current model.
 // For example, commands such as add/destroy-model, login/register, etc.
-// If the model was cached as currnet but the command is not expected to
+// If the model was cached as current but the command is not expected to
 // change current model, this call will still remove model details from the client cache
 // but will keep current model name intact to allow subsequent calls to try to resolve
 // model details on the controller.
@@ -340,7 +339,7 @@ func (c *CommandBase) doRefreshModels(store jujuclient.ClientStore, controllerNa
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer modelManager.Close()
+	defer func() { _ = modelManager.Close() }()
 
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil {

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -62,7 +62,7 @@ func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, baseCmd *modelcmd.ModelCo
 	baseCmd.SetAPIOpen(apiOpen)
 	modelcmd.InitContexts(&cmd.Context{Stderr: ioutil.Discard}, baseCmd)
 	modelcmd.SetRunStarted(baseCmd)
-	baseCmd.SetModelName("foo:admin/badmodel", false)
+	baseCmd.SetModelIdentifier("foo:admin/badmodel", false)
 	conn, err := baseCmd.NewAPIRoot()
 	c.Assert(conn, gc.IsNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)
@@ -124,7 +124,8 @@ func (s *BaseCommandSuite) TestMigratedModelErrorHandling(c *gc.C) {
 	baseCmd.SetAPIOpen(apiOpen)
 	modelcmd.InitContexts(&cmd.Context{Stderr: ioutil.Discard}, baseCmd)
 	modelcmd.SetRunStarted(baseCmd)
-	baseCmd.SetModelName("foo:admin/badmodel", false)
+
+	c.Assert(baseCmd.SetModelIdentifier("foo:admin/badmodel", false), jc.ErrorIsNil)
 
 	fingerprint, _ := cert.Fingerprint(coretesting.CACert)
 	specs := []struct {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -360,15 +360,19 @@ func (c *ModelCommandBase) modelDetails(controllerName, modelIdentifier string) 
 func (c *ModelCommandBase) modelFromStore(controllerName, modelIdentifier string) (
 	string, *jujuclient.ModelDetails, error,
 ) {
-	models, err := c.store.AllModels(controllerName)
-	if err != nil {
+	// Check if the model identifier is a name that identifies a stored model.
+	// This will be the most common case.
+	details, err := c.store.ModelByName(controllerName, modelIdentifier)
+	if err == nil {
+		return modelIdentifier, details, nil
+	}
+	if !errors.IsNotFound(err) {
 		return "", nil, errors.Trace(err)
 	}
 
-	// Check if the model identifier is a name that identifies a stored model.
-	// This will be the most common case.
-	if details, ok := models[modelIdentifier]; ok {
-		return modelIdentifier, &details, nil
+	models, err := c.store.AllModels(controllerName)
+	if err != nil {
+		return "", nil, errors.Trace(err)
 	}
 
 	// If the identifier is 6-8 characters or a valid UUID,

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -369,9 +369,9 @@ func (c *ModelCommandBase) modelFromStore(controllerName, modelIdentifier string
 		return "", nil, errors.Trace(err)
 	}
 
-	// If the identifier is at least characters long,
+	// If the identifier is at 6 least characters long,
 	// attempt to match one of the stored model UUIDs.
-	if len(modelIdentifier) > 6 {
+	if len(modelIdentifier) > 5 {
 		models, err := c.store.AllModels(controllerName)
 		if err != nil {
 			return "", nil, errors.Trace(err)

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -133,12 +133,11 @@ func (c *ModelCommandBase) maybeInitModel() error {
 	// returned [ErrNoModelSpecified,ErrNoControllersDefined,ErrNoCurrentController]
 	// at that point and so need to try again.
 	// If any other error result was returned, we bail early here.
-	retriableError := func(original error) bool {
-		return errors.Cause(c.initModelError) != ErrNoModelSpecified &&
-			errors.Cause(c.initModelError) != ErrNoControllersDefined &&
-			errors.Cause(c.initModelError) != ErrNoCurrentController
+	noRetry := func(original error) bool {
+		c := errors.Cause(c.initModelError)
+		return c != ErrNoModelSpecified && c != ErrNoControllersDefined && c != ErrNoCurrentController
 	}
-	if c.doneInitModel && retriableError(c.initModelError) {
+	if c.doneInitModel && noRetry(c.initModelError) {
 		return errors.Trace(c.initModelError)
 	}
 

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
 	"github.com/juju/juju/api"
@@ -370,10 +369,9 @@ func (c *ModelCommandBase) modelFromStore(controllerName, modelIdentifier string
 		return "", nil, errors.Trace(err)
 	}
 
-	// If the identifier is 6-8 characters or a valid UUID,
+	// If the identifier is at least characters long,
 	// attempt to match one of the stored model UUIDs.
-	l := len(modelIdentifier)
-	if (l > 5 && l < 9) || names.IsValidModel(modelIdentifier) {
+	if len(modelIdentifier) > 6 {
 		models, err := c.store.AllModels(controllerName)
 		if err != nil {
 			return "", nil, errors.Trace(err)

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -49,7 +49,7 @@ type ModelCommand interface {
 	// associated with.
 	ClientStore() jujuclient.ClientStore
 
-	// SetModelIdentifier sets the model name for this command.
+	// SetModelIdentifier sets the model identifier for this command.
 	// Setting the model identifier will also set the related controller name.
 	// The model name can be qualified with a controller name
 	// (controller:model), or unqualified, in which case it will be assumed
@@ -60,7 +60,7 @@ type ModelCommand interface {
 	//
 	// SetModelIdentifier is called prior to the wrapped command's Init method
 	// with the active model name.
-	// The model name is guaranteed to be non-empty at entry of Init.
+	// The model identifier is guaranteed to be non-empty at entry of Init.
 	SetModelIdentifier(modelIdentifier string, allowDefault bool) error
 
 	// ModelIdentifier returns a string identifying the target model.

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -58,6 +58,16 @@ var modelCommandModelTests = []struct {
 	expectController: "bar",
 	expectModel:      "noncurrentbar",
 }, {
+	about:            "explicit controller and model UUID, long form",
+	args:             []string{"--model", "bar:uuidbar2"},
+	expectController: "bar",
+	expectModel:      "uuidbar2",
+}, {
+	about:            "explicit controller and model UUID, short form",
+	args:             []string{"-m", "bar:uuidbar2"},
+	expectController: "bar",
+	expectModel:      "uuidbar2",
+}, {
 	about:            "implicit controller, explicit model, short form",
 	args:             []string{"-m", "explicit"},
 	expectController: "foo",
@@ -67,6 +77,16 @@ var modelCommandModelTests = []struct {
 	args:             []string{"--model", "explicit"},
 	expectController: "foo",
 	expectModel:      "explicit",
+}, {
+	about:            "implicit controller, explicit model UUID, short form",
+	args:             []string{"-m", "uuidfoo3"},
+	expectController: "foo",
+	expectModel:      "uuidfoo3",
+}, {
+	about:            "implicit controller, explicit model UUID, long form",
+	args:             []string{"--model", "uuidfoo3"},
+	expectController: "foo",
+	expectModel:      "uuidfoo3",
 }, {
 	about:            "explicit controller, implicit model",
 	args:             []string{"--model", "bar:"},
@@ -101,7 +121,7 @@ var modelCommandModelTests = []struct {
 	expectModel:      "noncurrentfoo",
 }}
 
-func (s *ModelCommandSuite) TestModelName(c *gc.C) {
+func (s *ModelCommandSuite) TestModelIdentifier(c *gc.C) {
 	s.store.Controllers["foo"] = jujuclient.ControllerDetails{}
 	s.store.Controllers["bar"] = jujuclient.ControllerDetails{}
 	s.store.CurrentControllerName = "foo"
@@ -116,7 +136,7 @@ func (s *ModelCommandSuite) TestModelName(c *gc.C) {
 		jujuclient.ModelDetails{ModelUUID: "uuidfoo1", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.store.UpdateModel("foo", "adminfoo/oncurrentfoo",
+	err = s.store.UpdateModel("foo", "adminfoo/noncurrentfoo",
 		jujuclient.ModelDetails{ModelUUID: "uuidfoo2", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -111,29 +111,38 @@ func (s *ModelCommandSuite) TestModelName(c *gc.C) {
 	s.store.Accounts["bar"] = jujuclient.AccountDetails{
 		User: "baz", Password: "hunter3",
 	}
+
 	err := s.store.UpdateModel("foo", "adminfoo/currentfoo",
 		jujuclient.ModelDetails{ModelUUID: "uuidfoo1", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.UpdateModel("foo", "adminfoo/oncurrentfoo",
 		jujuclient.ModelDetails{ModelUUID: "uuidfoo2", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.UpdateModel("foo", "bar/explicit",
 		jujuclient.ModelDetails{ModelUUID: "uuidfoo3", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.UpdateModel("foo", "bar/noncurrentfoo",
 		jujuclient.ModelDetails{ModelUUID: "uuidfoo4", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.UpdateModel("bar", "adminbar/currentbar",
 		jujuclient.ModelDetails{ModelUUID: "uuidbar1", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.UpdateModel("bar", "adminbar/noncurrentbar",
 		jujuclient.ModelDetails{ModelUUID: "uuidbar2", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.UpdateModel("bar", "baz/noncurrentbar",
 		jujuclient.ModelDetails{ModelUUID: "uuidbar3", ModelType: model.IAAS})
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.SetCurrentModel("foo", "adminfoo/currentfoo")
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = s.store.SetCurrentModel("bar", "adminbar/currentbar")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -240,10 +249,12 @@ func (*ModelCommandSuite) TestJoinModelName(c *gc.C) {
 func (s *ModelCommandSuite) assertRunHasModel(c *gc.C, expectControllerName, expectModelName string, args ...string) {
 	cmd, err := runTestCommand(c, s.store, args...)
 	c.Assert(err, jc.ErrorIsNil)
+
 	controllerName, err := cmd.ControllerName()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerName, gc.Equals, expectControllerName)
-	modelName, err := cmd.ModelName()
+
+	modelName, err := cmd.ModelIdentifier()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelName, gc.Equals, expectModelName)
 }
@@ -443,7 +454,7 @@ func (s *macaroonLoginSuite) newModelCommandBase() *modelcmd.ModelCommandBase {
 	c.SetClientStore(s.store)
 	modelcmd.InitContexts(&cmd.Context{Stderr: ioutil.Discard}, &c)
 	modelcmd.SetRunStarted(&c)
-	err := c.SetModelName(s.controllerName+":"+s.modelName, false)
+	err := c.SetModelIdentifier(s.controllerName+":"+s.modelName, false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description of change

This patch allows a full or partial model UUID to be used in the following situations:
- Commands that accept the `-m` option (including its long form `--model`).
- The `show-model` command.
- The `destroy-model` command.
- The `ssh-keys` command.

Accepted forms for the UUID are anything longer than 6 characters. This identifier is treated as a _prefix_ to the UUID for the purpose of determining a match.

The change does not apply to the following commands. A later patch will add that support:
- `switch`
- `migrate`

## QA steps

- Bootstrap.
- Use `show-model` default/controller to get the UUIDs.
- For each model, run `juju status -m <identifier>` for the full UUID and the > 6 character prefix forms.
- Do the same for `juju show-model <identifier>`.
- Run `juju destroy-model <identifier for default>` and check that the model is correctly removed.

## Documentation changes

Yes. Ping @pmatulis 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1828455