### PR TITLE
Malformed error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -738,7 +738,7 @@
   revision = "9b925afd677234e4146dde3cb1a11e187cbed64e"
 
 [[projects]]
-  digest = "1:4cb2e360aaa18a7369e22b26d997dc141ad7f336d964fadeaeca0976611d9995"
+  digest = "1:95ed103a60286cdb3c4404e2b19bb210c98a1a0110d4e8f66901b96cdb4fcbb5"
   name = "github.com/juju/testing"
   packages = [
     ".",
@@ -747,7 +747,8 @@
     "httptesting",
   ]
   pruneopts = ""
-  revision = "6570bd8f8541d15ce654437084f8edcd7b76637b"
+  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
+  source = "github.com/SimonRichardson/testing"
 
 [[projects]]
   digest = "1:c43a754dcd24720e8f651933c9685511be5cba937faabaf6abbc4360b5b1f228"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -738,7 +738,7 @@
   revision = "9b925afd677234e4146dde3cb1a11e187cbed64e"
 
 [[projects]]
-  digest = "1:eb9f2d033b8167d6647399d4f49e0280b98ddef6fb1d4a2cb036ce84267994b4"
+  digest = "1:6d9048e037a012d6f673e1f5084b53a589c93fbd481cc76528a3b8f525feff22"
   name = "github.com/juju/testing"
   packages = [
     ".",
@@ -747,8 +747,7 @@
     "httptesting",
   ]
   pruneopts = ""
-  revision = "fe4dde6a8d8a5c36350355052d6e04c427c6efcf"
-  source = "github.com/SimonRichardson/testing"
+  revision = "ce30eb24acd2c45a1bc42208835468ca619685a9"
 
 [[projects]]
   digest = "1:c43a754dcd24720e8f651933c9685511be5cba937faabaf6abbc4360b5b1f228"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -738,7 +738,7 @@
   revision = "9b925afd677234e4146dde3cb1a11e187cbed64e"
 
 [[projects]]
-  digest = "1:95ed103a60286cdb3c4404e2b19bb210c98a1a0110d4e8f66901b96cdb4fcbb5"
+  digest = "1:eb9f2d033b8167d6647399d4f49e0280b98ddef6fb1d4a2cb036ce84267994b4"
   name = "github.com/juju/testing"
   packages = [
     ".",
@@ -747,7 +747,7 @@
     "httptesting",
   ]
   pruneopts = ""
-  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
+  revision = "fe4dde6a8d8a5c36350355052d6e04c427c6efcf"
   source = "github.com/SimonRichardson/testing"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@
   name = "github.com/juju/romulus"
 
 [[constraint]]
-  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
+  revision = "fe4dde6a8d8a5c36350355052d6e04c427c6efcf"
   name = "github.com/juju/testing"
   source = "github.com/SimonRichardson/testing"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,9 +114,8 @@
   name = "github.com/juju/romulus"
 
 [[constraint]]
-  revision = "fe4dde6a8d8a5c36350355052d6e04c427c6efcf"
+  revision = "ce30eb24acd2c45a1bc42208835468ca619685a9"
   name = "github.com/juju/testing"
-  source = "github.com/SimonRichardson/testing"
 
 [[constraint]]
   revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,8 +114,9 @@
   name = "github.com/juju/romulus"
 
 [[constraint]]
-  revision = "6570bd8f8541d15ce654437084f8edcd7b76637b"
+  revision = "e25f034181e5ae6fa6cd7ba86c804f48388f1ff7"
   name = "github.com/juju/testing"
+  source = "github.com/SimonRichardson/testing"
 
 [[constraint]]
   revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 
 PROJECT := github.com/juju/juju
 PROJECT_DIR := $(shell go list -e -f '{{.Dir}}' $(PROJECT))
