### PR TITLE
replace SubnetTag with string for ciders in subnet commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1562,6 +1562,7 @@
   revision = "1ebf5c5481e815de683e57e0f46705ac567e4e58"
 
 [[projects]]
+  branch = "v2"
   digest = "1:4eaefc824f6794f155150392c6eea2c3f898b392e0b90e497cc3dd79bc4c99d5"
   name = "gopkg.in/juju/names.v2"
   packages = ["."]
@@ -2087,7 +2088,6 @@
     "gopkg.in/juju/charmstore.v5",
     "gopkg.in/juju/environschema.v1",
     "gopkg.in/juju/environschema.v1/form",
-    "gopkg.in/juju/names.v2",
     "gopkg.in/juju/names.v3",
     "gopkg.in/juju/worker.v1",
     "gopkg.in/juju/worker.v1/catacomb",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -158,10 +158,6 @@
   name = "gopkg.in/juju/environschema.v1"
 
 [[constraint]]
-  revision = "e057c73bd1beb18e9634151a2410c422bd2057f2"
-  name = "gopkg.in/juju/names.v2"
-
-[[constraint]]
   revision = "5ed389481ee8344db732cf8a65a8bbfeb42dc79d"
   name = "gopkg.in/juju/names.v3"
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -100,7 +100,7 @@ var facadeVersions = map[string]int{
 	"Storage":                      6,
 	"StorageProvisioner":           4,
 	"StringsWatcher":               1,
-	"Subnets":                      2,
+	"Subnets":                      3,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
 	"Uniter":                       12,

--- a/api/subnets/subnets.go
+++ b/api/subnets/subnets.go
@@ -5,7 +5,7 @@ package subnets
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -33,23 +33,20 @@ func NewAPI(caller base.APICallCloser) *API {
 }
 
 // AddSubnet adds an existing subnet to the model.
-func (api *API) AddSubnet(subnet names.SubnetTag, providerId network.Id, space names.SpaceTag, zones []string) error {
+func (api *API) AddSubnet(cidr string, providerId network.Id, space names.SpaceTag, zones []string) error {
 	var response params.ErrorResults
 	// Prefer ProviderId when set over CIDR.
-	subnetTag := subnet.String()
 	if providerId != "" {
-		subnetTag = ""
+		cidr = ""
 	}
 
-	params := params.AddSubnetsParams{
-		Subnets: []params.AddSubnetParams{{
-			SubnetTag:        subnetTag,
-			SubnetProviderId: string(providerId),
-			SpaceTag:         space.String(),
-			Zones:            zones,
-		}},
+	var args interface{}
+	if bestVer := api.BestAPIVersion(); bestVer < 3 {
+		args = makeAddSubnetsParamsV2(cidr, providerId, space, zones)
+	} else {
+		args = makeAddSubnetsParams(cidr, providerId, space, zones)
 	}
-	err := api.facade.FacadeCall("AddSubnets", params, &response)
+	err := api.facade.FacadeCall("AddSubnets", args, &response)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -58,20 +55,27 @@ func (api *API) AddSubnet(subnet names.SubnetTag, providerId network.Id, space n
 
 // CreateSubnet creates a new subnet with the provider.
 func (api *API) CreateSubnet(subnet names.SubnetTag, space names.SpaceTag, zones []string, isPublic bool) error {
-	var response params.ErrorResults
-	params := params.CreateSubnetsParams{
-		Subnets: []params.CreateSubnetParams{{
-			SubnetTag: subnet.String(),
-			SpaceTag:  space.String(),
-			Zones:     zones,
-			IsPublic:  isPublic,
-		}},
-	}
-	err := api.facade.FacadeCall("CreateSubnets", params, &response)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return response.OneError()
+	// TODO (hml) 2019-08-23
+	// This call is behind a feature flag and panics due to lack of
+	// facade on the the other end.  It's in the list to be audited
+	// for updates as part of current networking improvements.  Fix
+	// names.v2 SubnetTag at that time.
+	return errors.NewNotImplemented(nil, "CreateSubnet")
+
+	//var response params.ErrorResults
+	//params := params.CreateSubnetsParams{
+	//	Subnets: []params.CreateSubnetParams{{
+	//		SubnetTag: subnet.String(),
+	//		SpaceTag:  space.String(),
+	//		Zones:     zones,
+	//		IsPublic:  isPublic,
+	//	}},
+	//}
+	//err := api.facade.FacadeCall("CreateSubnets", params, &response)
+	//if err != nil {
+	//	return errors.Trace(err)
+	//}
+	//return response.OneError()
 }
 
 // ListSubnets fetches all the subnets known by the model.
@@ -90,4 +94,30 @@ func (api *API) ListSubnets(spaceTag *names.SpaceTag, zone string) ([]params.Sub
 		return nil, errors.Trace(err)
 	}
 	return response.Results, nil
+}
+
+func makeAddSubnetsParamsV2(cidr string, providerId network.Id, space names.SpaceTag, zones []string) params.AddSubnetsParamsV2 {
+	var subnetTag string
+	if cidr != "" {
+		subnetTag = "subnet-" + cidr
+	}
+	return params.AddSubnetsParamsV2{
+		Subnets: []params.AddSubnetParamsV2{{
+			SubnetTag:        subnetTag,
+			SubnetProviderId: string(providerId),
+			SpaceTag:         space.String(),
+			Zones:            zones,
+		}},
+	}
+}
+
+func makeAddSubnetsParams(cidr string, providerId network.Id, space names.SpaceTag, zones []string) params.AddSubnetsParams {
+	return params.AddSubnetsParams{
+		Subnets: []params.AddSubnetParams{{
+			CIDR:             cidr,
+			SubnetProviderId: string(providerId),
+			SpaceTag:         space.String(),
+			Zones:            zones,
+		}},
+	}
 }

--- a/api/subnets/subnets_test.go
+++ b/api/subnets/subnets_test.go
@@ -8,7 +8,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/subnets"
@@ -29,7 +29,11 @@ var _ = gc.Suite(&SubnetsSuite{})
 
 func (s *SubnetsSuite) prepareAPICall(c *gc.C, args apitesting.APICall) {
 	s.apiCaller = apitesting.APICallChecker(c, args)
-	s.api = subnets.NewAPI(s.apiCaller)
+	best := &apitesting.BestVersionCaller{
+		BestVersion:   3,
+		APICallerFunc: s.apiCaller.APICallerFunc,
+	}
+	s.api = subnets.NewAPI(best)
 	c.Check(s.api, gc.NotNil)
 	c.Check(s.apiCaller.CallCount, gc.Equals, 0)
 }
@@ -50,15 +54,14 @@ func (s *SubnetsSuite) TestNewAPIWithNilCaller(c *gc.C) {
 
 func makeAddSubnetsArgs(cidr, providerId, space string, zones []string) apitesting.APICall {
 	spaceTag := names.NewSpaceTag(space).String()
-	subnetTag := names.NewSubnetTag(cidr).String()
 	if providerId != "" {
-		subnetTag = ""
+		cidr = ""
 	}
 
 	expectArgs := params.AddSubnetsParams{
 		Subnets: []params.AddSubnetParams{{
 			SpaceTag:         spaceTag,
-			SubnetTag:        subnetTag,
+			CIDR:             cidr,
 			SubnetProviderId: providerId,
 			Zones:            zones,
 		}}}
@@ -126,7 +129,7 @@ func (s *SubnetsSuite) TestAddSubnet(c *gc.C) {
 	args := makeAddSubnetsArgs(cidr, providerId, space, zones)
 	s.prepareAPICall(c, args)
 	err := s.api.AddSubnet(
-		names.NewSubnetTag(cidr),
+		cidr,
 		network.Id(providerId),
 		names.NewSpaceTag(space),
 		zones,
@@ -144,7 +147,7 @@ func (s *SubnetsSuite) TestAddSubnetFails(c *gc.C) {
 	args.Error = errors.New("bang")
 	s.prepareAPICall(c, args)
 	err := s.api.AddSubnet(
-		names.NewSubnetTag(cidr),
+		cidr,
 		network.Id(providerId),
 		names.NewSpaceTag(space),
 		zones,
@@ -153,7 +156,41 @@ func (s *SubnetsSuite) TestAddSubnetFails(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "bang")
 }
 
+func (s *SubnetsSuite) TestAddSubnetV2(c *gc.C) {
+	var called bool
+	apicaller := &apitesting.BestVersionCaller{
+		APICallerFunc: apitesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Subnets")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "AddSubnets")
+				c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+				c.Assert(a, jc.DeepEquals, params.AddSubnetsParamsV2{
+					Subnets: []params.AddSubnetParamsV2{{
+						SpaceTag:  names.NewSpaceTag("testv2").String(),
+						SubnetTag: "subnet-1.1.1.0/24",
+					}}})
+				*result.(*params.ErrorResults) = params.ErrorResults{
+					Results: []params.ErrorResult{{}},
+				}
+				called = true
+				return nil
+			},
+		),
+		BestVersion: 2,
+	}
+	apiv2 := subnets.NewAPI(apicaller)
+	err := apiv2.AddSubnet("1.1.1.0/24", "", names.NewSpaceTag("testv2"), nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
 func (s *SubnetsSuite) TestCreateSubnet(c *gc.C) {
+	c.Skip("CreateSubnet to be audited")
 	cidr := "1.1.1.0/24"
 	space := "bar"
 	zones := []string{"foo", "bar"}
@@ -171,6 +208,7 @@ func (s *SubnetsSuite) TestCreateSubnet(c *gc.C) {
 }
 
 func (s *SubnetsSuite) TestCreateSubnetFails(c *gc.C) {
+	c.Skip("CreateSubnet to be audited ")
 	cidr := "1.1.1.0/24"
 	isPublic := true
 	space := "bar"

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -302,7 +302,8 @@ func AllFacades() *facade.Registry {
 
 	reg("StorageProvisioner", 3, storageprovisioner.NewFacadeV3)
 	reg("StorageProvisioner", 4, storageprovisioner.NewFacadeV4)
-	reg("Subnets", 2, subnets.NewAPI)
+	reg("Subnets", 2, subnets.NewAPIv2)
+	reg("Subnets", 3, subnets.NewAPI)
 	reg("Undertaker", 1, undertaker.NewUndertakerAPI)
 	reg("UnitAssigner", 1, unitassigner.New)
 

--- a/apiserver/common/networkingcommon/subnets.go
+++ b/apiserver/common/networkingcommon/subnets.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -258,24 +258,21 @@ func (cache *addSubnetsCache) cacheSubnets(ctx context.ProviderCallContext) erro
 	return nil
 }
 
-// validateSubnet ensures either subnetTag or providerId is valid (not both),
+// validateSubnet ensures either cidr or providerId is valid (not both),
 // then uses the cache to validate and lookup the provider SubnetInfo for the
 // subnet, if found.
-func (cache *addSubnetsCache) validateSubnet(ctx context.ProviderCallContext, subnetTag, providerId string) (*network.SubnetInfo, error) {
-	haveTag := subnetTag != ""
+func (cache *addSubnetsCache) validateSubnet(ctx context.ProviderCallContext, cidr, providerId string) (*network.SubnetInfo, error) {
+	haveCidr := cidr != ""
 	haveProviderId := providerId != ""
 
-	if !haveTag && !haveProviderId {
-		return nil, errors.Errorf("either SubnetTag or SubnetProviderId is required")
-	} else if haveTag && haveProviderId {
-		return nil, errors.Errorf("SubnetTag and SubnetProviderId cannot be both set")
+	if !haveCidr && !haveProviderId {
+		return nil, errors.Errorf("either CIDR or SubnetProviderId is required")
+	} else if haveCidr && haveProviderId {
+		return nil, errors.Errorf("CIDR and SubnetProviderId cannot be both set")
 	}
-	var tag names.SubnetTag
-	if haveTag {
-		var err error
-		tag, err = names.ParseSubnetTag(subnetTag)
-		if err != nil {
-			return nil, errors.Annotate(err, "given SubnetTag is invalid")
+	if haveCidr {
+		if !network.IsValidCidr(cidr) {
+			return nil, errors.New(fmt.Sprintf("%q is not a valid CIDR", cidr))
 		}
 	}
 
@@ -284,16 +281,16 @@ func (cache *addSubnetsCache) validateSubnet(ctx context.ProviderCallContext, su
 		return nil, errors.Trace(err)
 	}
 
-	if haveTag {
-		providerIds, ok := cache.providerIdsByCIDR[tag.Id()]
+	if haveCidr {
+		providerIds, ok := cache.providerIdsByCIDR[cidr]
 		if !ok || providerIds.IsEmpty() {
-			return nil, errors.NotFoundf("subnet with CIDR %q", tag.Id())
+			return nil, errors.NotFoundf("subnet with CIDR %q", cidr)
 		}
 		if providerIds.Size() > 1 {
 			ids := `"` + strings.Join(providerIds.SortedValues(), `", "`) + `"`
 			return nil, errors.Errorf(
 				"multiple subnets with CIDR %q: retry using ProviderId from: %s",
-				tag.Id(), ids,
+				cidr, ids,
 			)
 		}
 		// A single CIDR matched.
@@ -304,11 +301,11 @@ func (cache *addSubnetsCache) validateSubnet(ctx context.ProviderCallContext, su
 	if !ok || info == nil {
 		return nil, errors.NotFoundf(
 			"subnet with CIDR %q and ProviderId %q",
-			tag.Id(), providerId,
+			cidr, providerId,
 		)
 	}
 	// Do last-call validation.
-	if !names.IsValidSubnet(info.CIDR) {
+	if !network.IsValidCidr(info.CIDR) {
 		_, ipnet, err := net.ParseCIDR(info.CIDR)
 		if err != nil && info.CIDR != "" {
 			// The underlying error is not important here, just that
@@ -336,7 +333,7 @@ func (cache *addSubnetsCache) validateSubnet(ctx context.ProviderCallContext, su
 func addOneSubnet(
 	ctx context.ProviderCallContext, api NetworkBacking, args params.AddSubnetParams, cache *addSubnetsCache,
 ) error {
-	subnetInfo, err := cache.validateSubnet(ctx, args.SubnetTag, args.SubnetProviderId)
+	subnetInfo, err := cache.validateSubnet(ctx, args.CIDR, args.SubnetProviderId)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/common/networkingcommon/subnets.go
+++ b/apiserver/common/networkingcommon/subnets.go
@@ -258,6 +258,12 @@ func (cache *addSubnetsCache) cacheSubnets(ctx context.ProviderCallContext) erro
 	return nil
 }
 
+// TODO (hml) 2019-08-27
+// This logic needs to be updated when auditing add-subnet and the
+// subnet cache.  You need a providerId or cidr if there is only
+// one of that cidr in the network.  If there are duplicate cidrs
+// in the network, the providerId will be required.
+//
 // validateSubnet ensures either cidr or providerId is valid (not both),
 // then uses the cache to validate and lookup the provider SubnetInfo for the
 // subnet, if found.

--- a/apiserver/common/networkingcommon/subnets_test.go
+++ b/apiserver/common/networkingcommon/subnets_test.go
@@ -274,7 +274,7 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		Zones:    []string{"any", "ignored"},
 	}, {
 		// both tag and id set; same as above
-		SubnetTag:        "any",
+		CIDR:             "any",
 		SubnetProviderId: "any",
 	}, {
 		// lookup by id needed, no cached subnets; ModelConfig(): error
@@ -305,19 +305,16 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		SpaceTag:         "unit-foo-0",
 	}, {
 		// invalid tag (no kind): error (no calls)
-		SubnetTag: "invalid",
-	}, {
-		// invalid subnet tag (another kind): same as above
-		SubnetTag: "application-bar",
+		CIDR: "invalid",
 	}, {
 		// cached lookup by missing CIDR: not found error
-		SubnetTag: "subnet-1.2.3.0/24",
+		CIDR: "1.2.3.0/24",
 	}, {
 		// cached lookup by duplicate CIDR: multiple choices error
-		SubnetTag: "subnet-10.10.0.0/24",
+		CIDR: "10.10.0.0/24",
 	}, {
 		// cached lookup by CIDR with empty provider id: ok; space tag is required error
-		SubnetTag: "subnet-10.20.0.0/16",
+		CIDR: "10.20.0.0/16",
 	}, {
 		// cached lookup by id with invalid CIDR: cannot be added error
 		SubnetProviderId: "sn-invalid",
@@ -329,16 +326,16 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		SubnetProviderId: "sn-awesome",
 	}, {
 		// cached lookup by CIDR: ok; valid tag; caching spaces: AllSpaces(): error
-		SubnetTag: "subnet-10.30.1.0/24",
-		SpaceTag:  "space-unverified",
+		CIDR:     "10.30.1.0/24",
+		SpaceTag: "space-unverified",
 	}, {
 		// exactly as above, except AllSpaces(): ok; cached lookup: space not found
-		SubnetTag: "subnet-2001:db8::/32",
-		SpaceTag:  "space-missing",
+		CIDR:     "2001:db8::/32",
+		SpaceTag: "space-missing",
 	}, {
 		// both cached lookups (CIDR, space): ok; no provider or given zones: error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
+		CIDR:     "10.42.0.0/16",
+		SpaceTag: "space-dmz",
 	}, {
 		// like above; with provider zones, extra given: error
 		SubnetProviderId: "vlan-42",
@@ -352,29 +349,29 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		},
 	}, {
 		// like above; no provider, only given zones; caching: AllZones(): error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"any", "ignored"},
+		CIDR:     "10.42.0.0/16",
+		SpaceTag: "space-dmz",
+		Zones:    []string{"any", "ignored"},
 	}, {
 		// as above, but unknown zones given: cached: AllZones(): ok; unknown zones error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"missing", "gone"},
+		CIDR:     "10.42.0.0/16",
+		SpaceTag: "space-dmz",
+		Zones:    []string{"missing", "gone"},
 	}, {
 		// as above, but unknown and unavailable zones given: same error (no calls)
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone4", "missing", "zone2"},
+		CIDR:     "10.42.0.0/16",
+		SpaceTag: "space-dmz",
+		Zones:    []string{"zone4", "missing", "zone2"},
 	}, {
 		// as above, but unavailable zones given: Zones contains unavailable error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone2", "zone4"},
+		CIDR:     "10.42.0.0/16",
+		SpaceTag: "space-dmz",
+		Zones:    []string{"zone2", "zone4"},
 	}, {
 		// as above, but available and unavailable zones given: same error as above
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone4", "zone3"},
+		CIDR:     "10.42.0.0/16",
+		SpaceTag: "space-dmz",
+		Zones:    []string{"zone4", "zone3"},
 	}, {
 		// everything succeeds, using caches as needed, until: AddSubnet(): error
 		SubnetProviderId: "sn-ipv6",
@@ -383,9 +380,9 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		// restriction of provider zones [zone1, zone3]
 	}, {
 		// cached lookups by CIDR, space: ok; duplicated provider id: unavailable zone2
-		SubnetTag: "subnet-10.99.88.0/24",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone2"},
+		CIDR:     "10.99.88.0/24",
+		SpaceTag: "space-dmz",
+		Zones:    []string{"zone2"},
 		// due to the duplicate ProviderId provider zones from subnet
 		// with the last ProviderId=sn-deadbeef are used
 		// (10.10.0.0/24); [zone2], not the 10.99.88.0/24 provider
@@ -398,8 +395,8 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		// restriction of provider zones [zone1, zone3]
 	}, {
 		// success (CIDR lookup; with provider (no given) zones): AddSubnet(): ok
-		SubnetTag: "subnet-10.30.1.0/24",
-		SpaceTag:  "space-private",
+		CIDR:     "10.30.1.0/24",
+		SpaceTag: "space-private",
 		// Zones not given, so provider zones are used instead: [zone3]
 	}, {
 		// success (id lookup; given zones match provider zones) AddSubnet(): ok
@@ -445,9 +442,9 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		message   string
 		satisfier func(error) bool
 	}{
-		{"either SubnetTag or SubnetProviderId is required", nil},
-		{"either SubnetTag or SubnetProviderId is required", nil},
-		{"SubnetTag and SubnetProviderId cannot be both set", nil},
+		{"either CIDR or SubnetProviderId is required", nil},
+		{"either CIDR or SubnetProviderId is required", nil},
+		{"CIDR and SubnetProviderId cannot be both set", nil},
 		{"opening environment: config not found", params.IsCodeNotFound},
 		{"opening environment: provider not found", params.IsCodeNotFound},
 		{"cannot get provider subnets: subnets not found", params.IsCodeNotFound},
@@ -456,8 +453,7 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		{`given SpaceTag is invalid: "invalid" is not a valid tag`, nil},
 		{`given SpaceTag is invalid: "unit-foo" is not a valid unit tag`, nil},
 		{`given SpaceTag is invalid: "unit-foo-0" is not a valid space tag`, nil},
-		{`given SubnetTag is invalid: "invalid" is not a valid tag`, nil},
-		{`given SubnetTag is invalid: "application-bar" is not a valid subnet tag`, nil},
+		{`"invalid" is not a valid CIDR`, nil},
 		{`subnet with CIDR "1.2.3.0/24" not found`, params.IsCodeNotFound},
 		{
 			`multiple subnets with CIDR "10.10.0.0/24": ` +
@@ -685,9 +681,9 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 	// Pass 2 arguments covering all cases we need.
 	args := params.AddSubnetsParams{
 		Subnets: []params.AddSubnetParams{{
-			SubnetTag: "subnet-10.42.0.0/16",
-			SpaceTag:  "space-dmz",
-			Zones:     []string{"zone1"},
+			CIDR:     "10.42.0.0/16",
+			SpaceTag: "space-dmz",
+			Zones:    []string{"zone1"},
 		}, {
 			SubnetProviderId: "vlan-42",
 			SpaceTag:         "space-private",

--- a/apiserver/facades/client/subnets/subnets_test.go
+++ b/apiserver/facades/client/subnets/subnets_test.go
@@ -28,7 +28,7 @@ type SubnetsSuite struct {
 
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
-	facade     subnets.SubnetsAPI
+	facade     *subnets.API
 
 	callContext context.ProviderCallContext
 }
@@ -321,320 +321,6 @@ func (s *SubnetsSuite) TestAllSpacesFailure(c *gc.C) {
 	)
 }
 
-func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
-	apiservertesting.BackingInstance.SetUp(c, apiservertesting.StubNetworkingEnvironName, apiservertesting.WithZones, apiservertesting.WithSpaces, apiservertesting.WithSubnets)
-
-	args := params.AddSubnetsParams{Subnets: []params.AddSubnetParams{{
-		// nothing set; early exit: no calls
-	}, {
-		// neither tag nor id set: the rest is ignored; same as above
-		SpaceTag: "any",
-		Zones:    []string{"any", "ignored"},
-	}, {
-		// both tag and id set; same as above
-		SubnetTag:        "any",
-		SubnetProviderId: "any",
-	}, {
-		// lookup by id needed, no cached subnets; ModelConfig(): error
-		SubnetProviderId: "any",
-	}, {
-		// same as above, need to cache subnets; ModelConfig(): ok; Open(): error
-		SubnetProviderId: "ignored",
-	}, {
-		// as above, caching again; ModelConfig(), Open(): ok; Subnets(): error
-		SubnetProviderId: "unimportant",
-	}, {
-		// exactly as above, except all 3 calls ok; cached lookup: id not found
-		SubnetProviderId: "missing",
-	}, {
-		// cached lookup by id (no calls): not found error
-		SubnetProviderId: "void",
-	}, {
-		// cached lookup by id: ok; parsing space tag: invalid tag error
-		SubnetProviderId: "sn-deadbeef",
-		SpaceTag:         "invalid",
-	}, {
-		// as above, but slightly different error: invalid space tag error
-		SubnetProviderId: "sn-zadf00d",
-		SpaceTag:         "unit-foo",
-	}, {
-		// as above; yet another similar error (valid tag with another kind)
-		SubnetProviderId: "vlan-42",
-		SpaceTag:         "unit-foo-0",
-	}, {
-		// invalid tag (no kind): error (no calls)
-		SubnetTag: "invalid",
-	}, {
-		// invalid subnet tag (another kind): same as above
-		SubnetTag: "application-bar",
-	}, {
-		// cached lookup by missing CIDR: not found error
-		SubnetTag: "subnet-1.2.3.0/24",
-	}, {
-		// cached lookup by duplicate CIDR: multiple choices error
-		SubnetTag: "subnet-10.10.0.0/24",
-	}, {
-		// cached lookup by CIDR with empty provider id: ok; space tag is required error
-		SubnetTag: "subnet-10.20.0.0/16",
-	}, {
-		// cached lookup by id with invalid CIDR: cannot be added error
-		SubnetProviderId: "sn-invalid",
-	}, {
-		// cached lookup by id with empty CIDR: cannot be added error
-		SubnetProviderId: "sn-empty",
-	}, {
-		// cached lookup by id with incorrectly specified CIDR: cannot be added error
-		SubnetProviderId: "sn-awesome",
-	}, {
-		// cached lookup by CIDR: ok; valid tag; caching spaces: AllSpaces(): error
-		SubnetTag: "subnet-10.30.1.0/24",
-		SpaceTag:  "space-unverified",
-	}, {
-		// exactly as above, except AllSpaces(): ok; cached lookup: space not found
-		SubnetTag: "subnet-2001:db8::/32",
-		SpaceTag:  "space-missing",
-	}, {
-		// both cached lookups (CIDR, space): ok; no provider or given zones: error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-	}, {
-		// like above; with provider zones, extra given: error
-		SubnetProviderId: "vlan-42",
-		SpaceTag:         "space-private",
-		Zones: []string{
-			"zone2",   // not allowed, existing, unavailable
-			"zone3",   // allowed, existing, available
-			"missing", // not allowed, non-existing
-			"zone3",   // duplicates are ignored (should they ?)
-			"zone1",   // not allowed, existing, available
-		},
-	}, {
-		// like above; no provider, only given zones; caching: AllZones(): error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"any", "ignored"},
-	}, {
-		// as above, but unknown zones given: cached: AllZones(): ok; unknown zones error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"missing", "gone"},
-	}, {
-		// as above, but unknown and unavailable zones given: same error (no calls)
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone4", "missing", "zone2"},
-	}, {
-		// as above, but unavailable zones given: Zones contains unavailable error
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone2", "zone4"},
-	}, {
-		// as above, but available and unavailable zones given: same error as above
-		SubnetTag: "subnet-10.42.0.0/16",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone4", "zone3"},
-	}, {
-		// everything succeeds, using caches as needed, until: AddSubnet(): error
-		SubnetProviderId: "sn-ipv6",
-		SpaceTag:         "space-dmz",
-		Zones:            []string{"zone1"},
-		// restriction of provider zones [zone1, zone3]
-	}, {
-		// cached lookups by CIDR, space: ok; duplicated provider id: unavailable zone2
-		SubnetTag: "subnet-10.99.88.0/24",
-		SpaceTag:  "space-dmz",
-		Zones:     []string{"zone2"},
-		// due to the duplicate ProviderId provider zones from subnet
-		// with the last ProviderId=sn-deadbeef are used
-		// (10.10.0.0/24); [zone2], not the 10.99.88.0/24 provider
-		// zones: [zone1, zone2].
-	}, {
-		// same as above, but AddSubnet(): ok; success (backing verified later)
-		SubnetProviderId: "sn-ipv6",
-		SpaceTag:         "space-dmz",
-		Zones:            []string{"zone1"},
-		// restriction of provider zones [zone1, zone3]
-	}, {
-		// success (CIDR lookup; with provider (no given) zones): AddSubnet(): ok
-		SubnetTag: "subnet-10.30.1.0/24",
-		SpaceTag:  "space-private",
-		// Zones not given, so provider zones are used instead: [zone3]
-	}, {
-		// success (id lookup; given zones match provider zones) AddSubnet(): ok
-		SubnetProviderId: "sn-zadf00d",
-		SpaceTag:         "space-private",
-		Zones:            []string{"zone1"},
-	}}}
-	apiservertesting.SharedStub.SetErrors(
-		// caching subnets (1st attempt): fails
-		errors.NotFoundf("config"), // BackingInstance.ModelConfig (1st call)
-
-		// caching subnets (2nd attepmt): fails
-		nil,                          // BackingInstance.ModelConfig (2nd call)
-		nil,                          // BackingInstance.CloudSpec (1st call)
-		errors.NotFoundf("provider"), // ProviderInstance.Open (1st call)
-
-		// caching subnets (3rd attempt): fails
-		nil,                         // BackingInstance.ModelConfig (3rd call)
-		nil,                         // BackingInstance.CloudSpec (2nd call)
-		nil,                         // ProviderInstance.Open (2nd call)
-		errors.NotFoundf("subnets"), // NetworkingEnvironInstance.Subnets (1st call)
-
-		// caching subnets (4th attempt): succeeds
-		nil, // BackingInstance.ModelConfig (4th call)
-		nil, // BackingInstance.CloudSpec (3rd call)
-		nil, // ProviderInstance.Open (3rd call)
-		nil, // NetworkingEnvironInstance.Subnets (2nd call)
-
-		// caching spaces (1st and 2nd attempts)
-		errors.NotFoundf("spaces"), // BackingInstance.AllSpaces (1st call)
-		nil,                        // BackingInstance.AllSpaces (2nd call)
-
-		// cacing zones (1st and 2nd attempts)
-		errors.NotFoundf("zones"), // BackingInstance.AvailabilityZones (1st call)
-		nil,                       // BackingInstance.AvailabilityZones (2nd call)
-
-		// validation done; adding subnets to backing store
-		errors.NotFoundf("state"), // BackingInstance.AddSubnet (1st call)
-		// the next 3 BackingInstance.AddSubnet calls succeed(2nd call)
-	)
-
-	expectedErrors := []struct {
-		message   string
-		satisfier func(error) bool
-	}{
-		{"either SubnetTag or SubnetProviderId is required", nil},
-		{"either SubnetTag or SubnetProviderId is required", nil},
-		{"SubnetTag and SubnetProviderId cannot be both set", nil},
-		{"opening environment: config not found", params.IsCodeNotFound},
-		{"opening environment: provider not found", params.IsCodeNotFound},
-		{"cannot get provider subnets: subnets not found", params.IsCodeNotFound},
-		{`subnet with CIDR "" and ProviderId "missing" not found`, params.IsCodeNotFound},
-		{`subnet with CIDR "" and ProviderId "void" not found`, params.IsCodeNotFound},
-		{`given SpaceTag is invalid: "invalid" is not a valid tag`, nil},
-		{`given SpaceTag is invalid: "unit-foo" is not a valid unit tag`, nil},
-		{`given SpaceTag is invalid: "unit-foo-0" is not a valid space tag`, nil},
-		{`given SubnetTag is invalid: "invalid" is not a valid tag`, nil},
-		{`given SubnetTag is invalid: "application-bar" is not a valid subnet tag`, nil},
-		{`subnet with CIDR "1.2.3.0/24" not found`, params.IsCodeNotFound},
-		{
-			`multiple subnets with CIDR "10.10.0.0/24": ` +
-				`retry using ProviderId from: "sn-deadbeef", "sn-zadf00d"`, nil,
-		},
-		{"SpaceTag is required", nil},
-		{`subnet with CIDR "invalid" and ProviderId "sn-invalid": invalid CIDR`, nil},
-		{`subnet with ProviderId "sn-empty": empty CIDR`, nil},
-		{
-			`subnet with ProviderId "sn-awesome": ` +
-				`incorrect CIDR format "0.1.2.3/4", expected "0.0.0.0/4"`, nil,
-		},
-		{"cannot validate given SpaceTag: spaces not found", params.IsCodeNotFound},
-		{`space "missing" not found`, params.IsCodeNotFound},
-		{"Zones cannot be discovered from the provider and must be set", nil},
-		{`Zones contain zones not allowed by the provider: "missing", "zone1", "zone2"`, nil},
-		{"given Zones cannot be validated: zones not found", params.IsCodeNotFound},
-		{`Zones contain unknown zones: "gone", "missing"`, nil},
-		{`Zones contain unknown zones: "missing"`, nil},
-		{`Zones contain unavailable zones: "zone2", "zone4"`, nil},
-		{`Zones contain unavailable zones: "zone4"`, nil},
-		{"state not found", params.IsCodeNotFound},
-		{`Zones contain unavailable zones: "zone2"`, nil},
-		{"", nil},
-		{"", nil},
-		{"", nil},
-	}
-	expectedBackingInfos := []networkingcommon.BackingSubnetInfo{{
-		ProviderId:        "sn-ipv6",
-		ProviderNetworkId: "",
-		CIDR:              "2001:db8::/32",
-		VLANTag:           0,
-		AvailabilityZones: []string{"zone1"},
-		SpaceName:         "dmz",
-	}, {
-		ProviderId:        "vlan-42",
-		ProviderNetworkId: "",
-		CIDR:              "10.30.1.0/24",
-		VLANTag:           42,
-		AvailabilityZones: []string{"zone3"},
-		SpaceName:         "private",
-	}, {
-		ProviderId:        "sn-zadf00d",
-		ProviderNetworkId: "godspeed",
-		CIDR:              "10.10.0.0/24",
-		VLANTag:           0,
-		AvailabilityZones: []string{"zone1"},
-		SpaceName:         "private",
-	}}
-	c.Check(expectedErrors, gc.HasLen, len(args.Subnets))
-	results, err := s.facade.AddSubnets(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(results.Results), gc.Equals, len(args.Subnets))
-	for i, result := range results.Results {
-		c.Logf("result #%d: expected: %q", i, expectedErrors[i].message)
-		if expectedErrors[i].message == "" {
-			if !c.Check(result.Error, gc.IsNil) {
-				c.Logf("unexpected error: %v; args: %#v", result.Error, args.Subnets[i])
-			}
-			continue
-		}
-		if !c.Check(result.Error, gc.NotNil) {
-			c.Logf("unexpected success; args: %#v", args.Subnets[i])
-			continue
-		}
-		c.Check(result.Error.Message, gc.Equals, expectedErrors[i].message)
-		if expectedErrors[i].satisfier != nil {
-			c.Check(result.Error, jc.Satisfies, expectedErrors[i].satisfier)
-		} else {
-			c.Check(result.Error.Code, gc.Equals, "")
-		}
-	}
-
-	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub,
-		// caching subnets (1st attempt): fails
-		apiservertesting.BackingCall("ModelConfig"),
-
-		// caching subnets (2nd attepmt): fails
-		apiservertesting.BackingCall("ModelConfig"),
-		apiservertesting.BackingCall("CloudSpec"),
-		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
-
-		// caching subnets (3rd attempt): fails
-		apiservertesting.BackingCall("ModelConfig"),
-		apiservertesting.BackingCall("CloudSpec"),
-		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
-		apiservertesting.NetworkingEnvironCall("Subnets", s.callContext, instance.UnknownId, []network.Id(nil)),
-
-		// caching subnets (4th attempt): succeeds
-		apiservertesting.BackingCall("ModelConfig"),
-		apiservertesting.BackingCall("CloudSpec"),
-		apiservertesting.ProviderCall("Open", apiservertesting.BackingInstance.EnvConfig),
-		apiservertesting.NetworkingEnvironCall("Subnets", s.callContext, instance.UnknownId, []network.Id(nil)),
-
-		// caching spaces (1st and 2nd attempts)
-		apiservertesting.BackingCall("AllSpaces"),
-		apiservertesting.BackingCall("AllSpaces"),
-
-		// cacing zones (1st and 2nd attempts)
-		apiservertesting.BackingCall("AvailabilityZones"),
-		apiservertesting.BackingCall("AvailabilityZones"),
-
-		// validation done; adding subnets to backing store
-		apiservertesting.BackingCall("AddSubnet", expectedBackingInfos[0]),
-		apiservertesting.BackingCall("AddSubnet", expectedBackingInfos[0]),
-		apiservertesting.BackingCall("AddSubnet", expectedBackingInfos[1]),
-		apiservertesting.BackingCall("AddSubnet", expectedBackingInfos[2]),
-	)
-	apiservertesting.ResetStub(apiservertesting.SharedStub)
-
-	// Finally, check that no params yields no results.
-	results, err = s.facade.AddSubnets(params.AddSubnetsParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.NotNil)
-	c.Assert(results.Results, gc.HasLen, 0)
-
-	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub)
-}
-
 func (s *SubnetsSuite) CheckAddSubnetsFails(
 	c *gc.C, envName string,
 	withZones, withSpaces, withSubnets apiservertesting.SetUpFlag,
@@ -740,9 +426,9 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 	// Pass 2 arguments covering all cases we need.
 	args := params.AddSubnetsParams{
 		Subnets: []params.AddSubnetParams{{
-			SubnetTag: "subnet-10.42.0.0/16",
-			SpaceTag:  "space-dmz",
-			Zones:     []string{"zone1"},
+			CIDR:     "10.42.0.0/16",
+			SpaceTag: "space-dmz",
+			Zones:    []string{"zone1"},
 		}, {
 			SubnetProviderId: "vlan-42",
 			SpaceTag:         "space-private",
@@ -801,6 +487,41 @@ func (s *SubnetsSuite) TestAddSubnetsWhenNetworkingEnvironNotSupported(c *gc.C) 
 		"model networking features not supported",
 		params.IsCodeNotSupported,
 	)
+}
+
+func (s *SubnetsSuite) TestAddSubnetAPI(c *gc.C) {
+	apiservertesting.BackingInstance.SetUp(c, apiservertesting.StubNetworkingEnvironName,
+		apiservertesting.WithZones, apiservertesting.WithSpaces, apiservertesting.WithSubnets)
+	results, err := s.facade.AddSubnets(params.AddSubnetsParams{
+		Subnets: []params.AddSubnetParams{
+			{
+				SpaceTag: "space-dmz",
+				CIDR:     "10.42.0.0/16",
+				Zones:    []string{"zone1"},
+			},
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(len(results.Results), gc.Equals, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+}
+
+func (s *SubnetsSuite) TestAddSubnetAPIv2(c *gc.C) {
+	apiservertesting.BackingInstance.SetUp(c, apiservertesting.StubNetworkingEnvironName,
+		apiservertesting.WithZones, apiservertesting.WithSpaces, apiservertesting.WithSubnets)
+	apiV2 := &subnets.APIv2{s.facade}
+	results, err := apiV2.AddSubnets(params.AddSubnetsParamsV2{
+		Subnets: []params.AddSubnetParamsV2{
+			{
+				SpaceTag:  "space-dmz",
+				SubnetTag: "subnet-10.42.0.0/16",
+				Zones:     []string{"zone1"},
+			},
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(len(results.Results), gc.Equals, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
 }
 
 func (s *SubnetsSuite) TestListSubnetsAndFiltering(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -32887,7 +32887,7 @@
     },
     {
         "Name": "Subnets",
-        "Version": 2,
+        "Version": 3,
         "Schema": {
             "type": "object",
             "properties": {
@@ -32934,6 +32934,9 @@
                 "AddSubnetParams": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "provider-network-id": {
                             "type": "string"
                         },
@@ -32941,9 +32944,6 @@
                             "type": "string"
                         },
                         "subnet-provider-id": {
-                            "type": "string"
-                        },
-                        "subnet-tag": {
                             "type": "string"
                         },
                         "vlan-tag": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -591,11 +591,29 @@ type AddSubnetsParams struct {
 	Subnets []AddSubnetParams `json:"subnets"`
 }
 
-// AddSubnetParams holds a subnet and space tags, subnet provider ID,
+// AddSubnetParams holds a cidr and space tags, subnet provider ID,
 // and a list of zones to associate the subnet to. Either SubnetTag or
 // SubnetProviderId must be set, but not both. Zones can be empty if
 // they can be discovered
 type AddSubnetParams struct {
+	CIDR              string   `json:"cidr,omitempty"`
+	SubnetProviderId  string   `json:"subnet-provider-id,omitempty"`
+	ProviderNetworkId string   `json:"provider-network-id,omitempty"`
+	SpaceTag          string   `json:"space-tag"`
+	VLANTag           int      `json:"vlan-tag,omitempty"`
+	Zones             []string `json:"zones,omitempty"`
+}
+
+// AddSubnetsParams holds the arguments of AddSubnets APIv2 call.
+type AddSubnetsParamsV2 struct {
+	Subnets []AddSubnetParamsV2 `json:"subnets"`
+}
+
+// AddSubnetParams holds a subnet and space tags, subnet provider ID,
+// and a list of zones to associate the subnet to. Either SubnetTag or
+// SubnetProviderId must be set, but not both. Zones can be empty if
+// they can be discovered
+type AddSubnetParamsV2 struct {
 	SubnetTag         string   `json:"subnet-tag,omitempty"`
 	SubnetProviderId  string   `json:"subnet-provider-id,omitempty"`
 	ProviderNetworkId string   `json:"provider-network-id,omitempty"`

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
@@ -26,7 +26,7 @@ func NewAddCommand() modelcmd.ModelCommand {
 type AddCommand struct {
 	SubnetCommandBase
 
-	CIDR       names.SubnetTag
+	CIDR       string
 	RawCIDR    string // before normalizing (e.g. 10.10.0.0/8 to 10.0.0.0/8)
 	ProviderId string
 	Space      names.SpaceTag
@@ -35,7 +35,7 @@ type AddCommand struct {
 
 const addCommandDoc = `
 Adds an existing subnet to Juju, making it available for use. Unlike
-"juju add-subnet", this command does not create a new subnet, so it
+"juju create-subnet", this command does not create a new subnet, so it
 is supported on a wider variety of clouds (where SDN features are not
 available, e.g. MAAS). The subnet will be associated with the given
 existing Juju network space.
@@ -100,10 +100,10 @@ func (c *AddCommand) Init(args []string) (err error) {
 // Run implements Command.Run.
 func (c *AddCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
-		if c.CIDR.Id() != "" && c.RawCIDR != c.CIDR.Id() {
+		if c.CIDR != "" && c.RawCIDR != c.CIDR {
 			ctx.Infof(
 				"WARNING: using CIDR %q instead of the incorrectly specified %q.",
-				c.CIDR.Id(), c.RawCIDR,
+				c.CIDR, c.RawCIDR,
 			)
 		}
 
@@ -124,7 +124,7 @@ func (c *AddCommand) Run(ctx *cmd.Context) error {
 		if c.ProviderId != "" {
 			ctx.Infof("added subnet with ProviderId %q in space %q", c.ProviderId, c.Space.Id())
 		} else {
-			ctx.Infof("added subnet with CIDR %q in space %q", c.CIDR.Id(), c.Space.Id())
+			ctx.Infof("added subnet with CIDR %q in space %q", c.CIDR, c.Space.Id())
 		}
 		return nil
 	})

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/subnet"
@@ -97,7 +97,7 @@ func (s *AddSuite) TestInit(c *gc.C) {
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 			command := command.(*subnet.AddCommand)
-			c.Check(command.CIDR.Id(), gc.Equals, test.expectCIDR)
+			c.Check(command.CIDR, gc.Equals, test.expectCIDR)
 			c.Check(command.RawCIDR, gc.Equals, test.expectRawCIDR)
 			c.Check(command.ProviderId, gc.Equals, test.expectProviderId)
 			c.Check(command.Space.Id(), gc.Equals, test.expectSpace)
@@ -117,7 +117,7 @@ func (s *AddSuite) TestRunWithIPv4CIDRSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		names.NewSubnetTag("10.20.0.0/24"),
+		"10.20.0.0/24",
 		network.Id(""),
 		names.NewSpaceTag("myspace"),
 		[]string(nil),
@@ -140,7 +140,7 @@ func (s *AddSuite) TestRunWithIncorrectlyGivenCIDRSucceedsWithWarning(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		names.NewSubnetTag("10.0.0.0/8"),
+		"10.0.0.0/8",
 		network.Id(""),
 		names.NewSpaceTag("myspace"),
 		[]string(nil),
@@ -156,7 +156,7 @@ func (s *AddSuite) TestRunWithProviderIdSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		names.SubnetTag{},
+		"",
 		network.Id("foo"),
 		names.NewSpaceTag("myspace"),
 		s.Strings("zone1", "zone2"),
@@ -172,7 +172,7 @@ func (s *AddSuite) TestRunWithIPv6CIDRSucceeds(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		names.NewSubnetTag("2001:db8::/32"),
+		"2001:db8::/32",
 		network.Id(""),
 		names.NewSpaceTag("hyperspace"),
 		[]string(nil),
@@ -190,7 +190,7 @@ func (s *AddSuite) TestRunWithExistingSubnetFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		names.NewSubnetTag("10.10.0.0/24"),
+		"10.10.0.0/24",
 		network.Id(""),
 		names.NewSpaceTag("space"),
 		[]string(nil),
@@ -208,7 +208,7 @@ func (s *AddSuite) TestRunWithNonExistingSpaceFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		names.NewSubnetTag("10.10.0.0/24"),
+		"10.10.0.0/24",
 		network.Id(""),
 		names.NewSpaceTag("space"),
 		s.Strings("zone1", "zone2"),
@@ -236,7 +236,7 @@ func (s *AddSuite) TestRunWithAmbiguousCIDRDisplaysError(c *gc.C) {
 
 	s.api.CheckCallNames(c, "AddSubnet", "Close")
 	s.api.CheckCall(c, 0, "AddSubnet",
-		names.NewSubnetTag("10.10.0.0/24"),
+		"10.10.0.0/24",
 		network.Id(""),
 		names.NewSpaceTag("space"),
 		s.Strings("zone1", "zone2"),

--- a/cmd/juju/subnet/create.go
+++ b/cmd/juju/subnet/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -25,7 +25,7 @@ func NewCreateCommand() modelcmd.ModelCommand {
 type CreateCommand struct {
 	SubnetCommandBase
 
-	CIDR      names.SubnetTag
+	CIDR      string
 	Space     names.SpaceTag
 	Zones     set.Strings
 	IsPublic  bool
@@ -167,7 +167,7 @@ func (c *CreateCommand) Run(ctx *cmd.Context) error {
 		// Create the new subnet.
 		err := api.CreateSubnet(c.CIDR, c.Space, c.Zones.SortedValues(), c.IsPublic)
 		if err != nil {
-			return errors.Annotatef(err, "cannot create subnet %q", c.CIDR.Id())
+			return errors.Annotatef(err, "cannot create subnet %q", c.CIDR)
 		}
 
 		zones := strings.Join(c.Zones.SortedValues(), ", ")
@@ -177,7 +177,7 @@ func (c *CreateCommand) Run(ctx *cmd.Context) error {
 		}
 		ctx.Infof(
 			"created a %s subnet %q in space %q with zones %s",
-			accessType, c.CIDR.Id(), c.Space.Id(), zones,
+			accessType, c.CIDR, c.Space.Id(), zones,
 		)
 		return nil
 	})

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/cmd/juju/subnet"
 )

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/subnet"
@@ -192,17 +192,17 @@ func (sa *StubAPI) AllSpaces() ([]names.Tag, error) {
 	return sa.Spaces, nil
 }
 
-func (sa *StubAPI) CreateSubnet(subnetCIDR names.SubnetTag, spaceTag names.SpaceTag, zones []string, isPublic bool) error {
+func (sa *StubAPI) CreateSubnet(subnetCIDR string, spaceTag names.SpaceTag, zones []string, isPublic bool) error {
 	sa.MethodCall(sa, "CreateSubnet", subnetCIDR, spaceTag, zones, isPublic)
 	return sa.NextErr()
 }
 
-func (sa *StubAPI) AddSubnet(cidr names.SubnetTag, id network.Id, spaceTag names.SpaceTag, zones []string) error {
+func (sa *StubAPI) AddSubnet(cidr string, id network.Id, spaceTag names.SpaceTag, zones []string) error {
 	sa.MethodCall(sa, "AddSubnet", cidr, id, spaceTag, zones)
 	return sa.NextErr()
 }
 
-func (sa *StubAPI) RemoveSubnet(subnetCIDR names.SubnetTag) error {
+func (sa *StubAPI) RemoveSubnet(subnetCIDR string) error {
 	sa.MethodCall(sa, "RemoveSubnet", subnetCIDR)
 	return sa.NextErr()
 }

--- a/cmd/juju/subnet/remove.go
+++ b/cmd/juju/subnet/remove.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"gopkg.in/juju/names.v2"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -24,7 +23,7 @@ func NewRemoveCommand() modelcmd.ModelCommand {
 type RemoveCommand struct {
 	SubnetCommandBase
 
-	CIDR names.SubnetTag
+	CIDR string
 }
 
 const removeCommandDoc = `
@@ -74,10 +73,10 @@ func (c *RemoveCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		// Try removing the subnet.
 		if err := api.RemoveSubnet(c.CIDR); err != nil {
-			return errors.Annotatef(err, "cannot remove subnet %q", c.CIDR.Id())
+			return errors.Annotatef(err, "cannot remove subnet %q", c.CIDR)
 		}
 
-		ctx.Infof("marked subnet %q for removal", c.CIDR.Id())
+		ctx.Infof("marked subnet %q for removal", c.CIDR)
 		return nil
 	})
 }

--- a/cmd/juju/subnet/remove_test.go
+++ b/cmd/juju/subnet/remove_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/feature"
@@ -71,7 +70,7 @@ func (s *RemoveSuite) TestRunWithIPv4CIDRSucceeds(c *gc.C) {
 	)
 
 	s.api.CheckCallNames(c, "RemoveSubnet", "Close")
-	s.api.CheckCall(c, 0, "RemoveSubnet", names.NewSubnetTag("10.20.0.0/16"))
+	s.api.CheckCall(c, 0, "RemoveSubnet", "10.20.0.0/16")
 }
 
 func (s *RemoveSuite) TestRunWithIPv6CIDRSucceeds(c *gc.C) {
@@ -82,7 +81,7 @@ func (s *RemoveSuite) TestRunWithIPv6CIDRSucceeds(c *gc.C) {
 	)
 
 	s.api.CheckCallNames(c, "RemoveSubnet", "Close")
-	s.api.CheckCall(c, 0, "RemoveSubnet", names.NewSubnetTag("2001:db8::/32"))
+	s.api.CheckCall(c, 0, "RemoveSubnet", "2001:db8::/32")
 }
 
 func (s *RemoveSuite) TestRunWithNonExistingSubnetFails(c *gc.C) {
@@ -95,17 +94,18 @@ func (s *RemoveSuite) TestRunWithNonExistingSubnetFails(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	s.api.CheckCallNames(c, "RemoveSubnet", "Close")
-	s.api.CheckCall(c, 0, "RemoveSubnet", names.NewSubnetTag("10.10.0.0/24"))
+	s.api.CheckCall(c, 0, "RemoveSubnet", "10.10.0.0/24")
 }
 
 func (s *RemoveSuite) TestRunWithSubnetInUseFails(c *gc.C) {
 	s.api.SetErrors(errors.Errorf("subnet %q is still in use", "10.10.0.0/24"))
 
-	s.AssertRunFails(c,
+	err := s.AssertRunFails(c,
 		`cannot remove subnet "10.10.0.0/24": subnet "10.10.0.0/24" is still in use`,
 		"10.10.0.0/24",
 	)
+	c.Assert(err, gc.NotNil)
 
 	s.api.CheckCallNames(c, "RemoveSubnet", "Close")
-	s.api.CheckCall(c, 0, "RemoveSubnet", names.NewSubnetTag("10.10.0.0/24"))
+	s.api.CheckCall(c, 0, "RemoveSubnet", "10.10.0.0/24")
 }

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v2"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/subnets"
@@ -25,7 +25,7 @@ type SubnetAPI interface {
 	io.Closer
 
 	// AddSubnet adds an existing subnet to Juju.
-	AddSubnet(cidr names.SubnetTag, id network.Id, spaceTag names.SpaceTag, zones []string) error
+	AddSubnet(cidr string, id network.Id, spaceTag names.SpaceTag, zones []string) error
 
 	// ListSubnets returns information about subnets known to Juju,
 	// optionally filtered by space and/or zone (both can be empty).
@@ -38,13 +38,13 @@ type SubnetAPI interface {
 	AllSpaces() ([]names.Tag, error)
 
 	// CreateSubnet creates a new Juju subnet.
-	CreateSubnet(subnetCIDR names.SubnetTag, spaceTag names.SpaceTag, zones []string, isPublic bool) error
+	CreateSubnet(subnetCIDR string, spaceTag names.SpaceTag, zones []string, isPublic bool) error
 
 	// RemoveSubnet marks an existing subnet as no longer used, which
 	// will cause it to get removed at some point after all its
 	// related entites are cleaned up. It will fail if the subnet is
 	// still in use by any machines.
-	RemoveSubnet(subnetCIDR names.SubnetTag) error
+	RemoveSubnet(subnetCIDR string) error
 }
 
 // mvpAPIShim forwards SubnetAPI methods to the real API facade for
@@ -60,7 +60,7 @@ func (m *mvpAPIShim) Close() error {
 	return m.apiState.Close()
 }
 
-func (m *mvpAPIShim) AddSubnet(cidr names.SubnetTag, id network.Id, spaceTag names.SpaceTag, zones []string) error {
+func (m *mvpAPIShim) AddSubnet(cidr string, id network.Id, spaceTag names.SpaceTag, zones []string) error {
 	return m.facade.AddSubnet(cidr, id, spaceTag, zones)
 }
 
@@ -135,18 +135,18 @@ func (s *SubnetCommandBase) CheckNumArgs(args []string, errors []error) error {
 // expected format is returned instead without an error. Otherwise,
 // when strict is true and given is incorrectly formatted, an error
 // will be returned.
-func (s *SubnetCommandBase) ValidateCIDR(given string, strict bool) (names.SubnetTag, error) {
+func (s *SubnetCommandBase) ValidateCIDR(given string, strict bool) (string, error) {
 	_, ipNet, err := net.ParseCIDR(given)
 	if err != nil {
 		logger.Debugf("cannot parse CIDR %q: %v", given, err)
-		return names.SubnetTag{}, errors.Errorf("%q is not a valid CIDR", given)
+		return "", errors.Errorf("%q is not a valid CIDR", given)
 	}
 	if strict && given != ipNet.String() {
 		expected := ipNet.String()
-		return names.SubnetTag{}, errors.Errorf("%q is not correctly specified, expected %q", given, expected)
+		return "", errors.Errorf("%q is not correctly specified, expected %q", given, expected)
 	}
 	// Already validated, so shouldn't error here.
-	return names.NewSubnetTag(ipNet.String()), nil
+	return ipNet.String(), nil
 }
 
 // ValidateSpace parses given and returns an error if it's not a valid

--- a/cmd/juju/subnet/subnet_test.go
+++ b/cmd/juju/subnet/subnet_test.go
@@ -131,7 +131,7 @@ func (s *SubnetCommandBaseSuite) TestValidateCIDR(c *gc.C) {
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 		}
-		c.Check(validated.Id(), gc.Equals, test.output)
+		c.Check(validated, gc.Equals, test.output)
 	}
 }
 


### PR DESCRIPTION
## Description of change

Replace SubnetTag with string for ciders in subnet commands.  The Subnets API and facade were updated accordingly.   This is the last part of replacing names.v2 with names.v3 work.  names.v2 is removed from deps as part at of this merge.

## QA steps

Test juju add-subnet with permutations of client and controller versions.
