### PR TITLE
Enable multipass and LXD-based builds

### DIFF
--- a/snap/plugins/x-dep.py
+++ b/snap/plugins/x-dep.py
@@ -61,7 +61,7 @@ class DepPlugin(snapcraft.BasePlugin):
         }
 
         # The import path must be specified.
-        schema["required"].append("go-importpath")
+        schema["required"] = ["go-importpath"]
 
         return schema
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic
 grade: devel
+base: core18
 
 apps:
   juju:


### PR DESCRIPTION
## Description of change

Enable multipass and LXD-based builds
    
If a base is not specified in snapcraft.yaml then snapcraft tries to use
the host system to build a snap (equivalent to --destructive-mode), see

* LP: #1842371;
* https://snapcraft.io/docs/base-snaps.

This is why core18 is specified as a base with this change.

Also, the dep plugin present in the Juju repository tries to append the
"required" key to the json schema taken from the base class under
snapcraft/_baseplugin.py which results in the following error:

  File "/root/project/snap/plugins/x-dep.py", line 64, in schema
    schema["required"].append("go-importpath")
KeyError: 'required'

As BasePlugin's 'schema' class method does not include the "required"
key it needs to be added.

Note: using --use-lxd might be a better idea considering LP: #1842376 -
Juju needs a lot of memory to be built which is more than 2 GiB
allocated for multipass VMs at the time of writing.

## QA steps

Old behavior:

snapcraft --destructive-mode

Multipass (expected to fail unless SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY is
set to something 4G - 6G, see LP: #1842376):

snapcraft

LXD:

snapcraft --use-lxd

## Documentation changes

CI build scripts will need to pass --destructive mode if there is an
expectation that the execution environment will be used as is.