### PR TITLE
Fixes lp#1564168: Secrets can be shown in json and yaml - warn in tabular.

### DIFF
--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -34,7 +34,7 @@ Note that there can be multiple sets of credentials and, thus, multiple
 names.
 
 Actual authentication material is exposed with the '--show-secrets' 
-option.
+option in json or yaml formats. Secrets are not shown in tabular format.
 
 A controller, and subsequently created models, can be created with a 
 different set of credentials but any action taken within the model (e.g.:
@@ -132,7 +132,7 @@ func (c *listCredentialsCommand) Info() *cmd.Info {
 
 func (c *listCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.showSecrets, "show-secrets", false, "Show secrets")
+	f.BoolVar(&c.showSecrets, "show-secrets", false, "Show secrets, applicable to yaml or json formats only")
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
@@ -180,6 +180,9 @@ func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 		personalCloudNames = append(personalCloudNames, name)
 	}
 
+	if c.showSecrets && c.out.Name() == "tabular" {
+		ctxt.Infof("secrets are not shown in tabular format")
+	}
 	displayCredentials := make(map[string]CloudCredential)
 	var missingClouds []string
 	for cloudName, cred := range credentials {

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -123,6 +123,20 @@ mycloud  me
 `[1:])
 }
 
+func (s *listCredentialsSuite) TestListCredentialsTabularShowsNoSecrets(c *gc.C) {
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store, s.personalCloudsFunc, s.cloudByNameFunc), "--show-secrets")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "secrets are not shown in tabular format\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+Cloud    Credentials
+aws      down*, bob
+azure    azhja
+google   default
+mycloud  me
+
+`[1:])
+}
+
 func (s *listCredentialsSuite) TestListCredentialsTabularMissingCloud(c *gc.C) {
 	s.store.Credentials["missingcloud"] = jujucloud.CloudCredential{}
 	out := s.listCredentials(c)


### PR DESCRIPTION
## Description of change

When listing credentials, users may ask to see secrets (if they have access to them). However, secrets could be very big and, thus, are not suitable for a tabular output.

This has always been the case, this PR just makes this very explicit by mentioning this fact in command help, --show-secrets option help output as well as informing the user when an option is used with a tabular output.

## QA steps

1. list credentials with --show-credential in tabular format should inform user that "secrets are not shown in tabular format"

## Bug reference

https://bugs.launchpad.net/juju/+bug/1564168
