### PR TITLE
Change feature.Generations to a controller feature flag.

### DIFF
--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/os"
 	"github.com/juju/os/series"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -182,8 +181,12 @@ func newFacade(ctx facade.Context) (*Client, error) {
 		return nil, errors.Trace(err)
 	}
 
+	controllerCfg, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	var modelCache *cache.Model
-	if featureflag.Enabled(feature.Generations) {
+	if controllerCfg.Features().Contains(feature.Generations) {
 		// NOTE:
 		// Issues with the model cache updating fast enough were causing
 		// intermittent failures in statusUnitTestSuite.TestMigrationInProgress

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -353,7 +353,7 @@ func (s *statusUnitTestSuite) TestWorkloadVersionOkWithUnset(c *gc.C) {
 }
 
 func (s *statusUnitTestSuite) TestMigrationInProgress(c *gc.C) {
-	s.SetFeatureFlags(feature.Generations)
+	setGenerationsControllerConfig(c, s.State)
 	// Create a host model because controller models can't be migrated.
 	state2 := s.Factory.MakeModel(c, nil)
 	defer state2.Close()
@@ -845,7 +845,7 @@ var _ = gc.Suite(&filteringBranchesSuite{})
 
 func (s *filteringBranchesSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.Generations)
+	setGenerationsControllerConfig(c, s.State)
 
 	s.appA = "mysql"
 	s.appB = "wordpress"
@@ -1030,4 +1030,11 @@ type mockLeadershipReader struct{}
 
 func (m mockLeadershipReader) Leaders() (map[string]string, error) {
 	return make(map[string]string), nil
+}
+
+func setGenerationsControllerConfig(c *gc.C, st *state.State) {
+	err := st.UpdateControllerConfig(map[string]interface{}{
+		"features": []interface{}{feature.Generations},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -164,6 +164,10 @@ func (ctx *context) setAgentPresence(c *gc.C, p presence.Agent) *presence.Pinger
 
 func (s *StatusSuite) newContext(c *gc.C) *context {
 	st := s.Environ.(testing.GetStater).GetStateInAPIServer()
+	err := st.UpdateControllerConfig(map[string]interface{}{
+		"features": []interface{}{feature.Generations},
+	}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// We make changes in the API server's state so that
 	// our changes to presence are immediately noticed
@@ -4619,7 +4623,6 @@ func (ua setToolsUpgradeAvailable) step(c *gc.C, ctx *context) {
 }
 
 func (s *StatusSuite) TestStatusAllFormats(c *gc.C) {
-	s.SetFeatureFlags(feature.Generations)
 	for i, t := range statusTests {
 		c.Logf("test %d: %s", i, t.summary)
 		func(t testCase) {


### PR DESCRIPTION
## Description of change

Allow for branches to be displayed or not in juju status with a controller feature config value.  

## QA steps

1. export JUJU_DEV_FEATURE_FLAGS=generations
2. juju bootstrap
2. juju add-branch apple
3. juju status   <- no branch displayed
4. juju controller-config features=[generations]
3. juju status   <- apple branch displayed

## Documentation changes

Discourse page on juju branches will require updating.

