### PR TITLE
Fix podspec parsing errors

### DIFF
--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -34,6 +34,8 @@ var (
 	AttemptMicroK8sCloud     = attemptMicroK8sCloud
 	EnsureMicroK8sSuitable   = ensureMicroK8sSuitable
 	NewK8sBroker             = newK8sBroker
+	ToYaml                   = toYaml
+	Indent                   = indent
 )
 
 type (

--- a/caas/kubernetes/provider/k8stypes_test.go
+++ b/caas/kubernetes/provider/k8stypes_test.go
@@ -46,7 +46,12 @@ containers:
   - name: gitlab
     image: gitlab/latest
     imagePullPolicy: Always
-    command: ["sh", "-c"]
+    command:
+      - sh
+      - -c
+      - |
+        set -ex
+        echo "do some stuff here for gitlab container"
     args: ["doIt", "--debug"]
     workingDir: "/path/to/here"
     ports:
@@ -97,7 +102,12 @@ initContainers:
   - name: gitlab-init
     image: gitlab-init/latest
     imagePullPolicy: Always
-    command: ["sh", "-c"]
+    command:
+      - sh
+      - -c
+      - |
+        set -ex
+        echo "do some stuff here for gitlab-init container"
     args: ["doIt", "--debug"]
     workingDir: "/path/to/here"
     ports:
@@ -180,9 +190,12 @@ foo: bar
 			},
 		},
 		Containers: []caas.ContainerSpec{{
-			Name:       "gitlab",
-			Image:      "gitlab/latest",
-			Command:    []string{"sh", "-c"},
+			Name:  "gitlab",
+			Image: "gitlab/latest",
+			Command: []string{"sh", "-c", `
+set -ex
+echo "do some stuff here for gitlab container"
+`[1:]},
 			Args:       []string{"doIt", "--debug"},
 			WorkingDir: "/path/to/here",
 			Ports: []caas.ContainerPort{
@@ -249,9 +262,12 @@ foo: bar
 			},
 		}},
 		InitContainers: []caas.ContainerSpec{{
-			Name:       "gitlab-init",
-			Image:      "gitlab-init/latest",
-			Command:    []string{"sh", "-c"},
+			Name:  "gitlab-init",
+			Image: "gitlab-init/latest",
+			Command: []string{"sh", "-c", `
+set -ex
+echo "do some stuff here for gitlab-init container"
+`[1:]},
 			Args:       []string{"doIt", "--debug"},
 			WorkingDir: "/path/to/here",
 			Ports: []caas.ContainerPort{

--- a/caas/kubernetes/provider/template.go
+++ b/caas/kubernetes/provider/template.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+)
+
+var containerTemplate = `
+  - name: {{.Name}}
+    {{if .Ports}}
+    ports:
+    {{- range .Ports }}
+      - containerPort: {{.ContainerPort}}
+        {{if .Name}}name: {{.Name}}{{end}}
+        {{if .Protocol}}protocol: {{.Protocol}}{{end}}
+    {{- end}}
+    {{end}}
+    {{if .Command}}
+    command: 
+{{ toYaml .Command | indent 6 }}
+    {{end}}
+    {{if .Args}}
+    args: 
+{{ toYaml .Args | indent 6 }}
+    {{end}}
+    {{if .WorkingDir}}
+    workingDir: {{.WorkingDir}}
+    {{end}}
+    {{if .Config}}
+    env:
+    {{- range $k, $v := .Config }}
+      - name: {{$k}}
+        value: {{$v}}
+    {{- end}}
+    {{end}}`[1:]
+
+var defaultPodTemplateStr = fmt.Sprintf(`
+pod:
+  containers:
+  {{- range .Containers }}
+%s
+  {{- end}}
+  {{if .InitContainers}}
+  initContainers:
+  {{- range .InitContainers }}
+%s
+  {{- end}}
+  {{end}}
+`[1:], containerTemplate, containerTemplate)
+
+var defaultPodTemplate = template.Must(template.New("").Funcs(templateAddons).Parse(defaultPodTemplateStr))
+
+func toYaml(val interface{}) (string, error) {
+	data, err := yaml.Marshal(val)
+	if err != nil {
+		return "", errors.Annotatef(err, "marshalling to yaml for %v", val)
+	}
+	return string(data), nil
+}
+
+func indent(n int, str string) string {
+	out := ""
+	prefix := strings.Repeat(" ", n)
+	for _, line := range strings.Split(str, "\n") {
+		out += prefix + line + "\n"
+	}
+	return out
+}
+
+var templateAddons = template.FuncMap{
+	"toYaml": toYaml,
+	"indent": indent,
+}

--- a/caas/kubernetes/provider/template_test.go
+++ b/caas/kubernetes/provider/template_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/testing"
+)
+
+type templateSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&templateSuite{})
+
+func (t *templateSuite) TestToYaml(c *gc.C) {
+	in := struct {
+		Command []string `yaml:"command,omitempty"`
+	}{
+		Command: []string{"sh", "-c", `
+set -ex
+echo "do some stuff here for gitlab container"
+`[1:]},
+	}
+	out, err := provider.ToYaml(in)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out, jc.DeepEquals, `
+command:
+- sh
+- -c
+- |
+  set -ex
+  echo "do some stuff here for gitlab container"
+`[1:])
+}
+
+func (t *templateSuite) TestIndent(c *gc.C) {
+	out := provider.Indent(6, `
+line 1
+line 2
+line 3`[1:])
+	c.Assert(out, jc.DeepEquals, `
+      line 1
+      line 2
+      line 3
+`[1:])
+
+	out = provider.Indent(8, `
+line 1
+line 2
+line 3`[1:])
+	c.Assert(out, jc.DeepEquals, `
+        line 1
+        line 2
+        line 3
+`[1:])
+}


### PR DESCRIPTION
## Description of change

Added helper funcs to go template for better podspec parsing and also fixing a bug related podspec parsing errors for container commands include shell scripts;

## QA steps

- prepare caas model;
- deploy containers commands like these (https://paste.ubuntu.com/p/P2sQTKxpq7/);


## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1832783
