### PR TITLE
Wait for controller idle when waiting for model idle.

### DIFF
--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -892,6 +892,7 @@ func (s *filteringBranchesSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = ru.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 }
 
 func (s *filteringBranchesSuite) TestFullStatusBranchNoFilter(c *gc.C) {

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -27,6 +27,16 @@ const (
 	modelAppearingTimeout = 5 * time.Second
 )
 
+var (
+	// IdleFunc allows tests to be able to get callbacks when the controller
+	// hasn't been given any changes for a specified time.
+	IdleFunc func()
+
+	// IdleTime relates to how long the controller needs to wait with no changes
+	// to be considered idle.
+	IdleTime = 50 * time.Millisecond
+)
+
 // Clock defines the clockish methods used by the controller.
 type Clock interface {
 	After(time.Duration) <-chan time.Time
@@ -58,10 +68,11 @@ type Controller struct {
 	// from a type-agnostic viewpoint.
 	manager *residentManager
 
-	changes <-chan interface{}
-	notify  func(interface{})
-	hub     *pubsub.SimpleHub
-	models  map[string]*Model
+	changes  <-chan interface{}
+	notify   func(interface{})
+	idleFunc func()
+	hub      *pubsub.SimpleHub
+	models   map[string]*Model
 
 	tomb    tomb.Tomb
 	mu      sync.Mutex
@@ -83,12 +94,13 @@ func newController(config ControllerConfig, manager *residentManager) (*Controll
 	}
 
 	c := &Controller{
-		manager: manager,
-		changes: config.Changes,
-		notify:  config.Notify,
-		hub:     newPubSubHub(),
-		models:  make(map[string]*Model),
-		metrics: createControllerGauges(),
+		manager:  manager,
+		changes:  config.Changes,
+		notify:   config.Notify,
+		idleFunc: IdleFunc,
+		hub:      newPubSubHub(),
+		models:   make(map[string]*Model),
+		metrics:  createControllerGauges(),
 	}
 
 	manager.dying = c.tomb.Dying()
@@ -97,10 +109,19 @@ func newController(config ControllerConfig, manager *residentManager) (*Controll
 }
 
 func (c *Controller) loop() error {
+	var idle <-chan time.Time
+	if c.idleFunc != nil {
+		logger.Tracef("controller %p set idle timeout to %s", c, IdleTime)
+		idle = time.After(IdleTime)
+	}
 	for {
 		select {
 		case <-c.tomb.Dying():
 			return nil
+		case <-idle:
+			logger.Tracef("controller %p is idle", c)
+			c.idleFunc()
+			idle = time.After(IdleTime)
 		case change := <-c.changes:
 			var err error
 
@@ -136,6 +157,10 @@ func (c *Controller) loop() error {
 
 			if err != nil {
 				logger.Errorf("processing cache change: %s", err.Error())
+			}
+
+			if c.idleFunc != nil {
+				idle = time.After(IdleTime)
 			}
 		}
 	}

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -122,9 +122,11 @@ type JujuConnSuite struct {
 	Factory             *factory.Factory
 	ProviderCallContext context.ProviderCallContext
 
-	txnSyncNotify     chan struct{}
-	modelWatcherIdle  chan string
-	modelWatcherMutex *sync.Mutex
+	idleFuncMutex       sync.Mutex
+	txnSyncNotify       chan struct{}
+	modelWatcherIdle    chan string
+	controllerIdle      chan struct{}
+	controllerIdleCount int
 }
 
 const AdminSecret = "dummy-secret"
@@ -149,9 +151,10 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 
 	s.txnSyncNotify = make(chan struct{})
 	s.modelWatcherIdle = nil
-	s.modelWatcherMutex = &sync.Mutex{}
+	s.controllerIdle = nil
 	s.PatchValue(&statewatcher.TxnPollNotifyFunc, s.txnNotifyFunc)
 	s.PatchValue(&statewatcher.HubWatcherIdleFunc, s.hubWatcherIdleFunc)
+	s.PatchValue(&cache.IdleFunc, s.controllerIdleFunc)
 	s.setUpConn(c)
 	s.Factory = factory.NewFactory(s.State, s.StatePool)
 }
@@ -180,9 +183,9 @@ func (s *JujuConnSuite) txnNotifyFunc() {
 }
 
 func (s *JujuConnSuite) hubWatcherIdleFunc(modelUUID string) {
-	s.modelWatcherMutex.Lock()
+	s.idleFuncMutex.Lock()
 	idleChan := s.modelWatcherIdle
-	s.modelWatcherMutex.Unlock()
+	s.idleFuncMutex.Unlock()
 	if idleChan == nil {
 		return
 	}
@@ -193,6 +196,32 @@ func (s *JujuConnSuite) hubWatcherIdleFunc(modelUUID string) {
 	// within a short wait, we don't send the message.
 	select {
 	case idleChan <- modelUUID:
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+func (s *JujuConnSuite) controllerIdleFunc() {
+	s.idleFuncMutex.Lock()
+	idleChan := s.controllerIdle
+	s.idleFuncMutex.Unlock()
+	if idleChan == nil {
+		return
+	}
+	// Here we have a similar condition to the txn watcher idle.
+	// Between test start and when we listen, there may be an idle event.
+	// So when we have an idleChan set, we wait for the second idle before
+	// we signal that we're idle.
+	if s.controllerIdleCount == 0 {
+		s.controllerIdleCount++
+		return
+	}
+	// There is a very small race condition between when the
+	// idle channel is cleared and when the function exits.
+	// Under normal circumstances, there is a goroutine in a tight loop
+	// reading off the idle channel. If the channel isn't read
+	// within a short wait, we don't send the message.
+	select {
+	case idleChan <- struct{}{}:
 	case <-time.After(testing.ShortWait):
 	}
 }
@@ -219,37 +248,56 @@ func (s *JujuConnSuite) WaitForModelWatchersIdle(c *gc.C, modelUUID string) {
 	logger := loggo.GetLogger("test")
 	logger.Infof("waiting for model %s to be idle", modelUUID)
 	s.WaitForNextSync(c)
-	s.modelWatcherMutex.Lock()
-	idleChan := make(chan string)
-	s.modelWatcherIdle = idleChan
-	s.modelWatcherMutex.Unlock()
+	watcherIdleChan := make(chan string)
+	controllerIdleChan := make(chan struct{})
+	// Now, in theory we shouldn't start waiting for the controller to be idle until
+	// we have noticed that the model watcher is idle. In practice, if the model watcher
+	// isn't idle, the controller won't yet be idle. Once the watcher is idle, it is also
+	// very likely that the controller will become idle very soon after. We do it this way
+	// so we don't add 50ms to every call of this function. In practice that time without
+	// events should be shared across both the things we are waiting on, so that idle time
+	// happens in parallel.
+	s.idleFuncMutex.Lock()
+	s.modelWatcherIdle = watcherIdleChan
+	s.controllerIdleCount = 0
+	s.controllerIdle = controllerIdleChan
+	s.idleFuncMutex.Unlock()
 
 	defer func() {
-		s.modelWatcherMutex.Lock()
+		s.idleFuncMutex.Lock()
 		s.modelWatcherIdle = nil
-		s.modelWatcherMutex.Unlock()
+		s.controllerIdle = nil
+		s.idleFuncMutex.Unlock()
 		// Clear out any pending events.
 		for {
 			select {
-			case <-idleChan:
+			case <-watcherIdleChan:
+			case <-controllerIdleChan:
 			default:
 				return
 			}
 		}
+		logger.Infof("WaitForModelWatchersIdle(%q) done", modelUUID)
 	}()
 
 	timeout := time.After(gitjujutesting.LongWait)
+watcher:
 	for {
 		select {
-		case uuid := <-idleChan:
+		case uuid := <-watcherIdleChan:
+			logger.Infof("model %s is idle", uuid)
 			if uuid == modelUUID {
-				return
-			} else {
-				logger.Infof("model %s is idle", uuid)
+				break watcher
 			}
 		case <-timeout:
-			c.Fatal("no sync event sent, is the watcher dead?")
+			c.Fatal("no idle event sent, is the watcher dead?")
 		}
+	}
+	select {
+	case <-controllerIdleChan:
+		// done
+	case <-time.After(gitjujutesting.LongWait):
+		c.Fatal("no controller idle event sent, is the controller dead?")
 	}
 }
 


### PR DESCRIPTION
Some tests are getting information from the controller. This will happen more as we use the cache controller for juju status.

This branch adds an idle func for the cache package in a similar way to the state watcher package. This allows the JujuConnSuite to wait for the model cache to be idle after processing txn watcher events. 

Among other things, this should fix the intermittent test failure of filteringBranchesSuite.TestFullStatusBranchNoFilter in the apiserver/facades/client/client package.