### PR TITLE
Credential validity visibility on model status.

### DIFF
--- a/core/status/status.go
+++ b/core/status/status.go
@@ -332,6 +332,7 @@ func ValidModelStatus(status Status) bool {
 		Available,
 		Busy,
 		Destroying,
+		Suspended, // For  model, this means that its cloud credential is invalid and model will not be doing any cloud calls.
 		Error:
 		return true
 	default:

--- a/core/status/status_test.go
+++ b/core/status/status_test.go
@@ -3,6 +3,7 @@
 package status_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/status"
@@ -47,5 +48,53 @@ func (s *StatusSuite) TestModification(c *gc.C) {
 	for k, v := range testcases {
 		c.Logf("Testing modification status %d %s", k, v.name)
 		c.Assert(v.status.KnownModificationStatus(), gc.Equals, v.valid)
+	}
+}
+
+func (s *StatusSuite) TestValidModelStatus(c *gc.C) {
+	for _, v := range []status.Status{
+		status.Available,
+		status.Busy,
+		status.Destroying,
+		status.Error,
+		status.Suspended,
+	} {
+		c.Assert(status.ValidModelStatus(v), jc.IsTrue, gc.Commentf("status %q is not valid for a model", v))
+	}
+}
+
+func (s *StatusSuite) TestInvalidModelStatus(c *gc.C) {
+	for _, v := range []status.Status{
+		status.Active,
+		status.Allocating,
+		status.Applied,
+		status.Attached,
+		status.Attaching,
+		status.Blocked,
+		status.Broken,
+		status.Detached,
+		status.Detaching,
+		status.Down,
+		status.Empty,
+		status.Executing,
+		status.Failed,
+		status.Idle,
+		status.Joined,
+		status.Joining,
+		status.Lost,
+		status.Maintenance,
+		status.Pending,
+		status.Provisioning,
+		status.ProvisioningError,
+		status.Rebooting,
+		status.Running,
+		status.Suspending,
+		status.Started,
+		status.Stopped,
+		status.Terminated,
+		status.Unknown,
+		status.Waiting,
+	} {
+		c.Assert(status.ValidModelStatus(v), jc.IsFalse, gc.Commentf("status %q is valid for a model", v))
 	}
 }

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/permission"
 )
 
@@ -116,21 +117,61 @@ func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential 
 		tag: convertCloudCredentialToState(tag, credential),
 	}
 	annotationMsg := "updating cloud credentials"
