### PR TITLE
Added k8s bootstrap failure handling.

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2045,6 +2045,19 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 	return units, nil
 }
 
+func (k *kubernetesClient) getPod(podName string) (*core.Pod, error) {
+	pods := k.client().CoreV1().Pods(k.namespace)
+	pod, err := pods.Get(podName, v1.GetOptions{
+		IncludeUninitialized: true,
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil, errors.NotFoundf("pod not found")
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return pod, nil
+}
+
 func (k *kubernetesClient) volumeInfoForEmptyDir(vol core.Volume, volMount core.VolumeMount, now time.Time) (*caas.FilesystemInfo, error) {
 	size := uint64(vol.EmptyDir.SizeLimit.Size())
 	return &caas.FilesystemInfo{
@@ -2066,6 +2079,17 @@ func (k *kubernetesClient) volumeInfoForEmptyDir(vol core.Volume, volMount core.
 			},
 		},
 	}, nil
+}
+
+func (k *kubernetesClient) getPVC(claimName string) (*core.PersistentVolumeClaim, error) {
+	pvcs := k.client().CoreV1().PersistentVolumeClaims(k.namespace)
+	pvc, err := pvcs.Get(claimName, v1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil, errors.NotFoundf("pvc not found")
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return pvc, nil
 }
 
 func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.VolumeMount, claimName string, now time.Time) (*caas.FilesystemInfo, error) {
@@ -2102,7 +2126,7 @@ func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.Volum
 	if statusMessage == "" {
 		// If there are any events for this pvc we can use the
 		// most recent to set the status.
-		eventList, err := k.getEvents(pvc.Name)
+		eventList, err := k.getEvents(pvc.Name, "PersistentVolumeClaim")
 		if err != nil {
 			return nil, errors.Annotate(err, "unable to get events for PVC")
 		}
@@ -2193,7 +2217,7 @@ func (k *kubernetesClient) getPODStatus(pod core.Pod, now time.Time) (string, st
 	if statusMessage == "" {
 		// If there are any events for this pod we can use the
 		// most recent to set the status.
-		eventList, err := k.getEvents(pod.Name)
+		eventList, err := k.getEvents(pod.Name, "Pod")
 		if err != nil {
 			return "", "", time.Time{}, errors.Trace(err)
 		}
@@ -2215,7 +2239,7 @@ func (k *kubernetesClient) getStatefulSetStatus(ss *apps.StatefulSet) (string, s
 	if ss.Status.ReadyReplicas == ss.Status.Replicas {
 		jujuStatus = status.Active
 	}
-	return k.getStatusFromEvents(ss.Name, jujuStatus)
+	return k.getStatusFromEvents(ss.Name, "StatefulSet", jujuStatus)
 }
 
 func (k *kubernetesClient) getDeploymentStatus(deployment *apps.Deployment) (string, status.Status, error) {
@@ -2227,11 +2251,11 @@ func (k *kubernetesClient) getDeploymentStatus(deployment *apps.Deployment) (str
 	if deployment.Status.ReadyReplicas == deployment.Status.Replicas {
 		jujuStatus = status.Active
 	}
-	return k.getStatusFromEvents(deployment.Name, jujuStatus)
+	return k.getStatusFromEvents(deployment.Name, "Deployment", jujuStatus)
 }
 
-func (k *kubernetesClient) getStatusFromEvents(parentName string, jujuStatus status.Status) (string, status.Status, error) {
-	events, err := k.getEvents(parentName)
+func (k *kubernetesClient) getStatusFromEvents(name, kind string, jujuStatus status.Status) (string, status.Status, error) {
+	events, err := k.getEvents(name, kind)
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -659,7 +659,9 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 	}(namespaceWatcher, s.clock)
 
 	c.Assert(destroyFunc(), jc.ErrorIsNil)
-	c.Assert(workertest.CheckKilled(c, s.watcher), jc.ErrorIsNil)
+	for _, watcher := range s.watchers {
+		c.Assert(workertest.CheckKilled(c, watcher), jc.ErrorIsNil)
+	}
 	c.Assert(namespaceWatcher.IsStopped(), jc.IsTrue)
 }
 


### PR DESCRIPTION
## Description of change

Kubernetes bootstrap now handles controller pod creation timing out and unrecoverable errors. At timeout it tries to find the most relevant reason why the controller pod took so long to start. Specifically it handles when a PersistentVolumeClaim does not bind, and generally other _unschedulable_ reasons such as no suitable node available.

## QA steps

**Add a bad storage class:**
```
kubectl apply -f - <<EOM
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: bad
provisioner: bad-provisioner
reclaimPolicy: Delete
volumeBindingMode: Immediate
EOM
```
**Add k8s cloud using bad storage class:**
```
juju add-k8s test --storage=bad
```
**Bootstrap controller:**
```
juju bootstrap test --config bootstrap-timeout=120
```
**Old behaviour:**
```
Creating Juju controller "test-localhost" on test/localhost
Creating k8s resources for controller "controller-test-localhost"
<waits-forever>
```
**New behaviour:**
```
Creating Juju controller "test-localhost" on test/localhost
Creating k8s resources for controller "controller-test-localhost"
ERROR failed to bootstrap model: creating controller stack for controller: creating statefulset for controller: timed out waiting for controller pod: unschedulable: pvc storage-controller-0 pending due to ExternalProvisioning - waiting for a volume to be created, either by external provisioner "bad-provisioner" or manually created by system administrator
```

## Documentation changes

Fairly self-documenting, as this exposes more errors to the user. Most error messages are sourced from kubernetes, so finding a solution should be easier.

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1831682](https://bugs.launchpad.net/juju/+bug/1831682)
