### PR TITLE
Allow OpenStack provider to use Cinder block devices as root disk

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1403,7 +1403,7 @@
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:3bc94878ebb5ec72f58047fc1a613de37ba4ef2b0c152480c2b6400fa3a875a8"
+  digest = "1:4522ac4db1745a0d44497f164cc9a05219f5f801d11f181839db2578868a2e2f"
   name = "gopkg.in/goose.v2"
   packages = [
     ".",
@@ -1429,7 +1429,7 @@
     "testservices/swiftservice",
   ]
   pruneopts = ""
-  revision = "13b769d3462eedac5f8ec2458f8e61a0dfe54d51"
+  revision = "b9ae5f99205fa37cf5dc547c61a9e2be0f75fa6b"
 
 [[projects]]
   digest = "1:445becf3878aa9bd50dfa972bd65f974ed2468c09350ab9ce28b1e4adce464df"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1875,7 +1875,6 @@
     "github.com/coreos/go-systemd/dbus",
     "github.com/coreos/go-systemd/unit",
     "github.com/coreos/go-systemd/util",
-    "github.com/davecgh/go-spew/spew",
     "github.com/docker/distribution/reference",
     "github.com/dustin/go-humanize",
     "github.com/golang/mock/gomock",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1403,7 +1403,7 @@
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:4522ac4db1745a0d44497f164cc9a05219f5f801d11f181839db2578868a2e2f"
+  digest = "1:116113ad2ba26a24f3c81618696697566a4c54603f5bcb028759de859059fa55"
   name = "gopkg.in/goose.v2"
   packages = [
     ".",
@@ -1429,7 +1429,7 @@
     "testservices/swiftservice",
   ]
   pruneopts = ""
-  revision = "b9ae5f99205fa37cf5dc547c61a9e2be0f75fa6b"
+  revision = "f18d0f2f8f9bc5b5234a338670210c4bf4328ab4"
 
 [[projects]]
   digest = "1:445becf3878aa9bd50dfa972bd65f974ed2468c09350ab9ce28b1e4adce464df"
@@ -1875,6 +1875,7 @@
     "github.com/coreos/go-systemd/dbus",
     "github.com/coreos/go-systemd/unit",
     "github.com/coreos/go-systemd/util",
+    "github.com/davecgh/go-spew/spew",
     "github.com/docker/distribution/reference",
     "github.com/dustin/go-humanize",
     "github.com/golang/mock/gomock",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -488,7 +488,7 @@
 
 [[constraint]]
   name = "gopkg.in/goose.v2"
-  revision = "b9ae5f99205fa37cf5dc547c61a9e2be0f75fa6b"
+  revision = "f18d0f2f8f9bc5b5234a338670210c4bf4328ab4"
 
 [[override]]
   name = "gopkg.in/httprequest.v1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -488,7 +488,7 @@
 
 [[constraint]]
   name = "gopkg.in/goose.v2"
-  revision = "13b769d3462eedac5f8ec2458f8e61a0dfe54d51"
+  revision = "b9ae5f99205fa37cf5dc547c61a9e2be0f75fa6b"
 
 [[override]]
   name = "gopkg.in/httprequest.v1"

--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -140,6 +140,11 @@ func (v *Value) HasCpuCores() bool {
 	return v.CpuCores != nil && *v.CpuCores > 0
 }
 
