### PR TITLE
Fixes lp#1830216: Treat unauthorised errors from AWS as an invalid credential.

### DIFF
--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -231,9 +231,9 @@ var maybeConvertCredentialError = func(err error, ctx context.ProviderCallContex
 		case "SignatureDoesNotMatch":
 			return convert(common.CredentialNotValidf(err, badKeys))
 		case "OptInRequired":
-			return errors.Annotate(err, unauthorized)
+			return convert(common.CredentialNotValidf(err, unauthorized))
 		case "UnauthorizedOperation":
-			return errors.Annotate(err, unauthorized)
+			return convert(common.CredentialNotValidf(err, unauthorized))
 		default:
 			// This error is unrelated to access keys, account or credentials...
 			return err

--- a/provider/ec2/provider_test.go
+++ b/provider/ec2/provider_test.go
@@ -172,7 +172,7 @@ func (s *ProviderSuite) TestMaybeConvertCredentialErrorAppendsAuthorisationFailu
 	} {
 		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code}, context.NewCloudCallContext())
 		c.Assert(err, gc.NotNil)
-		c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
+		c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 		c.Assert(err.Error(), jc.Contains, fmt.Sprintf("\nPlease subscribe to the requested Amazon service. \n"+
 			"You are currently not authorized to use it.\n"+
 			"New Amazon accounts might take some time to be activated while \n"+


### PR DESCRIPTION
## Description of change

Straight forward port of https://github.com/juju/juju/pull/10257

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830216
