### PR TITLE
Add a skip_state_tests build tag and apply tags in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ pre-check:
 check: dep pre-check test
 
 test: dep
-	go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
+	@echo 'go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$PROJECT_PACKAGES -check.v'
+	@go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
 
 install: dep rebuild-schema go-install
 

--- a/state/no_skip_test.go
+++ b/state/no_skip_test.go
@@ -1,0 +1,11 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !skip_state_tests
+
+package state_test
+
+// runStateTests controls whether to run the state tests - in this
+// case the skip_state_tests build tag hasn't been set so they'll be
+// run as normal.
+const runStateTests = true

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -10,5 +10,8 @@ import (
 )
 
 func TestPackage(t *testing.T) {
+	if !runStateTests {
+		t.Skip("skipping state tests since the skip_state_tests build tag was set")
+	}
 	coretesting.MgoTestPackage(t)
 }

--- a/state/skip_test.go
+++ b/state/skip_test.go
@@ -1,0 +1,10 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build skip_state_tests
+
+package state_test
+
+// runStateTests controls whether to run the state tests - in this case
+// the skip_state_tests build tag has been set so they'll be skipped.
+const runStateTests = false


### PR DESCRIPTION
## Description of change

This will enable some test jobs (particularly the arm64 one) to skip running the state tests as part of the normal build, since they take too long.

The state tests can be skipped using `go test --tags skip_state_tests` or `make test BUILD_TAGS=skip_state_tests`.

## QA steps

* Ran tests with and without the skip build tag, saw the state tests being skipped.

## Documentation changes

None

## Bug reference

None