### PR TITLE
Missing commands and calls for blocked changes.

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1581,6 +1581,9 @@ func (api *APIBase) ScaleApplications(args params.ScaleApplicationsParams) (para
 	if err := api.checkCanWrite(); err != nil {
 		return params.ScaleApplicationResults{}, errors.Trace(err)
 	}
+	if err := api.check.ChangeAllowed(); err != nil {
+		return params.ScaleApplicationResults{}, errors.Trace(err)
+	}
 	scaleApplication := func(arg params.ScaleApplicationParams) (*params.ScaleApplicationInfo, error) {
 		if arg.Scale < 0 && arg.ScaleChange == 0 {
 			return nil, errors.NotValidf("scale < 0")

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -863,6 +863,18 @@ func (s *ApplicationSuite) TestScaleApplicationsCAASModel(c *gc.C) {
 	app.CheckCall(c, 0, "Scale", 5)
 }
 
+func (s *ApplicationSuite) TestScaleApplicationsBlocked(c *gc.C) {
+	application.SetModelType(s.api, state.ModelTypeCAAS)
+	s.blockChecker.SetErrors(common.ServerError(common.OperationBlockedError("test block")))
+	_, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{{
+			ApplicationTag: "application-postgresql",
+			Scale:          5,
+		}}})
+	c.Assert(err, gc.ErrorMatches, "test block")
+	c.Assert(err, jc.Satisfies, params.IsCodeOperationBlocked)
+}
+
 func (s *ApplicationSuite) TestScaleApplicationsCAASModelScaleChange(c *gc.C) {
 	application.SetModelType(s.api, state.ModelTypeCAAS)
 	s.backend.applications["postgresql"].scale = 2

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/applicationoffers"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
 )
@@ -170,7 +171,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 	}
 	localName, err := targetClient.Consume(arg)
 	if err != nil {
-		return errors.Trace(err)
+		return block.ProcessBlockedError(errors.Annotatef(err, "could consume %v", url.AsLocal().String()), block.BlockChange)
 	}
 	ctx.Infof("Added %s as %s", c.remoteApplication, localName)
 	return nil

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -171,7 +171,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 	}
 	localName, err := targetClient.Consume(arg)
 	if err != nil {
-		return block.ProcessBlockedError(errors.Annotatef(err, "could consume %v", url.AsLocal().String()), block.BlockChange)
+		return block.ProcessBlockedError(errors.Annotatef(err, "could not consume %v", url.AsLocal().String()), block.BlockChange)
 	}
 	ctx.Infof("Added %s as %s", c.remoteApplication, localName)
 	return nil

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -88,7 +88,7 @@ func (s *ConsumeSuite) TestConsumeBlocked(c *gc.C) {
 	s.mockAPI.SetErrors(nil, &params.Error{Code: params.CodeOperationBlocked, Message: "nope"})
 	_, err := s.runConsume(c, "model.application")
 	s.mockAPI.CheckCallNames(c, "GetConsumeDetails", "Consume", "Close", "Close")
-	c.Assert(err.Error(), jc.Contains, `could consume bob/model.application: nope`)
+	c.Assert(err.Error(), jc.Contains, `could not consume bob/model.application: nope`)
 	c.Assert(err.Error(), jc.Contains, `All operations that change model have been disabled for the current model.`)
 }
 

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -84,6 +84,14 @@ func (s *ConsumeSuite) TestErrorFromAPI(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "infirmary")
 }
 
