### PR TITLE
Require a subscription ID for Azure during add-credential when there are multiple accounts

### DIFF
--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -61,10 +61,9 @@ func (c environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud
 	interactiveSchema := cloud.CredentialSchema{{
 		credAttrSubscriptionId, cloud.CredentialAttr{Description: "Azure subscription ID"},
 	}}
-	if _, err := c.azureCLI.ShowAccount(""); err == nil {
-		// If az account show returns successfully then we can
-		// use that to get at least some login details, otherwise
-		// we need the user to supply their subscription ID.
+
+	accounts, err := c.azureCLI.ListAccounts()
+	if err == nil && len(accounts) == 1 {
 		interactiveSchema[0].CredentialAttr.Optional = true
 	}
 	return map[cloud.AuthType]cloud.CredentialSchema{


### PR DESCRIPTION
> NOTE
>
> Acceptance tests not yet updated. Pending discussion.

When users have more than one Azure subscription, Juju can associate the wrong one to a cloud during add-credential. Rather than making people use `az set --subscription <id>`, then `juju add-credential azure`, we make subscription ID compulsory when we detect that the user has multiple accounts.  

## QA steps

* Create multiple Azure subscriptions
* Run `az account list --refresh`
* Run `juju add-credential azure`

Subscription-id is now required by the interactive session. Example output:

> $ juju add-credential azure
> Enter credential name: test
>
> Auth Types
>   interactive
>   service-principal-secret
> 
> Select auth type [interactive]: 
> 
> Enter subscription-id: 


## Documentation changes

Check Azure docs.

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1829909