### PR TITLE
Migrate Spaces With IDs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -488,11 +488,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:446b7fde9070a70bcbbda3bfc163a26994f6486c99f86e65be83b7da588e6b80"
+  digest = "1:5aa491dc49e09cab723640e2b5d6d5e75cb98d442dcea04dd880089f06fd6721"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "9daa941ef37578e70e66a5f97ab64b1f2b2bd410"
+  revision = "e5397239cbdadecd1ee144b827efb904f3108fbb"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "9daa941ef37578e70e66a5f97ab64b1f2b2bd410"
+  revision = "e5397239cbdadecd1ee144b827efb904f3108fbb"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1127,8 +1127,8 @@ func (e *exporter) spaces() error {
 			continue
 		}
 
-		// TODO (manadart 2019-07-12): Update juju/description and export IDs.
 		e.model.AddSpace(description.SpaceArgs{
+			Id:         space.Id(),
 			Name:       space.Name(),
 			Public:     space.IsPublic(),
 			ProviderID: string(space.ProviderId()),

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -967,7 +967,10 @@ func (s *MigrationExportSuite) TestSpaces(c *gc.C) {
 
 	spaces := model.Spaces()
 	c.Assert(spaces, gc.HasLen, 1)
+
 	space := spaces[0]
+
+	c.Assert(space.Id(), gc.Not(gc.Equals), "")
 	c.Assert(space.Name(), gc.Equals, "one")
 	c.Assert(space.ProviderID(), gc.Equals, "provider")
 	c.Assert(space.Public(), jc.IsTrue)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1242,8 +1242,16 @@ func (i *importer) spaces() error {
 			continue
 		}
 
-		_, err := i.st.AddSpace(s.Name(), network.Id(s.ProviderID()), nil, s.Public())
-		if err != nil {
+		if s.Id() == "" {
+			if _, err := i.st.AddSpace(s.Name(), network.Id(s.ProviderID()), nil, s.Public()); err != nil {
+				i.logger.Errorf("error importing space %s: %s", s.Name(), err)
+				return errors.Annotate(err, s.Name())
+			}
+			continue
+		}
+
+		ops := i.st.addSpaceTxnOps(s.Id(), s.Name(), network.Id(s.ProviderID()), s.Public())
+		if err := i.st.db().RunTransaction(ops); err != nil {
 			i.logger.Errorf("error importing space %s: %s", s.Name(), err)
 			return errors.Annotate(err, s.Name())
 		}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1057,6 +1057,7 @@ func (s *MigrationImportSuite) TestSpaces(c *gc.C) {
 	imported, err := newSt.Space(space.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
+	c.Assert(imported.Id(), gc.Equals, space.Id())
 	c.Assert(imported.Name(), gc.Equals, space.Name())
 	c.Assert(imported.ProviderId(), gc.Equals, space.ProviderId())
 	c.Assert(imported.IsPublic(), gc.Equals, space.IsPublic())

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -65,7 +65,9 @@ func (s *MigrationImportSuite) TestExisting(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }
 
-func (s *MigrationImportSuite) importModel(c *gc.C, st *state.State, transform ...func(map[string]interface{})) (*state.Model, *state.State) {
+func (s *MigrationImportSuite) importModel(
+	c *gc.C, st *state.State, transform ...func(map[string]interface{}),
+) (*state.Model, *state.State) {
 	out, err := st.Export()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1052,15 +1054,31 @@ func (s *MigrationImportSuite) TestSpaces(c *gc.C) {
 	space := s.Factory.MakeSpace(c, &factory.SpaceParams{
 		Name: "one", ProviderID: corenetwork.Id("provider"), IsPublic: true})
 
-	_, newSt := s.importModel(c, s.State)
+	spaceNoID := s.Factory.MakeSpace(c, &factory.SpaceParams{
+		Name: "no-id", ProviderID: corenetwork.Id("provider2"), IsPublic: true})
+
+	// Blank the ID from the second space to check that import creates it.
+	_, newSt := s.importModel(c, s.State, func(desc map[string]interface{}) {
+		spaces := desc["spaces"].(map[interface{}]interface{})
+		for _, item := range spaces["spaces"].([]interface{}) {
+			sp := item.(map[interface{}]interface{})
+			if sp["name"] == spaceNoID.Name() {
+				sp["id"] = ""
+			}
+		}
+	})
 
 	imported, err := newSt.Space(space.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(imported.Id(), gc.Equals, space.Id())
-	c.Assert(imported.Name(), gc.Equals, space.Name())
-	c.Assert(imported.ProviderId(), gc.Equals, space.ProviderId())
-	c.Assert(imported.IsPublic(), gc.Equals, space.IsPublic())
+	c.Check(imported.Id(), gc.Equals, space.Id())
+	c.Check(imported.Name(), gc.Equals, space.Name())
+	c.Check(imported.ProviderId(), gc.Equals, space.ProviderId())
+	c.Check(imported.IsPublic(), gc.Equals, space.IsPublic())
+
+	imported, err = newSt.Space(spaceNoID.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(imported.Id(), gc.Not(gc.Equals), "")
 }
 
 func (s *MigrationImportSuite) TestDestroyEmptyModel(c *gc.C) {


### PR DESCRIPTION
## Description of change

This patch updates the `juju/description` dependency so that space encode/decode accommodates the newly added space ID.

It also ensures that migrations include the space IDs where they already exist, and creates them when migrating from an old controller.

## QA steps

- Bootstrap a 2.6 controller (src) to AWS and add a space.
- Bootstrap a controller with this version (dst) to AWS and destroy the default model.
- On the `src` controller, run `juju migrate default src`.
- Once complete connect to Mongo on `dst` and run `db.spaces.find().pretty()`.
- There should be 3 spaces, all with IDs:
  - A default space (ID=0) for each of the `controller` and `default` models.
  - The space (ID=1) that we created on `src`.

## Documentation changes

None.

## Bug reference

N/A
