### PR TITLE
Err formatting fix

### DIFF
--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -160,7 +160,7 @@ func returnNotFoundOperationErrors(operation *compute.Operation) error {
 		result := waitError{operation, nil}
 		for _, err := range operation.Error.Errors {
 			if err.Code == "RESOURCE_NOT_FOUND" {
-				result.cause = errors.NotFoundf("resource", err.Message)
+				result.cause = errors.NotFoundf("%v: resource", err.Message)
 				continue
 			}
 			logger.Errorf("GCE operation error: (%s) %s", err.Code, err.Message)


### PR DESCRIPTION
## Description of change

2.5 accepted error forming without a formatting directive but 2.6 insists on it. Backporting to keep codebase in sync.