+func (s *ConsumeSuite) TestConsumeBlocked(c *gc.C) {
+	s.mockAPI.SetErrors(nil, &params.Error{Code: params.CodeOperationBlocked, Message: "nope"})
+	_, err := s.runConsume(c, "model.application")
+	s.mockAPI.CheckCallNames(c, "GetConsumeDetails", "Consume", "Close", "Close")
+	c.Assert(err.Error(), jc.Contains, `could consume bob/model.application: nope`)
+	c.Assert(err.Error(), jc.Contains, `All operations that change model have been disabled for the current model.`)
+}
+
 func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 	s.mockAPI.localName = "mary-weep"
 	var (

--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -104,7 +105,8 @@ func (c *scaleApplicationCommand) Run(ctx *cmd.Context) error {
 		Scale:           c.scale,
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return block.ProcessBlockedError(errors.Annotatef(err, "could not scale application %q", c.applicationName), block.BlockChange)
+
 	}
 	if err := result.Error; err != nil {
 		return err

--- a/cmd/juju/application/scaleapplication_test.go
+++ b/cmd/juju/application/scaleapplication_test.go
@@ -72,6 +72,13 @@ func (s *ScaleApplicationSuite) TestScaleApplication(c *gc.C) {
 	c.Assert(out, gc.Equals, `foo scaled to 2 units`)
 }
 
+func (s *ScaleApplicationSuite) TestScaleApplicationBlocked(c *gc.C) {
+	s.mockAPI.SetErrors(&params.Error{Code: params.CodeOperationBlocked, Message: "nope"})
+	_, err := s.runScaleApplication(c, "foo", "2")
+	c.Assert(err.Error(), jc.Contains, `could not scale application "foo": nope`)
+	c.Assert(err.Error(), jc.Contains, `All operations that change model have been disabled for the current model.`)
+}
+
 func (s *ScaleApplicationSuite) TestScaleApplicationWrongModel(c *gc.C) {
 	store := jujuclienttesting.MinimalStore()
 	_, err := cmdtesting.RunCommand(c, NewScaleCommandForTest(s.mockAPI, store), "foo", "2")

--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -43,6 +43,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     import-ssh-key
     model-defaults
     model-config
+    reload-spaces
     remove-application
     remove-machine
     remove-relation
@@ -52,6 +53,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     resolved
     retry-provisioning
     run
+    scale-application
     set-credential
     set-constraints
     set-series

--- a/cmd/juju/model/setcredential.go
+++ b/cmd/juju/model/setcredential.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -150,7 +151,7 @@ func (c *modelCredentialCommand) Run(ctx *cmd.Context) error {
 
 	err = modelClient.ChangeModelCredential(modelTag, credentialTag)
 	if err != nil {
-		return fail(errors.Trace(err))
+		return block.ProcessBlockedError(errors.Annotate(err, "could not set model credential"), block.BlockChange)
 	}
 	ctx.Infof("Changed cloud credential on model %q to %q.", modelName, c.credential)
 	return nil

--- a/cmd/juju/model/setcredential_test.go
+++ b/cmd/juju/model/setcredential_test.go
@@ -162,9 +162,8 @@ func (s *ModelCredentialCommandSuite) TestSetCredentialErred(c *gc.C) {
 	s.modelClient.SetErrors(errors.New("kaboom"))
 	err := s.assertRemoteCredentialFound(c, `
 Found credential remotely, on the controller. Not looking locally...
-Failed to change model credential: kaboom
 `[1:])
-	c.Assert(err, gc.ErrorMatches, "kaboom")
+	c.Assert(err, gc.ErrorMatches, "could not set model credential: kaboom")
 }
 
 func (s *ModelCredentialCommandSuite) TestSetCredentialBlocked(c *gc.C) {

--- a/cmd/juju/model/setcredential_test.go
+++ b/cmd/juju/model/setcredential_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/model"
 	coremodel "github.com/juju/juju/core/model"
@@ -164,6 +165,15 @@ Found credential remotely, on the controller. Not looking locally...
 Failed to change model credential: kaboom
 `[1:])
 	c.Assert(err, gc.ErrorMatches, "kaboom")
+}
+
+func (s *ModelCredentialCommandSuite) TestSetCredentialBlocked(c *gc.C) {
+	s.modelClient.SetErrors(&params.Error{Code: params.CodeOperationBlocked, Message: "nope"})
+	err := s.assertRemoteCredentialFound(c, `
+Found credential remotely, on the controller. Not looking locally...
+`[1:])
+	c.Assert(err.Error(), jc.Contains, `could not set model credential: nope`)
+	c.Assert(err.Error(), jc.Contains, `All operations that change model have been disabled for the current model.`)
 }
 
 func (s *ModelCredentialCommandSuite) assertRemoteCredentialFound(c *gc.C, expectedStderr string) error {

--- a/cmd/juju/space/add.go
+++ b/cmd/juju/space/add.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -73,7 +74,7 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 			if params.IsCodeUnauthorized(err) {
 				common.PermissionsMessage(ctx.Stderr, "add a space")
 			}
-			return errors.Annotatef(err, "cannot add space %q", c.Name)
+			return block.ProcessBlockedError(errors.Annotatef(err, "cannot add space %q", c.Name), block.BlockChange)
 		}
 
 		ctx.Infof("added space %q with %s", c.Name, msgSuffix)

--- a/cmd/juju/space/reload.go
+++ b/cmd/juju/space/reload.go
@@ -45,7 +45,7 @@ func (c *ReloadCommand) Run(ctx *cmd.Context) error {
 			if errors.IsNotSupported(err) {
 				ctx.Infof("cannot reload spaces: %v", err)
 			}
-			return block.ProcessBlockedError(errors.Annotate(err, "cannot reload spaces"), block.BlockChange)
+			return block.ProcessBlockedError(errors.Annotate(err, "could not reload spaces"), block.BlockChange)
 		}
 		return nil
 	})

--- a/cmd/juju/space/reload.go
+++ b/cmd/juju/space/reload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -44,7 +45,7 @@ func (c *ReloadCommand) Run(ctx *cmd.Context) error {
 			if errors.IsNotSupported(err) {
 				ctx.Infof("cannot reload spaces: %v", err)
 			}
-			return errors.Annotate(err, "cannot reload spaces")
+			return block.ProcessBlockedError(errors.Annotate(err, "cannot reload spaces"), block.BlockChange)
 		}
 		return nil
 	})

--- a/cmd/juju/storage/attach.go
+++ b/cmd/juju/storage/attach.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -85,7 +86,7 @@ func (c *attachStorageCommand) Run(ctx *cmd.Context) error {
 		if params.IsCodeUnauthorized(err) {
 			common.PermissionsMessage(ctx.Stderr, "attach storage")
 		}
-		return errors.Trace(err)
+		return block.ProcessBlockedError(errors.Annotatef(err, "could not attach storage %v", c.storageIds), block.BlockChange)
 	}
 	for i, result := range results {
 		if result.Error == nil {

--- a/cmd/juju/storage/attach_test.go
+++ b/cmd/juju/storage/attach_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"regexp"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"
@@ -56,7 +57,7 @@ func (s *AttachStorageSuite) TestAttachUnauthorizedError(c *gc.C) {
 	fake.SetErrors(nil, &params.Error{Code: params.CodeUnauthorized, Message: "nope"})
 	cmd := storage.NewAttachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
 	ctx, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1")
-	c.Assert(err, gc.ErrorMatches, "nope")
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("could not attach storage [bar/1]: nope"))
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 You do not have permission to attach storage.
 You may ask an administrator to grant you access with "juju grant".

--- a/cmd/juju/storage/attach_test.go
+++ b/cmd/juju/storage/attach_test.go
@@ -4,12 +4,13 @@
 package storage_test
 
 import (
+	"regexp"
+
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"regexp"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"

--- a/cmd/juju/storage/attach_test.go
+++ b/cmd/juju/storage/attach_test.go
@@ -64,6 +64,15 @@ You may ask an administrator to grant you access with "juju grant".
 `)
 }
 
+func (s *AttachStorageSuite) TestAttachBlocked(c *gc.C) {
+	var fake fakeEntityAttacher
+	fake.SetErrors(nil, &params.Error{Code: params.CodeOperationBlocked, Message: "nope"})
+	cmd := storage.NewAttachStorageCommandForTest(fake.new, jujuclienttesting.MinimalStore())
+	_, err := cmdtesting.RunCommand(c, cmd, "foo/0", "bar/1")
+	c.Assert(err.Error(), jc.Contains, `could not attach storage [bar/1]: nope`)
+	c.Assert(err.Error(), jc.Contains, `All operations that change model have been disabled for the current model.`)
+}
+
 func (s *AttachStorageSuite) TestAttachInitErrors(c *gc.C) {
 	s.testAttachInitError(c, []string{}, "attach-storage requires a unit ID and at least one storage ID")
 	s.testAttachInitError(c, []string{"unit/0"}, "attach-storage requires a unit ID and at least one storage ID")


### PR DESCRIPTION
## Description of change

This PR adds commands and api calls that should be prevented by CHANGE block.

* [only cli addition is needed, apiserver is done] attach-storage
* [only cli addition is needed, apiserver is done] consume
* reload-spaces
* add-space
* scale-application
* [only cli addition is needed, apiserver is done]  set-credential

## Bug reference

https://bugs.launchpad.net/juju/+bug/1832255
