### PR TITLE
migrations: Retry validation in the migration minion

### DIFF
--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -193,6 +193,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			FortressName:      migrationFortressName,
+			Clock:             config.Clock,
 			APIOpen:           api.Open,
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -499,6 +499,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			FortressName:      migrationFortressName,
+			Clock:             config.Clock,
 			APIOpen:           api.Open,
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -204,6 +204,7 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 		UpgradeStepsLock:     a.upgradeComplete,
 		UpgradeCheckLock:     a.initialUpgradeCheckComplete,
 		MachineLock:          machineLock,
+		Clock:                clock.WallClock,
 	})
 
 	engine, err := dependency.NewEngine(dependencyEngineConfig())

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -233,6 +233,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			FortressName:      migrationFortressName,
+			Clock:             clock.WallClock,
 			APIOpen:           api.Open,
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -99,6 +99,9 @@ type ManifoldsConfig struct {
 	// This is used by a number of workers to ensure serialisation of actions
 	// across the machine.
 	MachineLock machinelock.Lock
+
+	// Clock supplies timekeeping services to various workers.
+	Clock clock.Clock
 }
 
 // Manifolds returns a set of co-configured manifolds covering the various
@@ -233,7 +236,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			FortressName:      migrationFortressName,
-			Clock:             clock.WallClock,
+			Clock:             config.Clock,
 			APIOpen:           api.Open,
 			ValidateMigration: config.ValidateMigration,
 			NewFacade:         migrationminion.NewFacade,
@@ -286,7 +289,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		leadershipTrackerName: ifNotMigrating(leadership.Manifold(leadership.ManifoldConfig{
 			AgentName:           agentName,
 			APICallerName:       apiCallerName,
-			Clock:               clock.WallClock,
+			Clock:               config.Clock,
 			LeadershipGuarantee: config.LeadershipGuarantee,
 		})),
 
@@ -308,7 +311,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:             agentName,
 			APICallerName:         apiCallerName,
 			MachineLock:           config.MachineLock,
-			Clock:                 clock.WallClock,
+			Clock:                 config.Clock,
 			LeadershipTrackerName: leadershipTrackerName,
 			CharmDirName:          charmDirName,
 			HookRetryStrategyName: hookRetryStrategyName,
@@ -334,7 +337,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:                agentName,
 			APICallerName:            apiCallerName,
 			MachineLock:              config.MachineLock,
-			Clock:                    clock.WallClock,
+			Clock:                    config.Clock,
 			NewHookRunner:            meterstatus.NewHookRunner,
 			NewMeterStatusAPIClient:  msapi.NewClient,
 			NewConnectedStatusWorker: meterstatus.NewConnectedStatusWorker,

--- a/worker/migrationminion/manifold_test.go
+++ b/worker/migrationminion/manifold_test.go
@@ -1,0 +1,92 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationminion_test
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker/migrationminion"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	config migrationminion.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validConfig()
+}
+
+func (s *ManifoldSuite) validConfig() migrationminion.ManifoldConfig {
+	return migrationminion.ManifoldConfig{
+		AgentName:         "agent",
+		APICallerName:     "api-caller",
+		FortressName:      "fortress",
+		Clock:             struct{ clock.Clock }{},
+		APIOpen:           func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
+		ValidateMigration: func(base.APICaller) error { return nil },
+		NewFacade:         func(base.APICaller) (migrationminion.Facade, error) { return nil, nil },
+		NewWorker:         func(migrationminion.Config) (worker.Worker, error) { return nil, nil },
+	}
+}
+
+func (s *ManifoldSuite) TestValid(c *gc.C) {
+	c.Check(s.config.Validate(), jc.ErrorIsNil)
+}
+
+func (s *ManifoldSuite) TestMissingAgentName(c *gc.C) {
+	s.config.AgentName = ""
+	s.checkNotValid(c, "empty AgentName not valid")
+}
+
+func (s *ManifoldSuite) TestMissingAPICallerName(c *gc.C) {
+	s.config.APICallerName = ""
+	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldSuite) TestMissingFortressName(c *gc.C) {
+	s.config.FortressName = ""
+	s.checkNotValid(c, "empty FortressName not valid")
+}
+
+func (s *ManifoldSuite) TestMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	s.checkNotValid(c, "nil Clock not valid")
+}
+
+func (s *ManifoldSuite) TestMissingAPIOpen(c *gc.C) {
+	s.config.APIOpen = nil
+	s.checkNotValid(c, "nil APIOpen not valid")
+}
+
+func (s *ManifoldSuite) TestMissingValidateMigration(c *gc.C) {
+	s.config.ValidateMigration = nil
+	s.checkNotValid(c, "nil ValidateMigration not valid")
+}
+
+func (s *ManifoldSuite) TestMissingNewFacade(c *gc.C) {
+	s.config.NewFacade = nil
+	s.checkNotValid(c, "nil NewFacade not valid")
+}
+
+func (s *ManifoldSuite) TestMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldSuite) checkNotValid(c *gc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, gc.ErrorMatches, expect)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}

