### PR TITLE
Fixes lp#1837008: rax detecting credentials missing labels.

### DIFF
--- a/provider/rackspace/credentials.go
+++ b/provider/rackspace/credentials.go
@@ -4,6 +4,8 @@
 package rackspace
 
 import (
+	"fmt"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/provider/openstack"
 )
@@ -50,7 +52,9 @@ func (c Credentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	for k, v := range result.AuthCredentials {
 		attr := v.Attributes()
 		delete(attr, openstack.CredAttrDomainName)
-		result.AuthCredentials[k] = cloud.NewCredential(v.AuthType(), attr)
+		one := cloud.NewCredential(v.AuthType(), attr)
+		one.Label = fmt.Sprintf("rackspace credential for user %q", attr[openstack.CredAttrUserName])
+		result.AuthCredentials[k] = one
 	}
 	return result, nil
 }

--- a/provider/rackspace/credentials_test.go
+++ b/provider/rackspace/credentials_test.go
@@ -43,5 +43,6 @@ func (CredentialSuite) TestDetectCredentialsNoDomain(c *gc.C) {
 		if _, ok := attr[openstack.CredAttrDomainName]; ok {
 			c.Fatal("Domain name exists in rackspace creds and should not.")
 		}
+		c.Assert(v.Label, gc.Not(gc.Equals), "")
 	}
 }


### PR DESCRIPTION
## Description of change

When using 'autoload-credentials' on a client that has rackspace credentials, Juju would present these credentials as misleading empty:

```
$ juju autoload-credentials

Looking for cloud and credential information locally...
1. LXD credential "localhost" (new)
2. openstack region "<unspecified>" project "" user "" (existing, will overwrite)
3. (new)
Select a credential to save by number, or type Q to quit: 1
``` 
This was due to rackspace provider not providing a label for its credentials unlike other providers.

## QA steps

1. run 'autoload-credentials' on client with rackspace cloud credentials file.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1837008
