### PR TITLE
Fixes lp#1841885: clear models credential when it's removed.

### DIFF
--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -31,6 +31,7 @@ type Backend interface {
 	AllCloudCredentials(user names.UserTag) ([]state.Credential, error)
 	CredentialModelsAndOwnerAccess(tag names.CloudCredentialTag) ([]state.CredentialOwnerModelAccess, error)
 	CredentialModels(tag names.CloudCredentialTag) (map[string]string, error)
+	RemoveModelsCredential(tag names.CloudCredentialTag) error
 
 	ControllerConfig() (controller.Config, error)
 	ControllerInfo() (*state.ControllerInfo, error)

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -878,7 +878,7 @@ func (s *cloudSuite) TestRevokeCredentials(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "RemoveCloudCredential")
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "RemoveCloudCredential", "RemoveModelsCredential")
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, jc.DeepEquals, &params.Error{
 		Message: `"machine-0" is not a valid cloudcred tag`,
@@ -901,7 +901,7 @@ func (s *cloudSuite) TestRevokeCredentialsAdminAccess(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "RemoveCloudCredential")
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels", "RemoveCloudCredential", "RemoveModelsCredential")
 	c.Assert(results.Results, gc.HasLen, 1)
 	// admin can revoke others' credentials
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -953,7 +953,7 @@ func (s *cloudSuite) TestRevokeCredentialsForceCantGetModels(c *gc.C) {
 		args: []params.RevokeCredentialArg{
 			{Tag: "cloudcred-meep_julia_three", Force: true},
 		},
-		callsMade: []string{"ControllerTag", "CredentialModels", "RemoveCloudCredential"},
+		callsMade: []string{"ControllerTag", "CredentialModels", "RemoveCloudCredential", "RemoveModelsCredential"},
 		results: params.ErrorResults{
 			Results: []params.ErrorResult{
 				{}, // no error: credential deleted
@@ -1021,7 +1021,7 @@ func (s *cloudSuite) TestRevokeCredentialsForceHasModel(c *gc.C) {
 		args: []params.RevokeCredentialArg{
 			{Tag: "cloudcred-meep_julia_three", Force: true},
 		},
-		callsMade: []string{"ControllerTag", "CredentialModels", "RemoveCloudCredential"},
+		callsMade: []string{"ControllerTag", "CredentialModels", "RemoveCloudCredential", "RemoveModelsCredential"},
 		results: params.ErrorResults{
 			Results: []params.ErrorResult{
 				{},
@@ -1043,7 +1043,7 @@ func (s *cloudSuite) TestRevokeCredentialsForceMany(c *gc.C) {
 			{Tag: "cloudcred-meep_julia_three", Force: true},
 			{Tag: "cloudcred-meep_bruce_three"},
 		},
-		callsMade: []string{"ControllerTag", "CredentialModels", "RemoveCloudCredential", "CredentialModels"},
+		callsMade: []string{"ControllerTag", "CredentialModels", "RemoveCloudCredential", "RemoveModelsCredential", "CredentialModels"},
 		results: params.ErrorResults{
 			Results: []params.ErrorResult{
 				{},
@@ -1053,6 +1053,33 @@ func (s *cloudSuite) TestRevokeCredentialsForceMany(c *gc.C) {
 		expectedLog: []string{
 			` WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but it is used by model deadbeef-0bad-400d-8000-4b1d0d06f00d`,
 			` WARNING juju.apiserver.cloud credential cloudcred-meep_bruce_three cannot be deleted as it is used by model deadbeef-0bad-400d-8000-4b1d0d06f00d`,
+		},
+	}
+	s.assertRevokeCredentials(c, t)
+}
+
+func (s *cloudSuite) TestRevokeCredentialsClearModelCredentialsError(c *gc.C) {
+	s.backend.SetErrors(
+		nil,                  // RemoveCloudCredential
+		errors.New("kaboom"), // RemoveModelsCredential
+	)
+	t := revokeCredentialData{
+		f: func(tag names.CloudCredentialTag) (map[string]string, error) {
+			return map[string]string{
+				coretesting.ModelTag.Id(): "modelName",
+			}, nil
+		},
+		args: []params.RevokeCredentialArg{
+			{Tag: "cloudcred-meep_julia_three", Force: true},
+		},
+		callsMade: []string{"ControllerTag", "CredentialModels", "RemoveCloudCredential", "RemoveModelsCredential"},
+		results: params.ErrorResults{
+			Results: []params.ErrorResult{
+				{common.ServerError(errors.New("kaboom"))},
+			},
+		},
+		expectedLog: []string{
+			` WARNING juju.apiserver.cloud credential cloudcred-meep_julia_three will be deleted but it is used by model deadbeef-0bad-400d-8000-4b1d0d06f00d`,
 		},
 	}
 	s.assertRevokeCredentials(c, t)
@@ -1303,6 +1330,11 @@ func (st *mockBackend) RemoveCloudAccess(cloud string, user names.UserTag) error
 	st.MethodCall(st, "RemoveCloudAccess", cloud, user)
 	st.cloudAccess = permission.NoAccess
 	return nil
+}
+
+func (st *mockBackend) RemoveModelsCredential(tag names.CloudCredentialTag) error {
+	st.MethodCall(st, "RemoveModelsCredential", tag)
+	return st.NextErr()
 }
 
 type mockUser struct {

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -479,35 +479,39 @@ func (st *State) CredentialModels(tag names.CloudCredentialTag) (map[string]stri
 
 // RemoveModelsCredential clears out given credential reference from all models that have it.
 func (st *State) RemoveModelsCredential(tag names.CloudCredentialTag) error {
-	coll, cleanup := st.db().GetCollection(modelsC)
-	defer cleanup()
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		logger.Tracef("creating operations to remove models credential, attempt %d", attempt)
+		coll, cleanup := st.db().GetCollection(modelsC)
+		defer cleanup()
 
-	sel := bson.D{
-		{"cloud-credential", tag.Id()},
-		{"life", bson.D{{"$ne", Dead}}},
-	}
-	iter := coll.Find(sel).Iter()
-	defer iter.Close()
-
-	var ops []txn.Op
-	var doc bson.M
-	for iter.Next(&doc) {
-		id, ok := doc["_id"]
-		if !ok {
-			return errors.New("no id found in model doc")
+		sel := bson.D{
+			{"cloud-credential", tag.Id()},
+			{"life", bson.D{{"$ne", Dead}}},
 		}
+		iter := coll.Find(sel).Iter()
+		defer iter.Close()
 
-		ops = append(ops, txn.Op{
-			C:      modelsC,
-			Id:     id,
-			Assert: txn.DocExists,
-			Update: bson.D{{"$set", bson.D{{"cloud-credential", ""}}}},
-		})
+		var ops []txn.Op
+		var doc bson.M
+		for iter.Next(&doc) {
+			id, ok := doc["_id"]
+			if !ok {
+				return nil, errors.New("no id found in model doc")
+			}
+
+			ops = append(ops, txn.Op{
+				C:      modelsC,
+				Id:     id,
+				Assert: notDeadDoc,
+				Update: bson.D{{"$set", bson.D{{"cloud-credential", ""}}}},
+			})
+		}
+		if err := iter.Close(); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return ops, nil
 	}
-	if err := iter.Close(); err != nil {
-		return errors.Trace(err)
-	}
-	return st.runRawTransaction(ops)
+	return st.db().Run(buildTxn)
 }
 
 // CredentialOwnerModelAccess stores cloud credential model information for the credential owner

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -477,6 +477,39 @@ func (st *State) CredentialModels(tag names.CloudCredentialTag) (map[string]stri
 	return results, nil
 }
 
+// RemoveModelsCredential clears out given credential reference from all models that have it.
+func (st *State) RemoveModelsCredential(tag names.CloudCredentialTag) error {
+	coll, cleanup := st.db().GetCollection(modelsC)
+	defer cleanup()
+
+	sel := bson.D{
+		{"cloud-credential", tag.Id()},
+		{"life", bson.D{{"$ne", Dead}}},
+	}
+	iter := coll.Find(sel).Iter()
+	defer iter.Close()
+
+	var ops []txn.Op
+	var doc bson.M
+	for iter.Next(&doc) {
+		id, ok := doc["_id"]
+		if !ok {
+			return errors.New("no id found in model doc")
+		}
+
+		ops = append(ops, txn.Op{
+			C:      modelsC,
+			Id:     id,
+			Assert: txn.DocExists,
+			Update: bson.D{{"$set", bson.D{{"cloud-credential", ""}}}},
+		})
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	return st.runRawTransaction(ops)
+}
+
 // CredentialOwnerModelAccess stores cloud credential model information for the credential owner
 // or an error retrieving it.
 type CredentialOwnerModelAccess struct {

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -226,6 +226,26 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsTouchesCredentialModel
 	assertModelStatus(c, s.StatePool, testModelUUID, status.Available)
 }
 
+func (s *CloudCredentialsSuite) TestRemoveModelsCredential(c *gc.C) {
+	cloudName, credentialOwner, credentialTag := assertCredentialCreated(c, s.ConnSuite)
+	modelUUID := assertModelCreated(c, s.ConnSuite, cloudName, credentialTag, credentialOwner.Tag(), "model-for-cloud")
+
+	err := s.State.RemoveModelsCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	aModel, helper, err := s.StatePool.GetModel(modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	defer helper.Release()
+	_, isSet := aModel.CloudCredential()
+	c.Assert(isSet, jc.IsFalse)
+}
+
+func (s *CloudCredentialsSuite) TestRemoveModelsCredentialNotUsed(c *gc.C) {
+	_, _, credentialTag := assertCredentialCreated(c, s.ConnSuite)
+	err := s.State.RemoveModelsCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *CloudCredentialsSuite) assertCredentialInvalidated(c *gc.C, tag names.CloudCredentialTag) {
 	err := s.State.AddCloud(cloud.Cloud{
 		Name:      "stratus",


### PR DESCRIPTION
## Description of change

Under normal circumstances, Juju will not allow to delete a credential that is being used by existing models. However, when using an API and when the credential removal is forced, there is a way to by-pass this restriction and delete a credential that is currently in-use. It leaves the system in a bit of a twist as Juju will see that the model has a credential set but not the actual value of the credential. This condition is currently treated the same way as an invalid credential, i.e. all models that use deleted credential will be suspended. However, it's cleaner to clear out these references.

This PR deletes credential references when credential is deleted preserving referential integrity.  

## Bug reference

https://bugs.launchpad.net/juju/+bug/1841885
