### PR TITLE
use state WatchConfigSettingsHash

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2756,13 +2756,13 @@ func (u *UniterAPI) WatchConfigSettingsHash(args params.Entities) (params.String
 			continue
 		}
 
-		unit, err := u.getCacheUnit(tag)
+		unit, err := u.getUnit(tag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
 
-		w, err := unit.WatchConfigSettings()
+		w, err := unit.WatchConfigSettingsHash()
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue


### PR DESCRIPTION
## Description of change

It seems the cached settings change is not always reacting like state setting change.

## QA steps

1. 

```bash
$ DOCKER_USERNAME=ur-repo make microk8s-operator-update
```

2.

```bash
$ juju bootstrap microk8s k1 --config caas-image-repo=ur-repo --config='logging-config="<root>=TRACE"'
```

3.

```bash
$ juju add-model $MODEL_NAME microk8s
```

4.

```bash
$ juju deploy cs:~juju/mariadb-k8s-0 --debug && \
juju deploy cs:~juju/mediawiki-k8s-3 --debug  --config juju-external-hostname=192.168.56.2.xip.io && \
juju relate mediawiki-k8s:db mariadb-k8s:server && \
juju expose mediawiki-k8s
```

5. expected result, but `sometimes` only `3` pods created, no `pod/mediawiki-k8s-f867b46f8-z79x9` created.

```bash
$ microk8s.kubectl get po -o wide -n $MODEL_NAME
NAME                            READY   STATUS    RESTARTS   AGE   IP          NODE                   NOMINATED NODE   READINESS GATES
mariadb-k8s-0                   1/1     Running   0          30s   10.1.1.95   kelvinliu-virtualbox   <none>           <none>
mariadb-k8s-operator-0          1/1     Running   0          38s   10.1.1.93   kelvinliu-virtualbox   <none>           <none>
mediawiki-k8s-f867b46f8-z79x9   1/1     Running   0          12s   10.1.1.96   kelvinliu-virtualbox   <none>           <none>
mediawiki-k8s-operator-0        1/1     Running   0          31s   10.1.1.94   kelvinliu-virtualbox   <none>           <none>
```

6. expected result, but `sometimes` only `2` svc created, no `svc/mediawiki-k8s` created.

```bash
$ microk8s.kubectl get svc -o wide -n $MODEL_NAME
NAME                    TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE     SELECTOR
mariadb-k8s             ClusterIP   10.152.183.9     <none>        3306/TCP   2m12s   juju-app=mariadb-k8s
mariadb-k8s-endpoints   ClusterIP   None             <none>        <none>     2m12s   juju-app=mariadb-k8s
mediawiki-k8s           ClusterIP   10.152.183.238   <none>        80/TCP     114s    juju-app=mediawiki-k8s
```


Note: run `3-6` with a different  `$MODEL_NAME` again to reproduce

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?* 

## Bug reference

*Please add a link to any bugs that this change is related to.*
