### PR TITLE
Do Not Evaluate Watcher Hash on Branch Removal

### DIFF
--- a/core/cache/charmconfigwatcher.go
+++ b/core/cache/charmconfigwatcher.go
@@ -188,32 +188,13 @@ func (w *CharmConfigWatcher) branchRemoved(topic string, msg interface{}) {
 	}
 
 	// The branch we are tracking was deleted.
-	// One of the following scenarios will ensue:
-	// 1) The branch was aborted and this is the only message we will receive.
-	//    Clearing the branch info and checking whether to notify is fine.
-	//    We will send at most one notification.
-	// 2) The branch was committed and this is the first related message.
-	//    There will be a subsequent message for the master settings change.
-	//    If the branch changes mutate master config, there will be 2
-	//    notifications sent.
-	// 3) The branch was committed and this is the second related message,
-	//    coming after the master settings change message.
-	//    The first message should have resulted in no notification,
-	//    because the new master is the same as master + branch deltas.
-	//    When the branch info is removed config remains unchanged,
-	//	  so there is no notification for the second message wither.
-
-	// TODO (manadart 2019-06-18): A fix for case (2) above would be to change
-	// the cache worker so that a completed branch is not sent as a deletion,
-	// rather as a normal change. We could then detect committed vs aborted and
-	// ensure that at most one notification is sent.
-	// We would check for notification on aborted, but ignore commits,
-	// relying on the master settings change message to determine whether to
-	// notify. After processing the update, we would then evict the branch.
-
+	// Since we know that a branch with tracking units can not be aborted,
+	// the branch must have been committed.
+	// This means that we can anticipate a message for a master settings change
+	// (it may even have preceded this event), so just clear the branch info
+	// without reevaluating the hash.
 	w.branchName = ""
 	w.branchDeltas = nil
-	w.checkConfig()
 }
 
 // isTracking returns true if this watcher's unit is tracking the input branch.

--- a/core/cache/charmconfigwatcher_test.go
+++ b/core/cache/charmconfigwatcher_test.go
@@ -89,30 +89,13 @@ func (s *charmConfigWatcherSuite) TestTrackingBranchMasterChangedNotified(c *gc.
 	w.AssertStops()
 }
 
-func (s *charmConfigWatcherSuite) TestTrackingBranchCommittedMasterChangeFirstNotNotified(c *gc.C) {
-	w := s.newWatcher(c, defaultUnitName, defaultCharmURL)
+func (s *charmConfigWatcherSuite) TestTrackingBranchCommittedNotNotified(c *gc.C) {
+	w := s.newWatcher(c, "redis/0", defaultCharmURL)
 	s.assertOneChange(c, w, map[string]interface{}{"password": defaultPassword}, defaultCharmURL)
-
-	// Publish a change to master configuration.
-	// This represents a commit where the master assumes the branch deltas.
-	hc, _ := newHashCache(map[string]interface{}{"password": defaultPassword}, nil, nil)
-	s.Hub.Publish(applicationConfigChange, hc)
-	w.AssertNoChange()
 
 	// Publish a branch removal.
 	s.Hub.Publish(modelBranchRemove, branchName)
 	w.AssertNoChange()
-	w.AssertStops()
-}
-
-func (s *charmConfigWatcherSuite) TestTrackingBranchAbortedNotified(c *gc.C) {
-	w := s.newWatcher(c, defaultUnitName, defaultCharmURL)
-	s.assertOneChange(c, w, map[string]interface{}{"password": defaultPassword}, defaultCharmURL)
-
-	// Publish a branch removal.
-	// This should change the effective config and cause notification.
-	s.Hub.Publish(modelBranchRemove, branchName)
-	s.assertOneChange(c, w, map[string]interface{}{}, defaultCharmURL)
 	w.AssertStops()
 }
 


### PR DESCRIPTION
## Description of change

This patch is simple change based on branch removal behaviour. It is in lieu of https://github.com/juju/juju/pull/10381, which is not required.

If the `charmConfigWatcher` gets a branch removal message, no config re-evaluation occurs and no notification is sent.

## QA steps

- Bootstrap
- `juju deploy redis`.
- Run `juju debug-log --include redis/0` in a separate terminal.
- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- `juju add-branch test-branch`.
- `juju track test-branch redis/0`.
- `juju config redis password=branch-pass --branch test-branch`.
- `juju commit test-branch`.
- Check in the other terminal that the config-changed hook fires just once.

## Documentation changes

None.

## Bug reference

N/A
