### PR TITLE
Fix/lp 1838782

### DIFF
--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -88,6 +88,13 @@ func (c *Client) SetStatus(
 	return result.OneError()
 }
 
+func convertNotFound(err error) error {
+	if params.IsCodeNotFound(err) {
+		return errors.NewNotFound(err, "")
+	}
+	return err
+}
+
 // Charm returns information about the charm currently assigned
 // to the application, including url, force upgrade and sha etc.
 func (c *Client) Charm(application string) (_ *charm.URL, forceUpgrade bool, sha256 string, vers int, _ error) {
@@ -106,7 +113,7 @@ func (c *Client) Charm(application string) (_ *charm.URL, forceUpgrade bool, sha
 		return nil, false, "", 0, errors.Errorf("expected 1 result, got %d", n)
 	}
 	if err := results.Results[0].Error; err != nil {
-		return nil, false, "", 0, errors.Trace(err)
+		return nil, false, "", 0, errors.Trace(convertNotFound(err))
 	}
 	result := results.Results[0].Result
 	curl, err := charm.ParseURL(result.URL)

--- a/state/storage.go
+++ b/state/storage.go
@@ -406,11 +406,8 @@ func (sb *storageBackend) destroyStorageInstance(
 		case nil:
 			return ops, nil
 		default:
-			if !force {
-				return nil, errors.Trace(err)
-			}
 			logger.Warningf("could not destroy storage instance %v: %v", tag.Id(), err)
-			return ops, nil
+			return nil, errors.Trace(err)
 		}
 	}
 	return sb.mb.db().Run(buildTxn)

--- a/worker/caasoperator/remotestate/watcher.go
+++ b/worker/caasoperator/remotestate/watcher.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
-	jworker "github.com/juju/juju/worker"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1/catacomb"
 )
@@ -84,7 +83,8 @@ func (w *RemoteStateWatcher) Snapshot() Snapshot {
 func (w *RemoteStateWatcher) loop() (err error) {
 	defer func() {
 		if errors.IsNotFound(err) {
-			err = jworker.ErrTerminateAgent
+			logger.Debugf("ignoring error %v and exit", err)
+			err = nil
 		}
 	}()
 


### PR DESCRIPTION
## Description of change

fix `--force` broken issue on `destroy-model` cmd;

driveby fix: exit peacefully if `RemoteStateWatcher` got `not found` error(application has already been removed in this case);

## QA steps

1. deploy workload;

```bash
$ juju add-model t1 microk8s && juju deploy cs:~kelvin.liu/mariadb-k8s-3
```

2. destroy model with `--force`;

```bash
$ juju destroy-model t1 --destroy-storage -y --debug --force
```


## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1838782