### PR TITLE
Add Load Balancer SKU name model config for Azure provider

### DIFF
--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -42,7 +42,14 @@ func (s *configSuite) TestValidateNew(c *gc.C) {
 func (s *configSuite) TestValidateInvalidStorageAccountType(c *gc.C) {
 	s.assertConfigInvalid(
 		c, testing.Attrs{"storage-account-type": "savings"},
-		`invalid storage account type "savings", expected one of: \["Standard_LRS" "Standard_GRS" "Standard_RAGRS" "Standard_ZRS" "Premium_LRS"\]`,
+		`invalid storage account type "savings", expected one of: \["Premium_LRS" "Premium_ZRS" "Standard_GRS" "Standard_LRS" "Standard_RAGRS" "Standard_ZRS"\]`,
+	)
+}
+
+func (s *configSuite) TestValidateInvalidLoadBalancerSkuName(c *gc.C) {
+	s.assertConfigInvalid(
+		c, testing.Attrs{"load-balancer-sku-name": "premium"},
+		`invalid load balancer SKU name "Premium", expected one of: \["Basic" "Standard"\]`,
 	)
 }
 
@@ -69,6 +76,19 @@ func (s *configSuite) TestValidateStorageAccountTypeCantChange(c *gc.C) {
 	cfgNew := makeTestModelConfig(c, testing.Attrs{"storage-account-type": "Premium_LRS"})
 	_, err = s.provider.Validate(cfgNew, cfgOld)
 	c.Assert(err, gc.ErrorMatches, `cannot change immutable "storage-account-type" config \(Standard_LRS -> Premium_LRS\)`)
+}
+
+func (s *configSuite) TestValidateLoadBalancerSkuNameCanChange(c *gc.C) {
+	cfgOld := makeTestModelConfig(c, testing.Attrs{"load-balancer-sku-name": "Standard"})
+	_, err := s.provider.Validate(cfgOld, cfgOld)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfgNew := makeTestModelConfig(c, testing.Attrs{"load-balancer-sku-name": "Basic"})
+	_, err = s.provider.Validate(cfgNew, cfgOld)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.provider.Validate(cfgOld, cfgNew)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *configSuite) assertConfigValid(c *gc.C, attrs testing.Attrs) {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -987,9 +987,7 @@ func (s *environSuite) assertStartInstanceRequests(
 				Name:       storageAccountName,
 				Location:   "westus",
 				Tags:       to.StringMap(s.envTags),
-				StorageSku: &storage.Sku{
-					Name: storage.SkuName("Standard_LRS"),
-				},
+				Sku:        &armtemplates.Sku{Name: "Standard_LRS"},
 			})
 			vmDependsOn = append(vmDependsOn,
 				`[resourceId('Microsoft.Storage/storageAccounts', '`+storageAccountName+`')]`,
@@ -1008,15 +1006,13 @@ func (s *environSuite) assertStartInstanceRequests(
 		)
 		var (
 			availabilitySetProperties  interface{}
-			availabilityStorageOptions *storage.Sku
+			availabilityStorageOptions armtemplates.Sku
 		)
 		if !args.unmanagedStorage {
 			availabilitySetProperties = &compute.AvailabilitySetProperties{
 				PlatformFaultDomainCount: to.Int32Ptr(3),
 			}
-			availabilityStorageOptions = &storage.Sku{
-				Name: "Aligned",
-			}
+			availabilityStorageOptions.Name = "Aligned"
 		}
 		templateResources = append(templateResources, armtemplates.Resource{
 			APIVersion: computeAPIVersion,
@@ -1025,7 +1021,7 @@ func (s *environSuite) assertStartInstanceRequests(
 			Location:   "westus",
 			Tags:       to.StringMap(s.envTags),
 			Properties: availabilitySetProperties,
-			StorageSku: availabilityStorageOptions,
+			Sku:        &availabilityStorageOptions,
 		})
 		availabilitySetSubResource = &compute.SubResource{
 			ID: to.StringPtr(availabilitySetId),
@@ -1059,7 +1055,7 @@ func (s *environSuite) assertStartInstanceRequests(
 			PublicIPAllocationMethod: network.Static,
 			PublicIPAddressVersion:   "IPv4",
 		},
-		StorageSku: &storage.Sku{Name: "Standard", Tier: "Regional"},
+		Sku: &armtemplates.Sku{Name: "Standard"},
 	}, {
 		APIVersion: networkAPIVersion,
 		Type:       "Microsoft.Network/networkInterfaces",

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -65,6 +65,10 @@ type ProviderConfig struct {
 
 	// AzureCLI is the interface the to Azure CLI (az) command.
 	AzureCLI AzureCLI
+
+	// LoadBalancerSkuName is the load balancer SKU name.
+	// Legal values are determined by the Azure SDK.
+	LoadBalancerSkuName string
 }
 
 // Validate validates the Azure provider configuration.

--- a/provider/azure/internal/armtemplates/template.go
+++ b/provider/azure/internal/armtemplates/template.go
@@ -3,8 +3,6 @@
 
 package armtemplates
 
-import "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage"
-
 const (
 	schema         = "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
 	contentVersion = "1.0.0.0"
@@ -29,6 +27,13 @@ func (t *Template) Map() (map[string]interface{}, error) {
 	return m, nil
 }
 
+// Sku represents an Azure SKU. Each API (compute/networking/storage)
+// defines its own SKU types, but we use a common type because we
+// don't require many fields.
+type Sku struct {
+	Name string `json:"name,omitempty"`
+}
+
 // Resource describes a template resource. For information on the
 // individual fields, see https://azure.microsoft.com/en-us/documentation/articles/resource-group-authoring-templates/.
 type Resource struct {
@@ -43,5 +48,5 @@ type Resource struct {
 	Resources  []Resource        `json:"resources,omitempty"`
 
 	// Non-uniform attributes.
-	StorageSku *storage.Sku `json:"sku,omitempty"`
+	Sku *Sku `json:"sku,omitempty"`
 }

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -1001,8 +1001,6 @@ func storageAccountTemplateResource(
 		Name:       accountName,
 		Location:   location,
 		Tags:       envTags,
-		StorageSku: &armstorage.Sku{
-			Name: armstorage.SkuName(accountType),
-		},
+		Sku:        &armtemplates.Sku{Name: accountType},
 	}
 }

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage"
 	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/autorest/to"
 	jc "github.com/juju/testing/checkers"
@@ -174,9 +173,7 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeployment(
 		Type:     "Microsoft.Storage/storageAccounts",
 		Name:     storageAccountName,
 		Location: "westus",
-		StorageSku: &storage.Sku{
-			Name: storage.SkuName("Standard_LRS"),
-		},
+		Sku:      &armtemplates.Sku{Name: "Standard_LRS"},
 	}}
 
 	var actual resources.Deployment


### PR DESCRIPTION
Juju 2.5 changed the default [Azure Load Balancer SKU](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview#skus) from Basic to Standard. Unfortunately, models created by Juju 2.4 get stuck when their controllers are upgraded.

This change introduces a model config parameter `load-balancer-sku-name` (name chosen to be consistent with the Azure SDK naming scheme) that allows for operators to select between Basic and Standard types. It also cleans up some of the internals of the Azure provider, which should make it friendlier to newcomers to the code.

## QA steps
```
snap install juju # (if required)
snap switch juju channel=2.4/stable
/snap/juju/current/bin/juju bootstrap azure c-az
/snap/juju/current/bin/juju deploy ubuntu
```

(Assuming `juju` is this branch)

```
juju upgrade-model -m controller --build-agent
```
>```
> no prepackaged agent binaries available, using local agent binary 2.5.8.1 (built from source)
> best version:
>    2.5.8.1
> started upgrade to 2.5.8.1
>```

```
juju model-config -m controller load-balancer-sku-name=Basic
juju add-unit ubuntu
```


## Documentation changes

Required. We need to document the new model config parameter.

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1824465
