### PR TITLE
AddSpace should take a slice of SubnetIDs, not CIDRs

### DIFF
--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -108,6 +108,14 @@ func (s *stateShim) AllSubnets() ([]BackingSubnet, error) {
 	return subnets, nil
 }
 
+func (s *stateShim) Subnet(cidr string) (BackingSubnet, error) {
+	result, err := s.st.Subnet(cidr)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &subnetShim{Subnet: result}, nil
+}
+
 func (s *stateShim) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {
 	// TODO(dimitern): Fix this to get them from state when available!
 	return nil, nil

--- a/apiserver/common/networkingcommon/spaces.go
+++ b/apiserver/common/networkingcommon/spaces.go
@@ -59,14 +59,20 @@ func CreateOneSpace(backing NetworkBacking, args params.CreateSpaceParams) error
 		return errors.Trace(err)
 	}
 
-	for _, cidr := range args.CIDRs {
+	subnetIDs := make([]string, len(args.CIDRs))
+	for i, cidr := range args.CIDRs {
 		if !network.IsValidCidr(cidr) {
 			return errors.New(fmt.Sprintf("%q is not a valid CIDR", cidr))
 		}
+		subnet, err := backing.Subnet(cidr)
+		if err != nil {
+			return err
+		}
+		subnetIDs[i] = subnet.ID()
 	}
 
 	// Add the validated space.
-	err = backing.AddSpace(spaceTag.Id(), network.Id(args.ProviderId), args.CIDRs, args.Public)
+	err = backing.AddSpace(spaceTag.Id(), network.Id(args.ProviderId), subnetIDs, args.Public)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -28,6 +28,7 @@ import (
 // and just use *state.Subnet.
 type BackingSubnet interface {
 	CIDR() string
+	ID() string
 	VLANTag() int
 	ProviderId() corenetwork.Id
 	ProviderNetworkId() corenetwork.Id
@@ -123,6 +124,8 @@ type NetworkBacking interface {
 
 	// AllSubnets returns all backing subnets.
 	AllSubnets() ([]BackingSubnet, error)
+
+	Subnet(cidr string) (BackingSubnet, error)
 
 	// ModelTag returns the tag of the model this state is associated to.
 	ModelTag() names.ModelTag

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -148,39 +148,66 @@ func (s *SpacesSuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 		apiservertesting.ZonedNetworkingEnvironCall("SupportsSpaces", s.callContext),
 	}
 
-	// AddSpace from the api always uses an empty ProviderId.
-	addSpaceCalls := append(
-		baseCalls, apiservertesting.BackingCall("AddSpace", p.Name, network.Id(""), p.Subnets, p.Public),
-	)
-
-	if p.Error == "" || p.MakesCall {
-		apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub, addSpaceCalls...)
-	} else {
+	// If we have an expected error, no calls to Subnet() nor
+	// AddSpace() should be made.  Check the methods called and
+	// return.  The exception is TestAddSpacesAPIError cause an
+	// error after Subnet() is called.
+	if p.Error != "" && !subnetCallMade() {
 		apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub, baseCalls...)
+		return
 	}
+
+	allCalls := baseCalls
+	subnetIDs := []string{}
+	for _, cidr := range p.Subnets {
+		allCalls = append(allCalls, apiservertesting.BackingCall("Subnet", cidr))
+		for _, fakeSN := range apiservertesting.BackingInstance.Subnets {
+			if fakeSN.CIDR() == cidr {
+				subnetIDs = append(subnetIDs, fakeSN.ID())
+			}
+		}
+	}
+
+	// Only add the call to AddSpace() if there are no errors
+	// which have continued to this point.
+	if p.Error == "" {
+		allCalls = append(allCalls, apiservertesting.BackingCall("AddSpace", p.Name, network.Id(""), subnetIDs, p.Public))
+	}
+	apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub, allCalls...)
+}
+
+func subnetCallMade() bool {
+	for _, call := range apiservertesting.SharedStub.Calls() {
+		if call.FuncName == "Subnet" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *SpacesSuite) TestAddSpacesOneSubnet(c *gc.C) {
 	p := checkAddSpacesParams{
 		Name:    "foo",
-		Subnets: []string{"10.0.0.0/24"},
+		Subnets: []string{"10.10.0.0/24"},
 	}
 	s.checkAddSpaces(c, p)
 }
 
 func (s *SpacesSuite) TestAddSpacesTwoSubnets(c *gc.C) {
+	apiservertesting.BackingInstance.AdditionalSubnets()
 	p := checkAddSpacesParams{
 		Name:    "foo",
-		Subnets: []string{"10.0.0.0/24", "10.0.1.0/24"},
+		Subnets: []string{"10.10.0.0/24", "10.0.2.0/24"},
 	}
 	s.checkAddSpaces(c, p)
 }
 
 func (s *SpacesSuite) TestAddSpacesManySubnets(c *gc.C) {
+	apiservertesting.BackingInstance.AdditionalSubnets()
 	p := checkAddSpacesParams{
 		Name: "foo",
-		Subnets: []string{"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24",
-			"10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"},
+		Subnets: []string{"10.10.0.0/24", "10.0.2.0/24",
+			"10.0.3.0/24", "10.0.4.0/24"},
 	}
 	s.checkAddSpaces(c, p)
 }
@@ -195,52 +222,9 @@ func (s *SpacesSuite) TestAddSpacesAPIError(c *gc.C) {
 	)
 	p := checkAddSpacesParams{
 		Name:      "foo",
-		Subnets:   []string{"10.0.0.0/24"},
+		Subnets:   []string{"10.10.0.0/24"},
 		MakesCall: true,
 		Error:     "space-foo already exists",
-	}
-	s.checkAddSpaces(c, p)
-}
-
-func (s *SpacesSuite) TestCreateInvalidSpace(c *gc.C) {
-	p := checkAddSpacesParams{
-		Name:    "-",
-		Subnets: []string{"10.0.0.0/24"},
-		Error:   `"space--" is not a valid space tag`,
-	}
-	s.checkAddSpaces(c, p)
-}
-
-func (s *SpacesSuite) TestCreateInvalidCIDR(c *gc.C) {
-	p := checkAddSpacesParams{
-		Name:    "foo",
-		Subnets: []string{"bar"},
-		Error:   `"bar" is not a valid CIDR`,
-	}
-	s.checkAddSpaces(c, p)
-}
-
-func (s *SpacesSuite) TestPublic(c *gc.C) {
-	p := checkAddSpacesParams{
-		Name:    "foo",
-		Subnets: []string{"10.0.0.0/24"},
-		Public:  true,
-	}
-	s.checkAddSpaces(c, p)
-}
-
-func (s *SpacesSuite) TestEmptySpaceName(c *gc.C) {
-	p := checkAddSpacesParams{
-		Subnets: []string{"10.0.0.0/24"},
-		Error:   `"" is not a valid tag`,
-	}
-	s.checkAddSpaces(c, p)
-}
-
-func (s *SpacesSuite) TestNoSubnets(c *gc.C) {
-	p := checkAddSpacesParams{
-		Name:    "foo",
-		Subnets: nil,
 	}
 	s.checkAddSpaces(c, p)
 }
@@ -339,41 +323,6 @@ func (s *SpacesSuite) TestListSpacesSubnetsSingleSubnetError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *SpacesSuite) TestCreateSpacesModelConfigError(c *gc.C) {
-	apiservertesting.SharedStub.SetErrors(
-		errors.New("boom"), // Backing.ModelConfig()
-	)
-
-	spaces := params.CreateSpacesParams{}
-	_, err := s.facade.CreateSpaces(spaces)
-	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
-}
-
-func (s *SpacesSuite) TestCreateSpacesProviderOpenError(c *gc.C) {
-	apiservertesting.SharedStub.SetErrors(
-		nil,                // Backing.ModelConfig()
-		nil,                // Backing.CloudSpec()
-		errors.New("boom"), // Provider.Open()
-	)
-
-	spaces := params.CreateSpacesParams{}
-	_, err := s.facade.CreateSpaces(spaces)
-	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
-}
-
-func (s *SpacesSuite) TestCreateSpacesNotSupportedError(c *gc.C) {
-	apiservertesting.SharedStub.SetErrors(
-		nil,                            // Backing.ModelConfig()
-		nil,                            // Backing.CloudSpec()
-		nil,                            // Provider.Open()
-		errors.NotSupportedf("spaces"), // ZonedNetworkingEnviron.SupportsSpaces()
-	)
-
-	spaces := params.CreateSpacesParams{}
-	_, err := s.facade.CreateSpaces(spaces)
-	c.Assert(err, gc.ErrorMatches, "spaces not supported")
-}
-
 func (s *SpacesSuite) TestListSpacesNotSupportedError(c *gc.C) {
 	apiservertesting.SharedStub.SetErrors(
 		nil,                            // Backing.ModelConfig()
@@ -417,7 +366,7 @@ func (s *SpacesSuite) TestCreateSpacesAPIv4(c *gc.C) {
 		Spaces: []params.CreateSpaceParamsV4{
 			{
 				SpaceTag:   "space-foo",
-				SubnetTags: []string{"subnet-10.0.0.0/24"},
+				SubnetTags: []string{"subnet-10.10.0.0/24"},
 			},
 		},
 	})

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -113,6 +113,21 @@ func (s StubNetwork) SetUpSuite(c *gc.C) {
 		ProviderId:        "vlan-42",
 		VLANTag:           42,
 		AvailabilityZones: []string{"zone3"},
+	}, {
+		CIDR:              "10.0.2.0/24",
+		ProviderId:        "sn-zadf00d-2",
+		ProviderNetworkId: "godspeed-2",
+		AvailabilityZones: []string{"zone1"},
+	}, {
+		CIDR:              "10.0.3.0/24",
+		ProviderId:        "sn-zadf00d-3",
+		ProviderNetworkId: "godspeed-3",
+		AvailabilityZones: []string{"zone1"},
+	}, {
+		CIDR:              "10.0.4.0/24",
+		ProviderId:        "sn-zadf00d-4",
+		ProviderNetworkId: "godspeed-4",
+		AvailabilityZones: []string{"zone1"},
 	}}
 
 	environs.RegisterProvider(StubProviderType, ProviderInstance)
