### PR TITLE
2.6 - Model Cache Returns Applications and Machines as Copies

### DIFF
--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -53,7 +53,7 @@ func (s modelCacheShim) Machine(machineId string) (ModelCacheMachine, error) {
 }
 
 type modelCacheMachine struct {
-	*cache.Machine
+	cache.Machine
 }
 
 func (m *modelCacheMachine) WatchLXDProfileVerificationNeeded() (cache.NotifyWatcher, error) {
@@ -87,5 +87,5 @@ type modelCacheUnit struct {
 }
 
 type modelCacheApplication struct {
-	*cache.Application
+	cache.Application
 }

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -49,6 +49,7 @@ func (a *Application) CharmURL() string {
 
 // Config returns a copy of the current application config.
 func (a *Application) Config() map[string]interface{} {
+	a.metrics.ApplicationConfigReads.Inc()
 	return a.details.Config
 }
 

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -105,6 +105,13 @@ func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Unlock()
 }
 
+// copy returns a copy of the unit, ensuring appropriate deep copying.
+func (a *Application) copy() Application {
+	ca := *a
+	ca.details = ca.details.copy()
+	return ca
+}
+
 // topic prefixes the input string with the application name.
 func (a *Application) topic(suffix string) string {
 	return a.details.Name + ":" + suffix

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -4,8 +4,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/juju/pubsub"
 )
 
@@ -34,32 +32,24 @@ type Application struct {
 	// Link to model?
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
-	mu      sync.Mutex
 
 	details    ApplicationChange
 	configHash string
 	hashCache  *hashCache
 }
 
+// Note that these property accessors are not lock-protected.
+// They are intended for calling from external packages that have retrieved a
+// deep copy from the cache.
+
 // CharmURL returns the charm url string for this application.
 func (a *Application) CharmURL() string {
-	a.mu.Lock()
-	defer a.mu.Unlock()
 	return a.details.CharmURL
 }
 
 // Config returns a copy of the current application config.
 func (a *Application) Config() map[string]interface{} {
-	a.mu.Lock()
-
-	cfg := make(map[string]interface{}, len(a.details.Config))
-	for k, v := range a.details.Config {
-		cfg[k] = v
-	}
-	a.metrics.ApplicationConfigReads.Inc()
-
-	a.mu.Unlock()
-	return cfg
+	return a.details.Config
 }
 
 // WatchConfig creates a watcher for the application config.
@@ -76,8 +66,6 @@ type appCharmUrlChange struct {
 }
 
 func (a *Application) setDetails(details ApplicationChange) {
-	a.mu.Lock()
-
 	// If this is the first receipt of details, set the removal message.
 	if a.removalMessage == nil {
 		a.removalMessage = RemoveApplication{
@@ -101,8 +89,6 @@ func (a *Application) setDetails(details ApplicationChange) {
 		a.hashCache = hashCache
 		a.hub.Publish(a.topic(applicationConfigChange), hashCache)
 	}
-
-	a.mu.Unlock()
 }
 
 // copy returns a copy of the unit, ensuring appropriate deep copying.

--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -23,10 +23,17 @@ var _ = gc.Suite(&ApplicationSuite{})
 func (s *ApplicationSuite) TestConfigIncrementsReadCount(c *gc.C) {
 	m := s.NewApplication(appChange, nil)
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(0))
+
 	m.Config()
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(1))
 	m.Config()
 	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(2))
+
+	// Goroutine safety.
+	go m.Config()
+	go m.Config()
+	go m.Config()
+	c.Check(testutil.ToFloat64(s.Gauges.ApplicationConfigReads), gc.Equals, float64(5))
 }
 
 // See model_test.go for other config watcher tests.

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -5,8 +5,6 @@ package cache
 
 import (
 	"github.com/juju/pubsub"
-
-	"github.com/juju/juju/core/settings"
 )
 
 // Branch represents an active branch in a cached model.
