### PR TITLE
Better error messages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -461,14 +461,14 @@
   revision = "9c5c9712527c7986f012361e7d13756b4d99543d"
 
 [[projects]]
-  digest = "1:c14a973d9b66b6a4b8b21ae7a345a032c80d3574cc1391d37d59a2c793892356"
+  digest = "1:7699a4597477ccffbf8310edc22eb2c976782fae3790b463eea62a0b39f42898"
   name = "github.com/juju/cmd"
   packages = [
     ".",
     "cmdtesting",
   ]
   pruneopts = ""
-  revision = "26546fa0123cbf702dff02aec8700af5cd944c2d"
+  revision = "0ed15c27f59d51d10b1f1fe3671825f8f785ff72"
 
 [[projects]]
   digest = "1:243ec2217cb77ad028a956bf4d886b0f070d2dbfe861ceadfcf270412c2e7b90"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -461,14 +461,14 @@
   revision = "9c5c9712527c7986f012361e7d13756b4d99543d"
 
 [[projects]]
-  digest = "1:7699a4597477ccffbf8310edc22eb2c976782fae3790b463eea62a0b39f42898"
+  digest = "1:d2b54c9eb7d2ae6ad4ab7d2463b0804c3a1aa9c908b8ec3d6f75ddd3ce87bd4c"
   name = "github.com/juju/cmd"
   packages = [
     ".",
     "cmdtesting",
   ]
   pruneopts = ""
-  revision = "0ed15c27f59d51d10b1f1fe3671825f8f785ff72"
+  revision = "0c5c82a8dfc6992939365fc947d7399e0e2428ae"
 
 [[projects]]
   digest = "1:243ec2217cb77ad028a956bf4d886b0f070d2dbfe861ceadfcf270412c2e7b90"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -288,7 +288,7 @@
 
 [[constraint]]
   name = "github.com/juju/cmd"
-  revision = "26546fa0123cbf702dff02aec8700af5cd944c2d"
+  revision = "0ed15c27f59d51d10b1f1fe3671825f8f785ff72"
 
 [[constraint]]
   name = "github.com/juju/collections"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -288,7 +288,7 @@
 
 [[constraint]]
   name = "github.com/juju/cmd"
-  revision = "0ed15c27f59d51d10b1f1fe3671825f8f785ff72"
+  revision = "0c5c82a8dfc6992939365fc947d7399e0e2428ae"
 
 [[constraint]]
   name = "github.com/juju/collections"

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -224,12 +224,12 @@ func NewJujuCommand(ctx *cmd.Context) cmd.Command {
 		Doc:  jujuDoc,
 		MissingCallback: RunPlugin(func(ctx *cmd.Context, subcommand string, args []string) error {
 			if cmdName, _, ok := jcmd.FindClosestSubCommand(subcommand); ok {
-				return NotFoundCommand{
+				return &NotFoundCommand{
 					ArgName: subcommand,
 					CmdName: cmdName,
 				}
 			}
-			return &cmd.UnrecognizedCommand{Name: subcommand}
+			return cmd.DefaultUnrecognizedCommand(subcommand)
 		}),
 		UserAliasesFilename: osenv.JujuXDGDataHomePath("aliases"),
 		FlagKnownAs:         "option",
@@ -237,6 +237,11 @@ func NewJujuCommand(ctx *cmd.Context) cmd.Command {
 	registerCommands(jcmd, ctx)
 	return jcmd
 }
+
+const notFoundCommandMessage = `juju: %q is not a juju command. See "juju --help".
+
+Did you mean:
+	%s`
 
 // NotFoundCommand gives valuable feedback to the operator about what commands
 // could be available if a mistake around the subcommand name is given.
@@ -246,10 +251,7 @@ type NotFoundCommand struct {
 }
 
 func (c NotFoundCommand) Error() string {
-	return fmt.Sprintf(`juju: %q is not a juju command. See "juju --help".
-
-Did you mean:
-	%s`, c.ArgName, c.CmdName)
+	return fmt.Sprintf(notFoundCommandMessage, c.ArgName, c.CmdName)
 }
 
 type commandRegistry interface {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -248,7 +248,7 @@ type NotFoundCommand struct {
 func (c NotFoundCommand) Error() string {
 	return fmt.Sprintf(`juju: %q is not a juju command. See "juju --help".
 
-Did you mean this?
+Did you mean:
 	%s`, c.ArgName, c.CmdName)
 }
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -75,6 +75,13 @@ func syncToolsHelpText() string {
 func (s *MainSuite) TestRunMain(c *gc.C) {
 	jujuclienttesting.SetupMinimalFileStore(c)
 
+	missingCommandMessage := func(wanted, actual string) string {
+		return fmt.Sprintf("ERROR %s\n", NotFoundCommand{
+			ArgName: wanted,
+			CmdName: actual,
+		}.Error())
+	}
+
 	// The test array structure needs to be inline here as some of the
 	// expected values below use deployHelpText().  This constructs the deploy
 	// command and runs gets the help for it.  When the deploy command is
@@ -90,7 +97,7 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "juju help foo doesn't exist",
 		args:    []string{"help", "foo"},
 		code:    1,
-		out:     "ERROR unknown command or topic for foo\n",
+		out:     missingCommandMessage("foo", "gui"),
 	}, {
 		summary: "juju help deploy shows the default help without global options",
 		args:    []string{"help", "deploy"},
@@ -117,10 +124,15 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		code:    0,
 		out:     configHelpText(),
 	}, {
-		summary: "unknown command",
+		summary: "unknown command with match",
 		args:    []string{"discombobulate"},
 		code:    1,
-		out:     "ERROR unrecognized command: juju discombobulate\n",
+		out:     missingCommandMessage("discombobulate", "diff-bundle"),
+	}, {
+		summary: "unknown command",
+		args:    []string{"pseudopseudohypoparathyroidism"},
+		code:    1,
+		out:     "ERROR unrecognized command: juju pseudopseudohypoparathyroidism\n",
 	}, {
 		summary: "unknown option before command",
 		args:    []string{"--cheese", "bootstrap"},

--- a/cmd/juju/commands/plugin.go
+++ b/cmd/juju/commands/plugin.go
@@ -47,6 +47,7 @@ func extractJujuArgs(args []string) []string {
 	return jujuArgs
 }
 
+// RunPlugin attempts to find the plugin on path to run
 func RunPlugin(callback cmd.MissingCallback) cmd.MissingCallback {
 	return func(ctx *cmd.Context, subcommand string, args []string) error {
 		cmdName := JujuPluginPrefix + subcommand


### PR DESCRIPTION
## Description of change

The following changes how Plugin call back is called. Instead of
terminating inside the Plugin callback, we instead allow more of a
middleware approach, that each callback can be composed. This allows
us to do some very useful things with the return values of the
failed callback.

For example we can use the subcommand name to return a helpful
message like:

```
ERROR juju: "controllerss" is not a juju command. See "juju --help".

Did you mean this?
	controllers
```

See: https://github.com/juju/cmd/pull/65

## QA steps

```
juju controllerss
```

Should return:

```
ERROR juju: "controllerss" is not a juju command. See "juju --help".

Did you mean this?
	controllers
```
