### PR TITLE
Check for "not found" When Acquiring LXD Image

### DIFF
--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -41,16 +41,17 @@ func (s *Server) FindImage(
 	callback environs.StatusCallbackFunc,
 ) (SourcedImage, error) {
 	if callback != nil {
-		callback(status.Provisioning, "acquiring LXD image", nil)
+		_ = callback(status.Provisioning, "acquiring LXD image", nil)
 	}
 
 	// First we check if we have the image locally.
 	localAlias := seriesLocalAlias(series, arch)
 	var target string
 	entry, _, err := s.GetImageAlias(localAlias)
-	if err != nil {
+	if err != nil && !IsLXDNotFound(err) {
 		return SourcedImage{}, errors.Trace(err)
 	}
+
 	if entry != nil {
 		// We already have an image with the given alias, so just use that.
 		target = entry.Target
@@ -144,7 +145,7 @@ func (s *Server) CopyRemoteImage(
 			}
 			for _, key := range []string{"fs_progress", "download_progress"} {
 				if value, ok := op.Metadata[key]; ok {
-					callback(status.Provisioning, fmt.Sprintf("Retrieving image: %s", value.(string)), nil)
+					_ = callback(status.Provisioning, fmt.Sprintf("Retrieving image: %s", value.(string)), nil)
 					return
 				}
 			}

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -77,7 +77,7 @@ func (s *imageSuite) TestFindImageLocalServerUnknownSeries(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	iSvr := s.NewMockServer(ctrl)
-	iSvr.EXPECT().GetImageAlias("juju/pldlinux/"+s.Arch()).Return(nil, lxdtesting.ETag, nil)
+	iSvr.EXPECT().GetImageAlias("juju/pldlinux/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found"))
 
 	jujuSvr, err := lxd.NewServer(iSvr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -101,8 +101,8 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 	image := lxdapi.Image{Filename: "this-is-our-image"}
 	alias := lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-remote-target"}}
 	gomock.InOrder(
-		iSvr.EXPECT().GetImageAlias("juju/xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, nil),
-		rSvr1.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, nil),
+		iSvr.EXPECT().GetImageAlias("juju/xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
+		rSvr1.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
 		rSvr2.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
 		rSvr2.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
 	)
@@ -170,7 +170,7 @@ func (s *imageSuite) TestFindImageRemoteServersNotFound(c *gc.C) {
 
 	alias := lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-remote-target"}}
 	gomock.InOrder(
-		iSvr.EXPECT().GetImageAlias("juju/bionic/"+s.Arch()).Return(nil, lxdtesting.ETag, nil),
+		iSvr.EXPECT().GetImageAlias("juju/bionic/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
 		rSvr.EXPECT().GetImageAlias("bionic/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
 		rSvr.EXPECT().GetImage("foo-remote-target").Return(
 			nil, lxdtesting.ETag, errors.New("failed to retrieve image")),


### PR DESCRIPTION
## Description of change

This patch checks for a "not found" error before returning from LXD image acquisition.

## QA steps

This may only be possible on machines that do not have juju-specific aliases for LXD images.

To reproduce:
- Run `lxc image list` and identify an image from xenial/bionic/cosmic/disco that you do *not* have an alias for.
- Bootstrap localhost with develop using this series as the `bootstrap-series` option.
- Observe the "not found" error.

To verify:
- Do the same with this patch and observe bootstrap success.

## Documentation changes

None.

## Bug reference

https://travis-ci.org/juju/python-libjuju/jobs/574250632
