### PR TITLE
De-dupe store in list cloud.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -46,7 +46,6 @@ func NewAddCloudCommandForTest(
 func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (ListCloudsAPI, error)) *listCloudsCommand {
 	return &listCloudsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		store:                     store,
 		listCloudsAPIFunc:         cloudAPI,
 	}
 }

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -32,7 +32,6 @@ type listCloudsCommand struct {
 
 	// Used when querying a controller for its cloud details
 	controllerName    string
-	store             jujuclient.ClientStore
 	listCloudsAPIFunc func(controllerName string) (ListCloudsAPI, error)
 }
 
@@ -106,7 +105,6 @@ func NewListCloudsCommand() cmd.Command {
 			Store:       store,
 			EnabledFlag: feature.MultiCloud,
 		},
-		store: store,
 	}
 	c.listCloudsAPIFunc = c.cloudAPI
 
@@ -114,7 +112,7 @@ func NewListCloudsCommand() cmd.Command {
 }
 
 func (c *listCloudsCommand) cloudAPI(controllerName string) (ListCloudsAPI, error) {
-	root, err := c.NewAPIRoot(c.store, controllerName, "")
+	root, err := c.NewAPIRoot(c.Store, controllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

While working on 'credentials', I've noticed that 'clouds' has 2 references to client store one directly on the command, one in the super command. Only one reference is needed and considering that both are implementation of the file store, consequences of having two instances could be surprising.

This PR de-dupe the reference, only keeping the one on the super-command.
