### PR TITLE
 Expose mongo for OCI HA controllers

### DIFF
--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -453,6 +453,32 @@ func (e *environSuite) TestControllerInstancesOneController(c *gc.C) {
 	c.Check(len(ids), gc.Equals, 1)
 }
 
+func (e *environSuite) TestCloudInit(c *gc.C) {
+	cfg, err := oci.GetCloudInitConfig(e.env, "quantal", 1234, 4321)
+	c.Assert(err, jc.ErrorIsNil)
+	script, err := cfg.RenderScript()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(script, jc.Contains, "/sbin/iptables -I INPUT -p tcp --dport 1234 -j ACCEPT")
+	c.Check(script, jc.Contains, "/sbin/iptables -I INPUT -p tcp --dport 4321 -j ACCEPT")
+	c.Check(script, jc.Contains, "/etc/init.d/netfilter-persistent save")
+
+	cfg, err = oci.GetCloudInitConfig(e.env, "quantal", 0, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	script, err = cfg.RenderScript()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(script, gc.Not(jc.Contains), "/sbin/iptables -I INPUT -p tcp --dport 1234 -j ACCEPT")
+	c.Check(script, gc.Not(jc.Contains), "/sbin/iptables -I INPUT -p tcp --dport 4321 -j ACCEPT")
+	c.Check(script, gc.Not(jc.Contains), "/etc/init.d/netfilter-persistent save")
+
+	cfg, err = oci.GetCloudInitConfig(e.env, "centos7", 1234, 4321)
+	c.Assert(err, jc.ErrorIsNil)
+	script, err = cfg.RenderScript()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(script, jc.Contains, "firewall-cmd --zone=public --add-port=1234/tcp --permanent")
+	c.Check(script, jc.Contains, "firewall-cmd --zone=public --add-port=4321/tcp --permanent")
+	c.Check(script, jc.Contains, "firewall-cmd --reload")
+}
+
 type instanceTermination struct {
 	instanceId string
 	err        error

--- a/provider/oci/export_test.go
+++ b/provider/oci/export_test.go
@@ -5,6 +5,7 @@ package oci
 
 import (
 	"github.com/juju/clock"
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/provider/common"
 	"github.com/oracle/oci-go-sdk/core"
 )
@@ -37,4 +38,8 @@ func NewInstanceWithConfigurator(
 
 	i.newInstanceConfigurator = factory
 	return i, nil
+}
+
+func GetCloudInitConfig(env *Environ, series string, apiPort int, statePort int) (cloudinit.CloudConfig, error) {
+	return env.getCloudInitConfig(series, apiPort, statePort)
 }


### PR DESCRIPTION
## Description of change

Exposes mongo port so that ha controllers can connect to each other.

NOTE: Follow up work should include supporting OCI network groups so that controller's vnics can be isolated.

## QA steps

Bootstrap and enable-ha should work.
```
juju bootstrap --config compartment-id=... oracle oc
juju enable-ha
juju status -m controller
juju destroy-controller oc --destroy-all-models
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1834972
https://bugs.launchpad.net/juju/+bug/1834974
