### PR TITLE
Excessivewarnings on controller with ci runs on GCE

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -912,6 +912,7 @@ class ModelClient:
             'name',
             'password',
             'private-key',
+            'project-id',
             'region',
             'sdc-key-id',
             'sdc-url',


### PR DESCRIPTION
## Description of change

The config value "project-id" from the cloud-city environments.yaml should not be added to the model-config during ci test runs.  It's used by the GCE credentials, not provider and causes excessive warning messages in the controller log.


