### PR TITLE
Update run-action CLI text

### DIFF
--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -62,7 +62,7 @@ If the leader syntax is used, the leader unit for the application will be
 resolved before the action is enqueued.
 
 Many actions take parameters. Params can be supplied as a YAML file or as 
-arguments on the command line. Specify a file with the --params <params.yaml>.
+arguments on the command line. Specify a file with --params <params.yaml>.
 Arguments directly on the command line use a <key>=<value> syntax. Nested keys 
 require dots as a delimiter: <key1>.<key2>.<key3>=<value> (See examples below)
 


### PR DESCRIPTION
Grammar/style improvements. Make style consistent with other docs.
Explain --wait option. Add explanations for each of the examples. Link
to web documentation.

## QA steps

* Run `juju help run-action`

## Documentation changes

-

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1835962