### PR TITLE
Don't create a second state pool in the JujuConnSuite.

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -509,7 +509,7 @@ type migrationSuite struct {
 var _ = gc.Suite(&migrationSuite{})
 
 func (s *migrationSuite) startSync(c *gc.C, st *state.State) {
-	backingSt, err := s.BackingStatePool.Get(st.ModelUUID())
+	backingSt, err := s.StatePool.Get(st.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	backingSt.StartSync()
 	backingSt.Release()

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -697,11 +697,6 @@ func (s *CAASStatusSuite) SetUpTest(c *gc.C) {
 	// Set up a CAAS model to replace the IAAS one.
 	st := s.Factory.MakeCAASModel(c, nil)
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
-	// Close the state pool before the state object itself.
-	s.StatePool.Close()
-	s.StatePool = nil
-	err := s.State.Close()
-	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 	s.Factory = factory.NewFactory(s.State, nil)
 	m, err := st.Model()

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -123,11 +123,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	})
 	s.CleanupSuite.AddCleanup(func(*gc.C) { _ = st.Close() })
 
-	// Close the state pool before the state object itself.
-	c.Assert(s.StatePool.Close(), jc.ErrorIsNil)
-	s.StatePool = nil
-	err = s.State.Close()
-	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -878,11 +878,6 @@ func (s *CAASDeploySuiteBase) SetUpTest(c *gc.C) {
 		CloudName: "caascloud",
 	})
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
-	// Close the state pool before the state object itself.
-	s.StatePool.Close()
-	s.StatePool = nil
-	err = s.State.Close()
-	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 }
 

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -49,11 +49,6 @@ func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
 	// Set up a CAAS model to replace the IAAS one.
 	st := s.Factory.MakeCAASModel(c, nil)
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
-	// Close the state pool before the state object itself.
-	s.StatePool.Close()
-	s.StatePool = nil
-	err := s.State.Close()
-	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 }
 

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -44,11 +44,6 @@ func (s *dblogSuite) TestControllerAgentLogsGoToDBCAAS(c *gc.C) {
 	// Set up a CAAS model to replace the IAAS one.
 	st := s.Factory.MakeCAASModel(c, nil)
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
-	// Close the state pool before the state object itself.
-	s.StatePool.Close()
-	s.StatePool = nil
-	err := s.State.Close()
-	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
 	s.Factory = factory.NewFactory(st, s.StatePool)
 	node, err := s.State.AddControllerNode()

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -111,6 +111,8 @@ type JujuConnSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	envtesting.ToolsFixture
 
+	InitialLoggingConfig string
+
 	DefaultToolsStorageDir string
 	DefaultToolsStorage    storage.Storage
 
@@ -160,6 +162,9 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	if s.InitialLoggingConfig != "" {
+		loggo.ConfigureLoggers(s.InitialLoggingConfig)
+	}
 
 	// This needs to be a pointer as there are other Mixin structures
 	// that copy the lock otherwise. Yet another reason to move away from

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -933,3 +933,28 @@ func (s ModelBackendShim) isController() bool {
 func (s ModelBackendShim) txnLogWatcher() watcher.BaseWatcher {
 	return s.Watcher
 }
+
+// SetClockForTesting is an exported function to allow tests
+// to set the internal clock for the State instance. It is named such
+// that it should be obvious if it is ever called from a non-test package.
+// TODO (thumper): This is a terrible method and we should remove it.
+// NOTE: this should almost never be needed.
+func (st *State) SetClockForTesting(clock clock.Clock) error {
+	// Need to restart the lease workers so they get the new clock.
+	// Stop them first so they don't try to use it when we're setting it.
+	hub := st.workers.hub
+	st.workers.Kill()
+	err := st.workers.Wait()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	st.stateClock = clock
+	if db, ok := st.database.(*database); ok {
+		db.clock = clock
+	}
+	err = st.start(st.controllerTag, hub)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/state/state.go
+++ b/state/state.go
@@ -2519,30 +2519,6 @@ func tagForGlobalKey(key string) (string, bool) {
 	return p + key[2:], true
 }
 
-// SetClockForTesting is an exported function to allow other packages
-// to set the internal clock for the State instance. It is named such
-// that it should be obvious if it is ever called from a non-test package.
-// TODO (thumper): This is a terrible method and we should remove it.
-func (st *State) SetClockForTesting(clock clock.Clock) error {
-	// Need to restart the lease workers so they get the new clock.
-	// Stop them first so they don't try to use it when we're setting it.
-	hub := st.workers.hub
-	st.workers.Kill()
-	err := st.workers.Wait()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	st.stateClock = clock
-	if db, ok := st.database.(*database); ok {
-		db.clock = clock
-	}
-	err = st.start(st.controllerTag, hub)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
 // GlobalClockUpdater returns a new globalclock.Updater using the
 // State's *mgo.Session.
 func (st *State) GlobalClockUpdater() (coreglobalclock.Updater, error) {

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -1157,6 +1157,7 @@ func (s *InstanceModeSuite) assertIngressCidrs(c *gc.C, ingress []string, expect
 		Endpoints: []charm.Relation{{Name: "db", Interface: "mysql", Role: "requirer", Scope: "global"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	// Create the firewaller facade on the offering model.
 	fw := s.newFirewaller(c)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -12,9 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
-	"time"
 
-	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -44,8 +42,6 @@ type UniterSuite struct {
 }
 
 var _ = gc.Suite(&UniterSuite{})
-
-var leaseClock *testclock.Clock
 
 // This guarantees that we get proper platform
 // specific error directly from their source
@@ -78,15 +74,9 @@ func (s *UniterSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *UniterSuite) SetUpTest(c *gc.C) {
-	zone, err := time.LoadLocation("")
-	c.Assert(err, jc.ErrorIsNil)
-	now := time.Date(2030, 11, 11, 11, 11, 11, 11, zone)
-	leaseClock = testclock.NewClock(now)
 	s.updateStatusHookTicker = newManualTicker()
 	s.GitSuite.SetUpTest(c)
 	s.JujuConnSuite.SetUpTest(c)
-	err = s.State.SetClockForTesting(leaseClock)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UniterSuite) TearDownTest(c *gc.C) {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1618,7 +1618,6 @@ func (mock *mockLeaderTracker) setLeader(c *gc.C, isLeader bool) {
 		)
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
-		leaseClock.Advance(61 * time.Second)
 		time.Sleep(coretesting.ShortWait)
 	}
 	mock.isLeader = isLeader


### PR DESCRIPTION
The JujuConnSuite was creating a second state pool. Both the state pool instances were calling the same callback function to tell the suite that the txnwatcher and hubwatchers were idle. This meant that sometimes when we asked for a model to be idle, one of the watchers would be, but the other may still be busy, leading to weird intermittent failures.
