### PR TITLE
Increase instance size for GKE functional test

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -185,7 +185,7 @@ class GKE(Base):
                 name='default-pool',
                 initial_node_count=1,
                 config=dict(
-                    machine_type='n1-standard-1',
+                    machine_type='n1-standard-2',
                 ),
                 autoscaling=dict(
                     enabled=True,


### PR DESCRIPTION
## Description of change

Increase instance size for GKE functional test due controller pod requiring too much memory for an n1-standard-1 instance.

