### PR TITLE
Show Space IDs in "juju spaces" Output

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -94,7 +94,7 @@ var facadeVersions = map[string]int{
 	"Resumer":                      2,
 	"RetryStrategy":                1,
 	"Singular":                     2,
-	"Spaces":                       3,
+	"Spaces":                       4,
 	"SSHClient":                    2,
 	"StatusHistory":                2,
 	"Storage":                      6,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -287,8 +287,9 @@ func AllFacades() *facade.Registry {
 	reg("SSHClient", 1, sshclient.NewFacade)
 	reg("SSHClient", 2, sshclient.NewFacade) // v2 adds AllAddresses() method.
 
-	reg("Spaces", 2, spaces.NewAPIV2)
-	reg("Spaces", 3, spaces.NewAPI)
+	reg("Spaces", 2, spaces.NewAPIv2)
+	reg("Spaces", 3, spaces.NewAPIv3)
+	reg("Spaces", 4, spaces.NewAPI)
 
 	reg("StatusHistory", 2, statushistory.NewAPI)
 

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -83,6 +83,9 @@ type BackingSubnetInfo struct {
 // BackingSpace defines the methods supported by a Space entity stored
 // persistently.
 type BackingSpace interface {
+	// ID returns the ID of the space.
+	Id() string
+
 	// Name returns the space name.
 	Name() string
 

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -118,6 +118,7 @@ func (api *spacesAPI) ListSpaces() (results params.ListSpacesResults, err error)
 	results.Results = make([]params.Space, len(spaces))
 	for i, space := range spaces {
 		result := params.Space{}
+		result.Id = space.Id()
 		result.Name = space.Name()
 
 		subnets, err := space.Subnets()

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -16,19 +16,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// API defines the methods the Spaces API facade implements.
-type API interface {
-	CreateSpaces(params.CreateSpacesParams) (params.ErrorResults, error)
-	ListSpaces() (params.ListSpacesResults, error)
-	ReloadSpaces() error
-}
-
-// APIV2 is missing ReloadSpaces method
-type APIV2 interface {
-	CreateSpaces(params.CreateSpacesParams) (params.ErrorResults, error)
-	ListSpaces() (params.ListSpacesResults, error)
-}
-
 // BlockChecker defines the block-checking functionality required by
 // the application facade. This is implemented by
 // apiserver/common.BlockChecker.
@@ -37,8 +24,18 @@ type BlockChecker interface {
 	RemoveAllowed() error
 }
 
-// spacesAPI implements the API interface.
-type spacesAPI struct {
+// APIv2 provides the spaces API facade for versions < 3.
+type APIv2 struct {
+	*APIv3
+}
+
+// APIv3 provides the spaces API facade for version 3.
+type APIv3 struct {
+	*API
+}
+
+// API provides the spaces API facade for version 4.
+type API struct {
 	backing    networkingcommon.NetworkBacking
 	resources  facade.Resources
 	authorizer facade.Authorizer
@@ -47,9 +44,27 @@ type spacesAPI struct {
 	check BlockChecker
 }
 
+// NewAPIv2 is a wrapper that creates a V2 spaces API.
+func NewAPIv2(st *state.State, res facade.Resources, auth facade.Authorizer) (*APIv2, error) {
+	api, err := NewAPIv3(st, res, auth)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv2{api}, nil
+}
+
+// NewAPIv3 is a wrapper that creates a V3 spaces API.
+func NewAPIv3(st *state.State, res facade.Resources, auth facade.Authorizer) (*APIv3, error) {
+	api, err := NewAPI(st, res, auth)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv3{api}, nil
+}
+
 // NewAPI creates a new Space API server-side facade with a
 // state.State backing.
-func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (API, error) {
+func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (*API, error) {
 	stateShim, err := networkingcommon.NewStateShim(st)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -59,12 +74,18 @@ func NewAPI(st *state.State, res facade.Resources, auth facade.Authorizer) (API,
 
 // newAPIWithBacking creates a new server-side Spaces API facade with
 // the given Backing.
-func newAPIWithBacking(backing networkingcommon.NetworkBacking, check BlockChecker, ctx context.ProviderCallContext, resources facade.Resources, authorizer facade.Authorizer) (API, error) {
+func newAPIWithBacking(
+	backing networkingcommon.NetworkBacking,
+	check BlockChecker,
+	ctx context.ProviderCallContext,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+) (*API, error) {
 	// Only clients can access the Spaces facade.
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	return &spacesAPI{
+	return &API{
 		backing:    backing,
 		resources:  resources,
 		authorizer: authorizer,
@@ -73,14 +94,9 @@ func newAPIWithBacking(backing networkingcommon.NetworkBacking, check BlockCheck
 	}, nil
 }
 
-// NewAPIV2 is a wrapper that creates a V2 spaces API.
-func NewAPIV2(st *state.State, res facade.Resources, auth facade.Authorizer) (APIV2, error) {
-	return NewAPI(st, res, auth)
-}
-
 // CreateSpaces creates a new Juju network space, associating the
 // specified subnets with it (optional; can be empty).
-func (api *spacesAPI) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {
+func (api *API) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {
 	isAdmin, err := api.authorizer.HasPermission(permission.AdminAccess, api.backing.ModelTag())
 	if err != nil && !errors.IsNotFound(err) {
 		return results, errors.Trace(err)
@@ -96,7 +112,7 @@ func (api *spacesAPI) CreateSpaces(args params.CreateSpacesParams) (results para
 }
 
 // ListSpaces lists all the available spaces and their associated subnets.
-func (api *spacesAPI) ListSpaces() (results params.ListSpacesResults, err error) {
+func (api *API) ListSpaces() (results params.ListSpacesResults, err error) {
 	canRead, err := api.authorizer.HasPermission(permission.ReadAccess, api.backing.ModelTag())
 	if err != nil && !errors.IsNotFound(err) {
 		return results, errors.Trace(err)
@@ -138,8 +154,11 @@ func (api *spacesAPI) ListSpaces() (results params.ListSpacesResults, err error)
 	return results, nil
 }
 
+// ReloadSpaces is not available via the V2 API.
+func (u *APIv2) ReloadSpaces(_, _ struct{}) {}
+
 // RefreshSpaces refreshes spaces from substrate
-func (api *spacesAPI) ReloadSpaces() error {
+func (api *API) ReloadSpaces() error {
 	canWrite, err := api.authorizer.HasPermission(permission.WriteAccess, api.backing.ModelTag())
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -27,7 +27,7 @@ type SpacesSuite struct {
 
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
-	facade     spaces.API
+	facade     *spaces.API
 
 	callContext  context.ProviderCallContext
 	blockChecker mockBlockChecker

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -248,6 +248,7 @@ func (s *SpacesSuite) TestNoSubnets(c *gc.C) {
 
 func (s *SpacesSuite) TestListSpacesDefault(c *gc.C) {
 	expected := []params.Space{{
+		Id:   "1",
 		Name: "default",
 		Subnets: []params.Subnet{{
 			CIDR:       "192.168.0.0/24",
@@ -263,6 +264,7 @@ func (s *SpacesSuite) TestListSpacesDefault(c *gc.C) {
 			SpaceTag:   "space-default",
 		}},
 	}, {
+		Id:   "2",
 		Name: "dmz",
 		Subnets: []params.Subnet{{
 			CIDR:       "192.168.1.0/24",
@@ -272,6 +274,7 @@ func (s *SpacesSuite) TestListSpacesDefault(c *gc.C) {
 			SpaceTag:   "space-dmz",
 		}},
 	}, {
+		Id:   "3",
 		Name: "private",
 		Subnets: []params.Subnet{{
 			CIDR:       "192.168.2.0/24",
@@ -281,9 +284,10 @@ func (s *SpacesSuite) TestListSpacesDefault(c *gc.C) {
 			SpaceTag:   "space-private",
 		}},
 	}}
-	spaces, err := s.facade.ListSpaces()
+
+	result, err := s.facade.ListSpaces()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(spaces.Results, jc.DeepEquals, expected)
+	c.Assert(result.Results, jc.DeepEquals, expected)
 }
 
 func (s *SpacesSuite) TestListSpacesAllSpacesError(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -29606,7 +29606,7 @@
     },
     {
         "Name": "Spaces",
-        "Version": 3,
+        "Version": 4,
         "Schema": {
             "type": "object",
             "properties": {
@@ -29745,6 +29745,9 @@
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
+                        "id": {
+                            "type": "string"
+                        },
                         "name": {
                             "type": "string"
                         },
@@ -29757,6 +29760,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
+                        "id",
                         "name",
                         "subnets"
                     ]

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -641,6 +641,7 @@ type ListSpacesResults struct {
 
 // Space holds the information about a single space and its associated subnets.
 type Space struct {
+	Id      string   `json:"id"`
 	Name    string   `json:"name"`
 	Subnets []Subnet `json:"subnets"`
 	Error   *Error   `json:"error,omitempty"`

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -121,6 +121,7 @@ type errReturner func() error
 
 // FakeSpace implements networkingcommon.BackingSpace for testing.
 type FakeSpace struct {
+	SpaceId   string
 	SpaceName string
 	SubnetIds []string
 	Public    bool
@@ -128,6 +129,10 @@ type FakeSpace struct {
 }
 
 var _ networkingcommon.BackingSpace = (*FakeSpace)(nil)
+
+func (f *FakeSpace) Id() string {
+	return f.SpaceId
+}
 
 func (f *FakeSpace) Name() string {
 	return f.SpaceName
@@ -396,18 +401,22 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 		// FakeSpace.Subnets().
 		sb.Spaces = []networkingcommon.BackingSpace{
 			&FakeSpace{
+				SpaceId:   "1",
 				SpaceName: "default",
 				SubnetIds: []string{"192.168.0.0/24", "192.168.3.0/24"},
 				NextErr:   sb.NextErr},
 			&FakeSpace{
+				SpaceId:   "2",
 				SpaceName: "dmz",
 				SubnetIds: []string{"192.168.1.0/24"},
 				NextErr:   sb.NextErr},
 			&FakeSpace{
+				SpaceId:   "3",
 				SpaceName: "private",
 				SubnetIds: []string{"192.168.2.0/24"},
 				NextErr:   sb.NextErr},
 			&FakeSpace{
+				SpaceId:   "4",
 				SpaceName: "private",
 				SubnetIds: []string{"192.168.2.0/24"},
 				NextErr:   sb.NextErr}, // duplicates are ignored when caching spaces.

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -10,11 +10,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gosuri/uitable"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
-	"github.com/gosuri/uitable"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -40,13 +40,18 @@ Supplying the --short option will list just the space names.
 The --output argument allows the command's output to be redirected to a file. 
 
 Examples:
+
+List spaces and their subnets:
+
 	juju spaces
+
+List spaces:
+
 	juju spaces --short
-	juju spaces --format yaml
-	juju spaces --format json
 
 See also:
 	add-space
+	reload-spaces
 `
 
 // Info is defined on the cmd.Command interface.

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -215,6 +215,7 @@ func printTabularLong(writer io.Writer, value interface{}) error {
 		for cidr := range s.Subnets {
 			cidrs = append(cidrs, cidr)
 		}
+		sort.Strings(cidrs)
 
 		table.AddRow(s.Id, spaceName(s.Name), cidrs[0])
 		for i := 1; i < len(cidrs); i++ {

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -35,11 +35,19 @@ type ListCommand struct {
 }
 
 const listCommandDoc = `
-Displays all defined spaces. If --short is not given both spaces and
-their subnets are displayed, otherwise just a list of spaces. The
---format argument has the same semantics as in other CLI commands -
-"yaml" is the default. The --output argument allows the command
-output to be redirected to a file. `
+Displays all defined spaces. By default both spaces and their subnets are displayed.
+Supplying the --short option will list just the space names.
+The --output argument allows the command's output to be redirected to a file. 
+
+Examples:
+	juju spaces
+	juju spaces --short
+	juju spaces --format yaml
+	juju spaces --format json
+
+See also:
+	add-space
+`
 
 // Info is defined on the cmd.Command interface.
 func (c *ListCommand) Info() *cmd.Info {

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -88,8 +88,12 @@ func (s *ListSuite) TestOutputFormats(c *gc.C) {
 	outDir := c.MkDir()
 	expectedYAML := `
 spaces:
-  (default): {}
-  space1:
+- id: "0"
+  name: ""
+  subnets: {}
+- id: "1"
+  name: space1
+  subnets:
     2001:db8::/32:
       type: ipv6
       provider-id: subnet-public
@@ -102,7 +106,9 @@ spaces:
       status: 'error: invalid subnet CIDR: invalid'
       zones:
       - zone1
-  space2:
+- id: "2"
+  name: space2
+  subnets:
     4.3.2.0/28:
       type: ipv4
       provider-id: vlan-42
@@ -120,37 +126,58 @@ spaces:
 	unwrap := regexp.MustCompile(`[\s+\n]`)
 	expectedJSON := unwrap.ReplaceAllLiteralString(`
 {
-  "spaces": {
-    "(default)": {},
-    "space1": {
-      "2001:db8::/32": {
-        "type": "ipv6",
-        "provider-id": "subnet-public",
-        "status": "terminating",
-        "zones": ["zone2"]
-      },
-      "invalid": {
-        "type": "unknown",
-        "provider-id": "no-such",
-        "status": "error: invalid subnet CIDR: invalid",
-        "zones": ["zone1"]
+  "spaces": [
+    {
+      "id": "0",
+      "name": "",
+      "subnets": {}
+    },
+    {
+      "id": "1",
+      "name": "space1",
+      "subnets": {
+        "2001:db8::/32": {
+          "type": "ipv6",
+          "provider-id": "subnet-public",
+          "status": "terminating",
+          "zones": [
+            "zone2"
+          ]
+        },
+        "invalid": {
+          "type": "unknown",
+          "provider-id": "no-such",
+          "status": "error: invalid subnet CIDR: invalid",
+          "zones": [
+            "zone1"
+          ]
+        }
       }
     },
-    "space2": {
-      "10.1.2.0/24": {
-        "type": "ipv4",
-        "provider-id": "subnet-private",
-        "status": "in-use",
-        "zones": ["zone1","zone2"]
-      },
-      "4.3.2.0/28": {
-        "type": "ipv4",
-        "provider-id": "vlan-42",
-        "status": "terminating",
-        "zones": ["zone1"]
+    {
+      "id": "2",
+      "name": "space2",
+      "subnets": {
+        "10.1.2.0/24": {
+          "type": "ipv4",
+          "provider-id": "subnet-private",
+          "status": "in-use",
+          "zones": [
+            "zone1",
+            "zone2"
+          ]
+        },
+        "4.3.2.0/28": {
+          "type": "ipv4",
+          "provider-id": "vlan-42",
+          "status": "terminating",
+          "zones": [
+            "zone1"
+          ]
+        }
       }
     }
-  }
+  ]
 }
 `, "") + "\n"
 	// Work around the big unwrap hammer above.
@@ -178,13 +205,13 @@ spaces:
 `, "") + "\n"
 
 	expectedTabular := `
-Space  Subnets
-(default)
-space1  2001:db8::/32
-        invalid
-space2  10.1.2.0/24
-        4.3.2.0/28
-
+Space  Name       Subnets      
+0      (default)               
+1      space1     2001:db8::/32
+                  invalid      
+2      space2     10.1.2.0/24  
+                  4.3.2.0/28   
+                               
 `[1:]
 
 	expectedShortTabular := `
@@ -293,13 +320,13 @@ func (s *ListSuite) TestRunWhenNoSpacesExistSucceedsWithProperFormat(c *gc.C) {
 
 	s.AssertRunSucceeds(c,
 		`no spaces to display\n`,
-		"{\"spaces\":{}}\n", // json formatted stdout.
+		"{\"spaces\":[]}\n", // json formatted stdout.
 		"--format=json",
 	)
 
 	s.AssertRunSucceeds(c,
 		`no spaces to display\n`,
-		"spaces: {}\n", // yaml formatted stdout.
+		"spaces: []\n", // yaml formatted stdout.
 		"--format=yaml",
 	)
 

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -191,11 +191,14 @@ func NewStubAPI() *StubAPI {
 		VLANTag:    42,
 	}}
 	spaces := []params.Space{{
+		Id:   "0",
 		Name: network.DefaultSpaceName,
 	}, {
+		Id:      "1",
 		Name:    "space1",
 		Subnets: append([]params.Subnet{}, subnets[:2]...),
 	}, {
+		Id:      "2",
 		Name:    "space2",
 		Subnets: append([]params.Subnet{}, subnets[2:]...),
 	}}

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/space"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
@@ -190,6 +191,8 @@ func NewStubAPI() *StubAPI {
 		VLANTag:    42,
 	}}
 	spaces := []params.Space{{
+		Name: network.DefaultSpaceName,
+	}, {
 		Name:    "space1",
 		Subnets: append([]params.Subnet{}, subnets[:2]...),
 	}, {

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -173,15 +173,14 @@ func (s *cmdSpaceSuite) TestSpaceCreateWithSubnets(c *gc.C) {
 	c.Assert(subnets[1].SpaceName(), gc.Equals, "myspace")
 }
 
-// TODO (manadart 2019-07-22): Fix this so that spaces are output with IDs.
 func (s *cmdSpaceSuite) TestSpaceListDefaultOnly(c *gc.C) {
 	stdout, _, err := s.Run(c, "spaces")
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := `
-Space  Subnets
-
-
+Space  Name       Subnets
+0      (default)         
+                         
 `[1:]
 
 	c.Assert(stdout, gc.Equals, expected)
@@ -191,7 +190,7 @@ func (s *cmdSpaceSuite) TestSpaceListOneResultNoSubnets(c *gc.C) {
 	s.AddSpace(c, "myspace", nil, true)
 
 	// The default space is listed in addition to the one we added.
-	expectedOutput := "{\"spaces\":{\"\":{},\"myspace\":{}}}\n"
+	expectedOutput := "{\"spaces\":[{\"id\":\"0\",\"name\":\"\",\"subnets\":{}},{\"id\":\"1\",\"name\":\"myspace\",\"subnets\":{}}]}\n"
 	stdout, _, err := s.Run(c, "list-spaces", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdout, jc.Contains, expectedOutput)
@@ -213,9 +212,11 @@ func (s *cmdSpaceSuite) TestSpaceListMoreResults(c *gc.C) {
 	// We dont' check the output in detail, just a few things - the
 	// rest it tested separately.
 	c.Assert(stdout, jc.Contains, "spaces:")
-	c.Assert(stdout, jc.Contains, "space1:")
+	c.Assert(stdout, jc.Contains, "id: \"0\"")
+	c.Assert(stdout, jc.Contains, "id: \"1\"")
+	c.Assert(stdout, jc.Contains, "name: space1")
 	c.Assert(stdout, jc.Contains, "10.10.2.0/24:")
-	c.Assert(stdout, jc.Contains, "space2:")
+	c.Assert(stdout, jc.Contains, "name: space2")
 	c.Assert(stdout, jc.Contains, "10.20.0.0/24:")
 	c.Assert(stdout, jc.Contains, "zones:")
 	c.Assert(stdout, jc.Contains, "zone1")


### PR DESCRIPTION
## Description of change

This patch ensures that the output of `juju spaces` shows the new space IDs.

The structure of the command output is changed accordingly, from a map of space name to space data, to a slice of spaces.

## QA steps

- Bootstrap to AWS.
- `juju add-space new-space 172.31.0.0/20`.
- `juju spaces`.
- Output should be:
```
Space  Name       Subnets
0      (default)
1      new-space  252.0.0.0/12
                  172.31.0.0/20
```

## Documentation changes

None.

## Bug reference

N/A
