### PR TITLE
Output warning info when series is invalid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -630,14 +630,15 @@
   revision = "5b81707e882b8293e6cf77854b4cd49f29776e11"
 
 [[projects]]
-  digest = "1:98ba3905f2fd6c33f64c401123e6626d35f012293daa8f68b5e264d85edfa0f7"
+  digest = "1:c240055e597aaa5201fde60bc691316a880043baf91e2bed83fbd105380d8c67"
   name = "github.com/juju/os"
   packages = [
     ".",
     "series",
   ]
   pruneopts = ""
-  revision = "c23cb5719c78fb34bcf0eefecf4137dd95436877"
+  revision = "e63c2eb61b1ee98f4d045f4fffbec36f1df51cf9"
+  source = "github.com/SimonRichardson/os"
 
 [[projects]]
   digest = "1:8fd6c21ba9a864b949672e63800d1bd71a3d8ac8e085cc22143b97f1261ad634"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -630,15 +630,14 @@
   revision = "5b81707e882b8293e6cf77854b4cd49f29776e11"
 
 [[projects]]
-  digest = "1:c240055e597aaa5201fde60bc691316a880043baf91e2bed83fbd105380d8c67"
+  digest = "1:3e72155e0539d15e73b75829b9ba0878bd633ae44b5f4c34ed94b16038042032"
   name = "github.com/juju/os"
   packages = [
     ".",
     "series",
   ]
   pruneopts = ""
-  revision = "e63c2eb61b1ee98f4d045f4fffbec36f1df51cf9"
-  source = "github.com/SimonRichardson/os"
+  revision = "88a4c6ac59c1950f118f058d920204c9182b9927"
 
 [[projects]]
   digest = "1:8fd6c21ba9a864b949672e63800d1bd71a3d8ac8e085cc22143b97f1261ad634"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,8 +90,9 @@
   name = "github.com/juju/naturalsort"
 
 [[constraint]]
-  revision = "c23cb5719c78fb34bcf0eefecf4137dd95436877"
+  revision = "e63c2eb61b1ee98f4d045f4fffbec36f1df51cf9"
   name = "github.com/juju/os"
+  source = "github.com/SimonRichardson/os"
 
 [[constraint]]
   revision = "ba21344fff207f4fa06b0a08bac386b179a2e6a1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,9 +90,8 @@
   name = "github.com/juju/naturalsort"
 
 [[constraint]]
-  revision = "e63c2eb61b1ee98f4d045f4fffbec36f1df51cf9"
+  revision = "88a4c6ac59c1950f118f058d920204c9182b9927"
   name = "github.com/juju/os"
-  source = "github.com/SimonRichardson/os"
 
 [[constraint]]
   revision = "ba21344fff207f4fa06b0a08bac386b179a2e6a1"

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -668,10 +668,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		fromBundle:          true,
 	}
 	series, err := selector.charmSeries()
-	if err != nil {
-		if errors.IsNotSupported(err) {
-			return errors.Errorf("%v is not available on the following %v", cURL.Name, err)
-		}
+	if err = charmValidationError(series, cURL.Name, errors.Trace(err)); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -1403,10 +1403,7 @@ func (c *DeployCommand) maybeReadLocalCharm(apiRoot DeployAPI) (deployFn, error)
 		}
 
 		seriesName, err = seriesSelector.charmSeries()
