### PR TITLE
Fix panic in metrics gathering.

### DIFF
--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -138,6 +138,21 @@ func createControllerGauges() *ControllerGauges {
 	}
 }
 
+// Describe is part of the prometheus.Collector interface.
+func (c *ControllerGauges) Describe(ch chan<- *prometheus.Desc) {
+	c.ModelConfigReads.Describe(ch)
+	c.ModelHashCacheHit.Describe(ch)
+	c.ModelHashCacheMiss.Describe(ch)
+
+	c.ApplicationConfigReads.Describe(ch)
+	c.ApplicationHashCacheHit.Describe(ch)
+	c.ApplicationHashCacheMiss.Describe(ch)
+
+	c.LXDProfileChangeError.Describe(ch)
+	c.LXDProfileChangeHit.Describe(ch)
+	c.LXDProfileChangeMiss.Describe(ch)
+}
+
 // Collect is part of the prometheus.Collector interface.
 func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
 	c.ModelConfigReads.Collect(ch)
@@ -232,6 +247,8 @@ func NewMetricsCollector(controller *Controller) *Collector {
 
 // Describe is part of the prometheus.Collector interface.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.controller.metrics.Describe(ch)
+
 	c.models.Describe(ch)
 	c.machines.Describe(ch)
 	c.applications.Describe(ch)
@@ -279,6 +296,7 @@ func (c *Collector) updateMetrics() {
 }
 
 func (c *Collector) updateModelMetrics(modelUUID string) {
+	logger.Tracef("updating cache metrics for %s", modelUUID)
 	model, err := c.controller.Model(modelUUID)
 	if err != nil {
 		logger.Debugf("error getting model: %v", err)
@@ -303,7 +321,7 @@ func (c *Collector) updateModelMetrics(modelUUID string) {
 		c.units.With(prometheus.Labels{
 			agentStatusLabel:    string(unit.details.AgentStatus.Status),
 			lifeLabel:           string(unit.details.Life),
-			instanceStatusLabel: string(unit.details.WorkloadStatus.Status),
+			workloadStatusLabel: string(unit.details.WorkloadStatus.Status),
 		}).Inc()
 	}
 

--- a/core/cache/metrics_test.go
+++ b/core/cache/metrics_test.go
@@ -1,0 +1,59 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package cache_test
+
+import (
+	"bytes"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/cache"
+)
+
+// The metrics hook into the ControllerSuite as it has
+// the base methods we need to enable this cleanly.
+
+func (s *ControllerSuite) TestCollect(c *gc.C) {
+	loggo.GetLogger("juju.core.cache").SetLogLevel(loggo.TRACE)
+	controller, events := s.new(c)
+
+	// Note that the model change is processed last.
+	s.processChange(c, charmChange, events)
+	s.processChange(c, appChange, events)
+	s.processChange(c, machineChange, events)
+	s.processChange(c, unitChange, events)
+	s.processChange(c, modelChange, events)
+
+	collector := cache.NewMetricsCollector(controller)
+
+	expected := bytes.NewBuffer([]byte(`
+# HELP juju_cache_applications Number of applications managed by the controller.
+# TYPE juju_cache_applications gauge
+juju_cache_applications{life="alive"} 1
+# HELP juju_cache_machines Number of machines managed by the controller.
+# TYPE juju_cache_machines gauge
+juju_cache_machines{agent_status="active",instance_status="active",life="alive"} 1
+# HELP juju_cache_models Number of models in the controller.
+# TYPE juju_cache_models gauge
+juju_cache_models{life="alive",status="active"} 1
+# HELP juju_cache_units Number of units managed by the controller.
+# TYPE juju_cache_units gauge
+juju_cache_units{agent_status="active",life="alive",workload_status="active"} 1
+		`[1:]))
+
+	err := testutil.CollectAndCompare(
+		collector, expected,
+		"juju_cache_models",
+		"juju_cache_machines",
+		"juju_cache_applications",
+		"juju_cache_units")
+	if !c.Check(err, jc.ErrorIsNil) {
+		c.Logf("\nerror:\n%v", err)
+	}
+
+	workertest.CleanKill(c, controller)
+}


### PR DESCRIPTION
Due to missing test coverage, we didn't notice that the metrics collector would panic if there were any units. This is clearly bad.

## QA steps

Bootstrap and deploy a unit. Then ssh into the controller and run juju_metrics.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1831836