### PR TITLE
2.6 - Script to remove juju services from a machine

### DIFF
--- a/scripts/removejujuservices.bash
+++ b/scripts/removejujuservices.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# WARNING
+# This script will clean a host previously used to run a Juju controller/machine.
+# Running this on a live installation will render Juju inoperable.
+
+for path_to_unit in $(ls /etc/systemd/system/juju*); do
+  echo "removing juju service: $path_to_unit"
+  unit=$(basename "$path_to_unit")
+  systemctl stop "$unit"
+  systemctl disable "$unit"
+  systemctl daemon-reload
+done
+
+echo "removing /var/lib/juju/db/*"
+rm -rf /var/lib/juju/db/*
+
+echo "removing /var/lib/juju/raft/*"
+rm -rf /var/lib/juju/raft/*


### PR DESCRIPTION
## Description of change

Adds a bash script to the scripts directory that can be used to remove juju services from a machine.

## QA steps

- Bootstrap a manual machine.
- Kill the controller.
- Run the script.
- Check that the machine can be bootstrapped again and does not throw out with `Already Provisioned`.

## Documentation changes

None.

## Bug reference

N/A
