### PR TITLE
2.6 - Model Cache Refactoring

### DIFF
--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -83,7 +83,7 @@ type modelCacheCharm struct {
 }
 
 type modelCacheUnit struct {
-	*cache.Unit
+	cache.Unit
 }
 
 type modelCacheApplication struct {

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	// the application's charm url has changed.
-	applicationCharmURLChange = "application-charmurl-change"
-	// application config has changed.
+	// An application charm URL has changed.
+	applicationCharmURLChange = "application-charm-url-change"
+	// Application config has changed.
 	applicationConfigChange = "application-config-change"
 )
 
@@ -51,12 +51,14 @@ func (a *Application) CharmURL() string {
 // Config returns a copy of the current application config.
 func (a *Application) Config() map[string]interface{} {
 	a.mu.Lock()
+
 	cfg := make(map[string]interface{}, len(a.details.Config))
 	for k, v := range a.details.Config {
 		cfg[k] = v
 	}
-	a.mu.Unlock()
 	a.metrics.ApplicationConfigReads.Inc()
+
+	a.mu.Unlock()
 	return cfg
 }
 
@@ -87,10 +89,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 	a.setStale(false)
 
 	if a.details.CharmURL != details.CharmURL {
-		a.hub.Publish(
-			a.modelTopic(applicationCharmURLChange),
-			appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL},
-		)
+		a.hub.Publish(applicationCharmURLChange, appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})
 	}
 
 	a.details = details
@@ -109,8 +108,4 @@ func (a *Application) setDetails(details ApplicationChange) {
 // topic prefixes the input string with the application name.
 func (a *Application) topic(suffix string) string {
 	return a.details.Name + ":" + suffix
-}
-
-func (a *Application) modelTopic(suffix string) string {
-	return modelTopic(a.details.ModelUUID, suffix)
 }

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -106,11 +106,9 @@ func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Unlock()
 }
 
