### PR TITLE
Move DefaultSpaceName to "core" Package

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2161,7 +2161,7 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 			defaultIngressAddresses = append(defaultIngressAddresses, a.Value)
 		}
 		networkInfos = make(map[string]state.MachineNetworkInfoResult)
-		networkInfos[environs.DefaultSpaceName] = state.MachineNetworkInfoResult{
+		networkInfos[corenetwork.DefaultSpaceName] = state.MachineNetworkInfoResult{
 			NetworkInfos: []network.NetworkInfo{{Addresses: interfaceAddr}},
 		}
 	}

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
@@ -467,7 +468,7 @@ func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.Appli
 			if result.Bindings == nil {
 				result.Bindings = make(map[string]string)
 			}
-			result.Bindings[ep.Name] = environs.DefaultSpaceName
+			result.Bindings[ep.Name] = network.DefaultSpaceName
 		}
 		spaceNames.Add(spaceName)
 	}
@@ -524,7 +525,7 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceNames []string) (m
 	results := make(map[string]params.RemoteSpace)
 	for _, name := range spaceNames {
 		space := environs.DefaultSpaceInfo
-		if name != environs.DefaultSpaceName {
+		if name != network.DefaultSpaceName {
 			dbSpace, err := backend.Space(name)
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
@@ -84,7 +85,7 @@ type mockEnviron struct {
 
 func (e *mockEnviron) ProviderSpaceInfo(ctx context.ProviderCallContext, space *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	e.stub.MethodCall(e, "ProviderSpaceInfo", space)
-	spaceName := environs.DefaultSpaceName
+	spaceName := corenetwork.DefaultSpaceName
 	if space != nil {
 		spaceName = space.Name
 	}

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+const (
+	// DefaultSpaceId is the ID of the default network space.
+	// Application endpoints are bound to this space by default
+	// if no explicit binding is specified.
+	DefaultSpaceId = "0"
+
+	// DefaultSpaceName is the name of the default network space.
+	DefaultSpaceName = ""
+)

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -21,11 +21,6 @@ var SupportsNetworking = supportsNetworking
 // to get information about the default space.
 var DefaultSpaceInfo *network.SpaceInfo
 
-// TODO (manadart 2019-07-03): Move this to core.
-// DefaultSpaceName is the name of the default space (to which
-// application endpoints are bound if no explicit binding is given).
-const DefaultSpaceName = ""
-
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/environs"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/mongo/utils"
 )
 
@@ -111,7 +111,7 @@ func mergeBindings(newMap, oldMap map[string]string, meta *charm.Meta) (map[stri
 
 		updated[key] = effectiveValue
 	}
-	if defaultBinding != environs.DefaultSpaceName {
+	if defaultBinding != network.DefaultSpaceName {
 		updated[defaultEndpointName] = defaultBinding
 	}
 
@@ -276,7 +276,7 @@ func validateEndpointBindingsForCharm(st *State, bindings map[string]string, cha
 		if endpoint != defaultEndpointName && !endpointsNamesSet.Contains(endpoint) {
 			return errors.NotValidf("unknown endpoint %q", endpoint)
 		}
-		if space != environs.DefaultSpaceName && !spacesNamesSet.Contains(space) {
+		if space != network.DefaultSpaceName && !spacesNamesSet.Contains(space) {
 			return errors.NotValidf("unknown space %q", space)
 		}
 	}
@@ -290,10 +290,10 @@ func DefaultEndpointBindingsForCharm(charmMeta *charm.Meta) map[string]string {
 	allRelations := charmMeta.CombinedRelations()
 	bindings := make(map[string]string, len(allRelations)+len(charmMeta.ExtraBindings))
 	for name := range allRelations {
-		bindings[name] = environs.DefaultSpaceName
+		bindings[name] = network.DefaultSpaceName
 	}
 	for name := range charmMeta.ExtraBindings {
-		bindings[name] = environs.DefaultSpaceName
+		bindings[name] = network.DefaultSpaceName
 	}
 	return bindings
 }

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -138,7 +138,7 @@ func (addr *Address) DeviceName() string {
 	return addr.doc.DeviceName
 }
 
-// Device returns the LinkLayeyDevice this IP address is assigned to.
+// Device returns the LinkLayerDevice this IP address is assigned to.
 func (addr *Address) Device() (*LinkLayerDevice, error) {
 	return addr.machineProxy().LinkLayerDevice(addr.doc.DeviceName)
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/juju/core/network"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/description"
 	"github.com/juju/errors"
@@ -17,7 +19,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/resource"
@@ -1123,7 +1124,7 @@ func (e *exporter) spaces() error {
 		// We do not export the default space because it is created by default
 		// with the new model. This is OK, because it is immutable.
 		// Any subnets added to the space will still be exported.
-		if space.Name() == environs.DefaultSpaceName {
+		if space.Name() == network.DefaultSpaceName {
 			continue
 		}
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -21,8 +21,8 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/payload"
@@ -1239,7 +1239,7 @@ func (i *importer) spaces() error {
 	for _, s := range i.model.Spaces() {
 		// The default space should not have been exported, but be defensive.
 		// Any subnets added to the space will be imported subsequently.
-		if s.Name() == environs.DefaultSpaceName {
+		if s.Name() == corenetwork.DefaultSpaceName {
 			continue
 		}
 

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/environs"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
@@ -335,7 +335,7 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the default model was created.
-	_, err = st.Space(environs.DefaultSpaceName)
+	_, err = st.Space(corenetwork.DefaultSpaceName)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -20,7 +20,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/environs"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 )
 
@@ -641,7 +641,7 @@ func NetworksForRelation(
 	// If the endpoint for this relation is not bound to a space, or
 	// is bound to the default space, we need to look up the ingress
 	// address info which is aware of cross model relations.
-	if boundSpace == environs.DefaultSpaceName || err != nil {
+	if boundSpace == corenetwork.DefaultSpaceName || err != nil {
 		_, crossmodel, err := rel.RemoteApplication()
 		if err != nil {
 			return "", nil, nil, errors.Trace(err)

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/environs"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 )
 
@@ -301,9 +301,9 @@ func createDefaultSpaceOp() txn.Op {
 		C:  spacesC,
 		Id: "0",
 		Insert: spaceDoc{
-			Id:       "0",
+			Id:       corenetwork.DefaultSpaceId,
 			Life:     Alive,
-			Name:     environs.DefaultSpaceName,
+			Name:     corenetwork.DefaultSpaceName,
 			IsPublic: true,
 		},
 	}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/environs"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
@@ -412,7 +412,7 @@ func (s *SpacesSuite) assertInvalidSpaceNameErrorAndWasNotAdded(c *gc.C, err err
 
 	// The default space will be present, although we cannot add it.
 	// Only check non-default names.
-	if name != environs.DefaultSpaceName {
+	if name != corenetwork.DefaultSpaceName {
 		s.assertSpaceNotFound(c, name)
 	}
 }

--- a/state/spacesdiscovery_test.go
+++ b/state/spacesdiscovery_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
@@ -196,7 +197,7 @@ func checkSpacesEqual(c *gc.C, spaces []*state.Space, spaceInfos []network.Space
 	// Filter out the default space for comparisons.
 	filtered := spaces[:0]
 	for _, s := range spaces {
-		if s.Name() != environs.DefaultSpaceName {
+		if s.Name() != corenetwork.DefaultSpaceName {
 			filtered = append(filtered, s)
 		}
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs"
 	mgoutils "github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/presence"
@@ -3205,8 +3204,8 @@ func (u *Unit) GetSpaceForBinding(bindingName string) (string, error) {
 	boundSpace, known := bindings[bindingName]
 	if !known {
 		// If default binding is not explicitly defined we'll use default space
-		if bindingName == environs.DefaultSpaceName {
-			return environs.DefaultSpaceName, nil
+		if bindingName == corenetwork.DefaultSpaceName {
+			return corenetwork.DefaultSpaceName, nil
 		}
 		return "", errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", bindingName))
 	}


### PR DESCRIPTION
## Description of change

This patch is a mechanical change to move `environs.DefaultSpaceName` into the `core/network` package. It also adds `DefaultSpaceId`.

Depends on #10422. Change is in last commit.

## QA steps

Build and unit tests green.

## Documentation changes

None.

## Bug reference

N/A
