### PR TITLE
Merge 2.6 into develop

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1547,7 +1547,7 @@
   revision = "fd59336b4621bc2a70bf96d9e2f49954115ad19b"
 
 [[projects]]
-  digest = "1:655012e2c1425cab51166b6d34a4edffe358bad76c11b47e0b1e2435101306c8"
+  digest = "1:5081ff05b4471731df7fa7457083397c2663791cd5809858a899306cdfe29b63"
   name = "gopkg.in/juju/worker.v1"
   packages = [
     ".",
@@ -1557,7 +1557,7 @@
     "workertest",
   ]
   pruneopts = ""
-  revision = "5398f2291f2c69afe604411634e0d008bdf453a0"
+  revision = "40da96d5fd22ba01076f56ba5fc6aa06315153c5"
 
 [[projects]]
   digest = "1:01aef8078808543c15a4cc0e669d92d37215564600e19ebabbd694939b727977"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -500,7 +500,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/worker.v1"
-  revision = "5398f2291f2c69afe604411634e0d008bdf453a0"
+  revision = "40da96d5fd22ba01076f56ba5fc6aa06315153c5"
 
 [[override]]
   name = "gopkg.in/macaroon-bakery.v1"

--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -291,6 +291,9 @@ func (c *Client) UpdateUnits(arg params.UpdateApplicationUnits) error {
 	if result.Results[0].Error == nil {
 		return nil
 	}
+	if params.IsCodeForbidden(result.Results[0].Error) {
+		return errors.NewForbidden(result.Results[0].Error, "")
+	}
 	return maybeNotFound(result.Results[0].Error)
 }
 
@@ -307,6 +310,9 @@ func (c *Client) UpdateApplicationService(arg params.UpdateApplicationServiceArg
 	}
 	if result.Results[0].Error == nil {
 		return nil
+	}
+	if params.IsCodeForbidden(result.Results[0].Error) {
+		return errors.NewForbidden(result.Results[0].Error, "")
 	}
 	return maybeNotFound(result.Results[0].Error)
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -541,6 +541,17 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			}
 			return rst, st, entity.Tag(), nil
 		},
