### PR TITLE
Fix race in TestUniterRelations

### DIFF
--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -708,7 +708,12 @@ func (w *RemoteStateWatcher) relationsChanged(keys []string) error {
 				continue
 			}
 			ruw, err := w.st.WatchRelationUnits(relationTag, w.unit.Tag())
-			if err != nil {
+			// Deal with the race where the Relation call above returned
+			// a valid, perhaps dying relation, but by the time we ask to
+			// watch it, we get unauthorized because it is no longer around.
+			if params.IsCodeNotFoundOrCodeUnauthorized(err) {
+				continue
+			} else if err != nil {
 				return errors.Trace(err)
 			}
 			// Because of the delay before handing off responsibility to

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
 	gc "gopkg.in/check.v1"
@@ -947,6 +948,7 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 }
 
 func (s *UniterSuite) TestUniterRelations(c *gc.C) {
+	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
 	waitDyingHooks := custom{func(c *gc.C, ctx *context) {
 		// There is no ordering relationship between relation hooks and
 		// leader-settings-changed hooks; and while we're dying we may


### PR DESCRIPTION
There is a race in the construction of the remote state watcher that gets tickled by this test.

If the uniter notices that the endpoint has gone away before the 'verifyRunning' step, then there is the potential for an error. If the API call to get the relation succeeds, and then the underlying database object is removed, the follow up call in the uniter to watch the relation will fail with permission denied. The loop handles the case where the permission denied is returned from the first call, but not the second. This is a relatively small window, but we seem to hit this race quite often.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812111
