### PR TITLE
Get a test FAIL if the package doesn't build.

### DIFF
--- a/scripts/schemadocs/package_test.go
+++ b/scripts/schemadocs/package_test.go
@@ -5,8 +5,10 @@ package main_test
 
 import (
 	"testing"
+
+	gc "gopkg.in/check.v1"
 )
 
-// TestPackage just ensures that this package will build
-func TestPackage(t *testing.T) {
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
 }

--- a/scripts/schemadocs/schema_test.go
+++ b/scripts/schemadocs/schema_test.go
@@ -1,0 +1,12 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main_test
+
+import (
+	"testing"
+)
+
+// TestPackage just ensures that this package will build
+func TestPackage(t *testing.T) {
+}

--- a/scripts/schemadocs/schemadocs.go
+++ b/scripts/schemadocs/schemadocs.go
@@ -291,7 +291,7 @@ var tmplFuncs = template.FuncMap{
 		if strings.HasPrefix(name, "#/") {
 			name = name[2:]
 		}
-		return strings.ReplaceAll(name, "/", "_")
+		return strings.Replace(name, "/", "_", -1)
 	},
 	"defName": func(name string) string {
 		return strings.TrimPrefix(name, "#/definitions/")


### PR DESCRIPTION
It seems that when running `go test ./...`
if a subdirectory fails to build, but we have no tests in
that directory the failure we get is:
```
./schemadocs.go:294:10: undefined: strings.ReplaceAll
```

However there isn't anything that clearly indicates a failure. By adding
a dummy Test function we get:
```
./schemadocs.go:294:10: undefined: strings.ReplaceAll
FAIL    github.com/juju/juju/scripts/schemadocs [build failed]
```

Which at least means we can find the issue in the test run output.
