### PR TITLE
2.6 - resolve local charms relative to bundle base path

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -324,7 +324,23 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			}
 		}
 
+		// While the bundle verifier code takes the bundle base path
+		// into account when checking for the presence of local charms,
+		// the bundlechanges code doesn't do the same and instead uses
+		// the current working directory for resolving local charms. If
+		// the CWD does not match the bundle base path then the code in
+		// bundlechanges (which assumes that the bundle has already
+		// been properly validated) will panic trying to parse local
+		// charm paths as URLs.
+		//
+		// As a work-around for making everything work as expected, we
+		// will handle relative charm path resolution at this point.
 		if h.isLocalCharm(spec.Charm) {
+			path, err := h.resolveRelativeCharmPath(name, spec.Charm)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			spec.Charm = path
 			continue
 		}
 
@@ -349,6 +365,27 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 	// effort, so for now the bundle handling is doing no implicit endpoint
 	// handling.
 	return nil
+}
+
+func (h *bundleHandler) resolveRelativeCharmPath(app, path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	absPath, err := filepath.Abs(filepath.Join(h.bundleDir, path))
+	if err != nil {
+		return "", errors.NotValidf("charm path %q in application %q", path, app)
+	}
+
+	if _, err = os.Stat(absPath); err == nil {
+		return absPath, nil
+	}
+
+	if os.IsNotExist(err) {
+		return "", errors.Errorf("charm path in application %q does not exist: %s", app, path)
+	}
+
+	return "", errors.Annotatef(err, "stat operation for local charm path %q failed", absPath)
 }
 
 func (h *bundleHandler) getChanges() error {

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -1045,6 +1045,28 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentWithBundleO
 	c.Assert(settings["blog-title"], gc.Equals, "magic bundle config")
 }
 
+func (s *BundleDeployCharmStoreSuite) TestDeployLocalBundleWithRelativeCharmPaths(c *gc.C) {
+	bundleDir := c.MkDir()
+	_ = testcharms.RepoWithSeries("bionic").ClonedDirPath(bundleDir, "dummy")
+
+	bundleFile := filepath.Join(bundleDir, "bundle.yaml")
+	bundleContent := `
+series: bionic
+applications:
+  dummy:
+    charm: ./dummy
+`
+	c.Assert(
+		ioutil.WriteFile(bundleFile, []byte(bundleContent), 0644),
+		jc.ErrorIsNil)
+
+	err := runDeploy(c, bundleFile)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.Application("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c *gc.C) {
 	charmsPath := c.MkDir()
 	_, wpch := testcharms.UploadCharmWithSeries(c, s.client, "xenial/wordpress-42", "wordpress", "bionic")


### PR DESCRIPTION
## Description of change

This PR actually fixes two separate issues that in combination cause `juju deploy` to panic when deploying bundles that reference local charms using relative paths.

First, a bit of context: when we deploy a bundle, we **first verify its contents** and then pass it to the `bundlechanges` package which yields a list of changes that need to be applied in order to deploy the bundle. One of these changes requests is `AddCharm` which contains the **resolved** path (local/remote) for each charm in the bundle.

Unfortunately, the `bundlechanges` package is set up in such a way so that relative local bundle paths are resolved against the **current working directory** instead of the base path of the bundle. In the majority of cases, the two directories coincide and the deployment proceeds as expected. However, if we are deploying a bundle located outside the CWD, the lookup for relative charms will fail!  That's one of the issues that must be addressed.

So why does it panic then? Here is where it gets more interesting! The bundlechanges code assumes that the bundle has been **pre-validated** when it is asked to generate the list of changes to be applied.  As a result, the code invokes several `MustXXX` functions which, as the name prefix implies, should either succeed or panic. In this particular case, `bundlechanges` invokes `charm.MustParseURL` which panics if provided with a relative path. 

If we are pre-validating the bundle shouldn't we have caught this problem earlier? TLDR: no! Apparently, the bundle validator code receives the bundle base path as an argument and uses that to verify that local charms actually exist. As a result, if the local bundles are found at the expected location,  bundle validation succeeds but the following call to the bundlechanges package panics.

One way to fix this is to patch bundlechanges to also receive the base path of the bundle as an argument. The problem here is that bundlechanges (which is not versioned) has diverged and now includes support for the bundle-cmr feature which (for now) we don't want to back-port to 2.6.

As a result, the best course of action is to add a hook into the `resolveCharmsAndEndpoints` method of the `bundleHandler` (cmd/juju/application/bundle.go), resolve relative charm paths (remember that we have already validated the bundle so we know they exist) and overwrite the charm URL with the resolved path.

This addresses the problem but comes with a small caveat. Because the `resolveCharmsAndEndpoints` method is invoked on a fully composed bundle (i.e. a bundle with any overlays merged in) it is currently not possible to resolve relative charm paths introduced by overlays _unless the overlay is located at the same place as the bundle_.

Note: the bundle-cmr changes that recently landed on develop introduce extensive refactoring to the way that overlays are merged and will allow us to address the above caveat as well.

## QA steps

```console
# Run these steps in the juju folder
$ mkdir foo
$ cat > foo/bundle.yaml << EOT
series: bionic
applications:
  dummy:
    charm: ./dummy/
EOT
$  cp -r testcharms/charm-repo/bionic/dummy foo

# Try to deploy with an older juju cli
$ cd foo
$ juju deploy --dry-run ./bundle.yaml
Changes to deploy bundle:
- upload charm ./dummy/
- deploy application dummy using ./dummy/

# Now try to deploy with an older juju cli from a different CWD
$ cd ../
$ juju deploy --dry-run ./foo/bundle.yaml
panic: charm or bundle URL has invalid form: "./dummy/"
... stack trace sniped ...

# Now try the same with the juju cli from this PR
Changes to deploy bundle:
- upload charm $your-cwd/foo/dummy
- deploy application dummy using $your-cwd/foo/dummy

# Try the same with an overlay that lives on a different location than the bundle
$ cat > foo/bundle2.yaml << EOT
series: bionic
applications:
  wordpress:
    charm: wordpress
EOT
$ cat > ovl.yaml << EOT
applications:
  wordpress:
    charm: ./foo/dummy
EOT

$ juju deploy --dry-run ./foo/bundle2.yaml --overlay ovl.yaml
ERROR cannot deploy bundle: the provided bundle has the following errors:
charm path in application "wordpress" does not exist: $your-cwd/foo/foo/dummy

# Note that the above command tried to find the charm in $your-cwd/foo/foo 
# (used the base path of the bundle instead of the overlay). This will be 
# fixed in a future PR for the develop branch (see description for explanation)
```

## Bug reference

This PR fixes:

- https://bugs.launchpad.net/juju/+bug/1838560
- https://bugs.launchpad.net/charm-nova-cell-controller/+bug/1804063 (dup)