### PR TITLE
Enforce change block on attach-resource/attach.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -541,6 +541,17 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			}
 			return rst, st, entity.Tag(), nil
 		},
+		ChangeAllowedFunc: func(req *http.Request) error {
+			st, err := httpCtxt.stateForRequestUnauthenticated(req)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			blockChecker := common.NewBlockChecker(st)
+			if err := blockChecker.ChangeAllowed(); err != nil {
+				return errors.Trace(err)
+			}
+			return nil
+		},
 	}
 	unitResourcesHandler := &UnitResourcesHandler{
 		NewOpener: func(req *http.Request, tagKinds ...string) (resource.Opener, state.PoolHelper, error) {

--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -27,6 +27,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     add-unit
     add-ssh-key
     add-user
+    attach-resource
     attach-storage
     change-user-password
     config

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/resource"
 )
@@ -155,5 +156,8 @@ func (c *UploadCommand) upload(rf resourceValue, client UploadClient) error {
 	}
 	defer f.Close()
 	err = client.Upload(rf.application, rf.name, rf.value, f)
-	return errors.Trace(err)
+	if err := block.ProcessBlockedError(err, block.BlockChange); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Description of change

Added change block checks for attach-resource/attach.

## QA steps

`juju disable-command all`
`juju attach-resource <application-name> name=<resource name>`
```
ERROR failed to upload resource "name": the operation has been blocked

All operations that change model have been disabled for the current model.
To enable changes, run

    juju enable-command all
```

## Documentation changes

CLI doc for enable-command and disable-command was updated.

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1832255](https://bugs.launchpad.net/juju/+bug/1832255)