### PR TITLE
2.6 - Add ConfigSettings() Method to Cached Unit

### DIFF
--- a/core/cache/charm_test.go
+++ b/core/cache/charm_test.go
@@ -22,5 +22,8 @@ var charmChange = cache.CharmChange{
 	LXDProfile: lxdprofile.Profile{
 		Config: map[string]string{"key": "value"},
 	},
-	DefaultConfig: map[string]interface{}{"foo": "bar"},
+	DefaultConfig: map[string]interface{}{
+		"key":       "default-value",
+		"something": "else",
+	},
 }

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -66,9 +66,9 @@ func (u *Unit) Ports() []network.Port {
 	return u.details.Ports
 }
 
-// WatchCharmConfig returns a new watcher that will notify when the
+// WatchConfigSettings returns a new watcher that will notify when the
 // effective application charm config for this unit changes.
-func (u *Unit) WatchCharmConfig() (*CharmConfigWatcher, error) {
+func (u *Unit) WatchConfigSettings() (*CharmConfigWatcher, error) {
 	cfg := charmConfigWatcherConfig{
 		model:                u.model,
 		unitName:             u.details.Name,

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -7,12 +7,11 @@ import (
 	"fmt"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/juju/core/settings"
-
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/settings"
 )
 
 // Unit represents a unit in a cached model.

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -6,7 +6,12 @@ package cache
 import (
 	"fmt"
 
+	"github.com/juju/collections/set"
+	"github.com/juju/juju/core/settings"
+
 	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6"
+
 	"github.com/juju/juju/core/network"
 )
 
@@ -64,6 +69,55 @@ func (u *Unit) CharmURL() string {
 // Ports returns the exposed ports for the unit.
 func (u *Unit) Ports() []network.Port {
 	return u.details.Ports
+}
+
+// Config settings returns the effective charm configuration for this unit
+// taking into account whether it is tracking a model branch.
+func (u *Unit) ConfigSettings() (charm.Settings, error) {
+	appName := u.details.Application
+	app, err := u.model.Application(appName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg := app.Config()
+	if cfg == nil {
+		cfg = make(map[string]interface{})
+	}
+
+	// Apply any branch-based deltas to the master settings
+	var deltas settings.ItemChanges
+	for _, b := range u.model.Branches() {
+		if units := b.AssignedUnits()[appName]; len(units) > 0 {
+			if set.NewStrings(units...).Contains(u.details.Name) {
+				deltas = b.AppConfig(appName)
+				break
+			}
+		}
+	}
+
+	for _, delta := range deltas {
+		switch {
+		case delta.IsAddition(), delta.IsModification():
+			cfg[delta.Key] = delta.NewValue
+		case delta.IsDeletion():
+			delete(cfg, delta.Key)
+		}
+	}
+
+	// Fill in any empty values with charm defaults.
+	ch, err := u.model.Charm(u.details.CharmURL)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	charmDefaults := ch.DefaultConfig()
+
+	for k, v := range charmDefaults {
+		if _, ok := cfg[k]; !ok {
+			cfg[k] = v
+		}
+	}
+
+	return cfg, nil
 }
 
 // WatchConfigSettings returns a new watcher that will notify when the

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -6,10 +6,12 @@ package cache_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/settings"
 	"github.com/juju/juju/core/status"
 )
 
@@ -31,6 +33,81 @@ func (s *UnitSuite) TestWatchCharmConfigNewWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	workertest.CleanKill(c, w)
+}
+
+func (s *UnitSuite) TestConfigSettingsNoBranch(c *gc.C) {
+	m := s.NewModel(modelChange)
+	m.UpdateCharm(charmChange, s.Manager)
+	m.UpdateApplication(appChange, s.Manager)
+	m.UpdateUnit(unitChange, s.Manager)
+
+	u, err := m.Unit(unitChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := u.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := charm.Settings{
+		"key":       "value",
+		"another":   "foo",
+		"something": "else",
+	}
+	c.Assert(cfg, gc.DeepEquals, expected)
+}
+
+func (s *UnitSuite) TestConfigSettingsBranch(c *gc.C) {
+	m := s.NewModel(modelChange)
+	m.UpdateCharm(charmChange, s.Manager)
+	m.UpdateApplication(appChange, s.Manager)
+	m.UpdateUnit(unitChange, s.Manager)
+
+	br := branchChange
+	br.AssignedUnits = map[string][]string{appChange.Name: {unitChange.Name}}
+	br.Config = map[string]settings.ItemChanges{
+		appChange.Name: {
+			settings.MakeAddition("new-key", "new-value"),
+			settings.MakeDeletion("key", "this-will-revert-to-default"),
+			settings.MakeModification("another", "foo", "new-foo"),
+		},
+	}
+	m.UpdateBranch(br, s.Manager)
+
+	u, err := m.Unit(unitChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := u.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := charm.Settings{
+		"key":       "default-value",
+		"another":   "new-foo",
+		"new-key":   "new-value",
+		"something": "else",
+	}
+	c.Assert(cfg, gc.DeepEquals, expected)
+
+}
+
+func (s *UnitSuite) TestConfigSettingsDefaultsOnly(c *gc.C) {
+	appNoCfg := appChange
+	appNoCfg.Config = nil
+
+	m := s.NewModel(modelChange)
+	m.UpdateCharm(charmChange, s.Manager)
+	m.UpdateApplication(appNoCfg, s.Manager)
+	m.UpdateUnit(unitChange, s.Manager)
+
+	u, err := m.Unit(unitChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := u.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := charm.Settings{
+		"key":       "default-value",
+		"something": "else",
+	}
+	c.Assert(cfg, gc.DeepEquals, expected)
 }
 
 var unitChange = cache.UnitChange{

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -27,7 +27,7 @@ func (s *UnitSuite) TestWatchCharmConfigNewWatcher(c *gc.C) {
 	u, err := m.Unit(unitChange.Name)
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := u.WatchCharmConfig()
+	w, err := u.WatchConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 
 	workertest.CleanKill(c, w)


### PR DESCRIPTION
## Description of change

This patch adds a `ConfigSettings` method to the `cache.Unit` type, congruent with the same method on `state.Unit`. It also renames the new `WatchCharmConfig` method to `WatchConfigSettings` for the same congruence.

## QA steps

Accompanying tests. QA steps to accompany following patch.

## Documentation changes

None.

## Bug reference

N/A
