### PR TITLE
dev - support charm channel in bundles

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -451,11 +451,11 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:de54a8a2f94ace7552f36b0eca53166f3751886e338cf5953e192d2e30123de5"
+  digest = "1:3bf45368929d01a44755247cee64f93057c8a0f012ade9a227e4a60a6d2b85ff"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "bb96ad9a5018f64e67f46f63496580c8956b4fbf"
+  revision = "2ab5b6004f111b9f4792a67b14e2f03c37e0af1d"
 
 [[projects]]
   digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"
@@ -1487,18 +1487,7 @@
   revision = "77bc1b09aca2e72adbb0a608f2ba4ede37e9f704"
 
 [[projects]]
-  digest = "1:86df7d2874a5250cf64324e2ce4e88fea552aa1f5c1a3f065599bd1f381ce939"
-  name = "gopkg.in/juju/charmrepo.v2"
-  packages = [
-    ".",
-    "csclient",
-    "csclient/params",
-  ]
-  pruneopts = ""
-  revision = "653bbd81990d2d7d48e0fb931a3b0f52c694572f"
-
-[[projects]]
-  digest = "1:58b987791edd26aa46f1964df3fad56359386e5b872bd145c4cd5eadfb7be646"
+  digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"
   name = "gopkg.in/juju/charmrepo.v3"
   packages = [
     ".",
@@ -1507,7 +1496,7 @@
     "testing",
   ]
   pruneopts = ""
-  revision = "7778a447283bd71109671c20818544514e16e9d9"
+  revision = "2adcece4e962a51e0793b8562560cf9da874026f"
 
 [[projects]]
   digest = "1:74fbfdf0898041a163a696f0a901b6f4740a47ceffb1839d514ba75699a60c3e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/hashicorp/raft-boltdb"
 
 [[constraint]]
-  revision = "bb96ad9a5018f64e67f46f63496580c8956b4fbf"
+  revision = "2ab5b6004f111b9f4792a67b14e2f03c37e0af1d"
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
@@ -150,7 +150,7 @@
   revision = "77bc1b09aca2e72adbb0a608f2ba4ede37e9f704"
 
 [[constraint]]
-  revision = "7778a447283bd71109671c20818544514e16e9d9"
+  revision = "2adcece4e962a51e0793b8562560cf9da874026f"
   name = "gopkg.in/juju/charmrepo.v3"
 
 [[constraint]]
@@ -493,10 +493,6 @@
 [[override]]
   name = "gopkg.in/httprequest.v1"
   revision = "1a21782420ea13c3c6fb1d03578f446b3248edb1"
-
-[[override]]
-  name = "gopkg.in/juju/charmrepo.v2"
-  revision = "653bbd81990d2d7d48e0fb931a3b0f52c694572f"
 
 [[constraint]]
   name = "gopkg.in/juju/worker.v1"

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -169,7 +169,7 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"django", ""},
+		Args:   []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -189,7 +189,7 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty"},
+		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -241,7 +241,7 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"django", "kubernetes"},
+		Args:   []interface{}{"django", "kubernetes", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -261,7 +261,7 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:haproxy-42", "kubernetes"},
+		Args:   []interface{}{"cs:haproxy-42", "kubernetes", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -311,7 +311,7 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"django", ""},
+		Args:   []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -330,7 +330,7 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty"},
+		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",

--- a/apiserver/facades/client/client/bundles_test.go
+++ b/apiserver/facades/client/client/bundles_test.go
@@ -36,7 +36,7 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"django", ""},
+		Args:   []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -55,7 +55,7 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty"},
+		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",

--- a/charmstore/fakeclient.go
+++ b/charmstore/fakeclient.go
@@ -427,9 +427,8 @@ func (r Repository) Resolve(ref *charm.URL) (canonRef *charm.URL, supportedSerie
 // ResolveWithChannel disambiguates a charm to a specific revision.
 //
 // Part of the cmd/juju/application.DeployAPI interface
-func (r Repository) ResolveWithChannel(ref *charm.URL) (*charm.URL, params.Channel, []string, error) {
-	canonRef, supportedSeries, err := r.Resolve(ref)
-	return canonRef, r.channel, supportedSeries, err
+func (r Repository) ResolveWithPreferredChannel(ref *charm.URL, preferredChannel params.Channel) (*charm.URL, params.Channel, []string, error) {
+	return r.addRevision(ref), preferredChannel, []string{"trusty", "wily", "quantal"}, nil
 }
 
 // Get retrieves a charm from the repository.

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -357,12 +357,16 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			continue
 		}
 
-		h.ctx.Infof("Resolving charm: %s", spec.Charm)
+		var fromChannel string
+		if spec.Channel != "" {
+			fromChannel = fmt.Sprintf(" from channel: %s", spec.Channel)
+		}
+		h.ctx.Infof("Resolving charm: %s%s", spec.Charm, fromChannel)
 		ch, err := charm.ParseURL(spec.Charm)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		url, _, _, err := resolveCharm(h.api.ResolveWithChannel, ch)
+		url, _, _, err := resolveCharm(h.api.ResolveWithPreferredChannel, ch, csparams.Channel(spec.Channel))
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve URL %q", spec.Charm)
 		}
