### PR TITLE
2.6 - Fix Errant Branch Tracking by Cache Config Watcher

### DIFF
--- a/core/cache/charmconfigwatcher.go
+++ b/core/cache/charmconfigwatcher.go
@@ -42,10 +42,10 @@ type charmConfigWatcherConfig struct {
 }
 
 // CharmConfigWatcher watches application charm config on behalf of a unit.
-// The configuration is based on whether the unit is tracking an active model branch.
-// If keys are specified the watcher only signals a change when at least one
-// of those keys changes value. If no keys are specified,
-// any change in the config will trigger the watcher to notify.
+// The watcher will notify if either of the following events cause a change
+// to the unit's effective configuration:
+// - Changes to the charm config settings for the unit's application.
+// - Changes to a model branch being tracked by the unit.
 type CharmConfigWatcher struct {
 	*notifyWatcherBase
 
@@ -62,9 +62,8 @@ type CharmConfigWatcher struct {
 	configHash     string
 }
 
-// newUnitConfigWatcher returns a new watcher for the input config keys
-// with a baseline hash of their config values from the input hash cache.
-// As per the cache requirements, hashes are only generated from sorted keys.
+// newUnitConfigWatcher returns a new watcher for the unit indicated in the
+// input configuration.
 func newCharmConfigWatcher(cfg charmConfigWatcherConfig) (*CharmConfigWatcher, error) {
 	w := &CharmConfigWatcher{
 		notifyWatcherBase: newNotifyWatcherBase(),
@@ -153,11 +152,10 @@ func (w *CharmConfigWatcher) branchChanged(_ string, msg interface{}) {
 	}
 
 	// If we do not know whether we are tracking this branch, find out.
-	if w.branchName == "" {
-		if w.isTracking(b) {
-			w.branchName = b.Name()
-		}
-	} else if w.branchName != b.Name() {
+	if w.branchName == "" && w.isTracking(b) {
+		w.branchName = b.Name()
+	}
+	if w.branchName != b.Name() {
 		return
 	}
 

--- a/core/cache/charmconfigwatcher_test.go
+++ b/core/cache/charmconfigwatcher_test.go
@@ -40,6 +40,26 @@ func (s *charmConfigWatcherSuite) TestTrackingBranchChangedNotified(c *gc.C) {
 	w.AssertStops()
 }
 
+func (s *charmConfigWatcherSuite) TestNotTrackingBranchChangedNotNotified(c *gc.C) {
+	// This will initialise the watcher without branch info.
+	w := s.newWatcher(c, "redis/9")
+	s.assertWatcherConfig(c, w, map[string]interface{}{})
+
+	// Publish a branch change with altered config.
+	b := Branch{
+		details: BranchChange{
+			Name:   branchName,
+			Config: map[string]settings.ItemChanges{"redis": {settings.MakeAddition("password", "new-pass")}},
+		},
+	}
+	s.Hub.Publish(branchChange, b)
+
+	// Nothing should change.
+	w.AssertNoChange()
+	s.assertWatcherConfig(c, w, map[string]interface{}{})
+	w.AssertStops()
+}
+
 func (s *charmConfigWatcherSuite) TestDifferentBranchChangedNotNotified(c *gc.C) {
 	w := s.newWatcher(c, "redis/0")
 


### PR DESCRIPTION
## Description of change

This patch fixes an edge case in the cache charm config watcher where a unit not tracking any branch would start tracking a branch changed in the cache.

Includes some outdated comment updates.

## QA steps

See new unit test; fails before, passes after.

## Documentation changes

None.

## Bug reference

N/A
