### PR TITLE
Relax time comparison test in juju list-models

### DIFF
--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -144,7 +144,7 @@ models:
   life: alive
   status:
     current: available
-    since: just now
+    since: .*
   access: admin
   last-connection: just now
   sla-owner: admin


### PR DESCRIPTION
This commit reverts a restriction to the `juju list-models` output that was added in PR #10045.  

## QA steps

N/A

## Documentation changes

None

## Bug reference

- #10045 