### PR TITLE
1833155: Tie the watcher life cycle to the catacomb

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -89,12 +89,16 @@ func NewProvisionerTask(
 ) (ProvisionerTask, error) {
 	machineChanges := machineWatcher.Changes()
 	workers := []worker.Worker{machineWatcher}
+
 	var retryChanges watcher.NotifyChannel
 	if retryWatcher != nil {
 		retryChanges = retryWatcher.Changes()
 		workers = append(workers, retryWatcher)
 	}
+
 	profileChanges := profileWatcher.Changes()
+	workers = append(workers, profileWatcher)
+
 	task := &provisionerTask{
 		controllerUUID:             controllerUUID,
 		machineTag:                 machineTag,

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -127,6 +127,8 @@ func (s *ProvisionerTaskSuite) TestStartStop(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = workertest.CheckKilled(c, s.machineErrorRetryWatcher)
 	c.Assert(err, jc.ErrorIsNil)
+	err = workertest.CheckKilled(c, s.modelMachinesProfileWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 	s.machineGetter.CheckNoCalls(c)
 	s.instanceBroker.CheckNoCalls(c)
 }


### PR DESCRIPTION
## Description of change

The machines profile watcher was missing the ability to tie itself
to the provisioner task life-cycle, which means that when a
provisioner task was killed or restarted then the watcher was still
spinning and never cleaned up, leaking as a resource.

There is another problem that @jameinel spotted in the creation of
the provisioner task, is that if the provisioner errored out on
the construction of the provisioner task, then we never killed the
other watchers and they could also be leaked. We should look at
those in the near future to ensure that any watchers that die on
construction are also cleaned up.

## QA steps

Ensure that the following test passes:

```console
go test -v ./worker/provisioner/... -check.v -check.f=ProvisionerTaskSuite.TestStartStop
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1833155
