### PR TITLE
Make scripts/schema.bash work for mac too

### DIFF
--- a/scripts/schema.bash
+++ b/scripts/schema.bash
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Copyright 2019 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
-current_schema_sha=$(git show HEAD:apiserver/facades/schema.json | sha256sum | awk '{ print $1 }')
-tmpfile=$(mktemp /tmp/schema-XXXXX.json)
+current_schema_sha=$(git show HEAD:apiserver/facades/schema.json | shasum -a 1 | awk '{ print $1 }')
+tmpfile=$(mktemp /tmp/schema-XXXXX)
 make SCHEMA_PATH=$tmpfile rebuild-schema
-new_schema_sha=$(cat $tmpfile | sha256sum | awk '{ print $1 }')
+new_schema_sha=$(cat $tmpfile | shasum -a 1 | awk '{ print $1 }')
 
 if [ $current_schema_sha != $new_schema_sha ]; then
     (>&2 echo "Error: facades schema is not in sync. Run 'make rebuild-schema' and commit source.")


### PR DESCRIPTION
## Description of change

Make scripts/schema.bash work for mac too: change sha256sum to shasum -a 1; remove json suffix on mktemp file template.

## QA steps

Run the script on ubuntu and mac
