### PR TITLE
strings.ReplaceAll() is go 1.12 and is not backward compatible.

### DIFF
--- a/scripts/schemadocs/schemadocs.go
+++ b/scripts/schemadocs/schemadocs.go
@@ -291,7 +291,7 @@ var tmplFuncs = template.FuncMap{
 		if strings.HasPrefix(name, "#/") {
 			name = name[2:]
 		}
-		return strings.ReplaceAll(name, "/", "_")
+		return strings.Replace(name, "/", "_", -1)
 	},
 	"defName": func(name string) string {
 		return strings.TrimPrefix(name, "#/definitions/")


### PR DESCRIPTION
## Description of change

Discovered during ppc64el, s390x and centos7 ci tests.