### PR TITLE
Incoming CIDR should be a string in Spaces api and facade, not a SubnetTag.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -94,7 +94,7 @@ var facadeVersions = map[string]int{
 	"Resumer":                      2,
 	"RetryStrategy":                1,
 	"Singular":                     2,
-	"Spaces":                       4,
+	"Spaces":                       5,
 	"SSHClient":                    2,
 	"StatusHistory":                2,
 	"Storage":                      6,

--- a/api/spaces/spaces.go
+++ b/api/spaces/spaces.go
@@ -5,7 +5,7 @@ package spaces
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -31,27 +31,18 @@ func NewAPI(caller base.APICallCloser) *API {
 	}
 }
 
-func makeCreateSpaceParams(name string, subnetIds []string, public bool) params.CreateSpaceParams {
-	spaceTag := names.NewSpaceTag(name).String()
-	subnetTags := make([]string, len(subnetIds))
-
-	for i, s := range subnetIds {
-		subnetTags[i] = names.NewSubnetTag(s).String()
-	}
-
-	return params.CreateSpaceParams{
-		SpaceTag:   spaceTag,
-		SubnetTags: subnetTags,
-		Public:     public,
-	}
-}
-
 // CreateSpace creates a new Juju network space, associating the
 // specified subnets with it (optional; can be empty).
 func (api *API) CreateSpace(name string, subnetIds []string, public bool) error {
 	var response params.ErrorResults
 	createSpacesParams := params.CreateSpacesParams{
-		Spaces: []params.CreateSpaceParams{makeCreateSpaceParams(name, subnetIds, public)},
+		Spaces: []params.CreateSpaceParams{
+			{
+				SpaceTag: names.NewSpaceTag(name).String(),
+				CIDRs:    subnetIds,
+				Public:   public,
+			},
+		},
 	}
 	err := api.facade.FacadeCall("CreateSpaces", createSpacesParams, &response)
 	if err != nil {

--- a/api/spaces/spaces_test.go
+++ b/api/spaces/spaces_test.go
@@ -29,7 +29,11 @@ var _ = gc.Suite(&SpacesSuite{})
 
 func (s *SpacesSuite) init(c *gc.C, args apitesting.APICall) {
 	s.apiCaller = apitesting.APICallChecker(c, args)
-	s.api = spaces.NewAPI(s.apiCaller)
+	best := &apitesting.BestVersionCaller{
+		BestVersion:   5,
+		APICallerFunc: s.apiCaller.APICallerFunc,
+	}
+	s.api = spaces.NewAPI(best)
 	c.Check(s.api, gc.NotNil)
 	c.Check(s.apiCaller.CallCount, gc.Equals, 0)
 }
@@ -90,6 +94,40 @@ func (s *SpacesSuite) TestCreateSpace(c *gc.C) {
 		}
 		s.testCreateSpace(c, name, subnets)
 	}
+}
+
+func (s *SpacesSuite) TestCreateSpaceV4(c *gc.C) {
+	var called bool
+	apicaller := &apitesting.BestVersionCaller{
+		APICallerFunc: apitesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Spaces")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "CreateSpaces")
+				c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+				c.Assert(a, jc.DeepEquals, params.CreateSpacesParamsV4{
+					Spaces: []params.CreateSpaceParamsV4{{
+						SpaceTag:   names.NewSpaceTag("testv4").String(),
+						SubnetTags: []string{"subnet-1.1.1.0/24"},
+						Public:     false,
+					}}})
+				*result.(*params.ErrorResults) = params.ErrorResults{
+					Results: []params.ErrorResult{{}},
+				}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 4,
+	}
+	apiv4 := spaces.NewAPI(apicaller)
+	err := apiv4.CreateSpace("testv4", []string{"1.1.1.0/24"}, false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
 }
 
 func (s *SpacesSuite) TestCreateSpaceEmptyResults(c *gc.C) {

--- a/api/spaces/spaces_test.go
+++ b/api/spaces/spaces_test.go
@@ -10,7 +10,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/spaces"
@@ -46,20 +46,15 @@ func (s *SpacesSuite) TestNewAPIWithNilCaller(c *gc.C) {
 	c.Assert(panicFunc, gc.PanicMatches, "caller is nil")
 }
 
-func makeArgs(name string, subnets []string) (string, []string, apitesting.APICall) {
+func makeArgs(name string, cidrs []string) (string, []string, apitesting.APICall) {
 	spaceTag := names.NewSpaceTag(name).String()
-	subnetTags := []string{}
-
-	for _, s := range subnets {
-		subnetTags = append(subnetTags, names.NewSubnetTag(s).String())
-	}
 
 	expectArgs := params.CreateSpacesParams{
 		Spaces: []params.CreateSpaceParams{
 			{
-				SpaceTag:   spaceTag,
-				SubnetTags: subnetTags,
-				Public:     true,
+				SpaceTag: spaceTag,
+				CIDRs:    cidrs,
+				Public:   true,
 			}}}
 
 	expectResults := params.ErrorResults{
@@ -72,7 +67,7 @@ func makeArgs(name string, subnets []string) (string, []string, apitesting.APICa
 		Args:    expectArgs,
 		Results: expectResults,
 	}
-	return name, subnets, args
+	return name, cidrs, args
 }
 
 func (s *SpacesSuite) testCreateSpace(c *gc.C, name string, subnets []string) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -290,7 +290,8 @@ func AllFacades() *facade.Registry {
 
 	reg("Spaces", 2, spaces.NewAPIv2)
 	reg("Spaces", 3, spaces.NewAPIv3)
-	reg("Spaces", 4, spaces.NewAPI)
+	reg("Spaces", 4, spaces.NewAPIv4)
+	reg("Spaces", 5, spaces.NewAPI)
 
 	reg("StatusHistory", 2, statushistory.NewAPI)
 

--- a/apiserver/common/networkingcommon/spaces_test.go
+++ b/apiserver/common/networkingcommon/spaces_test.go
@@ -60,9 +60,7 @@ func (s *SpacesSuite) checkCreateSpaces(c *gc.C, p checkCreateSpacesParams) {
 		args.SpaceTag = "space-" + p.Name
 	}
 	if len(p.Subnets) > 0 {
-		for _, cidr := range p.Subnets {
-			args.SubnetTags = append(args.SubnetTags, "subnet-"+cidr)
-		}
+		args.CIDRs = p.Subnets
 	}
 	args.Public = p.Public
 	args.ProviderId = p.ProviderId
@@ -106,11 +104,11 @@ func (s *SpacesSuite) TestCreateInvalidSpace(c *gc.C) {
 	s.checkCreateSpaces(c, p)
 }
 
-func (s *SpacesSuite) TestCreateInvalidSubnet(c *gc.C) {
+func (s *SpacesSuite) TestCreateInvalidCIDR(c *gc.C) {
 	p := checkCreateSpacesParams{
 		Name:    "foo",
 		Subnets: []string{"bar"},
-		Error:   `"subnet-bar" is not a valid subnet tag`,
+		Error:   `"bar" is not a valid CIDR`,
 	}
 	s.checkCreateSpaces(c, p)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -29842,7 +29842,7 @@
     },
     {
         "Name": "Spaces",
-        "Version": 4,
+        "Version": 5,
         "Schema": {
             "type": "object",
             "properties": {
@@ -29873,6 +29873,12 @@
                 "CreateSpaceParams": {
                     "type": "object",
                     "properties": {
+                        "cidrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "provider-id": {
                             "type": "string"
                         },
@@ -29881,17 +29887,11 @@
                         },
                         "space-tag": {
                             "type": "string"
-                        },
-                        "subnet-tags": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "subnet-tags",
+                        "cidrs",
                         "space-tag",
                         "public"
                     ]

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -620,6 +620,20 @@ type CreateSubnetParams struct {
 }
 
 // CreateSpacesParams olds the arguments of the AddSpaces API call.
+type CreateSpacesParamsV4 struct {
+	Spaces []CreateSpaceParamsV4 `json:"spaces"`
+}
+
+// CreateSpaceParams holds the space tag and at least one subnet
+// tag required to create a new space.
+type CreateSpaceParamsV4 struct {
+	SubnetTags []string `json:"subnet-tags"`
+	SpaceTag   string   `json:"space-tag"`
+	Public     bool     `json:"public"`
+	ProviderId string   `json:"provider-id,omitempty"`
+}
+
+// CreateSpacesParams olds the arguments of the AddSpaces API call.
 type CreateSpacesParams struct {
 	Spaces []CreateSpaceParams `json:"spaces"`
 }
@@ -627,7 +641,7 @@ type CreateSpacesParams struct {
 // CreateSpaceParams holds the space tag and at least one subnet
 // tag required to create a new space.
 type CreateSpaceParams struct {
-	SubnetTags []string `json:"subnet-tags"`
+	CIDRs      []string `json:"cidrs"`
 	SpaceTag   string   `json:"space-tag"`
 	Public     bool     `json:"public"`
 	ProviderId string   `json:"provider-id,omitempty"`

--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"

--- a/cmd/juju/space/rename.go
+++ b/cmd/juju/space/rename.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"

--- a/cmd/juju/space/space.go
+++ b/cmd/juju/space/space.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/spaces"


### PR DESCRIPTION
## Description of change

Change Spaces api and facade to accept a CIDR as a string to be verified, not a names.v2 SubnetTag.  The facade version was incremented to 5

## QA steps

1. juju bootstrap maas.
2. juju subnets
2. juju add-space testme <valid network cidr> - succeeds
2. use older client against new controller:
2. juju add-space testme <valid network cidr>  - succeeds
3. juju spaces to verify
