### PR TITLE
Support k8s bootstrap constraints

### DIFF
--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -15,7 +15,6 @@ var unsupportedConstraints = []string{
 	constraints.VirtType,
 	constraints.Container,
 	constraints.Arch,
-	constraints.RootDisk,
 	constraints.InstanceType,
 	constraints.Spaces,
 }

--- a/caas/kubernetes/provider/constraints_test.go
+++ b/caas/kubernetes/provider/constraints_test.go
@@ -80,7 +80,6 @@ func (s *ConstraintsSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 		"virt-type",
 		"arch",
 		"instance-type",
-		"root-disk",
 		"spaces",
 		"container",
 	}

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -316,7 +316,7 @@ type stateInitializationParamsInternal struct {
 	ControllerInheritedConfig               map[string]interface{}            `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
 	HostedModelConfig                       map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
-	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id"`
+	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id,omitempty"`
 	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
 	BootstrapMachineHardwareCharacteristics *instance.HardwareCharacteristics `yaml:"bootstrap-machine-hardware,omitempty"`
 	ModelConstraints                        constraints.Value                 `yaml:"model-constraints"`

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/arch"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v2"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/juju/paths"
@@ -340,6 +338,7 @@ func NewBootstrapControllerPodConfig(
 	config controller.Config,
 	controllerName,
 	series string,
+	bootstrapConstraints constraints.Value,
 ) (*ControllerPodConfig, error) {
 	// For a bootstrap pod, the caller must provide the state.Info
 	// and the api.Info. The machine id must *always* be "0".
@@ -354,23 +353,10 @@ func NewBootstrapControllerPodConfig(
 	for k, v := range config {
 		pcfg.Controller.Config[k] = v
 	}
-	// TODO(bootstrap): remove me.
-	arch := arch.AMD64
-	var cores uint64 = 2
-	var mem uint64 = 123
-	var rootDisk uint64 = 123
 	pcfg.Bootstrap = &BootstrapConfig{
 		BootstrapConfig: instancecfg.BootstrapConfig{
 			StateInitializationParams: instancecfg.StateInitializationParams{
-				// TODO(bootstrap): remove me once agentbootstrap.initBootstrapMachine works for CAAS bootstrap in jujud.
-				BootstrapMachineHardwareCharacteristics: &instance.HardwareCharacteristics{
-					Arch:     &arch,
-					CpuCores: &cores,
-					Mem:      &mem,
-					RootDisk: &rootDisk,
-				},
-				BootstrapMachineInstanceId:  "i-0a373a526fcf5c882",
-				BootstrapMachineConstraints: constraints.Value{Mem: &mem},
+				BootstrapMachineConstraints: bootstrapConstraints,
 			},
 		},
 	}

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/podcfg"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/testing"
@@ -60,6 +61,7 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 		cfg,
 		"controller-1",
 		"kubernetes",
+		constraints.Value{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
@@ -74,9 +76,23 @@ func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
 		cfg,
 		"controller-1",
 		"kubernetes",
+		constraints.Value{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	c.Assert(podConfig.GetControllerImagePath(), gc.Equals, "path/to/my/repo/jujud-operator:6.6.6")
 	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "path/to/my/repo/juju-db:4.0")
+}
+
+func (*podcfgSuite) TestBootstrapConstraints(c *gc.C) {
+	cfg := testing.FakeControllerConfig()
+	cons := constraints.MustParse("mem=4G")
+	podConfig, err := podcfg.NewBootstrapControllerPodConfig(
+		cfg,
+		"controller-1",
+		"kubernetes",
+		cons,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(podConfig.Bootstrap.BootstrapMachineConstraints, gc.DeepEquals, cons)
 }


### PR DESCRIPTION
## Description of change

Add proper support for k8s bootstrap constraints (mem and cpu-power and also root-disk).
Remove previously hard coded data from the bootstrap pod spec.

## QA steps

juju bootstrap microk8s --bootstrap-constraints="root-disk=10000 mem=4G"

Use kubectl to verify that controller disk PVC and pod containers have the correct values.