### PR TITLE
Backport pr 10236: remove mem=2G constraints from test bundles and add centos7 to charms

### DIFF
--- a/acceptancetests/repository/bundles-lxc.yaml
+++ b/acceptancetests/repository/bundles-lxc.yaml
@@ -15,7 +15,6 @@ dense-scaled:
         - "0"
     apache2:
       charm: "cs:trusty/apache2-1"
-      constraints: mem=2G
       num_units: 1
       annotations:
         "gui-x": "742.5529174804688"
@@ -28,7 +27,6 @@ dense-scaled:
         "gui-y": "318.2304229736328"
     haproxy:
       charm: "cs:trusty/haproxy-2"
-      constraints: mem=2G
       num_units: 1
       annotations:
         "gui-x": "1152.2492065429688"

--- a/acceptancetests/repository/bundles-lxd.yaml
+++ b/acceptancetests/repository/bundles-lxd.yaml
@@ -15,7 +15,6 @@ dense-scaled:
         - "0"
     apache2:
       charm: "cs:trusty/apache2-1"
-      constraints: mem=2G
       num_units: 1
       annotations:
         "gui-x": "742.5529174804688"
@@ -28,7 +27,6 @@ dense-scaled:
         "gui-y": "318.2304229736328"
     haproxy:
       charm: "cs:trusty/haproxy-2"
-      constraints: mem=2G
       num_units: 1
       annotations:
         "gui-x": "1152.2492065429688"

--- a/acceptancetests/repository/charms-centos/dummy-sink/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-sink/metadata.yaml
@@ -8,3 +8,5 @@ provides:
     interface: dummy-token
 categories:
   - misc
+series:
+  - centos7

--- a/acceptancetests/repository/charms-centos/dummy-source/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-source/metadata.yaml
@@ -8,3 +8,5 @@ requires:
     interface: dummy-token
 categories:
   - misc
+series:
+  - centos7

--- a/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-sink/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-sink/metadata.yaml
@@ -8,3 +8,5 @@ provides:
     interface: dummy-token
 categories:
   - misc
+series:
+  - centos7

--- a/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-source/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-source/metadata.yaml
@@ -8,3 +8,5 @@ requires:
     interface: dummy-token
 categories:
   - misc
+series:
+  - centos7

--- a/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-subordinate/metadata.yaml
@@ -11,8 +11,5 @@ requires:
 categories:
   - misc
 series:
-  - trusty
-  - xenial
-  - artful
-  - bionic
-  - disco
+  - centos7
+

--- a/acceptancetests/repository/charms-centos/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/metadata.yaml
@@ -11,8 +11,5 @@ requires:
 categories:
   - misc
 series:
-  - trusty
-  - xenial
-  - artful
-  - bionic
-  - disco
+  - centos7
+

--- a/acceptancetests/repository/scale-lxc.yaml
+++ b/acceptancetests/repository/scale-lxc.yaml
@@ -2,14 +2,12 @@ dense-scaled:
   services:
     apache2:
       charm: "cs:trusty/apache2-1"
-      constraints: mem=2G
       num_units: 1
     "apache2-reverseproxy":
       charm: "cs:~abentley/trusty/apache2-reverseproxy-4"
       num_units: 0
     haproxy:
       charm: "cs:trusty/haproxy-2"
-      constraints: mem=2G
       num_units: 1
     "python-django":
       charm: "cs:trusty/python-django-12"

--- a/acceptancetests/repository/scale-lxd.yaml
+++ b/acceptancetests/repository/scale-lxd.yaml
@@ -2,14 +2,12 @@ dense-scaled:
   services:
     apache2:
       charm: "cs:trusty/apache2-1"
-      constraints: mem=2G
       num_units: 1
     "apache2-reverseproxy":
       charm: "cs:~abentley/trusty/apache2-reverseproxy-4"
       num_units: 0
     haproxy:
       charm: "cs:trusty/haproxy-2"
-      constraints: mem=2G
       num_units: 1
     "python-django":
       charm: "cs:trusty/python-django-12"

--- a/acceptancetests/repository/scale2-lxc.yaml
+++ b/acceptancetests/repository/scale2-lxc.yaml
@@ -6,7 +6,6 @@ machines:
 services:
   apache2:
     charm: "cs:trusty/apache2-19"
-    constraints: mem=2G
     num_units: 1
     to:
       - "1"
@@ -16,7 +15,6 @@ services:
   haproxy:
     series: trusty
     charm: "./trusty/haproxy"
-    constraints: mem=2G
     num_units: 1
     to:
       - "2"

--- a/acceptancetests/repository/scale2-lxd.yaml
+++ b/acceptancetests/repository/scale2-lxd.yaml
@@ -6,7 +6,6 @@ machines:
 services:
   apache2:
     charm: "cs:trusty/apache2-19"
-    constraints: mem=2G
     num_units: 1
     to:
       - "1"
@@ -16,7 +15,6 @@ services:
   haproxy:
     series: trusty
     charm: "haproxy"
-    constraints: mem=2G
     num_units: 1
     to:
       - "2"

--- a/acceptancetests/repository/scale2lxd.yaml
+++ b/acceptancetests/repository/scale2lxd.yaml
@@ -6,7 +6,6 @@ machines:
 services:
   apache2:
     charm: "cs:trusty/apache2-19"
-    constraints: mem=2G
     num_units: 1
     to:
       - "1"
@@ -16,7 +15,6 @@ services:
   haproxy:
     series: trusty
     charm: "./trusty/haproxy"
-    constraints: mem=2G
     num_units: 1
     to:
       - "2"


### PR DESCRIPTION
## Description of change

remove mem=2G constraints from test bundles and add centos7 to charms
