### PR TITLE
2.6 - Add Branches to Model Cache

### DIFF
--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -61,11 +61,10 @@ func (b *Branch) setDetails(details BranchChange) {
 	b.details = details
 }
 
-// copy returns a copy of the branch.
+// copy returns a copy of the branch, ensuring appropriate deep copying.
+// This method is called while the cache model is locked,
+// and so should no require its own lock protection.
 func (b *Branch) copy() Branch {
-	b.mu.Lock()
-
-	// Copy the AssignedUnits map.
 	var cAssignedUnits map[string][]string
 	bAssignedUnits := b.details.AssignedUnits
 	if bAssignedUnits != nil {
@@ -79,7 +78,6 @@ func (b *Branch) copy() Branch {
 		}
 	}
 
-	// Copy the Config map.
 	var cConfig map[string]settings.ItemChanges
 	bConfig := b.details.Config
 	if bConfig != nil {
@@ -102,6 +100,5 @@ func (b *Branch) copy() Branch {
 	cb.details.AssignedUnits = cAssignedUnits
 	cb.details.Config = cConfig
 
-	b.mu.Unlock()
 	return cb
 }

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	"github.com/juju/pubsub"
+
+	"github.com/juju/juju/core/settings"
 )
 
 // Branch represents an active branch in a cached model.
@@ -19,8 +21,7 @@ type Branch struct {
 	hub     *pubsub.SimpleHub
 	mu      sync.Mutex
 
-	details    BranchChange
-	configHash string
+	details BranchChange
 }
 
 func newBranch(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Branch {
@@ -29,6 +30,16 @@ func newBranch(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) 
 		metrics:  metrics,
 		hub:      hub,
 	}
+}
+
+// Note that these property accessors are not lock-protected.
+// They are intended for calling from external packages that have retrieved a
+// deep copy from the cache.
+
+// AssignedUnits returns a map of the names of units tracking this branch,
+// keyed by application names with changes made under the branch.
+func (b *Branch) AssignedUnits() map[string][]string {
+	return b.details.AssignedUnits
 }
 
 func (b *Branch) setDetails(details BranchChange) {
@@ -48,4 +59,49 @@ func (b *Branch) setDetails(details BranchChange) {
 	// TODO (manadart 2019-05-29): Publish changes for config deltas and tracking units.
 
 	b.details = details
+}
+
+// copy returns a copy of the branch.
+func (b *Branch) copy() Branch {
+	b.mu.Lock()
+
+	// Copy the AssignedUnits map.
+	var cAssignedUnits map[string][]string
+	bAssignedUnits := b.details.AssignedUnits
+	if bAssignedUnits != nil {
+		cAssignedUnits = make(map[string][]string, len(bAssignedUnits))
+		for k, v := range bAssignedUnits {
+			units := make([]string, len(v))
+			for i, u := range v {
+				units[i] = u
+			}
+			cAssignedUnits[k] = units
+		}
+	}
+
+	// Copy the Config map.
+	var cConfig map[string]settings.ItemChanges
+	bConfig := b.details.Config
+	if bConfig != nil {
+		cConfig = make(map[string]settings.ItemChanges, len(bConfig))
+		for k, v := range bConfig {
+			changes := make(settings.ItemChanges, len(v))
+			for i, ch := range v {
+				changes[i] = settings.ItemChange{
+					Type:     ch.Type,
+					Key:      ch.Key,
+					NewValue: ch.NewValue,
+					OldValue: ch.OldValue,
+				}
+			}
+			cConfig[k] = changes
+		}
+	}
+
+	cb := *b
+	cb.details.AssignedUnits = cAssignedUnits
+	cb.details.Config = cConfig
+
+	b.mu.Unlock()
+	return cb
 }

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/juju/pubsub"
+)
+
+// Branch represents an active branch in a cached model.
+type Branch struct {
+	// Resident identifies the branch as a type-agnostic cached entity
+	// and tracks resources that it is responsible for cleaning up.
+	*Resident
+
+	metrics *ControllerGauges
+	hub     *pubsub.SimpleHub
+	mu      sync.Mutex
+
+	details    BranchChange
+	configHash string
+}
+
+func newBranch(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Branch {
+	return &Branch{
+		Resident: res,
+		metrics:  metrics,
+		hub:      hub,
+	}
+}
+
+func (b *Branch) setDetails(details BranchChange) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// If this is the first receipt of details, set the removal message.
+	if b.removalMessage == nil {
+		b.removalMessage = RemoveBranch{
+			ModelUUID: details.ModelUUID,
+			Name:      details.Name,
+		}
+	}
+
+	b.setStale(false)
+
+	// TODO (manadart 2019-05-29): Publish changes for config deltas and tracking units.
+
+	b.details = details
+}

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -96,9 +96,15 @@ func (b *Branch) copy() Branch {
 		}
 	}
 
