### PR TITLE
2.6 Retrieve Unit Config From Model Cache

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -510,6 +510,11 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	err = s.apiUnit.SetCharmURL(s.wordpressCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
+	// We need the model to settle so that the cache is populated.
+	uuid := s.State.ModelUUID()
+	s.State.StartSync()
+	s.WaitForModelWatchersIdle(c, uuid)
+
 	settings, err = s.apiUnit.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, charm.Settings{
@@ -522,12 +527,16 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.State.StartSync()
+	s.WaitForModelWatchersIdle(c, uuid)
+
 	settings, err = s.apiUnit.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, charm.Settings{
 		"blog-title": "superhero paparazzi",
 	})
 }
+
 func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	// Make sure WatchConfigSettingsHash returns an error when
 	// no charm URL is set, as its state counterpart does.

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -54,6 +54,7 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 
 	s.ctrl = cachetest.NewTestController(cachetest.ModelEvents)
 	s.ctrl.Init(c)
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, s.ctrl.Controller) })
 
 	// Add the current model to the controller.
 	m := cachetest.ModelChangeFromState(c, s.State)
@@ -61,8 +62,6 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 
 	// Ensure it is processed before we create the logger API.
 	_ = s.ctrl.NextChange(c)
-
-	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, s.ctrl.Controller) })
 
 	s.logger, err = s.makeLoggerAPI(s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -51,7 +51,8 @@ func (s *uniterGoalStateSuite) SetUpTest(c *gc.C) {
 		Charm: loggingCharm,
 	})
 
