### PR TITLE
Add show-action command

### DIFF
--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -65,6 +65,18 @@ func (c *ListCommand) FullSchema() bool {
 	return c.fullSchema
 }
 
+type ShowCommand struct {
+	*showCommand
+}
+
+func (c *ShowCommand) ApplicationTag() names.ApplicationTag {
+	return c.applicationTag
+}
+
+func (c *ShowCommand) ActionName() string {
+	return c.actionName
+}
+
 func NewShowOutputCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ShowOutputCommand) {
 	c := &showOutputCommand{}
 	c.SetClientStore(store)
@@ -87,6 +99,12 @@ func NewListCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ListComm
 	c := &listCommand{}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ListCommand{c}
+}
+
+func NewShowCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ShowCommand) {
+	c := &showCommand{}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ShowCommand{c}
 }
 
 func NewRunCommandForTest(store jujuclient.ClientStore) (cmd.Command, *RunCommand) {

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -12,12 +12,14 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/naturalsort"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 func NewListCommand() cmd.Command {
@@ -36,7 +38,14 @@ const listDoc = `
 List the actions available to run on the target application, with a short
 description.  To show the full schema for the actions, use --schema.
 
-For more information, see also the 'run-action' command, which executes actions.
+Examples:
+    juju list-actions postgresql
+    juju list-actions postgresql --format yaml
+    juju list-actions postgresql --schema
+
+See also:
+    run-action
+    show-action
 `
 
 // Set up the output.
@@ -63,13 +72,17 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *listCommand) Info() *cmd.Info {
-	return jujucmd.Info(&cmd.Info{
+	info := jujucmd.Info(&cmd.Info{
 		Name:    "actions",
 		Args:    "<application name>",
 		Purpose: "List actions defined for an application.",
 		Doc:     listDoc,
 		Aliases: []string{"list-actions"},
 	})
+	if featureflag.Enabled(feature.JujuV3) {
+		info.Doc = strings.Replace(info.Doc, "run-action", "run", -1)
+	}
+	return info
 }
 
 // Init validates the application name and any other options.
@@ -81,11 +94,11 @@ func (c *listCommand) Init(args []string) error {
 	case 0:
 		return errors.New("no application name specified")
 	case 1:
-		svcName := args[0]
-		if !names.IsValidApplication(svcName) {
-			return errors.Errorf("invalid application name %q", svcName)
+		appName := args[0]
+		if !names.IsValidApplication(appName) {
+			return errors.Errorf("invalid application name %q", appName)
 		}
-		c.applicationTag = names.NewApplicationTag(svcName)
+		c.applicationTag = names.NewApplicationTag(appName)
 		return nil
 	default:
 		return cmd.CheckEmpty(args[1:])

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -22,7 +22,7 @@ import (
 
 type ListSuite struct {
 	BaseActionSuite
-	svc            *state.Application
+	app            *state.Application
 	wrappedCommand cmd.Command
 	command        *action.ListCommand
 }
@@ -38,7 +38,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 	tests := []struct {
 		should               string
 		args                 []string
-		expectedSvc          names.ApplicationTag
+		expectedApp          names.ApplicationTag
 		expectedOutputSchema bool
 		expectedErr          string
 	}{{
@@ -56,7 +56,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "init properly with valid application name",
 		args:        []string{validApplicationId},
-		expectedSvc: names.NewApplicationTag(validApplicationId),
+		expectedApp: names.NewApplicationTag(validApplicationId),
 	}, {
 		should:      "schema with tabular output",
 		args:        []string{"--format=tabular", "--schema", validApplicationId},
@@ -65,12 +65,12 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		should:               "init properly with valid application name and --schema",
 		args:                 []string{"--format=yaml", "--schema", validApplicationId},
 		expectedOutputSchema: true,
-		expectedSvc:          names.NewApplicationTag(validApplicationId),
+		expectedApp:          names.NewApplicationTag(validApplicationId),
 	}, {
 		should:               "default to yaml output when --schema option is specified",
 		args:                 []string{"--schema", validApplicationId},
 		expectedOutputSchema: true,
-		expectedSvc:          names.NewApplicationTag(validApplicationId),
+		expectedApp:          names.NewApplicationTag(validApplicationId),
 	}}
 
 	for i, t := range tests {
@@ -82,7 +82,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 			err := cmdtesting.InitCommand(s.wrappedCommand, args)
 			if t.expectedErr == "" {
 				c.Check(err, jc.ErrorIsNil)
-				c.Check(s.command.ApplicationTag(), gc.Equals, t.expectedSvc)
+				c.Check(s.command.ApplicationTag(), gc.Equals, t.expectedApp)
 				c.Check(s.command.FullSchema(), gc.Equals, t.expectedOutputSchema)
 			} else {
 				c.Check(err, gc.ErrorMatches, t.expectedErr)

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -71,8 +71,15 @@ var someCharmActions = map[string]params.ActionSpec{
 	"snapshot": {
 		Description: "Take a snapshot of the database.",
 		Params: map[string]interface{}{
-			"foo": map[string]interface{}{
-				"bar": "baz",
+			"properties": map[string]interface{}{
+				"name": map[string]interface{}{
+					"type":        "string",
+					"description": "snapshot name",
+				},
+				"full": map[string]interface{}{
+					"type":        "boolean",
+					"description": "take a full backup",
+				},
 			},
 			"baz": "bar",
 		},
@@ -80,16 +87,20 @@ var someCharmActions = map[string]params.ActionSpec{
 	"kill": {
 		Description: "Kill the database.",
 		Params: map[string]interface{}{
-			"bar": map[string]interface{}{
-				"baz": "foo",
+			"properties": map[string]interface{}{
+				"baz": map[string]interface{}{
+					"type": "string",
+				},
 			},
 			"foo": "baz",
 		},
 	},
 	"no-description": {
 		Params: map[string]interface{}{
-			"bar": map[string]interface{}{
-				"baz": "foo",
+			"properties": map[string]interface{}{
+				"baz": map[string]interface{}{
+					"type": "string",
+				},
 			},
 			"foo": "baz",
 		},

--- a/cmd/juju/action/show.go
+++ b/cmd/juju/action/show.go
@@ -1,0 +1,125 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/utils/featureflag"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/feature"
+)
+
+type showCommand struct {
+	ActionCommandBase
+
+	applicationTag names.ApplicationTag
+	actionName     string
+
+	out cmd.Output
+}
+
+var showActionDoc = `
+Show detailed information about an action on the target application.
+
+Examples:
+    juju show-action postgresql backup
+
+See also:
+    list-actions
+    run-action
+`
+
+// NewShowCommand returns a command to print action information.
+func NewShowCommand() cmd.Command {
+	return modelcmd.Wrap(&showCommand{})
+}
+
+func (c *showCommand) Init(args []string) error {
+	switch len(args) {
+	case 0:
+		return errors.New("no application name specified")
+	case 1:
+		return errors.New("no action name specified")
+	case 2:
+		appName := args[0]
+		if !names.IsValidApplication(appName) {
+			return errors.Errorf("invalid application name %q", appName)
+		}
+		c.applicationTag = names.NewApplicationTag(appName)
+		c.actionName = args[1]
+		return nil
+	default:
+		return cmd.CheckEmpty(args[2:])
+	}
+}
+
+func (c *showCommand) Info() *cmd.Info {
+	info := jujucmd.Info(&cmd.Info{
+		Name:    "show-action",
+		Args:    "<application name> <action name>",
+		Purpose: "Shows detailed information about an action.",
+		Doc:     showActionDoc,
+	})
+	if featureflag.Enabled(feature.JujuV3) {
+		info.Doc = strings.Replace(info.Doc, "run-action", "run", -1)
+	}
+	return info
+}
+
+func (c *showCommand) Run(ctx *cmd.Context) error {
+	api, err := c.NewActionAPIClient()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	actions, err := api.ApplicationCharmActions(params.Entity{Tag: c.applicationTag.String()})
+	if err != nil {
+		return err
+	}
+	info, ok := actions[c.actionName]
+	if !ok {
+		ctx.Infof("unknown action %q\n", c.actionName)
+		return cmd.ErrSilent
+	}
+
+	fmt.Fprintln(ctx.Stdout, info.Description+"\n\nArguments")
+
+	args := make(map[string]actionArg)
+	properties, ok := info.Params["properties"].(map[string]interface{})
+	if ok {
+		for argName, info := range properties {
+			infoMap, ok := info.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			args[argName] = actionArg{
+				Type:        infoMap["type"],
+				Description: infoMap["description"],
+			}
+		}
+	}
+
+	argInfo, err := yaml.Marshal(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	fmt.Fprintln(ctx.Stdout, string(argInfo))
+	return nil
+}
+
+type actionArg struct {
+	// Use a struct so we can control the order of the printed values.
+	Type        interface{} `yaml:"type"`
+	Description interface{} `yaml:"description"`
+}

--- a/cmd/juju/action/show_test.go
+++ b/cmd/juju/action/show_test.go
@@ -1,0 +1,159 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action_test
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/action"
+	"github.com/juju/juju/state"
+)
+
+type ShowSuite struct {
+	BaseActionSuite
+	app            *state.Application
+	wrappedCommand cmd.Command
+	command        *action.ShowCommand
+}
+
+var _ = gc.Suite(&ShowSuite{})
+
+func (s *ShowSuite) SetUpTest(c *gc.C) {
+	s.BaseActionSuite.SetUpTest(c)
+	s.wrappedCommand, s.command = action.NewShowCommandForTest(s.store)
+}
+
+func (s *ShowSuite) TestInit(c *gc.C) {
+	tests := []struct {
+		should         string
+		args           []string
+		expectedApp    names.ApplicationTag
+		expectedAction string
+		expectedErr    string
+	}{{
+		should:      "fail with missing application name",
+		args:        []string{},
+		expectedErr: "no application name specified",
+	}, {
+		should:      "fail with missing action name",
+		args:        []string{validApplicationId},
+		expectedErr: "no action name specified",
+	}, {
+		should:      "fail with invalid application name",
+		args:        []string{invalidApplicationId, "doIt"},
+		expectedErr: "invalid application name \"" + invalidApplicationId + "\"",
+	}, {
+		should:      "fail with too many args",
+		args:        []string{"one", "two", "things"},
+		expectedErr: "unrecognized args: \\[\"things\"\\]",
+	}, {
+		should:         "init properly with valid application name",
+		args:           []string{validApplicationId, "doIt"},
+		expectedApp:    names.NewApplicationTag(validApplicationId),
+		expectedAction: "doIt",
+	}}
+
+	for i, t := range tests {
+		for _, modelFlag := range s.modelFlags {
+			c.Logf("test %d should %s: juju show-action defined %s", i,
+				t.should, strings.Join(t.args, " "))
+			s.wrappedCommand, s.command = action.NewShowCommandForTest(s.store)
+			args := append([]string{modelFlag, "admin"}, t.args...)
+			err := cmdtesting.InitCommand(s.wrappedCommand, args)
+			if t.expectedErr == "" {
+				c.Check(err, jc.ErrorIsNil)
+				c.Check(s.command.ApplicationTag(), gc.Equals, t.expectedApp)
+				c.Check(s.command.ActionName(), gc.Equals, t.expectedAction)
+			} else {
+				c.Check(err, gc.ErrorMatches, t.expectedErr)
+			}
+		}
+	}
+}
+
+func (s *ShowSuite) TestShow(c *gc.C) {
+	simpleOutput := `
+Take a snapshot of the database.
+
+Arguments
+full:
+  type: boolean
+  description: take a full backup
+name:
+  type: string
+  description: snapshot name
+
+`[1:]
+
+	tests := []struct {
+		should           string
+		expectNoResults  bool
+		expectMessage    string
+		withArgs         []string
+		withAPIErr       string
+		withCharmActions map[string]params.ActionSpec
+		expectedErr      string
+	}{{
+		should:      "pass back API error correctly",
+		withArgs:    []string{validApplicationId, "doIt"},
+		withAPIErr:  "an API error",
+		expectedErr: "an API error",
+	}, {
+		should:          "work properly when no results found",
+		withArgs:        []string{validApplicationId, "snapshot"},
+		expectNoResults: true,
+		expectedErr:     "cmd: error out silently",
+		expectMessage:   `unknown action "snapshot"`,
+	}, {
+		should:           "error when unknown action specified",
+		withArgs:         []string{validApplicationId, "something"},
+		withCharmActions: someCharmActions,
+		expectMessage:    `unknown action "something"`,
+		expectedErr:      "cmd: error out silently",
+	}, {
+		should:           "get results properly",
+		withArgs:         []string{validApplicationId, "snapshot"},
+		withCharmActions: someCharmActions,
+	}}
+
+	for i, t := range tests {
+		for _, modelFlag := range s.modelFlags {
+			func() {
+				c.Logf("test %d should %s", i, t.should)
+
+				fakeClient := &fakeAPIClient{charmActions: t.withCharmActions}
+				if t.withAPIErr != "" {
+					fakeClient.apiErr = errors.New(t.withAPIErr)
+				}
+				restore := s.patchAPIClient(fakeClient)
+				defer restore()
+
+				args := append([]string{modelFlag, "admin"}, t.withArgs...)
+				s.wrappedCommand, s.command = action.NewShowCommandForTest(s.store)
+				ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, args...)
+
+				if t.expectedErr != "" || t.withAPIErr != "" {
+					c.Check(err, gc.ErrorMatches, t.expectedErr)
+					if t.expectMessage != "" {
+						msg := cmdtesting.Stderr(ctx)
+						msg = strings.Replace(msg, "\n", "", -1)
+						c.Check(msg, gc.Matches, t.expectMessage)
+					}
+				} else {
+					c.Assert(err, gc.IsNil)
+					c.Check(cmdtesting.Stdout(ctx), gc.Equals, simpleOutput)
+				}
+
+			}()
+		}
+	}
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -386,6 +386,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(action.NewRunCommand())
 	r.Register(action.NewShowOutputCommand())
 	r.Register(action.NewListCommand())
+	r.Register(action.NewShowCommand())
 	r.Register(action.NewCancelCommand())
 
 	// Manage controller availability

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -574,6 +574,7 @@ var commandNames = []string{
 	"set-plan",
 	"set-series",
 	"set-wallet",
+	"show-action",
 	"show-action-output",
 	"show-action-status",
 	"show-application",


### PR DESCRIPTION
## Description of change

Add a show-action command.
Prints the metadata about the specified action.
Reuses existing test infrastructure from list-action in the unit tests.

Driveby fix for adjusting list-action help when "juju-v3" feature flag in enabled.

## QA steps

deploy a charm with actions
juju show-action app action

