### PR TITLE
Remove novote attribute from machine

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -45,6 +45,7 @@ type ModelManagerBackend interface {
 	ControllerModelTag() names.ModelTag
 	IsController() bool
 	ControllerConfig() (controller.Config, error)
+	ControllerNodes() ([]ControllerNode, error)
 	ModelConfigDefaultValues(cloudName string) (config.ModelDefaultAttributes, error)
 	UpdateModelConfigDefaultValues(update map[string]interface{}, remove []string, regionSpec *environs.CloudRegionSpec) error
 	Unit(name string) (*state.Unit, error)
@@ -213,6 +214,18 @@ func (st modelManagerStateShim) Model() (Model, error) {
 // Name implements ModelManagerBackend.
 func (st modelManagerStateShim) Name() string {
 	return st.model.Name()
+}
+
+func (st modelManagerStateShim) ControllerNodes() ([]ControllerNode, error) {
+	nodes, err := st.State.ControllerNodes()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]ControllerNode, len(nodes))
+	for i, n := range nodes {
+		result[i] = n
+	}
+	return result, nil
 }
 
 func (st modelManagerStateShim) IsController() bool {

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -45,6 +45,7 @@ type Backend interface {
 	Application(string) (*state.Application, error)
 	Charm(*charm.URL) (*state.Charm, error)
 	ControllerConfig() (controller.Config, error)
+	ControllerNodes() ([]state.ControllerNode, error)
 	ControllerTag() names.ControllerTag
 	ControllerTimestamp() (*time.Time, error)
 	EndpointsRelation(...state.Endpoint) (*state.Relation, error)
@@ -160,4 +161,16 @@ func (s stateShim) ModelConfig() (*config.Config, error) {
 
 func (s stateShim) ModelTag() names.ModelTag {
 	return names.NewModelTag(s.State.ModelUUID())
+}
+
+func (s stateShim) ControllerNodes() ([]state.ControllerNode, error) {
+	nodes, err := s.State.ControllerNodes()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]state.ControllerNode, len(nodes))
+	for i, n := range nodes {
+		result[i] = n
+	}
+	return result, nil
 }

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -272,8 +272,6 @@ func controllersChanges(change state.ControllersChanges) params.ControllersChang
 		Added:      machineIdsToTags(change.Added...),
 		Maintained: machineIdsToTags(change.Maintained...),
 		Removed:    machineIdsToTags(change.Removed...),
-		Promoted:   machineIdsToTags(change.Promoted...),
-		Demoted:    machineIdsToTags(change.Demoted...),
 		Converted:  machineIdsToTags(change.Converted...),
 	}
 }

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -470,7 +470,9 @@ func (s *clientSuite) TestEnableHA0Preserves(c *gc.C) {
 	c.Assert(machines[2].Destroy(), jc.ErrorIsNil)
 	c.Assert(machines[2].Refresh(), jc.ErrorIsNil)
 	c.Assert(machines[2].SetHasVote(false), jc.ErrorIsNil)
-	c.Assert(s.State.RemoveControllerReference(machines[2]), jc.ErrorIsNil)
+	node, err := s.State.ControllerNode(machines[2].Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.State.RemoveControllerReference(node), jc.ErrorIsNil)
 	c.Assert(machines[2].EnsureDead(), jc.ErrorIsNil)
 	enableHAResult, err = s.enableHA(c, 0, emptyCons, defaultSeries, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -507,7 +509,9 @@ func (s *clientSuite) TestEnableHA0Preserves5(c *gc.C) {
 	c.Assert(machines[4].SetHasVote(false), jc.ErrorIsNil)
 	c.Assert(machines[4].Destroy(), jc.ErrorIsNil)
 	c.Assert(machines[4].Refresh(), jc.ErrorIsNil)
-	c.Assert(s.State.RemoveControllerReference(machines[4]), jc.ErrorIsNil)
+	node, err := s.State.ControllerNode(machines[4].Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.State.RemoveControllerReference(node), jc.ErrorIsNil)
 	c.Assert(machines[4].EnsureDead(), jc.ErrorIsNil)
 
 	// Keeping all alive but one, will bring up 1 more server to preserve 5
@@ -597,7 +601,6 @@ func (s *clientSuite) TestEnableHABootstrap(c *gc.C) {
 	c.Assert(enableHAResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
 	c.Assert(enableHAResult.Removed, gc.HasLen, 0)
 	c.Assert(enableHAResult.Converted, gc.HasLen, 0)
-	c.Assert(enableHAResult.Demoted, gc.HasLen, 0)
 }
 
 func (s *clientSuite) TestHighAvailabilityCAASFails(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -274,6 +274,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"Model",
 		"IsController",
 		"AllMachines",
+		"ControllerNodes",
 		"LatestMigration",
 	)
 
@@ -442,6 +443,7 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 		"Model",
 		"IsController",
 		"AllMachines",
+		"ControllerNodes",
 		"LatestMigration",
 	)
 	s.caasBroker.CheckCallNames(c, "Create")

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -16126,19 +16126,7 @@
                                 "type": "string"
                             }
                         },
-                        "demoted": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "maintained": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "promoted": {
                             "type": "array",
                             "items": {
                                 "type": "string"

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -785,8 +785,6 @@ type ControllersChanges struct {
 	Added      []string `json:"added,omitempty"`
 	Maintained []string `json:"maintained,omitempty"`
 	Removed    []string `json:"removed,omitempty"`
-	Promoted   []string `json:"promoted,omitempty"`
-	Demoted    []string `json:"demoted,omitempty"`
 	Converted  []string `json:"converted,omitempty"`
 }
 

--- a/cmd/juju/commands/enableha.go
+++ b/cmd/juju/commands/enableha.go
@@ -117,14 +117,6 @@ func formatSimple(writer io.Writer, value interface{}) error {
 			enableHAResult.Removed,
 		},
 		{
-			"promoting machines: %s\n",
-			enableHAResult.Promoted,
-		},
-		{
-			"demoting machines: %s\n",
-			enableHAResult.Demoted,
-		},
-		{
 			"converting machines: %s\n",
 			enableHAResult.Converted,
 		},
@@ -195,8 +187,6 @@ type availabilityInfo struct {
 	Maintained []string `json:"maintained,omitempty" yaml:"maintained,flow,omitempty"`
 	Removed    []string `json:"removed,omitempty" yaml:"removed,flow,omitempty"`
 	Added      []string `json:"added,omitempty" yaml:"added,flow,omitempty"`
-	Promoted   []string `json:"promoted,omitempty" yaml:"promoted,flow,omitempty"`
-	Demoted    []string `json:"demoted,omitempty" yaml:"demoted,flow,omitempty"`
 	Converted  []string `json:"converted,omitempty" yaml:"converted,flow,omitempty"`
 }
 
@@ -244,8 +234,6 @@ func (c *enableHACommand) Run(ctx *cmd.Context) error {
 		Added:      machineTagsToIds(enableHAResult.Added...),
 		Removed:    machineTagsToIds(enableHAResult.Removed...),
 		Maintained: machineTagsToIds(enableHAResult.Maintained...),
-		Promoted:   machineTagsToIds(enableHAResult.Promoted...),
-		Demoted:    machineTagsToIds(enableHAResult.Demoted...),
 		Converted:  machineTagsToIds(enableHAResult.Converted...),
 	}
 	return c.out.Write(ctx, result)

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -34,11 +34,6 @@ type MachineTemplate struct {
 	// when the first (bootstrap) machine is added.
 	Jobs []MachineJob
 
-	// NoVote holds whether a machine running
-	// a controller should abstain from peer voting.
-	// It is ignored if Jobs does not contain JobManageModel.
-	NoVote bool
-
 	// Addresses holds the addresses to be associated with the
 	// new machine.
 	//
@@ -515,7 +510,6 @@ func (st *State) machineDocForTemplate(template MachineTemplate, id string) *mac
 		Addresses:               fromNetworkAddresses(template.Addresses, OriginMachine),
 		PreferredPrivateAddress: fromNetworkAddress(privateAddr, OriginMachine),
 		PreferredPublicAddress:  fromNetworkAddress(publicAddr, OriginMachine),
-		NoVote:                  template.NoVote,
 		Placement:               template.Placement,
 	}
 }

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -237,6 +237,12 @@ func (m *backingMachine) machineAndAgentStatus(entity Entity, info *multiwatcher
 }
 
 func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string) error {
+	wantsVote := false
+	node, err := st.ControllerNode(m.Id)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+	wantsVote = err == nil && node.WantsVote()
 	info := &multiwatcher.MachineInfo{
 		ModelUUID:                st.ModelUUID(),
 		Id:                       m.Id,
@@ -247,7 +253,7 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string)
 		SupportedContainers:      m.SupportedContainers,
 		SupportedContainersKnown: m.SupportedContainersKnown,
 		HasVote:                  m.HasVote,
-		WantsVote:                wantsVote(m.Jobs, m.NoVote),
+		WantsVote:                wantsVote,
 	}
 	addresses := network.MergedAddresses(networkAddresses(m.MachineAddresses), networkAddresses(m.Addresses))
 	for _, addr := range addresses {

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -1065,6 +1065,10 @@ func (st *State) cleanupForceDestroyedMachineInternal(machineId string, maxWait 
 		return errors.Trace(err)
 	}
 	if machine.IsManager() {
+		node, err := st.ControllerNode(machineId)
+		if err != nil {
+			return errors.Annotatef(err, "cannot get controller node for machine %v", machineId)
+		}
 		if machine.HasVote() {
 			// we remove the vote from the machine so that it can be torn down cleanly. Note that this isn't reflected
 			// in the actual replicaset, so users using --force should be careful.
@@ -1087,7 +1091,7 @@ func (st *State) cleanupForceDestroyedMachineInternal(machineId string, maxWait 
 				return errors.Trace(err)
 			}
 		}
-		if err := st.RemoveControllerReference(machine); err != nil {
+		if err := st.RemoveControllerReference(node); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -369,8 +369,6 @@ func (s *CleanupSuite) TestCleanupForceDestroyedControllerMachine(c *gc.C) {
 	c.Check(changes.Added, gc.HasLen, 2)
 	c.Check(changes.Removed, gc.HasLen, 0)
 	c.Check(changes.Maintained, gc.HasLen, 1)
-	c.Check(changes.Promoted, gc.HasLen, 0)
-	c.Check(changes.Demoted, gc.HasLen, 0)
 	c.Check(changes.Converted, gc.HasLen, 0)
 	for _, mid := range changes.Added {
 		m, err := s.State.Machine(mid)
@@ -384,7 +382,9 @@ func (s *CleanupSuite) TestCleanupForceDestroyedControllerMachine(c *gc.C) {
 	// controller member anymore
 	c.Assert(machine.Refresh(), jc.ErrorIsNil)
 	c.Check(machine.Life(), gc.Equals, state.Dying)
-	c.Check(machine.WantsVote(), jc.IsFalse)
+	node, err := s.State.ControllerNode(machine.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(node.WantsVote(), jc.IsFalse)
 	c.Check(machine.HasVote(), jc.IsTrue)
 	c.Check(machine.Jobs(), jc.DeepEquals, []state.MachineJob{state.JobManageModel})
 	controllerInfo, err := s.State.ControllerInfo()

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -567,20 +567,9 @@ func UpdateModelUserLastConnection(st *State, e permission.UserAccess, when time
 	return model.updateLastModelConnection(e.UserTag, when)
 }
 
-func (m *Machine) SetWantsVote(wantsVote bool) error {
-	ops := []txn.Op{{
-		C:      machinesC,
-		Id:     m.doc.DocID,
-		Update: bson.M{"$set": bson.M{"novote": !wantsVote}},
-	},
-		setControllerWantsVoteOp(m.st, m.Id(), wantsVote),
-	}
-	err := m.st.runRawTransaction(ops)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	m.doc.NoVote = !wantsVote
-	return nil
+func SetWantsVote(st *State, id string, wantsVote bool) error {
+	op := setControllerWantsVoteOp(st, id, wantsVote)
+	return st.runRawTransaction([]txn.Op{op})
 }
 
 func RemoveEndpointBindingsForApplication(c *gc.C, app *Application) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -573,7 +573,6 @@ func (i *importer) makeMachineDoc(m description.Machine) (*machineDoc, error) {
 		Life:                     Alive,
 		Tools:                    i.makeTools(m.Tools()),
 		Jobs:                     jobs,
-		NoVote:                   true,  // State servers can't be migrated yet.
 		HasVote:                  false, // State servers can't be migrated yet.
 		PasswordHash:             m.PasswordHash(),
 		Clean:                    !i.machineHasUnits(machineTag),

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -317,9 +317,8 @@ func (s *MigrationSuite) TestMachineDocFields(c *gc.C) {
 		"ModelUUID",
 		// Life is always alive, confirmed by export precheck.
 		"Life",
-		// NoVote and HasVote only matter for machines with manage state job
+		// HasVote only matters for machines with manage state job
 		// and we don't support migrating the controller model.
-		"NoVote",
 		"HasVote",
 		// Ignored at this stage, could be an issue if mongo 3.0 isn't
 		// available.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1410,7 +1410,9 @@ func (s *StateSuite) TestAddMachineCanOnlyAddControllerForMachine0(c *gc.C) {
 	m, err := s.State.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, "0")
-	c.Assert(m.WantsVote(), jc.IsTrue)
+	node, err := s.State.ControllerNode(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(node.HasVote(), jc.IsFalse)
 	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
 
 	// Check that the controller information is correct.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -635,11 +635,10 @@ func (s *UnitSuite) setMachineVote(c *gc.C, id string, hasVote bool) {
 
 func (s *UnitSuite) demoteMachine(c *gc.C, m *state.Machine) {
 	s.setMachineVote(c, m.Id(), false)
-	err := m.SetWantsVote(false)
+	c.Assert(state.SetWantsVote(s.State, m.Id(), false), jc.ErrorIsNil)
+	node, err := s.State.ControllerNode(m.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.RemoveControllerReference(m)
+	err = s.State.RemoveControllerReference(node)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2182,8 +2182,12 @@ func AddControllerNodeDocs(pool *StatePool) error {
 	for _, m := range docs {
 		docId := m["_id"].(string)
 		mid := m["machineid"].(string)
-		hasvote := m["hasvote"].(bool)
-		wantsvote := !m["novote"].(bool)
+		hasvote, _ := m["hasvote"].(bool)
+		novote, ok := m["novote"].(bool)
+		if !ok {
+			continue
+		}
+		wantsvote := !novote
 		modelUUID, _, ok := splitDocID(docId)
 		if !ok {
 			logger.Warningf("unexpected machine doc id %q", docId)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3245,6 +3245,10 @@ func (s *upgradesSuite) TestAddControllerNodeDocs(c *gc.C) {
 		"machineid": "3",
 		"jobs":      []MachineJob{JobHostUnits},
 	}, bson.M{
+		"_id":       ensureModelUUID(uuid1, "5"),
+		"machineid": "5",
+		"jobs":      []MachineJob{JobManageModel},
+	}, bson.M{
 		"_id":       ensureModelUUID(uuid2, "1"),
 		"machineid": "1",
 		"novote":    false,

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -552,7 +552,7 @@ func (p *peerGroupChanges) updateAddressesFromInternal() error {
 		// configured HA space when there are multiple cloud-local addresses.
 		if !unchanged {
 			multipleAddresses = append(multipleAddresses, id)
-			if err := m.controller.SetStatus(getStatusInfo(multiAddressMessage)); err != nil {
+			if err := m.host.SetStatus(getStatusInfo(multiAddressMessage)); err != nil {
 				return errors.Trace(err)
 			}
 		}
@@ -581,7 +581,7 @@ func (p *peerGroupChanges) updateAddressesFromSpace() error {
 			if errors.IsNotFound(err) {
 				noAddresses = append(noAddresses, id)
 				msg := fmt.Sprintf("no addresses in configured juju-ha-space %q", space)
-				if err := m.controller.SetStatus(getStatusInfo(msg)); err != nil {
+				if err := m.host.SetStatus(getStatusInfo(msg)); err != nil {
 					return errors.Trace(err)
 				}
 				continue

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -390,6 +390,7 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 		c.Assert(info, gc.NotNil)
 
 		desired, err = desiredPeerGroup(info)
+		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(desired.isChanged, jc.IsFalse)
 		c.Assert(desired.stepDownPrimary, jc.IsFalse)
 		countPrimaries := 0

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -192,7 +192,17 @@ func (st *fakeState) controller(id string) *fakeController {
 }
 
 func (st *fakeState) ControllerNode(id string) (ControllerNode, error) {
-	if err := st.errors.errorFor("State.Controller", id); err != nil {
+	if err := st.errors.errorFor("State.ControllerNode", id); err != nil {
+		return nil, err
+	}
+	if m := st.controller(id); m != nil {
+		return m, nil
+	}
+	return nil, errors.NotFoundf("controller %s", id)
+}
+
+func (st *fakeState) ControllerHost(id string) (ControllerHost, error) {
+	if err := st.errors.errorFor("State.ControllerHost", id); err != nil {
 		return nil, err
 	}
 	if m := st.controller(id); m != nil {

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -19,6 +19,10 @@ type StateShim struct {
 }
 
 func (s StateShim) ControllerNode(id string) (ControllerNode, error) {
+	return s.State.ControllerNode(id)
+}
+
+func (s StateShim) ControllerHost(id string) (ControllerHost, error) {
 	return s.State.Machine(id)
 }
 

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -401,7 +401,10 @@ var fatalErrorsTests = []struct {
 	errPattern: "Session.CurrentMembers",
 	expectErr:  "creating peer group info: cannot get replica set members: sample",
 }, {
-	errPattern: "State.Controller *",
+	errPattern: "State.ControllerNode *",
+	expectErr:  `cannot get controller "10": sample`,
+}, {
+	errPattern: "State.ControllerHost *",
 	expectErr:  `cannot get controller "10": sample`,
 }}
 


### PR DESCRIPTION
## Description of change

A previous PR introduced a new controller node which has the "wants vote" and "has vote" attributes for a controller.
The PR removes the machine NoVote attribute and modifies the peer grouper and enable ha code to use the new controller node attribute.
It also deletes old unused ha code which supported promoting and demoting machines as a controller; we no longer do that and instead remove machines no longer needed as a controller.

There's still a bit of cruft until the "hasvote" attribute is removed.

## QA steps

bootstrap
enable-ha
remove a controller, check ha status
enable ha again, check status
remove mongo primary, check status
add a machine
enable-ha --to, check status



