### PR TITLE
2.6 fix intermittent login failure

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -855,6 +855,11 @@ func (s *loginSuite) TestOtherModel(c *gc.C) {
 	model, err := modelState.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	info.ModelTag = model.ModelTag()
+
+	// Ensure that the model has been added to the cache before
+	// we try to log in.
+	s.EnsureCachedModel(c, model.UUID())
+
 	st := s.openAPIWithoutLogin(c, info)
 
 	err = st.Login(modelOwner.UserTag(), "password", "", nil)

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -363,6 +363,10 @@ func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
 	// Get API connection to hosted model.
 	apiInfo := s.APIInfo(c)
 	apiInfo.ModelTag = model2.ModelTag()
+	// To avoid the race between the cache on the model creation,
+	// make sure the cache has the model before progressing.
+	s.EnsureCachedModel(c, model2.UUID())
+
 	conn, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	client := conn.Client()

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/pubsub/controller"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/lease"
 	"github.com/juju/juju/worker/modelcache"
 )
@@ -38,8 +39,10 @@ var _ = gc.Suite(&sharedServerContextSuite{})
 func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 
+	initialized := gate.NewLock()
 	modelCache, err := modelcache.NewWorker(modelcache.Config{
-		Logger: loggo.GetLogger("test"),
+		InitializedGate: initialized,
+		Logger:          loggo.GetLogger("test"),
 		WatcherFactory: func() modelcache.BackingWatcher {
 			return s.StatePool.SystemState().WatchAllModels(s.StatePool)
 		},

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -390,11 +390,21 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			SetStatePool:           config.SetStatePool,
 		}),
 
