### PR TITLE
2.6 - Update juju/description Dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -488,11 +488,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:9146a31e6c2252fd2b49741aa48619521515dab364e28a8df4385dbb6995c9ac"
+  digest = "1:446b7fde9070a70bcbbda3bfc163a26994f6486c99f86e65be83b7da588e6b80"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "adb93fec16ac45ed5e262d94f8dfe5f71210ea3f"
+  revision = "9daa941ef37578e70e66a5f97ab64b1f2b2bd410"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "adb93fec16ac45ed5e262d94f8dfe5f71210ea3f"
+  revision = "9daa941ef37578e70e66a5f97ab64b1f2b2bd410"
   name = "github.com/juju/description"
 
 [[constraint]]


### PR DESCRIPTION
## Description of change

When volumes are attached, a `VolumeAttachmentPlan` is created. This was introduced for the OCI provider to allow local machines actions for storage attachment. For non-OCI providers this plan is created without device attributes, which violates the schema logic in `juju/description`, which in turn causes migrations to fail.

The new dependency resolves this.

## QA steps

- Bootstrap 

## Documentation changes

- `juju bootstrap aws aws-src --no-gui --debug`.
- `juju create-storage-pool iops ebs volume-type=provisioned-iops iops=30`.
- `juju deploy postgresql --storage pgdata=iops,10G`.
- `juju bootstrap aws aws-dst --no-gui --debug`.
- `juju destroy-model default -y`.
- `juju switch aws-src`
- `juju migrate default aws-dst` (may have to wait for a relation here and re-run).
- Check that the model is migrated without error.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1834115