@@ -455,6 +470,20 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 			&FakeSubnet{Info: info0, id: info0.SpaceID},
 			&FakeSubnet{Info: info1, id: info1.SpaceID},
 		}
+	}
+}
+
+func (sb *StubBacking) AdditionalSubnets() {
+	for i, info := range ProviderInstance.Subnets[10:] {
+		sb.Subnets = append(sb.Subnets, &FakeSubnet{
+			Info: networkingcommon.BackingSubnetInfo{
+				CIDR:              info.CIDR,
+				ProviderId:        info.ProviderId,
+				ProviderNetworkId: info.ProviderNetworkId,
+				AvailabilityZones: info.AvailabilityZones},
+			id: strconv.Itoa(i + 30),
+		},
+		)
 	}
 }
 

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -145,7 +146,7 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 		return outputSubnets, err
 	}
 
-	for _, subnetId := range f.SubnetIds {
+	for i, subnetId := range f.SubnetIds {
 		providerId := network.Id("provider-" + subnetId)
 
 		// Pick the third element of the IP address and use this to
@@ -173,7 +174,7 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 			AvailabilityZones: zones,
 			Status:            status,
 		}
-		outputSubnets = append(outputSubnets, &FakeSubnet{Info: backing})
+		outputSubnets = append(outputSubnets, &FakeSubnet{Info: backing, id: strconv.Itoa(i)})
 	}
 
 	return outputSubnets, nil