-PROJECT_PACKAGES := $(shell go list $(PROJECT)/... | grep -v /vendor/)
+PROJECT_PACKAGES := $(shell go list $(PROJECT)/... | grep -v /vendor/ | grep -v /acceptancetests/)
 
 # Allow the tests to take longer on arm platforms.
 ifeq ($(shell uname -p | sed -E 's/.*(armel|armhf|aarch64|ppc64le|ppc64|s390x).*/golang/'), golang)

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -110,9 +110,9 @@ func (s *charmsSuite) TestCharmsServedSecurely(c *gc.C) {
 	url := s.charmsURL("")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "GET",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/debuglog_db_test.go
+++ b/apiserver/debuglog_db_test.go
@@ -38,9 +38,9 @@ func (s *debugLogDBSuite) TestBadParams(c *gc.C) {
 func (s *debugLogDBSuite) TestWithHTTP(c *gc.C) {
 	uri := s.logURL("http", nil).String()
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         uri,
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "GET",
+		URL:          uri,
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/resources_mig_test.go
+++ b/apiserver/resources_mig_test.go
@@ -72,9 +72,9 @@ func (s *resourcesUploadSuite) TestServedSecurely(c *gc.C) {
 	url := s.resourcesURL("")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "GET",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -76,7 +76,7 @@ func (s *restSuite) TestRestServedSecurely(c *gc.C) {
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
 		Method:      "GET",
 		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -74,8 +74,8 @@ func (s *restSuite) TestRestServedSecurely(c *gc.C) {
 	url := s.restURL(s.State.ModelUUID(), "")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "GET",
-		URL:         url.String(),
+		Method:       "GET",
+		URL:          url.String(),
 		ExpectStatus: http.StatusBadRequest,
 	})
 }

--- a/apiserver/testing/http.go
+++ b/apiserver/testing/http.go
@@ -30,6 +30,10 @@ type HTTPRequestParams struct {
 	// nil.
 	ExpectError string
 
+	// ExpectStatus holds the expected HTTP status code.
+	// http.StatusOK is assumed if this is zero.
+	ExpectStatus int
+
 	// tag holds the tag to authenticate as.
 	Tag string
 
@@ -64,15 +68,16 @@ type HTTPRequestParams struct {
 func SendHTTPRequest(c *gc.C, p HTTPRequestParams) *http.Response {
 	c.Logf("sendRequest: %s", p.URL)
 	hp := httptesting.DoRequestParams{
-		Do:          p.Do,
-		Method:      p.Method,
-		URL:         p.URL,
-		Body:        p.Body,
-		JSONBody:    p.JSONBody,
-		Header:      make(http.Header),
-		Username:    p.Tag,
-		Password:    p.Password,
-		ExpectError: p.ExpectError,
+		Do:           p.Do,
+		Method:       p.Method,
+		URL:          p.URL,
+		Body:         p.Body,
+		JSONBody:     p.JSONBody,
+		Header:       make(http.Header),
+		Username:     p.Tag,
+		Password:     p.Password,
+		ExpectError:  p.ExpectError,
+		ExpectStatus: p.ExpectStatus,
 	}
 	if p.ContentType != "" {
 		hp.Header.Set("Content-Type", p.ContentType)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -106,9 +106,9 @@ func (s *toolsSuite) TestToolsUploadedSecurely(c *gc.C) {
 	url := s.toolsURL("")
 	url.Scheme = "http"
 	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "PUT",
-		URL:         url.String(),
-		ExpectError: `.*malformed HTTP response.*`,
+		Method:       "PUT",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
 	})
 }
 

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -243,7 +243,7 @@ func (s *WorkerSuite) TestMinTLSVersion(c *gc.C) {
 	tlsConfig.MaxVersion = tls.VersionSSL30
 
 	conn, err := tls.Dial("tcp", parsed.Host, tlsConfig)
-	c.Assert(err, gc.ErrorMatches, "tls: no supported versions satisfy MinVersion and MaxVersion")
+	c.Assert(err, gc.ErrorMatches, ".*tls:.*version.*")
 	c.Assert(conn, gc.IsNil)
 }
 

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -243,7 +243,7 @@ func (s *WorkerSuite) TestMinTLSVersion(c *gc.C) {
 	tlsConfig.MaxVersion = tls.VersionSSL30
 
 	conn, err := tls.Dial("tcp", parsed.Host, tlsConfig)
-	c.Assert(err, gc.ErrorMatches, ".*protocol version not supported")
+	c.Assert(err, gc.ErrorMatches, "tls: no supported versions satisfy MinVersion and MaxVersion")
 	c.Assert(conn, gc.IsNil)
 }
 


### PR DESCRIPTION
## Description of change

When attempting to contact HTTPS url using a HTTP endpoint, in
go version < 1.12 it would return with a malformed garbage error.
In go version >= 1.12 the error is no longer returned and instead
a status code of 400 is returned.

In order to handle this is the correct manor for both past and future
runtimes we should hide this fact and just get prior errors report
that a bad request was sent.

## QA steps

Tests go green.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1837357
