### PR TITLE
Add support for k8s juju-run

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -555,11 +555,11 @@
   revision = "e1ad140384f254c82f89450d9a7c8dd38a632838"
 
 [[projects]]
-  digest = "1:f8d71df5366f8cd94412859a652e23ba428eae9ff21f0d8baac52017b3eca99b"
+  digest = "1:fa2a8cf80188aa8fc36adeec7c416bbb506fc19acdf0bf91027f0f315e20fc1f"
   name = "github.com/juju/gomaasapi"
   packages = ["."]
   pruneopts = ""
-  revision = "7f9373c5e79e1b4f27e46dfe1166a9ec0c147b81"
+  revision = "0ab1eb636aba97733a62e850ffea2c8729bf9718"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -74,7 +74,7 @@
   name = "github.com/juju/gojsonschema"
 
 [[constraint]]
-  revision = "7f9373c5e79e1b4f27e46dfe1166a9ec0c147b81"
+  revision = "0ab1eb636aba97733a62e850ffea2c8729bf9718"
   name = "github.com/juju/gomaasapi"
 
 [[constraint]]

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ OPERATOR_IMAGE_PATH      = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TA
 
 operator-image:
     ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
-		@BUILD_TAGS="minimal provider_kubernetes" make install
+		make install
     else
 		@echo "skipping to build jujud bin, use existing one at ${JUJUD_BIN_DIR}/jujud."
     endif

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -75,6 +75,16 @@ const (
 
 	// OperatorPodIPEnvName is the environment name for operator pod IP.
 	OperatorPodIPEnvName = "JUJU_OPERATOR_POD_IP"
+
+	// OperatorPodIPEnvName is the environment name for operator service IP.
+	OperatorServiceIPEnvName = "JUJU_OPERATOR_SERVICE_IP"
+
+	// OperatorInfoFile is the file containing info about the operator,
+	// copied to the workload pod so the hook tools and juju-run can function.
+	OperatorInfoFile = "operator.yaml"
+
+	// JujuRunServerSocketPort is the port used by juju run callbacks.
+	JujuRunServerSocketPort = 30666
 )
 
 var (
@@ -566,10 +576,43 @@ func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, e
 
 // EnsureOperator creates or updates an operator pod with the given application
 // name, agent path, and operator config.
-func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caas.OperatorConfig) error {
+func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caas.OperatorConfig) (err error) {
 	logger.Debugf("creating/updating %s operator", appName)
 
 	operatorName := k.operatorName(appName)
+
+	var cleanups []func()
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, f := range cleanups {
+			f()
+		}
+	}()
+
+	service := &core.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   operatorName,
+			Labels: map[string]string{labelOperator: appName},
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{labelOperator: appName},
+			Type:     core.ServiceTypeClusterIP,
+			Ports: []core.ServicePort{
+				{Protocol: core.ProtocolTCP, Port: JujuRunServerSocketPort, TargetPort: intstr.FromInt(JujuRunServerSocketPort)}},
+		},
+	}
+	if err := k.ensureK8sService(service); err != nil {
+		return errors.Annotatef(err, "creating or updating service for %v operator", appName)
+	}
+	cleanups = append(cleanups, func() { k.deleteService(operatorName) })
+	services := k.client().CoreV1().Services(k.namespace)
+	svc, err := services.Get(operatorName, v1.GetOptions{IncludeUninitialized: false})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// TODO(caas) use secrets for storing agent password?
 	if config.AgentConf == nil {
 		// We expect that the config map already exists,
@@ -629,6 +672,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	pod, err := operatorPod(
 		operatorName,
 		appName,
+		svc.Spec.ClusterIP,
 		agentPath,
 		config.OperatorImagePath,
 		config.Version.String(),
@@ -845,10 +889,13 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 		PropagationPolicy: &defaultPropagationPolicy,
 	})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return nil
+		return errors.Trace(err)
 	}
 
 	// Finally the operator itself.
+	if err := k.deleteService(operatorName); err != nil {
+		return errors.Trace(err)
+	}
 	if err := k.deleteStatefulSet(operatorName); err != nil {
 		return errors.Trace(err)
 	}
@@ -2482,7 +2529,7 @@ func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) 
 
 // operatorPod returns a *core.Pod for the operator pod
 // of the specified application.
