### PR TITLE
application data bag: Add application data to relations in state

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -2387,11 +2387,24 @@ func (a *Application) UpdateLeaderSettings(token leadership.Token, updates map[s
 	// There's no compelling reason to have these methods on Application -- and
 	// thus require an extra db read to access them -- but it stops the State
 	// type getting even more cluttered.
+	key := leadershipSettingsKey(a.doc.Name)
+	converted := make(map[string]interface{}, len(updates))
+	for k, v := range updates {
+		converted[k] = v
+	}
+	err := updateLeaderSettings(a.st.db(), token, key, converted)
+	if errors.IsNotFound(err) {
+		return errors.NotFoundf("application %q", a.doc.Name)
+	} else if err != nil {
+		return errors.Annotatef(err, "application %q", a.doc.Name)
+	}
+	return nil
+}
 
+func updateLeaderSettings(db Database, token leadership.Token, key string, updates map[string]interface{}) error {
 	// We can calculate the actual update ahead of time; it's not dependent
 	// upon the current state of the document. (*Writing* it should depend
 	// on document state, but that's handled below.)
-	key := leadershipSettingsKey(a.doc.Name)
 	sets := bson.M{}
 	unsets := bson.M{}
 	for unescapedKey, value := range updates {
@@ -2422,11 +2435,9 @@ func (a *Application) UpdateLeaderSettings(token leadership.Token, updates map[s
 		// Read the current document state so we can abort if there's
 		// no actual change; and the version number so we can assert
 		// on it and prevent these settings from landing late.
-		doc, err := readSettingsDoc(a.st.db(), settingsC, key)
-		if errors.IsNotFound(err) {
-			return nil, errors.NotFoundf("application %q", a.doc.Name)
-		} else if err != nil {
-			return nil, errors.Annotatef(err, "application %q", a.doc.Name)
+		doc, err := readSettingsDoc(db, settingsC, key)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 		if isNullChange(doc.Settings) {
 			return nil, jujutxn.ErrNoOperations
@@ -2438,7 +2449,7 @@ func (a *Application) UpdateLeaderSettings(token leadership.Token, updates map[s
 			Update: update,
 		}}, nil
 	}
-	return a.st.db().Run(buildTxnWithLeadership(buildTxn, token))
+	return db.Run(buildTxnWithLeadership(buildTxn, token))
 }
 
 var ErrSubordinateConstraints = stderrors.New("constraints do not apply to subordinate applications")

--- a/state/application_leader_test.go
+++ b/state/application_leader_test.go
@@ -220,12 +220,15 @@ func (s *ApplicationLeaderSuite) destroyApplication(c *gc.C) {
 }
 
 // fakeToken implements leadership.Token.
-type fakeToken struct{}
+type fakeToken struct {
+	err error
+}
 
-// Check is part of the leadership.Token interface. It always claims success,
-// and never checks or writes the userdata.
-func (*fakeToken) Check(int, interface{}) error {
-	return nil
+// Check is part of the leadership.Token interface. It returns its
+// contained error (which defaults to nil), and never checks or writes
+// the userdata.
+func (t *fakeToken) Check(int, interface{}) error {
+	return t.err
 }
 
 // failToken implements leadership.Token.

--- a/state/application_leader_test.go
+++ b/state/application_leader_test.go
@@ -100,12 +100,12 @@ func (s *ApplicationLeaderSuite) TestTxnRevnoChange(c *gc.C) {
 
 func (s *ApplicationLeaderSuite) TestTokenError(c *gc.C) {
 	err := s.application.UpdateLeaderSettings(&failToken{}, map[string]string{"blah": "blah"})
-	c.Check(err, gc.ErrorMatches, "prerequisites failed: something bad happened")
+	c.Check(err, gc.ErrorMatches, `application "mysql": prerequisites failed: something bad happened`)
 }
 
 func (s *ApplicationLeaderSuite) TestTokenAssertFailure(c *gc.C) {
 	err := s.application.UpdateLeaderSettings(&raceToken{}, map[string]string{"blah": "blah"})
-	c.Check(err, gc.ErrorMatches, "prerequisites failed: too late")
+	c.Check(err, gc.ErrorMatches, `application "mysql": prerequisites failed: too late`)
 }
 
 func (s *ApplicationLeaderSuite) TestReadWriteDying(c *gc.C) {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1073,6 +1073,15 @@ func (e *exporter) relations() error {
 				Limit:           ep.Limit,
 				Scope:           string(ep.Scope),
 			})
+
+			key := relationApplicationSettingsKey(relation.Id(), ep)
+			appSettingsDoc, found := e.modelSettings[key]
+			if !found && !e.cfg.SkipSettings && !e.cfg.SkipRelationData {
+				return errors.Errorf("missing application settings for %q application %q", relation, ep.ApplicationName)
+			}
+			delete(e.modelSettings, key)
+			exEndPoint.SetApplicationSettings(appSettingsDoc.Settings)
+
 			// We expect a relationScope and settings for each of the
 			// units of the specified application, unless it is a
 			// remote application.

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1074,7 +1074,7 @@ func (e *exporter) relations() error {
 				Scope:           string(ep.Scope),
 			})
 
-			key := relationApplicationSettingsKey(relation.Id(), ep)
+			key := relationApplicationSettingsKey(relation.Id(), ep.ApplicationName)
 			appSettingsDoc, found := e.modelSettings[key]
 			if !found && !e.cfg.SkipSettings && !e.cfg.SkipRelationData {
 				return errors.Errorf("missing application settings for %q application %q", relation, ep.ApplicationName)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -860,6 +860,18 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 	err = ru.EnterScope(mysqlSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
+	wordpressAppSettings := map[string]interface{}{
+		"war": "worlds",
+	}
+	err = rel.UpdateApplicationSettings(wordpress, &fakeToken{}, wordpressAppSettings)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mysqlAppSettings := map[string]interface{}{
+		"million": "one",
+	}
+	err = rel.UpdateApplicationSettings(mysql, &fakeToken{}, mysqlAppSettings)
+	c.Assert(err, jc.ErrorIsNil)
+
 	model, err := s.State.Export()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -877,21 +889,22 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 		exEndpoint description.Endpoint,
 		unitName string,
 		ep state.Endpoint,
-		settings map[string]interface{},
+		settings, appSettings map[string]interface{},
 	) {
 		c.Logf("%#v", exEndpoint)
 		c.Check(exEndpoint.ApplicationName(), gc.Equals, ep.ApplicationName)
 		c.Check(exEndpoint.Name(), gc.Equals, ep.Name)
 		c.Check(exEndpoint.UnitCount(), gc.Equals, 1)
 		c.Check(exEndpoint.Settings(unitName), jc.DeepEquals, settings)
+		c.Check(exEndpoint.ApplicationSettings(), jc.DeepEquals, appSettings)
 		c.Check(exEndpoint.Role(), gc.Equals, string(ep.Role))
 		c.Check(exEndpoint.Interface(), gc.Equals, ep.Interface)
 		c.Check(exEndpoint.Optional(), gc.Equals, ep.Optional)
 		c.Check(exEndpoint.Limit(), gc.Equals, ep.Limit)
 		c.Check(exEndpoint.Scope(), gc.Equals, string(ep.Scope))
 	}
-	checkEndpoint(exEps[0], mysql_0.Name(), msEp, mysqlSettings)
-	checkEndpoint(exEps[1], wordpress_0.Name(), wpEp, wordpressSettings)
+	checkEndpoint(exEps[0], mysql_0.Name(), msEp, mysqlSettings, mysqlAppSettings)
+	checkEndpoint(exEps[1], wordpress_0.Name(), wpEp, wordpressSettings, wordpressAppSettings)
 
 	// Make sure there is a status.
 	status := exRel.Status()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1191,13 +1191,7 @@ func (i *importer) relation(rel description.Relation) error {
 	// unit of the application, and an op that adds the relation settings
 	// for each unit.
 	for _, endpoint := range rel.Endpoints() {
-		importedEp, err := dbRelation.Endpoint(endpoint.ApplicationName())
-		if err != nil {
-			// This should never happen - we just created endpoints
-			// from the import data.
-			return errors.Trace(err)
-		}
-		appKey := relationApplicationSettingsKey(dbRelation.Id(), importedEp)
+		appKey := relationApplicationSettingsKey(dbRelation.Id(), endpoint.ApplicationName())
 		appSettings := endpoint.ApplicationSettings()
 		ops = append(ops, createSettingsOp(settingsC, appKey, appSettings))
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1191,6 +1191,16 @@ func (i *importer) relation(rel description.Relation) error {
 	// unit of the application, and an op that adds the relation settings
 	// for each unit.
 	for _, endpoint := range rel.Endpoints() {
+		importedEp, err := dbRelation.Endpoint(endpoint.ApplicationName())
+		if err != nil {
+			// This should never happen - we just created endpoints
+			// from the import data.
+			return errors.Trace(err)
+		}
+		appKey := relationApplicationSettingsKey(dbRelation.Id(), importedEp)
+		appSettings := endpoint.ApplicationSettings()
+		ops = append(ops, createSettingsOp(settingsC, appKey, appSettings))
+
 		units := i.applicationUnits[endpoint.ApplicationName()]
 		for unitName, settings := range endpoint.AllSettings() {
 			unit, ok := units[unitName]

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2094,6 +2094,48 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 	c.Assert(imported.Type(), gc.Equals, state.ModelTypeIAAS)
 }
 
+func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C) {
+	wordpress := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	mysql := state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
+	eps, err := s.State.InferEndpoints("mysql", "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	wordpressSettings := map[string]interface{}{
+		"venusian": "superbug",
+	}
+	err = rel.UpdateApplicationSettings(wordpress, &fakeToken{}, wordpressSettings)
+	c.Assert(err, jc.ErrorIsNil)
+	mysqlSettings := map[string]interface{}{
+		"planet b": "perihelion",
+	}
+	err = rel.UpdateApplicationSettings(mysql, &fakeToken{}, mysqlSettings)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, newSt := s.importModel(c, s.State)
+
+	newWordpress, err := newSt.Application("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(state.RelationCount(newWordpress), gc.Equals, 1)
+	rels, err := newWordpress.Relations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rels, gc.HasLen, 1)
+
+	newRel := rels[0]
+
+	newWpSettings, err := newRel.ApplicationSettings(newWordpress)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newWpSettings, gc.DeepEquals, wordpressSettings)
+
+	newMysql, err := newSt.Application("mysql")
+	c.Assert(err, jc.ErrorIsNil)
+
+	newMysqlSettings, err := newRel.ApplicationSettings(newMysql)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newMysqlSettings, gc.DeepEquals, mysqlSettings)
+}
+
 // newModel replaces the uuid and name of the config attributes so we
 // can use all the other data to validate imports. An owner and name of the
 // model are unique together in a controller.

--- a/state/relation.go
+++ b/state/relation.go
@@ -782,8 +782,8 @@ func (change relationSettingsCleanupChange) Prepare(db Database) ([]txn.Op, erro
 
 }
 
-func relationApplicationSettingsKey(id int, ep Endpoint) string {
-	return fmt.Sprintf("%s#%s#%s", relationGlobalScope(id), ep.Role, ep.ApplicationName)
+func relationApplicationSettingsKey(id int, application string) string {
+	return fmt.Sprintf("%s#%s", relationGlobalScope(id), application)
 }
 
 // ApplicationSettings returns the application-level settings for the
@@ -793,7 +793,7 @@ func (r *Relation) ApplicationSettings(app *Application) (map[string]interface{}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	applicationKey := relationApplicationSettingsKey(r.Id(), ep)
+	applicationKey := relationApplicationSettingsKey(r.Id(), ep.ApplicationName)
 	s, err := readSettings(r.st.db(), settingsC, applicationKey)
 	if err != nil {
 		return nil, errors.Annotatef(err, "relation %q application %q", r.String(), app.Name())
@@ -811,7 +811,7 @@ func (r *Relation) UpdateApplicationSettings(app *Application, token leadership.
 	if err != nil {
 		return errors.Trace(err)
 	}
-	key := relationApplicationSettingsKey(r.Id(), ep)
+	key := relationApplicationSettingsKey(r.Id(), ep.ApplicationName)
 	err = updateLeaderSettings(r.st.db(), token, key, updates)
 	if errors.IsNotFound(err) {
 		return errors.NotFoundf("relation %q application %q", r, app.Name())
@@ -828,7 +828,7 @@ func (r *Relation) WatchApplicationSettings(app *Application) (NotifyWatcher, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	key := relationApplicationSettingsKey(r.Id(), ep)
+	key := relationApplicationSettingsKey(r.Id(), ep.ApplicationName)
 	watcher := newEntityWatcher(r.st, settingsC, r.st.docID(key))
 	return watcher, nil
 }

--- a/state/relation.go
+++ b/state/relation.go
@@ -780,3 +780,22 @@ func (change relationSettingsCleanupChange) Prepare(db Database) ([]txn.Op, erro
 	return ops, nil
 
 }
+
+func relationApplicationSettingsKey(id int, ep Endpoint) string {
+	return fmt.Sprintf("%s#%s#%s", relationGlobalScope(id), ep.Role, ep.ApplicationName)
+}
+
+// ApplicationSettings returns the application-level settings for the
+// specified application in this relation.
+func (r *Relation) ApplicationSettings(app *Application) (map[string]interface{}, error) {
+	ep, err := r.Endpoint(app.Name())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	applicationKey := relationApplicationSettingsKey(r.Id(), ep)
+	s, err := readSettings(r.st.db(), settingsC, applicationKey)
+	if err != nil {
+		return nil, errors.Annotatef(err, "relation %q application %q", r.String(), app.Name())
+	}
+	return s.Map(), nil
+}

--- a/state/relation.go
+++ b/state/relation.go
@@ -820,3 +820,15 @@ func (r *Relation) UpdateApplicationSettings(app *Application, token leadership.
 	}
 	return nil
 }
+
+// WatchApplicationSettings returns a notify watcher that will signal
+// whenever the specified application's relation settings are changed.
+func (r *Relation) WatchApplicationSettings(app *Application) (NotifyWatcher, error) {
+	ep, err := r.Endpoint(app.Name())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	key := relationApplicationSettingsKey(r.Id(), ep)
+	watcher := newEntityWatcher(r.st, settingsC, r.st.docID(key))
+	return watcher, nil
+}

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -804,7 +804,7 @@ func (s *RelationSuite) TestApplicationSettings(c *gc.C) {
 	c.Assert(settingsMap, gc.HasLen, 0)
 
 	settings := state.NewStateSettings(s.State)
-	key := fmt.Sprintf("r#%d#provider#mysql", relation.Id())
+	key := fmt.Sprintf("r#%d#mysql", relation.Id())
 	err = settings.ReplaceSettings(key, map[string]interface{}{
 		"bailterspace": "blammo",
 	})
@@ -825,7 +825,7 @@ func (s *RelationSuite) TestApplicationSettingsPeer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	settings := state.NewStateSettings(s.State)
-	key := fmt.Sprintf("r#%d#peer#riak", rel.Id())
+	key := fmt.Sprintf("r#%d#riak", rel.Id())
 	err = settings.ReplaceSettings(key, map[string]interface{}{
 		"mermaidens": "disappear",
 	})

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -906,7 +906,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsNotLeader(c *gc.C) {
 			"rendezvouse": "rendezvous",
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, "prerequisites failed: not the leader")
+	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: not the leader`)
 
 	settingsMap, err := relation.ApplicationSettings(mysql)
 	c.Assert(err, jc.ErrorIsNil)
@@ -932,7 +932,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
 			"rendezvouse": "rendezvous",
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, "prerequisites failed: too late")
+	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: too late`)
 
 	c.Assert(token.checkedOnce, gc.Equals, true)
 	settingsMap, err := relation.ApplicationSettings(mysql)

--- a/state/state.go
+++ b/state/state.go
@@ -1113,7 +1113,11 @@ func (st *State) addPeerRelationsOps(applicationname string, peers map[string]ch
 				Insert: relDoc,
 			},
 			createStatusOp(st, relationGlobalScope(relId), relationStatusDoc),
-			createSettingsOp(settingsC, relationApplicationSettingsKey(relId, eps[0]), nil),
+			createSettingsOp(
+				settingsC,
+				relationApplicationSettingsKey(relId, eps[0].ApplicationName),
+				map[string]interface{}{},
+			),
 		)
 	}
 	return ops, nil
@@ -2171,8 +2175,8 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 		}, createStatusOp(st, relationGlobalScope(id), relationStatusDoc))
 
 		for _, ep := range eps {
-			key := relationApplicationSettingsKey(id, ep)
-			settingsOp := createSettingsOp(settingsC, key, nil)
+			key := relationApplicationSettingsKey(id, ep.ApplicationName)
+			settingsOp := createSettingsOp(settingsC, key, map[string]interface{}{})
 			ops = append(ops, settingsOp)
 		}
 		return ops, nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4808,3 +4808,36 @@ func (s *StateSuite) TestControllerTimestamp(c *gc.C) {
 
 	c.Assert(*got, jc.DeepEquals, now)
 }
+
+func (s *StateSuite) TestAddRelationCreatesApplicationSettings(c *gc.C) {
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	eps, err := s.State.InferEndpoints("wordpress", "mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	settings := state.NewStateSettings(s.State)
+
+	mysqlKey := fmt.Sprintf("r#%d#provider#mysql", rel.Id())
+	_, err = settings.ReadSettings(mysqlKey)
+	c.Assert(err, jc.ErrorIsNil)
+
+	wpKey := fmt.Sprintf("r#%d#requirer#wordpress", rel.Id())
+	_, err = settings.ReadSettings(wpKey)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *StateSuite) TestPeerRelationCreatesApplicationSettings(c *gc.C) {
+	app := state.AddTestingApplication(c, s.State, "riak", state.AddTestingCharm(c, s.State, "riak"))
+	ep, err := app.Endpoint("ring")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.EndpointsRelation(ep)
+	c.Assert(err, jc.ErrorIsNil)
+
+	settings := state.NewStateSettings(s.State)
+
+	key := fmt.Sprintf("r#%d#peer#riak", rel.Id())
+	_, err = settings.ReadSettings(key)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4819,11 +4819,11 @@ func (s *StateSuite) TestAddRelationCreatesApplicationSettings(c *gc.C) {
 
 	settings := state.NewStateSettings(s.State)
 
-	mysqlKey := fmt.Sprintf("r#%d#provider#mysql", rel.Id())
+	mysqlKey := fmt.Sprintf("r#%d#mysql", rel.Id())
 	_, err = settings.ReadSettings(mysqlKey)
 	c.Assert(err, jc.ErrorIsNil)
 
-	wpKey := fmt.Sprintf("r#%d#requirer#wordpress", rel.Id())
+	wpKey := fmt.Sprintf("r#%d#wordpress", rel.Id())
 	_, err = settings.ReadSettings(wpKey)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -4837,7 +4837,7 @@ func (s *StateSuite) TestPeerRelationCreatesApplicationSettings(c *gc.C) {
 
 	settings := state.NewStateSettings(s.State)
 
-	key := fmt.Sprintf("r#%d#peer#riak", rel.Id())
+	key := fmt.Sprintf("r#%d#riak", rel.Id())
 	_, err = settings.ReadSettings(key)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2573,16 +2573,13 @@ func EnsureRelationApplicationSettings(pool *StatePool) error {
 
 		var ops []txn.Op
 		for _, rel := range relations {
-			if rel.Life() != Alive {
-				continue
-			}
 			for _, ep := range rel.Endpoints() {
-				key := relationApplicationSettingsKey(rel.Id(), ep)
+				key := relationApplicationSettingsKey(rel.Id(), ep.ApplicationName)
 				id := st.docID(key)
 				if allSettings.Contains(id) {
 					continue
 				}
-				ops = append(ops, createSettingsOp(settingsC, key, nil))
+				ops = append(ops, createSettingsOp(settingsC, key, map[string]interface{}{}))
 			}
 		}
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -331,13 +331,28 @@ func (s *upgradesSuite) TestStripLocalUserDomainLastConnection(c *gc.C) {
 }
 
 func (s *upgradesSuite) assertStrippedUserData(c *gc.C, coll *mgo.Collection, expected []bson.M) {
-	s.assertUpgradedData(c, StripLocalUserDomain, expectUpgradedData{coll, expected, nil})
+	s.assertUpgradedData(c, StripLocalUserDomain, upgradedData(coll, expected))
 }
 
 type expectUpgradedData struct {
 	coll     *mgo.Collection
 	expected []bson.M
 	filter   bson.D
+}
+
+func upgradedData(coll *mgo.Collection, expected []bson.M) expectUpgradedData {
+	return expectUpgradedData{
+		coll:     coll,
+		expected: expected,
+	}
+}
+
+func upgradedDataWithFilter(coll *mgo.Collection, expected []bson.M, filter bson.D) expectUpgradedData {
+	return expectUpgradedData{
+		coll:     coll,
+		expected: expected,
+		filter:   filter,
+	}
 }
 
 func (s *upgradesSuite) assertUpgradedData(c *gc.C, upgrade func(*StatePool) error, expect ...expectUpgradedData) {
@@ -407,7 +422,7 @@ func (s *upgradesSuite) TestRenameAddModelPermission(c *gc.C) {
 		"subject-global-key": "mary@external",
 		"access":             "add-model",
 	}}
-	s.assertUpgradedData(c, RenameAddModelPermission, expectUpgradedData{coll, expected, nil})
+	s.assertUpgradedData(c, RenameAddModelPermission, upgradedData(coll, expected))
 }
 
 func (s *upgradesSuite) TestAddMigrationAttempt(c *gc.C) {
@@ -438,7 +453,7 @@ func (s *upgradesSuite) TestAddMigrationAttempt(c *gc.C) {
 			"attempt": 2,
 		},
 	}
-	s.assertUpgradedData(c, AddMigrationAttempt, expectUpgradedData{coll, expected, nil})
+	s.assertUpgradedData(c, AddMigrationAttempt, upgradedData(coll, expected))
 }
 
 func (s *upgradesSuite) TestAddLocalCharmSequences(c *gc.C) {
@@ -492,7 +507,7 @@ func (s *upgradesSuite) TestAddLocalCharmSequences(c *gc.C) {
 	}
 	s.assertUpgradedData(
 		c, AddLocalCharmSequences,
-		expectUpgradedData{sequences, expected, nil},
+		upgradedData(sequences, expected),
 	)
 
 	// Expect Dead charm documents to be removed.
@@ -585,8 +600,8 @@ func (s *upgradesSuite) TestUpdateLegacyLXDCloud(c *gc.C) {
 		return UpdateLegacyLXDCloudCredentials(st, "foo", newCred)
 	}
 	s.assertUpgradedData(c, f,
-		expectUpgradedData{cloudColl, expectedClouds, nil},
-		expectUpgradedData{cloudCredColl, expectedCloudCreds, nil},
+		upgradedData(cloudColl, expectedClouds),
+		upgradedData(cloudCredColl, expectedCloudCreds),
 	)
 }
 
@@ -688,8 +703,8 @@ func (s *upgradesSuite) TestUpdateLegacyLXDCloudUnchanged(c *gc.C) {
 		return UpdateLegacyLXDCloudCredentials(st, "foo", newCred)
 	}
 	s.assertUpgradedData(c, f,
-		expectUpgradedData{cloudColl, expectedClouds, nil},
-		expectUpgradedData{cloudCredColl, expectedCloudCreds, nil},
+		upgradedData(cloudColl, expectedClouds),
+		upgradedData(cloudCredColl, expectedCloudCreds),
 	)
 }
 
@@ -731,7 +746,7 @@ func (s *upgradesSuite) TestUpgradeNoProxy(c *gc.C) {
 		}}
 
 	s.assertUpgradedData(c, UpgradeNoProxyDefaults,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -880,8 +895,8 @@ func (s *upgradesSuite) TestAddNonDetachableStorageMachineId(c *gc.C) {
 	}}
 
 	s.assertUpgradedData(c, AddNonDetachableStorageMachineId,
-		expectUpgradedData{volumesColl, expectedVolumes, nil},
-		expectUpgradedData{filesystemsColl, expectedFilesystems, nil},
+		upgradedData(volumesColl, expectedVolumes),
+		upgradedData(filesystemsColl, expectedFilesystems),
 	)
 }
 
@@ -938,7 +953,7 @@ func (s *upgradesSuite) TestRemoveNilValueApplicationSettings(c *gc.C) {
 		}}
 
 	s.assertUpgradedData(c, RemoveNilValueApplicationSettings,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -976,7 +991,7 @@ func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettingsKeepExisting(
 	}
 
 	s.assertUpgradedData(c, AddControllerLogCollectionsSizeSettings,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -1009,7 +1024,7 @@ func (s *upgradesSuite) TestAddControllerLogCollectionsSizeSettings(c *gc.C) {
 	}
 
 	s.assertUpgradedData(c, AddControllerLogCollectionsSizeSettings,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -1103,7 +1118,7 @@ func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
 	sort.Sort(expectedSettings)
 
 	s.assertUpgradedData(c, AddUpdateStatusHookSettings,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -1325,7 +1340,7 @@ func (s *upgradesSuite) TestAddStorageInstanceConstraints(c *gc.C) {
 	}}
 
 	s.assertUpgradedData(c, AddStorageInstanceConstraints,
-		expectUpgradedData{storageInstancesColl, expectedStorageInstances, nil},
+		upgradedData(storageInstancesColl, expectedStorageInstances),
 	)
 }
 
@@ -1774,8 +1789,8 @@ func (s *upgradesSuite) TestCorrectRelationUnitCounts(c *gc.C) {
 		"departing":  false,
 	}}
 	s.assertUpgradedData(c, CorrectRelationUnitCounts,
-		expectUpgradedData{relations, expectedRelations, nil},
-		expectUpgradedData{scopes, expectedScopes, nil},
+		upgradedData(relations, expectedRelations),
+		upgradedData(scopes, expectedScopes),
 	)
 }
 
@@ -1802,7 +1817,7 @@ func (s *upgradesSuite) TestAddModelEnvironVersion(c *gc.C) {
 		"environ-version": 1,
 	}}
 	s.assertUpgradedData(c, AddModelEnvironVersion,
-		expectUpgradedData{models, expectedModels, nil},
+		upgradedData(models, expectedModels),
 	)
 }
 
@@ -1830,7 +1845,7 @@ func (s *upgradesSuite) TestAddModelType(c *gc.C) {
 		"type": "caas",
 	}}
 	s.assertUpgradedData(c, AddModelType,
-		expectUpgradedData{models, expectedModels, nil})
+		upgradedData(models, expectedModels))
 }
 
 func (s *upgradesSuite) checkAddPruneSettings(c *gc.C, ageProp, sizeProp, defaultAge, defaultSize string, updateFunc func(pool *StatePool) error) {
@@ -1888,7 +1903,7 @@ func (s *upgradesSuite) checkAddPruneSettings(c *gc.C, ageProp, sizeProp, defaul
 	sort.Sort(expectedSettings)
 
 	s.assertUpgradedData(c, updateFunc,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -1939,7 +1954,7 @@ func (s *upgradesSuite) TestMigrateLeasesToGlobalTime(c *gc.C) {
 		"writer":     "ghost",
 	}}
 	s.assertUpgradedData(c, MigrateLeasesToGlobalTime,
-		expectUpgradedData{leases, expectedLeases, nil},
+		upgradedData(leases, expectedLeases),
 	)
 }
 
@@ -1980,9 +1995,7 @@ func (s *upgradesSuite) TestMoveOldAuditLogRename(c *gc.C) {
 	}
 	err := auditLog.Insert(data[0], data[1])
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUpgradedData(c, MoveOldAuditLog,
-		expectUpgradedData{oldLog, data, nil},
-	)
+	s.assertUpgradedData(c, MoveOldAuditLog, upgradedData(oldLog, data))
 
 	db := s.state.MongoSession().DB("juju")
 	cols, err := db.CollectionNames()
@@ -2069,7 +2082,7 @@ func (s *upgradesSuite) TestMigrateLeasesToGlobalTimeWithNewTarget(c *gc.C) {
 		"writer":     "gobble",
 	}}
 	s.assertUpgradedData(c, MigrateLeasesToGlobalTime,
-		expectUpgradedData{leases, expectedLeases, nil},
+		upgradedData(leases, expectedLeases),
 	)
 }
 
@@ -2141,7 +2154,7 @@ func (s *upgradesSuite) TestAddRelationStatus(c *gc.C) {
 	}}
 
 	s.assertUpgradedData(c, AddRelationStatus,
-		expectUpgradedData{statuses, expectedStatuses, nil},
+		upgradedData(statuses, expectedStatuses),
 	)
 }
 
