### PR TITLE
Remove pycrypto, appears unused

### DIFF
--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -38,7 +38,6 @@ python-novaclient>=6.0.2
 pyOpenSSL>=17.5.0
 boto3>=1.5.18
 pyaml>=17.12.1
-pycrypto==2.6.1
 dnspython==1.16.0
 google-api-python-client==1.7.8
 google-cloud-container==0.2.1


### PR DESCRIPTION
Removing due to security warnings from GH.

pycryto is an old library no longer maintained with security issues. In checking the use of it I don't find any uses of the library directly. I attempted to remove it and setup a venv with the rest of the requirements.txt and nothing pulled it in as a dep. I think it's just unused. 