@@ -57,39 +55,7 @@ func (b *Branch) setDetails(details BranchChange) {
 
 // copy returns a copy of the branch, ensuring appropriate deep copying.
 func (b *Branch) copy() Branch {
-	var cAssignedUnits map[string][]string
-	bAssignedUnits := b.details.AssignedUnits
-	if bAssignedUnits != nil {
-		cAssignedUnits = make(map[string][]string, len(bAssignedUnits))
-		for k, v := range bAssignedUnits {
-			units := make([]string, len(v))
-			for i, u := range v {
-				units[i] = u
-			}
-			cAssignedUnits[k] = units
-		}
-	}
-
-	var cConfig map[string]settings.ItemChanges
-	bConfig := b.details.Config
-	if bConfig != nil {
-		cConfig = make(map[string]settings.ItemChanges, len(bConfig))
-		for k, v := range bConfig {
-			changes := make(settings.ItemChanges, len(v))
-			for i, ch := range v {
-				changes[i] = settings.ItemChange{
-					Type:     ch.Type,
-					Key:      ch.Key,
-					NewValue: ch.NewValue,
-					OldValue: ch.OldValue,
-				}
-			}
-			cConfig[k] = changes
-		}
-	}
-
 	cb := *b
-	cb.details.AssignedUnits = cAssignedUnits
-	cb.details.Config = cConfig
+	cb.details = cb.details.copy()
 	return cb
 }

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -48,6 +48,17 @@ type ApplicationChange struct {
 	WorkloadVersion string
 }
 
+// copy returns a deep copy of the ApplicationChange.
+func (a ApplicationChange) copy() ApplicationChange {
+	cons := a.Constraints.String()
+	a.Constraints = constraints.MustParse(cons)
+
+	a.Config = copyDataMap(a.Config)
+	a.Status = copyStatusInfo(a.Status)
+
+	return a
+}
+
 // RemoveApplication represents the situation when an application
 // is removed from a model in the database.
 type RemoveApplication struct {

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -28,7 +28,7 @@ type MachineLXDProfileWatcher struct {
 // MachineAppModeler is a point of use model for MachineLXDProfileWatcher to
 // get Applications, Charms and Units.
 type MachineAppModeler interface {
-	Application(string) (*Application, error)
+	Application(string) (Application, error)
 	Charm(string) (*Charm, error)
 	Unit(string) (Unit, error)
 }

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -44,7 +44,7 @@ type MachineLXDProfileWatcherConfig struct {
 	provisionedTopic string
 	unitAddTopic     string
 	unitRemoveTopic  string
-	machine          *Machine
+	machine          Machine
 	modeler          MachineAppModeler
 	metrics          *ControllerGauges
 	hub              *pubsub.SimpleHub
@@ -88,7 +88,7 @@ func newMachineLXDProfileWatcher(config MachineLXDProfileWatcherConfig) (*Machin
 }
 
 // init sets up the initial data used to determine when a notify occurs.
-func (w *MachineLXDProfileWatcher) init(machine *Machine) error {
+func (w *MachineLXDProfileWatcher) init(machine Machine) error {
 	units, err := machine.Units()
 	if err != nil {
 		return errors.Annotatef(err, "failed to get units to start MachineLXDProfileWatcher")

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -17,8 +17,8 @@ type lxdProfileWatcherSuite struct {
 	cache.EntitySuite
 
 	model    *cache.Model
-	machine0 *cache.Machine
-	machine1 *cache.Machine
+	machine0 cache.Machine
+	machine1 cache.Machine
 	wc0      NotifyWatcherC
 }
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -6,7 +6,6 @@ package cache
 import (
 	"fmt"
 	"regexp"
-	"sync"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
@@ -33,7 +32,6 @@ type Machine struct {
 	*Resident
 
 	model *Model
-	mu    sync.Mutex
 
 	details    MachineChange
 	configHash string

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -35,50 +35,46 @@ type Machine struct {
 	model *Model
 	mu    sync.Mutex
 
-	modelUUID  string
 	details    MachineChange
 	configHash string
 }
 
+// Note that these property accessors are not lock-protected.
+// They are intended for calling from external packages that have retrieved a
+// deep copy from the cache.
+
 // Id returns the id string of this machine.
 func (m *Machine) Id() string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	return m.details.Id
 }
 
 // InstanceId returns the provider specific instance id for this machine and
-// returns not provisioned if instance id is empty
+// returns not provisioned if instance ID is empty.
 func (m *Machine) InstanceId() (instance.Id, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if m.details.InstanceId == "" {
 		return "", errors.NotProvisionedf("machine %v", m.details.Id)
 	}
 	return instance.Id(m.details.InstanceId), nil
 }
 
-// CharmProfiles returns the cached list of charm profiles for the machine
+// CharmProfiles returns the cached list of charm profiles for the machine.
 func (m *Machine) CharmProfiles() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	return m.details.CharmProfiles
 }
 
 // ContainerType returns the cached container type hosting this machine.
 func (m *Machine) ContainerType() instance.ContainerType {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	return instance.ContainerType(m.details.ContainerType)
+}
+
+// Config returns configuration settings for the machine.
+func (m *Machine) Config() map[string]interface{} {
+	return m.details.Config
 }
 
 // Units returns all the units that have been assigned to the machine
 // including subordinates.
 func (m *Machine) Units() ([]Unit, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	units := m.model.Units()
 
 	var result []Unit
@@ -147,7 +143,7 @@ func (m *Machine) WatchLXDProfileVerificationNeeded() (*MachineLXDProfileWatcher
 		provisionedTopic: m.topic(machineProvisioned),
 		unitAddTopic:     modelUnitAdd,
 		unitRemoveTopic:  modelUnitRemove,
-		machine:          m,
+		machine:          m.copy(),
 		modeler:          m.model,
 		metrics:          m.model.metrics,
 		hub:              m.model.hub,
@@ -161,9 +157,6 @@ func (m *Machine) containerRegexp() (*regexp.Regexp, error) {
 }
 
 func (m *Machine) setDetails(details MachineChange) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	// If this is the first receipt of details, set the removal message.
 	if m.removalMessage == nil {
 		m.removalMessage = RemoveMachine{
@@ -190,6 +183,12 @@ func (m *Machine) setDetails(details MachineChange) {
 		m.configHash = configHash
 		// TODO: publish config change...
 	}
+}
+
+func (m *Machine) copy() Machine {
+	cm := *m
+	cm.details = cm.details.copy()
+	return cm
 }
 
 func (m *Machine) topic(suffix string) string {

--- a/core/cache/machine_test.go
+++ b/core/cache/machine_test.go
@@ -24,7 +24,7 @@ type machineSuite struct {
 	cache.EntitySuite
 
 	model    *cache.Model
-	machine0 *cache.Machine
+	machine0 cache.Machine
 	wc0      StringsWatcherC
 }
 
@@ -226,7 +226,7 @@ func (s *machineSuite) setupMachine0Container(c *gc.C) {
 	s.model.UpdateMachine(mc, s.Manager)
 }
 
-func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []string) (*cache.Machine, []cache.Unit) {
+func (s *machineSuite) setupMachineWithUnits(c *gc.C, machineId string, apps []string) (cache.Machine, []cache.Unit) {
 	mc := machineChange
 	mc.Id = machineId
 	s.model.UpdateMachine(mc, s.Manager)

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -97,18 +97,6 @@ func (m *Model) Report() map[string]interface{} {
 	}
 }
 
-// Application returns the application for the input name.
-// If the application is not found, a NotFoundError is returned.
-func (m *Model) Application(appName string) (*Application, error) {
-	defer m.doLocked()()
-
-	app, found := m.applications[appName]
-	if !found {
-		return nil, errors.NotFoundf("application %q", appName)
-	}
-	return app, nil
-}
-
 // Charm returns the charm for the input charmURL.
 // If the charm is not found, a NotFoundError is returned.
 func (m *Model) Charm(charmURL string) (*Charm, error) {
@@ -122,6 +110,7 @@ func (m *Model) Charm(charmURL string) (*Charm, error) {
 }
 
 // TODO (manadart 2019-05-30): Access to these entities returns copies:
+// - applications
 // - machines
 // - units
 // - branches
@@ -143,6 +132,18 @@ func (m *Model) Branch(name string) (Branch, error) {
 		}
 	}
 	return Branch{}, errors.NotFoundf("branch %q", name)
+}
+
+// Application returns the application for the input name.
+// If the application is not found, a NotFoundError is returned.
+func (m *Model) Application(appName string) (Application, error) {
+	defer m.doLocked()()
+
+	app, found := m.applications[appName]
+	if !found {
+		return Application{}, errors.NotFoundf("application %q", appName)
+	}
+	return app.copy(), nil
 }
 
 // Units returns all units in the model.

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -121,32 +121,8 @@ func (m *Model) Charm(charmURL string) (*Charm, error) {
 	return charm, nil
 }
 
-// Machines makes a copy of the model's machine collection and returns it.
-func (m *Model) Machines() map[string]*Machine {
-	machines := make(map[string]*Machine)
-
-	m.mu.Lock()
-	for k, v := range m.machines {
-		machines[k] = v
-	}
-	m.mu.Unlock()
-
-	return machines
-}
-
-// Machine returns the machine with the input id.
-// If the machine is not found, a NotFoundError is returned.
-func (m *Model) Machine(machineId string) (*Machine, error) {
-	defer m.doLocked()()
-
-	machine, found := m.machines[machineId]
-	if !found {
-		return nil, errors.NotFoundf("machine %q", machineId)
-	}
-	return machine, nil
-}
-
 // TODO (manadart 2019-05-30): Access to these entities returns copies:
+// - machines
 // - units
 // - branches
 // All of the other entity retrieval should be changed to work in the same
@@ -193,6 +169,32 @@ func (m *Model) Unit(unitName string) (Unit, error) {
 		return Unit{}, errors.NotFoundf("unit %q", unitName)
 	}
 	return unit.copy(), nil
+}
+
+// Machines makes a copy of the model's machine collection and returns it.
+func (m *Model) Machines() map[string]Machine {
+	m.mu.Lock()
+
+	machines := make(map[string]Machine, len(m.machines))
+	for k, v := range m.machines {
+		machines[k] = v.copy()
+	}
+
+	m.mu.Unlock()
+
+	return machines
+}
+
+// Machine returns the machine with the input id.
+// If the machine is not found, a NotFoundError is returned.
+func (m *Model) Machine(machineId string) (Machine, error) {
+	defer m.doLocked()()
+
+	machine, found := m.machines[machineId]
+	if !found {
+		return Machine{}, errors.NotFoundf("machine %q", machineId)
+	}
+	return machine.copy(), nil
 }
 
 // WatchMachines returns a PredicateStringsWatcher to notify about

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -170,6 +170,23 @@ func (s *ModelSuite) TestMachineNotFoundError(c *gc.C) {
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
+func (s *ModelSuite) TestMachineReturnsCopy(c *gc.C) {
+	m := s.NewModel(modelChange, nil)
+	m.UpdateMachine(machineChange, s.Manager)
+
+	m1, err := m.Machine(machineChange.Id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make a change to the map returned in the copy.
+	mc := m1.Config()
+	mc["mister"] = "squiggle"
+
+	// Get another copy from the model and ensure it is unchanged.
+	m2, err := m.Machine(machineChange.Id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m2.Config(), gc.DeepEquals, machineChange.Config)
+}
+
 func (s *ModelSuite) TestUnitNotFoundError(c *gc.C) {
 	m := s.NewModel(modelChange, nil)
 	_, err := m.Unit("nope")

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -158,6 +158,23 @@ func (s *ModelSuite) TestApplicationNotFoundError(c *gc.C) {
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
+func (s *ModelSuite) TestApplicationReturnsCopy(c *gc.C) {
+	m := s.NewModel(modelChange, nil)
+	m.UpdateApplication(appChange, s.Manager)
+
+	a1, err := m.Application(appChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make a change to the map returned in the copy.
+	ac := a1.Config()
+	ac["mister"] = "squiggle"
+
+	// Get another copy from the model and ensure it is unchanged.
+	a2, err := m.Application(appChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(a2.Config(), gc.DeepEquals, appChange.Config)
+}
+
 func (s *ModelSuite) TestCharmNotFoundError(c *gc.C) {
 	m := s.NewModel(modelChange, nil)
 	_, err := m.Charm("nope")

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -18,8 +18,7 @@ type Unit struct {
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
 
-	details    UnitChange
-	configHash string
+	details UnitChange
 }
 
 func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub, res *Resident) *Unit {

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -4,12 +4,9 @@
 package cache
 
 import (
-	"time"
-
 	"github.com/juju/pubsub"
 
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/status"
 )
 
 // Unit represents a unit in a cached model.
@@ -93,52 +90,7 @@ func (u *Unit) setDetails(details UnitChange) {
 
 // copy returns a copy of the unit, ensuring appropriate deep copying.
 func (u *Unit) copy() Unit {
-	var cPorts []network.Port
-	uPorts := u.details.Ports
-	if uPorts != nil {
-		cPorts = make([]network.Port, len(uPorts))
-		for i, p := range uPorts {
-			cPorts[i] = p
-		}
-	}
-
-	var cPortRanges []network.PortRange
-	uPortRanges := u.details.PortRanges
-	if uPortRanges != nil {
-		cPortRanges = make([]network.PortRange, len(uPortRanges))
-		for i, p := range uPortRanges {
-			cPortRanges[i] = p
-		}
-	}
-
 	cu := *u
-	cu.details.Ports = cPorts
-	cu.details.PortRanges = cPortRanges
-	cu.details.WorkloadStatus = copyStatusInfo(u.details.WorkloadStatus)
-	cu.details.AgentStatus = copyStatusInfo(u.details.AgentStatus)
+	cu.details = cu.details.copy()
 	return cu
-}
-
-func copyStatusInfo(info status.StatusInfo) status.StatusInfo {
-	var cData map[string]interface{}
-	iData := info.Data
-	if iData != nil {
-		cData = make(map[string]interface{}, len(iData))
-		for i, d := range iData {
-			cData[i] = d
-		}
-	}
-
-	var cSince *time.Time
-	if info.Since != nil {
-		s := *info.Since
-		cSince = &s
-	}
-
-	return status.StatusInfo{
-		Status:  info.Status,
-		Message: info.Message,
-		Data:    cData,
-		Since:   cSince,
-	}
 }


### PR DESCRIPTION
## Description of change

- Applications and machines are supplied by the cache as copies instead of references.
- Copy methods are implemented on `<Entity>Change` structs.

## QA steps

No materialised changes. New unit tests cover copying.
Regressions can be checked with the same steps as for #10062

## Documentation changes

None.

## Bug reference

N/A
