### PR TITLE
Add-credential customisable region and individual adds with file.

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -39,7 +39,7 @@ formatted YAML-formatted file. Details of the format are provided at
 
 The ` + "`--replace`" + ` option is required if credential information 
 for the named cloud already exists locally. All such information will be 
-overwritten.
+overwritten. This option is DEPRECATED, use 'juju update-credential' instead.
 
 About credentials.yaml:
 Here is a sample credentials.yaml showing four credentials being stored 
@@ -84,7 +84,6 @@ multiple credentials.
 Examples:
     juju add-credential google
     juju add-credential aws -f ~/credentials.yaml
-    juju add-credential aws --replace -f ~/credentials.yaml
 
 Notes:
 If you are setting up Juju for the first time, consider running
@@ -122,6 +121,9 @@ type addCredentialCommand struct {
 	CredentialsFile string
 
 	cloud *jujucloud.Cloud
+
+	// Region is the region that credentials will be validated for before an update.
+	Region string
 }
 
 // NewAddCredentialCommand returns a command to add credential information.
@@ -145,6 +147,7 @@ func (c *addCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
 	f.BoolVar(&c.Replace, "replace", false, "Overwrite existing credential information")
 	f.StringVar(&c.CredentialsFile, "f", "", "The YAML file containing credentials to add")
+	f.StringVar(&c.Region, "region", "", "Cloud region that credential is valid for")
 }
 
 func (c *addCredentialCommand) Init(args []string) (err error) {
@@ -156,6 +159,11 @@ func (c *addCredentialCommand) Init(args []string) (err error) {
 }
 
 func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
+	if c.Replace {
+		// TODO (anastasiamac 2019-07-10) --replace and everything related to it should be removed.
+		// https://bugs.launchpad.net/juju/+bug/1821279
+		ctxt.Warningf("--replace is DEPRECATED. Use 'juju update-credential' to update credentials.")
+	}
 	// Check that the supplied cloud is valid.
 	var err error
 	if c.cloud, err = common.CloudOrProvider(c.CloudName, c.cloudByNameFunc); err != nil {
@@ -174,10 +182,23 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	schemas := credentialsProvider.CredentialSchemas()
-	if c.CredentialsFile == "" {
-		return c.interactiveAddCredential(ctxt, schemas)
+	existingCredentials, err := c.existingCredentialsForCloud()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if c.Region != "" {
+		if err := ValidCloudRegion(c.cloud, c.Region); err != nil {
+			return err
+		}
 	}
 
+	if c.CredentialsFile == "" {
+		return c.interactiveAddCredential(ctxt, schemas, existingCredentials)
+	}
+
+	if c.Region == "" {
+		c.Region = existingCredentials.DefaultRegion
+	}
 	data, err := ioutil.ReadFile(c.CredentialsFile)
 	if err != nil {
 		return errors.Annotate(err, "reading credentials file")
@@ -190,14 +211,6 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 	credentials, ok := specifiedCredentials[c.CloudName]
 	if !ok {
 		return errors.Errorf("no credentials for cloud %s exist in file %s", c.CloudName, c.CredentialsFile)
-	}
-	existingCredentials, err := c.existingCredentialsForCloud()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	// If there are *any* credentials already for the cloud, we'll ask for the --replace flag.
-	if !c.Replace && len(existingCredentials.AuthCredentials) > 0 && len(credentials.AuthCredentials) > 0 {
-		return errors.Errorf("local credentials for cloud %q already exist; use --replace to overwrite / merge", c.CloudName)
 	}
 
 	// We could get a duplicate "interactive" entry for the validAuthType() call,
@@ -216,19 +229,22 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 		return false
 	}
 
+	provider, err := environs.Provider(c.cloud.Type)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	var allNames []string
 	for name, cred := range credentials.AuthCredentials {
 		if !names.IsValidCloudCredentialName(name) {
 			return errors.Errorf("%q is not a valid credential name", name)
 		}
 
+		if _, ok := existingCredentials.AuthCredentials[name]; ok {
+			ctxt.Warningf("credential %q for cloud %q already exists locally, use 'juju update-credential %v %v' to update it", name, c.CloudName, c.CloudName, name)
+			continue
+		}
 		if !validAuthType(cred.AuthType()) {
 			return errors.Errorf("credential %q contains invalid auth type %q, valid auth types for cloud %q are %v", name, cred.AuthType(), c.CloudName, c.cloud.AuthTypes)
-		}
-
-		provider, err := environs.Provider(c.cloud.Type)
-		if err != nil {
-			return errors.Trace(err)
 		}
 
 		// When in non-interactive mode we still sometimes want to finalize a
@@ -236,25 +252,26 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 		// bootstrap happens or improve security models, where by we remove any
 		// shared/secret passwords (lxd remote security).
 		// This is optional and is backwards compatible with other providers.
-		if shouldFinalizeCredential(provider, cred) {
-			newCredential, err := c.finalizeProvider(ctxt, cred.AuthType(), cred.Attributes())
+		if ShouldFinalizeCredential(provider, cred) {
+			newCredential, err := FinalizeProvider(ctxt, c.cloud, c.Region, existingCredentials.DefaultRegion, cred.AuthType(), cred.Attributes())
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Errorf("Could not verify credential %v for cloud %v locally: %v", name, c.CloudName, err)
 			}
 			cred = *newCredential
 		}
+
 		existingCredentials.AuthCredentials[name] = cred
 		allNames = append(allNames, name)
+	}
+	if len(allNames) == 0 {
+		fmt.Fprintf(ctxt.Stdout, "No local credentials for cloud %q changed.\n", c.CloudName)
+		return nil
 	}
 	err = c.store.UpdateCredential(c.CloudName, *existingCredentials)
 	if err != nil {
 		return err
 	}
-	verb := "added"
-	if c.Replace {
-		verb = "updated"
-	}
-	fmt.Fprintf(ctxt.Stdout, "Credentials %q %v for cloud %q.\n", strings.Join(allNames, ", "), verb, c.CloudName)
+	fmt.Fprintf(ctxt.Stdout, "Credentials %q added locally for cloud %q.\n", strings.Join(allNames, ", "), c.CloudName)
 	return nil
 }
 
@@ -271,7 +288,7 @@ func (c *addCredentialCommand) existingCredentialsForCloud() (*jujucloud.CloudCr
 	return existingCredentials, nil
 }
 
-func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schemas map[jujucloud.AuthType]jujucloud.CredentialSchema) error {
+func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schemas map[jujucloud.AuthType]jujucloud.CredentialSchema, existingCredentials *jujucloud.CloudCredential) error {
 	errout := interact.NewErrWriter(ctxt.Stdout)
 	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, errout)
 
@@ -280,11 +297,6 @@ func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schem
 		return err
 	}
 
