### PR TITLE
Removing an offer removes its remote application

### DIFF
--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -639,6 +639,8 @@ func (s *applicationOffersSuite) TestRemoveOffersWithConnectionsForce(c *gc.C) {
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	wordpress, err := s.State.RemoteApplication("remote-wordpress")
+	c.Assert(err, jc.ErrorIsNil)
 	wordpressEP, err := rwordpress.Endpoint("db")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -674,6 +676,9 @@ func (s *applicationOffersSuite) TestRemoveOffersWithConnectionsForce(c *gc.C) {
 	c.Assert(conn, gc.HasLen, 0)
 	s.assertInScope(c, wpru, false)
 	s.assertInScope(c, mysqlru, true)
+	err = wordpress.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, wordpress, state.Dying)
 }
 
 func (s *applicationOffersSuite) TestRemovingApplicationFailsRace(c *gc.C) {

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -249,8 +249,8 @@ func copyAttributes(values attributeMap) attributeMap {
 	return result
 }
 
-// DestroyRemoteApplicationOperation returns a model operation to destroy remote application.
-func (s *RemoteApplication) DestroyRemoteApplicationOperation(force bool) *DestroyRemoteApplicationOperation {
+// DestroyOperation returns a model operation to destroy remote application.
+func (s *RemoteApplication) DestroyOperation(force bool) *DestroyRemoteApplicationOperation {
 	return &DestroyRemoteApplicationOperation{
 		app:             &RemoteApplication{st: s.st, doc: s.doc},
 		ForcedOperation: ForcedOperation{Force: force},
@@ -296,6 +296,8 @@ func (op *DestroyRemoteApplicationOperation) Build(attempt int) ([]txn.Op, error
 
 // Done is part of the ModelOperation interface.
 func (op *DestroyRemoteApplicationOperation) Done(err error) error {
+	// NOTE(tsm): if you change the business logic here, check
+	//            that RemoveOfferOperation is modified to suit
 	if err != nil {
 		if !op.Force {
 			return errors.Annotatef(err, "cannot destroy remote application %q", op.app)
@@ -314,7 +316,7 @@ func (s *RemoteApplication) DestroyWithForce(force bool, maxWait time.Duration) 
 			s.doc.Life = Dying
 		}
 	}()
-	op := s.DestroyRemoteApplicationOperation(force)
+	op := s.DestroyOperation(force)
 	op.MaxWait = maxWait
 	err = s.st.ApplyOperation(op)
 	return op.Errors, err


### PR DESCRIPTION
When attempting to remove an offer for a charm that hasn't completed its install process, Juju won't proceed. It complains that a relation still exists. This happens because the `RemoteApplication` lingers.

## QA steps

**Quality Assurance Setup**

```
juju bootstrap localhost c-local
juju add-model app
juju add-model data

juju bootstrap microk8s c-micro
juju add-model data
```

**Test: cross-model offer can be removed**

Consume an offer between two models. Removing the offer should succeed when there are 0 relations. 

```bash
juju switch c-local:app
juju deploy cs:ubuntu-devenv-6

juju switch c-micro:data
juju deploy cs:~juju/mariadb-k8s
juju offer mariadb-k8s:server

juju switch c-local:app
juju consume c-micro:admin/data.mariadb-k8s db
juju add-relation ubuntu-devenv db
juju remove-offer c-micro:admin/data.mariadb-k8s    # should fail

juju remove-relation ubuntu-devenv db
juju remove-offer c-micro:admin/data.mariadb-k8s    # should succeed
```

**Test: a broken database with a working application server**

```bash
juju switch c-local:data
juju deploy cs:~tim-clicks/fail-1
juju offer fail:db

juju switch c-local:app
juju consume data.db
juju deploy cs:ubuntu-devenv-6 devenv
juju remove-offer data.fail:db                      # should succeed
```

**Test: a working database with a broken application server**

```bash
juju switch c-local:data
juju deploy postgresql-199 pg

juju switch c-local:app
juju deploy cs:~tim-clicks/fail
juju offer pg:psql 

juju switch app
juju consume data.pg
juju add-relation pg fail
juju remove-relation pg fail
juju remove-offer data:pg                           # should succeed
```
## Documentation changes

None. Current behaviour is a bug, the `remove-offer` should now be working as described.

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1813886
