### PR TITLE
Treat Resetting a Branch Config Key to Master as a Normal Modification

### DIFF
--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -272,7 +272,7 @@ func (api *API) oneBranchInfo(branch Generation, detailed bool) (params.Generati
 		if err != nil {
 			return params.Generation{}, errors.Trace(err)
 		}
-		branchApp.ConfigChanges = deltas[appName].CurrentSettings(defaults)
+		branchApp.ConfigChanges = deltas[appName].EffectiveChanges(defaults)
 
 		// TODO (manadart 2019-04-12): Charm URL.
 

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -200,6 +200,7 @@ func (s *modelGenerationSuite) testBranchInfo(c *gc.C, branchNames []string, det
 	c.Check(genApp.ConfigChanges, gc.DeepEquals, map[string]interface{}{
 		"password":  "added-pass",
 		"databases": 16,
+		"port":      8000,
 	})
 
 	// Unit lists are only populated when detailed is true.
@@ -294,7 +295,7 @@ func (s *modelGenerationSuite) expectConfig() {
 	s.mockGen.EXPECT().Config().Return(map[string]settings.ItemChanges{"redis": {
 		settings.MakeAddition("password", "added-pass"),
 		settings.MakeDeletion("databases", 100),
-		settings.MakeModification("ignored-key", "unchanged", "unchanged"),
+		settings.MakeModification("port", 7000, 8000),
 	}})
 }
 

--- a/core/settings/settings.go
+++ b/core/settings/settings.go
@@ -5,7 +5,6 @@ package settings
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6"
@@ -137,10 +136,8 @@ func (c ItemChanges) ApplyDeltaSource(oldChanges ItemChanges) (ItemChanges, erro
 	// then we know that the setting was reset to its original value.
 	// If this setting is subsequently reinstated, it is possible to lose the
 	// original "from" value if master is updated in the meantime.
-	// So we maintain a no-op entry (same from/to) in order to retain the old
+	// So we maintain an entry with the same to/from in order to retain the old
 	// value from when the configuration setting was first touched.
-	// These values are not shown to an operator who views a "diff"
-	// for the branch.
 	for key, old := range m {
 		res = append(res, MakeModification(key, old.OldValue, old.OldValue))
 	}
@@ -148,18 +145,14 @@ func (c ItemChanges) ApplyDeltaSource(oldChanges ItemChanges) (ItemChanges, erro
 	return res, nil
 }
 
-// CurrentSettings returns the current effective values indicated by this set
-// of changes. It uses the input default settings to return a value for items
-// that have been deleted.
-func (c ItemChanges) CurrentSettings(defaults charm.Settings) map[string]interface{} {
+// EffectiveChanges returns the effective changes resulting from the
+// application of these changes to the input defaults.
+func (c ItemChanges) EffectiveChanges(defaults charm.Settings) map[string]interface{} {
 	result := make(map[string]interface{})
 	for _, change := range c {
 		key := change.Key
 
 		switch {
-		case change.IsModification() && reflect.DeepEqual(change.OldValue, change.NewValue):
-			// These are placeholders that we do not apply.
-			// See comment in ApplyDeltaSource, above.
 		case change.IsDeletion():
 			result[key] = defaults[key]
 		default:

--- a/core/settings/settings_test.go
+++ b/core/settings/settings_test.go
@@ -93,12 +93,11 @@ func (*settingsSuite) TestApplyDeltaSource(c *gc.C) {
 	}
 }
 
-func (*settingsSuite) TestCurrentSettings(c *gc.C) {
+func (*settingsSuite) TestEffectiveSettings(c *gc.C) {
 	changes := ItemChanges{
 		MakeAddition("key1", "new-val"),
 		MakeModification("key2", "old-val", "other-val"),
 		MakeDeletion("key3", "old-deleted-val"),
-		MakeModification("key4", "same-value-ignored", "same-value-ignored"),
 	}
 
 	defaults := map[string]interface{}{
@@ -111,5 +110,5 @@ func (*settingsSuite) TestCurrentSettings(c *gc.C) {
 		"key2": "other-val",
 		"key3": "default-deleted-val",
 	}
-	c.Check(changes.CurrentSettings(defaults), gc.DeepEquals, exp)
+	c.Check(changes.EffectiveChanges(defaults), gc.DeepEquals, exp)
 }


### PR DESCRIPTION
## Description of change

This patch changes behaviour that affects the `diff` command for branches.

Previously, if a branch-based configuration setting was deleted, then set back to the same value as in the master settings, we would hide this as a no-op from an operator who ran `diff`.

Now, this change is included as if the user set that value on the branch. If the master value changes in the meantime and the operator desires that the branch use that setting, it must be explicitly set to the desired value.

## QA steps

- Bootstrap
- `juju deploy redis`.
- `juju config redis port=1234`.
- `export JUJU_DEV_FEATURE_FLAGS=generations`.
- `juju add-branch test-branch`.
- `juju track test-branch redis/0`.
- Check that `juju diff test-branch` shows no config changes.
- `juju config redis --reset port --branch test-branch`
- Check that `juju diff test-branch` shows "port: 6379" (charm default).
- `juju config redis port=1234 --branch test-branch`.
- Check that `juju diff test-branch` shows "port: 1234".

## Documentation changes

None.

## Bug reference

N/A
