### PR TITLE
Piped through workload-context for juju run for CAAS.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -11,7 +11,7 @@ package api
 // New facades should start at 1.
 // Facades that existed before versioning start at 0.
 var facadeVersions = map[string]int{
-	"Action":                       3,
+	"Action":                       4,
 	"ActionPruner":                 1,
 	"Agent":                        2,
 	"AgentTools":                   1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -132,6 +132,7 @@ func AllFacades() *facade.Registry {
 
 	reg("Action", 2, action.NewActionAPIV2)
 	reg("Action", 3, action.NewActionAPIV3)
+	reg("Action", 4, action.NewActionAPIV4)
 	reg("ActionPruner", 1, actionpruner.NewAPI)
 	reg("Agent", 2, agent.NewAgentAPIV2)
 	reg("AgentTools", 1, agenttools.NewFacade)

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -32,6 +32,11 @@ type APIv2 struct {
 
 // APIv3 provides the Action API facade for version 3.
 type APIv3 struct {
+	*APIv4
+}
+
+// APIv4 provides the Action API facade for version 4.
+type APIv4 struct {
 	*ActionAPI
 }
 
@@ -46,11 +51,20 @@ func NewActionAPIV2(ctx facade.Context) (*APIv2, error) {
 
 // NewActionAPIV3 returns an initialized ActionAPI for version 3.
 func NewActionAPIV3(ctx facade.Context) (*APIv3, error) {
-	api, err := newActionAPI(ctx.State(), ctx.Resources(), ctx.Auth())
+	api, err := NewActionAPIV4(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &APIv3{api}, nil
+}
+
+// NewActionAPIV4 returns an initialized ActionAPI for version 4.
+func NewActionAPIV4(ctx facade.Context) (*APIv4, error) {
+	api, err := newActionAPI(ctx.State(), ctx.Resources(), ctx.Auth())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv4{api}, nil
 }
 
 func newActionAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ActionAPI, error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1,7 +1,7 @@
 [
     {
         "Name": "Action",
-        "Version": 3,
+        "Version": 4,
         "Schema": {
             "type": "object",
             "properties": {
@@ -470,6 +470,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "workload-context": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false,

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -672,6 +672,10 @@ type RunParams struct {
 	Machines     []string      `json:"machines,omitempty"`
 	Applications []string      `json:"applications,omitempty"`
 	Units        []string      `json:"units,omitempty"`
+
+	// WorkloadContext for CAAS is true when the Commands should be run on
+	// the workload not the operator.
+	WorkloadContext bool `json:"workload-context,omitempty"`
 }
 
 // RunResult contains the result from an individual run call on a machine.

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -13,6 +13,7 @@ import (
 // commonModelFacadeNames lists facades that are shared between CAAS
 // and IAAS models.
 var commonModelFacadeNames = set.NewStrings(
+	"Action",
 	"ActionPruner",
 	"AllWatcher",
 	"Agent",

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -65,7 +65,6 @@ type APIClient interface {
 // ActionCommandBase is the base type for action sub-commands.
 type ActionCommandBase struct {
 	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
 }
 
 // NewActionAPIClient returns a client for the action api endpoint.

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -47,9 +48,9 @@ func newRunCommand(store jujuclient.ClientStore, timeAfter func(time.Duration) <
 // runCommand is responsible for running arbitrary commands on remote machines.
 type runCommand struct {
 	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
 	out          cmd.Output
 	all          bool
+	operator     bool
 	timeout      time.Duration
 	machines     []string
 	applications []string
@@ -86,6 +87,9 @@ had two units, "mysql/0" and "mysql/1", then
 is equivalent to
   --unit mysql/0,mysql/1
 
+If --operator is provided on CAAS modelas, commands are executed on the operator
+instead of the workload. On IAAS models, --operator has no effect.
+
 Commands run for applications or units are executed in a 'hook context' for
 the unit.
 
@@ -121,6 +125,7 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 		"default": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.all, "all", false, "Run the commands on all the machines")
+	f.BoolVar(&c.operator, "operator", false, "Run the commands on the operator (CAAS-only)")
 	f.DurationVar(&c.timeout, "timeout", 5*time.Minute, "How long to wait before the remote command is considered to have failed")
 	f.Var(cmd.NewStringsValue(nil, &c.machines), "machine", "One or more machine ids")
 	f.Var(cmd.NewStringsValue(nil, &c.applications), "a", "One or more application names")
@@ -244,6 +249,21 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
+	modelType, err := c.ModelType()
+	if err != nil {
+		return errors.Annotatef(err, "unable to get model type")
+	}
+
+	if modelType == model.CAAS {
+		if client.BestAPIVersion() < 4 {
+			return errors.Errorf("CAAS controller does not support juju run" +
+				"\nconsider upgrading your controller")
+		}
+		if len(c.machines) > 0 {
+			return errors.Errorf("unable to target machines with a CAAS controller")
+		}
+	}
+
 	var runResults []params.ActionResult
 	if c.all {
 		runResults, err = client.RunOnAllMachines(c.commands, c.timeout)
@@ -264,6 +284,14 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 			Machines:     c.machines,
 			Applications: c.applications,
 			Units:        c.units,
+		}
+		if c.operator {
+			if modelType != model.CAAS {
+				return errors.Errorf("only CAAS models support the --operator flag")
+			}
+		}
+		if modelType == model.CAAS {
+			params.WorkloadContext = !c.operator
 		}
 		runResults, err = client.Run(params)
 	}

--- a/core/actions/actions.go
+++ b/core/actions/actions.go
@@ -29,6 +29,10 @@ var PredefinedActionsSpec = map[string]charm.ActionSpec{
 					"type":        "number",
 					"description": "timeout for command execution",
 				},
+				"workload-context": map[string]interface{}{
+					"type":        "boolean",
+					"description": "run the command in CAAS workload context",
+				},
 			},
 		},
 	},

--- a/worker/meterstatus/context.go
+++ b/worker/meterstatus/context.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -60,6 +61,13 @@ func (ctx *limitedContext) SetEnvVars(vars map[string]string) {
 // UnitName implements runner.Context.
 func (ctx *limitedContext) UnitName() string {
 	return ctx.unitName
+}
+
+// ModelType implements runner.Context
+func (ctx *limitedContext) ModelType() model.ModelType {
+	// Can return IAAS constant because meter status is only used in Uniter.
+	// TODO(caas): Required for CAAS support.
+	return model.IAAS
 }
 
 // SetProcess implements runner.Context.

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/metrics/spool"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -44,6 +45,13 @@ func (ctx *hookContext) HookVars(paths context.Paths) ([]string, error) {
 // UnitName implements runner.Context.
 func (ctx *hookContext) UnitName() string {
 	return ctx.unitName
+}
+
+// ModelType implements runner.Context
+func (ctx *hookContext) ModelType() model.ModelType {
+	// Can return IAAS constant because collect-metrics is only used in Uniter.
+	// TODO(caas): Required for CAAS support.
+	return model.IAAS
 }
 
 // Flush implements runner.Context.

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/version"
@@ -147,6 +148,9 @@ type HookContext struct {
 
 	// modelName is the human friendly name of the environment.
 	modelName string
+
+	// modelType
+	modelType model.ModelType
 
 	// unitName is the human friendly name of the local unit.
 	unitName string
@@ -307,6 +311,11 @@ func (ctx *HookContext) Id() string {
 
 func (ctx *HookContext) UnitName() string {
 	return ctx.unitName
+}
+
+// ModelType of the context we are running in.
+func (ctx *HookContext) ModelType() model.ModelType {
+	return ctx.modelType
 }
 
 // UnitStatus will return the status for the current Unit.

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -169,6 +169,7 @@ func (f *contextFactory) coreContext() (*HookContext, error) {
 		LeadershipContext:  leadershipContext,
 		uuid:               f.modelUUID,
 		modelName:          f.modelName,
+		modelType:          f.modelType,
 		unitName:           f.unit.Name(),
 		assignedMachineTag: f.machineTag,
 		relations:          f.getContextRelations(),
@@ -252,6 +253,11 @@ func (f *contextFactory) CommandContext(commandInfo CommandInfo) (*HookContext, 
 	ctx.remoteUnitName = remoteUnitName
 	ctx.id = f.newId("run-commands")
 	return ctx, nil
+}
+
+// ModelType is part of the ContextFactory interface.
+func (f *contextFactory) ModelType() model.ModelType {
+	return f.modelType
 }
 
 // getContextRelations updates the factory's relation caches, and uses them

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/model"
 	environscontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -241,6 +242,7 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.UnitName(), gc.Equals, "storage-block/0")
+	c.Assert(ctx.ModelType(), gc.Equals, model.IAAS)
 	s.AssertStorageContext(c, ctx, "data/0", storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
 		Location: "/dev/sdb",
@@ -286,6 +288,7 @@ func (s *ContextFactorySuite) TestNewHookContextCAASModel(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.UnitName(), gc.Equals, unit.Name())
+	c.Assert(ctx.ModelType(), gc.Equals, model.CAAS)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertNotRelationContext(c, ctx)
 	s.AssertNotStorageContext(c, ctx)


### PR DESCRIPTION
## Description of change
- Enables `juju run` and `juju action` for CAAS.
- Adds `--operator` flag to `juju run` to tell `juju-run` action to execute on the CAAS operator for the unit.
- Adds checks to `juju run` dependent on model type.
- Adds model type to HookContext for action choosing how to run the action.
- Currently `juju run` for CASS (without --operator) errors with unimplemented error, this will change with @ycliuhw exec work to run on the workload pod.
- Currently `juju run-action` for CAAS runs in the CAAS operator pod, this will change with @ycliuhw exec work to run on the workload pod.

## QA steps

```
make microk8s-operator-update
juju bootstrap microk8s
```

```
cd `mktemp -d`
charm pull cs:~kubeflow-charmers/redis-k8s-26
mkdir redis-k8s/actions
cat >redis-k8s/actions/test <<EOM
#!/bin/sh
echo test
action-fail "things went according to plan"
EOM
chmod +x redis-k8s/actions/test
cat >redis-k8s/actions.yaml <<EOM
test:
  description: Just a test action
EOM
juju deploy ./redis-k8s --resource oci-image=redis:latest
```

These should fail with `run in CAAS workload not implemented`
```
juju run --unit=redis-k8s/0 "echo hello"
juju run --application=redis-k8s "echo hello"
```

These should succeed with `hello`
```
juju run --unit=redis-k8s/0 --operator "echo hello"
juju run --application=redis-k8s --operator "echo hello"
```

Application should have a test action
```
juju list-actions redis-k8s
```
```
Action  Description
test    Just a test action
```
```
juju run-action redis-k8s/0 test
```
```
juju show-action-status | grep -A 4 'action: test'
```
```
- action: test
  completed at: "2019-07-24 03:43:08"
  id: 704a7787-e961-4a09-86af-7229470af5de
  status: failed
  unit: redis-k8s/1
```
```
juju show-action-output 704a7787-e961-4a09-86af-7229470af5de
```
```
message: things went according to plan
status: failed
timing:
  completed: 2019-07-24 03:43:08 +0000 UTC
  enqueued: 2019-07-24 03:43:07 +0000 UTC
  started: 2019-07-24 03:43:08 +0000 UTC
```
## Documentation changes

- `juju run` works against updated CAAS controllers.
- `juju run` takes an --operator flag to run command on CAAS operator pod.
- `juju 
