### PR TITLE
Replace SpaceName with SpaceID in subnetDoc

### DIFF
--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -35,21 +35,18 @@ func (s *cmdSpaceSuite) AddSubnets(c *gc.C, infos []network.SubnetInfo) []*state
 
 func (s *cmdSpaceSuite) MakeSubnetInfos(c *gc.C, space string, cidrTemplate string, count int) (
 	infos []network.SubnetInfo,
-	ids []string,
 ) {
 	infos = make([]network.SubnetInfo, count)
-	ids = make([]string, count)
 	for i := range infos {
-		ids[i] = fmt.Sprintf(cidrTemplate, i)
 		infos[i] = network.SubnetInfo{
 			// ProviderId it needs to be unique in state.
 			ProviderId:        network.Id(fmt.Sprintf("sub-%d", rand.Int())),
-			CIDR:              ids[i],
+			CIDR:              fmt.Sprintf(cidrTemplate, i),
 			SpaceName:         space,
 			AvailabilityZones: []string{"zone1"},
 		}
 	}
-	return infos, ids
+	return infos
 }
 
 func (s *cmdSpaceSuite) AddSpace(c *gc.C, name string, ids []string, public bool) *state.Space {
@@ -151,7 +148,7 @@ func (s *cmdSpaceSuite) TestSpaceCreateNoSubnets(c *gc.C) {
 }
 
 func (s *cmdSpaceSuite) TestSpaceCreateWithSubnets(c *gc.C) {
-	infos, _ := s.MakeSubnetInfos(c, "", "10.1%d.0.0/16", 2)
+	infos := s.MakeSubnetInfos(c, "", "10.1%d.0.0/16", 2)
 	s.AddSubnets(c, infos)
 
 	_, stderr, err := s.Run(
@@ -198,13 +195,13 @@ func (s *cmdSpaceSuite) TestSpaceListOneResultNoSubnets(c *gc.C) {
 }
 
 func (s *cmdSpaceSuite) TestSpaceListMoreResults(c *gc.C) {
-	infos1, ids1 := s.MakeSubnetInfos(c, "space1", "10.10.%d.0/24", 3)
+	infos1 := s.MakeSubnetInfos(c, "space1", "10.10.%d.0/24", 3)
+	s.AddSpace(c, "space1", nil, true)
 	s.AddSubnets(c, infos1)
-	s.AddSpace(c, "space1", ids1, true)
 
-	infos2, ids2 := s.MakeSubnetInfos(c, "space2", "10.20.%d.0/24", 1)
+	infos2 := s.MakeSubnetInfos(c, "space2", "10.20.%d.0/24", 1)
+	s.AddSpace(c, "space2", nil, false)
 	s.AddSubnets(c, infos2)
-	s.AddSpace(c, "space2", ids2, false)
 
 	stdout, stderr, err := s.Run(c, "list-spaces", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -344,6 +344,10 @@ func (s *ipAddressesStateSuite) TestAllSpacesHandlesUnknownSubnets(c *gc.C) {
 }
 
 func resetSubnet(c *gc.C, st *state.State, subnetInfo corenetwork.SubnetInfo) {
+	// TODO (hml) 2019-07-26
+	// This comment is no longer valid.  Changes are in progress.
+	// Update when complete.
+	//
 	// We currently don't allow updating a subnet's information, so remove it
 	// and add it with the new value.
 	// XXX(jam): We should add mutation operations instead of this ugly hack
@@ -384,6 +388,8 @@ func (s *ipAddressesStateSuite) TestAllSpacesMultiSpace(c *gc.C) {
 		CIDR:      "10.20.0.0/16",
 		SpaceName: "default",
 	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("dmz-ipv6", "not-default", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, corenetwork.SubnetInfo{
 		CIDR:      "fc00::/64",

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1175,6 +1175,8 @@ func (e *exporter) subnets() error {
 			ProviderId:        string(subnet.ProviderId()),
 			ProviderNetworkId: string(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
+			// TODO (hml) 2019-07-25
+			// add migration for SpaceID and remove SpaceName once SpaceInfo updated.
 			SpaceName:         subnet.SpaceName(),
 			AvailabilityZones: subnet.AvailabilityZones(),
 			FanLocalUnderlay:  subnet.FanLocalUnderlay(),

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1095,13 +1095,14 @@ func (s *MigrationBaseSuite) TestRelationScopeSkipped(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
+	// TODO (hml) 2019-07-25
+	// Add SpaceID once migration piece done.
 	sn := corenetwork.SubnetInfo{
 		CIDR:              "10.0.0.0/24",
 		ProviderId:        corenetwork.Id("foo"),
 		ProviderNetworkId: corenetwork.Id("rust"),
 		VLANTag:           64,
 		AvailabilityZones: []string{"bar"},
-		SpaceName:         "bam",
 	}
 	sn.SetFan("100.2.0.0/16", "253.0.0.0/8")
 
@@ -1121,7 +1122,6 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.ProviderNetworkId(), gc.Equals, "rust")
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZones(), gc.DeepEquals, []string{"bar"})
-	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "100.2.0.0/16")
 	c.Assert(subnet.FanOverlay(), gc.Equals, "253.0.0.0/8")
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1348,7 +1348,8 @@ func (i *importer) subnets() error {
 			ProviderId:        network.Id(subnet.ProviderId()),
 			ProviderNetworkId: network.Id(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
-			SpaceName:         subnet.SpaceName(),
+			// TODO (hml) 2019-07-25
+			// add migration for SpaceID once SubnetInfo Updated
 			AvailabilityZones: subnet.AvailabilityZones(),
 		}
 		info.SetFan(subnet.FanLocalUnderlay(), subnet.FanOverlay())

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1179,13 +1179,14 @@ func (s *MigrationImportSuite) TestLinkLayerDeviceMigratesReferences(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
+	// TODO (hml) 2019-07-25
+	// Add SpaceID once migration piece done.
 	original, err := s.State.AddSubnet(corenetwork.SubnetInfo{
 		CIDR:              "10.0.0.0/24",
 		ProviderId:        corenetwork.Id("foo"),
 		ProviderNetworkId: corenetwork.Id("elm"),
 		VLANTag:           64,
 		AvailabilityZones: []string{"bar"},
-		SpaceName:         "bam",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSpace("bam", "", nil, true)
@@ -1201,15 +1202,15 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.ProviderNetworkId(), gc.Equals, corenetwork.Id("elm"))
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZones(), gc.DeepEquals, []string{"bar"})
-	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "")
 	c.Assert(subnet.FanOverlay(), gc.Equals, "")
 }
 
 func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {
+	// TODO (hml) 2019-07-25
+	// Add SpaceID once migration piece done.
 	_, err := s.State.AddSubnet(corenetwork.SubnetInfo{
-		CIDR:      "100.2.0.0/16",
-		SpaceName: "bam",
+		CIDR: "100.2.0.0/16",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1237,7 +1238,6 @@ func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {
 	c.Assert(subnet.ProviderNetworkId(), gc.Equals, corenetwork.Id("elm"))
 	c.Assert(subnet.VLANTag(), gc.Equals, 64)
 	c.Assert(subnet.AvailabilityZones(), gc.DeepEquals, []string{"bar"})
-	c.Assert(subnet.SpaceName(), gc.Equals, "bam")
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "100.2.0.0/16")
 	c.Assert(subnet.FanOverlay(), gc.Equals, "253.0.0.0/8")
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -654,7 +654,7 @@ func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
 	migrated := set.NewStrings(
 		"CIDR",
 		"VLANTag",
-		"SpaceName",
+		"SpaceID",
 		"ProviderId",
 		"AvailabilityZones",
 		"ProviderNetworkId",

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -486,6 +486,16 @@ func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
 	c.Assert(actual, jc.SameContents, []*state.Space{first, second, third, defaultSpace})
 }
 
+func (s *SpacesSuite) TestSpaceByID(c *gc.C) {
+	_, err := s.State.SpaceByID(network.DefaultSpaceId)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SpacesSuite) TestSpaceByIDNotFound(c *gc.C) {
+	_, err := s.State.SpaceByID("42")
+	c.Assert(err, gc.ErrorMatches, "space id \"42\" not found")
+}
+
 func (s *SpacesSuite) TestEnsureDeadSetsLifeToDeadWhenAlive(c *gc.C) {
 	space := s.addAliveSpace(c, "alive")
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -68,6 +68,7 @@ type StateBackend interface {
 	AddControllerNodeDocs() error
 	AddSpaceIdToSpaceDocs() error
 	ChangeSubnetAZtoSlice() error
+	ChangeSubnetSpaceNameToSpaceID() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -268,4 +269,8 @@ func (s stateBackend) AddSpaceIdToSpaceDocs() error {
 
 func (s stateBackend) ChangeSubnetAZtoSlice() error {
 	return state.ChangeSubnetAZtoSlice(s.pool)
+}
+
+func (s stateBackend) ChangeSubnetSpaceNameToSpaceID() error {
+	return state.ChangeSubnetSpaceNameToSpaceID(s.pool)
 }

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -27,5 +27,12 @@ func stateStepsFor27() []Step {
 				return context.State().ChangeSubnetAZtoSlice()
 			},
 		},
+		&upgradeStep{
+			description: "change subnet SpaceName to SpaceID",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().ChangeSubnetSpaceNameToSpaceID()
+			},
+		},
 	}
 }

--- a/upgrades/steps_27_test.go
+++ b/upgrades/steps_27_test.go
@@ -37,3 +37,9 @@ func (s *steps27Suite) TestChangeSubnetAZtoSlice(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps27Suite) TestChangeSubnetSpaceNameToSpaceID(c *gc.C) {
+	step := findStateStep(c, v27, `change subnet SpaceName to SpaceID`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
## Description of change

Add SpaceID to subnetDoc.  This is part of a larger body of work of Network Model Improvements.  It is also the first step in replacing the SpaceName with SpaceID for subnets.  Related upgrades will work.  Migration is a follow on pieces, as are updates to users of SpaceName within the juju code.

New state.SpaceByID() and subnet.SpaceID().

## QA steps

Bootstrap maas with multiple spaces with juju 2.6 stable.  Upgrade to current code.  No expected differences around spaces or subnets, output of `juju subnets` and `juju spaces` should stay the same.  Verify in juju-db that the subnetDoc has correct space-id instead of space-name.