+		// The model cache initialized gate is used to make sure the api server
+		// isn't created before the model cache has been initialized with the
+		// initial state of the world.
+		modelCacheInitializedGateName: gate.Manifold(),
+		modelCacheInitializedFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
+			GateName:  modelCacheInitializedGateName,
+			NewWorker: gate.NewFlagWorker,
+		}),
+
 		// The modelcache manifold creates a cache.Controller and keeps
 		// it up to date using an all model watcher. The controller is then
 		// used by the apiserver.
 		modelCacheName: modelcache.Manifold(modelcache.ManifoldConfig{
 			StateName:            stateName,
+			InitializedGateName:  modelCacheInitializedGateName,
 			Logger:               loggo.GetLogger("juju.worker.modelcache"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            modelcache.NewWorker,
@@ -679,7 +689,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:            httpserver.NewWorkerShim,
 		}),
 
-		apiServerName: apiserver.Manifold(apiserver.ManifoldConfig{
+		apiServerName: ifModelCacheInitialized(apiserver.Manifold(apiserver.ManifoldConfig{
 			AgentName:              agentName,
 			AuthenticatorName:      httpServerArgsName,
 			ClockName:              clockName,
@@ -701,7 +711,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Presence:                          config.PresenceRecorder,
 			NewWorker:                         apiserver.NewWorker,
 			NewMetricsCollector:               apiserver.NewMetricsCollector,
-		}),
+		})),
 
 		modelWorkerManagerName: ifFullyUpgraded(modelworkermanager.Manifold(modelworkermanager.ManifoldConfig{
 			StateName:      stateName,
@@ -1016,6 +1026,12 @@ var ifLegacyLeasesEnabled = engine.Housing{
 	},
 }.Decorate
 
+var ifModelCacheInitialized = engine.Housing{
+	Flags: []string{
+		modelCacheInitializedFlagName,
+	},
+}.Decorate
+
 const (
 	agentName              = "agent"
 	agentConfigUpdaterName = "agent-config-updater"
@@ -1067,6 +1083,8 @@ const (
 	txnPrunerName                 = "transaction-pruner"
 	certificateWatcherName        = "certificate-watcher"
 	modelCacheName                = "model-cache"
+	modelCacheInitializedFlagName = "model-cache-initialized-flag"
+	modelCacheInitializedGateName = "model-cache-initialized-gate"
 	modelWorkerManagerName        = "model-worker-manager"
 	peergrouperName               = "peer-grouper"
 	restoreWatcherName            = "restore-watcher"

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -393,22 +393,22 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The model cache initialized gate is used to make sure the api server
 		// isn't created before the model cache has been initialized with the
 		// initial state of the world.
-		modelCacheInitializedGateName: gate.Manifold(),
-		modelCacheInitializedFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
+		modelCacheInitializedGateName: ifController(gate.Manifold()),
+		modelCacheInitializedFlagName: ifController(gate.FlagManifold(gate.FlagManifoldConfig{
 			GateName:  modelCacheInitializedGateName,
 			NewWorker: gate.NewFlagWorker,
-		}),
+		})),
 
 		// The modelcache manifold creates a cache.Controller and keeps
 		// it up to date using an all model watcher. The controller is then
 		// used by the apiserver.
-		modelCacheName: modelcache.Manifold(modelcache.ManifoldConfig{
+		modelCacheName: ifController(modelcache.Manifold(modelcache.ManifoldConfig{
 			StateName:            stateName,
 			InitializedGateName:  modelCacheInitializedGateName,
 			Logger:               loggo.GetLogger("juju.worker.modelcache"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            modelcache.NewWorker,
-		}),
+		})),
 
 		// The api-config-watcher manifold monitors the API server
 		// addresses in the agent config and bounces when they

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -93,6 +93,8 @@ func (ms *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
 			"migration-minion",
 			"migration-inactive-flag",
 			"model-cache",
+			"model-cache-initialized-flag",
+			"model-cache-initialized-gate",
 			"model-worker-manager",
 			"peer-grouper",
 			"presence",
@@ -166,6 +168,8 @@ func (ms *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
 			"migration-minion",
 			"migration-inactive-flag",
 			"model-cache",
+			"model-cache-initialized-flag",
+			"model-cache-initialized-gate",
 			"model-worker-manager",
 			"peer-grouper",
 			"presence",
@@ -236,6 +240,8 @@ func (ms *ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"legacy-leases-flag",
 		"log-forwarder",
 		"model-cache",
+		"model-cache-initialized-flag",
+		"model-cache-initialized-gate",
 		"model-worker-manager",
 		"peer-grouper",
 		"presence",
@@ -432,6 +438,8 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"is-controller-flag",
 		"lease-manager",
 		"model-cache",
+		"model-cache-initialized-flag",
+		"model-cache-initialized-gate",
 		"raft-transport",
 		"restore-watcher",
 		"state",
@@ -558,6 +566,8 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"is-controller-flag",
 		"lease-manager",
 		"model-cache",
+		"model-cache-initialized-flag",
+		"model-cache-initialized-gate",
 		"raft-transport",
 		"restore-watcher",
 		"state",
@@ -721,9 +731,16 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 
 	"model-cache": {
 		"agent",
+		"model-cache-initialized-gate",
 		"state",
 		"state-config-watcher",
 	},
+
+	"model-cache-initialized-flag": {
+		"model-cache-initialized-gate",
+	},
+
+	"model-cache-initialized-gate": {},
 
 	"model-worker-manager": {
 		"agent",

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -289,6 +289,9 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"certificate-watcher",
 		"audit-config-updater",
 		"is-primary-controller-flag",
+		"model-cache",
+		"model-cache-initialized-flag",
+		"model-cache-initialized-gate",
 		"lease-manager",
 		"legacy-leases-flag",
 		"raft-transport",
@@ -731,16 +734,26 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 
 	"model-cache": {
 		"agent",
+		"is-controller-flag",
 		"model-cache-initialized-gate",
 		"state",
 		"state-config-watcher",
 	},
 
 	"model-cache-initialized-flag": {
+		"agent",
+		"is-controller-flag",
 		"model-cache-initialized-gate",
+		"state",
+		"state-config-watcher",
 	},
 
-	"model-cache-initialized-gate": {},
+	"model-cache-initialized-gate": {
+		"agent",
+		"is-controller-flag",
+		"state",
+		"state-config-watcher",
+	},
 
 	"model-worker-manager": {
 		"agent",

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -253,6 +253,28 @@ func (s *JujuConnSuite) WaitForModelWatchersIdle(c *gc.C, modelUUID string) {
 	}
 }
 
+// EnsureCachedModel is used to ensure that the model specified is
+// in the model cache. This is used when tests create models and then
+// want to do things with those models where the actions may touch
+// the model cache.
+func (s *JujuConnSuite) EnsureCachedModel(c *gc.C, uuid string) {
+	start := time.Now()
+	for {
+		_, err := s.Controller.Model(uuid)
+		if err == nil {
+			break
+		}
+		if errors.IsNotFound(err) {
+			time.Sleep(testing.ShortWait)
+		} else {
+			c.Errorf("problem getting model from cache: %v", err)
+		}
+		if time.Now().Sub(start) > testing.LongWait {
+			c.Errorf("model %v not seen in cache", uuid)
+		}
+	}
+}
+
 func (s *JujuConnSuite) AdminUserTag(c *gc.C) names.UserTag {
 	owner, err := s.State.ControllerOwner()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/modelcache/manifold_test.go
+++ b/worker/modelcache/manifold_test.go
@@ -16,6 +16,7 @@ import (
 	dt "gopkg.in/juju/worker.v1/dependency/testing"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/modelcache"
 	workerstate "github.com/juju/juju/worker/state"
 )
@@ -31,6 +32,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.config = modelcache.ManifoldConfig{
 		StateName:            "state",
+		InitializedGateName:  "initialized-gate",
 		Logger:               loggo.GetLogger("test"),
 		PrometheusRegisterer: noopRegisterer{},
 		NewWorker: func(modelcache.Config) (worker.Worker, error) {
@@ -44,12 +46,19 @@ func (s *ManifoldSuite) manifold() dependency.Manifold {
 }
 
 func (s *ManifoldSuite) TestInputs(c *gc.C) {
-	c.Check(s.manifold().Inputs, jc.DeepEquals, []string{"state"})
+	c.Check(s.manifold().Inputs, jc.DeepEquals, []string{"state", "initialized-gate"})
 }
 
 func (s *ManifoldSuite) TestConfigValidation(c *gc.C) {
 	err := s.config.Validate()
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingInitializedGateName(c *gc.C) {
+	s.config.InitializedGateName = ""
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "empty InitializedGateName not valid")
 }
 
 func (s *ManifoldSuite) TestConfigValidationMissingStateName(c *gc.C) {
@@ -89,9 +98,21 @@ func (s *ManifoldSuite) TestManifoldCallsValidate(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `missing Logger not valid`)
 }
 
-func (s *ManifoldSuite) TestAgentMissing(c *gc.C) {
+func (s *ManifoldSuite) TestStateMissing(c *gc.C) {
 	context := dt.StubContext(nil, map[string]interface{}{
-		"state": dependency.ErrMissing,
+		"state":            dependency.ErrMissing,
+		"initialized-gate": gate.NewLock(),
+	})
+
+	w, err := s.manifold().Start(context)
+	c.Check(w, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestInitializedGateMissing(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{
+		"state":            &fakeStateTracker{},
+		"initialized-gate": dependency.ErrMissing,
 	})
 
 	w, err := s.manifold().Start(context)
@@ -108,7 +129,8 @@ func (s *ManifoldSuite) TestNewWorkerArgs(c *gc.C) {
 
 	tracker := &fakeStateTracker{}
 	context := dt.StubContext(nil, map[string]interface{}{
-		"state": tracker,
+		"state":            tracker,
+		"initialized-gate": gate.NewLock(),
 	})
 
 	w, err := s.manifold().Start(context)
@@ -128,7 +150,8 @@ func (s *ManifoldSuite) TestNewWorkerArgs(c *gc.C) {
 func (s *ManifoldSuite) TestNewWorkerErrorReleasesState(c *gc.C) {
 	tracker := &fakeStateTracker{}
 	context := dt.StubContext(nil, map[string]interface{}{
-		"state": tracker,
+		"state":            tracker,
+		"initialized-gate": gate.NewLock(),
 	})
 
 	worker, err := s.manifold().Start(context)


### PR DESCRIPTION
This branch fixes two different intermittent failures due to the model not being found in the model cache.
This happens when the apiserver code is creating the facade context.

The fix is to ensure that the model exists in the cache before continuing with the test. A helper method has been added to the JujuConnSuite as this is the one that triggers it most.

Additionally the apiserver is now not created in the engine until the model cache has been initialized. This will help avoid login issues to the apiserver if there are many models.

## QA steps

* bootstrap a controller
* deploy something to ensure the components are hooked up

## Documentation changes

No user facing impact.
