### PR TITLE
Fixes lp#1840205: show default region from client store.

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -596,8 +596,8 @@ func (c *AddCAASCommand) validateCloudRegion(ctx *cmd.Context, cloudRegion strin
 				return details.CloudType, nil
 			}
 			if region == "" && details.DefaultRegion != "" {
-				logger.Debugf("cloud region not provided, using client default %q", details.DefaultRegion)
-				return jujucloud.BuildHostCloudRegion(details.CloudType, details.DefaultRegion), nil
+				logger.Debugf("cloud region not provided by user, using client default %q", details.DefaultRegion)
+				region = details.DefaultRegion
 			}
 			for k := range details.RegionsMap {
 				if k == region {

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -157,13 +157,13 @@ type AddCAASCommand struct {
 	cloudMetadataStore    CloudMetadataStore
 	newClientConfigReader func(string) (clientconfig.ClientConfigFunc, error)
 
-	getAllCloudDetails func() (map[string]*jujucmdcloud.CloudDetails, error)
+	getAllCloudDetails func(jujuclient.CredentialGetter) (map[string]*jujucmdcloud.CloudDetails, error)
 }
 
 // NewAddCAASCommand returns a command to add caas information.
 func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
-	cmd := &AddCAASCommand{
+	command := &AddCAASCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
 			Store:       store,
 			EnabledFlag: feature.MultiCloud,
@@ -174,17 +174,17 @@ func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 			return clientconfig.NewClientConfigReader(caasType)
 		},
 	}
-	cmd.addCloudAPIFunc = func() (AddCloudAPI, error) {
-		root, err := cmd.NewAPIRoot(cmd.store, cmd.controllerName, "")
+	command.addCloudAPIFunc = func() (AddCloudAPI, error) {
+		root, err := command.NewAPIRoot(command.store, command.controllerName, "")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return cloudapi.NewClient(root), nil
 	}
 
-	cmd.brokerGetter = cmd.newK8sClusterBroker
-	cmd.getAllCloudDetails = jujucmdcloud.GetAllCloudDetails
-	return modelcmd.WrapBase(cmd)
+	command.brokerGetter = command.newK8sClusterBroker
+	command.getAllCloudDetails = jujucmdcloud.GetAllCloudDetails
+	return modelcmd.WrapBase(command)
 }
 
 // Info returns help information about the command.
@@ -536,7 +536,7 @@ func (c *AddCAASCommand) tryEnsureCloudTypeForHostRegion(cloudOption, regionOpti
 	}
 	logger.Debugf("cloud %q region %q", cloudNameOrType, region)
 
-	clouds, err := c.getAllCloudDetails()
+	clouds, err := c.getAllCloudDetails(c.Store)
 	if err != nil {
 		return "", errors.Annotate(err, "listing cloud regions")
 	}
@@ -576,7 +576,7 @@ func (c *AddCAASCommand) validateCloudRegion(ctx *cmd.Context, cloudRegion strin
 		return cloudRegion, nil
 	}
 
-	clouds, err := c.getAllCloudDetails()
+	clouds, err := c.getAllCloudDetails(c.Store)
 	if err != nil {
 		return "", errors.Annotate(err, "listing cloud regions")
 	}
@@ -594,6 +594,10 @@ func (c *AddCAASCommand) validateCloudRegion(ctx *cmd.Context, cloudRegion strin
 					))
 				}
 				return details.CloudType, nil
+			}
+			if region == "" && details.DefaultRegion != "" {
+				logger.Debugf("cloud region not provided, using client default %q", details.DefaultRegion)
+				return jujucloud.BuildHostCloudRegion(details.CloudType, details.DefaultRegion), nil
 			}
 			for k := range details.RegionsMap {
 				if k == region {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -306,6 +306,19 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists, emptyClientConfig, 
 						"ap-southeast-2": {Name: "ap-southeast-2", Endpoint: "https://ec2.ap-northeast-2.amazonaws.com"},
 					},
 				},
