### PR TITLE
portsDoc.SubnetID should be an ID not a CIDR

### DIFF
--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -25,6 +25,10 @@ type State interface {
 	FindEntity(tag names.Tag) (state.Entity, error)
 
 	FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error)
+
+	SubnetByID(id string) (Subnet, error)
+
+	Subnet(cidr string) (Subnet, error)
 }
 
 // TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
@@ -57,4 +61,17 @@ func (st stateShim) WatchOpenedPorts() state.StringsWatcher {
 func (s stateShim) FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error) {
 	api := state.NewFirewallRules(s.st)
 	return api.Rule(service)
+}
+
+type Subnet interface {
+	ID() string
+	CIDR() string
+}
+
+func (s stateShim) SubnetByID(id string) (Subnet, error) {
+	return s.st.SubnetByID(id)
+}
+
+func (s stateShim) Subnet(cidr string) (Subnet, error) {
+	return s.st.Subnet(cidr)
 }

--- a/state/ports.go
+++ b/state/ports.go
@@ -259,7 +259,7 @@ func (p *Ports) verifySubnetAliveWhenSet() error {
 		return nil
 	}
 
-	subnet, err := p.st.Subnet(p.doc.SubnetID)
+	subnet, err := p.st.SubnetByID(p.doc.SubnetID)
 	if err != nil {
 		return errors.Trace(err)
 	} else if subnet.Life() != Alive {

--- a/state/ports_test.go
+++ b/state/ports_test.go
@@ -44,7 +44,7 @@ func (s *PortsDocSuite) SetUpTest(c *gc.C) {
 	s.subnet, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.portsOnSubnet, err = state.GetOrCreatePorts(s.State, s.machine.Id(), s.subnet.CIDR())
+	s.portsOnSubnet, err = state.GetOrCreatePorts(s.State, s.machine.Id(), s.subnet.ID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.portsOnSubnet, gc.NotNil)
 
@@ -54,8 +54,7 @@ func (s *PortsDocSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *PortsDocSuite) TestCreatePortsWithSubnet(c *gc.C) {
-	c.Skip("Temporary for subnet cidr to id change.")
-	s.testCreatePortsWithSubnetID(c, s.subnet.CIDR())
+	s.testCreatePortsWithSubnetID(c, s.subnet.ID())
 }
 
 func (s *PortsDocSuite) testCreatePortsWithSubnetID(c *gc.C, subnetID string) {
@@ -82,7 +81,6 @@ func (s *PortsDocSuite) TestCreatePortsWithoutSubnet(c *gc.C) {
 }
 
 func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
-	c.Skip("Temporary for subnet cidr to id change.")
 	testCases := []struct {
 		about    string
 		existing []state.PortRange
@@ -261,7 +259,7 @@ func (s *PortsDocSuite) TestOpenAndClosePorts(c *gc.C) {
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
 
-		ports, err := state.GetOrCreatePorts(s.State, s.machine.Id(), s.subnet.CIDR())
+		ports, err := state.GetOrCreatePorts(s.State, s.machine.Id(), s.subnet.ID())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(ports, gc.NotNil)
 
@@ -364,7 +362,6 @@ func (s *PortsDocSuite) TestCloseInvalidRange(c *gc.C) {
 }
 
 func (s *PortsDocSuite) TestRemovePortsDoc(c *gc.C) {
-	c.Skip("Temporary for subnet cidr to id change.")
 	portRange := state.PortRange{
 		FromPort: 100,
 		ToPort:   200,
@@ -374,7 +371,7 @@ func (s *PortsDocSuite) TestRemovePortsDoc(c *gc.C) {
 	err := s.portsOnSubnet.OpenPorts(portRange)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ports, err := state.GetPorts(s.State, s.machine.Id(), s.subnet.CIDR())
+	ports, err := state.GetPorts(s.State, s.machine.Id(), s.subnet.ID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ports, gc.NotNil)
 
@@ -386,10 +383,10 @@ func (s *PortsDocSuite) TestRemovePortsDoc(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	ports, err = state.GetPorts(s.State, s.machine.Id(), s.subnet.CIDR())
+	ports, err = state.GetPorts(s.State, s.machine.Id(), s.subnet.ID())
 	c.Assert(ports, gc.IsNil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, `ports for machine "0", subnet "0.1.2.0/24" not found`)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`ports for machine %q, subnet %q not found`, s.machine.Id(), s.subnet.ID()))
 }
 
 func (s *PortsDocSuite) TestWatchPorts(c *gc.C) {
@@ -406,14 +403,13 @@ func (s *PortsDocSuite) TestWatchPorts(c *gc.C) {
 	wc.AssertChange()
 	wc.AssertNoChange()
 
-	c.Skip("Temporary for subnet cidr to id change.")
 	portRange := state.PortRange{
 		FromPort: 100,
 		ToPort:   200,
 		UnitName: s.unit1.Name(),
 		Protocol: "TCP",
 	}
-	expectChange := fmt.Sprintf("%s:%s", s.machine.Id(), s.subnet.CIDR())
+	expectChange := fmt.Sprintf("%s:%s", s.machine.Id(), s.subnet.ID())
 	// Open a port range, detect a change.
 	err := s.portsOnSubnet.OpenPorts(portRange)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3608,9 +3608,8 @@ func (s *StateSuite) TestWatchMinUnitsDiesOnStateClose(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchSubnets(c *gc.C) {
-	c.Skip("Temporary for subnet cidr to id change.")
 	filter := func(id interface{}) bool {
-		return id != "10.20.0.0/24"
+		return id != "0"
 	}
 	w := s.State.WatchSubnets(filter)
 	defer statetesting.AssertStop(c, w)
@@ -3623,7 +3622,8 @@ func (s *StateSuite) TestWatchSubnets(c *gc.C) {
 	_, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.20.0.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "10.0.0.0/24"})
-	wc.AssertChange("10.0.0.0/24")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange("1")
 	wc.AssertNoChange()
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/juju/collections/set"
@@ -1433,11 +1434,13 @@ func (u *Unit) OpenPortsOnSubnet(subnetID, protocol string, fromPort, toPort int
 func (u *Unit) checkSubnetAliveWhenSet(subnetID string) error {
 	if subnetID == "" {
 		return nil
-	} else if !names.IsValidSubnet(subnetID) {
+	}
+
+	if _, err := strconv.Atoi(subnetID); err != nil {
 		return errors.Errorf("invalid subnet ID %q", subnetID)
 	}
 
-	subnet, err := u.st.Subnet(subnetID)
+	subnet, err := u.st.SubnetByID(subnetID)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Annotatef(err, "getting subnet %q", subnetID)
 	} else if errors.IsNotFound(err) || subnet.Life() != Alive {

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1383,7 +1383,7 @@ func (s *UnitSuite) TestOpenedPortsOnInvalidSubnet(c *gc.C) {
 
 func (s *UnitSuite) TestOpenedPortsOnUnknownSubnet(c *gc.C) {
 	// We're not adding the 127.0.0.0/8 subnet to test the "not found" case.
-	s.testOpenedPorts(c, "127.0.0.0/8", `subnet "127.0.0.0/8" not found or not alive`)
+	s.testOpenedPorts(c, "4", `subnet "4" not found or not alive`)
 }
 
 func (s *UnitSuite) TestOpenedPortsOnDeadSubnet(c *gc.C) {
@@ -1394,23 +1394,21 @@ func (s *UnitSuite) TestOpenedPortsOnDeadSubnet(c *gc.C) {
 	err = subnet.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.testOpenedPorts(c, "0.1.2.0/24", `subnet "0.1.2.0/24" not found or not alive`)
+	s.testOpenedPorts(c, subnet.ID(), fmt.Sprintf(`subnet %q not found or not alive`, subnet.ID()))
 }
 
 func (s *UnitSuite) TestOpenedPortsOnAliveIPv4Subnet(c *gc.C) {
-	c.Skip("Temporary for subnet cidr to id change.")
-	_, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "192.168.0.0/16"})
+	subnet, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "192.168.0.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.testOpenedPorts(c, "192.168.0.0/16", "")
+	s.testOpenedPorts(c, subnet.ID(), "")
 }
 
 func (s *UnitSuite) TestOpenedPortsOnAliveIPv6Subnet(c *gc.C) {
-	c.Skip("Temporary for subnet cidr to id change.")
-	_, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "2001:db8::/64"})
+	subnet, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "2001:db8::/64"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.testOpenedPorts(c, "2001:db8::/64", "")
+	s.testOpenedPorts(c, subnet.ID(), "")
 }
 
 func (s *UnitSuite) TestOpenedPortsOnEmptySubnet(c *gc.C) {


### PR DESCRIPTION
## Description of change

Update OpenPort(), ClosePort() and firewaller apiserver to handle ports.SubnetID() as an ID not a CIDR.  

So far it appears that ports.SubnetID has be set to anything other than an empty string.  Thus no migration and upgrade steps are necessary.

## QA steps

Bootstrap with a provider using subnets, no changes should be apparent.  Nor new errors in the controller logs.

Most testing will be done by CI tests.
