### PR TITLE
Remove trusted-bundles feature flag

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/os/series"
 	"github.com/juju/romulus"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/juju/charmrepo.v3"
@@ -47,7 +46,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/storage"
 )
@@ -846,7 +844,7 @@ func (c *DeployCommand) deployBundle(spec bundleDeploySpec) (rErr error) {
 	}
 
 	// Short-circuit trust checks if the operator specifies '--force'
-	if featureflag.Enabled(feature.TrustedBundles) && !c.Trust {
+	if !c.Trust {
 		if tl := appsRequiringTrust(spec.bundleData.Applications); len(tl) != 0 && !c.Force {
 			return errors.Errorf(`Bundle cannot be deployed without trusting applications with your cloud credentials.
 Please repeat the deploy command with the --trust argument if you consent to trust the following application(s):

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/loggo"
@@ -570,8 +569,6 @@ func (s *DeploySuite) TestErrorDeployingBundlesRequiringTrust(c *gc.C) {
 			expAppList: []string{"aws-integrator"},
 		},
 	}
-
-	s.SetFeatureFlags(feature.TrustedBundles)
 
 	for specIndex, spec := range specs {
 		c.Logf("[spec %d] %s", specIndex, spec.descr)

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -61,7 +61,3 @@ const MongoDbSSTXN = "mongodb-sstxn"
 // MultiCloud tells Juju to allow a different IAAS cloud to the one the controller
 // was bootstrapped on to be added to the controller.
 const MultiCloud = "multi-cloud"
-
-// TrustedBundles prevents juju CLI from deploying bundles that request access
-// to cloud credentials unless the operator explicitly trusts them.
-const TrustedBundles = "trusted-bundles"


### PR DESCRIPTION
## Description of change

Now that all the moving parts of the trusted bundles feature are in place and we cannot break any future release, we can safely remove the feature flag introduced by #10262.

NOTE: this PR should not be merged before #10289 lands.

## Documentation changes

@pmatulis  this change will allow us to ship this feature with the next 2.6.x release so we should ensure that any relevant docs are updated before that time.