### PR TITLE
Multi-cloud CLI defaults to --local unless feature flag set

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -27,6 +27,7 @@ import (
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -160,9 +161,12 @@ type AddCAASCommand struct {
 func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	cmd := &AddCAASCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		cloudMetadataStore:        cloudMetadataStore,
-		store:                     store,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store:       store,
+			EnabledFlag: feature.MultiCloud,
+		},
+		cloudMetadataStore: cloudMetadataStore,
+		store:              store,
 		newClientConfigReader: func(caasType string) (clientconfig.ClientConfigFunc, error) {
 			return clientconfig.NewClientConfigReader(caasType)
 		},

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -57,9 +58,13 @@ type RemoveCAASCommand struct {
 func NewRemoveCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	cmd := &RemoveCAASCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		cloudMetadataStore:        cloudMetadataStore,
-		store:                     store,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store:       store,
+			EnabledFlag: feature.MultiCloud,
+		},
+
+		cloudMetadataStore: cloudMetadataStore,
+		store:              store,
 	}
 	cmd.apiFunc = func() (RemoveCloudAPI, error) {
 		root, err := cmd.NewAPIRoot(cmd.store, cmd.controllerName, "")

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -113,14 +114,14 @@ you can specify which to upload with the --credential option.
 
 Examples:
     juju add-cloud
-    juju add-cloud --local mycloud ~/mycloud.yaml
+    juju add-cloud mycloud ~/mycloud.yaml
+    juju add-cloud --replace mycloud ~/mycloud2.yaml
 
 If the "multi-cloud" feature flag is turned on in the controller:
 
-    juju add-cloud mycloud ~/mycloud.yaml
-    juju add-cloud --replace mycloud ~/mycloud2.yaml
     juju add-cloud --controller mycontroller mycloud
     juju add-cloud --controller mycontroller mycloud --credential mycred
+    juju add-cloud --local mycloud ~/mycloud.yaml
 
 See also: 
     clouds`
@@ -167,9 +168,12 @@ func NewAddCloudCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	cloudCallCtx := context.NewCloudCallContext()
 	store := jujuclient.NewFileClientStore()
 	c := &AddCloudCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		cloudMetadataStore:        cloudMetadataStore,
-		CloudCallCtx:              cloudCallCtx,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store:       store,
+			EnabledFlag: feature.MultiCloud,
+		},
+		cloudMetadataStore: cloudMetadataStore,
+		CloudCallCtx:       cloudCallCtx,
 		// Ping is provider.Ping except in tests where we don't actually want to
 		// require a valid cloud.
 		Ping: func(p environs.EnvironProvider, endpoint string) error {

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -41,11 +42,10 @@ var listCloudsDoc = "" +
 	"Output includes fundamental properties for each cloud known to the\n" +
 	"current Juju client: name, number of regions, default region, type,\n" +
 	"and description.\n" +
-	"\nThe default behaviour is to show clouds available on the current controller,\n" +
-	"or another controller specified using --controller.\n" +
-	"\nIf --local is specified, the output shows public clouds known to Juju out of the box;\n" +
-	"these can be used to bootstrap a controller. Clouds may change between Juju versions.\n" +
+	"If the multi-cloud feature flag is not enabled, the default behaviour is to\n" +
+	"show clouds known to Juju out of the box; these can be used to bootstrap a controller.\n" +
 	"In addition to these public clouds, the 'localhost' cloud (local LXD) is also listed.\n" +
+	"With the multi-cloud feature flag, a controller is specified using --controller.\n" +
 	"If you supply a controller name the clouds known on the controller will be displayed.\n" +
 	"\nThis command's default output format is 'tabular'.\n" +
 	"\nCloud metadata sometimes changes, e.g. AWS adds a new region. Use the\n" +
@@ -80,8 +80,11 @@ type ListCloudsAPI interface {
 func NewListCloudsCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &listCloudsCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		store:                     store,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store:       store,
+			EnabledFlag: feature.MultiCloud,
+		},
+		store: store,
 	}
 	c.listCloudsAPIFunc = c.cloudAPI
 

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -18,9 +19,10 @@ var usageRemoveCloudSummary = `
 Removes a user-defined cloud from Juju.`[1:]
 
 var usageRemoveCloudDetails = `
-Remove a named, user-defined cloud from Juju. The current
-controller is used unless the --controller option is specified.
+Remove a named, user-defined cloud from Juju's internal cache.
 
+If the multi-cloud feature flag is enabled, the cloud is removed from a controller.
+The current controller is used unless the --controller option is specified.
 If --local is specified, Juju removes the cloud from internal cache.
 
 Examples:
@@ -53,8 +55,11 @@ type removeCloudAPI interface {
 func NewRemoveCloudCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &removeCloudCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		store:                     store,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store:       store,
+			EnabledFlag: feature.MultiCloud,
+		},
+		store: store,
 	}
 	c.removeCloudAPIFunc = c.cloudAPI
 	return modelcmd.WrapBase(c)

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -17,6 +17,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -42,8 +43,9 @@ options.
 If ‘--include-config’ is used, additional configuration (key, type, and
 description) specific to the cloud are displayed if available.
 
+If the multi-cloud feature flag is enabled, Juju shows a cloud on a controller,
+otherwise Juju shows the cloud from internal cache.
 The current controller is used unless the --controller option is specified.
-
 If --local is specified, Juju shows the cloud from internal cache.
 
 Examples:
@@ -67,8 +69,11 @@ type showCloudAPI interface {
 func NewShowCloudCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &showCloudCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		store:                     store,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store:       store,
+			EnabledFlag: feature.MultiCloud,
+		},
+		store: store,
 	}
 	c.showCloudAPIFunc = c.cloudAPI
 	return modelcmd.WrapBase(c)

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -13,6 +13,7 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -76,9 +77,12 @@ var NewUpdateCloudCommand = func(cloudMetadataStore CloudMetadataStore) cmd.Comm
 func newUpdateCloudCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &updateCloudCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		cloudMetadataStore:        cloudMetadataStore,
-		store:                     store,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store:       store,
+			EnabledFlag: feature.MultiCloud,
+		},
+		cloudMetadataStore: cloudMetadataStore,
+		store:              store,
 	}
 	c.updateCloudAPIFunc = c.updateCloudAPI
 

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
 	"github.com/juju/juju/api"
@@ -389,6 +390,7 @@ type OptionalControllerCommand struct {
 	CommandBase
 	Store jujuclient.ClientStore
 
+	EnabledFlag    string
 	Local          bool
 	controllerName string
 }
@@ -405,7 +407,9 @@ func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 // A non default controller can be chosen using the --controller option.
 // Use the --local arg to return an empty string, meaning no controller is selected.
 func (c *OptionalControllerCommand) ControllerNameFromArg() (string, error) {
-	if c.Local {
+	requireExplicitController := !featureflag.Enabled(c.EnabledFlag)
+	if c.Local || (requireExplicitController && c.controllerName == "") {
+		c.Local = true
 		return "", nil
 	}
 	controllerName := c.controllerName


### PR DESCRIPTION
## Description of change

The various cloud CLI commands default to --local unless the "multi-cloud" feature flag is set.
You can still explicitly specify a controller with --controller even without the feature flag.

## QA steps

Without feature flag, juju clouds shows all the out of the box clouds and requires --controller to show controller clouds.
With feature flag, juju clouds requires --local to show out of the box clouds.
Same with other cloud commands.

## Documentation changes

Doc based on previous release notes should be amended.
