### PR TITLE
Include offer acl in export bundle output

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -488,11 +488,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:275bd9a998fd204096b4be01d147090298b9fb5471a3c055940004f78db8c4e0"
+  digest = "1:9146a31e6c2252fd2b49741aa48619521515dab364e28a8df4385dbb6995c9ac"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "d998a354f984c57a34feb889acbfa6c2c2247641"
+  revision = "adb93fec16ac45ed5e262d94f8dfe5f71210ea3f"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"
@@ -1468,7 +1468,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:553348ac4f92d33caf035fa8eea8eab3b950a3649487bd0b26eb392cb2e04f56"
+  digest = "1:620c0ee37e66d0442bd601d7edf7239a0126984649a243c046ffe85718aba2b1"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1476,7 +1476,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "b0b4c5138c321b98c1497ddf436f1e49b8b35ae2"
+  revision = "54cd06b3e6b4e35c57464f13dcce189980323354"
 
 [[projects]]
   digest = "1:86df7d2874a5250cf64324e2ce4e88fea552aa1f5c1a3f065599bd1f381ce939"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "d998a354f984c57a34feb889acbfa6c2c2247641"
+  revision = "adb93fec16ac45ed5e262d94f8dfe5f71210ea3f"
   name = "github.com/juju/description"
 
 [[constraint]]
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "b0b4c5138c321b98c1497ddf436f1e49b8b35ae2"
+  revision = "54cd06b3e6b4e35c57464f13dcce189980323354"
 
 [[constraint]]
   revision = "7778a447283bd71109671c20818544514e16e9d9"

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/os/series"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
@@ -25,6 +26,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/storage"
 )
@@ -396,11 +398,12 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 		}
 
 		// Populate offer list
-		if offerList := application.Offers(); offerList != nil {
+		if offerList := application.Offers(); offerList != nil && featureflag.Enabled(feature.CMRAwareBundles) {
 			newApplication.Offers = make(map[string]*charm.OfferSpec)
 			for _, offer := range offerList {
 				newApplication.Offers[offer.OfferName()] = &charm.OfferSpec{
 					Endpoints: offer.Endpoints(),
+					ACL:       offer.ACL(),
 				}
 			}
 		}

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/bundle"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -542,6 +543,7 @@ applications:
 }
 
 func (s *bundleSuite) TestExportBundleWithApplicationOffers(c *gc.C) {
+	s.SetFeatureFlags(feature.CMRAwareBundles)
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
 		Config: map[string]interface{}{
 			"name": "awesome",
@@ -560,7 +562,12 @@ func (s *bundleSuite) TestExportBundleWithApplicationOffers(c *gc.C) {
 	_ = app.AddOffer(description.ApplicationOfferArgs{
 		OfferName: "my-offer",
 		Endpoints: []string{"endpoint-1", "endpoint-2"},
+		ACL: map[string]string{
+			"admin": "admin",
+			"foo":   "consume",
+		},
 	})
+
 	_ = app.AddOffer(description.ApplicationOfferArgs{
 		OfferName: "my-other-offer",
 		Endpoints: []string{"endpoint-1", "endpoint-2"},
@@ -585,6 +592,9 @@ applications:
         endpoints:
         - endpoint-1
         - endpoint-2
+        acl:
+          admin: admin
+          foo: consume
       my-other-offer:
         endpoints:
         - endpoint-1

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -64,4 +64,4 @@ const MultiCloud = "multi-cloud"
 
 // CMRAwareBundles allows Juju to recognize and handle offer and saas blocks
 // when deploying bundles.
-const CMRAwareBundles = "cmr-aware-bundles"
+const CMRAwareBundles = "bundle-cmr"

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -770,9 +770,24 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		for _, ep := range offer.Endpoints {
 			endpoints = append(endpoints, ep.Name)
 		}
+
+		userMap, err := e.st.GetOfferUsers(offer.OfferUUID)
+		if err != nil {
+			return errors.Annotatef(err, "ACL for offer %s", offer.OfferName)
+		}
+
+		var acl map[string]string
+		if len(userMap) != 0 {
+			acl = make(map[string]string, len(userMap))
+			for user, access := range userMap {
+				acl[user] = accessToString(access)
+			}
+		}
+
 		_ = exApplication.AddOffer(description.ApplicationOfferArgs{
 			OfferName: offer.OfferName,
 			Endpoints: endpoints,
+			ACL:       acl,
 		})
 	}
 


### PR DESCRIPTION
## Description of change

This PR brings in the changes from juju/description and charms.v6 and updates the bundle exporting code to include an ACL for each offer.

In addition, the (server-side) bundle exporting code will now suppress the offer list from the output unless the `bundle-cmr` feature flag has been set. This change is intentional as we don't want older clients to receive bundles with offers when they talk to a newer controller. 

This seems like a good idea, given that we may need to further tweak the bundle struct further until all the cmr in bundle bits land. For instance: we haven't yet reached a decision regarding whether the ACLs should be part of an overlay or not, etc.

## QA steps

```console 
$ export JUJU_DEV_FEATURE_FLAGS=bundle-cmr
$ juju bootstrap lxd test --no-gui

$ juju deploy ./testcharms/charm-repo/bundle/apache2-with-offers

Resolving charm: cs:apache2-26
Executing changes:
- upload charm cs:apache2-26 for series bionic
- deploy application apache2 on bionic using cs:apache2-26
- create offer my-offer using apache2:apache-website,website-cache
- create offer my-other-offer using apache2:apache-website
Deploy of bundle completed.

# Add a new user and grant them consume access to the offer
$ juju add-user foo
$ juju grant foo consume admin/default.my-offer

$ juju export-bundle
series: bionic
applications:
  apache2:
    charm: cs:apache2-26
    offers:
      my-offer:
        endpoints:
        - apache-website
        - website-cache
        acl:
          admin: admin
          everyone@external: read
          foo: consume
      my-other-offer:
        endpoints:
        - apache-website
        acl:
          admin: admin
          everyone@external: read
```