### PR TITLE
Expose trust key when exporting bundles

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -23,7 +23,7 @@ var facadeVersions = map[string]int{
 	"ApplicationScaler":            1,
 	"Backups":                      2,
 	"Block":                        2,
-	"Bundle":                       2,
+	"Bundle":                       3,
 	"CAASAgent":                    1,
 	"CAASFirewaller":               1,
 	"CAASOperator":                 1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -158,6 +158,7 @@ func AllFacades() *facade.Registry {
 	reg("Block", 2, block.NewAPI)
 	reg("Bundle", 1, bundle.NewFacadeV1)
 	reg("Bundle", 2, bundle.NewFacadeV2)
+	reg("Bundle", 3, bundle.NewFacadeV3)
 	reg("CharmRevisionUpdater", 2, charmrevisionupdater.NewCharmRevisionUpdaterAPI)
 	reg("Charms", 2, charms.NewFacade)
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -41,6 +41,13 @@ type APIv2 struct {
 	*BundleAPI
 }
 
+// APIv3 provides the Bundle API facade for version 3. It is otherwise
+// identical to V2 with the exception that the V3 ExportBundle implementation
+// also exposes the the current trust status for each application.
+type APIv3 struct {
+	*BundleAPI
+}
+
 // BundleAPI implements the Bundle interface and is the concrete implementation
 // of the API end point.
 type BundleAPI struct {
@@ -68,6 +75,16 @@ func NewFacadeV2(ctx facade.Context) (*APIv2, error) {
 		return nil, errors.Trace(err)
 	}
 	return &APIv2{api}, nil
+}
+
+// NewFacadeV3 provides the signature required for facade registration
+// for version 3.
+func NewFacadeV3(ctx facade.Context) (*APIv3, error) {
+	api, err := newFacade(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv3{api}, nil
 }
 
 // NewFacade provides the required signature for facade registration.

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
+	appFacade "github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
@@ -369,6 +370,12 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 			if result := b.constraints(application.Constraints()); len(result) != 0 {
 				newApplication.Constraints = strings.Join(result, " ")
 			}
+		}
+
+		// If this application has been trusted by the operator, set the
+		// Trust field of the ApplicationSpec to true
+		if appConfig := application.ApplicationConfig(); appConfig != nil {
+			newApplication.RequiresTrust = appConfig[appFacade.TrustConfigOptionName] == true
 		}
 
 		data.Applications[application.Name()] = newApplication

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -67,9 +67,9 @@ func NewDumpDBCommandForTest(api DumpDBAPI, store jujuclient.ClientStore) cmd.Co
 }
 
 // NewExportBundleCommandForTest returns a ExportBundleCommand with the api provided as specified.
-func NewExportBundleCommandForTest(api ExportBundleAPI, store jujuclient.ClientStore) cmd.Command {
-	cmd := &exportBundleCommand{newAPIFunc: func() (ExportBundleAPI, error) {
-		return api, nil
+func NewExportBundleCommandForTest(bundleAPI ExportBundleAPI, cfgAPI ConfigAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &exportBundleCommand{newAPIFunc: func() (ExportBundleAPI, ConfigAPI, error) {
+		return bundleAPI, cfgAPI, nil
 	}}
 	cmd.SetClientStore(store)
 	return modelcmd.Wrap(cmd)

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -8,12 +8,15 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	appFacade "github.com/juju/juju/apiserver/facades/client/application"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/model"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
@@ -22,9 +25,10 @@ import (
 
 type ExportBundleCommandSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	fake  *fakeExportBundleClient
-	stub  *jujutesting.Stub
-	store *jujuclient.MemStore
+	fakeBundle *fakeExportBundleClient
+	fakeConfig *fakeConfigClient
+	stub       *jujutesting.Stub
+	store      *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&ExportBundleCommandSuite{})
@@ -32,7 +36,11 @@ var _ = gc.Suite(&ExportBundleCommandSuite{})
 func (s *ExportBundleCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.stub = &jujutesting.Stub{}
-	s.fake = &fakeExportBundleClient{
+	s.fakeBundle = &fakeExportBundleClient{
+		Stub:           s.stub,
+		bestAPIVersion: 3,
+	}
+	s.fakeConfig = &fakeConfigClient{
 		Stub: s.stub,
 	}
 	s.store = jujuclient.NewMemStore()
@@ -50,12 +58,12 @@ func (s *ExportBundleCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ExportBundleCommandSuite) TearDownTest(c *gc.C) {
-	if s.fake.filename != "" {
-		err := os.Remove(s.fake.filename + ".yaml")
+	if s.fakeBundle.filename != "" {
+		err := os.Remove(s.fakeBundle.filename + ".yaml")
 		if !os.IsNotExist(err) {
 			c.Check(err, jc.ErrorIsNil)
 		}
-		err = os.Remove(s.fake.filename)
+		err = os.Remove(s.fakeBundle.filename)
 		if !os.IsNotExist(err) {
 			c.Check(err, jc.ErrorIsNil)
 		}
@@ -65,7 +73,7 @@ func (s *ExportBundleCommandSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *ExportBundleCommandSuite) TestExportBundleSuccessNoFilename(c *gc.C) {
-	s.fake.result = "applications:\n" +
+	s.fakeBundle.result = "applications:\n" +
 		"  mysql:\n" +
 		"    charm: \"\"\n" +
 		"    num_units: 1\n" +
@@ -85,9 +93,9 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessNoFilename(c *gc.C) {
 		"- - wordpress:db\n" +
 		"  - mysql:mysql\n"
 
-	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fake, s.store))
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store))
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []jujutesting.StubCall{
+	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
 		{"ExportBundle", nil},
 	})
 
@@ -115,8 +123,8 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessNoFilename(c *gc.C) {
 }
 
 func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
-	s.fake.filename = filepath.Join(c.MkDir(), "mymodel")
-	s.fake.result = "applications:\n" +
+	s.fakeBundle.filename = filepath.Join(c.MkDir(), "mymodel")
+	s.fakeBundle.result = "applications:\n" +
 		"  magic:\n" +
 		"    charm: cs:zesty/magic\n" +
 		"    series: zesty\n" +
@@ -128,15 +136,15 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 		"series: xenial\n" +
 		"relations:\n" +
 		"- []\n"
-	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fake, s.store), "--filename", s.fake.filename)
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []jujutesting.StubCall{
+	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
 		{"ExportBundle", nil},
 	})
 
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fake.filename))
-	output, err := ioutil.ReadFile(s.fake.filename)
+	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
+	output, err := ioutil.ReadFile(s.fakeBundle.filename)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "applications:\n"+
 		"  magic:\n"+
@@ -153,27 +161,149 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 }
 
 func (s *ExportBundleCommandSuite) TestExportBundleFailNoFilename(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fake, s.store), "--filename")
