### PR TITLE
dev - resolve local charms relative to bundle base path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1476,7 +1476,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:f33ecd7fc165d99a08d28f3559396da2426a35c9877443dadfa230aef2560054"
+  digest = "1:ed246f348bdaa738a066035e2551a826e966f55a5528d6f44f9e8270c04a3888"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1484,7 +1484,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "b0e282572b0939cfc2658678d24adb74d2b9435a"
+  revision = "77bc1b09aca2e72adbb0a608f2ba4ede37e9f704"
 
 [[projects]]
   digest = "1:86df7d2874a5250cf64324e2ce4e88fea552aa1f5c1a3f065599bd1f381ce939"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "b0e282572b0939cfc2658678d24adb74d2b9435a"
+  revision = "77bc1b09aca2e72adbb0a608f2ba4ede37e9f704"
 
 [[constraint]]
   revision = "7778a447283bd71109671c20818544514e16e9d9"

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -353,23 +353,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			}
 		}
 
-		// While the bundle verifier code takes the bundle base path
-		// into account when checking for the presence of local charms,
-		// the bundlechanges code doesn't do the same and instead uses
-		// the current working directory for resolving local charms. If
-		// the CWD does not match the bundle base path then the code in
-		// bundlechanges (which assumes that the bundle has already
-		// been properly validated) will panic trying to parse local
-		// charm paths as URLs.
-		//
-		// As a work-around for making everything work as expected, we
-		// will handle relative charm path resolution at this point.
 		if h.isLocalCharm(spec.Charm) {
-			path, err := h.resolveRelativeCharmPath(name, spec.Charm)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			spec.Charm = path
 			continue
 		}
 
@@ -394,27 +378,6 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 	// effort, so for now the bundle handling is doing no implicit endpoint
 	// handling.
 	return nil
-}
-
-func (h *bundleHandler) resolveRelativeCharmPath(app, path string) (string, error) {
-	if filepath.IsAbs(path) {
-		return path, nil
-	}
-
-	absPath, err := filepath.Abs(filepath.Join(h.bundleDir, path))
-	if err != nil {
-		return "", errors.NotValidf("charm path %q in application %q", path, app)
-	}
-
-	if _, err = os.Stat(absPath); err == nil {
-		return absPath, nil
-	}
-
-	if os.IsNotExist(err) {
-		return "", errors.Errorf("charm path in application %q does not exist: %s", app, path)
-	}
-
-	return "", errors.Annotatef(err, "stat operation for local charm path %q failed", absPath)
 }
 
 func (h *bundleHandler) getChanges() error {


### PR DESCRIPTION
## Description of change

This PR updates the develop branch to use the latest `charm.v6` version which includes an improved fix for resolving relative charm paths when deploying bundles (compared to the one that landed on the 2.6 branch via #10484).

The main problem with the 2.6 fix is that it was applied against the composed (with all overlays already merged in) bundle and that all relative charm paths were resolved using the base path of the bundle. The 2.6 fix does not work properly if an overlay living at a different location than the bundle specifies a relative charm path.

However, the develop branch uses a different code path (introduced by #10476) and merges overlays via helper functions provided by the `charm.v6` package. The new way of doing things enables us to properly resolve relative paths even for overlays.

Consequently, the original fix has now been removed but its related test has been kept so we can avoid any regressions in the future.

## QA steps

Exactly the same as with #10484 with the exception that the **last** QA step that involves an overlay **must work** as expected with the juju CLI from this PR.