### PR TITLE
'add-cloud' ASK-or-TELL

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -1003,7 +1003,7 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 	if !cfg.Features().Contains(feature.MultiCloud) {
 		if cloudArgs.Cloud.Type != string(provider.K8s_ProviderType) {
 			return errors.Errorf(
-				"feature flag %q needs to be enabled to add a %q cloud", feature.MultiCloud, cloudArgs.Cloud.Type)
+				"controller side feature flag %q needs to be enabled to add a %q cloud", feature.MultiCloud, cloudArgs.Cloud.Type)
 		}
 	}
 

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -1003,7 +1003,7 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 	if !cfg.Features().Contains(feature.MultiCloud) {
 		if cloudArgs.Cloud.Type != string(provider.K8s_ProviderType) {
 			return errors.Errorf(
-				"controller side feature flag %q needs to be enabled to add a %q cloud", feature.MultiCloud, cloudArgs.Cloud.Type)
+				"feature flag %q needs to be enabled to add a %q cloud", feature.MultiCloud, cloudArgs.Cloud.Type)
 		}
 	}
 

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -265,7 +265,7 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 		}
 	}
 
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
@@ -495,7 +495,7 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 		return nil, errors.Trace(err)
 	}
 	if !c.Local {
-		ctrlUUID, err := c.ControllerUUID(c.store, c.controllerName)
+		ctrlUUID, err := c.ControllerUUID(c.store, c.ControllerName)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -715,12 +715,12 @@ func (c *AddCAASCommand) addCredentialToLocal(cloudName string, newCredential ju
 }
 
 func (c *AddCAASCommand) addCredentialToController(apiClient AddCloudAPI, newCredential jujucloud.Credential, credentialName string) error {
-	_, err := c.store.ControllerByName(c.controllerName)
+	_, err := c.store.ControllerByName(c.ControllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	currentAccountDetails, err := c.store.AccountDetails(c.controllerName)
+	currentAccountDetails, err := c.store.AccountDetails(c.ControllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -92,7 +92,7 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 		return errors.Errorf("missing k8s name.")
 	}
 	c.cloudName = args[0]
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
@@ -101,7 +101,7 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 
 // Run is defined on the Command interface.
 func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
-	if c.controllerName == "" && !c.Local {
+	if c.ControllerName == "" && !c.Local {
 		return errors.Errorf(
 			"There are no controllers running.\nTo remove cloud %q from the local cache, use the --local option.", c.cloudName)
 	}
@@ -112,7 +112,7 @@ func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
 	if err := c.store.UpdateCredential(c.cloudName, cloud.CloudCredential{}); err != nil {
 		return errors.Annotatef(err, "cannot remove credential from local cache")
 	}
-	if c.controllerName == "" {
+	if c.ControllerName == "" {
 		return nil
 	}
 

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -305,12 +305,10 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		newCloud, err = c.readCloudFromFile(ctxt)
 	} else {
 		if c.Cloud != "" {
-			// It's possible that the user wants to add an existing local client to a current controller,
+			// It's possible that the user wants to add an existing local cloud to a current controller,
 			// i.e. 'juju add-cloud aws'. So let's see if we can find the cloud.
 			newCloud, err = common.CloudByName(c.Cloud)
-			if err == nil {
-				c.existsLocally = newCloud.Name != ""
-			}
+			c.existsLocally = err == nil
 		}
 		if !c.existsLocally {
 			newCloud, err = c.runInteractive(ctxt)
@@ -393,11 +391,11 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	// Add a credential for the newly added cloud.
 	err = c.addCredentialToController(ctxt, *newCloud, api)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Warningf("%v", err)
 		ctxt.Infof("To upload credentials to the controller for cloud %q, use \n"+
 			"* 'add-model' with --credential option or\n"+
 			"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
-		return cmd.ErrSilent
+		return returnErr
 	}
 	ctxt.Infof("Credentials for cloud %q added to controller %q.", c.Cloud, c.ControllerName)
 	return returnErr

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -336,14 +336,14 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		} else {
 			ctxt.Infof("Cloud %q successfully %v to your local client.", newCloud.Name, operation)
 			if len(newCloud.AuthTypes) != 0 {
-				ctxt.Infof("You will need to add credentials for this cloud (`juju add-credential %s`)", newCloud.Name)
-				ctxt.Infof("before you can use it in creating either a controller (`juju bootstrap %s`) or", newCloud.Name)
-				ctxt.Infof("a model (`juju add-model <your model name> %s`).", newCloud.Name)
+				ctxt.Infof("You will need to add a credential for this cloud (`juju add-credential %s`)", newCloud.Name)
+				ctxt.Infof("before you can use it to bootstrap a controller (`juju bootstrap %s`) or", newCloud.Name)
+				ctxt.Infof("to create a model (`juju add-model <your model name> %s`).", newCloud.Name)
 			}
 		}
 	}
 	if !c.Replace && c.existsLocally {
-		returnErr = errors.AlreadyExistsf("use `update-cloud %s --local` to override known definition: %q", newCloud.Name, newCloud.Name)
+		returnErr = errors.AlreadyExistsf("use `update-cloud %s --local` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
 	}
 	if c.Local {
 		return returnErr
@@ -359,7 +359,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		}
 	}
 	if c.ControllerName == "" {
-		ctxt.Infof("There are no controllers specified - not adding cloud %q remotely.", newCloud.Name)
+		ctxt.Infof("There are no controllers specified - not adding cloud %q to any controller.", newCloud.Name)
 		return returnErr
 	}
 
@@ -374,7 +374,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		if params.ErrCode(err) == params.CodeAlreadyExists {
 			ctxt.Infof("Cloud %q already exists on the controller %q.", c.Cloud, c.ControllerName)
-			ctxt.Infof("To upload credentials to the controller for cloud %q, use \n"+
+			ctxt.Infof("To upload a credential to the controller for cloud %q, use \n"+
 				"* 'add-model' with --credential option or\n"+
 				"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
 			return returnErr
@@ -392,12 +392,12 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	err = c.addCredentialToController(ctxt, *newCloud, api)
 	if err != nil {
 		logger.Warningf("%v", err)
-		ctxt.Infof("To upload credentials to the controller for cloud %q, use \n"+
+		ctxt.Infof("To upload a credential to the controller for cloud %q, use \n"+
 			"* 'add-model' with --credential option or\n"+
 			"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
 		return returnErr
 	}
-	ctxt.Infof("Credentials for cloud %q added to controller %q.", c.Cloud, c.ControllerName)
+	ctxt.Infof("Credential for cloud %q added to controller %q.", c.Cloud, c.ControllerName)
 	return returnErr
 }
 

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -173,6 +172,9 @@ type AddCloudCommand struct {
 
 	// Force holds whether user wants to force addition of the cloud.
 	Force bool
+
+	// existsLocally whether this cloud already exists locally.
+	existsLocally bool
 }
 
 // NewAddCloudCommand returns a command to add cloud information.
@@ -181,8 +183,7 @@ func NewAddCloudCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &AddCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store:       store,
-			EnabledFlag: feature.MultiCloud,
+			Store: store,
 		},
 		cloudMetadataStore: cloudMetadataStore,
 		CloudCallCtx:       cloudCallCtx,
@@ -197,7 +198,7 @@ func NewAddCloudCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 }
 
 func (c *AddCloudCommand) cloudAPI() (AddCloudAPI, error) {
-	root, err := c.NewAPIRoot(c.Store, c.controllerName, "")
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -240,10 +241,6 @@ func (c *AddCloudCommand) Init(args []string) (err error) {
 	if len(args) > 2 {
 		return cmd.CheckEmpty(args[2:])
 	}
-	c.controllerName, err = c.ControllerNameFromArg()
-	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
-		return errors.Trace(err)
-	}
 	return nil
 }
 
@@ -269,12 +266,12 @@ func (c *AddCloudCommand) findLocalCredential(ctx *cmd.Context, cloud jujucloud.
 }
 
 func (c *AddCloudCommand) addCredentialToController(ctx *cmd.Context, cloud jujucloud.Cloud, apiClient AddCloudAPI) error {
-	_, err := c.Store.ControllerByName(c.controllerName)
+	_, err := c.Store.ControllerByName(c.ControllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	currentAccountDetails, err := c.Store.AccountDetails(c.controllerName)
+	currentAccountDetails, err := c.Store.AccountDetails(c.ControllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -302,29 +299,70 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.Replace {
 		ctxt.Warningf("'add-cloud --replace' is deprecated. Use 'update-cloud' instead.")
 	}
-	if c.CloudFile == "" && c.controllerName == "" {
-		return c.runInteractive(ctxt)
-	}
-
 	var newCloud *jujucloud.Cloud
 	var err error
 	if c.CloudFile != "" {
 		newCloud, err = c.readCloudFromFile(ctxt)
 	} else {
-		// No cloud file specified so we try and use a named
-		// cloud that already has been added to the local cache.
-		newCloud, err = cloudFromLocal(c.Store, c.Cloud)
+		if c.Cloud != "" {
+			// It's possible that the user wants to add an existing local client to a current controller,
+			// i.e. 'juju add-cloud aws'. So let's see if we can find the cloud.
+			newCloud, err = common.CloudByName(c.Cloud)
+			if err == nil {
+				c.existsLocally = newCloud.Name != ""
+			}
+		}
+		if !c.existsLocally {
+			newCloud, err = c.runInteractive(ctxt)
+		}
 	}
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	if c.controllerName == "" {
-		if !c.Local {
-			ctxt.Infof(
-				"There are no controllers running.\nAdding cloud to local cache so you can use it to bootstrap a controller.\n")
+	// All clouds must have at least one default region - lp#1819409.
+	if len(newCloud.Regions) == 0 {
+		newCloud.Regions = []jujucloud.Region{{Name: "default"}}
+	}
+
+	var returnErr error
+	if c.Replace || !c.existsLocally {
+		operation := "added"
+		if c.Replace {
+			operation = "updated"
 		}
-		return addLocalCloud(c.cloudMetadataStore, *newCloud)
+		err = addLocalCloud(c.cloudMetadataStore, *newCloud)
+		if err != nil {
+			ctxt.Infof("Cloud %q was not %v locally: %v", newCloud.Name, operation, err)
+			returnErr = cmd.ErrSilent
+		} else {
+			ctxt.Infof("Cloud %q successfully %v to your local client.", newCloud.Name, operation)
+			if len(newCloud.AuthTypes) != 0 {
+				ctxt.Infof("You will need to add credentials for this cloud (`juju add-credential %s`)", newCloud.Name)
+				ctxt.Infof("before you can use it in creating either a controller (`juju bootstrap %s`) or", newCloud.Name)
+				ctxt.Infof("a model (`juju add-model <your model name> %s`).", newCloud.Name)
+			}
+		}
+	}
+	if !c.Replace && c.existsLocally {
+		returnErr = errors.AlreadyExistsf("use `update-cloud %s --local` to override known definition: %q", newCloud.Name, newCloud.Name)
+	}
+	if c.Local {
+		return returnErr
+	}
+	ctxt.Infof("")
+
+	// At this stage, the user may have specified the controller via a --controller option.
+	// If not, let's see if there is a current controller that can be detected.
+	if c.ControllerName == "" {
+		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("add cloud %q to", newCloud.Name))
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if c.ControllerName == "" {
+		ctxt.Infof("There are no controllers specified - not adding cloud %q remotely.", newCloud.Name)
+		return returnErr
 	}
 
 	// A controller has been specified so upload the cloud details
@@ -337,21 +375,21 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	err = api.AddCloud(*newCloud, c.Force)
 	if err != nil {
 		if params.ErrCode(err) == params.CodeAlreadyExists {
-			ctxt.Infof("Cloud %q already exists on the controller %q.", c.Cloud, c.controllerName)
+			ctxt.Infof("Cloud %q already exists on the controller %q.", c.Cloud, c.ControllerName)
 			ctxt.Infof("To upload credentials to the controller for cloud %q, use \n"+
 				"* 'add-model' with --credential option or\n"+
 				"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
-			return nil
+			return returnErr
 		}
 		if params.ErrCode(err) == params.CodeIncompatibleClouds {
 			logger.Infof("%v", err)
 			ctxt.Infof("Adding a cloud of type %q might not function correctly on this controller.\n"+
 				"If you really want to do this, use --force.", newCloud.Type)
-			return nil
+			return returnErr
 		}
 		return err
 	}
-	ctxt.Infof("Cloud %q added to controller %q.", c.Cloud, c.controllerName)
+	ctxt.Infof("Cloud %q added to controller %q.", c.Cloud, c.ControllerName)
 	// Add a credential for the newly added cloud.
 	err = c.addCredentialToController(ctxt, *newCloud, api)
 	if err != nil {
@@ -361,8 +399,8 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 			"* 'add-credential -c %v'.", newCloud.Name, newCloud.Name)
 		return cmd.ErrSilent
 	}
-	ctxt.Infof("Credentials for cloud %q added to controller %q.", c.Cloud, c.controllerName)
-	return nil
+	ctxt.Infof("Credentials for cloud %q added to controller %q.", c.Cloud, c.ControllerName)
+	return returnErr
 }
 
 func cloudFromLocal(store jujuclient.CredentialGetter, cloudName string) (*jujucloud.Cloud, error) {
@@ -400,29 +438,36 @@ func cloudFromLocal(store jujuclient.CredentialGetter, cloudName string) (*jujuc
 }
 
 func (c *AddCloudCommand) readCloudFromFile(ctxt *cmd.Context) (*jujucloud.Cloud, error) {
-	r := cloudFileReader{
+	r := &cloudFileReader{
 		cloudMetadataStore: c.cloudMetadataStore,
+		cloudName:          c.Cloud,
 	}
-	return r.readCloudFromFile(c.Cloud, c.CloudFile, ctxt, c.Replace)
+	newCloud, err := r.readCloudFromFile(c.CloudFile, ctxt)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.Cloud = r.cloudName
+	c.existsLocally = r.alreadyExists
+	return newCloud, nil
 }
 
-func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
+func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) (*jujucloud.Cloud, error) {
 	errout := interact.NewErrWriter(ctxt.Stdout)
 	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, errout)
 
 	cloudType, err := queryCloudType(pollster)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	name, err := queryName(c.cloudMetadataStore, c.Cloud, cloudType, pollster)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	provider, err := environs.Provider(cloudType)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	// At this stage, since we do not have a reference to any model, nor can we get it,
@@ -459,18 +504,18 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
 
 	v, err := pollster.QuerySchema(provider.CloudSchema())
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	b, err := yaml.Marshal(v)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	filename, alt, err := addCertificate(b)
 	switch {
 	case errors.IsNotFound(err):
 	case err != nil:
-		return errors.Annotate(err, "CA Certificate")
+		return nil, errors.Annotate(err, "CA Certificate")
 	default:
 		ctxt.Infof("Successfully read CA Certificate from %s", filename)
 		b = alt
@@ -478,20 +523,11 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) error {
 
 	newCloud, err := c.cloudMetadataStore.ParseOneCloud(b)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	newCloud.Name = name
 	newCloud.Type = cloudType
-	if err := addLocalCloud(c.cloudMetadataStore, newCloud); err != nil {
-		return errors.Trace(err)
-	}
-	ctxt.Infof("Cloud %q successfully added", name)
-	if len(newCloud.AuthTypes) != 0 {
-		ctxt.Infof("")
-		ctxt.Infof("You will need to add credentials for this cloud (`juju add-credential %s`)", name)
-		ctxt.Infof("before creating a controller (`juju bootstrap %s`).", name)
-	}
-	return nil
+	return &newCloud, nil
 }
 
 // addCertificate reads the cloud certificate file if available and adds the contents
@@ -666,19 +702,39 @@ func addLocalCloud(cloudMetadataStore PersonalCloudMetadataStore, newCloud jujuc
 
 type cloudFileReader struct {
 	cloudMetadataStore CloudMetadataStore
+	cloudName          string
+	alreadyExists      bool
 }
 
-func (p cloudFileReader) readCloudFromFile(cloud, cloudFile string, ctxt *cmd.Context, ignoreExisting bool) (*jujucloud.Cloud, error) {
+func (p *cloudFileReader) readCloudFromFile(cloudFile string, ctxt *cmd.Context) (*jujucloud.Cloud, error) {
 	specifiedClouds, err := p.cloudMetadataStore.ParseCloudMetadataFile(cloudFile)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if specifiedClouds == nil {
+	if len(specifiedClouds) == 0 {
 		return nil, errors.New("no personal clouds are defined")
 	}
-	newCloud, ok := specifiedClouds[cloud]
-	if !ok {
-		return nil, errors.Errorf("cloud %q not found in file %q", cloud, cloudFile)
+
+	var newCloud jujucloud.Cloud
+	if p.cloudName == "" {
+		if len(specifiedClouds) == 1 {
+			for k, v := range specifiedClouds {
+				newCloud = v
+				// User did not specify cloud name aka as a command argument,
+				// use what is in th file.
+				p.cloudName = k
+			}
+		} else {
+			if p.cloudName == "" {
+				return nil, errors.Errorf("there is more than one cloud defined in file %q, specify a cloud name to select one", cloudFile)
+			}
+		}
+	} else {
+		var ok bool
+		newCloud, ok = specifiedClouds[p.cloudName]
+		if !ok {
+			return nil, errors.Errorf("cloud %q not found in file %q", p.cloudName, cloudFile)
+		}
 	}
 
 	// first validate cloud input
@@ -701,14 +757,16 @@ func (p cloudFileReader) readCloudFromFile(cloud, cloudFile string, ctxt *cmd.Co
 			return nil, errors.NotSupportedf("auth type %q", authType)
 		}
 	}
-	if !ignoreExisting {
-		if err := p.verifyName(cloud); err != nil {
+	if err := p.verifyName(p.cloudName); err != nil {
+		if !errors.IsAlreadyExists(err) {
 			return nil, errors.Trace(err)
 		}
+		p.alreadyExists = true
 	}
 	return &newCloud, nil
 }
-func (p cloudFileReader) verifyName(name string) error {
+
+func (p *cloudFileReader) verifyName(name string) error {
 	public, _, err := p.cloudMetadataStore.PublicCloudMetadata()
 	if err != nil {
 		return err
@@ -718,14 +776,14 @@ func (p cloudFileReader) verifyName(name string) error {
 		return err
 	}
 	if _, ok := personal[name]; ok {
-		return errors.Errorf("%q already exists; use `update-cloud` to replace this existing cloud", name)
+		return errors.AlreadyExistsf("use `update-cloud %s --local` to replace this cloud locally: %q", name, name)
 	}
 	msg, err := nameExists(name, public)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if msg != "" {
-		return errors.Errorf(msg + "; use `update-cloud` to override this definition")
+		return errors.AlreadyExistsf(msg + "; use `update-cloud --local` to override this definition locally")
 	}
 	return nil
 }

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -41,10 +41,9 @@ var _ = gc.Suite(&addSuite{})
 
 func (s *addSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	store := jujuclient.NewMemStore()
-	store.Controllers["mycontroller"] = jujuclient.ControllerDetails{}
-	store.CurrentControllerName = "mycontroller"
-	s.store = store
+	s.store = jujuclient.NewMemStore()
+	s.store.Controllers["mycontroller"] = jujuclient.ControllerDetails{}
+	s.store.CurrentControllerName = "mycontroller"
 	s.addCloudF = func(cloud jujucloud.Cloud, force bool) error { return nil }
 }
 
@@ -141,6 +140,17 @@ var (
             auth-types: [oauth1]
             endpoint: "http://garagemaas"`
 
+	manyCloudsYamlFile = `
+        clouds:
+          garage-maas:
+            type: maas
+            auth-types: [oauth1]
+            endpoint: "http://garagemaas"
+          home-garage-maas:
+            type: maas
+            auth-types: [oauth1]
+            endpoint: "http://garagemaas"`
+
 	garageMAASCloud = jujucloud.Cloud{
 		Name:      "garage-maas",
 		Type:      "maas",
@@ -172,7 +182,7 @@ func (*addSuite) TestAddBadFilename(c *gc.C) {
 
 func (s *addSuite) TestAddBadCloudName(c *gc.C) {
 	fake := newFakeCloudMetadataStore()
-	fake.Call("ParseCloudMetadataFile", "testFile").Returns(map[string]jujucloud.Cloud{}, nil)
+	fake.Call("ParseCloudMetadataFile", "testFile").Returns(map[string]jujucloud.Cloud{"notcloud": {}}, nil)
 
 	_, err := s.runCommand(c, fake, "cloud", "testFile")
 	c.Assert(err, gc.ErrorMatches, `cloud "cloud" not found in file .*`)
@@ -187,6 +197,7 @@ func (s *addSuite) TestAddInvalidCloudName(c *gc.C) {
 }
 
 func (s *addSuite) TestAddExisting(c *gc.C) {
+	s.store.CurrentControllerName = ""
 	fake := newFakeCloudMetadataStore()
 
 	cloudFile := prepareTestCloudYaml(c, homeStackYamlFile)
@@ -201,7 +212,7 @@ func (s *addSuite) TestAddExisting(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(mockCloud, nil)
 
 	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "\"homestack\" already exists; use `update-cloud` to replace this existing cloud")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud homestack --local` to override known definition: \"homestack\" already exists")
 }
 
 func (s *addSuite) TestAddExistingReplace(c *gc.C) {
@@ -216,6 +227,7 @@ func (s *addSuite) TestAddExistingReplace(c *gc.C) {
 
 	fake.Call("ParseCloudMetadataFile", cloudFile.Name()).Returns(mockCloud, nil)
 	fake.Call("PersonalCloudMetadata").Returns(mockCloud, nil)
+	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
 
 	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name(), "--replace", "--local")
@@ -225,6 +237,7 @@ func (s *addSuite) TestAddExistingReplace(c *gc.C) {
 }
 
 func (s *addSuite) TestAddExistingPublic(c *gc.C) {
+	s.store.CurrentControllerName = ""
 	cloudFile := prepareTestCloudYaml(c, awsYamlFile)
 	defer cloudFile.Close()
 	defer os.Remove(cloudFile.Name())
@@ -238,10 +251,11 @@ func (s *addSuite) TestAddExistingPublic(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "aws", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "\"aws\" is the name of a public cloud; use `update-cloud` to override this definition")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud aws --local` to override known definition: \"aws\" already exists")
 }
 
 func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
+	s.store.CurrentControllerName = ""
 	cloudFile := prepareTestCloudYaml(c, localhostYamlFile)
 	defer cloudFile.Close()
 	defer os.Remove(cloudFile.Name())
@@ -255,7 +269,7 @@ func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "localhost", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "\"localhost\" is the name of a built-in cloud; use `update-cloud` to override this definition")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud localhost --local` to override known definition: \"localhost\" already exists")
 }
 
 func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {
@@ -274,8 +288,17 @@ func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {
 
 	_, err = s.runCommand(c, fake, "aws", cloudFile.Name(), "--replace", "--local")
 	c.Assert(err, jc.ErrorIsNil)
-
 	c.Check(writeCall(), gc.Equals, 1)
+}
+
+func addDefaultRegion(in map[string]jujucloud.Cloud) map[string]jujucloud.Cloud {
+	for k, v := range in {
+		if len(v.Regions) == 0 {
+			v.Regions = []jujucloud.Region{{Name: "default"}}
+			in[k] = v
+		}
+	}
+	return in
 }
 
 func (s *addSuite) TestAddNew(c *gc.C) {
@@ -285,12 +308,15 @@ func (s *addSuite) TestAddNew(c *gc.C) {
 
 	mockCloud, err := jujucloud.ParseCloudMetadataFile(cloudFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mockCloud["garage-maas"].Regions, gc.HasLen, 0)
 
 	fake := newFakeCloudMetadataStore()
 	fake.Call("ParseCloudMetadataFile", cloudFile.Name()).Returns(mockCloud, nil)
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
+
+	// but here mockCloud should have a region attached...
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
 	_, err = s.runCommand(c, fake, "garage-maas", cloudFile.Name(), "--local")
 	c.Assert(err, jc.ErrorIsNil)
@@ -310,14 +336,17 @@ func (s *addSuite) TestAddLocalDefault(c *gc.C) {
 	fake.Call("ParseCloudMetadataFile", cloudFile.Name()).Returns(mockCloud, nil)
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
 	ctx, err := s.runCommand(c, fake, "garage-maas", cloudFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(numCallsToWrite(), gc.Equals, 1)
-	out := cmdtesting.Stderr(ctx)
-	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `There are no controllers running.Adding cloud to local cache so you can use it to bootstrap a controller.*`)
+	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
+		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
+		"a model (`juju add-model <your model name> garage-maas`).\n"+
+		"\n"+
+		"There are no controllers specified - not adding cloud \"garage-maas\" remotely.\n")
 }
 
 func (s *addSuite) TestAddNewInvalidAuthType(c *gc.C) {
@@ -362,10 +391,13 @@ func (api *fakeAddCloudAPI) AddCredential(tag string, credential jujucloud.Crede
 	return nil
 }
 
-func (s *addSuite) setupControllerCloudScenario(c *gc.C) (
+func (s *addSuite) setupControllerCloudScenarioWithClientAndFile(c *gc.C,
+	clientF func() (cloud.AddCloudAPI, error),
+	api *fakeAddCloudAPI,
+	cloudsFile string) (
 	string, *cloud.AddCloudCommand, *jujuclient.MemStore, *fakeAddCloudAPI, jujucloud.Credential, func() int,
 ) {
-	cloudfile := prepareTestCloudYaml(c, garageMaasYamlFile)
+	cloudfile := prepareTestCloudYaml(c, cloudsFile)
 	s.AddCleanup(func(_ *gc.C) {
 		defer cloudfile.Close()
 		defer os.Remove(cloudfile.Name())
@@ -378,7 +410,7 @@ func (s *addSuite) setupControllerCloudScenario(c *gc.C) (
 	fake.Call("ParseCloudMetadataFile", cloudfile.Name()).Returns(mockCloud, nil)
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
-	callCounter := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
+	callCounter := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
 	store := jujuclient.NewMemStore()
 	store.Controllers["mycontroller"] = jujuclient.ControllerDetails{}
@@ -390,20 +422,36 @@ func (s *addSuite) setupControllerCloudScenario(c *gc.C) (
 	store.Credentials["garage-maas"] = jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{"default": cred},
 	}
+	command := cloud.NewAddCloudCommandForTest(fake, store, clientF)
+	return cloudfile.Name(), command, store, api, cred, callCounter
+}
 
+func (s *addSuite) setupControllerCloudScenarioWithClient(c *gc.C,
+	clientF func() (cloud.AddCloudAPI, error),
+	api *fakeAddCloudAPI) (string, *cloud.AddCloudCommand, *jujuclient.MemStore, *fakeAddCloudAPI, jujucloud.Credential, func() int) {
+	return s.setupControllerCloudScenarioWithClientAndFile(c, clientF, api, garageMaasYamlFile)
+}
+
+func (s *addSuite) setupControllerCloudScenario(c *gc.C) (string, *cloud.AddCloudCommand, *jujuclient.MemStore, *fakeAddCloudAPI, jujucloud.Credential, func() int) {
+	return s.setupControllerCloudScenarioWithFile(c, garageMaasYamlFile)
+}
+
+func (s *addSuite) setupControllerCloudScenarioWithFile(c *gc.C, cloudsFile string) (string, *cloud.AddCloudCommand, *jujuclient.MemStore, *fakeAddCloudAPI, jujucloud.Credential, func() int) {
 	api := &fakeAddCloudAPI{
 		Stub:      jujutesting.Stub{},
 		addCloudF: s.addCloudF,
 	}
-	command := cloud.NewAddCloudCommandForTest(fake, store, func() (cloud.AddCloudAPI, error) {
-		return api, nil
-	})
-	return cloudfile.Name(), command, store, api, cred, callCounter
+	return s.setupControllerCloudScenarioWithClientAndFile(c,
+		func() (cloud.AddCloudAPI, error) {
+			return api, nil
+		},
+		api,
+		cloudsFile)
 }
 
 func (s *addSuite) asssertAddToController(c *gc.C, force bool) {
 	cloudFileName, command, _, api, cred, _ := s.setupControllerCloudScenario(c)
-	args := []string{"garage-maas", cloudFileName}
+	args := []string{"garage-maas", cloudFileName, "--skipPrompt"}
 	if force {
 		args = append(args, "--force")
 	}
@@ -417,12 +465,17 @@ func (s *addSuite) asssertAddToController(c *gc.C, force bool) {
 			Description: "Metal As A Service",
 			AuthTypes:   jujucloud.AuthTypes{"oauth1"},
 			Endpoint:    "http://garagemaas",
+			Regions:     []jujucloud.Region{{Name: "default"}},
 		},
 		force)
 	api.CheckCall(c, 1, "AddCredential", "cloudcred-garage-maas_fred_default", cred)
-	out := cmdtesting.Stderr(ctx)
-	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `Cloud "garage-maas" added to controller "mycontroller".Credentials for cloud "garage-maas" added to controller "mycontroller".`)
+	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
+		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
+		"a model (`juju add-model <your model name> garage-maas`).\n\n"+
+		"Cloud \"garage-maas\" added to controller \"mycontroller\".\n"+
+		"Credentials for cloud \"garage-maas\" added to controller \"mycontroller\".\n")
+
 }
 
 func (s *addSuite) TestAddToController(c *gc.C) {
@@ -434,7 +487,7 @@ func (s *addSuite) TestAddToControllerIncompatibleCloud(c *gc.C) {
 		return params.Error{Code: params.CodeIncompatibleClouds}
 	}
 	cloudFileName, command, _, api, _, _ := s.setupControllerCloudScenario(c)
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName)
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "--skipPrompt")
 	c.Assert(err, jc.ErrorIsNil)
 	api.CheckCallNames(c, "AddCloud", "Close")
 	api.CheckCall(c, 0, "AddCloud",
@@ -444,11 +497,12 @@ func (s *addSuite) TestAddToControllerIncompatibleCloud(c *gc.C) {
 			Description: "Metal As A Service",
 			AuthTypes:   jujucloud.AuthTypes{"oauth1"},
 			Endpoint:    "http://garagemaas",
+			Regions:     []jujucloud.Region{{Name: "default"}},
 		},
 		false)
 	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `Adding a cloud of type "maas" might not function correctly on this controller.If you really want to do this, use --force.`)
+	c.Assert(out, jc.Contains, `Adding a cloud of type "maas" might not function correctly on this controller.If you really want to do this, use --force.`)
 }
 
 func (s *addSuite) TestForceAddToController(c *gc.C) {
@@ -466,28 +520,48 @@ func (s *addSuite) TestAddLocal(c *gc.C) {
 	c.Check(numCalls(), gc.Equals, 1)
 }
 
+func (s *addSuite) TestAddLocalNoCloudName(c *gc.C) {
+	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenario(c)
+	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--local")
+	c.Assert(err, jc.ErrorIsNil)
+	api.CheckNoCalls(c)
+	c.Check(numCalls(), gc.Equals, 1)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
+		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
+		"a model (`juju add-model <your model name> garage-maas`).\n")
+}
+
+func (s *addSuite) TestAddLocalNoCloudNameButManyCloudsInFile(c *gc.C) {
+	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenarioWithFile(c, manyCloudsYamlFile)
+	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--local")
+	c.Assert(err.Error(), jc.Contains, "there is more than one cloud defined in file")
+	api.CheckNoCalls(c)
+	c.Check(numCalls(), gc.Equals, 0)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+}
+
 func (s *addSuite) TestAddToControllerBadController(c *gc.C) {
-	cloudFileName, command, store, _, _, _ := s.setupControllerCloudScenario(c)
+	cloudFileName, command, store, _, _, _ := s.setupControllerCloudScenarioWithClient(c, func() (cloud.AddCloudAPI, error) {
+		return nil, errors.NotFoundf("controller badcontroller")
+	}, nil)
 	store.Credentials = nil
 
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "badcontroller")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-Cloud "garage-maas" added to controller "badcontroller".
-To upload credentials to the controller for cloud "garage-maas", use 
-* 'add-model' with --credential option or
-* 'add-credential -c garage-maas'.
-`[1:])
-	c.Assert(c.GetTestLog(), jc.Contains, "controller badcontroller not found")
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "badcontroller", "--skipPrompt")
+	c.Assert(err, gc.ErrorMatches, "controller badcontroller not found")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
+		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
+		"a model (`juju add-model <your model name> garage-maas`).\n\n")
 }
 
 func (s *addSuite) TestAddToControllerMissingCredential(c *gc.C) {
 	cloudFileName, command, store, _, _, _ := s.setupControllerCloudScenario(c)
 	store.Credentials = nil
 
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller")
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--skipPrompt")
 	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
 Cloud "garage-maas" added to controller "mycontroller".
 To upload credentials to the controller for cloud "garage-maas", use 
 * 'add-model' with --credential option or
@@ -500,14 +574,17 @@ func (s *addSuite) TestAddToControllerAmbiguousCredential(c *gc.C) {
 	cloudFileName, command, store, _, cred, _ := s.setupControllerCloudScenario(c)
 	store.Credentials["garage-maas"].AuthCredentials["another"] = cred
 
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller")
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--skipPrompt")
 	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-Cloud "garage-maas" added to controller "mycontroller".
-To upload credentials to the controller for cloud "garage-maas", use 
-* 'add-model' with --credential option or
-* 'add-credential -c garage-maas'.
-`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
+		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
+		"a model (`juju add-model <your model name> garage-maas`).\n"+
+		"\n"+
+		"Cloud \"garage-maas\" added to controller \"mycontroller\".\n"+
+		"To upload credentials to the controller for cloud \"garage-maas\", use \n"+
+		"* 'add-model' with --credential option or\n"+
+		"* 'add-credential -c garage-maas'.\n")
 	c.Assert(c.GetTestLog(), jc.Contains, `more than one credential is available`)
 }
 
@@ -551,7 +628,7 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 	m1Cloud := garageMAASCloud
 	m1Cloud.Name = "m1"
 	m1Metadata := map[string]jujucloud.Cloud{"m1": m1Cloud}
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(m1Metadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	err := cmdtesting.InitCommand(command, []string{"--local"})
@@ -572,9 +649,10 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(numCallsToWrite(), gc.Equals, 1)
-	c.Assert(out.String(), gc.Equals, "Cloud \"m1\" successfully added\n\n"+
+	c.Assert(out.String(), gc.Equals, "Cloud \"m1\" successfully added to your local client.\n"+
 		"You will need to add credentials for this cloud (`juju add-credential m1`)\n"+
-		"before creating a controller (`juju bootstrap m1`).\n")
+		"before you can use it in creating either a controller (`juju bootstrap m1`) or\n"+
+		"a model (`juju add-model <your model name> m1`).\n")
 }
 
 func (*addSuite) TestInteractiveManual(c *gc.C) {
@@ -589,7 +667,7 @@ func (*addSuite) TestInteractiveManual(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 	fake.Call("ParseOneCloud", []byte("endpoint: 192.168.1.6\n")).Returns(manCloud, nil)
 	manMetadata := map[string]jujucloud.Cloud{"man": manCloud}
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", manMetadata).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	err := cmdtesting.InitCommand(command, []string{"--local"})
@@ -623,7 +701,7 @@ Select cloud type:
 Enter a name for your manual cloud: 
 Enter the ssh connection string for controller, username@<hostname or IP> or <hostname or IP>: 
 `[1:])
-	c.Assert(errOut.String(), gc.Equals, "Cloud \"man\" successfully added\n")
+	c.Assert(errOut.String(), gc.Equals, "Cloud \"man\" successfully added to your local client.\n")
 }
 
 func (*addSuite) TestInteractiveManualInvalidName(c *gc.C) {
@@ -634,7 +712,7 @@ func (*addSuite) TestInteractiveManualInvalidName(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 	fake.Call("ParseOneCloud", []byte("endpoint: 192.168.1.6\n")).Returns(manCloud, nil)
 	manMetadata := map[string]jujucloud.Cloud{"man": manCloud}
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", manMetadata).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	err := cmdtesting.InitCommand(command, []string{"--local"})
@@ -683,7 +761,7 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 		"  foo: {}\n"
 	fake.Call("ParseOneCloud", []byte(expectedYAMLarg)).Returns(vsphereCloud, nil)
 	vsphereMetadata := map[string]jujucloud.Cloud{"mvs": vsphereCloud}
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", vsphereMetadata).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(vsphereMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	err := cmdtesting.InitCommand(command, []string{"--local"})
@@ -728,7 +806,7 @@ func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(homestackMetadata(), nil)
 	manMetadata := map[string]jujucloud.Cloud{"homestack": manualCloud}
 	fake.Call("ParseOneCloud", []byte("endpoint: 192.168.1.6\n")).Returns(manualCloud, nil)
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", manMetadata).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	err := cmdtesting.InitCommand(command, []string{"--local"})
@@ -765,7 +843,7 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 		"homestack":  homestackCloud,
 		"homestack2": homestack2Cloud,
 	}
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", compoundCloudMetadata).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(compoundCloudMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	err := cmdtesting.InitCommand(command, []string{"--local"})
@@ -789,6 +867,17 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(numCallsToWrite(), gc.Equals, 1)
+	c.Check(out.String(), gc.Matches, regexp.QuoteMeta("Cloud Types\n"+
+		"  lxd\n"+
+		"  maas\n"+
+		"  manual\n"+
+		"  openstack\n"+
+		"  vsphere\n\n"+
+		"Select cloud type: \n"+
+		"Enter a name for your manual cloud: \n"+
+		"A cloud named \"homestack\" already exists. Do you want to replace that definition? (y/N): \n"+
+		"Enter a name for your manual cloud: \n"+
+		"Enter the ssh connection string for controller, username@<hostname or IP> or <hostname or IP>: \n"))
 }
 
 func (s *addSuite) TestInteractiveAddCloud_PromptForNameIsCorrect(c *gc.C) {
@@ -855,7 +944,7 @@ clouds:
 	fake.Call("ParseCloudMetadataFile", cloudFile.Name()).Returns(mockCloud, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
-	fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
+	fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
 	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--local")
 	c.Check(err, jc.ErrorIsNil)
@@ -882,7 +971,7 @@ clouds:
 	fake.Call("ParseCloudMetadataFile", cloudFile.Name()).Returns(mockCloud, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
-	fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
+	fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
 	var logWriter loggo.TestWriter
 	writerName := "add_cloud_tests_writer"
@@ -929,7 +1018,7 @@ func (s *addSuite) TestInvalidCredentialMessage(c *gc.C) {
 	m1Cloud := garageMAASCloud
 	m1Cloud.Name = "m1"
 	m1Metadata := map[string]jujucloud.Cloud{"m1": m1Cloud}
-	fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
+	fake.Call("WritePersonalCloudMetadata", addDefaultRegion(m1Metadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	command.Ping = func(environs.EnvironProvider, string) error {
@@ -1129,7 +1218,7 @@ func testInteractiveOpenstack(c *gc.C, myOpenstack jujucloud.Cloud, expectedYAML
 
 	fake.Call("ParseOneCloud", []byte(expectedYAMLarg)).Returns(myOpenstack, nil)
 	m1Metadata := map[string]jujucloud.Cloud{"os1": myOpenstack}
-	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", m1Metadata).Returns(nil)
+	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(m1Metadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
 	err := cmdtesting.InitCommand(command, []string{"--local"})
@@ -1146,10 +1235,10 @@ func testInteractiveOpenstack(c *gc.C, myOpenstack jujucloud.Cloud, expectedYAML
 
 	c.Check(err, jc.ErrorIsNil)
 	var output = addStdErrMsg +
-		"Cloud \"os1\" successfully added\n" +
-		"\n" +
+		"Cloud \"os1\" successfully added to your local client.\n" +
 		"You will need to add credentials for this cloud (`juju add-credential os1`)\n" +
-		"before creating a controller (`juju bootstrap os1`).\n"
+		"before you can use it in creating either a controller (`juju bootstrap os1`) or\n" +
+		"a model (`juju add-model <your model name> os1`).\n"
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, output)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, stdOutMsg)
 

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -451,7 +451,7 @@ func (s *addSuite) setupControllerCloudScenarioWithFile(c *gc.C, cloudsFile stri
 
 func (s *addSuite) asssertAddToController(c *gc.C, force bool) {
 	cloudFileName, command, _, api, cred, _ := s.setupControllerCloudScenario(c)
-	args := []string{"garage-maas", cloudFileName, "--skipPrompt"}
+	args := []string{"garage-maas", cloudFileName, "--no-prompt"}
 	if force {
 		args = append(args, "--force")
 	}
@@ -487,7 +487,7 @@ func (s *addSuite) TestAddToControllerIncompatibleCloud(c *gc.C) {
 		return params.Error{Code: params.CodeIncompatibleClouds}
 	}
 	cloudFileName, command, _, api, _, _ := s.setupControllerCloudScenario(c)
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "--skipPrompt")
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	api.CheckCallNames(c, "AddCloud", "Close")
 	api.CheckCall(c, 0, "AddCloud",
@@ -547,7 +547,7 @@ func (s *addSuite) TestAddToControllerBadController(c *gc.C) {
 	}, nil)
 	store.Credentials = nil
 
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "badcontroller", "--skipPrompt")
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "badcontroller", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, "controller badcontroller not found")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
 		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+
@@ -559,7 +559,7 @@ func (s *addSuite) TestAddToControllerMissingCredential(c *gc.C) {
 	cloudFileName, command, store, _, _, _ := s.setupControllerCloudScenario(c)
 	store.Credentials = nil
 
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--skipPrompt")
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
 Cloud "garage-maas" added to controller "mycontroller".
@@ -574,7 +574,7 @@ func (s *addSuite) TestAddToControllerAmbiguousCredential(c *gc.C) {
 	cloudFileName, command, store, _, cred, _ := s.setupControllerCloudScenario(c)
 	store.Credentials["garage-maas"].AuthCredentials["another"] = cred
 
-	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--skipPrompt")
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
 		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -212,7 +212,7 @@ func (s *addSuite) TestAddExisting(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(mockCloud, nil)
 
 	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud homestack --local` to override known definition: \"homestack\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud homestack --local` to override known definition: local cloud \"homestack\" already exists")
 }
 
 func (s *addSuite) TestAddExistingReplace(c *gc.C) {
@@ -251,7 +251,7 @@ func (s *addSuite) TestAddExistingPublic(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "aws", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud aws --local` to override known definition: \"aws\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud aws --local` to override known definition: local cloud \"aws\" already exists")
 }
 
 func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
@@ -269,7 +269,7 @@ func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "localhost", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud localhost --local` to override known definition: \"localhost\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud localhost --local` to override known definition: local cloud \"localhost\" already exists")
 }
 
 func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {
@@ -342,11 +342,11 @@ func (s *addSuite) TestAddLocalDefault(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(numCallsToWrite(), gc.Equals, 1)
 	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
-		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
-		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
-		"a model (`juju add-model <your model name> garage-maas`).\n"+
+		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it to bootstrap a controller (`juju bootstrap garage-maas`) or\n"+
+		"to create a model (`juju add-model <your model name> garage-maas`).\n"+
 		"\n"+
-		"There are no controllers specified - not adding cloud \"garage-maas\" remotely.\n")
+		"There are no controllers specified - not adding cloud \"garage-maas\" to any controller.\n")
 }
 
 func (s *addSuite) TestAddNewInvalidAuthType(c *gc.C) {
@@ -470,11 +470,11 @@ func (s *addSuite) asssertAddToController(c *gc.C, force bool) {
 		force)
 	api.CheckCall(c, 1, "AddCredential", "cloudcred-garage-maas_fred_default", cred)
 	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
-		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
-		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
-		"a model (`juju add-model <your model name> garage-maas`).\n\n"+
+		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it to bootstrap a controller (`juju bootstrap garage-maas`) or\n"+
+		"to create a model (`juju add-model <your model name> garage-maas`).\n\n"+
 		"Cloud \"garage-maas\" added to controller \"mycontroller\".\n"+
-		"Credentials for cloud \"garage-maas\" added to controller \"mycontroller\".\n")
+		"Credential for cloud \"garage-maas\" added to controller \"mycontroller\".\n")
 
 }
 
@@ -527,9 +527,9 @@ func (s *addSuite) TestAddLocalNoCloudName(c *gc.C) {
 	api.CheckNoCalls(c)
 	c.Check(numCalls(), gc.Equals, 1)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
-		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
-		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
-		"a model (`juju add-model <your model name> garage-maas`).\n")
+		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it to bootstrap a controller (`juju bootstrap garage-maas`) or\n"+
+		"to create a model (`juju add-model <your model name> garage-maas`).\n")
 }
 
 func (s *addSuite) TestAddLocalNoCloudNameButManyCloudsInFile(c *gc.C) {
@@ -550,9 +550,9 @@ func (s *addSuite) TestAddToControllerBadController(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "badcontroller", "--skipPrompt")
 	c.Assert(err, gc.ErrorMatches, "controller badcontroller not found")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
-		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
-		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
-		"a model (`juju add-model <your model name> garage-maas`).\n\n")
+		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it to bootstrap a controller (`juju bootstrap garage-maas`) or\n"+
+		"to create a model (`juju add-model <your model name> garage-maas`).\n\n")
 }
 
 func (s *addSuite) TestAddToControllerMissingCredential(c *gc.C) {
@@ -563,7 +563,7 @@ func (s *addSuite) TestAddToControllerMissingCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
 Cloud "garage-maas" added to controller "mycontroller".
-To upload credentials to the controller for cloud "garage-maas", use 
+To upload a credential to the controller for cloud "garage-maas", use 
 * 'add-model' with --credential option or
 * 'add-credential -c garage-maas'.
 `[1:])
@@ -577,12 +577,12 @@ func (s *addSuite) TestAddToControllerAmbiguousCredential(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--skipPrompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
-		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
-		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+
-		"a model (`juju add-model <your model name> garage-maas`).\n"+
+		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+
+		"before you can use it to bootstrap a controller (`juju bootstrap garage-maas`) or\n"+
+		"to create a model (`juju add-model <your model name> garage-maas`).\n"+
 		"\n"+
 		"Cloud \"garage-maas\" added to controller \"mycontroller\".\n"+
-		"To upload credentials to the controller for cloud \"garage-maas\", use \n"+
+		"To upload a credential to the controller for cloud \"garage-maas\", use \n"+
 		"* 'add-model' with --credential option or\n"+
 		"* 'add-credential -c garage-maas'.\n")
 	c.Assert(c.GetTestLog(), jc.Contains, `more than one credential is available`)
@@ -650,9 +650,9 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 
 	c.Check(numCallsToWrite(), gc.Equals, 1)
 	c.Assert(out.String(), gc.Equals, "Cloud \"m1\" successfully added to your local client.\n"+
-		"You will need to add credentials for this cloud (`juju add-credential m1`)\n"+
-		"before you can use it in creating either a controller (`juju bootstrap m1`) or\n"+
-		"a model (`juju add-model <your model name> m1`).\n")
+		"You will need to add a credential for this cloud (`juju add-credential m1`)\n"+
+		"before you can use it to bootstrap a controller (`juju bootstrap m1`) or\n"+
+		"to create a model (`juju add-model <your model name> m1`).\n")
 }
 
 func (*addSuite) TestInteractiveManual(c *gc.C) {
@@ -1236,9 +1236,9 @@ func testInteractiveOpenstack(c *gc.C, myOpenstack jujucloud.Cloud, expectedYAML
 	c.Check(err, jc.ErrorIsNil)
 	var output = addStdErrMsg +
 		"Cloud \"os1\" successfully added to your local client.\n" +
-		"You will need to add credentials for this cloud (`juju add-credential os1`)\n" +
-		"before you can use it in creating either a controller (`juju bootstrap os1`) or\n" +
-		"a model (`juju add-model <your model name> os1`).\n"
+		"You will need to add a credential for this cloud (`juju add-credential os1`)\n" +
+		"before you can use it to bootstrap a controller (`juju bootstrap os1`) or\n" +
+		"to create a model (`juju add-model <your model name> os1`).\n"
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, output)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, stdOutMsg)
 

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -560,7 +560,7 @@ func (s *addSuite) TestAddToControllerMissingCredential(c *gc.C) {
 	store.Credentials = nil
 
 	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--skipPrompt")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
 Cloud "garage-maas" added to controller "mycontroller".
 To upload credentials to the controller for cloud "garage-maas", use 
@@ -575,7 +575,7 @@ func (s *addSuite) TestAddToControllerAmbiguousCredential(c *gc.C) {
 	store.Credentials["garage-maas"].AuthCredentials["another"] = cred
 
 	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "mycontroller", "--skipPrompt")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
 		"You will need to add credentials for this cloud (`juju add-credential garage-maas`)\n"+
 		"before you can use it in creating either a controller (`juju bootstrap garage-maas`) or\n"+

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -175,11 +175,11 @@ func (c *addCredentialCommand) Init(args []string) (err error) {
 		return errors.New("Usage: juju add-credential <cloud-name> [-f <credentials.yaml>]")
 	}
 	c.CloudName = args[0]
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
-	if c.controllerName == "" {
+	if c.ControllerName == "" {
 		// No controller was specified explicitly and we did not detect a current controller,
 		// this operation should be local only.
 		c.Local = true
@@ -586,7 +586,7 @@ func (c *addCredentialCommand) promptFieldValue(p *interact.Pollster, attr jujuc
 }
 
 func (c *addCredentialCommand) credentialsAPI() (CredentialAPI, error) {
-	root, err := c.NewAPIRoot(c.Store, c.controllerName, "")
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -621,11 +621,11 @@ func (c *addCredentialCommand) addRemoteCredentials(ctxt *cmd.Context, all map[s
 		fmt.Fprintf(ctxt.Stdout, "No remote cloud %v found on the controller %v: credentials are not added remotely.\n"+
 			"Use 'juju clouds -c %v' to see what clouds are available remotely.\n"+
 			"User 'juju add-cloud %v -c %v' to add your cloud to the controller.\n",
-			c.CloudName, c.controllerName, c.controllerName, c.CloudName, c.controllerName)
+			c.CloudName, c.ControllerName, c.ControllerName, c.CloudName, c.ControllerName)
 		return nil
 	}
 
-	accountDetails, err := c.Store.AccountDetails(c.controllerName)
+	accountDetails, err := c.Store.AccountDetails(c.ControllerName)
 	if err != nil {
 		return err
 	}
@@ -641,7 +641,7 @@ func (c *addCredentialCommand) addRemoteCredentials(ctxt *cmd.Context, all map[s
 	results, err := client.UpdateCloudsCredentials(verified)
 	if err != nil {
 		logger.Errorf("%v", err)
-		ctxt.Warningf("Could not add credentials remotely, on controller %q", c.controllerName)
+		ctxt.Warningf("Could not add credentials remotely, on controller %q", c.ControllerName)
 	}
 	return processUpdateCredentialResult(ctxt, accountDetails, "added", results)
 }

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -133,11 +133,11 @@ func (c *detectCredentialsCommand) Init(args []string) (err error) {
 		c.cloudType = strings.ToLower(args[0])
 		return cmd.CheckEmpty(args[1:])
 	}
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
-	if c.controllerName == "" {
+	if c.ControllerName == "" {
 		// No controller was specified explicitly and we did not detect a current controller,
 		// this operation should be local only.
 		c.Local = true
@@ -156,7 +156,7 @@ type discoveredCredential struct {
 
 func (c *detectCredentialsCommand) credentialsAPI() (CredentialAPI, error) {
 	var err error
-	root, err := c.NewAPIRoot(c.Store, c.controllerName, "")
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -462,7 +462,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 		fmt.Fprintf(ctxt.Stdout, "No credentials loaded remotely.\n")
 		return nil
 	}
-	accountDetails, err := c.Store.AccountDetails(c.controllerName)
+	accountDetails, err := c.Store.AccountDetails(c.ControllerName)
 	if err != nil {
 		return err
 	}
@@ -490,7 +490,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 			result, err := client.UpdateCloudsCredentials(verified)
 			if err != nil {
 				logger.Errorf("%v", err)
-				ctxt.Warningf("Could not add credentials remotely, on controller %q", c.controllerName)
+				ctxt.Warningf("Could not add credentials remotely, on controller %q", c.ControllerName)
 			}
 			results = append(results, result...)
 		}

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -140,7 +140,7 @@ func (c *listCloudsCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init populates the command with the args from the command line.
 func (c *listCloudsCommand) Init(args []string) (err error) {
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
@@ -148,7 +148,7 @@ func (c *listCloudsCommand) Init(args []string) (err error) {
 }
 
 func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
-	if c.controllerName == "" {
+	if c.ControllerName == "" {
 		details, err := listCloudDetails(c.Store)
 
 		if err != nil {
@@ -157,7 +157,7 @@ func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 		return details, nil
 	}
 
-	api, err := c.listCloudsAPIFunc(c.controllerName)
+	api, err := c.listCloudsAPIFunc(c.ControllerName)
 	if err != nil {
 		return nil, err
 	}
@@ -189,13 +189,13 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 		}
 		result = clouds
 	default:
-		if c.controllerName == "" && !c.Local {
+		if c.ControllerName == "" && !c.Local {
 			ctxt.Infof(
 				"There are no controllers running.\nYou can bootstrap a new controller using one of these clouds:\n")
 		}
-		if c.controllerName != "" {
+		if c.ControllerName != "" {
 			ctxt.Infof(
-				"Clouds on controller %q:\n\n", c.controllerName)
+				"Clouds on controller %q:\n\n", c.ControllerName)
 		}
 		result = details
 	}

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -87,7 +87,7 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 		return errors.New("Usage: juju remove-cloud <cloud name>")
 	}
 	c.Cloud = args[0]
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
@@ -95,8 +95,8 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 }
 
 func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
-	if c.controllerName == "" {
-		if c.controllerName == "" && !c.Local {
+	if c.ControllerName == "" {
+		if c.ControllerName == "" && !c.Local {
 			return errors.Errorf(
 				"There are no controllers running.\nTo remove cloud %q from the local cache, use the --local option.", c.Cloud)
 		}
@@ -123,7 +123,7 @@ func (c *removeCloudCommand) removeLocalCloud(ctxt *cmd.Context) error {
 }
 
 func (c *removeCloudCommand) removeControllerCloud(ctxt *cmd.Context) error {
-	api, err := c.removeCloudAPIFunc(c.controllerName)
+	api, err := c.removeCloudAPIFunc(c.ControllerName)
 	if err != nil {
 		return err
 	}
@@ -132,6 +132,6 @@ func (c *removeCloudCommand) removeControllerCloud(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	ctxt.Infof("Cloud %q on controller %q removed", c.Cloud, c.controllerName)
+	ctxt.Infof("Cloud %q on controller %q removed", c.Cloud, c.ControllerName)
 	return nil
 }

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -93,7 +93,7 @@ func (c *removeCredentialCommand) Info() *cmd.Info {
 }
 
 func (c *removeCredentialCommand) credentialsAPI() (RemoveCredentialAPI, error) {
-	root, err := c.NewAPIRoot(c.Store, c.controllerName, "")
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -106,11 +106,11 @@ func (c *removeCredentialCommand) Init(args []string) (err error) {
 	}
 	c.cloud = args[0]
 	c.credential = args[1]
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
 	}
-	if c.controllerName == "" {
+	if c.ControllerName == "" {
 		// No controller was specified explicitly and we did not detect a current controller,
 		// this operation should be local only.
 		c.Local = true
@@ -189,10 +189,10 @@ func (c *removeCredentialCommand) maybeRemoteCloud(ctxt *cmd.Context, client Rem
 
 func (c *removeCredentialCommand) removeFromController(ctxt *cmd.Context, client RemoveCredentialAPI) error {
 	if !c.remoteCloudFound {
-		ctxt.Infof("No stored credentials exist remotely since cloud %q is not found on the controller %q.", c.cloud, c.controllerName)
+		ctxt.Infof("No stored credentials exist remotely since cloud %q is not found on the controller %q.", c.cloud, c.ControllerName)
 		return cmd.ErrSilent
 	}
-	accountDetails, err := c.Store.AccountDetails(c.controllerName)
+	accountDetails, err := c.Store.AccountDetails(c.ControllerName)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (c *removeCredentialCommand) removeFromController(ctxt *cmd.Context, client
 	if err := client.RevokeCredential(names.NewCloudCredentialTag(id)); err != nil {
 		return errors.Annotate(err, "could not remove remote credential")
 	}
-	ctxt.Infof("Credential %q removed from the controller %q.", c.credential, c.controllerName)
+	ctxt.Infof("Credential %q removed from the controller %q.", c.credential, c.ControllerName)
 	return nil
 }
 

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -103,7 +103,7 @@ func (c *showCloudCommand) Init(args []string) error {
 		return errors.New("no cloud specified")
 	}
 	var err error
-	c.controllerName, err = c.ControllerNameFromArg()
+	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil {
 		return errors.Wrap(err, errors.New(err.Error()+"\nUse --local to query the local cache."))
 	}
@@ -124,7 +124,7 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 		cloud *CloudDetails
 		err   error
 	)
-	if c.controllerName == "" {
+	if c.ControllerName == "" {
 		cloud, err = c.getLocalCloud()
 	} else {
 		cloud, err = c.getControllerCloud()
@@ -151,7 +151,7 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *showCloudCommand) getControllerCloud() (*CloudDetails, error) {
-	api, err := c.showCloudAPIFunc(c.controllerName)
+	api, err := c.showCloudAPIFunc(c.ControllerName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -437,6 +437,10 @@ func (c *OptionalControllerCommand) ControllerNameFromArg() (string, error) {
 	return controllerName, nil
 }
 
+// MaybePromptCurrentController checks if there is a current controller on a client.
+// If there is and the user did not want to be prompted, the current controller will be returned.
+// Otherwise, the user will be prompted if the current controller should be used and
+// based on the answer the current controller may or may not be returned.
 func (c *OptionalControllerCommand) MaybePromptCurrentController(ctxt *cmd.Context, action string) (string, error) {
 	all, err := c.Store.AllControllers()
 	if err != nil {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -405,7 +405,7 @@ func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Local, "local", false, "Local operation only; controller not affected")
 	f.StringVar(&c.ControllerName, "c", "", "Controller to operate in")
 	f.StringVar(&c.ControllerName, "controller", "", "")
-	f.BoolVar(&c.SkipCurrentControllerPrompt, "skipPrompt", false, "Skip prompting for confirmation to use current controller, always use it when detected")
+	f.BoolVar(&c.SkipCurrentControllerPrompt, "no-prompt", false, "Skip prompting for confirmation to use current controller, always use it when detected")
 }
 
 // ControllerNameFromArg returns either a controller name or empty string.

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -274,7 +274,7 @@ func (s *OptionalControllerCommandSuite) TestDetectCurrentControllerSkipPrompt(c
 		"fred": {},
 	}
 	store.CurrentControllerName = "fred"
-	s.assertDetectCurrentController(c, store, "fred", "--skipPrompt")
+	s.assertDetectCurrentController(c, store, "fred", "--no-prompt")
 }
 
 func (s *OptionalControllerCommandSuite) assertDetectCurrentControllerPrompt(c *gc.C, userAnswer, expectedControllerName string) {
@@ -289,7 +289,7 @@ func (s *OptionalControllerCommandSuite) assertDetectCurrentControllerPrompt(c *
 	controllerName, err := command.MaybePromptCurrentController(ctx, "test on")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerName, gc.Equals, expectedControllerName)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Do you want to test on current controller \"fred\".? (Y/n): \n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Do you want to test on current controller \"fred\"? (Y/n): \n")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 

--- a/featuretests/cmd_juju_cloud_test.go
+++ b/featuretests/cmd_juju_cloud_test.go
@@ -46,7 +46,7 @@ clouds:
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
 	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll", "--force")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cloud "testdummy" already exists on the controller "kontroll".`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }


### PR DESCRIPTION
## Description of change

Juju has the ability to add clouds locally to a a current Juju client as well as remotely to a running controller. However, the original implementation took users by surprise. This PR proposes a change to the original implementation to eliminate the element of surprise. As such I have removed the client side feature flag whilst the controller side remains in place.

General logic for adding local and/or remote entities such as cloud and credentials are: 
* If no controller is specified nor current controller is detected, operation is local only;
* If a --local option is specified, operation is local only;
* If a controller is specified via -c or --controller, operation is both local as well as remote on the specified controller;
* If a controller is not specified but a current controller is detected, operation is local as well as the user is prompted to confirm if the addition should happen remotely to the current controller;
* If a controller is not specified but a current controller is detected AND --no-prompt option is specified, operation is both local as well remote (addition to current controller).

There also were some inconsistency is handling file cloud definition vs interactive mode, like inconsistent user messaging, etc. These have all been corrected here.

Drive-by:

* when adding with file, if no cloud name specified but there is only one cloud in the file, use it;
* if there is no cloud specified but there is more than one cloud defined in a file, err out;
* clouds that do not have a region, will be given a default region - https://bugs.launchpad.net/juju/+bug/1819409

## QA steps

* add local cloud interactively (no controllers known on this client)
```
$ juju add-cloud
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: openstack

Enter a name for your openstack cloud: stratus

Enter the API endpoint url for the cloud []: [REDACTED]

Enter a path to the CA certificate for your cloud if one is required to access it. (optional) [none]: 

Auth Types
  access-key
  userpass

Select one or more auth types separated by commas: userpass

Enter region name: one

Enter the API endpoint url for the region [use cloud api url]: 

Enter another region? (y/N): N

Cloud "stratus" successfully added to your local client.
You will need to add a credential for this cloud (`juju add-credential stratus`)
before you can use it to bootstrap a controller (`juju bootstrap stratus`) or
to create a model (`juju add-model <your model name> stratus`).

There are no controllers specified - not adding cloud "stratus" to any controller.
```
* adding cloud with a file (no controllers are not known to this client):
```
$ juju add-cloud fluffystack -f ~/a.yaml
Cloud "fluffystack" successfully added to your local client.
You will need to add a credential for this cloud (`juju add-credential fluffystack`)
before you can use it to bootstrap a controller (`juju bootstrap fluffystack`) or
to create a model (`juju add-model <your model name> fluffystack`).

There are no controllers specified - not adding cloud "fluffystack" to any controller.
```
* add cloud to a specified controller with file
```
$ juju add-cloud fluffystack -f ~/a.yaml -c mycontroller
Adding a cloud of type "openstack" might not function correctly on this controller.
If you really want to do this, use --force.

$ juju add-cloud -c mycontroller fluffystack -f ~/a.yaml --force

Cloud "fluffystack" added to controller "mycontroller".
WARNING loading credentials: credentials for cloud fluffystack not found
To upload a credential to the controller for cloud "fluffystack", use 
* 'add-model' with --credential option or
* 'add-credential -c fluffystack'.
```

* add cloud to the detected current controller with prompt:
```
$ juju add-cloud fluffystack -f ~/a.yaml --force

Do you want to add cloud "fluffystack" to current controller "mycontroller"? (Y/n): 

Cloud "fluffystack" added to controller "mycontroller".
WARNING loading credentials: credentials for cloud fluffystack not found
To upload a credential to the controller for cloud "fluffystack", use 
* 'add-model' with --credential option or
* 'add-credential -c fluffystack'.
```

*  add cloud to the detected current controller without prompt:
```
$ juju add-cloud fluffystack -f ~/a.yaml --force --no-prompt

Cloud "fluffystack" added to controller "mycontroller".
WARNING loading credentials: credentials for cloud fluffystack not found
To upload a credential to the controller for cloud "fluffystack", use 
* 'add-model' with --credential option or
* 'add-credential -c fluffystack'.
```

