### PR TITLE
backport pr 10230: add disco for nw-deploy and other tests

### DIFF
--- a/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-subordinate/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms-centos/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
+++ b/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
@@ -14,3 +14,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/dummy-resource/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-resource/metadata.yaml
@@ -9,6 +9,7 @@ series:
   - xenial
   - artful
   - bionic
+  - disco
 resources:
   foo:
     type: file

--- a/acceptancetests/repository/charms/dummy-sink/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-sink/metadata.yaml
@@ -13,3 +13,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/dummy-source/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-source/metadata.yaml
@@ -13,4 +13,5 @@ series:
   - xenial
   - artful
   - bionic
+  - disco
 

--- a/acceptancetests/repository/charms/dummy-storage/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-storage/metadata.yaml
@@ -11,6 +11,7 @@ series:
   - xenial
   - artful
   - bionic
+  - disco
 storage:
   single-fs:
     type: filesystem

--- a/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/fill-logs/metadata.yaml
+++ b/acceptancetests/repository/charms/fill-logs/metadata.yaml
@@ -9,3 +9,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
@@ -19,3 +19,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
@@ -16,3 +16,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/mysql/metadata.yaml
+++ b/acceptancetests/repository/charms/mysql/metadata.yaml
@@ -40,3 +40,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/network-health/metadata.yaml
+++ b/acceptancetests/repository/charms/network-health/metadata.yaml
@@ -11,6 +11,7 @@ series:
   - xenial
   - artful
   - bionic
+  - disco
 requires:
   juju-info:
     interface: juju-info

--- a/acceptancetests/repository/charms/peer-xplod/metadata.yaml
+++ b/acceptancetests/repository/charms/peer-xplod/metadata.yaml
@@ -12,6 +12,7 @@ series:
   - xenial
   - artful
   - bionic
+  - disco
 subordinate: false
 peers:
   xplod:

--- a/acceptancetests/repository/charms/simple-resolve/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resolve/metadata.yaml
@@ -10,3 +10,4 @@ series:
   - bionic
   - trusty
   - artful
+  - disco

--- a/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
@@ -13,6 +13,7 @@ series:
   - xenial
   - artful
   - bionic
+  - disco
 resources:
   index:
     type: file

--- a/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
@@ -14,3 +14,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/statusstresser/metadata.yaml
+++ b/acceptancetests/repository/charms/statusstresser/metadata.yaml
@@ -10,3 +10,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/ubuntu/metadata.yaml
+++ b/acceptancetests/repository/charms/ubuntu/metadata.yaml
@@ -10,3 +10,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/update-status-tester/metadata.yaml
+++ b/acceptancetests/repository/charms/update-status-tester/metadata.yaml
@@ -10,3 +10,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/charms/wordpress/metadata.yaml
+++ b/acceptancetests/repository/charms/wordpress/metadata.yaml
@@ -23,4 +23,5 @@ series:
   - xenial
   - artful
   - bionic
+  - disco
 

--- a/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco

--- a/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - xenial
   - artful
   - bionic
+  - disco


### PR DESCRIPTION
## Description of change

Add disco as a choice for charms used by juju ci tests.
