### PR TITLE
Update log db storage to not use tags.

### DIFF
--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -78,7 +78,7 @@ func makeLogTailerParams(reqParams debugLogParams) state.LogTailerParams {
 
 func formatLogRecord(r *state.LogRecord) *params.LogMessage {
 	return &params.LogMessage{
-		Entity:    r.Entity.String(),
+		Entity:    r.Entity,
 		Timestamp: r.Time,
 		Severity:  r.Level.String(),
 		Module:    r.Module,

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -96,7 +95,7 @@ func (s *debugLogDBIntSuite) TestFullRequest(c *gc.C) {
 	tailer := newFakeLogTailer()
 	tailer.logsCh <- &state.LogRecord{
 		Time:     time.Date(2015, 6, 19, 15, 34, 37, 0, time.UTC),
-		Entity:   names.NewMachineTag("99"),
+		Entity:   "machine-99",
 		Module:   "some.where",
 		Location: "code.go:42",
 		Level:    loggo.INFO,
@@ -104,7 +103,7 @@ func (s *debugLogDBIntSuite) TestFullRequest(c *gc.C) {
 	}
 	tailer.logsCh <- &state.LogRecord{
 		Time:     time.Date(2015, 6, 19, 15, 36, 40, 0, time.UTC),
-		Entity:   names.NewUnitTag("foo/2"),
+		Entity:   "unit-foo-2",
 		Module:   "else.where",
 		Location: "go.go:22",
 		Level:    loggo.ERROR,
@@ -146,7 +145,7 @@ func (s *debugLogDBIntSuite) TestMaxLines(c *gc.C) {
 	for i := 0; i < 5; i++ {
 		tailer.logsCh <- &state.LogRecord{
 			Time:     time.Date(2015, 6, 19, 15, 34, 37, 0, time.UTC),
-			Entity:   names.NewMachineTag("99"),
+			Entity:   "machine-99",
 			Module:   "some.where",
 			Location: "code.go:42",
 			Level:    loggo.INFO,

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/version"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
@@ -34,7 +33,7 @@ type agentLoggingStrategy struct {
 	dblogger   recordLogger
 	releaser   func()
 	version    version.Number
-	entity     names.Tag
+	entity     string
 	filePrefix string
 }
 
@@ -142,7 +141,7 @@ func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 		return errors.Trace(err)
 	}
 	s.version = ver
-	s.entity = entity.Tag()
+	s.entity = entity.Tag().String()
 	s.filePrefix = st.ModelUUID() + ":"
 	s.dblogger = s.dbloggers.get(st.State)
 	s.releaser = func() {
@@ -176,7 +175,7 @@ func (s *agentLoggingStrategy) WriteLog(m params.LogRecord) error {
 		Message:  m.Message,
 	}}), "logging to DB failed")
 
-	m.Entity = s.entity.String()
+	m.Entity = s.entity
 	fileErr := errors.Annotate(
 		logToFile(s.fileLogger, s.filePrefix, m),
 		"logging to logsink.log failed",

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -231,7 +231,7 @@ func (h *logStreamRequestHandler) apiFromRecords(records []*state.LogRecord) par
 			ID:        rec.ID,
 			ModelUUID: rec.ModelUUID,
 			Version:   rec.Version.String(),
-			Entity:    rec.Entity.String(),
+			Entity:    rec.Entity,
 			Timestamp: rec.Time,
 			Module:    rec.Module,
 			Location:  rec.Location,

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -105,7 +104,7 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 		ModelUUID: "deadbeef-...",
 		Version:   version.Current,
 		Time:      time.Date(2015, 6, 19, 15, 34, 37, 0, time.UTC),
-		Entity:    names.NewMachineTag("99"),
+		Entity:    "machine-99",
 		Module:    "some.where",
 		Location:  "code.go:42",
 		Level:     loggo.INFO,
@@ -115,7 +114,7 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 		ModelUUID: "deadbeef-...",
 		Version:   version.Current,
 		Time:      time.Date(2015, 6, 19, 15, 36, 40, 0, time.UTC),
-		Entity:    names.NewUnitTag("foo/2"),
+		Entity:    "unit-foo-2",
 		Module:    "else.where",
 		Location:  "go.go:22",
 		Level:     loggo.ERROR,
@@ -132,7 +131,7 @@ func (s *LogStreamIntSuite) TestFullRequest(c *gc.C) {
 			Records: []params.LogStreamRecord{{
 				ID:        rec.ID,
 				ModelUUID: rec.ModelUUID,
-				Entity:    rec.Entity.String(),
+				Entity:    rec.Entity,
 				Version:   version.Current.String(),
 				Timestamp: rec.Time,
 				Module:    rec.Module,

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
@@ -80,17 +79,9 @@ func (s *migrationLoggingStrategy) Close() error {
 // WriteLog is part of the logsink.LogWriteCloser interface.
 func (s *migrationLoggingStrategy) WriteLog(m params.LogRecord) error {
 	level, _ := loggo.ParseLevel(m.Level)
-	var entity names.Tag
-	if m.Entity != "" {
-		var err error
-		entity, err = names.ParseTag(m.Entity)
-		if err != nil {
-			return errors.Annotate(err, "parsing entity from log record")
-		}
-	}
 	err := s.dblogger.Log([]state.LogRecord{{
 		Time:     m.Time,
-		Entity:   entity,
+		Entity:   m.Entity,
 		Module:   m.Module,
 		Location: m.Location,
 		Level:    level,

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -193,7 +193,7 @@ func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, statePool *state.Stat
 		writer.WriteString(c.format(
 			rec.Time,
 			rec.Level,
-			rec.Entity.String(),
+			rec.Entity,
 			rec.Module,
 			rec.Message,
 		) + "\n")

--- a/featuretests/cmd_juju_dumplogs_test.go
+++ b/featuretests/cmd_juju_dumplogs_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
@@ -56,7 +55,7 @@ func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
 		for i := 0; i < 3; i++ {
 			err := w.Log([]state.LogRecord{{
 				Time:     t,
-				Entity:   names.NewMachineTag("42"),
+				Entity:   "machine-42",
 				Version:  version.Current,
 				Module:   "module",
 				Location: "location",

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -178,7 +178,7 @@ func (s *debugLogDbSuite1) TestLogsAPI(c *gc.C) {
 	t := time.Date(2015, 6, 23, 13, 8, 49, 0, time.UTC)
 	err := dbLogger.Log([]state.LogRecord{{
 		Time:     t,
-		Entity:   names.NewMachineTag("99"),
+		Entity:   "not-a-tag",
 		Version:  version.Current,
 		Module:   "juju.foo",
 		Location: "code.go:42",
@@ -186,7 +186,7 @@ func (s *debugLogDbSuite1) TestLogsAPI(c *gc.C) {
 		Message:  "all is well",
 	}, {
 		Time:     t.Add(time.Second),
-		Entity:   names.NewMachineTag("99"),
+		Entity:   "not-a-tag",
 		Version:  version.Current,
 		Module:   "juju.bar",
 		Location: "go.go:99",
@@ -217,7 +217,7 @@ func (s *debugLogDbSuite1) TestLogsAPI(c *gc.C) {
 
 	// Read the 2 lines that are in the logs collection.
 	assertMessage(common.LogMessage{
-		Entity:    "machine-99",
+		Entity:    "not-a-tag",
 		Timestamp: t,
 		Severity:  "INFO",
 		Module:    "juju.foo",
@@ -225,7 +225,7 @@ func (s *debugLogDbSuite1) TestLogsAPI(c *gc.C) {
 		Message:   "all is well",
 	})
 	assertMessage(common.LogMessage{
-		Entity:    "machine-99",
+		Entity:    "not-a-tag",
 		Timestamp: t.Add(time.Second),
 		Severity:  "ERROR",
 		Module:    "juju.bar",
@@ -236,7 +236,7 @@ func (s *debugLogDbSuite1) TestLogsAPI(c *gc.C) {
 	// Now write and observe another log. This should be read from the oplog.
 	err = dbLogger.Log([]state.LogRecord{{
 		Time:     t.Add(2 * time.Second),
-		Entity:   names.NewMachineTag("99"),
+		Entity:   "not-a-tag",
 		Version:  version.Current,
 		Module:   "ju.jitsu",
 		Location: "no.go:3",
@@ -244,7 +244,7 @@ func (s *debugLogDbSuite1) TestLogsAPI(c *gc.C) {
 		Message:  "beep beep",
 	}})
 	assertMessage(common.LogMessage{
-		Entity:    "machine-99",
+		Entity:    "not-a-tag",
 		Timestamp: t.Add(2 * time.Second),
 		Severity:  "WARNING",
 		Module:    "ju.jitsu",
@@ -263,7 +263,8 @@ func (s *debugLogDbSuite2) TestLogsUsesStartTime(c *gc.C) {
 	dbLogger := state.NewDbLogger(s.State)
 	defer dbLogger.Close()
 
-	entity := names.NewMachineTag("99")
+	entity := "not-a-tag"
+
 	version := version.Current
 	t1 := time.Date(2015, 6, 23, 13, 8, 49, 100, time.UTC)
 	// Check that start time has subsecond resolution.
@@ -320,7 +321,7 @@ func (s *debugLogDbSuite2) TestLogsUsesStartTime(c *gc.C) {
 		}
 	}
 	assertMessage(common.LogMessage{
-		Entity:    "machine-99",
+		Entity:    "not-a-tag",
 		Timestamp: t3,
 		Severity:  "ERROR",
 		Module:    "juju.bar",
@@ -328,7 +329,7 @@ func (s *debugLogDbSuite2) TestLogsUsesStartTime(c *gc.C) {
 		Message:   "born ruffians",
 	})
 	assertMessage(common.LogMessage{
-		Entity:    "machine-99",
+		Entity:    "not-a-tag",
 		Timestamp: t4,
 		Severity:  "WARNING",
 		Module:    "juju.baz",

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -518,7 +518,7 @@ func AssertHostPortConversion(c *gc.C, netHostPort network.HostPort) {
 
 // MakeLogDoc creates a database document for a single log message.
 func MakeLogDoc(
-	entity names.Tag,
+	entity string,
 	t time.Time,
 	module string,
 	location string,
@@ -528,7 +528,7 @@ func MakeLogDoc(
 	return &logDoc{
 		Id:       bson.NewObjectId(),
 		Time:     t.UnixNano(),
-		Entity:   entity.String(),
+		Entity:   entity,
 		Version:  version.Current.String(),
 		Module:   module,
 		Location: location,

--- a/state/logdb/buf_test.go
+++ b/state/logdb/buf_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/logdb"
@@ -57,13 +56,13 @@ func (s *BufferedLoggerSuite) TestLogFlushes(c *gc.C) {
 	const bufsz = 3
 	b := logdb.NewBufferedLogger(&s.mock, bufsz, time.Minute, s.clock)
 	in := []state.LogRecord{{
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "foo",
 	}, {
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "bar",
 	}, {
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "baz",
 	}}
 
@@ -86,13 +85,13 @@ func (s *BufferedLoggerSuite) TestLogFlushesMultiple(c *gc.C) {
 	const bufsz = 1
 	b := logdb.NewBufferedLogger(&s.mock, bufsz, time.Minute, s.clock)
 	in := []state.LogRecord{{
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "foo",
 	}, {
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "bar",
 	}, {
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "baz",
 	}}
 
@@ -112,10 +111,10 @@ func (s *BufferedLoggerSuite) TestTimerFlushes(c *gc.C) {
 
 	b := logdb.NewBufferedLogger(&s.mock, bufsz, flushInterval, s.clock)
 	in := []state.LogRecord{{
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "foo",
 	}, {
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "bar",
 	}}
 
@@ -164,13 +163,13 @@ func (s *BufferedLoggerSuite) TestLogOverCapacity(c *gc.C) {
 	// until the timer triggers.
 	b := logdb.NewBufferedLogger(&s.mock, bufsz, flushInterval, s.clock)
 	in := []state.LogRecord{{
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "foo",
 	}, {
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "bar",
 	}, {
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "baz",
 	}}
 
@@ -198,7 +197,7 @@ func (s *BufferedLoggerSuite) TestFlushReportsError(c *gc.C) {
 	s.mock.SetErrors(errors.New("nope"))
 	b := logdb.NewBufferedLogger(&s.mock, 2, time.Minute, s.clock)
 	err := b.Log([]state.LogRecord{{
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "foo",
 	}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -210,7 +209,7 @@ func (s *BufferedLoggerSuite) TestLogReportsError(c *gc.C) {
 	s.mock.SetErrors(errors.New("nope"))
 	b := logdb.NewBufferedLogger(&s.mock, 1, time.Minute, s.clock)
 	err := b.Log([]state.LogRecord{{
-		Entity:  names.NewMachineTag("0"),
+		Entity:  "not-a-tag",
 		Message: "foo",
 	}})
 	c.Assert(err, gc.ErrorMatches, "nope")

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -438,48 +438,6 @@ func (s *LogTailerSuite) TestModelFiltering(c *gc.C) {
 	s.checkLogTailerFiltering(c, s.otherState, state.LogTailerParams{}, writeLogs, assert)
 }
 
-func (s *LogTailerSuite) TestTailingSkipsBadDocs(c *gc.C) {
-	writeLogs := func() {
-		s.writeLogs(c, s.modelUUID, 1, logTemplate{
-			Entity: emptyTag{},
-		})
-		s.writeLogs(c, s.modelUUID, 1, logTemplate{
-			Message: "good1",
-		})
-		s.writeLogs(c, s.modelUUID, 1, logTemplate{
-			Message: "good2",
-		})
-	}
-
-	assert := func(tailer state.LogTailer) {
-		messages := map[string]bool{}
-		defer func() {
-			c.Assert(messages, gc.HasLen, 2)
-			for m := range messages {
-				if m != "good1" && m != "good2" {
-					c.Fatalf("received message: %v", m)
-				}
-			}
-		}()
-		count := 0
-		for {
-			select {
-			case log := <-tailer.Logs():
-				c.Assert(log.ModelUUID, gc.Equals, s.State.ModelUUID())
-				messages[log.Message] = true
-				count++
-				c.Logf("count %d", count)
-				if count >= 2 {
-					return
-				}
-			case <-time.After(coretesting.ShortWait):
-				c.Fatalf("timeout waiting for logs %d", count)
-			}
-		}
-	}
-	s.checkLogTailerFiltering(c, s.State, state.LogTailerParams{}, writeLogs, assert)
-}
-
 func (s *LogTailerSuite) TestTailingLogsOnlyForOneModel(c *gc.C) {
 	writeLogs := func() {
 		s.writeLogs(c, s.otherUUID, 1, logTemplate{
@@ -627,9 +585,9 @@ func (s *LogTailerSuite) TestNoTail(c *gc.C) {
 }
 
 func (s *LogTailerSuite) TestIncludeEntity(c *gc.C) {
-	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
-	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
-	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	machine0 := logTemplate{Entity: "machine-0"}
+	foo0 := logTemplate{Entity: "unit-foo-0"}
+	foo1 := logTemplate{Entity: "unit-foo-1"}
 	writeLogs := func() {
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 		s.writeLogs(c, s.otherUUID, 2, foo0)
@@ -650,9 +608,9 @@ func (s *LogTailerSuite) TestIncludeEntity(c *gc.C) {
 }
 
 func (s *LogTailerSuite) TestIncludeEntityWildcard(c *gc.C) {
-	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
-	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
-	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	machine0 := logTemplate{Entity: "machine-0"}
+	foo0 := logTemplate{Entity: "unit-foo-0"}
+	foo1 := logTemplate{Entity: "unit-foo-1"}
 	writeLogs := func() {
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 		s.writeLogs(c, s.otherUUID, 2, foo0)
@@ -672,9 +630,9 @@ func (s *LogTailerSuite) TestIncludeEntityWildcard(c *gc.C) {
 }
 
 func (s *LogTailerSuite) TestExcludeEntity(c *gc.C) {
-	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
-	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
-	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	machine0 := logTemplate{Entity: "machine-0"}
+	foo0 := logTemplate{Entity: "unit-foo-0"}
+	foo1 := logTemplate{Entity: "unit-foo-1"}
 	writeLogs := func() {
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 		s.writeLogs(c, s.otherUUID, 2, foo0)
@@ -694,9 +652,9 @@ func (s *LogTailerSuite) TestExcludeEntity(c *gc.C) {
 }
 
 func (s *LogTailerSuite) TestExcludeEntityWildcard(c *gc.C) {
-	machine0 := logTemplate{Entity: names.NewMachineTag("0")}
-	foo0 := logTemplate{Entity: names.NewUnitTag("foo/0")}
-	foo1 := logTemplate{Entity: names.NewUnitTag("foo/1")}
+	machine0 := logTemplate{Entity: "machine-0"}
+	foo0 := logTemplate{Entity: "unit-foo-0"}
+	foo1 := logTemplate{Entity: "unit-foo-1"}
 	writeLogs := func() {
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 		s.writeLogs(c, s.otherUUID, 2, foo0)
@@ -808,7 +766,7 @@ func (s *LogTailerSuite) checkLogTailerFiltering(
 }
 
 type logTemplate struct {
-	Entity   names.Tag
+	Entity   string
 	Version  version.Number
 	Module   string
 	Location string
@@ -873,8 +831,8 @@ func (s *LogTailerSuite) deleteLogOplogEntry(modelUUID string, doc interface{}) 
 }
 
 func (s *LogTailerSuite) normaliseLogTemplate(lt *logTemplate) {
-	if lt.Entity == nil {
-		lt.Entity = names.NewMachineTag("0")
+	if lt.Entity == "" {
+		lt.Entity = "not-a-tag"
 	}
 	if lt.Version == version.Zero {
 		lt.Version = jujuversion.Current

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -149,14 +149,14 @@ func (s *LogsSuite) TestDbLogger(c *gc.C) {
 	t1 := t0.Add(time.Second)
 	err := logger.Log([]state.LogRecord{{
 		Time:     t0,
-		Entity:   names.NewMachineTag("45"),
+		Entity:   "machine-45",
 		Module:   "some.where",
 		Location: "foo.go:99",
 		Level:    loggo.INFO,
 		Message:  "all is well",
 	}, {
 		Time:     t1,
-		Entity:   names.NewMachineTag("47"),
+		Entity:   "machine-47",
 		Module:   "else.where",
 		Location: "bar.go:42",
 		Level:    loggo.ERROR,
@@ -190,7 +190,7 @@ func (s *LogsSuite) TestPruneLogsByTime(c *gc.C) {
 	log := func(t time.Time, msg string) {
 		err := dbLogger.Log([]state.LogRecord{{
 			Time:     t,
-			Entity:   names.NewMachineTag("22"),
+			Entity:   "machine-22",
 			Version:  jujuversion.Current,
 			Module:   "module",
 			Location: "loc",
@@ -283,7 +283,7 @@ func (s *LogsSuite) generateLogs(c *gc.C, st *state.State, endTime time.Time, co
 		ts := endTime.Add(-time.Duration(i) * time.Second)
 		err := dbLogger.Log([]state.LogRecord{{
 			Time:     ts,
-			Entity:   names.NewMachineTag("0"),
+			Entity:   "machine-0",
 			Version:  jujuversion.Current,
 			Module:   "module",
 			Location: "loc",

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3082,7 +3082,7 @@ func writeLogs(c *gc.C, st *state.State, n int) {
 	for i := 0; i < n; i++ {
 		err := dbLogger.Log([]state.LogRecord{{
 			Time:     time.Now(),
-			Entity:   names.NewApplicationTag("van-occupanther"),
+			Entity:   "application-van-occupanther",
 			Module:   "chasing after deer",
 			Location: "in a log house",
 			Level:    loggo.INFO,

--- a/worker/dblogpruner/worker_test.go
+++ b/worker/dblogpruner/worker_test.go
@@ -185,7 +185,7 @@ func (s *suite) addLogs(c *gc.C, t0 time.Time, text string, count int) {
 		t := t0.Add(-time.Duration(offset) * time.Second)
 		dbLogger.Log([]state.LogRecord{{
 			Time:     t,
-			Entity:   names.NewMachineTag("0"),
+			Entity:   "not-a-tag",
 			Version:  version.Current,
 			Module:   "some.module",
 			Location: "foo.go:42",


### PR DESCRIPTION
Once we have a log entry we never use it to retrieve the underlying entity. We just spend time getting the value in and out of a tag again on the server side. None of these changes impact the apiserver streaming format nor how the values are actually stored in the database.

## QA steps

Bootstrap LXD
Deploy ubuntu-lite
Check both debug-log command, and SSH into the machines to check the logs on disk. Nothing there changes.

## Documentation changes

No user facing change at all.