### PR TITLE
[dev] refactor installation of lxd, kvm and mongo deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -651,7 +651,7 @@
   revision = "88a4c6ac59c1950f118f058d920204c9182b9927"
 
 [[projects]]
-  digest = "1:8fd6c21ba9a864b949672e63800d1bd71a3d8ac8e085cc22143b97f1261ad634"
+  digest = "1:477061a46f9584f862cd45dea6096b3149c76106b917ccfcf78d6bba53dabc74"
   name = "github.com/juju/packaging"
   packages = [
     ".",
@@ -660,7 +660,7 @@
     "manager",
   ]
   pruneopts = ""
-  revision = "ba21344fff207f4fa06b0a08bac386b179a2e6a1"
+  revision = "6caf1fe053515833fa8d541cb8ee9b3b50ef3592"
 
 [[projects]]
   digest = "1:529c96edf33ad02d0460dcd152750b00b34a8424d1fb1c42790e5e7a30d003fb"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,7 @@
   name = "github.com/juju/os"
 
 [[constraint]]
-  revision = "ba21344fff207f4fa06b0a08bac386b179a2e6a1"
+  revision = "6caf1fe053515833fa8d541cb8ee9b3b50ef3592"
   name = "github.com/juju/packaging"
 
 [[constraint]]

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -123,7 +123,7 @@ func checkIff(checker gc.Checker, condition bool) gc.Checker {
 	return gc.Not(checker)
 }
 
-var aptgetRegexp = "(.|\n)*" + regexp.QuoteMeta("apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet ")
+var aptgetRegexp = "(.|\n)*" + regexp.QuoteMeta("apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::Options::=--force-unsafe-io --assume-yes --quiet ")
 
 func (s *configureSuite) TestAptSources(c *gc.C) {
 	for _, series := range allSeries {

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/juju/juju/packaging"
+	"github.com/juju/juju/packaging/dependency"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -90,11 +92,20 @@ func (initialisationInternalSuite) TestAutoStartPool(c *gc.C) {
 }
 
 func (initialisationInternalSuite) TestRequiredPackagesAMD64(c *gc.C) {
-	got := getRequiredPackages("amd64")
-	c.Assert(got, jc.DeepEquals, []string{"qemu-kvm", "qemu-utils", "genisoimage", "libvirt-bin"})
+	got, err := dependency.KVM("amd64").PackageList("bionic")
+	c.Assert(err, gc.IsNil)
+	assertPkgListMatches(c, got, []string{"qemu-kvm", "qemu-utils", "genisoimage", "libvirt-bin"})
 }
 
 func (initialisationInternalSuite) TestRequiredPackagesARM64(c *gc.C) {
-	got := getRequiredPackages("arm64")
-	c.Assert(got, jc.DeepEquals, []string{"qemu-efi", "qemu-kvm", "qemu-utils", "genisoimage", "libvirt-bin"})
+	got, err := dependency.KVM("arm64").PackageList("bionic")
+	c.Assert(err, gc.IsNil)
+	assertPkgListMatches(c, got, []string{"qemu-efi", "qemu-kvm", "qemu-utils", "genisoimage", "libvirt-bin"})
+}
+
+func assertPkgListMatches(c *gc.C, got []packaging.Package, exp []string) {
+	c.Assert(len(got), gc.Equals, len(exp))
+	for i := 0; i < len(got); i++ {
+		c.Assert(got[i].Name, gc.Equals, exp[i])
+	}
 }

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -164,6 +164,21 @@ func (s *InitialiserSuite) TestNoSeriesPackages(c *gc.C) {
 	})
 }
 
