### PR TITLE
Bring in worker.v1 dependency changes.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1540,7 +1540,7 @@
   revision = "fd59336b4621bc2a70bf96d9e2f49954115ad19b"
 
 [[projects]]
-  digest = "1:deb1b0b9f4c4a65246fc1cd82b9d9a3c2ac834a04ef899055853d44770e4c31d"
+  digest = "1:655012e2c1425cab51166b6d34a4edffe358bad76c11b47e0b1e2435101306c8"
   name = "gopkg.in/juju/worker.v1"
   packages = [
     ".",
@@ -1550,7 +1550,7 @@
     "workertest",
   ]
   pruneopts = ""
-  revision = "187c8117684679e0e261b1d6f488a404d1d093c9"
+  revision = "5398f2291f2c69afe604411634e0d008bdf453a0"
 
 [[projects]]
   digest = "1:01aef8078808543c15a4cc0e669d92d37215564600e19ebabbd694939b727977"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -500,7 +500,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/worker.v1"
-  revision = "187c8117684679e0e261b1d6f488a404d1d093c9"
+  revision = "5398f2291f2c69afe604411634e0d008bdf453a0"
 
 [[override]]
   name = "gopkg.in/macaroon-bakery.v1"

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -161,13 +161,14 @@ func GetJujuVersion(machineAgent string, dataDir string) (version.Number, error)
 
 func dependencyEngineConfig() dependency.EngineConfig {
 	return dependency.EngineConfig{
-		IsFatal:       util.IsFatal,
-		WorstError:    util.MoreImportantError,
-		ErrorDelay:    3 * time.Second,
-		BounceDelay:   10 * time.Millisecond,
-		BackoffFactor: 1.2,
-		MaxDelay:      2 * time.Minute,
-		Clock:         clock.WallClock,
-		Logger:        loggo.GetLogger("juju.worker.dependency"),
+		IsFatal:          util.IsFatal,
+		WorstError:       util.MoreImportantError,
+		ErrorDelay:       3 * time.Second,
+		BounceDelay:      10 * time.Millisecond,
+		BackoffFactor:    1.2,
+		BackoffResetTime: 1 * time.Minute,
+		MaxDelay:         2 * time.Minute,
+		Clock:            clock.WallClock,
+		Logger:           loggo.GetLogger("juju.worker.dependency"),
 	}
 }


### PR DESCRIPTION
## Description of change

Change the BackoffResetTime to 1 minute so that any errors within 1
minute of starting will be treated as things that should be retried, but
not on a fast cadence.

## QA steps

```
$ juju bootstrap lxd lxd
// Trigger some sort of error in the workers. An obvious on is 'out of disk space'.
$ juju debug-log
// Watch that the workers are being restarted, but each time they take a bit 
// longer to come back up again.
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1827664