### PR TITLE
Add cloud adds a default region when needed server-side.

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -1023,7 +1023,7 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 	aCloud := common.CloudFromParams(cloudArgs.Name, cloudArgs.Cloud)
 	// All clouds must have at least one 'default' region, lp#1819409.
 	if len(aCloud.Regions) == 0 {
-		aCloud.Regions = []cloud.Region{{Name: "default"}}
+		aCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
 	}
 
 	err = api.backend.AddCloud(aCloud, api.apiUser.Name())

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	environscontext "github.com/juju/juju/environs/context"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 )
@@ -1002,16 +1001,6 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 	} else if !isAdmin {
 		return common.ServerError(common.ErrPerm)
 	}
-	cfg, err := api.backend.ControllerConfig()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if !cfg.Features().Contains(feature.MultiCloud) {
-		if cloudArgs.Cloud.Type != string(provider.K8s_ProviderType) {
-			return errors.Errorf(
-				"feature flag %q needs to be enabled to add a %q cloud", feature.MultiCloud, cloudArgs.Cloud.Type)
-		}
-	}
 
 	if cloudArgs.Cloud.Type != string(provider.K8s_ProviderType) {
 		// All non-k8s cloud need to go through whitelist.
@@ -1030,7 +1019,14 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 			logger.Infof("force adding cloud %q of type %q to controller bootstrapped on cloud type %q", cloudArgs.Name, cloudArgs.Cloud.Type, controllerCloud.Type)
 		}
 	}
-	err = api.backend.AddCloud(common.CloudFromParams(cloudArgs.Name, cloudArgs.Cloud), api.apiUser.Name())
+
+	aCloud := common.CloudFromParams(cloudArgs.Name, cloudArgs.Cloud)
+	// All clouds must have at least one 'default' region, lp#1819409.
+	if len(aCloud.Regions) == 0 {
+		aCloud.Regions = []cloud.Region{{Name: "default"}}
+	}
+
+	err = api.backend.AddCloud(aCloud, api.apiUser.Name())
 	return errors.Trace(err)
 }
 

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -237,9 +237,9 @@ func (s *cloudSuiteV2) TestAddCloudInV2(c *gc.C) {
 		}}
 	err := s.apiv2.AddCloud(paramsCloud)
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerTag", "ControllerConfig", "ControllerInfo", "Cloud", "AddCloud")
+	s.backend.CheckCallNames(c, "ControllerTag", "ControllerInfo", "Cloud", "AddCloud")
 	s.backend.CheckCall(c, 0, "ControllerTag")
