### PR TITLE
merge 2.6 into 2.6

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -810,6 +810,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			FSM:                  leaseFSM,
 			RequestTopic:         leaseRequestTopic,
 			Logger:               loggo.GetLogger("juju.worker.lease.raft"),
+			LogDir:               agentConfig.LogDir(),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            leasemanager.NewWorker,
 			NewStore:             leasemanager.NewStore,

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -94,9 +94,11 @@ func HasDenialStatusCode(err error) bool {
 	// contains response status code and description in error.Error.
 	// We have to examine the error message to determine whether the error is related to authentication failure.
 	if cause, ok := errors.Cause(err).(*url.Error); ok {
-		for code, desc := range AuthorisationFailureStatusCodes {
-			if strings.Contains(cause.Error(), fmt.Sprintf(": %v %v", code, desc)) {
-				return true
+		for code, descs := range AuthorisationFailureStatusCodes {
+			for _, desc := range descs {
+				if strings.Contains(cause.Error(), fmt.Sprintf(": %v %v", code, desc)) {
+					return true
+				}
 			}
 		}
 	}
@@ -104,13 +106,17 @@ func HasDenialStatusCode(err error) bool {
 
 }
 
-// AuthorisationFailureStatusCodes contains http status code nad description that signify authorisation difficulties.
-var AuthorisationFailureStatusCodes = map[int]string{
-	http.StatusUnauthorized:      "Unauthorized",
-	http.StatusPaymentRequired:   "Payment Required",
-	http.StatusForbidden:         "Forbidden",
-	http.StatusProxyAuthRequired: "Proxy Auth Required",
+// AuthorisationFailureStatusCodes contains http status code and
+// description that signify authorisation difficulties.
+//
+// Google does not always use standard HTTP descriptions, which
+// is why a single status code can map to multiple descriptions.
+var AuthorisationFailureStatusCodes = map[int][]string{
+	http.StatusUnauthorized:      {"Unauthorized"},
+	http.StatusPaymentRequired:   {"Payment Required"},
+	http.StatusForbidden:         {"Forbidden", "Access Not Configured"},
+	http.StatusProxyAuthRequired: {"Proxy Auth Required"},
 	// OAuth 2.0 also implements RFC#6749, so we need to cater for specific BadRequest errors.
 	// https://tools.ietf.org/html/rfc6749#section-5.2
-	http.StatusBadRequest: "Bad Request",
+	http.StatusBadRequest: {"Bad Request"},
 }

--- a/provider/gce/google/errors_test.go
+++ b/provider/gce/google/errors_test.go
@@ -61,11 +61,20 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	google.HandleCredentialError(s.googleError, ctx)
 	c.Assert(called, jc.IsFalse)
 
-	for code, desc := range google.AuthorisationFailureStatusCodes {
-		called = false
-		s.internalError.SetMessage(code, desc)
+	for code, descs := range google.AuthorisationFailureStatusCodes {
+		for _, desc := range descs {
+			called = false
+			s.internalError.SetMessage(code, desc)
+			google.HandleCredentialError(s.googleError, ctx)
+			c.Assert(called, jc.IsTrue)
+		}
+	}
+
+	called = false
+	for code := range google.AuthorisationFailureStatusCodes {
+		s.internalError.SetMessage(code, "Some strange error")
 		google.HandleCredentialError(s.googleError, ctx)
-		c.Assert(called, jc.IsTrue)
+		c.Assert(called, jc.IsFalse)
 	}
 }
 

--- a/state/workers.go
+++ b/state/workers.go
@@ -4,14 +4,17 @@
 package state
 
 import (
+	"path"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/os/series"
 	"github.com/juju/pubsub"
 	"gopkg.in/juju/worker.v1"
 
 	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/state/watcher"
 	jworker "github.com/juju/juju/worker"
@@ -101,6 +104,14 @@ func (st *State) newLeaseManager(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	series, err := series.HostSeries()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logDir, err := paths.LogDir(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	manager, err := lease.NewManager(lease.ManagerConfig{
 		Secretary: func(_ string) (lease.Secretary, error) {
 			return secretary, nil
@@ -110,6 +121,7 @@ func (st *State) newLeaseManager(
 		Logger:     loggo.GetLogger("juju.worker.lease.mongo"),
 		MaxSleep:   time.Minute,
 		EntityUUID: entityUUID,
+		LogDir:     path.Join(logDir, "juju"),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/lease/config.go
+++ b/worker/lease/config.go
@@ -63,6 +63,10 @@ type ManagerConfig struct {
 	// logging purposes.
 	EntityUUID string
 
+	// LogDir is the directory to write a debugging log file in the
+	// case that the worker times out waiting to shut down.
+	LogDir string
+
 	PrometheusRegisterer prometheus.Registerer
 }
 

--- a/worker/lease/manager_async_test.go
+++ b/worker/lease/manager_async_test.go
@@ -191,8 +191,9 @@ func (s *AsyncSuite) TestExpiryInterruptedRetry(c *gc.C) {
 		// Stopping the worker should cancel the retry.
 		c.Assert(worker.Stop(manager), jc.ErrorIsNil)
 
-		// Advance the clock to trigger the next expire retry
-		c.Assert(clock.WaitAdvance(50*time.Millisecond, coretesting.ShortWait, 1), jc.ErrorIsNil)
+		// Advance the clock to trigger the next expire retry (second
+		// expected timer is the shutdown timeout check).
+		c.Assert(clock.WaitAdvance(50*time.Millisecond, coretesting.ShortWait, 2), jc.ErrorIsNil)
 
 		// Allow some wallclock time for a non-cancelled retry to
 		// happen if stopping the worker didn't cancel it. This is not

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -59,6 +59,7 @@ type ManifoldConfig struct {
 	FSM                  *raftlease.FSM
 	RequestTopic         string
 	Logger               lease.Logger
+	LogDir               string
 	PrometheusRegisterer prometheus.Registerer
 	NewWorker            func(lease.ManagerConfig) (worker.Worker, error)
 	NewStore             func(raftlease.StoreConfig) *raftlease.Store
@@ -158,6 +159,7 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 		Logger:               s.config.Logger,
 		MaxSleep:             MaxSleep,
 		EntityUUID:           controllerUUID,
+		LogDir:               s.config.LogDir,
 		PrometheusRegisterer: s.config.PrometheusRegisterer,
 	})
 	if err != nil {


### PR DESCRIPTION
## Description of change

This merges recent changes on the 2.5 branch into the 2.6 branch. This was primarily to get the lease manager timeout change but also includes @timClicks's GCE credentials fixes (which are in develop and 2.5 but not 2.6).

## QA steps

* Smoke test bootstrap and deploy.

## Documentation changes

None

## Bug reference

None