### PR TITLE
Fixes lp#1566583: unset default credential/region.

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -97,7 +97,7 @@ If you are setting up Juju for the first time, consider running
 credentials manually.
 
 This command does not set default regions nor default credentials for the
-cloud. The commands ` + "`juju set-default-region`" + ` and ` + "`juju set-default-credential`" + `
+cloud. The commands ` + "`juju default-region`" + ` and ` + "`juju default-credential`" + `
 provide that functionality.
 
 By default, after validating the contents, credentials are added both 
@@ -112,8 +112,8 @@ instructions.
 See also: 
     credentials
     remove-credential
-    set-default-credential
-    set-default-region
+    default-credential
+    default-region
     autoload-credentials
 `
 

--- a/cmd/juju/cloud/defaultcredential.go
+++ b/cmd/juju/cloud/defaultcredential.go
@@ -87,7 +87,7 @@ func (c *setDefaultCredentialCommand) Init(args []string) (err error) {
 
 // SetFlags initializes the flags supported by the command.
 func (c *setDefaultCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.reset, "reset", false, "Reset default region for the cloud")
+	f.BoolVar(&c.reset, "reset", false, "Reset default credential for the cloud")
 }
 
 func hasCredential(credential string, credentials map[string]jujucloud.Credential) bool {

--- a/cmd/juju/cloud/defaultcredential.go
+++ b/cmd/juju/cloud/defaultcredential.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
@@ -29,12 +30,15 @@ This command sets a locally stored credential to be used as a default.
 Default credentials avoid the need to specify a particular set of 
 credentials when more than one are available for a given cloud.
 
-To unset previously set default credential for a cloud, use the command
+To unset previously set default credential for a cloud, use --reset option.
+
+To view currently set default credential for a cloud, use the command
 without a credential name argument.
 
 Examples:
-    juju set-default-credential google credential_name
-    juju set-default-credential google
+    juju default-credential google credential_name
+    juju default-credential google
+    juju default-credential google --reset
 
 See also: 
     credentials
@@ -48,6 +52,7 @@ type setDefaultCredentialCommand struct {
 	store      jujuclient.CredentialStore
 	cloud      string
 	credential string
+	reset      bool
 }
 
 // NewSetDefaultCredentialCommand returns a command to set the default credential for a cloud.
@@ -59,7 +64,8 @@ func NewSetDefaultCredentialCommand() cmd.Command {
 
 func (c *setDefaultCredentialCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "set-default-credential",
+		Name:    "default-credential",
+		Aliases: []string{"set-default-credential"},
 		Args:    "<cloud name> [<credential name>]",
 		Purpose: usageSetDefaultCredentialSummary,
 		Doc:     usageSetDefaultCredentialDetails,
@@ -68,7 +74,7 @@ func (c *setDefaultCredentialCommand) Info() *cmd.Info {
 
 func (c *setDefaultCredentialCommand) Init(args []string) (err error) {
 	if len(args) < 1 {
-		return errors.New("Usage: juju set-default-credential <cloud-name> [<credential-name>]")
+		return errors.New("Usage: juju default-credential <cloud-name> [<credential-name>]")
 	}
 	c.cloud = args[0]
 	end := 1
@@ -77,6 +83,11 @@ func (c *setDefaultCredentialCommand) Init(args []string) (err error) {
 		end = 2
 	}
 	return cmd.CheckEmpty(args[end:])
+}
+
+// SetFlags initializes the flags supported by the command.
+func (c *setDefaultCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.reset, "reset", false, "Reset default region for the cloud")
 }
 
 func hasCredential(credential string, credentials map[string]jujucloud.Credential) bool {
@@ -97,6 +108,15 @@ func (c *setDefaultCredentialCommand) Run(ctxt *cmd.Context) error {
 		cred = &jujucloud.CloudCredential{}
 	} else if err != nil {
 		return err
+	}
+	if !c.reset && c.credential == "" {
+		// We are just reading the value.
+		if cred.DefaultCredential != "" {
+			ctxt.Infof("Default credential for cloud %q is %q on this client.", c.cloud, cred.DefaultCredential)
+			return nil
+		}
+		ctxt.Infof("Default credential for cloud %q is not set on this client.", c.cloud)
+		return nil
 	}
 	msg := fmt.Sprintf("Default credential for cloud %q is no longer set on this client.", c.cloud)
 	if c.credential != "" {

--- a/cmd/juju/cloud/defaultcredential_test.go
+++ b/cmd/juju/cloud/defaultcredential_test.go
@@ -26,7 +26,7 @@ var _ = gc.Suite(&defaultCredentialSuite{})
 func (s *defaultCredentialSuite) TestBadArgs(c *gc.C) {
 	cmd := cloud.NewSetDefaultCredentialCommand()
 	_, err := cmdtesting.RunCommand(c, cmd)
-	c.Assert(err, gc.ErrorMatches, `Usage: juju set-default-credential <cloud-name> \[<credential-name>\]`)
+	c.Assert(err, gc.ErrorMatches, `Usage: juju default-credential <cloud-name> \[<credential-name>\]`)
 	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "credential", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
@@ -67,7 +67,7 @@ func (s *defaultCredentialSuite) TestSetDefaultCredentialBuiltIn(c *gc.C) {
 	s.assertSetDefaultCredential(c, "localhost")
 }
 
-func (s *defaultCredentialSuite) TestUnsetDefaultCredential(c *gc.C) {
+func (s *defaultCredentialSuite) TestReadDefaultCredential(c *gc.C) {
 	cloudName := "aws"
 	store := jujuclient.NewMemStore()
 	store.Credentials[cloudName] = jujucloud.CloudCredential{
@@ -75,6 +75,32 @@ func (s *defaultCredentialSuite) TestUnsetDefaultCredential(c *gc.C) {
 	}
 	cmd := cloud.NewSetDefaultCredentialCommandForTest(store)
 	ctx, err := cmdtesting.RunCommand(c, cmd, cloudName)
+	c.Assert(err, jc.ErrorIsNil)
+	output := cmdtesting.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, fmt.Sprintf(`Default credential for cloud %q is "my-sekrets" on this client.`, cloudName))
+}
+
+func (s *defaultCredentialSuite) TestReadDefaultCredentialNoneSet(c *gc.C) {
+	cloudName := "aws"
+	store := jujuclient.NewMemStore()
+	store.Credentials[cloudName] = jujucloud.CloudCredential{}
+	cmd := cloud.NewSetDefaultCredentialCommandForTest(store)
+	ctx, err := cmdtesting.RunCommand(c, cmd, cloudName)
+	c.Assert(err, jc.ErrorIsNil)
+	output := cmdtesting.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, fmt.Sprintf(`Default credential for cloud %q is not set on this client.`, cloudName))
+}
+
+func (s *defaultCredentialSuite) TestResetDefaultCredential(c *gc.C) {
+	cloudName := "aws"
+	store := jujuclient.NewMemStore()
+	store.Credentials[cloudName] = jujucloud.CloudCredential{
+		DefaultCredential: "my-sekrets",
+	}
+	cmd := cloud.NewSetDefaultCredentialCommandForTest(store)
+	ctx, err := cmdtesting.RunCommand(c, cmd, cloudName, "--reset")
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)

--- a/cmd/juju/cloud/defaultregion.go
+++ b/cmd/juju/cloud/defaultregion.go
@@ -53,7 +53,7 @@ func NewSetDefaultRegionCommand() cmd.Command {
 
 // SetFlags initializes the flags supported by the command.
 func (c *setDefaultRegionCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.reset, "reset", false, "Reset default credential for the cloud")
+	f.BoolVar(&c.reset, "reset", false, "Reset default region for the cloud")
 }
 
 func (c *setDefaultRegionCommand) Info() *cmd.Info {

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -95,7 +95,7 @@ Example:
 See also:
     list-credentials
     remove-credential
-    set-default-credential
+    default-credential
     add-credential
 `[1:]
 

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -86,8 +86,8 @@ See also:
     credentials
     controllers
     regions
