### PR TITLE
Add max-debug-log-duration to controller config.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -728,11 +728,11 @@
   revision = "cca922e065df403dc5088294f7f546e838d13708"
 
 [[projects]]
-  digest = "1:635b65b0b4a17f59ab380b6ec8efb91783e20c6b1b48f0a7ef12cb0d953d1d50"
+  digest = "1:db82eb6a66dc5e2608a5769dbaa2f874dfc036953cbe7681e6987fe10c27235c"
   name = "github.com/juju/schema"
   packages = ["."]
   pruneopts = ""
-  revision = "64a6158e90710d0a16c6bd3cf0a6be6b2e80193c"
+  revision = "1f8aaeef09898fcee40fe43b8de422533b0cac2b"
 
 [[projects]]
   digest = "1:e3f03b6b31f1b273e4b37b1ac54fb10a0553fbc6c66441fe5388450caa385129"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -336,7 +336,7 @@
 
 [[constraint]]
   name = "github.com/juju/schema"
-  revision = "64a6158e90710d0a16c6bd3cf0a6be6b2e80193c"
+  revision = "1f8aaeef09898fcee40fe43b8de422533b0cac2b"
 
 [[constraint]]
   name = "github.com/juju/terms-client"

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -39,6 +39,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.JujuManagementSpace,
 		controller.AuditLogExcludeMethods,
 		// TODO(thumper): remove MaxLogsAge and MaxLogsSize in 2.7 branch.
+		controller.MaxDebugLogDuration,
 		controller.MaxLogsAge,
 		controller.MaxLogsSize,
 		controller.MaxPruneTxnBatchSize,


### PR DESCRIPTION
This branch adds a new controller-config attribute to control the maximum time a debug-log session will be left running before the apiserver terminates the connection.

The default is 24 hours. This should be more than enough for normal debug-log usage. 

## QA steps

* bootstrap a lxd controller
* juju controller-config max-debug-log-duration=10s
* juju debug-log -m controller

You should be disconnected and the command finishes after ten seconds.

## Documentation changes

We will want to update the docs around debug-log to mention that there is a controller setting that can control how long they are connected for. Also need to update the controller-config docs to show the new setting.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1840203
