### PR TITLE
Expose subnet.IsPublic() and add to subnet migrations

### DIFF
--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -57,6 +57,9 @@ type SubnetInfo struct {
 	// It may be empty if this is not a fan subnet,
 	// or if this subnet information comes from a provider.
 	FanInfo *FanCIDRs
+
+	// IsPublic describes whether a subnet is public or not.
+	IsPublic bool
 }
 
 // SetFan sets the fan networking information for the subnet.

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1179,6 +1179,7 @@ func (e *exporter) subnets() error {
 			AvailabilityZones: subnet.AvailabilityZones(),
 			FanLocalUnderlay:  subnet.FanLocalUnderlay(),
 			FanOverlay:        subnet.FanOverlay(),
+			IsPublic:          subnet.IsPublic(),
 		}
 		e.model.AddSubnet(args)
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1103,6 +1103,7 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 		VLANTag:           64,
 		AvailabilityZones: []string{"bar"},
 		SpaceName:         sp.Name(),
+		IsPublic:          true,
 	}
 	sn.SetFan("100.2.0.0/16", "253.0.0.0/8")
 
@@ -1123,6 +1124,7 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.SpaceID(), gc.Equals, sp.Id())
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "100.2.0.0/16")
 	c.Assert(subnet.FanOverlay(), gc.Equals, "253.0.0.0/8")
+	c.Assert(subnet.IsPublic(), gc.Equals, true)
 }
 
 func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1349,6 +1349,7 @@ func (i *importer) subnets() error {
 			ProviderNetworkId: network.Id(subnet.ProviderNetworkId()),
 			VLANTag:           subnet.VLANTag(),
 			AvailabilityZones: subnet.AvailabilityZones(),
+			IsPublic:          subnet.IsPublic(),
 		}
 		info.SetFan(subnet.FanLocalUnderlay(), subnet.FanOverlay())
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1187,6 +1187,7 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 		VLANTag:           64,
 		SpaceName:         "bam",
 		AvailabilityZones: []string{"bar"},
+		IsPublic:          true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1203,6 +1204,7 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.SpaceID(), gc.Equals, sp.Id())
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, "")
 	c.Assert(subnet.FanOverlay(), gc.Equals, "")
+	c.Assert(subnet.IsPublic(), gc.Equals, true)
 }
 
 func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -647,9 +647,6 @@ func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
 		"ModelUUID",
 		// Always alive, not explicitly exported.
 		"Life",
-
-		// Currently unused (never set or exposed).
-		"IsPublic",
 	)
 	migrated := set.NewStrings(
 		"CIDR",
@@ -660,6 +657,7 @@ func (s *MigrationSuite) TestSubnetDocFields(c *gc.C) {
 		"ProviderNetworkId",
 		"FanLocalUnderlay",
 		"FanOverlay",
+		"IsPublic",
 	)
 	s.AssertExportedFields(c, subnetDoc{}, migrated.Union(ignored))
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -33,12 +33,10 @@ type subnetDoc struct {
 	CIDR              string   `bson:"cidr"`
 	VLANTag           int      `bson:"vlantag,omitempty"`
 	AvailabilityZones []string `bson:"availability-zones,omitempty"`
-	// TODO: add IsPublic to SubnetArgs, add an IsPublic method and add
-	// IsPublic to migration import/export.
-	IsPublic         bool   `bson:"is-public,omitempty"`
-	SpaceID          string `bson:"space-id,omitempty"`
-	FanLocalUnderlay string `bson:"fan-local-underlay,omitempty"`
-	FanOverlay       string `bson:"fan-overlay,omitempty"`
+	IsPublic          bool     `bson:"is-public,omitempty"`
+	SpaceID           string   `bson:"space-id,omitempty"`
+	FanLocalUnderlay  string   `bson:"fan-local-underlay,omitempty"`
+	FanOverlay        string   `bson:"fan-overlay,omitempty"`
 }
 
 // Life returns whether the subnet is Alive, Dying or Dead.
@@ -67,6 +65,11 @@ func (s *Subnet) FanOverlay() string {
 
 func (s *Subnet) FanLocalUnderlay() string {
 	return s.doc.FanLocalUnderlay
+}
+
+// IsPublic returns true if the subnet is public.
+func (s *Subnet) IsPublic() bool {
+	return s.doc.IsPublic
 }
 
 // EnsureDead sets the Life of the subnet to Dead, if it's Alive. If the subnet
@@ -353,6 +356,7 @@ func (st *State) newSubnetFromArgs(args network.SubnetInfo) (*Subnet, error) {
 		SpaceID:           sp.Id(),
 		FanLocalUnderlay:  args.FanLocalUnderlay(),
 		FanOverlay:        args.FanOverlay(),
+		IsPublic:          args.IsPublic,
 	}
 	subnet := &Subnet{doc: subDoc, st: st, spaceID: sp.Id()}
 	err = subnet.Validate()
@@ -382,6 +386,7 @@ func (st *State) addSubnetOps(args network.SubnetInfo) []txn.Op {
 		SpaceID:           sp.Id(),
 		FanLocalUnderlay:  args.FanLocalUnderlay(),
 		FanOverlay:        args.FanOverlay(),
+		IsPublic:          args.IsPublic,
 	}
 	ops := []txn.Op{
 		{

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -40,6 +40,7 @@ func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
 		AvailabilityZones: []string{"Timbuktu"},
 		SpaceName:         "foo",
 		ProviderNetworkId: "wildbirds",
+		IsPublic:          true,
 	}
 	subnetInfo.SetFan("10.0.0.0/8", "172.16.0.0/16")
 
@@ -64,6 +65,7 @@ func (s *SubnetSuite) assertSubnetMatchesInfo(c *gc.C, subnet *state.Subnet, inf
 	c.Assert(subnet.ProviderNetworkId(), gc.Equals, info.ProviderNetworkId)
 	c.Assert(subnet.FanLocalUnderlay(), gc.Equals, info.FanLocalUnderlay())
 	c.Assert(subnet.FanOverlay(), gc.Equals, info.FanOverlay())
+	c.Assert(subnet.IsPublic(), gc.Equals, info.IsPublic)
 }
 
 func (s *SubnetSuite) TestAddSubnetFailsWithEmptyCIDR(c *gc.C) {


### PR DESCRIPTION
## Description of change

Add IsPublic to SubnetInfo{}.  Use when creating a new subnet.  This is prep work.  
Export subnet IsPublic() and include in migrations.

## QA steps

No changes to current juju subnet behavior should be seen.

No provider currently sets the IsPublic flag on a subnet?  The create-subnet command 
behind the "post-net-cli-mvp" feature flag currently panics.  The only way to test 
migration would be to bootstrap a provider with networks.  Edit the db to set 
"is-public" to true on one. Do a juju migration and check the db values again.  Or rely
on the unit test.