-    set-default-credential
-    set-default-region
+    default-credential
+    default-region
     show-cloud
     update-clouds
 `

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -81,7 +81,7 @@ See also:
     add-credential
     update-credential
     remove-credential
-    set-default-credential
+    default-credential
     autoload-credentials
     show-credentials
 `

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -33,7 +33,7 @@ Examples:
 See also: 
     credentials
     add-credential
-    set-default-credential
+    default-credential
     autoload-credentials`
 
 // NewremoveCredentialCommand returns a command to remove a named credential for a cloud.

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -451,6 +451,8 @@ var commandNames = []string{
 	"debug-hook",
 	"debug-hooks",
 	"debug-log",
+	"default-credential",
+	"default-region",
 	"deploy",
 	"destroy-controller",
 	"destroy-model",


### PR DESCRIPTION
## Description of change

'set-default-credential' and 'set-default-region' allow user to specify what cloud credential/region they would like Juju to use by default when a confusion is possible, to avoid guessing incorrectly.

Once the defaults were set, there was no means of clearing them unless manually modifying client files. This PR introduces means of 'unsetting' these defaults. The UX follows an established Juju convention - if the argument is not specified, we want the 'unset' functionality of the command rather than 'set', see 'juju config' etc.

## QA steps

1. set/clear default credential
2. set/clear default region

## Bug reference

https://bugs.launchpad.net/juju/+bug/1566583