@@ -2186,7 +2199,7 @@ func (s *upgradesSuite) TestDeleteCloudImageMetadata(c *gc.C) {
 
 	coll, closer := s.state.db().GetRawCollection(cloudimagemetadataC)
 	defer closer()
-	s.assertUpgradedData(c, DeleteCloudImageMetadata, expectUpgradedData{coll, expected, nil})
+	s.assertUpgradedData(c, DeleteCloudImageMetadata, upgradedData(coll, expected))
 }
 
 func (s *upgradesSuite) TestCopyMongoSpaceToHASpaceConfigWhenValid(c *gc.C) {
@@ -2342,7 +2355,7 @@ func (s *upgradesSuite) TestCreateMissingApplicationConfig(c *gc.C) {
 	})
 
 	s.assertUpgradedData(c, CreateMissingApplicationConfig,
-		expectUpgradedData{settingsColl, expected, nil})
+		upgradedData(settingsColl, expected))
 }
 
 func (s *upgradesSuite) TestRemoveVotingMachineIds(c *gc.C) {
@@ -2364,7 +2377,7 @@ func (s *upgradesSuite) TestRemoveVotingMachineIds(c *gc.C) {
 		}
 		delete(doc, "votingmachineids")
 	}
-	s.assertUpgradedData(c, RemoveVotingMachineIds, expectUpgradedData{coll: controllerColl, expected: expectedDocs, filter: nil})
+	s.assertUpgradedData(c, RemoveVotingMachineIds, upgradedData(controllerColl, expectedDocs))
 }
 
 func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
