### PR TITLE
Merge pull request #10586 from anastasiamac/lp1841885

### DIFF
--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -31,6 +31,7 @@ type Backend interface {
 	AllCloudCredentials(user names.UserTag) ([]state.Credential, error)
 	CredentialModelsAndOwnerAccess(tag names.CloudCredentialTag) ([]state.CredentialOwnerModelAccess, error)
 	CredentialModels(tag names.CloudCredentialTag) (map[string]string, error)
+	RemoveModelsCredential(tag names.CloudCredentialTag) error
 
 	ControllerConfig() (controller.Config, error)
 	ControllerInfo() (*state.ControllerInfo, error)

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -902,9 +902,15 @@ func (api *CloudAPI) RevokeCredentialsCheckModels(args params.RevokeCredentialAr
 				continue
 			}
 		}
-
-		if err := api.backend.RemoveCloudCredential(tag); err != nil {
+		err = api.backend.RemoveCloudCredential(tag)
+		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
+		} else {
+			// If credential was successfully removed, we also want to clear all references to it from the models.
+			// lp#1841885
+			if err := api.backend.RemoveModelsCredential(tag); err != nil {
+				results.Results[i].Error = common.ServerError(err)
+			}
 		}
 	}
 	return results, nil

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
@@ -224,6 +225,56 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsTouchesCredentialModel
 	err = s.State.UpdateCloudCredential(tag, cred)
 	c.Assert(err, jc.ErrorIsNil)
 	assertModelStatus(c, s.StatePool, testModelUUID, status.Available)
+}
+
+func (s *CloudCredentialsSuite) TestRemoveModelsCredential(c *gc.C) {
+	cloudName, credentialOwner, credentialTag := assertCredentialCreated(c, s.ConnSuite)
+	modelUUID := assertModelCreated(c, s.ConnSuite, cloudName, credentialTag, credentialOwner.Tag(), "model-for-cloud")
+
+	err := s.State.RemoveModelsCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	aModel, helper, err := s.StatePool.GetModel(modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	defer helper.Release()
+	_, isSet := aModel.CloudCredential()
+	c.Assert(isSet, jc.IsFalse)
+}
+
+func (s *CloudCredentialsSuite) TestRemoveModelsCredentialConcurrentModelDelete(c *gc.C) {
+	logger := loggo.GetLogger("juju.state")
+	logger.SetLogLevel(loggo.TRACE)
+	cloudName, credentialOwner, credentialTag := assertCredentialCreated(c, s.ConnSuite)
+	modelUUID := assertModelCreated(c, s.ConnSuite, cloudName, credentialTag, credentialOwner.Tag(), "model-for-cloud")
+
+	deleteModel := func() {
+		aModel, helper, err := s.StatePool.GetModel(modelUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		defer helper.Release()
+		err = aModel.SetDead()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(aModel.Refresh(), jc.ErrorIsNil)
+		c.Assert(aModel.Life(), gc.Equals, state.Dead)
+	}
+	defer state.SetBeforeHooks(c, s.State, deleteModel).Check()
+
+	err := s.State.RemoveModelsCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	aModel, helper, err := s.StatePool.GetModel(modelUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	defer helper.Release()
+	_, isSet := aModel.CloudCredential()
+	// Since the model was marked 'dead' in the middle of 1st transaction attempt,
+	// and 2nd attempt would not have picked it up, the model credential would not actually be cleared.
+	c.Assert(isSet, jc.IsTrue)
+	c.Assert(c.GetTestLog(), jc.Contains, "creating operations to remove models credential, attempt 1")
+}
+
+func (s *CloudCredentialsSuite) TestRemoveModelsCredentialNotUsed(c *gc.C) {
+	_, _, credentialTag := assertCredentialCreated(c, s.ConnSuite)
+	err := s.State.RemoveModelsCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *CloudCredentialsSuite) assertCredentialInvalidated(c *gc.C, tag names.CloudCredentialTag) {


### PR DESCRIPTION
https://github.com/juju/juju/pull/10586

## Description of change

Under normal circumstances, Juju will not allow to delete a credential that is being used by existing models. However, when using an API and when the credential removal is forced, there is a way to by-pass this restriction and delete a credential that is currently in-use. It leaves the system in a bit of a twist as Juju will see that the model has a credential set but not the actual value of the credential. This condition is currently treated the same way as an invalid credential, i.e. all models that use deleted credential will be suspended. However, it's cleaner to clear out these references.

This PR deletes credential references when credential is deleted preserving referential integrity. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1841885

## Please provide the following details to expedite Pull Request review:

----

## Description of change

*Please replace with a description about why this change is needed?*

## QA steps

*Please replace with how we can verify that the change works?*

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?* 

## Bug reference

*Please add a link to any bugs that this change is related to.*