@@ -299,6 +300,7 @@ func (f *FakeZone) GoString() string {
 // FakeSubnet implements networkingcommon.BackingSubnet for testing.
 type FakeSubnet struct {
 	Info networkingcommon.BackingSubnetInfo
+	id   string
 }
 
 var _ networkingcommon.BackingSubnet = (*FakeSubnet)(nil)
@@ -314,6 +316,10 @@ func (f *FakeSubnet) Status() string {
 
 func (f *FakeSubnet) CIDR() string {
 	return f.Info.CIDR
+}
+
+func (f *FakeSubnet) ID() string {
+	return f.id
 }
 
 func (f *FakeSubnet) AvailabilityZones() []string {
@@ -445,10 +451,9 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 			SpaceName:         "dmz",
 			SpaceID:           "2",
 		}
-
 		sb.Subnets = []networkingcommon.BackingSubnet{
-			&FakeSubnet{info0},
-			&FakeSubnet{info1},
+			&FakeSubnet{Info: info0, id: info0.SpaceID},
+			&FakeSubnet{Info: info1, id: info1.SpaceID},
 		}
 	}
 }
@@ -522,6 +527,19 @@ func (sb *StubBacking) AllSubnets() ([]networkingcommon.BackingSubnet, error) {
 		output = append(output, subnet)
 	}
 	return output, nil
