### PR TITLE
Wait for model to appear in cache.

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -114,6 +114,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 
 	// apiRoot is the API root exposed to the client after login.
 	var apiRoot rpc.Root = newAPIRoot(
+		a.srv.clock,
 		a.root.state,
 		a.root.shared,
 		a.srv.facades,

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -44,7 +44,7 @@ func NewErrRoot(err error) *errRoot {
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(facades *facade.Registry) rpc.Root {
-	return newAPIRoot(nil, nil, facades, common.NewResources(), nil)
+	return newAPIRoot(clock.WallClock, nil, nil, facades, common.NewResources(), nil)
 }
 
 // TestingAPIHandler gives you an APIHandler that isn't connected to

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -4,6 +4,8 @@
 package facadetest
 
 import (
+	"github.com/juju/clock"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
@@ -50,6 +52,11 @@ func (context Context) Hub() facade.Hub {
 // Controller is part of the facade.Context interface.
 func (context Context) Controller() *cache.Controller {
 	return context.Controller_
+}
+
+// CachedModel is part of the facade.Context interface.
+func (context Context) CachedModel(uuid string) (*cache.Model, error) {
+	return context.Controller_.WaitForModel(uuid, clock.WallClock)
 }
 
 // Resources is part of the facade.Context interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -69,6 +69,15 @@ type Context interface {
 	// in the database.
 	Controller() *cache.Controller
 
+	// CachedModel returns the in-memory representation of the specified
+	// model. This call will wait for the model to appear in the cache.
+	// The method optimistically expects the model to exist in the cache
+	// or appear very soon. If the model doesn't appear, the database is
+	// checked. A NotFound error is returned if the model no longer exists
+	// in the database, or a Timeout error is returned if the model didn't
+	// appear, but should have.
+	CachedModel(uuid string) (*cache.Model, error)
+
 	// Presence returns an instance that is able to be asked for
 	// the current model presence.
 	Presence() Presence

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -32,16 +32,17 @@ var _ = gc.Suite(&charmsSuite{})
 // charmsSuiteContext implements the facade.Context interface.
 type charmsSuiteContext struct{ cs *charmsSuite }
 
-func (ctx *charmsSuiteContext) Abort() <-chan struct{}        { return nil }
-func (ctx *charmsSuiteContext) Auth() facade.Authorizer       { return ctx.cs.auth }
-func (ctx *charmsSuiteContext) Dispose()                      {}
-func (ctx *charmsSuiteContext) Resources() facade.Resources   { return common.NewResources() }
-func (ctx *charmsSuiteContext) State() *state.State           { return ctx.cs.State }
-func (ctx *charmsSuiteContext) StatePool() *state.StatePool   { return nil }
-func (ctx *charmsSuiteContext) ID() string                    { return "" }
-func (ctx *charmsSuiteContext) Presence() facade.Presence     { return nil }
-func (ctx *charmsSuiteContext) Hub() facade.Hub               { return nil }
-func (ctx *charmsSuiteContext) Controller() *cache.Controller { return nil }
+func (ctx *charmsSuiteContext) Abort() <-chan struct{}                        { return nil }
+func (ctx *charmsSuiteContext) Auth() facade.Authorizer                       { return ctx.cs.auth }
+func (ctx *charmsSuiteContext) Dispose()                                      {}
+func (ctx *charmsSuiteContext) Resources() facade.Resources                   { return common.NewResources() }
+func (ctx *charmsSuiteContext) State() *state.State                           { return ctx.cs.State }
+func (ctx *charmsSuiteContext) StatePool() *state.StatePool                   { return nil }
+func (ctx *charmsSuiteContext) ID() string                                    { return "" }
+func (ctx *charmsSuiteContext) Presence() facade.Presence                     { return nil }
+func (ctx *charmsSuiteContext) Hub() facade.Hub                               { return nil }
+func (ctx *charmsSuiteContext) Controller() *cache.Controller                 { return nil }
+func (ctx *charmsSuiteContext) CachedModel(uuid string) (*cache.Model, error) { return nil, nil }
 
 func (ctx *charmsSuiteContext) LeadershipClaimer(string) (leadership.Claimer, error) { return nil, nil }
 func (ctx *charmsSuiteContext) LeadershipChecker() (leadership.Checker, error)       { return nil, nil }

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	"github.com/juju/juju/environs/manual/winrmprovisioner"
-	"github.com/juju/juju/feature"
 
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
@@ -182,24 +181,9 @@ func newFacade(ctx facade.Context) (*Client, error) {
 		return nil, errors.Trace(err)
 	}
 
-	controllerCfg, err := st.ControllerConfig()
+	modelCache, err := ctx.CachedModel(modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
-	}
-	var modelCache *cache.Model
-	if controllerCfg.Features().Contains(feature.Generations) {
-		// NOTE:
-		// Issues with the model cache updating fast enough were causing
-		// intermittent failures in statusUnitTestSuite.TestMigrationInProgress
-		// preventing merges and causing angst.  Hide use of the model
-		// cache behind a feature flag until these issues are resolved.
-		// A longer term solution would be to move to using the db for
-		// branch data in status output, if the model cache issues are
-		// not resolved before the branches feature is released.
-		modelCache, err = ctx.CachedModel(modelUUID)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 	}
 
 	return NewClient(

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -196,7 +196,7 @@ func newFacade(ctx facade.Context) (*Client, error) {
 		// A longer term solution would be to move to using the db for
 		// branch data in status output, if the model cache issues are
 		// not resolved before the branches feature is released.
-		modelCache, err = ctx.Controller().Model(modelUUID)
+		modelCache, err = ctx.CachedModel(modelUUID)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -96,6 +96,16 @@ func (s *serverSuite) clientForState(c *gc.C, st *state.State) *client.Client {
 	})
 }
 
+func (s *serverSuite) TestNewFacadeWaitsForCachedModel(c *gc.C) {
+	setGenerationsControllerConfig(c, s.State)
+	state := s.Factory.MakeModel(c, nil)
+	defer state.Close()
+	// When run in a stress situation, we should hit the race where
+	// the model exists in the database but the cache hasn't been updated
+	// before we ask for the client.
+	_ = s.clientForState(c, state)
+}
+
 func (s *serverSuite) TestModelInfo(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/root_internal_test.go
+++ b/apiserver/root_internal_test.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/cache"
+	statetesting "github.com/juju/juju/state/testing"
+)
+
+type facadeContextSuite struct {
+	statetesting.StateSuite
+
+	changes    chan interface{}
+	handled    chan interface{}
+	controller *cache.Controller
+	clock      *testclock.Clock
+}
+
+var _ = gc.Suite(&facadeContextSuite{})
+
+func (s *facadeContextSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+
+	s.changes = make(chan interface{})
+	s.handled = make(chan interface{})
+
+	controller, err := cache.NewController(cache.ControllerConfig{
+		Changes: s.changes,
+		Notify: func(e interface{}) {
+			s.handled <- e
+		}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.controller = controller
+	s.clock = testclock.NewClock(time.Now())
+}
+
+func (s *facadeContextSuite) newContext() *facadeContext {
+	// This is a bare minimum facade context for these tests.
+	return &facadeContext{
+		r: &apiRoot{
+			clock: s.clock,
+			shared: &sharedServerContext{
+				controller: s.controller,
+				logger:     loggo.GetLogger("test"),
+			},
+			state: s.State,
+		},
+	}
+}
+
+func (s *facadeContextSuite) processChange(c *gc.C, change interface{}) {
+	select {
+	case s.changes <- change:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("controller did not read change")
+	}
+	select {
+	case obtained := <-s.handled:
+		c.Check(obtained, jc.DeepEquals, change)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("controller did not handle change")
+	}
+}
+
+func (s *facadeContextSuite) TestCachedModelValid(c *gc.C) {
+	// Populate the cache with the model we are looking for.
+	s.processChange(c, cache.ModelChange{
+		ModelUUID: "some-uuid",
+	})
+	// We don't need to advance the clock to get the model
+	// as it is already in the cache.
+	ctx := s.newContext()
+	model, err := ctx.CachedModel("some-uuid")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.UUID(), gc.Equals, "some-uuid")
+}
+
+func (s *facadeContextSuite) TestCachedModelMissing(c *gc.C) {
+	ctx := s.newContext()
+	done := make(chan interface{})
+	go func() {
+		defer close(done)
+		model, err := ctx.CachedModel("some-uuid")
+		c.Check(err, jc.Satisfies, errors.IsNotFound)
+		c.Check(model, gc.IsNil)
+	}()
+
+	s.clock.WaitAdvance(10*time.Second, testing.LongWait, 1)
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Error("CachedModel didn't return")
+	}
+}
+
+func (s *facadeContextSuite) TestCachedModelTimeout(c *gc.C) {
+	// Make a model in the DB, but don't tell the cache about it.
+	state := s.Factory.MakeModel(c, nil)
+	defer state.Close()
+
+	ctx := s.newContext()
+	done := make(chan interface{})
+	go func() {
+		defer close(done)
+		model, err := ctx.CachedModel(state.ModelUUID())
+		c.Check(err, jc.Satisfies, errors.IsTimeout)
+		c.Check(model, gc.IsNil)
+	}()
+
+	s.clock.WaitAdvance(10*time.Second, testing.LongWait, 1)
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Error("CachedModel didn't return")
+	}
+}

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -74,8 +74,15 @@ func (m *Model) Config() map[string]interface{} {
 	return cfg
 }
 
+// UUID returns the model's model-uuid.
+func (m *Model) UUID() string {
+	defer m.doLocked()()
+	return m.details.ModelUUID
+}
+
 // Name returns the current model's name.
 func (m *Model) Name() string {
+	defer m.doLocked()()
 	return m.details.Name
 }
 

--- a/core/cache/modelwatcher.go
+++ b/core/cache/modelwatcher.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/juju/pubsub"
+	"gopkg.in/tomb.v2"
+)
+
+// ModelWatcher will pass back models added to the cache.
+type ModelWatcher interface {
+	Watcher
+	Changes() <-chan *Model
+}
+
+type modelWatcher struct {
+	tomb    tomb.Tomb
+	changes chan *Model
+	// We can't send down a closed channel, so protect the sending
+	// with a mutex and bool. Since you can't really even ask a channel
+	// if it is closed.
+	closed bool
+	mu     sync.Mutex
+
+	modelUUID string
+}
+
+func newModelWatcher(uuid string, hub *pubsub.SimpleHub, model *Model) *modelWatcher {
+	// We use a single entry buffered channel for the changes.
+	// The model may already exist, in which case the model is sent down
+	// the changes channel immediately.
+	w := &modelWatcher{
+		changes:   make(chan *Model, 1),
+		modelUUID: uuid,
+	}
+	if model != nil {
+		// Since changes is buffered, this doesn't block.
+		w.changes <- model
+	}
+	unsub := hub.Subscribe(modelUpdatedTopic, w.onUpdate)
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
+		unsub()
+		return nil
+	})
+
+	return w
+}
+
+// Changes is part of the core watcher definition.
+func (w *modelWatcher) Changes() <-chan *Model {
+	return w.changes
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *modelWatcher) Kill() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return
+	}
+
+	// The watcher must be dying or dead before we close the channel.
+	// Otherwise readers could fail, but the watcher's tomb would indicate
+	// "still alive".
+	w.tomb.Kill(nil)
+	w.closed = true
+	close(w.changes)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *modelWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Stop is currently required by the Resources wrapper in the apiserver.
+func (w *modelWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *modelWatcher) onUpdate(topic string, data interface{}) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return
+	}
+
+	model, ok := data.(*Model)
+	if !ok {
+		logger.Criticalf("programming error: topic data expected *Model, got %T", data)
+		return
+	}
+
+	if model.UUID() == w.modelUUID {
+		// If there is no cached change, then we should be able to send immediately
+		// with no block.
+		//
+		// We explicitly don't sent with a select on the dying channel because we are inside
+		// the mutex, so no one else would be able to kill the watcher. If we try to move this
+		// outside of the mutex, we hit the potential for someone to kill the worker while we are
+		// trying to send, which would cause us to send down a closed channel which causes a panic.
+		select {
+		case w.changes <- model:
+		default:
+			// If there is a pending change then that is fine. We know the controller doesn't
+			// recreate models, and any new model will have a different UUID.
+		}
+	}
+}

