### PR TITLE
Load Spaces from Provider Earlier in Bootstrap

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -586,7 +586,14 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, args agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, _ state.NewPolicyFunc) (_ *state.Controller, resultErr error) {
+	initializeState := func(
+		_ environs.BootstrapEnviron,
+		_ names.UserTag,
+		_ agent.ConfigSetter,
+		args agentbootstrap.InitializeStateParams,
+		dialOpts mongo.DialOpts,
+		_ state.NewPolicyFunc,
+	) (_ *state.Controller, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.Timeout, gc.Equals, 30*time.Second)
@@ -607,7 +614,14 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, _ agentbootstrap.InitializeStateParams, dialOpts mongo.DialOpts, _ state.NewPolicyFunc) (_ *state.Controller, resultErr error) {
+	initializeState := func(
+		_ environs.BootstrapEnviron,
+		_ names.UserTag,
+		_ agent.ConfigSetter,
+		_ agentbootstrap.InitializeStateParams,
+		dialOpts mongo.DialOpts,
+		_ state.NewPolicyFunc,
+	) (_ *state.Controller, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.SocketTimeout, gc.Equals, 1*time.Minute)


### PR DESCRIPTION
## Description of change

When we replace space name with space ID on machine/service address docs, spaces will need to be loaded before setting API addresses, so that space IDs can be determined.

This patch simply moves the logic to load spaces from the provider, to earlier in the bootstrap process.

Sundry code cleanups are included.

## QA steps

- Bootstrap to MAAS
- Run `juju spaces` and ensure that the MAAS-defined spaces are present.

## Documentation changes

None.

## Bug reference

N/A
