### PR TITLE
application data bag: API changes 

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1603,6 +1603,114 @@ func (u *UniterAPI) ReadRemoteSettings(args params.RelationUnitPairs) (params.Se
 	return result, nil
 }
 
+// WatchRelationApplicationSettings watches for changes to a
+// relation's application settings. Only accessible for agents that
+// are members of the relation and counterparts of the requested
+// application.
+func (u *UniterAPI) WatchRelationApplicationSettings(args params.RelationApplications) (params.NotifyWatchResults, error) {
+	result := params.NotifyWatchResults{
+		Results: make([]params.NotifyWatchResult, len(args.RelationApplications)),
+	}
+
+	canAccess := func(rel *state.Relation, app *state.Application) (bool, error) {
+		relatedEPs, err := rel.RelatedEndpoints(app.Name())
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+
+		var authApplication string
+		switch tag := u.auth.GetAuthTag().(type) {
+		case names.ApplicationTag:
+			authApplication = tag.Id()
+		case names.UnitTag:
+			unit, err := u.st.Unit(tag.Id())
+			if err != nil {
+				return false, errors.Trace(err)
+			}
+			relUnit, err := rel.Unit(unit)
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, errors.Trace(err)
+			}
+			inScope, err := relUnit.InScope()
+			if err != nil {
+				return false, errors.Trace(err)
+			}
+			if !inScope {
+				return false, nil
+			}
+			authApplication = unit.ApplicationName()
+		default:
+			return false, nil
+		}
+		for _, ep := range relatedEPs {
+			if authApplication == ep.ApplicationName {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	watchOne := func(rel, app string) (string, error) {
+		relTag, err := names.ParseRelationTag(rel)
+		if err != nil {
+			return "", common.ErrPerm
+		}
+		relation, err := u.st.KeyRelation(relTag.Id())
+		if errors.IsNotFound(err) {
+			return "", common.ErrPerm
+		}
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+
+		appTag, err := names.ParseApplicationTag(app)
+		if err != nil {
+			return "", common.ErrPerm
+		}
+		application, err := u.st.Application(appTag.Id())
+		if errors.IsNotFound(err) {
+			return "", common.ErrPerm
+		}
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+
+		allowed, err := canAccess(relation, application)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		if !allowed {
+			return "", common.ErrPerm
+		}
+
+		w, err := relation.WatchApplicationSettings(application)
+		if errors.IsNotFound(err) {
+			return "", common.ErrPerm
+		}
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+
+		if _, ok := <-w.Changes(); ok {
+			return u.resources.Register(w), nil
+		}
+		return "", watcher.EnsureErr(w)
+	}
+
+	for i, arg := range args.RelationApplications {
+		id, err := watchOne(arg.Relation, arg.Application)
+		result.Results[i].NotifyWatcherId = id
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
 // UpdateSettings persists all changes made to the local settings of
 // all given pairs of relation and unit. Keys with empty values are
 // considered a signal to delete these values.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2069,28 +2069,31 @@ func (u *UniterAPI) getRelationAppSettings(canAccess common.AuthFunc, relTag str
 
 func (u *UniterAPI) getRemoteRelationAppSettings(rel *state.Relation, appTag names.ApplicationTag) (map[string]interface{}, error) {
 	// Check that the application is actually remote.
-	var localAppTag names.ApplicationTag
+	var localAppName string
 	switch tag := u.auth.GetAuthTag().(type) {
 	case names.UnitTag:
 		unit, err := u.st.Unit(tag.Id())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		app, err := unit.Application()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		localAppTag = app.ApplicationTag()
+		localAppName = unit.ApplicationName()
 	case names.ApplicationTag:
-		localAppTag = tag
+		localAppName = tag.Id()
 	}
-	if localAppTag == appTag {
+	relatedEPs, err := rel.RelatedEndpoints(localAppName)
+	if err != nil {
 		return nil, common.ErrPerm
 	}
 
-	// Check that the application is actually related.
-	_, err := rel.Endpoint(appTag.Id())
-	if err != nil {
+	var isRelatedToLocalApp bool
+	for _, ep := range relatedEPs {
+		if appTag.Id() == ep.ApplicationName {
+			isRelatedToLocalApp = true
+			break
+		}
+	}
+
+	if !isRelatedToLocalApp {
 		return nil, common.ErrPerm
 	}
 

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1522,14 +1522,29 @@ func (u *UniterAPI) ReadSettings(args params.RelationUnits) (params.SettingsResu
 			var node *state.Settings
 			node, err = relUnit.Settings()
 			settings = node.Map()
+
 		case names.ApplicationTag:
+			var relation *state.Relation
+			relation, err = u.getRelation(arg.Relation)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			endpoints := relation.Endpoints()
+			isPeerRelation := len(endpoints) == 1 && endpoints[0].Role == charm.RolePeer
 			token := u.leadershipChecker.LeadershipCheck(tag.Id(), u.auth.GetAuthTag().Id())
 			canAccess := func(tag names.Tag) bool {
-				// Only allow the leader unit to read the application
-				// settings.
-				return canAccessApp(tag) && token.Check(0, nil) == nil
+				if !canAccessApp(tag) {
+					return false
+				}
+				if isPeerRelation {
+					return true
+				}
+				// For provider-requirer relations only allow the
+				// leader unit to read the application settings.
+				return token.Check(0, nil) == nil
 			}
 			settings, err = u.getRelationAppSettings(canAccess, arg.Relation, tag)
+
 		default:
 			return nil, common.ErrPerm
 		}
@@ -1981,16 +1996,24 @@ func (u *UniterAPI) getOneRelationById(relId int) (params.RelationResult, error)
 	return result, nil
 }
 
-func (u *UniterAPI) getRelationAndUnit(canAccess common.AuthFunc, relTag string, unitTag names.UnitTag) (*state.Relation, *state.Unit, error) {
+func (u *UniterAPI) getRelation(relTag string) (*state.Relation, error) {
 	tag, err := names.ParseRelationTag(relTag)
 	if err != nil {
-		return nil, nil, common.ErrPerm
+		return nil, common.ErrPerm
 	}
 	rel, err := u.st.KeyRelation(tag.Id())
 	if errors.IsNotFound(err) {
-		return nil, nil, common.ErrPerm
+		return nil, common.ErrPerm
 	} else if err != nil {
-		return nil, nil, err
+		return nil, err
+	}
+	return rel, nil
+}
+
+func (u *UniterAPI) getRelationAndUnit(canAccess common.AuthFunc, relTag string, unitTag names.UnitTag) (*state.Relation, *state.Unit, error) {
+	rel, err := u.getRelation(relTag)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
 	}
 	if !canAccess(unitTag) {
 		return nil, nil, common.ErrPerm

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2736,6 +2736,7 @@ func (s *uniterSuite) TestWatchRelationApplicationSettings(c *gc.C) {
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, relUnit, true)
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	args := params.RelationApplications{RelationApplications: []params.RelationApplication{{
 		Relation:    rel.Tag().String(),
@@ -2822,6 +2823,7 @@ func (s *uniterSuite) TestWatchRelationApplicationSettingsPeerRelation(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 	err = relUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	auth := apiservertesting.FakeAuthorizer{Tag: riakUnit.Tag()}
 	uniter := s.newUniterAPI(c, s.State, auth)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2494,6 +2494,47 @@ func (s *uniterSuite) TestReadRemoteSettingsWithNonStringValuesFails(c *gc.C) {
 	})
 }
 
+func (s *uniterSuite) TestReadRemoteApplicationSettingsForPeerRelation(c *gc.C) {
+	riak := s.AddTestingApplication(c, "riak", s.AddTestingCharm(c, "riak"))
+	ep, err := riak.Endpoint("ring")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.EndpointsRelation(ep)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = rel.UpdateApplicationSettings(riak, &fakeToken{}, map[string]interface{}{
+		"black midi": "ducter",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	riakUnit := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: riak,
+		Machine:     s.machine0,
+	})
+
+	relUnit, err := rel.Unit(riakUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = relUnit.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	auth := apiservertesting.FakeAuthorizer{Tag: riakUnit.Tag()}
+	uniter := s.newUniterAPI(c, s.State, auth)
+
+	args := params.RelationUnitPairs{RelationUnitPairs: []params.RelationUnitPair{{
+		Relation:   rel.Tag().String(),
+		LocalUnit:  "unit-riak-0",
+		RemoteUnit: "application-riak",
+	}}}
+	result, err := uniter.ReadRemoteSettings(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.SettingsResults{
+		Results: []params.SettingsResult{
+			{Settings: params.Settings{
+				"black midi": "ducter",
+			}},
+		},
+	})
+}
+
 func (s *uniterSuite) TestUpdateSettings(c *gc.C) {
 	rel := s.addRelation(c, "wordpress", "mysql")
 	relUnit, err := rel.Unit(s.wordpressUnit)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/environschema.v1"
@@ -2341,6 +2342,7 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 		{Relation: "relation-42", LocalUnit: "unit-foo-0", RemoteUnit: "foo"},
 		{Relation: rel.Tag().String(), LocalUnit: "unit-wordpress-0", RemoteUnit: "unit-wordpress-0"},
 		{Relation: rel.Tag().String(), LocalUnit: "unit-wordpress-0", RemoteUnit: "unit-mysql-0"},
+		{Relation: rel.Tag().String(), LocalUnit: "unit-wordpress-0", RemoteUnit: "application-mysql"},
 		{Relation: "relation-42", LocalUnit: "unit-wordpress-0", RemoteUnit: ""},
 		{Relation: "relation-foo", LocalUnit: "", RemoteUnit: ""},
 		{Relation: "application-wordpress", LocalUnit: "unit-foo-0", RemoteUnit: "user-foo"},
@@ -2352,14 +2354,20 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 	}}
 	result, err := s.uniter.ReadRemoteSettings(args)
 
-	// We don't set the remote unit settings on purpose to test the error.
+	// We don't set the remote unit settings on purpose
+	// to test the error.
 	expectErr := `cannot read settings for unit "mysql/0" in relation "wordpress:db mysql:server": unit "mysql/0": settings`
+
+	// The application settings are always initialised to empty when
+	// the relation is created.
 	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("%s", pretty.Sprint(result))
 	c.Assert(result, jc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.NotFoundError(expectErr)},
+			{Settings: params.Settings{}},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -2409,6 +2417,52 @@ func (s *uniterSuite) TestReadRemoteSettings(c *gc.C) {
 	err = s.mysqlUnit.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 	result, err = s.uniter.ReadRemoteSettings(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, expect)
+}
+
+func (s *uniterSuite) TestReadRemoteSettingsForApplication(c *gc.C) {
+	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
+	rel := s.addRelation(c, "wordpress", "mysql")
+	relUnit, err := rel.Unit(s.wordpressUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	settings := map[string]interface{}{
+		"some": "settings",
+	}
+	err = relUnit.EnterScope(settings)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, relUnit, true)
+
+	// Set some application settings for mysql and check that we can
+	// see them.
+	err = rel.UpdateApplicationSettings(s.mysql, &fakeToken{}, map[string]interface{}{
+		"problem thinker": "fireproof",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.RelationUnitPairs{RelationUnitPairs: []params.RelationUnitPair{{
+		Relation:   rel.Tag().String(),
+		LocalUnit:  "unit-wordpress-0",
+		RemoteUnit: "application-mysql",
+	}, {
+		Relation:   rel.Tag().String(),
+		LocalUnit:  "unit-wordpress-0",
+		RemoteUnit: "application-wordpress",
+	}, {
+		Relation:   rel.Tag().String(),
+		LocalUnit:  "unit-wordpress-0",
+		RemoteUnit: "application-logging",
+	}}}
+	expect := params.SettingsResults{
+		Results: []params.SettingsResult{
+			{Settings: params.Settings{
+				"problem thinker": "fireproof",
+			}},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	}
+	result, err := s.uniter.ReadRemoteSettings(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, expect)
 }
@@ -4480,4 +4534,12 @@ func (s *uniterAPIErrorSuite) TestGetStorageStateError(c *gc.C) {
 	})
 
 	c.Assert(err, gc.ErrorMatches, "kaboom")
+}
+
+type fakeToken struct {
+	err error
+}
+
+func (t *fakeToken) Check(int, interface{}) error {
+	return t.err
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2549,6 +2549,123 @@ func (s *uniterSuite) TestUpdateSettings(c *gc.C) {
 	})
 }
 
+func (s *uniterSuite) TestWatchRelationApplicationSettings(c *gc.C) {
+	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
+	rel := s.addRelation(c, "wordpress", "mysql")
+	relUnit, err := rel.Unit(s.wordpressUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = relUnit.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, relUnit, true)
+
+	args := params.RelationApplications{RelationApplications: []params.RelationApplication{{
+		Relation:    rel.Tag().String(),
+		Application: "application-logging",
+	}, {
+		Relation:    rel.Tag().String(),
+		Application: "unit-wordpress-0",
+	}, {
+		Relation:    rel.Tag().String(),
+		Application: "application-mysql",
+	}, {
+		Relation:    rel.Tag().String(),
+		Application: "application-wordpress",
+	}}}
+
+	result, err := s.uniter.WatchRelationApplicationSettings(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+			{NotifyWatcherId: "1"},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+	resource := s.resources.Get("1")
+	defer statetesting.AssertStop(c, resource)
+
+	wc := statetesting.NewNotifyWatcherC(c, s.State, resource.(state.NotifyWatcher))
+	wc.AssertNoChange()
+
+	// Set some application settings for mysql and check that we get a
+	// notification for it.
+	err = rel.UpdateApplicationSettings(s.mysql, &fakeToken{}, map[string]interface{}{
+		"problem thinker": "fireproof",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	wc.AssertOneChange()
+
+	// Check we don't get notified about a change to wordpress
+	// settings.
+	err = rel.UpdateApplicationSettings(s.wordpress, &fakeToken{}, map[string]interface{}{
+		"tent": "house",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNoChange()
+}
+
+func (s *uniterSuite) TestWatchRelationApplicationSettingsUnrelatedUnit(c *gc.C) {
+	logging := s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
+	rel := s.addRelation(c, "logging", "mysql")
+
+	args := params.RelationApplications{
+		RelationApplications: []params.RelationApplication{{
+			Relation:    rel.Tag().String(),
+			Application: logging.Tag().String(),
+		}},
+	}
+	results, err := s.uniter.WatchRelationApplicationSettings(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
+func (s *uniterSuite) TestWatchRelationApplicationSettingsPeerRelation(c *gc.C) {
+	riak := s.AddTestingApplication(c, "riak", s.AddTestingCharm(c, "riak"))
+	rels, err := riak.Relations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rels, gc.HasLen, 1)
+	rel := rels[0]
+
+	riakUnit := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: riak,
+		Machine:     s.machine0,
+	})
+
+	relUnit, err := rel.Unit(riakUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = relUnit.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	auth := apiservertesting.FakeAuthorizer{Tag: riakUnit.Tag()}
+	uniter := s.newUniterAPI(c, s.State, auth)
+
+	args := params.RelationApplications{
+		RelationApplications: []params.RelationApplication{{
+			Relation:    rel.Tag().String(),
+			Application: riak.Tag().String(),
+		}},
+	}
+	results, err := uniter.WatchRelationApplicationSettings(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{NotifyWatcherId: "1"},
+		},
+	})
+
+	c.Assert(s.resources.Count(), gc.Equals, 1)
+	resource := s.resources.Get("1")
+	statetesting.AssertStop(c, resource)
+}
+
 func (s *uniterSuite) TestWatchRelationUnits(c *gc.C) {
 	// Add a relation between wordpress and mysql and enter scope with
 	// mysqlUnit.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -36081,6 +36081,14 @@
                 "RelationUnitSettings": {
                     "type": "object",
                     "properties": {
+                        "application-settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "relation": {
                             "type": "string"
                         },
@@ -36100,7 +36108,8 @@
                     "required": [
                         "relation",
                         "unit",
-                        "settings"
+                        "settings",
+                        "application-settings"
                     ]
                 },
                 "RelationUnitStatus": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -34515,6 +34515,17 @@
                         }
                     }
                 },
+                "WatchRelationApplicationSettings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationApplications"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
                 "WatchRelationUnits": {
                     "type": "object",
                     "properties": {
@@ -35881,6 +35892,37 @@
                         "from-port",
                         "to-port",
                         "protocol"
+                    ]
+                },
+                "RelationApplication": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "relation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation",
+                        "application"
+                    ]
+                },
+                "RelationApplications": {
+                    "type": "object",
+                    "properties": {
+                        "relation-applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationApplication"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-applications"
                     ]
                 },
                 "RelationIds": {

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -39,7 +39,7 @@ type leadershipToken struct {
 func (t leadershipToken) Check(attempt int, out interface{}) error {
 	err := t.token.Check(attempt, out)
 	if errors.Cause(err) == lease.ErrNotHeld {
-		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationName)
+		return leadership.NewNotLeaderError(t.unitName, t.applicationName)
 	}
 	return errors.Trace(err)
 }

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -309,11 +309,12 @@ type RelationUnitPairs struct {
 }
 
 // RelationUnitSettings holds a relation tag, a unit tag and local
-// unit settings.
+// unit and app-level settings.
 type RelationUnitSettings struct {
-	Relation string   `json:"relation"`
-	Unit     string   `json:"unit"`
-	Settings Settings `json:"settings"`
+	Relation            string   `json:"relation"`
+	Unit                string   `json:"unit"`
+	Settings            Settings `json:"settings"`
+	ApplicationSettings Settings `json:"application-settings"`
 }
 
 // RelationUnitsSettings holds the arguments for making a EnterScope

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -632,6 +632,18 @@ type RelationUnitStatusResults struct {
 	Results []RelationUnitStatusResult `json:"results"`
 }
 
+// RelationApplications holds a set of pairs of relation & application
+// tags.
+type RelationApplications struct {
+	RelationApplications []RelationApplication `json:"relation-applications"`
+}
+
+// RelationApplication holds one (relation, application) pair.
+type RelationApplication struct {
+	Relation    string `json:"relation"`
+	Application string `json:"application"`
+}
+
 // MachineStorageIdsWatchResult holds a MachineStorageIdsWatcher id,
 // changes and an error (if any).
 type MachineStorageIdsWatchResult struct {

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -11,6 +11,7 @@ reference to non-core code.
 package leadership
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
@@ -28,6 +29,32 @@ var ErrClaimDenied = errors.New("leadership claim denied")
 // ErrBlockCancelled is returned from BlockUntilLeadershipReleased
 // if the client cancels the request by closing the cancel channel.
 var ErrBlockCancelled = errors.New("waiting for leadership cancelled by client")
+
+// NewNotLeaderError returns an error indicating that this unit is not
+// the leader of that application.
+func NewNotLeaderError(unit, application string) error {
+	return &notLeaderError{unit: unit, application: application}
+}
+
+type notLeaderError struct {
+	unit        string
+	application string
+}
+
+// Error is part of error.
+func (e notLeaderError) Error() string {
+	return fmt.Sprintf("%q is not leader of %q", e.unit, e.application)
+}
+
+// IsNotLeaderError returns whether this error represents a token
+// check that failed because the unit in question wasn't the leader.
+func IsNotLeaderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := errors.Cause(err).(*notLeaderError)
+	return ok
+}
 
 // Claimer exposes leadership acquisition capabilities.
 type Claimer interface {

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -89,7 +89,7 @@ type leadershipToken struct {
 func (t leadershipToken) Check(attempt int, out interface{}) error {
 	err := t.token.Check(attempt, out)
 	if errors.Cause(err) == lease.ErrNotHeld {
-		return errors.Errorf("%q is not leader of %q", t.unitName, t.applicationName)
+		return leadership.NewNotLeaderError(t.unitName, t.applicationName)
 	}
 	return errors.Trace(err)
 }

--- a/state/state_leader_test.go
+++ b/state/state_leader_test.go
@@ -118,6 +118,7 @@ func (s *LeadershipSuite) TestCheck(c *gc.C) {
 	var ops2 []txn.Op
 	err = token.Check(1, &ops2)
 	c.Check(err, gc.ErrorMatches, `"application/0" is not leader of "application"`)
+	c.Check(err, jc.Satisfies, leadership.IsNotLeaderError)
 	c.Check(ops2, gc.IsNil)
 }
 


### PR DESCRIPTION
## Description of change

These are the server-side API changes needed to support application settings for relations in the uniter.
* Adds Uniter.WatchRelationApplicationSettings 
* Extends ReadSettings and ReadRemoteSettings to accept an application tag as well as a unit tag. ReadSettings can only read application settings if the requesting unit is the leader.
* UpdateSettings now optionally accepts ApplicationSettings alongside unit settings. A unit can only update application settings if it's the leader.

Doesn't bump the Uniter facade version - all of these changes *should* be backwards compatible, and we don't need to be as conservative with version bumps for agent facades.

Part of the implementation of [Application relation data bag](https://docs.google.com/document/d/19Uh-Cy0IU5-9sXSLQjsqBvRvuOi4ZEQ0PRetIBJKhPU/edit)

## QA steps

* Unit tests only, needs uniter changes for any behaviour difference to be visible.

## Documentation changes
None

## Bug reference
None