### PR TITLE
Local credentials tolerate per-cloud malformed credentials.

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -464,7 +464,7 @@ func ParseCredentialCollection(data []byte) (*CredentialCollection, error) {
 	return &collection, nil
 }
 
-// CloudCredential returns a copy of the CloudCredential for the specifed cloud or
+// CloudCredential returns a copy of the CloudCredential for the specified cloud or
 // an error when the CloudCredential was not found or failed to pass validation.
 func (c *CredentialCollection) CloudCredential(cloudName string) (*CloudCredential, error) {
 	credentialValue, ok := c.Credentials[cloudName]

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -199,7 +199,7 @@ func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 		if errors.IsNotFound(err) {
 			continue
 		} else if err != nil {
-			ctxt.Infof("error loading credential for cloud %v: %v", cloudName, err)
+			ctxt.Warningf("error loading credential for cloud %v: %v", cloudName, err)
 			continue
 		}
 		if !c.showSecrets {

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -28,7 +28,8 @@ type listCredentialsSuite struct {
 var _ = gc.Suite(&listCredentialsSuite{
 	personalCloudsFunc: func() (map[string]jujucloud.Cloud, error) {
 		return map[string]jujucloud.Cloud{
-			"mycloud": {},
+			"mycloud":      {},
+			"missingcloud": {},
 		}, nil
 	},
 	cloudByNameFunc: func(name string) (*jujucloud.Cloud, error) {

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -6,11 +6,10 @@ package cloud_test
 import (
 	"strings"
 
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
-
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -135,6 +135,15 @@ func (s *listCredentialsSuite) TestListCredentialsTabularInvalidCredential(c *gc
 		}
 		return s.store.CredentialForCloud(cloudName)
 	}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestListCredentialsTabularInvalidCredential"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+		logWriter.Clear()
+	}()
+
 	ctx := s.listCredentialsWithStore(c, store)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Cloud   Credentials
@@ -143,9 +152,12 @@ azure   azhja
 google  default
 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-error loading credential for cloud mycloud: expected error
-`[1:])
+	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
+		{
+			Level:   loggo.WARNING,
+			Message: `error loading credential for cloud mycloud: expected error`,
+		},
+	})
 }
 
 func (s *listCredentialsSuite) TestListCredentialsTabularMissingCloud(c *gc.C) {
@@ -244,6 +256,15 @@ func (s *listCredentialsSuite) TestListCredentialsYAMLWithSecretsInvalidCredenti
 		}
 		return s.store.CredentialForCloud(cloudName)
 	}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestListCredentialsYAMLWithSecretsInvalidCredential"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+		logWriter.Clear()
+	}()
+
 	ctx := s.listCredentialsWithStore(c, store, "--format", "yaml", "--show-secrets")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 local-credentials:
@@ -277,9 +298,12 @@ local-credentials:
       access-key: key
       secret-key: secret
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-error loading credential for cloud mycloud: expected error
-`[1:])
+	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
+		{
+			Level:   loggo.WARNING,
+			Message: `error loading credential for cloud mycloud: expected error`,
+		},
+	})
 }
 
 func (s *listCredentialsSuite) TestListCredentialsYAMLNoSecrets(c *gc.C) {
@@ -352,13 +376,25 @@ func (s *listCredentialsSuite) TestListCredentialsJSONWithSecretsInvalidCredenti
 		}
 		return s.store.CredentialForCloud(cloudName)
 	}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestListCredentialsJSONWithSecretsInvalidCredential"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+		logWriter.Clear()
