### PR TITLE
Add SpaceID to SubnetInfo. 

### DIFF
--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -91,7 +91,7 @@ func (s *stateShim) AddSubnet(info BackingSubnetInfo) (BackingSubnet, error) {
 		ProviderId:        info.ProviderId,
 		ProviderNetworkId: info.ProviderNetworkId,
 		AvailabilityZones: info.AvailabilityZones,
-		SpaceName:         info.SpaceName,
+		SpaceID:           info.SpaceID,
 	})
 	return nil, err // Drop the first result, as it's unused.
 }

--- a/apiserver/common/networkingcommon/subnets_test.go
+++ b/apiserver/common/networkingcommon/subnets_test.go
@@ -487,21 +487,21 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		CIDR:              "2001:db8::/32",
 		VLANTag:           0,
 		AvailabilityZones: []string{"zone1"},
-		SpaceName:         "dmz",
+		SpaceID:           "2",
 	}, {
 		ProviderId:        "vlan-42",
 		ProviderNetworkId: "",
 		CIDR:              "10.30.1.0/24",
 		VLANTag:           42,
 		AvailabilityZones: []string{"zone3"},
-		SpaceName:         "private",
+		SpaceID:           "3",
 	}, {
 		ProviderId:        "sn-zadf00d",
 		ProviderNetworkId: "godspeed",
 		CIDR:              "10.10.0.0/24",
 		VLANTag:           0,
 		AvailabilityZones: []string{"zone1"},
-		SpaceName:         "private",
+		SpaceID:           "3",
 	}}
 	c.Check(expectedErrors, gc.HasLen, len(args.Subnets))
 

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -34,6 +34,7 @@ type BackingSubnet interface {
 	AvailabilityZones() []string
 	Status() string
 	SpaceName() string
+	SpaceID() string
 	Life() life.Value
 }
 
