### PR TITLE
upgrade-controller: pass controller to subcommand

### DIFF
--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -268,7 +268,13 @@ func (c *upgradeControllerCommand) upgradeIAASController(ctx *cmd.Context) error
 	}}
 	jcmd.SetClientStore(c.ClientStore())
 	wrapped := modelcmd.Wrap(jcmd)
-	args := append(c.rawArgs, "-m", bootstrap.ControllerModelName)
+	controllerName, err := c.ControllerName()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	fullControllerModelName := modelcmd.JoinModelName(controllerName,
+		bootstrap.ControllerModelName)
+	args := append(c.rawArgs, "-m", fullControllerModelName)
 	if c.vers != "" {
 		args = append(args, "--agent-version", c.vers)
 	}


### PR DESCRIPTION
## Description of change

`juju upgrade-controller -c <controller-name>` previously would error when there isn't a current-controller set.
Additionally, when upgrading an IAAS controller, it would previously upgrade the current-controller, even though the controller specified in the command was different.

## QA steps

Quick test:
Bootstrap to an IAAS (not k8s) e.g. `juju bootstrap localhost`
Remove the current-controller line from `controllers.yaml`.
Run `juju upgrade-controller -c localhost-localhost`
It should not error with `ERROR No selected controller.`

Additional test:
Bootstrap 2 controllers with an old version.
Check which controller is the current-controller.
`juju upgrade-controller -c <not-the-current-controller>`
Check that the current-controller is still using the old version.

## Documentation changes

N/A

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1832779](https://bugs.launchpad.net/juju/+bug/1832779)