### PR TITLE
Bump golang 1.12

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -731,7 +731,7 @@
   revision = "9b925afd677234e4146dde3cb1a11e187cbed64e"
 
 [[projects]]
-  digest = "1:4cb2e360aaa18a7369e22b26d997dc141ad7f336d964fadeaeca0976611d9995"
+  digest = "1:95ed103a60286cdb3c4404e2b19bb210c98a1a0110d4e8f66901b96cdb4fcbb5"
   name = "github.com/juju/testing"
   packages = [
     ".",
@@ -740,7 +740,8 @@
     "httptesting",
   ]
   pruneopts = ""
-  revision = "6570bd8f8541d15ce654437084f8edcd7b76637b"
+  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
+  source = "github.com/SimonRichardson/testing"
 
 [[projects]]
   digest = "1:c43a754dcd24720e8f651933c9685511be5cba937faabaf6abbc4360b5b1f228"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -740,8 +740,7 @@
     "httptesting",
   ]
   pruneopts = ""
-  revision = "c2059796eac0de8f72fede36c1ac323cf15f3ccf"
-  source = "github.com/SimonRichardson/testing"
+  revision = "e81189438503b1e5c94efe95a604372b33eee7a2"
 
 [[projects]]
   digest = "1:c43a754dcd24720e8f651933c9685511be5cba937faabaf6abbc4360b5b1f228"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -731,7 +731,7 @@
   revision = "9b925afd677234e4146dde3cb1a11e187cbed64e"
 
 [[projects]]
-  digest = "1:95ed103a60286cdb3c4404e2b19bb210c98a1a0110d4e8f66901b96cdb4fcbb5"
+  digest = "1:41acc45bab6f3fcbe700b6e0b5db88c8c42a045306dbe4d63f5c6bc949aec66d"
   name = "github.com/juju/testing"
   packages = [
     ".",
@@ -740,7 +740,7 @@
     "httptesting",
   ]
   pruneopts = ""
-  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
+  revision = "c2059796eac0de8f72fede36c1ac323cf15f3ccf"
   source = "github.com/SimonRichardson/testing"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@
   name = "github.com/juju/romulus"
 
 [[constraint]]
-  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
+  revision = "c2059796eac0de8f72fede36c1ac323cf15f3ccf"
   name = "github.com/juju/testing"
   source = "github.com/SimonRichardson/testing"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,8 +114,9 @@
   name = "github.com/juju/romulus"
 
 [[constraint]]
-  revision = "6570bd8f8541d15ce654437084f8edcd7b76637b"
+  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
   name = "github.com/juju/testing"
+  source = "github.com/SimonRichardson/testing"
 
 [[constraint]]
   revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,9 +114,8 @@
   name = "github.com/juju/romulus"
 
 [[constraint]]
-  revision = "c2059796eac0de8f72fede36c1ac323cf15f3ccf"
+  revision = "e81189438503b1e5c94efe95a604372b33eee7a2"
   name = "github.com/juju/testing"
-  source = "github.com/SimonRichardson/testing"
 
 [[constraint]]
   revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,8 @@ rebuild-dependencies:
 # Install packages required to develop Juju and run tests. The stable
 # PPA includes the required mongodb-server binaries.
 install-dependencies:
-	@echo Installing go-1.11 snap
-	@sudo snap install go --channel=1.11/stable --classic
+	@echo Installing go-1.12 snap
+	@sudo snap install go --channel=1.12/stable --classic
 	@echo Adding juju PPA for mongodb
 	@sudo apt-add-repository --yes ppa:juju/stable
 	@sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ If you are looking for binary releases of `juju`, they are available in the snap
 Installing Go
 --------------
 