+				"teststack": {
+					Source:           "private",
+					CloudType:        "openstack",
+					CloudDescription: "openstack for this test",
+					AuthTypes:        []string{"jsonfile", "oauth2"},
+					Regions: yaml.MapSlice{
+						{Key: "aregion", Value: map[string]string{"Name": "aregion", "Endpoint": "endpoint"}},
+					},
+					RegionsMap: map[string]jujucmdcloud.RegionDetails{
+						"aregion": {Name: "aregion", Endpoint: "endpoint"},
+					},
+					DefaultRegion: "aregion",
+				},
 				"maas1": {
 					CloudType:        "maas",
 					CloudDescription: "maas Cloud",
@@ -329,38 +342,38 @@ func (s *addCAASSuite) runCommand(c *gc.C, stdin io.Reader, com cmd.Command, arg
 }
 
 func (s *addCAASSuite) TestAddExtraArg(c *gc.C) {
-	cmd := s.makeCommand(c, true, true, true)
-	_, err := s.runCommand(c, nil, cmd, "k8sname", "extra")
+	command := s.makeCommand(c, true, true, true)
+	_, err := s.runCommand(c, nil, command, "k8sname", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *addCAASSuite) TestEmptyKubeConfigFileWithoutStdin(c *gc.C) {
-	cmd := s.makeCommand(c, true, true, true)
-	_, err := s.runCommand(c, nil, cmd, "k8sname")
+	command := s.makeCommand(c, true, true, true)
+	_, err := s.runCommand(c, nil, command, "k8sname")
 	c.Assert(err, gc.ErrorMatches, `No k8s cluster definitions found in config`)
 }
 
 func (s *addCAASSuite) TestAddNameClash(c *gc.C) {
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "mrcloud1")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "mrcloud1")
 	c.Assert(err, gc.ErrorMatches, `"mrcloud1" is the name of a public cloud`)
 }
 
 func (s *addCAASSuite) TestMissingName(c *gc.C) {
-	cmd := s.makeCommand(c, true, true, true)
-	_, err := s.runCommand(c, nil, cmd)
+	command := s.makeCommand(c, true, true, true)
+	_, err := s.runCommand(c, nil, command)
 	c.Assert(err, gc.ErrorMatches, `missing k8s name.`)
 }
 
 func (s *addCAASSuite) TestMissingArgs(c *gc.C) {
-	cmd := s.makeCommand(c, true, true, true)
-	_, err := s.runCommand(c, nil, cmd)
+	command := s.makeCommand(c, true, true, true)
+	_, err := s.runCommand(c, nil, command)
 	c.Assert(err, gc.ErrorMatches, `missing k8s name.`)
 }
 
 func (s *addCAASSuite) TestNonExistClusterName(c *gc.C) {
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "non existing cluster name")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "non existing cluster name")
 	c.Assert(err, gc.ErrorMatches, `context for cluster name "non existing cluster name" not found`)
 }
 
@@ -389,8 +402,8 @@ func (s *addCAASSuite) TestInit(c *gc.C) {
 		},
 	} {
 		args := append([]string{"myk8s"}, ts.args...)
-		cmd := s.makeCommand(c, true, false, true)
-		_, err := s.runCommand(c, nil, cmd, args...)
+		command := s.makeCommand(c, true, false, true)
+		_, err := s.runCommand(c, nil, command, args...)
 		c.Check(err, gc.ErrorMatches, ts.expectedErrStr)
 	}
 }
