### PR TITLE
Improve user facing messaging when adding cloud/model.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -161,7 +161,6 @@ type AddCloudCommand struct {
 	// These attributes are used when adding a cloud to a controller.
 	controllerName  string
 	credentialName  string
-	store           jujuclient.ClientStore
 	addCloudAPIFunc func() (AddCloudAPI, error)
 }
 
@@ -181,14 +180,13 @@ func NewAddCloudCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 		Ping: func(p environs.EnvironProvider, endpoint string) error {
 			return p.Ping(cloudCallCtx, endpoint)
 		},
-		store: store,
 	}
 	c.addCloudAPIFunc = c.cloudAPI
 	return modelcmd.WrapBase(c)
 }
 
 func (c *AddCloudCommand) cloudAPI() (AddCloudAPI, error) {
-	root, err := c.NewAPIRoot(c.store, c.controllerName, "")
+	root, err := c.NewAPIRoot(c.Store, c.controllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -243,7 +241,7 @@ specify a credential using the --credential argument`[1:],
 )
 
 func (c *AddCloudCommand) findLocalCredential(ctx *cmd.Context, cloud jujucloud.Cloud, credentialName string) (*jujucloud.Credential, string, error) {
-	credential, chosenCredentialName, _, err := modelcmd.GetCredentials(ctx, c.store, modelcmd.GetCredentialsParams{
+	credential, chosenCredentialName, _, err := modelcmd.GetCredentials(ctx, c.Store, modelcmd.GetCredentialsParams{
 		Cloud:          cloud,
 		CredentialName: credentialName,
 	})
@@ -259,12 +257,12 @@ func (c *AddCloudCommand) findLocalCredential(ctx *cmd.Context, cloud jujucloud.
 }
 
 func (c *AddCloudCommand) addCredentialToController(ctx *cmd.Context, cloud jujucloud.Cloud, apiClient AddCloudAPI) error {
-	_, err := c.store.ControllerByName(c.controllerName)
+	_, err := c.Store.ControllerByName(c.controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	currentAccountDetails, err := c.store.AccountDetails(c.controllerName)
+	currentAccountDetails, err := c.Store.AccountDetails(c.controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -325,15 +323,27 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	}
 	defer api.Close()
 	err = api.AddCloud(*newCloud)
-	if err != nil && params.ErrCode(err) != params.CodeAlreadyExists {
-		return err
-	}
-	// Add a credential for the newly added cloud.
-	err = c.addCredentialToController(ctxt, *newCloud, api)
 	if err != nil {
+		if params.ErrCode(err) == params.CodeAlreadyExists {
+			ctxt.Infof("Cloud %q already exists on the controller %q.", c.Cloud, c.controllerName)
+			ctxt.Infof("To upload credentials to the controller for cloud %q, use \n"+
+				"* 'add-model' with --credential option or\n"+
+				"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
+			return nil
+		}
 		return err
 	}
 	ctxt.Infof("Cloud %q added to controller %q.", c.Cloud, c.controllerName)
+	// Add a credential for the newly added cloud.
+	err = c.addCredentialToController(ctxt, *newCloud, api)
+	if err != nil {
+		logger.Errorf("%v", err)
+		ctxt.Infof("To upload credentials to the controller for cloud %q, use \n"+
+			"* 'add-model' with --credential option or\n"+
+			"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
+		return cmd.ErrSilent
+	}
+	ctxt.Infof("Credentials for cloud %q added to controller %q.", c.Cloud, c.controllerName)
 	return nil
 }
 

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -44,7 +44,6 @@ func NewAddCloudCommandForTest(
 		Ping: func(p environs.EnvironProvider, endpoint string) error {
 			return nil
 		},
-		store:           store,
 		addCloudAPIFunc: cloudAPI,
 	}
 }

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -206,7 +206,9 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	if c.CloudRegion != "" {
 		cloudTag, cloud, cloudRegion, err = c.getCloudRegion(cloudClient)
 		if err != nil {
-			return errors.Trace(err)
+			logger.Errorf("%v", err)
+			ctx.Infof("Use 'juju clouds' to see a list of all available clouds or 'juju add-cloud' to a add one.")
+			return cmd.ErrSilent
 		}
 	} else {
 		if cloudTag, cloud, err = maybeGetControllerCloud(cloudClient); err != nil {
@@ -214,7 +216,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	// Find a credential to use with the new model.
+	// Find a local credential to use with the new model.
 	// If credential was found on the controller, it will be nil in return.
 	credential, credentialTag, cloudRegion, err := c.findCredential(ctx, cloudClient, &findCredentialParams{
 		cloudTag:    cloudTag,
@@ -223,7 +225,12 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		modelOwner:  modelOwner,
 	})
 	if err != nil {
-		return errors.Trace(err)
+		logger.Errorf("%v", err)
+		ctx.Infof("Use \n* 'juju add-credential -c' to upload a credential to a controller or\n" +
+			"* 'juju autoload-credentials' to add credenitals from local files or\n" +
+			"* 'juju add-model --credential' to use a local credential.\n" +
+			"Use 'juju credentials' to list all available credentials.\n")
+		return cmd.ErrSilent
 	}
 
 	// Upload the credential if it was explicitly set and we have found it locally.

--- a/featuretests/cmd_juju_cloud_test.go
+++ b/featuretests/cmd_juju_cloud_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/commands"
+	jujutesting "github.com/juju/juju/juju/testing"
+)
+
+type CmdCloudSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *CmdCloudSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+}
+
+func (s *CmdCloudSuite) TestAddCloudDuplicate(c *gc.C) {
+	s.Home.AddFiles(c, testing.TestFile{
+		Name: ".local/share/clouds.yaml",
+		Data: `
+clouds:
+  testdummy:
+    type: rackspace
+    description: Dummy Test Cloud Metadata
+    auth-types: [ userpass ]
+`,
+	})
+
+	ctx, err := s.run(c, "controller-config", "features=[multi-cloud]")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll")
+	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cloud "testdummy" added to controller "kontroll".`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+
+	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cloud "testdummy" already exists on the controller "kontroll".`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+}
+
+func (s *CmdCloudSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	context := cmdtesting.Context(c)
+	command := commands.NewJujuCommand(context)
+	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
+	err := command.Run(context)
+	loggo.RemoveWriter("warning")
+	return context, err
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -42,6 +42,7 @@ func init() {
 	gc.Suite(&blockSuite{})
 	gc.Suite(&cmdControllerSuite{})
 	gc.Suite(&CmdCredentialSuite{})
+	gc.Suite(&CmdCloudSuite{})
 	gc.Suite(&cmdJujuSuite{})
 	gc.Suite(&cmdJujuSuiteNoCAAS{})
 	gc.Suite(&cmdLoginSuite{})


### PR DESCRIPTION
## Description of change

Adding a cloud as well as adding a model can be simple and exhilarating but when things go wrong and starts do not quiet align, Juju can be better at helping users fixing the problems.

This PR improves user facing messaging that occur due to credentials misalignment - either local/remote clouds do not work, credentials does not exist remotely on the controller, etc.

For example, when adding a cloud remotely that does not have local credentials to upload, the user will be presented with some guidance:
```
$ juju add-cloud manymore -c mycontroller
Cloud "manymore" added to controller "mycontroller".
ERROR loading credentials: credentials for cloud manymore not found
To upload credentials to the controller for cloud "manymore", use 
* 'add-model' with --credential option or
* 'add-credential -c manymore'.
```

When adding a duplicate cloud to the controller previously, Juju will not say anything and act as if it was a successful operation. This PR reports duplicate name and error. 

When model is being added to the cloud that does not exist on the controller, users are also guided as to how to add that cloud.