--- a/worker/migrationminion/validate_test.go
+++ b/worker/migrationminion/validate_test.go
@@ -4,6 +4,7 @@
 package migrationminion_test
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -39,6 +40,12 @@ func (*ValidateSuite) TestMissingFacade(c *gc.C) {
 	checkNotValid(c, config, "nil Facade not valid")
 }
 
+func (*ValidateSuite) TestMissingClock(c *gc.C) {
+	config := validConfig()
+	config.Clock = nil
+	checkNotValid(c, config, "nil Clock not valid")
+}
+
 func (*ValidateSuite) TestMissingGuard(c *gc.C) {
 	config := validConfig()
 	config.Guard = nil
@@ -62,6 +69,7 @@ func validConfig() migrationminion.Config {
 		Agent:             struct{ agent.Agent }{},
 		Guard:             struct{ fortress.Guard }{},
 		Facade:            struct{ migrationminion.Facade }{},
+		Clock:             struct{ clock.Clock }{},
 		APIOpen:           func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
 		ValidateMigration: func(base.APICaller) error { return nil },
 	}

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -4,10 +4,14 @@
 package migrationminion
 
 import (
+	"time"
+
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
+	"gopkg.in/retry.v1"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -16,6 +20,21 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/worker/fortress"
+)
+
+const (
+	// maxRetries is the number of times we'll attempt validation
+	// before giving up.
+	maxRetries = 10
+
+	// initialRetryDelay is the starting delay - this will be
+	// increased exponentially up maxRetries.
+	initialRetryDelay = 50 * time.Millisecond
+
+	// retryBackoffFactor is how much longer we wait after a failing
+	// retry.  Retrying 10 times starting at 50ms and backing off 1.6x
+	// gives us a total delay time of about 9s.
+	retryBackoffFactor = 1.6
 )
 
 var logger = loggo.GetLogger("juju.worker.migrationminion")
@@ -31,6 +50,7 @@ type Config struct {
 	Agent             agent.Agent
 	Facade            Facade
 	Guard             fortress.Guard
+	Clock             clock.Clock
 	APIOpen           func(*api.Info, api.DialOpts) (api.Connection, error)
 	ValidateMigration func(base.APICaller) error
 }
@@ -45,6 +65,9 @@ func (config Config) Validate() error {
 	}
 	if config.Guard == nil {
 		return errors.NotValidf("nil Guard")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if config.APIOpen == nil {
 		return errors.NotValidf("nil APIOpen")
@@ -149,7 +172,25 @@ func (w *Worker) doQUIESCE(status watcher.MigrationStatus) error {
 }
 
 func (w *Worker) doVALIDATION(status watcher.MigrationStatus) error {
-	err := w.validate(status)
+	attempt := retry.StartWithCancel(
+		retry.LimitCount(maxRetries, retry.Exponential{
+			Initial: initialRetryDelay,
+			Factor:  retryBackoffFactor,
+			Jitter:  true,
+		}),
+		w.config.Clock,
+		w.catacomb.Dying(),
+	)
+	var err error
+	for attempt.Next() {
+		err = w.validate(status)
+		if err == nil {
+			break
+		}
+		if attempt.More() {
+			logger.Debugf("validation failed (retrying): %v", err)
+		}
+	}
 	if err != nil {
 		// Don't return this error just log it and report to the
 		// migrationmaster that things didn't work out.


### PR DESCRIPTION
## Description of change

In CI tests we were seeing errors in migration where the minions in unit agents would fail validation (and abort the migration) because the target controller wasn't ready - in this case because the model wasn't yet in the model cache. Have the minions in the various agents retry just in case.

## QA steps

* Bootstrap two controllers A and B.
* Add a model named m in A and deploy some things into it.
* Migrate m to B.
* Check that it works (not sure whether it's worth using iptables to force an agent to have to retry - tha's checked in the unit tests)

## Documentation changes

None

## Bug reference

None
