### PR TITLE
ESM Support for deployments

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/os/series"
@@ -90,7 +91,17 @@ type CharmDeployAPI interface {
 }
 
 var supportedJujuSeries = func() []string {
-	return series.SupportedJujuSeries()
+	// We support all of the juju series AND all the ESM supported series.
+	// Juju is congruant with the Ubuntu release cycle for it's own series (not
+	// including centos and windows), so that should be reflected here.
+	//
+	// For non-LTS releases; they'll appear in juju/os as default available, but
+	// after reading the `/usr/share/distro-info/ubuntu.csv` on the Ubuntu distro
+	// the non-LTS should disapear if they're not in the release window for that
+	// series.
+	supportedJujuSeries := set.NewStrings(series.SupportedJujuSeries()...)
+	esmSupportedJujuSeries := set.NewStrings(series.ESMSupportedJujuSeries()...)
+	return supportedJujuSeries.Union(esmSupportedJujuSeries).Values()
 }
 
 // DeployAPI represents the methods of the API the deploy


### PR DESCRIPTION
## Description of change

The following ensures that we do add esm support for deployments.

## QA steps

1. Deploy  acceptancetests/repository/charms-centos/dummy-source, after adding to metadata.yaml:
```
series:
  - centos7
```
2. Deploy acceptancetests/repository/charms/dummy-source --series disco, it maybe necessary to add to metadata.yaml:
```
series:
  - disco
```
3. Other deploys should work as expected and per https://github.com/juju/juju/pull/10125.
