### PR TITLE
Forward-port: "avoid agent uninstall for fatal connection errors"

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -269,16 +269,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 	// connectFilter exists:
 	//  1) to let us retry api connections immediately on password change,
 	//     rather than causing the dependency engine to wait for a while;
-	//  2) to ensure that certain connection failures correctly trigger
-	//     complete agent removal. (It's not safe to let any agent other
-	//     than the machine mess around with SetCanUninstall).
+	//  2) to decide how to deal with fatal, non-recoverable errors
+	//     e.g apicaller.ErrConnectImpossible.
 	connectFilter := func(err error) error {
 		cause := errors.Cause(err)
 		if cause == apicaller.ErrConnectImpossible {
-			err2 := coreagent.SetCanUninstall(config.Agent)
-			if err2 != nil {
-				return errors.Trace(err2)
-			}
 			return jworker.ErrTerminateAgent
 		} else if cause == apicaller.ErrChangedPassword {
 			return dependency.ErrBounce

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -316,7 +316,7 @@ func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *gc.C) {
 			dataPath: c.MkDir(),
 		},
 	}
-	manifolds := machine.Manifolds(machine.ManifoldsConfig{
+	manifolds := machine.IAASManifolds(machine.ManifoldsConfig{
 		Agent: ag,
 	})
 

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/agent/machine"
 	"github.com/juju/juju/testing"
+	jworker "github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/gate"
 )
 
@@ -306,6 +308,27 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
 		}
 	}
+}
+
+func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *gc.C) {
+	ag := &mockAgent{
+		conf: mockConfig{
+			dataPath: c.MkDir(),
+		},
+	}
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{
+		Agent: ag,
+	})
+
+	c.Assert(manifolds["api-caller"], gc.Not(gc.IsNil))
+	apiCaller := manifolds["api-caller"]
+
+	// Check that when the api-caller maps non-recoverable errors to
+	// ErrTerminateAgent and that it does not create an uninstall file for
+	// the agent.
+	err := apiCaller.Filter(apicaller.ErrConnectImpossible)
+	c.Assert(err, gc.Equals, jworker.ErrTerminateAgent)
+	c.Assert(agent.CanUninstall(ag), gc.Equals, false)
 }
 
 func checkContains(c *gc.C, names []string, seek string) {
@@ -1035,9 +1058,10 @@ func (ma *mockAgent) ChangeConfig(f agent.ConfigMutator) error {
 
 type mockConfig struct {
 	agent.ConfigSetter
-	tag    names.Tag
-	ssiSet bool
-	ssi    params.StateServingInfo
+	tag      names.Tag
+	ssiSet   bool
+	ssi      params.StateServingInfo
+	dataPath string
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -1062,4 +1086,11 @@ func (mc *mockConfig) SetStateServingInfo(info params.StateServingInfo) {
 
 func (mc *mockConfig) LogDir() string {
 	return "log-dir"
+}
+
+func (mc *mockConfig) DataDir() string {
+	if mc.dataPath != "" {
+		return mc.dataPath
+	}
+	return "data-dir"
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -213,32 +213,6 @@ func (s *MachineLegacyLeasesSuite) TestRunStop(c *gc.C) {
 	c.Assert(charmrepo.CacheDir, gc.Equals, filepath.Join(ac.DataDir(), "charmcache"))
 }
 
-func (s *MachineLegacyLeasesSuite) TestWithDeadMachine(c *gc.C) {
-	m, ac, _ := s.primeAgent(c, state.JobHostUnits)
-	err := m.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-	a := s.newAgent(c, m)
-	err = runWithTimeout(a)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = os.Stat(ac.DataDir())
-	c.Assert(err, jc.Satisfies, os.IsNotExist)
-}
-
-func (s *MachineLegacyLeasesSuite) TestWithRemovedMachine(c *gc.C) {
-	m, ac, _ := s.primeAgent(c, state.JobHostUnits)
-	err := m.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-	err = m.Remove()
-	c.Assert(err, jc.ErrorIsNil)
-	a := s.newAgent(c, m)
-	err = runWithTimeout(a)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = os.Stat(ac.DataDir())
-	c.Assert(err, jc.Satisfies, os.IsNotExist)
-}
-
 func (s *MachineLegacyLeasesSuite) TestDyingMachine(c *gc.C) {
 	m, _, _ := s.primeAgent(c, state.JobHostUnits)
 	a := s.newAgent(c, m)
@@ -787,11 +761,14 @@ func (s *MachineLegacyLeasesSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C)
 }
 
 func (s *MachineLegacyLeasesSuite) TestMachineAgentUninstall(c *gc.C) {
+	c.Skip("test takes over 30s to complete; we need to investigate why it takes so long for the agent to appear as alive")
+
 	m, ac, _ := s.primeAgent(c, state.JobHostUnits)
-	err := m.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
 	a := s.newAgent(c, m)
-	err = runWithTimeout(a)
+
+	// Wait for the agent to become alive, then run EnsureDead and wait
+	// for the agent to exit
+	err := s.WithAliveAgent(m, a, m.EnsureDead)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// juju-* symlinks should have been removed on termination.

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -255,6 +255,44 @@ func (s *commonMachineSuite) setFakeMachineAddresses(c *gc.C, machine *state.Mac
 	dummy.SetInstanceAddresses(insts[0], addrs)
 }
 
+// WithAliveAgent starts the agent, wait till it becomes alive and then invokes
+// the provided cb. Once the callback returns, WithAliveAgent will block until
+// the agent either exits or exceeds its run timeout. In both cases, any error
+// returned by the agent's Run method will be captured and returned to the
+// caller.
+func (s *commonMachineSuite) WithAliveAgent(m *state.Machine, a *MachineAgent, cb func() error) error {
+	// achilleasa: the agent usually takes a around 30 seconds
+	waitTime := coretesting.LongWait * 3
+
+	errCh := make(chan error, 1)
+	go func() {
+		select {
+		case errCh <- a.Run(nil):
+		case <-time.After(waitTime):
+			errCh <- fmt.Errorf("time out waiting for agent to complete its run")
+		}
+		a.Stop()
+		close(errCh)
+	}()
+
+	if err := m.WaitAgentPresence(waitTime); err != nil {
+		return err
+	}
+
+	if cb != nil {
+		if err := cb(); err != nil {
+			return err
+		}
+	}
+
+	// Wait for agent to exit or timeout
+	for err := range errCh {
+		return err
+	}
+
+	return nil
+}
+
 // opRecvTimeout waits for any of the given kinds of operation to
 // be received from ops, and times out if not.
 func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds ...dummy.Operation) dummy.Operation {


### PR DESCRIPTION
## Description of change

This is a forward-port of #10193 to the 2.6 branch