### PR TITLE
Use spec name for zone name

### DIFF
--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -85,6 +85,11 @@ func NewRemoteServer(spec ServerSpec) (*Server, error) {
 		return nil, errors.Trace(err)
 	}
 	svr, err := NewServer(cSvr)
+	// If we're not clustered we should set the name to the name of the cloud
+	// spec name, so that we can use that name for the zones.
+	if err == nil && !svr.IsClustered() {
+		svr.name = spec.Name
+	}
 	return svr, err
 }
 


### PR DESCRIPTION
## Description of change

When not in clustered mode and trying to use a different name for
the LXD profile in clouds.yaml, the server name will be wrongly
be reported by lxd as the host name. With recent changes to the
cloud spec and credentials, this will cause LXD to fail bootstrapping.

The bug in question refers to 2.5.9, but in fact a lot of reworking of
credentials have made this fix non-trivial to back port it and make it
work easily.

By over writing the server name with the spec name in non-clustered
environments we should then be allowed to bootstrap at will.

## QA steps

If you change your `~/.local/share/juju/clouds.yaml` to copy and
paste the "lxd" cloud you have existing, but change the name (in
this instance to "local"):

```yaml
clouds:
  lxd:
    type: lxd
    auth-types: [certificate]
    endpoint: https://192.168.1.201:8443
    regions:
      default:
        endpoint: https://192.168.1.201:8443
  local:
    type: lxd
    auth-types: [certificate]
    endpoint: https://192.168.1.201:8443
    regions:
      default:
        endpoint: https://192.168.1.201:8443
```

Then run bootstrap

```console
juju bootstrap local test --no-gui
```

The following should bootstrap fine.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813650
