### PR TITLE
leases: Fix leadership flapping for multiple models with the same application

### DIFF
--- a/acceptancetests/repository/charms/mysql/README.md
+++ b/acceptancetests/repository/charms/mysql/README.md
@@ -12,7 +12,7 @@ To deploy a MySQL service:
 
     juju deploy mysql
 
-Once deployed, you can retrive the MySQL root user password by logging in to the machine via `juju ssh` and readin the `/var/lib/mysql/mysql.passwd` file. To log in as root MySQL User at the MySQL console you can issue the following:
+Once deployed, you can retrieve the MySQL root user password by logging in to the machine via `juju ssh` and readin the `/var/lib/mysql/mysql.passwd` file. To log in as root MySQL User at the MySQL console you can issue the following:
 
     juju ssh mysql/0
     mysql -u root -p=`cat /var/lib/mysql/mysql.passwd`

--- a/acceptancetests/repository/trusty/mysql/README.md
+++ b/acceptancetests/repository/trusty/mysql/README.md
@@ -12,7 +12,7 @@ To deploy a MySQL service:
 
     juju deploy mysql
 
-Once deployed, you can retrive the MySQL root user password by logging in to the machine via `juju ssh` and readin the `/var/lib/mysql/mysql.passwd` file. To log in as root MySQL User at the MySQL console you can issue the following:
+Once deployed, you can retrieve the MySQL root user password by logging in to the machine via `juju ssh` and readin the `/var/lib/mysql/mysql.passwd` file. To log in as root MySQL User at the MySQL console you can issue the following:
 
     juju ssh mysql/0
     mysql -u root -p=`cat /var/lib/mysql/mysql.passwd`

--- a/acceptancetests/repository/xenial/mysql/README.md
+++ b/acceptancetests/repository/xenial/mysql/README.md
@@ -12,7 +12,7 @@ To deploy a MySQL service:
 
     juju deploy mysql
 
-Once deployed, you can retrive the MySQL root user password by logging in to the machine via `juju ssh` and readin the `/var/lib/mysql/mysql.passwd` file. To log in as root MySQL User at the MySQL console you can issue the following:
+Once deployed, you can retrieve the MySQL root user password by logging in to the machine via `juju ssh` and readin the `/var/lib/mysql/mysql.passwd` file. To log in as root MySQL User at the MySQL console you can issue the following:
 
     juju ssh mysql/0
     mysql -u root -p=`cat /var/lib/mysql/mysql.passwd`

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -1384,7 +1384,7 @@ func (c *DeployCommand) maybeReadLocalCharm(apiRoot DeployAPI) (deployFn, error)
 		}
 
 		if len(ch.Meta().Series) == 0 {
-			logger.Warningf("%s does not delcare supported series in metadata.yml", ch.Meta().Name)
+			logger.Warningf("%s does not declare supported series in metadata.yml", ch.Meta().Name)
 		}
 
 		seriesName, err = seriesSelector.charmSeries()

--- a/environs/manual/winrmprovisioner/winrmprovisioner.go
+++ b/environs/manual/winrmprovisioner/winrmprovisioner.go
@@ -160,7 +160,7 @@ func InitAdministratorUser(args *manual.ProvisionMachineArgs) error {
 		return nil
 	}
 
-	logger.Infof("Winrm https connection is broken, can't retrive a response")
+	logger.Infof("Winrm https connection is broken, can't retrieve a response")
 	logger.Infof("Reverting back to usecure client interactions")
 	args.WinRM.Client = defClient
 

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -146,7 +146,7 @@ func (c OpenstackCredentials) DetectCredentials() (*cloud.CloudCredential, error
 func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, string, error) {
 	creds, err := identity.CredentialsFromEnv()
 	if err != nil {
-		return nil, "", "", errors.Errorf("failed to retrive cred from env : %v", err)
+		return nil, "", "", errors.Errorf("failed to retrieve cred from env : %v", err)
 	}
 	if creds.TenantName == "" {
 		logger.Debugf("neither OS_TENANT_NAME nor OS_PROJECT_NAME environment variable not set")

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -205,7 +205,7 @@ func (EnvironProvider) DetectRegions() ([]cloud.Region, error) {
 	// return return a region using them.
 	creds, err := identity.CredentialsFromEnv()
 	if err != nil {
-		return nil, errors.Errorf("failed to retrive cred from env : %v", err)
+		return nil, errors.Errorf("failed to retrieve cred from env : %v", err)
 	}
 	if creds.Region == "" {
 		return nil, errors.NewNotFound(nil, "OS_REGION_NAME environment variable not set")

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -627,7 +627,9 @@ func (manager *Manager) pinned(namespace, modelUUID string) map[string][]string 
 func (manager *Manager) leases(namespace, modelUUID string) map[string]string {
 	leases := make(map[string]string)
 	for key, lease := range manager.config.Store.Leases() {
-		leases[key.Lease] = lease.Holder
+		if key.Namespace == namespace && key.ModelUUID == modelUUID {
+			leases[key.Lease] = lease.Holder
+		}
 	}
 	return leases
 }


### PR DESCRIPTION
## Description of change

The bound lease reader wasn't filtering leases by namespace and model before adding them to the map of lease -> holder, so if you have two models with the same application but different units are the leader
in each, status would show the leadership flapping for them (although the actual leadership wasn't changing).

Filtering by the namespace and model passed in fixes the flapping, but a better fix is to use the changed structure of the FSM (to group leases by namespace and model) to get the leaders directly. That will follow in a later PR.

## QA steps

* Bootstrap a controller and add two models.
* Deploy the same application to each model with multiple units.
```
juju bootstrap localhost E --build-agent --verbose --model-default='logging-config="<root>=DEBUG"' --debug  && juju add-model m1 && juju deploy -n4 ~jameinel/ubuntu-lite && juju add-model m2 && juju deploy -n4 ~jameinel/ubuntu-lite
```
* Since unit 0 will very likely be the leader in each model, remove unit 0 from one and wait for the lease to expire.
```
juju remove-unit -m m1 ubuntu-lite/0
```
* Watching status for each model should show distinct consistent leaders in each model.

## Documentation changes
None

## Bug reference
None