-	cb := *b
-	cb.details.AssignedUnits = cAssignedUnits
-	cb.details.Config = cConfig
+	cDetails := b.details
+	cDetails.AssignedUnits = cAssignedUnits
+	cDetails.Config = cConfig
 
-	return cb
+	// Copy everything except the mutex.
+	return Branch{
+		Resident: b.Resident,
+		metrics:  b.metrics,
+		hub:      b.hub,
+		details:  cDetails,
+	}
 }

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -39,7 +39,7 @@ func (b *Branch) setDetails(details BranchChange) {
 	if b.removalMessage == nil {
 		b.removalMessage = RemoveBranch{
 			ModelUUID: details.ModelUUID,
-			Name:      details.Name,
+			Id:        details.Id,
 		}
 	}
 

--- a/core/cache/branch_test.go
+++ b/core/cache/branch_test.go
@@ -21,7 +21,7 @@ var branchChange = cache.BranchChange{
 	Id:            "0",
 	Name:          "testing-branch",
 	AssignedUnits: map[string][]string{"redis": {"redis/0", "redis/1"}},
-	Config:        map[string][]settings.ItemChange{"redis": {settings.MakeAddition("password", "pass666")}},
+	Config:        map[string]settings.ItemChanges{"redis": {settings.MakeAddition("password", "pass666")}},
 	Completed:     0,
 	GenerationId:  0,
 }

--- a/core/cache/branch_test.go
+++ b/core/cache/branch_test.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/settings"
+)
+
+type BranchSuite struct {
+	cache.EntitySuite
+}
+
+var _ = gc.Suite(&BranchSuite{})
+
+var branchChange = cache.BranchChange{
+	ModelUUID:     "model-uuid",
+	Name:          "testing-branch",
+	AssignedUnits: map[string][]string{"redis": {"redis/0", "redis/1"}},
+	Config:        map[string][]settings.ItemChange{"redis": {settings.MakeAddition("password", "pass666")}},
+	Completed:     0,
+	GenerationId:  0,
+}