@@ -435,9 +448,13 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 			expectedErrStr: `validating cloud region "maas/non-existing-region": cloud "maas" does not have a region, but "non-existing-region" provided`,
 		},
 		{
-			title:          "missing region --cloud=ec2",
+			title:          "missing region --cloud=ec2 with no cloud default region",
 			cloud:          "ec2",
 			expectedErrStr: `validating cloud region "ec2": cloud region "ec2" not valid`,
+		},
+		{
+			title: "missing region --cloud=teststack but cloud has default region",
+			cloud: "teststack",
 		},
 		{
 			title:          "cloud option contains region --cloud=gce/us-east1",
@@ -470,7 +487,7 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 	} {
 		c.Logf("%v: %s", i, ts.title)
 		delete(s.initialCloudMap, "myk8s")
-		cmd := s.makeCommand(c, true, false, true)
+		command := s.makeCommand(c, true, false, true)
 		args := []string{
 			"myk8s", "-c", "foo", "--cluster-name", "mrcloud2",
 		}
@@ -480,18 +497,18 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 		if ts.cloud != "" {
 			args = append(args, "--cloud", ts.cloud)
 		}
-		_, err := s.runCommand(c, nil, cmd, args...)
+		_, err := s.runCommand(c, nil, command, args...)
 		if ts.expectedErrStr == "" {
-			c.Check(err, jc.ErrorIsNil)
+			c.Assert(err, jc.ErrorIsNil)
 		} else {
-			c.Check(err, gc.ErrorMatches, ts.expectedErrStr)
+			c.Assert(err, gc.ErrorMatches, ts.expectedErrStr)
 		}
 	}
 }
 
 func (s *addCAASSuite) TestGatherClusterRegionMetaRegionNoMatchesThenIgnored(c *gc.C) {
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cloudMetadataStore.CheckCall(c, 2, "WritePersonalCloudMetadata",
 		map[string]cloud.Cloud{
@@ -604,8 +621,8 @@ func (s *addCAASSuite) TestGatherClusterRegionMetaRegionMatchesAndPassThrough(c 
 	s.fakeCloudAPI.isCloudRegionRequired = true
 	cloudRegion := "gce/us-east1"
 
-	cmd := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
+	command := s.makeCommand(c, true, false, true)
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s".`)
 	s.assertAddCloudResult(c, cloudRegion, "", "operator-sc", false)
@@ -615,8 +632,8 @@ func (s *addCAASSuite) TestGatherClusterMetadataError(c *gc.C) {
 	var result *jujucaas.ClusterMetadata
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, errors.New("oops"))
 
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
 	expectedErr := `
 	Juju needs to query the k8s cluster to ensure that the recommended
 	storage defaults are available and to detect the cluster's cloud/region.
@@ -631,8 +648,8 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRegions(c *gc.C) {
 	var result jujucaas.ClusterMetadata
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(&result, nil)
 
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "mrcloud2")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2")
 	expectedErr := `
 	Juju needs to query the k8s cluster to ensure that the recommended
 	storage defaults are available and to detect the cluster's cloud/region.
@@ -651,8 +668,8 @@ func (s *addCAASSuite) TestGatherClusterMetadataUnknownError(c *gc.C) {
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, nil)
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("foo"))
 
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "mrcloud2")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2")
 	expectedErr := `
 	Juju needs to query the k8s cluster to ensure that the recommended
 	storage defaults are available and to detect the cluster's cloud/region.
@@ -666,8 +683,8 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRecommendedStorageError(c *gc.
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(
 		&jujucaas.NonPreferredStorageError{PreferredStorage: jujucaas.PreferredStorage{Name: "disk"}})
 
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "mrcloud2")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2")
 	expectedErr := `
 	No recommended storage configuration is defined on this cluster.
 	Run add-k8s again with --storage=<name> and Juju will use the
@@ -690,8 +707,8 @@ func (s *addCAASSuite) TestUnknownClusterExistingStorageClass(c *gc.C) {
 		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
-	cmd := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
+	command := s.makeCommand(c, true, false, true)
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
@@ -716,8 +733,8 @@ func (s *addCAASSuite) TestCreateDefaultStorageProvisioner(c *gc.C) {
 		Provisioner: "kubernetes.io/gce-pd",
 	}).Returns(storageProvisioner, nil)
 
-	cmd := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
+	command := s.makeCommand(c, true, false, true)
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
@@ -739,8 +756,8 @@ func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
 		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
-	cmd := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
+	command := s.makeCommand(c, true, false, true)
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
@@ -763,8 +780,8 @@ func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStora
 		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
-	cmd := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--cloud", "maas")
+	command := s.makeCommand(c, true, false, true)
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--cloud", "maas")
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
@@ -776,8 +793,8 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 	s.fakeCloudAPI.isCloudRegionRequired = true
 	cloudRegion := "gce/us-east1"
 
-	cmd := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, cmd, "myk8s", "--cluster-name", "mrcloud2", "--local")
+	command := s.makeCommand(c, true, false, true)
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--local")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `k8s substrate "mrcloud2" added as cloud "myk8s".You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
 	c.Assert(strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1), gc.Equals, expected)
