### PR TITLE
Fix race in TestWatchAPIHostPorts.

### DIFF
--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -50,7 +50,10 @@ func (s *machinerSuite) SetUpTest(c *gc.C) {
 	// Create the machiner API facade.
 	s.machiner = machiner.NewState(s.st)
 	c.Assert(s.machiner, gc.NotNil)
-	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.machiner, s.BackingState)
+	waitForModelWatchersIdle := func(c *gc.C) {
+		s.JujuConnSuite.WaitForModelWatchersIdle(c, s.BackingState.ModelUUID())
+	}
+	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.machiner, s.BackingState, waitForModelWatchersIdle)
 }
 
 func (s *machinerSuite) TestMachineAndMachineTag(c *gc.C) {

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -76,7 +76,10 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(s.provisioner, gc.NotNil)
 
 	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.provisioner, s.BackingState, s.Model)
-	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.provisioner, s.BackingState)
+	waitForModelWatchersIdle := func(c *gc.C) {
+		s.JujuConnSuite.WaitForModelWatchersIdle(c, s.BackingState.ModelUUID())
+	}
+	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.provisioner, s.BackingState, waitForModelWatchersIdle)
 }
 
 func (s *provisionerSuite) assertGetOneMachine(c *gc.C, tag names.MachineTag) provisioner.MachineProvisioner {

--- a/api/testing/apiaddresser.go
+++ b/api/testing/apiaddresser.go
@@ -14,14 +14,16 @@ import (
 )
 
 type APIAddresserTests struct {
-	state  *state.State
-	facade APIAddresserFacade
+	state                    *state.State
+	facade                   APIAddresserFacade
+	waitForModelWatchersIdle func(c *gc.C)
 }
 
-func NewAPIAddresserTests(facade APIAddresserFacade, st *state.State) *APIAddresserTests {
+func NewAPIAddresserTests(facade APIAddresserFacade, st *state.State, waitForModelWatchersIdle func(c *gc.C)) *APIAddresserTests {
 	return &APIAddresserTests{
-		state:  st,
-		facade: facade,
+		state:                    st,
+		facade:                   facade,
+		waitForModelWatchersIdle: waitForModelWatchersIdle,
 	}
 }
 
@@ -70,6 +72,7 @@ func (s *APIAddresserTests) TestWatchAPIHostPorts(c *gc.C) {
 	}
 	// Make sure we are changing the value
 	c.Assert(hostports, gc.Not(gc.DeepEquals), expectServerAddrs)
+	s.waitForModelWatchersIdle(c)
 
 	c.Logf("starting api host port watcher")
 	w, err := s.facade.WatchAPIHostPorts()

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -24,7 +24,10 @@ var _ = gc.Suite(&stateSuite{})
 
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.uniterSuite.SetUpTest(c)
-	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.uniter, s.BackingState)
+	waitForModelWatchersIdle := func(c *gc.C) {
+		s.JujuConnSuite.WaitForModelWatchersIdle(c, s.BackingState.ModelUUID())
+	}
+	s.APIAddresserTests = apitesting.NewAPIAddresserTests(s.uniter, s.BackingState, waitForModelWatchersIdle)
 	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.uniter, s.BackingState, s.Model)
 }
 


### PR DESCRIPTION
Yet another case where we are creating a watcher before necessary creation events have finished flowing through the low level event subsystem.

Since it is a mixin test class, we need to pass it a method to sync on since it can't access the JujuConnSuite methods directly.