+func (s *InitialiserSuite) TestInstallViaSnap(c *gc.C) {
+	PatchLXDViaSnap(s, false)
+
+	PatchHostSeries(s, "disco")
+
+	paccmder := commands.NewSnapPackageCommander()
+
+	err := NewContainerInitialiser().Initialise()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.calledCmds, gc.DeepEquals, []string{
+		paccmder.InstallCmd("--classic lxd"),
+	})
+}
+
 func (s *InitialiserSuite) TestLXDInitBionic(c *gc.C) {
 	s.patchDF100GB()
 	PatchHostSeries(s, "bionic")

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/utils/featureflag"
 	"gopkg.in/mgo.v2"
 
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/packaging"
@@ -709,26 +708,6 @@ func installMongod(operatingsystem string, numaCtl bool, dataDir string) error {
 		return err
 	}
 
-	// Work around SELinux on centos7
-	if operatingsystem == "centos7" {
-		cmd := []string{"chcon", "-R", "-v", "-t", "mongod_var_lib_t", "/var/lib/juju/"}
-		logger.Infof("running %s %v", cmd[0], cmd[1:])
-		_, err := utils.RunCommand(cmd[0], cmd[1:]...)
-		if err != nil {
-			logger.Errorf("chcon failed to change file security context error %s", err)
-			return err
-		}
-
-		cmd = []string{"semanage", "port", "-a", "-t", "mongod_port_t", "-p", "tcp", strconv.Itoa(controller.DefaultStatePort)}
-		logger.Infof("running %s %v", cmd[0], cmd[1:])
-		_, err = utils.RunCommand(cmd[0], cmd[1:]...)
-		if err != nil {
-			if !strings.Contains(err.Error(), "exit status 1") {
-				logger.Errorf("semanage failed to provide access on port %d error %s", controller.DefaultStatePort, err)
-				return err
-			}
-		}
-	}
 	return nil
 }
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -20,8 +20,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/os/series"
-	"github.com/juju/packaging/config"
-	"github.com/juju/packaging/manager"
 	"github.com/juju/replicaset"
 	"github.com/juju/utils"
 	"github.com/juju/utils/featureflag"
@@ -30,6 +28,8 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/packaging"
+	"github.com/juju/juju/packaging/dependency"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/service/snap"
@@ -49,9 +49,6 @@ var (
 	// MongodSystemPath is actually just the system path
 	MongodSystemPath = "/usr/bin/mongod"
 
-	// This is NUMACTL package name for apt-get
-	numaCtlPkg = "numactl"
-
 	// mininmumSystemMongoVersion is the minimum version we would allow to be used from /usr/bin/mongod.
 	minimumSystemMongoVersion = Version{Major: 3, Minor: 4}
 )
