### PR TITLE
Remove bundle-cmr feature flag from the codebase

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/os/series"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/yaml.v2"
@@ -27,7 +26,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/storage"
 )
@@ -433,7 +431,7 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 		}
 
 		// Populate offer list
-		if offerList := application.Offers(); offerList != nil && featureflag.Enabled(feature.CMRAwareBundles) {
+		if offerList := application.Offers(); offerList != nil {
 			newApplication.Offers = make(map[string]*charm.OfferSpec)
 			for _, offer := range offerList {
 				newApplication.Offers[offer.OfferName()] = &charm.OfferSpec{
@@ -466,14 +464,13 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 		data.Machines[machine.Id()] = newMachine
 	}
 
-	if featureflag.Enabled(feature.CMRAwareBundles) {
-		for _, application := range model.RemoteApplications() {
-			newSaas := &charm.SaasSpec{
-				URL: application.URL(),
-			}
-			data.Saas[application.Name()] = newSaas
+	for _, application := range model.RemoteApplications() {
+		newSaas := &charm.SaasSpec{
+			URL: application.URL(),
 		}
+		data.Saas[application.Name()] = newSaas
 	}
+
 	// If there is only one series used, make it the default and remove
 	// series from all the apps and machines.
 	size := usedSeries.Size()

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/bundle"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -543,7 +542,6 @@ applications:
 }
 
 func (s *bundleSuite) TestExportBundleWithApplicationOffers(c *gc.C) {
-	s.SetFeatureFlags(feature.CMRAwareBundles)
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
 		Config: map[string]interface{}{
 			"name": "awesome",
@@ -620,7 +618,6 @@ applications:
 }
 
 func (s *bundleSuite) TestExportBundleWithSaas(c *gc.C) {
-	s.SetFeatureFlags(feature.CMRAwareBundles)
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
 		Config: map[string]interface{}{
 			"name": "awesome",

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/utils/featureflag"
 	"github.com/kr/pretty"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charm.v6/resource"
@@ -38,7 +37,6 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
@@ -396,23 +394,6 @@ func (h *bundleHandler) getChanges() error {
 		})
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	// Filter cmr-related changes if the feature flag is not enabled. We
-	// need to do it here rather in handleChanges() as the bundle handler
-	// will also iterate the list to print out a changelog.
-	if !featureflag.Enabled(feature.CMRAwareBundles) {
-		var filtered []bundlechanges.Change
-		for _, ch := range changes {
-			if ch.Method() == "createOffer" ||
-				ch.Method() == "consumeOffer" ||
-				ch.Method() == "grantOfferAccess" {
-				continue
-			}
-
-			filtered = append(filtered, ch)
-		}
-		changes = filtered
 	}
 
 	h.changes = changes

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/loggo"
@@ -711,7 +710,6 @@ func (s *DeploySuite) TestDeployBundleWithOffers(c *gc.C) {
 		},
 	}
 
-	s.SetFeatureFlags(feature.CMRAwareBundles)
 	bundlePath := testcharms.RepoWithSeries("bionic").ClonedBundleDirPath(c.MkDir(), "apache2-with-offers")
 	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), bundlePath)
 	c.Assert(err, jc.ErrorIsNil)
@@ -805,7 +803,6 @@ func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 		},
 	}
 
-	s.SetFeatureFlags(feature.CMRAwareBundles)
 	bundlePath := testcharms.RepoWithSeries("bionic").ClonedBundleDirPath(c.MkDir(), "wordpress-with-saas")
 	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), bundlePath)
 	c.Assert(err, jc.ErrorIsNil)

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -61,7 +61,3 @@ const MongoDbSSTXN = "mongodb-sstxn"
 // MultiCloud tells Juju to allow a different IAAS cloud to the one the controller
 // was bootstrapped on to be added to the controller.
 const MultiCloud = "multi-cloud"
-
-// CMRAwareBundles allows Juju to recognize and handle offer and saas blocks
-// when deploying bundles.
-const CMRAwareBundles = "bundle-cmr"


### PR DESCRIPTION
Now that all the required bits for supporting bundles with offers/saas
blocks have landed on develop, we can safely remove the feature flag.