### PR TITLE
Add new juju call semantics for actions

### DIFF
--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -4,6 +4,8 @@
 package action
 
 import (
+	"time"
+
 	"github.com/juju/cmd"
 	"gopkg.in/juju/names.v3"
 
@@ -47,6 +49,10 @@ func (c *CallCommand) ParseStrings() bool {
 
 func (c *CallCommand) ParamsYAML() cmd.FileVar {
 	return c.paramsYAML
+}
+
+func (c *CallCommand) MaxWait() time.Duration {
+	return c.maxWait
 }
 
 func (c *CallCommand) Args() [][]string {

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -10,11 +10,13 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/feature"
 )
 
 func NewShowOutputCommand() cmd.Command {
@@ -49,18 +51,27 @@ func (c *showOutputCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *showOutputCommand) Info() *cmd.Info {
-	return jujucmd.Info(&cmd.Info{
+	info := jujucmd.Info(&cmd.Info{
 		Name:    "show-action-output",
 		Args:    "<action ID>",
 		Purpose: "Show results of an action by ID.",
 		Doc:     showOutputDoc,
 	})
+	if featureflag.Enabled(feature.JujuV3) {
+		info.Name = "show-operation"
+		info.Args = "<operation ID>"
+		info.Purpose = "Show results of an operation by ID."
+	}
+	return info
 }
 
 // Init validates the action ID and any other options.
 func (c *showOutputCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
+		if featureflag.Enabled(feature.JujuV3) {
+			return errors.New("no operation ID specified")
+		}
 		return errors.New("no action ID specified")
 	case 1:
 		c.requestedId = args[0]

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -55,12 +55,14 @@ func (c *showOutputCommand) Info() *cmd.Info {
 		Name:    "show-action-output",
 		Args:    "<action ID>",
 		Purpose: "Show results of an action by ID.",
+		Aliases: []string{"show-operation"},
 		Doc:     showOutputDoc,
 	})
 	if featureflag.Enabled(feature.JujuV3) {
 		info.Name = "show-operation"
 		info.Args = "<operation ID>"
 		info.Purpose = "Show results of an operation by ID."
+		info.Aliases = nil
 	}
 	return info
 }

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -44,7 +44,7 @@ func (s *ShowOutputSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d: it should %s: juju show-action-output %s", i,
+			c.Logf("test %d: it should %s: juju show-operation %s", i,
 				t.should, strings.Join(t.args, " "))
 			cmd, _ := action.NewShowOutputCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -382,15 +382,14 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	}
 
 	// Manage and control actions
-	r.Register(action.NewStatusCommand())
 	r.Register(action.NewShowOutputCommand())
 	r.Register(action.NewListCommand())
 	r.Register(action.NewShowCommand())
 	r.Register(action.NewCancelCommand())
-	if featureflag.Enabled(feature.JujuV3) {
-		r.Register(action.NewCallCommand())
-	} else {
+	r.Register(action.NewCallCommand())
+	if !featureflag.Enabled(feature.JujuV3) {
 		r.Register(action.NewRunActionCommand())
+		r.Register(action.NewStatusCommand())
 	}
 
 	// Manage controller availability

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -585,6 +585,7 @@ var commandNames = []string{
 	"show-machine",
 	"show-model",
 	"show-offer",
+	"show-operation",
 	"show-status",
 	"show-status-log",
 	"show-storage",
@@ -631,7 +632,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"show-operation",
+// Currently no commands behind feature flags.
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -447,6 +447,7 @@ var commandNames = []string{
 	"bootstrap",
 	"budget",
 	"cached-images",
+	"call",
 	"cancel-action",
 	"change-user-password",
 	"charm",
@@ -575,8 +576,6 @@ var commandNames = []string{
 	"set-series",
 	"set-wallet",
 	"show-action",
-	"show-action-output",
-	"show-action-status",
 	"show-application",
 	"show-backup",
 	"show-cloud",
@@ -632,7 +631,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"call",
+	"show-operation",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {
@@ -647,6 +646,8 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	if !featureflag.Enabled(feature.JujuV3) {
 		cmdSet.Add("run-action")
 		cmdSet.Add("run")
+		cmdSet.Add("show-action-status")
+		cmdSet.Add("show-action-output")
 	}
 
 	// 1. Default Commands. Disable all features.
@@ -665,7 +666,8 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	unknown = registered.Difference(cmdSet)
 	c.Assert(unknown, jc.DeepEquals, set.NewStrings())
 	missing = cmdSet.Difference(registered)
-	c.Assert(missing, jc.DeepEquals, set.NewStrings("run", "run-action"))
+	c.Assert(missing, jc.DeepEquals, set.NewStrings(
+		"run", "run-action", "show-action-status", "show-action-output"))
 }
 
 func getHelpCommandNames(c *gc.C) set.Strings {
@@ -747,7 +749,7 @@ func (s *MainSuite) TestRegisterCommands(c *gc.C) {
 	copy(expected, commandNames)
 	expected = append(expected, extraNames...)
 	if !featureflag.Enabled(feature.JujuV3) {
-		expected = append(expected, "run-action")
+		expected = append(expected, "run-action", "show-action-status", "show-action-output")
 	}
 	sort.Strings(expected)
 	c.Check(registry.names, jc.DeepEquals, expected)


### PR DESCRIPTION
## Description of change

juju call <action> runs the action synchronously by default. There's a new --background option to run async, plus a new --max-wait option to set the timeout (defaults to 60s).
The output has been improved - there's a new (default) format option "plain". This prints the raw action data resulting from action-set calls in the charm, without all the other metadata such as completion times etc. You can still get that using --format yaml.

For Juju v3, show-action-output becomes show-operation.
And juju call is moved out from behind the feature flag because it's no longer called "run" and so doesn't conflict with an existing command.

## QA steps

```
$ juju call mariadb-k8s/0 hello who=world
Running Operation 259d3f7b-f7ec-47a1-890c-51cc3c9d4ffb
message: |-
  Hello world!

$ juju call mariadb-k8s/0 mariadb-k8s/1 hello who=world
Running Operation 4cc85bca-c49a-4b04-877b-e953db64db06
Running Operation 3bcee0d5-7c4f-4f94-8171-afeae8e1acea
mariadb-k8s/0:
  id: 4cc85bca-c49a-4b04-877b-e953db64db06
  output: |
    message: |-
      Hello world!
mariadb-k8s/1:
  id: 3bcee0d5-7c4f-4f94-8171-afeae8e1acea
  output: |
    message: |-
      Hello world!

$ juju call mariadb-k8s/0 hello who=world --background
Scheduled Operation 669ab354-2140-49f9-87ba-9b61f9f29901
Check status with 'juju show-operation 669ab354-2140-49f9-87ba-9b61f9f29901'

$ juju call mariadb-k8s/0 mariadb-k8s/1 hello who=world --background
Scheduled Operations:
mariadb-k8s/0:
  id: c02bcd7c-2f97-4990-8b5b-e1bc5644129a
mariadb-k8s/1:
  id: 3f56d600-aa16-44c3-8f06-d65974bd3e3d
Check status with 'juju show-operation <id>'
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1769062