+// HasRootDisk returns true if the contraints.Value specifies a RootDisk size.
+func (v *Value) HasRootDisk() bool {
+	return v.RootDisk != nil && *v.RootDisk > 0
+}
+
 // HasRootDiskSource returns true if the constraints.Value specifies a
 // source for its root disk.
 func (v *Value) HasRootDiskSource() bool {

--- a/core/constraints/constraints_test.go
+++ b/core/constraints/constraints_test.go
@@ -489,6 +489,15 @@ func (s *ConstraintsSuite) TestHasRootDiskSource(c *gc.C) {
 	c.Check(con.HasRootDiskSource(), jc.IsFalse)
 }
 
+func (s *ConstraintsSuite) TestHasRootDisk(c *gc.C) {
+	con := constraints.MustParse("root-disk=32G")
+	c.Check(con.HasRootDisk(), jc.IsTrue)
+	con = constraints.MustParse("root-disk=")
+	c.Check(con.HasRootDisk(), jc.IsFalse)
+	con = constraints.MustParse("root-disk-source=pilgrim")
+	c.Check(con.HasRootDisk(), jc.IsFalse)
+}
+
 func (s *ConstraintsSuite) TestIsEmpty(c *gc.C) {
 	con := constraints.Value{}
 	c.Check(&con, jc.Satisfies, constraints.IsEmpty)

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -35,7 +35,7 @@ func AcceptAllFlavors(nova.FlavorDetail) bool {
 // The instance type comes from querying the flavors supported by the deployment.
 func findInstanceSpec(
 	e *Environ,
-	ic *instances.InstanceConstraint,
+	ic instances.InstanceConstraint,
 	imageMetadata []*imagemetadata.ImageMetadata,
 ) (*instances.InstanceSpec, error) {
 	// First construct all available instance types from the supported flavors.
@@ -44,6 +44,15 @@ func findInstanceSpec(
 	if err != nil {
 		return nil, err
 	}
+
+	if ic.Constraints.HasRootDiskSource() && *ic.Constraints.RootDiskSource == "volume" {
+		// When the root disk is a volume (i.e. cinder block volume)
+		// we don't want to match on RootDisk size. If an instance requires
+		// a very large root disk we don't want to select a larger instance type
+		// to fit a disk that won't be local to the instance.
+		ic.Constraints.RootDisk = nil
+	}
+
 	// Not all needed information is available in flavors,
 	// for e.g. architectures or virtualisation types.
 	// For these properties, we assume that all instance types support
@@ -62,14 +71,6 @@ func findInstanceSpec(
 			RootDisk: uint64(flavor.Disk * 1024),
 			// tags not currently supported on openstack
 		}
-		if ic.Constraints.HasRootDiskSource() &&
-			*ic.Constraints.RootDiskSource == "volume" {
-			// When the root disk is a volume (i.e. cinder block volume)
-			// we don't want to match on RootDisk size. If an instance requires
-			// a very large root disk we don't want to select a larger instance type
-			// to fit a disk that won't be local to the instance.
-			instanceType.RootDisk = 0
-		}
 		if ic.Constraints.HasVirtType() {
 			// Instance Type virtual type depends on the virtual type of the selected image, i.e.
 			// picking an image with a virt type gives a machine with this virt type.
@@ -79,7 +80,7 @@ func findInstanceSpec(
 	}
 
 	images := instances.ImageMetadataToImages(imageMetadata)
-	spec, err := instances.FindInstanceSpec(images, ic, allInstanceTypes)
+	spec, err := instances.FindInstanceSpec(images, &ic, allInstanceTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -62,6 +62,14 @@ func findInstanceSpec(
 			RootDisk: uint64(flavor.Disk * 1024),
 			// tags not currently supported on openstack
 		}
+		if ic.Constraints.HasRootDiskSource() &&
+			*ic.Constraints.RootDiskSource == "volume" {
+			// When the root disk is a volume (i.e. cinder block volume)
+			// we don't want to match on RootDisk size. If an instance requires
+			// a very large root disk we don't want to select a larger instance type
+			// to fit a disk that won't be local to the instance.
+			instanceType.RootDisk = 0
+		}
 		if ic.Constraints.HasVirtType() {
 			// Instance Type virtual type depends on the virtual type of the selected image, i.e.
 			// picking an image with a virt type gives a machine with this virt type.

--- a/provider/openstack/init.go
+++ b/provider/openstack/init.go
@@ -10,6 +10,9 @@ import (
 
 const (
 	providerType = "openstack"
+
+	rootDiskSourceVolume = "volume"
+	rootDiskSourceLocal  = "local"
 )
 
 func init() {

--- a/provider/openstack/init.go
+++ b/provider/openstack/init.go
@@ -11,10 +11,15 @@ import (
 const (
 	providerType = "openstack"
 
-	rootDiskSourceVolume = "volume"
-	rootDiskSourceLocal  = "local"
 	// Default root disk size when root-disk-source is volume.
 	defaultRootDiskSize = 30 * 1024 // 30 GiB
+)
+
+const (
+	// BlockDeviceMapping source volume type for cinder block device.
+	rootDiskSourceVolume = "volume"
+	// BlockDeviceMapping source volume type for local block device.
+	rootDiskSourceLocal = "local"
 )
 
 func init() {

--- a/provider/openstack/init.go
+++ b/provider/openstack/init.go
@@ -13,6 +13,8 @@ const (
 
 	rootDiskSourceVolume = "volume"
 	rootDiskSourceLocal  = "local"
+	// Default root disk size when root-disk-source is volume.
+	defaultRootDiskSize = 30 * 1024 // 30 GiB
 )
 
 func init() {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1434,6 +1434,13 @@ func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
+func (s *localServerSuite) TestPrecheckInstanceInvalidRootDiskConstraint(c *gc.C) {
+	env := s.Open(c, s.env.Config())
+	cons := constraints.MustParse("instance-type=m1.small root-disk=10G")
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Constraints: cons})
+	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless when constraint root-disk-source=volume`)
+}
+
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=test-available"
 	err := t.env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Placement: placement})

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -2384,6 +2384,34 @@ func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZoneConflictsP
 	c.Assert(err, gc.ErrorMatches, `cannot create instance in zone "az2", as this will prevent attaching the requested disks in zone "az1"`)
 }
 
+func (t *localServerSuite) TestStartInstanceVolumeRootBlockDevice(c *gc.C) {
+	err := bootstrapEnv(c, t.env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := constraints.Parse("root-disk-source=volume")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = testing.StartInstanceWithParams(t.env, t.callCtx, "1", environs.StartInstanceParams{
+		ControllerUUID: t.ControllerUUID,
+		Constraints:    cons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (t *localServerSuite) TestStartInstanceVolumeRootBlockDeviceSized(c *gc.C) {
+	err := bootstrapEnv(c, t.env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := constraints.Parse("root-disk-source=volume root-disk=10G")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = testing.StartInstanceWithParams(t.env, t.callCtx, "1", environs.StartInstanceParams{
+		ControllerUUID: t.ControllerUUID,
+		Constraints:    cons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	err := bootstrapEnv(c, t.env)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1335,7 +1335,8 @@ func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {
 	consB := constraints.MustParse("instance-type=m1.small")
 	cons, err := validator.Merge(consA, consB)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.DeepEquals, constraints.MustParse("arch=amd64 instance-type=m1.small"))
+	// NOTE: root-disk and instance-type constraints are checked by PrecheckInstance.
+	c.Assert(cons, gc.DeepEquals, constraints.MustParse("arch=amd64 instance-type=m1.small root-disk=10G"))
 }
 
 func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
@@ -1438,7 +1439,7 @@ func (s *localServerSuite) TestPrecheckInstanceInvalidRootDiskConstraint(c *gc.C
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small root-disk=10G")
 	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: supportedversion.SupportedLTS(), Constraints: cons})
-	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless when constraint root-disk-source=volume`)
+	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless constraint root-disk-source=volume`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
@@ -2391,32 +2392,108 @@ func (t *localServerSuite) TestStartInstanceVolumeAttachmentsAvailZoneConflictsP
 	c.Assert(err, gc.ErrorMatches, `cannot create instance in zone "az2", as this will prevent attaching the requested disks in zone "az1"`)
 }
 
+// novaInstaceStartedWithOpts exposes run server options used to start an instance.
+type novaInstaceStartedWithOpts interface {
+	NovaInstanceStartedWithOpts() *nova.RunServerOpts
+}
+
 func (t *localServerSuite) TestStartInstanceVolumeRootBlockDevice(c *gc.C) {
+	// diskSizeGiB should be equal to the openstack.defaultRootDiskSize
+	diskSizeGiB := 30
+
 	err := bootstrapEnv(c, t.env)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons, err := constraints.Parse("root-disk-source=volume")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = testing.StartInstanceWithParams(t.env, t.callCtx, "1", environs.StartInstanceParams{
+	res, err := testing.StartInstanceWithParams(t.env, t.callCtx, "1", environs.StartInstanceParams{
 		ControllerUUID: t.ControllerUUID,
 		Constraints:    cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+
+	runOpts := res.Instance.(novaInstaceStartedWithOpts).NovaInstanceStartedWithOpts()
+	c.Assert(runOpts, gc.NotNil)
+	c.Assert(runOpts.BlockDeviceMappings, gc.NotNil)
+	deviceMapping := runOpts.BlockDeviceMappings[0]
+	c.Assert(deviceMapping, jc.DeepEquals, nova.BlockDeviceMapping{
+		BootIndex:           0,
+		UUID:                "1",
+		SourceType:          "image",
+		DestinationType:     "volume",
+		DeleteOnTermination: true,
+		VolumeSize:          diskSizeGiB,
+	})
 }
 
 func (t *localServerSuite) TestStartInstanceVolumeRootBlockDeviceSized(c *gc.C) {
+	diskSizeGiB := 10
+
 	err := bootstrapEnv(c, t.env)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons, err := constraints.Parse("root-disk-source=volume root-disk=10G")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = testing.StartInstanceWithParams(t.env, t.callCtx, "1", environs.StartInstanceParams{
+	res, err := testing.StartInstanceWithParams(t.env, t.callCtx, "1", environs.StartInstanceParams{
 		ControllerUUID: t.ControllerUUID,
 		Constraints:    cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+
+	c.Assert(res.Hardware.RootDisk, gc.NotNil)
+	c.Assert(*res.Hardware.RootDisk, gc.Equals, uint64(diskSizeGiB*1024))
+
+	runOpts := res.Instance.(novaInstaceStartedWithOpts).NovaInstanceStartedWithOpts()
+	c.Assert(runOpts, gc.NotNil)
+	c.Assert(runOpts.BlockDeviceMappings, gc.NotNil)
+	deviceMapping := runOpts.BlockDeviceMappings[0]
+	c.Assert(deviceMapping, jc.DeepEquals, nova.BlockDeviceMapping{
+		BootIndex:           0,
+		UUID:                "1",
+		SourceType:          "image",
+		DestinationType:     "volume",
+		DeleteOnTermination: true,
+		VolumeSize:          diskSizeGiB,
+	})
+}
+
+func (t *localServerSuite) TestStartInstanceLocalRootBlockDevice(c *gc.C) {
+	err := bootstrapEnv(c, t.env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := constraints.Parse("root-disk=1G")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons.HasRootDisk(), jc.IsTrue)
+	c.Assert(*cons.RootDisk, gc.Equals, uint64(1024))
+
+	res, err := testing.StartInstanceWithParams(t.env, t.callCtx, "1", environs.StartInstanceParams{
+		ControllerUUID: t.ControllerUUID,
+		Constraints:    cons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+
+	c.Assert(res.Hardware.RootDisk, gc.NotNil)
+	// Check local disk requirements are met.
+	c.Assert(*res.Hardware.RootDisk, jc.GreaterThan, uint64(1024-1))
+
+	runOpts := res.Instance.(novaInstaceStartedWithOpts).NovaInstanceStartedWithOpts()
+	c.Assert(runOpts, gc.NotNil)
+	c.Assert(runOpts.BlockDeviceMappings, gc.NotNil)
+	deviceMapping := runOpts.BlockDeviceMappings[0]
+	c.Assert(deviceMapping, jc.DeepEquals, nova.BlockDeviceMapping{
+		BootIndex:           0,
+		UUID:                "1",
+		SourceType:          "image",
+		DestinationType:     "local",
+		DeleteOnTermination: true,
+		// VolumeSize is 0 when a local disk is used.
+		VolumeSize: 0,
+	})
 }
 
 func (t *localServerSuite) TestInstanceTags(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"math"
 	"net/url"
 	"path"
 	"strconv"
@@ -1385,10 +1384,10 @@ func (e *Environ) configureRootDisk(ctx context.ProviderCallContext, args enviro
 			size = *args.Constraints.RootDisk
 		}
 		if size <= 0 {
-			return errors.Errorf("root disk size cannot be 0")
+			size = defaultRootDiskSize
 		}
-		sizeGB := int(math.Ceil(float64(size) / 1024.0))
-		rootDiskMapping.VolumeSize = sizeGB
+		sizeGB := common.MiBToGiB(size)
+		rootDiskMapping.VolumeSize = int(sizeGB)
 	default:
 		return errors.Errorf("invalid %s %s", constraints.RootDiskSource, rootDiskSource)
 	}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1059,7 +1059,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 
 	series := args.Tools.OneSeries()
 	arches := args.Tools.Arches()
-	spec, err := findInstanceSpec(e, &instances.InstanceConstraint{
+	spec, err := findInstanceSpec(e, instances.InstanceConstraint{
 		Region:      e.cloud().Region,
 		Series:      series,
 		Arches:      arches,

--- a/provider/openstack/series_test.go
+++ b/provider/openstack/series_test.go
@@ -492,7 +492,7 @@ func FindInstanceSpec(
 	imageMetadata []*imagemetadata.ImageMetadata,
 ) (spec *instances.InstanceSpec, err error) {
 	env := e.(*Environ)
-	return findInstanceSpec(env, &instances.InstanceConstraint{
+	return findInstanceSpec(env, instances.InstanceConstraint{
 		Series:      series,
 		Arches:      []string{arch},
 		Region:      env.cloud().Region,

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -332,6 +332,9 @@ func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.
 	if cons.HasRootDiskSource() {
 		c.Assert(constraints.RootDiskSource(), gc.Equals, *cons.RootDiskSource)
 	}
+	if cons.HasRootDisk() {
+		c.Assert(constraints.RootDisk(), gc.Equals, *cons.RootDisk)
+	}
 
 	tools, err := machine1.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
@@ -499,6 +502,9 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 	}
 	if cons.HasRootDiskSource() {
 		c.Assert(constraints.RootDiskSource(), gc.Equals, *cons.RootDiskSource)
+	}
+	if cons.HasRootDisk() {
+		c.Assert(constraints.RootDisk(), gc.Equals, *cons.RootDisk)
 	}
 
 	history := exported.StatusHistory()


### PR DESCRIPTION
## Description of change

Current behaviour of the OpenStack provider is to use local (ephemeral) block devices as the
root disk. This change adds constraints root-disk-source=volume to OpenStack to bind a new
cinder block device as the root disk. The device is created with the size passed in via root-disk constraint or uses the default root-disk size for the instance type selected.

Constraint validation is limited and therefore you can't add an instance-type constraint with root-disk-source constraint, because the mutual exclusivity of root-disk and instance-type must be maintained (for local disks).

NOTE: The cinder block device is destroyed on machine termination which follows the current behaviour of local disks on machine termination.

## QA steps

Using an OpenStack cloud:
`juju add-machine --constraints "root-disk-source=volume"`
and
`juju add-machine --constraints "root-disk-source=volume root-disk=10G"`

After the machine has started, you can validate by running `nova volume-list`
```
+--------------------------------------+--------+--------------+------+-------------+--------------------------------------+
| ID                                   | Status | Display Name | Size | Volume Type | Attached to                          |
+--------------------------------------+--------+--------------+------+-------------+--------------------------------------+
| 1ace235e-506e-4583-a7b0-77cdcaa8a82c | in-use |              | 10   | None        | ce48e628-4fd4-48a8-b699-e24d7a69c1a7 |
+--------------------------------------+--------+--------------+------+-------------+--------------------------------------+
```

## Documentation changes

Current user workflows are unchanged when root-disk-source is not set.

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1746073](https://bugs.launchpad.net/juju/+bug/1746073)