@@ -797,18 +814,18 @@ func mockStdinPipe(content string) (*os.File, error) {
 }
 
 func (s *addCAASSuite) TestCorrectParseFromStdIn(c *gc.C) {
-	cmd := s.makeCommand(c, true, true, false)
+	command := s.makeCommand(c, true, true, false)
 	stdIn, err := mockStdinPipe(kubeConfigStr)
 	defer stdIn.Close()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.runCommand(c, stdIn, cmd, "myk8s", "-c", "foo")
+	_, err = s.runCommand(c, stdIn, command, "myk8s", "-c", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStoreClouds(c, "gce/us-east1")
 }
 
 func (s *addCAASSuite) TestAddGkeCluster(c *gc.C) {
-	cmd := s.makeCommand(c, true, true, false)
-	_, err := s.runCommand(c, nil, cmd, "-c", "foo", "--gke", "myk8s", "--region", "us-east1")
+	command := s.makeCommand(c, true, true, false)
+	_, err := s.runCommand(c, nil, command, "-c", "foo", "--gke", "myk8s", "--region", "us-east1")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStoreClouds(c, "gce/us-east1")
 }
@@ -890,8 +907,8 @@ func (s *addCAASSuite) assertStoreClouds(c *gc.C, hostCloud string) {
 }
 
 func (s *addCAASSuite) TestCorrectUseCurrentContext(c *gc.C) {
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "-c", "foo", "myk8s")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "-c", "foo", "myk8s")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cloudMetadataStore.CheckCall(c, 2, "WritePersonalCloudMetadata",
 		map[string]cloud.Cloud{
@@ -940,8 +957,8 @@ func (s *addCAASSuite) TestCorrectUseCurrentContext(c *gc.C) {
 }
 
 func (s *addCAASSuite) TestCorrectSelectContext(c *gc.C) {
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cloudMetadataStore.CheckCall(c, 2, "WritePersonalCloudMetadata",
 		map[string]cloud.Cloud{
@@ -990,7 +1007,7 @@ func (s *addCAASSuite) TestCorrectSelectContext(c *gc.C) {
 }
 
 func (s *addCAASSuite) TestOnlyOneClusterProvider(c *gc.C) {
-	cmd := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, cmd, "myk8s", "-c", "foo", "--aks", "--gke")
+	command := s.makeCommand(c, true, false, true)
+	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--aks", "--gke")
 	c.Assert(err, gc.ErrorMatches, "only one of '--gke' or '--aks' can be supplied")
 }

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -319,6 +319,19 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists, emptyClientConfig, 
 					},
 					DefaultRegion: "aregion",
 				},
+				"brokenteststack": {
+					Source:           "private",
+					CloudType:        "azure",
+					CloudDescription: "azure for this test",
+					AuthTypes:        []string{"jsonfile", "oauth2"},
+					Regions: yaml.MapSlice{
+						{Key: "aregion", Value: map[string]string{"Name": "aregion", "Endpoint": "endpoint"}},
+					},
+					RegionsMap: map[string]jujucmdcloud.RegionDetails{
+						"aregion": {Name: "aregion", Endpoint: "endpoint"},
+					},
+					DefaultRegion: "notknownregion",
+				},
 				"maas1": {
 					CloudType:        "maas",
 					CloudDescription: "maas Cloud",
@@ -451,6 +464,11 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 			title:          "missing region --cloud=ec2 with no cloud default region",
 			cloud:          "ec2",
 			expectedErrStr: `validating cloud region "ec2": cloud region "ec2" not valid`,
+		},
+		{
+			title:          "missing region --cloud=brokenteststack and cloud's default region is not a cloud region",
+			cloud:          "brokenteststack",
+			expectedErrStr: `validating cloud region "azure": cloud region "azure" not valid`,
 		},
 		{
 			title: "missing region --cloud=teststack but cloud has default region",

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -24,7 +24,7 @@ func NewAddCAASCommandForTest(
 	newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error),
 	getAllCloudDetails func() (map[string]*jujucmdcloud.CloudDetails, error),
 ) cmd.Command {
-	cmd := &AddCAASCommand{
+	command := &AddCAASCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
 		cloudMetadataStore:        cloudMetadataStore,
 		store:                     store,
@@ -32,9 +32,11 @@ func NewAddCAASCommandForTest(
 		brokerGetter:              brokerGetter,
 		k8sCluster:                k8sCluster,
 		newClientConfigReader:     newClientConfigReaderFunc,
-		getAllCloudDetails:        getAllCloudDetails,
+		getAllCloudDetails: func(jujuclient.CredentialGetter) (map[string]*jujucmdcloud.CloudDetails, error) {
+			return getAllCloudDetails()
+		},
 	}
-	return cmd
+	return command
 }
 
 func NewRemoveCAASCommandForTest(
@@ -42,13 +44,13 @@ func NewRemoveCAASCommandForTest(
 	store jujuclient.ClientStore,
 	removeCloudAPIFunc func() (RemoveCloudAPI, error),
 ) cmd.Command {
-	cmd := &RemoveCAASCommand{
+	command := &RemoveCAASCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
 		cloudMetadataStore:        cloudMetadataStore,
 		store:                     store,
 		apiFunc:                   removeCloudAPIFunc,
 	}
-	return cmd
+	return command
 }
 
 type fakeCluster struct {
@@ -82,6 +84,7 @@ func (f *fakeCluster) ensureExecutable() error {
 	return nil
 }
 
+// TODO exported function with unexported type :(
 func FakeCluster(config string) k8sCluster {
 	return &fakeCluster{config: config, cloudType: "gce"}
 }

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -301,7 +301,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	} else {
 		// No cloud file specified so we try and use a named
 		// cloud that already has been added to the local cache.
-		newCloud, err = cloudFromLocal(c.Cloud)
+		newCloud, err = cloudFromLocal(c.Store, c.Cloud)
 	}
 	if err != nil {
 		return errors.Trace(err)
@@ -347,8 +347,8 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	return nil
 }
 
-func cloudFromLocal(cloudName string) (*jujucloud.Cloud, error) {
-	details, err := listCloudDetails()
+func cloudFromLocal(store jujuclient.CredentialGetter, cloudName string) (*jujucloud.Cloud, error) {
+	details, err := listCloudDetails(store)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -149,7 +149,7 @@ func (c *listCloudsCommand) Init(args []string) (err error) {
 
 func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 	if c.controllerName == "" {
-		details, err := listCloudDetails()
+		details, err := listCloudDetails(c.Store)
 
 		if err != nil {
 			return nil, err
@@ -168,7 +168,7 @@ func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 	}
 	details := newCloudList()
 	for _, cloud := range controllerClouds {
-		cloudDetails := makeCloudDetails(cloud)
+		cloudDetails := makeCloudDetails(c.Store, cloud)
 		// TODO: Better categorization than public.
 		details.public[cloud.Name] = cloudDetails
 	}
@@ -180,14 +180,14 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	var output interface{}
+	var result interface{}
 	switch c.out.Name() {
 	case "yaml", "json":
 		clouds := details.all()
 		for _, cloud := range clouds {
 			cloud.CloudType = displayCloudType(cloud.CloudType)
 		}
-		output = clouds
+		result = clouds
 	default:
 		if c.controllerName == "" && !c.Local {
 			ctxt.Infof(
@@ -197,10 +197,10 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 			ctxt.Infof(
 				"Clouds on controller %q:\n\n", c.controllerName)
 		}
-		output = details
+		result = details
 	}
 
-	err = c.out.Write(ctxt, output)
+	err = c.out.Write(ctxt, result)
 	if err != nil {
 		return err
 	}
@@ -239,14 +239,14 @@ func (c *cloudList) all() map[string]*CloudDetails {
 	return result
 }
 
-func listCloudDetails() (*cloudList, error) {
+func listCloudDetails(store jujuclient.CredentialGetter) (*cloudList, error) {
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
 		return nil, err
 	}
 	details := newCloudList()
 	for name, cloud := range clouds {
-		cloudDetails := makeCloudDetails(cloud)
+		cloudDetails := makeCloudDetails(store, cloud)
 		details.public[name] = cloudDetails
 	}
 
@@ -256,7 +256,7 @@ func listCloudDetails() (*cloudList, error) {
 		return nil, errors.Trace(err)
 	}
 	for name, cloud := range builtinClouds {
-		cloudDetails := makeCloudDetails(cloud)
+		cloudDetails := makeCloudDetails(store, cloud)
 		cloudDetails.Source = "built-in"
 		details.builtin[name] = cloudDetails
 	}
@@ -266,7 +266,7 @@ func listCloudDetails() (*cloudList, error) {
 		return nil, err
 	}
 	for name, cloud := range personalClouds {
-		cloudDetails := makeCloudDetails(cloud)
+		cloudDetails := makeCloudDetails(store, cloud)
 		cloudDetails.Source = "local"
 		details.personal[name] = cloudDetails
 		// Delete any built-in or public clouds with same name.
@@ -291,12 +291,12 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 
 	cloudNamesSorted := func(someClouds map[string]*CloudDetails) []string {
 		// For tabular we'll sort alphabetically, user clouds last.
-		var names []string
+		var cloudNames []string
 		for name := range someClouds {
-			names = append(names, name)
+			cloudNames = append(cloudNames, name)
 		}
-		sort.Strings(names)
-		return names
+		sort.Strings(cloudNames)
+		return cloudNames
 	}
 
 	printClouds := func(someClouds map[string]*CloudDetails, color *ansiterm.Context) {
@@ -304,9 +304,11 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 
 		for _, name := range cloudNames {
 			info := someClouds[name]
-			defaultRegion := ""
-			if len(info.Regions) > 0 {
-				defaultRegion = info.RegionsMap[info.Regions[0].Key.(string)].Name
+			defaultRegion := info.DefaultRegion
+			if defaultRegion == "" {
+				if len(info.Regions) > 0 {
+					defaultRegion = info.RegionsMap[info.Regions[0].Key.(string)].Name
+				}
 			}
 			description := info.CloudDescription
 			if len(description) > 40 {

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -24,7 +24,7 @@ import (
 type showSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	api   *fakeShowCloudAPI
-	store jujuclient.ClientStore
+	store *jujuclient.MemStore
 }
 
 var _ = gc.Suite(&showSuite{})
@@ -43,7 +43,7 @@ func (s *showSuite) TestShowBadArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "no cloud specified")
 }
 
-func (s *showSuite) TestShowLocal(c *gc.C) {
+func (s *showSuite) assertShowLocal(c *gc.C, expectedOutput string) {
 	cmd := cloud.NewShowCloudCommandForTest(
 		s.store,
 		func(controllerName string) (cloud.ShowCloudAPI, error) {
@@ -53,11 +53,31 @@ func (s *showSuite) TestShowLocal(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, cmd, "aws-china", "--local")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, `
+	c.Assert(out, gc.Equals, expectedOutput)
+}
+
+func (s *showSuite) TestShowLocal(c *gc.C) {
+	s.assertShowLocal(c, `
 defined: public
 type: ec2
 description: Amazon China
 auth-types: [access-key]
+regions:
+  cn-north-1:
+    endpoint: https://ec2.cn-north-1.amazonaws.com.cn
+  cn-northwest-1:
+    endpoint: https://ec2.cn-northwest-1.amazonaws.com.cn
+`[1:])
+}
+
+func (s *showSuite) TestShowLocalWithDefaultCloud(c *gc.C) {
+	s.store.Credentials["aws-china"] = jujucloud.CloudCredential{DefaultRegion: "cn-north-1"}
+	s.assertShowLocal(c, `
+defined: public
+type: ec2
+description: Amazon China
+auth-types: [access-key]
+default-region: cn-north-1
 regions:
   cn-north-1:
     endpoint: https://ec2.cn-north-1.amazonaws.com.cn

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -178,7 +178,7 @@ func (c *updateCloudCommand) updateControllerFromFile(ctxt *cmd.Context) error {
 }
 
 func (c *updateCloudCommand) updateControllerCacheFromLocalCache(ctxt *cmd.Context) error {
-	newCloud, err := cloudFromLocal(c.Cloud)
+	newCloud, err := cloudFromLocal(c.Store, c.Cloud)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

By default, Juju will pick the first region for the clouds that have more than one region. Users can change that to suit their needs and preferences using 'juju default-region' command. This will be the region used by all commands - bootstrap, add-model, credential validations, etc - that care about region if the user does not explicitly specify a  region using a --region option at CLI.

Whilst Juju was mostly correctly using the default region when user set it, Juju was not correctly reporting it in 'juju clouds', 'juju show-cloud', etc.

This PR fixes this.

As a drive-by some renamed some variables in tests that were colliding with imported packages names.

## QA steps

1. set default region
2. make sure it is shown correctly where needed

## Bug reference

https://bugs.launchpad.net/juju/+bug/1840205
