### PR TITLE
Start making HA/peergrouper independent of machine

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -37,8 +37,8 @@ const (
 	// BootstrapNonce is used as a nonce for the initial controller machine.
 	BootstrapNonce = "user-admin:bootstrap"
 
-	// BootstrapMachineId is the ID of the initial controller machine.
-	BootstrapMachineId = "0"
+	// BootstrapControllerId is the ID of the initial controller.
+	BootstrapControllerId = "0"
 )
 
 // These are base values used for the corresponding defaults.

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -79,7 +79,7 @@ func InitializeState(
 	dialOpts mongo.DialOpts,
 	newPolicy state.NewPolicyFunc,
 ) (_ *state.Controller, _ *state.Machine, resultErr error) {
-	if c.Tag() != names.NewMachineTag(agent.BootstrapMachineId) {
+	if c.Tag() != names.NewMachineTag(agent.BootstrapControllerId) {
 		return nil, nil, errors.Errorf("InitializeState not called with bootstrap machine's configuration")
 	}
 	servingInfo, ok := c.StateServingInfo()
@@ -197,7 +197,7 @@ func InitializeState(
 		}
 	}
 
-	if err := ensureHostedModel(isCAAS, cloudSpec, provider, args, st, ctrl, adminUser, cloudCredentialTag); err != nil {
+	if err := ensureHostedModel(cloudSpec, provider, args, st, ctrl, adminUser, cloudCredentialTag); err != nil {
 		return nil, nil, errors.Annotate(err, "ensuring hosted model")
 	}
 	return ctrl, m, nil
@@ -205,7 +205,6 @@ func InitializeState(
 
 // ensureHostedModel ensures hosted model.
 func ensureHostedModel(
-	isCAAS bool,
 	cloudSpec environs.CloudSpec,
 	provider environs.EnvironProvider,
 	args InitializeStateParams,
@@ -385,7 +384,7 @@ func initBootstrapMachine(
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create bootstrap machine in state")
 	}
-	if m.Id() != agent.BootstrapMachineId {
+	if m.Id() != agent.BootstrapControllerId {
 		return nil, errors.Errorf("bootstrap machine expected id 0, got %q", m.Id())
 	}
 	// Read the machine agent's password and change it to

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -470,7 +470,7 @@ func (s *clientSuite) TestEnableHA0Preserves(c *gc.C) {
 	c.Assert(machines[2].Destroy(), jc.ErrorIsNil)
 	c.Assert(machines[2].Refresh(), jc.ErrorIsNil)
 	c.Assert(machines[2].SetHasVote(false), jc.ErrorIsNil)
-	c.Assert(s.State.RemoveControllerMachine(machines[2]), jc.ErrorIsNil)
+	c.Assert(s.State.RemoveControllerNode(machines[2]), jc.ErrorIsNil)
 	c.Assert(machines[2].EnsureDead(), jc.ErrorIsNil)
 	enableHAResult, err = s.enableHA(c, 0, emptyCons, defaultSeries, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -507,7 +507,7 @@ func (s *clientSuite) TestEnableHA0Preserves5(c *gc.C) {
 	c.Assert(machines[4].SetHasVote(false), jc.ErrorIsNil)
 	c.Assert(machines[4].Destroy(), jc.ErrorIsNil)
 	c.Assert(machines[4].Refresh(), jc.ErrorIsNil)
-	c.Assert(s.State.RemoveControllerMachine(machines[4]), jc.ErrorIsNil)
+	c.Assert(s.State.RemoveControllerNode(machines[4]), jc.ErrorIsNil)
 	c.Assert(machines[4].EnsureDead(), jc.ErrorIsNil)
 
 	// Keeping all alive but one, will bring up 1 more server to preserve 5

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -53,7 +53,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/juju/paths"
-	jujuversion "github.com/juju/juju/juju/version"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
@@ -354,7 +353,7 @@ please choose a different hosted model name then try again.`, hostedModelName),
 	return &environs.BootstrapResult{
 		// TODO(bootstrap): review this default arch and series(required for determining DataDir etc.) later.
 		Arch:                   arch.AMD64,
-		Series:                 jujuversion.SupportedLTS(),
+		Series:                 "kubernetes",
 		CaasBootstrapFinalizer: finalizer,
 	}, nil
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -228,11 +228,11 @@ func bootstrapCAAS(
 	jujuVersion := jujuversion.Current
 
 	// set agent version before finalizing bootstrap config
-	if err := setBootstrapToolsVersion(environ, jujuVersion); err != nil {
+	if err := setBootstrapAgentVersion(environ, jujuVersion); err != nil {
 		return errors.Trace(err)
 	}
 	podConfig.JujuVersion = jujuVersion
-	if err := finalizePodBootstrapConfig(ctx, podConfig, args, environ.Config()); err != nil {
+	if err := finalizePodBootstrapConfig(podConfig, args, environ.Config()); err != nil {
 		return errors.Annotate(err, "finalizing bootstrap instance config")
 	}
 	if err := result.CaasBootstrapFinalizer(ctx, podConfig, args.DialOpts); err != nil {
@@ -502,7 +502,7 @@ func bootstrapIAAS(
 	// in that case the specific version will be the only version available.
 	newestToolVersion, _ := matchingTools.Newest()
 	// set agent version before finalizing bootstrap config
-	if err := setBootstrapToolsVersion(environ, newestToolVersion); err != nil {
+	if err := setBootstrapAgentVersion(environ, newestToolVersion); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -631,7 +631,6 @@ func finalizeInstanceBootstrapConfig(
 }
 
 func finalizePodBootstrapConfig(
-	ctx environs.BootstrapContext,
 	pcfg *podcfg.ControllerPodConfig,
 	args BootstrapParams,
 	cfg *config.Config,
@@ -821,8 +820,8 @@ func getBootstrapToolsVersion(possibleTools coretools.List) (coretools.List, err
 	return toolsList, nil
 }
 
-// setBootstrapToolsVersion updates the agent-version configuration attribute.
-func setBootstrapToolsVersion(environ environs.Configer, toolsVersion version.Number) error {
+// setBootstrapAgentVersion updates the agent-version configuration attribute.
+func setBootstrapAgentVersion(environ environs.Configer, toolsVersion version.Number) error {
 	cfg := environ.Config()
 	if agentVersion, _ := cfg.AgentVersion(); agentVersion != toolsVersion {
 		cfg, err := cfg.Apply(map[string]interface{}{

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -808,7 +808,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 	i := &dummyInstance{
 		id:           BootstrapInstanceId,
 		addresses:    network.NewAddresses("localhost"),
-		machineId:    agent.BootstrapMachineId,
+		machineId:    agent.BootstrapControllerId,
 		series:       series,
 		firewallMode: e.Config().FirewallMode(),
 		state:        estate,

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -1087,7 +1087,7 @@ func (st *State) cleanupForceDestroyedMachineInternal(machineId string, maxWait 
 				return errors.Trace(err)
 			}
 		}
-		if err := st.RemoveControllerMachine(machine); err != nil {
+		if err := st.RemoveControllerNode(machine); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -239,7 +239,7 @@ func (s *EnableHASuite) progressControllerToDead(c *gc.C, id string) {
 	// Pretend to be the peergrouper, notice the machine doesn't want to vote, so get rid of its vote, and remove it
 	// as a controller machine.
 	m.SetHasVote(false)
-	c.Assert(s.State.RemoveControllerMachine(m), jc.ErrorIsNil)
+	c.Assert(s.State.RemoveControllerNode(m), jc.ErrorIsNil)
 	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
 	c.Assert(m.EnsureDead(), jc.ErrorIsNil)
 }
@@ -450,7 +450,7 @@ func (s *EnableHASuite) TestDestroyRaceLastController(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(m.SetWantsVote(false), jc.ErrorIsNil)
 			c.Check(m.SetHasVote(false), jc.ErrorIsNil)
-			c.Check(s.State.RemoveControllerMachine(m), jc.ErrorIsNil)
+			c.Check(s.State.RemoveControllerNode(m), jc.ErrorIsNil)
 			c.Logf("removed machine %s", id)
 			m0.Refresh()
 			c.Logf("machine 0: %s wants %t has %t", m0.Life(), m0.WantsVote(), m0.HasVote())
@@ -470,14 +470,14 @@ func (s *EnableHASuite) TestRemoveControllerMachineOneMachine(c *gc.C) {
 	m0, err := s.State.AddMachine("bionic", state.JobManageModel)
 	m0.SetHasVote(true)
 	m0.SetWantsVote(true)
-	err = s.State.RemoveControllerMachine(m0)
+	err = s.State.RemoveControllerNode(m0)
 	c.Assert(err, gc.ErrorMatches, "machine 0 cannot be removed as a controller as it still wants to vote")
 	m0.SetWantsVote(false)
-	err = s.State.RemoveControllerMachine(m0)
+	err = s.State.RemoveControllerNode(m0)
 	c.Assert(err, gc.ErrorMatches, "machine 0 cannot be removed as a controller as it still has a vote")
 	m0.SetHasVote(false)
 	// it seems odd that we would end up the last controller but not have a vote, but we care about the DB integrity
-	err = s.State.RemoveControllerMachine(m0)
+	err = s.State.RemoveControllerNode(m0)
 	c.Assert(err, gc.ErrorMatches, "machine 0 cannot be removed as it is the last controller")
 }
 
@@ -491,7 +491,7 @@ func (s *EnableHASuite) TestRemoveControllerMachine(c *gc.C) {
 	c.Assert(m0.Destroy(), jc.ErrorIsNil)
 	m0.SetHasVote(false)
 	m0.Refresh()
-	err = s.State.RemoveControllerMachine(m0)
+	err = s.State.RemoveControllerNode(m0)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertControllerInfo(c, []string{"1", "2"}, []string{"1", "2"}, nil)
 	m0.Refresh()
@@ -515,7 +515,7 @@ func (s *EnableHASuite) TestRemoveControllerMachineVoteRace(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(m0.SetWantsVote(true), jc.ErrorIsNil)
 	}).Check()
-	err = s.State.RemoveControllerMachine(m0)
+	err = s.State.RemoveControllerNode(m0)
 	c.Check(err, gc.ErrorMatches, "machine 0 cannot be removed as a controller as it still wants to vote")
 	m0.Refresh()
 	c.Check(m0.WantsVote(), jc.IsTrue)
@@ -537,7 +537,7 @@ func (s *EnableHASuite) TestRemoveControllerMachineRace(c *gc.C) {
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(m.SetWantsVote(false), jc.ErrorIsNil)
 		c.Check(m.SetHasVote(false), jc.ErrorIsNil)
-		c.Check(s.State.RemoveControllerMachine(m), jc.ErrorIsNil)
+		c.Check(s.State.RemoveControllerNode(m), jc.ErrorIsNil)
 	}
 	defer state.SetBeforeHooks(c, s.State, func() {
 		// we sneakily remove machine 1 just before 0 can be removed, this causes the removal of m0 to be retried
@@ -546,7 +546,7 @@ func (s *EnableHASuite) TestRemoveControllerMachineRace(c *gc.C) {
 		// then we remove machine 2, leaving 0 as the last machine, and that aborts the removal
 		removeOne("2")
 	}).Check()
-	err = s.State.RemoveControllerMachine(m0)
+	err = s.State.RemoveControllerNode(m0)
 	c.Assert(err, gc.ErrorMatches, "machine 0 cannot be removed as it is the last controller")
 	m0.Refresh()
 	c.Check(m0.WantsVote(), jc.IsFalse)

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -32,7 +32,7 @@ const (
 
 type desiredPeerGroupTest struct {
 	about    string
-	machines []*machineTracker
+	machines []*controllerTracker
 	statuses []replicaset.MemberStatus
 	members  []replicaset.Member
 
@@ -102,7 +102,7 @@ func membersToTestMembers(m []replicaset.Member) []TestMember {
 func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 	return []desiredPeerGroupTest{
 		{
-			about:         "one machine, one more proposed member",
+			about:         "one controller, one more proposed member",
 			machines:      mkMachines("10v 11v", ipVersion),
 			statuses:      mkStatuses("0p", ipVersion),
 			members:       mkMembers("0v", ipVersion),
@@ -110,7 +110,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectVoting:  []bool{true, false},
 			expectChanged: true,
 		}, {
-			about:         "one machine, two more proposed members",
+			about:         "one controller, two more proposed members",
 			machines:      mkMachines("10v 11v 12v", ipVersion),
 			statuses:      mkStatuses("0p", ipVersion),
 			members:       mkMembers("0v", ipVersion),
@@ -118,7 +118,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectVoting:  []bool{true, false, false},
 			expectChanged: true,
 		}, {
-			about:         "single machine, no change",
+			about:         "single controller, no change",
 			machines:      mkMachines("11v", ipVersion),
 			members:       mkMembers("1v", ipVersion),
 			statuses:      mkStatuses("1p", ipVersion),
@@ -131,7 +131,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			members:      mkMembers("1v 2v", ipVersion),
 			statuses:     mkStatuses("1p 2s", ipVersion),
 			expectVoting: []bool{true},
-			expectErr:    "voting non-machine member.* found in peer group",
+			expectErr:    "non voting member.* found in peer group",
 		}, {
 			about:    "extra member with >1 votes",
 			machines: mkMachines("11v", ipVersion),
@@ -145,9 +145,9 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			}),
 			statuses:     mkStatuses("1p 2s", ipVersion),
 			expectVoting: []bool{true},
-			expectErr:    "voting non-machine member.* found in peer group",
+			expectErr:    "non voting member.* found in peer group",
 		}, {
-			about:         "one machine has become ready to vote (no change)",
+			about:         "one controller has become ready to vote (no change)",
 			machines:      mkMachines("11v 12v", ipVersion),
 			members:       mkMembers("1v 2", ipVersion),
 			statuses:      mkStatuses("1p 2s", ipVersion),
@@ -163,7 +163,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectMembers: mkMembers("1v 2v 3v", ipVersion),
 			expectChanged: true,
 		}, {
-			about:         "one machine has become ready to vote but one is not healthy",
+			about:         "one controller has become ready to vote but one is not healthy",
 			machines:      mkMachines("11v 12v", ipVersion),
 			members:       mkMembers("1v 2", ipVersion),
 			statuses:      mkStatuses("1p 2sH", ipVersion),
@@ -187,7 +187,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectMembers: mkMembers("1v 2v 3v 4", ipVersion),
 			expectChanged: true,
 		}, {
-			about:         "one machine ready to lose vote with no others -> no change",
+			about:         "one controller ready to lose vote with no others -> no change",
 			machines:      mkMachines("11", ipVersion),
 			members:       mkMembers("1v", ipVersion),
 			statuses:      mkStatuses("1p", ipVersion),
@@ -195,7 +195,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectMembers: mkMembers("1v", ipVersion),
 			expectChanged: false,
 		}, {
-			about:         "one machine ready to lose vote -> votes removed from secondaries",
+			about:         "one controller ready to lose vote -> votes removed from secondaries",
 			machines:      mkMachines("11v 12v 13", ipVersion),
 			members:       mkMembers("1v 2v 3v", ipVersion),
 			statuses:      mkStatuses("1s 2p 3s", ipVersion),
@@ -219,7 +219,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectMembers: mkMembers("1v", ipVersion),
 			expectChanged: true,
 		}, {
-			about:         "machine removed as controller -> removed from member",
+			about:         "controller removed as controller -> removed from member",
 			machines:      mkMachines("11v 12", ipVersion),
 			members:       mkMembers("1v 2 3", ipVersion),
 			statuses:      mkStatuses("1p 2s 3s", ipVersion),
@@ -243,8 +243,8 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectMembers: mkMembers("1v 2v 3 4 5 6v 7v 8v", ipVersion),
 			expectChanged: true,
 		}, {
-			about: "a changed machine address should propagate to the members",
-			machines: append(mkMachines("11v 12v", ipVersion), &machineTracker{
+			about: "a changed controller address should propagate to the members",
+			machines: append(mkMachines("11v 12v", ipVersion), &controllerTracker{
 				id:        "13",
 				wantsVote: true,
 				addresses: []network.Address{{
@@ -263,8 +263,8 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			}),
 			expectChanged: true,
 		}, {
-			about: "a machine's address is ignored if it changes to empty",
-			machines: append(mkMachines("11v 12v", ipVersion), &machineTracker{
+			about: "a controller's address is ignored if it changes to empty",
+			machines: append(mkMachines("11v 12v", ipVersion), &controllerTracker{
 				id:        "13",
 				wantsVote: true,
 			}),
@@ -314,7 +314,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectMembers: mkMembers("1 2 3v", ipVersion),
 			expectChanged: true,
 		}, {
-			about:         "add machine, non-voting still add it to the replica set",
+			about:         "add controller, non-voting still add it to the replica set",
 			machines:      mkMachines("11v 12v 13v 14", ipVersion),
 			members:       mkMembers("1v 2v 3v", ipVersion),
 			statuses:      mkStatuses("1s 2s 3p", ipVersion),
@@ -322,7 +322,7 @@ func desiredPeerGroupTests(ipVersion TestIPVersion) []desiredPeerGroupTest {
 			expectMembers: mkMembers("1v 2v 3v 4", ipVersion),
 			expectChanged: true,
 		}, {
-			about:          "remove primary machine",
+			about:          "remove primary controller",
 			machines:       mkMachines("11 12v 13v", ipVersion),
 			members:        mkMembers("1v 2v 3v", ipVersion),
 			statuses:       mkStatuses("1p 2s 3s", ipVersion),
@@ -345,7 +345,7 @@ func (s *desiredPeerGroupSuite) TestDesiredPeerGroupIPv6(c *gc.C) {
 func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIPVersion) {
 	for ti, test := range desiredPeerGroupTests(ipVersion) {
 		c.Logf("\ntest %d: %s", ti, test.about)
-		trackerMap := make(map[string]*machineTracker)
+		trackerMap := make(map[string]*controllerTracker)
 		for _, m := range test.machines {
 			c.Assert(trackerMap[m.Id()], gc.IsNil)
 			trackerMap[m.Id()] = m
@@ -374,9 +374,9 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 		c.Assert(desired.stepDownPrimary, gc.Equals, test.expectStepDown)
 		c.Assert(membersToTestMembers(members), jc.DeepEquals, membersToTestMembers(test.expectMembers))
 		for i, m := range test.machines {
-			vote, votePresent := desired.machineVoting[m.Id()]
+			vote, votePresent := desired.nodeVoting[m.Id()]
 			c.Check(votePresent, jc.IsTrue)
-			c.Check(vote, gc.Equals, test.expectVoting[i], gc.Commentf("machine %s", m.Id()))
+			c.Check(vote, gc.Equals, test.expectVoting[i], gc.Commentf("controller %s", m.Id()))
 		}
 
 		// Assure ourselves that the total number of desired votes is odd in
@@ -395,9 +395,9 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 		countPrimaries := 0
 		c.Assert(err, gc.IsNil)
 		for i, m := range test.machines {
-			vote, votePresent := desired.machineVoting[m.Id()]
+			vote, votePresent := desired.nodeVoting[m.Id()]
 			c.Check(votePresent, jc.IsTrue)
-			c.Check(vote, gc.Equals, test.expectVoting[i], gc.Commentf("machine %s", m.Id()))
+			c.Check(vote, gc.Equals, test.expectVoting[i], gc.Commentf("controller %s", m.Id()))
 			if isPrimaryMember(info, m.Id()) {
 				countPrimaries += 1
 			}
@@ -418,7 +418,7 @@ func (s *desiredPeerGroupSuite) TestCheckExtraMembersReturnsErrorWhenVoterFound(
 		info: &peerGroupInfo{extra: []replicaset.Member{{Votes: &v}}},
 	}
 	err := peerChanges.checkExtraMembers()
-	c.Check(err, gc.ErrorMatches, "voting non-machine member .+ found in peer group")
+	c.Check(err, gc.ErrorMatches, "non voting member .+ found in peer group")
 }
 
 func (s *desiredPeerGroupSuite) TestCheckExtraMembersReturnsTrueWhenCheckMade(c *gc.C) {
@@ -462,14 +462,14 @@ func newFloat64(f float64) *float64 {
 
 // mkMachines returns a slice of *machineTracker based on
 // the given description.
-// Each machine in the description is white-space separated
-// and holds the decimal machine id followed by an optional
-// "v" if the machine wants a vote.
-func mkMachines(description string, ipVersion TestIPVersion) []*machineTracker {
+// Each controller in the description is white-space separated
+// and holds the decimal controller id followed by an optional
+// "v" if the controller wants a vote.
+func mkMachines(description string, ipVersion TestIPVersion) []*controllerTracker {
 	descrs := parseDescr(description)
-	ms := make([]*machineTracker, len(descrs))
+	ms := make([]*controllerTracker, len(descrs))
 	for i, d := range descrs {
-		ms[i] = &machineTracker{
+		ms[i] = &controllerTracker{
 			id: fmt.Sprint(d.id),
 			addresses: []network.Address{{
 				Value: fmt.Sprintf(ipVersion.formatHost, d.id),
@@ -483,7 +483,7 @@ func mkMachines(description string, ipVersion TestIPVersion) []*machineTracker {
 }
 
 func memberTag(id string) map[string]string {
-	return map[string]string{jujuMachineKey: id}
+	return map[string]string{jujuNodeKey: id}
 }
 
 // mkMembers returns a slice of replicaset.Member based on the given
@@ -491,8 +491,8 @@ func memberTag(id string) map[string]string {
 // Each member in the description is white-space separated and holds the decimal
 // replica-set id optionally followed by the characters:
 //	- 'v' if the member is voting.
-// 	- 'T' if the member has no associated machine tags.
-// Unless the T flag is specified, the machine tag
+// 	- 'T' if the member has no associated controller tags.
+// Unless the T flag is specified, the controller tag
 // will be the replica-set id + 10.
 func mkMembers(description string, ipVersion TestIPVersion) []replicaset.Member {
 	descrs := parseDescr(description)

--- a/worker/peergrouper/initiate.go
+++ b/worker/peergrouper/initiate.go
@@ -78,7 +78,7 @@ func attemptInitiateMongoServer(dialInfo *mgo.DialInfo, memberHostPort string) e
 		memberHostPort,
 		mongo.ReplicaSetName,
 		map[string]string{
-			jujuMachineKey: agent.BootstrapMachineId,
+			jujuNodeKey: agent.BootstrapControllerId,
 		},
 	)
 }

--- a/worker/peergrouper/machinetracker_test.go
+++ b/worker/peergrouper/machinetracker_test.go
@@ -21,7 +21,7 @@ var _ = gc.Suite(&machineTrackerSuite{})
 func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddress(c *gc.C) {
 	spaceName := network.SpaceName("ha-space")
 
-	m := &machineTracker{
+	m := &controllerTracker{
 		addresses: []network.Address{
 			{
 				Value:     "192.168.5.5",
@@ -46,7 +46,7 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddre
 }
 
 func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceEmptyWhenNoAddressFound(c *gc.C) {
-	m := &machineTracker{
+	m := &controllerTracker{
 		id: "3",
 		addresses: []network.Address{
 			{
@@ -58,20 +58,20 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceEmptyWhenNoAddressF
 
 	addrs, err := m.SelectMongoAddressFromSpace(666, "bad-space")
 	c.Check(addrs, gc.Equals, "")
-	c.Check(err, gc.ErrorMatches, `addresses for machine "3" in space "bad-space" not found`)
+	c.Check(err, gc.ErrorMatches, `addresses for controller node "3" in space "bad-space" not found`)
 }
 
 func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorForEmptySpace(c *gc.C) {
-	m := &machineTracker{
+	m := &controllerTracker{
 		id: "3",
 	}
 
 	_, err := m.SelectMongoAddressFromSpace(666, "")
-	c.Check(err, gc.ErrorMatches, `empty space supplied as an argument for selecting Mongo address for machine "3"`)
+	c.Check(err, gc.ErrorMatches, `empty space supplied as an argument for selecting Mongo address for controller node "3"`)
 }
 
 func (s *machineTrackerSuite) TestGetPotentialMongoHostPortsReturnsAllAddresses(c *gc.C) {
-	m := &machineTracker{
+	m := &controllerTracker{
 		id: "3",
 		addresses: []network.Address{
 			{

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -33,8 +33,8 @@ import (
 type fakeState struct {
 	mu               sync.Mutex
 	errors           errorPatterns
-	machines         map[string]*fakeMachine
-	controllers      voyeur.Value // of *state.ControllerInfo
+	controllers      map[string]*fakeController
+	controllerInfo   voyeur.Value // of *state.ControllerInfo
 	statuses         voyeur.Value // of statuses collection
 	controllerConfig voyeur.Value // of controller.Config
 	session          *fakeMongoSession
@@ -43,9 +43,9 @@ type fakeState struct {
 }
 
 var (
-	_ State        = (*fakeState)(nil)
-	_ Machine      = (*fakeMachine)(nil)
-	_ MongoSession = (*fakeMongoSession)(nil)
+	_ State          = (*fakeState)(nil)
+	_ ControllerNode = (*fakeController)(nil)
+	_ MongoSession   = (*fakeMongoSession)(nil)
 )
 
 type errorPatterns struct {
@@ -110,7 +110,7 @@ func (e *errorPatterns) resetErrors() {
 
 func NewFakeState() *fakeState {
 	st := &fakeState{
-		machines: make(map[string]*fakeMachine),
+		controllers: make(map[string]*fakeController),
 	}
 	st.session = newFakeMongoSession(st, &st.errors)
 	st.controllerConfig.Set(controller.Config{})
@@ -146,7 +146,7 @@ func (st *fakeState) checkInvariants() {
 // checkInvariants checks that all the expected invariants
 // in the state hold true. Currently we check that:
 // - total number of votes is odd.
-// - member voting status implies that machine has vote.
+// - member voting status implies that controller has vote.
 func checkInvariants(st *fakeState) error {
 	st.mu.Lock()
 	defer st.mu.Unlock()
@@ -158,15 +158,15 @@ func checkInvariants(st *fakeState) error {
 			votes = *m.Votes
 		}
 		voteCount += votes
-		if id, ok := m.Tags[jujuMachineKey]; ok {
+		if id, ok := m.Tags[jujuNodeKey]; ok {
 			if votes > 0 {
-				m := st.machines[id]
+				m := st.controllers[id]
 				if m == nil {
-					return fmt.Errorf("voting member with machine id %q has no associated Machine", id)
+					return fmt.Errorf("voting member with controller id %q has no associated Controller", id)
 				}
 
 				if !m.doc().hasVote {
-					return fmt.Errorf("machine %q should be marked as having the vote, but does not", id)
+					return fmt.Errorf("controller %q should be marked as having the vote, but does not", id)
 				}
 			}
 		}
@@ -181,59 +181,59 @@ type invariantChecker interface {
 	checkInvariants()
 }
 
-// machine is similar to Machine except that
+// controller is similar to Controller except that
 // it bypasses the error mocking machinery.
-// It returns nil if there is no machine with the
+// It returns nil if there is no controller with the
 // given id.
-func (st *fakeState) machine(id string) *fakeMachine {
+func (st *fakeState) controller(id string) *fakeController {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	return st.machines[id]
+	return st.controllers[id]
 }
 
-func (st *fakeState) Machine(id string) (Machine, error) {
-	if err := st.errors.errorFor("State.Machine", id); err != nil {
+func (st *fakeState) ControllerNode(id string) (ControllerNode, error) {
+	if err := st.errors.errorFor("State.Controller", id); err != nil {
 		return nil, err
 	}
-	if m := st.machine(id); m != nil {
+	if m := st.controller(id); m != nil {
 		return m, nil
 	}
-	return nil, errors.NotFoundf("machine %s", id)
+	return nil, errors.NotFoundf("controller %s", id)
 }
 
-func (st *fakeState) addMachine(id string, wantsVote bool) *fakeMachine {
+func (st *fakeState) addController(id string, wantsVote bool) *fakeController {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	logger.Infof("fakeState.addMachine %q", id)
-	if st.machines[id] != nil {
+	logger.Infof("fakeState.addController %q", id)
+	if st.controllers[id] != nil {
 		panic(fmt.Errorf("id %q already used", id))
 	}
-	doc := machineDoc{
+	doc := controllerDoc{
 		id:         id,
 		wantsVote:  wantsVote,
 		statusInfo: status.StatusInfo{Status: status.Started},
 		life:       state.Alive,
 	}
-	m := &fakeMachine{
+	m := &fakeController{
 		errors:  &st.errors,
 		checker: st,
 	}
-	st.machines[id] = m
+	st.controllers[id] = m
 	m.val.Set(doc)
 	return m
 }
 
-func (st *fakeState) removeMachine(id string) {
+func (st *fakeState) removeController(id string) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	if st.machines[id] == nil {
-		panic(fmt.Errorf("removing non-existent machine %q", id))
+	if st.controllers[id] == nil {
+		panic(fmt.Errorf("removing non-existent controller %q", id))
 	}
-	delete(st.machines, id)
+	delete(st.controllers, id)
 }
 
 func (st *fakeState) setControllers(ids ...string) {
-	st.controllers.Set(&state.ControllerInfo{
+	st.controllerInfo.Set(&state.ControllerInfo{
 		MachineIds: ids,
 	})
 }
@@ -242,11 +242,11 @@ func (st *fakeState) ControllerInfo() (*state.ControllerInfo, error) {
 	if err := st.errors.errorFor("State.ControllerInfo"); err != nil {
 		return nil, err
 	}
-	return deepCopy(st.controllers.Get()).(*state.ControllerInfo), nil
+	return deepCopy(st.controllerInfo.Get()).(*state.ControllerInfo), nil
 }
 
 func (st *fakeState) WatchControllerInfo() state.NotifyWatcher {
-	return WatchValue(&st.controllers)
+	return WatchValue(&st.controllerInfo)
 }
 
 func (st *fakeState) WatchControllerStatusChanges() state.StringsWatcher {
@@ -273,20 +273,20 @@ func (st *fakeState) ControllerConfig() (controller.Config, error) {
 	return deepCopy(st.controllerConfig.Get()).(controller.Config), nil
 }
 
-func (st *fakeState) RemoveControllerMachine(m Machine) error {
+func (st *fakeState) RemoveControllerNode(c ControllerNode) error {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	controllerInfo := st.controllers.Get().(*state.ControllerInfo)
-	machineIds := controllerInfo.MachineIds
-	var newMachineIds []string
-	machineId := m.Id()
-	for _, id := range machineIds {
-		if id == machineId {
+	controllerInfo := st.controllerInfo.Get().(*state.ControllerInfo)
+	controllerIds := controllerInfo.MachineIds
+	var newControllerIds []string
+	controllerId := c.Id()
+	for _, id := range controllerIds {
+		if id == controllerId {
 			continue
 		}
-		newMachineIds = append(newMachineIds, id)
+		newControllerIds = append(newControllerIds, id)
 	}
-	st.setControllers(newMachineIds...)
+	st.setControllers(newControllerIds...)
 	return nil
 }
 
@@ -299,14 +299,14 @@ func (st *fakeState) setHASpace(spaceName string) {
 	st.controllerConfig.Set(cfg)
 }
 
-type fakeMachine struct {
+type fakeController struct {
 	mu      sync.Mutex
 	errors  *errorPatterns
-	val     voyeur.Value // of machineDoc
+	val     voyeur.Value // of controllerDoc
 	checker invariantChecker
 }
 
-type machineDoc struct {
+type controllerDoc struct {
 	id         string
 	wantsVote  bool
 	hasVote    bool
@@ -316,78 +316,78 @@ type machineDoc struct {
 	life       state.Life
 }
 
-func (m *fakeMachine) doc() machineDoc {
-	return m.val.Get().(machineDoc)
+func (m *fakeController) doc() controllerDoc {
+	return m.val.Get().(controllerDoc)
 }
 
-func (m *fakeMachine) Refresh() error {
+func (m *fakeController) Refresh() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	doc := m.doc()
-	if err := m.errors.errorFor("Machine.Refresh", doc.id); err != nil {
+	if err := m.errors.errorFor("Controller.Refresh", doc.id); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *fakeMachine) GoString() string {
+func (m *fakeController) GoString() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return fmt.Sprintf("&fakeMachine{%#v}", m.doc())
+	return fmt.Sprintf("&fakeController{%#v}", m.doc())
 }
 
-func (m *fakeMachine) Id() string {
+func (m *fakeController) Id() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.doc().id
 }
 
-func (m *fakeMachine) Life() state.Life {
+func (m *fakeController) Life() state.Life {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.doc().life
 }
 
-func (m *fakeMachine) Watch() state.NotifyWatcher {
+func (m *fakeController) Watch() state.NotifyWatcher {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return WatchValue(&m.val)
 }
 
-func (m *fakeMachine) WantsVote() bool {
+func (m *fakeController) WantsVote() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.doc().wantsVote
 }
 
-func (m *fakeMachine) HasVote() bool {
+func (m *fakeController) HasVote() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.doc().hasVote
 }
 
-func (m *fakeMachine) Addresses() []network.Address {
+func (m *fakeController) Addresses() []network.Address {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.doc().addresses
 }
 
-func (m *fakeMachine) Status() (status.StatusInfo, error) {
+func (m *fakeController) Status() (status.StatusInfo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.doc().statusInfo, nil
 }
 
-func (m *fakeMachine) SetStatus(sInfo status.StatusInfo) error {
-	m.mutate(func(doc *machineDoc) {
+func (m *fakeController) SetStatus(sInfo status.StatusInfo) error {
+	m.mutate(func(doc *controllerDoc) {
 		doc.statusInfo = sInfo
 	})
 	return nil
 }
 
-// mutate atomically changes the machineDoc of
+// mutate atomically changes the controllerDoc of
 // the receiver by mutating it with the provided function.
-func (m *fakeMachine) mutate(f func(*machineDoc)) {
+func (m *fakeController) mutate(f func(*controllerDoc)) {
 	m.mu.Lock()
 	doc := m.doc()
 	f(&doc)
@@ -396,32 +396,32 @@ func (m *fakeMachine) mutate(f func(*machineDoc)) {
 	m.mu.Unlock()
 }
 
-func (m *fakeMachine) setAddresses(addrs ...network.Address) {
-	m.mutate(func(doc *machineDoc) {
+func (m *fakeController) setAddresses(addrs ...network.Address) {
+	m.mutate(func(doc *controllerDoc) {
 		doc.addresses = addrs
 	})
 }
 
-// SetHasVote implements Machine.SetHasVote.
-func (m *fakeMachine) SetHasVote(hasVote bool) error {
+// SetHasVote implements Controller.SetHasVote.
+func (m *fakeController) SetHasVote(hasVote bool) error {
 	doc := m.doc()
-	if err := m.errors.errorFor("Machine.SetHasVote", doc.id, hasVote); err != nil {
+	if err := m.errors.errorFor("Controller.SetHasVote", doc.id, hasVote); err != nil {
 		return err
 	}
-	m.mutate(func(doc *machineDoc) {
+	m.mutate(func(doc *controllerDoc) {
 		doc.hasVote = hasVote
 	})
 	return nil
 }
 
-func (m *fakeMachine) setWantsVote(wantsVote bool) {
-	m.mutate(func(doc *machineDoc) {
+func (m *fakeController) setWantsVote(wantsVote bool) {
+	m.mutate(func(doc *controllerDoc) {
 		doc.wantsVote = wantsVote
 	})
 }
 
-func (m *fakeMachine) advanceLifecycle(life state.Life, wantsVote bool) {
-	m.mutate(func(doc *machineDoc) {
+func (m *fakeController) advanceLifecycle(life state.Life, wantsVote bool) {
+	m.mutate(func(doc *controllerDoc) {
 		doc.life = life
 		doc.wantsVote = wantsVote
 	})

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -18,16 +18,16 @@ type StateShim struct {
 	*state.State
 }
 
-func (s StateShim) Machine(id string) (Machine, error) {
+func (s StateShim) ControllerNode(id string) (ControllerNode, error) {
 	return s.State.Machine(id)
+}
+
+func (s StateShim) RemoveControllerNode(c ControllerNode) error {
+	return s.State.RemoveControllerNode(c)
 }
 
 func (s StateShim) Space(name string) (Space, error) {
 	return s.State.Space(name)
-}
-
-func (s StateShim) RemoveControllerMachine(m Machine) error {
-	return s.State.RemoveControllerMachine(m.(*state.Machine))
 }
 
 // MongoSessionShim wraps a *mgo.Session to conform to the


### PR DESCRIPTION
## Description of change

Currently, we stuff HA related information into machine entities, and store in state as part of the machine doc. For k8s, we don't have machines and so want to rework the model so that HA info is managed separately to the concept of a machine. There will ultimately be a HA node entity for each controller. This ensures correct separation of cencerns etc.

The PR simply starts out by renaming a bunch of machine related structs/interfaces/methods etc in preparation for further work.

## QA steps

bootstrap and deploy a k8s app
bootstrap and enable HA on a vm cloud

