### PR TITLE
raft leases: use fast path to get leadership for a model (2.6 forward merge)

### DIFF
--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -37,6 +37,13 @@ type Store interface {
 	// Supplying any lease keys will filter the return for those requested.
 	Leases(keys ...Key) map[Key]Info
 
+	// LeaseGroup returns a snapshot of all of the leases for a
+	// particular namespace/model combination. This is useful for
+	// reporting holder information for a model, and can often be
+	// implemented more efficiently than getting all leases when there
+	// are many models.
+	LeaseGroup(namespace, modelUUID string) map[Key]Info
+
 	// Refresh reads all lease state from the database.
 	Refresh() error
 

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -135,6 +135,21 @@ func (s *leaseStore) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	return results
 }
 
+// LeaseGroup is part of lease.Store.
+func (s *leaseStore) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
+	leases := s.Leases()
+	if len(leases) == 0 {
+		return leases
+	}
+	results := make(map[lease.Key]lease.Info)
+	for key, info := range leases {
+		if key.Namespace == namespace && key.ModelUUID == modelUUID {
+			results[key] = info
+		}
+	}
+	return results
+}
+
 // Refresh is part of lease.Store.
 func (s *leaseStore) Refresh() error {
 	return nil

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -108,6 +108,17 @@ func (store *store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	return leases
 }
 
+// LeaseGroup is part of the lease.Store interface. For the state
+// store it's identical to Leases() because each store is specific to
+// a namespace/model combination.
+func (store *store) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
+	cfg := store.config
+	if namespace != cfg.Namespace || modelUUID != cfg.ModelUUID {
+		return nil
+	}
+	return store.Leases()
+}
+
 // ClaimLease is part of the lease.Store interface.
 func (store *store) ClaimLease(key lease.Key, request lease.Request, _ <-chan struct{}) error {
 	return store.request(key.Lease, request, store.claimLeaseOps, "claiming")

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -626,10 +626,8 @@ func (manager *Manager) pinned(namespace, modelUUID string) map[string][]string 
 
 func (manager *Manager) leases(namespace, modelUUID string) map[string]string {
 	leases := make(map[string]string)
-	for key, lease := range manager.config.Store.Leases() {
-		if key.Namespace == namespace && key.ModelUUID == modelUUID {
-			leases[key.Lease] = lease.Holder
-		}
+	for key, lease := range manager.config.Store.LeaseGroup(namespace, modelUUID) {
+		leases[key.Lease] = lease.Holder
 	}
 	return leases
 }

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -123,6 +123,17 @@ func (store *Store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	return result
 }
 
+// LeaseGroup is part of the lease.Store interface.
+func (store *Store) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
+	results := make(map[lease.Key]lease.Info)
+	for key, info := range store.Leases() {
+		if key.Namespace == namespace && key.ModelUUID == modelUUID {
+			results[key] = info
+		}
+	}
+	return results
+}
+
 func (store *Store) closeIfEmpty() {
 	// This must be called with the lock held.
 	if store.runningCalls > 1 {


### PR DESCRIPTION
## Description of change

The raft lease FSM stores leases grouped by namespace+model uuid so there's no need to get all leases and then filter them by model. This can mean a lot more work when there are a lot of models. Add a lease.Store.LeaseGroup interface method to get a group of leases, and add it to all of the store implementations.

This is a trivial forward-merge of #10316 from the 2.5 branch.

## QA steps

* Bootstrap a controller, add two models and deploy an application with multiple units in each model.
```
juju bootstrap localhost E --build-agent --verbose --model-default='logging-config="<root>=DEBUG"' --model-default="enable-os-upgrade=false" --debug  && juju add-model m1 && juju deploy -n4 ~jameinel/ubuntu-lite && juju add-model m2 && juju deploy -n4 ~jameinel/ubuntu-lite
```
* Once all the units are ready remove unit 0 in one of the models (to see the leadership change).
```
juju remove-unit -m m1 ubuntu-lite/0
```
* Status in each model shows different leaders.
* Removing the leader shows leadership being claimed by another unit once the lease expires.

## Documentation changes

None

## Bug reference

None
