### PR TITLE
Allow custom lxd cloud name

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -150,12 +150,19 @@ func (p environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 
 	remoteCertCredentials, err := p.detectRemoteCredentials(certPEM, keyPEM)
 	if err != nil {
-		logger.Errorf("unable to detect LXC credentials: %s", err)
+		logger.Errorf("unable to detect remote LXC credentials: %s", err)
+	}
+	localCertCredentials, err := p.detectLocalCredentials(certPEM, keyPEM)
+	if err != nil {
+		logger.Errorf("unable to detect local LXC credentials: %s", err)
 	}
 
 	authCredentials := make(map[string]cloud.Credential)
 	for k, v := range remoteCertCredentials {
 		authCredentials[k] = v
+	}
+	if localCertCredentials != nil {
+		authCredentials["localhost"] = *localCertCredentials
 	}
 	return &cloud.CloudCredential{
 		AuthCredentials: authCredentials,


### PR DESCRIPTION
## Description of change

The following allows a custom lxd cloud name to be used in clouds
yaml if you're using something that the provider doesn't know.

## QA steps

## QA steps

If you change your `~/.local/share/juju/clouds.yaml` to copy and
paste the "lxd" cloud you have existing, but change the name (in
this instance to "local"):

```yaml
clouds:
  lxd:
    type: lxd
    auth-types: [certificate]
    endpoint: https://192.168.1.201:8443
    regions:
      default:
        endpoint: https://192.168.1.201:8443
  local:
    type: lxd
    auth-types: [certificate]
    endpoint: https://192.168.1.201:8443
    regions:
      default:
        endpoint: https://192.168.1.201:8443
```

Then run bootstrap

```console
juju bootstrap local test --no-gui
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1813650