### PR TITLE
Fix the rewriting of the mongo config on agent start.

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -588,8 +588,8 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 		return zeroVersion, errors.Trace(err)
 	}
 	if installed {
-		// Exists does a check against the contents of the service config file.
-		// The return value is true iff the contest is the same.
+		// Exists() does a check against the contents of the service config file.
+		// The return value is true iff the content is the same.
 		exists, err := svc.Exists()
 		if err != nil {
 			return zeroVersion, errors.Trace(err)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -582,20 +582,44 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 		return mongodVersion, nil
 	}
 
-	running, err := svc.Running()
+	// Installed tells us if there exists a service of the right name.
+	installed, err := svc.Installed()
 	if err != nil {
 		return zeroVersion, errors.Trace(err)
 	}
-	if running {
-		return mongodVersion, nil
+	if installed {
+		// Exists does a check against the contents of the service config file.
+		// The return value is true iff the contest is the same.
+		exists, err := svc.Exists()
+		if err != nil {
+			return zeroVersion, errors.Trace(err)
+		}
+		if exists {
+			logger.Debugf("mongo exists as expected")
+			running, err := svc.Running()
+			if err != nil {
+				return zeroVersion, errors.Trace(err)
+			}
+
+			if !running {
+				return mongodVersion, errors.Trace(svc.Start())
+			}
+			return mongodVersion, nil
+		}
+		logger.Debugf("updating mongo service configuration")
 	}
 
+	// We want to write or rewrite the contents of the service.
+	// Stop is a no-op if the service doesn't exist or isn't running.
+	if err := svc.Stop(); err != nil {
+		return zeroVersion, errors.Annotatef(err, "failed to stop mongo")
+	}
 	dbDir := DbDir(args.DataDir)
 	if err := makeJournalDirs(dbDir); err != nil {
-		return zeroVersion, errors.Errorf("error creating journal directories: %v", err)
+		return zeroVersion, fmt.Errorf("error creating journal directories: %v", err)
 	}
 	if err := preallocOplog(dbDir, oplogSizeMB); err != nil {
-		return zeroVersion, errors.Errorf("error creating oplog files: %v", err)
+		return zeroVersion, fmt.Errorf("error creating oplog files: %v", err)
 	}
 
 	if err := service.InstallAndStart(svc); err != nil {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -616,10 +616,10 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 	}
 	dbDir := DbDir(args.DataDir)
 	if err := makeJournalDirs(dbDir); err != nil {
-		return zeroVersion, fmt.Errorf("error creating journal directories: %v", err)
+		return zeroVersion, errors.Errorf("error creating journal directories: %v", err)
 	}
 	if err := preallocOplog(dbDir, oplogSizeMB); err != nil {
-		return zeroVersion, fmt.Errorf("error creating oplog files: %v", err)
+		return zeroVersion, errors.Errorf("error creating oplog files: %v", err)
 	}
 
 	if err := service.InstallAndStart(svc); err != nil {

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -223,9 +224,16 @@ type ConfigArgs struct {
 
 type configArgsConverter map[string]string
 
+// The generated command line arguments need to be in a deterministic order.
 func (conf configArgsConverter) asCommandLineArguments() string {
+	keys := make([]string, 0, len(conf))
+	for key := range conf {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
 	command := make([]string, 0, len(conf)*2)
-	for key, value := range conf {
+	for _, key := range keys {
+		value := conf[key]
 		if len(key) >= 2 {
 			key = "--" + key
 		} else if len(key) == 1 {
@@ -540,14 +548,6 @@ func EnsureServiceInstalled(dataDir string, statePort int, oplogSizeMB int, setN
 	service, err := mongoArgs.asService()
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	alreadyInstalled, err := service.Installed()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if alreadyInstalled {
-		return nil
 	}
 
 	err = service.Install()


### PR DESCRIPTION
During the 2.6 refactor of the mongo service code, the rewriting of the mongod service config was mistakenly removed.

This branch reinstates the 2.5 logic around the checking of the service. Also adds a test and makes sure that the arguments for the config are output in a deterministic order.

## QA steps

```
juju bootstrap lxd test
juju model-config -m controller logging-config=juju=info:juju.mongo=debug
juju run -m controller --machine 0 'cat /lib/systemd/system/juju-db/juju-db.service'
# Note no --wiredTigerCacheSizeGB flag
juju controller-config mongo-memory-profile=low
# Wait a few seconds
juju run -m controller --machine 0 'cat /lib/systemd/system/juju-db/juju-db.service'
# Note that the flag turned up.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1840731