@@ -515,7 +519,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 
-	url, channel, _, err := resolveCharm(h.api.ResolveWithChannel, ch)
+	url, channel, _, err := resolveCharm(h.api.ResolveWithPreferredChannel, ch, csparams.Channel(p.Channel))
 	if err != nil {
 		return errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
 	}

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -179,9 +179,7 @@ func (c *bundleDiffCommand) bundleDataSource(ctx *cmd.Context) (charm.BundleData
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	bundleURL, _, err := resolveBundleURL(
-		charmStore, c.bundle,
-	)
+	bundleURL, _, err := resolveBundleURL(charmStore, c.bundle, c.channel)
 	if err != nil && !errors.IsNotValid(err) {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/bundlediff_test.go
+++ b/cmd/juju/application/bundlediff_test.go
@@ -349,8 +349,8 @@ type mockCharmStore struct {
 	bundle  *mockBundle
 }
 
-func (s *mockCharmStore) ResolveWithChannel(url *charm.URL) (*charm.URL, csparams.Channel, []string, error) {
-	s.stub.AddCall("ResolveWithChannel", url)
+func (s *mockCharmStore) ResolveWithPreferredChannel(url *charm.URL, preferredChannel csparams.Channel) (*charm.URL, csparams.Channel, []string, error) {
+	s.stub.AddCall("ResolveWithPreferredChannel", url, preferredChannel)
 	return s.url, s.channel, s.series, s.stub.NextErr()
 }
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -302,7 +302,7 @@ func NewDeployCommand() modelcmd.ModelCommand {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		cstoreClient := newCharmStoreClient(bakeryClient, csURL).WithChannel(deployCmd.Channel)
+		cstoreClient := newCharmStoreClient(bakeryClient, csURL)
 
 		return &deployAPIAdapter{
 			Connection:        apiRoot,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2570,13 +2570,13 @@ func (f *fakeDeployAPI) ModelGet() (map[string]interface{}, error) {
 	return results[0].(map[string]interface{}), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) ResolveWithChannel(url *charm.URL) (
+func (f *fakeDeployAPI) ResolveWithPreferredChannel(url *charm.URL, preferredChannel csclientparams.Channel) (
 	*charm.URL,
 	csclientparams.Channel,
 	[]string,
 	error,
 ) {
-	results := f.MethodCall(f, "ResolveWithChannel", url)
+	results := f.MethodCall(f, "ResolveWithPreferredChannel", url, preferredChannel)
 
 	return results[0].(*charm.URL),
 		results[1].(csclientparams.Channel),
@@ -2805,7 +2805,7 @@ func withCharmRepoResolvable(
 	fakeAPI *fakeDeployAPI,
 	url *charm.URL,
 ) {
-	fakeAPI.Call("ResolveWithChannel", url).Returns(
+	fakeAPI.Call("ResolveWithPreferredChannel", url, csclientparams.NoChannel).Returns(
 		url,
 		csclientparams.Channel(""),
 		[]string{"bionic"}, // Supported series

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -28,20 +28,24 @@ type SeriesConfig interface {
 	DefaultSeries() (string, bool)
 }
 
-// ResolveCharmFunc is the type of a function that resolves a charm URL.
+// ResolveCharmFunc is the type of a function that resolves a charm URL with
+// an optionally specified preferred channel.
 type ResolveCharmFunc func(
-	resolveWithChannel func(*charm.URL) (*charm.URL, csparams.Channel, []string, error),
+	resolveWithChannel func(*charm.URL, csparams.Channel) (*charm.URL, csparams.Channel, []string, error),
 	url *charm.URL,
+	preferredChannel csparams.Channel,
 ) (*charm.URL, csparams.Channel, []string, error)
 
 func resolveCharm(
-	resolveWithChannel func(*charm.URL) (*charm.URL, csparams.Channel, []string, error),
+	resolveWithChannel func(*charm.URL, csparams.Channel) (*charm.URL, csparams.Channel, []string, error),
 	url *charm.URL,
+	preferredChannel csparams.Channel,
 ) (*charm.URL, csparams.Channel, []string, error) {
 	if url.Schema != "cs" {
 		return nil, csparams.NoChannel, nil, errors.Errorf("unknown schema for charm URL %q", url)
 	}
-	resultURL, channel, supportedSeries, err := resolveWithChannel(url)
+
+	resultURL, channel, supportedSeries, err := resolveWithChannel(url, preferredChannel)
 	if err != nil {
 		return nil, csparams.NoChannel, nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -583,7 +583,7 @@ func (c *upgradeCharmCommand) addCharm(
 	}
 
 	// Charm has been supplied as a URL so we resolve and deploy using the store.
-	newURL, channel, supportedSeries, err := c.ResolveCharm(charmRepo.ResolveWithChannel, refURL)
+	newURL, channel, supportedSeries, err := c.ResolveCharm(charmRepo.ResolveWithPreferredChannel, refURL, c.Channel)
 	if err != nil {
 		return id, nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -87,10 +87,11 @@ func (s *UpgradeCharmSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.resolveCharm = func(
-		resolveWithChannel func(*charm.URL) (*charm.URL, csclientparams.Channel, []string, error),
+		resolveWithChannel func(*charm.URL, csclientparams.Channel) (*charm.URL, csclientparams.Channel, []string, error),
 		url *charm.URL,
+		preferredChannel csclientparams.Channel,
 	) (*charm.URL, csclientparams.Channel, []string, error) {
-		s.AddCall("ResolveCharm", resolveWithChannel, url)
+		s.AddCall("ResolveCharm", resolveWithChannel, url, preferredChannel)
 		if err := s.NextErr(); err != nil {
 			return nil, csclientparams.NoChannel, nil, err
 		}
@@ -656,13 +657,13 @@ var upgradeCharmAuthorizationTests = []struct {
 	uploadURL:    "cs:~bob/trusty/wordpress5-10",
 	switchURL:    "cs:~bob/trusty/wordpress5",
 	readPermUser: "bob",
-	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress5": cannot get "/~bob/trusty/wordpress5/meta/any\?include=id&include=supported-series&include=published": access denied for user "client-username"`,
+	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress5": cannot get "/~bob/trusty/wordpress5/meta/any\?channel=stable&include=id&include=supported-series&include=published": access denied for user "client-username"`,
 }, {
 	about:        "non-public charm, fully resolved, access denied",
 	uploadURL:    "cs:~bob/trusty/wordpress6-47",
 	switchURL:    "cs:~bob/trusty/wordpress6-47",
 	readPermUser: "bob",
-	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress6-47": cannot get "/~bob/trusty/wordpress6-47/meta/any\?include=id&include=supported-series&include=published": access denied for user "client-username"`,
+	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress6-47": cannot get "/~bob/trusty/wordpress6-47/meta/any\?channel=stable&include=id&include=supported-series&include=published": access denied for user "client-username"`,
 }}
 
 func (s *UpgradeCharmCharmStoreStateSuite) TestUpgradeCharmAuthorization(c *gc.C) {


### PR DESCRIPTION
## Description of change

This PR introduces support for bundles which can specify a per-application channel for fetching its charm. 

Prior to the changes introduced by this PR, the value of the `--channel` parameter was injected into the charmstore client and used to resolve metadata/URLs for **all** charms. So for example, if we attempted to deploy a bundle from the `edge` channel (e.g. `juju deploy --channel edge cs:$some-bundle-in-edge`), each charm within the bundle would be looked up from the edge channel and potentially cause issues like (1677404; see bug reference below).

The various resolve URL implementations used by the deploy/updatecharm/bundle diff commands have been updated to use the appropriate channel when resolving bundle/charm URLS. The lookup rules are summarized below:

- For **bundle** deployments, use the value of `--channel` flag (if provided)
- For **individual charm** deployments (e.g. `juju deploy mysql`), use the value of `--channel` flag (if provided)
- For deploying **charms within a bundle**, use the value of the [channel](https://github.com/juju/charm/blob/v6/bundledata.go#L198) application-level bundle attribute if one is provided.

## QA steps

```console 
$ juju bootstrap lxd test --no-gui

## Deploy remote charm from a specific channel
$ juju deploy --channel edge cs:~juju-qa/bionic/dummy-in-edge
Located charm "cs:~juju-qa/bionic/dummy-in-edge-0".
Deploying charm "cs:~juju-qa/bionic/dummy-in-edge-0".

## Deploy local bundle with different channels per charm
$ cat > charm-channels.yaml << EOT
applications:
  dummy-in-edge:
    charm: cs:~juju-qa/bionic/dummy-in-edge
    channel: edge
  other-dummy-in-beta:
    charm: cs:~juju-qa/bionic/other-dummy-in-beta
    channel: beta
  wordpress:
    charm: wordpress
EOT

$ juju deploy ./charm-channels.yaml --debug --dry-run

12:24:33 INFO  juju.cmd supercommand.go:79 running juju [2.7-beta1 4039b10d183fb7f4cd147601e30e57e658dc1dfb gc go1.12.6]
12:24:33 DEBUG juju.cmd supercommand.go:80   args: []string{"juju", "deploy", "./charm-channels.yaml", "--debug", "--dry-run"}
12:24:33 INFO  juju.juju api.go:67 connecting to API addresses: [10.65.47.252:17070]
12:24:33 DEBUG juju.api apiclient.go:1092 successfully dialed "wss://10.65.47.252:17070/model/eb7cdd10-383c-49d9-8b3f-70176cbe1e73/api"
12:24:33 INFO  juju.api apiclient.go:624 connection established to "wss://10.65.47.252:17070/model/eb7cdd10-383c-49d9-8b3f-70176cbe1e73/api"
12:24:33 INFO  juju.juju api.go:67 connecting to API addresses: [10.65.47.252:17070]
12:24:33 DEBUG juju.api apiclient.go:1092 successfully dialed "wss://10.65.47.252:17070/api"
12:24:33 INFO  juju.api apiclient.go:624 connection established to "wss://10.65.47.252:17070/api"
12:24:33 DEBUG juju.cmd.juju.application bundle.go:308 model: &bundlechanges.Model{
    Applications: {
    },
    Machines: {
    },
    Relations:        nil,
    ConstraintsEqual: func(string, string) bool {...},
    Sequence:         {"application-dummy-in-edge":1, "machine":1},
    sequence:         {},
    MachineMap:       {},
    logger:           nil,
}
12:24:33 INFO  cmd bundle.go:366 Resolving charm: cs:~juju-qa/bionic/dummy-in-edge from channel: edge
12:24:33 DEBUG httpbakery client.go:243 client do GET https://api.jujucharms.com/charmstore/v5/~juju-qa/bionic/dummy-in-edge/meta/any?channel=edge&include=id&include=supported-series&include=published {
12:24:33 DEBUG httpbakery client.go:245 } -> error <nil>
12:24:33 INFO  cmd bundle.go:366 Resolving charm: cs:~juju-qa/bionic/other-dummy-in-beta from channel: beta
12:24:33 DEBUG httpbakery client.go:243 client do GET https://api.jujucharms.com/charmstore/v5/~juju-qa/bionic/other-dummy-in-beta/meta/any?channel=beta&include=id&include=supported-series&include=published {
12:24:33 DEBUG httpbakery client.go:245 } -> error <nil>
12:24:33 INFO  cmd bundle.go:366 Resolving charm: wordpress
12:24:33 DEBUG httpbakery client.go:243 client do GET https://api.jujucharms.com/charmstore/v5/wordpress/meta/any?include=id&include=supported-series&include=published {
12:24:34 DEBUG httpbakery client.go:245 } -> error <nil>
Changes to deploy bundle:
- upload charm cs:~juju-qa/bionic/dummy-in-edge-0 for series bionic from channel edge
- deploy application dummy-in-edge on bionic using cs:~juju-qa/bionic/dummy-in-edge-0
- upload charm cs:~juju-qa/bionic/other-dummy-in-beta-0 for series bionic from channel beta
- deploy application other-dummy-in-beta on bionic using cs:~juju-qa/bionic/other-dummy-in-beta-0
- upload charm cs:trusty/wordpress-5 for series trusty
- deploy application wordpress on trusty using cs:trusty/wordpress-5
12:24:34 DEBUG juju.api monitor.go:35 RPC connection died
12:24:34 INFO  cmd supercommand.go:508 command finished

## Deploy remote bundle from "candidate" channel where charms are resolved by the default channel (tests fix for the bug below)

$  juju deploy --channel candidate cs:~juju-qa/bundle/bundle-in-candidate-0 --debug --dry-run
12:29:35 INFO  juju.cmd supercommand.go:79 running juju [2.7-beta1 4039b10d183fb7f4cd147601e30e57e658dc1dfb gc go1.12.6]
12:29:35 DEBUG juju.cmd supercommand.go:80   args: []string{"juju", "deploy", "--channel", "candidate", "cs:~juju-qa/bundle/bundle-in-candidate-0", "--debug", "--dry-run"}
12:29:35 INFO  juju.juju api.go:67 connecting to API addresses: [10.65.47.252:17070]
12:29:35 DEBUG juju.api apiclient.go:1092 successfully dialed "wss://10.65.47.252:17070/model/eb7cdd10-383c-49d9-8b3f-70176cbe1e73/api"
12:29:35 INFO  juju.api apiclient.go:624 connection established to "wss://10.65.47.252:17070/model/eb7cdd10-383c-49d9-8b3f-70176cbe1e73/api"
12:29:35 INFO  juju.juju api.go:67 connecting to API addresses: [10.65.47.252:17070]
12:29:35 DEBUG juju.api apiclient.go:1092 successfully dialed "wss://10.65.47.252:17070/api"
12:29:35 INFO  juju.api apiclient.go:624 connection established to "wss://10.65.47.252:17070/api"
12:29:35 DEBUG juju.cmd.juju.application deploy.go:1440 cannot interpret as local charm: file does not exist
12:29:35 DEBUG juju.cmd.juju.application deploy.go:1304 cannot interpret as a redeployment of a local charm from the controller
12:29:35 DEBUG httpbakery client.go:243 client do GET https://api.jujucharms.com/charmstore/v5/~juju-qa/bundle/bundle-in-candidate-0/meta/any?channel=candidate&include=id&include=supported-series&include=published {
12:29:35 DEBUG httpbakery client.go:245 } -> error <nil>
12:29:35 DEBUG httpbakery client.go:243 client do GET https://api.jujucharms.com/charmstore/v5/~juju-qa/bundle/bundle-in-candidate-0/archive {
12:29:35 DEBUG httpbakery client.go:245 } -> error <nil>
12:29:35 INFO  cmd deploy.go:1544 Located bundle "cs:~juju-qa/bundle/bundle-in-candidate-0"
12:29:36 DEBUG juju.cmd.juju.application bundle.go:308 model: &bundlechanges.Model{
    Applications: {
    },
    Machines: {
    },
    Relations:        nil,
    ConstraintsEqual: func(string, string) bool {...},
    Sequence:         {"application-dummy-in-edge":1, "machine":1},
    sequence:         {},
    MachineMap:       {},
    logger:           nil,
}
12:29:36 INFO  cmd bundle.go:366 Resolving charm: wordpress
12:29:36 DEBUG httpbakery client.go:243 client do GET https://api.jujucharms.com/charmstore/v5/wordpress/meta/any?include=id&include=supported-series&include=published {
12:29:36 DEBUG httpbakery client.go:245 } -> error <nil>
Changes to deploy bundle:
- upload charm cs:trusty/wordpress-5 for series trusty
- deploy application wordpress on trusty using cs:trusty/wordpress-5
- set annotations for wordpress
12:29:36 INFO  cmd bundle.go:1070   setting annotations:
12:29:36 INFO  cmd bundle.go:1072     bundleURL: "cs:~juju-qa/bundle/bundle-in-candidate-0"
12:29:36 DEBUG juju.api monitor.go:35 RPC connection died
12:29:36 INFO  cmd supercommand.go:508 command finished
```

You will also need to make similar tests for `upgrade-charm` and `bundle-diff` but please keep in mind that upgrade charm uses `stable` as the default value for the channel argument!

## Important notes / questions

- The `charm` command does not yet support per-charm channels. Attempting to push the bundle from the QA steps will fail (addressed by https://github.com/juju/charmstore/pull/885)
- Any other piece of code (except the go client) using `bundlechanges` will need to be updated to handle the channel which is exposed as part of the `AddCharm` change type.

@mitechie ^^^

## Documentation changes

We probably need to update our docs to clarify how users can specify the channel for each charm in a bundle.

## Bug reference

The changes introduced by this PR also fix the issues reported in  https://bugs.launchpad.net/juju/+bug/1677404 