### PR TITLE
2.6 Cache Testing Infrastructure

### DIFF
--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -4,8 +4,6 @@
 package logger_test
 
 import (
-	"time"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
@@ -21,7 +19,6 @@ import (
 	"github.com/juju/juju/core/cache/cachetest"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
-	"github.com/juju/juju/testing"
 )
 
 type loggerSuite struct {
@@ -34,11 +31,10 @@ type loggerSuite struct {
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
 
-	change     cache.ModelChange
-	changes    chan interface{}
-	controller *cache.Controller
-	events     chan interface{}
-	capture    func(change interface{})
+	change  cache.ModelChange
+	ctrl    *cachetest.TestController
+	events  <-chan interface{}
+	capture func(change interface{})
 }
 
 var _ = gc.Suite(&loggerSuite{})
@@ -58,44 +54,18 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 		Tag: s.rawMachine.Tag(),
 	}
 
-	s.events = make(chan interface{})
-	notify := func(change interface{}) {
-		send := false
-		switch change.(type) {
-		case cache.ModelChange:
-			send = true
-		case cache.RemoveModel:
-			send = true
-		default:
-			// no-op
-		}
-		if send {
-			c.Logf("sending %#v", change)
-			select {
-			case s.events <- change:
-			case <-time.After(testing.LongWait):
-				c.Fatalf("change not processed by test")
-			}
-		}
-	}
+	s.ctrl = cachetest.NewTestController(cachetest.ModelEvents)
+	s.events = s.ctrl.Init(c)
 
-	s.changes = make(chan interface{})
-	controller, err := cache.NewController(cache.ControllerConfig{
-		Changes: s.changes,
-		Notify:  notify,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.controller = controller
-	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, s.controller) })
 	// Add the current model to the controller.
