### PR TITLE
2.6 - Fix Model Cache Restart and All-Watcher Shutdown

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1573,9 +1573,8 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 
 	st, err := b.getState(modelUUID)
 	if err != nil {
-		if exists, modelErr := b.st.ModelExists(modelUUID); exists && modelErr == nil {
-			// The entity's model is gone so remove the entity
-			// from the store.
+		if errors.IsNotFound(err) {
+			// The entity's model is gone so remove the entity from the store.
 			_ = doc.removed(all, modelUUID, id, nil)
 			return nil
 		}

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -318,7 +318,12 @@ func (sm *storeManager) respond() {
 		changes := sm.all.ChangesSince(revno)
 		if len(changes) == 0 {
 			if req.noChanges != nil {
-				req.noChanges <- struct{}{}
+				select {
+				case req.noChanges <- struct{}{}:
+				case <-sm.tomb.Dying():
+					return
+				}
+
 				sm.removeWaitingReq(w, req)
 			}
 			continue
@@ -326,10 +331,13 @@ func (sm *storeManager) respond() {
 
 		req.changes = changes
 		w.revno = sm.all.latestRevno
+
 		select {
 		case req.reply <- true:
 		case <-sm.tomb.Dying():
+			return
 		}
+
 		sm.removeWaitingReq(w, req)
 		sm.seen(revno)
 	}

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -163,14 +163,22 @@ func (c *cacheWorker) loop() error {
 			c.watcher = c.config.WatcherFactory()
 			c.mu.Unlock()
 
-			err := c.processWatcher(watcherChanges)
-			if err == nil {
-				// We are done, so exit
+			// processWatcher only returns nil if we are dying.
+			// This condition will be handled at the top of the loop.
+			if err := c.processWatcher(watcherChanges); err != nil {
+				// If the backing watcher has stopped, such as for state going
+				// away altogether, die with an error and let the dependency
+				// engine handle starting us up again.
+				if state.IsErrStopped(err) {
+					_ = c.watcher.Stop()
+					c.catacomb.Kill(err)
+					return
+				}
+
+				// For any other errors, get a new watcher.
+				c.config.Logger.Errorf("watcher error: %v, getting new watcher", err)
 				_ = c.watcher.Stop()
-				return
 			}
-			c.config.Logger.Errorf("watcher error, %v, getting new watcher", err)
-			_ = c.watcher.Stop()
 		}
 	}()
 
@@ -179,7 +187,8 @@ func (c *cacheWorker) loop() error {
 		case <-c.catacomb.Dying():
 			return c.catacomb.ErrDying()
 		case deltas := <-watcherChanges:
-			// Process changes and send info down changes channel
+			// Translate multi-watcher deltas into cache changes
+			// and supply them via the changes channel.
 			for _, d := range deltas {
 				if logger := c.config.Logger; logger.IsTraceEnabled() {
 					logger.Tracef(pretty.Sprint(d))
@@ -204,12 +213,9 @@ func (c *cacheWorker) processWatcher(watcherChanges chan<- []multiwatcher.Delta)
 	for {
 		deltas, err := c.watcher.Next()
 		if err != nil {
-			if state.IsErrStopped(err) {
-				return nil
-			} else {
-				return errors.Trace(err)
-			}
+			return errors.Trace(err)
 		}
+
 		select {
 		case <-c.catacomb.Dying():
 			return nil

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -97,8 +97,7 @@ func (s *WorkerSuite) start(c *gc.C) worker.Worker {
 	w, err := modelcache.NewWorker(config)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
-		// State going away will kill the worker with a non-nil error.
-		workertest.DirtyKill(c, w)
+		workertest.CleanKill(c, w)
 	})
 	return w
 }


### PR DESCRIPTION
## Description of change

This patch does 2 main things:
- If a model is removed, it prevents a running all-watcher from closing.
- If the watcher backing the cache worker is shut down cleanly, that worker exists - for any other error, a new watcher is created and the worker proceeds.

## QA steps

Reproduce:
- With 2.6.3, bootstrap.
- Run `juju debug log -m controller` in a separate terminal.
- `juju destroy-model default -y` and observe the "model not found" errors.

Confirm:
- Same as above and observe that the cache does not bounce, and the "not found" errors are gone.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1832294
