### PR TITLE
Fix useage of k8s charm deployment override

### DIFF
--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -123,15 +123,20 @@ func (s *BaseSuite) setupController(c *gc.C) *gomock.Controller {
 		s.watchers = append(s.watchers, w)
 		return w, err
 	}
-	return s.setupBroker(c, ctrl, newK8sRestClientFunc, newK8sWatcherForTest)
+	randomPrefixFunc := func() (string, error) {
+		return "appuuid", nil
+	}
+	return s.setupBroker(c, ctrl, newK8sRestClientFunc, newK8sWatcherForTest, randomPrefixFunc)
 }
 
 func (s *BaseSuite) setupBroker(c *gc.C, ctrl *gomock.Controller,
 	newK8sRestClientFunc provider.NewK8sClientFunc,
-	newK8sWatcherFunc provider.NewK8sWatcherFunc) *gomock.Controller {
+	newK8sWatcherFunc provider.NewK8sWatcherFunc,
+	randomPrefixFunc provider.RandomPrefixFunc) *gomock.Controller {
 	s.clock = testclock.NewClock(time.Time{})
 	var err error
-	s.broker, err = provider.NewK8sBroker(s.controllerUUID, s.k8sRestConfig, s.cfg, newK8sRestClientFunc, newK8sWatcherFunc, s.clock)
+	s.broker, err = provider.NewK8sBroker(s.controllerUUID, s.k8sRestConfig, s.cfg, newK8sRestClientFunc,
+		newK8sWatcherFunc, randomPrefixFunc, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	return ctrl
 }

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -192,7 +192,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		s.watchers = append(s.watchers, w)
 		return w, err
 	}
