### PR TITLE
Removing an application removes offers with no connections

### DIFF
--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -239,8 +239,12 @@ func (c *removeApplicationCommand) removeApplications(
 	for i, name := range c.ApplicationNames {
 		result := results[i]
 		if result.Error != nil {
-			ctx.Infof("removing application %s failed: %s", name, result.Error)
 			anyFailed = true
+			err := result.Error.Error()
+			if params.IsCodeNotSupported(result.Error) {
+				err = errors.New("another user was updating application; please try again").Error()
+			}
+			ctx.Infof("removing application %s failed: %s", name, err)
 			continue
 		}
 		ctx.Infof("removing application %s", name)

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -146,6 +146,7 @@ func (s *RemoveApplicationSuite) TestNoWaitWithoutForce(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
 }
 
+//TODO(tsm) remove unused RemoveCharmStoreCharmsSuite
 type RemoveCharmStoreCharmsSuite struct {
 	legacyCharmStoreSuite
 	ctx *cmd.Context

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -118,3 +118,12 @@ wordpress:
     url: ""
 `[1:])
 }
+
+func (s *CmdApplicationSuite) TestRemoveApplication(c *gc.C) {
+	s.setupApplications(c)
+
+	ctx, err := cmdtesting.RunCommand(c, application.NewRemoveApplicationCommand(), "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "removing application wordpress\n")
+}

--- a/state/application.go
+++ b/state/application.go
@@ -212,8 +212,8 @@ func (a *Application) Destroy() (err error) {
 			a.doc.Life = Dying
 		}
 	}()
-	op := a.DestroyOperation() // TODO(tsm): driveby fix - remove dupe call
-	err = a.st.ApplyOperation(a.DestroyOperation())
+	op := a.DestroyOperation()
+	err = a.st.ApplyOperation(op)
 	if len(op.Errors) != 0 {
 		logger.Warningf("operational errors destroying application %v: %v", a.Name(), op.Errors)
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -212,7 +212,7 @@ func (a *Application) Destroy() (err error) {
 			a.doc.Life = Dying
 		}
 	}()
-	op := a.DestroyOperation()
+	op := a.DestroyOperation() // TODO(tsm): driveby fix - remove dupe call
 	err = a.st.ApplyOperation(a.DestroyOperation())
 	if len(op.Errors) != 0 {
 		logger.Warningf("operational errors destroying application %v: %v", a.Name(), op.Errors)
@@ -284,6 +284,22 @@ func (op *DestroyApplicationOperation) Build(attempt int) ([]txn.Op, error) {
 
 // Done is part of the ModelOperation interface.
 func (op *DestroyApplicationOperation) Done(err error) error {
+	if err == nil {
+		return err
+	}
+	connected, err2 := applicationHasConnectedOffers(op.app.st, op.app.Name())
+	if err2 != nil {
+		err = errors.Trace(err2)
+	} else if connected {
+		rels, err2 := op.app.st.AllRelations()
+		if err2 != nil {
+			err = errors.Trace(err2)
+		}
+		err = errors.Errorf("application is used by %d offer%s", len(rels), plural(len(rels)))
+	} else {
+		err = errors.NewNotSupported(err, "change to the application detected")
+	}
+
 	return errors.Annotatef(err, "cannot destroy application %q", op.app)
 }
 
@@ -350,16 +366,43 @@ func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 	}
 	ops = append(ops, resOps...)
 
-	// We can't delete an application if it is being offered.
+	// We can't delete an application if it is being offered,
+	// unless those offers have no relations.
 	if !op.RemoveOffers {
 		countOp, n, err := countApplicationOffersRefOp(op.app.st, op.app.Name())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if n != 0 {
-			return nil, errors.Errorf("application is used by %d offer%s", n, plural(n))
+		if n == 0 {
+			ops = append(ops, countOp)
+		} else {
+			connected, err := applicationHasConnectedOffers(op.app.st, op.app.Name())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if connected {
+				return nil, errors.Errorf("application is used by %d offer%s", n, plural(n))
+			}
+			// None of our offers are connected,
+			// it's safe to remove them.
+			removeOfferOps, err := removeApplicationOffersOps(op.app.st, op.app.Name())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, removeOfferOps...)
+			ops = append(ops, txn.Op{
+				C:  applicationsC,
+				Id: op.app.doc.DocID,
+				Assert: bson.D{
+					// We're using the txn-revno here because relationcount is too
+					// coarse-grained for what we need. Using the revno will
+					// create false positives during concurrent updates of the
+					// model, but eliminates the possibility of it entering
+					// an inconsistent state.
+					{"txn-revno", op.app.doc.TxnRevno},
+				},
+			})
 		}
-		ops = append(ops, countOp)
 	}
 
 	// If the application has no units, and all its known relations will be

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -273,9 +273,6 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 			for _, ru := range remoteUnits {
 				leaveScopeOps, err := ru.leaveScopeForcedOps(&op.ForcedOperation)
 				if err != nil && err != jujutxn.ErrNoOperations {
-					if !op.Force { // TODO(tsm): remove block, will never succeed
-						return nil, errors.Trace(err)
-					}
 					op.AddError(err)
 				}
 				ops = append(ops, leaveScopeOps...)

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -273,7 +273,7 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 			for _, ru := range remoteUnits {
 				leaveScopeOps, err := ru.leaveScopeForcedOps(&op.ForcedOperation)
 				if err != nil && err != jujutxn.ErrNoOperations {
-					if !op.Force {
+					if !op.Force { // TODO(tsm): remove block, will never succeed
 						return nil, errors.Trace(err)
 					}
 					op.AddError(err)
@@ -312,6 +312,37 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 	return ops, nil
 }
 
+// applicationOffersDocs returns the offer docs for the given application
+func applicationOffersDocs(st *State, application string) ([]applicationOfferDoc, error) {
+	applicationOffersCollection, closer := st.db().GetCollection(applicationOffersC)
+	defer closer()
+	query := bson.D{{"application-name", application}}
+	var docs []applicationOfferDoc
+	if err := applicationOffersCollection.Find(query).All(&docs); err != nil {
+		return nil, errors.Annotatef(err, "reading application %q offers", application)
+	}
+	return docs, nil
+}
+
+// applicationHasConnectedOffers returns true when any of the the application's
+// offers have connections
+func applicationHasConnectedOffers(st *State, application string) (bool, error) {
+	offers, err := applicationOffersDocs(st, application)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	for _, offer := range offers {
+		connections, err := st.OfferConnections(offer.OfferUUID)
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		if len(connections) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // removeApplicationOffersOps returns txn.Ops that will remove all offers for
 // the specified application. No assertions on the application or the offer
 // connections are made; the caller is responsible for ensuring that offer
@@ -330,20 +361,15 @@ func removeApplicationOffersOps(st *State, application string) ([]txn.Op, error)
 	if n == 0 {
 		return []txn.Op{countRefsOp}, nil
 	}
-
-	applicationOffersCollection, closer := st.db().GetCollection(applicationOffersC)
-	defer closer()
-	query := bson.D{{"application-name", application}}
-	var docs []applicationOfferDoc
-	if err := applicationOffersCollection.Find(query).All(&docs); err != nil {
-		return nil, errors.Annotatef(err, "reading application %q offers", application)
+	docs, err := applicationOffersDocs(st, application)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-
 	var ops []txn.Op
 	for _, doc := range docs {
 		ops = append(ops, txn.Op{
 			C:      applicationOffersC,
-			Id:     doc.OfferName,
+			Id:     doc.DocID,
 			Assert: txn.DocExists,
 			Remove: true,
 		})

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -41,6 +41,7 @@ const (
 	MachinesC         = machinesC
 	ModelEntityRefsC  = modelEntityRefsC
 	ApplicationsC     = applicationsC
+	OfferConnectionsC = offerConnectionsC
 	EndpointBindingsC = endpointBindingsC
 	ControllersC      = controllersC
 	UsersC            = usersC
@@ -52,20 +53,21 @@ const (
 )
 
 var (
-	BinarystorageNew        = &binarystorageNew
-	ImageStorageNewStorage  = &imageStorageNewStorage
-	MachineIdLessThan       = machineIdLessThan
-	GetOrCreatePorts        = getOrCreatePorts
-	GetPorts                = getPorts
-	CombineMeterStatus      = combineMeterStatus
-	ApplicationGlobalKey    = applicationGlobalKey
-	CloudGlobalKey          = cloudGlobalKey
-	RegionSettingsGlobalKey = regionSettingsGlobalKey
-	ModelGlobalKey          = modelGlobalKey
-	MergeBindings           = mergeBindings
-	UpgradeInProgressError  = errUpgradeInProgress
-	DBCollectionSizeToInt   = dbCollectionSizeToInt
-	NewEntityWatcher        = newEntityWatcher
+	BinarystorageNew              = &binarystorageNew
+	ImageStorageNewStorage        = &imageStorageNewStorage
+	MachineIdLessThan             = machineIdLessThan
+	GetOrCreatePorts              = getOrCreatePorts
+	GetPorts                      = getPorts
+	CombineMeterStatus            = combineMeterStatus
+	ApplicationGlobalKey          = applicationGlobalKey
+	CloudGlobalKey                = cloudGlobalKey
+	RegionSettingsGlobalKey       = regionSettingsGlobalKey
+	ModelGlobalKey                = modelGlobalKey
+	MergeBindings                 = mergeBindings
+	UpgradeInProgressError        = errUpgradeInProgress
+	DBCollectionSizeToInt         = dbCollectionSizeToInt
+	NewEntityWatcher              = newEntityWatcher
+	ApplicationHasConnectedOffers = applicationHasConnectedOffers
 )
 
 type (


### PR DESCRIPTION
This change allows the remove application command to also remove any associated offers along with the application, so long as those offers have zero connections.

## QA steps

Deploy application
Offer relation
Destroy application

## Documentation changes

Required.

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1830292