### PR TITLE
Ensure that the cached model exists during facade creation.

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -113,7 +113,8 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	}
 
 	// apiRoot is the API root exposed to the client after login.
-	var apiRoot rpc.Root = newAPIRoot(
+	var apiRoot rpc.Root
+	apiRoot, err = newAPIRoot(
 		a.srv.clock,
 		a.root.state,
 		a.root.shared,
@@ -121,6 +122,9 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 		a.root.resources,
 		a.root,
 	)
+	if err != nil {
+		return fail, errors.Trace(err)
+	}
 	apiRoot, err = restrictAPIRoot(
 		a.srv,
 		apiRoot,

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -44,7 +44,13 @@ func NewErrRoot(err error) *errRoot {
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(facades *facade.Registry) rpc.Root {
-	return newAPIRoot(clock.WallClock, nil, nil, facades, common.NewResources(), nil)
+	root, err := newAPIRoot(clock.WallClock, nil, nil, facades, common.NewResources(), nil)
+	if err != nil {
+		// While not ideal, this is only in test code, and there are a bunch of other functions
+		// that depend on this one that don't return errors either.
+		panic(err)
+	}
+	return root
 }
 
 // TestingAPIHandler gives you an APIHandler that isn't connected to


### PR DESCRIPTION
More of the facades require the cached model to exist. Instead of pushing the necessity for each facade to call the CachedModel method, have this done further up the stack. This addresses one of the issues with model migration validation for unit agents, where the model is imported and then the units are asked to validate, but the uniter facade fails looking for the model from the cache.

The pubsub integration test has outlived its usefulness. With the raft leadership using it as a core component, we will notice if something goes wrong elsewhere. 

The alternative to removing it is to move it into the feature tests and use a JujuConnSuite. Which is why I leaned on the side of just removing it.

## QA steps

*  unit tests keep passing