@@ -60,20 +57,12 @@ var (
 type StorageEngine string
 
 const (
-	// JujuMongoPackage is the mongo package Juju uses when
-	// installing mongo.
-	JujuMongoPackage = "juju-mongodb3.2"
-
 	// JujuDbSnap is the snap of MongoDB that Juju uses.
 	JujuDbSnap = "juju-db"
 
 	// JujuDbSnapMongodPath is the path that the juju-db snap
 	// makes mongod available at
 	JujuDbSnapMongodPath = "/snap/bin/juju-db.mongod"
-
-	// JujuMongoToolsPackage is the mongo package Juju uses when
-	// installing mongo tools to get mongodump etc.
-	JujuMongoToolsPackage = "juju-mongo-tools3.2"
 
 	// MMAPV1 is the default storage engine in mongo db up to 3.x
 	MMAPV1 StorageEngine = "mmapv1"
@@ -685,15 +674,6 @@ func logVersion(mongoPath string) {
 	logger.Debugf("using mongod: %s --version: %q", mongoPath, output)
 }
 
-func installPackage(pkg string, pacconfer config.PackagingConfigurer, pacman manager.PackageManager) error {
-	// apply release targeting if needed.
-	if pacconfer.IsCloudArchivePackage(pkg) {
-		pkg = strings.Join(pacconfer.ApplyCloudArchiveTarget(pkg), " ")
-	}
-
-	return pacman.Install(pkg)
-}
-
 func getSnapChannel() string {
 	return fmt.Sprintf("%s/%s", SnapTrack, SnapRisk)
 }
@@ -725,59 +705,15 @@ func installMongod(operatingsystem string, numaCtl bool, dataDir string) error {
 		return service.Install()
 	}
 
-	// fetch the packaging configuration manager for the current operating system.
-	pacconfer, err := config.NewPackagingConfigurer(operatingsystem)
-	if err != nil {
+	if err := packaging.InstallDependency(dependency.Mongo(numaCtl), operatingsystem); err != nil {
 		return err
-	}
-
-	// fetch the package manager implementation for the current operating system.
-	pacman, err := manager.NewPackageManager(operatingsystem)
-	if err != nil {
-		return err
-	}
-
-	// CentOS requires "epel-release" for the epel repo mongodb-server is in.
-	if operatingsystem == "centos7" {
-		// install epel-release
-		if err := pacman.Install("epel-release"); err != nil {
-			return err
-		}
-	}
-	mongoPkgs, fallbackPkgs := packagesForSeries(operatingsystem)
-
-	if numaCtl {
-		logger.Infof("installing %v and %s", mongoPkgs, numaCtlPkg)
-		if err = installPackage(numaCtlPkg, pacconfer, pacman); err != nil {
-			return errors.Trace(err)
-		}
-	} else {
-		logger.Infof("installing %v", mongoPkgs)
-	}
-
-	for i := range mongoPkgs {
-		if err = installPackage(mongoPkgs[i], pacconfer, pacman); err != nil {
-			break
-		}
-	}
-	if err != nil && len(fallbackPkgs) == 0 {
-		return errors.Trace(err)
-	}
-	if err != nil {
-		logger.Errorf("installing mongo failed: %v", err)
-		logger.Infof("will try fallback packages %v", fallbackPkgs)
-		for i := range fallbackPkgs {
-			if err = installPackage(fallbackPkgs[i], pacconfer, pacman); err != nil {
-				return errors.Trace(err)
-			}
-		}
 	}
 
 	// Work around SELinux on centos7
 	if operatingsystem == "centos7" {
 		cmd := []string{"chcon", "-R", "-v", "-t", "mongod_var_lib_t", "/var/lib/juju/"}
 		logger.Infof("running %s %v", cmd[0], cmd[1:])
-		_, err = utils.RunCommand(cmd[0], cmd[1:]...)
+		_, err := utils.RunCommand(cmd[0], cmd[1:]...)
 		if err != nil {
 			logger.Errorf("chcon failed to change file security context error %s", err)
 			return err
@@ -794,24 +730,6 @@ func installMongod(operatingsystem string, numaCtl bool, dataDir string) error {
 		}
 	}
 	return nil
-}
-
-// packagesForSeries returns the name of the mongo package for the series
-// of the machine that it is going to be running on plus a fallback for
-// options where the package is going to be ready eventually but might not
-// yet be.
-func packagesForSeries(series string) ([]string, []string) {
-	switch series {
-	case "precise", "centos7":
-		return []string{"mongodb-server"}, []string{}
-	case "trusty":
-		return []string{"juju-mongodb"}, []string{}
-	case "xenial", "artful":
-		return []string{JujuMongoPackage, JujuMongoToolsPackage}, []string{}
-	default:
-		// Bionic and newer
-		return []string{"mongodb-server-core", "mongodb-clients"}, []string{}
-	}
 }
 
 // DbDir returns the dir where mongo storage is.

--- a/packaging/dependency/kvm.go
+++ b/packaging/dependency/kvm.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/packaging"
+	"github.com/juju/utils/arch"
+)
+
+// KVM returns a dependency instance for installing KVM support.
+func KVM(arch string) packaging.Dependency {
+	return &kvmDependency{arch: arch}
+}
+
+type kvmDependency struct {
+	arch string
+}
+
+// PackageList implements packaging.Dependency.
+func (dep kvmDependency) PackageList(series string) ([]packaging.Package, error) {
+	var pkgList []string
+
+	switch series {
+	case "centos7", "opensuseleap":
+		return nil, errors.NotSupportedf("installing kvm on series %q", series)
+	default:
+		if dep.arch == arch.ARM64 {
+			// ARM64 doesn't support legacy BIOS so it requires Extensible Firmware
+			// Interface.
+			pkgList = append(pkgList, "qemu-efi")
+		}
+
+		pkgList = append(pkgList,
+			// `qemu-kvm` must be installed before `libvirt-bin` on trusty. It appears
+			// that upstart doesn't reload libvirtd if installed after, and we see
+			// errors related to `qemu-kvm` not being installed.
+			"qemu-kvm",
+			"qemu-utils",
+			"genisoimage",
+			"libvirt-bin",
+		)
+
+		return packaging.MakePackageList(packaging.AptPackageManager, "", pkgList...), nil
+	}
+}

--- a/packaging/dependency/lxd.go
+++ b/packaging/dependency/lxd.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/packaging"
+)
+
+const blankSeries = ""
+
+// LXD returns a dependency instance for installing lxd support
+func LXD() packaging.Dependency {
+	return lxdDependency{}
+}
+
+type lxdDependency struct{}
+
+// PackageList implements packaging.Dependency.
+func (lxdDependency) PackageList(series string) ([]packaging.Package, error) {
+	var pkg packaging.Package
+
+	switch series {
+	case "centos7", "opensuseleap", "precise":
+		return nil, errors.NotSupportedf("LXD containers on series %q", series)
+	case "trusty", "xenial", "bionic", blankSeries:
+		pkg.Name = "lxd"
+		pkg.PackageManager = packaging.AptPackageManager
+	default: // Use snaps for cosmic and beyond
+		pkg.Name = "lxd"
+		pkg.InstallOptions = "--classic"
+		pkg.PackageManager = packaging.SnapPackageManager
+	}
+
+	return []packaging.Package{pkg}, nil
+}

--- a/packaging/dependency/mongo.go
+++ b/packaging/dependency/mongo.go
@@ -4,6 +4,7 @@
 package dependency
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/juju/packaging"
 )
 
