### PR TITLE
Use k8s cload creeated by add-k8s --local for bootstrapping

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -432,11 +432,8 @@ class JujuData:
             }.get(provider, provider)
 
         if provider == 'kubernetes':
-            host_cloud_region, k8s_base_cloud, _ = self.get_host_cloud_region()
-            if k8s_base_cloud == 'microk8s':
-                # microk8s is built-in cloud.
-                return k8s_base_cloud
-            return self.find_cloud_by_host_cloud_region(host_cloud_region)
+            _, k8s_base_cloud, _ = self.get_host_cloud_region()
+            return k8s_base_cloud
 
         endpoint = ''
         if provider == 'maas':

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -212,6 +212,9 @@ class JujuData:
         result._cloud_name = self._cloud_name
         result.logging_config = self.logging_config
         return result
+        
+    def set_cloud_name(self, name):
+        self._cloud_name = name
 
     @classmethod
     def from_env(cls, env):
@@ -364,8 +367,7 @@ class JujuData:
         raise LookupError('No such endpoint: {}'.format(endpoint))
 
     def find_cloud_by_host_cloud_region(self, host_cloud_region):
-        if not self.clouds['clouds']:
-            self.load_yaml()
+        self.load_yaml()
         for cloud, cloud_config in self.clouds['clouds'].items():
             if cloud_config['type'] != 'kubernetes':
                 continue

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -171,7 +171,7 @@ class Base(object):
                 '--cluster-name', self.kubeconfig_cluster_name,
             )
             # use this local cloud to bootstrap later.
-            self.bs_manager.client.env._cloud_name = self.cloud_name
+            self.bs_manager.client.env.set_cloud_name(self.cloud_name)
         else:
             args += (
                 '--controller', self.client.env.controller.name,

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -118,6 +118,7 @@ class Base(object):
 
     def __init__(self, bs_manager, timeout=1800):
         self.client = bs_manager.client
+        self.bs_manager = bs_manager
         # register cleanup_hook
         bs_manager.cleanup_hook = self.ensure_cleanup
 
@@ -169,6 +170,8 @@ class Base(object):
                 '--local',
                 '--cluster-name', self.kubeconfig_cluster_name,
             )
+            # use this local cloud to bootstrap later.
+            self.bs_manager.client.env._cloud_name = self.cloud_name
         else:
             args += (
                 '--controller', self.client.env.controller.name,


### PR DESCRIPTION
## Description of change

Set the cloud-name in JujuData for bootstrapping to k8s cloud created by add-k8s --local 

## QA steps

To run a test locally with lxd and locally complied juju:

  * ```$ mkdir /tmp/test-run```
  * ```$ export JUJU_HOME=/tmp/test-run```
  * ```$ vim $JUJU_HOME/environments.yaml  # copy gke & microk8s environment from cloud-city```
    ```yaml
    environments:
        gke:
            type: kubernetes
            test-mode: true
            ...
        microk8s:
            type: kubernetes
            test-mode: true
            ...
       
    ```
  * ```export JUJU_REPOSITORY=$GOPATH/src/github.com/juju/juju/acceptancetests/repository```
  * ```mkdir /tmp/artifacts```
  * Now you can run the test with:
     * ```$ ./acceptancetests/assess_caas_deploy_charms.py gke $GOPATH/bin/juju /tmp/artifacts nw-caas-deploy-charms-gke --caas-image-repo=jujuqabot --caas-provider=GKE --k8s-controller --debug```
    * ```$ ./acceptancetests/assess_caas_deploy_charms.py microk8s $GOPATH/bin/juju /tmp/artifacts nw-caas-deploy-charms-microk8s --caas-image-repo=jujuqabot --caas-provider=MICROK8S --k8s-controller --debug```


## Documentation changes

None

## Bug reference

None