+	}()
+
 	ctx := s.listCredentialsWithStore(c, store, "--format", "json", "--show-secrets")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 {"local-credentials":{"aws":{"default-credential":"down","default-region":"ap-southeast-2","cloud-credentials":{"bob":{"auth-type":"access-key","details":{"access-key":"key","secret-key":"secret"}},"down":{"auth-type":"userpass","details":{"password":"password","username":"user"}}}},"azure":{"cloud-credentials":{"azhja":{"auth-type":"userpass","details":{"application-id":"app-id","application-password":"app-secret","subscription-id":"subscription-id","tenant-id":"tenant-id"}}}},"google":{"cloud-credentials":{"default":{"auth-type":"oauth2","details":{"client-email":"email","client-id":"id","private-key":"key"}}}}}}
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-error loading credential for cloud mycloud: expected error
-`[1:])
+	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
+		{
+			Level:   loggo.WARNING,
+			Message: `error loading credential for cloud mycloud: expected error`,
+		},
+	})
 }
 
 func (s *listCredentialsSuite) TestListCredentialsJSONNoSecrets(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -45,8 +45,7 @@ func formatCloudDetailsTabular(ctx *cmd.Context, clouds cloudList, credStore juj
 		for _, name := range cloudNames {
 			cred, err := credStore.CredentialForCloud(name)
 			if err != nil && !errors.IsNotFound(err) {
-				ctx.Warningf("error loading credential for cloud %v: %v", name, err)
-				p(name, "ERROR", "")
+				ctx.Infof("error loading credential for cloud %v: %v", name, err)
 				continue
 			}
 			if err != nil || len(cred.AuthCredentials) == 0 {

--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -24,7 +24,7 @@ type cloudList struct {
 	personal []string
 }
 
-func formatCloudDetailsTabular(clouds cloudList, credStore jujuclient.CredentialStore) ([]byte, error) {
+func formatCloudDetailsTabular(ctx *cmd.Context, clouds cloudList, credStore jujuclient.CredentialStore) ([]byte, error) {
 	var out bytes.Buffer
 	const (
 		// To format things into columns.
@@ -45,7 +45,9 @@ func formatCloudDetailsTabular(clouds cloudList, credStore jujuclient.Credential
 		for _, name := range cloudNames {
 			cred, err := credStore.CredentialForCloud(name)
 			if err != nil && !errors.IsNotFound(err) {
-				return errors.Annotatef(err, "error loading credential for cloud %q", name)
+				ctx.Warningf("error loading credential for cloud %v: %v", name, err)
+				p(name, "ERROR", "")
+				continue
 			}
 			if err != nil || len(cred.AuthCredentials) == 0 {
 				p(name, "", "")
@@ -108,7 +110,7 @@ func printClouds(ctx *cmd.Context, credStore jujuclient.CredentialStore) error {
 	for name := range personalClouds {
 		clouds.personal = append(clouds.personal, name)
 	}
-	out, err := formatCloudDetailsTabular(clouds, credStore)
+	out, err := formatCloudDetailsTabular(ctx, clouds, credStore)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/commands/bootstrap_clouds.go
+++ b/cmd/juju/commands/bootstrap_clouds.go
@@ -45,7 +45,7 @@ func formatCloudDetailsTabular(ctx *cmd.Context, clouds cloudList, credStore juj
 		for _, name := range cloudNames {
 			cred, err := credStore.CredentialForCloud(name)
 			if err != nil && !errors.IsNotFound(err) {
-				ctx.Infof("error loading credential for cloud %v: %v", name, err)
+				ctx.Warningf("error loading credential for cloud %v: %v", name, err)
 				continue
 			}
 			if err != nil || len(cred.AuthCredentials) == 0 {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1810,7 +1810,7 @@ func (s *BootstrapSuite) TestBootstrapPrintClouds(c *gc.C) {
 
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--clouds")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, `
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
 You can bootstrap on these clouds. See ‘--regions <cloud>’ for all regions.
 Cloud                            Credentials  Default Region
 aws                              fred         us-west-1
@@ -1824,9 +1824,7 @@ google
 joyent                                        
 oracle                                        
 oracle-classic                                
-rackspace                                     
-localhost                                     
-microk8s                                      
+rackspace                                     \n?(localhost\s+)?(microk8s\s+)?
 dummy-cloud                      joe          home
 dummy-cloud-dummy-region-config               
 dummy-cloud-with-config                       
