### PR TITLE
Unassign unit from active branches when unit is removed.

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -876,6 +876,10 @@ func NewInstanceCharmProfileDataCompatibilityWatcher(backend ModelBackendShim, m
 	return watchInstanceCharmProfileCompatibilityData(backend, memberId)
 }
 
+func UnitBranch(m *Model, unitName string) (*Generation, error) {
+	return m.unitBranch(unitName)
+}
+
 // ModelBackendShim is required to live here in the export_test.go file because
 // there is issues placing this in the test files themselves. The strangeness
 // exhibits itself from the fact that `clock() clock.Clock` doesn't type

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1819,6 +1819,28 @@ func (s *UnitSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *UnitSuite) TestRemoveUnassignsFromBranch(c *gc.C) {
+	// Add unit to a branch
+	c.Assert(s.Model.AddBranch("apple", "testuser"), jc.ErrorIsNil)
+	branch, err := s.Model.Branch("apple")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(branch.AssignUnit(s.unit.Name()), jc.ErrorIsNil)
+	c.Assert(branch.Refresh(), jc.ErrorIsNil)
+	c.Assert(branch.AssignedUnits(), gc.DeepEquals, map[string][]string{
+		s.application.Name(): {s.unit.Name()},
+	})
+
+	// remove the unit
+	c.Assert(s.unit.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(s.unit.Remove(), jc.ErrorIsNil)
+
+	// verify branch no longer tracks unit
+	c.Assert(branch.Refresh(), jc.ErrorIsNil)
+	c.Assert(branch.AssignedUnits(), gc.DeepEquals, map[string][]string{
+		s.application.Name(): {},
+	})
+}
+
 func (s *UnitSuite) TestRemovePathological(c *gc.C) {
 	// Add a relation between wordpress and mysql...
 	wordpress := s.application


### PR DESCRIPTION
## Description of change

When a unit is removed, it should also be unassigned from the branch tracking it.  "juju diff misses when unit tracking is removed" is a side effect of this not being done.

## QA steps

2. export JUJU_DEV_FEATURE_FLAGS=generations
1. juju bootstrap localhost
2. juju deploy grafana -n 3
2. juju add-branch change-pass
2. juju track change-pass grafana/0
2. juju diff   <- progress shows 1/3
2. juju remove-unit grafana/0    <- wait for unit removal to complete.
2. juju diff  <- progress shows 0/2
2. juju abort change-pass
2. juju remove-unit grafana/2  <- no adverse impact removing unit not tracked.
3. juju debug-log -m controller, check for failures 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1834553
