### PR TITLE
Clarify naming of metrics related to the MachineLXDProfileWatcher.

### DIFF
--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -152,9 +152,9 @@ func (w *MachineLXDProfileWatcher) applicationCharmURLChange(topic string, value
 	defer func(notify *bool) {
 		if *notify {
 			w.notify()
-			w.metrics.LXDProfileChangeHit.Inc()
+			w.metrics.LXDProfileChangeNotification.Inc()
 		} else {
-			w.metrics.LXDProfileChangeMiss.Inc()
+			w.metrics.LXDProfileNoChange.Inc()
 		}
 	}(&notify)
 
@@ -207,9 +207,9 @@ func (w *MachineLXDProfileWatcher) addUnit(topic string, value interface{}) {
 		if *notify {
 			logger.Tracef("notifying due to add unit requires lxd profile change machine-%s", w.machineId)
 			w.notify()
-			w.metrics.LXDProfileChangeHit.Inc()
+			w.metrics.LXDProfileChangeNotification.Inc()
 		} else {
-			w.metrics.LXDProfileChangeMiss.Inc()
+			w.metrics.LXDProfileNoChange.Inc()
 		}
 	}(&notify)
 
@@ -301,9 +301,9 @@ func (w *MachineLXDProfileWatcher) removeUnit(topic string, value interface{}) {
 		if *notify {
 			logger.Tracef("notifying due to remove unit requires lxd profile change machine-%s", w.machineId)
 			w.notify()
-			w.metrics.LXDProfileChangeHit.Inc()
+			w.metrics.LXDProfileChangeNotification.Inc()
 		} else {
-			w.metrics.LXDProfileChangeMiss.Inc()
+			w.metrics.LXDProfileNoChange.Inc()
 		}
 	}(&notify)
 
@@ -348,7 +348,7 @@ func (w *MachineLXDProfileWatcher) provisionedChange(topic string, _ interface{}
 	}
 
 	logger.Tracef("notifying due to machine-%s now provisioned", w.machineId)
-	w.metrics.LXDProfileChangeHit.Inc()
+	w.metrics.LXDProfileChangeNotification.Inc()
 	w.notify()
 }
 

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -397,6 +397,6 @@ func (s *lxdProfileWatcherSuite) assertStartOneMachineNotProvisionedWatcher(c *g
 func (s *lxdProfileWatcherSuite) assertChangeValidateMetrics(c *gc.C, assert func(), err, hit, miss int) {
 	assert()
 	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileChangeError), gc.Equals, float64(err))
-	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileChangeHit), gc.Equals, float64(hit))
-	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileChangeMiss), gc.Equals, float64(miss))
+	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileChangeNotification), gc.Equals, float64(hit))
+	c.Check(testutil.ToFloat64(s.Gauges.LXDProfileNoChange), gc.Equals, float64(miss))
 }

--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -65,9 +65,9 @@ type ControllerGauges struct {
 	ApplicationHashCacheHit  prometheus.Gauge
 	ApplicationHashCacheMiss prometheus.Gauge
 
-	LXDProfileChangeError prometheus.Gauge
-	LXDProfileChangeHit   prometheus.Gauge
-	LXDProfileChangeMiss  prometheus.Gauge
+	LXDProfileChangeError        prometheus.Gauge
+	LXDProfileChangeNotification prometheus.Gauge
+	LXDProfileNoChange           prometheus.Gauge
 }
 
 func createControllerGauges() *ControllerGauges {
@@ -118,21 +118,21 @@ func createControllerGauges() *ControllerGauges {
 			prometheus.GaugeOpts{
 				Namespace: metricsNamespace,
 				Name:      "lxdprofile_change_error",
-				Help:      "The number of times there was an error calculating LXD profile changes.",
+				Help:      "The number of times there was an error calculating LXD profile related changes.",
 			},
 		),
-		LXDProfileChangeHit: prometheus.NewGauge(
+		LXDProfileChangeNotification: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: metricsNamespace,
-				Name:      "lxdprofile_change_hit",
-				Help:      "The number of times an LXD Profile change was found.",
+				Name:      "lxdprofile_change_notify",
+				Help:      "The number of times an LXD Profile related change triggered a notification.",
 			},
 		),
-		LXDProfileChangeMiss: prometheus.NewGauge(
+		LXDProfileNoChange: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: metricsNamespace,
-				Name:      "lxdprofile_change_miss",
-				Help:      "The number of times an LXD Profile change was not found.",
+				Name:      "lxdprofile_no_change",
+				Help:      "The number of times an LXD Profile related change did not trigger a notification.",
 			},
 		),
 	}
@@ -149,8 +149,8 @@ func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
 	c.ApplicationHashCacheMiss.Collect(ch)
 
 	c.LXDProfileChangeError.Collect(ch)
-	c.LXDProfileChangeHit.Collect(ch)
-	c.LXDProfileChangeMiss.Collect(ch)
+	c.LXDProfileChangeNotification.Collect(ch)
+	c.LXDProfileNoChange.Collect(ch)
 }
 
 // Collector is a prometheus.Collector that collects metrics about


### PR DESCRIPTION
## Description of change

Clarify naming of metrics related to the MachineLXDProfileWatcher.
Rename LXDProfileChangeHit to LXDProfileChangeNotify.  Rename
LXDProfileChangeMiss to LXDProfileNoChange.

## QA steps

juju bootstrap lxd
juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd" <-- all should be 0
juju deploy ./testcharms/charm-repo/quantal/lxd-profile
juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd" <-- all should be 0
juju upgrade-charm lxd-profile --path ./testcharms/charm-repo/quantal/lxd-profile
juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd" <-- notify increases to 1
juju deploy ~/charms/ubuntu
juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd" <-- no_change increases to 2, 1 for each machine.
juju upgrade-charm ubuntu --path ~/charms/ubuntu
juju run -m controller --machine 0 juju_metrics | grep "^juju_cache_lxd" <-- no_change increases to 4, 1 for each machine.
