### PR TITLE
2.6 Add Charm Config Defaults to Multi-Watcher and Model Cache

### DIFF
--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -28,7 +28,7 @@ func (s modelCacheShim) Charm(charmURL string) (ModelCacheCharm, error) {
 		return nil, err
 	}
 	return &modelCacheCharm{
-		Charm: ch,
+		Charm: &ch,
 	}, nil
 }
 

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -69,10 +69,44 @@ type RemoveApplication struct {
 // CharmChange represents either a new charm, or a change
 // to an existing charm in a model.
 type CharmChange struct {
-	ModelUUID    string
-	CharmURL     string
-	CharmVersion string
-	LXDProfile   lxdprofile.Profile
+	ModelUUID     string
+	CharmURL      string
+	CharmVersion  string
+	LXDProfile    lxdprofile.Profile
+	DefaultConfig map[string]interface{}
+}
+
+func (c CharmChange) copy() CharmChange {
+	var cpConfig map[string]string
+	pConfig := c.LXDProfile.Config
+	if pConfig != nil {
+		cpConfig = make(map[string]string, len(pConfig))
+		for k, v := range pConfig {
+			cpConfig[k] = v
+		}
+	}
+	c.LXDProfile.Config = cpConfig
+
+	var cpDevices map[string]map[string]string
+	pDevices := c.LXDProfile.Devices
+	if pDevices != nil {
+		cpDevices = make(map[string]map[string]string, len(pDevices))
+		for dName, dCfg := range pDevices {
+			var cCfg map[string]string
+			if dCfg != nil {
+				cCfg = make(map[string]string, len(dCfg))
+				for k, v := range dCfg {
+					cCfg[k] = v
+				}
+			}
+			cpDevices[dName] = cCfg
+		}
+	}
+	c.LXDProfile.Devices = cpDevices
+
+	c.DefaultConfig = copyDataMap(c.DefaultConfig)
+
+	return c
 }
 
 // RemoveCharm represents the situation when an charm

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -4,8 +4,6 @@
 package cache
 
 import (
-	"sync"
-
 	"github.com/juju/pubsub"
 
 	"github.com/juju/juju/core/lxdprofile"
@@ -29,21 +27,21 @@ type Charm struct {
 	// Link to model?
 	metrics *ControllerGauges
 	hub     *pubsub.SimpleHub
-	mu      sync.Mutex
 
 	details CharmChange
 }
 
 // LXDProfile returns the lxd profile of this charm.
 func (c *Charm) LXDProfile() lxdprofile.Profile {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	return c.details.LXDProfile
 }
 
-func (c *Charm) setDetails(details CharmChange) {
-	c.mu.Lock()
+// DefaultConfig returns the default configuration settings for the charm.
+func (c *Charm) DefaultConfig() map[string]interface{} {
+	return c.details.DefaultConfig
+}
 
+func (c *Charm) setDetails(details CharmChange) {
 	// If this is the first receipt of details, set the removal message.
 	if c.removalMessage == nil {
 		c.removalMessage = RemoveCharm{
@@ -54,6 +52,11 @@ func (c *Charm) setDetails(details CharmChange) {
 
 	c.setStale(false)
 	c.details = details
+}
 
-	c.mu.Unlock()
+// copy returns a copy of the unit, ensuring appropriate deep copying.
+func (c *Charm) copy() Charm {
+	cc := *c
+	cc.details = cc.details.copy()
+	return cc
 }

--- a/core/cache/charm_test.go
+++ b/core/cache/charm_test.go
@@ -22,4 +22,5 @@ var charmChange = cache.CharmChange{
 	LXDProfile: lxdprofile.Profile{
 		Config: map[string]string{"key": "value"},
 	},
+	DefaultConfig: map[string]interface{}{"foo": "bar"},
 }

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -29,7 +29,7 @@ type MachineLXDProfileWatcher struct {
 // get Applications, Charms and Units.
 type MachineAppModeler interface {
 	Application(string) (Application, error)
-	Charm(string) (*Charm, error)
+	Charm(string) (Charm, error)
 	Unit(string) (Unit, error)
 }
 

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -99,26 +99,6 @@ func (m *Model) Report() map[string]interface{} {
 	}
 }
 
-// Charm returns the charm for the input charmURL.
-// If the charm is not found, a NotFoundError is returned.
-func (m *Model) Charm(charmURL string) (*Charm, error) {
-	defer m.doLocked()()
-
-	charm, found := m.charms[charmURL]
-	if !found {
-		return nil, errors.NotFoundf("charm %q", charmURL)
-	}
-	return charm, nil
-}
-
-// TODO (manadart 2019-05-30): Access to these entities returns copies:
-// - applications
-// - machines
-// - units
-// - branches
-// All of the other entity retrieval should be changed to work in the same
-// fashion, and the lock guarding of member access removed where possible.
-
 // Branches returns all active branches in the model.
 func (m *Model) Branches() map[string]Branch {
 	m.mu.Lock()
@@ -209,6 +189,18 @@ func (m *Model) Machine(machineId string) (Machine, error) {
 		return Machine{}, errors.NotFoundf("machine %q", machineId)
 	}
 	return machine.copy(), nil
+}
+
+// Charm returns the charm for the input charmURL.
+// If the charm is not found, a NotFoundError is returned.
+func (m *Model) Charm(charmURL string) (Charm, error) {
+	defer m.doLocked()()
+
+	charm, found := m.charms[charmURL]
+	if !found {
+		return Charm{}, errors.NotFoundf("charm %q", charmURL)
+	}
+	return charm.copy(), nil
 }
 
 // WatchMachines returns a PredicateStringsWatcher to notify about

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -189,6 +189,23 @@ func (s *ModelSuite) TestCharmNotFoundError(c *gc.C) {
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
+func (s *ModelSuite) TestCharmReturnsCopy(c *gc.C) {
+	m := s.NewModel(modelChange)
+	m.UpdateCharm(charmChange, s.Manager)
+
+	ch1, err := m.Charm(charmChange.CharmURL)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make a change to the map returned in the copy.
+	cc := ch1.DefaultConfig()
+	cc["mister"] = "squiggle"
+
+	// Get another copy from the model and ensure it is unchanged.
+	ch2, err := m.Charm(charmChange.CharmURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch2.DefaultConfig(), gc.DeepEquals, charmChange.DefaultConfig)
+}
+
 func (s *ModelSuite) TestMachineNotFoundError(c *gc.C) {
 	m := s.NewModel(modelChange)
 	_, err := m.Machine("nope")

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -602,7 +602,13 @@ func (ch *backingCharm) updated(st *State, store *multiwatcherStore, id string) 
 	}
 
 	if ch.LXDProfile != nil && !ch.LXDProfile.Empty() {
-		info.LXDProfile = toMulitwatcherProfile(ch.LXDProfile)
+		info.LXDProfile = toMultiwatcherProfile(ch.LXDProfile)
+	}
+
+	if ch.Config != nil {
+		if ds := ch.Config.DefaultSettings(); len(ds) > 0 {
+			info.DefaultConfig = ds
+		}
 	}
 
 	store.Update(info)
@@ -622,7 +628,7 @@ func (ch *backingCharm) mongoId() string {
 	return ch.DocID
 }
 
-func toMulitwatcherProfile(profile *charm.LXDProfile) *multiwatcher.Profile {
+func toMultiwatcherProfile(profile *charm.LXDProfile) *multiwatcher.Profile {
 	unescapedProfile := unescapeLXDProfile(profile)
 	return &multiwatcher.Profile{
 		Config:      unescapedProfile.Config,

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -156,9 +156,10 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	})
 
 	add(&multiwatcher.CharmInfo{
-		ModelUUID: modelUUID,
-		CharmURL:  applicationCharmURL(wordpress).String(),
-		Life:      multiwatcher.Life("alive"),
+		ModelUUID:     modelUUID,
+		CharmURL:      applicationCharmURL(wordpress).String(),
+		Life:          multiwatcher.Life("alive"),
+		DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 	})
 
 	logging := AddTestingApplication(c, st, "logging", AddTestingCharm(c, st, "logging"))
@@ -1132,9 +1133,10 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		},
 	}, {
 		Entity: &multiwatcher.CharmInfo{
-			ModelUUID: s.state.ModelUUID(),
-			CharmURL:  "local:quantal/quantal-wordpress-3",
-			Life:      multiwatcher.Life("alive"),
+			ModelUUID:     s.state.ModelUUID(),
+			CharmURL:      "local:quantal/quantal-wordpress-3",
+			Life:          multiwatcher.Life("alive"),
+			DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 		},
 	}, {
 		Entity: &multiwatcher.ApplicationInfo{
@@ -2102,9 +2104,10 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		},
 	}, {
 		Entity: &multiwatcher.CharmInfo{
-			ModelUUID: st1.ModelUUID(),
-			CharmURL:  "local:quantal/quantal-wordpress-3",
-			Life:      multiwatcher.Life("alive"),
+			ModelUUID:     st1.ModelUUID(),
+			CharmURL:      "local:quantal/quantal-wordpress-3",
+			Life:          multiwatcher.Life("alive"),
+			DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 		},
 	}, {
 		Removed: true,
@@ -2970,18 +2973,19 @@ func testChangeCharms(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, [
 				}}
 		},
 		func(c *gc.C, st *State) changeTestCase {
-			charm := AddTestingCharm(c, st, "wordpress")
+			ch := AddTestingCharm(c, st, "wordpress")
 			return changeTestCase{
 				about: "charm is added if it's in backing but not in Store",
 				change: watcher.Change{
 					C:  "charms",
-					Id: st.docID(charm.URL().String()),
+					Id: st.docID(ch.URL().String()),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.CharmInfo{
-						ModelUUID: st.ModelUUID(),
-						CharmURL:  charm.URL().String(),
-						Life:      multiwatcher.Life("alive"),
+						ModelUUID:     st.ModelUUID(),
+						CharmURL:      ch.URL().String(),
+						Life:          multiwatcher.Life("alive"),
+						DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 					}}}
 		},
 	}

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -226,6 +226,8 @@ type CharmInfo struct {
 	CharmVersion string   `json:"charm-version"`
 	Life         Life     `json:"life"`
 	LXDProfile   *Profile `json:"profile"`
+	// DefaultConfig is derived from state-stored *charm.Config.
+	DefaultConfig map[string]interface{} `json:"config"`
 }
 
 // EntityId returns a unique identifier for an charm across

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -227,7 +227,7 @@ type CharmInfo struct {
 	Life         Life     `json:"life"`
 	LXDProfile   *Profile `json:"profile"`
 	// DefaultConfig is derived from state-stored *charm.Config.
-	DefaultConfig map[string]interface{} `json:"config"`
+	DefaultConfig map[string]interface{} `json:"config,omitempty"`
 }
 
 // EntityId returns a unique identifier for an charm across

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -400,9 +400,10 @@ func (c *cacheWorker) translateCharm(d multiwatcher.Delta) interface{} {
 	}
 
 	return cache.CharmChange{
-		ModelUUID:  value.ModelUUID,
-		CharmURL:   value.CharmURL,
-		LXDProfile: coreLXDProfile(value.LXDProfile),
+		ModelUUID:     value.ModelUUID,
+		CharmURL:      value.CharmURL,
+		LXDProfile:    coreLXDProfile(value.LXDProfile),
+		DefaultConfig: value.DefaultConfig,
 	}
 }
 


### PR DESCRIPTION
## Description of change

In order to serve charm config settings from the cache, we need to store the charm defaults so that they can be combined with master settings and branch deltas.

This patch:
- Adds `DefaultConfig` to the mult-watcher delta for charms. It is extracted from the charm doc so we can transport and store it as a map, rather than depending on the upstream type.
- Adds `DefaultConfig` to the cached charm type and ensures it is populated by the cache worker.
- Completes the work to ensure that non-model cached entities are always returned from the cache as copies.

## QA steps

Unit tests verify changes; forthcoming patches will flex this change with QA steps.
Regressions can be checked with the same steps as for #10062

## Documentation changes

None.

## Bug reference

N/A
