### PR TITLE
2.5 - Restore Oracle OCI Provider Operation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1031,7 +1031,7 @@
   version = "v1.0.0-rc1"
 
 [[projects]]
-  digest = "1:5b6cfb1e5aa514a8ea62ebbda2f23874e5aa86fa1792f2c6f1643dc7538f7f45"
+  digest = "1:a5f72b318ab8d863ccb8c16468eeff36cafb6357d9f1f90197df7ca7f53dbe5e"
   name = "github.com/oracle/oci-go-sdk"
   packages = [
     "common",
@@ -1039,7 +1039,7 @@
     "identity",
   ]
   pruneopts = ""
-  revision = "ad5c34ed0cf8169d6817e2a37ec3e4521f856368"
+  revision = "72941f7f9bfa6550f640b797fde43b19b1574911"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -131,7 +131,7 @@
 
 [[constraint]]
   name = "github.com/oracle/oci-go-sdk"
-  revision = "ad5c34ed0cf8169d6817e2a37ec3e4521f856368"
+  revision = "72941f7f9bfa6550f640b797fde43b19b1574911"
 
 [[constraint]]
   revision = "8c3190dff075bf5442c9eedbf8f8ed6144a099e7"

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -445,13 +445,10 @@ func (e *Environ) getCloudInitConfig(series string, apiPort int) (cloudinit.Clou
 	}
 	switch operatingSystem {
 	case os.Ubuntu:
-		fwCmd := fmt.Sprintf(
-			"/sbin/iptables -I INPUT -p tcp --dport %d -j ACCEPT", apiPort)
-		cloudcfg.AddRunCmd(fwCmd)
+		cloudcfg.AddRunCmd(fmt.Sprintf("/sbin/iptables -I INPUT -p tcp --dport %d -j ACCEPT", apiPort))
 		cloudcfg.AddScripts("/etc/init.d/netfilter-persistent save")
 	case os.CentOS:
-		fwCmd := fmt.Sprintf("firewall-cmd --zone=public --add-port=%d/tcp --permanent", apiPort)
-		cloudcfg.AddRunCmd(fwCmd)
+		cloudcfg.AddRunCmd(fmt.Sprintf("firewall-cmd --zone=public --add-port=%d/tcp --permanent", apiPort))
 		cloudcfg.AddRunCmd("firewall-cmd --reload")
 	}
 	return cloudcfg, nil
@@ -773,6 +770,8 @@ func (e *Environ) PrecheckInstance(envcontext.ProviderCallContext, environs.Prec
 }
 
 // InstanceTypes implements environs.InstancePrechecker.
-func (e *Environ) InstanceTypes(envcontext.ProviderCallContext, constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (e *Environ) InstanceTypes(
+	envcontext.ProviderCallContext, constraints.Value,
+) (instances.InstanceTypesWithCostMetadata, error) {
 	return instances.InstanceTypesWithCostMetadata{}, errors.NotImplementedf("InstanceTypes")
 }

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -445,13 +445,10 @@ func (e *Environ) getCloudInitConfig(series string, apiPort int) (cloudinit.Clou
 	}
 	switch operatingSystem {
 	case os.Ubuntu:
-		fwCmd := fmt.Sprintf(
-			"/sbin/iptables -I INPUT -p tcp --dport %d -j ACCEPT", apiPort)
-		cloudcfg.AddRunCmd(fwCmd)
+		cloudcfg.AddRunCmd(fmt.Sprintf("/sbin/iptables -I INPUT -p tcp --dport %d -j ACCEPT", apiPort))
 		cloudcfg.AddScripts("/etc/init.d/netfilter-persistent save")
 	case os.CentOS:
-		fwCmd := fmt.Sprintf("firewall-cmd --zone=public --add-port=%d/tcp --permanent", apiPort)
-		cloudcfg.AddRunCmd(fwCmd)
+		cloudcfg.AddRunCmd(fmt.Sprintf("firewall-cmd --zone=public --add-port=%d/tcp --permanent", apiPort))
 		cloudcfg.AddRunCmd("firewall-cmd --reload")
 	}
 	return cloudcfg, nil

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -585,9 +585,9 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 		return nil, errors.Annotate(err, "cannot make user data")
 	}
 
