### PR TITLE
Add Created, CreatedBy, and CompletedBy to a Branch in the model cache.

### DIFF
--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -58,6 +58,28 @@ func (b *Branch) AppConfig(appName string) settings.ItemChanges {
 	return b.details.Config[appName]
 }
 
+// Created returns a Unix timestamp indicating when this generation
+// was created.
+func (b *Branch) Created() int64 {
+	return b.details.Created
+}
+
+// CreatedBy returns user who created the branch.
+func (b *Branch) CreatedBy() string {
+	return b.details.CreatedBy
+}
+
+// Completed returns a Unix timestamp indicating when this generation
+// was committed.
+func (b *Branch) Completed() int64 {
+	return b.details.Completed
+}
+
+// CreatedBy returns user who committed the branch.
+func (b *Branch) CompletedBy() string {
+	return b.details.CompletedBy
+}
+
 func (b *Branch) setDetails(details BranchChange) {
 	// If this is the first receipt of details, set the removal message.
 	if b.removalMessage == nil {

--- a/core/cache/branch_test.go
+++ b/core/cache/branch_test.go
@@ -45,6 +45,9 @@ var branchChange = cache.BranchChange{
 	Name:          "testing-branch",
 	AssignedUnits: map[string][]string{"redis": {"redis/0", "redis/1"}},
 	Config:        map[string]settings.ItemChanges{"redis": {settings.MakeAddition("password", "pass666")}},
+	Created:       0,
+	CreatedBy:     "test-user",
 	Completed:     0,
+	CompletedBy:   "different-user",
 	GenerationId:  0,
 }

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -252,7 +252,10 @@ type BranchChange struct {
 	Name          string
 	AssignedUnits map[string][]string
 	Config        map[string]settings.ItemChanges
+	Created       int64
+	CreatedBy     string
 	Completed     int64
+	CompletedBy   string
 	GenerationId  int
 }
 

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1369,7 +1369,10 @@ func (g *backingGeneration) updated(st *State, store *multiwatcherStore, id stri
 		Name:          g.Name,
 		AssignedUnits: assigned,
 		Config:        cfg,
+		Created:       g.Created,
+		CreatedBy:     g.CreatedBy,
 		Completed:     g.Completed,
+		CompletedBy:   g.CompletedBy,
 		GenerationId:  g.GenerationId,
 	}
 	store.Update(info)

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1920,6 +1920,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Id:            "0",
 			Name:          "new-branch",
 			AssignedUnits: map[string][]string{},
+			CreatedBy:     "test-user",
 		},
 	}})
 
@@ -2193,6 +2194,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Id:            "0",
 			Name:          "new-branch",
 			AssignedUnits: map[string][]string{wordpress.Name(): {wu.Name()}},
+			CreatedBy:     "test-user",
 		},
 	}}
 
@@ -4138,6 +4140,7 @@ func testChangeGenerations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 						Id:            st.localID(branch.doc.DocId),
 						Name:          "new-branch",
 						AssignedUnits: map[string][]string{},
+						CreatedBy:     "some-user",
 					}},
 			}
 		},
@@ -4164,6 +4167,7 @@ func testChangeGenerations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 						Id:            st.localID(branch.doc.DocId),
 						Name:          "new-branch",
 						AssignedUnits: map[string][]string{},
+						CreatedBy:     "some-user",
 					}},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.GenerationInfo{
@@ -4171,6 +4175,7 @@ func testChangeGenerations(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 						Id:            st.localID(branch.doc.DocId),
 						Name:          "new-branch",
 						AssignedUnits: map[string][]string{app.Name(): {u.Name()}},
+						CreatedBy:     "some-user",
 					}},
 			}
 		},

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -525,7 +525,10 @@ type GenerationInfo struct {
 	Name          string                  `json:"name"`
 	AssignedUnits map[string][]string     `json:"assigned-units"`
 	Config        map[string][]ItemChange `json:"charm-config"`
+	Created       int64                   `json:"created"`
+	CreatedBy     string                  `json:"created-by"`
 	Completed     int64                   `json:"completed"`
+	CompletedBy   string                  `json:"completed-by"`
 	GenerationId  int                     `json:"generation-id"`
 }
 

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -441,7 +441,10 @@ func (c *cacheWorker) translateBranch(d multiwatcher.Delta) interface{} {
 		Id:            value.Id,
 		AssignedUnits: value.AssignedUnits,
 		Config:        coreItemChanges(value.Config),
+		Created:       value.Created,
+		CreatedBy:     value.CreatedBy,
 		Completed:     value.Completed,
+		CompletedBy:   value.CompletedBy,
 		GenerationId:  value.GenerationId,
 	}
 }


### PR DESCRIPTION
## Description of change

Add Created, CreatedBy, and CompletedBy to a Branch in the model cache,
multiwatcher, allwatcher and modelcache worker. Including helper
functions to get the data from the model cache.

## QA steps

Not directly used yet.  Unit tests should all pass and no difference in juju functionality found.