+	_, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store), "--filename")
 	c.Assert(err, gc.NotNil)
 
 	c.Assert(err.Error(), gc.Equals, "option needs an argument: --filename")
 }
 
 func (s *ExportBundleCommandSuite) TestExportBundleSuccesssOverwriteFilename(c *gc.C) {
-	s.fake.filename = filepath.Join(c.MkDir(), "mymodel")
-	s.fake.result = "fake-data"
-	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fake, s.store), "--filename", s.fake.filename)
+	s.fakeBundle.filename = filepath.Join(c.MkDir(), "mymodel")
+	s.fakeBundle.result = "fake-data"
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
-	s.fake.CheckCalls(c, []jujutesting.StubCall{
+	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
 		{"ExportBundle", nil},
 	})
 
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fake.filename))
-	output, err := ioutil.ReadFile(s.fake.filename)
+	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
+	output, err := ioutil.ReadFile(s.fakeBundle.filename)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "fake-data")
 }
+
+func (s *ExportBundleCommandSuite) TestPatchOfExportedBundleToExposeTrustFlag(c *gc.C) {
+	s.fakeBundle.result = "applications:\n" +
+		"  aws-integrator:\n" +
+		"    charm: \"\"\n" +
+		"    num_units: 1\n" +
+		"    to:\n" +
+		"    - \"0\"\n" +
+		"  gcp-integrator:\n" +
+		"    charm: \"\"\n" +
+		"    num_units: 2\n" +
+		"    to:\n" +
+		"    - \"0\"\n" +
+		"    - \"1\"\n" +
+		"  ubuntu-lite:\n" +
+		"    charm: \"\"\n" +
+		"    num_units: 1\n" +
+		"    to:\n" +
+		"    - \"2\"\n" +
+		"machines:\n" +
+		"  \"0\": {}\n" +
+		"  \"1\": {}\n" +
+		"  \"2\": {}\n" +
+		"series: bionic\n"
+
+	// Pretend we target an older controller that does not expose the
+	// TrustRequired flag in the yaml output.
+	s.fakeBundle.bestAPIVersion = 2
+
+	s.fakeConfig.result = map[string]*params.ApplicationGetResults{
+		"aws-integrator": {
+			ApplicationConfig: map[string]interface{}{
+				appFacade.TrustConfigOptionName: map[string]interface{}{
+					"description": "Does this application have access to trusted credentials",
+					"default":     false,
+					"type":        "bool",
+					"value":       true,
+				},
+			},
+		},
+		"gcp-integrator": {
+			ApplicationConfig: map[string]interface{}{
+				appFacade.TrustConfigOptionName: map[string]interface{}{
+					"description": "Does this application have access to trusted credentials",
+					"default":     false,
+					"type":        "bool",
+					"value":       false,
+				},
+			},
+		},
+		"ubuntu-lite": {
+			ApplicationConfig: map[string]interface{}{
+				"unrelated": map[string]interface{}{
+					"description": "The question to the meaning of life",
+					"default":     42,
+					"type":        "int",
+					"value":       42,
+				},
+			},
+		},
+	}
+
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Since we are iterating a map with applications we cannot call
+	// stub.CheckCalls but instead need to collect the calls, sort them and
+	// run the checks manually.
+	var exportBundleCallCount, getConfigCallCount int
+	var getConfigAppList []string
+	for _, call := range s.stub.Calls() {
+		switch call.FuncName {
+		case "ExportBundle":
+			exportBundleCallCount++
+		case "Get":
+			getConfigCallCount++
+			getConfigAppList = append(getConfigAppList, call.Args[1].(string))
+		default:
+			c.Fatalf("unexpected call to %q", call.FuncName)
+		}
+	}
+	sort.Strings(getConfigAppList)
+
+	c.Assert(exportBundleCallCount, gc.Equals, 1)
+	c.Assert(getConfigCallCount, gc.Equals, 3)
+	c.Assert(getConfigAppList, gc.DeepEquals, []string{"aws-integrator", "gcp-integrator", "ubuntu-lite"})
+
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, ""+
+		"applications:\n"+
+		"  aws-integrator:\n"+
+		"    charm: \"\"\n"+
+		"    num_units: 1\n"+
+		"    to:\n"+
+		"    - \"0\"\n"+
+		"    trust: true\n"+
+		"  gcp-integrator:\n"+
+		"    charm: \"\"\n"+
+		"    num_units: 2\n"+
+		"    to:\n"+
+		"    - \"0\"\n"+
+		"    - \"1\"\n"+
+		"  ubuntu-lite:\n"+
+		"    charm: \"\"\n"+
+		"    num_units: 1\n"+
+		"    to:\n"+
+		"    - \"2\"\n"+
+		"machines:\n"+
+		"  \"0\": {}\n"+
+		"  \"1\": {}\n"+
+		"  \"2\": {}\n"+
+		"series: bionic\n")
+}
+
+type fakeExportBundleClient struct {
+	*jujutesting.Stub
+	result         string
+	filename       string
+	bestAPIVersion int
+}
+
+func (f *fakeExportBundleClient) BestAPIVersion() int { return f.bestAPIVersion }
 
 func (f *fakeExportBundleClient) Close() error { return nil }
 
