### PR TITLE
Fixes lp#1831527: misleading user errors.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -583,7 +583,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	}
 
 	switch {
-	case subnetErr != nil && (errors.IsNotFound(subnetErr) || isNotFoundError(err)):
+	case isNotFoundError(subnetErr):
 		return nil, errors.Trace(subnetErr)
 	case subnetErr != nil:
 		return nil, errors.Annotatef(maybeConvertCredentialError(subnetErr, ctx), "getting subnets for zone %q", availabilityZone)
@@ -1654,7 +1654,6 @@ func (e *environ) deleteSecurityGroupsForInstances(ctx context.ProviderCallConte
 // SecurityGroupCleaner defines provider instance methods needed to delete
 // a security group.
 type SecurityGroupCleaner interface {
-
 	// DeleteSecurityGroup deletes security group on the provider.
 	DeleteSecurityGroup(group ec2.SecurityGroup) (resp *ec2.SimpleResp, err error)
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -583,7 +583,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	}
 
 	switch {
-	case subnetErr != nil && errors.IsNotFound(subnetErr):
+	case subnetErr != nil && (errors.IsNotFound(subnetErr) || isNotFoundError(err)):
 		return nil, errors.Trace(subnetErr)
 	case subnetErr != nil:
 		return nil, errors.Annotatef(maybeConvertCredentialError(subnetErr, ctx), "getting subnets for zone %q", availabilityZone)

--- a/provider/gce/google/conn_instance.go
+++ b/provider/gce/google/conn_instance.go
@@ -90,7 +90,7 @@ func (gce *Connection) Instances(prefix string, statuses ...string) ([]Instance,
 func (gce *Connection) removeInstance(id, zone string) error {
 	err := gce.raw.RemoveInstance(gce.projectID, zone, id)
 	if err != nil {
-		if errors.IsNotFound(err) || IsNotFound(err) {
+		if IsNotFound(err) {
 			return nil
 		}
 		// TODO(ericsnow) Try removing the firewall anyway?
@@ -100,7 +100,7 @@ func (gce *Connection) removeInstance(id, zone string) error {
 	fwname := id
 	err = gce.raw.RemoveFirewall(gce.projectID, fwname)
 	if err != nil {
-		if errors.IsNotFound(err) || IsNotFound(err) {
+		if IsNotFound(err) {
 			return nil
 		}
 		return errors.Trace(err)

--- a/provider/gce/google/conn_instance.go
+++ b/provider/gce/google/conn_instance.go
@@ -90,16 +90,19 @@ func (gce *Connection) Instances(prefix string, statuses ...string) ([]Instance,
 func (gce *Connection) removeInstance(id, zone string) error {
 	err := gce.raw.RemoveInstance(gce.projectID, zone, id)
 	if err != nil {
+		if errors.IsNotFound(err) || IsNotFound(err) {
+			return nil
+		}
 		// TODO(ericsnow) Try removing the firewall anyway?
 		return errors.Trace(err)
 	}
 
 	fwname := id
 	err = gce.raw.RemoveFirewall(gce.projectID, fwname)
-	if errors.IsNotFound(err) {
-		return nil
-	}
 	if err != nil {
+		if errors.IsNotFound(err) || IsNotFound(err) {
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	return nil

--- a/provider/gce/google/conn_instance_test.go
+++ b/provider/gce/google/conn_instance_test.go
@@ -118,12 +118,13 @@ func (s *connSuite) TestConnectionAddInstanceFailed(c *gc.C) {
 func (s *connSuite) TestConnectionAddInstanceWaitFailed(c *gc.C) {
 	s.FakeConn.Instance = &s.RawInstanceFull
 
-	failure := s.NewWaitError(nil, errors.New("unknown"))
+	cause := errors.New("unknown")
+	failure := s.NewWaitError(nil, cause)
 	s.FakeConn.Err = failure
 
 	err := google.ConnAddInstance(s.Conn, &s.RawInstance, "mtype", "a-zone")
 
-	c.Check(errors.Cause(err), gc.Equals, failure)
+	c.Check(errors.Cause(err), gc.Equals, cause)
 }
 
 func (s *connSuite) TestConnectionAddInstanceGetFailed(c *gc.C) {

--- a/provider/gce/google/conn_network.go
+++ b/provider/gce/google/conn_network.go
@@ -21,7 +21,7 @@ import (
 // returned.
 func (gce Connection) firewallRules(fwname string) (ruleSet, error) {
 	firewalls, err := gce.raw.GetFirewalls(gce.projectID, fwname)
-	if errors.IsNotFound(err) || IsNotFound(err) {
+	if IsNotFound(err) {
 		return make(ruleSet), nil
 	}
 	if err != nil {

--- a/provider/gce/google/conn_network.go
+++ b/provider/gce/google/conn_network.go
@@ -21,7 +21,7 @@ import (
 // returned.
 func (gce Connection) firewallRules(fwname string) (ruleSet, error) {
 	firewalls, err := gce.raw.GetFirewalls(gce.projectID, fwname)
-	if errors.IsNotFound(err) {
+	if errors.IsNotFound(err) || IsNotFound(err) {
 		return make(ruleSet), nil
 	}
 	if err != nil {

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -131,10 +131,13 @@ var AuthorisationFailureStatusCodes = map[int][]string{
 	http.StatusBadRequest: {"Bad Request"},
 }
 
-// IsNotFound reports whether err contains `not found'.
+// IsNotFound reports if given error is of 'not found' type.
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), " not found")
+	if gerr, ok := errors.Cause(err).(*googleapi.Error); ok {
+		return gerr.Code == http.StatusNotFound
+	}
+	return errors.IsNotFound(err)
 }

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 
 	"github.com/juju/juju/environs/context"

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -120,3 +120,11 @@ var AuthorisationFailureStatusCodes = map[int][]string{
 	// https://tools.ietf.org/html/rfc6749#section-5.2
 	http.StatusBadRequest: {"Bad Request"},
 }
+
+// IsNotFound reports whether err contains `not found'.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), " not found")
+}

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 
 	"github.com/juju/juju/environs/context"
 )
@@ -94,6 +96,15 @@ func HasDenialStatusCode(err error) bool {
 	// contains response status code and description in error.Error.
 	// We have to examine the error message to determine whether the error is related to authentication failure.
 	if cause, ok := errors.Cause(err).(*url.Error); ok {
+		for code, descs := range AuthorisationFailureStatusCodes {
+			for _, desc := range descs {
+				if strings.Contains(cause.Error(), fmt.Sprintf(": %v %v", code, desc)) {
+					return true
+				}
+			}
+		}
+	}
+	if cause, ok := errors.Cause(err).(*googleapi.Error); ok {
 		for code, descs := range AuthorisationFailureStatusCodes {
 			for _, desc := range descs {
 				if strings.Contains(cause.Error(), fmt.Sprintf(": %v %v", code, desc)) {

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -365,7 +365,7 @@ func (rc *rawConn) waitOperation(projectID string, op *compute.Operation, attemp
 	}
 	if op.Error != nil {
 		for _, err := range op.Error.Errors {
-			logger.Errorf("GCE operation error %T: (%s) %s", err, err.Code, err.Message)
+			logger.Errorf("GCE operation error: (%s) %s", err.Code, err.Message)
 		}
 		return waitError{op, nil}
 	}

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -100,10 +100,6 @@ func (rc *rawConn) AddInstance(projectID, zoneName string, spec *compute.Instanc
 		// We are guaranteed the insert failed at the point.
 		return errors.Annotate(err, "sending new instance request")
 	}
-	if err := logOperationErrors(operation); err != nil {
-		return err
-	}
-
 	err = rc.waitOperation(projectID, operation, attemptsLong, logOperationErrors)
 	return errors.Trace(err)
 }
@@ -114,10 +110,6 @@ func (rc *rawConn) RemoveInstance(projectID, zone, id string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := returnNotFoundOperationErrors(operation); err != nil {
-		return err
-	}
-
 	err = rc.waitOperation(projectID, operation, attemptsLong, returnNotFoundOperationErrors)
 	return errors.Trace(err)
 }
@@ -147,10 +139,6 @@ func (rc *rawConn) AddFirewall(projectID string, firewall *compute.Firewall) err
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := logOperationErrors(operation); err != nil {
-		return err
-	}
-
 	err = rc.waitOperation(projectID, operation, attemptsLong, logOperationErrors)
 	return errors.Trace(err)
 }
@@ -161,10 +149,6 @@ func (rc *rawConn) UpdateFirewall(projectID, name string, firewall *compute.Fire
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := logOperationErrors(operation); err != nil {
-		return err
-	}
-
 	err = rc.waitOperation(projectID, operation, attemptsLong, logOperationErrors)
 	return errors.Trace(err)
 }
@@ -201,9 +185,6 @@ func (rc *rawConn) RemoveFirewall(projectID, name string) error {
 	operation, err := call.Do()
 	if err != nil {
 		return errors.Trace(convertRawAPIError(err))
-	}
-	if err := returnNotFoundOperationErrors(operation); err != nil {
-		return err
 	}
 
 	err = rc.waitOperation(projectID, operation, attemptsLong, returnNotFoundOperationErrors)
@@ -254,9 +235,6 @@ func (rc *rawConn) CreateDisk(project, zone string, spec *compute.Disk) error {
 	if err != nil {
 		return errors.Annotate(err, "could not create a new disk")
 	}
-	if err := logOperationErrors(op); err != nil {
-		return err
-	}
 	return errors.Trace(rc.waitOperation(project, op, attemptsLong, logOperationErrors))
 }
 
@@ -287,10 +265,6 @@ func (rc *rawConn) RemoveDisk(project, zone, id string) error {
 	if err != nil {
 		return errors.Annotatef(err, "could not delete disk %q", id)
 	}
-	if err := returnNotFoundOperationErrors(op); err != nil {
-		return err
-	}
-
 	return errors.Trace(rc.waitOperation(project, op, attemptsLong, returnNotFoundOperationErrors))
 }
 
@@ -442,9 +416,6 @@ func (rc *rawConn) SetMetadata(projectID, zone, instanceID string, metadata *com
 	op, err := call.Do()
 	if err != nil {
 		return errors.Trace(err)
-	}
-	if err := logOperationErrors(op); err != nil {
-		return err
 	}
 	err = rc.waitOperation(projectID, op, attemptsLong, logOperationErrors)
 	return errors.Trace(err)

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -365,7 +365,7 @@ func (rc *rawConn) waitOperation(projectID string, op *compute.Operation, attemp
 	}
 	if op.Error != nil {
 		for _, err := range op.Error.Errors {
-			logger.Errorf("GCE operation error: (%s) %s", err.Code, err.Message)
+			logger.Errorf("GCE operation error %T: (%s) %s", err, err.Code, err.Message)
 		}
 		return waitError{op, nil}
 	}

--- a/provider/oci/storage_volumes.go
+++ b/provider/oci/storage_volumes.go
@@ -428,8 +428,8 @@ func (v *volumeSource) attachVolume(ctx envcontext.ProviderCallContext, param st
 			req := ociCore.DetachVolumeRequest{
 				VolumeAttachmentId: volAttach.GetId(),
 			}
-			_, nestedErr := v.computeAPI.DetachVolume(context.Background(), req)
-			if nestedErr != nil {
+			res, nestedErr := v.computeAPI.DetachVolume(context.Background(), req)
+			if nestedErr != nil && !v.env.isNotFound(res.RawResponse) {
 				logger.Warningf("failed to cleanup volume attachment: %v", volAttach.GetId())
 				return
 			}
@@ -625,8 +625,8 @@ func (v *volumeSource) DetachVolumes(ctx envcontext.ProviderCallContext, params 
 						VolumeAttachmentId: attachment.Id,
 					}
 
-					_, err := v.computeAPI.DetachVolume(context.Background(), request)
-					if err != nil {
+					res, err := v.computeAPI.DetachVolume(context.Background(), request)
+					if err != nil && !v.env.isNotFound(res.RawResponse) {
 						if isAuthFailure(err, ctx) {
 							credErr = err
 							common.HandleCredentialError(err, ctx)

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -107,7 +107,7 @@ var newOpenstackStorage = func(env *Environ) (OpenstackStorage, error) {
 	client := env.clientUnlocked
 	if env.volumeURL == nil {
 		url, err := getVolumeEndpointURL(client, env.cloudUnlocked.Region)
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || gooseerrors.IsNotFound(err) {
 			// No volume endpoint found; Cinder is not supported.
 			return nil, errors.NotSupportedf("volumes")
 		} else if err != nil {
@@ -407,7 +407,7 @@ func destroyVolume(ctx context.ProviderCallContext, storageAdapter OpenstackStor
 		return false, nil
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || gooseerrors.IsNotFound(err) {
 			// The volume wasn't found; nothing
 			// to destroy, so we're done.
 			return nil
@@ -595,7 +595,7 @@ func cinderToJujuVolumeInfo(volume *cinder.Volume) storage.VolumeInfo {
 
 func detachVolume(instanceId, volumeId string, storageAdapter OpenstackStorage) error {
 	err := storageAdapter.DetachVolume(instanceId, volumeId)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !(errors.IsNotFound(err) || gooseerrors.IsNotFound(err)) {
 		return errors.Trace(err)
 	}
 	// The volume was successfully detached, or was

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1527,7 +1527,7 @@ func (e *Environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 		foundServers, err = e.listServers(ctx, ids)
 		if err != nil {
 			logger.Debugf("error listing servers: %v", err)
-			if !gooseerrors.IsNotFound(err) {
+			if !IsNotFoundError(err) {
 				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 				return nil, err
 			}
@@ -1861,7 +1861,7 @@ func (e *Environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 	novaClient := e.nova()
 	for _, id := range ids {
 		err := novaClient.DeleteServer(string(id))
-		if gooseerrors.IsNotFound(err) {
+		if IsNotFoundError(err) {
 			err = nil
 		}
 		if err != nil && firstErr == nil {

--- a/provider/openstack/storage.go
+++ b/provider/openstack/storage.go
@@ -11,7 +11,6 @@ import (
 
 	jujuerrors "github.com/juju/errors"
 	"github.com/juju/utils"
-	gooseerrors "gopkg.in/goose.v2/errors"
 	"gopkg.in/goose.v2/swift"
 
 	"github.com/juju/juju/environs/storage"
@@ -182,7 +181,7 @@ func (s *openstackstorage) RemoveAll() error {
 // maybeNotFound returns a errors.NotFoundError if the root cause of the specified error is due to a file or
 // container not being found.
 func maybeNotFound(err error) (error, bool) {
-	if err != nil && gooseerrors.IsNotFound(err) {
+	if err != nil && IsNotFoundError(err) {
 		return jujuerrors.NewNotFound(err, ""), true
 	}
 	return err, false


### PR DESCRIPTION
## Description of change

Occasionally, juju does not corectly check provider 'not found" errors which get propagated and are surfacing to the users causing confusion.

This PR improves error checks in provider code. I have examined all providers and am fairly certain that I have covered all occurrences.
  
## QA steps

1. bootstrap on gce
2. deploy something sizable.. I've used ```juju deploy cs:canonical-kubernetes```
3. once things settle, run ```juju kill-controller --debug -y -t0 <your controller> --show-log``` and watch the logs...

Before this PR, you'd get a few ```ERROR juju.provider.gce.gceapi conn_instance.go:131 while removing instance "juju-71b3b8-7": googleapi: Error 404: The resource 'projects/juju-239814/zones/us-east1-b/instances/juju-71b3b8-7' was not found, notFound```
After this PR, you will not get any ERROR (if killing is successful)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1831527
