### PR TITLE
CMR: leave scope on all relation units for terminated remote application

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -84,6 +84,9 @@ type Backend interface {
 
 	// FirewallRule returns the firewall rule for the specified service.
 	FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error)
+
+	// ApplyOperation applies a model operation to the state.
+	ApplyOperation(op state.ModelOperation) error
 }
 
 // Relation provides access a relation in global state.
@@ -239,4 +242,9 @@ type RemoteApplication interface {
 
 	// SetStatus sets the status of the remote application.
 	SetStatus(info status.StatusInfo) error
+
+	// TerminateOperation returns an operation that will set this
+	// remote application to terminated and leave it in a state
+	// enabling it to be removed cleanly.
+	TerminateOperation(string) state.ModelOperation
 }

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -203,6 +203,11 @@ func (st *mockState) WatchRemoteRelations() state.StringsWatcher {
 	return st.remoteRelationsWatcher
 }
 
+func (st *mockState) ApplyOperation(op state.ModelOperation) error {
+	st.MethodCall(st, "ApplyOperation", op)
+	return st.NextErr()
+}
+
 type mockControllerInfo struct {
 	uuid string
 	info crossmodel.ControllerInfo
@@ -308,6 +313,7 @@ type mockRemoteApplication struct {
 	url           string
 	life          state.Life
 	status        status.Status
+	terminated    bool
 	message       string
 	eps           []charm.Relation
 	consumerproxy bool
@@ -369,6 +375,17 @@ func (r *mockRemoteApplication) SetStatus(info status.StatusInfo) error {
 	r.status = info.Status
 	r.message = info.Message
 	return nil
+}
+
+func (r *mockRemoteApplication) TerminateOperation(message string) state.ModelOperation {
+	r.MethodCall(r, "TerminateOperation", message)
+	r.terminated = true
+	return &mockOperation{message: message}
+}
+
+type mockOperation struct {
+	state.ModelOperation
+	message string
 }
 
 type mockApplication struct {

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -411,10 +411,16 @@ func (f *RemoteRelationsAPI) SetRemoteApplicationsStatus(args params.SetStatus) 
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		err = app.SetStatus(status.StatusInfo{
-			Status:  status.Status(entity.Status),
-			Message: entity.Info,
-		})
+		statusValue := status.Status(entity.Status)
+		if statusValue == status.Terminated {
+			operation := app.TerminateOperation(entity.Info)
+			err = f.st.ApplyOperation(operation)
+		} else {
+			err = app.SetStatus(status.StatusInfo{
+				Status:  statusValue,
+				Message: entity.Info,
+			})
+		}
 		result.Results[i].Error = common.ServerError(err)
 	}
 	return result, nil

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -426,3 +426,21 @@ func (s *remoteRelationsSuite) TestSetRemoteApplicationsStatus(c *gc.C) {
 	c.Assert(remoteApp.status, gc.Equals, status.Blocked)
 	c.Assert(remoteApp.message, gc.Equals, "a message")
 }
+
+func (s *remoteRelationsSuite) TestSetRemoteApplicationsStatusTerminated(c *gc.C) {
+	remoteApp := newMockRemoteApplication("db2", "url")
+	s.st.remoteApplications["db2"] = remoteApp
+	entity := names.NewApplicationTag("db2")
+	result, err := s.api.SetRemoteApplicationsStatus(
+		params.SetStatus{Entities: []params.EntityStatusArgs{{
+			Tag:    entity.String(),
+			Status: "terminated",
+			Info:   "killer whales",
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(remoteApp.terminated, gc.Equals, true)
+	s.st.CheckCallNames(c, "RemoteApplication", "ApplyOperation")
+	s.st.CheckCall(c, 1, "ApplyOperation", &mockOperation{message: "killer whales"})
+}

--- a/state/status.go
+++ b/state/status.go
@@ -442,7 +442,7 @@ func setStatus(db Database, params setStatusParams) (err error) {
 		// If this status is not new (i.e. it is exactly the same as
 		// our last status), there is no need to update the record.
 		// Update here will only reset the 'Since' field.
-		return err
+		return nil
 	}
 
 	// Set the authoritative status document, or fail trying.

--- a/state/unit.go
+++ b/state/unit.go
@@ -947,6 +947,9 @@ func (op *ForcedOperation) AddError(one ...error) {
 
 // LastError returns last added error for this operation.
 func (op *ForcedOperation) LastError() error {
+	if len(op.Errors) == 0 {
+		return nil
+	}
 	return op.Errors[len(op.Errors)-1]
 }
 


### PR DESCRIPTION
## Description of change

When an offered application with a consumer is force-removed, it would leave the consuming model data in a bad state that prevented removing the application from consuming model with `remove-saas`.

To avoid this, leave scope for all the remote application's relation units when we see it go to Terminated state.

## QA steps

* Bootstrap a controller with two models.
* In model 1 deploy mariadb and offer the db endpoint.
* In model 2 deploy mediawiki and relate it to the mariadb offer.
* Once the connection is established and settled, remove the offer with --force.
* Removing the consumed application with remove-saas (no force) should remove it from model 2.

## Documentation changes
None

## Bug reference
None