@@ -2442,7 +2455,7 @@ func (s *upgradesSuite) TestUpgradeContainerImageStreamDefault(c *gc.C) {
 	c.Assert(iter.Close(), jc.ErrorIsNil)
 
 	s.assertUpgradedData(c, UpgradeContainerImageStreamDefault,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -2532,7 +2545,7 @@ func (s *upgradesSuite) TestRemoveContainerImageStreamFromNonModelSettings(c *gc
 	// because Settings documents have a ton of keys and nested sub documents.
 	// But it is a more accurate depiction of what is in that table.
 	s.assertUpgradedData(c, RemoveContainerImageStreamFromNonModelSettings,
-		expectUpgradedData{settingsColl, expectedSettings, nil},
+		upgradedData(settingsColl, expectedSettings),
 	)
 }
 
@@ -2583,7 +2596,7 @@ func (s *upgradesSuite) TestAddCloudModelCounts(c *gc.C) {
 		"_id":      "cloudModel#dummy",
 		"refcount": 1, // unchanged
 	}}
-	s.assertUpgradedData(c, AddCloudModelCounts, expectUpgradedData{refCountColl, expected, nil})
+	s.assertUpgradedData(c, AddCloudModelCounts, upgradedData(refCountColl, expected))
 }
 
 func (s *upgradesSuite) TestMigrateStorageMachineIdFields(c *gc.C) {
@@ -2713,10 +2726,10 @@ func (s *upgradesSuite) TestMigrateStorageMachineIdFields(c *gc.C) {
 	}}
 
 	s.assertUpgradedData(c, MigrateStorageMachineIdFields,
-		expectUpgradedData{volumesColl, expectedVolumes, nil},
-		expectUpgradedData{filesystemsColl, expectedFilesystems, nil},
-		expectUpgradedData{volumeAttachmentsColl, expectedVolumeAttachments, nil},
-		expectUpgradedData{filesystemAttachmentsColl, expectedFilesystemAttachments, nil},
+		upgradedData(volumesColl, expectedVolumes),
+		upgradedData(filesystemsColl, expectedFilesystems),
+		upgradedData(volumeAttachmentsColl, expectedVolumeAttachments),
+		upgradedData(filesystemAttachmentsColl, expectedFilesystemAttachments),
 	)
 }
 
