### PR TITLE
leases: Fix leadership flapping for multiple models with the same application

### DIFF
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -627,7 +627,9 @@ func (manager *Manager) pinned(namespace, modelUUID string) map[string][]string 
 func (manager *Manager) leases(namespace, modelUUID string) map[string]string {
 	leases := make(map[string]string)
 	for key, lease := range manager.config.Store.Leases() {
-		leases[key.Lease] = lease.Holder
+		if key.Namespace == namespace && key.ModelUUID == modelUUID {
+			leases[key.Lease] = lease.Holder
+		}
 	}
 	return leases
 }


### PR DESCRIPTION
## Description of change

The bound lease reader wasn't filtering leases by namespace and model before adding them to the map of lease -> holder, so if you have two models with the same application but different units are the leader
in each, status would show the leadership flapping for them (although the actual leadership wasn't changing).

Filtering by the namespace and model passed in fixes the flapping, but a better fix is to use the changed structure of the FSM (to group leases by namespace and model) to get the leaders directly. That will follow in a later PR.

This is a trivial backport of #10306 

## QA steps

* Bootstrap a controller and add two models.
* Deploy the same application to each model with multiple units.
```
juju bootstrap localhost E --build-agent --verbose --model-default='logging-config="<root>=DEBUG"' --debug  && juju add-model m1 && juju deploy -n4 ~jameinel/ubuntu-lite && juju add-model m2 && juju deploy -n4 ~jameinel/ubuntu-lite
```
* Since unit 0 will very likely be the leader in each model, remove unit 0 from one and wait for the lease to expire.
```
juju remove-unit -m m1 ubuntu-lite/0
```
* Watching status for each model should show distinct consistent leaders in each model.

## Documentation changes
None

## Bug reference
None