### PR TITLE
2.6 apply grant offer access changes when deploying bundles

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -403,7 +403,7 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 			for _, offer := range offerList {
 				newApplication.Offers[offer.OfferName()] = &charm.OfferSpec{
 					Endpoints: offer.Endpoints(),
-					ACL:       offer.ACL(),
+					ACL:       b.filterOfferACL(offer.ACL()),
 				}
 			}
 		}
@@ -471,6 +471,13 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 	}
 
 	return data, nil
+}
+
+// filterOfferACL prunes the input offer ACL to remove internal juju users that
+// we shouldn't export as part of the bundle.
+func (b *BundleAPI) filterOfferACL(in map[string]string) map[string]string {
+	delete(in, common.EveryoneTagName)
+	return in
 }
 
 func (b *BundleAPI) constraints(cons description.Constraints) []string {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -99,6 +99,7 @@ type CharmDeployAPI interface {
 type OfferAPI interface {
 	Offer(modelUUID, application string, endpoints []string, offerName, descr string) ([]apiparams.ErrorResult, error)
 	GetConsumeDetails(url string) (apiparams.ConsumeOfferDetails, error)
+	GrantOffer(user, access string, offerURLs ...string) error
 }
 
 var supportedJujuSeries = func() []string {
@@ -859,6 +860,10 @@ func (c *DeployCommand) deployBundle(spec bundleDeploySpec) (rErr error) {
 	var ok bool
 	if spec.targetModelUUID, ok = spec.apiRoot.ModelUUID(); !ok {
 		return errors.New("API connection is controller-only (should never happen)")
+	}
+
+	if spec.targetModelName, _, err = c.ModelDetails(); err != nil {
+		return errors.Annotatef(err, "could not retrieve model name")
 	}
 
 	spec.controllerName, err = c.ControllerName()

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -694,6 +694,17 @@ func (s *DeploySuite) TestDeployBundleWithOffers(c *gc.C) {
 		"",
 	).Returns([]params.ErrorResult{}, nil)
 
+	fakeAPI.Call("GrantOffer",
+		"admin",
+		"admin",
+		[]string{"controller.my-offer"},
+	).Returns(errors.New(`cannot grant admin access to user admin on offer admin/controller.my-offer: user already has "admin" access or greater`))
+	fakeAPI.Call("GrantOffer",
+		"bar",
+		"consume",
+		[]string{"controller.my-offer"},
+	).Returns(nil)
+
 	deploy := &DeployCommand{
 		NewAPIRoot: func() (DeployAPI, error) {
 			return fakeAPI, nil
@@ -706,12 +717,17 @@ func (s *DeploySuite) TestDeployBundleWithOffers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var offerCallCount int
+	var grantOfferCallCount int
 	for _, call := range fakeAPI.Calls() {
-		if call.FuncName == "Offer" {
+		switch call.FuncName {
+		case "Offer":
 			offerCallCount++
+		case "GrantOffer":
+			grantOfferCallCount++
 		}
 	}
 	c.Assert(offerCallCount, gc.Equals, 2)
+	c.Assert(grantOfferCallCount, gc.Equals, 2)
 }
 
 func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
@@ -2711,6 +2727,11 @@ func (f *fakeDeployAPI) GetConsumeDetails(offerURL string) (params.ConsumeOfferD
 func (f *fakeDeployAPI) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) {
 	results := f.MethodCall(f, "Consume", arg)
 	return results[0].(string), jujutesting.TypeAssertError(results[1])
+}
+
+func (f *fakeDeployAPI) GrantOffer(user, access string, offerURLs ...string) error {
+	res := f.MethodCall(f, "GrantOffer", user, access, offerURLs)
+	return jujutesting.TypeAssertError(res[0])
 }
 
 func stringToInterface(args []string) []interface{} {

--- a/testcharms/charm-repo/bundle/apache2-with-offers/bundle.yaml
+++ b/testcharms/charm-repo/bundle/apache2-with-offers/bundle.yaml
@@ -7,6 +7,9 @@ applications:
         endpoints:
         - apache-website
         - website-cache
+        acl:
+          admin: admin
+          bar: consume
       my-other-offer:
         endpoints:
         - apache-website


### PR DESCRIPTION
## Description of change

This PR updates the bundle deploy logic to support `GrantOfferAccess` changes which allow us to set up the ACL for offers in exported bundles. 

If we try to grant a user access to an offer **twice** the server will return an error such as ``cannot grant admin access to user admin on offer admin/controller.my-offer: user already has "admin" access or greater`. 

One example where this might happen is when your exported bundle contains a `admin: admin` ACL entry. Since `juju create-offer` will automatically set admin access for the user that runs the command, if we deploy the bundle as the admin user, we would hit the above error when the deployer attempts to grant (again) access to the admin.

In cases like this we can safely ignore this error. Ideally, we would like the controller to expose a status code that we can check against. Unfortunately, even if we implemented that for newer controllers we would still need to deal with older controllers (a new client should be able to create offers in older controllers). Therefore, the implementation falls-back to ugly error string testing to check for this particular error.

Additionally, the PR introduces a filtering mechanism for ACL entries prior to them being added to the export-bundle output. The filter removes internal juju accounts (everyone@external) that are implicitly
granted access to the offer at creation time and that should not be included in the export-bundle output.

## QA steps

```console
$ export JUJU_DEV_FEATURE_FLAGS=bundle-cmr

$ juju bootstrap lxd test --no-gui

# Set admin password and create user "bob"
$ juju change-user-passord
$ juju add-user bob
$ juju change-user-password bob

$ juju deploy apache2
$ juju offer apache2:apache-website my-offer
Application "apache2" endpoints [apache-website] available at "admin/default.my-offer"

# Show offer and note that we have "admin" access
$ juju show-offer admin/default.my-offer
Store  URL                     Access  Description                                    Endpoint        Interface       Role
test   admin/default.my-offer  admin   The Apache Software Foundation's goal is to    apache-website  apache-website  provider
                                       build a secure, efficient and extensible HTTP
                                       server as standards-compliant open source
                                       software. The result has long been the
                                       number...


$ juju grant bob consume admin/default.my-offer
$ juju export-bundle > bundle.yaml
$ cat bundle.yaml
series: bionic
applications:
  apache2:
    charm: cs:apache2-26
    num_units: 1
    to:
    - "0"
    offers:
      my-offer:
        endpoints:
        - apache-website
        acl:
          admin: admin
          bob: consume
machines:
  "0": {}

$ juju add-model new

$ juju deploy ./bundle.yaml
Resolving charm: cs:apache2-26
Executing changes:
- upload charm cs:apache2-26 for series bionic
- deploy application apache2 on bionic using cs:apache2-26
- add new machine 0
- create offer my-offer using apache2:apache-website
- grant user admin admin access to offer my-offer
- grant user bob consume access to offer my-offer
- add unit apache2/0 to new machine 0
Deploy of bundle completed.


# Now login as 'bob'
$ juju logout
$ juju login -u bob

# Note that bob has "consume" access
$ juju show-offer admin/default.my-offer
Store  URL                     Access   Description                                    Endpoint        Interface       Role
test   admin/default.my-offer  consume  The Apache Software Foundation's goal is to    apache-website  apache-website  provider
                                        build a secure, efficient and extensible HTTP
                                        server as standards-compliant open source
                                        software. The result has long been the
                                        number...
```