### PR TITLE
peergrouper watches k8s controller service instead of machine

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -544,11 +544,11 @@
   revision = "e1ad140384f254c82f89450d9a7c8dd38a632838"
 
 [[projects]]
-  digest = "1:3fb893d982a2db5906d00c288322edb39d6719910afba169da28552ca46f6410"
+  digest = "1:f8d71df5366f8cd94412859a652e23ba428eae9ff21f0d8baac52017b3eca99b"
   name = "github.com/juju/gomaasapi"
   packages = ["."]
   pruneopts = ""
-  revision = "8a8cec793ba70659ba95f1b9a491ba807169bfc3"
+  revision = "7f9373c5e79e1b4f27e46dfe1166a9ec0c147b81"
 
 [[projects]]
   branch = "master"
@@ -1562,11 +1562,11 @@
   revision = "1ebf5c5481e815de683e57e0f46705ac567e4e58"
 
 [[projects]]
-  digest = "1:f6e8802a71eceffa9b5ea7588ad541425202968d4f0dd0a9d8a5a4c7ae75709a"
+  digest = "1:60bf1190a2ff2f54984d2580596caf172359c0e1be26cbdb9109a3df8eaa9608"
   name = "gopkg.in/juju/names.v2"
   packages = ["."]
   pruneopts = ""
-  revision = "fd59336b4621bc2a70bf96d9e2f49954115ad19b"
+  revision = "35a970b00c44984ca675453f9e0144aed5219369"
 
 [[projects]]
   digest = "1:5081ff05b4471731df7fa7457083397c2663791cd5809858a899306cdfe29b63"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -74,7 +74,7 @@
   name = "github.com/juju/gojsonschema"
 
 [[constraint]]
-  revision = "8a8cec793ba70659ba95f1b9a491ba807169bfc3"
+  revision = "7f9373c5e79e1b4f27e46dfe1166a9ec0c147b81"
   name = "github.com/juju/gomaasapi"
 
 [[constraint]]
@@ -158,7 +158,7 @@
   name = "gopkg.in/juju/environschema.v1"
 
 [[constraint]]
