### PR TITLE
Fixes lp#1632735: validate bootstrap region when provided by users.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -517,7 +517,11 @@ to create a new model to deploy k8s workloads.
 			}
 			if len(allRegions) > 0 {
 				naturalsort.Sort(allRegions)
-				ctx.Infof("Available cloud regions are %v", strings.Join(allRegions, ", "))
+				plural := "s are"
+				if len(allRegions) == 1 {
+					plural = " is"
+				}
+				ctx.Infof("Available cloud region%v %v", plural, strings.Join(allRegions, ", "))
 			}
 			return errors.NotValidf("region %q for cloud %q", c.Region, c.Cloud)
 		}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1456,9 +1456,8 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegionsOneSpecified(c *gc.C) {
 		c, s.newBootstrapCommand(), "dummy-cloud-without-regions/my-region", "ctrl",
 		"--config", "default-series=precise",
 	)
-	c.Check(cmdtesting.Stderr(ctx), gc.Matches,
-		"region \"my-region\" not found \\(expected one of \\[\\]\\)\n\n.*\n")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(err, gc.ErrorMatches, `region "my-region" for cloud "dummy-cloud-without-regions" not valid`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderNoCredentials(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1863,6 +1863,14 @@ sa-east-1
 `[1:])
 }
 
+func (s *BootstrapSuite) TestBootstrapInvalidRegion(c *gc.C) {
+	resetJujuXDGDataHome(c)
+	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "aws/eu-west")
+	c.Assert(err, gc.ErrorMatches, `region "eu-west" for cloud "aws" not valid`)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
+}
+
 func (s *BootstrapSuite) TestBootstrapPrintCloudRegionsNoSuchCloud(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--regions", "foo")

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1516,9 +1516,9 @@ func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegionsInvalid(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy/not-dummy", "ctrl")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(err, gc.ErrorMatches, `region "not-dummy" for cloud "dummy" not valid`)
 	stderr := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
-	c.Assert(stderr, gc.Matches, `region "not-dummy" not found \(expected one of \["dummy"\]\)Specify an alternative region, or try "juju update-clouds".`)
+	c.Assert(stderr, gc.Matches, `Available cloud region is dummy`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderManyCredentialsCloudNoAuthTypes(c *gc.C) {


### PR DESCRIPTION
## Description of change

As per linked bug, when a user specified cloud as well as the region to which to bootstrap, Juju supplies unhelpful message about credentials rather than warning about invalid region.

This PR validates that a user supplied region is valid for a given cloud.

## QA steps

At bootstrap command, specify an invalid region for your desired cloud.
For example:
```
$ juju bootstrap aws/eu-west mycontroller 
Available cloud regions are ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2
ERROR  region "eu-west" for cloud "aws" not valid
```
## Bug reference

https://bugs.launchpad.nacet/juju/+bug/1632735
