### PR TITLE
Tests suite

### DIFF
--- a/core/machinelock/machinelock.go
+++ b/core/machinelock/machinelock.go
@@ -278,7 +278,6 @@ type report struct {
 }
 
 func (c *lock) Report(opts ...ReportOption) (string, error) {
-
 	includeStack := contains(opts, ShowStack)
 	detailsYAML := contains(opts, ShowDetailsYAML)
 

--- a/core/machinelock/machinelock_test.go
+++ b/core/machinelock/machinelock_test.go
@@ -79,7 +79,6 @@ test:
 }
 
 func (s *lockSuite) TestWaitingOutput(c *gc.C) {
-
 	s.addWaiting(c, "worker1", "being busy")
 	s.clock.Advance(time.Minute)
 	s.addWaiting(c, "worker", "")

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -64,7 +64,6 @@ func (s *configSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&configSuite{})
 
 func (s *configSuite) TestNewModelConfig(c *gc.C) {
-
 	type checker struct {
 		checker gc.Checker
 		value   interface{}

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -136,7 +136,6 @@ func (s *environInstanceSuite) TestInstances(c *gc.C) {
 }
 
 func (s *environInstanceSuite) TestInstancesFail(c *gc.C) {
-
 	newClientFunc := newClient
 	s.PatchValue(&newClient, func(spec environs.CloudSpec, uuid string) (*environClient, error) {
 		spec.Endpoint = "https://0.1.2.3:2000/api/2.0/"

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1135,7 +1135,6 @@ func (*environ) MaintainInstance(ctx context.ProviderCallContext, args environs.
 
 // StartInstance is specified in the InstanceBroker interface.
 func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-
 	defer delay()
 	machineId := args.InstanceConfig.MachineId
 	logger.Infof("dummy startinstance, machine %s", machineId)

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -317,7 +317,6 @@ func parseVolumeOptions(size uint64, attrs map[string]interface{}) (_ ec2.Create
 
 // CreateVolumes is specified on the storage.VolumeSource interface.
 func (v *ebsVolumeSource) CreateVolumes(ctx context.ProviderCallContext, params []storage.VolumeParams) (_ []storage.CreateVolumesResult, err error) {
-
 	// First, validate the params before we use them.
 	results := make([]storage.CreateVolumesResult, len(params))
 	instanceIds := set.NewStrings()

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1318,7 +1318,6 @@ func (e *environ) DestroyController(ctx context.ProviderCallContext, controllerU
 // destroyControllerManagedEnvirons destroys all environments managed by this
 // environment's controller.
 func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallContext, controllerUUID string) error {
-
 	// Terminate all instances managed by the controller.
 	instIds, err := e.allControllerManagedInstances(ctx, controllerUUID)
 	if err != nil {

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -171,7 +171,6 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 }
 
 func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.C) {
-
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
 		Series:      series.DefaultSupportedLTS(),

--- a/provider/oracle/network/firewall.go
+++ b/provider/oracle/network/firewall.go
@@ -707,7 +707,6 @@ func (f Firewall) convertFromSecRules(rules ...response.SecRule) (map[string][]n
 
 // secRuleToIngressRule convert all security rules into a map of ingress rules
 func (f Firewall) secRuleToIngresRule(rules ...response.SecRule) (map[string]network.IngressRule, error) {
-
 	applications, err := f.getAllApplicationsAsMap()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/oracle/network/firewall_test.go
+++ b/provider/oracle/network/firewall_test.go
@@ -849,7 +849,6 @@ func (f *firewallSuite) TestDeleteMachineSecList(c *gc.C) {
 }
 
 func (f *firewallSuite) TestDeleteMachineSecListWithErrors(c *gc.C) {
-
 	cfg := &fakeEnvironConfig{cfg: testing.ModelConfig(c)}
 
 	for _, fake := range []*providertest.FakeFirewallAPI{

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -1,0 +1,16 @@
+check_dependencies() {
+    local dep missing
+    missing=""
+
+    for dep in "$@"; do
+        if ! which "$dep" >/dev/null 2>&1; then
+            [ "$missing" ] && missing="$missing $dep" || missing="$dep"
+        fi
+    done
+
+    if [ "$missing" ]; then
+        echo "Missing dependencies: $missing" >&2
+        echo ""
+        exit 1
+    fi
+}

--- a/tests/includes/colors.sh
+++ b/tests/includes/colors.sh
@@ -1,0 +1,17 @@
+red() {
+    if tput setaf 1 &> /dev/null; then
+        tput sgr0
+        echo "$(tput setaf 1)${1}$(tput sgr0)"
+    else
+        echo "${1}"
+    fi
+}
+
+green() {
+    if tput setaf 1 &> /dev/null; then
+        tput sgr0
+        echo "$(tput setaf 2)${1}$(tput sgr0)"
+    else
+        echo "${1}"
+    fi
+}

--- a/tests/includes/date.sh
+++ b/tests/includes/date.sh
@@ -1,0 +1,5 @@
+add_date() {
+    while IFS= read -r line; do
+        printf '%s: %s\n' "$(date "+%Y-%m-%d %H:%M:%S")" "$line";
+    done
+}

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -41,9 +41,11 @@ destroy() {
 }
 
 cleanup_jujus() {
-    echo "====> Cleaning up jujus"
+    if [ -f "${TEST_DIR}/jujus" ]; then
+        echo "====> Cleaning up jujus"
 
-    while read -r juju_name; do
-        destroy "${juju_name}"
-    done < "${TEST_DIR}/jujus"
+        while read -r juju_name; do
+            destroy "${juju_name}"
+        done < "${TEST_DIR}/jujus"
+    fi
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -27,6 +27,13 @@ destroy() {
     name=${1}
     shift
 
+    # shellcheck disable=SC2034
+    OUT=$(juju controllers --format=json | jq '.controllers | keys' | grep "${name}" || true)
+    # shellcheck disable=SC2181
+    if [ $? -ne 0 ]; then
+        return
+    fi
+
     file="${TEST_DIR}/${name}_destroy.txt"
 
     echo "====> Destroying juju ${name}"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -33,14 +33,7 @@ bootstrap() {
     shift
 
     rnd=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
-    name=$(echo "ctrl-${rnd}")
-
-    OUT=$(juju models --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
-    if [ -n "${OUT}" ]; then
-        echo "${model} already exists. Use the following to clean up the environment:"
-        echo "    juju destroy-model --force -y ${model}"
-        exit 1
-    fi
+    name="ctrl-${rnd}"
 
     if [ ! -f "${TEST_DIR}/jujus" ]; then
         touch "${TEST_DIR}/jujus"
@@ -51,8 +44,16 @@ bootstrap() {
         unset BOOTSTRAP_REUSE
     fi
 
-    if [ ! -z "${BOOTSTRAP_REUSE}" ]; then
+    if [ -n "${BOOTSTRAP_REUSE}" ]; then
         echo "====> Reusing bootstrapped juju"
+
+        OUT=$(juju models --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
+        if [ -n "${OUT}" ]; then
+            echo "${model} already exists. Use the following to clean up the environment:"
+            echo "    juju destroy-model --force -y ${model}"
+            exit 1
+        fi
+
         add_model "${model}" "${provider}"
         name="${bootstrapped_name}"
     else
@@ -96,7 +97,7 @@ juju_bootstrap() {
     shift
 
     if [ -n "${output}" ]; then
-        juju bootstrap "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
+        juju bootstrap "${provider}" "${name}" -d "${model}" "$@" 2>&1 | add_date >"${output}"
     else
         juju bootstrap "${provider}" "${name}" -d "${model}" "$@"
     fi
@@ -116,14 +117,14 @@ destroy_model() {
         return
     fi
 
-    file="${TEST_DIR}/${name}-destroy.txt"
+    output="${TEST_DIR}/${name}-destroy.txt"
 
     echo "====> Destroying juju model ${name}"
-    echo "${name}" | xargs -I % juju destroy-model --force -y % > "${file}" 2>&1
-    CHK=$(cat "${file}" | grep -i "ERROR" || true)
+    echo "${name}" | xargs -I % juju destroy-model --force -y % 2>&1 | add_date >"${output}"
+    CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues"
-        cat "${file}" | xargs echo -I % "\\n%"
+        cat "${output}" | xargs echo -I % "\\n%"
         exit 1
     fi
     echo "====> Destroyed juju model ${name}"
@@ -142,14 +143,14 @@ destroy_controller() {
         return
     fi
 
-    file="${TEST_DIR}/${name}-destroy-controller.txt"
+    output="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ${name}"
-    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % > "${file}" 2>&1
-    CHK=$(cat "${file}" | grep -i "ERROR" || true)
+    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % 2>&1 | add_date >"${output}"
+    CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues"
-        cat "${file}" | xargs echo -I % "\\n%"
+        cat "${output}" | xargs echo -I % "\\n%"
         exit 1
     fi
     echo "====> Destroyed juju ${name}"
@@ -171,6 +172,7 @@ wait_for() {
     name=${1}
     query=${2}
 
+    # shellcheck disable=SC2046,SC2143
     until [ $(juju status --format=json 2> /dev/null | jq "${query}" | grep "${name}") ]; do
         juju status --relations
         sleep 5

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -1,0 +1,19 @@
+destroy() {
+    local name
+
+    name=${1}
+    shift
+
+    echo "==> Destroying juju ${name}"
+    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y %
+    echo "==> Destroyed juju ${name}"
+}
+
+cleanup_jujus() {
+    echo "==> Cleaning up jujus"
+
+    OUT=$(juju controllers --format=json | jq '.controllers | keys | .[]')
+    for NAME in $(echo "${OUT}" | tr " " "\n"); do
+        destroy "${NAME}"
+    done
+}

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -44,6 +44,7 @@ bootstrap() {
         unset BOOTSTRAP_REUSE
     fi
 
+    START_TIME=$(date +%s)
     if [ -n "${BOOTSTRAP_REUSE}" ]; then
         echo "====> Reusing bootstrapped juju"
 
@@ -60,8 +61,9 @@ bootstrap() {
         echo "====> Bootstrapping juju"
         juju_bootstrap "${provider}" "${name}" "${model}" "${output}"
     fi
+    END_TIME=$(date +%s)
 
-    echo "====> Bootstrapped juju"
+    echo "====> Bootstrapped juju ($((END_TIME-START_TIME))s)"
 
     export BOOTSTRAPPED_JUJU_CTRL_NAME="${name}"
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -1,13 +1,29 @@
+ensure() {
+    local model output
+
+    model=${1}
+    shift
+
+    output=${1}
+    shift
+
+    export BOOTSTRAP_REUSE="true"
+    bootstrap "${model}" "${output}"
+}
+
 bootstrap() {
-    local provider name model bootstrapped bootstrapped_name
+    local provider name output model bootstrapped_name
 
     case "${BOOTSTRAP_PROVIDER:-}" in
         "aws")
             provider="aws"
             ;;
-        *)
-            echo "Expected bootstrap provider, falling back to lxd."
+        "lxd")
             provider="lxd"
+            ;;
+        *)
+            echo "Unexpected bootstrap provider."
+            exit 1
     esac
 
     model=${1}
@@ -16,7 +32,7 @@ bootstrap() {
     output=${1}
     shift
 
-    rnd=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+    rnd=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
     name=$(echo "ctrl-${rnd}")
 
     OUT=$(juju models --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
@@ -26,57 +42,81 @@ bootstrap() {
         exit 1
     fi
 
-    bootstrapped="false"
-    if [ -n "${BOOTSTRAP_REUSE}" ]; then
-
-        bootstrapped_name=$(grep "." "${TEST_DIR}/jujus" | tail -n 1)
-        if [ -n "${bootstrapped_name}" ]; then
-            echo "====> Reusing bootstrapped juju"
-
-            OUT=$(juju controllers --format=json | jq '.controllers | .["${bootstrapped_name}"] | .cloud' | grep "${provider}" || true)
-            if [ -n "${OUT}" ]; then
-                juju add-model "${model}" "${provider}"
-            else
-                juju add-model "${model}"
-            fi
-            bootstrapped="true"
-            name="${bootstrapped_name}"
-        fi
+    if [ ! -f "${TEST_DIR}/jujus" ]; then
+        touch "${TEST_DIR}/jujus"
+    fi
+    bootstrapped_name=$(grep "." "${TEST_DIR}/jujus" | tail -n 1)
+    if [ -z "${bootstrapped_name}" ]; then
+        # No bootstrapped juju found, unset the the variable.
+        unset BOOTSTRAP_REUSE
     fi
 
-    if [ "${bootstrapped}" = "false" ]; then
+    if [ ! -z "${BOOTSTRAP_REUSE}" ]; then
+        echo "====> Reusing bootstrapped juju"
+        add_model "${model}" "${provider}"
+        name="${bootstrapped_name}"
+    else
         echo "====> Bootstrapping juju"
-        if [ -n "${output}" ]; then
-            juju bootstrap "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
-        else
-            juju bootstrap "${provider}" "${name}" -d "${model}" "$@"
-        fi
-        echo "${name}" >> "${TEST_DIR}/jujus"
-        bootstrapped="true"
+        juju_bootstrap "${provider}" "${name}" "${model}" "${output}"
     fi
-
-    echo "${model}" >> "${TEST_DIR}/models"
 
     echo "====> Bootstrapped juju"
 
-    export BOOTSTRAPPED="${bootstrapped}"
     export BOOTSTRAPPED_JUJU_CTRL_NAME="${name}"
 }
 
-destroy() {
+add_model() {
+    local model provider
+
+    model=${1}
+    provider=${2}
+
+    OUT=$(juju controllers --format=json | jq '.controllers | .["${bootstrapped_name}"] | .cloud' | grep "${provider}" || true)
+    if [ -n "${OUT}" ]; then
+        juju add-model "${model}" "${provider}"
+    else
+        juju add-model "${model}"
+    fi
+    echo "${model}" >> "${TEST_DIR}/models"
+}
+
+juju_bootstrap() {
+    local provider name model output
+
+    provider=${1}
+    shift
+
+    name=${1}
+    shift
+
+    model=${1}
+    shift
+
+    output=${1}
+    shift
+
+    if [ -n "${output}" ]; then
+        juju bootstrap "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
+    else
+        juju bootstrap "${provider}" "${name}" -d "${model}" "$@"
+    fi
+    echo "${name}" >> "${TEST_DIR}/jujus"
+}
+
+destroy_model() {
     local name
 
     name=${1}
     shift
 
     # shellcheck disable=SC2034
-    OUT=$(juju controllers --format=json | jq '.controllers | keys' | grep "${name}" || true)
+    OUT=$(juju models --format=json | jq '.models | .[] | .["short-name"]' | grep "${name}" || true)
     # shellcheck disable=SC2181
     if [ -z "${OUT}" ]; then
         return
     fi
 
-    file="${TEST_DIR}/${name}_destroy.txt"
+    file="${TEST_DIR}/${name}-destroy.txt"
 
     echo "====> Destroying juju model ${name}"
     echo "${name}" | xargs -I % juju destroy-model --force -y % > "${file}" 2>&1
@@ -102,7 +142,7 @@ destroy_controller() {
         return
     fi
 
-    file="${TEST_DIR}/${name}_destroy_controller.txt"
+    file="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ${name}"
     echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % > "${file}" 2>&1

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -1,31 +1,44 @@
 bootstrap() {
-    local provider name
+    set -eux
+    local provider name model
 
-    provider=${1}
-    shift
+    case "${BOOTSTRAP_PROVIDER:-}" in
+        "aws")
+            provider="aws"
+            ;;
+        *)
+            echo "Expected bootstrap provider, falling back to lxd."
+            provider="lxd"
+    esac
 
-    name=${1}
+    model=${1}
     shift
 
     output=${1}
     shift
 
-    OUT=$(juju controllers --format=json | jq '.controllers | keys' | grep "${name}" || true)
+    rnd=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+    name=$(echo "ctrl-${rnd}")
+
+    OUT=$(juju models --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
     if [ -n "${OUT}" ]; then
-        echo "${name} already exists. Use the following to clean up the environment:"
-        echo "    juju destroy-controller --destroy-all-models -y ${name}"
+        echo "${model} already exists. Use the following to clean up the environment:"
+        echo "    juju destroy-model --force -y ${model}"
         exit 1
     fi
 
     echo "====> Bootstrapping juju"
     if [ -n "${output}" ]; then
-        juju bootstrap "${provider}" "${name}" "$@" > "${output}" 2>&1
+        juju bootstrap "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
     else
-        juju bootstrap "${provider}" "${name}" "$@"
+        juju bootstrap "${provider}" "${name}" -d "${model}" "$@"
     fi
     echo "${name}" >> "${TEST_DIR}/jujus"
+    echo "${model}" >> "${TEST_DIR}/models"
 
     echo "====> Bootstrapped juju"
+
+    export BOOTSTRAPPED_JUJU_CTRL_NAME="${name}"
 }
 
 destroy() {
@@ -43,6 +56,32 @@ destroy() {
 
     file="${TEST_DIR}/${name}_destroy.txt"
 
+    echo "====> Destroying juju model ${name}"
+    echo "${name}" | xargs -I % juju destroy-model --force -y % > "${file}" 2>&1
+    CHK=$(cat "${file}" | grep -i "ERROR" || true)
+    if [ -n "${CHK}" ]; then
+        printf "\\nFound some issues"
+        cat "${file}" | xargs echo -I % "\\n%"
+        exit 1
+    fi
+    echo "====> Destroyed juju model ${name}"
+}
+
+destroy_controller() {
+    local name
+
+    name=${1}
+    shift
+
+    # shellcheck disable=SC2034
+    OUT=$(juju controllers --format=json | jq '.controllers | keys' | grep "${name}" || true)
+    # shellcheck disable=SC2181
+    if [ -z "${OUT}" ]; then
+        return
+    fi
+
+    file="${TEST_DIR}/${name}_destroy_controller.txt"
+
     echo "====> Destroying juju ${name}"
     echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % > "${file}" 2>&1
     CHK=$(cat "${file}" | grep -i "ERROR" || true)
@@ -59,7 +98,7 @@ cleanup_jujus() {
         echo "====> Cleaning up jujus"
 
         while read -r juju_name; do
-            destroy "${juju_name}"
+            destroy_controller "${juju_name}"
         done < "${TEST_DIR}/jujus"
     fi
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -1,19 +1,49 @@
+bootstrap() {
+    local provider name
+
+    provider=${1}
+    shift
+
+    name=${1}
+    shift
+
+    output=${1}
+    shift
+
+    echo "====> Bootstrapping juju"
+    if [ -n "${output}" ]; then
+        juju bootstrap "${provider}" "${name}" "$@" > "${output}" 2>&1
+    else
+        juju bootstrap "${provider}" "${name}" "$@"
+    fi
+    echo "${name}" >> "${TEST_DIR}/jujus"
+
+    echo "====> Bootstrapped juju"
+}
+
 destroy() {
     local name
 
     name=${1}
     shift
 
-    echo "==> Destroying juju ${name}"
-    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y %
-    echo "==> Destroyed juju ${name}"
+    file="${TEST_DIR}/${name}_destroy.txt"
+
+    echo "====> Destroying juju ${name}"
+    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % > "${file}" 2>&1
+    CHK=$(cat "${file}" | grep -i "ERROR" || true)
+    if [ -n "${CHK}" ]; then
+        printf "\\nFound some issues"
+        cat "${file}" | xargs echo -I % "\\n%"
+        exit 1
+    fi
+    echo "====> Destroyed juju ${name}"
 }
 
 cleanup_jujus() {
-    echo "==> Cleaning up jujus"
+    echo "====> Cleaning up jujus"
 
-    OUT=$(juju controllers --format=json | jq '.controllers | keys | .[]')
-    for NAME in $(echo "${OUT}" | tr " " "\n"); do
-        destroy "${NAME}"
-    done
+    while read -r juju_name; do
+        destroy "${juju_name}"
+    done < "${TEST_DIR}/jujus"
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -163,6 +163,7 @@ cleanup_jujus() {
         while read -r juju_name; do
             destroy_controller "${juju_name}"
         done < "${TEST_DIR}/jujus"
+        rm -f "${TEST_DIR}/jujus"
     fi
 }
 

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -1,0 +1,6 @@
+run() {
+  echo -n "====> Running: ${1}"
+  CMD=$(echo "${1}" | sed -E "s/ /_/g" | xargs -I % echo "run_%")
+  $CMD "$@"
+  echo "\r====> Success: ${1}"
+}

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -1,6 +1,20 @@
 run() {
-  echo -n "===> Running: ${1}"
-  CMD=$(echo "${1}" | sed -E "s/ /_/g" | xargs -I % echo "run_%")
+  CMD="${1}"
+  DESC=$(echo "${1}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
+
+  echo -n "===> [   ] Running: ${DESC}"
+  START_TIME=$(date +%s)
   $CMD "$@"
-  echo "\r===> Success: ${1}"
+  END_TIME=$(date +%s)
+  echo "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME-START_TIME))s)"
+}
+
+skip() {
+  CMD="${1}"
+  # shellcheck disable=SC2143,SC2046
+  if [ $(echo "${SKIP_LIST:-}" | grep -w "${CMD}") ]; then
+      echo "SKIP"
+      exit 1
+  fi
+  return
 }

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -1,6 +1,6 @@
 run() {
-  echo -n "====> Running: ${1}"
+  echo -n "===> Running: ${1}"
   CMD=$(echo "${1}" | sed -E "s/ /_/g" | xargs -I % echo "run_%")
   $CMD "$@"
-  echo "\r====> Success: ${1}"
+  echo "\r===> Success: ${1}"
 }

--- a/tests/includes/verbose.sh
+++ b/tests/includes/verbose.sh
@@ -1,0 +1,14 @@
+set_verbosity() {
+    case "${VERBOSE}" in
+    1)
+        set -e
+        ;;
+    2)
+        set -eux
+        ;;
+    *)
+        echo "Unexpected verbose level" >&2
+        exit 1
+        ;;
+    esac
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -61,11 +61,6 @@ trap cleanup EXIT HUP INT TERM
 
 # Setup test directory
 TEST_DIR=$(mktemp -d tmp.XXX)
-chmod +x "${TEST_DIR}"
-
-THERM_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-export THERM_DIR
-chmod +x "${THERM_DIR}"
 
 run_test() {
     TEST_CURRENT=${1}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -36,7 +36,7 @@ show_help() {
     echo ""
     echo "Usage:"
     echo "¯¯¯¯¯¯"
-    echo "cmd [-h] [-vV] [-s test] [-a file] [x file]"
+    echo "cmd [-h] [-vV] [-s test] [-a file] [-x file] [-r reuse] [-p provider type <lxd|aws>]"
     echo ""
     echo "    $(green 'cmd -h')        Display this help message"
     echo "    $(green 'cmd -v')        Verbose and debug messages"
@@ -44,6 +44,8 @@ show_help() {
     echo "    $(green 'cmd -s')        Skip tests using a comma seperated list"
     echo "    $(green 'cmd -a')        Create an atifact file"
     echo "    $(green 'cmd -x')        Output file from streaming the output"
+    echo "    $(green 'cmd -r')        Reuse bootstrapped controller"
+    echo "    $(green 'cmd -p')        Bootstrap provider to use when bootstrapping <lxd|aws>"
     echo ""
     echo "Tests:"
     echo "¯¯¯¯¯¯"
@@ -101,6 +103,14 @@ while getopts "h?:vVsax" opt; do
         ;;
     x)
         OUTPUT_FILE="${2}"
+        shift 2
+        ;;
+    r)
+        export BOOTSTRAP_REUSE="true"
+        shift
+        ;;
+    p)
+        export BOOTSTRAP_PROVIDER="${2}"
         shift 2
         ;;
     *)

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -60,12 +60,16 @@ TEST_RESULT=failure
 trap cleanup EXIT HUP INT TERM
 
 # Setup test directory
-TEST_DIR=$(mktemp -d tmp.XXX)
+TEST_DIR=$(mktemp -d tmp.XXX | xargs -I % echo "$(pwd)/%")
 
 run_test() {
     TEST_CURRENT=${1}
     TEST_CURRENT_DESCRIPTION=${2:-${1}}
     TEST_CURRENT_NAME=${TEST_CURRENT#"test_"}
+
+    if [ -n "${4}" ]; then
+        TEST_CURRENT=${4}
+    fi
 
     import_subdir_files "suites/${TEST_CURRENT_NAME}"
 
@@ -79,7 +83,7 @@ run_test() {
 
 # allow for running a specific set of tests
 if [ "$#" -gt 0 ]; then
-    run_test "test_${1}"
+    run_test "test_${1}" "" "$@"
     TEST_RESULT=success
     exit
 fi

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -48,9 +48,10 @@ cleanup() {
     echo ""
     if [ "$TEST_RESULT" != "success" ]; then
         echo "==> TEST DONE: ${TEST_CURRENT_DESCRIPTION}"
+    else
+        rm -rf "${TEST_DIR}"
+        echo "==> Tests Removed: ${TEST_DIR}"
     fi
-    rm -rf "${TEST_DIR}"
-    echo "==> Tests Removed: ${TEST_DIR}"
     echo "==> Test result: ${TEST_RESULT}"
 }
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -2,10 +2,13 @@
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
-export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002"
+export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005"
 
 OPTIND=1
-VERBOSE=0
+VERBOSE=1
+SKIP_LIST=""
+ARITFACT_FILE=""
+OUTPUT_FILE=""
 
 import_subdir_files() {
     test "$1"
@@ -18,21 +21,91 @@ import_subdir_files() {
 
 import_subdir_files includes
 
+# If adding a test suite, then ensure to add it here to be picked up!
+TEST_NAMES="test_static_analysis \
+            test_smoke \
+            test_cmr_bundles"
+
 show_help() {
-    echo "Juju test suite"
-    echo "Usage: cmd [-h] [-v]"
-    echo "    cmd -h        Display this help message"
-    echo "    cmd -v        Verbose and debug messages"
+    echo ""
+    echo "$(red 'Juju test suite')"
+    echo "¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯"
+    echo "Juju tests suite expects you to have a Juju available on your \$PATH,"
+    echo "so that if a tests needs to bootstrap it can just use that one"
+    echo "directly."
+    echo ""
+    echo "Usage:"
+    echo "¯¯¯¯¯¯"
+    echo "cmd [-h] [-vV] [-s test] [-a file] [x file]"
+    echo ""
+    echo "    $(green 'cmd -h')        Display this help message"
+    echo "    $(green 'cmd -v')        Verbose and debug messages"
+    echo "    $(green 'cmd -V')        Very verbose and debug messages"
+    echo "    $(green 'cmd -s')        Skip tests using a comma seperated list"
+    echo "    $(green 'cmd -a')        Create an atifact file"
+    echo "    $(green 'cmd -x')        Output file from streaming the output"
+    echo ""
+    echo "Tests:"
+    echo "¯¯¯¯¯¯¯¯¯"
+    echo "Available tests:"
+    echo ""
+
+    # Let's use the TEST_NAMES to print out what's available
+    output=""
+    for test in ${TEST_NAMES}; do
+        name=$(echo "${test}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
+        # shellcheck disable=SC2086
+        output="${output}\n    $(green ${test})|Runs the ${name}"
+    done
+    echo "${output}" | column -t -s "|"
+
+    echo ""
+    echo "Examples:"
+    echo "¯¯¯¯¯¯¯¯¯"
+    echo "Run a singular test:"
+    echo ""
+    echo "    $(green 'cmd static_analysis test_static_analysis_go')"
+    echo ""
+    echo "Run static analysis tests, but skip the go static analysis tests:"
+    echo ""
+    echo "    $(green 'cmd -s test_static_analysis_go static_analysis')"
+    echo ""
+    echo "Run a more verbose output and save that to an artifact tar (it"
+    echo "requires piping the output from stdout and stderr into a output.log,"
+    echo "which is then copied into the artifact tar file on test cleanup):"
+    echo ""
+    echo "    $(green 'cmd -V -a artifact.tar.gz -x output.log 2>&1|tee output.log')"
     exit 0
 }
 
-while getopts "h?:v" opt; do
+while getopts "h?:vVsax" opt; do
     case "${opt}" in
     h|\?)
         show_help
         ;;
-    v)  VERBOSE=1
+    v)
+        VERBOSE=1
+        shift
         ;;
+    V)
+        VERBOSE=2
+        shift
+        ;;
+    s)
+        SKIP_LIST="${2}"
+        shift 2
+        ;;
+    a)
+        ARITFACT_FILE="${2}"
+        shift 2
+        ;;
+    x)
+        OUTPUT_FILE="${2}"
+        shift 2
+        ;;
+    *)
+        echo "Unexpected argument ${opt}" >&2
+        exit 1
     esac
 done
 
@@ -40,6 +113,10 @@ shift $((OPTIND-1))
 
 [ "${1:-}" = "--" ] && shift
 
+export VERBOSE="${VERBOSE}"
+export SKIP_LIST="${SKIP_LIST}"
+
+echo ""
 
 echo "==> Checking for dependencies"
 check_dependencies curl jq shellcheck juju
@@ -48,7 +125,6 @@ if [ "${USER:-'root'}" = "root" ]; then
     echo "The testsuite must not be run as root." >&2
     exit 1
 fi
-
 
 cleanup() {
     # Allow for failures and stop tracing everything
@@ -71,17 +147,33 @@ cleanup() {
     cleanup_jujus
 
     echo ""
-    echo ""
-    if [ "$TEST_RESULT" != "success" ]; then
-        echo "==> TEST DONE: ${TEST_CURRENT_DESCRIPTION}"
-    else
+    if [ "${TEST_RESULT}" != "success" ]; then
+        echo "==> TESTS DONE: ${TEST_CURRENT_DESCRIPTION}"
+    fi
+    echo "==> Test result: ${TEST_RESULT}"
+
+    # Move any artifacts to the choosen location
+    if [ -n "${ARITFACT_FILE}" ]; then
+        echo "==> Test artifact: ${ARITFACT_FILE}"
+        if [ -f "${OUTPUT_FILE}" ]; then
+            cp "${OUTPUT_FILE}" "${TEST_DIR}"
+        fi
+        TAR_OUTPUT=$(tar -C "${TEST_DIR}" --transform s/./artifacts/ -zcvf "${ARITFACT_FILE}" ./ 2>&1)
+        # shellcheck disable=SC2181
+        if [ $? -ne 0 ]; then
+            echo "${TAR_OUTPUT}"
+            exit 1
+        fi
+    fi
+
+    if [ "${TEST_RESULT}" = "success" ]; then
         rm -rf "${TEST_DIR}"
         echo "==> Tests Removed: ${TEST_DIR}"
     fi
-    echo "==> Test result: ${TEST_RESULT}"
+
+    echo "==> TEST COMPLETE"
 }
 
-export BOOTSTRAP_REUSE=
 export BOOTSTRAP_PROVIDER="lxd"
 
 TEST_CURRENT=setup
@@ -118,8 +210,9 @@ if [ "$#" -gt 0 ]; then
     exit
 fi
 
-run_test test_static_analysis "running static analysis"
-run_test test_smoke "running smoke tests"
-run_test test_cmr_bundles "running cmr bundle acceptance tests"
+for test in ${TEST_NAMES}; do
+    name=$(echo "${test}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
+    run_test "${test}" "${name}"
+done
 
 TEST_RESULT=success

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -2,7 +2,7 @@
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
-export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028"
+export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002"
 
 import_subdir_files() {
     test "$1"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -46,7 +46,7 @@ show_help() {
     echo "    $(green 'cmd -x')        Output file from streaming the output"
     echo ""
     echo "Tests:"
-    echo "¯¯¯¯¯¯¯¯¯"
+    echo "¯¯¯¯¯¯"
     echo "Available tests:"
     echo ""
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -1,0 +1,92 @@
+#!/bin/sh -e
+[ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
+
+# Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
+export SHELLCHECK_OPTS="-e SC2230 -e SC2039"
+
+import_subdir_files() {
+    test "$1"
+    local file
+    for file in "$1"/*.sh; do
+        # shellcheck disable=SC1090
+        . "$file"
+    done
+}
+
+import_subdir_files includes
+
+echo "==> Checking for dependencies"
+check_dependencies curl jq shellcheck
+
+if [ "${USER:-'root'}" = "root" ]; then
+    echo "The testsuite must not be run as root." >&2
+    exit 1
+fi
+
+
+cleanup() {
+    # Allow for failures and stop tracing everything
+    set +ex
+
+    # Allow for inspection
+    if [ -n "${TEST_INSPECT:-}" ]; then
+        if [ "${TEST_RESULT}" != "success" ]; then
+            echo "==> TEST DONE: ${TEST_CURRENT_DESCRIPTION}"
+        fi
+        echo "==> Test result: ${TEST_RESULT}"
+        echo "Tests Completed (${TEST_RESULT}): hit enter to continue"
+
+        # shellcheck disable=SC2034
+        read -r nothing
+    fi
+
+    echo "==> Cleaning up"
+
+    echo ""
+    echo ""
+    if [ "$TEST_RESULT" != "success" ]; then
+        echo "==> TEST DONE: ${TEST_CURRENT_DESCRIPTION}"
+    fi
+    rm -rf "${TEST_DIR}"
+    echo "==> Tests Removed: ${TEST_DIR}"
+    echo "==> Test result: ${TEST_RESULT}"
+}
+
+TEST_CURRENT=setup
+TEST_RESULT=failure
+
+trap cleanup EXIT HUP INT TERM
+
+# Setup test directory
+TEST_DIR=$(mktemp -d tmp.XXX)
+chmod +x "${TEST_DIR}"
+
+THERM_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+export THERM_DIR
+chmod +x "${THERM_DIR}"
+
+run_test() {
+    TEST_CURRENT=${1}
+    TEST_CURRENT_DESCRIPTION=${2:-${1}}
+    TEST_CURRENT_NAME=${TEST_CURRENT#"test_"}
+
+    import_subdir_files "suites/${TEST_CURRENT_NAME}"
+
+    echo "==> TEST BEGIN: ${TEST_CURRENT_DESCRIPTION}"
+    START_TIME=$(date +%s)
+    ${TEST_CURRENT}
+    END_TIME=$(date +%s)
+
+    echo "==> TEST DONE: ${TEST_CURRENT_DESCRIPTION} ($((END_TIME-START_TIME))s)"
+}
+
+# allow for running a specific set of tests
+if [ "$#" -gt 0 ]; then
+    run_test "test_${1}"
+    TEST_RESULT=success
+    exit
+fi
+
+run_test test_static_analysis "running static analysis"
+
+TEST_RESULT=success

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -4,6 +4,9 @@
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
 export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002"
 
+OPTIND=1
+VERBOSE=0
+
 import_subdir_files() {
     test "$1"
     local file
@@ -14,6 +17,29 @@ import_subdir_files() {
 }
 
 import_subdir_files includes
+
+show_help() {
+    echo "Juju test suite"
+    echo "Usage: cmd [-h] [-v]"
+    echo "    cmd -h        Display this help message"
+    echo "    cmd -v        Verbose and debug messages"
+    exit 0
+}
+
+while getopts "h?:v" opt; do
+    case "${opt}" in
+    h|\?)
+        show_help
+        ;;
+    v)  VERBOSE=1
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+[ "${1:-}" = "--" ] && shift
+
 
 echo "==> Checking for dependencies"
 check_dependencies curl jq shellcheck juju

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -2,7 +2,7 @@
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
-export SHELLCHECK_OPTS="-e SC2230 -e SC2039"
+export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028"
 
 import_subdir_files() {
     test "$1"
@@ -16,7 +16,7 @@ import_subdir_files() {
 import_subdir_files includes
 
 echo "==> Checking for dependencies"
-check_dependencies curl jq shellcheck
+check_dependencies curl jq shellcheck juju
 
 if [ "${USER:-'root'}" = "root" ]; then
     echo "The testsuite must not be run as root." >&2
@@ -41,6 +41,8 @@ cleanup() {
     fi
 
     echo "==> Cleaning up"
+
+    cleanup_jujus
 
     echo ""
     echo ""
@@ -88,5 +90,7 @@ if [ "$#" -gt 0 ]; then
 fi
 
 run_test test_static_analysis "running static analysis"
+run_test test_smoke "running smoke tests"
+run_test test_cmr_bundles "running cmr bundle acceptance tests"
 
 TEST_RESULT=success

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -55,6 +55,9 @@ cleanup() {
     echo "==> Test result: ${TEST_RESULT}"
 }
 
+export BOOTSTRAP_REUSE=
+export BOOTSTRAP_PROVIDER="lxd"
+
 TEST_CURRENT=setup
 TEST_RESULT=failure
 

--- a/tests/suites/cmr_bundles/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/cmr_bundles/bundles/cmr_bundles_test_deploy.yaml
@@ -1,7 +1,7 @@
 series: bionic
 saas:
   mysql:
-    url: cmr_bundles_test_deploy:admin/default.mysql
+    url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/cmr-bundles-test-deploy.mysql
 applications:
   wordpress:
     charm: wordpress

--- a/tests/suites/cmr_bundles/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/cmr_bundles/bundles/cmr_bundles_test_deploy.yaml
@@ -1,0 +1,11 @@
+series: bionic
+saas:
+  mysql:
+    url: cmr_bundles_test_deploy:admin/default.mysql
+applications:
+  wordpress:
+    charm: wordpress
+    num_units: 1
+relations:
+- - wordpress:db
+  - mysql:db

--- a/tests/suites/cmr_bundles/deploy.sh
+++ b/tests/suites/cmr_bundles/deploy.sh
@@ -3,7 +3,7 @@ run_deploy() {
 
     file="${TEST_DIR}/cmr_bundles_test_deploy.txt"
 
-    bootstrap lxd "cmr_bundles_test_deploy" "${file}"
+    bootstrap "cmr-bundles-test-deploy" "${file}"
 
     juju deploy mysql
     wait_for "mysql" ".applications | keys[0]"
@@ -12,9 +12,12 @@ run_deploy() {
     juju add-model other
 
     juju switch other
-    juju deploy ./tests/suites/cmr_bundles/bundles/cmr_bundles_test_deploy.yaml
 
-    destroy "cmr_bundles_test_deploy"
+    bundle=./tests/suites/cmr_bundles/bundles/cmr_bundles_test_deploy.yaml
+    sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" > "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
+    juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
+
+    destroy "cmr-bundles-test-deploy"
 }
 
 test_deploy() {

--- a/tests/suites/cmr_bundles/deploy.sh
+++ b/tests/suites/cmr_bundles/deploy.sh
@@ -4,6 +4,17 @@ run_deploy() {
     file="${TEST_DIR}/cmr_bundles_test_deploy.txt"
 
     bootstrap lxd "cmr_bundles_test_deploy" "${file}"
+
+    juju deploy mysql
+    wait_for "mysql" ".applications | keys[0]"
+
+    juju offer mysql:db
+    juju add-model other
+
+    juju switch other
+    juju deploy ./tests/suites/cmr_bundles/bundles/cmr_bundles_test_deploy.yaml
+
+    destroy "cmr_bundles_test_deploy"
 }
 
 test_deploy() {
@@ -14,6 +25,8 @@ test_deploy() {
 
     (
         set -e
+
+        cd ../
 
         run "deploy"
     )

--- a/tests/suites/cmr_bundles/deploy.sh
+++ b/tests/suites/cmr_bundles/deploy.sh
@@ -1,9 +1,9 @@
 run_deploy() {
     echo
 
-    file="${TEST_DIR}/cmr_bundles_test_deploy.txt"
+    file="${TEST_DIR}/test-cmr-bundles-deploy.txt"
 
-    bootstrap "cmr-bundles-test-deploy" "${file}"
+    ensure "cmr-bundles-test-deploy" "${file}"
 
     juju deploy mysql
     wait_for "mysql" ".applications | keys[0]"
@@ -17,7 +17,7 @@ run_deploy() {
     sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" > "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
     juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 
-    destroy "cmr-bundles-test-deploy"
+    destroy_model "cmr-bundles-test-deploy"
 }
 
 test_deploy() {

--- a/tests/suites/cmr_bundles/deploy.sh
+++ b/tests/suites/cmr_bundles/deploy.sh
@@ -1,0 +1,20 @@
+run_deploy() {
+    echo
+
+    file="${TEST_DIR}/cmr_bundles_test_deploy.txt"
+
+    bootstrap lxd "cmr_bundles_test_deploy" "${file}"
+}
+
+test_deploy() {
+    if [ -n "${SKIP_CMR_BUNDLES_DEPLOY:-}" ]; then
+        echo "==> SKIP: Asked to skip CMR bundle deploy tests"
+        return
+    fi
+
+    (
+        set -e
+
+        run "deploy"
+    )
+}

--- a/tests/suites/cmr_bundles/deploy.sh
+++ b/tests/suites/cmr_bundles/deploy.sh
@@ -21,16 +21,16 @@ run_deploy() {
 }
 
 test_deploy() {
-    if [ -n "${SKIP_CMR_BUNDLES_DEPLOY:-}" ]; then
-        echo "==> SKIP: Asked to skip CMR bundle deploy tests"
+    if [ "$(skip 'test_deploy')" ]; then
+        echo "==> TEST SKIPPED: CMR bundle deploy tests"
         return
     fi
 
     (
-        set -e
+        set_verbosity
 
         cd ../
 
-        run "deploy"
+        run "run_deploy"
     )
 }

--- a/tests/suites/cmr_bundles/export_overlay.sh
+++ b/tests/suites/cmr_bundles/export_overlay.sh
@@ -8,7 +8,11 @@ run_export_overlay() {
     juju add-user bar
     juju deploy ./testcharms/charm-repo/bundle/apache2-with-offers
 
-    juju export-bundle
+    OUT=$(juju export-bundle 2>&1)
+    echo "${OUT}"
+
+    # ensure that overlay.yaml is exported
+    echo "${OUT}" | grep -- "--- # overlay.yaml"
 
     juju add-model test1
 
@@ -22,7 +26,13 @@ applications:
 EOT
 
     juju deploy ./testcharms/charm-repo/bundle/multi-doc-overlays --overlay overlay.yaml
-    juju export-bundle
+    OUT=$(juju export-bundle 2>&1)
+    echo "${OUT}"
+
+    # did the annotations and overlay get exported?
+    echo "${OUT}" | grep -- "--- # overlay.yaml"
+    echo "${OUT}" | grep "enc: bXktaW5jbHVkZQ=="
+    echo "${OUT}" | grep "raw: my-include"
 }
 
 test_export_overlay() {

--- a/tests/suites/cmr_bundles/export_overlay.sh
+++ b/tests/suites/cmr_bundles/export_overlay.sh
@@ -3,7 +3,7 @@ run_export_overlay() {
 
     file="${TEST_DIR}/cmr_bundles_test_export_overlay.txt"
 
-    bootstrap lxd "cmr_bundles_test_export_overlay" "${file}"
+    bootstrap "cmr-bundles-test-export-overlay" "${file}"
 
     juju add-user bar
     juju deploy ./testcharms/charm-repo/bundle/apache2-with-offers
@@ -34,7 +34,7 @@ EOT
     echo "${OUT}" | grep "enc: bXktaW5jbHVkZQ=="
     echo "${OUT}" | grep "raw: my-include"
 
-    destroy "cmr_bundles_test_export_overlay"
+    destroy "cmr-bundles-test-export-overlay"
 }
 
 test_export_overlay() {

--- a/tests/suites/cmr_bundles/export_overlay.sh
+++ b/tests/suites/cmr_bundles/export_overlay.sh
@@ -34,6 +34,8 @@ test_export_overlay() {
     (
         set -e
 
+        cd ../
+
         run "export overlay"
     )
 }

--- a/tests/suites/cmr_bundles/export_overlay.sh
+++ b/tests/suites/cmr_bundles/export_overlay.sh
@@ -1,0 +1,39 @@
+run_export_overlay() {
+    echo
+
+    file="${TEST_DIR}/cmr_bundles_test_export_overlay.txt"
+
+    bootstrap lxd "cmr_bundles_test_export_overlay" "${file}"
+
+    juju add-user bar
+    juju deploy ./testcharms/charm-repo/bundle/apache2-with-offers
+
+    juju export-bundle
+
+    juju add-model test1
+
+    echo -n 'my-include' > example.txt
+    cat > overlay.yaml << EOT
+applications:
+  wordpress:
+    annotations:
+      raw: include-file://example.txt
+      enc: include-base64://example.txt
+EOT
+
+    juju deploy ./testcharms/charm-repo/bundle/multi-doc-overlays --overlay overlay.yaml
+    juju export-bundle
+}
+
+test_export_overlay() {
+    if [ -n "${SKIP_CMR_BUNDLES_EXPORT_OVERLAY:-}" ]; then
+        echo "==> SKIP: Asked to skip CMR bundle deploy tests"
+        return
+    fi
+
+    (
+        set -e
+
+        run "export overlay"
+    )
+}

--- a/tests/suites/cmr_bundles/export_overlay.sh
+++ b/tests/suites/cmr_bundles/export_overlay.sh
@@ -33,6 +33,8 @@ EOT
     echo "${OUT}" | grep -- "--- # overlay.yaml"
     echo "${OUT}" | grep "enc: bXktaW5jbHVkZQ=="
     echo "${OUT}" | grep "raw: my-include"
+
+    destroy "cmr_bundles_test_export_overlay"
 }
 
 test_export_overlay() {

--- a/tests/suites/cmr_bundles/export_overlay.sh
+++ b/tests/suites/cmr_bundles/export_overlay.sh
@@ -38,16 +38,16 @@ EOT
 }
 
 test_export_overlay() {
-    if [ -n "${SKIP_CMR_BUNDLES_EXPORT_OVERLAY:-}" ]; then
-        echo "==> SKIP: Asked to skip CMR bundle deploy tests"
+    if [ "$(skip 'test_export_overlay')" ]; then
+        echo "==> TEST SKIPPED: CMR bundle deploy tests"
         return
     fi
 
     (
-        set -e
+        set_verbosity
 
         cd ../
 
-        run "export overlay"
+        run "run_export_overlay"
     )
 }

--- a/tests/suites/cmr_bundles/export_overlay.sh
+++ b/tests/suites/cmr_bundles/export_overlay.sh
@@ -1,9 +1,9 @@
 run_export_overlay() {
     echo
 
-    file="${TEST_DIR}/cmr_bundles_test_export_overlay.txt"
+    file="${TEST_DIR}/test-cmr-bundles-export-overlay.txt"
 
-    bootstrap "cmr-bundles-test-export-overlay" "${file}"
+    ensure "cmr-bundles-test-export-overlay" "${file}"
 
     juju add-user bar
     juju deploy ./testcharms/charm-repo/bundle/apache2-with-offers
@@ -34,7 +34,7 @@ EOT
     echo "${OUT}" | grep "enc: bXktaW5jbHVkZQ=="
     echo "${OUT}" | grep "raw: my-include"
 
-    destroy "cmr-bundles-test-export-overlay"
+    destroy_model "cmr-bundles-test-export-overlay"
 }
 
 test_export_overlay() {

--- a/tests/suites/cmr_bundles/task.sh
+++ b/tests/suites/cmr_bundles/task.sh
@@ -4,6 +4,12 @@ test_cmr_bundles() {
         return
     fi
 
+    file="${TEST_DIR}/test-cmr-bundles.txt"
+
+    bootstrap "test-cmr-bundles" "${file}"
+
     test_deploy
     test_export_overlay
+
+    destroy_controller "test-cmr-bundles"
 }

--- a/tests/suites/cmr_bundles/task.sh
+++ b/tests/suites/cmr_bundles/task.sh
@@ -1,6 +1,6 @@
 test_cmr_bundles() {
-    if [ -n "${SKIP_CMR_BUNDLES:-}" ]; then
-        echo "==> SKIP: Asked to skip CMR bundle tests"
+    if [ "$(skip 'test_cmr_bundles')" ]; then
+        echo "==> TEST SKIPPED: CMR bundle tests"
         return
     fi
 

--- a/tests/suites/cmr_bundles/task.sh
+++ b/tests/suites/cmr_bundles/task.sh
@@ -1,0 +1,8 @@
+test_cmr_bundles() {
+    if [ -n "${SKIP_CMR_BUNDLES:-}" ]; then
+        echo "==> SKIP: Asked to skip CMR bundle tests"
+        return
+    fi
+
+    juju bootstrap lxd "cmr_bundles_test"
+}

--- a/tests/suites/cmr_bundles/task.sh
+++ b/tests/suites/cmr_bundles/task.sh
@@ -4,5 +4,6 @@ test_cmr_bundles() {
         return
     fi
 
-    boostrap lxd "cmr_bundles_test"
+    test_deploy
+    test_export_overlay
 }

--- a/tests/suites/cmr_bundles/task.sh
+++ b/tests/suites/cmr_bundles/task.sh
@@ -4,5 +4,5 @@ test_cmr_bundles() {
         return
     fi
 
-    juju bootstrap lxd "cmr_bundles_test"
+    boostrap lxd "cmr_bundles_test"
 }

--- a/tests/suites/smoke/build.sh
+++ b/tests/suites/smoke/build.sh
@@ -1,0 +1,19 @@
+run_build() {
+    OUT=$(make go-build)
+    if [ -n "${OUT}" ]; then
+        printf "\\nFound some issues"
+        echo "\\n${OUT}"
+        exit 1
+    fi
+}
+
+test_build() {
+    (
+        set -e
+
+        cd ../
+
+        # Check that build runs
+        run "build"
+    )
+}

--- a/tests/suites/smoke/build.sh
+++ b/tests/suites/smoke/build.sh
@@ -8,17 +8,17 @@ run_build() {
 }
 
 test_build() {
-    if [ -n "${SKIP_SMOKE_BUILD:-}" ]; then
-        echo "==> SKIP: Asked to skip smoke build tests"
+    if [ "$(skip 'test_build')" ]; then
+        echo "==> TEST SKIPPED: smoke build tests"
         return
     fi
 
     (
-        set -e
+        set_verbosity
 
         cd ../
 
         # Check that build runs
-        run "build"
+        run "run_build"
     )
 }

--- a/tests/suites/smoke/build.sh
+++ b/tests/suites/smoke/build.sh
@@ -8,6 +8,11 @@ run_build() {
 }
 
 test_build() {
+    if [ -n "${SKIP_SMOKE_BUILD:-}" ]; then
+        echo "==> SKIP: Asked to skip smoke build tests"
+        return
+    fi
+
     (
         set -e
 

--- a/tests/suites/smoke/build.sh
+++ b/tests/suites/smoke/build.sh
@@ -1,7 +1,8 @@
 run_build() {
-    OUT=$(make go-build)
+    OUT=$(make go-build 2>&1 || true)
     if [ -n "${OUT}" ]; then
-        printf "\\nFound some issues"
+        echo ""
+        echo "$(red 'Found some issues:')"
         echo "\\n${OUT}"
         exit 1
     fi

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -16,15 +16,15 @@ run_deploy() {
 }
 
 test_deploy() {
-    if [ -n "${SKIP_SMOKE_DEPLOY:-}" ]; then
-        echo "==> SKIP: Asked to skip smoke deploy tests"
+    if [ "$(skip 'test_deploy')" ]; then
+        echo "==> TEST SKIPPED: smoke deploy tests"
         return
     fi
 
     (
-        set -e
+        set_verbosity
 
         # Check that deploy runs on LXD
-        run "deploy"
+        run "run_deploy"
     )
 }

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -1,13 +1,14 @@
 run_deploy() {
     echo
 
-    file="${TEST_DIR}/smoke-test-deploy.txt"
+    file="${2}"
 
     ensure "smoke-test-deploy" "${file}"
 
     CHK=$(cat "${file}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
-        printf "\\nFound some issues"
+        echo ""
+        echo "$(red 'Found some issues:')"
         cat "${file}" | xargs echo -I % "\\n%"
         exit 1
     fi
@@ -24,7 +25,9 @@ test_deploy() {
     (
         set_verbosity
 
+        file="${1}"
+
         # Check that deploy runs on LXD
-        run "run_deploy"
+        run "run_deploy" "${file}"
     )
 }

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -1,9 +1,10 @@
 run_deploy() {
     echo
 
-    file="${TEST_DIR}/smoke_test_deploy.txt"
+    file="${TEST_DIR}/smoke-test-deploy.txt"
 
-    bootstrap "smoke-test-deploy" "${file}"
+    ensure "smoke-test-deploy" "${file}"
+
     CHK=$(cat "${file}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues"
@@ -11,7 +12,7 @@ run_deploy() {
         exit 1
     fi
 
-    destroy "smoke-test-deploy"
+    destroy_model "smoke-test-deploy"
 }
 
 test_deploy() {

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -10,6 +10,8 @@ run_deploy() {
         cat "${file}" | xargs echo -I % "\\n%"
         exit 1
     fi
+
+    destroy "smoke_test_deploy"
 }
 
 test_deploy() {

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -1,7 +1,7 @@
 run_deploy() {
     echo
 
-    file="${TEST_DIR}/smoke_deploy.txt"
+    file="${TEST_DIR}/smoke_test_deploy.txt"
 
     bootstrap lxd "smoke_test_deploy" "${file}"
     CHK=$(cat "${file}" | grep -i "ERROR" || true)

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -3,7 +3,7 @@ run_deploy() {
 
     file="${TEST_DIR}/smoke_test_deploy.txt"
 
-    bootstrap lxd "smoke_test_deploy" "${file}"
+    bootstrap "smoke-test-deploy" "${file}"
     CHK=$(cat "${file}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues"
@@ -11,7 +11,7 @@ run_deploy() {
         exit 1
     fi
 
-    destroy "smoke_test_deploy"
+    destroy "smoke-test-deploy"
 }
 
 test_deploy() {

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -1,0 +1,27 @@
+run_deploy() {
+    echo
+
+    file="${TEST_DIR}/smoke_deploy.txt"
+
+    bootstrap lxd "smoke_test_deploy" "${file}"
+    CHK=$(cat "${file}" | grep -i "ERROR" || true)
+    if [ -n "${CHK}" ]; then
+        printf "\\nFound some issues"
+        cat "${file}" | xargs echo -I % "\\n%"
+        exit 1
+    fi
+}
+
+test_deploy() {
+    if [ -n "${SKIP_SMOKE_DEPLOY:-}" ]; then
+        echo "==> SKIP: Asked to skip smoke deploy tests"
+        return
+    fi
+
+    (
+        set -e
+
+        # Check that deploy runs on LXD
+        run "deploy"
+    )
+}

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -5,4 +5,5 @@ test_smoke() {
     fi
 
     test_build
+    test_deploy
 }

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -9,7 +9,7 @@ test_smoke() {
     bootstrap "test-smoke" "${file}"
 
     test_build
-    test_deploy
+    test_deploy "${file}"
 
     destroy_controller "test-smoke"
 }

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -1,0 +1,8 @@
+test_smoke() {
+    if [ -n "${SKIP_SMOKE:-}" ]; then
+        echo "==> SKIP: Asked to skip smoke tests"
+        return
+    fi
+
+    test_build
+}

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -1,6 +1,6 @@
 test_smoke() {
-    if [ -n "${SKIP_SMOKE:-}" ]; then
-        echo "==> SKIP: Asked to skip smoke tests"
+    if [ "$(skip 'test_smoke')" ]; then
+        echo "==> TEST SKIPPED: smoke tests"
         return
     fi
 

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -4,6 +4,12 @@ test_smoke() {
         return
     fi
 
+    file="${TEST_DIR}/test-smoke.txt"
+
+    bootstrap "test-smoke" "${file}"
+
     test_build
     test_deploy
+
+    destroy_controller "test-smoke"
 }

--- a/tests/suites/static_analysis/copyright.sh
+++ b/tests/suites/static_analysis/copyright.sh
@@ -9,17 +9,17 @@ run_copyright() {
 }
 
 test_copyright() {
-    if [ -n "${SKIP_STATIC_COPYRIGHT:-}" ]; then
-        echo "==> SKIP: Asked to skip static copyright analysis"
+    if [ "$(skip 'test_copyright')" ]; then
+        echo "==> TEST SKIPPED: static copyright analysis"
         return
     fi
 
     (
-        set -e
+        set_verbosity
 
         cd ../
 
         # Check for copyright notices
-        run "copyright"
+        run "run_copyright"
     )
 }

--- a/tests/suites/static_analysis/copyright.sh
+++ b/tests/suites/static_analysis/copyright.sh
@@ -1,0 +1,20 @@
+run_copyright() {
+    OUT=$(find . -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig)" | sort | xargs grep -L -E '// (Copyright|Code generated)')
+    LINES=$(echo "${OUT}" | wc -w)
+    if [ "$LINES" != 0 ]; then
+        echo "\\nThe following files are missing copyright headers"
+        echo "${OUT}"
+        exit 1
+    fi
+}
+
+test_copyright() {
+    (
+        set -e
+
+        cd ../
+
+        # Check for copyright notices
+        run "copyright"
+    )
+}

--- a/tests/suites/static_analysis/copyright.sh
+++ b/tests/suites/static_analysis/copyright.sh
@@ -9,6 +9,11 @@ run_copyright() {
 }
 
 test_copyright() {
+    if [ -n "${SKIP_STATIC_COPYRIGHT:-}" ]; then
+        echo "==> SKIP: Asked to skip static copyright analysis"
+        return
+    fi
+
     (
         set -e
 

--- a/tests/suites/static_analysis/copyright.sh
+++ b/tests/suites/static_analysis/copyright.sh
@@ -2,6 +2,8 @@ run_copyright() {
     OUT=$(find . -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig)" | sort | xargs grep -L -E '// (Copyright|Code generated)')
     LINES=$(echo "${OUT}" | wc -w)
     if [ "$LINES" != 0 ]; then
+        echo ""
+        echo "$(red 'Found some issues:')"
         echo "\\nThe following files are missing copyright headers"
         echo "${OUT}"
         exit 1

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,0 +1,59 @@
+test_static_analysis_go() {
+  if [ -n "${SKIP_STATIC:-}" ]; then
+    echo "==> SKIP: Asked to skip static analysis"
+    return
+  fi
+
+  (
+    set -e
+
+    cd ../
+
+    ## Functions starting by empty line
+    OUT=$(grep -Rrn --exclude-dir=vendor "^$" -B1 . | grep "func " | grep -v "}$" || true)
+    if [ -n "${OUT}" ]; then
+      printf "ERROR: Functions must not start with an empty line: \\n%s" "${OUT}"
+      exit 1
+    fi
+
+    ## go vet, if it exists
+    if go help vet >/dev/null 2>&1; then
+      go vet ./...
+    fi
+
+    ## golint
+    if which golint >/dev/null 2>&1; then
+      golint -set_exit_status ./
+    fi
+
+    ## deadcode
+    if which deadcode >/dev/null 2>&1; then
+      OUT=$(deadcode ./ 2>&1 || true)
+      if [ -n "${OUT}" ]; then
+        echo "${OUT}" >&2
+        exit 1
+      fi
+    fi
+
+    ## misspell
+    if which misspell >/dev/null 2>&1; then
+      OUT=$(misspell 2>/dev/null ./ | grep -Ev "^vendor/" || true)
+      if [ -n "${OUT}" ]; then
+        echo "Found some typos"
+        echo "${OUT}"
+        exit 1
+      fi
+    fi
+
+    ## ineffassign
+    if which ineffassign >/dev/null 2>&1; then
+      ineffassign ./
+    fi
+
+    # go fmt
+    gofmt -w -s ./
+
+    git add -u :/
+    git diff --exit-code
+  )
+}

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -9,6 +9,15 @@ run_func_vet() {
   fi
 }
 
+run_dep_check() {
+  OUT=$(dep check)
+  if [ -n "${OUT}" ]; then
+    printf "\\nFound some issues"
+    echo "\\n${OUT}" >&2
+    exit 1
+  fi
+}
+
 run_go_vet() {
   go vet -composites=false ./...
 }
@@ -74,6 +83,11 @@ test_static_analysis_go() {
     ## Functions starting by empty line
     run "func vet"
 
+    ## Check dependency is correct
+    if which dep >/dev/null 2>&1; then
+      run "dep check"
+    fi
+
     ## go vet, if it exists
     if go help vet >/dev/null 2>&1; then
       run "go vet"
@@ -95,9 +109,9 @@ test_static_analysis_go() {
     fi
 
     ## ineffassign
-    if which ineffassign >/dev/null 2>&1; then
-      run "ineffassign"
-    fi
+    # if which ineffassign >/dev/null 2>&1; then
+    #  run "ineffassign"
+    # fi
 
     ## go fmt
     run "go fmt" "${FILES}"

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -10,7 +10,7 @@ run_func_vet() {
 }
 
 run_dep_check() {
-  OUT=$(dep check)
+  OUT=$(dep check 2>&1 || true)
   if [ -n "${OUT}" ]; then
     printf "\\nFound some issues"
     echo "\\n${OUT}" >&2
@@ -19,11 +19,21 @@ run_dep_check() {
 }
 
 run_go_vet() {
-  go vet -composites=false ./...
+  OUT=$(go vet -composites=false ./... 2>&1 || true)
+  if [ -n "${OUT}" ]; then
+    printf "\\nFound some issues"
+    echo "\\n${OUT}" >&2
+    exit 1
+  fi
 }
 
 run_go_lint() {
-  golint -set_exit_status ./
+  OUT=$(golint -set_exit_status ./ 2>&1 || true)
+  if [ -n "${OUT}" ]; then
+    printf "\\nFound some issues"
+    echo "\\n${OUT}" >&2
+    exit 1
+  fi
 }
 
 run_deadcode() {

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -59,6 +59,11 @@ run_go_fmt() {
 }
 
 test_static_analysis_go() {
+  if [ -n "${SKIP_STATIC_GO:-}" ]; then
+      echo "==> SKIP: Asked to skip static go analysis"
+      return
+  fi
+
   (
     set -e
 

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,3 +1,57 @@
+run_func_vet() {
+  OUT=$(grep -Rrn --include \*.go --exclude-dir=vendor "^$" -B1 . | \
+      grep "func " | grep -v "}$" | \
+      sed -E "s/^(.+\\.go)-([0-9]+)-(.+)$/\1:\2 \3/" \
+      || true)
+  if [ -n "${OUT}" ]; then
+    printf "\\nERROR: Functions must not start with an empty line: \\n%s\\n" "${OUT}"
+    exit 1
+  fi
+}
+
+run_go_vet() {
+  go vet -composites=false ./...
+}
+
+run_go_lint() {
+  golint -set_exit_status ./
+}
+
+run_deadcode() {
+  OUT=$(deadcode ./ 2>&1 || true)
+  if [ -n "${OUT}" ]; then
+  # shellcheck disable=SC2028
+    echo "\\n${OUT}" >&2
+    exit 1
+  fi
+}
+
+run_misspell() {
+  FILES=$(find ./* -name '*.go' -not -name '.#*' -not -name '*_mock.go' | grep -v vendor/ | grep -v acceptancetests/)
+  OUT=$(misspell -source=go 2>/dev/null "$FILES" || true)
+  if [ -n "${OUT}" ]; then
+    printf "\\nFound some typos"
+    echo "${OUT}"
+    exit 1
+  fi
+}
+
+run_ineffassign() {
+  OUT=$(ineffassign ./ | grep -v "_test.go" | sed -E "s/^(.+src\\/github\\.com\\/juju\\/juju\\/)(.+)/\2/")
+  if [ -n "${OUT}" ]; then
+    printf "\\nFound some issues"
+    echo "${OUT}"
+    exit 1
+  fi
+}
+
+run_go_fmt() {
+  gofmt -w -s ./
+
+  git add -u :/
+  git diff --exit-code
+}
+
 test_static_analysis_go() {
   if [ -n "${SKIP_STATIC:-}" ]; then
     echo "==> SKIP: Asked to skip static analysis"
@@ -10,54 +64,34 @@ test_static_analysis_go() {
     cd ../
 
     ## Functions starting by empty line
-    OUT=$(grep -Rrn --include \*.go --exclude-dir=vendor "^$" -B1 . | \
-        grep "func " | grep -v "}$" | \
-        sed -E "s/^(.+\\.go)-([0-9]+)-(.+)$/sed '\2d' \1/" | \
-        sed -E "s/^\.\///" \
-        || true)
-    if [ -n "${OUT}" ]; then
-      printf "ERROR: Functions must not start with an empty line: \\n%s\\n" "${OUT}"
-      exit 1
-    fi
+    run "func vet" run_func_vet
 
     ## go vet, if it exists
     if go help vet >/dev/null 2>&1; then
-      go vet ./...
+      run "go vet" run_go_vet
     fi
 
     ## golint
     if which golint >/dev/null 2>&1; then
-      golint -set_exit_status ./
+      run "go lint" run_go_lint
     fi
 
     ## deadcode
     if which deadcode >/dev/null 2>&1; then
-      OUT=$(deadcode ./ 2>&1 || true)
-      if [ -n "${OUT}" ]; then
-        echo "${OUT}" >&2
-        exit 1
-      fi
+      run "deadcode" run_deadcode
     fi
 
     ## misspell
     if which misspell >/dev/null 2>&1; then
-      OUT=$(misspell 2>/dev/null ./ | grep -Ev "^vendor/" || true)
-      if [ -n "${OUT}" ]; then
-        echo "Found some typos"
-        echo "${OUT}"
-        exit 1
-      fi
+      run "misspell" run_misspell
     fi
 
     ## ineffassign
     if which ineffassign >/dev/null 2>&1; then
-      ineffassign ./
+      run "ineffassign" run_ineffassign
     fi
 
-    # go fmt
-    gofmt -w -s ./
-
-    git add -u :/
-    git diff --exit-code
+    ## go fmt
+    # run "gofmt" run_go_fmt
   )
 }

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -12,7 +12,8 @@ run_func_vet() {
 run_dep_check() {
   OUT=$(dep check 2>&1 || true)
   if [ -n "${OUT}" ]; then
-    printf "\\nFound some issues"
+    echo ""
+    echo "$(red 'Found some issues:')"
     echo "\\n${OUT}" >&2
     exit 1
   fi
@@ -21,7 +22,8 @@ run_dep_check() {
 run_go_vet() {
   OUT=$(go vet -composites=false ./... 2>&1 || true)
   if [ -n "${OUT}" ]; then
-    printf "\\nFound some issues"
+    echo ""
+    echo "$(red 'Found some issues:')"
     echo "\\n${OUT}" >&2
     exit 1
   fi
@@ -30,7 +32,8 @@ run_go_vet() {
 run_go_lint() {
   OUT=$(golint -set_exit_status ./ 2>&1 || true)
   if [ -n "${OUT}" ]; then
-    printf "\\nFound some issues"
+    echo ""
+    echo "$(red 'Found some issues:')"
     echo "\\n${OUT}" >&2
     exit 1
   fi
@@ -39,7 +42,8 @@ run_go_lint() {
 run_deadcode() {
   OUT=$(deadcode ./ 2>&1 || true)
   if [ -n "${OUT}" ]; then
-    printf "\\nFound some issues"
+    echo ""
+    echo "$(red 'Found some issues:')"
     echo "\\n${OUT}" >&2
     exit 1
   fi
@@ -49,7 +53,8 @@ run_misspell() {
   FILES=${2}
   OUT=$(misspell -source=go 2>/dev/null "${FILES}" || true)
   if [ -n "${OUT}" ]; then
-    printf "\\nFound some issues"
+    echo ""
+    echo "$(red 'Found some issues:')"
     echo "${OUT}"
     exit 1
   fi
@@ -58,7 +63,8 @@ run_misspell() {
 run_ineffassign() {
   OUT=$(ineffassign ./ | grep -v "_test.go" | sed -E "s/^(.+src\\/github\\.com\\/juju\\/juju\\/)(.+)/\2/")
   if [ -n "${OUT}" ]; then
-    printf "\\nFound some issues"
+    echo ""
+    echo "$(red 'Found some issues:')"
     echo "${OUT}"
     exit 1
   fi
@@ -69,7 +75,8 @@ run_go_fmt() {
   OUT=$(echo "${FILES}" | xargs gofmt -l -s)
   if [ -n "${OUT}" ]; then
     OUT=$(echo "${OUT}" | sed "s/^/  /")
-    printf "\\nFound some issues"
+    echo ""
+    echo "$(red 'Found some issues:')"
     for ITEM in ${OUT}; do
       echo "gofmt -s -w ${ITEM}"
     done

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -10,9 +10,13 @@ test_static_analysis_go() {
     cd ../
 
     ## Functions starting by empty line
-    OUT=$(grep -Rrn --exclude-dir=vendor "^$" -B1 . | grep "func " | grep -v "}$" || true)
+    OUT=$(grep -Rrn --include \*.go --exclude-dir=vendor "^$" -B1 . | \
+        grep "func " | grep -v "}$" | \
+        sed -E "s/^(.+\\.go)-([0-9]+)-(.+)$/sed '\2d' \1/" | \
+        sed -E "s/^\.\///" \
+        || true)
     if [ -n "${OUT}" ]; then
-      printf "ERROR: Functions must not start with an empty line: \\n%s" "${OUT}"
+      printf "ERROR: Functions must not start with an empty line: \\n%s\\n" "${OUT}"
       exit 1
     fi
 

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -66,7 +66,7 @@ run_ineffassign() {
 
 run_go_fmt() {
   FILES=${2}
-  OUT=$(echo "$FILES" | xargs gofmt -l -s)
+  OUT=$(echo "${FILES}" | xargs gofmt -l -s)
   if [ -n "${OUT}" ]; then
     OUT=$(echo "${OUT}" | sed "s/^/  /")
     printf "\\nFound some issues"
@@ -78,13 +78,13 @@ run_go_fmt() {
 }
 
 test_static_analysis_go() {
-  if [ -n "${SKIP_STATIC_GO:-}" ]; then
-      echo "==> SKIP: Asked to skip static go analysis"
+  if [ "$(skip 'test_static_analysis_go')" ]; then
+      echo "==> TEST SKIPPED: static go analysis"
       return
   fi
 
   (
-    set -e
+    set_verbosity
 
     cd ../
 
@@ -96,27 +96,27 @@ test_static_analysis_go() {
 
     ## Check dependency is correct
     if which dep >/dev/null 2>&1; then
-      run "dep check"
+      run "run_dep_check"
     fi
 
     ## go vet, if it exists
     if go help vet >/dev/null 2>&1; then
-      run "go vet"
+      run "run_go_vet"
     fi
 
     ## golint
     if which golint >/dev/null 2>&1; then
-      run "go lint"
+      run "run_go_lint"
     fi
 
     ## deadcode
     if which deadcode >/dev/null 2>&1; then
-      run "deadcode"
+      run "run_deadcode"
     fi
 
     ## misspell
     if which misspell >/dev/null 2>&1; then
-      run "misspell" "${FILES}"
+      run "run_misspell" "${FILES}"
     fi
 
     ## ineffassign
@@ -126,6 +126,6 @@ test_static_analysis_go() {
     # fi
 
     ## go fmt
-    run "go fmt" "${FILES}"
+    run "run_go_fmt" "${FILES}"
   )
 }

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -81,7 +81,8 @@ test_static_analysis_go() {
     FILES=$(find ./* -name '*.go' -not -name '.#*' -not -name '*_mock.go' | grep -v vendor/ | grep -v acceptancetests/)
 
     ## Functions starting by empty line
-    run "func vet"
+    # turned off until we get approval of test suite
+    # run "func vet"
 
     ## Check dependency is correct
     if which dep >/dev/null 2>&1; then
@@ -109,6 +110,7 @@ test_static_analysis_go() {
     fi
 
     ## ineffassign
+    # turned off until we get approval of test suite
     # if which ineffassign >/dev/null 2>&1; then
     #  run "ineffassign"
     # fi

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -1,3 +1,12 @@
+run_shellcheck() {
+  OUT=$(shellcheck --shell sh tests/*.sh tests/includes/*.sh tests/suites/**/*.sh)
+  if [ -n "${OUT}" ]; then
+    printf "\\nFound some typos"
+    echo "${OUT}"
+    exit 1
+  fi
+}
+
 test_static_analysis_shell() {
   if [ -n "${SKIP_STATIC:-}" ]; then
     echo "==> SKIP: Asked to skip static analysis"
@@ -11,20 +20,20 @@ test_static_analysis_shell() {
 
     # Shell static analysis
     if which shellcheck >/dev/null 2>&1; then
-      shellcheck --shell sh test/*.sh test/includes/*.sh test/suites/*.sh
+      run "shellcheck" run_shellcheck
     else
       echo "shellcheck not found, shell static analysis disabled"
     fi
 
     ## Mixed tabs/spaces in scripts
-    OUT=$(grep -Pr '\t' . | grep '\.sh:' || true)
+    OUT=$(grep -Pr '\t' tests/ | grep '\.sh:' || true)
     if [ -n "${OUT}" ]; then
       echo "ERROR: mixed tabs and spaces in script: ${OUT}"
       false
     fi
 
     ## Trailing whitespace in scripts
-    OUT=$(grep -r " $" . | grep '\.sh:' || true)
+    OUT=$(grep -r " $" tests/ | grep '\.sh:' || true)
     if [ -n "${OUT}" ]; then
       echo "ERROR: trailing whitespace in script: ${OUT}"
       false

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -24,27 +24,27 @@ run_trailing_whitespace() {
 }
 
 test_static_analysis_shell() {
-  if [ -n "${SKIP_STATIC_SHELL:-}" ]; then
-      echo "==> SKIP: Asked to skip static shell analysis"
+  if [ "$(skip 'test_static_analysis_shell')" ]; then
+      echo "==> TEST SKIPPED: static shell analysis"
       return
   fi
 
   (
-    set -e
+    set_verbosity
 
     cd ../
 
     # Shell static analysis
     if which shellcheck >/dev/null 2>&1; then
-      run "shellcheck"
+      run "run_shellcheck"
     else
       echo "shellcheck not found, shell static analysis disabled"
     fi
 
     ## Mixed tabs/spaces in scripts
-    run "whitespace"
+    run "run_whitespace"
 
     ## Trailing whitespace in scripts
-    run "trailing whitespace"
+    run "run_trailing_whitespace"
   )
 }

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -1,0 +1,33 @@
+test_static_analysis_shell() {
+  if [ -n "${SKIP_STATIC:-}" ]; then
+    echo "==> SKIP: Asked to skip static analysis"
+    return
+  fi
+
+  (
+    set -e
+
+    cd ../
+
+    # Shell static analysis
+    if which shellcheck >/dev/null 2>&1; then
+      shellcheck --shell sh test/*.sh test/includes/*.sh test/suites/*.sh
+    else
+      echo "shellcheck not found, shell static analysis disabled"
+    fi
+
+    ## Mixed tabs/spaces in scripts
+    OUT=$(grep -Pr '\t' . | grep '\.sh:' || true)
+    if [ -n "${OUT}" ]; then
+      echo "ERROR: mixed tabs and spaces in script: ${OUT}"
+      false
+    fi
+
+    ## Trailing whitespace in scripts
+    OUT=$(grep -r " $" . | grep '\.sh:' || true)
+    if [ -n "${OUT}" ]; then
+      echo "ERROR: trailing whitespace in script: ${OUT}"
+      false
+    fi
+  )
+}

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -24,6 +24,11 @@ run_trailing_whitespace() {
 }
 
 test_static_analysis_shell() {
+  if [ -n "${SKIP_STATIC_SHELL:-}" ]; then
+      echo "==> SKIP: Asked to skip static shell analysis"
+      return
+  fi
+
   (
     set -e
 

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -1,7 +1,8 @@
 run_shellcheck() {
   OUT=$(shellcheck --shell sh tests/*.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
   if [ -n "${OUT}" ]; then
-    printf "\\nFound some typos"
+    echo ""
+    echo "$(red 'Found some issues:')"
     echo "${OUT}"
     exit 1
   fi
@@ -10,7 +11,10 @@ run_shellcheck() {
 run_whitespace() {
   OUT=$(grep -Pr '\t' tests/ | grep '\.sh:' || true)
   if [ -n "${OUT}" ]; then
-    echo "\\nERROR: mixed tabs and spaces in script: ${OUT}"
+    echo ""
+    echo "$(red 'Found some issues:')"
+    echo "mixed tabs and spaces in script"
+    echo "${OUT}"
     exit 1
   fi
 }
@@ -18,7 +22,10 @@ run_whitespace() {
 run_trailing_whitespace() {
   OUT=$(grep -r " $" tests/ | grep '\.sh:' || true)
   if [ -n "${OUT}" ]; then
-    echo "\\nERROR: trailing whitespace in script: ${OUT}"
+    echo ""
+    echo "$(red 'Found some issues:')"
+    echo "trailing whitespace in script"
+    echo "${OUT}"
     exit 1
   fi
 }

--- a/tests/suites/static_analysis/schema.sh
+++ b/tests/suites/static_analysis/schema.sh
@@ -3,7 +3,8 @@ run_schema() {
     TMP=$(mktemp /tmp/schema-XXXXX)
     OUT=$(make SCHEMA_PATH="${TMP}" rebuild-schema 2>&1)
     if [ "${OUT}" != "Generating facade schema..." ]; then
-        printf "\\Found some issues:"
+        echo ""
+        echo "$(red 'Found some issues:')"
         echo "${OUT}"
         exit 1
     fi

--- a/tests/suites/static_analysis/schema.sh
+++ b/tests/suites/static_analysis/schema.sh
@@ -17,17 +17,17 @@ run_schema() {
 }
 
 test_schema() {
-    if [ -n "${SKIP_STATIC_SCHEMA:-}" ]; then
-        echo "==> SKIP: Asked to skip static schema analysis"
+    if [ "$(skip 'test_schema')" ]; then
+        echo "==> TEST SKIPPED: static schema analysis"
         return
     fi
 
     (
-        set -e
+        set_verbosity
 
         cd ../
 
         # Check for schema changes and ensure they've been committed
-        run "schema"
+        run "run_schema"
     )
 }

--- a/tests/suites/static_analysis/schema.sh
+++ b/tests/suites/static_analysis/schema.sh
@@ -1,0 +1,28 @@
+run_schema() {
+    CUR_SHA=$(git show HEAD:apiserver/facades/schema.json | shasum -a 1 | awk '{ print $1 }')
+    TMP=$(mktemp /tmp/schema-XXXXX)
+    OUT=$(make SCHEMA_PATH="${TMP}" rebuild-schema 2>&1)
+    if [ "${OUT}" != "Generating facade schema..." ]; then
+        printf "\\Found some issues:"
+        echo "${OUT}"
+        exit 1
+    fi
+    # shellcheck disable=SC2002
+    NEW_SHA=$(cat "${TMP}" | shasum -a 1 | awk '{ print $1 }')
+
+    if [ "${CUR_SHA}" != "${NEW_SHA}" ]; then
+        (>&2 echo "\\nError: facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
+        exit 1
+    fi
+}
+
+test_schema() {
+    (
+        set -e
+
+        cd ../
+
+        # Check for schema changes and ensure they've been committed
+        run "schema"
+    )
+}

--- a/tests/suites/static_analysis/schema.sh
+++ b/tests/suites/static_analysis/schema.sh
@@ -17,6 +17,11 @@ run_schema() {
 }
 
 test_schema() {
+    if [ -n "${SKIP_STATIC_SCHEMA:-}" ]; then
+        echo "==> SKIP: Asked to skip static schema analysis"
+        return
+    fi
+
     (
         set -e
 

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -1,6 +1,6 @@
 test_static_analysis() {
-    if [ -n "${SKIP_STATIC:-}" ]; then
-        echo "==> SKIP: Asked to skip static analysis"
+    if [ "$(skip 'test_static_analysis')" ]; then
+        echo "==> TEST SKIPPED: skip static analysis"
         return
     fi
 

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -1,12 +1,11 @@
-run() {
-  # shellcheck disable=SC2039
-  echo -n "====> Running: ${1}"
-  ${2}
-  # shellcheck disable=SC2059,SC2028
-  echo "\r====> Success: ${1}"
-}
-
 test_static_analysis() {
+    if [ -n "${SKIP_STATIC:-}" ]; then
+        echo "==> SKIP: Asked to skip static analysis"
+        return
+    fi
+
+    test_copyright
     test_static_analysis_go
     test_static_analysis_shell
+    test_schema
 }

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -1,0 +1,4 @@
+test_static_analysis() {
+    test_static_analysis_go
+    test_static_analysis_shell
+}

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -1,3 +1,11 @@
+run() {
+  # shellcheck disable=SC2039
+  echo -n "====> Running: ${1}"
+  ${2}
+  # shellcheck disable=SC2059,SC2028
+  echo "\r====> Success: ${1}"
+}
+
 test_static_analysis() {
     test_static_analysis_go
     test_static_analysis_shell


### PR DESCRIPTION
## Description of change

This is a first stab at improving the acceptance tests, with the aim of improving
readability and understanding of the acceptance tests. Everyone should have
knowledge of using the juju CLI, so if we take that into a concept and run with
it, we can then write some very basic acceptance tests using that well gained
knowledge. With one caveat, the lifecycle of a controller needs to be hidden
away inside of a function call so that we can tear down the controller that we
created safely. We can't use `show-controller` as we don't know which controller
to destroy safely.

## QA steps

Run the full test suite.

```sh
cd tests
./main.sh
```

Run the cmr bundles test suite

```sh
cd tests
./main.sh cmr_bundles
```

Run the cmr bundles test directly

```sh
cd tests
./main.sh cmr_bundles test_deploy
```
