### PR TITLE
Fix/kill controller removes k8s ns

### DIFF
--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -33,6 +33,7 @@ var (
 	GetLocalMicroK8sConfig   = getLocalMicroK8sConfig
 	AttemptMicroK8sCloud     = attemptMicroK8sCloud
 	EnsureMicroK8sSuitable   = ensureMicroK8sSuitable
+	NewK8sBroker             = newK8sBroker
 )
 
 type (

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -119,8 +119,8 @@ type NewK8sClientFunc func(c *rest.Config) (kubernetes.Interface, apiextensionsc
 // NewK8sWatcherFunc defines a function which returns a k8s watcher based on the supplied config.
 type NewK8sWatcherFunc func(wi watch.Interface, name string, clock jujuclock.Clock) (*kubernetesWatcher, error)
 
-// NewK8sBroker returns a kubernetes client for the specified k8s cluster.
-func NewK8sBroker(
+// newK8sBroker returns a kubernetes client for the specified k8s cluster.
+func newK8sBroker(
 	controllerUUID string,
 	k8sRestConfig *rest.Config,
 	cfg *config.Config,
@@ -154,7 +154,6 @@ func NewK8sBroker(
 		annotations: k8sannotations.New(nil).
 			Add(annotationModelUUIDKey, modelUUID),
 	}
-
 	if controllerUUID != "" {
 		// controllerUUID could be empty in add-k8s without -c because there might be no controller yet.
 		client.annotations.Add(annotationControllerUUIDKey, controllerUUID)
@@ -376,7 +375,13 @@ func (*kubernetesClient) Provider() caas.ContainerEnvironProvider {
 }
 
 // Destroy is part of the Broker interface.
-func (k *kubernetesClient) Destroy(callbacks context.ProviderCallContext) error {
+func (k *kubernetesClient) Destroy(callbacks context.ProviderCallContext) (err error) {
+	defer func() {
+		if k8serrors.ReasonForError(err) == v1.StatusReasonUnknown {
+			logger.Warningf("k8s cluster is not accessible %v", err)
+			err = nil
+		}
+	}()
 	watcher, err := k.WatchNamespace()
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -378,7 +378,7 @@ func (*kubernetesClient) Provider() caas.ContainerEnvironProvider {
 func (k *kubernetesClient) Destroy(callbacks context.ProviderCallContext) (err error) {
 	defer func() {
 		if k8serrors.ReasonForError(err) == v1.StatusReasonUnknown {
-			logger.Warningf("k8s cluster is not accessible %v", err)
+			logger.Warningf("k8s cluster is not accessible: %v", err)
 			err = nil
 		}
 	}()

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -105,7 +105,7 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	broker, err := NewK8sBroker(
+	broker, err := newK8sBroker(
 		args.ControllerUUID, k8sRestConfig, args.Config, newK8sClient, newKubernetesWatcher, jujuclock.WallClock,
 	)
 	if err != nil {


### PR DESCRIPTION
## Description of change

Fix: kill controller cmd now destroys k8s namespaces for caas models from cli;

## QA steps

- bootstrap

```bash
$ juju bootstrap microk8s $CNAME
```

- add-model

```bash
$ juju add-model $MNAME microk8s
$ juju deploy cs:~juju/mariadb-k8s-0
```

- kill controller

```bash
$ juju kill-controller -t 0 -y $CNAME
```

- check if the namespace has been removed

```bash
$ kubectl get ns | grep $MNAME
```


## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1832669