### PR TITLE
Warn if error is unknown k8s error in destroying namespace

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -377,7 +377,7 @@ func (*kubernetesClient) Provider() caas.ContainerEnvironProvider {
 // Destroy is part of the Broker interface.
 func (k *kubernetesClient) Destroy(callbacks context.ProviderCallContext) (err error) {
 	defer func() {
-		if k8serrors.ReasonForError(err) == v1.StatusReasonUnknown {
+		if err != nil && k8serrors.ReasonForError(err) == v1.StatusReasonUnknown {
 			logger.Warningf("k8s cluster is not accessible: %v", err)
 			err = nil
 		}


### PR DESCRIPTION
## Description of change

Only warn for unknown k8s error message in destroying namespace method.

## QA steps

- prepare a k8s model;
- kill controller;


## Documentation changes

None

## Bug reference

None