### PR TITLE
Allow more than 11 EBS volumes to be allocated to an AWS EC2 instances

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -995,7 +995,7 @@ func blockDeviceNamer(numbers bool) func() (requestName, actualName string, err 
 		// deviceLetterMin is the first letter to use for EBS block device names.
 		deviceLetterMin = 'f'
 		// deviceLetterMax is the last letter to use for EBS block device names.
-		deviceLetterMax = 'p'
+		deviceLetterMax = 'z'
 		// deviceNumMax is the maximum value for trailing numbers on block device name.
 		deviceNumMax = 6
 	)

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -1114,6 +1114,16 @@ func (*blockDeviceMappingSuite) TestBlockDeviceNamer(c *gc.C) {
 	expect("/dev/sdn", "xvdn")
 	expect("/dev/sdo", "xvdo")
 	expect("/dev/sdp", "xvdp")
+	expect("/dev/sdq", "xvdq")
+	expect("/dev/sdr", "xvdr")
+	expect("/dev/sds", "xvds")
+	expect("/dev/sdt", "xvdt")
+	expect("/dev/sdu", "xvdu")
+	expect("/dev/sdv", "xvdv")
+	expect("/dev/sdw", "xvdw")
+	expect("/dev/sdx", "xvdx")
+	expect("/dev/sdy", "xvdy")
+	expect("/dev/sdz", "xvdz")
 	expectErr("too many EBS volumes to attach")
 
 	// Now with numbers.
@@ -1134,6 +1144,16 @@ func (*blockDeviceMappingSuite) TestBlockDeviceNamer(c *gc.C) {
 	expectN("/dev/sdn", "xvdn")
 	expectN("/dev/sdo", "xvdo")
 	expectN("/dev/sdp", "xvdp")
+	expectN("/dev/sdq", "xvdq")
+	expectN("/dev/sdr", "xvdr")
+	expectN("/dev/sds", "xvds")
+	expectN("/dev/sdt", "xvdt")
+	expectN("/dev/sdu", "xvdu")
+	expectN("/dev/sdv", "xvdv")
+	expectN("/dev/sdw", "xvdw")
+	expectN("/dev/sdx", "xvdx")
+	expectN("/dev/sdy", "xvdy")
+	expectN("/dev/sdz", "xvdz")
 	expectErr("too many EBS volumes to attach")
 }
 


### PR DESCRIPTION
## Description of change

Juju currently puts on an artificial limit on the number of volumes that may be attached to an instance. From the bug report:

> The EBS volume provider currently limits each machine to a maximum of 
> 11 volume attachments, because it follows the AWS recommendation of 
> naming block devices in the range xvdf-xvdp. It is permissible to use 
> xvdf-xvdz, and it's not clear why those names are not recommended for use.
> 
> We should not artificially limit them, and just let the AWS APIs complain if there's an issue.

## QA steps

* bootstrap to AWS
* provision >11 storage volumes
* check `juju status --storage`, all storage units should have the status "attached"

## Documentation changes

None. 

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1517474
