### PR TITLE
2.6 Fixes Uniter Deployment Errors for Subordinates

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -840,7 +840,7 @@ func (u *UniterAPI) waitForCacheUnit(tag names.UnitTag, condition func(cu cache.
 			return errors.New("timed out waiting for change to be reflected in cache")
 		default:
 			cu, err := u.getCacheUnit(tag)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 			if condition(cu) {

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -126,7 +126,7 @@ func (m *Model) Branch(name string) (Branch, error) {
 			return b.copy(), nil
 		}
 	}
-	return Branch{}, errors.NotFoundf("branch %q", name)
+	return Branch{}, errors.NotFoundf("cached branch %q", name)
 }
 
 // Application returns the application for the input name.
@@ -136,7 +136,7 @@ func (m *Model) Application(appName string) (Application, error) {
 
 	app, found := m.applications[appName]
 	if !found {
-		return Application{}, errors.NotFoundf("application %q", appName)
+		return Application{}, errors.NotFoundf("cached application %q", appName)
 	}
 	return app.copy(), nil
 }
@@ -161,7 +161,7 @@ func (m *Model) Unit(unitName string) (Unit, error) {
 
 	unit, found := m.units[unitName]
 	if !found {
-		return Unit{}, errors.NotFoundf("unit %q", unitName)
+		return Unit{}, errors.NotFoundf("cached unit %q", unitName)
 	}
 	return unit.copy(), nil
 }
@@ -186,7 +186,7 @@ func (m *Model) Machine(machineId string) (Machine, error) {
 
 	machine, found := m.machines[machineId]
 	if !found {
-		return Machine{}, errors.NotFoundf("machine %q", machineId)
+		return Machine{}, errors.NotFoundf("cached machine %q", machineId)
 	}
 	return machine.copy(), nil
 }
@@ -198,14 +198,14 @@ func (m *Model) Charm(charmURL string) (Charm, error) {
 
 	charm, found := m.charms[charmURL]
 	if !found {
-		return Charm{}, errors.NotFoundf("charm %q", charmURL)
+		return Charm{}, errors.NotFoundf("cached charm %q", charmURL)
 	}
 	return charm.copy(), nil
 }
 
 // WatchMachines returns a PredicateStringsWatcher to notify about
-// added and removed machines in the model.  The initial event contains
-// a slice of the current machine ids.  Containers are excluded.
+// added and removed machines in the model. The initial event contains
+// a slice of the current machine ids. Containers are excluded.
 func (m *Model) WatchMachines() (*PredicateStringsWatcher, error) {
 	defer m.doLocked()()
 

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -116,7 +116,7 @@ func (opc *operationCallbacks) GetArchiveInfo(charmURL *corecharm.URL) (charm.Bu
 
 // SetCurrentCharm is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) SetCurrentCharm(charmURL *corecharm.URL) error {
-	return opc.u.unit.SetCharmURL(charmURL)
+	return errors.Annotate(opc.u.unit.SetCharmURL(charmURL), "setting charm URL")
 }
 
 // SetExecutingStatus is part of the operation.Callbacks interface.

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -592,7 +592,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 			Installed: true,
 		}
 		if err := u.unit.SetCharmURL(charmURL); err != nil {
-			return errors.Trace(err)
+			return errors.Annotate(err, "setting charm URL")
 		}
 	}
 	operationExecutor, err := u.newOperationExecutor(u.paths.State.OperationsFile, initialState, u.acquireExecutionLock)


### PR DESCRIPTION
## Description of change

This patch fixes intermittent errors observed in the field when subordinate charms are deployed.

Subordinates in particular can arrive at a situation where they are deploying units that have not arrived in the cache at all. This patch does not error on `NotFound` errors when ensuring cache coherence for unit charm URL.

Included are some error message enhancements.

#### Note that originally I had other changes accompanying this patch that allowed fall-back to state implementations for unit config settings retrieval and watching, but this appears to be the effective change. I will discuss/propose those separately.
See https://github.com/juju/juju/pull/10430 for those changes.

## QA steps

Apply this patch on top of the branch:
```
diff --git a/core/cache/model.go b/core/cache/model.go
index 9b350219e6..177b823308 100644
--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -7,6 +7,7 @@ import (
        "fmt"
        "regexp"
        "sync"
+       "time"

        "github.com/juju/errors"
        "github.com/juju/pubsub"
@@ -246,6 +247,8 @@ func (m *Model) updateApplication(ch ApplicationChange, rm *residentManager) {
        if !found {
                app = newApplication(m.metrics, m.hub, rm.new())
                m.applications[ch.Name] = app
+       } else {
+               time.Sleep(5 * time.Second)
        }
        app.setDetails(ch)
```
- Bootstrap.
- `juju deploy ubuntu -n 5`.
- `juju deploy telegraf --config flush_interval=5s`.
- `juju add-relation ubuntu telegraf`.
- Observe all telegraf units reach the deployed state.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1835374
