### PR TITLE
Fix/caas cmr egress ingress

### DIFF
--- a/cmd/juju/caas/cluster.go
+++ b/cmd/juju/caas/cluster.go
@@ -61,6 +61,7 @@ type clusterParams struct {
 	name       string
 	project    string
 	region     string
+	zone 	   string
 	credential string
 	// used with AKS
 	resourceGroup string
@@ -69,6 +70,7 @@ type clusterParams struct {
 type cluster struct {
 	name   string
 	region string
+	zone   string
 	// for AKS
 	resourceGroup string
 }

--- a/cmd/juju/caas/cluster.go
+++ b/cmd/juju/caas/cluster.go
@@ -61,7 +61,7 @@ type clusterParams struct {
 	name       string
 	project    string
 	region     string
-	zone 	   string
+	zone       string
 	credential string
 	// used with AKS
 	resourceGroup string

--- a/cmd/juju/caas/gke.go
+++ b/cmd/juju/caas/gke.go
@@ -185,9 +185,6 @@ func (g *gke) listClusters(account, project, region string) (map[string]cluster,
 	cmd := []string{
 		"gcloud", "container", "clusters", "list", "--filter", "status:RUNNING", "--account", account, "--project", project, "--format", "value\\(name,zone\\)",
 	}
-	if region != "" {
-		cmd = append(cmd, "--region", region)
-	}
 	result, err := runCommand(g, cmd, "")
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -203,7 +200,7 @@ func (g *gke) listClusters(account, project, region string) (map[string]cluster,
 		if len(parts) == 0 {
 			continue
 		}
-		c := cluster{name: parts[0]}
+		c := cluster{name: parts[0], region: region}
 		if len(parts) > 1 {
 			c.zone = parts[1]
 			region := regexp.MustCompile(`([a-z]+-[a-z0-9]+)`).FindStringSubmatch(c.zone)

--- a/cmd/juju/caas/gke.go
+++ b/cmd/juju/caas/gke.go
@@ -4,10 +4,10 @@
 package caas
 
 import (
-	"regexp"
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/juju/cmd"

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -879,7 +879,7 @@ func (s *RelationUnitSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
-	c.Assert(ingress, gc.DeepEquals, []string{"4.3.2.1"})
+	c.Assert(ingress, gc.DeepEquals, []string{"1.2.3.4"})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -879,7 +879,7 @@ func (s *RelationUnitSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
-	c.Assert(ingress, gc.DeepEquals, []string{"1.2.3.4"})
+	c.Assert(ingress, gc.DeepEquals, []string{"4.3.2.1"})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1266,9 +1266,9 @@ func (u *Unit) serviceAddress(scope string) (network.Address, error) {
 	if len(addresses) == 0 {
 		return network.Address{}, network.NoAddressError(scope)
 	}
-	getPublicAddr := func(addresses []network.Address) (network.Address, bool) {
+	getStrictPublicAddr := func(addresses []network.Address) (network.Address, bool) {
 		addr, ok := network.SelectPublicAddress(addresses)
-		return addr, ok && (addr.Scope == network.ScopePublic || addr.Scope == network.ScopeCloudLocal)
+		return addr, ok && addr.Scope == network.ScopePublic
 	}
 
 	getInternalAddr := func(addresses []network.Address) (network.Address, bool) {
@@ -1278,7 +1278,7 @@ func (u *Unit) serviceAddress(scope string) (network.Address, error) {
 	var addrMatch func([]network.Address) (network.Address, bool)
 	switch scope {
 	case "public":
-		addrMatch = getPublicAddr
+		addrMatch = getStrictPublicAddr
 	case "private":
 		addrMatch = getInternalAddr
 	default:

--- a/state/unit.go
+++ b/state/unit.go
@@ -1228,7 +1228,6 @@ func (u *Unit) AllAddresses() ([]network.Address, error) {
 		return nil, errors.Trace(err)
 	}
 	addresses := serviceInfo.Addresses()
-
 	// Second the address of the container.
 	addr, err := u.containerAddress()
 	if network.IsNoAddressError(err) {
@@ -1267,11 +1266,9 @@ func (u *Unit) serviceAddress(scope string) (network.Address, error) {
 	if len(addresses) == 0 {
 		return network.Address{}, network.NoAddressError(scope)
 	}
-
 	getStrictPublicAddr := func(addresses []network.Address) (network.Address, bool) {
 		addr, ok := network.SelectPublicAddress(addresses)
-		ok = ok && addr.Scope == network.ScopePublic
-		return addr, ok
+		return addr, ok && (addr.Scope == network.ScopePublic || addr.Scope == network.ScopeCloudLocal)
 	}
 
 	getInternalAddr := func(addresses []network.Address) (network.Address, bool) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -1266,7 +1266,7 @@ func (u *Unit) serviceAddress(scope string) (network.Address, error) {
 	if len(addresses) == 0 {
 		return network.Address{}, network.NoAddressError(scope)
 	}
-	getStrictPublicAddr := func(addresses []network.Address) (network.Address, bool) {
+	getPublicAddr := func(addresses []network.Address) (network.Address, bool) {
 		addr, ok := network.SelectPublicAddress(addresses)
 		return addr, ok && (addr.Scope == network.ScopePublic || addr.Scope == network.ScopeCloudLocal)
 	}
@@ -1278,7 +1278,7 @@ func (u *Unit) serviceAddress(scope string) (network.Address, error) {
 	var addrMatch func([]network.Address) (network.Address, bool)
 	switch scope {
 	case "public":
-		addrMatch = getStrictPublicAddr
+		addrMatch = getPublicAddr
 	case "private":
 		addrMatch = getInternalAddr
 	default:

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -175,6 +175,12 @@ func (aw *applicationWorker) loop() error {
 			if err != nil && !errors.IsNotFound(err) {
 				return errors.Trace(err)
 			}
+			// update svc info (addresses etc.) cloudservices.
+			if err = updateApplicationService(
+				names.NewApplicationTag(aw.application), service, aw.applicationUpdater,
+			); err != nil {
+				return errors.Trace(err)
+			}
 			haveNewStatus := true
 			if service.Id != "" {
 				lastStatus, ok := lastReportedStatus[service.Id]

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -183,15 +183,22 @@ func (w *deploymentWorker) loop() error {
 			if err != nil && !errors.IsNotFound(err) {
 				return errors.Annotate(err, "cannot get new service details")
 			}
-			err = w.applicationUpdater.UpdateApplicationService(params.UpdateApplicationServiceArg{
-				ApplicationTag: names.NewApplicationTag(w.application).String(),
-				ProviderId:     service.Id,
-				Addresses:      params.FromNetworkAddresses(service.Addresses...),
-			})
-			if err != nil {
+			if err = updateApplicationService(
+				names.NewApplicationTag(w.application), service, w.applicationUpdater,
+			); err != nil {
 				return errors.Trace(err)
 			}
 			serviceUpdated = true
 		}
 	}
+}
+
+func updateApplicationService(appTag names.ApplicationTag, svc *caas.Service, updater ApplicationUpdater) error {
+	return updater.UpdateApplicationService(
+		params.UpdateApplicationServiceArg{
+			ApplicationTag: appTag.String(),
+			ProviderId:     svc.Id,
+			Addresses:      params.FromNetworkAddresses(svc.Addresses...),
+		},
+	)
 }

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -194,6 +194,9 @@ func (w *deploymentWorker) loop() error {
 }
 
 func updateApplicationService(appTag names.ApplicationTag, svc *caas.Service, updater ApplicationUpdater) error {
+	if svc.Id == "" {
+		return nil
+	}
 	return updater.UpdateApplicationService(
 		params.UpdateApplicationServiceArg{
 			ApplicationTag: appTag.String(),


### PR DESCRIPTION

## Description of change

Fix CMR on caas models.
Now relation data bad can return correct `ingress_address` and `egress_subnets`;

## QA steps

1. deploy mariadb on caas model 1;

```bash
$ juju deploy cs:~juju/mariadb-k8s-0 --debug 
```

2. offer db;

```bash
$ juju offer $MODEL1.mariadb-k8s:server
```

3. deploy mediawiki on caas model 2;

```bash
$ juju deploy cs:~juju/mediawiki-k8s-3 --debug  --config kubernetes-service-type=LoadBalancer
```

4. relate;

```bahs
$ juju relate mediawiki-k8s:db $MODEL1.mariadb-k8s
```

## Documentation changes

No(bug fix);

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830252
