### PR TITLE
Fix the match to handle slower race tests.

### DIFF
--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -175,7 +175,7 @@ controller:
   life: alive
   status:
     current: available
-    since: just now
+    since: .*
   users:
     admin:
       display-name: admin


### PR DESCRIPTION
When the test is running under the race flag, it sometimes takes longer to create the model, so the since value needs to be more permissive than "just now". Took the same approach as the other tests in this suite.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1839566