### PR TITLE
Rbac resource name prefix

### DIFF
--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1506,7 +1506,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 
 	svcAccount := &core.ServiceAccount{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "build-robot",
+			Name:      "juju-test-build-robot",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
@@ -1514,7 +1514,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 	}
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "pod-reader",
+			Name:      "juju-test-pod-reader",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
@@ -1528,18 +1528,18 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 	}
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "read-pods",
+			Name:      "juju-test-read-pods",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: "pod-reader",
+			Name: "juju-test-pod-reader",
 			Kind: "ClusterRole",
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "build-robot",
+				Name:      "juju-test-build-robot",
 				Namespace: "test",
 			},
 		},
@@ -1664,7 +1664,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 
 	svcAccount := &core.ServiceAccount{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "build-robot",
+			Name:      "juju-test-build-robot",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
@@ -1672,7 +1672,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	}
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "pod-reader",
+			Name:      "juju-test-pod-reader",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
@@ -1686,18 +1686,18 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	}
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "read-pods",
+			Name:      "juju-test-read-pods",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: "pod-reader",
+			Name: "juju-test-pod-reader",
 			Kind: "ClusterRole",
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "build-robot",
+				Name:      "juju-test-build-robot",
 				Namespace: "test",
 			},
 		},
@@ -1720,7 +1720,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 		s.mockClusterRoles.EXPECT().Update(cr).Times(1).Return(cr, nil),
 		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
 			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*crb}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Delete("read-pods", s.deleteOptions(v1.DeletePropagationForeground, &crbUID)).Times(1).Return(nil),
+		s.mockClusterRoleBindings.EXPECT().Delete("juju-test-read-pods", s.deleteOptions(v1.DeletePropagationForeground, &crbUID)).Times(1).Return(nil),
 		s.mockClusterRoleBindings.EXPECT().Create(crb).Times(1).Return(crb, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
 			Return(nil, s.k8sNotFoundError()),
@@ -1824,7 +1824,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountReferenceExistingClu
 
 	svcAccount := &core.ServiceAccount{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "build-robot",
+			Name:      "juju-test-build-robot",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
@@ -1846,7 +1846,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountReferenceExistingClu
 	}
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "read-pods",
+			Name:      "juju-test-read-pods",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
@@ -1857,7 +1857,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountReferenceExistingClu
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "build-robot",
+				Name:      "juju-test-build-robot",
 				Namespace: "test",
 			},
 		},
@@ -1874,7 +1874,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountReferenceExistingClu
 		s.mockClusterRoles.EXPECT().Get("pod-reader", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(cr, nil),
 		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
 			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*crb}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Delete("read-pods", s.deleteOptions(v1.DeletePropagationForeground, &crbUID)).Times(1).Return(nil),
+		s.mockClusterRoleBindings.EXPECT().Delete("juju-test-read-pods", s.deleteOptions(v1.DeletePropagationForeground, &crbUID)).Times(1).Return(nil),
 		s.mockClusterRoleBindings.EXPECT().Create(crb).Times(1).Return(crb, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
 			Return(nil, s.k8sNotFoundError()),


### PR DESCRIPTION

## Description of change

- prefixing RBAC resource names: `juju-<model-name>-<resource-name>`;
- fallback to app name if no name was defined in podspec: `juju-<model-name>-<app-name>`;

## QA steps

- prefixing rbac resource names;

```yaml
serviceAccount:
  name: build-robot
  automountServiceAccountToken: true
  capabilities:
    roleBinding:
      name: read-pods  # binding name
      type: ClusterRoleBinding  # RoleBinding/ClusterRoleBinding
    role:
      name: pod-reader
      type: ClusterRole  # Role/ClusterRole
      rules:
      - apiGroups: [""] # "" indicates the core API group
        resources: ["pods", "namespaces"]
        verbs: ["get", "watch", "list"]
```

```bash
$ mkubectl get sa,roles,clusterroles,rolebindings,clusterrolebindings -o wide -n t1
NAME                                 SECRETS   AGE
serviceaccount/juju-t1-build-robot   1         4m43s

NAME                                                                       AGE
clusterrole.rbac.authorization.k8s.io/juju-t1-pod-reader                   4m54s

NAME                                                                  AGE   ROLE                                             USERS   GROUPS   SERVICEACCOUNTS
clusterrolebinding.rbac.authorization.k8s.io/juju-t1-read-pods        5m3s   ClusterRole/juju-t1-pod-reader                                    t1/juju-t1-build-robot

```

- no names in podspec;

```yaml
serviceAccount:
  # name: build-robot
  automountServiceAccountToken: true
  capabilities:
    roleBinding:
      # name: read-pods  # binding name
      type: ClusterRoleBinding  # RoleBinding/ClusterRoleBinding
    role:
      # name: pod-reader
      type: ClusterRole  # Role/ClusterRole
      rules:
      - apiGroups: [""] # "" indicates the core API group
        resources: ["pods", "namespaces"]
        verbs: ["get", "watch", "list"]
```

```bash
$ mkubectl get sa,roles,clusterroles,rolebindings,clusterrolebindings -o wide -n t1
NAME                                 SECRETS   AGE
serviceaccount/juju-t1-mariadb-k8s   1         64s

NAME                                                                       AGE
clusterrole.rbac.authorization.k8s.io/juju-t1-mariadb-k8s                  64s

NAME                                                                  AGE   ROLE                                             USERS   GROUPS   SERVICEACCOUNTS
clusterrolebinding.rbac.authorization.k8s.io/juju-t1-mariadb-k8s      116s   ClusterRole/juju-t1-mariadb-k8s                                   t1/juju-t1-mariadb-k8s

```

- no change for referencing exisitng roles/clusterroles;

```yaml
serviceAccount:
  name: build-robot
  automountServiceAccountToken: true
  capabilities:
    roleBinding:
      name: read-pods  # binding name
      type: ClusterRoleBinding  # RoleBinding/ClusterRoleBinding
    role:
      name: nginx-ingress-microk8s-clusterrole
      type: ClusterRole
```

```bash
$ mkubectl get sa,roles,clusterroles,rolebindings,clusterrolebindings -o wide -n t1
NAME                                 SECRETS   AGE
serviceaccount/juju-t1-build-robot   1         6m37s

NAME                                                                       AGE
clusterrole.rbac.authorization.k8s.io/nginx-ingress-microk8s-clusterrole   48m

NAME                                                                  AGE   ROLE                                             USERS   GROUPS   SERVICEACCOUNTS
clusterrolebinding.rbac.authorization.k8s.io/juju-t1-read-pods        61s   ClusterRole/nginx-ingress-microk8s-clusterrole                    t1/juju-t1-build-robot

```




## Documentation changes

None

## Bug reference

None
