### PR TITLE
Use whitelist when adding clouds.

### DIFF
--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -22,9 +22,16 @@ import (
 
 type cloudSuite struct {
 	gitjujutesting.IsolationSuite
+
+	called bool
 }
 
 var _ = gc.Suite(&cloudSuite{})
+
+func (s *cloudSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.called = false
+}
 
 func (s *cloudSuite) TestCloud(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(
@@ -48,6 +55,7 @@ func (s *cloudSuite) TestCloud(c *gc.C) {
 					Regions:   []params.CloudRegion{{Name: "nether", Endpoint: "endpoint"}},
 				},
 			})
+			s.called = true
 			return nil
 		},
 	)
@@ -61,6 +69,7 @@ func (s *cloudSuite) TestCloud(c *gc.C) {
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 		Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 	})
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestClouds(c *gc.C) {
@@ -86,6 +95,7 @@ func (s *cloudSuite) TestClouds(c *gc.C) {
 					Regions:   []params.CloudRegion{{Name: "nether", Endpoint: "endpoint"}},
 				},
 			}
+			s.called = true
 			return nil
 		},
 	)
@@ -105,6 +115,7 @@ func (s *cloudSuite) TestClouds(c *gc.C) {
 			Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 		},
 	})
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUserCredentials(c *gc.C) {
@@ -130,6 +141,7 @@ func (s *cloudSuite) TestUserCredentials(c *gc.C) {
 					},
 				}},
 			}
+			s.called = true
 			return nil
 		},
 	)
@@ -141,10 +153,10 @@ func (s *cloudSuite) TestUserCredentials(c *gc.C) {
 		names.NewCloudCredentialTag("foo/bob/one"),
 		names.NewCloudCredentialTag("foo/bob/two"),
 	})
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -170,7 +182,7 @@ func (s *cloudSuite) TestUpdateCredentialV2(c *gc.C) {
 				*result.(*params.ErrorResults) = params.ErrorResults{
 					Results: []params.ErrorResult{{}},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -180,11 +192,10 @@ func (s *cloudSuite) TestUpdateCredentialV2(c *gc.C) {
 	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredential(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -210,7 +221,7 @@ func (s *cloudSuite) TestUpdateCredential(c *gc.C) {
 				*result.(*params.UpdateCredentialResults) = params.UpdateCredentialResults{
 					Results: []params.UpdateCredentialResult{{}},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -220,11 +231,10 @@ func (s *cloudSuite) TestUpdateCredential(c *gc.C) {
 	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialErrorV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -236,7 +246,7 @@ func (s *cloudSuite) TestUpdateCredentialErrorV2(c *gc.C) {
 				*result.(*params.ErrorResults) = params.ErrorResults{
 					Results: []params.ErrorResult{{common.ServerError(errors.New("validation failure"))}},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -246,11 +256,10 @@ func (s *cloudSuite) TestUpdateCredentialErrorV2(c *gc.C) {
 	errs, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, gc.ErrorMatches, "validation failure")
 	c.Assert(errs, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialError(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -266,7 +275,7 @@ func (s *cloudSuite) TestUpdateCredentialError(c *gc.C) {
 						},
 					},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -276,11 +285,10 @@ func (s *cloudSuite) TestUpdateCredentialError(c *gc.C) {
 	errs, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, gc.ErrorMatches, "validation failure")
 	c.Assert(errs, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialCallErrorV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -289,7 +297,7 @@ func (s *cloudSuite) TestUpdateCredentialCallErrorV2(c *gc.C) {
 				a, result interface{},
 			) error {
 				c.Check(request, gc.Equals, "UpdateCredentials")
-				called = true
+				s.called = true
 				return errors.New("scary but true")
 			},
 		),
@@ -299,11 +307,10 @@ func (s *cloudSuite) TestUpdateCredentialCallErrorV2(c *gc.C) {
 	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, gc.ErrorMatches, "scary but true")
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialCallError(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -312,7 +319,7 @@ func (s *cloudSuite) TestUpdateCredentialCallError(c *gc.C) {
 				a, result interface{},
 			) error {
 				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
-				called = true
+				s.called = true
 				return errors.New("scary but true")
 			},
 		),
@@ -322,11 +329,10 @@ func (s *cloudSuite) TestUpdateCredentialCallError(c *gc.C) {
 	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, gc.ErrorMatches, "scary but true")
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialManyResultsV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -341,7 +347,7 @@ func (s *cloudSuite) TestUpdateCredentialManyResultsV2(c *gc.C) {
 						{},
 					},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -351,11 +357,10 @@ func (s *cloudSuite) TestUpdateCredentialManyResultsV2(c *gc.C) {
 	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, gc.ErrorMatches, `expected 1 result got 2 when updating credentials`)
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialManyResults(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -369,7 +374,7 @@ func (s *cloudSuite) TestUpdateCredentialManyResults(c *gc.C) {
 						{},
 						{},
 					}}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -379,11 +384,10 @@ func (s *cloudSuite) TestUpdateCredentialManyResults(c *gc.C) {
 	result, err := client.UpdateCredentialsCheckModels(testCredentialTag, testCredential)
 	c.Assert(err, gc.ErrorMatches, `expected 1 result got 2 when updating credentials`)
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCredentialModelErrors(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -408,7 +412,7 @@ func (s *cloudSuite) TestUpdateCredentialModelErrors(c *gc.C) {
 							},
 						},
 					}}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -427,7 +431,7 @@ func (s *cloudSuite) TestUpdateCredentialModelErrors(c *gc.C) {
 			},
 		},
 	})
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 var (
@@ -439,7 +443,6 @@ var (
 )
 
 func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
-	var called bool
 	apiCallerF := basetesting.APICallerFunc(
 		func(objType string,
 			version int,
@@ -458,7 +461,7 @@ func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 			*result.(*params.ErrorResults) = params.ErrorResults{
 				Results: []params.ErrorResult{{}},
 			}
-			called = true
+			s.called = true
 			return nil
 		},
 	)
@@ -471,11 +474,10 @@ func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 	tag := names.NewCloudCredentialTag("foo/bob/bar")
 	err := client.RevokeCredential(tag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestRevokeCredentialV2(c *gc.C) {
-	var called bool
 	apiCallerF := basetesting.APICallerFunc(
 		func(objType string,
 			version int,
@@ -492,7 +494,7 @@ func (s *cloudSuite) TestRevokeCredentialV2(c *gc.C) {
 			*result.(*params.ErrorResults) = params.ErrorResults{
 				Results: []params.ErrorResult{{}},
 			}
-			called = true
+			s.called = true
 			return nil
 		},
 	)
@@ -505,7 +507,7 @@ func (s *cloudSuite) TestRevokeCredentialV2(c *gc.C) {
 	tag := names.NewCloudCredentialTag("foo/bob/bar")
 	err := client.RevokeCredential(tag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestCredentials(c *gc.C) {
@@ -539,6 +541,7 @@ func (s *cloudSuite) TestCredentials(c *gc.C) {
 					},
 				},
 			}
+			s.called = true
 			return nil
 		},
 	)
@@ -562,64 +565,74 @@ func (s *cloudSuite) TestCredentials(c *gc.C) {
 			},
 		},
 	})
+	c.Assert(s.called, jc.IsTrue)
+}
+
+func (s *cloudSuite) createVersionedAddCloudCall(c *gc.C, v int, expectedArg params.AddCloudArgs) basetesting.BestVersionCaller {
+	return basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "AddCloud")
+				c.Check(a, jc.DeepEquals, expectedArg)
+				s.called = true
+				return nil
+			},
+		),
+		BestVersion: v,
+	}
+}
+
+var testCloud = cloud.Cloud{
+	Name:      "foo",
+	Type:      "dummy",
+	AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+	Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 }
 
 func (s *cloudSuite) TestAddCloudNotInV1API(c *gc.C) {
-	apiCaller := basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string,
-				version int,
-				id, request string,
-				a, result interface{},
-			) error {
-				c.Check(objType, gc.Equals, "Cloud")
-				c.Check(id, gc.Equals, "")
-				c.Check(request, gc.Equals, "AddCloud")
-				return nil
-			},
-		),
-		BestVersion: 1,
-	}
+	apiCaller := s.createVersionedAddCloudCall(c, 1, params.AddCloudArgs{})
 	client := cloudapi.NewClient(apiCaller)