-// topic prefixes the input string with the model ID and application name.
-// TODO (manadart 2019-03-14) The model ID will not be necessary when there is
-// one hub per model.
+// topic prefixes the input string with the application name.
 func (a *Application) topic(suffix string) string {
-	return a.details.ModelUUID + ":" + a.details.Name + ":" + suffix
+	return a.details.Name + ":" + suffix
 }
 
 func (a *Application) modelTopic(suffix string) string {

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -191,7 +191,6 @@ func (s *ControllerSuite) TestAddUnit(c *gc.C) {
 
 	unit, err := mod.Unit(unitChange.Name)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(unit, gc.NotNil)
 	s.AssertResident(c, unit.CacheId(), true)
 }
 

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -141,7 +141,7 @@ func (w *MachineLXDProfileWatcher) init(machine *Machine) error {
 // applicationCharmURLChange sends a notification if what is saved for its
 // charm lxdprofile changes.  No notification is sent if the profile pointer
 // begins and ends as nil.
-func (w *MachineLXDProfileWatcher) applicationCharmURLChange(topic string, value interface{}) {
+func (w *MachineLXDProfileWatcher) applicationCharmURLChange(_ string, value interface{}) {
 	// We don't want to respond to any events until we have been fully initialized.
 	select {
 	case <-w.initialized:
@@ -195,7 +195,7 @@ func (w *MachineLXDProfileWatcher) applicationCharmURLChange(topic string, value
 // addUnit modifies the map of applications being watched when a unit is
 // added to the machine.  Notification is sent if a new unit whose charm has
 // an lxd profile is added.
-func (w *MachineLXDProfileWatcher) addUnit(topic string, value interface{}) {
+func (w *MachineLXDProfileWatcher) addUnit(_ string, value interface{}) {
 	// We don't want to respond to any events until we have been fully initialized.
 	select {
 	case <-w.initialized:
@@ -213,7 +213,7 @@ func (w *MachineLXDProfileWatcher) addUnit(topic string, value interface{}) {
 		}
 	}(&notify)
 
-	unit, okUnit := value.(*Unit)
+	unit, okUnit := value.(Unit)
 	if !okUnit {
 		w.logError("programming error, value not of type *Unit")
 		return
@@ -246,7 +246,7 @@ func (w *MachineLXDProfileWatcher) addUnit(topic string, value interface{}) {
 	logger.Debugf("end of unit change %#v", w.applications)
 }
 
-func (w *MachineLXDProfileWatcher) add(unit *Unit) bool {
+func (w *MachineLXDProfileWatcher) add(unit Unit) bool {
 	unitName := unit.Name()
 	appName := unit.Application()
 
@@ -289,7 +289,7 @@ func (w *MachineLXDProfileWatcher) add(unit *Unit) bool {
 // removeUnit modifies the map of applications being watched when a unit is
 // removed from the machine.  Notification is sent if a unit being removed
 // has a profile and other units exist on the machine.
-func (w *MachineLXDProfileWatcher) removeUnit(topic string, value interface{}) {
+func (w *MachineLXDProfileWatcher) removeUnit(_ string, value interface{}) {
 	// We don't want to respond to any events until we have been fully initialized.
 	select {
 	case <-w.initialized:
@@ -307,26 +307,26 @@ func (w *MachineLXDProfileWatcher) removeUnit(topic string, value interface{}) {
 		}
 	}(&notify)
 
-	rUnit, ok := value.(unitLXDProfileRemove)
+	rUnit, ok := value.(Unit)
 	if !ok {
 		w.logError("programming error, value not of type unitLXDProfileRemove")
 		return
 	}
 
-	app, ok := w.applications[rUnit.appName]
+	app, ok := w.applications[rUnit.Application()]
 	if !ok {
 		w.logError("programming error, unit removed before being added, application name not found")
 		return
 	}
-	if !app.units.Contains(rUnit.name) {
+	if !app.units.Contains(rUnit.Name()) {
 		return
 	}
 	profile := app.charmProfile
-	app.units.Remove(rUnit.name)
+	app.units.Remove(rUnit.Name())
 	if app.units.Size() == 0 {
 		// the application has no more units on this machine,
 		// stop watching it.
-		delete(w.applications, rUnit.appName)
+		delete(w.applications, rUnit.Application())
 	}
 	// If there are additional units on the machine and the current
 	// application has an lxd profile, notify so it can be removed
@@ -339,7 +339,7 @@ func (w *MachineLXDProfileWatcher) removeUnit(topic string, value interface{}) {
 
 // provisionedChanged notifies when called.  Topic subscribed to is specific to
 // this machine.
-func (w *MachineLXDProfileWatcher) provisionedChange(topic string, _ interface{}) {
+func (w *MachineLXDProfileWatcher) provisionedChange(_ string, _ interface{}) {
 	// We don't want to respond to any events until we have been fully initialized.
 	select {
 	case <-w.initialized:

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -30,7 +30,7 @@ type MachineLXDProfileWatcher struct {
 type MachineAppModeler interface {
 	Application(string) (*Application, error)
 	Charm(string) (*Charm, error)
-	Unit(string) (*Unit, error)
+	Unit(string) (Unit, error)
 }
 
 type appInfo struct {

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -142,14 +142,14 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateWithProf
 	defer workertest.CleanKill(c, s.assertStartOneMachineWatcher(c))
 	// Add a new subordinate unit with a profile of a new application.
 	s.newUnitForMachineLXDProfileWatcherSubProfile(c, s.machine0.Id(), unitChange.Name)
-	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 0)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 1)
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateNoProfile(c *gc.C) {
 	defer workertest.CleanKill(c, s.assertStartOneMachineWatcher(c))
 	// Add a new subordinate unit with no profile of a new application.
 	s.newUnitForMachineLXDProfileWatcherNoProfile(c, s.machine0.Id(), unitChange.Name)
-	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 1)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 2)
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherRemoveUnitWithProfileTwoUnits(c *gc.C) {
@@ -157,7 +157,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherRemoveUnitWithProfi
 
 	// Add a new unit of a new application.
 	s.newUnitForMachineLXDProfileWatcherNoProfile(c, s.machine0.Id(), "")
-	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 1)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 0, 2)
 
 	// Remove the original unit which has a profile.
 	c.Assert(s.model.RemoveUnit(
@@ -165,7 +165,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherRemoveUnitWithProfi
 			ModelUUID: "model-uuid",
 			Name:      "application-name/0",
 		}), jc.ErrorIsNil)
-	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 1)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 2)
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherRemoveOnlyUnit(c *gc.C) {
@@ -222,7 +222,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherUnitChangeCharmURLN
 		Application: "new-application-name",
 		MachineId:   s.machine0.Id(),
 	}, s.Manager)
-	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 1, 0, 1)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 1, 0, 2)
 }
 
 func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherUnitChangeUnitCharmURLIgnored(c *gc.C) {

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -132,10 +132,10 @@ func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 
 // WatchLXDProfileVerificationNeeded notifies if any of the following happen
 // relative to this machine:
-//     1. A new unit whose charm has an lxd profile is added.
+//     1. A new unit whose charm has an LXD profile is added.
 //     2. A unit being removed has a profile and other units
 //        exist on the machine.
-//     3. The lxdprofile of an application with a unit on this
+//     3. The LXD profile of an application with a unit on this
 //        machine is added, removed, or exists.
 //     4. The machine's instanceId is changed, indicating it
 //        has been provisioned.
@@ -143,8 +143,8 @@ func (m *Machine) WatchLXDProfileVerificationNeeded() (*MachineLXDProfileWatcher
 	return newMachineLXDProfileWatcher(MachineLXDProfileWatcherConfig{
 		appTopic:         m.model.topic(applicationCharmURLChange),
 		provisionedTopic: m.topic(machineProvisioned),
-		unitAddTopic:     m.model.topic(modelUnitLXDProfileAdd),
-		unitRemoveTopic:  m.model.topic(modelUnitLXDProfileRemove),
+		unitAddTopic:     m.model.topic(modelUnitAdd),
+		unitRemoveTopic:  m.model.topic(modelUnitRemove),
 		machine:          m,
 		modeler:          m.model,
 		metrics:          m.model.metrics,

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -81,7 +81,7 @@ func (m *Machine) Units() ([]Unit, error) {
 
 	units := m.model.Units()
 
-	result := make([]Unit, 0)
+	var result []Unit
 	for unitName, unit := range units {
 		if unit.MachineId() == m.details.Id {
 			result = append(result, unit)

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -75,21 +75,23 @@ func (m *Machine) ContainerType() instance.ContainerType {
 
 // Units returns all the units that have been assigned to the machine
 // including subordinates.
-func (m *Machine) Units() ([]*Unit, error) {
+func (m *Machine) Units() ([]Unit, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	result := make([]*Unit, 0)
-	for unitName, unit := range m.model.units {
-		if unit.details.MachineId == m.details.Id {
+	units := m.model.Units()
+
+	result := make([]Unit, 0)
+	for unitName, unit := range units {
+		if unit.MachineId() == m.details.Id {
 			result = append(result, unit)
 		}
 		if unit.details.Subordinate {
-			principalUnit, found := m.model.units[unit.details.Principal]
+			principalUnit, found := units[unit.Principal()]
 			if !found {
-				return result, errors.NotFoundf("principal unit %q for subordinate %s", unit.details.Principal, unitName)
+				return result, errors.NotFoundf("principal unit %q for subordinate %s", unit.Principal(), unitName)
 			}
-			if principalUnit.details.MachineId == m.details.Id {
+			if principalUnit.MachineId() == m.details.Id {
 				result = append(result, unit)
 			}
 		}

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -119,7 +119,7 @@ func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 
 	w := newPredicateStringsWatcher(regexpPredicate(compiled), machines...)
 	deregister := m.registerWorker(w)
-	unsub := m.model.hub.Subscribe(m.modelTopic(modelAddRemoveMachine), w.changed)
+	unsub := m.model.hub.Subscribe(modelAddRemoveMachine, w.changed)
 
 	w.tomb.Go(func() error {
 		<-w.tomb.Dying()
@@ -143,10 +143,10 @@ func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 //        has been provisioned.
 func (m *Machine) WatchLXDProfileVerificationNeeded() (*MachineLXDProfileWatcher, error) {
 	return newMachineLXDProfileWatcher(MachineLXDProfileWatcherConfig{
-		appTopic:         m.model.topic(applicationCharmURLChange),
+		appTopic:         applicationCharmURLChange,
 		provisionedTopic: m.topic(machineProvisioned),
-		unitAddTopic:     m.model.topic(modelUnitAdd),
-		unitRemoveTopic:  m.model.topic(modelUnitRemove),
+		unitAddTopic:     modelUnitAdd,
+		unitRemoveTopic:  modelUnitRemove,
 		machine:          m,
 		modeler:          m.model,
 		metrics:          m.model.metrics,
@@ -158,10 +158,6 @@ func (m *Machine) WatchLXDProfileVerificationNeeded() (*MachineLXDProfileWatcher
 func (m *Machine) containerRegexp() (*regexp.Regexp, error) {
 	regExp := fmt.Sprintf("^%s%s", m.details.Id, names.ContainerSnippet)
 	return regexp.Compile(regExp)
-}
-
-func (m *Machine) modelTopic(suffix string) string {
-	return modelTopic(m.details.ModelUUID, suffix)
 }
 
 func (m *Machine) setDetails(details MachineChange) {
@@ -196,5 +192,5 @@ func (m *Machine) setDetails(details MachineChange) {
 }
 
 func (m *Machine) topic(suffix string) string {
-	return m.details.ModelUUID + ":" + m.details.Id + ":" + suffix
+	return m.details.Id + ":" + suffix
 }

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -209,20 +209,21 @@ func (s *machineSuite) setupMachine0Container(c *gc.C) {
 	s.model.UpdateMachine(mc, s.Manager)
 }
 
-func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []string) (*cache.Machine, []*cache.Unit) {
+func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []string) (*cache.Machine, []cache.Unit) {
 	mc := machineChange
 	mc.Id = machineId
 	s.model.UpdateMachine(mc, s.Manager)
 	machine, err := s.model.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 
-	units := make([]*cache.Unit, len(apps))
+	units := make([]cache.Unit, len(apps))
 	for i, name := range apps {
 		uc := unitChange
 		uc.MachineId = machineId
 		uc.Name = name + "/" + machineId
 		uc.Application = name
 		s.model.UpdateUnit(uc, s.Manager)
+
 		unit, err := s.model.Unit(uc.Name)
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
@@ -231,7 +232,7 @@ func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []s
 	return machine, units
 }
 
-type orderedUnits []*cache.Unit
+type orderedUnits []cache.Unit
 
 func (o orderedUnits) Len() int {
 	return len(o)

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -28,10 +28,8 @@ const (
 
 func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Model {
 	m := &Model{
-		Resident: res,
-		metrics:  metrics,
-		// TODO: consider a separate hub per model for better scalability
-		// when many models.
+		Resident:     res,
+		metrics:      metrics,
 		hub:          hub,
 		applications: make(map[string]*Application),
 		charms:       make(map[string]*Charm),

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -14,16 +14,15 @@ import (
 )
 
 const (
-	// a machine has been added or removed from the model.
-	modelAddRemoveMachine = "model-add-remove-machine"
-	// model config has changed.
+	// Model config has changed.
 	modelConfigChange = "model-config-change"
-	// a unit in the model has been added such than a lxd profile change
-	// maybe be necessary has been made.
-	modelUnitLXDProfileAdd = "model-unit-lxd-profile-add"
-	// a unit in the model has been removed such than a lxd profile change
-	// maybe be necessary has been made.
-	modelUnitLXDProfileRemove = "model-unit-remove"
+	// A machine has been added to, or removed from the model.
+	modelAddRemoveMachine = "model-add-remove-machine"
+	// A unit has landed on a machine, or a subordinate unit has been changed,
+	// Either of which likely indicate the addition of a unit to the model.
+	modelUnitAdd = "model-unit-add"
+	// A unit has been removed from the model.
+	modelUnitRemove = "model-unit-remove"
 )
 
 func newModel(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Model {
@@ -297,7 +296,7 @@ func (m *Model) removeUnit(ch RemoveUnit) error {
 
 	unit, ok := m.units[ch.Name]
 	if ok {
-		m.hub.Publish(m.topic(modelUnitLXDProfileRemove), unitLXDProfileRemove{name: ch.Name, appName: unit.details.Application})
+		m.hub.Publish(m.topic(modelUnitRemove), unitLXDProfileRemove{name: ch.Name, appName: unit.details.Application})
 		if err := unit.evict(); err != nil {
 			return errors.Trace(err)
 		}

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -146,15 +146,18 @@ func (m *Model) Machine(machineId string) (*Machine, error) {
 	return machine, nil
 }
 
+// TODO (manadart 2019-05-30): Access to these entities returns copies:
+// - units
+// - branches
+// All of the other entity retrieval should be changed to work in the same
+// fashion, and the lock guarding of member access removed where possible.
+
 // Branch returns the branch with the input name.
 // If the branch is not found, a NotFoundError is returned.
 // All API-level logic identifies active branches by their name whereas they
 // are managed in the cache by ID - we iterate over the map to locate them.
 // We do not expect many active branches to exist at once,
 // so the performance should be acceptable.
-// TODO (manadart 2019-05-30): Note that this returns a copy of the branch.
-// All of the other entity retrieval should be changed to work in the same
-// fashion, and the lock guarding of member access removed where possible.
 func (m *Model) Branch(name string) (Branch, error) {
 	defer m.doLocked()()
 

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -53,42 +53,43 @@ func (s *BaseSuite) AssertNoResidents(c *gc.C) {
 	c.Assert(s.Manager.residents, gc.HasLen, 0)
 }
 
+func (s *BaseSuite) AssertWorkerResource(c *gc.C, resident *Resident, id uint64, expectPresent bool) {
+	_, present := resident.workers[id]
+	c.Assert(present, gc.Equals, expectPresent)
+}
+
 // entitySuite is the base suite for testing cached entities
 // (models, applications, machines).
 type EntitySuite struct {
 	BaseSuite
 
 	Gauges *ControllerGauges
-	Hub    *pubsub.SimpleHub
 }
 
 func (s *EntitySuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	logger := loggo.GetLogger("test")
-	logger.SetLogLevel(loggo.TRACE)
-	s.Hub = pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
-		Logger: logger,
-	})
-
 	s.Gauges = createControllerGauges()
 }
 
 func (s *EntitySuite) NewModel(details ModelChange) *Model {
-	m := newModel(s.Gauges, s.Hub, s.Manager.new())
+	m := newModel(s.Gauges, s.newHub(), s.Manager.new())
 	m.setDetails(details)
 	return m
 }
 
 func (s *EntitySuite) NewApplication(details ApplicationChange) *Application {
-	a := newApplication(s.Gauges, s.Hub, s.NewResident())
+	a := newApplication(s.Gauges, s.newHub(), s.NewResident())
 	a.SetDetails(details)
 	return a
 }
 
-func (s *BaseSuite) AssertWorkerResource(c *gc.C, resident *Resident, id uint64, expectPresent bool) {
-	_, present := resident.workers[id]
-	c.Assert(present, gc.Equals, expectPresent)
+func (s *EntitySuite) newHub() *pubsub.SimpleHub {
+	logger := loggo.GetLogger("test")
+	logger.SetLogLevel(loggo.TRACE)
+	return pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
+		Logger: logger,
+	})
 }
 
 type ImportSuite struct{}

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -87,7 +87,7 @@ func (u *Unit) setDetails(details UnitChange) {
 	machineChange := u.details.MachineId != details.MachineId
 	u.details = details
 	if machineChange || u.details.Subordinate {
-		u.hub.Publish(u.modelTopic(modelUnitAdd), u)
+		u.hub.Publish(modelUnitAdd, u.copy())
 	}
 }
 
@@ -117,10 +117,6 @@ func (u *Unit) copy() Unit {
 	cu.details.WorkloadStatus = copyStatusInfo(u.details.WorkloadStatus)
 	cu.details.AgentStatus = copyStatusInfo(u.details.AgentStatus)
 	return cu
-}
-
-func (u *Unit) modelTopic(suffix string) string {
-	return modelTopic(u.details.ModelUUID, suffix)
 }
 
 func copyStatusInfo(info status.StatusInfo) status.StatusInfo {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -68,6 +68,11 @@ func (u *Unit) CharmURL() string {
 	return u.details.CharmURL
 }
 
+// Ports returns the exposed ports for the unit.
+func (u *Unit) Ports() []network.Port {
+	return u.details.Ports
+}
+
 func (u *Unit) setDetails(details UnitChange) {
 	// If this is the first receipt of details, set the removal message.
 	if u.removalMessage == nil {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -90,7 +90,7 @@ func (u *Unit) setDetails(details UnitChange) {
 	machineChange := u.details.MachineId != details.MachineId
 	u.details = details
 	if machineChange || u.details.Subordinate {
-		u.hub.Publish(u.modelTopic(modelUnitLXDProfileAdd), u)
+		u.hub.Publish(u.modelTopic(modelUnitAdd), u)
 	}
 
 	// TODO (manadart 2019-02-11): Maintain hash and publish changes.


### PR DESCRIPTION
## Description of change

This patch contains preparatory work for added branch-based charm configuration to the model cache. In particular:
- Each model now has its own pub/sub hub for better scalability.
- Pub/sub topics previously needing a model UUID name-space no longer do.
- The cache now returns deep-copied units instead of references, as per branches.
- For units and branches now returning copies, the unneeded lock infrastructure is removed.
- Some events previously specific to LXD profile watching are now generic.

## QA steps

Same as for https://github.com/juju/juju/pull/10062

## Documentation changes

None.

## Bug reference

N/A.
