### PR TITLE
Use service addresses for k8s charms

### DIFF
--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4184,13 +4184,11 @@ func (s *uniterSuite) TestNetworkInfoCAASModelRelation(c *gc.C) {
 	expectedResult := params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
 			{
-				Addresses: []params.InterfaceAddress{
-					{Address: "10.0.0.1"},
-				},
+				Addresses: []params.InterfaceAddress{},
 			},
 		},
-		EgressSubnets:    []string{"192.168.1.2/32"},
-		IngressAddresses: []string{"192.168.1.2"},
+		EgressSubnets:    []string{"54.32.1.2/32"},
+		IngressAddresses: []string{"54.32.1.2", "192.168.1.2"},
 	}
 
 	uniterAPI, err := uniter.NewUniterAPI(facadetest.Context{
@@ -4237,13 +4235,11 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 	expectedResult := params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
 			{
-				Addresses: []params.InterfaceAddress{
-					{Address: "10.0.0.1"},
-				},
+				Addresses: []params.InterfaceAddress{},
 			},
 		},
 		EgressSubnets:    []string{"54.32.1.2/32"},
-		IngressAddresses: []string{"54.32.1.2", "192.168.1.2", "10.0.0.1"},
+		IngressAddresses: []string{"54.32.1.2", "192.168.1.2"},
 	}
 
 	uniterAPI, err := uniter.NewUniterAPI(facadetest.Context{

--- a/caas/kubernetes/provider/config.go
+++ b/caas/kubernetes/provider/config.go
@@ -16,7 +16,7 @@ const (
 	defaultIngressSSLPassthrough = false
 	defaultIngressAllowHTTPKey   = false
 
-	serviceTypeConfigKey               = "kubernetes-service-type"
+	ServiceTypeConfigKey               = "kubernetes-service-type"
 	serviceExternalIPsConfigKey        = "kubernetes-service-external-ips"
 	serviceTargetPortConfigKey         = "kubernetes-service-target-port"
 	serviceLoadBalancerIPKey           = "kubernetes-service-loadbalancer-ip"
@@ -31,7 +31,7 @@ const (
 )
 
 var configFields = environschema.Fields{
-	serviceTypeConfigKey: {
+	ServiceTypeConfigKey: {
 		Description: "determines how the Service is exposed",
 		Type:        environschema.Tstring,
 		Group:       environschema.ProviderGroup,
@@ -89,7 +89,7 @@ var configFields = environschema.Fields{
 }
 
 var schemaDefaults = schema.Defaults{
-	serviceTypeConfigKey:     schema.Omit,
+	ServiceTypeConfigKey:     schema.Omit,
 	serviceAnnotationsKey:    schema.Omit,
 	ingressClassKey:          defaultIngressClass,
 	ingressSSLRedirectKey:    defaultIngressSSLRedirect,

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1733,7 +1733,7 @@ func (k *kubernetesClient) configureService(
 			return errors.NotSupportedf("service type %q", params.Deployment.ServiceType)
 		}
 	}
-	serviceType = core.ServiceType(config.GetString(serviceTypeConfigKey, string(serviceType)))
+	serviceType = core.ServiceType(config.GetString(ServiceTypeConfigKey, string(serviceType)))
 	annotations, err := config.GetStringMap(serviceAnnotationsKey, nil)
 	if err != nil {
 		return errors.Annotatef(err, "unexpected annotations: %#v", config.Get(serviceAnnotationsKey, nil))

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -875,7 +875,7 @@ func (s *RelationUnitSuite) TestNetworksForRelation(c *gc.C) {
 		network.NewScopedAddress("4.3.2.1", network.ScopePublic),
 	)
 
-	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.pu0, prr.rel, nil)
+	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.pu0, prr.rel, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
@@ -945,7 +945,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 
 	s.addDevicesWithAddresses(c, machine, "1.2.3.4/16", "2.2.3.4/16", "3.2.3.4/16", "4.3.2.1/16")
 
-	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.pu0, prr.rel, nil)
+	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.pu0, prr.rel, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "space-3")
@@ -968,7 +968,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.ru0, prr.rel, nil)
+	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.ru0, prr.rel, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
@@ -990,7 +990,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c 
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.ru0, prr.rel, nil)
+	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.ru0, prr.rel, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
@@ -1055,7 +1055,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationRemoteRelationDelayedPublicAd
 		}
 	}()
 
-	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.ru0, prr.rel, nil)
+	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.ru0, prr.rel, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure there we no errors in the go routine.
@@ -1079,7 +1079,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	prr := newProReqRelationForApps(c, st, mysql, gitlab)
 
 	// First no address.
-	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.pu0, prr.rel, nil)
+	boundSpace, ingress, egress, err := state.NetworksForRelation("", prr.pu0, prr.rel, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(boundSpace, gc.Equals, "")
 	c.Assert(ingress, gc.HasLen, 0)
@@ -1092,7 +1092,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.pu0.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	boundSpace, ingress, egress, err = state.NetworksForRelation("", prr.pu0, prr.rel, nil)
+	boundSpace, ingress, egress, err = state.NetworksForRelation("", prr.pu0, prr.rel, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")


### PR DESCRIPTION
## Description of change

The addresses provided to k8s charms are tweaked.

Key changes:
- k8s unit AllAddresses() returns only the service addresses, unless there's no service in which case the pod addresses are returned
- the address watcher used by the uniter watches the services addresses, not pod addresses
- when entering scope, only cloud local addresses are used (if any)
- for network-get calls, public addresses are polled if the k8s service type is load balancer or external ip

## QA steps

Deploy both cmr and non-cmr k8s scenarios and ensure relations are correctly created.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1830252
