### PR TITLE
'credentials' lists remote credentials as well.

### DIFF
--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -1188,33 +1188,29 @@ func (s *cloudSuite) TestCredentialContentsAllNoSecrets(c *gc.C) {
 
 	_true := true
 	_false := false
-	expected := []params.CredentialContentResult{
-		{
-			Result: &params.ControllerCredentialInfo{
-				Content: params.CredentialContent{
-					Name:       "one",
-					Cloud:      "meep",
-					AuthType:   "empty",
-					Valid:      &_true,
-					Attributes: map[string]string{},
-				},
-			},
+	expected := map[string]params.CredentialContent{
+		"one": {
+			Name:       "one",
+			Cloud:      "meep",
+			AuthType:   "empty",
+			Valid:      &_true,
+			Attributes: map[string]string{},
 		},
-		{
-			Result: &params.ControllerCredentialInfo{
-				Content: params.CredentialContent{
-					Name:     "two",
-					Cloud:    "meep",
-					AuthType: "userpass",
-					Valid:    &_false,
-					Attributes: map[string]string{
-						"username": "admin",
-					},
-				},
+		"two": {
+			Name:     "two",
+			Cloud:    "meep",
+			AuthType: "userpass",
+			Valid:    &_false,
+			Attributes: map[string]string{
+				"username": "admin",
 			},
 		},
 	}
-	c.Assert(results.Results, jc.DeepEquals, expected)
+
+	c.Assert(results.Results, gc.HasLen, len(expected))
+	for _, one := range results.Results {
+		c.Assert(one.Result.Content, gc.DeepEquals, expected[one.Result.Content.Name])
+	}
 }
 
 type mockBackend struct {

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -93,14 +93,18 @@ func NewUpdateCloudCommandForTest(
 }
 
 func NewListCredentialsCommandForTest(
-	testStore jujuclient.CredentialGetter,
+	testStore jujuclient.ClientStore,
 	personalCloudsFunc func() (map[string]jujucloud.Cloud, error),
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error),
+	apiF func(controllerName string) (ListCredentialsAPI, error),
 ) *listCredentialsCommand {
 	return &listCredentialsCommand{
-		store:              testStore,
-		personalCloudsFunc: personalCloudsFunc,
-		cloudByNameFunc:    cloudByNameFunc,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store: testStore,
+		},
+		personalCloudsFunc:     personalCloudsFunc,
+		cloudByNameFunc:        cloudByNameFunc,
+		listCredentialsAPIFunc: apiF,
 	}
 }
 
@@ -157,8 +161,8 @@ func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api cre
 }
 
 func NewShowCredentialCommandForTest(api CredentialContentAPI) cmd.Command {
-	cmd := &showCredentialCommand{newAPIFunc: func() (CredentialContentAPI, error) {
+	command := &showCredentialCommand{newAPIFunc: func() (CredentialContentAPI, error) {
 		return api, nil
 	}}
-	return modelcmd.WrapBase(cmd)
+	return modelcmd.WrapBase(command)
 }

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -4,15 +4,18 @@
 package cloud_test
 
 import (
+	"github.com/juju/juju/apiserver/common"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -26,6 +29,8 @@ type listCredentialsSuite struct {
 	store              *jujuclient.MemStore
 	personalCloudsFunc func() (map[string]jujucloud.Cloud, error)
 	cloudByNameFunc    func(string) (*jujucloud.Cloud, error)
+	apiF               func(controllerName string) (cloud.ListCredentialsAPI, error)
+	testAPI            *mockAPI
 }
 
 var _ = gc.Suite(&listCredentialsSuite{
@@ -113,16 +118,25 @@ func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
+	s.testAPI = &mockAPI{
+		credentialContentsF: func(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error) {
+			return nil, nil
+		},
+	}
+	s.apiF = func(controllerName string) (cloud.ListCredentialsAPI, error) {
+		return s.testAPI, nil
+	}
 }
 
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
 	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
+No remotely stored credentials to display.
 Cloud    Credentials
-aws      down*, bob
-azure    azhja
-google   default
-mycloud  me
+aws      down*, bob  
+azure    azhja       
+google   default     
+mycloud  me          
 
 `[1:])
 }
@@ -146,10 +160,11 @@ func (s *listCredentialsSuite) TestListCredentialsTabularInvalidCredential(c *gc
 
 	ctx := s.listCredentialsWithStore(c, store)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+No remotely stored credentials to display.
 Cloud   Credentials
-aws     down*, bob
-azure   azhja
-google  default
+aws     down*, bob  
+azure   azhja       
+google  default     
 
 `[1:])
 	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
@@ -161,15 +176,16 @@ google  default
 }
 
 func (s *listCredentialsSuite) TestListCredentialsTabularShowsNoSecrets(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store, s.personalCloudsFunc, s.cloudByNameFunc), "--show-secrets")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store, s.personalCloudsFunc, s.cloudByNameFunc, s.apiF), "--show-secrets")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "secrets are not shown in tabular format\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+No remotely stored credentials to display.
 Cloud    Credentials
-aws      down*, bob
-azure    azhja
-google   default
-mycloud  me
+aws      down*, bob  
+azure    azhja       
+google   default     
+mycloud  me          
 
 `[1:])
 }
@@ -181,11 +197,12 @@ func (s *listCredentialsSuite) TestListCredentialsTabularMissingCloud(c *gc.C) {
 The following clouds have been removed and are omitted from the results to avoid leaking secrets.
 Run with --show-secrets to display these clouds' credentials: missingcloud
 
+No remotely stored credentials to display.
 Cloud    Credentials
-aws      down*, bob
-azure    azhja
-google   default
-mycloud  me
+aws      down*, bob  
+azure    azhja       
+google   default     
+mycloud  me          
 
 `[1:])
 }