@@ -186,8 +316,22 @@ func (f *fakeExportBundleClient) ExportBundle() (string, error) {
 	return f.result, f.NextErr()
 }
 
-type fakeExportBundleClient struct {
+type fakeConfigClient struct {
 	*jujutesting.Stub
-	result   string
-	filename string
+	result map[string]*params.ApplicationGetResults
+}
+
+func (f *fakeConfigClient) Close() error { return nil }
+
+func (f *fakeConfigClient) Get(branch string, app string) (*params.ApplicationGetResults, error) {
+	f.MethodCall(f, "Get", branch, app)
+	if err := f.NextErr(); err != nil {
+		return nil, err
+	}
+
+	if f.result == nil {
+		return nil, f.NextErr()
+	}
+
+	return f.result[app], f.NextErr()
 }


### PR DESCRIPTION
## Description of change

This PR ensures that we correctly set the `trust` key for each application that the operator has explicitly trusted when exporting bundles via `juju export-bundle`. This PR is split in two parts.
 
The first part patches the server API so that we populate the `RequiresTrust` field of the `BundleData` type when exporting the bundle. It also bumps the Bundle API to V3. This change is needed to allow the client code to figure out if it can expect the trust flag to be included by the call to `ExportBundle` or whether it needs to use a fall-back approach (see below).

In order to be backwards-compatible with older controllers, the second part of the PR patches the client so that when it connects to an older controller it will first grab the exported bundle and then locally patch it to set the `trust` flag for the applications. To achieve this, the client will first unmarshal the yaml blob returned by the server and then proceed to iterate the list of applications included in the bundle. For each application, the client attempts to fetch its configuration from the server and checks whether the appropriate trust key is set. If that happens to be the case it will set the `RequiresTrust` key in the appropriate `ApplicationSpec` entry. Finally, the patched `BundleData` is marshaled back to yaml and returned back to the operator as usual.

## QA steps

```console 
$ juju bootstrap lxd test --no-gui

$ export JUJU_DEV_FEATURE_FLAGS=trusted-bundles

# Deploy a bundle with a single app requiring trust
$ juju deploy testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml --trust

$ juju export-bundle
applications:
  aws-integrator:
    charm: cs:~containers/aws-integrator-10
    num_units: 1
    to:
    - "2"
    trust: true      <- this is what you are looking for
  ubuntu-lite:
    charm: cs:~jameinel/ubuntu-lite-7
    num_units: 1
    to:
    - "3"
machines:
  "2": {}
  "3": {}
series: bionic

## Try against an older controller (2.5, 2.6 etc)
$ unset JUJU_DEV_FEATURE_FLAGS
$ juju bootstrap lxd older-controller --no-gui

# NOTE: older deploy does not support --trust
$ juju deploy testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
$ juju trust aws-integrator

# The following invocation will cause the juju client to locally patch the exported bundle
# NOTE: make sure to use the juju client from this PR
$ juju export-bundle
applications:
  aws-integrator:
    charm: cs:~containers/aws-integrator-10
    num_units: 1
    to:
    - "2"
    trust: true      <- this is what you are looking for
  ubuntu-lite:
    charm: cs:~jameinel/ubuntu-lite-7
    num_units: 1
    to:
    - "3"
machines:
  "2": {}
  "3": {}
series: bionic
```