@@ -22,19 +23,13 @@ func (dep mongoDependency) PackageList(series string) ([]packaging.Package, erro
 	var pkgList []string
 	var pm = packaging.AptPackageManager
 
-	// Same package name for all distros (centos, ubuntu etc.)
 	if dep.useNUMA {
 		pkgList = append(pkgList, "numactl")
 	}
 
 	switch series {
-	case "centos7":
-		// Use yum for centos
-		pm = packaging.YumPackageManager
-
-		// CentOS requires also requires "epel-release" for the
-		// epel repo mongodb-server is in.
-		pkgList = append(pkgList, "epel-release", "mongodb-server")
+	case "centos7", "opensuseleap", "precise":
+		return nil, errors.NotSupportedf("installing mongo on series %q", series)
 	case "trusty":
 		pkgList = append(pkgList, "juju-mongodb")
 	case "xenial":

--- a/packaging/dependency/mongo.go
+++ b/packaging/dependency/mongo.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency
+
+import (
+	"github.com/juju/juju/packaging"
+)
+
+type mongoDependency struct {
+	useNUMA bool
+}
+
+// Mongo returns a dependency for installing mongo server using the specified
+// NUMA settings.
+func Mongo(useNUMA bool) packaging.Dependency {
+	return mongoDependency{useNUMA: useNUMA}
+}
+
+// PackageList implements packaging.Dependency.
+func (dep mongoDependency) PackageList(series string) ([]packaging.Package, error) {
+	var pkgList []string
+	var pm = packaging.AptPackageManager
+
+	// Same package name for all distros (centos, ubuntu etc.)
+	if dep.useNUMA {
+		pkgList = append(pkgList, "numactl")
+	}
+
+	switch series {
+	case "centos7":
+		// Use yum for centos
+		pm = packaging.YumPackageManager
+
+		// CentOS requires also requires "epel-release" for the
+		// epel repo mongodb-server is in.
+		pkgList = append(pkgList, "epel-release", "mongodb-server")
+	case "trusty":
+		pkgList = append(pkgList, "juju-mongodb")
+	case "xenial":
+		// The tools package provides mongodump and friends.
+		pkgList = append(pkgList, "juju-mongodb3.2", "juju-mongo-tools3.2")
+	default: // Bionic and newer
+		pkgList = append(pkgList, "mongodb-server-core", "mongodb-clients")
+	}
+
+	return packaging.MakePackageList(pm, "", pkgList...), nil
+}

--- a/packaging/manager.go
+++ b/packaging/manager.go
@@ -1,0 +1,142 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package packaging
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/packaging/config"
+	"github.com/juju/packaging/manager"
+)
+
+var logger = loggo.GetLogger("juju.packaging")
+
+// PackageManagerName describes a package manager.
+type PackageManagerName string
+
+// The list of supported package managers.
+const (
+	AptPackageManager    PackageManagerName = "apt"
+	YumPackageManager    PackageManagerName = "yum"
+	ZypperPackageManager PackageManagerName = "zypper"
+	SnapPackageManager   PackageManagerName = "snap"
+)
+
+// Dependency is implemented by objects that can provide a series-specific
+// list of packages for installing a particular software dependency.
+type Dependency interface {
+	PackageList(series string) ([]Package, error)
+}
+
+// Package encapsulates the information required for installing a package.
+type Package struct {
+	// The name of the package to install
+	Name string
+
+	// Additional options to be passed to the package manager.
+	InstallOptions string
+
+	// The package manager to use for installing
+	PackageManager PackageManagerName
+}
+
+func (p *Package) appendInstallOptions(opt ...string) {
+	p.InstallOptions = strings.TrimSpace(
+		fmt.Sprintf("%s %s", p.InstallOptions, strings.Join(opt, " ")),
+	)
+}
+
+// MakePackageList returns a list of Package instances for each provided
+// package name. All package entries share the same package manager name and
+// install options.
+func MakePackageList(pm PackageManagerName, opts string, packages ...string) []Package {
+	var list []Package
+	for _, pkg := range packages {
+		list = append(list, Package{
+			Name:           pkg,
+			InstallOptions: opts,
+			PackageManager: pm,
+		})
+	}
+
+	return list
+}
+
+// InstallDependency executes the appropriate commands to install the specified
+// dependency targeting the provided series.
+func InstallDependency(dep Dependency, series string) error {
+	pkgManagers := make(map[PackageManagerName]manager.PackageManager)
+	pkgConfigurers := make(map[PackageManagerName]config.PackagingConfigurer)
+	pkgList, err := dep.PackageList(series)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, pkg := range pkgList {
+		pm := pkgManagers[pkg.PackageManager]
+		if pm == nil {
+			if pm, err = newPackageManager(pkg.PackageManager); err != nil {
+				return errors.Annotatef(err, "installing package %q via %q", pkg.Name, pkg.PackageManager)
+			}
+			pkgManagers[pkg.PackageManager] = pm
+		}
+
+		pkgConfer, exists := pkgConfigurers[pkg.PackageManager]
+		if !exists {
+			if pkgConfer, err = newPackageConfigurer(pkg.PackageManager, series); err != nil {
+				return errors.Annotatef(err, "installing package %q via %q", pkg.Name, pkg.PackageManager)
+			}
+			pkgConfigurers[pkg.PackageManager] = pkgConfer
+		}
+
+		if pkgConfer != nil {
+			if config.RequiresBackports(series, pkg.Name) {
+				extraOpts := fmt.Sprintf("--target-release %s-backports", series)
+				pkg.appendInstallOptions(extraOpts)
+			}
+		}
+
+		logger.Infof("installing %q via %q", pkg.Name, pkg.PackageManager)
+
+		pkgWithOpts := strings.TrimSpace(fmt.Sprintf("%s %s", pkg.InstallOptions, pkg.Name))
+		if err = pm.Install(pkgWithOpts); err != nil {
+			return errors.Annotatef(err, "installing package %q via %q", pkg.Name, pkg.PackageManager)
+		}
+	}
+
+	return nil
+}
+
+func newPackageManager(name PackageManagerName) (manager.PackageManager, error) {
+	switch name {
+	case AptPackageManager:
+		return manager.NewAptPackageManager(), nil
+	case YumPackageManager:
+		return manager.NewYumPackageManager(), nil
+	case ZypperPackageManager:
+		return manager.NewZypperPackageManager(), nil
+	case SnapPackageManager:
+		return manager.NewSnapPackageManager(), nil
+	default:
+		return nil, errors.NotImplementedf("%s package manager", name)
+	}
+}
+
+func newPackageConfigurer(name PackageManagerName, series string) (config.PackagingConfigurer, error) {
+	switch name {
+	case AptPackageManager:
+		return config.NewAptPackagingConfigurer(series), nil
+	case YumPackageManager:
+		return config.NewYumPackagingConfigurer(series), nil
+	case ZypperPackageManager:
+		return config.NewZypperPackagingConfigurer(series), nil
+	case SnapPackageManager:
+		return nil, nil
+	default:
+		return nil, errors.NotImplementedf("%s package configurer", name)
+	}
+}

--- a/packaging/manager_test.go
+++ b/packaging/manager_test.go
@@ -1,0 +1,112 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package packaging_test
+
+import (
+	"github.com/juju/juju/packaging"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&DependencyManagerTestSuite{})
+
+type DependencyManagerTestSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *DependencyManagerTestSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *DependencyManagerTestSuite) TestInstallWithCentos(c *gc.C) {
+	s.assertInstallCallsCorrectBinary(c, assertParams{
+		series:       "centos7",
+		pkg:          "foo",
+		pm:           packaging.YumPackageManager,
+		expPkgBinary: "yum",
+		expArgs: []string{
+			"--assumeyes", "--debuglevel=1", "install", "foo",
+		},
+	})
+}
+
+func (s *DependencyManagerTestSuite) TestInstallWithOpenSuse(c *gc.C) {
+	s.assertInstallCallsCorrectBinary(c, assertParams{
+		series:       "opensuseleap",
+		pkg:          "foo",
+		pm:           packaging.ZypperPackageManager,
+		expPkgBinary: "zypper",
+		expArgs: []string{
+			"--quiet", "--non-interactive", "install", "foo",
+		},
+	})
+}
+
+func (s *DependencyManagerTestSuite) TestInstallWithAptBackports(c *gc.C) {
+	s.assertInstallCallsCorrectBinary(c, assertParams{
+		series:       "trusty",
+		pkg:          "lxd", // requires backport on trusty
+		pm:           packaging.AptPackageManager,
+		expPkgBinary: "apt-get",
+		expArgs: []string{
+			"--option=Dpkg::Options::=--force-confold",
+			"--option=Dpkg::Options::=--force-unsafe-io",
+			"--assume-yes", "--quiet", "install",
+			"--target-release", "trusty-backports", "lxd",
+		},
+	})
+}
+
+func (s *DependencyManagerTestSuite) TestInstallWithAptOnBionic(c *gc.C) {
+	s.assertInstallCallsCorrectBinary(c, assertParams{
+		series:       "bionic",
+		pkg:          "lxd",
+		pm:           packaging.AptPackageManager,
+		expPkgBinary: "apt-get",
+		expArgs: []string{
+			"--option=Dpkg::Options::=--force-confold",
+			"--option=Dpkg::Options::=--force-unsafe-io",
+			"--assume-yes", "--quiet", "install", "lxd",
+		},
+	})
+}
+
+func (s *DependencyManagerTestSuite) TestInstallWithSnapOnDisco(c *gc.C) {
+	s.assertInstallCallsCorrectBinary(c, assertParams{
+		series:       "disco",
+		pkg:          "foo",
+		pm:           packaging.SnapPackageManager,
+		expPkgBinary: "snap", // cosmic and beyond default to snap
+		expArgs: []string{
+			"install", "foo",
+		},
+	})
+}
+
+type assertParams struct {
+	series       string
+	pkg          string
+	pm           packaging.PackageManagerName
+	expPkgBinary string
+	expArgs      []string
+}
+
+func (s *DependencyManagerTestSuite) assertInstallCallsCorrectBinary(c *gc.C, params assertParams) {
+	testing.PatchExecutableAsEchoArgs(c, s, params.expPkgBinary)
+
+	err := packaging.InstallDependency(fakeDep{
+		pkgs: packaging.MakePackageList(params.pm, "", params.pkg),
+	}, params.series)
+	c.Assert(err, gc.IsNil)
+	testing.AssertEchoArgs(c, params.expPkgBinary, params.expArgs...)
+}
+
+type fakeDep struct {
+	pkgs []packaging.Package
+}
+
+func (f fakeDep) PackageList(_ string) ([]packaging.Package, error) {
+	return f.pkgs, nil
+}

