### PR TITLE
Ensure Correct Publication of Machine Provisioned Events from Model Cache

### DIFF
--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -21,7 +21,7 @@ type ApplicationSuite struct {
 var _ = gc.Suite(&ApplicationSuite{})
 
 func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
-	m := s.NewApplication(appChange)
+	m := s.NewApplication(appChange, nil)
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(0))
 	m.Config()
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(1))
@@ -32,7 +32,7 @@ func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
 // See model_test.go for other config watcher tests.
 // Here we just check that WatchConfig is wired up properly.
 func (s *ApplicationSuite) TestConfigWatcherChange(c *gc.C) {
-	a := s.NewApplication(appChange)
+	a := s.NewApplication(appChange, nil)
 	w := a.WatchConfig()
 
 	// The worker is the first and only resource (1).

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -324,7 +324,7 @@ func (s *lxdProfileWatcherSuite) newUnit(c *gc.C, machineId, principal string, c
 }
 
 func (s *lxdProfileWatcherSuite) setupOneMachineLXDProfileWatcherScenario(c *gc.C) {
-	s.model = s.NewModel(modelChange)
+	s.model = s.NewModel(modelChange, nil)
 
 	s.model.UpdateMachine(machineChange, s.Manager)
 	machine, err := s.model.Machine(machineChange.Id)
@@ -372,7 +372,7 @@ func (s *lxdProfileWatcherSuite) assertStartOneMachineWatcher(c *gc.C) *cache.Ma
 }
 
 func (s *lxdProfileWatcherSuite) assertStartOneMachineNotProvisionedWatcher(c *gc.C) *cache.MachineLXDProfileWatcher {
-	s.model = s.NewModel(modelChange)
+	s.model = s.NewModel(modelChange, nil)
 
 	mChange := cache.MachineChange{
 		ModelUUID: "model-uuid",

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -174,11 +174,12 @@ func (m *Machine) setDetails(details MachineChange) {
 
 	m.setStale(false)
 
-	if details.InstanceId != m.details.InstanceId {
+	provisioned := details.InstanceId != m.details.InstanceId
+	m.details = details
+
+	if provisioned {
 		m.model.hub.Publish(m.topic(machineProvisioned), nil)
 	}
-
-	m.details = details
 
 	configHash, err := hash(details.Config)
 	if err != nil {

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -23,7 +23,7 @@ type ModelSuite struct {
 var _ = gc.Suite(&ModelSuite{})
 
 func (s *ModelSuite) TestReport(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{
 		"name":              "model-owner/test-model",
 		"life":              life.Value("alive"),
@@ -36,7 +36,7 @@ func (s *ModelSuite) TestReport(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfig(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	c.Assert(m.Config(), jc.DeepEquals, map[string]interface{}{
 		"key":     "value",
 		"another": "foo",
@@ -44,12 +44,12 @@ func (s *ModelSuite) TestConfig(c *gc.C) {
 }
 
 func (s *ModelSuite) TestNewModelGeneratesHash(c *gc.C) {
-	s.NewModel(modelChange)
+	s.NewModel(modelChange, nil)
 	c.Check(testutil.ToFloat64(s.Gauges.ModelHashCacheMiss), gc.Equals, float64(1))
 }
 
 func (s *ModelSuite) TestModelConfigIncrementsReadCount(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	c.Check(testutil.ToFloat64(s.Gauges.ModelConfigReads), gc.Equals, float64(0))
 	m.Config()
 	c.Check(testutil.ToFloat64(s.Gauges.ModelConfigReads), gc.Equals, float64(1))
@@ -61,7 +61,7 @@ func (s *ModelSuite) TestModelConfigIncrementsReadCount(c *gc.C) {
 // watcher, but using a cached model avoids the need to put scaffolding code in
 // export_test.go to create a watcher in isolation.
 func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig()
 	wc := NewNotifyWatcherC(c, w)
 	// Sends initial event.
@@ -70,7 +70,7 @@ func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig()
 	defer workertest.CleanKill(c, w)
 	wc := NewNotifyWatcherC(c, w)
@@ -93,7 +93,7 @@ func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig("key")
 	defer workertest.CleanKill(c, w)
 	wc := NewNotifyWatcherC(c, w)
@@ -111,7 +111,7 @@ func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig("key")
 
 	// The worker is the first and only resource (1).
@@ -137,7 +137,7 @@ func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherSameValuesCacheHit(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 
 	w := m.WatchConfig("key", "another")
 	defer workertest.CleanKill(c, w)
@@ -153,31 +153,31 @@ func (s *ModelSuite) TestConfigWatcherSameValuesCacheHit(c *gc.C) {
 }
 
 func (s *ModelSuite) TestApplicationNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Application("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestCharmNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Charm("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestMachineNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Machine("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestUnitNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Unit("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestUnitReturnsCopy(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	m.UpdateUnit(unitChange, s.Manager)
 
 	u1, err := m.Unit(unitChange.Name)
@@ -194,13 +194,13 @@ func (s *ModelSuite) TestUnitReturnsCopy(c *gc.C) {
 }
 
 func (s *ModelSuite) TestBranchNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Branch("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestBranchReturnsCopy(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	m.UpdateBranch(branchChange, s.Manager)
 
 	b1, err := m.Branch(branchChange.Name)

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -72,19 +72,27 @@ func (s *EntitySuite) SetUpTest(c *gc.C) {
 	s.Gauges = createControllerGauges()
 }
 
-func (s *EntitySuite) NewModel(details ModelChange) *Model {
-	m := newModel(s.Gauges, s.newHub(), s.Manager.new())
+func (s *EntitySuite) NewModel(details ModelChange, hub *pubsub.SimpleHub) *Model {
+	if hub == nil {
+		hub = s.NewHub()
+	}
+
+	m := newModel(s.Gauges, hub, s.Manager.new())
 	m.setDetails(details)
 	return m
 }
 
-func (s *EntitySuite) NewApplication(details ApplicationChange) *Application {
-	a := newApplication(s.Gauges, s.newHub(), s.NewResident())
+func (s *EntitySuite) NewApplication(details ApplicationChange, hub *pubsub.SimpleHub) *Application {
+	if hub == nil {
+		hub = s.NewHub()
+	}
+
+	a := newApplication(s.Gauges, hub, s.NewResident())
 	a.SetDetails(details)
 	return a
 }
 
-func (s *EntitySuite) newHub() *pubsub.SimpleHub {
+func (s *EntitySuite) NewHub() *pubsub.SimpleHub {
 	logger := loggo.GetLogger("test")
 	logger.SetLogLevel(loggo.TRACE)
 	return pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{


### PR DESCRIPTION
## Description of change

This patch fixes an edge case where if a machine arrives in the model cache already provisioned, then this fact is published on a topic with an empty machine ID prefix.

Now we set the machine details before publishing so the correct topic is used.

Some minor test infrastructure changes are included to allow flexibility with the testing hub.

## QA steps

New test fails before change; passes after.

## Documentation changes

None.

## Bug reference

N/A
