### PR TITLE
untrack destroyed application from active branches

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -880,6 +880,10 @@ func UnitBranch(m *Model, unitName string) (*Generation, error) {
 	return m.unitBranch(unitName)
 }
 
+func ApplicationBranches(m *Model, appName string) ([]*Generation, error) {
+	return m.applicationBranches(appName)
+}
+
 // ModelBackendShim is required to live here in the export_test.go file because
 // there is issues placing this in the test files themselves. The strangeness
 // exhibits itself from the fact that `clock() clock.Clock` doesn't type


### PR DESCRIPTION
## Description of change

    If an application tracked by an active branch is being destroyed,
    remove the application from assigned-units and any related config 
    changes from branches tracking it.

## QA steps

2. export JUJU_DEV_FEATURE_FLAGS=generations
1. juju bootstrap localhost
3. open new term running juju-db.bash, use db.generations.find({},{}).pretty() to verify changes during qa.
2. juju deploy grafana -n 2
2. juju deploy ubuntu -n 2
2. juju add-branch banana
2. juju add-branch apple
3. juju config ubuntu hostname=testone --branch banana
3. juju config ubuntu hostname=testtwo --branch apple
3. juju track apple grafana
2. juju remove-application ubuntu
3 check juju db
2. juju deploy ubuntu
3. juju remove-unit ubuntu/3     <- make sure app removed from branch, even with no units.
3. juju track banana ubuntu
3 check juju db
3. juju debug-log -m controller, check for failures 
