### PR TITLE
Handle the case where the state pool returns NotFound error.

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1428,10 +1428,11 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 
 	st, err := b.getState(modelUUID)
 	if err != nil {
-		if exists, modelErr := b.st.ModelExists(modelUUID); exists && modelErr == nil {
-			// The entity's model is gone so remove the entity
-			// from the store.
-			doc.removed(all, modelUUID, id, nil)
+		// The state pool will return a not found error if the model is
+		// in the process of being removed.
+		if errors.IsNotFound(err) {
+			// The entity's model is gone so remove the entity from the store.
+			_ = doc.removed(all, modelUUID, id, nil)
 			return nil
 		}
 		return errors.Trace(err) // prioritise getState error

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -902,11 +902,23 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 	// Retrieve the unit.
 	unit, err := st.Unit(newInfo.Name)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// It is possible that the event processing is happening slower
+			// than reality and a missing unit isn't that terrible.
+			logger.Debugf("unit %q not in DB", newInfo.Name)
+			return nil
+		}
 		return errors.Annotatef(err, "cannot retrieve unit %q", newInfo.Name)
 	}
 	// A change in a unit's status might also affect its application.
 	application, err := unit.Application()
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// It is possible that the event processing is happening slower
+			// than reality and a missing application isn't that terrible.
+			logger.Debugf("application for unit %q not in DB", newInfo.Name)
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	applicationId, ok := backingEntityIdForGlobalKey(st.ModelUUID(), application.globalKey())

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -103,7 +103,11 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 
 	select {
 	case <-w.all.tomb.Dying():
-		return nil, ErrStoppedf("shared state watcher")
+		err := w.all.tomb.Err()
+		if err == nil {
+			err = ErrStoppedf("shared state watcher")
+		}
+		return nil, err
 	case w.all.request <- req:
 	}
 
@@ -113,7 +117,11 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 	// the Multiwatcher, request, and storeManager types.
 	select {
 	case <-w.all.tomb.Dying():
-		return nil, ErrStoppedf("shared state watcher")
+		err := w.all.tomb.Err()
+		if err == nil {
+			err = ErrStoppedf("shared state watcher")
+		}
+		return nil, err
 	case ok := <-req.reply:
 		if !ok {
 			return nil, errors.Trace(NewErrStopped())

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -753,12 +753,30 @@ func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) 
 		c.Check(sm.Stop(), gc.ErrorMatches, "some error")
 	}()
 	w := &Multiwatcher{all: sm}
+
 	// Receive one delta to make sure that the storeManager
 	// has seen the initial state.
 	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{Id: "0"}}}, "")
 	c.Logf("setting fetch error")
 	b.setFetchError(errors.New("some error"))
+
 	c.Logf("updating entity")
+	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
+	checkNext(c, w, nil, "some error")
+}
+
+func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerStop(c *gc.C) {
+	b := newTestBacking([]multiwatcher.EntityInfo{&multiwatcher.MachineInfo{Id: "0"}})
+	sm := newStoreManager(b)
+	w := &Multiwatcher{all: sm}
+
+	// Receive one delta to make sure that the storeManager
+	// has seen the initial state.
+	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{Id: "0"}}}, "")
+
+	// Stop the the store manager cleanly and check that
+	// the next update returns ErrStopped.
+	c.Check(sm.Stop(), jc.ErrorIsNil)
 	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
 	checkNext(c, w, nil, ErrStoppedf("shared state watcher").Error())
 }

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -657,6 +657,7 @@ func (*storeManagerSuite) TestRunStop(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	d, err := w.Next()
 	c.Assert(err, gc.ErrorMatches, "shared state watcher was stopped")
+	c.Assert(err, jc.Satisfies, IsErrStopped)
 	c.Assert(d, gc.HasLen, 0)
 }
 
@@ -742,7 +743,7 @@ func (*storeManagerSuite) TestMultiwatcherStop(c *gc.C) {
 	w := &Multiwatcher{all: sm}
 	err := w.Stop()
 	c.Assert(err, jc.ErrorIsNil)
-	checkNext(c, w, nil, ErrStopped.Error())
+	checkNext(c, w, nil, NewErrStopped().Error())
 }
 
 func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) {
@@ -759,7 +760,7 @@ func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) 
 	b.setFetchError(errors.New("some error"))
 	c.Logf("updating entity")
 	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
-	checkNext(c, w, nil, `shared state watcher was stopped`)
+	checkNext(c, w, nil, ErrStoppedf("shared state watcher").Error())
 }
 
 func StoreIncRef(a *multiwatcherStore, id interface{}) {


### PR DESCRIPTION
This happens if a model is dying and being removed from the pool, but isn't yet removed.

## Bug reference

Partial fix for https://bugs.launchpad.net/juju/+bug/1832294