@@ -71,6 +72,7 @@ type BackingSubnetInfo struct {
 	// SpaceName holds the juju network space this subnet is
 	// associated with. Can be empty if not supported.
 	SpaceName string
+	SpaceID   string
 
 	// Status holds the status of the subnet. Normally this will be
 	// calculated from the reference count and Life of a subnet.
@@ -137,11 +139,10 @@ func BackingSubnetToParamsSubnet(subnet BackingSubnet) params.Subnet {
 	zones := subnet.AvailabilityZones()
 	status := subnet.Status()
 
-	// TODO(babbageclunk): make the empty string a valid space
-	// name, rather than treating blank as "doesn't have a space".
-	// lp:1672888
 	var spaceTag string
-	if subnet.SpaceName() != "" {
+	if subnet.SpaceName() != corenetwork.DefaultSpaceName {
+		// The BackingSubnet will be returning for client commands,
+		// thus the space name is appropriate here.
 		spaceTag = names.NewSpaceTag(subnet.SpaceName()).String()
 	}
 

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -171,9 +171,9 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithSingleNegativeAndPositi
 
 func (s *withoutControllerSuite) addSpacesAndSubnets(c *gc.C) {
 	// Add a couple of spaces.
-	_, err := s.State.AddSpace("space1", "first space id", nil, true)
+	space1, err := s.State.AddSpace("space1", "first space id", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSpace("space2", "", nil, false) // no provider ID
+	space2, err := s.State.AddSpace("space2", "", nil, false) // no provider ID
 	c.Assert(err, jc.ErrorIsNil)
 	// Add 1 subnet into space1, and 2 into space2.
 	// Each subnet is in a matching zone (e.g "subnet-#" in "zone#").
@@ -181,7 +181,7 @@ func (s *withoutControllerSuite) addSpacesAndSubnets(c *gc.C) {
 		CIDR:              "10.10.{{.}}.0/24",
 		ProviderId:        "subnet-{{.}}",
 		AvailabilityZones: []string{"zone{{.}}"},
-		SpaceName:         "{{if (eq . 0)}}space1{{else}}space2{{end}}",
+		SpaceID:           fmt.Sprintf("{{if (eq . 0)}}%s{{else}}%s{{end}}", space1.Id(), space2.Id()),
 		VLANTag:           42,
 	})
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3329,8 +3329,9 @@ func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
 		SpaceName: "internal",
 	}}
 	for _, info := range subnetInfos {
-		_, err := s.State.AddSpace(info.SpaceName, "", nil, false)
+		space, err := s.State.AddSpace(info.SpaceName, "", nil, false)
 		c.Assert(err, jc.ErrorIsNil)
+		info.SpaceID = space.Id()
 		_, err = s.State.AddSubnet(info)
 		c.Assert(err, jc.ErrorIsNil)
 	}
@@ -3578,9 +3579,10 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 		SpaceName: "layertwo",
 	}}
 	for _, info := range subnetInfos {
-		_, err := s.State.AddSpace(info.SpaceName, "", nil, false)
+		space, err := s.State.AddSpace(info.SpaceName, "", nil, false)
 		c.Assert(err, jc.ErrorIsNil)
 		if info.CIDR != "" {
+			info.SpaceID = space.Id()
 			_, err = s.State.AddSubnet(info)
 			c.Assert(err, jc.ErrorIsNil)
 		}

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -166,6 +166,7 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 
 		backing := networkingcommon.BackingSubnetInfo{
 			CIDR:              subnetId,
+			SpaceID:           f.SpaceId,
 			SpaceName:         f.SpaceName,
 			ProviderId:        providerId,
 			VLANTag:           vlantag,
@@ -335,6 +336,10 @@ func (f *FakeSubnet) SpaceName() string {
 	return f.Info.SpaceName
 }
 
+func (f *FakeSubnet) SpaceID() string {
+	return f.Info.SpaceID
+}
+
 func (f *FakeSubnet) Life() life.Value {
 	return life.Value(f.Info.Life)
 }
@@ -430,6 +435,7 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 			ProviderNetworkId: ProviderInstance.Subnets[0].ProviderNetworkId,
 			AvailabilityZones: ProviderInstance.Subnets[0].AvailabilityZones,
 			SpaceName:         "private",
+			SpaceID:           "3",
 		}
 		info1 := networkingcommon.BackingSubnetInfo{
 			CIDR:              ProviderInstance.Subnets[1].CIDR,
@@ -437,6 +443,7 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 			ProviderNetworkId: ProviderInstance.Subnets[1].ProviderNetworkId,
 			AvailabilityZones: ProviderInstance.Subnets[1].AvailabilityZones,
 			SpaceName:         "dmz",
+			SpaceID:           "2",
 		}
 
 		sb.Subnets = []networkingcommon.BackingSubnet{

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -55,12 +55,14 @@ type SubnetInfo struct {
 	AvailabilityZones []string
 
 	// SpaceID is the id of the space the subnet is associated with.
-	// It can be empty if the subnet is not associated with a space yet.
-	// SpaceID is preferred over SpaceName.
+	// Default value should be DefaultSpaceId. It can be empty if
+	// the subnet is returned from an networkingEnviron. SpaceID is
+	// preferred over SpaceName in state and non networkingEnviron use.
 	SpaceID string
 
 	// SpaceName is the name of the space the subnet is associated with.
-	// It can be empty if the subnet is not associated with a space yet.
+	// An empty string indicates it is part of the DefaultSpaceName OR
+	// if the SpaceID is set. Should primarily be used in an networkingEnviron.
 	SpaceName string
 
 	// FanInfo describes the fan networking setup for the subnet.

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -54,9 +54,13 @@ type SubnetInfo struct {
 	// availability zones.
 	AvailabilityZones []string
 
+	// SpaceID is the id of the space the subnet is associated with.
+	// It can be empty if the subnet is not associated with a space yet.
+	// SpaceID is preferred over SpaceName.
+	SpaceID string
+
 	// SpaceName is the name of the space the subnet is associated with.
 	// It can be empty if the subnet is not associated with a space yet.
-	// TODO (manadart 2019-07-11): Remove in lieu of SpaceId?
 	SpaceName string
 
 	// FanInfo describes the fan networking setup for the subnet.

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -42,7 +42,7 @@ func (s *cmdSpaceSuite) MakeSubnetInfos(c *gc.C, space string, cidrTemplate stri
 			// ProviderId it needs to be unique in state.
 			ProviderId:        network.Id(fmt.Sprintf("sub-%d", rand.Int())),
 			CIDR:              fmt.Sprintf(cidrTemplate, i),
-			SpaceName:         space,
+			SpaceID:           space,
 			AvailabilityZones: []string{"zone1"},
 		}
 	}
@@ -194,12 +194,12 @@ func (s *cmdSpaceSuite) TestSpaceListOneResultNoSubnets(c *gc.C) {
 }
 
 func (s *cmdSpaceSuite) TestSpaceListMoreResults(c *gc.C) {
-	infos1 := s.MakeSubnetInfos(c, "space1", "10.10.%d.0/24", 3)
-	s.AddSpace(c, "space1", nil, true)
+	space1 := s.AddSpace(c, "space1", nil, true)
+	infos1 := s.MakeSubnetInfos(c, space1.Id(), "10.10.%d.0/24", 3)
 	s.AddSubnets(c, infos1)
 
-	infos2 := s.MakeSubnetInfos(c, "space2", "10.20.%d.0/24", 1)
-	s.AddSpace(c, "space2", nil, false)
+	space2 := s.AddSpace(c, "space2", nil, false)
+	infos2 := s.MakeSubnetInfos(c, space2.Id(), "10.20.%d.0/24", 1)
 	s.AddSubnets(c, infos2)
 
 	stdout, stderr, err := s.Run(c, "list-spaces", "--format", "yaml")

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -81,8 +81,8 @@ func (s *cmdSubnetSuite) TestSubnetAddCIDRAndInvalidSpaceName(c *gc.C) {
 }
 
 func (s *cmdSubnetSuite) TestSubnetAddAlreadyExistingCIDR(c *gc.C) {
-	s.AddSpace(c, "foo", nil, true)
-	s.AddSubnet(c, network.SubnetInfo{CIDR: "0.10.0.0/24", SpaceName: "foo", ProviderId: "dummy-private"})
+	space := s.AddSpace(c, "foo", nil, true)
+	s.AddSubnet(c, network.SubnetInfo{CIDR: "0.10.0.0/24", SpaceID: space.Id(), ProviderId: "dummy-private"})
 
 	expectedError := `cannot add subnet: adding subnet "0.10.0.0/24": subnet "0.10.0.0/24" already exists`
 	s.RunAdd(c, expectedError, "0.10.0.0/24", "foo")
@@ -148,14 +148,14 @@ func (s *cmdSubnetSuite) TestSubnetListNoResults(c *gc.C) {
 }
 
 func (s *cmdSubnetSuite) TestSubnetListResultsWithFilters(c *gc.C) {
-	s.AddSpace(c, "myspace", nil, true)
+	space := s.AddSpace(c, "myspace", nil, true)
 	s.AddSubnet(c, network.SubnetInfo{
 		CIDR: "10.0.0.0/8",
 	})
 	s.AddSubnet(c, network.SubnetInfo{
 		CIDR:              "10.10.0.0/16",
 		AvailabilityZones: []string{"zone1"},
-		SpaceName:         "myspace",
+		SpaceID:           space.Id(),
 	})
 
 	context := s.Run(c,

--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -86,7 +86,7 @@ func AddSubnetsWithTemplate(c *gc.C, st *state.State, numSubnets uint, infoTempl
 
 		info.ProviderId = network.Id(permute(string(info.ProviderId)))
 		info.CIDR = permute(info.CIDR)
-		info.SpaceName = permute(info.SpaceName)
+		info.SpaceID = permute(info.SpaceID)
 
 		zones := make([]string, len(info.AvailabilityZones))
 		for i, az := range info.AvailabilityZones {

--- a/network/containerizer/bridgepolicy_test.go
+++ b/network/containerizer/bridgepolicy_test.go
@@ -105,11 +105,11 @@ func (s *bridgePolicyStateSuite) assertAllLinkLayerDevicesOnMachineMatchCount(
 }
 
 func (s *bridgePolicyStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {
-	_, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
+	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
-		CIDR:      CIDR,
-		SpaceName: spaceName,
+		CIDR:    CIDR,
+		SpaceID: space.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -258,7 +258,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesCorrectlyP
 	}
 	// Put each of those bridges into a different subnet that is part
 	// of the same space.
-	_, err := s.State.AddSpace("default", "default", nil, true)
+	space, err := s.State.AddSpace("default", "default", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	devAddresses := make([]state.LinkLayerDeviceAddress, len(devicesArgs))
@@ -266,8 +266,8 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesCorrectlyP
 		subnet := i*10 + 1
 		subnetCIDR := fmt.Sprintf("10.%d.0.0/24", subnet)
 		_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
-			CIDR:      subnetCIDR,
-			SpaceName: "default",
+			CIDR:    subnetCIDR,
+			SpaceID: space.Id(),
 		})
 		c.Assert(err, jc.ErrorIsNil)
 		devAddresses[i] = state.LinkLayerDeviceAddress{

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -362,42 +362,42 @@ func resetSubnet(c *gc.C, st *state.State, subnetInfo corenetwork.SubnetInfo) {
 
 func (s *ipAddressesStateSuite) TestAllSpacesOneSpace(c *gc.C) {
 	s.addTwoDevicesWithTwoAddressesEach(c)
-	_, err := s.State.AddSpace("default", "default", nil, true)
+	space, err := s.State.AddSpace("default", "default", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, corenetwork.SubnetInfo{
-		CIDR:      "10.20.0.0/16",
-		SpaceName: "default",
+		CIDR:    "10.20.0.0/16",
+		SpaceID: space.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, corenetwork.SubnetInfo{
-		CIDR:      "fc00::/64",
-		SpaceName: "default",
+		CIDR:    "fc00::/64",
+		SpaceID: space.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	spaces, err := s.machine.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"default"})
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{space.Name()})
 }
 
 func (s *ipAddressesStateSuite) TestAllSpacesMultiSpace(c *gc.C) {
 	s.addTwoDevicesWithTwoAddressesEach(c)
-	_, err := s.State.AddSpace("default", "default", nil, true)
+	space1, err := s.State.AddSpace("default", "default", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, corenetwork.SubnetInfo{
-		CIDR:      "10.20.0.0/16",
-		SpaceName: "default",
+		CIDR:    "10.20.0.0/16",
+		SpaceID: space1.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSpace("dmz-ipv6", "not-default", nil, true)
+	space2, err := s.State.AddSpace("dmz-ipv6", "not-default", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	resetSubnet(c, s.State, corenetwork.SubnetInfo{
-		CIDR:      "fc00::/64",
-		SpaceName: "dmz-ipv6",
+		CIDR:    "fc00::/64",
+		SpaceID: space2.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	spaces, err := s.machine.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{"default", "dmz-ipv6"})
+	c.Check(spaces.SortedValues(), gc.DeepEquals, []string{space1.Name(), space2.Name()})
 }
 
 func (s *ipAddressesStateSuite) TestAllSpacesIgnoresEmptySpaceNames(c *gc.C) {

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -632,11 +632,11 @@ func (s *linkLayerDevicesStateSuite) TestMachineRemoveAllLinkLayerDevicesNoError
 }
 
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {
-	_, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
+	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
-		CIDR:      CIDR,
-		SpaceName: spaceName,
+		CIDR:    CIDR,
+		SpaceID: space.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1116,7 +1116,7 @@ func (s *MigrationExportSuite) TestSubnets(c *gc.C) {
 		ProviderNetworkId: network.Id("rust"),
 		VLANTag:           64,
 		AvailabilityZones: []string{"bar"},
-		SpaceName:         sp.Name(),
+		SpaceID:           sp.Id(),
 		IsPublic:          true,
 	}
 	sn.SetFan("100.2.0.0/16", "253.0.0.0/8")
@@ -1146,9 +1146,9 @@ func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
 	})
-	_, err := s.State.AddSpace("testme", "", nil, true)
+	space, err := s.State.AddSpace("testme", "", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24", SpaceName: "testme"})
+	_, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24", SpaceID: space.Id()})
 	c.Assert(err, jc.ErrorIsNil)
 	deviceArgs := state.LinkLayerDeviceArgs{
 		Name: "foo",

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1369,20 +1369,16 @@ func (i *importer) subnets() error {
 			VLANTag:           subnet.VLANTag(),
 			AvailabilityZones: subnet.AvailabilityZones(),
 			IsPublic:          subnet.IsPublic(),
+			SpaceID:           subnet.SpaceID(),
 		}
 		info.SetFan(subnet.FanLocalUnderlay(), subnet.FanOverlay())
 
-		// TODO (hml) 2019-07-25
-		// update migration for SpaceID once SubnetInfo Updated.
-		spID := subnet.SpaceID()
-		if spID != "" {
-			sp, err := i.st.SpaceByID(spID)
+		if info.SpaceID == "" && info.SpaceName != "" {
+			space, err := i.st.Space(subnet.SpaceName())
 			if err != nil {
 				return errors.Trace(err)
 			}
-			info.SpaceName = sp.Name()
-		} else {
-			info.SpaceName = subnet.SpaceName()
+			info.SpaceID = space.Id()
 		}
 
 		snID := subnet.ID()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1234,7 +1234,7 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 		ProviderId:        network.Id("foo"),
 		ProviderNetworkId: network.Id("elm"),
 		VLANTag:           64,
-		SpaceName:         "bam",
+		SpaceID:           sp.Id(),
 		AvailabilityZones: []string{"bar"},
 		IsPublic:          true,
 	})
@@ -1244,7 +1244,7 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 		ProviderId:        network.Id("bar"),
 		ProviderNetworkId: network.Id("oak"),
 		VLANTag:           64,
-		SpaceName:         "bam",
+		SpaceID:           sp.Id(),
 		AvailabilityZones: []string{"bar"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1316,9 +1316,9 @@ func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
 	})
-	_, err := s.State.AddSpace("testme", "", nil, true)
+	space, err := s.State.AddSpace("testme", "", nil, true)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24", SpaceName: "testme"})
+	_, err = s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24", SpaceID: space.Id()})
 	c.Assert(err, jc.ErrorIsNil)
 	deviceArgs := state.LinkLayerDeviceArgs{
 		Name: "foo",

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -612,5 +612,5 @@ func (s *SpacesSuite) TestFanSubnetInheritsSpace(c *gc.C) {
 		}
 	}
 	c.Assert(foundSubnet, gc.NotNil)
-	c.Assert(foundSubnet.SpaceName(), gc.Equals, "space1")
+	c.Assert(foundSubnet.SpaceID(), gc.Equals, space.Id())
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1020,9 +1020,9 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithSpacesSuccess(c *gc.C) {
 	defer workertest.CleanKill(c, p)
 
 	// Add the spaces used in constraints.
-	_, err := s.State.AddSpace("space1", "", nil, false)
+	space1, err := s.State.AddSpace("space1", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSpace("space2", "", nil, false)
+	space2, err := s.State.AddSpace("space2", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add 1 subnet into space1, and 2 into space2.
@@ -1031,7 +1031,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesWithSpacesSuccess(c *gc.C) {
 		CIDR:              "10.10.{{.}}.0/24",
 		ProviderId:        "subnet-{{.}}",
 		AvailabilityZones: []string{"zone{{.}}"},
-		SpaceName:         "{{if (eq . 0)}}space1{{else}}space2{{end}}",
+		SpaceID:           fmt.Sprintf("{{if (lt . 2)}}%s{{else}}%s{{end}}", space1.Id(), space2.Id()),
 		VLANTag:           42,
 	})
 


### PR DESCRIPTION
## Description of change
Add SpaceID to SubnetInfo{}, for use when SubnetInfo is used to create a subnet and within state. When used for client calls, SubnetName is still appropriate as the data comes direct from the provider and no SpaceID is readily available

Update SubnetInfo use to prefer SpaceId over SpaceName when adding a subnet by stopping convertion of SpaceId to SpaceName solely to add data to SubnetInfo.  Caveates: SubnetInfo going to client output.  Migration import which calls addSubnetOps() directly.

Update tests using AddSubnet to have SubnetInfo arg providing a SubnetID instead of SubnetName.

## QA steps

Bootstrap AWS.  Ensure all of the subnets were added correctly, by running juju subnets and juju spaces.  Add a space and view the result.  Verify that juju subnets --space <new-space> yields correct results.

Bootstrap MaaS using a space constraint