### PR TITLE
Deploy a SAAS from another local controller

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1130,7 +1130,7 @@ func (h *bundleHandler) consumeOffer(change *bundlechanges.ConsumeOfferChange) e
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer controllerOfferAPI.Close()
+	defer func() { _ = controllerOfferAPI.Close() }()
 
 	// Ensure we use the Local url here as we have to ignore the source (read as
 	// target) controller, as the names of controllers might not match and we

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -800,6 +800,9 @@ func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 		NewAPIRoot: func() (DeployAPI, error) {
 			return fakeAPI, nil
 		},
+		NewConsumeDetailsAPI: func(url *charm.OfferURL) (ConsumeDetails, error) {
+			return fakeAPI, nil
+		},
 	}
 
 	s.SetFeatureFlags(feature.CMRAwareBundles)


### PR DESCRIPTION
## Description of change

The following changes how we consume details for a controller that
is found in the local store, that isn't the same controller as our
own. This is useful for cross controller model relations.

## QA steps

Note: I've skipped over export bundle command in this QA, to make it
easier to test.

```console
juju bootstrap lxd test
juju deploy mysql
juju offer mysql:db
juju status --relations
```

Save the following to a `bundle.yaml`

```yaml
series: trusty
saas:
  mysql:
    url: test:admin/default.mysql
applications:
  wordpress:
    charm: cs:trusty/wordpress-5
    num_units: 1
    to:
    - "0"
machines:
  "0": {}
relations:
- - wordpress:db
  - mysql:db
```

Then do the following:

```console
juju bootstrap lxd other
juju deploy ./bundle.yaml
```