+
+	existing, err := st.CloudCredential(tag)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Annotatef(err, "fetching cloud credentials")
+	}
+	exists := err == nil
+	var revert []*Model
+	if exists {
+		// Existing credential will become valid after this call, and
+		// the model status of all models that use it will be reverted.
+		if existing.Invalid != credential.Invalid && !credential.Invalid {
+			credentialModels, err := st.modelsWithCredential(tag)
+			if err != nil && !errors.IsNotFound(err) {
+				return errors.Annotatef(err, "getting models for credential %v", tag)
+			}
+			addSuspended := func(m *Model) error {
+				modelStatus, err := m.Status()
+				if err != nil {
+					return errors.Trace(err)
+				}
+				// We only interested if the models are currently suspended.
+				if modelStatus.Status == status.Suspended {
+					revert = append(revert, m)
+				}
+				return nil
+			}
+			for _, m := range credentialModels {
+				one, closer, err := st.model(m.UUID)
+				if err != nil {
+					// Something has gone wrong with this model... keep going.
+					logger.Warningf("model %v error: %v", m.UUID, err)
+					continue
+				}
+				// These models are used later on in the method and we want
+				// this closer to be deferred until the end of the whole method, not just the end of the loop.
+				defer closer()
+				if err := addSuspended(one); err != nil {
+					// We do not want to stop processing the rest of the models.
+					logger.Warningf("could not decide if model %v is suspended: %v", m.UUID, err)
+				}
+			}
+		}
+	}
+
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		cloudName := tag.Cloud().Id()
-		cloud, err := st.Cloud(cloudName)
+		aCloud, err := st.Cloud(cloudName)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ops, err := validateCloudCredentials(cloud, credentials)
+		ops, err := validateCloudCredentials(aCloud, credentials)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		_, err = st.CloudCredential(tag)
-		if err != nil && !errors.IsNotFound(err) {
-			return nil, errors.Maskf(err, "fetching cloud credentials")
-		}
-		if err == nil {
+		if exists {
 			ops = append(ops, updateCloudCredentialOp(tag, credential))
 		} else {
 			annotationMsg = "creating cloud credential"
@@ -143,6 +184,57 @@ func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential 
 	}
 	if err := st.db().Run(buildTxn); err != nil {
 		return errors.Annotate(err, annotationMsg)
+	}
+	if len(revert) > 0 {
+		for _, m := range revert {
+			if err := m.maybeRevertModelStatus(); err != nil {
+				logger.Warningf("could not revert status for model %v: %v", m.UUID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (st *State) model(uuid string) (*Model, func() error, error) {
+	closer := func() error { return nil }
+	// We explicitly don't start the workers.
+	modelState, err := st.newStateNoWorkers(uuid)
+	if err != nil {
+		// This model could have been removed.
+		if errors.IsNotFound(err) {
+			return nil, closer, nil
+		}
+		return nil, closer, errors.Trace(err)
+	}
+
+	closer = func() error { return modelState.Close() }
+	m, err := modelState.Model()
+	if err != nil {
+		return nil, closer, errors.Trace(err)
+	}
+	return m, closer, nil
+}
+
+func (m *Model) maybeRevertModelStatus() error {
+	// I don't know where you've been before you got here - get a clean slate.
+	err := m.Refresh()
+	if err != nil {
+		logger.Warningf("could not refresh model %v to revert its status: %v", m.UUID, err)
+	}
+	modelStatus, err := m.Status()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if modelStatus.Status != status.Suspended {
+		doc := statusDoc{
+			Status:     modelStatus.Status,
+			StatusInfo: modelStatus.Message,
+			Updated:    timeOrNow(nil, m.st.clock()).UnixNano(),
+		}
+
+		if _, err = probablyUpdateStatusHistory(m.st.db(), m.globalKey(), doc); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return nil
 }
@@ -348,8 +440,7 @@ func (st *State) AllCloudCredentials(user names.UserTag) ([]Credential, error) {
 	return credentials, nil
 }
 
-// CredentialModels returns all models that use given cloud credential.
-func (st *State) CredentialModels(tag names.CloudCredentialTag) (map[string]string, error) {
+func (st *State) modelsWithCredential(tag names.CloudCredentialTag) ([]modelDoc, error) {
 	coll, cleanup := st.db().GetCollection(modelsC)
 	defer cleanup()
 
@@ -366,9 +457,18 @@ func (st *State) CredentialModels(tag names.CloudCredentialTag) (map[string]stri
 	if len(docs) == 0 {
 		return nil, errors.NotFoundf("models that use cloud credentials %q", tag.Id())
 	}
+	return docs, nil
+}
 
-	results := make(map[string]string, len(docs))
-	for _, model := range docs {
+// CredentialModels returns all models that use given cloud credential.
+func (st *State) CredentialModels(tag names.CloudCredentialTag) (map[string]string, error) {
+	models, err := st.modelsWithCredential(tag)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[string]string, len(models))
+	for _, model := range models {
 		results[model.UUID] = model.Name
 	}
 	return results, nil

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -190,7 +190,7 @@ func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential 
 	if len(revert) > 0 {
 		for m, closer := range revert {
 			if err := m.maybeRevertModelStatus(); err != nil {
-				logger.Warningf("could not revert status for model %v: %v", m.UUID, err)
+				logger.Warningf("could not revert status for model %v: %v", m.UUID(), err)
 			}
 			defer closer()
 		}
@@ -222,7 +222,7 @@ func (m *Model) maybeRevertModelStatus() error {
 	// I don't know where you've been before you got here - get a clean slate.
 	err := m.Refresh()
 	if err != nil {
-		logger.Warningf("could not refresh model %v to revert its status: %v", m.UUID, err)
+		logger.Warningf("could not refresh model %v to revert its status: %v", m.UUID(), err)
 	}
 	modelStatus, err := m.Status()
 	if err != nil {

--- a/state/model.go
+++ b/state/model.go
@@ -623,6 +623,10 @@ func (m *Model) Owner() names.UserTag {
 	return names.NewUserTag(m.doc.Owner)
 }
 
+func modelStatusInvalidCredential() status.StatusInfo {
+	return status.StatusInfo{Status: status.Suspended, Message: "suspended since cloud credential is not valid"}
+}
+
 // Status returns the status of the model.
 func (m *Model) Status() (status.StatusInfo, error) {
 	// If model credential is invalid, model is suspended.
@@ -632,7 +636,7 @@ func (m *Model) Status() (status.StatusInfo, error) {
 			return status.StatusInfo{}, errors.Annotatef(err, "could not get model credential %v", credentialTag.Id())
 		}
 		if !credential.IsValid() {
-			return status.StatusInfo{Status: status.Suspended, Message: "suspended since cloud credential is not valid"}, nil
+			return modelStatusInvalidCredential(), nil
 		}
 	}
 

--- a/state/model.go
+++ b/state/model.go
@@ -625,6 +625,17 @@ func (m *Model) Owner() names.UserTag {
 
 // Status returns the status of the model.
 func (m *Model) Status() (status.StatusInfo, error) {
+	// If model credential is invalid, model is suspended.
+	if credentialTag, hasCredential := m.CloudCredential(); hasCredential {
+		credential, err := m.st.CloudCredential(credentialTag)
+		if err != nil {
+			return status.StatusInfo{}, errors.Annotatef(err, "could not get model credential %v", credentialTag.Id())
+		}
+		if !credential.IsValid() {
+			return status.StatusInfo{Status: status.Suspended, Message: "suspended since cloud credential is not valid"}, nil
+		}
+	}
+
 	modelStatus, err := getStatus(m.st.db(), m.globalKey(), "model")
 	if err != nil {
 		return modelStatus, err

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -126,7 +126,7 @@ func (m *Model) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
 	}
 	if updating && revert {
 		if err := m.maybeRevertModelStatus(); err != nil {
-			logger.Warningf("could not revert status for model %v: %v", m.UUID, err)
+			logger.Warningf("could not revert status for model %v: %v", m.UUID(), err)
 		}
 	}
 	return updating, m.Refresh()

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/status"
 )
 
 // InvalidateModelCredential invalidate cloud credential for the model
@@ -27,19 +28,52 @@ func (st *State) InvalidateModelCredential(reason string) error {
 		return nil
 	}
 
-	return errors.Trace(st.InvalidateCloudCredential(tag, reason))
+	if err := st.InvalidateCloudCredential(tag, reason); err != nil {
+		return errors.Trace(err)
+	}
+	if err := st.suspendCredentialModels(tag); err != nil {
+		// These updates are optimistic. If they fail, it's unfortunate but we are not going to stop the call.
+		logger.Warningf("could not suspend models that use credential %v: %v", tag.Id(), err)
+	}
+	return nil
+}
+
+func (st *State) suspendCredentialModels(tag names.CloudCredentialTag) error {
+	models, err := st.modelsWithCredential(tag)
+	if err != nil {
+		return errors.Annotatef(err, "could not determine what models use credential %v", tag.Id())
+	}
+	doc := statusDoc{
+		Status:     status.Suspended,
+		StatusInfo: "suspended since cloud credential is not valid",
+		Updated:    timeOrNow(nil, st.clock()).UnixNano(),
+	}
+	for _, m := range models {
+		one, closer, err := st.model(m.UUID)
+		if err != nil {
+			// Something has gone wrong with this model... keep going.
+			logger.Warningf("model %v error: %v", m.UUID, err)
+			continue
+		}
+		defer closer()
+		if _, err = probablyUpdateStatusHistory(one.st.db(), one.globalKey(), doc); err != nil {
+			// We do not want to stop processing the rest of the models.
+			logger.Warningf("%v", err)
+		}
+	}
+	return nil
 }
 
 // ValidateCloudCredential validates new cloud credential for this model.
 func (m *Model) ValidateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
-	cloud, err := m.st.Cloud(m.Cloud())
+	aCloud, err := m.st.Cloud(m.Cloud())
 	if err != nil {
 		return errors.Annotatef(err, "getting cloud %q", m.Cloud())
 	}
 
-	err = validateCredentialForCloud(cloud, tag, convertCloudCredentialToState(tag, credential))
+	err = validateCredentialForCloud(aCloud, tag, convertCloudCredentialToState(tag, credential))
 	if err != nil {
-		return errors.Annotatef(err, "validating credential %q for cloud %q", tag.Id(), cloud.Name)
+		return errors.Annotatef(err, "validating credential %q for cloud %q", tag.Id(), aCloud.Name)
 	}
 	return nil
 }
@@ -47,7 +81,14 @@ func (m *Model) ValidateCloudCredential(tag names.CloudCredentialTag, credential
 // SetCloudCredential sets new cloud credential for this model.
 // Returned bool indicates if model credential was set.
 func (m *Model) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
-	cloud, err := m.st.Cloud(m.Cloud())
+	// If model is suspended, after this call, it may be reverted since,
+	// if updated, model credential will be set to a valid credential.
+	modelStatus, err := m.Status()
+	if err != nil {
+		return false, errors.Annotatef(err, "getting model status %q", m.UUID())
+	}
+	revert := modelStatus.Status == status.Suspended
+	aCloud, err := m.st.Cloud(m.Cloud())
 	if err != nil {
 		return false, errors.Annotatef(err, "getting cloud %q", m.Cloud())
 	}
@@ -70,7 +111,7 @@ func (m *Model) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
 		if !credential.IsValid() {
 			return nil, errors.NotValidf("credential %q", tag.Id())
 		}
-		if err := validateCredentialForCloud(cloud, tag, credential); err != nil {
+		if err := validateCredentialForCloud(aCloud, tag, credential); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return []txn.Op{{
@@ -82,6 +123,11 @@ func (m *Model) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
 	}
 	if err := m.st.db().Run(buildTxn); err != nil {
 		return false, errors.Trace(err)
+	}
+	if updating && revert {
+		if err := m.maybeRevertModelStatus(); err != nil {
+			logger.Warningf("could not revert status for model %v: %v", m.UUID, err)
+		}
 	}
 	return updating, m.Refresh()
 }

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"fmt"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -5,17 +5,18 @@ package state_test
 
 import (
 	"fmt"
-
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type ModelCredentialSuite struct {
@@ -245,4 +246,110 @@ func (s *ModelCredentialSuite) addModel(c *gc.C, modelName string, tag names.Clo
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st
+}
+
+func (s *ModelCredentialSuite) TestInvalidateModelCredentialTouchesAllCredentialModels(c *gc.C) {
+	// This test checks that all models are affected when one of them invalidates a credential they all use...
+
+	// 1. create a credential
+	cloudName, credentialOwner, credentialTag := assertCredentialCreated(c, s.ConnSuite)
+
+	// 2. create some models to use it
+	modelUUIDs := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		modelUUIDs[i] = assertModelCreated(c, s.ConnSuite, cloudName, credentialTag, credentialOwner.Tag(), fmt.Sprintf("model-for-cloud%v", i))
+	}
+
+	// 3. invalidate credential
+	oneModelState, helper, err := s.StatePool.GetModel(modelUUIDs[0])
+	c.Assert(err, jc.ErrorIsNil)
+	defer helper.Release()
+	c.Assert(oneModelState.State().InvalidateModelCredential("testing invalidate for all credential models"), jc.ErrorIsNil)
+
+	// 4. check all models are suspended
+	for _, uuid := range modelUUIDs {
+		assertModelStatus(c, s.StatePool, uuid, status.Suspended)
+		assertModelHistories(c, s.StatePool, uuid, status.Suspended, status.Available)
+	}
+}
+
+func (s *ModelCredentialSuite) TestSetCredentialRevertsModelStatus(c *gc.C) {
+	// 1. create a credential
+	cloudName, credentialOwner, credentialTag := assertCredentialCreated(c, s.ConnSuite)
+
+	// 2. create some models to use it
+	validModelStatuses := []status.Status{
+		status.Available,
+		status.Busy,
+		status.Destroying,
+		status.Error,
+	}
+	desiredNumber := len(validModelStatuses)
+
+	modelUUIDs := make([]string, desiredNumber)
+	for i := 0; i < desiredNumber; i++ {
+		modelUUIDs[i] = assertModelCreated(c, s.ConnSuite, cloudName, credentialTag, credentialOwner.Tag(), fmt.Sprintf("model-for-cloud%v", i))
+		oneModelState, helper, err := s.StatePool.GetModel(modelUUIDs[i])
+		c.Assert(err, jc.ErrorIsNil)
+		defer helper.Release()
+		if validModelStatuses[i] != status.Available {
+			// any model would be in 'available' status on setup.
+			err = oneModelState.SetStatus(status.StatusInfo{Status: validModelStatuses[i]})
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(oneModelState.Refresh(), jc.ErrorIsNil)
+		}
+		if i == desiredNumber-1 {
+			// 3. invalidate credential on last model
+			c.Assert(oneModelState.State().InvalidateModelCredential("testing"), jc.ErrorIsNil)
+		}
+	}
+
+	// 4. check model is suspended
+	for i := 0; i < desiredNumber; i++ {
+		assertModelStatus(c, s.StatePool, modelUUIDs[i], status.Suspended)
+		if validModelStatuses[i] == status.Available {
+			assertModelHistories(c, s.StatePool, modelUUIDs[i], status.Suspended, status.Available)
+		} else {
+			assertModelHistories(c, s.StatePool, modelUUIDs[i], status.Suspended, validModelStatuses[i], status.Available)
+		}
+	}
+
+	// 5. create another credential on the same cloud
+	owner := s.Factory.MakeUser(c, &factory.UserParams{
+		Password: "secret",
+		Name:     "uncle",
+	})
+	anotherCredentialTag := createCredential(c, s.ConnSuite, cloudName, owner.Name(), "barfoo")
+
+	for i := 0; i < desiredNumber; i++ {
+		oneModelState, helper, err := s.StatePool.GetModel(modelUUIDs[i])
+		c.Assert(err, jc.ErrorIsNil)
+		defer helper.Release()
+
+		isSet, err := oneModelState.SetCloudCredential(anotherCredentialTag)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(isSet, jc.IsTrue)
+
+		// 5. Check model status is reverted
+		if validModelStatuses[i] == status.Available {
+			assertModelStatus(c, s.StatePool, modelUUIDs[i], status.Available)
+			assertModelHistories(c, s.StatePool, modelUUIDs[i], status.Available, status.Suspended, status.Available)
+		} else {
+			assertModelStatus(c, s.StatePool, modelUUIDs[i], validModelStatuses[i])
+			assertModelHistories(c, s.StatePool, modelUUIDs[i], validModelStatuses[i], status.Suspended, validModelStatuses[i], status.Available)
+		}
+	}
+}
+
+func assertModelHistories(c *gc.C, pool *state.StatePool, testModelUUID string, expected ...status.Status) []status.StatusInfo {
+	aModel, helper, err := pool.GetModel(testModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	defer helper.Release()
+	statusHistories, err := aModel.StatusHistory(status.StatusHistoryFilter{Size: 100})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusHistories, gc.HasLen, len(expected))
+	for i, one := range expected {
+		c.Assert(statusHistories[i].Status, gc.Equals, one)
+	}
+	return statusHistories
 }

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -450,3 +450,67 @@ func (p *modelSummaryProcessor) fillInLastAccess() error {
 	// actually connected to a model they were given access to.
 	return nil
 }
+
+// fillInStatusBasedOnCloudCredentialValidity fills in the Status on every model (if credential is invalid).
+func (p *modelSummaryProcessor) fillInStatusBasedOnCloudCredentialValidity() error {
+	credentialModels := map[names.CloudCredentialTag][]string{}
+	for _, model := range p.summaries {
+		if model.CloudCredentialTag == "" {
+			continue
+		}
+		tag, err := names.ParseCloudCredentialTag(model.CloudCredentialTag)
+		if err != nil {
+			logger.Warningf("could not parse cloud credential tag %v for model%v: %v", model.CloudCredentialTag, model.UUID, err)
+			// Don't stop the rest of the models
+			continue
+		}
+		summaries, ok := credentialModels[tag]
+		if !ok {
+			summaries = []string{}
+		}
+		credentialModels[tag] = append(summaries, model.UUID)
+	}
+	if len(credentialModels) != 0 {
+		if err := p.substituteModelStatusForInvalidCredentials(credentialModels); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (p *modelSummaryProcessor) substituteModelStatusForInvalidCredentials(credentials map[names.CloudCredentialTag][]string) error {
+	var ids []string
+	for tag := range credentials {
+		ids = append(ids, cloudCredentialDocID(tag))
+	}
+	// cloudCredentialsC is a global collection, so can be accessed from any state
+	perms, closer := p.st.db().GetCollection(cloudCredentialsC)
+	defer closer()
+	query := perms.Find(bson.M{"_id": bson.M{"$in": ids}})
+	iter := query.Iter()
+	defer iter.Close()
+
+	var doc cloudCredentialDoc
+	for iter.Next(&doc) {
+		if doc.Invalid {
+			tag, err := doc.cloudCredentialTag()
+			if err != nil {
+				logger.Warningf("could not get cloud credential tag %v: %v", doc.DocID, err)
+				// Don't stop the rest of the models
+				continue
+			}
+			for _, uuid := range credentials[tag] {
+				idx, ok := p.indexByUUID[uuid]
+				if !ok {
+					continue
+				}
+				details := &p.summaries[idx]
+				details.Status = modelStatusInvalidCredential()
+			}
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2/bson"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/permission"
@@ -64,10 +66,27 @@ func (s *ModelSummariesSuite) Setup4Models(c *gc.C) map[string]string {
 	modelUUIDs["user3model"] = st3.ModelUUID()
 	st3.Close()
 	owner := s.Model.Owner()
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:      "stratus",
+		Type:      "low",
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+	}, s.Owner.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	cred := cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+		"foo": "foo val",
+		"bar": "bar val",
+	})
+	tag := names.NewCloudCredentialTag(fmt.Sprintf("stratus/%v/foobar", owner.Name()))
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+
 	sharedSt := s.Factory.MakeModel(c, &factory.ModelParams{
 		Name: "shared",
 		// Owned by test-admin
-		Owner: owner,
+		Owner:           owner,
+		CloudName:       "stratus",
+		CloudCredential: tag,
 	})
 	modelUUIDs["shared"] = sharedSt.ModelUUID()
 	defer sharedSt.Close()
@@ -270,6 +289,44 @@ func (s *ModelSummariesSuite) TestContainsModelStatus(c *gc.C) {
 	defer ph.Release()
 	c.Assert(err, jc.ErrorIsNil)
 	err = shared.SetStatus(expectedStatus["shared"])
+	user1, ph, err := s.StatePool.GetModel(modelNameToUUID["user1model"])
+	defer ph.Release()
+	c.Assert(err, jc.ErrorIsNil)
+	err = user1.SetStatus(expectedStatus["user1model"])
+	c.Assert(err, jc.ErrorIsNil)
+	summaries, err := s.State.ModelSummariesForUser(names.NewUserTag("user1write"), false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(summaries, gc.HasLen, 2)
+	statuses := make(map[string]status.StatusInfo)
+	for _, summary := range summaries {
+		// We nil the time, because we don't want to compare it, we nil the Data map to avoid comparing an
+		// empty map to a nil map
+		st := summary.Status
+		st.Since = nil
+		st.Data = nil
+		statuses[summary.Name] = st
+	}
+	c.Check(statuses, jc.DeepEquals, expectedStatus)
+}
+
+func (s *ModelSummariesSuite) TestContainsModelStatusSuspended(c *gc.C) {
+	modelNameToUUID := s.Setup4Models(c)
+	expectedStatus := map[string]status.StatusInfo{
+		"shared": {
+			Status:  status.Suspended,
+			Message: "suspended since cloud credential is not valid",
+		},
+		"user1model": {
+			Status:  status.Busy,
+			Message: "human message",
+		},
+	}
+	shared, err := s.StatePool.Get(modelNameToUUID["shared"])
+	defer shared.Release()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(shared.InvalidateModelCredential("test"), jc.ErrorIsNil)
+
+	s.State.StartSync()
 	user1, ph, err := s.StatePool.GetModel(modelNameToUUID["user1model"])
 	defer ph.Release()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -211,6 +211,9 @@ func (st *State) ModelSummariesForUser(user names.UserTag, all bool) ([]ModelSum
 	if err := p.fillInFromStatus(); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if err := p.fillInStatusBasedOnCloudCredentialValidity(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if err := p.fillInJustUser(); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

Occasionally, cloud credentials used by the model become invalid.
This PR allows user to find out that this happened via 'juju models' or 'juju status'.
We now will tell the user that a model is suspended due to the credential being invalid. Once credential becomes valid again, the model status is reverted to whatever it was beforehand.

Model credential can become valid again if it is either updated with a new content or a different, new credential is set for the model.


## QA steps

1.    bootstrap
2.     add a model with a different credential
    [at this stage, juju output would look similar to this]
```
$ juju models
Controller: mycontroller

Model       Cloud/Region   Type  Status     Machines  Cores  Access  Last connection
controller  aws/us-east-1  ec2   available         1      4  admin   just now
default     aws/us-east-1  ec2   available         0      -  admin   12 minutes ago
trial*      aws/us-east-1  ec2   available         0      -  admin   never connected

$ juju status
Model  Controller    Cloud/Region   Version  SLA          Timestamp
trial  mycontroller  aws/us-east-1  2.6.3.1  unsupported  17:01:53+10:00

Model "admin/trial" is empty.
```
3.    disable second credential and try to deploy something on the model
    [at this stage, juju output will change to something like this]
```
$ juju models
Controller: mycontroller

Model       Cloud/Region   Type  Status     Machines  Cores  Access  Last connection
controller  aws/us-east-1  ec2   available         1      4  admin   just now
default     aws/us-east-1  ec2   available         0      -  admin   6 minutes ago
trial*      aws/us-east-1  ec2   suspended         0      -  admin   8 seconds ago

$ juju status
Model  Controller    Cloud/Region   Version  SLA          Timestamp       Notes
trial  mycontroller  aws/us-east-1  2.6.3.1  unsupported  17:00:31+10:00  suspended since cloud credential is not valid

Model "admin/trial" is empty.
```
4. re-enabling credential reverts model status and message to the original [shown in 2.]

## Bug reference

https://bugs.launchpad.net/juju/+bug/1822117