-	err := client.AddCloud(cloud.Cloud{
-		Name:      "foo",
-		Type:      "dummy",
-		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
-		Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
-	})
-
+	err := client.AddCloud(testCloud, false)
 	c.Assert(err, gc.ErrorMatches, "AddCloud\\(\\).* not implemented")
+	c.Assert(s.called, jc.IsFalse)
 }
 
 func (s *cloudSuite) TestAddCloudV2API(c *gc.C) {
-	var called bool
-	apiCaller := basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string,
-				version int,
-				id, request string,
-				a, result interface{},
-			) error {
-				called = true
-				c.Check(objType, gc.Equals, "Cloud")
-				c.Check(id, gc.Equals, "")
-				c.Check(request, gc.Equals, "AddCloud")
-				return nil
-			},
-		),
-		BestVersion: 2,
-	}
-
-	client := cloudapi.NewClient(apiCaller)
-	err := client.AddCloud(cloud.Cloud{
-		Name:      "foo",
-		Type:      "dummy",
-		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
-		Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+	apiCaller := s.createVersionedAddCloudCall(c, 2, params.AddCloudArgs{
+		Name:  "foo",
+		Cloud: common.CloudToParams(testCloud),
 	})
-
+	client := cloudapi.NewClient(apiCaller)
+	err := client.AddCloud(testCloud, false)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestAddCloudForceNotInVPriorTo6(c *gc.C) {
+	apiCaller := s.createVersionedAddCloudCall(c, 5, params.AddCloudArgs{})
+	client := cloudapi.NewClient(apiCaller)
+	err := client.AddCloud(testCloud, true)
+	c.Assert(err, gc.ErrorMatches, "AddCloud\\(\\).* not implemented")
+	c.Assert(s.called, jc.IsFalse)
+}
+
+func (s *cloudSuite) TestAddCloudForceFromV6(c *gc.C) {
+	force := true
+	apiCaller := s.createVersionedAddCloudCall(c, 6, params.AddCloudArgs{
+		Name:  "foo",
+		Cloud: common.CloudToParams(testCloud),
+		Force: &force,
+	})
+	client := cloudapi.NewClient(apiCaller)
+	err := client.AddCloud(testCloud, force)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloud(c *gc.C) {
@@ -631,7 +644,6 @@ func (s *cloudSuite) TestUpdateCloud(c *gc.C) {
 		Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
 	}
 
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -639,7 +651,7 @@ func (s *cloudSuite) TestUpdateCloud(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				called = true
+				s.called = true
 				c.Check(objType, gc.Equals, "Cloud")
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "UpdateCloud")
@@ -661,7 +673,7 @@ func (s *cloudSuite) TestUpdateCloud(c *gc.C) {
 	err := client.UpdateCloud(updatedCloud)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestAddCredentialNotInV1API(c *gc.C) {
@@ -672,6 +684,7 @@ func (s *cloudSuite) TestAddCredentialNotInV1API(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
+				s.called = true
 				return nil
 			},
 		),
@@ -681,11 +694,11 @@ func (s *cloudSuite) TestAddCredentialNotInV1API(c *gc.C) {
 	err := client.AddCredential("cloudcred-acloud-user-credname",
 		cloud.NewCredential(cloud.UserPassAuthType, map[string]string{}))
 
+	c.Assert(s.called, jc.IsFalse)
 	c.Assert(err, gc.ErrorMatches, "AddCredential\\(\\).* not implemented")
 }
 
 func (s *cloudSuite) TestAddCredentialV2API(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -693,7 +706,7 @@ func (s *cloudSuite) TestAddCredentialV2API(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				called = true
+				s.called = true
 				c.Check(objType, gc.Equals, "Cloud")
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "AddCredentials")
@@ -714,7 +727,7 @@ func (s *cloudSuite) TestAddCredentialV2API(c *gc.C) {
 			map[string]string{}))
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestCredentialContentsArgumentCheck(c *gc.C) {
@@ -771,6 +784,7 @@ func (s *cloudSuite) TestCredentialContentsAll(c *gc.C) {
 				*result.(*params.CredentialContentResults) = params.CredentialContentResults{
 					Results: expectedResults,
 				}
+				s.called = true
 				return nil
 			},
 		),
@@ -781,6 +795,7 @@ func (s *cloudSuite) TestCredentialContentsAll(c *gc.C) {
 	results, err := client.CredentialContents("", "", true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestCredentialContentsOne(c *gc.C) {
@@ -806,6 +821,7 @@ func (s *cloudSuite) TestCredentialContentsOne(c *gc.C) {
 						{},
 					},
 				}
+				s.called = true
 				return nil
 			},
 		),
@@ -816,6 +832,7 @@ func (s *cloudSuite) TestCredentialContentsOne(c *gc.C) {
 	results, err := client.CredentialContents("cloud-name", "credential-name", true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestCredentialContentsGotMoreThanBargainedFor(c *gc.C) {
@@ -832,6 +849,7 @@ func (s *cloudSuite) TestCredentialContentsGotMoreThanBargainedFor(c *gc.C) {
 						{},
 					},
 				}
+				s.called = true
 				return nil
 			},
 		),
@@ -842,6 +860,7 @@ func (s *cloudSuite) TestCredentialContentsGotMoreThanBargainedFor(c *gc.C) {
 	results, err := client.CredentialContents("cloud-name", "credential-name", true)
 	c.Assert(results, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result for credential \"cloud-name\" on cloud \"credential-name\", got 2")
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestCredentialContentsServerError(c *gc.C) {
@@ -852,6 +871,7 @@ func (s *cloudSuite) TestCredentialContentsServerError(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
+				s.called = true
 				return errors.New("boom")
 			}),
 		BestVersion: 2,
@@ -861,6 +881,7 @@ func (s *cloudSuite) TestCredentialContentsServerError(c *gc.C) {
 	results, err := client.CredentialContents("", "", true)
 	c.Assert(results, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestCredentialContentsNotInV2API(c *gc.C) {
@@ -871,6 +892,7 @@ func (s *cloudSuite) TestCredentialContentsNotInV2API(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
+				s.called = true
 				return nil
 			},
 		),
@@ -879,10 +901,10 @@ func (s *cloudSuite) TestCredentialContentsNotInV2API(c *gc.C) {
 	client := cloudapi.NewClient(apiCaller)
 	_, err := client.CredentialContents("", "", true)
 	c.Assert(err, gc.ErrorMatches, "CredentialContents\\(\\).* not implemented")
+	c.Assert(s.called, jc.IsFalse)
 }
 
 func (s *cloudSuite) TestRemoveCloud(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -890,7 +912,7 @@ func (s *cloudSuite) TestRemoveCloud(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				called = true
+				s.called = true
 				c.Check(objType, gc.Equals, "Cloud")
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "RemoveClouds")
@@ -911,7 +933,7 @@ func (s *cloudSuite) TestRemoveCloud(c *gc.C) {
 	client := cloudapi.NewClient(apiCaller)
 	err := client.RemoveCloud("foo")
 	c.Assert(err, gc.ErrorMatches, "FAIL")
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestRemoveCloudNotInV1API(c *gc.C) {
@@ -925,6 +947,7 @@ func (s *cloudSuite) TestRemoveCloudNotInV1API(c *gc.C) {
 				c.Check(objType, gc.Equals, "Cloud")
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "RemoveCloud")
+				s.called = true
 				return nil
 			},
 		),
@@ -933,11 +956,11 @@ func (s *cloudSuite) TestRemoveCloudNotInV1API(c *gc.C) {
 	client := cloudapi.NewClient(apiCaller)
 	err := client.RemoveCloud("foo")
 
+	c.Assert(s.called, jc.IsFalse)
 	c.Assert(err, gc.ErrorMatches, "RemoveCloud\\(\\).* not implemented")
 }
 
 func (s *cloudSuite) TestGrantCloud(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -945,7 +968,7 @@ func (s *cloudSuite) TestGrantCloud(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				called = true
+				s.called = true
 				c.Check(objType, gc.Equals, "Cloud")
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "ModifyCloudAccess")
@@ -968,7 +991,7 @@ func (s *cloudSuite) TestGrantCloud(c *gc.C) {
 	client := cloudapi.NewClient(apiCaller)
 	err := client.GrantCloud("fred", "admin", "fluffy")
 	c.Assert(err, gc.ErrorMatches, "FAIL")
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestGrantCloudAccessNotInV2API(c *gc.C) {
@@ -991,7 +1014,6 @@ func (s *cloudSuite) TestGrantCloudAccessNotInV2API(c *gc.C) {
 }
 
 func (s *cloudSuite) TestRevokeCloud(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -999,7 +1021,7 @@ func (s *cloudSuite) TestRevokeCloud(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				called = true
+				s.called = true
 				c.Check(objType, gc.Equals, "Cloud")
 				c.Check(id, gc.Equals, "")
 				c.Check(request, gc.Equals, "ModifyCloudAccess")
@@ -1022,7 +1044,7 @@ func (s *cloudSuite) TestRevokeCloud(c *gc.C) {
 	client := cloudapi.NewClient(apiCaller)
 	err := client.RevokeCloud("fred", "admin", "fluffy")
 	c.Assert(err, gc.ErrorMatches, "FAIL")
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestRevokeCloudAccessNotInV2API(c *gc.C) {
@@ -1053,7 +1075,6 @@ func createCredentials(n int) map[string]cloud.Credential {
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentials(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1079,7 +1100,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentials(c *gc.C) {
 				*result.(*params.UpdateCredentialResults) = params.UpdateCredentialResults{
 					Results: []params.UpdateCredentialResult{{}},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1089,11 +1110,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentials(c *gc.C) {
 	result, err := client.UpdateCloudsCredentials(createCredentials(1))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []params.UpdateCredentialResult{{}})
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsErrorV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1105,7 +1125,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsErrorV2(c *gc.C) {
 				*result.(*params.ErrorResults) = params.ErrorResults{
 					Results: []params.ErrorResult{{common.ServerError(errors.New("validation failure"))}},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1117,11 +1137,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsErrorV2(c *gc.C) {
 	c.Assert(errs, gc.DeepEquals, []params.UpdateCredentialResult{
 		{CredentialTag: "cloudcred-foo_bob_bar0", Error: &params.Error{Message: "validation failure", Code: ""}},
 	})
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsError(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1137,7 +1156,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsError(c *gc.C) {
 						},
 					},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1149,11 +1168,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsError(c *gc.C) {
 	c.Assert(errs, gc.DeepEquals, []params.UpdateCredentialResult{
 		{CredentialTag: "cloudcred-foo_bob_bar0", Error: common.ServerError(errors.New("validation failure"))},
 	})
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsCallErrorV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1162,7 +1180,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsCallErrorV2(c *gc.C) {
 				a, result interface{},
 			) error {
 				c.Check(request, gc.Equals, "UpdateCredentials")
-				called = true
+				s.called = true
 				return errors.New("scary but true")
 			},
 		),
@@ -1172,11 +1190,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsCallErrorV2(c *gc.C) {
 	result, err := client.UpdateCloudsCredentials(createCredentials(1))
 	c.Assert(err, gc.ErrorMatches, "scary but true")
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsCallError(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1185,7 +1202,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsCallError(c *gc.C) {
 				a, result interface{},
 			) error {
 				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
-				called = true
+				s.called = true
 				return errors.New("scary but true")
 			},
 		),
@@ -1195,11 +1212,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsCallError(c *gc.C) {
 	result, err := client.UpdateCloudsCredentials(createCredentials(1))
 	c.Assert(err, gc.ErrorMatches, "scary but true")
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsManyResultsV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1214,7 +1230,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyResultsV2(c *gc.C) {
 						{},
 					},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1224,11 +1240,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyResultsV2(c *gc.C) {
 	result, err := client.UpdateCloudsCredentials(createCredentials(1))
 	c.Assert(err, gc.ErrorMatches, `expected 1 result got 2 when updating credentials`)
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResultsV2(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1243,7 +1258,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResultsV2(c *gc.C) {
 						{},
 					},
 				}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1258,11 +1273,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResultsV2(c *gc.C) {
 		_, ok := in[one.CredentialTag]
 		c.Assert(ok, jc.IsTrue)
 	}
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsManyResults(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1276,7 +1290,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyResults(c *gc.C) {
 						{},
 						{},
 					}}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1286,11 +1300,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyResults(c *gc.C) {
 	result, err := client.UpdateCloudsCredentials(createCredentials(1))
 	c.Assert(err, gc.ErrorMatches, `expected 1 result got 2 when updating credentials`)
 	c.Assert(result, gc.IsNil)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResults(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1304,7 +1317,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResults(c *gc.C) {
 						{},
 						{},
 					}}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1315,11 +1328,10 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResults(c *gc.C) {
 	result, err := client.UpdateCloudsCredentials(createCredentials(count))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, count)
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }
 
 func (s *cloudSuite) TestUpdateCloudsCredentialsModelErrors(c *gc.C) {
-	var called bool
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -1344,7 +1356,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsModelErrors(c *gc.C) {
 							},
 						},
 					}}
-				called = true
+				s.called = true
 				return nil
 			},
 		),
@@ -1366,5 +1378,5 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsModelErrors(c *gc.C) {
 			},
 		},
 	})
-	c.Assert(called, jc.IsTrue)
+	c.Assert(s.called, jc.IsTrue)
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -171,7 +171,7 @@ func AllFacades() *facade.Registry {
 	reg("Cloud", 3, cloud.NewFacadeV3) // changes signature of UpdateCredentials, adds ModifyCloudAccess
 	reg("Cloud", 4, cloud.NewFacadeV4) // adds UpdateCloud
 	reg("Cloud", 5, cloud.NewFacadeV5) // Removes DefaultCloud, handles config in AddCloud
-	reg("Cloud", 6, cloud.NewFacadeV6) // Adds validity to CredentialContent
+	reg("Cloud", 6, cloud.NewFacadeV6) // Adds validity to CredentialContent, force for AddCloud
 
 	// CAAS related facades.
 	// Move these to the correct place above once the feature flag disappears.

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -1020,7 +1020,7 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 		}
 		if err := cloud.CurrentWhiteList().Check(controllerCloud.Type, cloudArgs.Cloud.Type); err != nil {
 			if cloudArgs.Force == nil || !*cloudArgs.Force {
-				return errors.Trace(err)
+				return common.ServerError(params.Error{Code: params.CodeIncompatibleClouds, Message: err.Error()})
 			}
 			logger.Infof("force adding cloud %q of type %q to controller bootstrapped on cloud type %q", cloudArgs.Name, cloudArgs.Cloud.Type, controllerCloud.Type)
 		}

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -230,18 +230,18 @@ func (s *cloudSuiteV2) TestAddCloudInV2(c *gc.C) {
 	paramsCloud := params.AddCloudArgs{
 		Name: "newcloudname",
 		Cloud: params.Cloud{
-			Type:      "fake",
+			Type:      "maas",
 			AuthTypes: []string{"empty", "userpass"},
 			Endpoint:  "fake-endpoint",
 			Regions:   []params.CloudRegion{{Name: "nether", Endpoint: "nether-endpoint"}},
 		}}
 	err := s.apiv2.AddCloud(paramsCloud)
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerTag", "ControllerConfig", "AddCloud")
+	s.backend.CheckCallNames(c, "ControllerTag", "ControllerConfig", "ControllerInfo", "Cloud", "AddCloud")
 	s.backend.CheckCall(c, 0, "ControllerTag")
-	s.backend.CheckCall(c, 2, "AddCloud", cloud.Cloud{
+	s.backend.CheckCall(c, 4, "AddCloud", cloud.Cloud{
 		Name:      "newcloudname",
-		Type:      "fake",
+		Type:      "maas",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 		Endpoint:  "fake-endpoint",
 		Regions:   []cloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
@@ -457,6 +457,11 @@ type mockBackendV2 struct {
 	models            map[names.CloudCredentialTag][]state.CredentialOwnerModelAccess
 	controllerCfg     controller.Config
 	credentialModelsF func(tag names.CloudCredentialTag) (map[string]string, error)
+}
+
+func (st *mockBackendV2) ControllerInfo() (*state.ControllerInfo, error) {
+	st.MethodCall(st, "ControllerInfo")
+	return &state.ControllerInfo{CloudName: "maas"}, nil
 }
 
 func (st *mockBackendV2) ControllerConfig() (controller.Config, error) {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -5,6 +5,7 @@ package cloud_test
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/juju/errors"
@@ -19,6 +20,7 @@ import (
 	cloudfacade "github.com/juju/juju/apiserver/facades/client/cloud"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
@@ -67,6 +69,7 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 	tagTwo, err := credentialTwo.CloudCredentialTag()
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerInfo := &state.ControllerInfo{CloudName: "dummy"}
 	s.backend = &mockBackend{
 		cloud: aCloud,
 		creds: map[string]state.Credential{
@@ -75,10 +78,12 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 		},
 		controllerCfg:     coretesting.FakeControllerConfig(),
 		credentialModelsF: func(tag names.CloudCredentialTag) (map[string]string, error) { return nil, nil },
+		controllerInfoF:   func() (*state.ControllerInfo, error) { return controllerInfo, nil },
 	}
 	s.ctlrBackend = &mockBackend{
 		cloud:             aCloud,
 		credentialModelsF: func(tag names.CloudCredentialTag) (map[string]string, error) { return nil, nil },
+		controllerInfoF:   func() (*state.ControllerInfo, error) { return controllerInfo, nil },
 	}
 
 	newModel := func(uuid string) *mockPooledModel {
@@ -223,27 +228,125 @@ func (s *cloudSuite) TestCloudInfoNonAdmin(c *gc.C) {
 }
 
 func (s *cloudSuite) TestAddCloud(c *gc.C) {
+	s.backend.cloud.Type = "maas"
 	s.backend.controllerCfg = controller.Config{
 		"features": []interface{}{"multi-cloud"},
 	}
 	paramsCloud := params.AddCloudArgs{
 		Name: "newcloudname",
 		Cloud: params.Cloud{
-			Type:      "fake",
+			Type:      "maas",
 			AuthTypes: []string{"empty", "userpass"},
 			Endpoint:  "fake-endpoint",
 			Regions:   []params.CloudRegion{{Name: "nether", Endpoint: "nether-endpoint"}},
 		}}
 	err := s.api.AddCloud(paramsCloud)
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerConfig", "AddCloud")
-	s.backend.CheckCall(c, 1, "AddCloud", cloud.Cloud{
+	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud", "AddCloud")
+	s.backend.CheckCall(c, 3, "AddCloud", cloud.Cloud{
+		Name:      "newcloudname",
+		Type:      "maas",
+		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+		Endpoint:  "fake-endpoint",
+		Regions:   []cloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
+	}, "admin")
+}
+
+func createAddCloudParam(cloudType string) params.AddCloudArgs {
+	if cloudType == "" {
+		cloudType = "fake"
+	}
+	return params.AddCloudArgs{
+		Name: "newcloudname",
+		Cloud: params.Cloud{
+			Type:      cloudType,
+			AuthTypes: []string{"empty", "userpass"},
+			Endpoint:  "fake-endpoint",
+			Regions:   []params.CloudRegion{{Name: "nether", Endpoint: "nether-endpoint"}},
+		},
+	}
+}
+
+func (s *cloudSuite) TestAddCloudNotWhitelisted(c *gc.C) {
+	s.backend.controllerCfg = controller.Config{
+		"features": []interface{}{"multi-cloud"},
+	}
+	err := s.api.AddCloud(createAddCloudParam(""))
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`
+controller cloud type "dummy" is not whitelisted, current whitelist: 
+ - controller cloud type "lxd" supports [lxd maas openstack]
+ - controller cloud type "maas" supports [maas openstack]
+ - controller cloud type "openstack" supports [openstack]`[1:]))
+	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud")
+}
+
+func (s *cloudSuite) TestAddCloudNotWhitelistedButForceAdded(c *gc.C) {
+	s.backend.controllerCfg = controller.Config{
+		"features": []interface{}{"multi-cloud"},
+	}
+	force := true
+	addCloudArg := createAddCloudParam("")
+	addCloudArg.Force = &force
+	err := s.api.AddCloud(addCloudArg)
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud", "AddCloud")
+	s.backend.CheckCall(c, 3, "AddCloud", cloud.Cloud{
 		Name:      "newcloudname",
 		Type:      "fake",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
 		Endpoint:  "fake-endpoint",
 		Regions:   []cloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
 	}, "admin")
+}
+
+func (s *cloudSuite) TestAddCloudControllerInfoErr(c *gc.C) {
+	s.backend.controllerCfg = controller.Config{
+		"features": []interface{}{"multi-cloud"},
+	}
+	s.backend.controllerInfoF = func() (*state.ControllerInfo, error) {
+		return nil, errors.New("kaboom")
+	}
+	err := s.api.AddCloud(createAddCloudParam(""))
+	c.Assert(err, gc.ErrorMatches, "kaboom")
+	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo")
+}
+
+func (s *cloudSuite) TestAddCloudControllerCloudErr(c *gc.C) {
+	s.backend.controllerCfg = controller.Config{
+		"features": []interface{}{"multi-cloud"},
+	}
+	s.backend.SetErrors(
+		// Since ControllerConfig and ControllerInfo do not use Stub errors, the first error will be used by Cloud call.
+		errors.New("kaboom"), // Cloud
+	)
+	err := s.api.AddCloud(createAddCloudParam(""))
+	c.Assert(err, gc.ErrorMatches, "kaboom")
+	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud")
+}
+
+func (s *cloudSuite) TestAddCloudK8sForceIrrelevant(c *gc.C) {
+	s.backend.controllerCfg = controller.Config{
+		"features": []interface{}{"multi-cloud"},
+	}
+	addCloudArg := createAddCloudParam(string(provider.K8s_ProviderType))
+	add := func() {
+		err := s.api.AddCloud(addCloudArg)
+		c.Assert(err, jc.ErrorIsNil)
+		s.backend.CheckCallNames(c, "ControllerConfig", "AddCloud")
+		s.backend.CheckCall(c, 1, "AddCloud", cloud.Cloud{
+			Name:      "newcloudname",
+			Type:      string(provider.K8s_ProviderType),
+			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+			Endpoint:  "fake-endpoint",
+			Regions:   []cloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
+		}, "admin")
+	}
+	add()
+
+	force := true
+	s.backend.ResetCalls()
+	addCloudArg.Force = &force
+	add()
 }
 
 func (s *cloudSuite) TestAddCloudNoFeatureFlag(c *gc.C) {
@@ -1223,11 +1326,17 @@ type mockBackend struct {
 
 	credentialModelsF func(tag names.CloudCredentialTag) (map[string]string, error)
 	credsModels       []state.CredentialOwnerModelAccess
+	controllerInfoF   func() (*state.ControllerInfo, error)
 }
 
 func (st *mockBackend) ControllerTag() names.ControllerTag {
 	st.MethodCall(st, "ControllerTag")
 	return names.NewControllerTag("deadbeef-1bad-500d-9000-4b1d0d06f00d")
+}
+
+func (st *mockBackend) ControllerInfo() (*state.ControllerInfo, error) {
+	st.MethodCall(st, "ControllerInfo")
+	return st.controllerInfoF()
 }
 
 func (st *mockBackend) ControllerConfig() (controller.Config, error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -10948,6 +10948,9 @@
                         "cloud": {
                             "$ref": "#/definitions/Cloud"
                         },
+                        "force": {
+                            "type": "boolean"
+                        },
                         "name": {
                             "type": "string"
                         }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -173,6 +173,7 @@ const (
 	CodeRetry                     = "retry"
 	CodeIncompatibleSeries        = "incompatible series"
 	CodeCloudRegionRequired       = "cloud region required"
+	CodeIncompatibleClouds        = "incompatible clouds"
 )
 
 // ErrCode returns the error code associated with

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -29,6 +29,7 @@ type CloudRegion struct {
 type AddCloudArgs struct {
 	Cloud Cloud  `json:"cloud"`
 	Name  string `json:"name"`
+	Force *bool  `json:"force,omitempty"`
 }
 
 // UpdateCloudArgs holds a cloud to be updated with its name.

--- a/cloud/whitelist.go
+++ b/cloud/whitelist.go
@@ -1,0 +1,60 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/provider/lxd/lxdnames"
+)
+
+// WhiteList contains a cloud compatibility matrix:
+// if controller was bootstrapped on a particular cloud type,
+// what other cloud types can be added to it.
+type WhiteList struct {
+	matrix map[string]set.Strings
+}
+
+// String constructs user friendly white list representation.
+func (w *WhiteList) String() string {
+	if len(w.matrix) == 0 {
+		return "empty whitelist"
+	}
+	sorted := []string{}
+	for one := range w.matrix {
+		sorted = append(sorted, one)
+	}
+	sort.Strings(sorted)
+	result := []string{}
+	for _, one := range sorted {
+		result = append(result, fmt.Sprintf(" - controller cloud type %q supports %v", one, w.matrix[one].SortedValues()))
+	}
+	return strings.Join(result, "\n")
+}
+
+// Check will err out if 'exiting' controller cloud type is
+// not compatible with a 'new' cloud type according to this white list.
+func (w *WhiteList) Check(existing, new string) error {
+	if list, ok := w.matrix[existing]; ok {
+		if !list.Contains(new) {
+			return errors.Errorf("cloud type %q is not whitelisted for controller cloud type %q, current whitelist: %v", new, existing, list.SortedValues())
+		}
+		return nil
+	}
+	return errors.Errorf("controller cloud type %q is not whitelisted, current whitelist: \n%v", existing, w)
+}
+
+// CurrentWhiteList returns current clouds whitelist supported by Juju.
+func CurrentWhiteList() *WhiteList {
+	return &WhiteList{map[string]set.Strings{
+		lxdnames.ProviderType: set.NewStrings(lxdnames.ProviderType, "maas", "openstack"),
+		"maas":                set.NewStrings("maas", "openstack"),
+		"openstack":           set.NewStrings("openstack"),
+	}}
+}

--- a/cloud/whitelist.go
+++ b/cloud/whitelist.go
@@ -38,7 +38,7 @@ func (w *WhiteList) String() string {
 	return strings.Join(result, "\n")
 }
 
-// Check will err out if 'exiting' controller cloud type is
+// Check will err out if 'existing' controller cloud type is
 // not compatible with a 'new' cloud type according to this white list.
 func (w *WhiteList) Check(existing, new string) error {
 	if list, ok := w.matrix[existing]; ok {

--- a/cloud/whitelist_test.go
+++ b/cloud/whitelist_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+)
+
+func (s *cloudSuite) TestWhitelistString(c *gc.C) {
+	c.Assert((&cloud.WhiteList{}).String(), gc.Equals, "empty whitelist")
+	c.Assert(cloud.CurrentWhiteList().String(), gc.Equals, `
+ - controller cloud type "lxd" supports [lxd maas openstack]
+ - controller cloud type "maas" supports [maas openstack]
+ - controller cloud type "openstack" supports [openstack]`[1:])
+}
+
+func (s *cloudSuite) TestCheckWhitelistSuccess(c *gc.C) {
+	c.Assert(cloud.CurrentWhiteList().Check("maas", "maas"), jc.ErrorIsNil)
+}
+
+func (s *cloudSuite) TestCheckWhitelistFail(c *gc.C) {
+	c.Assert(cloud.CurrentWhiteList().Check("ec2", "maas"), gc.ErrorMatches, `
+controller cloud type "ec2" is not whitelisted, current whitelist: 
+ - controller cloud type "lxd" supports \[lxd maas openstack\]
+ - controller cloud type "maas" supports \[maas openstack\]
+ - controller cloud type "openstack" supports \[openstack\]`[1:])
+
+	c.Assert(cloud.CurrentWhiteList().Check("openstack", "ec2"), gc.ErrorMatches,
+		`cloud type "ec2" is not whitelisted for controller cloud type "openstack", current whitelist: \[openstack\]`)
+}

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -43,7 +43,7 @@ type CloudMetadataStore interface {
 
 // AddCloudAPI - Implemented by cloudapi.Client.
 type AddCloudAPI interface {
-	AddCloud(jujucloud.Cloud) error
+	AddCloud(jujucloud.Cloud, bool) error
 	AddCredential(tag string, credential jujucloud.Credential) error
 	Close() error
 }
@@ -694,7 +694,8 @@ func addCloudToLocal(cloudMetadataStore CloudMetadataStore, newCloud jujucloud.C
 }
 
 func addCloudToController(apiClient AddCloudAPI, newCloud jujucloud.Cloud) error {
-	err := apiClient.AddCloud(newCloud)
+	// No need to force this addition as k8s is special.
+	err := apiClient.AddCloud(newCloud, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -106,8 +106,8 @@ func (api *fakeAddCloudAPI) Close() error {
 	return nil
 }
 
-func (api *fakeAddCloudAPI) AddCloud(kloud cloud.Cloud) error {
-	api.MethodCall(api, "AddCloud", kloud)
+func (api *fakeAddCloudAPI) AddCloud(kloud cloud.Cloud, force bool) error {
+	api.MethodCall(api, "AddCloud", kloud, force)
 	if kloud.HostCloudRegion == "" && api.isCloudRegionRequired {
 		return params.Error{Code: params.CodeCloudRegionRequired}
 	}
@@ -602,7 +602,7 @@ func (s *addCAASSuite) assertAddCloudResult(
 	if localOnly {
 		s.fakeCloudAPI.CheckNoCalls(c)
 	} else {
-		s.fakeCloudAPI.CheckCall(c, 0, "AddCloud", expectedCloudToAdd)
+		s.fakeCloudAPI.CheckCall(c, 0, "AddCloud", expectedCloudToAdd, false)
 	}
 	s.cloudMetadataStore.CheckCall(c, 2, "WritePersonalCloudMetadata",
 		map[string]cloud.Cloud{

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -116,7 +116,7 @@ When adding clouds to a controller, some clouds are whitelisted and can be easil
 %v
 
 Other cloud combinations can only be force added as the user must consider
-network routability and other consideration that are outside of Juju concerns.
+network routability and other considerations that are outside of Juju concerns.
 When forced addition is desired, use --force.
 
 Examples:
@@ -341,6 +341,12 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 			ctxt.Infof("To upload credentials to the controller for cloud %q, use \n"+
 				"* 'add-model' with --credential option or\n"+
 				"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
+			return nil
+		}
+		if params.ErrCode(err) == params.CodeIncompatibleClouds {
+			logger.Infof("%v", err)
+			ctxt.Infof("Adding a cloud of type %q might not function correctly on this controller.\n"+
+				"If you really want to do this, use --force.", newCloud.Type)
 			return nil
 		}
 		return err

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -112,8 +112,16 @@ do that. If there's only one credential for the cloud it will be
 uploaded to the controller. If the cloud has multiple local credentials
 you can specify which to upload with the --credential option.
 
+When adding clouds to a controller, some clouds are whitelisted and can be easily added:
+%v
+
+Other cloud combinations can only be force added as the user must consider
+network routability and other consideration that are outside of Juju concerns.
+When forced addition is desired, use --force.
+
 Examples:
     juju add-cloud
+    juju add-cloud --force
     juju add-cloud mycloud ~/mycloud.yaml
 
 If the "multi-cloud" feature flag is turned on in the controller:
@@ -129,7 +137,7 @@ See also:
 
 // AddCloudAPI - Implemented by cloudapi.Client.
 type AddCloudAPI interface {
-	AddCloud(jujucloud.Cloud) error
+	AddCloud(jujucloud.Cloud, bool) error
 	AddCredential(tag string, credential jujucloud.Credential) error
 	Close() error
 }
@@ -162,6 +170,9 @@ type AddCloudCommand struct {
 	controllerName  string
 	credentialName  string
 	addCloudAPIFunc func() (AddCloudAPI, error)
+
+	// Force holds whether user wants to force addition of the cloud.
+	Force bool
 }
 
 // NewAddCloudCommand returns a command to add cloud information.
@@ -199,7 +210,7 @@ func (c *AddCloudCommand) Info() *cmd.Info {
 		Name:    "add-cloud",
 		Args:    "<cloud name> [<cloud definition file>]",
 		Purpose: usageAddCloudSummary,
-		Doc:     usageAddCloudDetails,
+		Doc:     fmt.Sprintf(usageAddCloudDetails, jujucloud.CurrentWhiteList()),
 	})
 }
 
@@ -207,6 +218,7 @@ func (c *AddCloudCommand) Info() *cmd.Info {
 func (c *AddCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.OptionalControllerCommand.SetFlags(f)
 	f.BoolVar(&c.Replace, "replace", false, "DEPRECATED: Overwrite any existing cloud information for <cloud name>")
+	f.BoolVar(&c.Force, "force", false, "Force add cloud to the controller")
 	f.StringVar(&c.CloudFile, "f", "", "The path to a cloud definition file")
 	f.StringVar(&c.credentialName, "credential", "", "Credential to use for new cloud")
 }
@@ -322,7 +334,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	defer api.Close()
-	err = api.AddCloud(*newCloud)
+	err = api.AddCloud(*newCloud, c.Force)
 	if err != nil {
 		if params.ErrCode(err) == params.CodeAlreadyExists {
 			ctxt.Infof("Cloud %q already exists on the controller %q.", c.Cloud, c.controllerName)

--- a/featuretests/cmd_juju_cloud_test.go
+++ b/featuretests/cmd_juju_cloud_test.go
@@ -40,12 +40,12 @@ clouds:
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
-	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll")
+	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll", "--force")
 	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cloud "testdummy" added to controller "kontroll".`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
-	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll")
+	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll", "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cloud "testdummy" already exists on the controller "kontroll".`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")


### PR DESCRIPTION
## Description of change

In multi-cloud Juju world, it is easy to add clouds to a bootstrapped controller. However, some clouds are less compatible with each other. This PR introduces a whitelist of the clouds that Juju can support easily out of the box.

With all other cloud combinations, users need to be absolutely sure that they know what they are doing (networks and connectivity needs to be configured outside of Juju) and can use --force option to force cloud addition.

'add-cloud' help also provides whitelist now - https://pastebin.ubuntu.com/p/WXc9rnTv5J/

'add-model' already prevents users from adding models on a clouds that are not yet known to the controller (https://pastebin.ubuntu.com/p/5h496RkqYw/) so there is no need to provide a --force option here.

As a drive-by, this PR renames some variables that have been conflicting with imports names.

## QA steps
1. bootstrap a controller on a non-whitelisted cloud and enable multi-cloud feature for it. I used aws
2. Try adding cloud. You should be stopped -  https://pastebin.ubuntu.com/p/Gc6KRZPp3Z/
3. Using --force allows operation to proceed
4. Bootstrap a controller on a whitelisted cloud and enable multi-cloud feature for it. I used maas
5. Try adding non-whitelisted cloud. You should be stopped. I used lxd

## Bug reference

https://bugs.launchpad.net/juju/+bug/1825889
