### PR TITLE
Export bundle with SAAS block

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -290,13 +290,14 @@ type bundleOutput struct {
 	Type         string                            `yaml:"bundle,omitempty"`
 	Description  string                            `yaml:"description,omitempty"`
 	Series       string                            `yaml:"series,omitempty"`
+	Saas         map[string]*charm.SaasSpec        `yaml:"saas,omitempty"`
 	Applications map[string]*charm.ApplicationSpec `yaml:"applications,omitempty"`
 	Machines     map[string]*charm.MachineSpec     `yaml:"machines,omitempty"`
 	Relations    [][]string                        `yaml:"relations,omitempty"`
 }
 
-// Mask the new method from V1 API.
 // ExportBundle is not in V1 API.
+// Mask the new method from V1 API.
 func (u *APIv1) ExportBundle() (_, _ struct{}) { return }
 
 func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, error) {
@@ -308,6 +309,7 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 	defaultSeries := fmt.Sprintf("%v", value)
 
 	data := &bundleOutput{
+		Saas:         make(map[string]*charm.SaasSpec),
 		Applications: make(map[string]*charm.ApplicationSpec),
 		Machines:     make(map[string]*charm.MachineSpec),
 		Relations:    [][]string{},
@@ -429,6 +431,13 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 		}
 
 		data.Machines[machine.Id()] = newMachine
+	}
+
+	for _, application := range model.RemoteApplications() {
+		newSaas := &charm.SaasSpec{
+			URL: application.URL(),
+		}
+		data.Saas[application.Name()] = newSaas
 	}
 	// If there is only one series used, make it the default and remove
 	// series from all the apps and machines.

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -433,11 +433,13 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*bundleOutput, erro
 		data.Machines[machine.Id()] = newMachine
 	}
 
-	for _, application := range model.RemoteApplications() {
-		newSaas := &charm.SaasSpec{
-			URL: application.URL(),
+	if featureflag.Enabled(feature.CMRAwareBundles) {
+		for _, application := range model.RemoteApplications() {
+			newSaas := &charm.SaasSpec{
+				URL: application.URL(),
+			}
+			data.Saas[application.Name()] = newSaas
 		}
-		data.Saas[application.Name()] = newSaas
 	}
 	// If there is only one series used, make it the default and remove
 	// series from all the apps and machines.

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -605,6 +605,52 @@ applications:
 	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
 }
 
+func (s *bundleSuite) TestExportBundleWithSaas(c *gc.C) {
+	s.SetFeatureFlags(feature.CMRAwareBundles)
+	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
+		Config: map[string]interface{}{
+			"name": "awesome",
+			"uuid": "some-uuid",
+		},
+		CloudRegion: "some-region"})
+
+	app := s.st.model.AddApplication(s.minimalApplicationArgs(description.IAAS))
+	app.SetStatus(minimalStatusArgs())
+
+	remoteApp := s.st.model.AddRemoteApplication(description.RemoteApplicationArgs{
+		Tag: names.NewApplicationTag("awesome"),
+		URL: "test:admin/default.awesome",
+	})
+	remoteApp.SetStatus(minimalStatusArgs())
+
+	u := app.AddUnit(minimalUnitArgs(app.Type()))
+	u.SetAgentStatus(minimalStatusArgs())
+
+	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
+
+	result, err := s.facade.ExportBundle()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedResult := params.StringResult{nil, `
+series: trusty
+saas:
+  awesome:
+    url: test:admin/default.awesome
+applications:
+  ubuntu:
+    charm: cs:trusty/ubuntu
+    num_units: 1
+    to:
+    - "0"
+    options:
+      key: value
+    bindings:
+      juju-info: vlan2
+`[1:]}
+
+	c.Assert(result, gc.Equals, expectedResult)
+	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
+}
+
 func (s *bundleSuite) addApplicationToModel(model description.Model, name string, numUnits int) description.Application {
 	series := "xenial"
 	if model.Type() == "caas" {


### PR DESCRIPTION
## Description of change

The following just exports remote applications (SAAS) in the export
bundle command, if you've got a SAAS offering setup.

## QA steps

Setup and deploy mysql

```console
juju bootstrap lxd test
juju deploy mysql
juju offer mysql:db
juju status --relations
```

Create a new model and export the bundle

```console
juju add-model other
juju deploy wordpress
juju add-relation wordpress:db admin/default.mysql
juju export-bundle
```

The following should export the SAAS block with mysql in it.

```yaml
series: trusty
saas:
  mysql:
    url: test:admin/default.mysql
applications:
  wordpress:
    charm: cs:trusty/wordpress-5
    num_units: 1
    to:
    - "0"
machines:
  "0": {}
relations:
- - wordpress:db
  - mysql:db
```

## Documentation changes

Export bundle now includes a SAAS block if you've set on up.