@@ -2830,7 +2843,7 @@ func (s *upgradesSuite) TestMigrateAddModelPermissions(c *gc.C) {
 		"access":             "login",
 	}}
 	sort.Sort(expected)
-	s.assertUpgradedData(c, MigrateAddModelPermissions, expectUpgradedData{permissionsColl, expected, nil})
+	s.assertUpgradedData(c, MigrateAddModelPermissions, upgradedData(permissionsColl, expected))
 }
 
 func (s *upgradesSuite) TestSetEnableDiskUUIDOnVsphere(c *gc.C) {
@@ -2899,7 +2912,7 @@ func (s *upgradesSuite) TestSetEnableDiskUUIDOnVsphere(c *gc.C) {
 
 	c.Logf(pretty.Sprint(expectedSettings))
 	s.assertUpgradedData(c, SetEnableDiskUUIDOnVsphere,
-		expectUpgradedData{coll, expectedSettings, nil},
+		upgradedData(coll, expectedSettings),
 	)
 }
 
@@ -2925,7 +2938,7 @@ func (s *upgradesSuite) TestUpdateInheritedControllerConfig(c *gc.C) {
 
 	c.Logf(pretty.Sprint(expectedSettings))
 	s.assertUpgradedData(c, UpdateInheritedControllerConfig,
-		expectUpgradedData{coll, expectedSettings, nil},
+		upgradedData(coll, expectedSettings),
 	)
 }
 
@@ -3070,7 +3083,7 @@ func (s *upgradesSuite) TestEnsureDefaultModificationStatus(c *gc.C) {
 	sort.Sort(expected)
 	c.Log(pretty.Sprint(expected))
 	s.assertUpgradedData(c, EnsureDefaultModificationStatus,
-		expectUpgradedData{coll, expected, bson.D{{"_id", bson.RegEx{"#modification$", ""}}}},
+		upgradedDataWithFilter(coll, expected, bson.D{{"_id", bson.RegEx{"#modification$", ""}}}),
 	)
 }
 
@@ -3115,7 +3128,7 @@ func (s *upgradesSuite) TestEnsureApplicationDeviceConstraints(c *gc.C) {
 	sort.Sort(expected)
 	c.Log(pretty.Sprint(expected))
 	s.assertUpgradedData(c, EnsureApplicationDeviceConstraints,
-		expectUpgradedData{coll, expected, bson.D{{"_id", bson.RegEx{Pattern: ":adc#"}}}},
+		upgradedDataWithFilter(coll, expected, bson.D{{"_id", bson.RegEx{Pattern: ":adc#"}}}),
 	)
 }
 
@@ -3201,7 +3214,7 @@ func (s *upgradesSuite) TestUpdateK8sModelNameIndex(c *gc.C) {
 
 	sort.Sort(expected)
 	s.assertUpgradedData(c, UpdateK8sModelNameIndex,
-		expectUpgradedData{modelNameColl, expected, nil},
+		upgradedData(modelNameColl, expected),
 	)
 }
 
@@ -3235,7 +3248,7 @@ func (s *upgradesSuite) TestAddModelLogsSize(c *gc.C) {
 		},
 	}
 
