### PR TITLE
Ensure Uniter SetCharmURL Syncs With Cache

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -510,11 +510,6 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	err = s.apiUnit.SetCharmURL(s.wordpressCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	// We need the model to settle so that the cache is populated.
-	uuid := s.State.ModelUUID()
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, uuid)
-
 	settings, err = s.apiUnit.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, charm.Settings{
@@ -528,7 +523,7 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, uuid)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	settings, err = s.apiUnit.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -546,9 +541,6 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	// Now set the charm and try again.
 	err = s.apiUnit.SetCharmURL(s.wordpressCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
-
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w, err = s.apiUnit.WatchConfigSettingsHash()
 	wc := watchertest.NewStringsWatcherC(c, w, s.BackingState.StartSync)

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -7,6 +7,7 @@ package uniter
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -781,7 +782,7 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 }
 
 // SetCharmURL sets the charm URL for each given unit. An error will
-// be returned if a unit is dead, or the charm URL is not know.
+// be returned if a unit is dead, or the charm URL is not known.
 func (u *UniterAPI) SetCharmURL(args params.EntitiesCharmURL) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
@@ -805,12 +806,49 @@ func (u *UniterAPI) SetCharmURL(args params.EntitiesCharmURL) (params.ErrorResul
 				curl, err = charm.ParseURL(entity.CharmURL)
 				if err == nil {
 					err = unit.SetCharmURL(curl)
+					if err == nil {
+						// The uniter sets the charm URL at installation.
+						// It can then watch or request the unit's
+						// configuration any time after. We must ensure that
+						// the change is reflected in the cache, or those
+						// operations can result in an error.
+						err = u.waitForCacheUnit(
+							tag, func(cu cache.Unit) bool { return cu.CharmURL() == entity.CharmURL },
+						)
+					}
 				}
 			}
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}
 	return result, nil
+}
+
+// waitForCacheUnit watches the cache for the input unit tag and returns with
+// a nil error when the input condition is satisfied.
+// If the cache is not up-to-date within a minute (this is quite generous),
+// then an error is returned.
+// TODO (manadart 2019-06-28): This is a temporary solution.
+// A sufficiently generic approach should be arrived at in order to ensure
+// cache synchronisation with DB writes where it is operationally critical.
+func (u *UniterAPI) waitForCacheUnit(tag names.UnitTag, condition func(cu cache.Unit) bool) error {
+	timeout := time.After(time.Minute)
+
+	for {
+		select {
+		case <-timeout:
+			return errors.New("timed out waiting for change to be reflected in cache")
+		default:
+			cu, err := u.getCacheUnit(tag)
+			if err != nil {
+				return err
+			}
+			if condition(cu) {
+				return nil
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
 }
 
 // WorkloadVersion returns the workload version for all given units or applications.

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -72,13 +72,8 @@ func (s *UnitSuite) primeAgent(c *gc.C) (*state.Machine, *state.Unit, agent.Conf
 		Application: app,
 		Machine:     machine,
 		Password:    initialUnitPassword,
-		SetCharmURL: true,
 	})
 	conf, tools := s.PrimeAgent(c, unit.Tag(), initialUnitPassword)
-
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.Model.UUID())
-
 	return machine, unit, conf, tools
 }
 

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1560,9 +1560,6 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.apiLogin(c)
 
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.Model.UUID())
-
 	// Run the actual test.
 	ctx.run(c, []stepper{
 		serveCharm{},


### PR DESCRIPTION
## Description of change

This patch addresses a race where the uniter can call `SetCharmURL` and either retrieve or watch the unit's configuration settings before that change has propagated to the cache.

This crashes the uniter, preventing completion of installation. An error like this is observed:
```
DEBUG juju.worker.dependency engine.go:599 "uniter" manifold worker stopped: unit charm not set
```
We now wait until the cache is populated with the changed charm URL. This also allows removal of some test syncing logic added in recent patches.

#### This change is inelegant and definitely intended to be temporary. We need a generic solution to cache synchronisation on critial paths. 

## QA steps

- Bootstrap
- `juju deploy redis --config port=6388`.
- `juju add-unit redis -n 9`.
- Check that all units come up without error.

In my testing, the cache change is detected on the second tick of the loop, so inside the first 100 milliseconds.

## Documentation changes

None.

## Bug reference

N/A