@@ -193,8 +210,59 @@ mycloud  me
 func (s *listCredentialsSuite) TestListCredentialsTabularFiltered(c *gc.C) {
 	out := s.listCredentials(c, "aws")
 	c.Assert(out, gc.Equals, `
+No remotely stored credentials to display.
 Cloud  Credentials
-aws    down*, bob
+aws    down*, bob  
+
+`[1:])
+}
+
+func (s *listCredentialsSuite) TestListCredentialsTabularFilteredLocalOnly(c *gc.C) {
+	out := s.listCredentials(c, "aws", "--local")
+	c.Assert(out, gc.Equals, `
+Cloud  Credentials
+aws    down*, bob  
+
+`[1:])
+}
+
+func (s *listCredentialsSuite) TestListRemoteCredentialsWithSecrets(c *gc.C) {
+	s.testAPI.credentialContentsF = func(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error) {
+		c.Assert(withSecrets, jc.IsTrue)
+		return nil, nil
+	}
+	out := s.listCredentials(c, "aws", "--show-secrets", "--format", "yaml")
+	c.Assert(out, gc.Equals, `
+local-credentials:
+  aws:
+    default-credential: down
+    default-region: ap-southeast-2
+    bob:
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
+    down:
+      auth-type: userpass
+      password: password
+      username: user
+`[1:])
+}
+
+func (s *listCredentialsSuite) TestListAllCredentials(c *gc.C) {
+	s.testAPI.credentialContentsF = func(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error) {
+		return []params.CredentialContentResult{
+			{Result: &params.ControllerCredentialInfo{Content: params.CredentialContent{Cloud: "remote-cloud", Name: "remote-name"}}},
+			{Error: common.ServerError(errors.New("kabbom"))},
+		}, nil
+	}
+	out := s.listCredentials(c)
+	c.Assert(out, gc.Equals, `
+Cloud         Credentials
+remote-cloud  remote-name  
+aws           down*, bob   
+azure         azhja        
+google        default      
+mycloud       me           
 
 `[1:])
 }
@@ -439,7 +507,7 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 		},
 	}
 	out := strings.Replace(s.listCredentials(c), "\n", "", -1)
