### PR TITLE
Support trust flag when deploying bundles

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -369,9 +369,12 @@ type DeployCommand struct {
 	// NewAPIRoot stores a function which returns a new API root.
 	NewAPIRoot func() (DeployAPI, error)
 
-	// Trust signifies that the charm should be deployed with access to
-	// trusted credentials. That is, hooks run by the charm can access
-	// cloud credentials and other trusted access credentials.
+	// When deploying a charm, Trust signifies that the charm should be
+	// deployed with access to trusted credentials. That is, hooks run by
+	// the charm can access cloud credentials and other trusted access
+	// credentials. On the other hand, when deploying a bundle, Trust
+	// signifies that each application from the bundle that requires access
+	// to trusted credentials will be granted access.
 	Trust bool
 
 	machineMap string
@@ -670,8 +673,6 @@ func charmOnlyFlags() []string {
 		"bind", "config", "constraints", "n", "num-units",
 		"series", "to", "resource", "attach-storage",
 	}
-
-	charmOnlyFlags = append(charmOnlyFlags, "trust")
 
 	return charmOnlyFlags
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -618,6 +618,11 @@ func (s *DeploySuite) TestDeployBundlesRequiringTrust(c *gc.C) {
 		Series:          "bionic",
 		ConfigYAML:      "aws-integrator:\n  trust: \"true\"\n",
 	}).Returns(error(nil))
+	fakeAPI.Call("Deploy", application.DeployArgs{
+		CharmID:         jjcharmstore.CharmID{URL: inURL},
+		ApplicationName: inURL.Name,
+		Series:          "bionic",
+	}).Returns(errors.New("expected Deploy for aws-integrator to be called with 'trust: true'"))
 
 	fakeAPI.Call("AddUnits", application.AddUnitsParams{
 		ApplicationName: "aws-integrator",

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -960,7 +960,7 @@ func (s *DeploySuite) TestDeployFlags(c *gc.C) {
 	c.Assert(command.flagSet, jc.DeepEquals, flagSet)
 	// Add to the slice below if a new flag is introduced which is valid for
 	// both charms and bundles.
-	charmAndBundleFlags := []string{"channel", "storage", "device", "force"}
+	charmAndBundleFlags := []string{"channel", "storage", "device", "force", "trust"}
 	var allFlags []string
 	flagSet.VisitAll(func(flag *gnuflag.Flag) {
 		allFlags = append(allFlags, flag.Name)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -587,6 +587,69 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 	}
 }
 
+func (s *DeploySuite) TestDeployBundlesRequiringTrust(c *gc.C) {
+	cfgAttrs := map[string]interface{}{
+		"name": "name",
+		"uuid": "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"type": "foo",
+	}
+	fakeAPI := vanillaFakeModelAPI(cfgAttrs)
+	withAllWatcher(fakeAPI)
+
+	inURL := charm.MustParseURL("cs:~containers/aws-integrator")
+	withCharmRepoResolvable(fakeAPI, inURL)
+
+	// The aws-integrator charm requires trust and since the operator passes
+	// --trust we expect to see a "trust: true" config value in the yaml
+	// config passed to Deplly.
+	//
+	// As withCharmDeployable does not support passing a "ConfigYAML"
+	// it's easier to just invoke it to set up all other calls and then
+	// explicitly Deploy here.
+	withCharmDeployable(
+		fakeAPI, inURL, "bionic",
+		&charm.Meta{Name: "aws-integrator", Series: []string{"bionic"}},
+		nil, false, false, 0, nil, nil,
+	)
+
+	fakeAPI.Call("Deploy", application.DeployArgs{
+		CharmID:         jjcharmstore.CharmID{URL: inURL},
+		ApplicationName: inURL.Name,
+		Series:          "bionic",
+		ConfigYAML:      "aws-integrator:\n  trust: \"true\"\n",
+	}).Returns(error(nil))
+
+	fakeAPI.Call("AddUnits", application.AddUnitsParams{
+		ApplicationName: "aws-integrator",
+		NumUnits:        1,
+	}).Returns([]string{"aws-integrator/0"}, error(nil))
+
+	// The second charm from the bundle does not require trust so no
+	// additional configuration should be injected
+	ubURL := charm.MustParseURL("cs:~jameinel/ubuntu-lite-7")
+	withCharmRepoResolvable(fakeAPI, ubURL)
+	withCharmDeployable(
+		fakeAPI, ubURL, "bionic",
+		&charm.Meta{Name: "ubuntu-lite", Series: []string{"bionic"}},
+		nil, false, false, 0, nil, nil,
+	)
+
+	fakeAPI.Call("AddUnits", application.AddUnitsParams{
+		ApplicationName: "ubuntu-lite",
+		NumUnits:        1,
+	}).Returns([]string{"ubuntu-lite/0"}, error(nil))
+
+	deploy := &DeployCommand{
+		NewAPIRoot: func() (DeployAPI, error) {
+			return fakeAPI, nil
+		},
+	}
+
+	bundlePath := testcharms.RepoWithSeries("bionic").ClonedBundleDirPath(c.MkDir(), "aws-integrator-trust-single")
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), bundlePath, "--trust")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type fakeProvider struct {
 	caas.ContainerEnvironProvider
 }

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
@@ -3,3 +3,6 @@ services:
         charm: cs:~containers/aws-integrator        
         num_units: 1
         trust: true
+    ubuntu-lite:
+        charm: cs:~jameinel/ubuntu-lite-7
+        num_units: 1


### PR DESCRIPTION
## Description of change

This PR enables operators to deploy a bundle containing one or more applications that require trusted access to cloud credentials while at the same time granting them access to said credentials. This is achieved by passing the `--trust` flag to `juju deploy` calls. 

NOTE: the deploy command already accepted a `--trust` flag but prior to this PR this was only valid for deploying individual charms.

When a bundle is deployed, juju calls out to the [bundlechanges](https://github.com/juju/bundlechanges) package which basically scans the bundle data and returns back a list of changes that we need to apply in order to deploy the bundle. Each change type is modeled using a different Go type. The one we are interested in is called `AddApplicationChange` and as you can probably guess by the name, it requests the creation of a new application. The orchestration and execution of any changes that are returned by the bundlechanges code is handled by the `bundleHandler` type which lives in `cmd/juju/application/bundle.go`.

As the indicator of whether an application is trusted or not is nothing more than a simple configuration setting (`juju trust` manipulates its value through a facade) the solution implemented by this PR patches the `bundleHandler` code to inject the trust-related configuration option (if the operator provided `--trust`) to the application before calling the `Deploy` API.

## QA steps

```console 
$ juju bootstrap lxd test --no-gui

$ export JUJU_DEV_FEATURE_FLAGS=trusted-bundles

# Force-deploy a bundle with a single app requiring trust
$ juju deploy testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml --force

$ juju config aws-integrator | grep -A 6 application-config
application-config:
  trust:
    default: false
    description: Does this application have access to trusted credentials
    source: user
    type: bool
    value: false    <- you need to run "juju trust aws-integrator"

# Clean up
$ juju remove-application aws-integrator --force
$ juju remove-application ubuntu-lite --force

# IMPORTANT: wait till everything gets torn down before running the next step!

$ juju deploy testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml --trust

$ juju config aws-integrator | grep -A 6 application-config
application-config:
  trust:
    default: false
    description: Does this application have access to trusted credentials
    source: user
    type: bool
    value: true    <- all set!
```

## Documentation changes

@pmatulis This would be a good time to update the docs for `deploy --trust` so we are ready when its time to remove the feature flag