### PR TITLE
Improve model destruction messaging.

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -869,6 +869,7 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 	destroyStorage := true
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
 		{"UUID", nil},
+		{"Status", nil},
 		{"Destroy", []interface{}{state.DestroyModelParams{
 			DestroyStorage: &destroyStorage,
 			MaxWait:        common.MaxWait(nil),

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -394,6 +394,14 @@ type modelData struct {
 	errorCount       int
 }
 
+func (data *modelData) isEmpty() bool {
+	return data.errorCount == 0 &&
+		data.machineCount == 0 &&
+		data.applicationCount == 0 &&
+		data.volumeCount == 0 &&
+		data.filesystemCount == 0
+}
+
 func waitForModelDestroyed(
 	ctx *cmd.Context,
 	api DestroyModelAPI,
@@ -417,6 +425,7 @@ func waitForModelDestroyed(
 	// no wait for 1st time.
 	intervalSeconds := 0 * time.Second
 	timeoutAfter := clock.After(timeout)
+	printedOnce := false
 	for {
 		select {
 		case <-interrupted:
@@ -432,7 +441,17 @@ func waitForModelDestroyed(
 				// model has been destroyed successfully.
 				return nil
 			}
-			ctx.Infof(formatDestroyModelInfo(data) + "...")
+			msg := formatDestroyModelInfo(data)
+			if printedOnce && data.isEmpty() {
+				fmt.Fprint(ctx.Stderr, ".")
+			} else {
+				if data.isEmpty() {
+					printedOnce = true
+					fmt.Fprintf(ctx.Stderr, msg+"...")
+				} else {
+					fmt.Fprintln(ctx.Stderr, msg+"...")
+				}
+			}
 			intervalSeconds = 2 * time.Second
 		}
 	}
@@ -492,7 +511,7 @@ func getModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelTag) (
 	}
 	if err != nil {
 		if params.IsCodeNotFound(err) {
-			ctx.Infof("Model destroyed.")
+			ctx.Infof("\nModel destroyed.")
 		} else {
 			ctx.Infof("Unable to get the model status from the API: %v.", err)
 		}
@@ -542,13 +561,10 @@ func getModelStatus(ctx *cmd.Context, api DestroyModelAPI, tag names.ModelTag) (
 }
 
 func formatDestroyModelInfo(data *modelData) string {
-	out := "Waiting on model to be removed"
+	out := "Waiting for model to be removed"
 	if data.errorCount > 0 {
 		// always shows errorCount even if no machines and applications left.
 		out += fmt.Sprintf(", %d error(s)", data.errorCount)
-	}
-	if data.machineCount == 0 && data.applicationCount == 0 {
-		return out
 	}
 	if data.machineCount > 0 {
 		out += fmt.Sprintf(", %d machine(s)", data.machineCount)

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -426,6 +426,8 @@ func waitForModelDestroyed(
 	intervalSeconds := 0 * time.Second
 	timeoutAfter := clock.After(timeout)
 	reported := ""
+	lineLength := 0
+	const perLineLength = 80
 	for {
 		select {
 		case <-interrupted:
@@ -443,10 +445,17 @@ func waitForModelDestroyed(
 			}
 			msg := formatDestroyModelInfo(data)
 			if reported == msg {
+				if lineLength == perLineLength {
+					// Time to break to the next line.
+					fmt.Fprintln(ctx.Stderr)
+					lineLength = 0
+				}
 				fmt.Fprint(ctx.Stderr, ".")
+				lineLength++
 			} else {
 				fmt.Fprint(ctx.Stderr, fmt.Sprintf("\n%v...", msg))
 				reported = msg
+				lineLength = len(msg) + 3
 			}
 			intervalSeconds = 2 * time.Second
 		}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -317,7 +317,7 @@ upgrade the controller to version 2.3 or greater.
 	}
 
 	// Attempt to destroy the model.
-	ctx.Infof("Destroying model")
+	fmt.Fprint(ctx.Stderr, "Destroying model")
 	var destroyStorage *bool
 	if c.destroyStorage || c.releaseStorage {
 		destroyStorage = &c.destroyStorage
@@ -425,7 +425,7 @@ func waitForModelDestroyed(
 	// no wait for 1st time.
 	intervalSeconds := 0 * time.Second
 	timeoutAfter := clock.After(timeout)
-	printedOnce := false
+	reported := ""
 	for {
 		select {
 		case <-interrupted:
@@ -442,15 +442,11 @@ func waitForModelDestroyed(
 				return nil
 			}
 			msg := formatDestroyModelInfo(data)
-			if printedOnce && data.isEmpty() {
+			if reported == msg {
 				fmt.Fprint(ctx.Stderr, ".")
 			} else {
-				if data.isEmpty() {
-					printedOnce = true
-					fmt.Fprintf(ctx.Stderr, msg+"...")
-				} else {
-					fmt.Fprintln(ctx.Stderr, msg+"...")
-				}
+				fmt.Fprint(ctx.Stderr, fmt.Sprintf("\n%v...", msg))
+				reported = msg
 			}
 			intervalSeconds = 2 * time.Second
 		}

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -446,9 +446,7 @@ func (s *DestroySuite) TestDestroyCommandWait(c *gc.C) {
 	case <-done:
 		c.Assert(<-outStdErr, gc.Equals, `
 Destroying model
-Waiting for model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
-Waiting for model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
-`[1:])
+Waiting for model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)....`[1:])
 		c.Assert(<-outStdOut, gc.Equals, `
 
 The following errors were encountered during destroying the model.

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -446,8 +446,8 @@ func (s *DestroySuite) TestDestroyCommandWait(c *gc.C) {
 	case <-done:
 		c.Assert(<-outStdErr, gc.Equals, `
 Destroying model
-Waiting on model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
-Waiting on model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
+Waiting for model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
+Waiting for model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)...
 `[1:])
 		c.Assert(<-outStdOut, gc.Equals, `
 
@@ -461,6 +461,46 @@ Volume      0   failed to destroy volume 0
             1   failed to destroy volume 1
             2   failed to destroy volume 2
 `[1:])
+		// timeout after 3s.
+		c.Assert(<-outErr, jc.Satisfies, errors.IsTimeout)
+		checkModelExistsInStore(c, "test1:admin/test2", s.store)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for destroy cmd.")
+	}
+}
+
+func (s *DestroySuite) TestDestroyCommandLeanMessage(c *gc.C) {
+	checkModelExistsInStore(c, "test1:admin/test2", s.store)
+
+	s.api.modelInfoErr = []*params.Error{nil, nil}
+	s.api.modelStatusPayload = []base.ModelStatus{{
+		ApplicationCount:   0,
+		HostedMachineCount: 0,
+		Volumes:            []base.Volume{},
+		Filesystems:        []base.Filesystem{},
+	}}
+
+	done := make(chan struct{}, 1)
+	outErr := make(chan error, 1)
+	outStdOut := make(chan string, 1)
+	outStdErr := make(chan string, 1)
+
+	go func() {
+		// run destroy model cmd, and timeout in 3s.
+		ctx, err := s.runDestroyCommand(c, "test2", "-y", "-t", "3s")
+		outStdOut <- cmdtesting.Stdout(ctx)
+		outStdErr <- cmdtesting.Stderr(ctx)
+		outErr <- err
+		done <- struct{}{}
+	}()
+
+	c.Assert(s.clock.WaitAdvance(5*time.Second, testing.LongWait, 2), jc.ErrorIsNil)
+
+	select {
+	case <-done:
+		c.Assert(<-outStdErr, gc.Equals, `
+Destroying model
+Waiting for model to be removed....`[1:])
 		// timeout after 3s.
 		c.Assert(<-outErr, jc.Satisfies, errors.IsTimeout)
 		checkModelExistsInStore(c, "test1:admin/test2", s.store)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

Destroying a model can take a while. Previously, our messaging would repeat 
```
Waiting on model to be removed...
Waiting on model to be removed...
```
This PR improves it as per suggestion in the bug below.

As drive-by, this PR abort attempts at destroying a model with an invalid cloud credential if '--force' was not used.

In addition, previously when destroying models, if there were no application and machines left, we were not reporting to the user that they may have volumes and/or filesystems left. 

## QA steps

1. bootstrap
2. add model with a different credential and invalidate it.
3. destroy model (without force) should give a similar output:
```
$ juju destroy-model trial
WARNING! This command will destroy the "trial" model.
This includes all machines, applications, data and other resources.

Continue [y/N]? y
Destroying model
ERROR failed to destroy model "trial"
ERROR cannot destroy model: invalid cloud credential, use --force
```
4. long running destroy model will now look similar to:
```
$ juju destroy-model trial -y
Destroying model
Waiting for model to be removed............
Model destroyed.
```

Long lines are now wrapped at 80 characters. So, the above example could look like this [my live testing output...]:
```
$ juju destroy-model trial -y
Destroying model
Waiting for model to be removed.................................................
.................
Model destroyed.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830935