-	s.backend.CheckCall(c, 4, "AddCloud", cloud.Cloud{
+	s.backend.CheckCall(c, 3, "AddCloud", cloud.Cloud{
 		Name:      "newcloudname",
 		Type:      "maas",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -242,8 +242,8 @@ func (s *cloudSuite) TestAddCloud(c *gc.C) {
 		}}
 	err := s.api.AddCloud(paramsCloud)
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud", "AddCloud")
-	s.backend.CheckCall(c, 3, "AddCloud", cloud.Cloud{
+	s.backend.CheckCallNames(c, "ControllerInfo", "Cloud", "AddCloud")
+	s.backend.CheckCall(c, 2, "AddCloud", cloud.Cloud{
 		Name:      "newcloudname",
 		Type:      "maas",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
@@ -277,7 +277,7 @@ controller cloud type "dummy" is not whitelisted, current whitelist:
  - controller cloud type "lxd" supports [lxd maas openstack]
  - controller cloud type "maas" supports [maas openstack]
  - controller cloud type "openstack" supports [openstack]`[1:]))
-	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud")
+	s.backend.CheckCallNames(c, "ControllerInfo", "Cloud")
 }
 
 func (s *cloudSuite) TestAddCloudNotWhitelistedButForceAdded(c *gc.C) {
@@ -289,8 +289,8 @@ func (s *cloudSuite) TestAddCloudNotWhitelistedButForceAdded(c *gc.C) {
 	addCloudArg.Force = &force
 	err := s.api.AddCloud(addCloudArg)
 	c.Assert(err, jc.ErrorIsNil)
-	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud", "AddCloud")
-	s.backend.CheckCall(c, 3, "AddCloud", cloud.Cloud{
+	s.backend.CheckCallNames(c, "ControllerInfo", "Cloud", "AddCloud")
+	s.backend.CheckCall(c, 2, "AddCloud", cloud.Cloud{
 		Name:      "newcloudname",
 		Type:      "fake",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
@@ -308,7 +308,7 @@ func (s *cloudSuite) TestAddCloudControllerInfoErr(c *gc.C) {
 	}
 	err := s.api.AddCloud(createAddCloudParam(""))
 	c.Assert(err, gc.ErrorMatches, "kaboom")
-	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo")
+	s.backend.CheckCallNames(c, "ControllerInfo")
 }
 
 func (s *cloudSuite) TestAddCloudControllerCloudErr(c *gc.C) {
@@ -321,7 +321,7 @@ func (s *cloudSuite) TestAddCloudControllerCloudErr(c *gc.C) {
 	)
 	err := s.api.AddCloud(createAddCloudParam(""))
 	c.Assert(err, gc.ErrorMatches, "kaboom")
-	s.backend.CheckCallNames(c, "ControllerConfig", "ControllerInfo", "Cloud")
+	s.backend.CheckCallNames(c, "ControllerInfo", "Cloud")
 }
 
 func (s *cloudSuite) TestAddCloudK8sForceIrrelevant(c *gc.C) {
@@ -332,14 +332,15 @@ func (s *cloudSuite) TestAddCloudK8sForceIrrelevant(c *gc.C) {
 	add := func() {
 		err := s.api.AddCloud(addCloudArg)
 		c.Assert(err, jc.ErrorIsNil)
-		s.backend.CheckCallNames(c, "ControllerConfig", "AddCloud")
-		s.backend.CheckCall(c, 1, "AddCloud", cloud.Cloud{
-			Name:      "newcloudname",
-			Type:      string(provider.K8s_ProviderType),
-			AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
-			Endpoint:  "fake-endpoint",
-			Regions:   []cloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
-		}, "admin")
+		s.backend.CheckCalls(c, []gitjujutesting.StubCall{
+			{"AddCloud", []interface{}{cloud.Cloud{
+				Name:      "newcloudname",
+				Type:      string(provider.K8s_ProviderType),
+				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+				Endpoint:  "fake-endpoint",
+				Regions:   []cloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
+			}, "admin"}},
+		})
 	}
 	add()
 
@@ -349,17 +350,22 @@ func (s *cloudSuite) TestAddCloudK8sForceIrrelevant(c *gc.C) {
 	add()
 }
 
-func (s *cloudSuite) TestAddCloudNoFeatureFlag(c *gc.C) {
+func (s *cloudSuite) TestAddCloudNoRegion(c *gc.C) {
+	s.backend.cloud.Type = "maas"
 	paramsCloud := params.AddCloudArgs{
 		Name: "newcloudname",
 		Cloud: params.Cloud{
-			Type:      "fake",
+			Type:      "maas",
 			AuthTypes: []string{"empty", "userpass"},
 			Endpoint:  "fake-endpoint",
-			Regions:   []params.CloudRegion{{Name: "nether", Endpoint: "nether-endpoint"}},
 		}}
+	s.backend.addCloudF = func(cloud cloud.Cloud, user string) error {
+		c.Assert(cloud.Regions, gc.HasLen, 1)
+		return nil
+	}
 	err := s.api.AddCloud(paramsCloud)
-	c.Assert(err, gc.ErrorMatches, `feature flag "multi-cloud" needs to be enabled to add a "fake" cloud`)
+	c.Assert(err, jc.ErrorIsNil)
+
 }
 
 func (s *cloudSuite) TestAddCloudNoAdminPerms(c *gc.C) {
@@ -1354,6 +1360,7 @@ type mockBackend struct {
 	credentialModelsF func(tag names.CloudCredentialTag) (map[string]string, error)
 	credsModels       []state.CredentialOwnerModelAccess
 	controllerInfoF   func() (*state.ControllerInfo, error)
+	addCloudF         func(cloud cloud.Cloud, user string) error
 }
 
 func (st *mockBackend) ControllerTag() names.ControllerTag {
@@ -1406,9 +1413,12 @@ func (st *mockBackend) RemoveCloudCredential(tag names.CloudCredentialTag) error
 	return st.NextErr()
 }
 
-func (st *mockBackend) AddCloud(cloud cloud.Cloud, user string) error {
-	st.MethodCall(st, "AddCloud", cloud, user)
-	return st.NextErr()
+func (st *mockBackend) AddCloud(acloud cloud.Cloud, user string) error {
+	st.MethodCall(st, "AddCloud", acloud, user)
+	if st.addCloudF == nil {
+		return st.NextErr()
+	}
+	return st.addCloudF(acloud, user)
 }
 
 func (st *mockBackend) UpdateCloud(cloud cloud.Cloud) error {

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -260,6 +260,9 @@ type region struct {
 // CloudTypeCAAS is the kubernetes cloud type.
 const CloudTypeCAAS = "kubernetes"
 
+// DefaultCloudRegion is the name of the default region that Juju creates for clouds that do not define a region.
+const DefaultCloudRegion = "default"
+
 var caasCloudTypes = map[string]bool{
 	CloudTypeCAAS: true,
 }

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -320,7 +320,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 
 	// All clouds must have at least one default region - lp#1819409.
 	if len(newCloud.Regions) == 0 {
-		newCloud.Regions = []jujucloud.Region{{Name: "default"}}
+		newCloud.Regions = []jujucloud.Region{{Name: jujucloud.DefaultCloudRegion}}
 	}
 
 	var returnErr error


### PR DESCRIPTION
## Description of change

This PR ensures that all clouds are created with at least one region - if none were supplied, Juju will create a 'default region.

As a drive-by, remove multi-cloud feature flag from API: add-cloud can no happen without a 'multi-cloud' enabled on the controller. It is no longer required since we have improved add-coud experience dramatically, including introduction of 'white-list', force, etc.

## Bug reference

for 'default' region: https://bugs.launchpad.net/juju/+bug/1819409
for multi-cloud: https://bugs.launchpad.net/juju/+bug/1829342
