### PR TITLE
Display error when deploying bundles containing apps that require trust

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1461,7 +1461,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:f6560765e17f77f08ebd7358a026f4ce6c2829123ce6f81b97e90aee8efb1613"
+  digest = "1:0fc30411ea4cf01b4dec77e49f2f618c9fb8138fd16bff9e6cf3279d58553371"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1469,7 +1469,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "b4861dc361873d2618454bcfb8656c6cb77fdf69"
+  revision = "f915791435aa68df6d2b87b7ec16dac9f695a63e"
 
 [[projects]]
   digest = "1:86df7d2874a5250cf64324e2ce4e88fea552aa1f5c1a3f065599bd1f381ce939"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "b4861dc361873d2618454bcfb8656c6cb77fdf69"
+  revision = "f915791435aa68df6d2b87b7ec16dac9f695a63e"
 
 [[constraint]]
   revision = "7778a447283bd71109671c20818544514e16e9d9"

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/os/series"
 	"github.com/juju/romulus"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/juju/charmrepo.v3"
@@ -44,6 +46,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/storage"
 )
@@ -837,6 +840,12 @@ func (c *DeployCommand) deployBundle(
 	modelUUID, ok := apiRoot.ModelUUID()
 	if !ok {
 		return errors.New("API connection is controller-only (should never happen)")
+	}
+
+	if tl := appsRequiringTrust(data.Applications); len(tl) != 0 && featureflag.Enabled(feature.TrustedBundles) {
+		return errors.Errorf(`Bundle cannot be deployed without trusting applications with your cloud credentials.
+Please repeat the deploy command with the --trust argument if you consent to trust the following application(s):
+  - %s`, strings.Join(tl, "\n  - "))
 	}
 
 	for application, applicationSpec := range data.Applications {
@@ -1658,4 +1667,21 @@ func flagWithMinus(name string) string {
 		return "--" + name
 	}
 	return "-" + name
+}
+
+func appsRequiringTrust(appSpecList map[string]*charm.ApplicationSpec) []string {
+	var tl []string
+	for app, appSpec := range appSpecList {
+		// Trust requirements may be either specified as an option
+		// or via the "trust" field at the application spec level
+		optRequiresTrust := appSpec.Options != nil && appSpec.Options["trust"] == true
+		if appSpec.RequiresTrust || optRequiresTrust {
+			tl = append(tl, app)
+		}
+	}
+
+	// Since map iterations are random we should sort the list to ensure
+	// consistent output in any errors containing the returned list contents.
+	sort.Strings(tl)
+	return tl
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -61,3 +61,7 @@ const MongoDbSSTXN = "mongodb-sstxn"
 // MultiCloud tells Juju to allow a different IAAS cloud to the one the controller
 // was bootstrapped on to be added to the controller.
 const MultiCloud = "multi-cloud"
+
+// TrustedBundles prevents juju CLI from deploying bundles that request access
+// to cloud credentials unless the operator explicitly trusts them.
+const TrustedBundles = "trusted-bundles"

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/README.md
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/README.md
@@ -1,0 +1,1 @@
+A bundle with a single application requiring trust via a config option

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/bundle.yaml
@@ -1,0 +1,6 @@
+services:
+    aws-integrator:
+        charm: cs:~containers/aws-integrator        
+        num_units: 1
+        options:
+          trust: true

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-multi/README.md
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-multi/README.md
@@ -1,0 +1,1 @@
+A bundle with a multiple applications requiring trust

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-multi/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-multi/bundle.yaml
@@ -1,0 +1,9 @@
+services:
+    aws-integrator:
+        charm: cs:~containers/aws-integrator        
+        num_units: 1
+        trust: true
+    gcp-integrator:
+        charm: cs:~containers/gcp-integrator
+        num_units: 1
+        trust: true

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-single/README.md
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-single/README.md
@@ -1,0 +1,1 @@
+A bundle with a single application requiring trust

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
@@ -1,0 +1,5 @@
+services:
+    aws-integrator:
+        charm: cs:~containers/aws-integrator        
+        num_units: 1
+        trust: true


### PR DESCRIPTION
## Description of change

This PR updates the deploy command logic to emit an error when the operator attempts to deploy 
bundles that contain one or more apps that require trusted access to cloud credentials . Each application/service within a bundle can request trust by:

- definining `trust: true` at the application specification block level, OR
- by including a `trust: true` config option

The extra logic introduced by this PR is hidden behind the `trusted-bundles` feature flag as trust is still a work-in-progress feature.

NOTE: This PR only implements the error-emitting logic. A separate PR will introduce a mechanism for the operator to indicate that they indeed trust the apps requiring access to credentials.

## QA steps

```console
$ juju bootstrap lxd test --no-gui

$ export JUJU_DEV_FEATURE_FLAGS=trusted-bundles

# Deploy a bundle with a single app requiring trust
$ juju deploy testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
ERROR Bundle cannot be deployed without trusting applications with your cloud credentials.
Please repeat the deploy command with the --trust argument if you consent to trust the following application(s):
  - aws-integrator

# Deploy bundle with multiple apps requiring trust
$ juju deploy testcharms/charm-repo/bundle/aws-integrator-trust-multi/bundle.yaml
ERROR Bundle cannot be deployed without trusting applications with your cloud credentials.
Please repeat the deploy command with the --trust argument if you consent to trust the following application(s):
  - aws-integrator
  - gcp-integrator

# Finally, deploy a bundle with a single app requiring trust via a config option
$ juju deploy testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/bundle.yaml
ERROR Bundle cannot be deployed without trusting applications with your cloud credentials.
Please repeat the deploy command with the --trust argument if you consent to trust the following application(s):
  - aws-integrator
```