### PR TITLE
Add LANG to hook execution environment for linux.

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -655,6 +655,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 	// TODO(thumper): as work on proxies progress, there will be additional
 	// proxy settings to be added.
 	vars = append(vars,
+		"LANG=C.UTF-8",
 		"CHARM_DIR="+paths.GetCharmDir(), // legacy, embarrassing
 		"JUJU_CHARM_DIR="+paths.GetCharmDir(),
 		"JUJU_CONTEXT_ID="+context.id,

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -655,7 +655,6 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 	// TODO(thumper): as work on proxies progress, there will be additional
 	// proxy settings to be added.
 	vars = append(vars,
-		"LANG=C.UTF-8",
 		"CHARM_DIR="+paths.GetCharmDir(), // legacy, embarrassing
 		"JUJU_CHARM_DIR="+paths.GetCharmDir(),
 		"JUJU_CONTEXT_ID="+context.id,

--- a/worker/uniter/runner/context/env.go
+++ b/worker/uniter/runner/context/env.go
@@ -37,17 +37,18 @@ func ubuntuEnv(paths Paths) []string {
 	env := []string{
 		"APT_LISTCHANGES_FRONTEND=none",
 		"DEBIAN_FRONTEND=noninteractive",
+		"LANG=C.UTF-8",
 	}
 	env = append(env, path...)
 	return env
 }
 
 func centosEnv(paths Paths) []string {
-	return appendPath(paths)
+	return append(appendPath(paths), "LANG=C.UTF-8")
 }
 
 func opensuseEnv(paths Paths) []string {
-	return appendPath(paths)
+	return append(appendPath(paths), "LANG=C.UTF-8")
 }
 
 // windowsEnv adds windows specific environment variables. PSModulePath

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -172,9 +172,10 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
 	os.Setenv("PATH", "foo:bar")
 	ubuntuVars := []string{
-		"PATH=path-to-tools:foo:bar",
 		"APT_LISTCHANGES_FRONTEND=none",
 		"DEBIAN_FRONTEND=noninteractive",
+		"LANG=C.UTF-8",
+		"PATH=path-to-tools:foo:bar",
 	}
 
 	ctx, contextVars := s.getContext(false)


### PR DESCRIPTION
Instead of forcing all charm developers to set the LANG in their scripts, provide a sensible default.

## QA steps

* bootstrap a model
* deploy the ubuntu-lite charm
* juju run --unit ubuntu-lite/0 'echo $LANG'

## Documentation changes

We will want to update the environment variables that are set as part of the hook execution environment, if we actually have this documented.
 
## Bug reference

https://bugs.launchpad.net/juju/+bug/1334482