-	s.change = cachetest.ModelChangeFromState(c, s.State)
-	s.changes <- s.change
-	// Ensure it is processed before we create the logger api.
-	select {
-	case <-s.events:
-	case <-time.After(testing.LongWait):
-		c.Fatalf("change not processed by test")
-	}
+	m := cachetest.ModelChangeFromState(c, s.State)
+	s.ctrl.SendChange(m)
+
+	// Ensure it is processed before we create the logger API.
+	s.ctrl.NextChange(c, s.events)
+
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, s.ctrl.Controller) })
+
 	s.logger, err = s.makeLoggerAPI(s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -103,7 +73,7 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 func (s *loggerSuite) makeLoggerAPI(auth facade.Authorizer) (*logger.LoggerAPI, error) {
 	ctx := facadetest.Context{
 		Auth_:       auth,
-		Controller_: s.controller,
+		Controller_: s.ctrl.Controller,
 		Resources_:  s.resources,
 		State_:      s.State,
 	}
@@ -143,13 +113,10 @@ func (s *loggerSuite) TestWatchLoggingConfigNothing(c *gc.C) {
 }
 
 func (s *loggerSuite) setLoggingConfig(c *gc.C, loggingConfig string) {
-	s.change.Config["logging-config"] = loggingConfig
-	s.changes <- s.change
-	select {
-	case <-s.events:
-	case <-time.After(testing.LongWait):
-		c.Fatalf("change not processed by test")
-	}
+	m := cachetest.ModelChangeFromState(c, s.State)
+	m.Config["logging-config"] = loggingConfig
+	s.ctrl.SendChange(m)
+	s.ctrl.NextChange(c, s.events)
 }
 
 func (s *loggerSuite) TestWatchLoggingConfig(c *gc.C) {

--- a/apiserver/facades/agent/uniter/access.go
+++ b/apiserver/facades/agent/uniter/access.go
@@ -1,0 +1,129 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/facades/client/application"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/state"
+)
+
+// unitAccessor creates a accessUnit function for accessing a unit
+func unitAccessor(authorizer facade.Authorizer, st *state.State) common.GetAuthFunc {
+	return func() (common.AuthFunc, error) {
+		switch tag := authorizer.GetAuthTag().(type) {
+		case names.ApplicationTag:
+			// If called by an application agent, any of the units
+			// belonging to that application can be accessed.
+			app, err := st.Application(tag.Name)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			allUnits, err := app.AllUnits()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return func(tag names.Tag) bool {
+				for _, u := range allUnits {
+					if u.Tag() == tag {
+						return true
+					}
+				}
+				return false
+			}, nil
+		case names.UnitTag:
+			return func(tag names.Tag) bool {
+				return authorizer.AuthOwner(tag)
+			}, nil
+		default:
+			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
+		}
+	}
+}
+
+func applicationAccessor(authorizer facade.Authorizer, st *state.State) common.GetAuthFunc {
+	return func() (common.AuthFunc, error) {
+		switch tag := authorizer.GetAuthTag().(type) {
+		case names.ApplicationTag:
+			return func(applicationTag names.Tag) bool {
+				return tag == applicationTag
+			}, nil
+		case names.UnitTag:
+			entity, err := st.Unit(tag.Id())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			applicationName := entity.ApplicationName()
+			applicationTag := names.NewApplicationTag(applicationName)
+			return func(tag names.Tag) bool {
+				return tag == applicationTag
+			}, nil
+		default:
+			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
+		}
+	}
+}
+
+func machineAccessor(authorizer facade.Authorizer, st *state.State) common.GetAuthFunc {
+	return func() (common.AuthFunc, error) {
+		switch tag := authorizer.GetAuthTag().(type) {
+		// Application agents can't access machines.
+		case names.ApplicationTag:
+			return func(tag names.Tag) bool {
+				return false
+			}, nil
+		case names.UnitTag:
+			entity, err := st.Unit(tag.Id())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			machineId, err := entity.AssignedMachineId()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			machineTag := names.NewMachineTag(machineId)
+			return func(tag names.Tag) bool {
+				return tag == machineTag
+			}, nil
+		default:
+			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
+		}
+	}
+}
+
+func cloudSpecAccessor(authorizer facade.Authorizer, st *state.State) func() (func() bool, error) {
+	return func() (func() bool, error) {
+		var appName string
+		var err error
+
+		switch tag := authorizer.GetAuthTag().(type) {
+		case names.ApplicationTag:
+			appName = tag.Id()
+		case names.UnitTag:
+			entity, err := st.Unit(tag.Id())
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			appName = entity.ApplicationName()
+		default:
+			return nil, errors.Errorf("expected names.UnitTag or names.ApplicationTag, got %T", tag)
+		}
+
+		app, err := st.Application(appName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		config, err := app.ApplicationConfig()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return func() bool {
+			return config.GetBool(application.TrustConfigOptionName, false)
+		}, nil
+	}
+}

--- a/core/cache/cachetest/controller.go
+++ b/core/cache/cachetest/controller.go
@@ -1,0 +1,114 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cachetest
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+// TestController wraps a cache controller for testing.
+// It allows synchronisation of state objects with the cache
+// without the need for a multi-watcher and cache worker.
+type TestController struct {
+	*cache.Controller
+
+	matchers []func(interface{}) bool
+	changes  chan interface{}
+}
+
+// NewTestController returns creates and returns a new test controller
+// with an initial set of matchers for receiving cache event notifications.
+// The controller can be instantiated like this in suite/test setups in order
+// to retain a common set of matchers, but `Init` should be called in each
+// test (see below).
+func NewTestController(matchers ...func(interface{}) bool) *TestController {
+	return &TestController{
+		matchers: matchers,
+	}
+}
+
+// Init instantiates the inner cache controller and returns a channel for
+// synchronising tests. Based on the input matchers, cache events for those
+// types will be sent on the channel when the cache processes them.
+//
+// NOTE: It is recommended to perform this initialisation in the actual test
+// method rather than `SetupSuite` or `SetupTest` as different gc.C references
+// are supplied to each of those methods.
+func (tc *TestController) Init(c *gc.C, matchers ...func(interface{}) bool) <-chan interface{} {
+	events := make(chan interface{})
+	matchers = append(tc.matchers, matchers...)
+
+	notify := func(change interface{}) {
+		send := false
+		for _, m := range matchers {
+			if m(change) {
+				send = true
+				break
+			}
+		}
+
+		if send {
+			c.Logf("sending %#v", change)
+			select {
+			case events <- change:
+			case <-time.After(testing.LongWait):
+				c.Fatalf("change not processed by test")
+			}
+		}
+	}
+
+	tc.changes = make(chan interface{})
+	cc, err := cache.NewController(cache.ControllerConfig{
+		Changes: tc.changes,
+		Notify:  notify,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	tc.Controller = cc
+
+	return events
+}
+
+// UpdateModel updates the current model for the input state in the cache.
+func (tc *TestController) UpdateModel(c *gc.C, m *state.Model) {
+	tc.SendChange(ModelChange(c, m))
+}
+
+// UpdateCharm updates the input state charm in the cache.
+func (tc *TestController) UpdateCharm(modelUUID string, ch *state.Charm) {
+	tc.SendChange(CharmChange(modelUUID, ch))
+}
+
+// UpdateApplication updates the input state application in the cache.
+func (tc *TestController) UpdateApplication(c *gc.C, modelUUID string, app *state.Application) {
+	tc.SendChange(ApplicationChange(c, modelUUID, app))
+}
+
+// UpdateMachine updates the input state machine in the cache.
+func (tc *TestController) UpdateMachine(c *gc.C, modelUUID string, machine *state.Machine) {
+	tc.SendChange(MachineChange(c, modelUUID, machine))
+}
+
+func (tc *TestController) SendChange(change interface{}) {
+	tc.changes <- change
+}
+
+// NextChange returns the next change processed by the cache that satisfies a
+// matcher, or fails the test with a time-out.
+// This method should receive the channel returned by a call to `Init`.
+func (tc *TestController) NextChange(c *gc.C, changes <-chan interface{}) interface{} {
+	var obtained interface{}
+	select {
+	case obtained = <-changes:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("change not processed by test")
+	}
+	return obtained
+}

--- a/core/cache/cachetest/eventmatchers.go
+++ b/core/cache/cachetest/eventmatchers.go
@@ -1,0 +1,63 @@
+package cachetest
+
+import "github.com/juju/juju/core/cache"
+
+var ModelEvents = func(change interface{}) bool {
+	switch change.(type) {
+	case cache.ModelChange:
+		return true
+	case cache.RemoveModel:
+		return true
+	}
+	return false
+}
+
+var ApplicationEvents = func(change interface{}) bool {
+	switch change.(type) {
+	case cache.ApplicationChange:
+		return true
+	case cache.RemoveApplication:
+		return true
+	}
+	return false
+}
+
+var MachineEvents = func(change interface{}) bool {
+	switch change.(type) {
+	case cache.MachineChange:
+		return true
+	case cache.RemoveMachine:
+		return true
+	}
+	return false
+}
+
+var CharmEvents = func(change interface{}) bool {
+	switch change.(type) {
+	case cache.CharmChange:
+		return true
+	case cache.RemoveCharm:
+		return true
+	}
+	return false
+}
+
+var UnitEvents = func(change interface{}) bool {
+	switch change.(type) {
+	case cache.UnitChange:
+		return true
+	case cache.RemoveUnit:
+		return true
+	}
+	return false
+}
+
+var BranchEvents = func(change interface{}) bool {
+	switch change.(type) {
+	case cache.BranchChange:
+		return true
+	case cache.RemoveBranch:
+		return true
+	}
+	return false
+}

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -4,58 +4,166 @@
 package cachetest
 
 import (
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/state"
 )
 
 // ModelChangeFromState returns a ModelChange representing the current
 // model for the state object.
 func ModelChangeFromState(c *gc.C, st *state.State) cache.ModelChange {
-	model, err := st.Model()
+	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	return ModelChange(c, model)
+	return ModelChange(c, m)
 }
 
-// ModelChangeFromStateErr returns a ModelChange representing the current
-// model for the state object. May return an error.
-func ModelChangeFromStateErr(st *state.State) (cache.ModelChange, error) {
-	model, err := st.Model()
-	if err != nil {
-		return cache.ModelChange{}, errors.Trace(err)
-	}
-	return ModelChangeErr(model)
-}
-
-// ModelChange returns a ModelChange representing the current state of the model.
+// ModelChange returns a ModelChange representing the input state model.
 func ModelChange(c *gc.C, model *state.Model) cache.ModelChange {
-	change, err := ModelChangeErr(model)
+	cfg, err := model.Config()
 	c.Assert(err, jc.ErrorIsNil)
-	return change
-}
 
-// ModelChangeErr returns a ModelChange representing the current state of the model.
-// May return an error if unable to load config or status.
-func ModelChangeErr(model *state.Model) (cache.ModelChange, error) {
-	change := cache.ModelChange{
+	status, err := model.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	return cache.ModelChange{
 		ModelUUID: model.UUID(),
 		Name:      model.Name(),
 		Life:      life.Value(model.Life().String()),
 		Owner:     model.Owner().Name(),
+		Config:    cfg.AllAttrs(),
+		Status:    status,
 	}
-	config, err := model.Config()
-	if err != nil {
-		return cache.ModelChange{}, errors.Trace(err)
+}
+
+// CharmChange returns a CharmChange representing the input state charm.
+func CharmChange(modelUUID string, ch *state.Charm) cache.CharmChange {
+	prof := ch.LXDProfile()
+	cProf := lxdprofile.Profile{
+		Config:      prof.Config,
+		Description: prof.Description,
+		Devices:     prof.Devices,
 	}
-	change.Config = config.AllAttrs()
-	status, err := model.Status()
-	if err != nil {
-		return cache.ModelChange{}, errors.Trace(err)
+
+	return cache.CharmChange{
+		ModelUUID:     modelUUID,
+		CharmURL:      ch.URL().String(),
+		CharmVersion:  ch.Version(),
+		LXDProfile:    cProf,
+		DefaultConfig: ch.Config().DefaultSettings(),
 	}
-	change.Status = status
-	return change, nil
+}
+
+// ApplicationChange returns an ApplicationChange
+// representing the input state application.
+func ApplicationChange(c *gc.C, modelUUID string, app *state.Application) cache.ApplicationChange {
+	// Note that this will include charm defaults as if explicitly set.
+	// If this matters for tests, we will have to pass a state and attempt
+	// to access the settings document for this application charm config.
+	config, err := app.CharmConfig(model.GenerationMaster)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := app.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sts, err := app.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	cURL, _ := app.CharmURL()
+
+	return cache.ApplicationChange{
+		ModelUUID:   modelUUID,
+		Name:        app.Name(),
+		Exposed:     app.IsExposed(),
+		CharmURL:    cURL.Path(),
+		Life:        life.Value(app.Life().String()),
+		MinUnits:    app.MinUnits(),
+		Constraints: cons,
+		Config:      config,
+		Status:      sts,
+		// TODO: Subordinate, WorkloadVersion.
+	}
+}
+
+func MachineChange(c *gc.C, modelUUID string, machine *state.Machine) cache.MachineChange {
+	iid, err := machine.InstanceId()
+	c.Assert(err, jc.ErrorIsNil)
+
+	aSts, err := machine.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	iSts, err := machine.InstanceStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	hwc, err := machine.HardwareCharacteristics()
+	c.Assert(err, jc.ErrorIsNil)
+
+	chProf, err := machine.CharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sc, scKnown := machine.SupportedContainers()
+
+	return cache.MachineChange{
+		ModelUUID:                modelUUID,
+		Id:                       machine.Id(),
+		InstanceId:               string(iid),
+		AgentStatus:              aSts,
+		InstanceStatus:           iSts,
+		Life:                     life.Value(machine.Life().String()),
+		Series:                   machine.Series(),
+		ContainerType:            string(machine.ContainerType()),
+		SupportedContainers:      sc,
+		SupportedContainersKnown: scKnown,
+		HardwareCharacteristics:  hwc,
+		CharmProfiles:            chProf,
+		HasVote:                  machine.HasVote(),
+		WantsVote:                machine.WantsVote(),
+		// TODO: Config, Addresses.
+	}
+
+}
+
+// UnitChange returns a UnitChange representing the input state unit.
+func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
+	publicAddr, err := unit.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+
+	privateAddr, err := unit.PrivateAddress()
+	c.Assert(err, jc.ErrorIsNil)
+
+	machineId, err := unit.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+
+	pr, err := unit.OpenedPorts()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sts, err := unit.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	aSts, err := unit.AgentStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	principal, _ := unit.PrincipalName()
+	cURL, _ := unit.CharmURL()
+
+	return cache.UnitChange{
+		ModelUUID:      modelUUID,
+		Name:           unit.Name(),
+		Application:    unit.ApplicationName(),
+		Series:         unit.Series(),
+		CharmURL:       cURL.Path(),
+		Life:           life.Value(unit.Life().String()),
+		PublicAddress:  publicAddr.String(),
+		PrivateAddress: privateAddr.String(),
+		MachineId:      machineId,
+		PortRanges:     pr,
+		Principal:      principal,
+		WorkloadStatus: sts,
+		AgentStatus:    aSts,
+		// TODO: Subordinate
+	}
 }

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -83,7 +83,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 		cfg = make(map[string]interface{})
 	}
 
-	// Apply any branch-based deltas to the master settings
+	// Apply any branch-based deltas to the master settings.
 	var deltas settings.ItemChanges
 	for _, b := range u.model.Branches() {
 		if units := b.AssignedUnits()[appName]; len(units) > 0 {

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/cache/cachetest"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -119,7 +120,7 @@ func (s *WorkerSuite) checkModel(c *gc.C, obtained interface{}, model *state.Mod
 }
 
 func (s *WorkerSuite) TestInitialModel(c *gc.C) {
-	changes := s.captureEvents(c, modelEvents)
+	changes := s.captureEvents(c, cachetest.ModelEvents)
 	s.start(c)
 
 	obtained := s.nextChange(c, changes)
@@ -129,7 +130,7 @@ func (s *WorkerSuite) TestInitialModel(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestModelConfigChange(c *gc.C) {
-	changes := s.captureEvents(c, modelEvents)
+	changes := s.captureEvents(c, cachetest.ModelEvents)
 	w := s.start(c)
 	// discard initial event
 	s.nextChange(c, changes)
@@ -158,7 +159,7 @@ func (s *WorkerSuite) TestModelConfigChange(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestNewModel(c *gc.C) {
-	changes := s.captureEvents(c, modelEvents)
+	changes := s.captureEvents(c, cachetest.ModelEvents)
 	w := s.start(c)
 	// grab and discard the event for the initial model
 	s.nextChange(c, changes)
@@ -177,7 +178,7 @@ func (s *WorkerSuite) TestNewModel(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestRemovedModel(c *gc.C) {
-	changes := s.captureEvents(c, modelEvents)
+	changes := s.captureEvents(c, cachetest.ModelEvents)
 	w := s.start(c)
 
 	// grab and discard the event for the initial model
@@ -222,7 +223,7 @@ func (s *WorkerSuite) TestRemovedModel(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestAddApplication(c *gc.C) {
-	changes := s.captureEvents(c, applicationEvents)
+	changes := s.captureEvents(c, cachetest.ApplicationEvents)
 	w := s.start(c)
 
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{})
@@ -246,7 +247,7 @@ func (s *WorkerSuite) TestAddApplication(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestRemoveApplication(c *gc.C) {
-	changes := s.captureEvents(c, applicationEvents)
+	changes := s.captureEvents(c, cachetest.ApplicationEvents)
 	w := s.start(c)
 
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{})
@@ -275,7 +276,7 @@ func (s *WorkerSuite) TestRemoveApplication(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestAddMachine(c *gc.C) {
-	changes := s.captureEvents(c, machineEvents)
+	changes := s.captureEvents(c, cachetest.MachineEvents)
 	w := s.start(c)
 
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{})
@@ -299,7 +300,7 @@ func (s *WorkerSuite) TestAddMachine(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestRemoveMachine(c *gc.C) {
-	changes := s.captureEvents(c, machineEvents)
+	changes := s.captureEvents(c, cachetest.MachineEvents)
 	w := s.start(c)
 
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{})
@@ -333,7 +334,7 @@ func (s *WorkerSuite) TestRemoveMachine(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestAddCharm(c *gc.C) {
-	changes := s.captureEvents(c, charmEvents)
+	changes := s.captureEvents(c, cachetest.CharmEvents)
 	w := s.start(c)
 
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{})
@@ -357,7 +358,7 @@ func (s *WorkerSuite) TestAddCharm(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestRemoveCharm(c *gc.C) {
-	changes := s.captureEvents(c, charmEvents)
+	changes := s.captureEvents(c, cachetest.CharmEvents)
 	w := s.start(c)
 
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{})
@@ -389,7 +390,7 @@ func (s *WorkerSuite) TestRemoveCharm(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestAddUnit(c *gc.C) {
-	changes := s.captureEvents(c, unitEvents)
+	changes := s.captureEvents(c, cachetest.UnitEvents)
 	w := s.start(c)
 
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{})
@@ -414,7 +415,7 @@ func (s *WorkerSuite) TestAddUnit(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestRemoveUnit(c *gc.C) {
-	changes := s.captureEvents(c, unitEvents)
+	changes := s.captureEvents(c, cachetest.UnitEvents)
 	w := s.start(c)
 
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{})
@@ -443,7 +444,7 @@ func (s *WorkerSuite) TestRemoveUnit(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestAddBranch(c *gc.C) {
-	changes := s.captureEvents(c, branchEvents)
+	changes := s.captureEvents(c, cachetest.BranchEvents)
 	w := s.start(c)
 
 	branchName := "test-branch"
@@ -467,7 +468,7 @@ func (s *WorkerSuite) TestAddBranch(c *gc.C) {
 }
 
 func (s *WorkerSuite) TestRemoveBranch(c *gc.C) {
-	changes := s.captureEvents(c, branchEvents)
+	changes := s.captureEvents(c, cachetest.BranchEvents)
 	w := s.start(c)
 
 	branchName := "test-branch"
@@ -542,7 +543,7 @@ func (s *WorkerSuite) TestWatcherErrorCacheMarkSweep(c *gc.C) {
 		}
 	}
 
-	changes := s.captureEvents(c, modelEvents, applicationEvents)
+	changes := s.captureEvents(c, cachetest.ModelEvents, cachetest.ApplicationEvents)
 	w := s.start(c)
 	s.State.StartSync()
 
@@ -625,66 +626,6 @@ func (s *WorkerSuite) nextChange(c *gc.C, changes <-chan interface{}) interface{
 		c.Fatalf("no change")
 	}
 	return obtained
-}
-
-var modelEvents = func(change interface{}) bool {
-	switch change.(type) {
-	case cache.ModelChange:
-		return true
-	case cache.RemoveModel:
-		return true
-	}
-	return false
-}
-
-var applicationEvents = func(change interface{}) bool {
-	switch change.(type) {
-	case cache.ApplicationChange:
-		return true
-	case cache.RemoveApplication:
-		return true
-	}
-	return false
-}
-
-var machineEvents = func(change interface{}) bool {
-	switch change.(type) {
-	case cache.MachineChange:
-		return true
-	case cache.RemoveMachine:
-		return true
-	}
-	return false
-}
-
-var charmEvents = func(change interface{}) bool {
-	switch change.(type) {
-	case cache.CharmChange:
-		return true
-	case cache.RemoveCharm:
-		return true
-	}
-	return false
-}
-
-var unitEvents = func(change interface{}) bool {
-	switch change.(type) {
-	case cache.UnitChange:
-		return true
-	case cache.RemoveUnit:
-		return true
-	}
-	return false
-}
-
-var branchEvents = func(change interface{}) bool {
-	switch change.(type) {
-	case cache.BranchChange:
-		return true
-	case cache.RemoveBranch:
-		return true
-	}
-	return false
 }
 
 type noopRegisterer struct {


### PR DESCRIPTION
## Description of change

This patch generalises functionality for putting state entities directly into a cache for testing purposes. It obviates the need for running a multi-watcher and cache-worker for cache population.

Included is a relocation of uniter API server access control methods to their own module to tidy up the API constructor.

## QA steps

Tests from `apiserver/facades/agent/logger` and `worker/modelcache` continue to pass.

## Documentation changes

None.

## Bug reference

N/A
