### PR TITLE
2.6 Revert Uniter Cache Usage

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -543,28 +543,22 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	wc := watchertest.NewStringsWatcherC(c, w, s.BackingState.StartSync)
 	defer wc.AssertStops()
 
+	// Initial event - this is the sha-256 hash of an empty bson.D.
 	// See core/cache/hash.go for the hash implementation.
-	// This is a hash of the charm URL PLUS an empty map[string]interface{}.
-	wc.AssertChange("0affda4fb1eaa8df870459625aa93c85e9fd6fc5374ac69f509575d139032262")
+	wc.AssertChange("e8d7e8dfff0eed1e77b15638581672f7b25ecc1163cc5fd5a52d29d51d096c00")
 
 	err = s.wordpressApplication.UpdateCharmConfig(model.GenerationMaster, charm.Settings{
 		"blog-title": "sauceror central",
 	})
 
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.Model.UUID())
-
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange("bfeb5aee52e6dea59d9c2a0c35a4d7fffa690c7230b1dd66f16832e4094905ae")
+	wc.AssertChange("7ed6151e9c3d5144faf0946d20c283c466b4885dded6a6122ff3fdac7ee2334f")
 
 	// Non-change is not reported.
 	err = s.wordpressApplication.UpdateCharmConfig(model.GenerationMaster, charm.Settings{
 		"blog-title": "sauceror central",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	wc.AssertNoChange()
 }

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -544,7 +544,6 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	defer wc.AssertStops()
 
 	// Initial event - this is the sha-256 hash of an empty bson.D.
-	// See core/cache/hash.go for the hash implementation.
 	wc.AssertChange("e8d7e8dfff0eed1e77b15638581672f7b25ecc1163cc5fd5a52d29d51d096c00")
 
 	err = s.wordpressApplication.UpdateCharmConfig(model.GenerationMaster, charm.Settings{

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -522,9 +522,6 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.Model.UUID())
-
 	settings, err = s.apiUnit.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, charm.Settings{

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -51,9 +51,6 @@ func (s *uniterGoalStateSuite) SetUpTest(c *gc.C) {
 		Charm: loggingCharm,
 	})
 
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming the MySQL unit has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2777,8 +2777,6 @@ func (u *UniterAPI) goalStateUnits(app *state.Application, principalName string)
 // save this hash and use it to decide whether the config-changed hook
 // needs to be run (or whether this was just an agent restart with no
 // substantive config change).
-// TODO (manadart 2019-06-24): When other hash watchers are moved from state
-// over to the model cache, they can all share the `watchHashes` abstraction.
 func (u *UniterAPI) WatchConfigSettingsHash(args params.Entities) (params.StringsWatchResults, error) {
 	result := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
@@ -2794,13 +2792,13 @@ func (u *UniterAPI) WatchConfigSettingsHash(args params.Entities) (params.String
 			continue
 		}
 
-		unit, err := u.getCacheUnit(tag)
+		unit, err := u.getUnit(tag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
 
-		w, err := unit.WatchConfigSettings()
+		w, err := unit.WatchConfigSettingsHash()
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1062,8 +1062,8 @@ func (u *UniterAPI) ConfigSettings(args params.Entities) (params.ConfigSettingsR
 		}
 		err = common.ErrPerm
 		if canAccess(tag) {
-			var unit cache.Unit
-			unit, err = u.getCacheUnit(tag)
+			var unit *state.Unit
+			unit, err = u.getUnit(tag)
 			if err == nil {
 				var settings charm.Settings
 				settings, err = unit.ConfigSettings()

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -68,9 +68,6 @@ func (s *uniterSuiteBase) SetUpTest(c *gc.C) {
 
 	s.setupState(c)
 
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-
 	// Create a FakeAuthorizer so we can check permissions,
 	// set up assuming the wordpress unit has logged in.
 	s.authorizer = apiservertesting.FakeAuthorizer{
@@ -169,9 +166,6 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.State, *state.CAAS
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, m.UUID())
 
 	apiInfo, err := environs.APIInfo(
 		context.NewCloudCallContext(),
@@ -1043,9 +1037,6 @@ func (s *uniterSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "unit-mysql-0"},
 		{Tag: "unit-wordpress-0"},
@@ -1058,8 +1049,7 @@ func (s *uniterSuite) TestWatchConfigSettingsHash(c *gc.C) {
 			{Error: apiservertesting.ErrUnauthorized},
 			{
 				StringsWatcherId: "1",
-				// See core/cache/hash.go for the hash implementation.
-				Changes: []string{"754ed70cf17d2df2cc6a2dcb6cbfcb569a8357b97b5708e7a7ca0409505e1d0b"},
+				Changes:          []string{"af35e298300150f2c357b4a1c40c1109bde305841c6343113b634b9dada22d00"},
 			},
 			{Error: apiservertesting.ErrUnauthorized},
 		},
@@ -1248,9 +1238,6 @@ func (s *uniterSuite) TestWatchActionNotificationsPermissionDenied(c *gc.C) {
 func (s *uniterSuite) TestConfigSettings(c *gc.C) {
 	err := s.wordpressUnit.SetCharmURL(s.wpCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
-
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	settings, err := s.wordpressUnit.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3384,9 +3371,6 @@ func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
 		Machine:     s.machine1,
 	})
 
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-
 	// Create the resource registry separately to track invocations to register.
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
@@ -4202,9 +4186,6 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 
 	c.Assert(wp.Refresh(), jc.ErrorIsNil)
 	c.Assert(wpUnit.Refresh(), jc.ErrorIsNil)
-
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	args := params.NetworkInfoParams{
 		Unit:     wpUnit.Tag().String(),

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -152,10 +152,6 @@ func (s *ApplicationConfigSuite) TestConfigNoValueSingleSetting(c *gc.C) {
 }
 
 func (s *ApplicationConfigSuite) assertSameConfigOutput(c *gc.C, expectedValues settingsMap) {
-	// Let the model settle to ensure cache population.
-	s.State.StartSync()
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-
 	s.assertJujuConfigOutput(c, s.configCommandOutput(c, s.appName), expectedValues)
 	s.assertHookOutput(c, s.getHookOutput(c), expectedValues)
 }


### PR DESCRIPTION
## Description of change

This patch reverts changes that made uniter operations dependent on the model cache. In particular:
- Setting unit charm URL does not wait for the change to materialise in the cache.
- Configuration settings are retrieved from state instead of the cache.
- The configuration settings hash watcher watches state instead of the cache.

Various test synchronisation points made necessary by this original changes have also been reverted.

## QA steps

The errors in the linked bug are rectified. Subordinate units are deployed without error.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1835374
