### PR TITLE
'autoload-credentials' uploads credentials to the controller.

### DIFF
--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -466,6 +466,12 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 		return err
 	}
 
+	client, err := c.credentialAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
 	var results []params.UpdateCredentialResult
 	moreCloudInfoNeeded := false
 	for cloud, byCloud := range all {
@@ -480,11 +486,6 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 			if len(verified) == 0 {
 				return erred
 			}
-			client, err := c.credentialAPIFunc()
-			if err != nil {
-				return err
-			}
-			defer client.Close()
 			result, err := client.UpdateCloudsCredentials(verified)
 			if err != nil {
 				logger.Errorf("%v", err)

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -14,20 +14,25 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/naturalsort"
 
+	apicloud "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
 
 type detectCredentialsCommand struct {
+	modelcmd.OptionalControllerCommand
 	cmd.CommandBase
 	out cmd.Output
 
 	cloudType string
-	store     jujuclient.CredentialStore
 
 	// registeredProvidersFunc is set by tests to return all registered environ providers
 	registeredProvidersFunc func() []string
@@ -37,6 +42,11 @@ type detectCredentialsCommand struct {
 
 	// cloudByNameFunc is set by tests to return a named cloud.
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error)
+
+	// These attributes are used when adding credentials to a controller.
+	controllerName    string
+	credentialAPIFunc func() (CredentialAPI, error)
+	remoteClouds      map[string]jujucloud.Cloud
 }
 
 const detectCredentialsSummary = `Attempts to automatically add or replace credentials for a cloud.`
@@ -45,6 +55,12 @@ var detectCredentialsDoc = `
 Well known locations for specific clouds are searched and any found
 information is presented interactively to the user.
 An alternative to this command is ` + "`juju add-credential`" + `.
+
+By default, after validating the contents, credentials are loaded both 
+on the current controller and the current client device. 
+Use --controller option to load credentials to a different controller. 
+Use --local option to load credentials to the current device only.
+
 Below are the cloud types for which credentials may be autoloaded,
 including the locations searched.
 
@@ -86,14 +102,17 @@ See also:
 // NewDetectCredentialsCommand returns a command to add credential information to credentials.yaml.
 func NewDetectCredentialsCommand() cmd.Command {
 	c := &detectCredentialsCommand{
-		store:                   jujuclient.NewFileCredentialStore(),
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store: jujuclient.NewFileClientStore(),
+		},
 		registeredProvidersFunc: environs.RegisteredProviders,
 		cloudByNameFunc:         jujucloud.CloudByName,
 	}
 	c.allCloudsFunc = func() (map[string]jujucloud.Cloud, error) {
 		return c.allClouds()
 	}
-	return c
+	c.credentialAPIFunc = c.credentialsAPI
+	return modelcmd.WrapBase(c)
 }
 
 func (c *detectCredentialsCommand) Info() *cmd.Info {
@@ -105,10 +124,23 @@ func (c *detectCredentialsCommand) Info() *cmd.Info {
 	})
 }
 
+func (c *detectCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.OptionalControllerCommand.SetFlags(f)
+}
+
 func (c *detectCredentialsCommand) Init(args []string) (err error) {
 	if len(args) > 0 {
 		c.cloudType = strings.ToLower(args[0])
 		return cmd.CheckEmpty(args[1:])
+	}
+	c.controllerName, err = c.ControllerNameFromArg()
+	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
+		return errors.Trace(err)
+	}
+	if c.controllerName == "" {
+		// No controller was specified explicitly and we did not detect a current controller,
+		// this operation should be local only.
+		c.Local = true
 	}
 	return cmd.CheckEmpty(args)
 }
@@ -122,10 +154,26 @@ type discoveredCredential struct {
 	isNew            bool
 }
 
+func (c *detectCredentialsCommand) credentialsAPI() (CredentialAPI, error) {
+	var err error
+	root, err := c.NewAPIRoot(c.Store, c.controllerName, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apicloud.NewClient(root), nil
+}
+
 func (c *detectCredentialsCommand) allClouds() (map[string]jujucloud.Cloud, error) {
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
 		return nil, err
+	}
+	builtinClouds, err := common.BuiltInClouds()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for k, v := range builtinClouds {
+		clouds[k] = v
 	}
 	personalClouds, err := jujucloud.PersonalCloudMetadata()
 	if err != nil {
@@ -133,6 +181,26 @@ func (c *detectCredentialsCommand) allClouds() (map[string]jujucloud.Cloud, erro
 	}
 	for k, v := range personalClouds {
 		clouds[k] = v
+	}
+	if !c.Local {
+		// If there is a cloud definition for the same cloud both
+		// on the controller and on the client and they conflict,
+		// we want definition from the controller to take precedence.
+		client, err := c.credentialAPIFunc()
+		if err != nil {
+			return nil, err
+		}
+		defer client.Close()
+
+		remoteUserClouds, err := client.Clouds()
+		if err != nil {
+			return nil, err
+		}
+		c.remoteClouds = map[string]jujucloud.Cloud{}
+		for k, v := range remoteUserClouds {
+			clouds[k.Id()] = v
+			c.remoteClouds[k.Id()] = v
+		}
 	}
 	return clouds, nil
 }
@@ -191,9 +259,15 @@ func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
 			if errors.IsNotFound(err) || len(detected.AuthCredentials) == 0 {
 				continue
 			}
+			sortedName := []string{}
+			for credName := range detected.AuthCredentials {
+				sortedName = append(sortedName, credName)
+			}
+			naturalsort.Sort(sortedName)
 
 			// For each credential, construct meta info for which cloud it may pertain to etc.
-			for credName, newCred := range detected.AuthCredentials {
+			for _, credName := range sortedName {
+				newCred := detected.AuthCredentials[credName]
 				if credName == "" {
 					logger.Debugf("ignoring unnamed credential for provider %s", providerName)
 					continue
@@ -238,7 +312,7 @@ func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
 		fmt.Fprintln(ctxt.Stderr, "No cloud credentials found.")
 		return nil
 	}
-	return c.interactiveCredentialsUpdate(ctxt, discovered)
+	return c.interactiveCredentialsUpdate(ctxt, clouds, discovered)
 }
 
 // guessCloudInfo looks at all the compatible clouds for the provider name and
@@ -257,7 +331,7 @@ func (c *detectCredentialsCommand) guessCloudInfo(
 		if cloud.Type != providerName {
 			continue
 		}
-		credentials, err := c.store.CredentialForCloud(cloudName)
+		credentials, err := c.Store.CredentialForCloud(cloudName)
 		if err != nil && !errors.IsNotFound(err) {
 			return "", "", false, errors.Trace(err)
 		}
@@ -282,7 +356,12 @@ func (c *detectCredentialsCommand) guessCloudInfo(
 
 // interactiveCredentialsUpdate prints a list of the discovered credentials
 // and prompts the user to update their local credentials.
-func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Context, discovered []discoveredCredential) error {
+func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Context, clouds map[string]jujucloud.Cloud, discovered []discoveredCredential) error {
+	// by cloud, by region
+	loaded := map[string]map[string]map[string]jujucloud.Credential{}
+	quit := func(in string) bool {
+		return strings.ToLower(in) == "q"
+	}
 	for {
 		// Prompt for a credential to save.
 		c.printCredentialOptions(ctxt, discovered)
@@ -293,14 +372,13 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if strings.ToLower(input) == "q" {
-				return nil
+			if quit(input) {
+				goto upload
 			}
 			if input != "" {
 				break
 			}
 		}
-
 		// Check the entered number.
 		num, err := strconv.Atoi(input)
 		if err != nil || num < 1 || num > len(discovered) {
@@ -309,18 +387,30 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 		}
 		cred := discovered[num-1]
 		// Prompt for the cloud for which to save the credential.
-		cloudName, err := c.promptCloudName(ctxt.Stderr, ctxt.Stdin, cred.defaultCloudName, cred.cloudType)
+		cloudName, err := c.promptCloudName(ctxt.Stderr, ctxt.Stdin, cred.defaultCloudName)
 		if err != nil {
 			fmt.Fprintln(ctxt.Stderr, err.Error())
 			continue
 		}
+		if quit(cloudName) {
+			goto upload
+		}
+
 		if cloudName == "" {
 			fmt.Fprintln(ctxt.Stderr, "No cloud name entered.")
 			continue
 		}
+		cloud, err := common.CloudOrProvider(cloudName, c.cloudByNameFunc)
+		if err != nil {
+			fmt.Fprintln(ctxt.Stderr, err.Error())
+			continue
+		}
+		if cloud.Type != cred.cloudType {
+			fmt.Fprintln(ctxt.Stderr, errors.Errorf("chosen credentials not compatible with a %s cloud", cloud.Type))
+		}
 
 		// Reading existing info so we can apply updated values.
-		existing, err := c.store.CredentialForCloud(cloudName)
+		existing, err := c.Store.CredentialForCloud(cloudName)
 		if err != nil && !errors.IsNotFound(err) {
 			fmt.Fprintf(ctxt.Stderr, "error reading credential file: %v\n", err)
 			continue
@@ -334,15 +424,79 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 			existing.DefaultRegion = cred.region
 		}
 		existing.AuthCredentials[cred.credentialName] = cred.credential
-		if err := c.store.UpdateCredential(cloudName, *existing); err != nil {
-			fmt.Fprintf(ctxt.Stderr, "error saving credential: %v\n", err)
+		addLoadedCredential(loaded, cloudName, cred)
+		if err := c.Store.UpdateCredential(cloudName, *existing); err != nil {
+			fmt.Fprintf(ctxt.Stderr, "error saving credential locally: %v\n", err)
 		} else {
 			// Update so we display correctly next time list is printed.
 			cred.isNew = false
 			discovered[num-1] = cred
-			fmt.Fprintf(ctxt.Stderr, "Saved %s to cloud %s\n", cred.credential.Label, cloudName)
+			fmt.Fprintf(ctxt.Stderr, "Saved %s to cloud %s locally\n", cred.credential.Label, cloudName)
 		}
 	}
+upload:
+	if !c.Local {
+		fmt.Fprintln(ctxt.Stderr)
+		return c.addRemoteCredentials(ctxt, clouds, loaded)
+	}
+	return nil
+}
+
+func addLoadedCredential(all map[string]map[string]map[string]jujucloud.Credential, cloudName string, cred discoveredCredential) {
+	byCloud, ok := all[cloudName]
+	if !ok {
+		all[cloudName] = map[string]map[string]jujucloud.Credential{}
+		byCloud = all[cloudName]
+	}
+	byRegion, ok := byCloud[cred.region]
+	if !ok {
+		byCloud[cred.region] = map[string]jujucloud.Credential{}
+		byRegion = byCloud[cred.region]
+	}
+	byRegion[cred.credentialName] = cred.credential
+}
+
+func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, clouds map[string]jujucloud.Cloud, all map[string]map[string]map[string]jujucloud.Credential) error {
+	if len(all) == 0 {
+		fmt.Fprintf(ctxt.Stdout, "No credentials loaded remotely.\n")
+		return nil
+	}
+	accountDetails, err := c.Store.AccountDetails(c.controllerName)
+	if err != nil {
+		return err
+	}
+
+	var results []params.UpdateCredentialResult
+	moreCloudInfoNeeded := false
+	for cloud, byCloud := range all {
+		for region, byRegion := range byCloud {
+			aCloud, ok := c.remoteClouds[cloud]
+			if !ok {
+				ctxt.Infof("Cloud %q does not exist on the controller: not uploading credentials for it...", cloud)
+				moreCloudInfoNeeded = true
+				continue
+			}
+			verified, erred := verifyCredentialsForUpload(ctxt, accountDetails, &aCloud, region, byRegion)
+			if len(verified) == 0 {
+				return erred
+			}
+			client, err := c.credentialAPIFunc()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+			result, err := client.UpdateCloudsCredentials(verified)
+			if err != nil {
+				logger.Errorf("%v", err)
+				ctxt.Warningf("Could not add credentials remotely, on controller %q", c.controllerName)
+			}
+			results = append(results, result...)
+		}
+	}
+	if moreCloudInfoNeeded {
+		ctxt.Infof("Use 'juju clouds' to view all avalaible clouds and 'juju add-cloud' to add missing ones.")
+	}
+	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results)
 }
 
 func (c *detectCredentialsCommand) printCredentialOptions(ctxt *cmd.Context, discovered []discoveredCredential) {
@@ -366,7 +520,7 @@ func (c *detectCredentialsCommand) promptCredentialNumber(out io.Writer, in io.R
 	return strings.TrimSpace(input), nil
 }
 
-func (c *detectCredentialsCommand) promptCloudName(out io.Writer, in io.Reader, defaultCloudName, cloudType string) (string, error) {
+func (c *detectCredentialsCommand) promptCloudName(out io.Writer, in io.Reader, defaultCloudName string) (string, error) {
 	text := fmt.Sprintf(`Select the cloud it belongs to, or type Q to quit [%s]: `, defaultCloudName)
 	fmt.Fprint(out, text)
 	defer out.Write([]byte{'\n'})
@@ -374,21 +528,11 @@ func (c *detectCredentialsCommand) promptCloudName(out io.Writer, in io.Reader, 
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	cloudName := strings.TrimSpace(input)
-	if strings.ToLower(cloudName) == "q" {
-		return "", nil
+	input = strings.TrimSpace(input)
+	if input == "" {
+		input = defaultCloudName
 	}
-	if cloudName == "" {
-		return defaultCloudName, nil
-	}
-	cloud, err := common.CloudOrProvider(cloudName, c.cloudByNameFunc)
-	if err != nil {
-		return "", err
-	}
-	if cloud.Type != cloudType {
-		return "", errors.Errorf("chosen credentials not compatible with a %s cloud", cloud.Type)
-	}
-	return cloudName, nil
+	return input, nil
 }
 
 func readLine(stdin io.Reader) (string, error) {

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -407,6 +407,7 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 		}
 		if cloud.Type != cred.cloudType {
 			fmt.Fprintln(ctxt.Stderr, errors.Errorf("chosen credentials not compatible with a %s cloud", cloud.Type))
+			continue
 		}
 
 		// Reading existing info so we can apply updated values.

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -25,8 +27,10 @@ import (
 type detectCredentialsSuite struct {
 	testing.BaseSuite
 
-	store       *jujuclient.MemStore
-	aCredential jujucloud.CloudCredential
+	store             *jujuclient.MemStore
+	aCredential       jujucloud.CloudCredential
+	credentialAPIFunc func() (cloud.CredentialAPI, error)
+	api               *fakeUpdateCredentialAPI
 }
 
 var _ = gc.Suite(&detectCredentialsSuite{})
@@ -107,26 +111,38 @@ func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.store = jujuclient.NewMemStore()
 	s.aCredential = jujucloud.CloudCredential{}
+	s.api = &fakeUpdateCredentialAPI{
+		v:      5,
+		clouds: func() (map[names.CloudTag]jujucloud.Cloud, error) { return nil, nil },
+	}
+	s.credentialAPIFunc = func() (cloud.CredentialAPI, error) { return s.api, nil }
 }
 
 func (s *detectCredentialsSuite) run(c *gc.C, stdin io.Reader, clouds map[string]jujucloud.Cloud, args ...string) (*cmd.Context, error) {
-	registeredProvidersFunc := func() []string {
-		return []string{"mock-provider"}
-	}
 	allCloudsFunc := func() (map[string]jujucloud.Cloud, error) {
 		return clouds, nil
 	}
 	cloudByNameFunc := func(cloudName string) (*jujucloud.Cloud, error) {
-		if cloud, ok := clouds[cloudName]; ok {
-			return &cloud, nil
+		if one, ok := clouds[cloudName]; ok {
+			return &one, nil
 		}
 		return nil, errors.NotFoundf("cloud %s", cloudName)
+	}
+	return s.runWithCloudsFunc(c, stdin, allCloudsFunc, cloudByNameFunc, args...)
+}
+
+func (s *detectCredentialsSuite) runWithCloudsFunc(c *gc.C, stdin io.Reader,
+	cloudsFunc func() (map[string]jujucloud.Cloud, error),
+	cloudByNameFunc func(cloudName string) (*jujucloud.Cloud, error),
+	args ...string) (*cmd.Context, error) {
+	registeredProvidersFunc := func() []string {
+		return []string{"mock-provider"}
 	}
 	cloudType := ""
 	if len(args) > 0 {
 		cloudType = args[0]
 	}
-	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, allCloudsFunc, cloudByNameFunc, cloudType)
+	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, cloudsFunc, cloudByNameFunc, cloudType, s.credentialAPIFunc)
 	err := cmdtesting.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
@@ -254,4 +270,175 @@ func (s *detectCredentialsSuite) TestDetectCredentialInvalidChoice(c *gc.C) {
 	output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 	c.Assert(output, gc.Matches, ".*Invalid choice, enter a number between 1 and 2.*")
 	c.Assert(s.store.Credentials, gc.HasLen, 0)
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentialQuitOnCloud(c *gc.C) {
+	s.aCredential = jujucloud.CloudCredential{
+		DefaultRegion: "detected region",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"test":    s.credentialWithLabel(jujucloud.AccessKeyAuthType, "credential b"),
+			"another": s.credentialWithLabel(jujucloud.AccessKeyAuthType, "credential a")},
+	}
+
+	stdin := strings.NewReader("1\nQ\n")
+	ctx, err := s.run(c, stdin, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+
+Looking for cloud and credential information locally...
+
+1. credential a (new)
+2. credential b (new)
+Select a credential to save by number, or type Q to quit: 
+Select the cloud it belongs to, or type Q to quit []: 
+`[1:])
+	c.Assert(s.store.Credentials, gc.HasLen, 0)
+}
+
+func (s *detectCredentialsSuite) setupStore(c *gc.C) {
+	s.store.Controllers["controller"] = jujuclient.ControllerDetails{ControllerUUID: "cdcssc"}
+	s.store.CurrentControllerName = "controller"
+	s.store.Accounts = map[string]jujuclient.AccountDetails{
+		"controller": {
+			User: "admin@local",
+		},
+	}
+}
+
+func (s *detectCredentialsSuite) TestRemoteLoad(c *gc.C) {
+	// Ensure that there is a current controller to be picked for
+	// loading remotely.
+	s.setupStore(c)
+	cloudName := "test-cloud"
+	called := false
+	s.api.updateCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
+		c.Assert(cloudCredentials, gc.HasLen, 1)
+		called = true
+		expectedTag := names.NewCloudCredentialTag(fmt.Sprintf("%v/admin@local/blah", cloudName)).String()
+		for k := range cloudCredentials {
+			c.Assert(k, gc.DeepEquals, expectedTag)
+		}
+		return []params.UpdateCredentialResult{{CredentialTag: expectedTag}}, nil
+	}
+
+	remoteTestCloud := jujucloud.Cloud{
+		Name:             cloudName,
+		Type:             "mock-provider",
+		AuthTypes:        []jujucloud.AuthType{jujucloud.AccessKeyAuthType},
+		Endpoint:         "cloud-endpoint",
+		IdentityEndpoint: "cloud-identity-endpoint",
+		Regions: []jujucloud.Region{
+			{Name: "default region", Endpoint: "specialendpoint", IdentityEndpoint: "specialidentityendpoint", StorageEndpoint: "storageendpoint"},
+		},
+	}
+	s.api.clouds = func() (map[names.CloudTag]jujucloud.Cloud, error) {
+		return map[names.CloudTag]jujucloud.Cloud{
+			names.NewCloudTag(cloudName): remoteTestCloud,
+		}, nil
+	}
+	cred := jujucloud.NewCredential(jujucloud.AccessKeyAuthType, map[string]string{
+		"secret-key": "topsekret",
+		"access-key": "lesssekret",
+	})
+	cred.Label = "credential"
+	s.aCredential = jujucloud.CloudCredential{
+		DefaultRegion:   "default region",
+		AuthCredentials: map[string]jujucloud.Credential{"blah": cred},
+	}
+	cloudByNameFunc := func(cloudName string) (*jujucloud.Cloud, error) {
+		return &remoteTestCloud, nil
+	}
+
+	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", cloudName))
+	ctx, err := s.runWithCloudsFunc(c, stdin, nil, cloudByNameFunc)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, `
+
+Looking for cloud and credential information locally...
+
+1. credential (new)
+Select a credential to save by number, or type Q to quit: 
+Select the cloud it belongs to, or type Q to quit [test-cloud]: 
+Saved credential to cloud test-cloud locally
+
+1. credential (existing, will overwrite)
+Select a credential to save by number, or type Q to quit: 
+
+Controller credential "blah" for user "admin@local" on cloud "test-cloud" loaded.
+For more information, see ‘juju show-credential test-cloud blah’.
+`[1:])
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *detectCredentialsSuite) TestRemoteLoadNoRemoteCloud(c *gc.C) {
+	// Ensure that there is a current controller to be picked for
+	// loading remotely.
+	s.setupStore(c)
+	cloudName := "test-cloud"
+	called := false
+	s.api.updateCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
+		c.Assert(cloudCredentials, gc.HasLen, 1)
+		called = true
+		expectedTag := names.NewCloudCredentialTag(fmt.Sprintf("%v/admin@local/blah", cloudName)).String()
+		for k := range cloudCredentials {
+			c.Assert(k, gc.DeepEquals, expectedTag)
+		}
+		return []params.UpdateCredentialResult{{CredentialTag: expectedTag}}, nil
+	}
+
+	clouds := map[string]jujucloud.Cloud{
+		"test-cloud": {
+			Name:             cloudName,
+			Type:             "mock-provider",
+			AuthTypes:        []jujucloud.AuthType{jujucloud.AccessKeyAuthType},
+			Endpoint:         "cloud-endpoint",
+			IdentityEndpoint: "cloud-identity-endpoint",
+			Regions: []jujucloud.Region{
+				{Name: "default region", Endpoint: "specialendpoint", IdentityEndpoint: "specialidentityendpoint", StorageEndpoint: "storageendpoint"},
+			},
+		},
+	}
+	cred := jujucloud.NewCredential(jujucloud.AccessKeyAuthType, map[string]string{
+		"secret-key": "topsekret",
+		"access-key": "lesssekret",
+	})
+	cred.Label = "credential"
+	s.aCredential = jujucloud.CloudCredential{
+		DefaultRegion:   "default region",
+		AuthCredentials: map[string]jujucloud.Credential{"blah": cred},
+	}
+
+	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", cloudName))
+	ctx, err := s.run(c, stdin, clouds)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, `
+
+Looking for cloud and credential information locally...
+
+1. credential (new)
+Select a credential to save by number, or type Q to quit: 
+Select the cloud it belongs to, or type Q to quit [test-cloud]: 
+Saved credential to cloud test-cloud locally
+
+1. credential (existing, will overwrite)
+Select a credential to save by number, or type Q to quit: 
+
+Cloud "test-cloud" does not exist on the controller: not uploading credentials for it...
+Use 'juju clouds' to view all avalaible clouds and 'juju add-cloud' to add missing ones.
+`[1:])
+	c.Assert(called, jc.IsFalse)
+}
+
+func (s *detectCredentialsSuite) TestAddLoadedCredential(c *gc.C) {
+	all := map[string]map[string]map[string]jujucloud.Credential{}
+	cloud.AddLoadedCredentialForTest(all, "a", "b", "one", jujucloud.NewEmptyCredential())
+	cloud.AddLoadedCredentialForTest(all, "a", "b", "two", jujucloud.NewEmptyCredential())
+	cloud.AddLoadedCredentialForTest(all, "a", "c", "three", jujucloud.NewEmptyCredential())
+	cloud.AddLoadedCredentialForTest(all, "d", "a", "four", jujucloud.NewEmptyCredential())
+	c.Assert(all, gc.HasLen, 2)
+	c.Assert(all["d"], gc.DeepEquals, map[string]map[string]jujucloud.Credential{"a": {"four": jujucloud.NewEmptyCredential()}})
+	c.Assert(all["a"]["c"], gc.DeepEquals, map[string]jujucloud.Credential{"three": jujucloud.NewEmptyCredential()})
+	c.Assert(all["a"]["b"], gc.HasLen, 2)
 }


### PR DESCRIPTION
## Description of change

'autoload-credentials' scans known locations on local client (device) for cloud supplied files that may contain cloud credentials that a user wants Juju  to be aware of. Previously this command only had ability to add credentials to Juju client locally. This was confusing for the users and there were reports where operators would say 'I have just autoloaded credentials but Juju still cannot find them'.

This PR adds the ability to upload these discovered credentials to the controller to avoid confusion.

As a drive-by, fix for a linked bug to allow users to quit at 2nd prompt line too.

The command now also supports built-in clouds. For example, previously it could detect lxd credentials but not able to load them.

## QA steps

1. 'autoload-credentials' works locally without a current, bootstrapped controller
2.  'autoload-credentials' works with a current or specified controller
3. User can quit at a 'cloud name' prompt. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1837009
