### PR TITLE
add EC2 regions: eu-north-1, ap-east-1, and ap-northeast-3

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -23,6 +23,10 @@ clouds:
         endpoint: https://ec2.eu-west-3.amazonaws.com
       eu-central-1:
         endpoint: https://ec2.eu-central-1.amazonaws.com
+      eu-north-1:
+        endpoint: https://ec2.eu-north-1.amazonaws.com
+      ap-east-1:
+        endpoint: https://ec2.ap-east-1.amazonaws.com
       ap-south-1:
         endpoint: https://ec2.ap-south-1.amazonaws.com
       ap-southeast-1:
@@ -33,6 +37,8 @@ clouds:
         endpoint: https://ec2.ap-northeast-1.amazonaws.com
       ap-northeast-2:
         endpoint: https://ec2.ap-northeast-2.amazonaws.com
+      ap-northeast-3:
+        endpoint: https://ec2.ap-northeast-3.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
   aws-china:
@@ -51,6 +57,8 @@ clouds:
     regions:
       us-gov-west-1:
         endpoint: https://ec2.us-gov-west-1.amazonaws.com
+      us-gov-east-1:
+        endpoint: https://ec2.us-gov-east-1.amazonaws.com
   google:
     type: gce
     description: Google Cloud Platform

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -30,6 +30,10 @@ clouds:
         endpoint: https://ec2.eu-west-3.amazonaws.com
       eu-central-1:
         endpoint: https://ec2.eu-central-1.amazonaws.com
+      eu-north-1:
+        endpoint: https://ec2.eu-north-1.amazonaws.com
+      ap-east-1:
+        endpoint: https://ec2.ap-east-1.amazonaws.com
       ap-south-1:
         endpoint: https://ec2.ap-south-1.amazonaws.com
       ap-southeast-1:
@@ -40,6 +44,8 @@ clouds:
         endpoint: https://ec2.ap-northeast-1.amazonaws.com
       ap-northeast-2:
         endpoint: https://ec2.ap-northeast-2.amazonaws.com
+      ap-northeast-3:
+        endpoint: https://ec2.ap-northeast-3.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
   aws-china:
@@ -58,6 +64,8 @@ clouds:
     regions:
       us-gov-west-1:
         endpoint: https://ec2.us-gov-west-1.amazonaws.com
+      us-gov-east-1:
+        endpoint: https://ec2.us-gov-east-1.amazonaws.com
   google:
     type: gce
     description: Google Cloud Platform

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -45,11 +45,14 @@ eu-west-1
 eu-west-2
 eu-west-3
 eu-central-1
+eu-north-1
+ap-east-1
 ap-south-1
 ap-southeast-1
 ap-southeast-2
 ap-northeast-1
 ap-northeast-2
+ap-northeast-3
 sa-east-1
 
 `[1:])
@@ -85,6 +88,10 @@ eu-west-3:
   endpoint: https://ec2.eu-west-3.amazonaws.com
 eu-central-1:
   endpoint: https://ec2.eu-central-1.amazonaws.com
+eu-north-1:
+  endpoint: https://ec2.eu-north-1.amazonaws.com
+ap-east-1:
+  endpoint: https://ec2.ap-east-1.amazonaws.com
 ap-south-1:
   endpoint: https://ec2.ap-south-1.amazonaws.com
 ap-southeast-1:
@@ -95,6 +102,8 @@ ap-northeast-1:
   endpoint: https://ec2.ap-northeast-1.amazonaws.com
 ap-northeast-2:
   endpoint: https://ec2.ap-northeast-2.amazonaws.com
+ap-northeast-3:
+  endpoint: https://ec2.ap-northeast-3.amazonaws.com
 sa-east-1:
   endpoint: https://ec2.sa-east-1.amazonaws.com
 `[1:])

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1853,11 +1853,14 @@ eu-west-1
 eu-west-2
 eu-west-3
 eu-central-1
+eu-north-1
+ap-east-1
 ap-south-1
 ap-southeast-1
 ap-southeast-2
 ap-northeast-1
 ap-northeast-2
+ap-northeast-3
 sa-east-1
 `[1:])
 }
@@ -1866,7 +1869,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidRegion(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "aws/eu-west")
 	c.Assert(err, gc.ErrorMatches, `region "eu-west" for cloud "aws" not valid`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-west-1, eu-west-2, eu-west-3, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 }
 

--- a/provider/ec2/internal/ec2instancetypes/process_cost_data.go
+++ b/provider/ec2/internal/ec2instancetypes/process_cost_data.go
@@ -355,6 +355,7 @@ func locationToRegion(loc string) (string, bool) {
 		"Asia Pacific (Singapore)":   "ap-southeast-1",
 		"Asia Pacific (Sydney)":      "ap-southeast-2",
 		"Asia Pacific (Mumbai)":      "ap-south-1",
+		"Asia Pacific (Hong Kong)":   "ap-east-1",
 		"South America (Sao Paulo)":  "sa-east-1",
 		"AWS GovCloud (US-East)":     "us-gov-east-1",
 		"AWS GovCloud (US)":          "us-gov-west-1",


### PR DESCRIPTION
## Description of change

Add EC2 regions: eu-north-1, ap-east-1, ap-northeast-3 and us-gov-east-1.  Most have already been added to the instance cost calculations.  

## QA steps

1. juju regions aws
2. juju regions aws-gov
2. Verify endpoints here: https://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region