-	s.setupBroker(c, ctrl, newK8sRestClientFunc, newK8sWatcherForTest)
+	randomPrefixFunc := func() (string, error) {
+		return "appuuid", nil
+	}
+	s.setupBroker(c, ctrl, newK8sRestClientFunc, newK8sWatcherForTest, randomPrefixFunc)
 	// Broker's namespace is "controller" now - controllerModelConfig.Name()
 	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller")
 	c.Assert(

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -102,6 +102,9 @@ type kubernetesClient struct {
 
 	// newWatcher is the k8s watcher generator.
 	newWatcher NewK8sWatcherFunc
+
+	// randomPrefix generates an annotation for stateful sets.
+	randomPrefix RandomPrefixFunc
 }
 
 // To regenerate the mocks for the kubernetes Client used by this broker,
@@ -118,6 +121,9 @@ type NewK8sClientFunc func(c *rest.Config) (kubernetes.Interface, apiextensionsc
 // NewK8sWatcherFunc defines a function which returns a k8s watcher based on the supplied config.
 type NewK8sWatcherFunc func(wi watch.Interface, name string, clock jujuclock.Clock) (*kubernetesWatcher, error)
 
+// RandomPrefixFunc defines a function used to generate a random hex string.
+type RandomPrefixFunc func() (string, error)
+
 // newK8sBroker returns a kubernetes client for the specified k8s cluster.
 func newK8sBroker(
 	controllerUUID string,
@@ -125,6 +131,7 @@ func newK8sBroker(
 	cfg *config.Config,
 	newClient NewK8sClientFunc,
 	newWatcher NewK8sWatcherFunc,
+	randomPrefix RandomPrefixFunc,
 	clock jujuclock.Clock,
 ) (*kubernetesClient, error) {
 
@@ -150,6 +157,7 @@ func newK8sBroker(
 		modelUUID:                   modelUUID,
 		newWatcher:                  newWatcher,
 		newClient:                   newClient,
+		randomPrefix:                randomPrefix,
 		annotations: k8sannotations.New(nil).
 			Add(annotationModelUUIDKey, modelUUID),
 	}
@@ -1224,7 +1232,7 @@ func (k *kubernetesClient) EnsureService(
 	// Add a deployment controller or stateful set configured to create the specified number of units/pods.
 	// Defensively check to see if a stateful set is already used.
 	var useStatefulSet bool
-	if params.Deployment.ServiceType != "" {
+	if params.Deployment.DeploymentType != "" {
 		useStatefulSet = params.Deployment.DeploymentType == caas.DeploymentStateful
 	} else {
 		useStatefulSet = len(params.Filesystems) > 0
@@ -1249,11 +1257,10 @@ func (k *kubernetesClient) EnsureService(
 			randPrefix = existingStatefulSet.Annotations[labelApplicationUUID]
 		}
 		if randPrefix == "" {
-			var randPrefixBytes [4]byte
-			if _, err := io.ReadFull(rand.Reader, randPrefixBytes[0:4]); err != nil {
+			randPrefix, err = k.randomPrefix()
+			if err != nil {
 				return errors.Trace(err)
 			}
-			randPrefix = fmt.Sprintf("%x", randPrefixBytes)
 		}
 	}
 
@@ -1308,6 +1315,14 @@ func (k *kubernetesClient) EnsureService(
 	}
 
 	return nil
+}
+
+func randomPrefix() (string, error) {
+	var randPrefixBytes [4]byte
+	if _, err := io.ReadFull(rand.Reader, randPrefixBytes[0:4]); err != nil {
+		return "", errors.Trace(err)
+	}
+	return fmt.Sprintf("%x", randPrefixBytes), nil
 }
 
 // Upgrade sets the OCI image for the app's operator to the specified version.

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1143,6 +1143,82 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 	}
 
 	serviceArg := *basicServiceArg
+	serviceArg.Spec.Type = core.ServiceTypeClusterIP
+	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockSecrets.EXPECT().Update(s.secretArg(c, nil)).Times(1).
+			Return(nil, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Update(&serviceArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Create(&serviceArg).Times(1).
+			Return(nil, nil),
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+			Return(nil, nil),
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+			Return(nil, nil),
+	)
+
+	params := &caas.ServiceParams{
+		PodSpec: getBasicPodspec(),
+		Deployment: caas.DeploymentParams{
+			DeploymentType: caas.DeploymentStateful,
+		},
+	}
+	err = s.broker.EnsureService("app-name", nil, params, 2, application.ConfigAttributes{
+		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
+		"kubernetes-service-externalname":    "ext-name",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	unitSpec, err := provider.MakeUnitSpec("app-name", "app-name", getBasicPodspec())
+	c.Assert(err, jc.ErrorIsNil)
+	podSpec := provider.PodSpec(unitSpec)
+
+	numUnits := int32(2)
+	statefulSetArg := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "app-name",
+			Annotations: map[string]string{
+				"juju-app-uuid": "appuuid",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &numUnits,
+			Selector: &v1.LabelSelector{
+				MatchLabels: map[string]string{"juju-app": "app-name"},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"juju-app": "app-name"},
+					Annotations: map[string]string{
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+					},
+				},
+				Spec: podSpec,
+			},
+			PodManagementPolicy: apps.ParallelPodManagement,
+			ServiceName:         "app-name-endpoints",
+		},
+	}
+
+	serviceArg := *basicServiceArg
 	serviceArg.Spec.Type = core.ServiceTypeExternalName
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
@@ -1172,8 +1248,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 	params := &caas.ServiceParams{
 		PodSpec: getBasicPodspec(),
 		Deployment: caas.DeploymentParams{
-			DeploymentType: caas.DeploymentStateful,
-			ServiceType:    caas.ServiceExternal,
+			ServiceType: caas.ServiceExternal,
 		},
 	}
 	err = s.broker.EnsureService("app-name", nil, params, 2, application.ConfigAttributes{

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -106,7 +106,7 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 		return nil, errors.Trace(err)
 	}
 	broker, err := newK8sBroker(
-		args.ControllerUUID, k8sRestConfig, args.Config, newK8sClient, newKubernetesWatcher, jujuclock.WallClock,
+		args.ControllerUUID, k8sRestConfig, args.Config, newK8sClient, newKubernetesWatcher, randomPrefix, jujuclock.WallClock,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of change

k8s charms can specify a deployment type to override juju's default choice.
This was not being honoured due to a typo in the code.
The fix was one line - the rest is to account for adding a new test.

## QA steps

deploy a k8s charm without storage and ensure that the deployment can be forced to be stateful

## Bug reference
https://bugs.launchpad.net/juju/+bug/1839918
