### PR TITLE
Copy run-action command to run with feature flag

### DIFF
--- a/cmd/juju/action/call.go
+++ b/cmd/juju/action/call.go
@@ -31,13 +31,13 @@ var validLeader = regexp.MustCompile("^" + leaderSnippet + "$")
 // nameRule describes the name format of an action or keyName must match to be valid.
 var nameRule = charm.GetActionNameRule()
 
-func NewRunCommand() cmd.Command {
-	return modelcmd.Wrap(&runCommand{})
+func NewCallCommand() cmd.Command {
+	return modelcmd.Wrap(&callCommand{})
 }
 
-// runCommand enqueues an Action for running on the given unit with given
+// callCommand enqueues an Action for running on the given unit with given
 // params
-type runCommand struct {
+type callCommand struct {
 	ActionCommandBase
 	api           APIClient
 	unitReceivers []string
@@ -50,7 +50,7 @@ type runCommand struct {
 	args          [][]string
 }
 
-const runDoc = `
+const callDoc = `
 Queue an Action for execution on a given unit, with a given set of params.
 The Action ID is returned for use with 'juju show-action-output <ID>' or
 'juju show-action-status <ID>'.
@@ -76,19 +76,19 @@ explicit arguments will override the parameter file.
 
 Examples:
 
-    juju run mysql/3 backup --wait
-    juju run mysql/3 backup
-    juju run mysql/leader backup
+    juju call mysql/3 backup --wait
+    juju call mysql/3 backup
+    juju call mysql/leader backup
     juju show-action-output <ID>
-    juju run mysql/3 backup --params parameters.yml
-    juju run mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
-    juju run mysql/3 backup --params p.yml file.kind=xz file.quality=high
-    juju run sleeper/0 pause time=1000
-    juju run sleeper/0 pause --string-args time=1000
+    juju call mysql/3 backup --params parameters.yml
+    juju call mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
+    juju call mysql/3 backup --params p.yml file.kind=xz file.quality=high
+    juju call sleeper/0 pause time=1000
+    juju call sleeper/0 pause --string-args time=1000
 `
 
 // SetFlags offers an option for YAML output.
-func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *callCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ActionCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
 	f.Var(&c.paramsYAML, "params", "Path to yaml-formatted params file")
@@ -96,17 +96,17 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.wait, "wait", "Wait for results, with optional timeout")
 }
 
-func (c *runCommand) Info() *cmd.Info {
+func (c *callCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "run",
+		Name:    "call",
 		Args:    "<unit> [<unit> ...] <action name> [key.key.key...=value]",
 		Purpose: "Queue an action for execution.",
-		Doc:     runDoc,
+		Doc:     callDoc,
 	})
 }
 
 // Init gets the unit tag(s), action name and action arguments.
-func (c *runCommand) Init(args []string) (err error) {
+func (c *callCommand) Init(args []string) (err error) {
 	for _, arg := range args {
 		if names.IsValidUnit(arg) || validLeader.MatchString(arg) {
 			c.unitReceivers = append(c.unitReceivers, arg)
@@ -129,7 +129,7 @@ func (c *runCommand) Init(args []string) (err error) {
 	for _, arg := range args[len(c.unitReceivers)+1:] {
 		thisArg := strings.SplitN(arg, "=", 2)
 		if len(thisArg) != 2 {
-			return errors.Errorf("argument %q must be of the form key...=value", arg)
+			return errors.Errorf("argument %q must be of the form key.key.key...=value", arg)
 		}
 		keySlice := strings.Split(thisArg[0], ".")
 		// check each key for validity
@@ -139,13 +139,12 @@ func (c *runCommand) Init(args []string) (err error) {
 					"and contain only lowercase alphanumeric and hyphens", key)
 			}
 		}
-		// c.args={..., [key, key, key, key, value]}
 		c.args = append(c.args, append(keySlice, thisArg[1]))
 	}
 	return nil
 }
 
-func (c *runCommand) Run(ctx *cmd.Context) error {
+func (c *callCommand) Run(ctx *cmd.Context) error {
 	if err := c.ensureAPI(); err != nil {
 		return errors.Trace(err)
 	}
@@ -242,19 +241,19 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 
 		// Legacy Juju 1.25 output format for a single unit, no wait.
 		if !c.wait.forever && c.wait.d.Nanoseconds() <= 0 && len(results.Results) == 1 {
-			out := map[string]string{"Action queued with id": tag.Id()}
-			return c.out.Write(ctx, out)
+			results := map[string]string{"Action queued with id": tag.Id()}
+			return c.out.Write(ctx, results)
 		}
 	}
 
-	out := make(map[string]interface{}, len(results.Results))
+	info := make(map[string]interface{}, len(results.Results))
 
 	// Immediate return. This is the default, although rarely
 	// what cli users want. We should consider changing this
 	// default with Juju 3.0.
 	if !c.wait.forever && c.wait.d.Nanoseconds() <= 0 {
 		for _, result := range results.Results {
-			out[result.Action.Receiver] = result.Action.Tag
+			info[result.Action.Receiver] = result.Action.Tag
 			actionTag, err := names.ParseActionTag(result.Action.Tag)
 			if err != nil {
 				return err
@@ -263,12 +262,12 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 			if err != nil {
 				return err
 			}
-			out[result.Action.Receiver] = map[string]string{
+			info[result.Action.Receiver] = map[string]string{
 				"id":   actionTag.Id(),
 				"unit": unitTag.Id(),
 			}
 		}
-		return c.out.Write(ctx, out)
+		return c.out.Write(ctx, info)
 	}
 
 	var wait *time.Timer
@@ -296,12 +295,12 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		d := FormatActionResult(result)
 		d["id"] = tag.Id()       // Action ID is required in case we timed out.
 		d["unit"] = unitTag.Id() // Formatted unit is nice to have.
-		out[result.Action.Receiver] = d
+		info[result.Action.Receiver] = d
 	}
-	return c.out.Write(ctx, out)
+	return c.out.Write(ctx, info)
 }
 
-func (c *runCommand) ensureAPI() (err error) {
+func (c *callCommand) ensureAPI() (err error) {
 	if c.api != nil {
 		return nil
 	}

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -103,7 +103,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "fail with wrong formatting of k-v args",
 		args:        []string{validUnitId, "valid-action-name", "uh"},
-		expectError: "argument \"uh\" must be of the form key...=value",
+		expectError: "argument \"uh\" must be of the form key.key.key...=value",
 	}, {
 		should:      "fail with wrong formatting of k-v args",
 		args:        []string{validUnitId, "valid-action-name", "foo.Baz=3"},
@@ -201,7 +201,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			wrappedCommand, command := action.NewRunCommandForTest(s.store)
+			wrappedCommand, command := action.NewCallCommandForTest(s.store)
 			c.Logf("test %d: should %s:\n$ juju run (action) %s\n", i,
 				t.should, strings.Join(t.args, " "))
 			args := append([]string{modelFlag, "admin"}, t.args...)
@@ -429,7 +429,7 @@ func (s *RunSuite) TestRun(c *gc.C) {
 				restore := s.patchAPIClient(fakeClient)
 				defer restore()
 
-				wrappedCommand, _ := action.NewRunCommandForTest(s.store)
+				wrappedCommand, _ := action.NewCallCommandForTest(s.store)
 				args := append([]string{modelFlag, "admin"}, t.withArgs...)
 				ctx, err := cmdtesting.RunCommand(c, wrappedCommand, args...)
 

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -53,6 +53,30 @@ func (c *RunCommand) Args() [][]string {
 	return c.args
 }
 
+type RunActionCommand struct {
+	*runActionCommand
+}
+
+func (c *RunActionCommand) UnitNames() []string {
+	return c.unitReceivers
+}
+
+func (c *RunActionCommand) ActionName() string {
+	return c.actionName
+}
+
+func (c *RunActionCommand) ParseStrings() bool {
+	return c.parseStrings
+}
+
+func (c *RunActionCommand) ParamsYAML() cmd.FileVar {
+	return c.paramsYAML
+}
+
+func (c *RunActionCommand) Args() [][]string {
+	return c.args
+}
+
 type ListCommand struct {
 	*listCommand
 }
@@ -111,6 +135,12 @@ func NewRunCommandForTest(store jujuclient.ClientStore) (cmd.Command, *RunComman
 	c := &runCommand{}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &RunCommand{c}
+}
+
+func NewRunActionCommandForTest(store jujuclient.ClientStore) (cmd.Command, *RunActionCommand) {
+	c := &runActionCommand{}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &RunActionCommand{c}
 }
 
 func ActionResultsToMap(results []params.ActionResult) map[string]interface{} {

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -29,27 +29,27 @@ type CancelCommand struct {
 	*cancelCommand
 }
 
-type RunCommand struct {
-	*runCommand
+type CallCommand struct {
+	*callCommand
 }
 
-func (c *RunCommand) UnitNames() []string {
+func (c *CallCommand) UnitNames() []string {
 	return c.unitReceivers
 }
 
-func (c *RunCommand) ActionName() string {
+func (c *CallCommand) ActionName() string {
 	return c.actionName
 }
 
-func (c *RunCommand) ParseStrings() bool {
+func (c *CallCommand) ParseStrings() bool {
 	return c.parseStrings
 }
 
-func (c *RunCommand) ParamsYAML() cmd.FileVar {
+func (c *CallCommand) ParamsYAML() cmd.FileVar {
 	return c.paramsYAML
 }
 
-func (c *RunCommand) Args() [][]string {
+func (c *CallCommand) Args() [][]string {
 	return c.args
 }
 
@@ -131,10 +131,10 @@ func NewShowCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ShowComm
 	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ShowCommand{c}
 }
 
-func NewRunCommandForTest(store jujuclient.ClientStore) (cmd.Command, *RunCommand) {
-	c := &runCommand{}
+func NewCallCommandForTest(store jujuclient.ClientStore) (cmd.Command, *CallCommand) {
+	c := &callCommand{}
 	c.SetClientStore(store)
-	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &RunCommand{c}
+	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &CallCommand{c}
 }
 
 func NewRunActionCommandForTest(store jujuclient.ClientStore) (cmd.Command, *RunActionCommand) {

--- a/cmd/juju/action/runaction_test.go
+++ b/cmd/juju/action/runaction_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Canonical Ltd.
+// Copyright 2014, 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package action_test
@@ -21,30 +21,14 @@ import (
 	"github.com/juju/juju/cmd/juju/action"
 )
 
-var (
-	validParamsYaml = `
-out: name
-compression:
-  kind: xz
-  quality: high
-`[1:]
-	invalidParamsYaml = `
-broken-map:
-  foo:
-    foo
-    bar: baz
-`[1:]
-	invalidUTFYaml = "out: ok" + string([]byte{0xFF, 0xFF})
-)
-
-type RunSuite struct {
+type RunActionSuite struct {
 	BaseActionSuite
 	dir string
 }
 
-var _ = gc.Suite(&RunSuite{})
+var _ = gc.Suite(&RunActionSuite{})
 
-func (s *RunSuite) SetUpTest(c *gc.C) {
+func (s *RunActionSuite) SetUpTest(c *gc.C) {
 	s.BaseActionSuite.SetUpTest(c)
 	s.dir = c.MkDir()
 	c.Assert(utf8.ValidString(validParamsYaml), jc.IsTrue)
@@ -55,7 +39,7 @@ func (s *RunSuite) SetUpTest(c *gc.C) {
 	setupValueFile(c, s.dir, "invalidUTF.yml", invalidUTFYaml)
 }
 
-func (s *RunSuite) TestInit(c *gc.C) {
+func (s *RunActionSuite) TestInit(c *gc.C) {
 	tests := []struct {
 		should               string
 		args                 []string
@@ -201,8 +185,8 @@ func (s *RunSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			wrappedCommand, command := action.NewRunCommandForTest(s.store)
-			c.Logf("test %d: should %s:\n$ juju run (action) %s\n", i,
+			wrappedCommand, command := action.NewRunActionCommandForTest(s.store)
+			c.Logf("test %d: should %s:\n$ juju run-action %s\n", i,
 				t.should, strings.Join(t.args, " "))
 			args := append([]string{modelFlag, "admin"}, t.args...)
 			err := cmdtesting.InitCommand(wrappedCommand, args)
@@ -219,7 +203,7 @@ func (s *RunSuite) TestInit(c *gc.C) {
 	}
 }
 
-func (s *RunSuite) TestRun(c *gc.C) {
+func (s *RunActionSuite) TestRun(c *gc.C) {
 	tests := []struct {
 		should                 string
 		clientSetup            func(client *fakeAPIClient)
@@ -429,7 +413,7 @@ func (s *RunSuite) TestRun(c *gc.C) {
 				restore := s.patchAPIClient(fakeClient)
 				defer restore()
 
-				wrappedCommand, _ := action.NewRunCommandForTest(s.store)
+				wrappedCommand, _ := action.NewRunActionCommandForTest(s.store)
 				args := append([]string{modelFlag, "admin"}, t.withArgs...)
 				ctx, err := cmdtesting.RunCommand(c, wrappedCommand, args...)
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -383,11 +383,15 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage and control actions
 	r.Register(action.NewStatusCommand())
-	r.Register(action.NewRunCommand())
 	r.Register(action.NewShowOutputCommand())
 	r.Register(action.NewListCommand())
 	r.Register(action.NewShowCommand())
 	r.Register(action.NewCancelCommand())
+	if featureflag.Enabled(feature.JujuV3) {
+		r.Register(action.NewRunCommand())
+	} else {
+		r.Register(action.NewRunActionCommand())
+	}
 
 	// Manage controller availability
 	r.Register(newEnableHACommand())

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -388,7 +388,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(action.NewShowCommand())
 	r.Register(action.NewCancelCommand())
 	if featureflag.Enabled(feature.JujuV3) {
-		r.Register(action.NewRunCommand())
+		r.Register(action.NewCallCommand())
 	} else {
 		r.Register(action.NewRunActionCommand())
 	}

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -627,12 +627,12 @@ var commandNames = []string{
 
 // devFeatures are feature flags that impact registration of commands.
 var devFeatures = []string{
-	// Currently no feature flags.
+	feature.JujuV3,
 }
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-// Currently no commands behind feature flags.
+	"call",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {
@@ -646,6 +646,7 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	cmdSet := set.NewStrings(commandNames...)
 	if !featureflag.Enabled(feature.JujuV3) {
 		cmdSet.Add("run-action")
+		cmdSet.Add("run")
 	}
 
 	// 1. Default Commands. Disable all features.
@@ -664,7 +665,7 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	unknown = registered.Difference(cmdSet)
 	c.Assert(unknown, jc.DeepEquals, set.NewStrings())
 	missing = cmdSet.Difference(registered)
-	c.Assert(missing, jc.DeepEquals, set.NewStrings())
+	c.Assert(missing, jc.DeepEquals, set.NewStrings("run", "run-action"))
 }
 
 func getHelpCommandNames(c *gc.C) set.Strings {


### PR DESCRIPTION
## Description of change

To prepare for implementing the new juju call (action), copy the existing juju run-action command so that the new version can be easily changed, leaving the legacy run-action version untouched. The changes will be significant and easier to do separately in a new command rather than adding feature flag logic to the existing run-action command.

The runaction(_test).go and call(_test).go files are straight copies of run(_test).go

## QA steps

ensure juju run-action works still