### PR TITLE
Kill modelcache worker on watcher error.

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1573,9 +1573,10 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 
 	st, err := b.getState(modelUUID)
 	if err != nil {
-		if exists, modelErr := b.st.ModelExists(modelUUID); exists && modelErr == nil {
-			// The entity's model is gone so remove the entity
-			// from the store.
+		// The state pool will return a not found error if the model is
+		// in the process of being removed.
+		if errors.IsNotFound(err) {
+			// The entity's model is gone so remove the entity from the store.
 			_ = doc.removed(all, modelUUID, id, nil)
 			return nil
 		}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1384,6 +1384,26 @@ func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBacking() Backing {
 	return NewAllModelWatcherStateBacking(s.state, s.pool)
 }
 
+func (s *allModelWatcherStateSuite) TestMissingModelNotError(c *gc.C) {
+	b := s.NewAllModelWatcherStateBacking()
+	defer b.Release()
+	all := newStore()
+
+	dyingModel := "fake-uuid"
+	st, err := s.pool.Get(dyingModel)
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Release()
+
+	removed, err := s.pool.Remove(dyingModel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(removed, jc.IsFalse)
+
+	// If the state pool is in the process of removing a model, it will
+	// return a NotFound error.
+	err = b.Changed(all, watcher.Change{C: modelsC, Id: dyingModel})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 // performChangeTestCases runs a passed number of test cases for changes.
 func (s *allModelWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFuncs []changeTestFunc) {
 	for i, changeTestFunc := range changeTestFuncs {
@@ -4241,7 +4261,7 @@ func (tw *testWatcher) AssertNoChange(c *gc.C) {
 func (tw *testWatcher) AssertChanges(c *gc.C, expected int) {
 	var count int
 	tw.st.StartSync()
-	maxWait := tw.st.clock().After(testing.LongWait)
+	maxWait := time.After(testing.LongWait)
 done:
 	for {
 		select {

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -318,7 +318,12 @@ func (sm *storeManager) respond() {
 		changes := sm.all.ChangesSince(revno)
 		if len(changes) == 0 {
 			if req.noChanges != nil {
-				req.noChanges <- struct{}{}
+				select {
+				case req.noChanges <- struct{}{}:
+				case <-sm.tomb.Dying():
+					return
+				}
+
 				sm.removeWaitingReq(w, req)
 			}
 			continue
@@ -326,10 +331,13 @@ func (sm *storeManager) respond() {
 
 		req.changes = changes
 		w.revno = sm.all.latestRevno
+
 		select {
 		case req.reply <- true:
 		case <-sm.tomb.Dying():
+			return
 		}
+
 		sm.removeWaitingReq(w, req)
 		sm.seen(revno)
 	}

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -103,7 +103,11 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 
 	select {
 	case <-w.all.tomb.Dying():
-		return nil, ErrStoppedf("shared state watcher")
+		err := w.all.tomb.Err()
+		if err == nil {
+			err = ErrStoppedf("shared state watcher")
+		}
+		return nil, err
 	case w.all.request <- req:
 	}
 
@@ -113,7 +117,11 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 	// the Multiwatcher, request, and storeManager types.
 	select {
 	case <-w.all.tomb.Dying():
-		return nil, ErrStoppedf("shared state watcher")
+		err := w.all.tomb.Err()
+		if err == nil {
+			err = ErrStoppedf("shared state watcher")
+		}
+		return nil, err
 	case ok := <-req.reply:
 		if !ok {
 			return nil, errors.Trace(NewErrStopped())

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -753,12 +753,30 @@ func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) 
 		c.Check(sm.Stop(), gc.ErrorMatches, "some error")
 	}()
 	w := &Multiwatcher{all: sm}
+
 	// Receive one delta to make sure that the storeManager
 	// has seen the initial state.
 	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{Id: "0"}}}, "")
 	c.Logf("setting fetch error")
 	b.setFetchError(errors.New("some error"))
+
 	c.Logf("updating entity")
+	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
+	checkNext(c, w, nil, "some error")
+}
+
+func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerStop(c *gc.C) {
+	b := newTestBacking([]multiwatcher.EntityInfo{&multiwatcher.MachineInfo{Id: "0"}})
+	sm := newStoreManager(b)
+	w := &Multiwatcher{all: sm}
+
+	// Receive one delta to make sure that the storeManager
+	// has seen the initial state.
+	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{Id: "0"}}}, "")
+
+	// Stop the the store manager cleanly and check that
+	// the next update returns ErrStopped.
+	c.Check(sm.Stop(), jc.ErrorIsNil)
 	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
 	checkNext(c, w, nil, ErrStoppedf("shared state watcher").Error())
 }

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -163,14 +163,26 @@ func (c *cacheWorker) loop() error {
 			c.watcher = c.config.WatcherFactory()
 			c.mu.Unlock()
 
-			err := c.processWatcher(watcherChanges)
-			if err == nil {
-				// We are done, so exit
+			// processWatcher only returns nil if we are dying.
+			// That condition will be handled at the top of the loop.
+			if err := c.processWatcher(watcherChanges); err != nil {
+				// If the backing watcher has stopped and the watcher's tomb
+				// error is nil, this means a legitimate clean stop.
+				// Die with an error and let the dependency engine handle
+				// starting us up again.
+				if state.IsErrStopped(err) {
+					tombErr := c.watcher.Stop()
+					if tombErr == nil {
+						c.catacomb.Kill(err)
+						return
+					}
+					err = tombErr
+				}
+
+				// For any other errors, get a new watcher.
+				c.config.Logger.Errorf("watcher error: %v, getting new watcher", err)
 				_ = c.watcher.Stop()
-				return
 			}
-			c.config.Logger.Errorf("watcher error, %v, getting new watcher", err)
-			_ = c.watcher.Stop()
 		}
 	}()
 
@@ -179,7 +191,8 @@ func (c *cacheWorker) loop() error {
 		case <-c.catacomb.Dying():
 			return c.catacomb.ErrDying()
 		case deltas := <-watcherChanges:
-			// Process changes and send info down changes channel
+			// Translate multi-watcher deltas into cache changes
+			// and supply them via the changes channel.
 			for _, d := range deltas {
 				if logger := c.config.Logger; logger.IsTraceEnabled() {
 					logger.Tracef(pretty.Sprint(d))
@@ -204,12 +217,9 @@ func (c *cacheWorker) processWatcher(watcherChanges chan<- []multiwatcher.Delta)
 	for {
 		deltas, err := c.watcher.Next()
 		if err != nil {
-			if state.IsErrStopped(err) {
-				return nil
-			} else {
-				return errors.Trace(err)
-			}
+			return errors.Trace(err)
 		}
+
 		select {
 		case <-c.catacomb.Dying():
 			return nil

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -179,7 +179,6 @@ func (c *cacheWorker) loop() error {
 						c.catacomb.Kill(err)
 						return
 					}
-
 				}
 
 				// For any other errors, get a new watcher.
@@ -205,7 +204,7 @@ func (c *cacheWorker) loop() error {
 					select {
 					case c.changes <- value:
 					case <-c.catacomb.Dying():
-						return nil
+						return c.catacomb.ErrDying()
 					}
 				}
 			}

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -581,13 +581,16 @@ func (s *WorkerSuite) TestWatcherErrorStoppedKillsWorker(c *gc.C) {
 	mw := s.StatePool.SystemState().WatchAllModels(s.StatePool)
 	s.config.WatcherFactory = func() modelcache.BackingWatcher { return mw }
 
-	w := s.start(c)
+	config := s.config
+	config.Notify = s.notify
+	w, err := modelcache.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Stop the backing multiwatcher.
 	c.Assert(mw.Stop(), jc.ErrorIsNil)
 
 	// Check that the worker is killed.
-	err := workertest.CheckKilled(c, w)
+	err = workertest.CheckKilled(c, w)
 	c.Assert(err, jc.Satisfies, state.IsErrStopped)
 }
 


### PR DESCRIPTION
If the watcher backing the cache worker is shut down cleanly, that worker exists - for any other error, a new watcher is created and the worker proceeds.

This branch includes the same patch as #10321 and supersedes #10319.

The code is all taken from #10319 and a test to the allwatcher added. Along with a drive by fix for a max wait time. From previous PR:

This patch does 2 main things:
 - If a model is removed, it prevents a running all-watcher from closing.
 - If the watcher backing the cache worker is shut down cleanly, that worker exists - for any other error, a new watcher is created and the worker proceeds.

## QA steps

Reproduce:
 - With 2.6.3, bootstrap.
 - Run juju debug log -m controller in a separate terminal.
 - juju destroy-model default -y and observe the "model not found" errors.

Confirm:
 - Same as above and observe that the cache does not bounce, and the "not found" errors are gone.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1832294
