### PR TITLE
LXD: remove trailing slash

### DIFF
--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -496,7 +496,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 		}
 	}
 	if moreCloudInfoNeeded {
-		ctxt.Infof("Use 'juju clouds' to view all avalaible clouds and 'juju add-cloud' to add missing ones.")
+		ctxt.Infof("Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.")
 	}
 	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results)
 }

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -466,7 +466,7 @@ Saved credential to cloud test-cloud locally
 Select a credential to save by number, or type Q to quit: 
 
 Cloud "test-cloud" does not exist on the controller: not uploading credentials for it...
-Use 'juju clouds' to view all avalaible clouds and 'juju add-cloud' to add missing ones.
+Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.
 `[1:])
 	c.Assert(called, jc.IsFalse)
 }

--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -206,5 +206,5 @@ func EnsureHostPort(address string) (string, error) {
 	if uri.Port() == "" {
 		uri.Host = fmt.Sprintf("%s:%d", uri.Host, defaultPort)
 	}
-	return uri.String(), nil
+	return strings.TrimRight(uri.String(), "/"), nil
 }

--- a/container/lxd/connection_test.go
+++ b/container/lxd/connection_test.go
@@ -99,6 +99,10 @@ func (s *connectionSuite) TestEnsureHostPort(c *gc.C) {
 			Input:  "https://somewhere:123",
 			Output: "https://somewhere:123",
 		},
+		{
+			Input:  "https://somewhere:123/",
+			Output: "https://somewhere:123",
+		},
 	} {
 		got, err := lxd.EnsureHostPort(t.Input)
 		c.Assert(err, gc.IsNil)


### PR DESCRIPTION
## Description of change

When interacting with remote LXD servers we should ensure that we
strip the slash as LXD expects a URL without a ending of a slash.

## QA steps

Edit `~/.local/share/juju/clouds.yaml` adding a trailing slash at the end
of the LXD cloud urls. 

```console
juju bootstrap lxd test --no-gui --build-agent --debug
``` 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813767
