### PR TITLE
ControllerInfo machineids -> controllerids

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -629,12 +629,12 @@ func (p *ProvisionerAPI) DistributionGroup(args params.Entities) (params.Distrib
 
 // controllerInstances returns all environ manager instances.
 func controllerInstances(st *state.State) ([]instance.Id, error) {
-	info, err := st.ControllerInfo()
+	controllerIds, err := st.ControllerIds()
 	if err != nil {
 		return nil, err
 	}
-	instances := make([]instance.Id, 0, len(info.MachineIds))
-	for _, id := range info.MachineIds {
+	instances := make([]instance.Id, 0, len(controllerIds))
+	for _, id := range controllerIds {
 		machine, err := st.Machine(id)
 		if err != nil {
 			return nil, err
@@ -717,11 +717,11 @@ func (p *ProvisionerAPI) DistributionGroupByMachineId(args params.Entities) (par
 
 // controllerMachineIds returns a slice of all other environ manager machine.Ids.
 func controllerMachineIds(st *state.State, m *state.Machine) ([]string, error) {
-	info, err := st.ControllerInfo()
+	ids, err := st.ControllerIds()
 	if err != nil {
 		return nil, err
 	}
-	result := set.NewStrings(info.MachineIds...)
+	result := set.NewStrings(ids...)
 	result.Remove(m.Id())
 	return result.SortedValues(), nil
 }

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -102,7 +102,7 @@ func (api *HighAvailabilityAPI) enableHASingle(st *state.State, spec params.Cont
 		return params.ControllersChanges{}, errors.Trace(err)
 	}
 
-	cInfo, err := st.ControllerInfo()
+	controllerIds, err := st.ControllerIds()
 	if err != nil {
 		return params.ControllersChanges{}, err
 	}
@@ -110,7 +110,7 @@ func (api *HighAvailabilityAPI) enableHASingle(st *state.State, spec params.Cont
 	// If there were no supplied constraints, use the original bootstrap
 	// constraints.
 	if constraints.IsEmpty(&spec.Constraints) || spec.Series == "" {
-		referenceMachine, err := getReferenceController(st, cInfo.MachineIds)
+		referenceMachine, err := getReferenceController(st, controllerIds)
 		if err != nil {
 			return params.ControllersChanges{}, errors.Trace(err)
 		}
@@ -132,7 +132,7 @@ func (api *HighAvailabilityAPI) enableHASingle(st *state.State, spec params.Cont
 	if err != nil {
 		return params.ControllersChanges{}, errors.Annotate(err, "retrieving controller config")
 	}
-	if err = validateCurrentControllers(st, cfg, cInfo.MachineIds); err != nil {
+	if err = validateCurrentControllers(st, cfg, controllerIds); err != nil {
 		return params.ControllersChanges{}, errors.Trace(err)
 	}
 	spec.Constraints.Spaces = cfg.AsSpaceConstraints(spec.Constraints.Spaces)
@@ -150,23 +150,23 @@ func (api *HighAvailabilityAPI) enableHASingle(st *state.State, spec params.Cont
 }
 
 // getReferenceController looks up the ideal controller to use as a reference for Constraints and Series
-func getReferenceController(st *state.State, machineIds []string) (*state.Machine, error) {
+func getReferenceController(st *state.State, controllerIds []string) (*state.Machine, error) {
 	// Sort the controller IDs from low to high and take the first.
 	// This will typically give the initial bootstrap machine.
-	var controllerIds []int
-	for _, id := range machineIds {
+	var controllerNumbers []int
+	for _, id := range controllerIds {
 		idNum, err := strconv.Atoi(id)
 		if err != nil {
 			logger.Warningf("ignoring non numeric controller id %v", id)
 			continue
 		}
-		controllerIds = append(controllerIds, idNum)
+		controllerNumbers = append(controllerNumbers, idNum)
 	}
-	if len(controllerIds) == 0 {
+	if len(controllerNumbers) == 0 {
 		return nil, errors.Errorf("internal error; failed to find any controllers")
 	}
-	sort.Ints(controllerIds)
-	controllerId := controllerIds[0]
+	sort.Ints(controllerNumbers)
+	controllerId := controllerNumbers[0]
 
 	// Load the controller machine and get its constraints.
 	cm, err := st.Machine(strconv.Itoa(controllerId))

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -165,7 +165,7 @@ func (st *State) AddMachines(templates ...MachineTemplate) (_ []*Machine, err er
 		ms = append(ms, newMachine(st, mdoc))
 		ops = append(ops, addOps...)
 	}
-	ssOps, err := st.maintainControllersOps(controllerIds, nil)
+	ssOps, err := st.maintainControllersOps(controllerIds, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -77,9 +77,9 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, names.NewMachineTag("0"))
 	// Ensure there's one and only one controller.
-	controllerInfo, err := st.ControllerInfo()
+	controllerIds, err := st.ControllerIds()
 	c.Assert(err, jc.ErrorIsNil)
-	needController := len(controllerInfo.MachineIds) == 0
+	needController := len(controllerIds) == 0
 	if needController {
 		_, err = st.EnableHA(1, constraints.Value{}, "quantal", []string{m.Id()})
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -394,9 +394,9 @@ func (s *CleanupSuite) TestCleanupForceDestroyedControllerMachine(c *gc.C) {
 	c.Check(node.WantsVote(), jc.IsFalse)
 	c.Check(node.HasVote(), jc.IsTrue)
 	c.Check(machine.Jobs(), jc.DeepEquals, []state.MachineJob{state.JobManageModel})
-	controllerInfo, err := s.State.ControllerInfo()
+	controllerIds, err := s.State.ControllerIds()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(controllerInfo.MachineIds, gc.DeepEquals, append([]string{machine.Id()}, changes.Added...))
+	c.Check(controllerIds, gc.DeepEquals, append([]string{machine.Id()}, changes.Added...))
 	// ForceDestroy still won't kill the controller if it is flagged as having a vote
 	// We don't see the error because it is logged, but not returned.
 	s.assertCleanupRuns(c)
@@ -411,12 +411,12 @@ func (s *CleanupSuite) TestCleanupForceDestroyedControllerMachine(c *gc.C) {
 	// After we've run the cleanup for the controller machine, the machine should be dead, and it should not be
 	// present in the other documents.
 	assertLife(c, machine, state.Dead)
-	controllerInfo, err = s.State.ControllerInfo()
+	controllerIds, err = s.State.ControllerIds()
 	c.Assert(err, jc.ErrorIsNil)
-	sort.Strings(controllerInfo.MachineIds)
+	sort.Strings(controllerIds)
 	sort.Strings(changes.Added)
 	// Only the machines that were added should still be part of the controller
-	c.Check(controllerInfo.MachineIds, gc.DeepEquals, changes.Added)
+	c.Check(controllerIds, gc.DeepEquals, changes.Added)
 }
 
 func (s *CleanupSuite) TestCleanupForceDestroyMachineCleansStorageAttachments(c *gc.C) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -191,14 +191,17 @@ func (s *ControllerSuite) TestUpdateControllerConfigAcceptsSpaceWithAddresses(c 
 }
 
 func (s *ControllerSuite) TestControllerInfo(c *gc.C) {
-	ids, err := s.State.ControllerInfo()
+	info, err := s.State.ControllerInfo()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ids.CloudName, gc.Equals, "dummy")
-	c.Assert(ids.ModelTag, gc.Equals, s.modelTag)
-	c.Assert(ids.MachineIds, gc.HasLen, 0)
+	c.Assert(info.CloudName, gc.Equals, "dummy")
+	c.Assert(info.ModelTag, gc.Equals, s.modelTag)
+	c.Assert(info.ControllerIds, gc.HasLen, 0)
 
-	// TODO(rog) more testing here when we can actually add
-	// controllers.
+	node, err := s.State.AddControllerNode()
+	c.Assert(err, jc.ErrorIsNil)
+	info, err = s.State.ControllerInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.ControllerIds, jc.DeepEquals, []string{node.Id()})
 }
 
 func (s *ControllerSuite) testOpenParams() state.OpenParams {

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -185,14 +185,13 @@ func newUint64(i uint64) *uint64 {
 	return &i
 }
 
-func (s *EnableHASuite) assertControllerInfo(c *gc.C, machineIds []string, wantVoteMachineIds []string, placement []string) {
-	info, err := s.State.ControllerInfo()
+func (s *EnableHASuite) assertControllerInfo(c *gc.C, expectedIds []string, wantVoteMachineIds []string, placement []string) {
+	controllerIds, err := s.State.ControllerIds()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(info.ModelTag, gc.Equals, s.modelTag)
-	c.Check(info.MachineIds, jc.SameContents, machineIds)
+	c.Check(controllerIds, jc.SameContents, expectedIds)
 
 	foundVoting := make([]string, 0)
-	for i, id := range machineIds {
+	for i, id := range expectedIds {
 		m, err := s.State.Machine(id)
 		c.Assert(err, jc.ErrorIsNil)
 		if len(placement) == 0 || i >= len(placement) {
@@ -427,9 +426,9 @@ func (s *EnableHASuite) TestWatchControllerInfo(c *gc.C) {
 	info, err := s.State.ControllerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &state.ControllerInfo{
-		CloudName:  "dummy",
-		ModelTag:   s.modelTag,
-		MachineIds: []string{"0"},
+		CloudName:     "dummy",
+		ModelTag:      s.modelTag,
+		ControllerIds: []string{"0"},
 	})
 
 	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", nil)
@@ -441,9 +440,9 @@ func (s *EnableHASuite) TestWatchControllerInfo(c *gc.C) {
 	info, err = s.State.ControllerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &state.ControllerInfo{
-		CloudName:  "dummy",
-		ModelTag:   s.modelTag,
-		MachineIds: []string{"0", "1", "2"},
+		CloudName:     "dummy",
+		ModelTag:      s.modelTag,
+		ControllerIds: []string{"0", "1", "2"},
 	})
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1411,10 +1411,9 @@ func (s *StateSuite) TestAddMachineCanOnlyAddControllerForMachine0(c *gc.C) {
 	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
 
 	// Check that the controller information is correct.
-	info, err := s.State.ControllerInfo()
+	controllerIds, err := s.State.ControllerIds()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.ModelTag, gc.Equals, s.modelTag)
-	c.Assert(info.MachineIds, gc.DeepEquals, []string{"0"})
+	c.Assert(controllerIds, gc.DeepEquals, []string{"0"})
 
 	const errCannotAdd = "cannot add a new machine: controller jobs specified but not allowed"
 	m, err = s.State.AddOneMachine(template)
@@ -4091,7 +4090,7 @@ func (s *StateSuite) TestControllerInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ids.CloudName, gc.Equals, "dummy")
 	c.Assert(ids.ModelTag, gc.Equals, s.modelTag)
-	c.Assert(ids.MachineIds, gc.HasLen, 0)
+	c.Assert(ids.ControllerIds, gc.HasLen, 0)
 
 	// TODO(rog) more testing here when we can actually add
 	// controllers.

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2266,10 +2266,15 @@ func AddControllerNodeDocs(pool *StatePool) error {
 			Insert: doc,
 		})
 	}
-	if len(ops) > 0 {
-		return errors.Trace(st.runRawTransaction(ops))
-	}
-	return nil
+
+	ops = append(ops, txn.Op{
+		C:  controllersC,
+		Id: modelGlobalKey,
+		Update: bson.D{
+			{"$rename", bson.D{{"machineids", "controller-ids"}}},
+		},
+	})
+	return errors.Trace(st.runRawTransaction(ops))
 }
 
 // AddSpaceIdToSpaceDocs ensures that every space document includes a

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -246,15 +246,15 @@ func (st *fakeState) removeController(id string) {
 
 func (st *fakeState) setControllers(ids ...string) {
 	st.controllerInfo.Set(&state.ControllerInfo{
-		MachineIds: ids,
+		ControllerIds: ids,
 	})
 }
 
-func (st *fakeState) ControllerInfo() (*state.ControllerInfo, error) {
-	if err := st.errors.errorFor("State.ControllerInfo"); err != nil {
+func (st *fakeState) ControllerIds() ([]string, error) {
+	if err := st.errors.errorFor("State.ControllerIds"); err != nil {
 		return nil, err
 	}
-	return deepCopy(st.controllerInfo.Get()).(*state.ControllerInfo), nil
+	return deepCopy(st.controllerInfo.Get()).(*state.ControllerInfo).ControllerIds, nil
 }
 
 func (st *fakeState) WatchControllerInfo() state.StringsWatcher {
@@ -289,7 +289,7 @@ func (st *fakeState) RemoveControllerReference(c ControllerNode) error {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	controllerInfo := st.controllerInfo.Get().(*state.ControllerInfo)
-	controllerIds := controllerInfo.MachineIds
+	controllerIds := controllerInfo.ControllerIds
 	var newControllerIds []string
 	controllerId := c.Id()
 	for _, id := range controllerIds {

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -388,8 +388,8 @@ var fatalErrorsTests = []struct {
 	expectErr    string
 	advanceCount int
 }{{
-	errPattern: "State.ControllerInfo",
-	expectErr:  "cannot get controller info: sample",
+	errPattern: "State.ControllerIds",
+	expectErr:  "cannot get controller ids: sample",
 }, {
 	errPattern:   "Controller.SetHasVote 11 true",
 	expectErr:    `adding new voters: cannot set voting status of "11" to true: sample`,


### PR DESCRIPTION
## Description of change

The ControllerInfo entity contains a list of ids representing controller nodes. The mongo doc field is renamed from "machineids" to "controller-ids". The ids were accessed by first loading the controller info doc and getting the ids attribute - this has been abstracted behind a new ControllerIds() method to allow future optimisations. With this PR, separation of controller HA related info from machines is done, and k8s deployments have no machine related info in the model.

## QA steps

bootstrap 2.6 lxd
enable ha
upgrade
check the controller info doc in mongo
enable ha -n 5

bootstrap 2.6 k8s
upgrade
check the controller info doc in mongo
