### PR TITLE
[dev] Fix panic when deploying bundles where maps have nil values

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:ed246f348bdaa738a066035e2551a826e966f55a5528d6f44f9e8270c04a3888"
+  digest = "1:00d5f5c99780508ccdc0567c634dc4b4c5b28785647357a947ceb6cfca56e3f3"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "77bc1b09aca2e72adbb0a608f2ba4ede37e9f704"
+  revision = "cf3ec8f263e4b35e70f76f8b660284ac26517958"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "77bc1b09aca2e72adbb0a608f2ba4ede37e9f704"
+  revision = "cf3ec8f263e4b35e70f76f8b660284ac26517958"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"


### PR DESCRIPTION
## Description of change

The charm.v6 code that checks base bundles for the presence of overlay-specific options had a bug where the validation code would crash if the base bundle provided map entries (e.g. in options) with **nil** values.

This PR simply bumps the charm.v6 version to bring in the fix from https://github.com/juju/charm/pull/290

Note: this bug only affects dev releases and does **not** need to be back-ported to 2.6 as 2.6 does not use the same code path.

## QA steps

Try to deploy the following bundle with the latest edge snap (with --dry-run)
to verify it crashes. Then deploy the same with a juju binary built from 
this PR to verify that it does not crash (you will get unknown option errors as 
the options are bogus)

```yaml
# ssl_ca is left uninitialized so it resolves to nil
ssl_ca: &ssl_ca

applications:
  apache2:
    charm: apache2
    options:
      foo: bar
      ssl_ca: *ssl_ca
series: bionic
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1841105