### PR TITLE
Add new Azure South Africa North/West and France South regions

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -215,6 +215,10 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net
+      francesouth:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
       southafricanorth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -214,7 +214,15 @@ clouds:
       francecentral:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://graph.windows.net        
+        identity-endpoint: https://graph.windows.net
+      southafricanorth:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
+      southafricawest:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
     description: Microsoft Azure China

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -221,7 +221,15 @@ clouds:
       francecentral:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-        identity-endpoint: https://graph.windows.net       
+        identity-endpoint: https://graph.windows.net
+      southafricanorth:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
+      southafricawest:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
     description: Microsoft Azure China
@@ -327,5 +335,4 @@ clouds:
         endpoint: https://compute.em2.oraclecloud.com
       em3:
         endpoint: https://compute.em3.oraclecloud.com
-
 `

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -222,6 +222,10 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net
+      francesouth:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
       southafricanorth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -224,5 +224,8 @@ func (s *regionsSuite) TestListRegionsJson(c *gc.C) {
 		"koreacentral":       {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"koreasouth":         {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 		"francecentral":      {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"francesouth":        {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"southafricanorth":   {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
+		"southafricawest":    {Endpoint: "https://management.azure.com", IdentityEndpoint: "https://graph.windows.net", StorageEndpoint: "https://core.windows.net"},
 	})
 }

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1775,22 +1776,72 @@ func (env *azureEnviron) getInstanceTypesLocked(ctx context.ProviderCallContext)
 		return env.instanceTypes, nil
 	}
 
-	location := env.location
-	client := compute.VirtualMachineSizesClient{env.compute}
+	client := compute.ResourceSkusClient{env.compute}
 
-	result, err := client.List(stdcontext.Background(), location)
+	res, err := client.ListComplete(stdcontext.Background())
 	if err != nil {
 		return nil, errorutils.HandleCredentialError(errors.Annotate(err, "listing VM sizes"), ctx)
 	}
 	instanceTypes := make(map[string]instances.InstanceType)
-	if result.Value != nil {
-		for _, size := range *result.Value {
-			instanceType := newInstanceType(size)
-			instanceTypes[instanceType.Name] = instanceType
-			// Create aliases for standard role sizes.
-			if strings.HasPrefix(instanceType.Name, "Standard_") {
-				instanceTypes[instanceType.Name[len("Standard_"):]] = instanceType
+	sdkCtx := stdcontext.Background()
+	for ; res.NotDone(); err = res.NextWithContext(sdkCtx) {
+		if err != nil {
+			return nil, errors.Annotate(err, "listing resources")
+		}
+		resource := res.Value()
+		if resource.ResourceType == nil || *resource.ResourceType != "virtualMachines" {
+			continue
+		}
+		if resource.Restrictions != nil {
+			for _, r := range *resource.Restrictions {
+				if r.ReasonCode == compute.NotAvailableForSubscription {
+					continue
+				}
 			}
+		}
+		locationOk := false
+		if resource.Locations != nil {
+			for _, loc := range *resource.Locations {
+				if strings.ToLower(loc) == env.location {
+					locationOk = true
+					break
+				}
+			}
+		}
+		if !locationOk {
+			continue
+		}
+		var (
+			cores    *int32
+			mem      *int32
+			rootDisk *int32
+		)
+		for _, capability := range *resource.Capabilities {
+			if capability.Name == nil || capability.Value == nil {
+				continue
+			}
+			switch *capability.Name {
+			case "MemoryGB":
+				memValue, _ := strconv.ParseFloat(*capability.Value, 32)
+				mem = to.Int32Ptr(int32(1024 * memValue))
+			case "vCPUsAvailable", "vCPUs":
+				coresValue, _ := strconv.Atoi(*capability.Value)
+				cores = to.Int32Ptr(int32(coresValue))
+			case "OSVhdSizeMB":
+				rootDiskValue, _ := strconv.Atoi(*capability.Value)
+				rootDisk = to.Int32Ptr(int32(rootDiskValue))
+			}
+		}
+		instanceType := newInstanceType(compute.VirtualMachineSize{
+			Name:           resource.Name,
+			NumberOfCores:  cores,
+			OsDiskSizeInMB: rootDisk,
+			MemoryInMB:     mem,
+		})
+		instanceTypes[instanceType.Name] = instanceType
+		// Create aliases for standard role sizes.
+		if strings.HasPrefix(instanceType.Name, "Standard_") {
+			instanceTypes[instanceType.Name[len("Standard_"):]] = instanceType
 		}
 	}
 	env.instanceTypes = instanceTypes

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -107,7 +107,7 @@ type environSuite struct {
 	envTags            map[string]*string
 	vmTags             map[string]*string
 	group              *resources.Group
-	vmSizes            *compute.VirtualMachineSizeListResult
+	skus               *compute.ResourceSkusResult
 	storageAccounts    []storage.Account
 	storageAccount     *storage.Account
 	storageAccountKeys *storage.AccountListKeysResult
@@ -164,29 +164,50 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
-	vmSizes := []compute.VirtualMachineSize{{
-		Name:                 to.StringPtr("Standard_A1"),
-		NumberOfCores:        to.Int32Ptr(1),
-		OsDiskSizeInMB:       to.Int32Ptr(1047552),
-		ResourceDiskSizeInMB: to.Int32Ptr(71680),
-		MemoryInMB:           to.Int32Ptr(1792),
-		MaxDataDiskCount:     to.Int32Ptr(2),
+	resourceSkus := []compute.ResourceSku{{
+		Name:         to.StringPtr("Standard_A1"),
+		Locations:    to.StringSlicePtr([]string{"westus"}),
+		ResourceType: to.StringPtr("virtualMachines"),
+		Capabilities: &[]compute.ResourceSkuCapabilities{{
+			Name:  to.StringPtr("MemoryGB"),
+			Value: to.StringPtr("1.75"),
+		}, {
+			Name:  to.StringPtr("vCPUs"),
+			Value: to.StringPtr("1"),
+		}, {
+			Name:  to.StringPtr("OSVhdSizeMB"),
+			Value: to.StringPtr("1047552"),
+		}},
 	}, {
-		Name:                 to.StringPtr("Standard_D1"),
-		NumberOfCores:        to.Int32Ptr(1),
-		OsDiskSizeInMB:       to.Int32Ptr(1047552),
-		ResourceDiskSizeInMB: to.Int32Ptr(51200),
-		MemoryInMB:           to.Int32Ptr(3584),
-		MaxDataDiskCount:     to.Int32Ptr(2),
+		Name:         to.StringPtr("Standard_D1"),
+		Locations:    to.StringSlicePtr([]string{"westus"}),
+		ResourceType: to.StringPtr("virtualMachines"),
+		Capabilities: &[]compute.ResourceSkuCapabilities{{
+			Name:  to.StringPtr("MemoryGB"),
+			Value: to.StringPtr("3.5"),
+		}, {
+			Name:  to.StringPtr("vCPUs"),
+			Value: to.StringPtr("1"),
+		}, {
+			Name:  to.StringPtr("OSVhdSizeMB"),
+			Value: to.StringPtr("1047552"),
+		}},
 	}, {
-		Name:                 to.StringPtr("Standard_D2"),
-		NumberOfCores:        to.Int32Ptr(2),
-		OsDiskSizeInMB:       to.Int32Ptr(1047552),
-		ResourceDiskSizeInMB: to.Int32Ptr(102400),
-		MemoryInMB:           to.Int32Ptr(7168),
-		MaxDataDiskCount:     to.Int32Ptr(4),
+		Name:         to.StringPtr("Standard_D2"),
+		Locations:    to.StringSlicePtr([]string{"westus"}),
+		ResourceType: to.StringPtr("virtualMachines"),
+		Capabilities: &[]compute.ResourceSkuCapabilities{{
+			Name:  to.StringPtr("MemoryGB"),
+			Value: to.StringPtr("7"),
+		}, {
+			Name:  to.StringPtr("vCPUs"),
+			Value: to.StringPtr("2"),
+		}, {
+			Name:  to.StringPtr("OSVhdSizeMB"),
+			Value: to.StringPtr("1047552"),
+		}},
 	}}
-	s.vmSizes = &compute.VirtualMachineSizeListResult{Value: &vmSizes}
+	s.skus = &compute.ResourceSkusResult{Value: &resourceSkus}
 
 	s.storageAccount = &storage.Account{
 		Name: to.StringPtr("my-storage-account"),
@@ -362,7 +383,7 @@ func (s *environSuite) initResourceGroupSenders() azuretesting.Senders {
 }
 
 func (s *environSuite) startInstanceSenders(bootstrap bool) azuretesting.Senders {
-	senders := azuretesting.Senders{s.vmSizesSender()}
+	senders := azuretesting.Senders{s.resourceSkusSender()}
 	if s.ubuntuServerSKUs != nil {
 		senders = append(senders, s.makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs))
 	}
@@ -405,8 +426,8 @@ func (s *environSuite) publicIPAddressesSender(pips ...network.PublicIPAddress) 
 	return s.makeSender(".*/publicIPAddresses", network.PublicIPAddressListResult{Value: &pips})
 }
 
-func (s *environSuite) vmSizesSender() *azuretesting.MockSender {
-	return s.makeSender(".*/vmSizes", s.vmSizes)
+func (s *environSuite) resourceSkusSender() *azuretesting.MockSender {
+	return s.makeSender(".*/skus", s.skus)
 }
 
 func (s *environSuite) storageAccountSender() *azuretesting.MockSender {
@@ -1253,7 +1274,7 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
-	s.sender = append(s.sender, s.vmSizesSender())
+	s.sender = append(s.sender, s.resourceSkusSender())
 	s.sender = append(s.sender, s.initResourceGroupSenders()...)
 	s.sender = append(s.sender, s.startInstanceSendersNoSizes()...)
 	s.requests = nil
@@ -1588,7 +1609,7 @@ func (s *environSuite) TestConstraintsValidatorMerge(c *gc.C) {
 
 func (s *environSuite) constraintsValidator(c *gc.C) constraints.Validator {
 	env := s.openEnviron(c)
-	s.sender = azuretesting.Senders{s.vmSizesSender()}
+	s.sender = azuretesting.Senders{s.resourceSkusSender()}
 	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	return validator


### PR DESCRIPTION
## Description of change

Add the new Azure South Africa North , South Africa West, and France South regions.
However, instance lookup was broken on several regions. We were using a deprecated API so I had to re-engineer using a different API.

## QA steps

juju bootstrap azure/southafricanorth

## Bug reference

https://bugs.launchpad.net/juju/+bug/1839569
