### PR TITLE
Fix/lp 1831770

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -154,9 +154,12 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 		// Region is optional, but cloudType is required for next step.
 		return "", ClusterQueryError{}
 	}
-	k8sCloud.Regions = []cloud.Region{{
-		Name: region,
-	}}
+	if region != "" {
+		k8sCloud.Regions = []cloud.Region{{
+			Name:     region,
+			Endpoint: k8sCloud.Endpoint,
+		}}
+	}
 
 	// If the user has not specified storage and cloudType is usable, check Juju's opinionated defaults.
 	err = storageParams.MetadataChecker.CheckDefaultWorkloadStorage(
@@ -295,11 +298,6 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 	_, err = UpdateKubeCloudWithStorage(&mk8sCloud, storageUpdateParams)
 	if err != nil {
 		return cloud.Cloud{}, errors.Trace(err)
-	}
-	for i := range mk8sCloud.Regions {
-		if mk8sCloud.Regions[i].Endpoint == "" {
-			mk8sCloud.Regions[i].Endpoint = mk8sCloud.Endpoint
-		}
 	}
 	return mk8sCloud, nil
 }

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -14,14 +14,11 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/juju/osenv"
 )
-
-var logger = loggo.GetLogger("juju.cloud")
 
 //go:generate go run ../generate/filetoconst/filetoconst.go fallbackPublicCloudInfo fallback-public-cloud.yaml fallback_public_cloud.go 2015 cloud
 
@@ -521,7 +518,7 @@ func cloudFromInternal(in *cloud) Cloud {
 		Description:      in.Description,
 		CACertificates:   in.CACertificates,
 	}
-	meta.DenormaliseMetadata()
+	meta.denormaliseMetadata()
 	return meta
 }
 
