### PR TITLE
undertaker: Remove model if cloud-destroy fails and --force is specified

### DIFF
--- a/apiserver/facades/controller/undertaker/mock_test.go
+++ b/apiserver/facades/controller/undertaker/mock_test.go
@@ -98,11 +98,12 @@ func (m *mockState) ModelUUID() string {
 // mockModel implements Model interface and allows inspection of called
 // methods.
 type mockModel struct {
-	tod   time.Time
-	owner names.UserTag
-	life  state.Life
-	name  string
-	uuid  string
+	tod    time.Time
+	owner  names.UserTag
+	life   state.Life
+	name   string
+	uuid   string
+	forced bool
 
 	status     status.Status
 	statusInfo string
@@ -117,6 +118,10 @@ func (m *mockModel) Owner() names.UserTag {
 
 func (m *mockModel) Life() state.Life {
 	return m.life
+}
+
+func (m *mockModel) ForceDestroyed() bool {
+	return m.forced
 }
 
 func (m *mockModel) Tag() names.Tag {

--- a/apiserver/facades/controller/undertaker/state.go
+++ b/apiserver/facades/controller/undertaker/state.go
@@ -68,6 +68,10 @@ type Model interface {
 	// Life returns whether the model is Alive, Dying or Dead.
 	Life() state.Life
 
+	// ForceDestroyed returns whether the dying/dead model was
+	// destroyed with --force. Always false for alive models.
+	ForceDestroyed() bool
+
 	// Name returns the human friendly name of the model.
 	Name() string
 

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -69,11 +69,12 @@ func (u *UndertakerAPI) ModelInfo() (params.UndertakerModelInfoResult, error) {
 	}
 
 	result.Result = params.UndertakerModelInfo{
-		UUID:       model.UUID(),
-		GlobalName: model.Owner().String() + "/" + model.Name(),
-		Name:       model.Name(),
-		IsSystem:   u.st.IsController(),
-		Life:       params.Life(model.Life().String()),
+		UUID:           model.UUID(),
+		GlobalName:     model.Owner().String() + "/" + model.Name(),
+		Name:           model.Name(),
+		IsSystem:       u.st.IsController(),
+		Life:           params.Life(model.Life().String()),
+		ForceDestroyed: model.ForceDestroyed(),
 	}
 
 	return result, nil

--- a/apiserver/facades/controller/undertaker/undertaker_test.go
+++ b/apiserver/facades/controller/undertaker/undertaker_test.go
@@ -68,6 +68,7 @@ func (s *undertakerSuite) TestModelInfo(c *gc.C) {
 		{st, api, true, "admin"},
 	} {
 		test.st.model.life = state.Dying
+		test.st.model.forced = true
 
 		result, err := test.api.ModelInfo()
 		c.Assert(err, jc.ErrorIsNil)
@@ -81,6 +82,7 @@ func (s *undertakerSuite) TestModelInfo(c *gc.C) {
 		c.Assert(info.Name, gc.Equals, test.modelName)
 		c.Assert(info.IsSystem, gc.Equals, test.isSystem)
 		c.Assert(info.Life, gc.Equals, params.Dying)
+		c.Assert(info.ForceDestroyed, gc.Equals, true)
 	}
 }
 

--- a/apiserver/params/undertaker.go
+++ b/apiserver/params/undertaker.go
@@ -5,11 +5,12 @@ package params
 
 // UndertakerModelInfo returns information on an model needed by the undertaker worker.
 type UndertakerModelInfo struct {
-	UUID       string `json:"uuid"`
-	Name       string `json:"name"`
-	GlobalName string `json:"global-name"`
-	IsSystem   bool   `json:"is-system"`
-	Life       Life   `json:"life"`
+	UUID           string `json:"uuid"`
+	Name           string `json:"name"`
+	GlobalName     string `json:"global-name"`
+	IsSystem       bool   `json:"is-system"`
+	Life           Life   `json:"life"`
+	ForceDestroyed bool   `json:"force-destroyed"`
 }
 
 // UndertakerModelInfoResult holds the result of an API call that returns an

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -329,6 +329,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:      apiCallerName,
 			CloudDestroyerName: environTrackerName,
 
+			Logger:                       loggo.GetLogger("juju.worker.undertaker"),
 			NewFacade:                    undertaker.NewFacade,
 			NewWorker:                    undertaker.NewWorker,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
@@ -425,6 +426,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:      apiCallerName,
 			CloudDestroyerName: caasBrokerTrackerName,
 
+			Logger:                       loggo.GetLogger("juju.worker.undertaker"),
 			NewFacade:                    undertaker.NewFacade,
 			NewWorker:                    undertaker.NewWorker,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -244,8 +244,11 @@ func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 		"Name",
 		// Life will always be alive, or we won't be migrating.
 		"Life",
-		// ControllerUUID is recreated when the new model
-		// is created in the new controller (yay name changes).
+		// ForceDestroyed is only relevant for models that are being
+		// removed.
+		"ForceDestroyed",
+		// ControllerUUID is recreated when the new model is created
+		// in the new controller (yay name changes).
 		"ControllerUUID",
 
 		"Type",

--- a/state/model.go
+++ b/state/model.go
@@ -117,7 +117,7 @@ type modelDoc struct {
 	// ForceDestroyed is whether --force was specified when destroying
 	// this model. It only has any meaning when the model is dying or
 	// dead.
-	ForceDestroyed bool `bson:"force-destroyed"`
+	ForceDestroyed bool `bson:"force-destroyed,omitempty"`
 }
 
 // slaLevel enumerates the support levels available to a model.

--- a/state/model.go
+++ b/state/model.go
@@ -113,6 +113,11 @@ type modelDoc struct {
 
 	// MeterStatus is the current meter status of the model.
 	MeterStatus modelMeterStatusdoc `bson:"meter-status"`
+
+	// ForceDestroyed is whether --force was specified when destroying
+	// this model. It only has any meaning when the model is dying or
+	// dead.
+	ForceDestroyed bool `bson:"force-destroyed"`
 }
 
 // slaLevel enumerates the support levels available to a model.
@@ -615,6 +620,12 @@ func (m *Model) SetMigrationMode(mode MigrationMode) error {
 // Life returns whether the model is Alive, Dying or Dead.
 func (m *Model) Life() Life {
 	return m.doc.Life
+}
+
+// ForceDestroyed returns whether the destruction of a dying/dead
+// model was forced. It's always false for a model that's alive.
+func (m *Model) ForceDestroyed() bool {
+	return m.doc.ForceDestroyed
 }
 
 // Owner returns tag representing the owner of the model.
@@ -1265,6 +1276,7 @@ func (m *Model) destroyOps(
 				bson.D{
 					{"life", nextLife},
 					{"time-of-dying", m.st.nowToTheSecond()},
+					{"force-destroyed", force},
 				},
 			},
 		}

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1097,6 +1097,47 @@ func (s *ModelSuite) TestDestroyModelWithApplicationOffers(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *ModelSuite) TestForceDestroySetsForceDestroyed(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(model.ForceDestroyed(), gc.Equals, false)
+
+	force := true
+	err = model.Destroy(state.DestroyModelParams{
+		Force: &force,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(model.Life(), gc.Equals, state.Dying)
+	c.Assert(model.ForceDestroyed(), gc.Equals, true)
+}
+
+func (s *ModelSuite) TestNonForceDestroy(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	noForce := false
+	err = model.Destroy(state.DestroyModelParams{
+		Force: &noForce,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(model.Life(), gc.Equals, state.Dying)
+	c.Assert(model.ForceDestroyed(), gc.Equals, false)
+}
+
 func (s *ModelSuite) TestProcessDyingServerModelTransitionDyingToDead(c *gc.C) {
 	s.assertDyingModelTransitionDyingToDead(c, s.State)
 }

--- a/worker/undertaker/manifold.go
+++ b/worker/undertaker/manifold.go
@@ -19,6 +19,7 @@ type ManifoldConfig struct {
 	APICallerName      string
 	CloudDestroyerName string
 
+	Logger                       Logger
 	NewFacade                    func(base.APICaller) (Facade, error)
 	NewWorker                    func(Config) (worker.Worker, error)
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
@@ -49,6 +50,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		Facade:        facade,
 		Destroyer:     destroyer,
 		CredentialAPI: credentialAPI,
+		Logger:        config.Logger,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/undertaker/mock_test.go
+++ b/worker/undertaker/mock_test.go
@@ -88,9 +88,10 @@ type fixture struct {
 	info   params.UndertakerModelInfoResult
 	errors []error
 	dirty  bool
+	logger fakeLogger
 }
 
-func (fix fixture) cleanup(c *gc.C, w worker.Worker) {
+func (fix *fixture) cleanup(c *gc.C, w worker.Worker) {
 	if fix.dirty {
 		workertest.DirtyKill(c, w)
 	} else {
@@ -98,7 +99,7 @@ func (fix fixture) cleanup(c *gc.C, w worker.Worker) {
 	}
 }
 
-func (fix fixture) run(c *gc.C, test func(worker.Worker)) *testing.Stub {
+func (fix *fixture) run(c *gc.C, test func(worker.Worker)) *testing.Stub {
 	stub := &testing.Stub{}
 	environOrBroker := &mockDestroyer{
 		stub: stub,
@@ -112,6 +113,7 @@ func (fix fixture) run(c *gc.C, test func(worker.Worker)) *testing.Stub {
 		Facade:        facade,
 		Destroyer:     environOrBroker,
 		CredentialAPI: &fakeCredentialAPI{},
+		Logger:        &fix.logger,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer fix.cleanup(c, w)

--- a/worker/undertaker/validate_test.go
+++ b/worker/undertaker/validate_test.go
@@ -36,11 +36,18 @@ func (*ValidateSuite) TestNilCredentialAPI(c *gc.C) {
 	checkInvalid(c, config, "nil CredentialAPI not valid")
 }
 
+func (*ValidateSuite) TestNilLogger(c *gc.C) {
+	config := validConfig()
+	config.Logger = nil
+	checkInvalid(c, config, "nil Logger not valid")
+}
+
 func validConfig() undertaker.Config {
 	return undertaker.Config{
 		Facade:        &fakeFacade{},
 		Destroyer:     &fakeEnviron{},
 		CredentialAPI: &fakeCredentialAPI{},
+		Logger:        &fakeLogger{},
 	}
 }
 


### PR DESCRIPTION
## Description of change
There are various situations that might cause the undertaker's Destroy() call to fail - examples we've seen include kubernetes not being available or problems with other clouds. If the user has specified `--force` on the `destroy-model` command we should remove the model in spite of those errors.

## QA steps

* Bootstrap a controller and add a k8s to it.
* Create a k8s model.
* Stop the k8s instance.
* Destroy the model - the model will hang around and the undertaker will log errors about not being able to destroy it in k8x.
* Force-destroy the model - it should get removed successfully.

## Documentation changes
None

## Bug reference
https://bugs.launchpad.net/juju/+bug/1830216
https://bugs.launchpad.net/juju/+bug/1828870
https://bugs.launchpad.net/juju/+bug/1829423