### PR TITLE
'add-credential' also uploads it to a given controller when possible.

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -137,6 +137,7 @@ type addCredentialCommand struct {
 
 	// These attributes are used when adding credentials to a controller.
 	controllerName    string
+	remoteCloudFound  bool
 	credentialAPIFunc func() (CredentialAPI, error)
 }
 
@@ -606,6 +607,7 @@ func (c *addCredentialCommand) maybeRemoteCloud(ctxt *cmd.Context) error {
 	if remoteCloud, ok := remoteUserClouds[names.NewCloudTag(c.CloudName)]; ok {
 		ctxt.Infof("Using  remote cloud %q from the controller to verify credentials.", c.CloudName)
 		c.cloud = &remoteCloud
+		c.remoteCloudFound = true
 	}
 	return nil
 }
@@ -613,6 +615,13 @@ func (c *addCredentialCommand) maybeRemoteCloud(ctxt *cmd.Context) error {
 func (c *addCredentialCommand) addRemoteCredentials(ctxt *cmd.Context, all map[string]jujucloud.Credential) error {
 	if len(all) == 0 {
 		fmt.Fprintf(ctxt.Stdout, "No remote credentials for cloud %q added.\n", c.CloudName)
+		return nil
+	}
+	if !c.remoteCloudFound {
+		fmt.Fprintf(ctxt.Stdout, "No remote cloud %v found on the controller %v: credentials are not added remotely.\n"+
+			"Use 'juju clouds -c %v' to see what clouds are available remotely.\n"+
+			"User 'juju add-cloud %v -c %v' to add your cloud to the controller.\n",
+			c.CloudName, c.controllerName, c.controllerName, c.CloudName, c.controllerName)
 		return nil
 	}
 

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -585,7 +585,6 @@ func (c *addCredentialCommand) promptFieldValue(p *interact.Pollster, attr jujuc
 }
 
 func (c *addCredentialCommand) credentialsAPI() (CredentialAPI, error) {
-	var err error
 	root, err := c.NewAPIRoot(c.Store, c.controllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -126,12 +126,14 @@ func NewDetectCredentialsCommandForTest(
 }
 
 func NewAddCredentialCommandForTest(
-	testStore jujuclient.CredentialStore,
+	testStore jujuclient.ClientStore,
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error),
+	f func() (CredentialAPI, error),
 ) *AddCredentialCommand {
 	return &addCredentialCommand{
-		store:           testStore,
-		cloudByNameFunc: cloudByNameFunc,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore},
+		cloudByNameFunc:           cloudByNameFunc,
+		credentialAPIFunc:         f,
 	}
 }
 


### PR DESCRIPTION
## Description of change

'add-credential' only added it to local client cache. As per linked bug, this was confusing to the users and, in fact, was also restrictive as the only way to add your own credential to the controller was either by bootstrapping it or by creating a model. 

That also led to difficulties in scenario where users wanted to replace credential that a model uses ('set-model-credential') but said credential was not on the controller yet.

This PR ensures that a credential when added to client is also uploaded to a current or given controller. If controller is not provided/found, previous behavior is preserved, i.e. credential is only added locally. If only local addition is desired, i.e. no upload, a --local flag is provided as per similar commands. 

## QA steps

1. add credential without controller will only add locally
2. when a current controller exists or a different controller is provided, a credential is also uploaded to that controller [ verify with 'juju credentials -c <controller used>']

## Bug reference

https://bugs.launchpad.net/juju/+bug/1814395 (FP2)