-	c.Assert(out, gc.Equals, "Cloud  Credentialsaws    bob")
+	c.Assert(out, gc.Equals, "No remotely stored credentials to display.Cloud  Credentialsaws    bob  ")
 
 	out = strings.Replace(s.listCredentials(c, "--format", "yaml"), "\n", "", -1)
 	c.Assert(out, gc.Equals, "local-credentials:  aws:    bob:      auth-type: oauth2")
@@ -449,24 +517,24 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 }
 
 func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
-	listCmd := cloud.NewListCredentialsCommandForTest(jujuclient.NewMemStore(), s.personalCloudsFunc, s.cloudByNameFunc)
+	listCmd := cloud.NewListCredentialsCommandForTest(jujuclient.NewMemStore(), s.personalCloudsFunc, s.cloudByNameFunc, s.apiF)
 	ctx, err := cmdtesting.RunCommand(c, listCmd)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out := strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, "No locally stored credentials to display.")
+	c.Assert(out, gc.Equals, "No locally stored credentials to display.No remotely stored credentials to display.")
 
 	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out = strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, "local-credentials: {}")
+	c.Assert(out, gc.Equals, "{}")
 
 	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out = strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, `{"local-credentials":{}}`)
+	c.Assert(out, gc.Equals, `{}`)
 }
 
 func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {
@@ -476,7 +544,23 @@ func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {
 }
 
 func (s *listCredentialsSuite) listCredentialsWithStore(c *gc.C, store jujuclient.ClientStore, args ...string) *cmd.Context {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCredentialsCommandForTest(store, s.personalCloudsFunc, s.cloudByNameFunc), args...)
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCredentialsCommandForTest(store, s.personalCloudsFunc, s.cloudByNameFunc, s.apiF), args...)
 	c.Assert(err, jc.ErrorIsNil)
 	return ctx
+}
+
+type mockAPI struct {
+	jujutesting.Stub
+
+	credentialContentsF func(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error)
+}
+
+func (m *mockAPI) CredentialContents(cloud, credential string, withSecrets bool) ([]params.CredentialContentResult, error) {
+	m.AddCall("CredentialContents", cloud, credential, withSecrets)
+	return m.credentialContentsF(cloud, credential, withSecrets)
+}
+
+func (m *mockAPI) Close() error {
+	m.AddCall("Close")
+	return nil
 }

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -4,7 +4,6 @@
 package cloud_test
 
 import (
-	"github.com/juju/juju/apiserver/common"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -15,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -55,7 +55,6 @@ type CertificateGenerator interface {
 
 // NetLookup groups methods for looking up hosts and interface addresses.
 type NetLookup interface {
-
 	// LookupHost looks up the given host using the local resolver.
 	// It returns a slice of that host's addresses.
 	LookupHost(string) ([]string, error)
@@ -83,18 +82,21 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 				CredentialAttr: cloud.CredentialAttr{
 					Description:    "the path to the PEM-encoded LXD server certificate file",
 					ExpandFilePath: true,
+					Hidden:         true,
 				},
 			}, {
 				Name: credAttrClientCert,
 				CredentialAttr: cloud.CredentialAttr{
 					Description:    "the path to the PEM-encoded LXD client certificate file",
 					ExpandFilePath: true,
+					Hidden:         true,
 				},
 			}, {
 				Name: credAttrClientKey,
 				CredentialAttr: cloud.CredentialAttr{
 					Description:    "the path to the PEM-encoded LXD client key file",
 					ExpandFilePath: true,
+					Hidden:         true,
 				},
 			},
 		},


### PR DESCRIPTION
## Description of change

'juju credentials' has been only listing client credentials stored locally on user's device.
This is misleading and only tells half the credential story.

This PR lists both local and remote credentials. Remote  credentials are either pulled from the current controller or the controller specified by -c command option. 

To list only local credentials a --local option is provided. Local credentials are colored light blue in the output.


