### PR TITLE
Fix cmdSubnetSuite.TestSubnetAddAlreadyExistingCIDR

### DIFF
--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -315,7 +315,7 @@ func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
 		"mysql:server", "hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = runJujuCommand(c, "add-relation", "wordpress", "admin/controller.hosted-mysql")
+	_, err = runCommand(c, "add-relation", "wordpress", "admin/controller.hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := s.State.RemoteApplication("hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -342,7 +342,7 @@ func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 }
 
 func (s *crossmodelSuite) assertAddRelationSameControllerSuccess(c *gc.C, otherModeluser string) {
-	_, err := runJujuCommand(c, "add-relation", "-m", "admin/controller", "wordpress", otherModeluser+"/othermodel.hosted-mysql")
+	_, err := runCommand(c, "add-relation", "-m", "admin/controller", "wordpress", otherModeluser+"/othermodel.hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.RemoteApplication("hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -449,8 +449,8 @@ func (s *crossmodelSuite) changeUserPassword(c *gc.C, user, password string) {
 }
 
 func (s *crossmodelSuite) createTestUser(c *gc.C) {
-	runJujuCommand(c, "add-user", "test")
-	runJujuCommand(c, "grant", "test", "read", "controller")
+	runCommand(c, "add-user", "test")
+	runCommand(c, "grant", "test", "read", "controller")
 	s.changeUserPassword(c, "test", "hunter2")
 }
 
@@ -458,12 +458,12 @@ func (s *crossmodelSuite) loginTestUser(c *gc.C) {
 	// logout "admin" first; we'll need to give it
 	// a non-random password before we can do so.
 	s.changeUserPassword(c, "admin", "hunter2")
-	runJujuCommand(c, "logout")
+	runCommand(c, "logout")
 	s.runJujuCommndWithStdin(c, strings.NewReader("hunter2\nhunter2\n"), "login", "-u", "test")
 }
 
 func (s *crossmodelSuite) loginAdminUser(c *gc.C) {
-	runJujuCommand(c, "logout")
+	runCommand(c, "logout")
 	s.runJujuCommndWithStdin(c, strings.NewReader("hunter2\nhunter2\n"), "login", "-u", "admin")
 }
 
@@ -474,7 +474,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerPermissionDenied(c *gc.C)
 
 	s.createTestUser(c)
 	s.loginTestUser(c)
-	context, err := runJujuCommand(c, "add-relation", "-m", "admin/controller", "wordpress", "otheruser/othermodel.hosted-mysql")
+	context, err := runCommand(c, "add-relation", "-m", "admin/controller", "wordpress", "otheruser/othermodel.hosted-mysql")
 	c.Assert(err, gc.NotNil)
 	c.Assert(cmdtesting.Stderr(context), jc.Contains, `application offer "otheruser/othermodel.hosted-mysql" not found`)
 }
@@ -487,8 +487,8 @@ func (s *crossmodelSuite) TestAddRelationSameControllerPermissionAllowed(c *gc.C
 	s.createTestUser(c)
 
 	// Users with consume permission to the offer can add relations.
-	runJujuCommand(c, "grant", "test", "consume", "otheruser/othermodel.hosted-mysql")
-	runJujuCommand(c, "grant", "test", "write", "admin/controller")
+	runCommand(c, "grant", "test", "consume", "otheruser/othermodel.hosted-mysql")
+	runCommand(c, "grant", "test", "write", "admin/controller")
 
 	s.loginTestUser(c)
 	s.assertAddRelationSameControllerSuccess(c, "otheruser")

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -62,7 +62,7 @@ func (s *cmdSpaceSuite) AddSpace(c *gc.C, name string, ids []string, public bool
 const expectedSuccess = ""
 
 func (s *cmdSpaceSuite) Run(c *gc.C, args ...string) (string, string, error) {
-	context, err := runJujuCommand(c, args...)
+	context, err := runCommand(c, args...)
 	stdout, stderr := "", ""
 	if context != nil {
 		stdout = cmdtesting.Stdout(context)

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -36,7 +36,7 @@ func (s *cmdSubnetSuite) AddSpace(c *gc.C, name string, ids []string, public boo
 }
 
 func (s *cmdSubnetSuite) Run(c *gc.C, expectedError string, args ...string) *cmd.Context {
-	context, err := runJujuCommand(c, args...)
+	context, err := runCommand(c, args...)
 	if expectedError != "" {
 		c.Assert(err, gc.ErrorMatches, expectedError)
 	} else {
@@ -47,7 +47,7 @@ func (s *cmdSubnetSuite) Run(c *gc.C, expectedError string, args ...string) *cmd
 
 func (s *cmdSubnetSuite) RunAdd(c *gc.C, expectedError string, args ...string) (string, string, error) {
 	cmdArgs := append([]string{"add-subnet"}, args...)
-	ctx, err := runJujuCommand(c, cmdArgs...)
+	ctx, err := runCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
 		stdout = cmdtesting.Stdout(ctx)

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -81,9 +81,8 @@ func (s *cmdSubnetSuite) TestSubnetAddCIDRAndInvalidSpaceName(c *gc.C) {
 }
 
 func (s *cmdSubnetSuite) TestSubnetAddAlreadyExistingCIDR(c *gc.C) {
-	c.Skip("Temporary for subnet cidr to id change.")
 	s.AddSpace(c, "foo", nil, true)
-	s.AddSubnet(c, network.SubnetInfo{CIDR: "0.10.0.0/24", SpaceName: "foo"})
+	s.AddSubnet(c, network.SubnetInfo{CIDR: "0.10.0.0/24", SpaceName: "foo", ProviderId: "dummy-private"})
 
 	expectedError := `cannot add subnet: adding subnet "0.10.0.0/24": subnet "0.10.0.0/24" already exists`
 	s.RunAdd(c, expectedError, "0.10.0.0/24", "foo")

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -92,10 +92,9 @@ func TestPackage(t *testing.T) {
 }
 
 func runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	// Writers need to be reset, because
-	// they are set globally in the juju/cmd package and will
-	// return an error if we attempt to run two commands in the
-	// same test.
+	// Writers need to be reset, because they are set globally in the
+	// juju/cmd package and will return an error if we attempt to run
+	// two commands in the same test.
 	loggo.ResetWriters()
 	ctx := cmdtesting.Context(c)
 	command := jujucmd.NewJujuCommand(ctx)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 
-	jujucmd "github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/core/status"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/dummy"
@@ -68,7 +66,7 @@ func (s *cmdStorageSuite) SetUpTest(c *gc.C) {
 
 func runShow(c *gc.C, expectedError string, args ...string) {
 	cmdArgs := append([]string{"show-storage"}, args...)
-	context, err := runJujuCommand(c, cmdArgs...)
+	context, err := runCommand(c, cmdArgs...)
 	if expectedError == "" {
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
@@ -102,7 +100,7 @@ data/0:
         machine: "0"
         life: alive
 `[1:]
-	context, err := runJujuCommand(c, "show-storage", "data/0")
+	context, err := runCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Matches, expected)
 }
@@ -120,7 +118,7 @@ func (s *cmdStorageSuite) TestStorageShowNoMatch(c *gc.C) {
 
 func runList(c *gc.C, expectedOutput string, args ...string) {
 	cmdArgs := append([]string{"list-storage"}, args...)
-	context, err := runJujuCommand(c, cmdArgs...)
+	context, err := runCommand(c, cmdArgs...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)
 }
@@ -180,7 +178,7 @@ data/0:
         machine: "0"
         life: alive
 `[1:]
-	context, err := runJujuCommand(c, "show-storage", "data/0")
+	context, err := runCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Matches, expected)
 }
@@ -204,26 +202,14 @@ data/0:
         machine: "0"
         life: alive
 `[1:]
-	context, err := runJujuCommand(c, "show-storage", "data/0")
+	context, err := runCommand(c, "show-storage", "data/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Matches, expected)
 }
 
-func runJujuCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	// NOTE (alesstimec): Writers need to be reset, because
-	// they are set globally in the juju/cmd package and will
-	// return an error if we attempt to run two commands in the
-	// same test.
-	loggo.RemoveWriter("warning")
-	ctx, err := cmd.DefaultContext()
-	c.Assert(err, jc.ErrorIsNil)
-	command := jujucmd.NewJujuCommand(ctx)
-	return cmdtesting.RunCommand(c, command, args...)
-}
-
 func runPoolList(c *gc.C, args ...string) (string, string, error) {
 	cmdArgs := append([]string{"list-storage-pools"}, args...)
-	ctx, err := runJujuCommand(c, cmdArgs...)
+	ctx, err := runCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
 		stdout = cmdtesting.Stdout(ctx)
@@ -368,7 +354,7 @@ func (s *cmdStorageSuite) TestListPoolsNotNameAndNotProvider(c *gc.C) {
 
 func runPoolCreate(c *gc.C, args ...string) (string, string, error) {
 	cmdArgs := append([]string{"create-storage-pool"}, args...)
-	ctx, err := runJujuCommand(c, cmdArgs...)
+	ctx, err := runCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
 		stdout = cmdtesting.Stdout(ctx)
@@ -454,7 +440,7 @@ func assertPoolExists(c *gc.C, st *state.State, pname, providerType, attr string
 
 func runVolumeList(c *gc.C, args ...string) (string, string, error) {
 	cmdArgs := append([]string{"list-storage", "--volume"}, args...)
-	ctx, err := runJujuCommand(c, cmdArgs...)
+	ctx, err := runCommand(c, cmdArgs...)
 	return cmdtesting.Stdout(ctx), cmdtesting.Stderr(ctx), err
 }
 
@@ -478,17 +464,17 @@ Machine  Unit             Storage id  Volume id  Provider Id  Device  Size  Stat
 
 func runAddToUnit(c *gc.C, args ...string) (*cmd.Context, error) {
 	cmdArgs := append([]string{"add-storage"}, args...)
-	return runJujuCommand(c, cmdArgs...)
+	return runCommand(c, cmdArgs...)
 }
 
 func runAttachStorage(c *gc.C, args ...string) (*cmd.Context, error) {
 	cmdArgs := append([]string{"attach-storage"}, args...)
-	return runJujuCommand(c, cmdArgs...)
+	return runCommand(c, cmdArgs...)
 }
 
 func runDetachStorage(c *gc.C, args ...string) (*cmd.Context, error) {
 	cmdArgs := append([]string{"detach-storage"}, args...)
-	return runJujuCommand(c, cmdArgs...)
+	return runCommand(c, cmdArgs...)
 }
 
 func (s *cmdStorageSuite) TestStorageAddToUnitSuccess(c *gc.C) {
@@ -542,7 +528,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitCollapseUnitErrors(c *gc.C) {
 
 func (s *cmdStorageSuite) TestStorageAddToUnitInvalidUnitName(c *gc.C) {
 	cmdArgs := append([]string{"add-storage"}, "fluffyunit-0", "allecto=1")
-	context, err := runJujuCommand(c, cmdArgs...)
+	context, err := runCommand(c, cmdArgs...)
 	c.Assert(err, gc.ErrorMatches, `unit name "fluffyunit-0" not valid`)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "ERROR unit name \"fluffyunit-0\" not valid\n")
@@ -586,7 +572,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumesBefore, gc.HasLen, 1)
 
-	context, err := runJujuCommand(c, "storage")
+	context, err := runCommand(c, "storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 Unit                  Storage id  Type        Size  Status   Message
@@ -607,7 +593,7 @@ storage-filesystem/0  data/0      filesystem        pending
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumesAfter, gc.HasLen, 2)
 
-	context, err = runJujuCommand(c, "list-storage")
+	context, err = runCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
 Unit                  Storage id  Type        Size  Status   Message
@@ -659,7 +645,7 @@ func (s *cmdStorageSuite) TestStorageDetachAttach(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = vol.SetStatus(status.StatusInfo{Status: status.Detaching, Since: &time.Time{}})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := runJujuCommand(c, "list-storage")
+	ctx, err := runCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Unit             Storage id  Type   Pool         Size    Status     Message
@@ -687,7 +673,7 @@ storage-block/1  data/1      block                       pending
 	c.Assert(err, jc.ErrorIsNil)
 	err = vol.SetStatus(status.StatusInfo{Status: status.Attaching, Since: &time.Time{}})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err = runJujuCommand(c, "list-storage")
+	ctx, err = runCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Unit             Storage id  Type   Pool         Size    Status     Message
@@ -700,7 +686,7 @@ storage-block/1  data/1      block                       pending
 
 func runPoolUpdate(c *gc.C, args ...string) (string, string, error) {
 	cmdArgs := append([]string{"update-storage-pool"}, args...)
-	ctx, err := runJujuCommand(c, cmdArgs...)
+	ctx, err := runCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
 		stdout = cmdtesting.Stdout(ctx)
@@ -726,7 +712,7 @@ func (s *cmdStorageSuite) TestUpdateNoMatch(c *gc.C) {
 
 func runPoolDelete(c *gc.C, args ...string) (string, string, error) {
 	cmdArgs := append([]string{"remove-storage-pool"}, args...)
-	ctx, err := runJujuCommand(c, cmdArgs...)
+	ctx, err := runCommand(c, cmdArgs...)
 	stdout, stderr := "", ""
 	if ctx != nil {
 		stdout = cmdtesting.Stdout(ctx)


### PR DESCRIPTION
## Description of change

Fix cmdSubnetSuite.TestSubnetAddAlreadyExistingCIDR.  The duplicate checking when adding a subnet includes the providerID of the subnet.  The test was not including one, but the juju add-subnet feature test was including one in its AddSubnet() call.

Small clean up, no need for duplicate runCommand functions in the feature tests.  The one removed wasn't using the cmdtest context as it should.

## QA steps

Run the unit tests.
