### PR TITLE
vsphere: Apply constraints at clone time, not template VM import

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -472,7 +472,7 @@ func (c *Client) cloneVM(
 	vmConfigSpec := &types.VirtualMachineConfigSpec{}
 	err = c.buildConfigSpec(ctx, args, vmConfigSpec)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "building clone VM config")
 	}
 	newVAppConfig, err := customiseVAppConfig(ctx, srcVM, args)
 	if err != nil {

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -298,7 +298,7 @@ func (c *Client) CreateVirtualMachine(
 	args.UpdateProgress("cloning template")
 	vm, err := c.cloneVM(ctx, args, templateVM, vmFolder)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "cloning template VM")
 	}
 
 	taskWaiter := &taskWaiter{
@@ -414,11 +414,6 @@ func (c *Client) createImportSpec(
 		return nil, errors.Trace(err)
 	} else if spec.Error != nil {
 		return nil, errors.New(spec.Error[0].LocalizedMessage)
-	}
-	s := &spec.ImportSpec.(*types.VirtualMachineImportSpec).ConfigSpec
-	err = c.buildConfigSpec(ctx, args, s)
-	if err != nil {
-		return nil, errors.Trace(err)
 	}
 	return spec, nil
 }

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -116,11 +116,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 	case *methods.CloneVM_TaskBody:
 		req := req.(*methods.CloneVM_TaskBody).Req
 		specConfig := req.Spec.Config
-		var vAppConfig types.BaseVmConfigSpec
-		if specConfig != nil {
-			vAppConfig = specConfig.VAppConfig
-		}
-		r.MethodCall(r, "CloneVM_Task", vAppConfig)
+		r.MethodCall(r, "CloneVM_Task", req.Name, specConfig)
 		res.Res = &types.CloneVM_TaskResponse{cloneVMTask}
 	case *methods.CreateFolderBody:
 		req := req.(*methods.CreateFolderBody).Req


### PR DESCRIPTION
## Description of change

There's no point in building a config spec for the template VM because the constraints we have are the ones for a controller machine, so we need to apply the right ones to reset all of the config when we clone the template VM anyway.

`buildConfigSpec` is now only used from cloning which means it can be simplified a bit.

## QA steps

* Bootstrap a controller on vsphere. Ensure that the controller VM has our normal constraints (3.5G ram), and the template VM doesn't.
* Deploy applications with different memory, cpu and disk constraints - check that the VMs all have the right configuration once they're running.

## Documentation changes

None

## Bug reference

None