### PR TITLE
Fix issue with upgrading k8s charms with hook errors

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -404,7 +404,9 @@ func (op *caasOperator) loop() (err error) {
 						return err
 					}
 				} else {
-					aliveUnits[unitId] = make(chan struct{})
+					if _, ok := aliveUnits[unitId]; !ok {
+						aliveUnits[unitId] = make(chan struct{})
+					}
 				}
 				// Start a worker to manage any new units.
 				if _, err := op.runner.Worker(unitId, op.catacomb.Dying()); err == nil || unitLife == life.Dead {

--- a/worker/uniter/operation/deploy_test.go
+++ b/worker/uniter/operation/deploy_test.go
@@ -27,7 +27,14 @@ func (s *DeploySuite) testPrepareAlreadyDone(
 	c *gc.C, newDeploy newDeploy, kind operation.Kind,
 ) {
 	callbacks := &DeployCallbacks{}
-	factory := operation.NewFactory(operation.FactoryParams{Callbacks: callbacks})
+	deployer := &MockDeployer{
+		MockNotifyRevert:   &MockNoArgs{},
+		MockNotifyResolved: &MockNoArgs{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Deployer:  deployer,
+		Callbacks: callbacks,
+	})
 	op, err := newDeploy(factory, curl("cs:quantal/hive-23"))
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Prepare(operation.State{
@@ -478,7 +485,14 @@ func (s *DeploySuite) TestExecuteSuccess_Upgrade_PreserveNoHook(c *gc.C) {
 
 func (s *DeploySuite) TestCommitQueueInstallHook(c *gc.C) {
 	callbacks := NewDeployCommitCallbacks(nil)
-	factory := operation.NewFactory(operation.FactoryParams{Callbacks: callbacks})
+	deployer := &MockDeployer{
+		MockNotifyRevert:   &MockNoArgs{},
+		MockNotifyResolved: &MockNoArgs{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Deployer:  deployer,
+		Callbacks: callbacks,
+	})
 	op, err := factory.NewInstall(curl("cs:quantal/x-0"))
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Commit(operation.State{
@@ -496,7 +510,15 @@ func (s *DeploySuite) TestCommitQueueInstallHook(c *gc.C) {
 
 func (s *DeploySuite) testCommitQueueUpgradeHook(c *gc.C, newDeploy newDeploy) {
 	callbacks := NewDeployCommitCallbacks(nil)
-	factory := operation.NewFactory(operation.FactoryParams{Callbacks: callbacks})
+	deployer := &MockDeployer{
+		MockNotifyRevert:   &MockNoArgs{},
+		MockNotifyResolved: &MockNoArgs{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Deployer:  deployer,
+		Callbacks: callbacks,
+	})
+
 	op, err := newDeploy(factory, curl("cs:quantal/x-0"))
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Commit(operation.State{
@@ -526,7 +548,15 @@ func (s *DeploySuite) TestCommitQueueUpgradeHook_ResolvedUpgrade(c *gc.C) {
 
 func (s *DeploySuite) testCommitInterruptedHook(c *gc.C, newDeploy newDeploy) {
 	callbacks := NewDeployCommitCallbacks(nil)
-	factory := operation.NewFactory(operation.FactoryParams{Callbacks: callbacks})
+	deployer := &MockDeployer{
+		MockNotifyRevert:   &MockNoArgs{},
+		MockNotifyResolved: &MockNoArgs{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Deployer:  deployer,
+		Callbacks: callbacks,
+	})
+
 	op, err := newDeploy(factory, curl("cs:quantal/x-0"))
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Commit(operation.State{
@@ -556,7 +586,13 @@ func (s *DeploySuite) TestCommitInterruptedHook_ResolvedUpgrade(c *gc.C) {
 }
 
 func (s *DeploySuite) testDoesNotNeedGlobalMachineLock(c *gc.C, newDeploy newDeploy) {
-	factory := operation.NewFactory(operation.FactoryParams{})
+	deployer := &MockDeployer{
+		MockNotifyRevert:   &MockNoArgs{},
+		MockNotifyResolved: &MockNoArgs{},
+	}
+	factory := operation.NewFactory(operation.FactoryParams{
+		Deployer: deployer,
+	})
 	op, err := newDeploy(factory, curl("cs:quantal/x-0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -36,6 +36,9 @@ type factory struct {
 
 // newDeploy is the common code for creating arbitrary deploy operations.
 func (f *factory) newDeploy(kind Kind, charmURL *corecharm.URL, revert, resolved bool) (Operation, error) {
+	if f.config.Deployer == nil {
+		return nil, errors.New("deployer required")
+	}
 	if charmURL == nil {
 		return nil, errors.New("charm url required")
 	} else if kind != Install && kind != Upgrade {

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -28,7 +28,13 @@ func (s *FactorySuite) SetUpTest(c *gc.C) {
 	// verifying that inadequate args to the factory methods will produce
 	// the expected errors; and that the results of same get a string
 	// representation that does not depend on the factory attributes.
-	s.factory = operation.NewFactory(operation.FactoryParams{})
+	deployer := &MockDeployer{
+		MockNotifyRevert:   &MockNoArgs{},
+		MockNotifyResolved: &MockNoArgs{},
+	}
+	s.factory = operation.NewFactory(operation.FactoryParams{
+		Deployer: deployer,
+	})
 }
 
 func (s *FactorySuite) testNewDeployError(c *gc.C, newDeploy newDeploy) {


### PR DESCRIPTION
## Description of change

The k8s operator was incorrectly trying to use IAAS deploy operations instead of no-op deploys in some circumstances. An extra check is added to the deployer operation to error if it is constructed from a caas model.

## QA steps

Deploy a k8s charm with a hook error
Fix the hook error
upgrade-charm --force-units, ensure the hook is rerun and error is gone

Also check that upgrading the charm with the hook error still in place allows juju resolved to cause the hook to be rerun.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830259