-	s.assertUpgradedData(c, AddModelLogsSize, expectUpgradedData{settingsColl, expectedSettings, nil})
+	s.assertUpgradedData(c, AddModelLogsSize, upgradedData(settingsColl, expectedSettings))
 }
 
 func (s *upgradesSuite) TestAddControllerNodeDocs(c *gc.C) {
@@ -3317,7 +3330,7 @@ func (s *upgradesSuite) TestAddControllerNodeDocs(c *gc.C) {
 
 	sort.Sort(expected)
 	s.assertUpgradedData(c, AddControllerNodeDocs,
-		expectUpgradedData{controllerNodesColl, expected, nil},
+		upgradedData(controllerNodesColl, expected),
 	)
 
 	// Ensure obsolete machine doc fields are gone.
@@ -3446,7 +3459,7 @@ func (s *upgradesSuite) TestAddSpaceIdToSpaceDocs(c *gc.C) {
 	}
 
 	sort.Sort(expected)
-	s.assertUpgradedData(c, AddSpaceIdToSpaceDocs, expectUpgradedData{col, expected, nil})
+	s.assertUpgradedData(c, AddSpaceIdToSpaceDocs, upgradedData(col, expected))
 }
 
 func (s *upgradesSuite) TestEnsureRelationApplicationSettings(c *gc.C) {
@@ -3544,7 +3557,7 @@ func (s *upgradesSuite) TestEnsureRelationApplicationSettings(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = settingsCol.Insert(bson.M{
-		"_id":        ensureModelUUID(uuid1, "r#1#provider#mariadb"),
+		"_id":        ensureModelUUID(uuid1, "r#1#mariadb"),
 		"model-uuid": uuid1,
 		"settings": bson.M{
 			"olden-yolk": "blue paradigm",
@@ -3553,27 +3566,31 @@ func (s *upgradesSuite) TestEnsureRelationApplicationSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := bsonMById{{
-		"_id":        ensureModelUUID(uuid1, "r#0#peer#mariadb"),
+		"_id":        ensureModelUUID(uuid1, "r#0#mariadb"),
 		"model-uuid": uuid1,
 		"settings":   bson.M{},
 	}, {
-		"_id":        ensureModelUUID(uuid1, "r#1#provider#mariadb"),
+		"_id":        ensureModelUUID(uuid1, "r#1#mariadb"),
 		"model-uuid": uuid1,
 		"settings": bson.M{
 			"olden-yolk": "blue paradigm",
 		},
 	}, {
-		"_id":        ensureModelUUID(uuid1, "r#1#requirer#mediawiki"),
+		"_id":        ensureModelUUID(uuid1, "r#1#mediawiki"),
+		"model-uuid": uuid1,
+		"settings":   bson.M{},
+	}, {
+		"_id":        ensureModelUUID(uuid1, "r#2#mediawiki"),
+		"model-uuid": uuid1,
+		"settings":   bson.M{},
+	}, {
+		"_id":        ensureModelUUID(uuid1, "r#2#nrpe"),
 		"model-uuid": uuid1,
 		"settings":   bson.M{},
 	}}
 
 	s.assertUpgradedData(c, EnsureRelationApplicationSettings,
-		expectUpgradedData{
-			coll:     settingsCol,
-			expected: expected,
-			filter:   bson.D{{"_id", bson.RegEx{`:r#\d+#.*#.*$`, ""}}},
-		},
+		upgradedDataWithFilter(settingsCol, expected, bson.D{{"_id", bson.RegEx{`:r#\d+#.*$`, ""}}}),
 	)
 }
 
@@ -3618,7 +3635,7 @@ func (s *upgradesSuite) TestChangeSubnetAZtoSlice(c *gc.C) {
 	}
 
 	sort.Sort(expected)
-	s.assertUpgradedData(c, ChangeSubnetAZtoSlice, expectUpgradedData{col, expected, nil})
+	s.assertUpgradedData(c, ChangeSubnetAZtoSlice, upgradedData(col, expected))
 }
 
 func (s *upgradesSuite) TestChangeSubnetSpaceNameToSpaceID(c *gc.C) {
@@ -3670,7 +3687,7 @@ func (s *upgradesSuite) TestChangeSubnetSpaceNameToSpaceID(c *gc.C) {
 	}
 
 	sort.Sort(expected)
-	s.assertUpgradedData(c, ChangeSubnetSpaceNameToSpaceID, expectUpgradedData{col, expected, nil})
+	s.assertUpgradedData(c, ChangeSubnetSpaceNameToSpaceID, upgradedData(col, expected))
 }
 
 func (s *upgradesSuite) TestAddSubnetIdToSubnetDocs(c *gc.C) {
@@ -3723,7 +3740,7 @@ func (s *upgradesSuite) TestAddSubnetIdToSubnetDocs(c *gc.C) {
 	}
 
 	sort.Sort(expected)
-	s.assertUpgradedData(c, AddSubnetIdToSubnetDocs, expectUpgradedData{col, expected, nil})
+	s.assertUpgradedData(c, AddSubnetIdToSubnetDocs, upgradedData(col, expected))
 }
 
 func (s *upgradesSuite) TestReplacePortsDocSubnetIDCIDR(c *gc.C) {
@@ -3781,7 +3798,7 @@ func (s *upgradesSuite) TestReplacePortsDocSubnetIDCIDR(c *gc.C) {
 	}
 
 	sort.Sort(expected)
-	s.assertUpgradedData(c, ReplacePortsDocSubnetIDCIDR, expectUpgradedData{col, expected, nil})
+	s.assertUpgradedData(c, ReplacePortsDocSubnetIDCIDR, upgradedData(col, expected))
 }
 
 func (s *upgradesSuite) makeSpace(c *gc.C, uuid, name, id string) {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -71,6 +71,7 @@ type StateBackend interface {
 	ChangeSubnetSpaceNameToSpaceID() error
 	AddSubnetIdToSubnetDocs() error
 	ReplacePortsDocSubnetIDCIDR() error
+	EnsureRelationApplicationSettings() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -283,4 +284,8 @@ func (s stateBackend) AddSubnetIdToSubnetDocs() error {
 
 func (s stateBackend) ReplacePortsDocSubnetIDCIDR() error {
 	return state.ReplacePortsDocSubnetIDCIDR(s.pool)
+}
+
+func (s stateBackend) EnsureRelationApplicationSettings() error {
+	return state.EnsureRelationApplicationSettings(s.pool)
 }

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -48,5 +48,12 @@ func stateStepsFor27() []Step {
 				return context.State().ReplacePortsDocSubnetIDCIDR()
 			},
 		},
+		&upgradeStep{
+			description: "ensure application settings exist for all relations",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureRelationApplicationSettings()
+			},
+		},
 	}
 }

--- a/upgrades/steps_27_test.go
+++ b/upgrades/steps_27_test.go
@@ -52,6 +52,10 @@ func (s *steps27Suite) TestAddSubnetIdToSubnetDocs(c *gc.C) {
 
 func (s *steps27Suite) TestReplacePortsDocSubnetIDCIDR(c *gc.C) {
 	step := findStateStep(c, v27, `replace portsDoc.SubnetID as a CIDR with an ID.`)
-	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
+func (s *steps27Suite) TestEnsureRelationApplicationSettings(c *gc.C) {
+	step := findStateStep(c, v27, `ensure application settings exist for all relations`)
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }


### PR DESCRIPTION
## Description of change

The state changes to support application-level data bags on relations. Adds `Relation.ApplicationSettings`, `.WatchApplicationSettings` and `.UpdateApplicationSettings`, as well as an upgrade step to create application settings for each endpoint of existing relations.

Part of the implementation of [Application relation data bag](https://docs.google.com/document/d/19Uh-Cy0IU5-9sXSLQjsqBvRvuOi4ZEQ0PRetIBJKhPU/edit)

## QA steps

* Unit tests only - no API to call these yet.

## Documentation changes

We will need charming documentation for application relation data bags when the API and uniter changes are done.

## Bug reference

None