### PR TITLE
Drop the logging level from error to debug

### DIFF
--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -315,7 +315,12 @@ func (w *MachineLXDProfileWatcher) removeUnit(_ string, value interface{}) {
 
 	app, ok := w.applications[rUnit.Application()]
 	if !ok {
-		w.logDebug("unit removed before being added, application name not found")
+		// Previously this was a logError with a programming error, but in
+		// actual fact you can bump into this more often than not in legitimate
+		// circumstances. So instead of being an error, this should just be a
+		// debug log.
+		logger.Debugf("unit removed before being added, application name not found")
+		w.metrics.LXDProfileChangeError.Inc()
 		return
 	}
 	if !app.units.Contains(rUnit.Name()) {
@@ -354,10 +359,5 @@ func (w *MachineLXDProfileWatcher) provisionedChange(_ string, _ interface{}) {
 
 func (w *MachineLXDProfileWatcher) logError(msg string) {
 	logger.Errorf(msg)
-	w.metrics.LXDProfileChangeError.Inc()
-}
-
-func (w *MachineLXDProfileWatcher) logDebug(msg string) {
-	logger.Debugf(msg)
 	w.metrics.LXDProfileChangeError.Inc()
 }

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -315,7 +315,7 @@ func (w *MachineLXDProfileWatcher) removeUnit(_ string, value interface{}) {
 
 	app, ok := w.applications[rUnit.Application()]
 	if !ok {
-		w.logError("programming error, unit removed before being added, application name not found")
+		w.logDebug("unit removed before being added, application name not found")
 		return
 	}
 	if !app.units.Contains(rUnit.Name()) {
@@ -354,5 +354,10 @@ func (w *MachineLXDProfileWatcher) provisionedChange(_ string, _ interface{}) {
 
 func (w *MachineLXDProfileWatcher) logError(msg string) {
 	logger.Errorf(msg)
+	w.metrics.LXDProfileChangeError.Inc()
+}
+
+func (w *MachineLXDProfileWatcher) logDebug(msg string) {
+	logger.Debugf(msg)
 	w.metrics.LXDProfileChangeError.Inc()
 }


### PR DESCRIPTION
## Description of change

The following error can occur legitimately when you have a broken
deploy, so we don't need error, but as a debug.

## QA steps

```
juju bootstrap lxd test --no-gui
juju deploy cs:~juju-qa/bionic/dummy-in-edge-0 --series eoan --force
```

You shouldn't see a `juju.core.cache programming error, unit removed before being added, application name not found` at `ERROR` level