-	var rootDiskSizeGB int
+	var rootDiskSizeGB int64
 	if args.Constraints.RootDisk != nil {
-		rootDiskSizeGB = int(*args.Constraints.RootDisk) / 1024
+		rootDiskSizeGB = int64(*args.Constraints.RootDisk) / 1024
 		if int(*args.Constraints.RootDisk) < MinVolumeSizeMB {
 			logger.Warningf(
 				"selected disk size is too small (%d MB). Setting root disk size to minimum volume size (%d MB)",

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -445,10 +445,13 @@ func (e *Environ) getCloudInitConfig(series string, apiPort int) (cloudinit.Clou
 	}
 	switch operatingSystem {
 	case os.Ubuntu:
-		cloudcfg.AddRunCmd(fmt.Sprintf("/sbin/iptables -I INPUT -p tcp --dport %d -j ACCEPT", apiPort))
+		fwCmd := fmt.Sprintf(
+			"/sbin/iptables -I INPUT -p tcp --dport %d -j ACCEPT", apiPort)
+		cloudcfg.AddRunCmd(fwCmd)
 		cloudcfg.AddScripts("/etc/init.d/netfilter-persistent save")
 	case os.CentOS:
-		cloudcfg.AddRunCmd(fmt.Sprintf("firewall-cmd --zone=public --add-port=%d/tcp --permanent", apiPort))
+		fwCmd := fmt.Sprintf("firewall-cmd --zone=public --add-port=%d/tcp --permanent", apiPort)
+		cloudcfg.AddRunCmd(fwCmd)
 		cloudcfg.AddRunCmd("firewall-cmd --reload")
 	}
 	return cloudcfg, nil
@@ -770,8 +773,6 @@ func (e *Environ) PrecheckInstance(envcontext.ProviderCallContext, environs.Prec
 }
 
 // InstanceTypes implements environs.InstancePrechecker.
-func (e *Environ) InstanceTypes(
-	envcontext.ProviderCallContext, constraints.Value,
-) (instances.InstanceTypesWithCostMetadata, error) {
+func (e *Environ) InstanceTypes(envcontext.ProviderCallContext, constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	return instances.InstanceTypesWithCostMetadata{}, errors.NotImplementedf("InstanceTypes")
 }

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -1091,7 +1091,7 @@ func (e *environSuite) setupDeleteVcnExpectations(vcnId string) {
 }
 
 func (e *environSuite) setupDeleteVolumesExpectations() {
-	size := 50
+	size := int64(50)
 	volumes := []ociCore.Volume{
 		{
 			Id:                 makeStringPointer("fakeVolumeID1"),

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -939,41 +939,6 @@ func (e *environSuite) TestBootstrapNoMatchingTools(c *gc.C) {
 
 }
 
-func (e *environSuite) setupDeleteSecurityListExpectations(seclistId string, times int) {
-	request := ociCore.DeleteSecurityListRequest{
-		SecurityListId: makeStringPointer(seclistId),
-	}
-
-	response := ociCore.DeleteSecurityListResponse{
-		RawResponse: &http.Response{
-			StatusCode: 201,
-		},
-	}
-
-	expect := e.fw.EXPECT().DeleteSecurityList(context.Background(), request).Return(response, nil)
-	if times == 0 {
-		expect.AnyTimes()
-	} else {
-		expect.Times(times)
-	}
-
-	requestGet := ociCore.GetSecurityListRequest{
-		SecurityListId: makeStringPointer("fakeSecList"),
-	}
-
-	seclist := ociCore.SecurityList{
-		Id:             makeStringPointer("fakeSecList"),
-		LifecycleState: ociCore.SecurityListLifecycleStateTerminated,
-	}
-
-	responseGet := ociCore.GetSecurityListResponse{
-		SecurityList: seclist,
-	}
-
-	e.fw.EXPECT().GetSecurityList(context.Background(), requestGet).Return(responseGet, nil).AnyTimes()
-
-}
-
 func (e *environSuite) setupDeleteSubnetExpectations(subnetIds []string) {
 	for _, id := range subnetIds {
 		request := ociCore.DeleteSubnetRequest{
@@ -1002,35 +967,6 @@ func (e *environSuite) setupDeleteSubnetExpectations(subnetIds []string) {
 
 		e.netw.EXPECT().GetSubnet(context.Background(), requestGet).Return(responseGet, nil).AnyTimes()
 	}
-}
-
-func (e *environSuite) setupDeleteRouteTableExpectations(vcnId, routeTableId string, t map[string]string) {
-	e.setupListRouteTableExpectations(vcnId, t, 1)
-	request := ociCore.DeleteRouteTableRequest{
-		RtId: makeStringPointer(routeTableId),
-	}
-
-	response := ociCore.DeleteRouteTableResponse{
-		RawResponse: &http.Response{
-			StatusCode: 201,
-		},
-	}
-	e.netw.EXPECT().DeleteRouteTable(context.Background(), request).Return(response, nil).AnyTimes()
-
-	requestGet := ociCore.GetRouteTableRequest{
-		RtId: makeStringPointer(routeTableId),
-	}
-
-	rt := ociCore.RouteTable{
-		Id:             makeStringPointer(routeTableId),
-		LifecycleState: ociCore.RouteTableLifecycleStateTerminated,
-	}
-
-	responseGet := ociCore.GetRouteTableResponse{
-		RouteTable: rt,
-	}
-
-	e.netw.EXPECT().GetRouteTable(context.Background(), requestGet).Return(responseGet, nil).AnyTimes()
 }
 
 func (e *environSuite) setupDeleteInternetGatewayExpectations(vcnId, IgId string, t map[string]string) {
@@ -1172,10 +1108,7 @@ func (e *environSuite) TestDestroyController(c *gc.C) {
 	e.setupListInstancesExpectations(e.testInstanceID, ociCore.InstanceLifecycleStateTerminated, 0)
 	e.setupVcnExpectations(vcnId, machineTags, 1)
 	e.setupListSubnetsExpectations(vcnId, "fakeRouteTableId", machineTags, 1)
-	e.setupSecurityListExpectations(vcnId, machineTags, 1)
-	e.setupDeleteRouteTableExpectations(vcnId, "fakeRouteTableId", machineTags)
 	e.setupDeleteSubnetExpectations([]string{"fakeSubnetId1", "fakeSubnetId2", "fakeSubnetId3"})
-	e.setupDeleteSecurityListExpectations("fakeSecList", 0)
 	e.setupDeleteInternetGatewayExpectations(vcnId, "fakeGwId", machineTags)
 	e.setupDeleteVcnExpectations(vcnId)
 	e.setupDeleteVolumesExpectations()

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -496,7 +496,8 @@ func (e *Environ) ensureNetworksAndSubnets(
 	prefix := AllowAllPrefix
 	routeRules := []ociCore.RouteRule{
 		{
-			CidrBlock:       &prefix,
+			Destination:     &prefix,
+			DestinationType: ociCore.RouteRuleDestinationTypeCidrBlock,
 			NetworkEntityId: ig.Id,
 		},
 	}

--- a/provider/oci/storage_volumes.go
+++ b/provider/oci/storage_volumes.go
@@ -108,7 +108,7 @@ func (v *volumeSource) createVolume(ctx envcontext.ProviderCallContext, p storag
 	}
 	volTags[tags.JujuModel] = v.modelUUID
 
-	size := int(p.Size)
+	size := int64(p.Size)
 	requestDetails := ociCore.CreateVolumeDetails{
 		AvailabilityDomain: &availabilityZone,
 		CompartmentId:      v.env.ecfg().compartmentID(),

--- a/provider/oci/storage_volumes_test.go
+++ b/provider/oci/storage_volumes_test.go
@@ -53,7 +53,7 @@ func (s *storageVolumeSuite) newVolumeSource(c *gc.C) storage.VolumeSource {
 	return source
 }
 
-func (s *storageVolumeSuite) setupCreateVolumesExpectations(tag names.VolumeTag, size int) {
+func (s *storageVolumeSuite) setupCreateVolumesExpectations(tag names.VolumeTag, size int64) {
 	name := tag.String()
 	volTags := map[string]string{
 		tags.JujuModel: s.env.Config().UUID(),
@@ -151,7 +151,7 @@ func (s *storageVolumeSuite) TestCreateVolumesNilParams(c *gc.C) {
 	c.Assert(results, gc.HasLen, 0)
 }
 
-func (s *storageVolumeSuite) setupListVolumesExpectations(size int) map[string]ociCore.Volume {
+func (s *storageVolumeSuite) setupListVolumesExpectations(size int64) map[string]ociCore.Volume {
 	volTags := map[string]string{
 		tags.JujuModel: s.env.Config().UUID(),
 	}
@@ -250,7 +250,7 @@ func (s *storageVolumeSuite) TestValidateVolumeParams(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *storageVolumeSuite) setupDeleteVolumesExpectations(size int, id string) {
+func (s *storageVolumeSuite) setupDeleteVolumesExpectations(size int64, id string) {
 	volumes := s.setupListVolumesExpectations(size)
 
 	request := ociCore.DeleteVolumeRequest{


### PR DESCRIPTION
## Description of change

This patch addresses a breakage in the OCI provider.

The OCI cloud behaviour itself changed so that the default security list and route table for a VCN inherit the free-form tags from the VCN. 

We were using these tags to retrieve security lists and route tables created by Juju, which meant that we were detecting the default resources as Juju-managed ones. In turn this meant that those entities were not created by Juju with the necessary ingress/egress rules necessary for operation.

Instead of using the tags to retrieve local juju-managed resources, we now interrogate the display name for Juju-specific prefixes.

Additional changes include:
- Update of the Go OCI SDK to the most recent release, and accompanying type fixes.
- Mechanical fixes for line length and variable name conventions.
- Additional logging detail.

## QA steps

With the appropriate OCI credentials, ensure that 
```
juju bootstrap oracle --config compartment-id=ocid1.tenancy.oc1..aaaaaaaao7f7cccogqrg5emjxkxmctzbnhl6zdkkx36yq2jgxnm4p5vmysbq
``` 
is successful.

Note that destroying the controller displays an error for health ping time-out. The controller destruction *is* successful and no orphaned resources result. A later patch will address this at the same time as adding an acceptance test for this provider.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830390