--- a/packaging/package_test.go
+++ b/packaging/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package packaging_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Description of change

This PR originally began as a tentative fix for the attached bug. The bug manifests itself when trying to create an lxd container on a host running **cosmic** or **disco** that does not come with lxd pre-installed. While all disco images seem to come with lxd pre-installed (as a snap vs an apt pkg for bionic and earlier), this is not the case with images for the s390 arch.  By default, we try to install lxd via **apt**. 

The apt repos contain a transition package that actually performs `snap install lxd`. However, the package which is currently available cannot be installed in non-interactive mode: it displays a prompt for the operator to select which lxd version to install. Unfortunately, the prompt cannot be bypassed causing apt-get to block forever.

The solution for this issue is to install via snap on cosmic and onwards which essentially means 
we need to resolve to series-sniffing to decide which package manager (and package names) to use (the juju/packaging repo now includes a snap-based package manager via https://github.com/juju/packaging/pull/4 and https://github.com/juju/packaging/pull/5)

However, as I went through the code base I saw that we use the same pattern in more places:
- to install mongo dependencies when bootstrapping controllers
- to install kvm dependencies. The latter only works on ubuntu and only happens to work across different series because the required package names have not been renamed.

Evidently, the old approach where we first consulted the series to select a list of packages and then asked the `juju/packaging` repo to give us a suitable package manager cannot cover systems where multiple package managers can co-exist (e.g. apt/snap). Additionally, there are cases where we would want to install some packages from snap and others from snap (i.e. they are not available as snaps yet, we don't want them to auto-update etc.).

The solution proposed by this PR is to create an abstraction for a `Dependency`. Each dependency contains the package-selection logic for the series that we support and can be queried to obtain a list of packages **and** preferred package manager for installing each one. I have isolated the dependency requirements for lxd, kvm and mongo into standalone objects that live in the `packaging/dependency` juju pkg. 

The `packaging` package provides a helper for installing dependencies and handles all the low-level details for instantiating the appropriate package managers and injecting additional options (e.g. backports, cloud-tools) where required.

Finally, as an application of the boy-scout rule, I noticed that the `mongo` package contains centos-specific code (and tests) for bootstrapping purposes. Given that we only support bootstrapping on ubuntu (centos is fine for running workloads though), that code is never going to be used so it has been removed. As an extra layer of safety, the dependency object for mongo will return a `NotImplemented` error if asked to resolve the mongo packages on centos.

**Notes:**
To reduce the scope of changes for this PR, I have intentionally left out the changes required to configure proxies for systems with dual package managers (e.g. snap/apt on disco). This will be addressed via a separate PR

## QA steps

To simulate an image where lxd is not pre-installed, we will add two machines (based on bionic and disco), uninstall lxd and then try to add lxd containers on each. This should force a re-install of lxd using he appropriate package manager for each distro.

```console
$ juju bootstrap lxd test --no-gui
$ juju add-machine --series=bionic
$ juju add-machine --series=disco

# Wait for the machines to become available and run the following commands
$ juju run --machine 0 'sudo apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet purge lxd'
...
Removing lxd (3.0.3-0ubuntu1~18.04.1) ...
...

$ juju run --machine 1 'sudo snap remove lxd'
lxd removed

# Now create two lxd containers and check that juju re-install lxd using the correct package manager
$ juju add-machine lxd:0
created container 0/lxd/0

$ juju add-machine lxd:1
created container 1/lxd/0
 
# Wait for containers to become available and check lxd installations on host machines
$ juju run --machine 0 'which lxd'
/usr/bin/lxd       <-- apt version on bionic host

$ juju run --machine 1 'which lxd'
/snap/bin/lxd      <-- snap version on disco host
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1835187