-  revision = "fd59336b4621bc2a70bf96d9e2f49954115ad19b"
+  revision = "35a970b00c44984ca675453f9e0144aed5219369"
   name = "gopkg.in/juju/names.v2"
 
 [[constraint]]

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -193,7 +193,7 @@ LXC_BRIDGE="ignored"`[1:])
 	}
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	ctlr, m, err := agentbootstrap.InitializeState(
+	ctlr, err := agentbootstrap.InitializeState(
 		adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -274,6 +274,8 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(hostedCfg.AuthorizedKeys(), gc.Equals, newModelCfg.AuthorizedKeys())
 
 	// Check that the bootstrap machine looks correct.
+	m, err := st.Machine("0")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, "0")
 	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
 	c.Assert(m.Series(), gc.Equals, series.MustHostSeries())
@@ -368,7 +370,7 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	args := agentbootstrap.InitializeStateParams{}
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	_, _, err = agentbootstrap.InitializeState(adminUser, cfg, args, mongotest.DialOpts(), nil)
+	_, err = agentbootstrap.InitializeState(adminUser, cfg, args, mongotest.DialOpts(), nil)
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -428,13 +430,13 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	}
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	st, _, err := agentbootstrap.InitializeState(
+	st, err := agentbootstrap.InitializeState(
 		adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
-	st, _, err = agentbootstrap.InitializeState(
+	st, err = agentbootstrap.InitializeState(
 		adminUser, cfg, args, mongotest.DialOpts(), state.NewPolicyFunc(nil),
 	)
 	if err == nil {

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -305,7 +305,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	// Initialise state, and store any agent config (e.g. password) changes.
 	var controller *state.Controller
-	var m *state.Machine
 	err = c.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
 		var stateErr error
 		dialOpts := mongo.DefaultDialOpts()
@@ -322,7 +321,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		dialOpts.Direct = true
 
 		adminTag := names.NewLocalUserTag(adminUserName)
-		controller, m, stateErr = agentInitializeState(
+		controller, stateErr = agentInitializeState(
 			adminTag,
 			agentConfig,
 			agentbootstrap.InitializeStateParams{
@@ -387,8 +386,8 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		logger.Debugf("Juju GUI successfully set up")
 	}
 
-	// bootstrap machine always gets the vote
-	node, err := st.ControllerNode(m.Id())
+	// bootstrap nodes always get the vote
+	node, err := st.ControllerNode(agent.BootstrapControllerId)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -584,7 +584,7 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, args agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, _ state.NewPolicyFunc) (_ *state.Controller, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, args agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, _ state.NewPolicyFunc) (_ *state.Controller, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.Timeout, gc.Equals, 30*time.Second)
@@ -593,7 +593,7 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 			"name": "hosted-model",
 			"uuid": s.hostedModelUUID,
 		})
-		return nil, nil, errors.New("failed to initialize state")
+		return nil, errors.New("failed to initialize state")
 	}
 	s.PatchValue(&agentInitializeState, initializeState)
 	_, cmd, err := s.initBootstrapCommand(c, nil, "--timeout", "123s", s.bootstrapParamsFile)
@@ -605,11 +605,11 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, _ agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, _ state.NewPolicyFunc) (_ *state.Controller, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, _ agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, _ state.NewPolicyFunc) (_ *state.Controller, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.SocketTimeout, gc.Equals, 1*time.Minute)
-		return nil, nil, errors.New("failed to initialize state")
+		return nil, errors.New("failed to initialize state")
 	}
 
 	s.PatchValue(&agentInitializeState, initializeState)

--- a/mongo/admin.go
+++ b/mongo/admin.go
@@ -5,17 +5,12 @@ package mongo
 
 import (
 	"fmt"
-	"os"
 
 	"gopkg.in/mgo.v2"
 )
 
 // AdminUser is the name of the user that is initially created in mongo.
 const AdminUser = "admin"
-
-var (
-	processSignal = (*os.Process).Signal
-)
 
 // SetAdminMongoPassword sets the administrative password
 // to access a mongo database. If the password is non-empty,

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -642,6 +642,10 @@ func (d *fakeDevice) Hostname() string {
 	return ""
 }
 
+func (d *fakeDevice) Pool() gomaasapi.Pool {
+	return nil
+}
+
 func (d *fakeDevice) IPAddresses() []string {
 	addrs := make([]string, 0, len(d.interfaceSet))
 	for _, iface := range d.interfaceSet {

--- a/state/cloudservice.go
+++ b/state/cloudservice.go
@@ -62,7 +62,7 @@ func newCloudService(st *State, doc *cloudServiceDoc) *CloudService {
 
 // Id implements CloudServicer.
 func (c *CloudService) Id() string {
-	return c.doc.DocID
+	return c.st.localID(c.doc.DocID)
 }
 
 // ProviderId implements CloudServicer.
@@ -90,7 +90,7 @@ func (c *CloudService) cloudServiceDoc() (*cloudServiceDoc, error) {
 	defer closer()
 
 	var doc cloudServiceDoc
-	err := coll.FindId(c.Id()).One(&doc)
+	err := coll.FindId(c.doc.DocID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("cloud service %v", c.Id())
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1527,13 +1527,13 @@ func (s *StateSuite) TestSaveCloudService(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(svc.Refresh(), jc.ErrorIsNil)
-	c.Assert(state.LocalID(s.State, svc.Id()), gc.Equals, "a#cloud-svc-ID")
+	c.Assert(svc.Id(), gc.Equals, "a#cloud-svc-ID")
 	c.Assert(svc.ProviderId(), gc.Equals, "provider-id")
 	c.Assert(svc.Addresses(), gc.DeepEquals, network.NewAddresses("1.1.1.1"))
 
 	getResult, err := s.State.CloudService("cloud-svc-ID")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(state.LocalID(s.State, getResult.Id()), gc.Equals, "a#cloud-svc-ID")
+	c.Assert(getResult.Id(), gc.Equals, "a#cloud-svc-ID")
 	c.Assert(getResult.ProviderId(), gc.Equals, "provider-id")
 	c.Assert(getResult.Addresses(), gc.DeepEquals, network.NewAddresses("1.1.1.1"))
 }
@@ -1558,7 +1558,7 @@ func (s *StateSuite) TestSaveCloudServiceChangeAddressesAllGood(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(svc.Refresh(), jc.ErrorIsNil)
-	c.Assert(state.LocalID(s.State, svc.Id()), gc.Equals, "a#cloud-svc-ID")
+	c.Assert(svc.Id(), gc.Equals, "a#cloud-svc-ID")
 	c.Assert(svc.ProviderId(), gc.Equals, "provider-id")
 	c.Assert(svc.Addresses(), gc.DeepEquals, network.NewAddresses("2.2.2.2"))
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1654,6 +1654,11 @@ func (st *State) WatchControllerConfig() NotifyWatcher {
 	return newEntityWatcher(st, controllersC, controllerSettingsGlobalKey)
 }
 
+// Watch returns a watcher for observing changes to a controller service.
+func (c *CloudService) Watch() NotifyWatcher {
+	return newEntityWatcher(c.st, cloudServicesC, c.doc.DocID)
+}
+
 // Watch returns a watcher for observing changes to a machine.
 func (m *Machine) Watch() NotifyWatcher {
 	return newEntityWatcher(m.st, machinesC, m.doc.DocID)

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -4,9 +4,11 @@
 package peergrouper
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/replicaset"
 	"gopkg.in/mgo.v2"
 
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 )
 
@@ -23,7 +25,21 @@ func (s StateShim) ControllerNode(id string) (ControllerNode, error) {
 }
 
 func (s StateShim) ControllerHost(id string) (ControllerHost, error) {
-	return s.State.Machine(id)
+	// For IAAS models, controllers are machines.
+	// For CAAS models, access to the controller is via a k8s service.
+	model, err := s.State.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if model.Type() == state.ModelTypeIAAS {
+		return s.State.Machine(id)
+	}
+
+	cloudService, err := s.State.CloudService(model.ControllerUUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &cloudServiceShim{cloudService}, nil
 }
 
 func (s StateShim) RemoveControllerReference(c ControllerNode) error {
@@ -32,6 +48,30 @@ func (s StateShim) RemoveControllerReference(c ControllerNode) error {
 
 func (s StateShim) Space(name string) (Space, error) {
 	return s.State.Space(name)
+}
+
+// cloudServiceShim stubs out functionality not yet
+// supported by the k8s service abstraction.
+// We don't yet support HA on k8s.
+type cloudServiceShim struct {
+	*state.CloudService
+}
+
+func (*cloudServiceShim) Life() state.Life {
+	// We don't manage the life of a cloud service entity.
+	return state.Alive
+}
+
+func (*cloudServiceShim) Status() (status.StatusInfo, error) {
+	// We don't record the status of a cloud service entity.
+	return status.StatusInfo{
+		Status: status.Active,
+	}, nil
+}
+
+func (*cloudServiceShim) SetStatus(status.StatusInfo) error {
+	// We don't record the status of a cloud service entity.
+	return nil
 }
 
 // MongoSessionShim wraps a *mgo.Session to conform to the


### PR DESCRIPTION
## Description of change

Essentially a cleanup branch to prepare for removing machines from k8s models.
The peergrouper watches the k8s controller service (not machine) to get the api addresses.
Also fix cloud service id as it was incorrectly exposing the model uuid.
And remove some unused code.

Bring in new names.v2 dep to get controller agents.
As a driveby, also update the gomaasapi dep.

## QA steps

bootstrap on k8s and lxd
enable-ha on lxd