@@ -540,9 +537,9 @@ func (r *regions) UnmarshalYAML(f func(interface{}) error) error {
 
 // To keep the metadata concise, attributes on the metadata struct which
 // have the same value for each item may be moved up to a higher level in
-// the tree. DenormaliseMetadata descends the tree and fills in any missing
+// the tree. denormaliseMetadata descends the tree and fills in any missing
 // attributes with values from a higher level.
-func (cloud Cloud) DenormaliseMetadata() {
+func (cloud Cloud) denormaliseMetadata() {
 	for name, region := range cloud.Regions {
 		r := region
 		inherit(&r, &cloud)

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -421,6 +421,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	newCloud.DenormaliseMetadata()
 
 	if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
 		return errors.Trace(err)
@@ -649,7 +650,7 @@ func nameExists(name string, public map[string]jujucloud.Cloud) (string, error) 
 func addCloudToLocal(cloudMetadataStore CloudMetadataStore, newCloud jujucloud.Cloud) error {
 	personalClouds, err := cloudMetadataStore.PersonalCloudMetadata()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if personalClouds == nil {
 		personalClouds = make(map[string]jujucloud.Cloud)

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -421,7 +421,6 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	newCloud.DenormaliseMetadata()
 
 	if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
 		return errors.Trace(err)

--- a/environs/cloudspec.go
+++ b/environs/cloudspec.go
@@ -74,9 +74,11 @@ func MakeCloudSpec(cloud jujucloud.Cloud, cloudRegionName string, credential *ju
 		if err != nil {
 			return CloudSpec{}, errors.Annotate(err, "getting cloud region definition")
 		}
-		cloudSpec.Endpoint = cloudRegion.Endpoint
-		cloudSpec.IdentityEndpoint = cloudRegion.IdentityEndpoint
-		cloudSpec.StorageEndpoint = cloudRegion.StorageEndpoint
+		if !cloudRegion.IsEmpty() {
+			cloudSpec.Endpoint = cloudRegion.Endpoint
+			cloudSpec.IdentityEndpoint = cloudRegion.IdentityEndpoint
+			cloudSpec.StorageEndpoint = cloudRegion.StorageEndpoint
+		}
 	}
 	return cloudSpec, nil
 }

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -81,41 +81,35 @@ func createCloudOp(cloud cloud.Cloud) txn.Op {
 
 // updateCloudOp returns a txn.Op that will update
 // an existing cloud definition for the controller.
-func updateCloudOps(kld cloud.Cloud) txn.Op {
-	authTypes := make([]string, len(kld.AuthTypes))
-	for i, authType := range kld.AuthTypes {
+func updateCloudOps(cloud cloud.Cloud) txn.Op {
+	authTypes := make([]string, len(cloud.AuthTypes))
+	for i, authType := range cloud.AuthTypes {
 		authTypes[i] = string(authType)
 	}
-	cloudRegionsToDocs := func(rs []cloud.Region) map[string]cloudRegionSubdoc {
-		if len(rs) == 0 {
-			return nil
+	regions := make(map[string]cloudRegionSubdoc)
+	for _, region := range cloud.Regions {
+		regions[utils.EscapeKey(region.Name)] = cloudRegionSubdoc{
+			region.Endpoint,
+			region.IdentityEndpoint,
+			region.StorageEndpoint,
 		}
-		regions := make(map[string]cloudRegionSubdoc)
-		for _, region := range rs {
-			regions[utils.EscapeKey(region.Name)] = cloudRegionSubdoc{
-				region.Endpoint,
-				region.IdentityEndpoint,
-				region.StorageEndpoint,
-			}
-		}
-		return regions
 	}
 	updatedCloud := &cloudDoc{
-		DocID:            kld.Name,
-		Name:             kld.Name,
-		Type:             kld.Type,
+		DocID:            cloud.Name,
+		Name:             cloud.Name,
+		Type:             cloud.Type,
 		AuthTypes:        authTypes,
-		Endpoint:         kld.Endpoint,
-		Regions:          cloudRegionsToDocs(kld.Regions),
-		IdentityEndpoint: kld.IdentityEndpoint,
-		StorageEndpoint:  kld.StorageEndpoint,
-		CACertificates:   kld.CACertificates,
+		Endpoint:         cloud.Endpoint,
+		IdentityEndpoint: cloud.IdentityEndpoint,
+		StorageEndpoint:  cloud.StorageEndpoint,
+		Regions:          regions,
+		CACertificates:   cloud.CACertificates,
 	}
 	return txn.Op{
 		C:      cloudsC,
-		Id:     kld.Name,
+		Id:     cloud.Name,
 		Assert: txn.DocExists,
-		Update: bson.D{{"$set", updatedCloud}},
+		Update: bson.M{"$set": updatedCloud},
 	}
 }
 


### PR DESCRIPTION
## Description of change

Fix: k8s cloud endpoint gets overwritten by empty region endpoint; 

## QA steps

1. prepare a caas model;
2. deploy caas bundle;

```bash
$ juju deploy kubeflow --channel stable --debug
```

3. check no error;

```bash
$ kubectl get all,pv,pvc,cm,po,secrets,ing,endpoints -o wide -n t1
NAME                                                   READY   STATUS    RESTARTS   AGE   IP           NODE                                              NOMINATED NODE   READINESS GATES
pod/kubeflow-ambassador-798d59b959-7t2zw               1/1     Running   0          19m   10.1.8.4     ip-172-31-12-77.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-ambassador-operator-0                     1/1     Running   0          18m   10.1.73.22   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-jupyterhub-678864cd-f5qlm                 1/1     Running   0          18m   10.1.8.6     ip-172-31-12-77.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-jupyterhub-operator-0                     1/1     Running   0          18m   10.1.73.17   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-pytorch-operator-57bdb46d6d-vkd9r         1/1     Running   0          18m   10.1.99.4    ip-172-31-35-56.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-pytorch-operator-operator-0               1/1     Running   0          18m   10.1.73.23   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-seldon-api-frontend-7c5d664b-h7clz        1/1     Running   0          18m   10.1.8.7     ip-172-31-12-77.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-seldon-api-frontend-operator-0            1/1     Running   0          18m   10.1.73.18   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-seldon-cluster-manager-5f9bbd7f7c-jdtvc   1/1     Running   0          18m   10.1.99.7    ip-172-31-35-56.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-seldon-cluster-manager-operator-0         1/1     Running   0          18m   10.1.73.20   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-tf-job-dashboard-c798cbccd-dcn46          1/1     Running   0          18m   10.1.99.5    ip-172-31-35-56.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-tf-job-dashboard-operator-0               1/1     Running   0          17m   10.1.73.24   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-tf-job-operator-7665d55dd5-g66fp          1/1     Running   0          18m   10.1.99.6    ip-172-31-35-56.ap-southeast-2.compute.internal   <none>           <none>
pod/kubeflow-tf-job-operator-operator-0                1/1     Running   0          18m   10.1.73.19   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>
pod/redis-55c4784889-fzxdp                             1/1     Running   0          19m   10.1.8.5     ip-172-31-12-77.ap-southeast-2.compute.internal   <none>           <none>
pod/redis-operator-0                                   1/1     Running   0          18m   10.1.73.21   ip-172-31-22-17.ap-southeast-2.compute.internal   <none>           <none>

NAME                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE   SELECTOR
service/kubeflow-ambassador               ClusterIP   10.152.183.199   <none>        80/TCP              19m   juju-app=kubeflow-ambassador
service/kubeflow-jupyterhub               ClusterIP   10.152.183.148   <none>        8000/TCP,8081/TCP   18m   juju-app=kubeflow-jupyterhub
service/kubeflow-pytorch-operator         ClusterIP   10.152.183.154   <none>        9999/TCP            18m   juju-app=kubeflow-pytorch-operator
service/kubeflow-seldon-api-frontend      ClusterIP   10.152.183.200   <none>        8080/TCP,5000/TCP   18m   juju-app=kubeflow-seldon-api-frontend
service/kubeflow-seldon-cluster-manager   ClusterIP   10.152.183.97    <none>        8080/TCP            18m   juju-app=kubeflow-seldon-cluster-manager
service/kubeflow-tf-job-dashboard         ClusterIP   10.152.183.62    <none>        8080/TCP            18m   juju-app=kubeflow-tf-job-dashboard
service/kubeflow-tf-job-operator          ClusterIP   10.152.183.109   <none>        9999/TCP            18m   juju-app=kubeflow-tf-job-operator
service/redis                             ClusterIP   10.152.183.34    <none>        6379/TCP            19m   juju-app=redis

NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS               IMAGES                                                                                                                                                                    SELECTOR
deployment.apps/kubeflow-ambassador               1/1     1            1           19m   ambassador               registry.jujucharms.com/kubeflow-charmers/kubeflow-ambassador/ambassador-image@sha256:47e1f825110508660cae61a8e211bd7a46c5d1635abfa459eac7f676d7a06c6a                    juju-app=kubeflow-ambassador
deployment.apps/kubeflow-jupyterhub               1/1     1            1           18m   jupyterhub               registry.jujucharms.com/kubeflow-charmers/kubeflow-jupyterhub/jupyterhub-image@sha256:373eaca464ee2c7062772649ad701a90eb9dc5603d9cf4a2815459d37647b8f4                    juju-app=kubeflow-jupyterhub
deployment.apps/kubeflow-pytorch-operator         1/1     1            1           18m   pytorch-operator         registry.jujucharms.com/kubeflow-charmers/kubeflow-pytorch-operator/pytorch-operator-image@sha256:6cb7c3b23f78e0efd8f47ef43238a253ac56302995e3a1b6ba479ac7956c3126        juju-app=kubeflow-pytorch-operator
deployment.apps/kubeflow-seldon-api-frontend      1/1     1            1           18m   seldon-apiserver         registry.jujucharms.com/kubeflow-charmers/kubeflow-seldon-api-frontend/api-frontend-image@sha256:bd628a2f76d939cf76a26c5c739a2f448ec131a11fe4a5950b6ccaf2fa9eec86         juju-app=kubeflow-seldon-api-frontend
deployment.apps/kubeflow-seldon-cluster-manager   1/1     1            1           18m   seldon-cluster-manager   registry.jujucharms.com/kubeflow-charmers/kubeflow-seldon-cluster-manager/cluster-manager-image@sha256:35e2c4150b45509d4a3195b2e59248c20a46c2bc30e27c68ee934ce76e3a4965   juju-app=kubeflow-seldon-cluster-manager
deployment.apps/kubeflow-tf-job-dashboard         1/1     1            1           18m   tf-job-dashboard         registry.jujucharms.com/kubeflow-charmers/kubeflow-tf-job-dashboard/tf-operator-image@sha256:00ab02f87aa8159964e59ed1eca0a0bd31692986504bd43cfcccc780f1ffdba6             juju-app=kubeflow-tf-job-dashboard
deployment.apps/kubeflow-tf-job-operator          1/1     1            1           18m   tf-job-operator          registry.jujucharms.com/kubeflow-charmers/kubeflow-tf-job-operator/tf-operator-image@sha256:00ab02f87aa8159964e59ed1eca0a0bd31692986504bd43cfcccc780f1ffdba6              juju-app=kubeflow-tf-job-operator
deployment.apps/redis                             1/1     1            1           19m   redis                    registry.jujucharms.com/kubeflow-charmers/redis-k8s/redis-image@sha256:478392fbb4f132b36b8ead3435087553ee7e6f0395b3d64987ae195268d13493                                   juju-app=redis

NAME                                                         DESIRED   CURRENT   READY   AGE   CONTAINERS               IMAGES                                                                                                                                                                    SELECTOR
replicaset.apps/kubeflow-ambassador-798d59b959               1         1         1       19m   ambassador               registry.jujucharms.com/kubeflow-charmers/kubeflow-ambassador/ambassador-image@sha256:47e1f825110508660cae61a8e211bd7a46c5d1635abfa459eac7f676d7a06c6a                    juju-app=kubeflow-ambassador,pod-template-hash=798d59b959
replicaset.apps/kubeflow-jupyterhub-678864cd                 1         1         1       18m   jupyterhub               registry.jujucharms.com/kubeflow-charmers/kubeflow-jupyterhub/jupyterhub-image@sha256:373eaca464ee2c7062772649ad701a90eb9dc5603d9cf4a2815459d37647b8f4                    juju-app=kubeflow-jupyterhub,pod-template-hash=678864cd
replicaset.apps/kubeflow-pytorch-operator-57bdb46d6d         1         1         1       18m   pytorch-operator         registry.jujucharms.com/kubeflow-charmers/kubeflow-pytorch-operator/pytorch-operator-image@sha256:6cb7c3b23f78e0efd8f47ef43238a253ac56302995e3a1b6ba479ac7956c3126        juju-app=kubeflow-pytorch-operator,pod-template-hash=57bdb46d6d
replicaset.apps/kubeflow-seldon-api-frontend-7c5d664b        1         1         1       18m   seldon-apiserver         registry.jujucharms.com/kubeflow-charmers/kubeflow-seldon-api-frontend/api-frontend-image@sha256:bd628a2f76d939cf76a26c5c739a2f448ec131a11fe4a5950b6ccaf2fa9eec86         juju-app=kubeflow-seldon-api-frontend,pod-template-hash=7c5d664b
replicaset.apps/kubeflow-seldon-cluster-manager-5f9bbd7f7c   1         1         1       18m   seldon-cluster-manager   registry.jujucharms.com/kubeflow-charmers/kubeflow-seldon-cluster-manager/cluster-manager-image@sha256:35e2c4150b45509d4a3195b2e59248c20a46c2bc30e27c68ee934ce76e3a4965   juju-app=kubeflow-seldon-cluster-manager,pod-template-hash=5f9bbd7f7c
replicaset.apps/kubeflow-tf-job-dashboard-c798cbccd          1         1         1       18m   tf-job-dashboard         registry.jujucharms.com/kubeflow-charmers/kubeflow-tf-job-dashboard/tf-operator-image@sha256:00ab02f87aa8159964e59ed1eca0a0bd31692986504bd43cfcccc780f1ffdba6             juju-app=kubeflow-tf-job-dashboard,pod-template-hash=c798cbccd
replicaset.apps/kubeflow-tf-job-operator-7665d55dd5          1         1         1       18m   tf-job-operator          registry.jujucharms.com/kubeflow-charmers/kubeflow-tf-job-operator/tf-operator-image@sha256:00ab02f87aa8159964e59ed1eca0a0bd31692986504bd43cfcccc780f1ffdba6              juju-app=kubeflow-tf-job-operator,pod-template-hash=7665d55dd5
replicaset.apps/redis-55c4784889                             1         1         1       19m   redis                    registry.jujucharms.com/kubeflow-charmers/redis-k8s/redis-image@sha256:478392fbb4f132b36b8ead3435087553ee7e6f0395b3d64987ae195268d13493                                   juju-app=redis,pod-template-hash=55c4784889

NAME                                                        READY   AGE   CONTAINERS      IMAGES
statefulset.apps/kubeflow-ambassador-operator               1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4
statefulset.apps/kubeflow-jupyterhub-operator               1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4
statefulset.apps/kubeflow-pytorch-operator-operator         1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4
statefulset.apps/kubeflow-seldon-api-frontend-operator      1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4
statefulset.apps/kubeflow-seldon-cluster-manager-operator   1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4
statefulset.apps/kubeflow-tf-job-dashboard-operator         1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4
statefulset.apps/kubeflow-tf-job-operator-operator          1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4
statefulset.apps/redis-operator                             1/1     19m   juju-operator   jujusolutions/jujud-operator:2.6.4

NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                 STORAGECLASS            REASON   AGE
persistentvolume/pvc-65f46b32-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-kubeflow-ambassador-operator-0               juju-operator-storage            19m
persistentvolume/pvc-67403e65-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-kubeflow-jupyterhub-operator-0               juju-operator-storage            19m
persistentvolume/pvc-6883ca98-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-kubeflow-pytorch-operator-operator-0         juju-operator-storage            19m
persistentvolume/pvc-6a1095bc-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-kubeflow-seldon-api-frontend-operator-0      juju-operator-storage            19m
persistentvolume/pvc-6b602599-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-kubeflow-seldon-cluster-manager-operator-0   juju-operator-storage            19m
persistentvolume/pvc-6ced870c-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-kubeflow-tf-job-dashboard-operator-0         juju-operator-storage            19m
persistentvolume/pvc-6e986e4b-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-kubeflow-tf-job-operator-operator-0          juju-operator-storage            19m
persistentvolume/pvc-70065e9a-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            Delete           Bound    t1/charm-redis-operator-0                             juju-operator-storage            19m

NAME                                                                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS            AGE
persistentvolumeclaim/charm-kubeflow-ambassador-operator-0               Bound    pvc-65f46b32-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m
persistentvolumeclaim/charm-kubeflow-jupyterhub-operator-0               Bound    pvc-67403e65-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m
persistentvolumeclaim/charm-kubeflow-pytorch-operator-operator-0         Bound    pvc-6883ca98-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m
persistentvolumeclaim/charm-kubeflow-seldon-api-frontend-operator-0      Bound    pvc-6a1095bc-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m
persistentvolumeclaim/charm-kubeflow-seldon-cluster-manager-operator-0   Bound    pvc-6b602599-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m
persistentvolumeclaim/charm-kubeflow-tf-job-dashboard-operator-0         Bound    pvc-6ced870c-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m
persistentvolumeclaim/charm-kubeflow-tf-job-operator-operator-0          Bound    pvc-6e986e4b-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m
persistentvolumeclaim/charm-redis-operator-0                             Bound    pvc-70065e9a-9267-11e9-8f68-06ade6e964d4   1Gi        RWO            juju-operator-storage   19m

NAME                                                        DATA   AGE
configmap/kubeflow-ambassador-operator-config               1      19m
configmap/kubeflow-jupyterhub-configs-config                6      18m
configmap/kubeflow-jupyterhub-operator-config               1      19m
configmap/kubeflow-pytorch-operator-configs-config          1      18m
configmap/kubeflow-pytorch-operator-operator-config         1      19m
configmap/kubeflow-seldon-api-frontend-operator-config      1      19m
configmap/kubeflow-seldon-cluster-manager-operator-config   1      19m
configmap/kubeflow-tf-job-dashboard-operator-config         1      19m
configmap/kubeflow-tf-job-operator-configs-config           1      18m
configmap/kubeflow-tf-job-operator-operator-config          1      19m
configmap/redis-operator-config                             1      19m

NAME                                                                   TYPE                                  DATA   AGE
secret/default-token-9gxlx                                             kubernetes.io/service-account-token   3      20m
secret/kubeflow-ambassador-ambassador-secret                           kubernetes.io/dockerconfigjson        1      19m
secret/kubeflow-jupyterhub-jupyterhub-secret                           kubernetes.io/dockerconfigjson        1      18m
secret/kubeflow-pytorch-operator-pytorch-operator-secret               kubernetes.io/dockerconfigjson        1      18m
secret/kubeflow-seldon-api-frontend-seldon-apiserver-secret            kubernetes.io/dockerconfigjson        1      18m
secret/kubeflow-seldon-cluster-manager-seldon-cluster-manager-secret   kubernetes.io/dockerconfigjson        1      18m
secret/kubeflow-tf-job-dashboard-tf-job-dashboard-secret               kubernetes.io/dockerconfigjson        1      18m
secret/kubeflow-tf-job-operator-tf-job-operator-secret                 kubernetes.io/dockerconfigjson        1      18m
secret/redis-redis-secret                                              kubernetes.io/dockerconfigjson        1      19m

NAME                                        ENDPOINTS                     AGE
endpoints/kubeflow-ambassador               10.1.8.4:80                   19m
endpoints/kubeflow-jupyterhub               10.1.8.6:8081,10.1.8.6:8000   18m
endpoints/kubeflow-pytorch-operator         10.1.99.4:9999                18m
endpoints/kubeflow-seldon-api-frontend      10.1.8.7:5000,10.1.8.7:8080   18m
endpoints/kubeflow-seldon-cluster-manager   10.1.99.7:8080                18m
endpoints/kubeflow-tf-job-dashboard         10.1.99.5:8080                18m
endpoints/kubeflow-tf-job-operator          10.1.99.6:9999                18m
endpoints/redis                             10.1.8.5:6379                 19m

```


## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1831770