--- a/core/cache/branch_test.go
+++ b/core/cache/branch_test.go
@@ -18,6 +18,7 @@ var _ = gc.Suite(&BranchSuite{})
 
 var branchChange = cache.BranchChange{
 	ModelUUID:     "model-uuid",
+	Id:            "0",
 	Name:          "testing-branch",
 	AssignedUnits: map[string][]string{"redis": {"redis/0", "redis/1"}},
 	Config:        map[string][]settings.ItemChange{"redis": {settings.MakeAddition("password", "pass666")}},

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -131,7 +131,6 @@ type RemoveMachine struct {
 // it is no longer an active branch and will be removed from the cache.
 type BranchChange struct {
 	ModelUUID     string
-	Id            string
 	Name          string
 	AssignedUnits map[string][]string
 	Config        map[string][]settings.ItemChange
@@ -145,5 +144,5 @@ type BranchChange struct {
 // "in-flight" due to being committed or aborted.
 type RemoveBranch struct {
 	ModelUUID string
-	Id        string
+	Name      string
 }

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -134,7 +134,7 @@ type BranchChange struct {
 	Id            string
 	Name          string
 	AssignedUnits map[string][]string
-	Config        map[string][]settings.ItemChange
+	Config        map[string]settings.ItemChanges
 	Completed     int64
 	GenerationId  int
 }

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -131,6 +131,7 @@ type RemoveMachine struct {
 // it is no longer an active branch and will be removed from the cache.
 type BranchChange struct {
 	ModelUUID     string
+	Id            string
 	Name          string
 	AssignedUnits map[string][]string
 	Config        map[string][]settings.ItemChange
@@ -144,5 +145,5 @@ type BranchChange struct {
 // "in-flight" due to being committed or aborted.
 type RemoveBranch struct {
 	ModelUUID string
-	Name      string
+	Id        string
 }

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/settings"
 	"github.com/juju/juju/core/status"
 )
 
@@ -119,6 +120,30 @@ type MachineChange struct {
 // RemoveMachine represents the situation when a machine
 // is removed from a model in the database.
 type RemoveMachine struct {
+	ModelUUID string
+	Id        string
+}
+
+// BranchChange represents a change to an active model branch.
+// Note that this corresponds to a multi-watcher GenerationInfo payload,
+// and that the cache behaviour differs from other entities;
+// when a generation is completed (aborted or committed),
+// it is no longer an active branch and will be removed from the cache.
+type BranchChange struct {
+	ModelUUID     string
+	Id            string
+	Name          string
+	AssignedUnits map[string][]string
+	Config        map[string][]settings.ItemChange
+	Completed     int64
+	GenerationId  int
+}
+
+// RemoveBranch represents the situation when a branch is to be removed
+// from the cache. This will rarely be a result of deletion from the database.
+// It will usually be the result of the branch no longer being considered
+// "in-flight" due to being committed or aborted.
+type RemoveBranch struct {
 	ModelUUID string
 	Id        string
 }

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -224,7 +224,6 @@ func (s *ControllerSuite) TestAddBranch(c *gc.C) {
 
 	branch, err := mod.Branch(branchChange.Name)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(branch, gc.NotNil)
 	s.AssertResident(c, branch.CacheId(), true)
 }
 

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -56,6 +56,7 @@ func (s *ControllerSuite) TestAddModel(c *gc.C) {
 			"charm-count":       0,
 			"machine-count":     0,
 			"unit-count":        0,
+			"branch-count":      0,
 		}})
 
 	// The model has the first ID and is registered.
@@ -213,6 +214,39 @@ func (s *ControllerSuite) TestRemoveUnit(c *gc.C) {
 	s.AssertResident(c, unit.CacheId(), false)
 }
 
+func (s *ControllerSuite) TestAddBranch(c *gc.C) {
+	controller, events := s.new(c)
+	s.processChange(c, branchChange, events)
+
+	mod, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(mod.Report()["branch-count"], gc.Equals, 1)
+
+	branch, err := mod.Branch(branchChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(branch, gc.NotNil)
+	s.AssertResident(c, branch.CacheId(), true)
+}
+
+func (s *ControllerSuite) TestRemoveBranch(c *gc.C) {
+	controller, events := s.new(c)
+	s.processChange(c, branchChange, events)
+
+	mod, err := controller.Model(modelChange.ModelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	branch, err := mod.Branch(branchChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	remove := cache.RemoveBranch{
+		ModelUUID: modelChange.ModelUUID,
+		Name:      branchChange.Name,
+	}
+	s.processChange(c, remove, events)
+
+	c.Check(mod.Report()["unit-count"], gc.Equals, 0)
+	s.AssertResident(c, branch.CacheId(), false)
+}
+
 func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 	controller, events := s.new(c)
 
@@ -280,6 +314,10 @@ func (s *ControllerSuite) captureEvents(c *gc.C) <-chan interface{} {
 		case cache.UnitChange:
 			send = true
 		case cache.RemoveUnit:
+			send = true
+		case cache.BranchChange:
+			send = true
+		case cache.RemoveBranch:
 			send = true
 		default:
 			// no-op

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -239,7 +239,7 @@ func (s *ControllerSuite) TestRemoveBranch(c *gc.C) {
 
 	remove := cache.RemoveBranch{
 		ModelUUID: modelChange.ModelUUID,
-		Name:      branchChange.Name,
+		Id:        branchChange.Id,
 	}
 	s.processChange(c, remove, events)
 

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -44,3 +44,7 @@ func (m *Model) UpdateApplication(details ApplicationChange, manager *residentMa
 func (m *Model) UpdateCharm(details CharmChange, manager *residentManager) {
 	m.updateCharm(details, manager)
 }
+
+func (m *Model) UpdateBranch(details BranchChange, manager *residentManager) {
+	m.updateBranch(details, manager)
+}

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -37,6 +37,7 @@ func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *
 		charms:       make(map[string]*Charm),
 		machines:     make(map[string]*Machine),
 		units:        make(map[string]*Unit),
+		branches:     make(map[string]*Branch),
 	}
 	return m
 }
@@ -59,6 +60,7 @@ type Model struct {
 	charms       map[string]*Charm
 	machines     map[string]*Machine
 	units        map[string]*Unit
+	branches     map[string]*Branch
 }
 
 // Config returns the current model config.
@@ -94,6 +96,7 @@ func (m *Model) Report() map[string]interface{} {
 		"charm-count":       len(m.charms),
 		"machine-count":     len(m.machines),
 		"unit-count":        len(m.units),
+		"branch-count":      len(m.branches),
 	}
 }
 
@@ -144,6 +147,18 @@ func (m *Model) Machine(machineId string) (*Machine, error) {
 		return nil, errors.NotFoundf("machine %q", machineId)
 	}
 	return machine, nil
+}
+
+// Branch returns the machine with the input name.
+// If the branch is not found, a NotFoundError is returned.
+func (m *Model) Branch(name string) (*Branch, error) {
+	defer m.doLocked()()
+
+	branch, found := m.branches[name]
+	if !found {
+		return nil, errors.NotFoundf("branch %q", name)
+	}
+	return branch, nil
 }
 
 // WatchMachines returns a PredicateStringsWatcher to notify about
@@ -311,6 +326,40 @@ func (m *Model) removeMachine(ch RemoveMachine) error {
 			return errors.Trace(err)
 		}
 		delete(m.machines, ch.Id)
+	}
+	return nil
+}
+
+// updateBranch adds or updates the branch in the model.
+// Only "in-flight" branches should ever reside in the change.
+// A committed or aborted branch (with a non-zero time-stamp for completion)
+// should be passed through by the cache worker as a deletion.
+func (m *Model) updateBranch(ch BranchChange, rm *residentManager) {
+	m.mu.Lock()
+
+	branch, found := m.branches[ch.Name]
+	if !found {
+		branch = newBranch(m.metrics, m.hub, rm.new())
+		m.branches[ch.Name] = branch
+	}
+	branch.setDetails(ch)
+
+	m.mu.Unlock()
+}
+
+// removeBranch removes the branch from the model.
+func (m *Model) removeBranch(ch RemoveBranch) error {
+	defer m.doLocked()()
+
+	branch, ok := m.branches[ch.Name]
+	if ok {
+		// TODO (manadart 2019-05-29): Publish appropriate message(s) to cause
+		// any unit config watchers to use only the master settings (maybe).
+
+		if err := branch.evict(); err != nil {
+			return errors.Trace(err)
+		}
+		delete(m.branches, ch.Name)
 	}
 	return nil
 }

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -163,7 +163,7 @@ func (m *Model) Branch(name string) (Branch, error) {
 
 	for _, b := range m.branches {
 		if b.details.Name == name {
-			return *b, nil
+			return b.copy(), nil
 		}
 	}
 	return Branch{}, errors.NotFoundf("branch %q", name)

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -30,6 +30,7 @@ func (s *ModelSuite) TestReport(c *gc.C) {
 		"charm-count":       0,
 		"machine-count":     0,
 		"unit-count":        0,
+		"branch-count":      0,
 	})
 }
 

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -175,6 +175,29 @@ func (s *ModelSuite) TestUnitNotFoundError(c *gc.C) {
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
+func (s *ModelSuite) TestBranchNotFoundError(c *gc.C) {
+	m := s.NewModel(modelChange)
+	_, err := m.Branch("nope")
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (s *ModelSuite) TestBranchReturnsCopy(c *gc.C) {
+	m := s.NewModel(modelChange)
+	m.UpdateBranch(branchChange, s.Manager)
+
+	b1, err := m.Branch(branchChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make a change to the map returned in the copy.
+	au := b1.AssignedUnits()
+	au["banana"] = []string{"banana/1", "banana/2"}
+
+	// Get another copy from the model and ensure it is unchanged.
+	b2, err := m.Branch(branchChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(b2.AssignedUnits(), gc.DeepEquals, branchChange.AssignedUnits)
+}
+
 func (s *ControllerSuite) TestWatchMachineStops(c *gc.C) {
 	controller, _ := s.newWithMachine(c)
 	m, err := controller.Model(modelChange.ModelUUID)

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -105,6 +105,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/life",
 		"core/lxdprofile",
 		"core/network",
+		"core/settings",
 		"core/status",
 	})
 }

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -1,5 +1,6 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+
 package cache_test
 
 import (

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -462,9 +462,8 @@ func (s *WorkerSuite) TestAddBranch(c *gc.C) {
 	mod, err := controller.Model(modUUIDs[0])
 	c.Assert(err, jc.ErrorIsNil)
 
-	cachedBranch, err := mod.Branch(branchName)
+	_, err = mod.Branch(branchName)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(cachedBranch, gc.NotNil)
 }
 
 func (s *WorkerSuite) TestRemoveBranch(c *gc.C) {

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -88,7 +88,7 @@ func (s *WorkerSuite) TestExtractCacheController(c *gc.C) {
 	var controller *cache.Controller
 	var empty worker.Worker
 	err := modelcache.ExtractCacheController(empty, &controller)
-	c.Assert(err.Error(), gc.Equals, "in should be a *modelcache.cacheWorker; got <nil>")
+	c.Assert(err, gc.ErrorMatches, `in should be a \*modelcache.cacheWorker; got <nil>`)
 }
 
 func (s *WorkerSuite) start(c *gc.C) worker.Worker {
@@ -165,7 +165,7 @@ func (s *WorkerSuite) TestNewModel(c *gc.C) {
 
 	newState := s.Factory.MakeModel(c, nil)
 	s.State.StartSync()
-	defer newState.Close()
+	defer func() { _ = newState.Close() }()
 
 	obtained := s.nextChange(c, changes)
 	expected, err := newState.Model()
@@ -185,7 +185,7 @@ func (s *WorkerSuite) TestRemovedModel(c *gc.C) {
 
 	st := s.Factory.MakeModel(c, nil)
 	s.State.StartSync()
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 
 	// grab and discard the event for the new model
 	s.nextChange(c, changes)
@@ -442,6 +442,69 @@ func (s *WorkerSuite) TestRemoveUnit(c *gc.C) {
 	}
 }
 
+func (s *WorkerSuite) TestAddBranch(c *gc.C) {
+	changes := s.captureEvents(c, branchEvents)
+	w := s.start(c)
+
+	branchName := "test-branch"
+	c.Assert(s.State.AddBranch(branchName, "test-user"), jc.ErrorIsNil)
+	s.State.StartSync()
+
+	change := s.nextChange(c, changes)
+	obtained, ok := change.(cache.BranchChange)
+	c.Assert(ok, jc.IsTrue)
+	c.Check(obtained.Name, gc.Equals, "test-branch")
+
+	controller := s.getController(c, w)
+	modUUIDs := controller.ModelUUIDs()
+	c.Check(modUUIDs, gc.HasLen, 1)
+
+	mod, err := controller.Model(modUUIDs[0])
+	c.Assert(err, jc.ErrorIsNil)
+
+	cachedBranch, err := mod.Branch(branchName)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cachedBranch, gc.NotNil)
+}
+
+func (s *WorkerSuite) TestRemoveBranch(c *gc.C) {
+	changes := s.captureEvents(c, branchEvents)
+	w := s.start(c)
+
+	branchName := "test-branch"
+	c.Assert(s.State.AddBranch(branchName, "test-user"), jc.ErrorIsNil)
+	s.State.StartSync()
+	_ = s.nextChange(c, changes)
+
+	controller := s.getController(c, w)
+	modUUID := controller.ModelUUIDs()[0]
+
+	branch, err := s.State.Branch(branchName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Generation docs are not deleted from the DB in any current workflow.
+	// Committing the branch so that it is no longer active should cause
+	// a removal message to be emitted.
+	_, err = branch.Commit("test-user")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.State.StartSync()
+
+	// We will either get our branch event,
+	// or time-out after processing all the changes.
+	for {
+		change := s.nextChange(c, changes)
+		if _, ok := change.(cache.RemoveBranch); ok {
+			mod, err := controller.Model(modUUID)
+			c.Assert(err, jc.ErrorIsNil)
+
+			_, err = mod.Branch(branchName)
+			c.Check(errors.IsNotFound(err), jc.IsTrue)
+			return
+		}
+	}
+}
+
 func (s *WorkerSuite) TestWatcherErrorCacheMarkSweep(c *gc.C) {
 	// Some state to close over.
 	fakeModelSent := false
@@ -593,6 +656,16 @@ var unitEvents = func(change interface{}) bool {
 	case cache.UnitChange:
 		return true
 	case cache.RemoveUnit:
+		return true
+	}
+	return false
+}
+
+var branchEvents = func(change interface{}) bool {
+	switch change.(type) {
+	case cache.BranchChange:
+		return true
+	case cache.RemoveBranch:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Description of change

This patch adds branches to the model cache.

Processing of branches by the cache worker differs slightly from other entities in that if a branch has been committed or aborted (it has a non-zero completion time-stamp) then it is removed from the cache.

Depends on https://github.com/juju/juju/pull/10252.

## QA steps

No materialised functionality. Unit tests cover the new logic, and QA steps will accompany a following patch that adds unit config and watchers to the model cache.

## Documentation changes

None.

## Bug reference

N/A