-		if err != nil {
-			if errors.IsNotSupported(err) {
-				return nil, errors.Errorf("%v is not available on the following %v", ch.Meta().Name, err)
-			}
+		if err = charmValidationError(seriesName, ch.Meta().Name, errors.Trace(err)); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -1606,8 +1603,14 @@ func (c *DeployCommand) charmStoreCharm() (deployFn, error) {
 		if charm.IsUnsupportedSeriesError(err) {
 			return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 		}
-		if errors.IsNotSupported(err) {
-			return errors.Errorf("%v is not available on the following %v", storeCharmOrBundleURL.Name, err)
+		// although we try and get the charmSeries from the charm series
+		// selector it will return an error and an empty string for the series.
+		// So we need to approximate what the seriesName should be when
+		// displaying an error to the user. We do this by getting the potential
+		// series name.
+		seriesName := getPotentialSeriesName(series, storeCharmOrBundleURL.Series, userRequestedSeries)
+		if validationErr := charmValidationError(seriesName, storeCharmOrBundleURL.Name, errors.Trace(err)); validationErr != nil {
+			return errors.Trace(validationErr)
 		}
 
 		// Store the charm in the controller
@@ -1650,12 +1653,38 @@ func (c *DeployCommand) charmStoreCharm() (deployFn, error) {
 	}, nil
 }
 
+// Returns the first string that isn't empty.
+// If all strings are empty, then return an empty string.
+func getPotentialSeriesName(series ...string) string {
+	for _, s := range series {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
 // validateCharmSeriesWithName calls the validateCharmSeries, but handles the
 // error return value to check for NotSupported error and returns a custom error
 // message if that's found.
 func (c *DeployCommand) validateCharmSeriesWithName(series, name string) error {
-	if err := c.validateCharmSeries(series); err != nil {
+	err := c.validateCharmSeries(series)
+	return charmValidationError(series, name, errors.Trace(err))
+}
+
+// charmValidationError consumes an error along with a charmSeries and name
+// to help provide better feedback to the user when somethings gone wrong around
+// validating a charm validation
+func charmValidationError(charmSeries, name string, err error) error {
+	if err != nil {
 		if errors.IsNotSupported(err) {
+			if warningInfo := series.SeriesWarningInfo(charmSeries); len(warningInfo) > 0 {
+				logger.Warningf(
+					"Parsing issues occured when extracting the distro-info.\n"+
+						"You may want to try updating your distro-info using `apt-get update distro-info`"+
+						"\n  - %s", strings.Join(warningInfo, "\n  - "),
+				)
+			}
 			return errors.Errorf("%v is not available on the following %v", name, err)
 		}
 		return errors.Trace(err)

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -1678,11 +1678,14 @@ func (c *DeployCommand) validateCharmSeriesWithName(series, name string) error {
 func charmValidationError(charmSeries, name string, err error) error {
 	if err != nil {
 		if errors.IsNotSupported(err) {
+			// output the warning information to help track down the error.
+			// see: lp:1833763
 			if warningInfo := series.SeriesWarningInfo(charmSeries); len(warningInfo) > 0 {
 				logger.Warningf(
-					"Parsing issues occured when extracting the distro-info.\n"+
-						"You may want to try updating your distro-info using `apt-get update distro-info`"+
-						"\n  - %s", strings.Join(warningInfo, "\n  - "),
+					"Parsing issues occurred when extracting the distro-info.\n\n"+
+						"  - %s\n"+
+						"\nYou may want to try updating your distro-info using `apt-get update distro-info`\n",
+					strings.Join(warningInfo, "\n  - "),
 				)
 			}
 			return errors.Errorf("%v is not available on the following %v", name, err)


### PR DESCRIPTION
## Description of change

To help diagnose issues when the distro-info is out of date, we
print warnings to the command line to help operators understand
what the potential cause of the issue is.

In the PR we print out what warnings where made when parsing the
os series package. This should help operators diagnose the fact their
system is out of date and needs updating.


  - [x] Update dependency once `juju/os` PR has been approved.

## QA steps

The easiest way is to edit `/usr/share/distro-info/ubuntu.csv` and change
the Trusty line to the following:

```14.04 LTS,Trusty Tahr,trusty,2013-10-17,2014-04-17```

Ensure you have a bootstrapped controller and run the following:

`juju deploy cs:trusty/glance`

It should output the following:

```console
WARNING Parsing issues occured when extracting the distro-info.
You may want to try updating your distro-info using `apt-get update distro-info`
  - EOL date not found, falling back to release date, plus 5 years
  - EOL ESM date not found, falling back to EOL date
ERROR glance is not available on the following series: trusty not supported
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1833763
