### PR TITLE
Deprecate 'add-cloud --replace'.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -76,8 +76,8 @@ the controller needs to have the "multi-cloud" feature flag turned on.
 
 If --local is used, Juju stores that definition its internal cache directly.
 
-If <cloud name> already exists in Juju's cache, then the `[1:] + "`--replace`" + ` 
-option is required.
+DEPRECATED If <cloud name> already exists in Juju's cache, then the `[1:] + "`--replace`" + ` 
+option is required. Use 'update-credential' instead.
 
 A cloud definition file has the following YAML format:
 
@@ -123,7 +123,8 @@ If the "multi-cloud" feature flag is turned on in the controller:
     juju add-cloud --controller mycontroller mycloud --credential mycred
 
 See also: 
-    clouds`
+    clouds
+    update-credential`
 
 // AddCloudAPI - Implemented by cloudapi.Client.
 type AddCloudAPI interface {
@@ -138,6 +139,7 @@ type AddCloudCommand struct {
 	modelcmd.OptionalControllerCommand
 
 	// Replace, if true, existing cloud information is overwritten.
+	// TODO (anastasiamac 2019-6-4) Remove as redundant and unsupported for Juju 3.
 	Replace bool
 
 	// Cloud is the name of the cloud to add.
@@ -202,7 +204,7 @@ func (c *AddCloudCommand) Info() *cmd.Info {
 // SetFlags initializes the flags supported by the command.
 func (c *AddCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.OptionalControllerCommand.SetFlags(f)
-	f.BoolVar(&c.Replace, "replace", false, "Overwrite any existing cloud information for <cloud name>")
+	f.BoolVar(&c.Replace, "replace", false, "DEPRECATED: Overwrite any existing cloud information for <cloud name>")
 	f.StringVar(&c.CloudFile, "f", "", "The path to a cloud definition file")
 	f.StringVar(&c.credentialName, "credential", "", "Credential to use for new cloud")
 }
@@ -283,6 +285,9 @@ func (c *AddCloudCommand) addCredentialToController(ctx *cmd.Context, cloud juju
 // Run executes the add cloud command, adding a cloud based on a passed-in yaml
 // file or interactive queries.
 func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
+	if c.Replace {
+		ctxt.Warningf("'add-cloud --replace' is deprecated. Use 'update-cloud' instead.")
+	}
 	if c.CloudFile == "" && c.controllerName == "" {
 		return c.runInteractive(ctxt)
 	}


### PR DESCRIPTION
## Description of change

Merge pull request #10281 from anastasiamac/deprecate-add-cloud-replace-26

https://github.com/juju/juju/pull/10281

'add-cloud --replace' was an original way of updating existing cloud definitions locally.
With the introduction of a more aligned conventionally 'update-cloud', the Juju original version is now redundant.

This PR states that this option is deprecated and leads user to 'update-cloud'. It is intended to be removed in next major release.

## QA steps

1. 'juju help add-cloud' clearly messages that --replace option is deprecated.
2. when using --replace with add-cloud command (either interactive or non-interactive mode), users get notification:

```
$ juju add-cloud --replace canonistack 
WARNING 'add-cloud --replace' is deprecated. Use 'update-cloud' instead.
```

