### PR TITLE
Cache Error Message Detail

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -504,7 +504,7 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	// Make sure ConfigSettings returns an error when
 	// no charm URL is set, as its state counterpart does.
 	settings, err := s.apiUnit.ConfigSettings()
-	c.Assert(err, gc.ErrorMatches, "unit charm not set")
+	c.Assert(err, gc.ErrorMatches, "unit charm must be set before retrieving config")
 
 	// Now set the charm and try again.
 	err = s.apiUnit.SetCharmURL(s.wordpressCharm.URL())
@@ -536,7 +536,7 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	// Make sure WatchConfigSettingsHash returns an error when
 	// no charm URL is set, as its state counterpart does.
 	w, err := s.apiUnit.WatchConfigSettingsHash()
-	c.Assert(err, gc.ErrorMatches, "unit charm not set")
+	c.Assert(err, gc.ErrorMatches, "unit charm must be set before watching config")
 
 	// Now set the charm and try again.
 	err = s.apiUnit.SetCharmURL(s.wordpressCharm.URL())

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -504,7 +504,7 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	// Make sure ConfigSettings returns an error when
 	// no charm URL is set, as its state counterpart does.
 	settings, err := s.apiUnit.ConfigSettings()
-	c.Assert(err, gc.ErrorMatches, "unit charm must be set before retrieving config")
+	c.Assert(err, gc.ErrorMatches, "unit's charm URL must be set before retrieving config")
 
 	// Now set the charm and try again.
 	err = s.apiUnit.SetCharmURL(s.wordpressCharm.URL())
@@ -536,7 +536,7 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	// Make sure WatchConfigSettingsHash returns an error when
 	// no charm URL is set, as its state counterpart does.
 	w, err := s.apiUnit.WatchConfigSettingsHash()
-	c.Assert(err, gc.ErrorMatches, "unit charm must be set before watching config")
+	c.Assert(err, gc.ErrorMatches, "unit's charm URL must be set before watching config")
 
 	// Now set the charm and try again.
 	err = s.apiUnit.SetCharmURL(s.wordpressCharm.URL())

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -74,7 +74,7 @@ func (u *Unit) Ports() []network.Port {
 // taking into account whether it is tracking a model branch.
 func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	if u.details.CharmURL == "" {
-		return nil, errors.New("unit charm must be set before retrieving config")
+		return nil, errors.New("unit's charm URL must be set before retrieving config")
 	}
 
 	appName := u.details.Application
@@ -127,7 +127,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 // effective application charm config for this unit changes.
 func (u *Unit) WatchConfigSettings() (*CharmConfigWatcher, error) {
 	if u.details.CharmURL == "" {
-		return nil, errors.New("unit charm must be set before watching config")
+		return nil, errors.New("unit's charm URL must be set before watching config")
 	}
 
 	cfg := charmConfigWatcherConfig{

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -74,7 +74,7 @@ func (u *Unit) Ports() []network.Port {
 // taking into account whether it is tracking a model branch.
 func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	if u.details.CharmURL == "" {
-		return nil, errors.New("unit charm not set")
+		return nil, errors.New("unit charm must be set before retrieving config")
 	}
 
 	appName := u.details.Application
@@ -127,7 +127,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 // effective application charm config for this unit changes.
 func (u *Unit) WatchConfigSettings() (*CharmConfigWatcher, error) {
 	if u.details.CharmURL == "" {
-		return nil, errors.New("unit charm not set")
+		return nil, errors.New("unit charm must be set before watching config")
 	}
 
 	cfg := charmConfigWatcherConfig{

--- a/state/unit.go
+++ b/state/unit.go
@@ -144,7 +144,7 @@ func (u *Unit) Application() (*Application, error) {
 // specified.
 func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	if u.doc.CharmURL == nil {
-		return nil, fmt.Errorf("unit charm not set")
+		return nil, fmt.Errorf("unit's charm URL must be set before retrieving config")
 	}
 
 	// TODO (manadart 2019-02-21) Factor the current generation into this call.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -68,7 +68,7 @@ func (s *UnitSuite) TestApplication(c *gc.C) {
 
 func (s *UnitSuite) TestConfigSettingsNeedCharmURLSet(c *gc.C) {
 	_, err := s.unit.ConfigSettings()
-	c.Assert(err, gc.ErrorMatches, "unit charm not set")
+	c.Assert(err, gc.ErrorMatches, "unit's charm URL must be set before retrieving config")
 }
 
 func (s *UnitSuite) TestConfigSettingsIncludeDefaults(c *gc.C) {
@@ -118,7 +118,7 @@ func (s *UnitSuite) TestConfigSettingsReflectCharm(c *gc.C) {
 
 func (s *UnitSuite) TestWatchConfigSettingsNeedsCharmURL(c *gc.C) {
 	_, err := s.unit.WatchConfigSettings()
-	c.Assert(err, gc.ErrorMatches, "unit charm not set")
+	c.Assert(err, gc.ErrorMatches, "unit's charm URL must be set before watching config")
 }
 
 func (s *UnitSuite) TestWatchConfigSettings(c *gc.C) {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1771,7 +1771,7 @@ func (a *Application) WatchCharmConfig() (NotifyWatcher, error) {
 // could be somewhat simpler.
 func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 	if u.doc.CharmURL == nil {
-		return nil, fmt.Errorf("unit charm not set")
+		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
 	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
 	return newEntityWatcher(u.st, settingsC, u.st.docID(charmConfigKey)), nil
@@ -1790,7 +1790,7 @@ func (u *Unit) WatchApplicationConfigSettings() (NotifyWatcher, error) {
 // URL is not changed.
 func (u *Unit) WatchConfigSettingsHash() (StringsWatcher, error) {
 	if u.doc.CharmURL == nil {
-		return nil, fmt.Errorf("unit charm not set")
+		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
 	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
 	return newSettingsHashWatcher(u.st, charmConfigKey), nil


### PR DESCRIPTION
## Description of change

This patch modifies errors emitted by cached units for unset charm URL. Message now indicate the operation that was attempted.

## QA steps

No functional change. Unit tests verify new error text.

## Documentation changes

None.

## Bug reference

N/A
