### PR TITLE
'show-credential' for local credentials.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -160,9 +160,12 @@ func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api cre
 	return modelcmd.WrapController(c)
 }
 
-func NewShowCredentialCommandForTest(api CredentialContentAPI) cmd.Command {
-	command := &showCredentialCommand{newAPIFunc: func() (CredentialContentAPI, error) {
-		return api, nil
-	}}
+func NewShowCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialContentAPI) cmd.Command {
+	command := &showCredentialCommand{
+		store: testStore,
+		newAPIFunc: func() (CredentialContentAPI, error) {
+			return api, nil
+		},
+	}
 	return modelcmd.WrapBase(command)
 }

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -297,7 +297,7 @@ func (c *listCredentialsCommand) localCredentials(ctxt *cmd.Context) (map[string
 			continue
 		}
 		if !c.showSecrets {
-			if err := c.removeSecrets(cloudName, cred); err != nil {
+			if err := removeSecrets(cloudName, cred, c.cloudByNameFunc); err != nil {
 				if errors.IsNotValid(err) {
 					missingClouds = append(missingClouds, cloudName)
 					continue
@@ -329,8 +329,8 @@ func (c *listCredentialsCommand) localCredentials(ctxt *cmd.Context) (map[string
 	return displayCredentials, nil
 }
 
-func (c *listCredentialsCommand) removeSecrets(cloudName string, cloudCred *jujucloud.CloudCredential) error {
-	cloud, err := common.CloudOrProvider(cloudName, c.cloudByNameFunc)
+func removeSecrets(cloudName string, cloudCred *jujucloud.CloudCredential, cloudFinder func(string) (*jujucloud.Cloud, error)) error {
+	cloud, err := common.CloudOrProvider(cloudName, cloudFinder)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -51,7 +51,7 @@ func (c *showCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 		"yaml": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.ShowSecrets, "show-secrets", false, "Display credential secret attributes")
-	f.BoolVar(&c.Local, "local", false, "Local operation only; controller not affected")
+	f.BoolVar(&c.Local, "local", false, "Local operation only; controller credentials not shown")
 }
 
 func (c *showCredentialCommand) Init(args []string) error {

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/all"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -20,7 +22,8 @@ import (
 type ShowCredentialSuite struct {
 	coretesting.BaseSuite
 
-	api *fakeCredentialContentAPI
+	api   *fakeCredentialContentAPI
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&ShowCredentialSuite{})
@@ -28,11 +31,39 @@ var _ = gc.Suite(&ShowCredentialSuite{})
 func (s *ShowCredentialSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
+	s.store = &jujuclient.MemStore{
+		Controllers: map[string]jujuclient.ControllerDetails{
+			"controller": {},
+		},
+		CurrentControllerName: "controller",
+	}
 	s.api = &fakeCredentialContentAPI{v: 2}
 }
 
+func (s *ShowCredentialSuite) putCredentialsInStore(c *gc.C) {
+	authCreds := map[string]string{"access-key": "key", "secret-key": "secret"}
+	s.store.Accounts = map[string]jujuclient.AccountDetails{
+		"controller": {
+			User: "admin@local",
+		},
+	}
+	s.store.Credentials = map[string]jujucloud.CloudCredential{
+		"aws": {
+			AuthCredentials: map[string]jujucloud.Credential{
+				"my-credential": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, authCreds),
+			},
+		},
+		"somecloud": {
+			AuthCredentials: map[string]jujucloud.Credential{
+				"its-credential":         jujucloud.NewCredential(jujucloud.AccessKeyAuthType, authCreds),
+				"its-another-credential": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, authCreds),
+			},
+		},
+	}
+}
+
 func (s *ShowCredentialSuite) TestShowCredentialBadArgs(c *gc.C) {
-	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
 	_, err := cmdtesting.RunCommand(c, cmd, "cloud")
 	c.Assert(err, gc.ErrorMatches, "both cloud and credential name are needed")
 	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "credential", "extra")
@@ -41,30 +72,36 @@ func (s *ShowCredentialSuite) TestShowCredentialBadArgs(c *gc.C) {
 
 func (s *ShowCredentialSuite) TestShowCredentialAPIVersion(c *gc.C) {
 	s.api.v = 1
-	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
 	ctx, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "credential content lookup is not supported by this version of Juju\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+remote credential content lookup failed: remote credential content lookup in Juju v1 not supported
+No local or remote credentials to display.
+`[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	s.api.CheckCallNames(c, "BestAPIVersion", "Close")
 }
 
 func (s *ShowCredentialSuite) TestShowCredentialAPICallError(c *gc.C) {
 	s.api.SetErrors(errors.New("boom"), nil)
-	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
 	ctx, err := cmdtesting.RunCommand(c, cmd)
-	c.Assert(err, gc.ErrorMatches, "boom")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Getting credential content failed with: boom\n")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+remote credential content lookup failed: boom
+No local or remote credentials to display.
+`[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
 }
 
 func (s *ShowCredentialSuite) TestShowCredentialNone(c *gc.C) {
 	s.api.contents = []params.CredentialContentResult{}
-	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
 	ctx, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No credential to display\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No local or remote credentials to display.\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
 }
@@ -91,11 +128,12 @@ func (s *ShowCredentialSuite) TestShowCredentialOne(c *gc.C) {
 			},
 		},
 	}
-	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
 	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ``)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+local-credentials: {}
 controller-credentials:
   aws:
     credential-name:
@@ -114,6 +152,8 @@ controller-credentials:
 }
 
 func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
+	_true := true
+	_false := false
 	s.api.contents = []params.CredentialContentResult{
 		{
 			Result: &params.ControllerCredentialInfo{
@@ -121,6 +161,7 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 					Cloud:      "cloud-name",
 					Name:       "one",
 					AuthType:   "userpass",
+					Valid:      &_true,
 					Attributes: map[string]string{"username": "fred"},
 				},
 				// Don't have models here.
@@ -133,6 +174,7 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 					Cloud:    "cloud-name",
 					Name:     "two",
 					AuthType: "userpass",
+					Valid:    &_false,
 					Attributes: map[string]string{
 						"username":  "fred",
 						"something": "visible-attr",
@@ -152,6 +194,7 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 					Cloud:    "diff-cloud",
 					Name:     "three",
 					AuthType: "oauth1",
+					Valid:    &_true,
 					Attributes: map[string]string{
 						"something": "visible-attr",
 					},
@@ -162,19 +205,19 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 			},
 		},
 	}
-	cmd := cloud.NewShowCredentialCommandForTest(s.api)
+	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
 	ctx, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "boom\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+local-credentials: {}
 controller-credentials:
   cloud-name:
     one:
       content:
         auth-type: userpass
-        validity-check: invalid
+        validity-check: valid
         username: fred
-      models: {}
     two:
       content:
         auth-type: userpass
@@ -191,7 +234,7 @@ controller-credentials:
     three:
       content:
         auth-type: oauth1
-        validity-check: invalid
+        validity-check: valid
         something: visible-attr
       models:
         klmmodel: write

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -188,6 +188,7 @@ func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+local-credentials: {}
 controller-credentials:
   dummy:
     cred:
@@ -203,8 +204,9 @@ controller-credentials:
 func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
 	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "local credential content lookup failed: loading credentials: credentials for cloud dummy not found\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+local-credentials: {}
 controller-credentials:
   dummy:
     cred:


### PR DESCRIPTION
## Description of change

'show-credential' displayed details of the credentials stored remotely on the controller. This PR adjust the command to display details of locally stored credentials too. 

## QA steps

* 'juju show-credentials' shows both locally and remotely stored credentials (use -c to display credentials from controller other than current) for logged on user;
* 'juju-show-credentials --local' shows only local credentials
* 'juju show-credentials <cloud name> <credential name>' shows details of local and remote credential with name <credential name> for cloud with name <cloud name>. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1786862
and part of solution for  https://bugs.launchpad.net/juju/+bug/1814395