-	s.setupCache(c)
+	s.State.StartSync()
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming the MySQL unit has logged in.
@@ -65,7 +66,6 @@ func (s *uniterGoalStateSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	s.uniter = s.newUniterAPI(c, s.State, s.authorizer)
-
 }
 
 var (

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -74,7 +74,7 @@ func (s *uniterSuiteBase) SetUpTest(c *gc.C) {
 	s.setupCache(c)
 
 	// Create a FakeAuthorizer so we can check permissions,
-	// set up assuming unit 0 has logged in.
+	// set up assuming the wordpress unit has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.wordpressUnit.Tag(),
 	}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -65,10 +65,6 @@ type uniterSuiteBase struct {
 	mysqlCharm    *state.Charm
 	mysql         *state.Application
 	mysqlUnit     *state.Unit
-
-	meteredApplication *state.Application
-	meteredCharm       *state.Charm
-	meteredUnit        *state.Unit
 }
 
 func (s *uniterSuiteBase) SetUpTest(c *gc.C) {
@@ -125,18 +121,6 @@ func (s *uniterSuiteBase) setupState(c *gc.C) {
 	s.mysqlUnit = s.Factory.MakeUnit(c, &factory.UnitParams{
 		Application: s.mysql,
 		Machine:     s.machine1,
-	})
-
-	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{
-		Name: "metered",
-		URL:  "cs:quantal/metered",
-	})
-	s.meteredApplication = s.Factory.MakeApplication(c, &factory.ApplicationParams{
-		Charm: s.meteredCharm,
-	})
-	s.meteredUnit = s.Factory.MakeUnit(c, &factory.UnitParams{
-		Application: s.meteredApplication,
-		SetCharmURL: true,
 	})
 }
 
@@ -3235,12 +3219,28 @@ type unitMetricBatchesSuite struct {
 	uniterSuiteBase
 	*commontesting.ModelWatcherTest
 	uniter *uniter.UniterAPI
+
+	meteredApplication *state.Application
+	meteredCharm       *state.Charm
+	meteredUnit        *state.Unit
 }
 
 var _ = gc.Suite(&unitMetricBatchesSuite{})
 
 func (s *unitMetricBatchesSuite) SetUpTest(c *gc.C) {
 	s.uniterSuiteBase.SetUpTest(c)
+
+	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{
+		Name: "metered",
+		URL:  "cs:quantal/metered",
+	})
+	s.meteredApplication = s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Charm: s.meteredCharm,
+	})
+	s.meteredUnit = s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: s.meteredApplication,
+		SetCharmURL: true,
+	})
 
 	meteredAuthorizer := apiservertesting.FakeAuthorizer{
 		Tag: s.meteredUnit.Tag(),

--- a/core/cache/cachetest/controller.go
+++ b/core/cache/cachetest/controller.go
@@ -17,6 +17,9 @@ import (
 // TestController wraps a cache controller for testing.
 // It allows synchronisation of state objects with the cache
 // without the need for a multi-watcher and cache worker.
+// This is useful when testing with StateSuite;
+// JujuConnSuite sets up a cache worker and multiwatcher
+// to keep the model cache in sync.
 type TestController struct {
 	*cache.Controller
 

--- a/core/cache/cachetest/controller.go
+++ b/core/cache/cachetest/controller.go
@@ -95,6 +95,11 @@ func (tc *TestController) UpdateMachine(c *gc.C, modelUUID string, machine *stat
 	tc.SendChange(MachineChange(c, modelUUID, machine))
 }
 
+// UpdateUnit updates the input state unit in the cache.
+func (tc *TestController) UpdateUnit(c *gc.C, modelUUID string, unit *state.Unit) {
+	tc.SendChange(UnitChange(c, modelUUID, unit))
+}
+
 func (tc *TestController) SendChange(change interface{}) {
 	tc.changes <- change
 }

--- a/core/cache/cachetest/controller.go
+++ b/core/cache/cachetest/controller.go
@@ -18,8 +18,8 @@ import (
 // It allows synchronisation of state objects with the cache
 // without the need for a multi-watcher and cache worker.
 // This is useful when testing with StateSuite;
-// JujuConnSuite sets up a cache worker and multiwatcher
-// to keep the model cache in sync.
+// JujuConnSuite sets up a cache worker and multiwatcher to keep the model
+// cache in sync, so direct population using this technique is not necessary.
 type TestController struct {
 	*cache.Controller
 

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -131,11 +131,12 @@ func MachineChange(c *gc.C, modelUUID string, machine *state.Machine) cache.Mach
 
 // UnitChange returns a UnitChange representing the input state unit.
 func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
+	// If these addresses are not set in state, we simply eschew setting them
+	// in the cache rather than propagating such errors.
 	publicAddr, err := unit.PublicAddress()
 	if !network.IsNoAddressError(err) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
-
 	privateAddr, err := unit.PrivateAddress()
 	if !network.IsNoAddressError(err) {
 		c.Assert(err, jc.ErrorIsNil)

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -4,6 +4,7 @@
 package cachetest
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
@@ -130,16 +132,29 @@ func MachineChange(c *gc.C, modelUUID string, machine *state.Machine) cache.Mach
 // UnitChange returns a UnitChange representing the input state unit.
 func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
 	publicAddr, err := unit.PublicAddress()
-	c.Assert(err, jc.ErrorIsNil)
+	if !network.IsNoAddressError(err) {
+		c.Assert(err, jc.ErrorIsNil)
+	}
 
 	privateAddr, err := unit.PrivateAddress()
-	c.Assert(err, jc.ErrorIsNil)
+	if !network.IsNoAddressError(err) {
+		c.Assert(err, jc.ErrorIsNil)
+	}
 
 	machineId, err := unit.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
+	if !errors.IsNotAssigned(err) {
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	var charmURL string
+	if cURL, ok := unit.CharmURL(); ok {
+		charmURL = cURL.String()
+	}
 
 	pr, err := unit.OpenedPorts()
-	c.Assert(err, jc.ErrorIsNil)
+	if !errors.IsNotAssigned(err) {
+		c.Assert(err, jc.ErrorIsNil)
+	}
 
 	sts, err := unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -148,14 +163,13 @@ func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
 	c.Assert(err, jc.ErrorIsNil)
 
 	principal, _ := unit.PrincipalName()
-	cURL, _ := unit.CharmURL()
 
 	return cache.UnitChange{
 		ModelUUID:      modelUUID,
 		Name:           unit.Name(),
 		Application:    unit.ApplicationName(),
 		Series:         unit.Series(),
-		CharmURL:       cURL.Path(),
+		CharmURL:       charmURL,
 		Life:           life.Value(unit.Life().String()),
 		PublicAddress:  publicAddr.String(),
 		PrivateAddress: privateAddr.String(),

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -73,6 +73,10 @@ func (u *Unit) Ports() []network.Port {
 // Config settings returns the effective charm configuration for this unit
 // taking into account whether it is tracking a model branch.
 func (u *Unit) ConfigSettings() (charm.Settings, error) {
+	if u.details.CharmURL == "" {
+		return nil, errors.New("unit charm not set")
+	}
+
 	appName := u.details.Application
 	app, err := u.model.Application(appName)
 	if err != nil {


### PR DESCRIPTION
## Description of change

This patch updates the uniter API to retrieve unit charm config settings from the model cache.

It is the first of two parts, the second of which will alter configuration _watching_ to work from the cache. It is broken up to ease reviewing because most of this patch ensures that the uniter test suite continues to work with the _cachetest_ package functionality mixed in.

It is known that watching the DB for changes and retrieving them from the cache is not a desirable state - the second patch will follow as quickly as can be managed.

The functionality change is a handful of lines in _apiserver/facades/agent/uniter/uniter.go_.

## QA steps

- Bootstrap
- `juju deploy redis`.
- `juju config redis password=new-pass`.
- `juju ssh 0 cat /etc/redis/redis-charm.conf` and check that the line "requirepass new-pass" is present.
- `juju config redis databases=4`.
- `juju ssh 0 cat /etc/redis/redis-charm.conf` and check that the line "databases 4" is present.
- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- `juju add-branch test-branch`.
- `juju track test-branch redis/0`.
- `juju config redis password=branch-pass --branch test-branch`.
- `juju config redis databases=8 --branch master` (the watcher is still watching settings in state, so we need to invoke it by changing master settings).
- `juju ssh 0 cat /etc/redis/redis-charm.conf` and check that:
  - the line "databases 8" is present;
  - the line "requirepass branch-pass" (from branch-based settings) is present.

## Documentation changes

None.

## Bug reference

N/A