-`Juju's` source code currently depends on Go 1.11. One of the easiest ways
+`Juju's` source code currently depends on Go 1.12. One of the easiest ways
 to install golang is from a snap. You may need to first install
 the [snap client](https://snapcraft.io/docs/core/install). Installing the golang
 snap package is then as easy as
 
-    snap install go --channel=1.11/stable --classic
+    snap install go --channel=1.12/stable --classic
 
 You can read about the "classic" confinement policy [here](https://insights.ubuntu.com/2017/01/09/how-to-snap-introducing-classic-confinement/)
 
@@ -36,7 +36,7 @@ If you want to use `apt`, then you can add the [Golang Gophers PPA](https://laun
 
     sudo add-apt-repository ppa:gophers/archive
     sudo apt-get update
-    sudo apt install golang-1.11
+    sudo apt install golang-1.12
 
 Alternatively, you can always follow the official [binary installation instructions](https://golang.org/doc/install#install)
 

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -110,9 +110,9 @@ func (s *charmsSuite) TestCharmsServedSecurely(c *gc.C) {
 	url := s.charmsURL("")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "GET",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/debuglog_db_test.go
+++ b/apiserver/debuglog_db_test.go
@@ -38,9 +38,9 @@ func (s *debugLogDBSuite) TestBadParams(c *gc.C) {
 func (s *debugLogDBSuite) TestWithHTTP(c *gc.C) {
 	uri := s.logURL("http", nil).String()
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         uri,
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "GET",
+		URL:          uri,
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/resources_mig_test.go
+++ b/apiserver/resources_mig_test.go
@@ -72,9 +72,9 @@ func (s *resourcesUploadSuite) TestServedSecurely(c *gc.C) {
 	url := s.resourcesURL("")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "GET",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -76,7 +76,7 @@ func (s *restSuite) TestRestServedSecurely(c *gc.C) {
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
 		Method:      "GET",
 		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -74,8 +74,8 @@ func (s *restSuite) TestRestServedSecurely(c *gc.C) {
 	url := s.restURL(s.State.ModelUUID(), "")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         url.String(),
+		Method:       "GET",
+		URL:          url.String(),
 		ExpectStatus: http.StatusBadRequest,
 	})
 }

--- a/apiserver/testing/http.go
+++ b/apiserver/testing/http.go
@@ -30,6 +30,10 @@ type HTTPRequestParams struct {
 	// nil.
 	ExpectError string
 
+	// ExpectStatus holds the expected HTTP status code.
+	// http.StatusOK is assumed if this is zero.
+	ExpectStatus int
+
 	// tag holds the tag to authenticate as.
 	Tag string
 
@@ -64,15 +68,16 @@ type HTTPRequestParams struct {
 func SendHTTPRequest(c *gc.C, p HTTPRequestParams) *http.Response {
 	c.Logf("sendRequest: %s", p.URL)
 	hp := httptesting.DoRequestParams{
-		Do:          p.Do,
-		Method:      p.Method,
-		URL:         p.URL,
-		Body:        p.Body,
-		JSONBody:    p.JSONBody,
-		Header:      make(http.Header),
-		Username:    p.Tag,
-		Password:    p.Password,
-		ExpectError: p.ExpectError,
+		Do:           p.Do,
+		Method:       p.Method,
+		URL:          p.URL,
+		Body:         p.Body,
+		JSONBody:     p.JSONBody,
+		Header:       make(http.Header),
+		Username:     p.Tag,
+		Password:     p.Password,
+		ExpectError:  p.ExpectError,
+		ExpectStatus: p.ExpectStatus,
 	}
 	if p.ContentType != "" {
 		hp.Header.Set("Content-Type", p.ContentType)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -106,9 +106,9 @@ func (s *toolsSuite) TestToolsUploadedSecurely(c *gc.C) {
 	url := s.toolsURL("")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "PUT",
-		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "PUT",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -243,7 +243,7 @@ func (s *WorkerSuite) TestMinTLSVersion(c *gc.C) {
 	tlsConfig.MaxVersion = tls.VersionSSL30
 
 	conn, err := tls.Dial("tcp", parsed.Host, tlsConfig)
-	c.Assert(err, gc.ErrorMatches, ".*protocol version not supported")
+	c.Assert(err, gc.ErrorMatches, "tls: no supported versions satisfy MinVersion and MaxVersion")
 	c.Assert(conn, gc.IsNil)
 }
 


### PR DESCRIPTION
## Description of change

The following moves Juju to go version 1.12

## QA steps

Ensure that the tests pass and for safety:

```console
make clean dep go-install
```