-	// Prompt to overwrite if needed.
-	existingCredentials, err := c.existingCredentialsForCloud()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	verb := "added"
 	if _, ok := existingCredentials.AuthCredentials[credentialName]; ok {
 		fmt.Fprint(ctxt.Stdout, fmt.Sprintf("A credential %q already exists locally on this client.\n", credentialName))
@@ -311,6 +323,11 @@ func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schem
 			authTypeNames = append(authTypeNames, jujucloud.InteractiveAuthType)
 		}
 	}
+
+	err = c.promptCloudRegion(pollster, existingCredentials, ctxt.Stdout)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	authType, err := c.promptAuthType(pollster, authTypeNames, ctxt.Stdout)
 	if err != nil {
 		return errors.Trace(err)
@@ -325,7 +342,7 @@ func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schem
 		return errors.Trace(err)
 	}
 
-	newCredential, err := c.finalizeProvider(ctxt, authType, attrs)
+	newCredential, err := FinalizeProvider(ctxt, c.cloud, c.Region, existingCredentials.DefaultRegion, authType, attrs)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -339,26 +356,31 @@ func (c *addCredentialCommand) interactiveAddCredential(ctxt *cmd.Context, schem
 	return nil
 }
 
-func (c *addCredentialCommand) finalizeProvider(ctxt *cmd.Context, authType jujucloud.AuthType, attrs map[string]string) (*jujucloud.Credential, error) {
-	cloudEndpoint := c.cloud.Endpoint
-	cloudStorageEndpoint := c.cloud.StorageEndpoint
-	cloudIdentityEndpoint := c.cloud.IdentityEndpoint
-	if len(c.cloud.Regions) > 0 {
-		// NOTE(axw) we use the first region in the cloud,
-		// because this is all we need for Azure right now.
-		// Each region has the same endpoints, so it does
-		// not matter which one we use. If we expand
-		// credential generation to other providers, and
-		// they do have region-specific endpoints, then we
-		// should prompt the user for the region to use.
-		// That would be better left to the provider, though.
-		region := c.cloud.Regions[0]
+func FinalizeProvider(ctxt *cmd.Context, cloud *jujucloud.Cloud, regionName, defaultRegion string, authType jujucloud.AuthType, attrs map[string]string) (*jujucloud.Credential, error) {
+	cloudEndpoint := cloud.Endpoint
+	cloudStorageEndpoint := cloud.StorageEndpoint
+	cloudIdentityEndpoint := cloud.IdentityEndpoint
+	if len(cloud.Regions) > 0 {
+		// For some providers we must have a region to construct a valid credential, for e.g. azure.
+		// If a region was specified by the user, we'd use it;
+		// otherwise, we'd use default region if one is set or, if not, the first region.
+		if regionName == "" {
+			regionName = defaultRegion
+		}
+		region := cloud.Regions[0]
+		if regionName != "" {
+			for _, r := range cloud.Regions {
+				if r.Name == regionName {
+					region = r
+				}
+			}
+		}
 		cloudEndpoint = region.Endpoint
 		cloudStorageEndpoint = region.StorageEndpoint
 		cloudIdentityEndpoint = region.IdentityEndpoint
 	}
 
-	credentialsProvider, err := environs.Provider(c.cloud.Type)
+	credentialsProvider, err := environs.Provider(cloud.Type)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -386,6 +408,42 @@ func (c *addCredentialCommand) promptCredentialName(p *interact.Pollster, out io
 	}
 
 	return credentialName, nil
+}
+
+func (c *addCredentialCommand) promptCloudRegion(p *interact.Pollster, existingCredentials *jujucloud.CloudCredential, out io.Writer) error {
+	regions := c.cloud.Regions
+	if len(regions) == 0 {
+		return nil
+	}
+	if c.Region != "" {
+		fmt.Fprintf(out, "User specified region %q, using it.\n\n", c.Region)
+		return nil
+	}
+	choices := make([]string, len(regions))
+	for i, r := range regions {
+		choices[i] = r.Name
+	}
+
+	def := "any region, credential is not region specific"
+	var err error
+	c.Region, err = p.SelectVerify(interact.List{
+		Singular: "region",
+		Plural:   "regions",
+		Options:  choices,
+		Default:  def,
+	}, func(value string) (ok bool, errmsg string, err error) {
+		if value == "" {
+			return true, "", nil
+		}
+		if regionErr := ValidCloudRegion(c.cloud, value); regionErr != nil {
+			return false, regionErr.Error(), nil
+		}
+		return true, "", nil
+	})
+	if c.Region == def {
+		c.Region = ""
+	}
+	return errors.Trace(err)
 }
 
 func (c *addCredentialCommand) promptAuthType(p *interact.Pollster, authTypes []jujucloud.AuthType, out io.Writer) (jujucloud.AuthType, error) {
@@ -523,9 +581,18 @@ func enterFile(name, descr string, p *interact.Pollster, expanded, optional bool
 	return string(contents), errors.Trace(err)
 }
 
-func shouldFinalizeCredential(provider environs.EnvironProvider, cred jujucloud.Credential) bool {
+func ShouldFinalizeCredential(provider environs.EnvironProvider, cred jujucloud.Credential) bool {
 	if finalizer, ok := provider.(environs.RequestFinalizeCredential); ok {
 		return finalizer.ShouldFinalizeCredential(cred)
 	}
 	return false
+}
+
+func ValidCloudRegion(aCloud *jujucloud.Cloud, region string) error {
+	for _, r := range aCloud.Regions {
+		if r.Name == region {
+			return nil
+		}
+	}
+	return errors.NotValidf("provided region %q for cloud %q", region, aCloud.Name)
 }

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -176,7 +176,7 @@ func (s *addCredentialSuite) TestAddInvalidRegionSpecified(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `provided region "someregion" for cloud "somecloud" not valid`)
 }
 
-func (s *addCredentialSuite) testCloudWithRegions(c *gc.C) {
+func (s *addCredentialSuite) setupCloudWithRegions(c *gc.C) {
 	s.authTypes = []jujucloud.AuthType{jujucloud.UserPassAuthType}
 	s.cloudByNameFunc = func(cloudName string) (*jujucloud.Cloud, error) {
 		return &jujucloud.Cloud{
@@ -211,19 +211,19 @@ credentials:
 }
 
 func (s *addCredentialSuite) TestAddWithFileRegionSpecified(c *gc.C) {
-	s.testCloudWithRegions(c)
+	s.setupCloudWithRegions(c)
 	args := []string{"somecloud", "-f", s.createFileForAddCredential(c)}
 	s.assertCredentialAdded(c, "", args, "specialregion", "specialregion")
 }
 
 func (s *addCredentialSuite) TestAddWithFileNoRegionSpecified(c *gc.C) {
-	s.testCloudWithRegions(c)
+	s.setupCloudWithRegions(c)
 	args := []string{"somecloud", "-f", s.createFileForAddCredential(c)}
 	s.assertCredentialAdded(c, "", args, "", "")
 }
 
 func (s *addCredentialSuite) TestAddInteractiveNoRegionSpecified(c *gc.C) {
-	s.testCloudWithRegions(c)
+	s.setupCloudWithRegions(c)
 	args := []string{"somecloud"}
 
 	ctxt := s.assertCredentialAdded(c, "fred\n\nuser\npassword\n", args, "", "")
@@ -245,7 +245,7 @@ Credential "fred" added locally for cloud "somecloud".
 }
 
 func (s *addCredentialSuite) TestAddInteractiveInvalidRegionEntered(c *gc.C) {
-	s.testCloudWithRegions(c)
+	s.setupCloudWithRegions(c)
 	args := []string{"somecloud"}
 
 	ctxt := s.assertCredentialAdded(c, "fred\nnotknownregion\n\nuser\npassword\n", args, "", "")
@@ -269,7 +269,7 @@ Credential "fred" added locally for cloud "somecloud".
 }
 
 func (s *addCredentialSuite) TestAddInteractiveRegionSpecified(c *gc.C) {
-	s.testCloudWithRegions(c)
+	s.setupCloudWithRegions(c)
 	args := []string{"somecloud"}
 
 	ctxt := s.assertCredentialAdded(c, "fred\nuser\npassword\n", args, "specialregion", "specialregion")

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
+var (
+	ShouldFinalizeCredential = shouldFinalizeCredential
+)
+
 type (
 	UpdateCloudCommand   = updateCloudCommand
 	AddCredentialCommand = addCredentialCommand

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -14,15 +14,12 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
-var (
-	ShouldFinalizeCredential = shouldFinalizeCredential
-)
-
 type (
-	UpdateCloudCommand = updateCloudCommand
-	UpdateCloudAPI     = updateCloudAPI
-	ShowCloudAPI       = showCloudAPI
-	RemoveCloudAPI     = removeCloudAPI
+	UpdateCloudCommand   = updateCloudCommand
+	AddCredentialCommand = addCredentialCommand
+	UpdateCloudAPI       = updateCloudAPI
+	ShowCloudAPI         = showCloudAPI
+	RemoveCloudAPI       = removeCloudAPI
 )
 
 var (
@@ -127,7 +124,7 @@ func NewDetectCredentialsCommandForTest(
 func NewAddCredentialCommandForTest(
 	testStore jujuclient.CredentialStore,
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error),
-) *addCredentialCommand {
+) *AddCredentialCommand {
 	return &addCredentialCommand{
 		store:           testStore,
 		cloudByNameFunc: cloudByNameFunc,

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -269,7 +269,7 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 		}
 
 		if c.Region != "" {
-			if err := ValidCloudRegion(aCloud, c.Region); err != nil {
+			if err := validCloudRegion(aCloud, c.Region); err != nil {
 				logger.Errorf("%v", err)
 				ctx.Warningf("Region %q is not valid for cloud %v.", c.Region, cloudName)
 				erred = true
@@ -281,8 +281,8 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 			return errors.Trace(err)
 		}
 		for credentialName, credential := range cloudCredentials.AuthCredentials {
-			if ShouldFinalizeCredential(provider, credential) {
-				newCredential, err := FinalizeProvider(ctx, aCloud, c.Region, cloudCredentials.DefaultRegion, credential.AuthType(), credential.Attributes())
+			if shouldFinalizeCredential(provider, credential) {
+				newCredential, err := finalizeProvider(ctx, aCloud, c.Region, cloudCredentials.DefaultRegion, credential.AuthType(), credential.Attributes())
 				if err != nil {
 					logger.Errorf("%v", err)
 					logger.Warningf("Could not verify credential %v for cloud %v locally", credentialName, aCloud.Name)

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -5,7 +5,6 @@ package cloud
 
 import (
 	"fmt"
-	"github.com/juju/juju/environs"
 	"io/ioutil"
 
 	"github.com/juju/cmd"
@@ -19,6 +18,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
 


### PR DESCRIPTION
## Description of change

This is the first PR in the series that will renovate 'add-credential' for multi-cloud world.
This PR allows user to specify a region when adding a credential as well as allowing to add individual credential for a cloud when using a file (related to  linked bug).

We are also more vocal about deprecating '--replace' option.

As a drive-by, this PR fixes an oversight in 'update-credential' - when storing credential locally, only store file path not contents.

## QA steps

* In interactive mode, specify region when adding a credential;
* Add a credential using file for  cloud that already has a credential.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1817122 
