### PR TITLE
Warn about missing controller

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1130,7 +1130,7 @@ func (h *bundleHandler) consumeOffer(change *bundlechanges.ConsumeOfferChange) e
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer controllerOfferAPI.Close()
+	defer func() { _ = controllerOfferAPI.Close() }()
 
 	// Ensure we use the Local url here as we have to ignore the source (read as
 	// target) controller, as the names of controllers might not match and we

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -943,6 +943,17 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 		if url.Source == "" {
 			url.Source = controllerName
 		}
+
+		// if we know the controller isn't available locally, then we should
+		// let the user know as soon as possible, so that we can instruct them
+		// to login.
+		cs := c.ClientStore()
+		if _, err := cs.AccountDetails(url.Source); err != nil && errors.IsNotFound(err) {
+			return nil, errors.Errorf("Controller %q not found locally.\n"+
+				"Please try logging in to the controller using `juju login` to enable\n"+
+				"accessing the controller locally.", url.Source)
+		}
+
 		return c.NewConsumeDetailsAPI(url)
 	}
 

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -800,6 +800,9 @@ func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 		NewAPIRoot: func() (DeployAPI, error) {
 			return fakeAPI, nil
 		},
+		NewConsumeDetailsAPI: func(url *charm.OfferURL) (ConsumeDetails, error) {
+			return fakeAPI, nil
+		},
 	}
 
 	s.SetFeatureFlags(feature.CMRAwareBundles)

--- a/testcharms/charm-repo/bundle/wordpress-with-saas-no-local-ctrl/README.md
+++ b/testcharms/charm-repo/bundle/wordpress-with-saas-no-local-ctrl/README.md
@@ -1,0 +1,2 @@
+A bundle installing wordpress and using the mysql SAAS as the data store where
+the controller doesn't exist locally.

--- a/testcharms/charm-repo/bundle/wordpress-with-saas-no-local-ctrl/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-saas-no-local-ctrl/bundle.yaml
@@ -1,7 +1,7 @@
 series: bionic
 saas:
   mysql:
-    url: kontroll:admin/default.mysql
+    url: doesnotexist:admin/default.mysql
 applications:
   wordpress:
     charm: wordpress


### PR DESCRIPTION
## Description of change

This contains two things, the back port (i targeted the wrong branch in github) of
the consume SAAS bundle block and the error message when a controller isn't 
found locally.

## QA steps

See #10410 for it's QA steps (it shouldn't be needed as it's a backport)

Save the following yaml...
```yaml
series: trusty
saas:
  mysql:
    url: other:admin/default.mysql
applications:
  wordpress:
    charm: cs:trusty/wordpress-5
    num_units: 1
    to:
    - "0"
    expose: true
machines:
  "0": {}
relations:
- - wordpress:db
  - mysql:db
```

```console
juju bootstrap lxd test --no-gui
juju deploy saas.yaml
```

Expected output:
```
Executing changes:
- add new machine 3 (bundle machine 0)
- consume offer mysql at other:admin/default.mysql
ERROR cannot deploy bundle: Controller "other" not found locally.
Please try logging in to the controller using `juju login` to enable
accessing the controller locally.
```
