### PR TITLE
Reduce CAAS resource limits for controller/mongod.

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -181,7 +181,18 @@ class GKE(Base):
         # provision cluster.
         cluster = dict(
             name=self.gke_cluster_name,
-            initial_node_count=1,
+            node_pools=[dict(
+                name='default-pool',
+                initial_node_count=1,
+                config=dict(
+                    machine_type='n1-standard-1',
+                ),
+                autoscaling=dict(
+                    enabled=True,
+                    min_node_count=1,
+                    max_node_count=3,
+                ),
+            )],
         )
         logger.info('creating cluster -> %s', cluster)
         r = self.driver.create_cluster(

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1105,6 +1105,7 @@ func resourceTagsToAnnotations(in map[string]string) k8sannotations.Annotation {
 }
 
 func processConstraints(pod *core.PodSpec, appName string, cons constraints.Value) error {
+	// TODO(caas): Allow constraints to be set at the container level.
 	if mem := cons.Mem; mem != nil {
 		if err := configureConstraint(pod, "memory", fmt.Sprintf("%dMi", *mem)); err != nil {
 			return errors.Annotatef(err, "configuring memory constraint for %s", appName)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -191,6 +191,20 @@ func withDefaultControllerConstraints(cons constraints.Value) constraints.Value 
 	return cons
 }
 
+// withDefaultCAASControllerConstraints returns the given constraints,
+// updated to choose a default instance type appropriate for a
+// controller machine. We use this only if the user does not specify
+// any constraints that would otherwise control the instance type
+// selection.
+func withDefaultCAASControllerConstraints(cons constraints.Value) constraints.Value {
+	if !cons.HasInstanceType() && !cons.HasCpuCores() && !cons.HasCpuPower() && !cons.HasMem() {
+		// TODO(caas): Set memory constraints for mongod and controller containers independently.
+		var mem uint64 = 1.5 * 1024
+		cons.Mem = &mem
+	}
+	return cons
+}
+
 func bootstrapCAAS(
 	ctx environs.BootstrapContext,
 	environ environs.BootstrapEnviron,
@@ -218,7 +232,7 @@ func bootstrapCAAS(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	bootstrapConstraints = withDefaultControllerConstraints(bootstrapConstraints)
+	bootstrapConstraints = withDefaultCAASControllerConstraints(bootstrapConstraints)
 	bootstrapParams.BootstrapConstraints = bootstrapConstraints
 
 	result, err := environ.Bootstrap(ctx, callCtx, bootstrapParams)


### PR DESCRIPTION
## Reduce CAAS resource limits for controller/mongod.

- Reduced mongod/controller memory to 1.5GiB
- Enable auto-scaling on GKE test..

Currently unit constraints are set across all containers, which by default a k8s controller requests 7GiB of memory. IAAS controllers only request 3.5GiB of memory. This change drops memory constraints to 1.5GiB for the controller and mongod containers.

Additionally this change also fixes the GKE acceptance test to allow auto-scaling, as it is unknown what resources will be consumed by GKE system deployments.  
