### PR TITLE
Filter Addresses Using SpaceInfo Instead of Space Name

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -54,9 +54,15 @@ func (s *baseLoginSuite) SetUpTest(c *gc.C) {
 	if s.ControllerConfigAttrs == nil {
 		s.ControllerConfigAttrs = make(map[string]interface{})
 	}
-	s.ControllerConfigAttrs[corecontroller.JujuManagementSpace] = "mgmt01"
+
 	s.JujuConnSuite.SetUpTest(c)
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
+
+	_, err := s.State.AddSpace("mgmt01", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.UpdateControllerConfig(map[string]interface{}{corecontroller.JujuManagementSpace: "mgmt01"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *baseLoginSuite) newServer(c *gc.C) (*api.Info, *apiserver.Server) {
@@ -107,7 +113,7 @@ func (s *baseLoginSuite) openAPIWithoutLogin(c *gc.C, info0 *api.Info) api.Conne
 	info.Macaroons = nil
 	st, err := api.Open(&info, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { st.Close() })
+	s.AddCleanup(func(*gc.C) { _ = st.Close() })
 	return st
 }
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1950,7 +1950,7 @@ func providerSpaceInfoFromParams(space params.RemoteSpace) *environs.ProviderSpa
 		CloudType:          space.CloudType,
 		ProviderAttributes: space.ProviderAttributes,
 		SpaceInfo: network.SpaceInfo{
-			Name:       space.Name,
+			Name:       network.SpaceName(space.Name),
 			ProviderId: network.Id(space.ProviderId),
 		},
 	}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -594,7 +594,7 @@ func (m *mockBackend) AddRemoteApplication(args state.AddRemoteApplicationParams
 	for _, sp := range args.Spaces {
 		remoteSpaceInfo := state.RemoteSpace{
 			CloudType:          sp.CloudType,
-			Name:               sp.Name,
+			Name:               string(sp.Name),
 			ProviderId:         string(sp.ProviderId),
 			ProviderAttributes: sp.ProviderAttributes,
 		}

--- a/apiserver/facades/client/applicationoffers/conversions.go
+++ b/apiserver/facades/client/applicationoffers/conversions.go
@@ -16,7 +16,7 @@ import (
 func paramsFromProviderSpaceInfo(info *environs.ProviderSpaceInfo) params.RemoteSpace {
 	result := params.RemoteSpace{
 		CloudType:          info.CloudType,
-		Name:               info.Name,
+		Name:               string(info.Name),
 		ProviderId:         string(info.ProviderId),
 		ProviderAttributes: info.ProviderAttributes,
 	}
@@ -41,7 +41,7 @@ func providerSpaceInfoFromParams(space params.RemoteSpace) *environs.ProviderSpa
 		CloudType:          space.CloudType,
 		ProviderAttributes: space.ProviderAttributes,
 		SpaceInfo: network.SpaceInfo{
-			Name:       space.Name,
+			Name:       network.SpaceName(space.Name),
 			ProviderId: network.Id(space.ProviderId),
 		},
 	}
@@ -63,7 +63,7 @@ func providerSpaceInfoFromParams(space params.RemoteSpace) *environs.ProviderSpa
 // network.SpaceInfo.
 func spaceInfoFromState(space Space) (*network.SpaceInfo, error) {
 	result := &network.SpaceInfo{
-		Name:       space.Name(),
+		Name:       network.SpaceName(space.Name()),
 		ProviderId: space.ProviderId(),
 	}
 	subnets, err := space.Subnets()

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -87,9 +87,9 @@ func (e *mockEnviron) ProviderSpaceInfo(ctx context.ProviderCallContext, space *
 	e.stub.MethodCall(e, "ProviderSpaceInfo", space)
 	spaceName := corenetwork.DefaultSpaceName
 	if space != nil {
-		spaceName = space.Name
+		spaceName = string(space.Name)
 	}
-	if e.spaceInfo == nil || spaceName != e.spaceInfo.Name {
+	if e.spaceInfo == nil || spaceName != string(e.spaceInfo.Name) {
 		return nil, errors.NotFoundf("space %q", spaceName)
 	}
 	return e.spaceInfo, e.stub.NextErr()

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -526,11 +526,13 @@ type clientSuite struct {
 }
 
 func (s *clientSuite) SetUpTest(c *gc.C) {
-	if s.ControllerConfigAttrs == nil {
-		s.ControllerConfigAttrs = make(map[string]interface{})
-	}
-	s.ControllerConfigAttrs[controller.JujuManagementSpace] = "mgmt01"
 	s.baseSuite.SetUpTest(c)
+
+	_, err := s.State.AddSpace("mgmt01", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.UpdateControllerConfig(map[string]interface{}{controller.JujuManagementSpace: "mgmt01"}, nil)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 var _ = gc.Suite(&clientSuite{})

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -263,8 +263,8 @@ func ExactScopeMatch(addr Address, addrScopes ...Scope) bool {
 	return false
 }
 
-// SelectAddressesBySpaceNames filters the input slice of Addresses down to
-// those in the input space names.
+// SelectAddressesBySpaceNames filters the input slice of
+// Addresses down to those in the input spaces.
 func SelectAddressesBySpaces(addresses []Address, spaces ...SpaceInfo) ([]Address, bool) {
 	if len(spaces) == 0 {
 		logger.Errorf("addresses not filtered - no spaces given.")

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -846,25 +846,36 @@ func (*AddressSuite) TestExactScopeMatch(c *gc.C) {
 }
 
 func (s *AddressSuite) TestSelectAddressesBySpaceNamesFiltered(c *gc.C) {
-	sp := "thaSpace"
-	addrsSpace := []network.Address{network.NewAddressOnSpace(sp, "192.168.5.5")}
+	sp := network.SpaceInfo{
+		Name:       "thaSpace",
+		ProviderId: "",
+		Subnets:    nil,
+	}
+
+	addrsSpace := []network.Address{network.NewAddressOnSpace(string(sp.Name), "192.168.5.5")}
 	addrsNoSpace := []network.Address{network.NewAddress("127.0.0.1")}
 
-	filtered, ok := network.SelectAddressesBySpaceNames(append(addrsSpace, addrsNoSpace...), network.SpaceName(sp))
+	filtered, ok := network.SelectAddressesBySpaces(append(addrsSpace, addrsNoSpace...), sp)
 	c.Check(ok, jc.IsTrue)
 	c.Check(filtered, jc.DeepEquals, addrsSpace)
 }
 
 func (s *AddressSuite) TestSelectAddressesBySpaceNoSpaceFalse(c *gc.C) {
 	addrs := []network.Address{network.NewAddress("127.0.0.1")}
-	filtered, ok := network.SelectAddressesBySpaceNames(addrs)
+	filtered, ok := network.SelectAddressesBySpaces(addrs)
 	c.Check(ok, jc.IsFalse)
 	c.Check(filtered, jc.DeepEquals, addrs)
 }
 
 func (s *AddressSuite) TestSelectAddressesBySpaceNoneFound(c *gc.C) {
+	sp := network.SpaceInfo{
+		Name:       "noneSpace",
+		ProviderId: "",
+		Subnets:    nil,
+	}
+
 	addrs := []network.Address{network.NewAddress("127.0.0.1")}
-	filtered, ok := network.SelectAddressesBySpaceNames(addrs, "noneSpace")
+	filtered, ok := network.SelectAddressesBySpaces(addrs, sp)
 	c.Check(ok, jc.IsFalse)
 	c.Check(filtered, jc.DeepEquals, addrs)
 }

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -3,6 +3,8 @@
 
 package network
 
+import "strings"
+
 const (
 	// DefaultSpaceId is the ID of the default network space.
 	// Application endpoints are bound to this space by default
@@ -13,11 +15,14 @@ const (
 	DefaultSpaceName = ""
 )
 
+// SpaceName is the name of a network space.
+type SpaceName string
+
 // SpaceInfo defines a network space.
 type SpaceInfo struct {
 	// Name is the name of the space.
 	// It is used by operators for identifying a space and should be unique.
-	Name string
+	Name SpaceName
 
 	// ProviderId is the provider's unique identifier for the space,
 	// such as used by MAAS.
@@ -25,4 +30,27 @@ type SpaceInfo struct {
 
 	// Subnets are the subnets that have been grouped into this network space.
 	Subnets []SubnetInfo
+}
+
+// SpaceInfos is a collection of spaces.
+type SpaceInfos []SpaceInfo
+
+// String returns the comma-delimited names of the spaces in the collection.
+func (s SpaceInfos) String() string {
+	namesString := make([]string, len(s))
+	for i, v := range s {
+		namesString[i] = string(v.Name)
+	}
+	return strings.Join(namesString, ", ")
+}
+
+// HasSpaceWithName returns true if there is a space in the collection,
+// with the input name.
+func (s SpaceInfos) HasSpaceWithName(name SpaceName) bool {
+	for _, space := range s {
+		if space.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/testing"
+)
+
+type spaceSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&spaceSuite{})
+
+func (*spaceSuite) TestString(c *gc.C) {
+	result := network.SpaceInfos{
+		{Name: "space1"},
+		{Name: "space2"},
+		{Name: "space3"},
+	}.String()
+
+	c.Assert(result, gc.Equals, "space1, space2, space3")
+}
+
+func (*spaceSuite) TestHasSpaceWithName(c *gc.C) {
+	spaces := network.SpaceInfos{
+		{Name: "space1"},
+		{Name: "space2"},
+		{Name: "space3"},
+	}
+
+	c.Assert(spaces.HasSpaceWithName("space1"), jc.IsTrue)
+	c.Assert(spaces.HasSpaceWithName("space666"), jc.IsFalse)
+}

--- a/network/network.go
+++ b/network/network.go
@@ -77,7 +77,7 @@ func ConvertSpaceName(name string, existing set.Strings) string {
 	name = dashPrefix.ReplaceAllString(name, "")
 	// And any at the end.
 	name = dashSuffix.ReplaceAllString(name, "")
-	// Repleace multiple dashes with a single dash.
+	// Replace multiple dashes with a single dash.
 	name = multipleDashes.ReplaceAllString(name, "-")
 	// Special case of when the space name was only dashes or invalid
 	// characters!

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -750,7 +750,7 @@ func (env *maasEnviron) buildSpaceMap(ctx context.ProviderCallContext) (map[stri
 	spaceMap := make(map[string]corenetwork.SpaceInfo)
 	empty := set.Strings{}
 	for _, space := range spaces {
-		jujuName := network.ConvertSpaceName(space.Name, empty)
+		jujuName := network.ConvertSpaceName(string(space.Name), empty)
 		spaceMap[jujuName] = space
 	}
 	return spaceMap, nil
@@ -1858,7 +1858,7 @@ func (env *maasEnviron) spaces1(ctx context.ProviderCallContext) ([]corenetwork.
 			return nil, errors.Trace(err)
 		}
 
-		space := corenetwork.SpaceInfo{Name: name, ProviderId: providerId}
+		space := corenetwork.SpaceInfo{Name: corenetwork.SpaceName(name), ProviderId: providerId}
 		subnetsArray, err := spaceMap["subnets"].GetArray()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1890,7 +1890,7 @@ func (env *maasEnviron) spaces2(ctx context.ProviderCallContext) ([]corenetwork.
 			continue
 		}
 		outSpace := corenetwork.SpaceInfo{
-			Name:       space.Name(),
+			Name:       corenetwork.SpaceName(space.Name()),
 			ProviderId: corenetwork.Id(strconv.Itoa(space.ID())),
 			Subnets:    make([]corenetwork.SubnetInfo, len(space.Subnets())),
 		}

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -225,7 +225,7 @@ func (suite *maas2EnvironSuite) TestSpaces(c *gc.C) {
 	result, err := env.Spaces(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
-	c.Assert(result[0].Name, gc.Equals, "freckles")
+	c.Assert(result[0].Name, gc.Equals, corenetwork.SpaceName("freckles"))
 	c.Assert(result[0].ProviderId, gc.Equals, corenetwork.Id("4567"))
 	subnets := result[0].Subnets
 	c.Assert(subnets, gc.HasLen, 2)

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -226,10 +226,10 @@ func (e *OracleEnviron) buildSpacesMap(
 	}
 	spaceMap := make(map[string]corenetwork.SpaceInfo)
 	for _, space := range spaces {
-		jujuName := network.ConvertSpaceName(space.Name, empty)
+		jujuName := network.ConvertSpaceName(string(space.Name), empty)
 		spaceMap[jujuName] = space
 		empty.Add(jujuName)
-		providerIdMap[string(space.ProviderId)] = space.Name
+		providerIdMap[string(space.ProviderId)] = string(space.Name)
 	}
 	return spaceMap, providerIdMap, nil
 

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -332,7 +332,7 @@ func (e Environ) Spaces(ctx context.ProviderCallContext) ([]corenetwork.SpaceInf
 			logger.Infof("creating new space obj for %s and adding %s",
 				name, string(val.ProviderId))
 			exchanges[name] = corenetwork.SpaceInfo{
-				Name:       name,
+				Name:       corenetwork.SpaceName(name),
 				ProviderId: val.ProviderSpaceId,
 				Subnets: []corenetwork.SubnetInfo{
 					val,

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -68,7 +68,7 @@ func (s *ControllerAddressesSuite) TestControllerModel(c *gc.C) {
 
 func (s *ControllerAddressesSuite) TestOtherModel(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
+	defer func() { _ = st.Close() }()
 	addresses, err := st.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addresses, jc.SameContents, []string{"10.0.1.2:1234"})
@@ -238,6 +238,9 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDiffe
 }
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
+	_, err := s.State.AddSpace("mgmt01", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.SetJujuManagementSpace(c, "mgmt01")
 
 	addrs, err := s.State.APIHostPortsForClients()
@@ -364,6 +367,9 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
 }
 
 func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
+	_, err := s.State.AddSpace("mgmt01", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.SetJujuManagementSpace(c, "mgmt01")
 
 	w := s.State.WatchAPIHostPortsForAgents()
@@ -383,7 +389,7 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 		Port: 2,
 	}
 
-	err := s.State.SetAPIHostPorts([][]network.HostPort{{
+	err = s.State.SetAPIHostPorts([][]network.HostPort{{
 		mgmtHP,
 	}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/controller.go
+++ b/state/controller.go
@@ -157,20 +157,24 @@ func checkUpdateControllerConfig(name string) error {
 
 // checkSpaceIsAvailableToAllControllers checks if each controller machine has
 // at least one address in the input space. If not, an error is returned.
-func (st *State) checkSpaceIsAvailableToAllControllers(configSpace string) error {
+func (st *State) checkSpaceIsAvailableToAllControllers(spaceName string) error {
 	info, err := st.ControllerInfo()
 	if err != nil {
 		return errors.Annotate(err, "cannot get controller info")
 	}
 
+	space, err := st.Space(spaceName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	var missing []string
-	spaceName := network.SpaceName(configSpace)
 	for _, id := range info.MachineIds {
 		m, err := st.Machine(id)
 		if err != nil {
 			return errors.Annotate(err, "cannot get machine")
 		}
-		if _, ok := network.SelectAddressesBySpaceNames(m.Addresses(), spaceName); !ok {
+		if _, ok := network.SelectAddressesBySpaces(m.Addresses(), space.NetworkSpace()); !ok {
 			missing = append(missing, id)
 		}
 	}

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -161,6 +161,9 @@ func (s *ControllerSuite) TestRemovingUnknownName(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestUpdateControllerConfigRejectsSpaceWithoutAddresses(c *gc.C) {
+	_, err := s.State.AddSpace("mgmt-space", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
 	m, err := s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.SetMachineAddresses(network.NewAddress("192.168.9.9")), jc.ErrorIsNil)
@@ -173,6 +176,9 @@ func (s *ControllerSuite) TestUpdateControllerConfigRejectsSpaceWithoutAddresses
 }
 
 func (s *ControllerSuite) TestUpdateControllerConfigAcceptsSpaceWithAddresses(c *gc.C) {
+	_, err := s.State.AddSpace("mgmt-space", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
 	m, err := s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.SetProviderAddresses(network.NewAddressOnSpace("mgmt-space", "192.168.9.9")), jc.ErrorIsNil)

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -774,7 +774,7 @@ func (p AddRemoteApplicationParams) Validate() error {
 	}
 	spaceNames := set.NewStrings()
 	for _, space := range p.Spaces {
-		spaceNames.Add(space.Name)
+		spaceNames.Add(string(space.Name))
 	}
 	for endpoint, space := range p.Bindings {
 		if !spaceNames.Contains(space) {
@@ -836,7 +836,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 	for i, space := range args.Spaces {
 		spaces[i] = remoteSpaceDoc{
 			CloudType:          space.CloudType,
-			Name:               space.Name,
+			Name:               string(space.Name),
 			ProviderId:         string(space.ProviderId),
 			ProviderAttributes: space.ProviderAttributes,
 		}

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -71,7 +71,8 @@ func (s *Space) Subnets() ([]*Subnet, error) {
 	var doc subnetDoc
 	var results []*Subnet
 	// We ignore space-name field for FAN subnets...
-	iter := subnetsCollection.Find(bson.D{{"space-id", id}, bson.DocElem{"fan-local-underlay", bson.D{{"$exists", false}}}}).Iter()
+	iter := subnetsCollection.Find(
+		bson.D{{"space-id", id}, bson.DocElem{Name: "fan-local-underlay", Value: bson.D{{"$exists", false}}}}).Iter()
 	defer iter.Close()
 	for iter.Next(&doc) {
 		subnet := &Subnet{s.st, doc, id}
@@ -87,6 +88,15 @@ func (s *Space) Subnets() ([]*Subnet, error) {
 		return nil, errors.Annotatef(err, "cannot fetch subnets")
 	}
 	return results, nil
+}
+
+func (s *Space) NetworkSpace() network.SpaceInfo {
+	return network.SpaceInfo{
+		Name:       network.SpaceName(s.Name()),
+		ProviderId: s.ProviderId(),
+		// TODO (manadart 2019-08-13): Populate these after subnet refactor.
+		Subnets: nil,
+	}
 }
 
 // AddSpace creates and returns a new space.

--- a/state/spacesdiscovery.go
+++ b/state/spacesdiscovery.go
@@ -158,15 +158,14 @@ func (st *State) SaveSpacesFromProvider(providerSpaces []corenetwork.SpaceInfo) 
 	// TODO(mfoord): we need to delete spaces and subnets that no longer
 	// exist, so long as they're not in use.
 	for _, space := range providerSpaces {
-		// Check if the space is already in state, in which case we know
-		// its name.
+		// Check if the space is already in state,
+		// in which case we know its name.
 		stateSpace, ok := modelSpaceMap[space.ProviderId]
 		var spaceTag names.SpaceTag
 		if ok {
 			spaceName := stateSpace.Name()
 			if !names.IsValidSpace(spaceName) {
-				// Can only happen if an invalid name is stored
-				// in state.
+				// Can only happen if an invalid name is stored in state.
 				logger.Errorf("space %q has an invalid name, ignoring", spaceName)
 				continue
 
@@ -174,15 +173,11 @@ func (st *State) SaveSpacesFromProvider(providerSpaces []corenetwork.SpaceInfo) 
 			spaceTag = names.NewSpaceTag(spaceName)
 
 		} else {
-			// The space is new, we need to create a valid name for it
-			// in state.
-			spaceName := space.Name
-			// Convert the name into a valid name that isn't already in
-			// use.
-			spaceName = network.ConvertSpaceName(spaceName, spaceNames)
+			// The space is new, we need to create a valid name for it in state.
+			// Convert the name into a valid name that is not already in use.
+			spaceName := network.ConvertSpaceName(string(space.Name), spaceNames)
 			spaceNames.Add(spaceName)
 			spaceTag = names.NewSpaceTag(spaceName)
-			// We need to create the space.
 
 			logger.Debugf("Adding space %s from provider %s", spaceTag.String(), string(space.ProviderId))
 			_, err = st.AddSpace(spaceTag.Id(), space.ProviderId, []string{}, false)

--- a/state/spacesdiscovery_test.go
+++ b/state/spacesdiscovery_test.go
@@ -200,7 +200,7 @@ func checkSpacesEqual(c *gc.C, spaces []*state.Space, spaceInfos []network.Space
 	c.Assert(len(spaceInfos), gc.Equals, len(filtered))
 	for i, spaceInfo := range spaceInfos {
 		space := filtered[i]
-		c.Check(spaceInfo.Name, gc.Equals, space.Name())
+		c.Check(string(spaceInfo.Name), gc.Equals, space.Name())
 		c.Check(spaceInfo.ProviderId, gc.Equals, space.ProviderId())
 		subnets, err := space.Subnets()
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4286,6 +4286,9 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) 
 }
 
 func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
+	_, err := s.State.AddSpace("mgmt01", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.SetJujuManagementSpace(c, "mgmt01")
 
 	addrs, err := s.State.APIHostPortsForClients()
@@ -4412,6 +4415,9 @@ func (s *StateSuite) TestWatchAPIHostPortsForClients(c *gc.C) {
 }
 
 func (s *StateSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
+	_, err := s.State.AddSpace("mgmt01", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.SetJujuManagementSpace(c, "mgmt01")
 
 	w := s.State.WatchAPIHostPortsForAgents()
@@ -4431,7 +4437,7 @@ func (s *StateSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 		Port: 2,
 	}
 
-	err := s.State.SetAPIHostPorts([][]network.HostPort{{
+	err = s.State.SetAPIHostPorts([][]network.HostPort{{
 		mgmtHP,
 	}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/peergrouper/controllertracker.go
+++ b/worker/peergrouper/controllertracker.go
@@ -101,7 +101,7 @@ func (c *controllerTracker) SelectMongoAddressFromSpace(port int, space network.
 	addrs, ok := network.SelectHostPortsBySpaces(hostPorts, space)
 	if ok {
 		addr := addrs[0].NetAddr()
-		logger.Debugf("controller node %q selected address %q by space %q from %v", c.id, addr, space, hostPorts)
+		logger.Debugf("controller node %q selected address %q by space %q from %v", c.id, addr, space.Name, hostPorts)
 		return addr, nil
 	}
 

--- a/worker/peergrouper/controllertracker.go
+++ b/worker/peergrouper/controllertracker.go
@@ -88,16 +88,17 @@ func (c *controllerTracker) Addresses() []network.Address {
 // SelectMongoAddress returns the best address on the controller node for MongoDB peer
 // use, using the input space.
 // An error is returned if the empty space is supplied.
-func (c *controllerTracker) SelectMongoAddressFromSpace(port int, space network.SpaceName) (string, error) {
-	if space == "" {
-		return "", fmt.Errorf("empty space supplied as an argument for selecting Mongo address for controller node %q", c.id)
+func (c *controllerTracker) SelectMongoAddressFromSpace(port int, space network.SpaceInfo) (string, error) {
+	if space.Name == network.DefaultSpaceName {
+		return "", fmt.Errorf(
+			"empty space supplied as an argument for selecting Mongo address for controller node %q", c.id)
 	}
 
 	c.mu.Lock()
 	hostPorts := network.AddressesWithPort(c.addresses, port)
 	c.mu.Unlock()
 
-	addrs, ok := network.SelectHostPortsBySpaceNames(hostPorts, space)
+	addrs, ok := network.SelectHostPortsBySpaces(hostPorts, space)
 	if ok {
 		addr := addrs[0].NetAddr()
 		logger.Debugf("controller node %q selected address %q by space %q from %v", c.id, addr, space, hostPorts)
@@ -107,7 +108,7 @@ func (c *controllerTracker) SelectMongoAddressFromSpace(port int, space network.
 	// If we end up here, then there are no addresses available in the
 	// specified space. This should not happen, because the configured
 	// space is used as a constraint when first enabling HA.
-	return "", errors.NotFoundf("addresses for controller node %q in space %q", c.id, space)
+	return "", errors.NotFoundf("addresses for controller node %q in space %q", c.id, space.Name)
 }
 
 // GetPotentialMongoHostPorts simply returns all the available addresses

--- a/worker/peergrouper/controllertracker_test.go
+++ b/worker/peergrouper/controllertracker_test.go
@@ -20,6 +20,7 @@ var _ = gc.Suite(&machineTrackerSuite{})
 
 func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddress(c *gc.C) {
 	spaceName := network.SpaceName("ha-space")
+	space := network.SpaceInfo{Name: spaceName}
 
 	m := &controllerTracker{
 		addresses: []network.Address{
@@ -40,7 +41,7 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddre
 		},
 	}
 
-	addr, err := m.SelectMongoAddressFromSpace(666, spaceName)
+	addr, err := m.SelectMongoAddressFromSpace(666, space)
 	c.Assert(err, gc.IsNil)
 	c.Check(addr, gc.Equals, "192.168.5.5:666")
 }
@@ -56,7 +57,7 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceEmptyWhenNoAddressF
 		},
 	}
 
-	addrs, err := m.SelectMongoAddressFromSpace(666, "bad-space")
+	addrs, err := m.SelectMongoAddressFromSpace(666, network.SpaceInfo{Name: "bad-space"})
 	c.Check(addrs, gc.Equals, "")
 	c.Check(err, gc.ErrorMatches, `addresses for controller node "3" in space "bad-space" not found`)
 }
@@ -66,7 +67,7 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceErrorForEmptySpace(
 		id: "3",
 	}
 
-	_, err := m.SelectMongoAddressFromSpace(666, "")
+	_, err := m.SelectMongoAddressFromSpace(666, network.SpaceInfo{})
 	c.Check(err, gc.ErrorMatches, `empty space supplied as an argument for selecting Mongo address for controller node "3"`)
 }
 

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -39,7 +39,7 @@ type peerGroupInfo struct {
 	extra       []replicaset.Member
 	maxMemberId int
 	mongoPort   int
-	haSpace     network.SpaceName
+	haSpace     network.SpaceInfo
 }
 
 // desiredChanges tracks the specific changes we are asking to be made to the peer group.
@@ -81,7 +81,7 @@ func newPeerGroupInfo(
 	statuses []replicaset.MemberStatus,
 	members []replicaset.Member,
 	mongoPort int,
-	haSpace network.SpaceName,
+	haSpace network.SpaceInfo,
 ) (*peerGroupInfo, error) {
 	if len(members) == 0 {
 		return nil, fmt.Errorf("current member set is empty")
@@ -477,7 +477,7 @@ func (p *peerGroupChanges) getNodesVoting() {
 // the HA space if one is configured.
 func (p *peerGroupChanges) updateAddresses() error {
 	var err error
-	if p.info.haSpace == "" {
+	if p.info.haSpace.Name == network.DefaultSpaceName {
 		err = p.updateAddressesFromInternal()
 	} else {
 		err = p.updateAddressesFromSpace()
@@ -580,7 +580,7 @@ func (p *peerGroupChanges) updateAddressesFromSpace() error {
 		if err != nil {
 			if errors.IsNotFound(err) {
 				noAddresses = append(noAddresses, id)
-				msg := fmt.Sprintf("no addresses in configured juju-ha-space %q", space)
+				msg := fmt.Sprintf("no addresses in configured juju-ha-space %q", space.Name)
 				if err := m.host.SetStatus(getStatusInfo(msg)); err != nil {
 					return errors.Trace(err)
 				}
@@ -596,7 +596,8 @@ func (p *peerGroupChanges) updateAddressesFromSpace() error {
 
 	if len(noAddresses) > 0 {
 		ids := strings.Join(noAddresses, ", ")
-		return fmt.Errorf("no usable Mongo addresses found in configured juju-ha-space %q for nodes: %s", space, ids)
+		return fmt.Errorf(
+			"no usable Mongo addresses found in configured juju-ha-space %q for nodes: %s", space.Name, ids)
 	}
 	return nil
 }

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -351,7 +351,7 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 			trackerMap[m.Id()] = m
 		}
 
-		info, err := newPeerGroupInfo(trackerMap, test.statuses, test.members, mongoPort, network.SpaceName(""))
+		info, err := newPeerGroupInfo(trackerMap, test.statuses, test.members, mongoPort, network.SpaceInfo{})
 		c.Assert(err, jc.ErrorIsNil)
 
 		desired, err := desiredPeerGroup(info)
@@ -385,7 +385,7 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 
 		// Make sure that when the members are set as required, that there
 		// is no further change if desiredPeerGroup is called again.
-		info, err = newPeerGroupInfo(trackerMap, test.statuses, members, mongoPort, network.SpaceName(""))
+		info, err = newPeerGroupInfo(trackerMap, test.statuses, members, mongoPort, network.SpaceInfo{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(info, gc.NotNil)
 
@@ -409,7 +409,7 @@ func (s *desiredPeerGroupSuite) doTestDesiredPeerGroup(c *gc.C, ipVersion TestIP
 }
 
 func (s *desiredPeerGroupSuite) TestNewPeerGroupInfoErrWhenNoMembers(c *gc.C) {
-	_, err := newPeerGroupInfo(nil, nil, nil, 666, network.SpaceName(""))
+	_, err := newPeerGroupInfo(nil, nil, nil, 666, network.SpaceInfo{})
 	c.Check(err, gc.ErrorMatches, "current member set is empty")
 }
 

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -13,8 +13,7 @@ import (
 )
 
 // This file holds code that translates from State
-// to the interface expected internally by the
-// worker.
+// to the interface expected internally by the worker.
 
 type StateShim struct {
 	*state.State
@@ -72,6 +71,10 @@ func (*cloudServiceShim) Status() (status.StatusInfo, error) {
 func (*cloudServiceShim) SetStatus(status.StatusInfo) error {
 	// We don't record the status of a cloud service entity.
 	return nil
+}
+
+type spaceShim struct {
+	*state.Space
 }
 
 // MongoSessionShim wraps a *mgo.Session to conform to the


### PR DESCRIPTION
## Description of change

This patch is mechanical preparation for filtering address by space once `SpaceName` is no longer a member of `network.Address`.

Address filtering methods for the HA and management spaces now accept a `network.SpaceInfo` object rather than a string space name.

## QA steps

- Bootstrap to MAAS.
- Determine an available space to use.
- `juju controller-config juju-ha-space=<space>`
- `juju controller-config juju-mgmt-space=<space>`
- `juju enable-ha`
- Check the controller logs and ensure there are no address filtering errors and the the peergrouper is happy.

## Documentation changes

None.

## Bug reference

N/A
