### PR TITLE
Fixed enable-ha panic when passed invalid param.

### DIFF
--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -171,6 +171,9 @@ func (c *enableHACommand) Init(args []string) error {
 		c.Placement = make([]string, len(placementSpecs))
 		for i, spec := range placementSpecs {
 			p, err := instance.ParsePlacement(strings.TrimSpace(spec))
+			if err == nil && p == nil {
+				return errors.New("empty placement directive passed to enable-ha")
+			}
 			if err == nil && names.IsContainerMachine(p.Directive) {
 				return errors.New("enable-ha cannot be used with container placement directives")
 			}

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -207,6 +207,14 @@ func (s *EnableHASuite) TestEnableHAErrors(c *gc.C) {
 	c.Assert(s.fake.numControllers, gc.Equals, invalidNumServers)
 }
 
+func (s *EnableHASuite) TestEnableHAErrorsWithInvalidPlacement(c *gc.C) {
+	_, err := s.runEnableHA(c, "--to", "in,,valid", "-n", "3")
+	c.Assert(err, gc.ErrorMatches, "empty placement directive passed to enable-ha")
+
+	// Verify that enable-ha didn't call into the API
+	c.Assert(s.fake.numControllers, gc.Equals, invalidNumServers)
+}
+
 func (s *EnableHASuite) TestEnableHAAllows0(c *gc.C) {
 	// If the number of controllers is specified as "0", the API will
 	// then use the default number of 3.


### PR DESCRIPTION
## Description of change

`juju enable-ha` would panic when passed an empty placement directive.
This changes returns a more useful error to the user.

## QA steps

enable-ha should not panic when called with empty placement directive.
```
juju enable-ha --to ,2
ERROR empty placement directive passed to enable-ha
```

## Documentation changes

N/A

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1832777](https://bugs.launchpad.net/juju/+bug/1832777)