-func operatorPod(podName, appName, agentPath, operatorImagePath, version string, annotations k8sannotations.Annotation) (*core.Pod, error) {
+func operatorPod(podName, appName, operatorServiceIP, agentPath, operatorImagePath, version string, annotations k8sannotations.Annotation) (*core.Pod, error) {
 	configMapName := operatorConfigMapName(podName)
 	configVolName := configMapName
 
@@ -2523,6 +2570,7 @@ func operatorPod(podName, appName, agentPath, operatorImagePath, version string,
 				},
 				Env: []core.EnvVar{
 					{Name: "JUJU_APPLICATION", Value: appName},
+					{Name: OperatorServiceIPEnvName, Value: operatorServiceIP},
 					{
 						Name: OperatorPodIPEnvName,
 						ValueFrom: &core.EnvVarSource{

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/caasoperator"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
 	jworker "github.com/juju/juju/worker"
@@ -65,7 +66,8 @@ type CaasOperatorAgent struct {
 
 	prometheusRegistry *prometheus.Registry
 
-	newExecClient func(modelName string) (exec.Executor, error)
+	newExecClient     func(modelName string) (exec.Executor, error)
+	runListenerSocket func() (*sockets.Socket, error)
 }
 
 // NewCaasOperatorAgent creates a new CAASOperatorAgent instance properly initialized.
@@ -73,6 +75,7 @@ func NewCaasOperatorAgent(
 	ctx *cmd.Context,
 	bufferedLogger *logsender.BufferedLogWriter,
 	newExecClient func(modelName string) (exec.Executor, error),
+	runListenerSocket func() (*sockets.Socket, error),
 ) (*CaasOperatorAgent, error) {
 	prometheusRegistry, err := newPrometheusRegistry()
 	if err != nil {
@@ -87,6 +90,7 @@ func NewCaasOperatorAgent(
 		prometheusRegistry: prometheusRegistry,
 		preUpgradeSteps:    upgrades.PreUpgradeSteps,
 		newExecClient:      newExecClient,
+		runListenerSocket:  runListenerSocket,
 	}, nil
 }
 
@@ -231,6 +235,7 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		MachineLock:          op.machineLock,
 		PreviousAgentVersion: agentConfig.UpgradedToVersion(),
 		NewExecClient:        op.newExecClient,
+		RunListenerSocket:    op.runListenerSocket,
 	})
 
 	engine, err := dependency.NewEngine(dependencyEngineConfig())

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -6,6 +6,7 @@ package caasoperator
 import (
 	"time"
 
+	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/loggo"
 
 	"github.com/juju/clock"
@@ -96,6 +97,9 @@ type ManifoldsConfig struct {
 
 	// NewExecClient provides k8s execframework functionality for juju run commands or actions.
 	NewExecClient func(modelName string) (exec.Executor, error)
+
+	// RunListenerSocket returns a function to create a run listener socket.
+	RunListenerSocket func() (*sockets.Socket, error)
 }
 
 // Manifolds returns a set of co-configured manifolds covering the various
@@ -255,7 +259,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewCharmDownloader: func(caller base.APICaller) caasoperator.Downloader {
 				return api.NewCharmDownloader(caller)
 			},
-			NewExecClient: config.NewExecClient,
+			NewExecClient:     config.NewExecClient,
+			RunListenerSocket: config.RunListenerSocket,
 		})),
 	}
 }

