### PR TITLE
application data bag: Fix racy WatchApplicationSettings tests

### DIFF
--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -947,6 +947,7 @@ func (s *RelationSuite) TestWatchApplicationSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w, err := relation.WatchApplicationSettings(mysql)
 	c.Assert(err, jc.ErrorIsNil)
@@ -980,6 +981,7 @@ func (s *RelationSuite) TestWatchApplicationSettingsOtherEnd(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	w, err := relation.WatchApplicationSettings(mysql)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

The WatchApplicationSettings tests would fail intermittently.
Example: https://jenkins.juju.canonical.com/view/Unit%20tests/job/RunUnittests-race-amd64/1764/testReport/github/com_juju_juju_state/TestPackage/

They're getting two notifications on the watcher instead of the expected one about half the time under stress-race. Adding a StartSync fixes this.

## QA steps

* With the change the tests don't fail under stress-race.

## Documentation changes
None

## Bug reference
None