### PR TITLE
2.7 remove vestigial code

### DIFF
--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -154,10 +154,9 @@ type watchInfo struct {
 }
 
 type event struct {
-	ch        chan<- Change
-	key       watchKey
-	isDeleted bool
-	revno     int64
+	ch    chan<- Change
+	key   watchKey
+	revno int64
 }
 
 // Period is the delay between each sync.
@@ -600,10 +599,9 @@ func (w *Watcher) sync() error {
 						continue
 					}
 					evt := event{
-						ch:        info.ch,
-						key:       key,
-						isDeleted: revno == -1,
-						revno:     revno,
+						ch:    info.ch,
+						key:   key,
+						revno: revno,
 					}
 					w.syncEvents = append(w.syncEvents, evt)
 				}
@@ -613,10 +611,9 @@ func (w *Watcher) sync() error {
 					if revno > info.revno || revno < 0 && info.revno >= 0 {
 						infos[i].revno = revno
 						evt := event{
-							ch:        info.ch,
-							key:       key,
-							isDeleted: revno == -1,
-							revno:     revno,
+							ch:    info.ch,
+							key:   key,
+							revno: revno,
 						}
 						w.syncEvents = append(w.syncEvents, evt)
 					}

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -608,7 +608,7 @@ func (w *Watcher) sync() error {
 				// Queue notifications for per-document watches.
 				infos := w.watches[key]
 				for i, info := range infos {
-					if revno > info.revno || revno < 0 && info.revno >= 0 {
+					if revno > info.revno || (revno < 0 && info.revno >= 0) {
 						infos[i].revno = revno
 						evt := event{
 							ch:    info.ch,


### PR DESCRIPTION
## Description of change

While we were auditing the txn-revno stuff, we found a bit of vestigial code, so just clean it up, and update some parentheses so humans have an easier time understanding the code.

## QA steps

Nothing functional should change.

## Documentation changes

None.

## Bug reference

None.