+		ChangeAllowedFunc: func(req *http.Request) error {
+			st, err := httpCtxt.stateForRequestUnauthenticated(req)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			blockChecker := common.NewBlockChecker(st)
+			if err := blockChecker.ChangeAllowed(); err != nil {
+				return errors.Trace(err)
+			}
+			return nil
+		},
 	}
 	unitResourcesHandler := &UnitResourcesHandler{
 		NewOpener: func(req *http.Request, tagKinds ...string) (resource.Opener, state.PoolHelper, error) {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1604,6 +1604,9 @@ func (api *APIBase) ScaleApplications(args params.ScaleApplicationsParams) (para
 	if err := api.checkCanWrite(); err != nil {
 		return params.ScaleApplicationResults{}, errors.Trace(err)
 	}
+	if err := api.check.ChangeAllowed(); err != nil {
+		return params.ScaleApplicationResults{}, errors.Trace(err)
+	}
 	scaleApplication := func(arg params.ScaleApplicationParams) (*params.ScaleApplicationInfo, error) {
 		if arg.Scale < 0 && arg.ScaleChange == 0 {
 			return nil, errors.NotValidf("scale < 0")

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -899,6 +899,18 @@ func (s *ApplicationSuite) TestScaleApplicationsCAASModel(c *gc.C) {
 	app.CheckCall(c, 0, "Scale", 5)
 }
 
+func (s *ApplicationSuite) TestScaleApplicationsBlocked(c *gc.C) {
+	application.SetModelType(s.api, state.ModelTypeCAAS)
+	s.blockChecker.SetErrors(common.ServerError(common.OperationBlockedError("test block")))
+	_, err := s.api.ScaleApplications(params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{{
+			ApplicationTag: "application-postgresql",
+			Scale:          5,
+		}}})
+	c.Assert(err, gc.ErrorMatches, "test block")
+	c.Assert(err, jc.Satisfies, params.IsCodeOperationBlocked)
+}
+
 func (s *ApplicationSuite) TestScaleApplicationsCAASModelScaleChange(c *gc.C) {
 	application.SetModelType(s.api, state.ModelTypeCAAS)
 	s.backend.applications["postgresql"].scale = 2

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -33,6 +33,7 @@ var (
 	GetLocalMicroK8sConfig   = getLocalMicroK8sConfig
 	AttemptMicroK8sCloud     = attemptMicroK8sCloud
 	EnsureMicroK8sSuitable   = ensureMicroK8sSuitable
+	NewK8sBroker             = newK8sBroker
 )
 
 type (

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1906,9 +1906,20 @@ func (s *K8sBrokerSuite) TestUpgradeController(c *gc.C) {
 	defer ctrl.Finish()
 
 	ss := apps.StatefulSet{
-		ObjectMeta: v1.ObjectMeta{Name: "controller"},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "controller",
+			Annotations: map[string]string{
+				"juju-version": "1.1.1",
+			},
+			Labels: map[string]string{"juju-operator": "controller"},
+		},
 		Spec: apps.StatefulSetSpec{
 			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"juju-version": "1.1.1",
+					},
+				},
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{Image: "foo"},
@@ -1919,6 +1930,8 @@ func (s *K8sBrokerSuite) TestUpgradeController(c *gc.C) {
 		},
 	}
 	updated := ss
+	updated.Annotations["juju-version"] = "6.6.6"
+	updated.Spec.Template.Annotations["juju-version"] = "6.6.6"
 	updated.Spec.Template.Spec.Containers[1].Image = "juju-operator:6.6.6"
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("controller", v1.GetOptions{IncludeUninitialized: true}).Times(1).
@@ -1936,9 +1949,20 @@ func (s *K8sBrokerSuite) TestUpgradeOperator(c *gc.C) {
 	defer ctrl.Finish()
 
 	ss := apps.StatefulSet{
-		ObjectMeta: v1.ObjectMeta{Name: "test-app-operator"},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-app-operator",
+			Annotations: map[string]string{
+				"juju-version": "1.1.1",
+			},
+			Labels: map[string]string{"juju-app": "test-app"},
+		},
 		Spec: apps.StatefulSetSpec{
 			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"juju-version": "1.1.1",
+					},
+				},
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{Image: "foo"},
@@ -1949,6 +1973,8 @@ func (s *K8sBrokerSuite) TestUpgradeOperator(c *gc.C) {
 		},
 	}
 	updated := ss
+	updated.Annotations["juju-version"] = "6.6.6"
+	updated.Spec.Template.Annotations["juju-version"] = "6.6.6"
 	updated.Spec.Template.Spec.Containers[1].Image = "juju-operator:6.6.6"
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{IncludeUninitialized: true}).Times(1).

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -105,7 +105,7 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	broker, err := NewK8sBroker(
+	broker, err := newK8sBroker(
 		args.ControllerUUID, k8sRestConfig, args.Config, newK8sClient, newKubernetesWatcher, jujuclock.WallClock,
 	)
 	if err != nil {

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/applicationoffers"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
 )
@@ -170,7 +171,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 	}
 	localName, err := targetClient.Consume(arg)
 	if err != nil {
-		return errors.Trace(err)
+		return block.ProcessBlockedError(errors.Annotatef(err, "could not consume %v", url.AsLocal().String()), block.BlockChange)
 	}
 	ctx.Infof("Added %s as %s", c.remoteApplication, localName)
 	return nil

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -84,6 +84,14 @@ func (s *ConsumeSuite) TestErrorFromAPI(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "infirmary")
 }
 
+func (s *ConsumeSuite) TestConsumeBlocked(c *gc.C) {
+	s.mockAPI.SetErrors(nil, &params.Error{Code: params.CodeOperationBlocked, Message: "nope"})
+	_, err := s.runConsume(c, "model.application")
+	s.mockAPI.CheckCallNames(c, "GetConsumeDetails", "Consume", "Close", "Close")
+	c.Assert(err.Error(), jc.Contains, `could not consume bob/model.application: nope`)
+	c.Assert(err.Error(), jc.Contains, `All operations that change model have been disabled for the current model.`)
+}
+
 func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 	s.mockAPI.localName = "mary-weep"
 	var (

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -239,8 +239,12 @@ func (c *removeApplicationCommand) removeApplications(
 	for i, name := range c.ApplicationNames {
 		result := results[i]
 		if result.Error != nil {
-			ctx.Infof("removing application %s failed: %s", name, result.Error)
 			anyFailed = true
+			err := result.Error.Error()
+			if params.IsCodeNotSupported(result.Error) {
+				err = errors.New("another user was updating application; please try again").Error()
+			}
+			ctx.Infof("removing application %s failed: %s", name, err)
 			continue
 		}
 		ctx.Infof("removing application %s", name)

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -146,6 +146,7 @@ func (s *RemoveApplicationSuite) TestNoWaitWithoutForce(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
 }
 
+//TODO(tsm) remove unused RemoveCharmStoreCharmsSuite
 type RemoveCharmStoreCharmsSuite struct {
 	legacyCharmStoreSuite
 	ctx *cmd.Context

--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -104,7 +105,8 @@ func (c *scaleApplicationCommand) Run(ctx *cmd.Context) error {
 		Scale:           c.scale,
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return block.ProcessBlockedError(errors.Annotatef(err, "could not scale application %q", c.applicationName), block.BlockChange)
+
 	}
 	if err := result.Error; err != nil {
 		return err

--- a/cmd/juju/application/scaleapplication_test.go
+++ b/cmd/juju/application/scaleapplication_test.go
@@ -72,6 +72,13 @@ func (s *ScaleApplicationSuite) TestScaleApplication(c *gc.C) {
 	c.Assert(out, gc.Equals, `foo scaled to 2 units`)
 }
 
+func (s *ScaleApplicationSuite) TestScaleApplicationBlocked(c *gc.C) {
+	s.mockAPI.SetErrors(&params.Error{Code: params.CodeOperationBlocked, Message: "nope"})
+	_, err := s.runScaleApplication(c, "foo", "2")
+	c.Assert(err.Error(), jc.Contains, `could not scale application "foo": nope`)
+	c.Assert(err.Error(), jc.Contains, `All operations that change model have been disabled for the current model.`)
+}
+
 func (s *ScaleApplicationSuite) TestScaleApplicationWrongModel(c *gc.C) {
 	store := jujuclienttesting.MinimalStore()
 	_, err := cmdtesting.RunCommand(c, NewScaleCommandForTest(s.mockAPI, store), "foo", "2")

--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -27,6 +27,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     add-unit
     add-ssh-key
     add-user
+    attach-resource
     attach-storage
     change-user-password
     config
@@ -42,6 +43,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     import-ssh-key
     model-defaults
     model-config
+    reload-spaces
     remove-application
     remove-machine
     remove-relation
@@ -51,6 +53,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     resolved
     retry-provisioning
     run
+    scale-application
     set-credential
     set-constraints
     set-series

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -39,22 +39,40 @@ type listCloudsCommand struct {
 // listCloudsDoc is multi-line since we need to use ` to denote
 // commands for ease in markdown.
 var listCloudsDoc = "" +
-	"Output includes fundamental properties for each cloud known to the\n" +
-	"current Juju client: name, number of regions, default region, type,\n" +
-	"and description.\n" +
-	"If the multi-cloud feature flag is not enabled, the default behaviour is to\n" +
-	"show clouds known to Juju out of the box; these can be used to bootstrap a controller.\n" +
-	"In addition to these public clouds, the 'localhost' cloud (local LXD) is also listed.\n" +
-	"With the multi-cloud feature flag, a controller is specified using --controller.\n" +
-	"If you supply a controller name the clouds known on the controller will be displayed.\n" +
-	"\nThis command's default output format is 'tabular'.\n" +
-	"\nCloud metadata sometimes changes, e.g. AWS adds a new region. Use the\n" +
-	"`update-clouds` command to update the current Juju client accordingly.\n" +
-	"\nUse the `add-cloud` command to add a private cloud to the list of\n" +
-	"clouds known to the current Juju client.\n" +
-	"\nUse the `regions` command to list a cloud's regions. Use the\n" +
-	"`show-cloud` command to get more detail, such as regions and endpoints.\n" +
-	"\nFurther reading: https://docs.jujucharms.com/stable/clouds\n" + listCloudsDocExamples
+	"Display the fundamental properties for each cloud known to the current Juju client:\n" +
+	"name, number of regions, default region, type, and description\n" +
+	"\n" +
+	"The default behaviour is to show clouds available on the current controller.\n" +
+	"Another controller can specified using the --controller option. When no controllers\n" +
+	"are available, --local is implied.\n" +
+	"\n" +
+	"If --local is specified, the public clouds known to Juju out of the box are displayed,\n" +
+	"along with any which have been added with `add-cloud --local`. These clouds can be\n" +
+	"used to create a controller.\n" +
+	"\n" +
+	"Clouds may be listed that are co-hosted with the Juju client.  When the LXD hypervisor\n" +
+	"is detected, the 'localhost' cloud is made available.  When a microk8s installation is\n" +
+	"detected, the 'microk8s' cloud is displayed.\n" +
+	"\n" +
+	"This command's default output format is 'tabular'. Use 'json' and 'yaml' for\n" +
+	"machine-readable output.\n" +
+	"\n" +
+	"Cloud metadata sometimes changes, e.g. providers add regions. Use the `update-clouds`\n" +
+	"command to update the current Juju client.\n" +
+	"\n" +
+	"Use the `add-cloud` command to add a private cloud to the list of clouds known to the\n" +
+	"current Juju client.\n" +
+	"\n" +
+	"Use the `regions` command to list a cloud's regions.\n" +
+	"\n" +
+	"Use the `show-cloud` command to get more detail, such as regions and endpoints.\n" +
+	"\n" +
+	"Further reading:\n " +
+	"\n" +
+	"    Documentation:   https://docs.jujucharms.com/stable/clouds\n" +
+	"    microk8s:        https://microk8s.io/\n" +
+	"    LXD hypervisor:  https://linuxcontainers.org/lxd/\n" +
+	listCloudsDocExamples
 
 var listCloudsDocExamples = `
 Examples:
@@ -66,7 +84,11 @@ Examples:
 
 See also:
     add-cloud
+    credentials
+    controllers
     regions
+    set-default-credential
+    set-default-region
     show-cloud
     update-clouds
 `

--- a/cmd/juju/model/setcredential.go
+++ b/cmd/juju/model/setcredential.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -150,7 +151,7 @@ func (c *modelCredentialCommand) Run(ctx *cmd.Context) error {
 
 	err = modelClient.ChangeModelCredential(modelTag, credentialTag)
 	if err != nil {
-		return fail(errors.Trace(err))
+		return block.ProcessBlockedError(errors.Annotate(err, "could not set model credential"), block.BlockChange)
 	}
 	ctx.Infof("Changed cloud credential on model %q to %q.", modelName, c.credential)
 	return nil

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/resource"
 )
@@ -155,5 +156,8 @@ func (c *UploadCommand) upload(rf resourceValue, client UploadClient) error {
 	}
 	defer f.Close()
 	err = client.Upload(rf.application, rf.name, rf.value, f)
-	return errors.Trace(err)
+	if err := block.ProcessBlockedError(err, block.BlockChange); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }

--- a/cmd/juju/space/add.go
+++ b/cmd/juju/space/add.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -73,7 +74,7 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 			if params.IsCodeUnauthorized(err) {
 				common.PermissionsMessage(ctx.Stderr, "add a space")
 			}
-			return errors.Annotatef(err, "cannot add space %q", c.Name)
+			return block.ProcessBlockedError(errors.Annotatef(err, "cannot add space %q", c.Name), block.BlockChange)
 		}
 
 		ctx.Infof("added space %q with %s", c.Name, msgSuffix)

--- a/cmd/juju/space/reload.go
+++ b/cmd/juju/space/reload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -44,7 +45,7 @@ func (c *ReloadCommand) Run(ctx *cmd.Context) error {
 			if errors.IsNotSupported(err) {
 				ctx.Infof("cannot reload spaces: %v", err)
 			}
-			return errors.Annotate(err, "cannot reload spaces")
+			return block.ProcessBlockedError(errors.Annotate(err, "could not reload spaces"), block.BlockChange)
 		}
 		return nil
 	})

--- a/cmd/juju/storage/attach.go
+++ b/cmd/juju/storage/attach.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -85,7 +86,7 @@ func (c *attachStorageCommand) Run(ctx *cmd.Context) error {
 		if params.IsCodeUnauthorized(err) {
 			common.PermissionsMessage(ctx.Stderr, "attach storage")
 		}
-		return errors.Trace(err)
+		return block.ProcessBlockedError(errors.Annotatef(err, "could not attach storage %v", c.storageIds), block.BlockChange)
 	}
 	for i, result := range results {
 		if result.Error == nil {

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -21,7 +21,7 @@ type ApplicationSuite struct {
 var _ = gc.Suite(&ApplicationSuite{})
 
 func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
-	m := s.NewApplication(appChange)
+	m := s.NewApplication(appChange, nil)
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(0))
 	m.Config()
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(1))
@@ -32,7 +32,7 @@ func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
 // See model_test.go for other config watcher tests.
 // Here we just check that WatchConfig is wired up properly.
 func (s *ApplicationSuite) TestConfigWatcherChange(c *gc.C) {
-	a := s.NewApplication(appChange)
+	a := s.NewApplication(appChange, nil)
 	w := a.WatchConfig()
 
 	// The worker is the first and only resource (1).

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -324,7 +324,7 @@ func (s *lxdProfileWatcherSuite) newUnit(c *gc.C, machineId, principal string, c
 }
 
 func (s *lxdProfileWatcherSuite) setupOneMachineLXDProfileWatcherScenario(c *gc.C) {
-	s.model = s.NewModel(modelChange)
+	s.model = s.NewModel(modelChange, nil)
 
 	s.model.UpdateMachine(machineChange, s.Manager)
 	machine, err := s.model.Machine(machineChange.Id)
@@ -372,7 +372,7 @@ func (s *lxdProfileWatcherSuite) assertStartOneMachineWatcher(c *gc.C) *cache.Ma
 }
 
 func (s *lxdProfileWatcherSuite) assertStartOneMachineNotProvisionedWatcher(c *gc.C) *cache.MachineLXDProfileWatcher {
-	s.model = s.NewModel(modelChange)
+	s.model = s.NewModel(modelChange, nil)
 
 	mChange := cache.MachineChange{
 		ModelUUID: "model-uuid",

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -174,11 +174,12 @@ func (m *Machine) setDetails(details MachineChange) {
 
 	m.setStale(false)
 
-	if details.InstanceId != m.details.InstanceId {
+	provisioned := details.InstanceId != m.details.InstanceId
+	m.details = details
+
+	if provisioned {
 		m.model.hub.Publish(m.topic(machineProvisioned), nil)
 	}
-
-	m.details = details
 
 	configHash, err := hash(details.Config)
 	if err != nil {

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -23,7 +23,7 @@ type ModelSuite struct {
 var _ = gc.Suite(&ModelSuite{})
 
 func (s *ModelSuite) TestReport(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{
 		"name":              "model-owner/test-model",
 		"life":              life.Value("alive"),
@@ -36,7 +36,7 @@ func (s *ModelSuite) TestReport(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfig(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	c.Assert(m.Config(), jc.DeepEquals, map[string]interface{}{
 		"key":     "value",
 		"another": "foo",
@@ -44,12 +44,12 @@ func (s *ModelSuite) TestConfig(c *gc.C) {
 }
 
 func (s *ModelSuite) TestNewModelGeneratesHash(c *gc.C) {
-	s.NewModel(modelChange)
+	s.NewModel(modelChange, nil)
 	c.Check(testutil.ToFloat64(s.Gauges.ModelHashCacheMiss), gc.Equals, float64(1))
 }
 
 func (s *ModelSuite) TestModelConfigIncrementsReadCount(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	c.Check(testutil.ToFloat64(s.Gauges.ModelConfigReads), gc.Equals, float64(0))
 	m.Config()
 	c.Check(testutil.ToFloat64(s.Gauges.ModelConfigReads), gc.Equals, float64(1))
@@ -61,7 +61,7 @@ func (s *ModelSuite) TestModelConfigIncrementsReadCount(c *gc.C) {
 // watcher, but using a cached model avoids the need to put scaffolding code in
 // export_test.go to create a watcher in isolation.
 func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig()
 	wc := NewNotifyWatcherC(c, w)
 	// Sends initial event.
@@ -70,7 +70,7 @@ func (s *ModelSuite) TestConfigWatcherStops(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig()
 	defer workertest.CleanKill(c, w)
 	wc := NewNotifyWatcherC(c, w)
@@ -93,7 +93,7 @@ func (s *ModelSuite) TestConfigWatcherChange(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig("key")
 	defer workertest.CleanKill(c, w)
 	wc := NewNotifyWatcherC(c, w)
@@ -111,7 +111,7 @@ func (s *ModelSuite) TestConfigWatcherOneValue(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	w := m.WatchConfig("key")
 
 	// The worker is the first and only resource (1).
@@ -137,7 +137,7 @@ func (s *ModelSuite) TestConfigWatcherOneValueOtherChange(c *gc.C) {
 }
 
 func (s *ModelSuite) TestConfigWatcherSameValuesCacheHit(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 
 	w := m.WatchConfig("key", "another")
 	defer workertest.CleanKill(c, w)
@@ -153,31 +153,31 @@ func (s *ModelSuite) TestConfigWatcherSameValuesCacheHit(c *gc.C) {
 }
 
 func (s *ModelSuite) TestApplicationNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Application("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestCharmNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Charm("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestMachineNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Machine("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestUnitNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Unit("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestUnitReturnsCopy(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	m.UpdateUnit(unitChange, s.Manager)
 
 	u1, err := m.Unit(unitChange.Name)
@@ -194,13 +194,13 @@ func (s *ModelSuite) TestUnitReturnsCopy(c *gc.C) {
 }
 
 func (s *ModelSuite) TestBranchNotFoundError(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	_, err := m.Branch("nope")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *ModelSuite) TestBranchReturnsCopy(c *gc.C) {
-	m := s.NewModel(modelChange)
+	m := s.NewModel(modelChange, nil)
 	m.UpdateBranch(branchChange, s.Manager)
 
 	b1, err := m.Branch(branchChange.Name)

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -72,19 +72,27 @@ func (s *EntitySuite) SetUpTest(c *gc.C) {
 	s.Gauges = createControllerGauges()
 }
 
-func (s *EntitySuite) NewModel(details ModelChange) *Model {
-	m := newModel(s.Gauges, s.newHub(), s.Manager.new())
+func (s *EntitySuite) NewModel(details ModelChange, hub *pubsub.SimpleHub) *Model {
+	if hub == nil {
+		hub = s.NewHub()
+	}
+
+	m := newModel(s.Gauges, hub, s.Manager.new())
 	m.setDetails(details)
 	return m
 }
 
-func (s *EntitySuite) NewApplication(details ApplicationChange) *Application {
-	a := newApplication(s.Gauges, s.newHub(), s.NewResident())
+func (s *EntitySuite) NewApplication(details ApplicationChange, hub *pubsub.SimpleHub) *Application {
+	if hub == nil {
+		hub = s.NewHub()
+	}
+
+	a := newApplication(s.Gauges, hub, s.NewResident())
 	a.SetDetails(details)
 	return a
 }
 
-func (s *EntitySuite) newHub() *pubsub.SimpleHub {
+func (s *EntitySuite) NewHub() *pubsub.SimpleHub {
 	logger := loggo.GetLogger("test")
 	logger.SetLogLevel(loggo.TRACE)
 	return pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{

--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -37,6 +37,13 @@ type Store interface {
 	// Supplying any lease keys will filter the return for those requested.
 	Leases(keys ...Key) map[Key]Info
 
+	// LeaseGroup returns a snapshot of all of the leases for a
+	// particular namespace/model combination. This is useful for
+	// reporting holder information for a model, and can often be
+	// implemented more efficiently than getting all leases when there
+	// are many models.
+	LeaseGroup(namespace, modelUUID string) map[Key]Info
+
 	// Refresh reads all lease state from the database.
 	Refresh() error
 

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -118,3 +118,12 @@ wordpress:
     url: ""
 `[1:])
 }
+
+func (s *CmdApplicationSuite) TestRemoveApplication(c *gc.C) {
+	s.setupApplications(c)
+
+	ctx, err := cmdtesting.RunCommand(c, application.NewRemoveApplicationCommand(), "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "removing application wordpress\n")
+}

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -135,6 +135,21 @@ func (s *leaseStore) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	return results
 }
 
+// LeaseGroup is part of lease.Store.
+func (s *leaseStore) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
+	leases := s.Leases()
+	if len(leases) == 0 {
+		return leases
+	}
+	results := make(map[lease.Key]lease.Info)
+	for key, info := range leases {
+		if key.Namespace == namespace && key.ModelUUID == modelUUID {
+			results[key] = info
+		}
+	}
+	return results
+}
+
 // Refresh is part of lease.Store.
 func (s *leaseStore) Refresh() error {
 	return nil

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -984,11 +984,23 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 	// Retrieve the unit.
 	unit, err := st.Unit(newInfo.Name)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// It is possible that the event processing is happening slower
+			// than reality and a missing unit isn't that terrible.
+			logger.Debugf("unit %q not in DB", newInfo.Name)
+			return nil
+		}
 		return errors.Annotatef(err, "cannot retrieve unit %q", newInfo.Name)
 	}
 	// A change in a unit's status might also affect its application.
 	application, err := unit.Application()
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// It is possible that the event processing is happening slower
+			// than reality and a missing application isn't that terrible.
+			logger.Debugf("application for unit %q not in DB", newInfo.Name)
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	applicationId, ok := backingEntityIdForGlobalKey(st.ModelUUID(), application.globalKey())
@@ -1573,9 +1585,10 @@ func (b *allModelWatcherStateBacking) Changed(all *multiwatcherStore, change wat
 
 	st, err := b.getState(modelUUID)
 	if err != nil {
-		if exists, modelErr := b.st.ModelExists(modelUUID); exists && modelErr == nil {
-			// The entity's model is gone so remove the entity
-			// from the store.
+		// The state pool will return a not found error if the model is
+		// in the process of being removed.
+		if errors.IsNotFound(err) {
+			// The entity's model is gone so remove the entity from the store.
 			_ = doc.removed(all, modelUUID, id, nil)
 			return nil
 		}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1384,6 +1384,26 @@ func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBacking() Backing {
 	return NewAllModelWatcherStateBacking(s.state, s.pool)
 }
 
+func (s *allModelWatcherStateSuite) TestMissingModelNotError(c *gc.C) {
+	b := s.NewAllModelWatcherStateBacking()
+	defer b.Release()
+	all := newStore()
+
+	dyingModel := "fake-uuid"
+	st, err := s.pool.Get(dyingModel)
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Release()
+
+	removed, err := s.pool.Remove(dyingModel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(removed, jc.IsFalse)
+
+	// If the state pool is in the process of removing a model, it will
+	// return a NotFound error.
+	err = b.Changed(all, watcher.Change{C: modelsC, Id: dyingModel})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 // performChangeTestCases runs a passed number of test cases for changes.
 func (s *allModelWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFuncs []changeTestFunc) {
 	for i, changeTestFunc := range changeTestFuncs {
@@ -4241,7 +4261,7 @@ func (tw *testWatcher) AssertNoChange(c *gc.C) {
 func (tw *testWatcher) AssertChanges(c *gc.C, expected int) {
 	var count int
 	tw.st.StartSync()
-	maxWait := tw.st.clock().After(testing.LongWait)
+	maxWait := time.After(testing.LongWait)
 done:
 	for {
 		select {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -41,6 +41,7 @@ const (
 	MachinesC         = machinesC
 	ModelEntityRefsC  = modelEntityRefsC
 	ApplicationsC     = applicationsC
+	OfferConnectionsC = offerConnectionsC
 	EndpointBindingsC = endpointBindingsC
 	ControllersC      = controllersC
 	UsersC            = usersC
@@ -52,20 +53,21 @@ const (
 )
 
 var (
-	BinarystorageNew        = &binarystorageNew
-	ImageStorageNewStorage  = &imageStorageNewStorage
-	MachineIdLessThan       = machineIdLessThan
-	GetOrCreatePorts        = getOrCreatePorts
-	GetPorts                = getPorts
-	CombineMeterStatus      = combineMeterStatus
-	ApplicationGlobalKey    = applicationGlobalKey
-	CloudGlobalKey          = cloudGlobalKey
-	RegionSettingsGlobalKey = regionSettingsGlobalKey
-	ModelGlobalKey          = modelGlobalKey
-	MergeBindings           = mergeBindings
-	UpgradeInProgressError  = errUpgradeInProgress
-	DBCollectionSizeToInt   = dbCollectionSizeToInt
-	NewEntityWatcher        = newEntityWatcher
+	BinarystorageNew              = &binarystorageNew
+	ImageStorageNewStorage        = &imageStorageNewStorage
+	MachineIdLessThan             = machineIdLessThan
+	GetOrCreatePorts              = getOrCreatePorts
+	GetPorts                      = getPorts
+	CombineMeterStatus            = combineMeterStatus
+	ApplicationGlobalKey          = applicationGlobalKey
+	CloudGlobalKey                = cloudGlobalKey
+	RegionSettingsGlobalKey       = regionSettingsGlobalKey
+	ModelGlobalKey                = modelGlobalKey
+	MergeBindings                 = mergeBindings
+	UpgradeInProgressError        = errUpgradeInProgress
+	DBCollectionSizeToInt         = dbCollectionSizeToInt
+	NewEntityWatcher              = newEntityWatcher
+	ApplicationHasConnectedOffers = applicationHasConnectedOffers
 )
 
 type (

--- a/state/lease/store.go
+++ b/state/lease/store.go
@@ -108,6 +108,17 @@ func (store *store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	return leases
 }
 
+// LeaseGroup is part of the lease.Store interface. For the state
+// store it's identical to Leases() because each store is specific to
+// a namespace/model combination.
+func (store *store) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
+	cfg := store.config
+	if namespace != cfg.Namespace || modelUUID != cfg.ModelUUID {
+		return nil
+	}
+	return store.Leases()
+}
+
 // ClaimLease is part of the lease.Store interface.
 func (store *store) ClaimLease(key lease.Key, request lease.Request, _ <-chan struct{}) error {
 	return store.request(key.Lease, request, store.claimLeaseOps, "claiming")

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -753,12 +753,30 @@ func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) 
 		c.Check(sm.Stop(), gc.ErrorMatches, "some error")
 	}()
 	w := &Multiwatcher{all: sm}
+
 	// Receive one delta to make sure that the storeManager
 	// has seen the initial state.
 	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{Id: "0"}}}, "")
 	c.Logf("setting fetch error")
 	b.setFetchError(errors.New("some error"))
+
 	c.Logf("updating entity")
+	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
+	checkNext(c, w, nil, "some error")
+}
+
+func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerStop(c *gc.C) {
+	b := newTestBacking([]multiwatcher.EntityInfo{&multiwatcher.MachineInfo{Id: "0"}})
+	sm := newStoreManager(b)
+	w := &Multiwatcher{all: sm}
+
+	// Receive one delta to make sure that the storeManager
+	// has seen the initial state.
+	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{Id: "0"}}}, "")
+
+	// Stop the the store manager cleanly and check that
+	// the next update returns ErrStopped.
+	c.Check(sm.Stop(), jc.ErrorIsNil)
 	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
 	checkNext(c, w, nil, ErrStoppedf("shared state watcher").Error())
 }

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -182,7 +182,7 @@ func (aw *applicationWorker) loop() error {
 				err = updateApplicationService(
 					names.NewApplicationTag(aw.application), service, aw.applicationUpdater,
 				)
-				if params.IsCodeForbidden(err) {
+				if errors.IsForbidden(err) {
 					// ignore errors raised from SetScale because disordered events could happen often.
 					logger.Warningf("%v", err)
 				} else if err != nil {
@@ -315,7 +315,7 @@ func (aw *applicationWorker) clusterChanged(
 		args.Units = append(args.Units, unitParams)
 	}
 	if err := aw.unitUpdater.UpdateUnits(args); err != nil {
-		if params.IsCodeForbidden(err) {
+		if errors.IsForbidden(err) {
 			// ignore errors raised from SetScale because disordered events could happen often.
 			logger.Warningf("%v", err)
 			return nil

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -626,10 +626,8 @@ func (manager *Manager) pinned(namespace, modelUUID string) map[string][]string 
 
 func (manager *Manager) leases(namespace, modelUUID string) map[string]string {
 	leases := make(map[string]string)
-	for key, lease := range manager.config.Store.Leases() {
-		if key.Namespace == namespace && key.ModelUUID == modelUUID {
-			leases[key.Lease] = lease.Holder
-		}
+	for key, lease := range manager.config.Store.LeaseGroup(namespace, modelUUID) {
+		leases[key.Lease] = lease.Holder
 	}
 	return leases
 }

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -123,6 +123,17 @@ func (store *Store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 	return result
 }
 
+// LeaseGroup is part of the lease.Store interface.
+func (store *Store) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
+	results := make(map[lease.Key]lease.Info)
+	for key, info := range store.Leases() {
+		if key.Namespace == namespace && key.ModelUUID == modelUUID {
+			results[key] = info
+		}
+	}
+	return results
+}
+
 func (store *Store) closeIfEmpty() {
 	// This must be called with the lock held.
 	if store.runningCalls > 1 {

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -577,6 +577,23 @@ func (s *WorkerSuite) TestWatcherErrorCacheMarkSweep(c *gc.C) {
 	c.Check(cachedApp, gc.NotNil)
 }
 
+func (s *WorkerSuite) TestWatcherErrorStoppedKillsWorker(c *gc.C) {
+	mw := s.StatePool.SystemState().WatchAllModels(s.StatePool)
+	s.config.WatcherFactory = func() modelcache.BackingWatcher { return mw }
+
+	config := s.config
+	config.Notify = s.notify
+	w, err := modelcache.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Stop the backing multiwatcher.
+	c.Assert(mw.Stop(), jc.ErrorIsNil)
+
+	// Check that the worker is killed.
+	err = workertest.CheckKilled(c, w)
+	c.Assert(err, jc.Satisfies, state.IsErrStopped)
+}
+
 func (s *WorkerSuite) captureEvents(c *gc.C, matchers ...func(interface{}) bool) <-chan interface{} {
 	events := make(chan interface{})
 	s.notify = func(change interface{}) {


### PR DESCRIPTION
## Description of change

Merge from 2.6 to bring forward:
#10325 from manadart/2.6-ha-partial-placement
#10324 from manadart/2.5-into-2.6
#10322 from howbazaar/2.6-model-cache-restart
#10323 from ycliuhw/fix/kill-controller-removes-k8s-ns
#10310 from ycliuhw/fix/upgrade-model-caas
#10318 from babbageclunk/merge-lease-read-groups-2.6
#10263 from timClicks/2.6-cmd-remove-app-removes-offers-with-zero-connections
#10317 from howbazaar/2.6-merge-2.5
#10258 from timClicks/2.6-cli-list-clouds
#10314 from manadart/2.6-cache-machine-publish
#10312 from anastasiamac/missing-calls-for-change-block
#10311 from hpidcock/1832255-attach-resource-block

