### PR TITLE
Fixes lp#1833629: errors point to 'add-cloud --replace'.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -115,7 +115,6 @@ you can specify which to upload with the --credential option.
 Examples:
     juju add-cloud
     juju add-cloud mycloud ~/mycloud.yaml
-    juju add-cloud --replace mycloud ~/mycloud2.yaml
 
 If the "multi-cloud" feature flag is turned on in the controller:
 
@@ -125,6 +124,7 @@ If the "multi-cloud" feature flag is turned on in the controller:
 
 See also: 
     clouds
+    update-cloud
     update-credential`
 
 // AddCloudAPI - Implemented by cloudapi.Client.
@@ -689,14 +689,14 @@ func (p cloudFileReader) verifyName(name string) error {
 		return err
 	}
 	if _, ok := personal[name]; ok {
-		return errors.Errorf("%q already exists; use --replace to replace this existing cloud", name)
+		return errors.Errorf("%q already exists; use `update-cloud` to replace this existing cloud", name)
 	}
 	msg, err := nameExists(name, public)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if msg != "" {
-		return errors.Errorf(msg + "; use --replace to override this definition")
+		return errors.Errorf(msg + "; use `update-cloud` to override this definition")
 	}
 	return nil
 }

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -198,7 +198,7 @@ func (s *addSuite) TestAddExisting(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(mockCloud, nil)
 
 	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, `"homestack" already exists; use --replace to replace this existing cloud`)
+	c.Assert(err, gc.ErrorMatches, "\"homestack\" already exists; use `update-cloud` to replace this existing cloud")
 }
 
 func (s *addSuite) TestAddExistingReplace(c *gc.C) {
@@ -235,7 +235,7 @@ func (s *addSuite) TestAddExistingPublic(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "aws", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, `"aws" is the name of a public cloud; use --replace to override this definition`)
+	c.Assert(err, gc.ErrorMatches, "\"aws\" is the name of a public cloud; use `update-cloud` to override this definition")
 }
 
 func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
@@ -252,7 +252,7 @@ func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "localhost", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, `"localhost" is the name of a built-in cloud; use --replace to override this definition`)
+	c.Assert(err, gc.ErrorMatches, "\"localhost\" is the name of a built-in cloud; use `update-cloud` to override this definition")
 }
 
 func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {


### PR DESCRIPTION
## Description of change

Whilst 'add-cloud --replace' has been deprecated and the help text clearly states so, the error messages were still referring to it.

This PR updates missed error messages to point to a new way of updating clouds definitions.

## QA steps
Running 'add-cloud' on a known, existing cloud should err out with the messaging directing users to 'update-cloud' command instead.

```
$ juju add-cloud --local fluffystack -f ~/a.yaml
ERROR "fluffystack" already exists; use `update-cloud` to replace this existing cloud
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1833629
