### PR TITLE
Make EnsureService to do ports check if server spec and also to allow…

### DIFF
--- a/caas/containers.go
+++ b/caas/containers.go
@@ -56,6 +56,28 @@ type ContainerSpec struct {
 	ProviderContainer `yaml:"-"`
 }
 
+// Validate is defined on ProviderContainer.
+func (spec *ContainerSpec) Validate() error {
+	if spec.Name == "" {
+		return errors.New("spec name is missing")
+	}
+	if spec.Image == "" && spec.ImageDetails.ImagePath == "" {
+		return errors.New("spec image details is missing")
+	}
+	for _, fs := range spec.Files {
+		if fs.Name == "" {
+			return errors.New("file set name is missing")
+		}
+		if fs.MountPath == "" {
+			return errors.Errorf("mount path is missing for file set %q", fs.Name)
+		}
+	}
+	if spec.ProviderContainer != nil {
+		return spec.ProviderContainer.Validate()
+	}
+	return nil
+}
+
 // RBACType describes Role/Binding type.
 type RBACType string
 
@@ -195,28 +217,6 @@ func (spec *PodSpec) Validate() error {
 	}
 	if spec.ServiceAccount != nil {
 		return spec.ServiceAccount.Validate()
-	}
-	return nil
-}
-
-// Validate is defined on ProviderContainer.
-func (spec *ContainerSpec) Validate() error {
-	if spec.Name == "" {
-		return errors.New("spec name is missing")
-	}
-	if spec.Image == "" && spec.ImageDetails.ImagePath == "" {
-		return errors.New("spec image details is missing")
-	}
-	for _, fs := range spec.Files {
-		if fs.Name == "" {
-			return errors.New("file set name is missing")
-		}
-		if fs.MountPath == "" {
-			return errors.Errorf("mount path is missing for file set %q", fs.Name)
-		}
-	}
-	if spec.ProviderContainer != nil {
-		return spec.ProviderContainer.Validate()
 	}
 	return nil
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1118,9 +1118,6 @@ func (k *kubernetesClient) EnsureService(
 	if params == nil || params.PodSpec == nil {
 		return errors.Errorf("missing pod spec")
 	}
-	if params.PodSpec.OmitServiceFrontend && len(params.Filesystems) == 0 {
-		return errors.Errorf("kubernetes service is required when using storage")
-	}
 
 	var cleanups []func()
 	defer func() {
@@ -1294,6 +1291,9 @@ func (k *kubernetesClient) EnsureService(
 				}
 				ports = append(ports, p)
 			}
+		}
+		if len(ports) == 0 {
+			return errors.Errorf("ports are required for kubernetes service")
 		}
 
 		serviceAnnotations := annotations.Copy()
@@ -1752,7 +1752,8 @@ func (k *kubernetesClient) deleteVolumeClaims(appName string, p *core.Pod) ([]st
 }
 
 func (k *kubernetesClient) configureService(
-	appName, deploymentName string, containerPorts []core.ContainerPort,
+	appName, deploymentName string,
+	containerPorts []core.ContainerPort,
 	params *caas.ServiceParams,
 	config application.ConfigAttributes,
 ) error {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1204,6 +1204,82 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *K8sBrokerSuite) TestEnsureServiceServiceWithoutPortsNotValid(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	// unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", getBasicPodspec())
+	// c.Assert(err, jc.ErrorIsNil)
+	// podSpec := provider.PodSpec(unitSpec)
+
+	// numUnits := int32(2)
+	// statefulSetArg := &appsv1.StatefulSet{
+	// 	ObjectMeta: v1.ObjectMeta{
+	// 		Name: "app-name",
+	// 		Annotations: map[string]string{
+	// 			"juju-app-uuid": "appuuid",
+	// 		},
+	// 	},
+	// 	Spec: appsv1.StatefulSetSpec{
+	// 		Replicas: &numUnits,
+	// 		Selector: &v1.LabelSelector{
+	// 			MatchLabels: map[string]string{"juju-app": "app-name"},
+	// 		},
+	// 		Template: core.PodTemplateSpec{
+	// 			ObjectMeta: v1.ObjectMeta{
+	// 				Labels: map[string]string{"juju-app": "app-name"},
+	// 				Annotations: map[string]string{
+	// 					"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+	// 					"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+	// 				},
+	// 			},
+	// 			Spec: podSpec,
+	// 		},
+	// 		PodManagementPolicy: apps.ParallelPodManagement,
+	// 		ServiceName:         "app-name-endpoints",
+	// 	},
+	// }
+
+	serviceArg := *basicServiceArg
+	serviceArg.Spec.Type = core.ServiceTypeExternalName
+	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
+			Return(nil, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+		s.mockSecrets.EXPECT().Delete("app-name-test-secret", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+			Return(nil),
+	)
+	caasPodSpec := getBasicPodspec()
+	for k, v := range caasPodSpec.Containers {
+		v.Ports = []caas.ContainerPort{}
+		caasPodSpec.Containers[k] = v
+	}
+	c.Assert(caasPodSpec.OmitServiceFrontend, jc.IsFalse)
+	for _, v := range caasPodSpec.Containers {
+		c.Check(len(v.Ports), jc.DeepEquals, 0)
+	}
+	params := &caas.ServiceParams{
+		PodSpec: caasPodSpec,
+		Deployment: caas.DeploymentParams{
+			DeploymentType: caas.DeploymentStateful,
+			ServiceType:    caas.ServiceExternal,
+		},
+	}
+	err := s.broker.EnsureService(
+		"app-name",
+		func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil },
+		params, 2,
+		application.ConfigAttributes{
+			"kubernetes-service-loadbalancer-ip": "10.0.0.1",
+			"kubernetes-service-externalname":    "ext-name",
+		},
+	)
+	c.Assert(err, gc.ErrorMatches, `ports are required for kubernetes service`)
+}
+
 func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionCreate(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1208,38 +1208,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceServiceWithoutPortsNotValid(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	// unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", getBasicPodspec())
-	// c.Assert(err, jc.ErrorIsNil)
-	// podSpec := provider.PodSpec(unitSpec)
-
-	// numUnits := int32(2)
-	// statefulSetArg := &appsv1.StatefulSet{
-	// 	ObjectMeta: v1.ObjectMeta{
-	// 		Name: "app-name",
-	// 		Annotations: map[string]string{
-	// 			"juju-app-uuid": "appuuid",
-	// 		},
-	// 	},
-	// 	Spec: appsv1.StatefulSetSpec{
-	// 		Replicas: &numUnits,
-	// 		Selector: &v1.LabelSelector{
-	// 			MatchLabels: map[string]string{"juju-app": "app-name"},
-	// 		},
-	// 		Template: core.PodTemplateSpec{
-	// 			ObjectMeta: v1.ObjectMeta{
-	// 				Labels: map[string]string{"juju-app": "app-name"},
-	// 				Annotations: map[string]string{
-	// 					"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-	// 					"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-	// 				},
-	// 			},
-	// 			Spec: podSpec,
-	// 		},
-	// 		PodManagementPolicy: apps.ParallelPodManagement,
-	// 		ServiceName:         "app-name-endpoints",
-	// 	},
-	// }
-
 	serviceArg := *basicServiceArg
 	serviceArg.Spec.Type = core.ServiceTypeExternalName
 	gomock.InOrder(


### PR DESCRIPTION
## Description of change

Make EnsureService:

- do ports check if server spec;
- allow headless service has storage config

## QA steps

- deploy charm with omitServiceFrontend: false && no ports specified in containers;

```yaml
omitServiceFrontend: false
containers:
  - name: %(name)s
    imageDetails:
      imagePath: %(docker_image_path)s
      username: %(docker_image_username)s
      password: %(docker_image_password)s
    # ports:
    # - containerPort: %(port)s
    #   protocol: TCP
...
```

```
# got error: 
ports are required for kubernetes service
```

- deploy charm with omitServiceFrontend: true && no ports specified in containers - no errors;

```yaml
omitServiceFrontend: true
containers:
  - name: %(name)s
    imageDetails:
      imagePath: %(docker_image_path)s
      username: %(docker_image_username)s
      password: %(docker_image_password)s
    # ports:
    # - containerPort: %(port)s
    #   protocol: TCP
```

```bash
$ mkubectl get all,pv,pvc,cm,po,secrets,ing,endpoints -o wide -n t1

NAME                         READY   STATUS    RESTARTS   AGE     IP          NODE                   NOMINATED NODE   READINESS GATES
pod/mariadb-k8s-0            1/1     Running   0          2m29s   10.1.1.64   kelvinliu-virtualbox   <none>           <none>
pod/mariadb-k8s-operator-0   1/1     Running   0          2m37s   10.1.1.63   kelvinliu-virtualbox   <none>           <none>

NAME                            TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE     SELECTOR
service/mariadb-k8s-endpoints   ClusterIP   None         <none>        <none>    2m29s   juju-app=mariadb-k8s
# no service created for mariadb.

NAME                                    READY   AGE     CONTAINERS      IMAGES
statefulset.apps/mariadb-k8s            1/1     2m29s   mariadb-k8s     mariadb
statefulset.apps/mariadb-k8s-operator   1/1     2m37s   juju-operator   ycliuhw/jujud-operator:2.7-beta1

NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                STORAGECLASS        REASON   AGE     VOLUMEMODE
persistentvolume/pvc-e8217fdb-6ba9-45aa-b46a-d755427375f2   1Gi        RWO            Delete           Bound    t1/database-1cf00409-mariadb-k8s-0   microk8s-hostpath            2m29s   Filesystem
persistentvolume/pvc-fe742f7b-4630-4dbe-ac44-d263460c3779   1Gi        RWO            Delete           Bound    t1/charm-mariadb-k8s-operator-0      microk8s-hostpath            2m36s   Filesystem

NAME                                                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE     VOLUMEMODE
persistentvolumeclaim/charm-mariadb-k8s-operator-0      Bound    pvc-fe742f7b-4630-4dbe-ac44-d263460c3779   1Gi        RWO            microk8s-hostpath   2m37s   Filesystem
persistentvolumeclaim/database-1cf00409-mariadb-k8s-0   Bound    pvc-e8217fdb-6ba9-45aa-b46a-d755427375f2   1Gi        RWO            microk8s-hostpath   2m29s   Filesystem

NAME                                          DATA   AGE
configmap/mariadb-k8s-configurations-config   1      2m29s
configmap/mariadb-k8s-operator-config         1      2m37s

NAME                         TYPE                                  DATA   AGE
secret/default-token-tc2c2   kubernetes.io/service-account-token   3      9m32s


NAME                              ENDPOINTS   AGE
endpoints/mariadb-k8s-endpoints   10.1.1.64   2m29s

```


## Documentation changes

No.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1838664