+}
+
+func (sb *StubBacking) Subnet(cidr string) (networkingcommon.BackingSubnet, error) {
+	sb.MethodCall(sb, "Subnet", cidr)
+	if err := sb.NextErr(); err != nil {
+		return nil, err
+	}
+	for _, subnet := range sb.Subnets {
+		if subnet.CIDR() == cidr {
+			return subnet, nil
+		}
+	}
+	return nil, errors.NewNotFound(nil, fmt.Sprintf("subnet %q", cidr))
 }
 
 func (sb *StubBacking) AddSubnet(subnetInfo networkingcommon.BackingSubnetInfo) (networkingcommon.BackingSubnet, error) {

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -122,7 +122,7 @@ func (s *cmdSpaceSuite) TestSpaceCreateWithInvalidSubnets(c *gc.C) {
 }
 
 func (s *cmdSpaceSuite) TestSpaceCreateWithUnknownSubnet(c *gc.C) {
-	expectedError := `cannot add space "foo": adding space "foo": subnet "10.10.0.0/16" not found`
+	expectedError := `cannot add space "foo": subnet "10.10.0.0/16" not found`
 	s.RunAdd(c, expectedError, "foo", "10.10.0.0/16")
 }
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1278,11 +1278,11 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {
-	_, err := s.State.AddSubnet(network.SubnetInfo{
+	subnet, err := s.State.AddSubnet(network.SubnetInfo{
 		CIDR: "100.2.0.0/16",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	sp, err := s.State.AddSpace("bam", "", []string{"100.2.0.0/16"}, true)
+	sp, err := s.State.AddSpace("bam", "", []string{subnet.ID()}, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	sn := network.SubnetInfo{
@@ -1299,7 +1299,7 @@ func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {
 
 	_, newSt := s.importModel(c, s.State)
 
-	subnet, err := newSt.Subnet(original.CIDR())
+	subnet, err = newSt.Subnet(original.CIDR())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -910,14 +910,25 @@ func (s *RelationUnitSuite) addDevicesWithAddresses(c *gc.C, machine *state.Mach
 }
 
 func (s *RelationUnitSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
-	s.State.AddSubnet(network.SubnetInfo{CIDR: "1.2.0.0/16"})
-	s.State.AddSpace("space-1", "pid-1", []string{"1.2.0.0/16"}, false)
-	s.State.AddSubnet(network.SubnetInfo{CIDR: "2.2.0.0/16"})
-	s.State.AddSpace("space-2", "pid-2", []string{"2.2.0.0/16"}, false)
-	s.State.AddSubnet(network.SubnetInfo{CIDR: "3.2.0.0/16"})
-	s.State.AddSpace("space-3", "pid-3", []string{"2.2.0.0/16"}, false)
-	s.State.AddSubnet(network.SubnetInfo{CIDR: "4.3.0.0/16"})
-	s.State.AddSpace("public-4", "pid-4", []string{"4.3.0.0/16"}, true)
+	subnet1, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "1.2.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("space-1", "pid-1", []string{subnet1.ID()}, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnet2, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "2.2.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("space-2", "pid-2", []string{subnet2.ID()}, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnet3, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "3.2.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("space-3", "pid-3", []string{subnet3.ID()}, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnet4, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "4.3.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("public-4", "pid-4", []string{subnet4.ID()}, true)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// We want to have all bindings set so that no actual binding is
 	// really set to the default.
@@ -928,7 +939,7 @@ func (s *RelationUnitSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	}
 
 	prr := newProReqRelationWithBindings(c, &s.ConnSuite, charm.ScopeGlobal, bindings, nil)
-	err := prr.pu0.AssignToNewMachine()
+	err = prr.pu0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.pu0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -950,8 +961,8 @@ func (s *RelationUnitSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "space-3")
-	c.Assert(ingress, gc.DeepEquals, []string{"2.2.3.4"})
-	c.Assert(egress, gc.DeepEquals, []string{"2.2.3.4/32"})
+	c.Assert(ingress, gc.DeepEquals, []string{"3.2.3.4"})
+	c.Assert(egress, gc.DeepEquals, []string{"3.2.3.4/32"})
 }
 
 func (s *RelationUnitSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -99,12 +99,9 @@ func (s *Space) NetworkSpace() network.SpaceInfo {
 	}
 }
 
-// TODO (hml) 2019-08-06
-// slice of subnets, should be subnet ids not cidrs.
-//
 // AddSpace creates and returns a new space.
 func (st *State) AddSpace(
-	name string, providerId network.Id, subnets []string, isPublic bool) (newSpace *Space, err error,
+	name string, providerId network.Id, subnetIDs []string, isPublic bool) (newSpace *Space, err error,
 ) {
 	defer errors.DeferredAnnotatef(&err, "adding space %q", name)
 	if !names.IsValidSpace(name) {
@@ -120,8 +117,8 @@ func (st *State) AddSpace(
 			return nil, errors.AlreadyExistsf("space %q", name)
 		}
 
-		for _, subnetId := range subnets {
-			subnet, err := st.Subnet(subnetId)
+		for _, subnetId := range subnetIDs {
+			subnet, err := st.SubnetByID(subnetId)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -143,7 +140,7 @@ func (st *State) AddSpace(
 			}
 		}
 
-		ops, err := st.addSpaceWithSubnetsTxnOps(name, providerId, subnets, isPublic)
+		ops, err := st.addSpaceWithSubnetsTxnOps(name, providerId, subnetIDs, isPublic)
 		return ops, errors.Trace(err)
 	}
 
@@ -159,7 +156,7 @@ func (st *State) AddSpace(
 }
 
 func (st *State) addSpaceWithSubnetsTxnOps(
-	name string, providerId network.Id, subnets []string, isPublic bool,
+	name string, providerId network.Id, subnetIDs []string, isPublic bool,
 ) ([]txn.Op, error) {
 	// Space with ID zero is the default space; start at 1.
 	seq, err := sequenceWithMin(st, "space", 1)
@@ -170,17 +167,13 @@ func (st *State) addSpaceWithSubnetsTxnOps(
 
 	ops := st.addSpaceTxnOps(id, name, providerId, isPublic)
 
-	for _, cidr := range subnets {
-		sn, err := st.Subnet(cidr)
-		if err != nil {
-			return nil, err
-		}
+	for _, subnetID := range subnetIDs {
 		// TODO:(mfoord) once we have refcounting for subnets we should
 		// also assert that the refcount is zero as moving the space of a
 		// subnet in use is not permitted.
 		ops = append(ops, txn.Op{
 			C:      subnetsC,
-			Id:     sn.ID(),
+			Id:     subnetID,
 			Assert: bson.D{bson.DocElem{Name: "fan-local-underlay", Value: bson.D{{"$exists", false}}}},
 			Update: bson.D{{"$set", bson.D{{"space-id", id}}}},
 		})

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -329,7 +329,7 @@ func (s *SubnetSuite) TestUpdateMAASUndefinedSpace(c *gc.C) {
 	subnetInfo := network.SubnetInfo{CIDR: "8.8.8.0/24"}
 	subnet, err := s.State.AddSubnet(subnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddSpace(names.NewSpaceTag("undefined").Id(), network.Id("-1"), []string{"8.8.8.0/24"}, false)
+	_, err = s.State.AddSpace(names.NewSpaceTag("undefined").Id(), network.Id("-1"), []string{subnet.ID()}, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnetInfo.SpaceName = "testme"
@@ -369,7 +369,7 @@ func (s *SubnetSuite) TestUpdateNonEmpty(c *gc.C) {
 	expectedSubnetInfo := network.SubnetInfo{CIDR: "8.8.8.0/24", VLANTag: 42, AvailabilityZones: []string{"changeme-az", "testme-az"}}
 	subnet, err := s.State.AddSubnet(expectedSubnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedSpace, err := s.State.AddSpace("changeme", network.Id("2"), []string{"8.8.8.0/24"}, false)
+	expectedSpace, err := s.State.AddSpace("changeme", network.Id("2"), []string{subnet.ID()}, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newSubnetInfo := network.SubnetInfo{

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -151,7 +151,7 @@ type ModelParams struct {
 type SpaceParams struct {
 	Name       string
 	ProviderID network.Id
-	Subnets    []string
+	SubnetIDs  []string
 	IsPublic   bool
 }
 
@@ -816,7 +816,7 @@ func (factory *Factory) MakeSpace(c *gc.C, params *SpaceParams) *state.Space {
 	if params.Name == "" {
 		params.Name = uniqueString("space-")
 	}
-	space, err := factory.st.AddSpace(params.Name, params.ProviderID, params.Subnets, params.IsPublic)
+	space, err := factory.st.AddSpace(params.Name, params.ProviderID, params.SubnetIDs, params.IsPublic)
 	c.Assert(err, jc.ErrorIsNil)
 	return space
 }


### PR DESCRIPTION
## Description of change

As part of the continuing network cleanup, state.AddSpace() should take a slice of SubnetIDs, not CIDRs.  Updated current unit tests appropriately.  A side effect is that networkingcommon.CreateOneSpace() will now validate the Subnet exists instead of waiting for state to do it.

## QA steps

1. Bootstrap maas
2. juju spaces
3. juju add-space testme <cidr not in a space from above>
