### PR TITLE
Fix race in catacomb registration.

### DIFF
--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -153,11 +153,9 @@ func newWorker(config Config) (*mutaterWorker, error) {
 	err = catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
 		Work: w.loop,
+		Init: []worker.Worker{watcher},
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := w.catacomb.Add(watcher); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return w, nil


### PR DESCRIPTION
There is a subtle race in the invoking of the catacomb. The watcher is used in the loop function, but not added to the catacomb until after the the Invoke call. This means that the loop function could terminate before the watcher has been added. This causes intermittent failures in our tests.
