### PR TITLE
LXD certificates are hidden attributes.

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -55,7 +55,6 @@ type CertificateGenerator interface {
 
 // NetLookup groups methods for looking up hosts and interface addresses.
 type NetLookup interface {
-
 	// LookupHost looks up the given host using the local resolver.
 	// It returns a slice of that host's addresses.
 	LookupHost(string) ([]string, error)
@@ -83,18 +82,21 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 				CredentialAttr: cloud.CredentialAttr{
 					Description:    "the path to the PEM-encoded LXD server certificate file",
 					ExpandFilePath: true,
+					Hidden:         true,
 				},
 			}, {
 				Name: credAttrClientCert,
 				CredentialAttr: cloud.CredentialAttr{
 					Description:    "the path to the PEM-encoded LXD client certificate file",
 					ExpandFilePath: true,
+					Hidden:         true,
 				},
 			}, {
 				Name: credAttrClientKey,
 				CredentialAttr: cloud.CredentialAttr{
 					Description:    "the path to the PEM-encoded LXD client key file",
 					ExpandFilePath: true,
+					Hidden:         true,
 				},
 			},
 		},


### PR DESCRIPTION
## Description of change

All cloud authentication mechanisms can specify attributes that are hidden by default - password, secret keys, etc.
LXD certificate auth type was missing Hidden property settings for such secret properties.
These properties can only be visible to  the owner of the credential when a show-secret option is provided.

```
$ juju credentials localhost --format yaml
local-credentials:
  localhost:
    default-credential: localhost
    localhost:
      auth-type: certificate
```
not

```
$ juju credentials localhost --format yaml
local-credentials:
  localhost:
    default-credential: localhost
    localhost:
      auth-type: certificate
      client-cert: <REDACTED>
      client-key: <REDACTED>
      server-cert: <REDACTED>
```