--- a/cmd/jujud/agent/caasoperator_test.go
+++ b/cmd/jujud/agent/caasoperator_test.go
@@ -56,7 +56,7 @@ func (s *CAASOperatorSuite) newBufferedLogWriter() *logsender.BufferedLogWriter 
 
 func (s *CAASOperatorSuite) TestParseSuccess(c *gc.C) {
 	// Now init actually reads the agent configuration file.
-	a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient)
+	a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmdtesting.InitCommand(a, []string{
 		"--data-dir", s.dataDir(),
@@ -68,7 +68,7 @@ func (s *CAASOperatorSuite) TestParseSuccess(c *gc.C) {
 }
 
 func (s *CAASOperatorSuite) TestParseMissing(c *gc.C) {
-	uc, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient)
+	uc, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmdtesting.InitCommand(uc, []string{
 		"--data-dir", "jc",
@@ -85,7 +85,7 @@ func (s *CAASOperatorSuite) TestParseNonsense(c *gc.C) {
 		{"--application-name", "wordpress/wild/9"},
 		{"--application-name", "20"},
 	} {
-		a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient)
+		a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient, nil)
 		c.Assert(err, jc.ErrorIsNil)
 
 		err = cmdtesting.InitCommand(a, append(args, "--data-dir", "jc"))
@@ -94,7 +94,7 @@ func (s *CAASOperatorSuite) TestParseNonsense(c *gc.C) {
 }
 
 func (s *CAASOperatorSuite) TestParseUnknown(c *gc.C) {
-	a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient)
+	a, err := NewCaasOperatorAgent(nil, s.newBufferedLogWriter(), newExecClient, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = cmdtesting.InitCommand(a, []string{

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -194,7 +194,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	}
 	jujud.Register(unitAgent)
 
-	caasOperatorAgent, err := agentcmd.NewCaasOperatorAgent(ctx, bufferedLogger, k8sexec.NewInCluster)
+	caasOperatorAgent, err := agentcmd.NewCaasOperatorAgent(ctx, bufferedLogger, k8sexec.NewInCluster, nil)
 	if err != nil {
 		return -1, errors.Trace(err)
 	}

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -329,12 +329,9 @@ func (s *RunTestSuite) runListenerForAgent(c *gc.C, agent string) {
 		socket.Network = "unix"
 		socket.Address = fmt.Sprintf("%s/run.socket", agentDir)
 	}
-	listener, err := uniter.NewRunListener(uniter.RunListenerConfig{
-		Socket:        &socket,
-		CommandRunner: &mockRunner{c},
-	})
+	listener, err := uniter.NewRunListener(socket)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(listener, gc.NotNil)
+	listener.RegisterRunner("foo/1", &mockRunner{c})
 	s.AddCleanup(func(*gc.C) {
 		c.Assert(listener.Close(), jc.ErrorIsNil)
 	})

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -138,6 +138,17 @@ func (s *RunTestSuite) runCommand() *RunCommand {
 	}
 }
 
+func (s *RunTestSuite) TestInferredUnit(c *gc.C) {
+	dataDir := c.MkDir()
+	runCommand := &RunCommand{dataDir: dataDir}
+	err := os.MkdirAll(filepath.Join(dataDir, "agents", "unit-foo-66"), 0700)
+	c.Assert(err, jc.ErrorIsNil)
+	err = cmdtesting.InitCommand(runCommand, []string{"status-get"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(runCommand.unit.String(), gc.Equals, "unit-foo-66")
+	c.Assert(runCommand.commands, gc.Equals, "status-get")
+}
+
 func (s *RunTestSuite) TestInsideContext(c *gc.C) {
 	s.PatchEnvironment("JUJU_CONTEXT_ID", "fake-id")
 	runCommand := s.runCommand()

--- a/worker/caasoperator/action_test.go
+++ b/worker/caasoperator/action_test.go
@@ -5,10 +5,13 @@ package caasoperator_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -38,6 +41,16 @@ func (s *actionSuite) setupExecClient(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
+func (s *actionSuite) symlinkJujudCommand(out *bytes.Buffer, baseDir string, file string) exec.ExecParams {
+	cmd := fmt.Sprintf("test -f %s || ln -s "+baseDir+"/tools/unit-gitlab-k8s-0/jujud %s", file, file)
+	return exec.ExecParams{
+		PodName:  "gitlab-xxxx",
+		Commands: strings.Split(cmd, " "),
+		Stdout:   out,
+		Stderr:   out,
+	}
+}
+
 func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
 	ctrl := s.setupExecClient(c)
 	defer ctrl.Finish()
@@ -61,7 +74,8 @@ func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
 	runnerExecFunc := caasoperator.GetNewRunnerExecutor(s.executor, operatorPaths)(s.unitAPI, unitPaths)
 	cancel := make(<-chan struct{}, 1)
 	out := bytes.NewBufferString("")
-	gomock.InOrder(
+
+	calls := []*gomock.Call{
 		s.unitAPI.EXPECT().Refresh().Times(1).Return(nil),
 		s.unitAPI.EXPECT().ProviderID().Times(1).Return("gitlab-xxxx"),
 		s.unitAPI.EXPECT().Name().Times(1).Return("gitlab-k8s/0"),
@@ -69,7 +83,7 @@ func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
 		s.executor.EXPECT().Exec(
 			exec.ExecParams{
 				PodName:  "gitlab-xxxx",
-				Commands: []string{"test", "-d", baseDir + "/agents/application-gitlab-k8s", "||", "mkdir", "-p", baseDir + "/agents/application-gitlab-k8s"},
+				Commands: []string{"test", "-d", baseDir + "/agents/unit-gitlab-k8s-0", "||", "mkdir", "-p", baseDir + "/agents/unit-gitlab-k8s-0"},
 				Stdout:   out,
 				Stderr:   out,
 			}, cancel,
@@ -80,7 +94,27 @@ func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
 					Path: baseDir + "/agents/application-gitlab-k8s/charm",
 				},
 				Dest: exec.FileResource{
-					Path:    baseDir + "/agents/application-gitlab-k8s",
+					Path:    baseDir + "/agents/unit-gitlab-k8s-0",
+					PodName: "gitlab-xxxx",
+				},
+			}, cancel,
+		).Times(1).Return(nil),
+
+		s.executor.EXPECT().Exec(
+			exec.ExecParams{
+				PodName:  "gitlab-xxxx",
+				Commands: []string{"test", "-d", baseDir + "/tools/unit-gitlab-k8s-0", "||", "mkdir", "-p", baseDir + "/tools/unit-gitlab-k8s-0"},
+				Stdout:   out,
+				Stderr:   out,
+			}, cancel,
+		).Times(1).Return(nil),
+		s.executor.EXPECT().Copy(
+			exec.CopyParam{
+				Src: exec.FileResource{
+					Path: baseDir + "/tools/jujud",
+				},
+				Dest: exec.FileResource{
+					Path:    baseDir + "/tools/unit-gitlab-k8s-0",
 					PodName: "gitlab-xxxx",
 				},
 			}, cancel,
@@ -97,55 +131,24 @@ func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
 		s.executor.EXPECT().Copy(
 			exec.CopyParam{
 				Src: exec.FileResource{
-					Path: baseDir + "/agents/unit-gitlab-k8s-0/charm",
+					Path: filepath.Join(os.TempDir(), "operator.yaml"),
 				},
 				Dest: exec.FileResource{
-					Path:    baseDir + "/agents/unit-gitlab-k8s-0",
+					Path:    baseDir + "/agents/unit-gitlab-k8s-0/operator.yaml",
 					PodName: "gitlab-xxxx",
 				},
 			}, cancel,
 		).Times(1).Return(nil),
+	}
+	calls = append(calls,
+		s.executor.EXPECT().Exec(s.symlinkJujudCommand(out, baseDir, "/usr/bin/juju-run"),
+			cancel).Times(1).Return(nil))
+	for _, cmdName := range jujuc.CommandNames() {
+		s.executor.EXPECT().Exec(s.symlinkJujudCommand(out, baseDir, baseDir+"/tools/unit-gitlab-k8s-0/"+cmdName),
+			cancel).Times(1).Return(nil)
+	}
 
-		s.executor.EXPECT().Exec(
-			exec.ExecParams{
-				PodName:  "gitlab-xxxx",
-				Commands: []string{"test", "-d", baseDir + "/tools", "||", "mkdir", "-p", baseDir + "/tools"},
-				Stdout:   out,
-				Stderr:   out,
-			}, cancel,
-		).Times(1).Return(nil),
-		s.executor.EXPECT().Copy(
-			exec.CopyParam{
-				Src: exec.FileResource{
-					Path: baseDir + "/tools/jujud",
-				},
-				Dest: exec.FileResource{
-					Path:    baseDir + "/tools",
-					PodName: "gitlab-xxxx",
-				},
-			}, cancel,
-		).Times(1).Return(nil),
-
-		s.executor.EXPECT().Exec(
-			exec.ExecParams{
-				PodName:  "gitlab-xxxx",
-				Commands: []string{"test", "-d", baseDir + "/tools", "||", "mkdir", "-p", baseDir + "/tools"},
-				Stdout:   out,
-				Stderr:   out,
-			}, cancel,
-		).Times(1).Return(nil),
-		s.executor.EXPECT().Copy(
-			exec.CopyParam{
-				Src: exec.FileResource{
-					Path: baseDir + "/tools/unit-gitlab-k8s-0",
-				},
-				Dest: exec.FileResource{
-					Path:    baseDir + "/tools",
-					PodName: "gitlab-xxxx",
-				},
-			}, cancel,
-		).Times(1).Return(nil),
-
+	calls = append(calls,
 		s.executor.EXPECT().Exec(
 			exec.ExecParams{
 				PodName:  "gitlab-xxxx",
@@ -154,8 +157,8 @@ func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
 				Stdout:   out,
 				Stderr:   out,
 			}, cancel,
-		).Times(1).Return(nil),
-	)
+		).Times(1).Return(nil))
+	gomock.InOrder(calls...)
 
 	_, err = runnerExecFunc(
 		runner.ExecParams{

--- a/worker/caasoperator/action_test.go
+++ b/worker/caasoperator/action_test.go
@@ -83,6 +83,18 @@ func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
 		s.executor.EXPECT().Exec(
 			exec.ExecParams{
 				PodName:  "gitlab-xxxx",
+				Commands: []string{"test", "-f", baseDir + "/agents/unit-gitlab-k8s-0/operator.yaml", "||", "echo notfound"},
+				Stdout:   out,
+				Stderr:   out,
+			}, cancel,
+		).Times(1).DoAndReturn(func(...interface{}) error {
+			out.WriteString("notfound")
+			return nil
+		}),
+
+		s.executor.EXPECT().Exec(
+			exec.ExecParams{
+				PodName:  "gitlab-xxxx",
 				Commands: []string{"test", "-d", baseDir + "/agents/unit-gitlab-k8s-0", "||", "mkdir", "-p", baseDir + "/agents/unit-gitlab-k8s-0"},
 				Stdout:   out,
 				Stderr:   out,

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -44,8 +44,9 @@ var (
 
 	jujudSymlinks = []string{
 		jujuRun,
-		jujuDumpLogs,
-		jujuIntrospect,
+		// TODO(caas) - these are only for the controller operator
+		//jujuDumpLogs,
+		//jujuIntrospect,
 	}
 )
 

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/exec"
 	coreleadership "github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/leadership"
 	"github.com/juju/juju/worker/uniter"
@@ -43,7 +44,8 @@ type ManifoldConfig struct {
 	NewClient          func(base.APICaller) Client
 	NewCharmDownloader func(base.APICaller) Downloader
 
-	NewExecClient func(modelName string) (exec.Executor, error)
+	NewExecClient     func(modelName string) (exec.Executor, error)
+	RunListenerSocket func() (*sockets.Socket, error)
 }
 
 func (config ManifoldConfig) Validate() error {
@@ -146,21 +148,26 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return leadership.NewTracker(unitTag, claimer, clock, config.LeadershipGuarantee)
 			}
 
+			runListenerSocketFunc := config.RunListenerSocket
+			if runListenerSocketFunc == nil {
+				runListenerSocketFunc = runListenerSocket
+			}
 			wCfg := Config{
-				ModelUUID:          agentConfig.Model().Id(),
-				ModelName:          model.Name,
-				Application:        applicationTag.Id(),
-				CharmGetter:        client,
-				Clock:              clock,
-				PodSpecSetter:      client,
-				DataDir:            agentConfig.DataDir(),
-				Downloader:         downloader,
-				StatusSetter:       client,
-				UnitGetter:         client,
-				UnitRemover:        client,
-				ApplicationWatcher: client,
-				VersionSetter:      client,
-				StartUniterFunc:    uniter.StartUniter,
+				ModelUUID:             agentConfig.Model().Id(),
+				ModelName:             model.Name,
+				Application:           applicationTag.Id(),
+				CharmGetter:           client,
+				Clock:                 clock,
+				PodSpecSetter:         client,
+				DataDir:               agentConfig.DataDir(),
+				Downloader:            downloader,
+				StatusSetter:          client,
+				UnitGetter:            client,
+				UnitRemover:           client,
+				ApplicationWatcher:    client,
+				VersionSetter:         client,
+				StartUniterFunc:       uniter.StartUniter,
+				RunListenerSocketFunc: runListenerSocketFunc,
 
 				LeadershipTrackerFunc: leadershipTrackerFunc,
 				UniterFacadeFunc:      newUniterFunc,

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -155,12 +155,14 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(config.LeadershipTrackerFunc, gc.NotNil)
 	c.Assert(config.UniterFacadeFunc, gc.NotNil)
 	c.Assert(config.StartUniterFunc, gc.NotNil)
+	c.Assert(config.RunListenerSocketFunc, gc.NotNil)
 	c.Assert(config.UniterParams.UpdateStatusSignal, gc.NotNil)
 	c.Assert(config.UniterParams.NewOperationExecutor, gc.NotNil)
 	c.Assert(config.UniterParams.NewRemoteRunnerExecutor, gc.NotNil)
 	config.LeadershipTrackerFunc = nil
 	config.StartUniterFunc = nil
 	config.UniterFacadeFunc = nil
+	config.RunListenerSocketFunc = nil
 	config.UniterParams.UpdateStatusSignal = nil
 	config.UniterParams.NewOperationExecutor = nil
 	config.UniterParams.NewRemoteRunnerExecutor = nil

--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/errors"
 	jujuos "github.com/juju/os"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/juju/sockets"
@@ -118,44 +120,55 @@ func NewPaths(dataDir string, unitTag names.UnitTag, isRemote bool) Paths {
 	return NewWorkerPaths(dataDir, unitTag, "", isRemote)
 }
 
+// TODO(caas) - move me to generic helper for reading operator config yaml
+func socketIP(baseDir string) (string, error) {
+	// IP address to use for the socket can either be an env var
+	// (when we are the caas operator and are creating the socket to listen),
+	// or inside a YAML file (when we are juju-run and need to see where
+	// to connect to).
+	podIP := os.Getenv(provider.OperatorPodIPEnvName)
+	if podIP != "" {
+		return podIP, nil
+	}
+	ipAddrFile := filepath.Join(baseDir, provider.OperatorInfoFile)
+	ipAddrData, err := ioutil.ReadFile(ipAddrFile)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	var socketIP string
+	var data map[string]interface{}
+	if err := yaml.Unmarshal(ipAddrData, &data); err == nil {
+		socketIP, _ = data["operator-address"].(string)
+	}
+	return socketIP, nil
+}
+
 // NewWorkerPaths returns the set of filesystem paths that the supplied unit worker should
 // use, given the supplied root juju data directory path and worker identifier.
 // Distinct worker identifiers ensure that runtime paths of different worker do not interfere.
 func NewWorkerPaths(dataDir string, unitTag names.UnitTag, worker string, isRemote bool) Paths {
+	baseDir := agent.Dir(dataDir, unitTag)
 	join := filepath.Join
-	baseDir := join(dataDir, "agents", unitTag.String())
 	stateDir := join(baseDir, "state")
 
 	newSocket := func(name string, abstract bool) sockets.Socket {
-		// IP address to use for the socket can either be an env var
-		// (when we are the caas operator and are creating the socket to listen),
-		// or inside a YAML file (when we are juju-run and need to see where
-		// to connect to).
-		podIP := os.Getenv(provider.OperatorPodIPEnvName)
-		if podIP == "" {
-			ipAddrFile := join(baseDir, provider.OperatorInfoFile)
-			ipAddrData, err := ioutil.ReadFile(ipAddrFile)
-			if err == nil {
-				var data map[string]interface{}
-				if err := yaml.Unmarshal(ipAddrData, &data); err == nil {
-					podIP, _ = data["operator-address"].(string)
-				}
-				// If we have an IP address, it's always remote.
-				isRemote = true
+		if isRemote {
+			socketIP, err := socketIP(baseDir)
+			if err != nil {
+				logger.Warningf("unable to get IP address for jujuc socket: %v", err)
+				return sockets.Socket{}
 			}
-		}
-		logger.Debugf("using operator address: %v", podIP)
-		if isRemote && podIP != "" {
+			logger.Debugf("using operator address: %v", socketIP)
 			switch name {
 			case "agent":
 				return sockets.Socket{
 					Network: "tcp",
-					Address: fmt.Sprintf("%s:%d", podIP, jujucServerSocketPort+unitTag.Number()),
+					Address: fmt.Sprintf("%s:%d", socketIP, jujucServerSocketPort+unitTag.Number()),
 				}
 			case "run":
 				return sockets.Socket{
 					Network: "tcp",
-					Address: fmt.Sprintf("%s:%d", podIP, provider.JujuRunServerSocketPort),
+					Address: fmt.Sprintf("%s:%d", socketIP, provider.JujuRunServerSocketPort),
 				}
 			default:
 				logger.Warningf("caas model socket name %q, fallback to unix protocol", name)

--- a/worker/uniter/paths_test.go
+++ b/worker/uniter/paths_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -116,12 +117,28 @@ func (s *PathsSuite) TestOther(c *gc.C) {
 	})
 }
 
-func (s *PathsSuite) TestTCPRemote(c *gc.C) {
+func (s *PathsSuite) TestTCPRemoteEnvVar(c *gc.C) {
 	defer os.Setenv(provider.OperatorPodIPEnvName, os.Getenv(provider.OperatorPodIPEnvName))
 	os.Setenv(provider.OperatorPodIPEnvName, "1.1.1.1")
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Unknown })
 
 	dataDir := c.MkDir()
+	s.assertTCPRemote(c, dataDir)
+}
+
+func (s *PathsSuite) TestTCPRemoteYamlFile(c *gc.C) {
+	dataDir := c.MkDir()
+
+	unitTag := names.NewUnitTag("some-application/323")
+	ipAddrFile := filepath.Join(dataDir, "agents", unitTag.String(), "operator.yaml")
+	err := os.MkdirAll(filepath.Dir(ipAddrFile), 0700)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(ipAddrFile, []byte("operator-address: 1.1.1.1"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertTCPRemote(c, dataDir)
+}
+
+func (s *PathsSuite) assertTCPRemote(c *gc.C, dataDir string) {
 	unitTag := names.NewUnitTag("some-application/323")
 	paths := uniter.NewPaths(dataDir, unitTag, true)
 
@@ -130,7 +147,7 @@ func (s *PathsSuite) TestTCPRemote(c *gc.C) {
 	c.Assert(paths, jc.DeepEquals, uniter.Paths{
 		ToolsDir: relData("tools/unit-some-application-323"),
 		Runtime: uniter.RuntimePaths{
-			JujuRunSocket:     sockets.Socket{Network: "unix", Address: relAgent("run.socket")},
+			JujuRunSocket:     sockets.Socket{Network: "tcp", Address: "1.1.1.1:30666"},
 			JujucServerSocket: sockets.Socket{Network: "tcp", Address: "1.1.1.1:30323"},
 		},
 		State: uniter.StatePaths{

--- a/worker/uniter/runlistener_test.go
+++ b/worker/uniter/runlistener_test.go
@@ -39,12 +39,9 @@ func (s *ListenerSuite) SetUpTest(c *gc.C) {
 
 // Mirror the params to uniter.NewRunListener, but add cleanup to close it.
 func (s *ListenerSuite) NewRunListener(c *gc.C) *uniter.RunListener {
-	listener, err := uniter.NewRunListener(uniter.RunListenerConfig{
-		Socket:        &s.socketPath,
-		CommandRunner: &mockRunner{c},
-	})
+	listener, err := uniter.NewRunListener(s.socketPath)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(listener, gc.NotNil)
+	listener.RegisterRunner("test/0", &mockRunner{c})
 	s.AddCleanup(func(*gc.C) {
 		c.Assert(listener.Close(), jc.ErrorIsNil)
 	})
@@ -72,6 +69,7 @@ func (s *ListenerSuite) TestClientCall(c *gc.C) {
 		RelationId:      -1,
 		RemoteUnitName:  "",
 		ForceRemoteUnit: false,
+		UnitName:        "test/0",
 	}
 	err = client.Call(uniter.JujuRunEndpoint, args, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -79,6 +77,26 @@ func (s *ListenerSuite) TestClientCall(c *gc.C) {
 	c.Assert(string(result.Stdout), gc.Equals, "some-command stdout")
 	c.Assert(string(result.Stderr), gc.Equals, "some-command stderr")
 	c.Assert(result.Code, gc.Equals, 42)
+}
+
+func (s *ListenerSuite) TestUnregisterRunner(c *gc.C) {
+	listener := s.NewRunListener(c)
+	listener.UnregisterRunner("test/0")
+
+	client, err := sockets.Dial(s.socketPath)
+	c.Assert(err, jc.ErrorIsNil)
+	defer client.Close()
+
+	var result exec.ExecResponse
+	args := uniter.RunCommandsArgs{
+		Commands:        "some-command",
+		RelationId:      -1,
+		RemoteUnitName:  "",
+		ForceRemoteUnit: false,
+		UnitName:        "test/0",
+	}
+	err = client.Call(uniter.JujuRunEndpoint, args, &result)
+	c.Assert(err, gc.ErrorMatches, ".*no runner is registered for unit test/0")
 }
 
 type ChannelCommandRunnerSuite struct {

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -135,7 +135,11 @@ func (runner *runner) getRemoteExecutor(rModel runMode) (ExecFunc, error) {
 
 // RunCommands exists to satisfy the Runner interface.
 func (runner *runner) RunCommands(commands string) (*utilexec.ExecResponse, error) {
-	result, err := runner.runCommandsWithTimeout(commands, 0, clock.WallClock, runOnLocal)
+	runMode := runOnLocal
+	if runner.context.ModelType() == model.CAAS {
+		runMode = runOnRemote
+	}
+	result, err := runner.runCommandsWithTimeout(commands, 0, clock.WallClock, runMode)
 	return result, runner.context.Flush("run commands", err)
 }
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -133,6 +133,7 @@ type UniterParams struct {
 	HookRetryStrategy       params.RetryStrategy
 	NewOperationExecutor    NewOperationExecutorFunc
 	NewRemoteRunnerExecutor NewRunnerExecutorFunc
+	RunListener             *RunListener
 	TranslateResolverErr    func(error) error
 	Clock                   clock.Clock
 	ApplicationChannel      watcher.NotifyChannel
@@ -193,6 +194,7 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 		clock:                   uniterParams.Clock,
 		downloader:              uniterParams.Downloader,
 		applicationChannel:      uniterParams.ApplicationChannel,
+		runListener:             uniterParams.RunListener,
 	}
 	startFunc := func() (worker.Worker, error) {
 		if err := catacomb.Invoke(catacomb.Plan{
@@ -430,6 +432,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	if errors.Cause(err) == ErrCAASUnitDead {
 		err = nil
 	}
+	u.runListener.UnregisterRunner(u.unit.Name())
 	logger.Infof("unit %q shutting down: %s", u.unit, err)
 	return err
 }
@@ -618,6 +621,18 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	}
 	u.operationExecutor = operationExecutor
 
+	if u.runListener == nil {
+		socket := u.paths.Runtime.JujuRunSocket
+		logger.Debugf("starting juju-run listener on %v", socket)
+		u.runListener, err = NewRunListener(socket)
+		if err != nil {
+			return errors.Annotate(err, "creating juju run listener")
+		}
+		rlw := NewRunListenerWrapper(u.runListener)
+		if err := u.catacomb.Add(rlw); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	commandRunner, err := NewChannelCommandRunner(ChannelCommandRunnerConfig{
 		Abort:          u.catacomb.Dying(),
 		Commands:       u.commands,
@@ -626,19 +641,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	if err != nil {
 		return errors.Annotate(err, "creating command runner")
 	}
-	socket := u.paths.Runtime.JujuRunSocket
-	logger.Debugf("starting juju-run listener on %v", socket)
-	u.runListener, err = NewRunListener(RunListenerConfig{
-		Socket:        &socket,
-		CommandRunner: commandRunner,
-	})
-	if err != nil {
-		return errors.Annotate(err, "creating juju run listener")
-	}
-	rlw := newRunListenerWrapper(u.runListener)
-	if err := u.catacomb.Add(rlw); err != nil {
-		return errors.Trace(err)
-	}
+	u.runListener.RegisterRunner(u.unit.Name(), commandRunner)
 	return nil
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1458,6 +1458,7 @@ func (cmds relationRunCommands) step(c *gc.C, ctx *context) {
 		Commands:       commands,
 		RelationId:     0,
 		RemoteUnitName: "",
+		UnitName:       "u/0",
 	}
 	result, err := ctx.uniter.RunCommands(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1474,6 +1475,7 @@ func (cmds runCommands) step(c *gc.C, ctx *context) {
 		Commands:       commands,
 		RelationId:     -1,
 		RemoteUnitName: "",
+		UnitName:       "u/0",
 	}
 	result, err := ctx.uniter.RunCommands(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1490,6 +1492,7 @@ func (cmds asyncRunCommands) step(c *gc.C, ctx *context) {
 		Commands:       commands,
 		RelationId:     -1,
 		RemoteUnitName: "",
+		UnitName:       "u/0",
 	}
 
 	var socketPath string


### PR DESCRIPTION
## Description of change

Add support for juju-run on the k8s workload pods.
- create an application operator service and map port 30666 to the operator pod
- the long running juju run listener opens a socket on port 30666
- in action prepare(), change the setup so only files and symlinks needed are copied
- create symlinks for juju-run and also an operator.yaml file with the service address
- juju-run uses the operator.yaml file to open a socket to the address of the service

Drive by fix: include latest upstream gomaas

## QA steps

bootstrap k8s
deploy a charm with an action
run the action
exec into the workload pod
juju-run <unitname> status-set "active hello"