@@ -1875,7 +1873,7 @@ func (s *BootstrapSuite) TestBootstrapPrintCloudsInvalidCredential(c *gc.C) {
 
 	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), "--clouds")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, `
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
 You can bootstrap on these clouds. See ‘--regions <cloud>’ for all regions.
 Cloud                            Credentials  Default Region
 aws                              fred         us-west-1
@@ -1889,9 +1887,7 @@ google
 joyent                                        
 oracle                                        
 oracle-classic                                
-rackspace                                     
-localhost                                     
-microk8s                                      
+rackspace                                     \n?(localhost\s+)?(microk8s\s+)?
 dummy-cloud-dummy-region-config               
 dummy-cloud-with-config                       
 dummy-cloud-with-region-config                

--- a/jujuclient/credentials.go
+++ b/jujuclient/credentials.go
@@ -23,15 +23,15 @@ func JujuCredentialsPath() string {
 
 // ReadCredentialsFile loads all credentials defined in a given file.
 // If the file is not found, it is not an error.
-func ReadCredentialsFile(file string) (map[string]cloud.CloudCredential, error) {
+func ReadCredentialsFile(file string) (*cloud.CredentialContainer, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return &cloud.CredentialContainer{}, nil
 		}
 		return nil, err
 	}
-	credentials, err := cloud.ParseCredentials(data)
+	credentials, err := cloud.ParseCredentialContainer(data)
 	if err != nil {
 		return nil, err
 	}
@@ -40,17 +40,10 @@ func ReadCredentialsFile(file string) (map[string]cloud.CloudCredential, error) 
 
 // WriteCredentialsFile marshals to YAML details of the given credentials
 // and writes it to the credentials file.
-func WriteCredentialsFile(credentials map[string]cloud.CloudCredential) error {
-	data, err := yaml.Marshal(credentialsCollection{credentials})
+func WriteCredentialsFile(credentials *cloud.CredentialContainer) error {
+	data, err := yaml.Marshal(credentials)
 	if err != nil {
 		return errors.Annotate(err, "cannot marshal yaml credentials")
 	}
 	return utils.AtomicWriteFile(JujuCredentialsPath(), data, os.FileMode(0600))
-}
-
-// credentialsCollection is a struct containing cloud credential information,
-// used marshalling and unmarshalling.
-type credentialsCollection struct {
-	// Credentials is a map of cloud credentials, keyed on cloud name.
-	Credentials map[string]cloud.CloudCredential `yaml:"credentials"`
 }

--- a/jujuclient/credentials.go
+++ b/jujuclient/credentials.go
@@ -23,15 +23,15 @@ func JujuCredentialsPath() string {
 
 // ReadCredentialsFile loads all credentials defined in a given file.
 // If the file is not found, it is not an error.
-func ReadCredentialsFile(file string) (*cloud.CredentialContainer, error) {
+func ReadCredentialsFile(file string) (*cloud.CredentialCollection, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &cloud.CredentialContainer{}, nil
+			return &cloud.CredentialCollection{}, nil
 		}
 		return nil, err
 	}
-	credentials, err := cloud.ParseCredentialContainer(data)
+	credentials, err := cloud.ParseCredentialCollection(data)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func ReadCredentialsFile(file string) (*cloud.CredentialContainer, error) {
 
 // WriteCredentialsFile marshals to YAML details of the given credentials
 // and writes it to the credentials file.
-func WriteCredentialsFile(credentials *cloud.CredentialContainer) error {
+func WriteCredentialsFile(credentials *cloud.CredentialCollection) error {
 	data, err := yaml.Marshal(credentials)
 	if err != nil {
 		return errors.Annotate(err, "cannot marshal yaml credentials")

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -756,55 +756,42 @@ func (s *store) UpdateCredential(cloudName string, details cloud.CloudCredential
 	}
 	defer releaser.Release()
 
-	all, err := ReadCredentialsFile(JujuCredentialsPath())
+	credentials, err := ReadCredentialsFile(JujuCredentialsPath())
 	if err != nil {
 		return errors.Annotate(err, "cannot get credentials")
 	}
 
-	if len(all) == 0 {
-		all = make(map[string]cloud.CloudCredential)
-	}
-
-	// Clear the default credential if we are removing that one.
-	if existing, ok := all[cloudName]; ok && existing.DefaultCredential != "" {
-		stillHaveDefault := false
-		for name := range details.AuthCredentials {
-			if name == existing.DefaultCredential {
-				stillHaveDefault = true
-				break
-			}
-		}
-		if !stillHaveDefault {
-			details.DefaultCredential = ""
-		}
-	}
-	if len(details.AuthCredentials) > 0 {
-		all[cloudName] = details
-	} else {
-		delete(all, cloudName)
-	}
-
-	return WriteCredentialsFile(all)
+	credentials.UpdateCloudCredential(cloudName, details)
+	return WriteCredentialsFile(credentials)
 }
 
 // CredentialForCloud implements CredentialGetter.
 func (s *store) CredentialForCloud(cloudName string) (*cloud.CloudCredential, error) {
-	cloudCredentials, err := s.AllCredentials()
+	credentialContainer, err := ReadCredentialsFile(JujuCredentialsPath())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	credentials, ok := cloudCredentials[cloudName]
-	if !ok {
-		return nil, errors.NotFoundf("credentials for cloud %s", cloudName)
+	credential, err := credentialContainer.CloudCredential(cloudName)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return &credentials, nil
+	return credential, nil
 }
 
 // AllCredentials implements CredentialGetter.
 func (s *store) AllCredentials() (map[string]cloud.CloudCredential, error) {
-	cloudCredentials, err := ReadCredentialsFile(JujuCredentialsPath())
+	credentialContainer, err := ReadCredentialsFile(JujuCredentialsPath())
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	cloudNames := credentialContainer.CloudNames()
+	cloudCredentials := make(map[string]cloud.CloudCredential)
+	for _, cloud := range cloudNames {
+		v, err := credentialContainer.CloudCredential(cloud)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cloudCredentials[cloud] = *v
 	}
 	return cloudCredentials, nil
 }

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -767,11 +767,11 @@ func (s *store) UpdateCredential(cloudName string, details cloud.CloudCredential
 
 // CredentialForCloud implements CredentialGetter.
 func (s *store) CredentialForCloud(cloudName string) (*cloud.CloudCredential, error) {
-	credentialContainer, err := ReadCredentialsFile(JujuCredentialsPath())
+	credentialCollection, err := ReadCredentialsFile(JujuCredentialsPath())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	credential, err := credentialContainer.CloudCredential(cloudName)
+	credential, err := credentialCollection.CloudCredential(cloudName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -780,14 +780,14 @@ func (s *store) CredentialForCloud(cloudName string) (*cloud.CloudCredential, er
 
 // AllCredentials implements CredentialGetter.
 func (s *store) AllCredentials() (map[string]cloud.CloudCredential, error) {
-	credentialContainer, err := ReadCredentialsFile(JujuCredentialsPath())
+	credentialCollection, err := ReadCredentialsFile(JujuCredentialsPath())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cloudNames := credentialContainer.CloudNames()
+	cloudNames := credentialCollection.CloudNames()
 	cloudCredentials := make(map[string]cloud.CloudCredential)
 	for _, cloud := range cloudNames {
-		v, err := credentialContainer.CloudCredential(cloud)
+		v, err := credentialCollection.CloudCredential(cloud)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

Malformed credential.yaml files produce unhelpful errors and prevent the user
from moving forward despite the command not requiring cloud credential that is malformed.

For example `juju bootstrap --clouds`, `juju remove-credential`, `juju list-credentials` etc that depend on a cloud credential from the local credential store will fail regardless of if they need the credential.

The change allows the local file credential store via CredentialForCloud to access credentials without requiring the whole credentials.yaml file to be validate. Instead validation is performed lazily when the
particular credential is accessed.

Both `juju bootstrap --clouds` and `juju list-credentials` treat individual cloud credential entries independently and warn instead of returning an error.

## QA steps

Alter an entry in credentials.yaml and change the field name `auth-type` to `auth_type` to force validation to fail.

Run `juju bootstrap --clouds` and it should WARN with the credential error, but should still list available clouds to bootstrap.

Run `juju list-credentials` and it should WARN with the credential error, but should still list available clouds and their information (except the invalid ones).

Run `juju bootstrap localhost` and it should deploy successfully and mutate the `credentials.yaml` file leaving the malformed entry.

## Documentation changes

Credentials that don't map to a cloud name no longer list in `juju list-credentials`

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1616523](https://bugs.launchpad.net/juju/+bug/1616523)
