### PR TITLE
Add ID to Mongo Space Documents

### DIFF
--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -496,7 +496,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 		}
 	}
 	if moreCloudInfoNeeded {
-		ctxt.Infof("Use 'juju clouds' to view all avalaible clouds and 'juju add-cloud' to add missing ones.")
+		ctxt.Infof("Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.")
 	}
 	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results)
 }

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -466,7 +466,7 @@ Saved credential to cloud test-cloud locally
 Select a credential to save by number, or type Q to quit: 
 
 Cloud "test-cloud" does not exist on the controller: not uploading credentials for it...
-Use 'juju clouds' to view all avalaible clouds and 'juju add-cloud' to add missing ones.
+Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.
 `[1:])
 	c.Assert(called, jc.IsFalse)
 }

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -21,6 +21,7 @@ var SupportsNetworking = supportsNetworking
 // to get information about the default space.
 var DefaultSpaceInfo *network.SpaceInfo
 
+// TODO (manadart 2019-07-03): Move this to core.
 // DefaultSpaceName is the name of the default space (to which
 // application endpoints are bound if no explicit binding is given).
 const DefaultSpaceName = ""

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -173,18 +173,25 @@ func (s *cmdSpaceSuite) TestSpaceCreateWithSubnets(c *gc.C) {
 	c.Assert(subnets[1].SpaceName(), gc.Equals, "myspace")
 }
 
-func (s *cmdSpaceSuite) TestSpaceListNoResults(c *gc.C) {
-	_, stderr, err := s.Run(c, "spaces")
+// TODO (manadart 2019-07-22): Fix this so that spaces are output with IDs.
+func (s *cmdSpaceSuite) TestSpaceListDefaultOnly(c *gc.C) {
+	stdout, _, err := s.Run(c, "spaces")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stderr, jc.Contains,
-		"no spaces to display\n",
-	)
+
+	expected := `
+Space  Subnets
+
+
+`[1:]
+
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func (s *cmdSpaceSuite) TestSpaceListOneResultNoSubnets(c *gc.C) {
 	s.AddSpace(c, "myspace", nil, true)
 
-	expectedOutput := "{\"spaces\":{\"myspace\":{}}}\n"
+	// The default space is listed in addition to the one we added.
+	expectedOutput := "{\"spaces\":{\"\":{},\"myspace\":{}}}\n"
 	stdout, _, err := s.Run(c, "list-spaces", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdout, jc.Contains, expectedOutput)

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -93,14 +93,7 @@ func (s *cmdSubnetSuite) TestSubnetAddValidCIDRUnknownByTheProvider(c *gc.C) {
 	s.RunAdd(c, expectedError, "10.0.0.0/8", "myspace")
 }
 
-func (s *cmdSubnetSuite) TestSubnetAddWithoutAnySpaces(c *gc.C) {
-	expectedError := `cannot add subnet: no spaces defined`
-	s.RunAdd(c, expectedError, "0.10.0.0/24", "whatever")
-}
-
 func (s *cmdSubnetSuite) TestSubnetAddWithUnknownSpace(c *gc.C) {
-	s.AddSpace(c, "yourspace", nil, true)
-
 	expectedError := `cannot add subnet: space "myspace" not found`
 	s.RunAdd(c, expectedError, "0.10.0.0/24", "myspace")
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -383,8 +383,13 @@ func allCollections() CollectionSchema {
 
 		// -----
 
-		providerIDsC:          {},
-		spacesC:               {},
+		providerIDsC: {},
+		spacesC: {
+			indexes: []mgo.Index{
+				{Key: []string{"model-uuid", "spaceid"}},
+				{Key: []string{"model-uuid", "name"}},
+			},
+		},
 		subnetsC:              {},
 		linkLayerDevicesC:     {},
 		linkLayerDevicesRefsC: {},

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -388,6 +388,7 @@ func (st *State) modelSetupOps(controllerUUID string, args ModelArgs, inherited 
 			args.EnvironVersion,
 		),
 		createUniqueOwnerModelNameOp(args.Owner, args.Config.Name()),
+		createDefaultSpaceOp(),
 	)
 	ops = append(ops, modelUserOps...)
 	return ops, modelStatusDoc, nil

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -215,12 +215,16 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(access, gc.Equals, permission.AdminAccess)
 
 	// Check that the cloud's model count is initially 1.
-	cloud, err := s.State.Cloud("dummy")
+	cl, err := s.State.Cloud("dummy")
 	c.Assert(err, jc.ErrorIsNil)
 
-	refCount, err := state.CloudModelRefCount(s.State, cloud.Name)
+	refCount, err := state.CloudModelRefCount(s.State, cl.Name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(refCount, gc.Equals, 1)
+
+	// Check that the default space is created.
+	_, err = s.State.Space("")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/resource"
@@ -1119,6 +1120,14 @@ func (e *exporter) spaces() error {
 	e.logger.Debugf("read %d spaces", len(spaces))
 
 	for _, space := range spaces {
+		// We do not export the default space because it is created by default
+		// with the new model. This is OK, because it is immutable.
+		// Any subnets added to the space will still be exported.
+		if space.Name() == environs.DefaultSpaceName {
+			continue
+		}
+
+		// TODO (manadart 2019-07-12): Update juju/description and export IDs.
 		e.model.AddSpace(description.SpaceArgs{
 			Name:       space.Name(),
 			Public:     space.IsPublic(),

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1237,8 +1237,7 @@ func (i *importer) makeRelationDoc(rel description.Relation) *relationDoc {
 func (i *importer) spaces() error {
 	i.logger.Debugf("importing spaces")
 	for _, s := range i.model.Spaces() {
-		// We do not import the default space because it is created by default
-		// with the new model. This is OK, because it is immutable.
+		// The default space should not have been exported, but be defensive.
 		// Any subnets added to the space will be imported subsequently.
 		if s.Name() == environs.DefaultSpaceName {
 			continue

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/juju/juju/environs"
-
 	"github.com/juju/description"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -24,6 +22,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/payload"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -595,10 +595,12 @@ func (s *MigrationSuite) TestHistoricalStatusDocFields(c *gc.C) {
 
 func (s *MigrationSuite) TestSpaceDocFields(c *gc.C) {
 	ignored := set.NewStrings(
+		"DocId",
 		// Always alive, not explicitly exported.
 		"Life",
 	)
 	migrated := set.NewStrings(
+		"Id",
 		"Name",
 		"IsPublic",
 		"ProviderId",

--- a/state/model.go
+++ b/state/model.go
@@ -402,9 +402,6 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 	}
 	ops = append(ops, incCloudRefOp)
 
-	// Create a record for the default space.
-	ops = append(ops, createDefaultSpaceOp())
-
 	err = newSt.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		// Check that the cloud exists.

--- a/state/model.go
+++ b/state/model.go
@@ -402,6 +402,9 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 	}
 	ops = append(ops, incCloudRefOp)
 
+	// Create a record for the default space.
+	ops = append(ops, createDefaultSpaceOp())
+
 	err = newSt.db().RunTransaction(ops)
 	if err == txn.ErrAborted {
 		// Check that the cloud exists.

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
@@ -331,6 +332,10 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 
 	// Ensure the model is functional by adding a machine
 	_, err = st.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the default model was created.
+	_, err = st.Space(environs.DefaultSpaceName)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"strconv"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/mgo.v2"
@@ -20,10 +22,17 @@ type Space struct {
 }
 
 type spaceDoc struct {
+	DocId      string `bson:"_id"`
+	Id         string `bson:"spaceid"`
 	Life       Life   `bson:"life"`
 	Name       string `bson:"name"`
 	IsPublic   bool   `bson:"is-public"`
 	ProviderId string `bson:"providerid,omitempty"`
+}
+
+// Id returns the space ID.
+func (s *Space) Id() string {
+	return s.doc.Id
 }
 
 // Life returns whether the space is Alive, Dying or Dead.
@@ -81,25 +90,82 @@ func (s *Space) Subnets() (results []*Subnet, err error) {
 }
 
 // AddSpace creates and returns a new space.
-func (st *State) AddSpace(name string, providerId network.Id, subnets []string, isPublic bool) (newSpace *Space, err error) {
+func (st *State) AddSpace(
+	name string, providerId network.Id, subnets []string, isPublic bool) (newSpace *Space, err error,
+) {
 	defer errors.DeferredAnnotatef(&err, "adding space %q", name)
 	if !names.IsValidSpace(name) {
 		return nil, errors.NewNotValid(nil, "invalid space name")
 	}
 
-	spaceDoc := spaceDoc{
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if _, err := st.Space(name); err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, errors.Annotatef(err, "checking for existing space")
+			}
+		} else {
+			return nil, errors.AlreadyExistsf("space %q", name)
+		}
+
+		for _, subnetId := range subnets {
+			subnet, err := st.Subnet(subnetId)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if subnet.FanLocalUnderlay() != "" {
+				return nil, errors.Errorf(
+					"cannot set space for FAN subnet %q - it is always inherited from underlay", subnet.CIDR())
+			}
+		}
+
+		// The ops will assert that the ID is unique,
+		// but we check explicitly in order to return an indicative error.
+		if providerId != "" {
+			exists, err := st.networkEntityGlobalKeyExists("space", providerId)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if exists {
+				return nil, errors.Errorf("provider ID %q not unique", providerId)
+			}
+		}
+
+		ops, err := st.addSpaceTxnOps(name, providerId, subnets, isPublic)
+		return ops, errors.Trace(err)
+	}
+
+	err = st.db().Run(buildTxn)
+	if err != nil {
+		err = onAbort(err, ErrDead)
+		logger.Errorf("cannot add space to the model: %v", err)
+		return nil, errors.Trace(err)
+	}
+
+	space, err := st.Space(name)
+	return space, errors.Trace(err)
+}
+
+func (st *State) addSpaceTxnOps(name string, providerId network.Id, subnets []string, isPublic bool) ([]txn.Op, error) {
+	// Space with ID zero is the default space; start at 1.
+	seq, err := sequenceWithMin(st, "space", 1)
+	if err != nil {
+		return nil, err
+	}
+	id := strconv.Itoa(seq)
+
+	doc := spaceDoc{
+		Id:         id,
 		Life:       Alive,
 		Name:       name,
 		IsPublic:   isPublic,
 		ProviderId: string(providerId),
 	}
-	newSpace = &Space{doc: spaceDoc, st: st}
 
 	ops := []txn.Op{{
 		C:      spacesC,
-		Id:     name,
+		Id:     id,
 		Assert: txn.DocMissing,
-		Insert: spaceDoc,
+		Insert: doc,
 	}}
 
 	if providerId != "" {
@@ -113,35 +179,13 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 		ops = append(ops, txn.Op{
 			C:      subnetsC,
 			Id:     subnetId,
-			Assert: bson.D{bson.DocElem{"fan-local-underlay", bson.D{{"$exists", false}}}},
+			Assert: bson.D{bson.DocElem{Name: "fan-local-underlay", Value: bson.D{{"$exists", false}}}},
+			// TODO (manadart 2019-07-02): Change this to use the space ID.
 			Update: bson.D{{"$set", bson.D{{"space-name", name}}}},
 		})
 	}
 
-	if err := st.db().RunTransaction(ops); err == txn.ErrAborted {
-		if _, err := st.Space(name); err == nil {
-			return nil, errors.AlreadyExistsf("space %q", name)
-		}
-		for _, subnetId := range subnets {
-			subnet, err := st.Subnet(subnetId)
-			if errors.IsNotFound(err) {
-				return nil, err
-			}
-			if subnet.FanLocalUnderlay() != "" {
-				return nil, errors.Errorf("Can't set space for FAN subnet %q - it's always inherited from underlay", subnet.CIDR())
-			}
-		}
-		if err := newSpace.Refresh(); err != nil {
-			if errors.IsNotFound(err) {
-				return nil, errors.Errorf("ProviderId %q not unique", providerId)
-			}
-			return nil, errors.Trace(err)
-		}
-		return nil, errors.Trace(err)
-	} else if err != nil {
-		return nil, err
-	}
-	return newSpace, nil
+	return ops, nil
 }
 
 // Space returns a space from state that matches the provided name. An error
@@ -152,7 +196,7 @@ func (st *State) Space(name string) (*Space, error) {
 	defer closer()
 
 	var doc spaceDoc
-	err := spaces.FindId(name).One(&doc)
+	err := spaces.Find(bson.M{"name": name}).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("space %q", name)
 	}
@@ -167,7 +211,7 @@ func (st *State) AllSpaces() ([]*Space, error) {
 	spacesCollection, closer := st.db().GetCollection(spacesC)
 	defer closer()
 
-	docs := []spaceDoc{}
+	var docs []spaceDoc
 	err := spacesCollection.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all spaces")
@@ -191,7 +235,7 @@ func (s *Space) EnsureDead() (err error) {
 
 	ops := []txn.Op{{
 		C:      spacesC,
-		Id:     s.doc.Name,
+		Id:     s.doc.Id,
 		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		Assert: isAliveDoc,
 	}}
@@ -215,7 +259,7 @@ func (s *Space) Remove() (err error) {
 
 	ops := []txn.Op{{
 		C:      spacesC,
-		Id:     s.doc.Name,
+		Id:     s.doc.Id,
 		Remove: true,
 		Assert: isDeadDoc,
 	}}
@@ -238,7 +282,7 @@ func (s *Space) Refresh() error {
 	defer closer()
 
 	var doc spaceDoc
-	err := spaces.FindId(s.doc.Name).One(&doc)
+	err := spaces.FindId(s.doc.Id).One(&doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("space %q", s)
 	} else if err != nil {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
 )
 
@@ -290,4 +291,19 @@ func (s *Space) Refresh() error {
 	}
 	s.doc = doc
 	return nil
+}
+
+// createDefaultSpaceOp returns a transaction operation
+// that creates the default space (id=0).
+func createDefaultSpaceOp() txn.Op {
+	return txn.Op{
+		C:  spacesC,
+		Id: "0",
+		Insert: spaceDoc{
+			Id:       "0",
+			Life:     Alive,
+			Name:     environs.DefaultSpaceName,
+			IsPublic: true,
+		},
+	}
 }

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -155,6 +155,7 @@ func (st *State) addSpaceTxnOps(name string, providerId network.Id, subnets []st
 	id := strconv.Itoa(seq)
 
 	doc := spaceDoc{
+		DocId:      st.docID(id),
 		Id:         id,
 		Life:       Alive,
 		Name:       name,
@@ -164,7 +165,7 @@ func (st *State) addSpaceTxnOps(name string, providerId network.Id, subnets []st
 
 	ops := []txn.Op{{
 		C:      spacesC,
-		Id:     id,
+		Id:     doc.DocId,
 		Assert: txn.DocMissing,
 		Insert: doc,
 	}}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -97,6 +97,10 @@ func (s *SpacesSuite) assertSpaceMatchesArgs(c *gc.C, space *state.Space, args a
 
 	c.Assert(space.Life(), gc.Equals, state.Alive)
 	c.Assert(space.String(), gc.Equals, args.Name)
+
+	// The space ID is not empty and not equivalent to the default space.
+	c.Assert(space.Id(), gc.Not(gc.Equals), "")
+	c.Assert(space.Id(), gc.Not(gc.Equals), "0")
 }
 
 func (s *SpacesSuite) TestAddSpaceWithNoSubnetsAndEmptyProviderId(c *gc.C) {
@@ -279,7 +283,7 @@ func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesButSameProviderIdFailsIn
 }
 
 func (s *SpacesSuite) assertProviderIdNotUniqueErrorForArgs(c *gc.C, err error, args addSpaceArgs) {
-	expectedError := fmt.Sprintf("adding space %q: ProviderId %q not unique", args.Name, args.ProviderId)
+	expectedError := fmt.Sprintf("adding space %q: provider ID %q not unique", args.Name, args.ProviderId)
 	c.Assert(err, gc.ErrorMatches, expectedError)
 }
 

--- a/state/spacesdiscovery_test.go
+++ b/state/spacesdiscovery_test.go
@@ -193,9 +193,17 @@ func checkSubnetsEqual(c *gc.C, subnets []*state.Subnet, subnetInfos []network.S
 }
 
 func checkSpacesEqual(c *gc.C, spaces []*state.Space, spaceInfos []network.SpaceInfo) {
-	c.Assert(len(spaceInfos), gc.Equals, len(spaces))
+	// Filter out the default space for comparisons.
+	filtered := spaces[:0]
+	for _, s := range spaces {
+		if s.Name() != environs.DefaultSpaceName {
+			filtered = append(filtered, s)
+		}
+	}
+
+	c.Assert(len(spaceInfos), gc.Equals, len(filtered))
 	for i, spaceInfo := range spaceInfos {
-		space := spaces[i]
+		space := filtered[i]
 		c.Check(spaceInfo.Name, gc.Equals, space.Name())
 		c.Check(spaceInfo.ProviderId, gc.Equals, space.ProviderId())
 		subnets, err := space.Subnets()

--- a/state/state.go
+++ b/state/state.go
@@ -2413,6 +2413,24 @@ func (st *State) networkEntityGlobalKeyRemoveOp(globalKey string, providerId net
 	}
 }
 
+func (st *State) networkEntityGlobalKeyExists(globalKey string, providerId network.Id) (bool, error) {
+	col, closer := st.db().GetCollection(providerIDsC)
+	defer closer()
+
+	key := st.networkEntityGlobalKey(globalKey, providerId)
+	doc := &providerIdDoc{}
+	err := col.FindId(key).One(doc)
+
+	switch err {
+	case nil:
+		return true, nil
+	case mgo.ErrNotFound:
+		return false, nil
+	default:
+		return false, errors.Annotatef(err, "reading provider ID %q", key)
+	}
+}
+
 func (st *State) networkEntityGlobalKey(globalKey string, providerId network.Id) string {
 	return st.docID(globalKey + ":" + string(providerId))
 }

--- a/state/state.go
+++ b/state/state.go
@@ -2418,8 +2418,8 @@ func (st *State) networkEntityGlobalKeyExists(globalKey string, providerId netwo
 	defer closer()
 
 	key := st.networkEntityGlobalKey(globalKey, providerId)
-	doc := &providerIdDoc{}
-	err := col.FindId(key).One(doc)
+	var doc providerIdDoc
+	err := col.FindId(key).One(&doc)
 
 	switch err {
 	case nil:

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2310,19 +2310,7 @@ func AddSpaceIdToSpaceDocs(pool *StatePool) (err error) {
 			})
 		}
 
-		// Insert the default space at the end in case there was
-		// a space in the model named "0".
-		defaultDoc := spaceDoc{
-			Id:       "0",
-			Life:     Alive,
-			Name:     "",
-			IsPublic: true,
-		}
-		ops = append(ops, txn.Op{
-			C:      spacesC,
-			Id:     "0",
-			Insert: defaultDoc,
-		})
+		ops = append(ops, createDefaultSpaceOp())
 
 		return errors.Trace(st.db().RunTransaction(ops))
 	}))

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2252,11 +2252,6 @@ func AddControllerNodeDocs(pool *StatePool) error {
 // It also adds a doc for the default space (ID=0).
 func AddSpaceIdToSpaceDocs(pool *StatePool) (err error) {
 	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
-		// Make sure we do not add a default space to the controller model.
-		if st.isController() {
-			return nil
-		}
-
 		col, closer := st.db().GetCollection(spacesC)
 		defer closer()
 
@@ -2296,6 +2291,7 @@ func AddSpaceIdToSpaceDocs(pool *StatePool) (err error) {
 			id := strconv.Itoa(seq)
 
 			newDoc := spaceDoc{
+				DocId:      st.docID(id),
 				Id:         id,
 				Life:       oldDoc.Life,
 				Name:       oldDoc.Name,
@@ -2305,7 +2301,7 @@ func AddSpaceIdToSpaceDocs(pool *StatePool) (err error) {
 
 			ops = append(ops, txn.Op{
 				C:      spacesC,
-				Id:     id,
+				Id:     newDoc.DocId,
 				Insert: newDoc,
 			})
 		}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2246,3 +2246,84 @@ func AddControllerNodeDocs(pool *StatePool) error {
 	}
 	return nil
 }
+
+// AddSpaceIdToSpaceDocs ensures that every space document includes a
+// a sequentially generated ID.
+// It also adds a doc for the default space (ID=0).
+func AddSpaceIdToSpaceDocs(pool *StatePool) (err error) {
+	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
+		// Make sure we do not add a default space to the controller model.
+		if st.isController() {
+			return nil
+		}
+
+		col, closer := st.db().GetCollection(spacesC)
+		defer closer()
+
+		type oldSpaceDoc struct {
+			SpaceId    string `bson:"spaceid"`
+			Life       Life   `bson:"life"`
+			Name       string `bson:"name"`
+			IsPublic   bool   `bson:"is-public"`
+			ProviderId string `bson:"providerid,omitempty"`
+		}
+
+		var docs []oldSpaceDoc
+		err := col.Find(nil).All(&docs)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		var ops []txn.Op
+		for _, oldDoc := range docs {
+			// A doc with a space ID has already been upgraded.
+			if oldDoc.SpaceId != "" {
+				continue
+			}
+
+			// We cannot edit _id, so we need to delete and re-create each doc.
+			ops = append(ops, txn.Op{
+				C:      spacesC,
+				Id:     oldDoc.Name,
+				Assert: txn.DocExists,
+				Remove: true,
+			})
+
+			seq, err := sequenceWithMin(st, "space", 1)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			id := strconv.Itoa(seq)
+
+			newDoc := spaceDoc{
+				Id:         id,
+				Life:       oldDoc.Life,
+				Name:       oldDoc.Name,
+				IsPublic:   oldDoc.IsPublic,
+				ProviderId: oldDoc.ProviderId,
+			}
+
+			ops = append(ops, txn.Op{
+				C:      spacesC,
+				Id:     id,
+				Insert: newDoc,
+			})
+		}
+
+		// Insert the default space at the end in case there was
+		// a space in the model named "0".
+		defaultDoc := spaceDoc{
+			Id:       "0",
+			Life:     Alive,
+			Name:     "",
+			IsPublic: true,
+		}
+		ops = append(ops, txn.Op{
+			C:      spacesC,
+			Id:     "0",
+			Insert: defaultDoc,
+		})
+
+		return errors.Trace(st.db().RunTransaction(ops))
+	}))
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3117,7 +3117,7 @@ func (s *upgradesSuite) TestEnsureApplicationDeviceConstraints(c *gc.C) {
 	sort.Sort(expected)
 	c.Log(pretty.Sprint(expected))
 	s.assertUpgradedDataWithFilter(c, EnsureApplicationDeviceConstraints,
-		bson.D{{"_id", bson.RegEx{":adc#", ""}}},
+		bson.D{{"_id", bson.RegEx{Pattern: ":adc#"}}},
 		expectUpgradedData{coll, expected},
 	)
 }
@@ -3310,6 +3310,76 @@ func (s *upgradesSuite) TestAddControllerNodeDocs(c *gc.C) {
 	s.assertUpgradedData(c, AddControllerNodeDocs,
 		expectUpgradedData{controllerNodesColl, expected},
 	)
+}
+
+func (s *upgradesSuite) TestAddSpaceIdToSpaceDocs(c *gc.C) {
+	col, closer := s.state.db().GetRawCollection(spacesC)
+	defer closer()
+
+	model1 := s.makeModel(c, "model-1", coretesting.Attrs{})
+	model2 := s.makeModel(c, "model-2", coretesting.Attrs{})
+	defer func() {
+		_ = model1.Close()
+		_ = model2.Close()
+	}()
+
+	uuid1 := model1.ModelUUID()
+	uuid2 := model2.ModelUUID()
+
+	err := col.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid1, "space1"),
+		"model-uuid": uuid1,
+		"life":       Alive,
+		"name":       "space1",
+		"is-public":  true,
+		"providerid": "provider1",
+	}, bson.M{
+		"_id":        ensureModelUUID(uuid2, "space2"),
+		"model-uuid": uuid2,
+		"life":       Alive,
+		"name":       "space2",
+		"is-public":  false,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := bsonMById{
+		// The altered spaces:
+		{
+			"_id":        uuid1 + ":1",
+			"model-uuid": uuid1,
+			"spaceid":    "1",
+			"life":       0,
+			"name":       "space1",
+			"is-public":  true,
+			"providerid": "provider1",
+		}, {
+			"_id":        uuid2 + ":1",
+			"model-uuid": uuid2,
+			"spaceid":    "1",
+			"life":       0,
+			"name":       "space2",
+			"is-public":  false,
+		},
+		// The default space for each model.
+		{
+			"_id":        uuid1 + ":0",
+			"model-uuid": uuid1,
+			"spaceid":    "0",
+			"life":       0,
+			"name":       "",
+			"is-public":  true,
+		}, {
+			"_id":        uuid2 + ":0",
+			"model-uuid": uuid2,
+			"spaceid":    "0",
+			"life":       0,
+			"name":       "",
+			"is-public":  true,
+		},
+	}
+
+	sort.Sort(expected)
+	s.assertUpgradedData(c, AddSpaceIdToSpaceDocs, expectUpgradedData{col, expected})
 }
 
 type docById []bson.M

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3325,6 +3325,7 @@ func (s *upgradesSuite) TestAddSpaceIdToSpaceDocs(c *gc.C) {
 
 	uuid1 := model1.ModelUUID()
 	uuid2 := model2.ModelUUID()
+	uuidc := s.state.controllerModelTag.Id()
 
 	err := col.Insert(bson.M{
 		"_id":        ensureModelUUID(uuid1, "space1"),
@@ -3360,7 +3361,7 @@ func (s *upgradesSuite) TestAddSpaceIdToSpaceDocs(c *gc.C) {
 			"name":       "space2",
 			"is-public":  false,
 		},
-		// The default space for each model.
+		// The default space for each model, including the controller.
 		{
 			"_id":        uuid1 + ":0",
 			"model-uuid": uuid1,
@@ -3371,6 +3372,13 @@ func (s *upgradesSuite) TestAddSpaceIdToSpaceDocs(c *gc.C) {
 		}, {
 			"_id":        uuid2 + ":0",
 			"model-uuid": uuid2,
+			"spaceid":    "0",
+			"life":       0,
+			"name":       "",
+			"is-public":  true,
+		}, {
+			"_id":        uuidc + ":0",
+			"model-uuid": uuidc,
 			"spaceid":    "0",
 			"life":       0,
 			"name":       "",

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -66,6 +66,7 @@ type StateBackend interface {
 	UpdateK8sModelNameIndex() error
 	AddModelLogsSize() error
 	AddControllerNodeDocs() error
+	AddSpaceIdToSpaceDocs() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -258,4 +259,8 @@ func (s stateBackend) AddModelLogsSize() error {
 
 func (s stateBackend) AddControllerNodeDocs() error {
 	return state.AddControllerNodeDocs(s.pool)
+}
+
+func (s stateBackend) AddSpaceIdToSpaceDocs() error {
+	return state.AddSpaceIdToSpaceDocs(s.pool)
 }

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -13,5 +13,12 @@ func stateStepsFor27() []Step {
 				return context.State().AddControllerNodeDocs()
 			},
 		},
+		&upgradeStep{
+			description: "recreated spaces with IDs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddSpaceIdToSpaceDocs()
+			},
+		},
 	}
 }

--- a/upgrades/steps_27_test.go
+++ b/upgrades/steps_27_test.go
@@ -25,3 +25,9 @@ func (s *steps27Suite) TestCreateControllerNodes(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps27Suite) TestAddSpaceIdToSpaceDocs(c *gc.C) {
+	step := findStateStep(c, v27, `recreated spaces with IDs`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade.go
+++ b/upgrades/upgrade.go
@@ -115,15 +115,6 @@ func hasStateTarget(targets []Target) bool {
 	return false
 }
 
-func hasDatabaseMasterTarget(targets []Target) bool {
-	for _, target := range targets {
-		if target == DatabaseMaster {
-			return true
-		}
-	}
-	return false
-}
-
 // runUpgradeSteps finds all the upgrade operations relevant to
 // the targets given and runs the associated upgrade steps.
 //


### PR DESCRIPTION
## Description of change

This patch changes spaces from being identified by name, to being identified by a sequential ID in the same fashion as machines.

This is the first in a series of changes. Entities referring to a space still do so via the space name and spaces are still looked up via name.

The default spaces is now included as a space document with ID 0, and is inserted at model creation.

New upgrade logic ensures the creation of numerically identified spaces and the default space document.

## QA steps

### Upgrade Steps

- Bootstrap to AWS with the existing 2.6 branch.
- Run `juju subsets` and choose one of the CIDRs to use for a space.
- `juju add-space test space <the CIDR you chose>`.
- Build this patch and run `juju upgrade-model -m controller --build-agent`.
- Connect to Mongo on the controller and run `db.spaces.find().pretty()`.
- There should be 2 spaces - the one we created and the new default space.
- Both spaces should have a numerical `spaceid` field.
- Check that the `subnets` and `spaces` commands report correct output.

### Default Space Creation

- Bootstrap to LXD.
- Connect to Mongo on the controller and run `db.spaces.find().pretty()`.
- Result should indicate the default space for the controller and default models, similar to:
```
{
        "_id" : "02d50784-e68e-4293-8ccf-93ab704fda05:0",
        "spaceid" : "0",
        "life" : 0,
        "name" : "",
        "is-public" : true,
        "model-uuid" : "02d50784-e68e-4293-8ccf-93ab704fda05",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5d25ab820ced8f11d07f7463_a2c9cbd4"
        ]
}
{
        "_id" : "5a9d089f-dfa5-408d-8363-5ca6122640f8:0",
        "spaceid" : "0",
        "life" : 0,
        "name" : "",
        "is-public" : true,
        "model-uuid" : "5a9d089f-dfa5-408d-8363-5ca6122640f8",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5d25ab830ced8f11d07f7468_c40e5246"
        ]
}
```

## Documentation changes

None yet.

## Bug reference

N/A
