### PR TITLE
supportedJujuSeries() must include EMS and non Ubuntu juju supported series.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -623,14 +623,14 @@
   revision = "5b81707e882b8293e6cf77854b4cd49f29776e11"
 
 [[projects]]
-  digest = "1:5d0c254971cd92b4b9ac035202ff4501b1140be8aedbf7e69b4b986a359423d5"
+  digest = "1:98ba3905f2fd6c33f64c401123e6626d35f012293daa8f68b5e264d85edfa0f7"
   name = "github.com/juju/os"
   packages = [
     ".",
     "series",
   ]
   pruneopts = ""
-  revision = "b4dc09ce9ed2506a6c31763fa0742f4ebcbdceef"
+  revision = "c23cb5719c78fb34bcf0eefecf4137dd95436877"
 
 [[projects]]
   digest = "1:8fd6c21ba9a864b949672e63800d1bd71a3d8ac8e085cc22143b97f1261ad634"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,7 +90,7 @@
   name = "github.com/juju/naturalsort"
 
 [[constraint]]
-  revision = "b4dc09ce9ed2506a6c31763fa0742f4ebcbdceef"
+  revision = "c23cb5719c78fb34bcf0eefecf4137dd95436877"
   name = "github.com/juju/os"
 
 [[constraint]]

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -90,7 +90,7 @@ type CharmDeployAPI interface {
 }
 
 var supportedJujuSeries = func() []string {
-	return append(series.ESMSupportedJujuSeries(), kubernetesSeriesName)
+	return series.SupportedJujuSeries()
 }
 
 // DeployAPI represents the methods of the API the deploy


### PR DESCRIPTION
## Description of change

For the juju deploy command, supportedJujuSeries() must include EMS,  Ubuntu juju supported series and non Ubuntu juju supported series, otherwise juju deploy to series such as Disco or centos7 will require --force .

Requires: https://github.com/juju/os/pull/7

## QA steps

1. Deploy  acceptancetests/repository/charms-centos/dummy-source, after adding to metadata.yaml:
```
series:
  - centos7
```
2. Deploy acceptancetests/repository/charms/dummy-source --series disco, it maybe necessary to add to metadata.yaml:
```
series:
  - disco
```
3. Other deploys should work as expected and per https://github.com/juju/juju/pull/10125.