--- a/core/cache/modelwatcher_test.go
+++ b/core/cache/modelwatcher_test.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"time"
+
+	"github.com/juju/juju/testing"
+	"github.com/kr/pretty"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+)
+
+type modelWatcherSuite struct {
+	EntitySuite
+}
+
+var _ = gc.Suite(&modelWatcherSuite{})
+
+var modelChange = ModelChange{
+	ModelUUID: "some-uuid",
+}
+
+func (s *modelWatcherSuite) TestWorkerNoModel(c *gc.C) {
+	w := newModelWatcher("some-uuid", s.Hub, nil)
+	workertest.CleanKill(c, w)
+}
+
+func (s *modelWatcherSuite) TestWorkerWithModel(c *gc.C) {
+	w := newModelWatcher("some-uuid", s.Hub, s.NewModel(modelChange))
+	workertest.CleanKill(c, w)
+}
+
+func (s *modelWatcherSuite) TestChangesWithModel(c *gc.C) {
+	model := s.NewModel(modelChange)
+	w := newModelWatcher("some-uuid", s.Hub, model)
+	defer workertest.CleanKill(c, w)
+
+	select {
+	case m := <-w.Changes():
+		c.Assert(m.UUID(), gc.Equals, "some-uuid")
+	case <-time.After(testing.ShortWait):
+		// There should be no time needed to wait as the model should be immediately
+		// available on the changes channel.
+		c.Errorf("No change after %s", testing.ShortWait)
+	}
+
+	// Send another event and make sure we can read one off.
+	s.Hub.Publish(modelUpdatedTopic, model)
+
+	select {
+	case m := <-w.Changes():
+		c.Assert(m.UUID(), gc.Equals, "some-uuid")
+	case <-time.After(testing.ShortWait):
+		// There should be no time needed to wait as the model should be immediately
+		// available on the changes channel.
+		c.Errorf("No change after %s", testing.ShortWait)
+	}
+}
+
+func (s *modelWatcherSuite) TestChangesNoModel(c *gc.C) {
+	w := newModelWatcher("some-uuid", s.Hub, nil)
+	defer workertest.CleanKill(c, w)
+
+	select {
+	case m := <-w.Changes():
+		c.Errorf("unexpected change %s", pretty.Sprint(m))
+	case <-time.After(testing.ShortWait):
+	}
+
+	model := s.NewModel(modelChange)
+	s.Hub.Publish(modelUpdatedTopic, model)
+
+	select {
+	case m := <-w.Changes():
+		c.Assert(m.UUID(), gc.Equals, "some-uuid")
+	case <-time.After(testing.ShortWait):
+		// There should be no time needed to wait as the model should be immediately
+		// available on the changes channel.
+		c.Errorf("No change after %s", testing.ShortWait)
+	}
+}
+
+func (s *modelWatcherSuite) TestChangesDifferentModel(c *gc.C) {
+	w := newModelWatcher("some-uuid", s.Hub, nil)
+	defer workertest.CleanKill(c, w)
+
+	model := s.NewModel(ModelChange{
+		ModelUUID: "other-uuid",
+	})
+	s.Hub.Publish(modelUpdatedTopic, model)
+
+	select {
+	case m := <-w.Changes():
+		c.Errorf("unexpected change %s", pretty.Sprint(m))
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+func (s *modelWatcherSuite) TestMultipleUpdates(c *gc.C) {
+	w := newModelWatcher("some-uuid", s.Hub, nil)
+	defer workertest.CleanKill(c, w)
+
+	model := s.NewModel(modelChange)
+	s.Hub.Publish(modelUpdatedTopic, model)
+	s.Hub.Publish(modelUpdatedTopic, model)
+	handled := s.Hub.Publish(modelUpdatedTopic, model)
+
+	// We know the events are handled in order, so we only need to wait for the
+	// last of the three events to have been processed.
+	select {
+	case <-handled:
+	case <-time.After(testing.LongWait):
+		c.Errorf("publish event not handled")
+	}
+
+	select {
+	case m := <-w.Changes():
+		c.Assert(m.UUID(), gc.Equals, "some-uuid")
+	case <-time.After(testing.ShortWait):
+		// There should be no time needed to wait as the model should be immediately
+		// available on the changes channel.
+		c.Errorf("No change after %s", testing.ShortWait)
+	}
+}

--- a/core/cache/modelwatcher_test.go
+++ b/core/cache/modelwatcher_test.go
@@ -6,10 +6,11 @@ package cache
 import (
 	"time"
 
-	"github.com/juju/juju/testing"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/testing"
 )
 
 type modelWatcherSuite struct {

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -58,7 +58,6 @@ func newNotifyWatcherBase() *notifyWatcherBase {
 }
 
 // Changes is part of the core watcher definition.
-// The changes channel is never closed.
 func (w *notifyWatcherBase) Changes() <-chan struct{} {
 	return w.changes
 }


### PR DESCRIPTION
This branch introduces a method on the cache controller WaitForModel. The intent here is that a model may have been created, but the cache doesn't yet know about it. The expectation is that the cache will very soon know about the model.

If the model is already in the cache, the method returns very quickly. This allows us to remove the generations feature flag from the client facade constructor.

This waiting for a model to appear is hidden in the FacadeContext object. This required threading through the clock in a few more apiserver places.
