### PR TITLE
fix intermittent failures in statusUnitTestSuite.TestMigrationInProgress

### DIFF
--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/os"
 	"github.com/juju/os/series"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -27,6 +28,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	"github.com/juju/juju/environs/manual/winrmprovisioner"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -180,9 +182,20 @@ func newFacade(ctx facade.Context) (*Client, error) {
 		return nil, errors.Trace(err)
 	}
 
-	modelCache, err := ctx.Controller().Model(modelUUID)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var modelCache *cache.Model
+	if featureflag.Enabled(feature.Generations) {
+		// NOTE:
+		// Issues with the model cache updating fast enough were causing
+		// intermittent failures in statusUnitTestSuite.TestMigrationInProgress
+		// preventing merges and causing angst.  Hide use of the model
+		// cache behind a feature flag until these issues are resolved.
+		// A longer term solution would be to move to using the db for
+		// branch data in status output, if the model cache issues are
+		// not resolved before the branches feature is released.
+		modelCache, err = ctx.Controller().Model(modelUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	return NewClient(

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -806,6 +806,12 @@ func fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Re
 }
 
 func fetchBranches(m *cache.Model) map[string]cache.Branch {
+	// Unless you're using the generations feature flag,
+	// the model cache model will be nil.  See note in
+	// newFacade().
+	if m == nil {
+		return make(map[string]cache.Branch)
+	}
 	// m.Branches() returns only active branches.
 	b := m.Branches()
 	branches := make(map[string]cache.Branch, len(b))

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -352,14 +353,16 @@ func (s *statusUnitTestSuite) TestWorkloadVersionOkWithUnset(c *gc.C) {
 }
 
 func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
-	c.Skip("this test is quite flaky and causes about 8/10 CI runs to fail")
-
+	s.SetFeatureFlags(feature.Generations)
 	// Create a host model because controller models can't be migrated.
 	state2 := s.Factory.MakeModel(c, nil)
 	defer state2.Close()
 
 	model2, err := state2.Model()
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.State.StartSync()
+	s.WaitForModelWatchersIdle(c, model2.UUID())
 
 	// Get API connection to hosted model.
 	apiInfo := s.APIInfo(c)
@@ -838,6 +841,7 @@ var _ = gc.Suite(&filteringBranchesSuite{})
 
 func (s *filteringBranchesSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.Generations)
 
 	s.appA = "mysql"
 	s.appB = "wordpress"

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	environscontext "github.com/juju/juju/environs/context"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -4618,6 +4619,7 @@ func (ua setToolsUpgradeAvailable) step(c *gc.C, ctx *context) {
 }
 
 func (s *StatusSuite) TestStatusAllFormats(c *gc.C) {
+	s.SetFeatureFlags(feature.Generations)
 	for i, t := range statusTests {
 		c.Logf("test %d: %s", i, t.summary)
 		func(t testCase) {


### PR DESCRIPTION
## Description of change

Only use the model cache model in apiserver client if behind 
the generations feature flag. Causing intermittent failures in 
TestMigrationInProgress, and might cause issues for users too.
Changing use of feature flag after bootstrap is possible, as it's
found in the controller config.

TestMigrationInProgress uses a sync to wait for the model to 
show up in the case, remove Skip().

## QA steps

1. juju bootstrap localhost tuesday
4. juju deploy ubuntu 
3. juju status -- show no branch info
3. juju destroy-controller --destroy-all-models --destroy-storage --yes tuesday
1. export JUJU_DEV_FEATURE_FLAGS=generations
1. juju bootstrap localhost tuesday
4. juju deploy ubuntu 
5. juju add-branch apple
6. juju track apple ubuntu
3. juju status  -- shows the apple branch
