### PR TITLE
Cleaner test runs (for /tmp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ run-tests:
 	$(eval TMP := $(shell mktemp -d juju-test-XXXX --tmpdir))
 	@echo 'go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$PROJECT_PACKAGES -check.v'
 	@TMPDIR=$(TMP) go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
-	rm -r $(TMP)
+	@rm -r $(TMP)
 
 install: dep rebuild-schema go-install
 

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,18 @@ else
 	TEST_TIMEOUT := 1800s
 endif
 
+# Limit concurrency on s390x.
+ifeq ($(shell uname -p | sed -E 's/.*(s390x).*/golang/'), golang)
+	TEST_ARGS := -p 4
+else
+	TEST_ARGS := 
+endif
+
 # Enable verbose testing for reporting.
 ifeq ($(VERBOSE_CHECK), 1)
-	CHECK_ARGS = -v
+	CHECK_ARGS = -v $(TEST_ARGS)
 else
-	CHECK_ARGS =
+	CHECK_ARGS = $(TEST_ARGS)
 endif
 
 GIT_COMMIT = $(shell git -C $(PROJECT_DIR) rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,9 @@ check: dep pre-check run-tests
 
 test: dep run-tests
 
+# Can't make the length of the TMP dir too long or it hits socket name length issues.
 run-tests:
-	$(eval TMP := $(shell mktemp -d juju-test-XXXX --tmpdir))
+	$(eval TMP := $(shell mktemp -d jj-XXX --tmpdir))
 	@echo 'go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$PROJECT_PACKAGES -check.v'
 	@TMPDIR=$(TMP) go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
 	@rm -r $(TMP)

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,14 @@ pre-check:
 	@echo running pre-test checks
 	@INCLUDE_GOLINTERS=1 $(PROJECT_DIR)/scripts/verify.bash
 
-check: dep pre-check test
+check: dep pre-check run-tests
 
-test: dep
-	go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
+test: dep run-tests
+
+run-tests:
+	$(eval TMP := $(shell mktemp -d juju-test-XXXXXXXX --tmpdir))
+	TMPDIR=$(TMP) go test $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
+	rm -r $(TMP)
 
 install: dep rebuild-schema go-install
 
@@ -204,7 +208,7 @@ local-operator-update: check-k8s-model operator-image
 	$(foreach wm,$(kubeworkers), juju ssh -m ${JUJU_K8S_MODEL} $(wm) -- "zcat /tmp/jujud-operator-image.tar.gz | docker load" ; )
 
 .PHONY: build check install release-install release-build go-build go-install
-.PHONY: clean format simplify
+.PHONY: clean format simplify test run-tests
 .PHONY: install-dependencies
 .PHONY: rebuild-dependencies
 .PHONY: dep check-deps

--- a/api/backups/base_test.go
+++ b/api/backups/base_test.go
@@ -17,13 +17,16 @@ import (
 
 type baseSuite struct {
 	jujutesting.JujuConnSuite
-	backupstesting.BaseSuite
+	Meta    *stbackups.Metadata
+	Storage *backupstesting.FakeStorage
+
 	client *backups.Client
 }
 
 func (s *baseSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
 	s.JujuConnSuite.SetUpTest(c)
+	s.Meta = backupstesting.NewMetadata()
+	s.Storage = &backupstesting.FakeStorage{}
 	client, err := backups.NewClient(s.APIState)
 	c.Assert(err, gc.IsNil)
 	s.client = client

--- a/api/backups/remove_test.go
+++ b/api/backups/remove_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type removeSuite struct {
-	backupsSuite
+	baseSuite
 }
 
 var _ = gc.Suite(&removeSuite{})

--- a/api/backups/restore_test.go
+++ b/api/backups/restore_test.go
@@ -4,11 +4,10 @@
 package backups_test
 
 import (
+	"github.com/golang/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/golang/mock/gomock"
 	"github.com/juju/juju/api/backups"
-
 	"github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/apiserver/params"
 )

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -49,7 +48,6 @@ import (
 // into each of the other per-mode suites.
 type firewallerBaseSuite struct {
 	jujutesting.JujuConnSuite
-	testing.OsEnvSuite
 	op                 <-chan dummy.Operation
 	charm              *state.Charm
 	controllerMachine  *state.Machine
@@ -65,26 +63,10 @@ type firewallerBaseSuite struct {
 	credentialsFacade *credentialvalidator.Facade
 }
 
-func (s *firewallerBaseSuite) SetUpSuite(c *gc.C) {
-	s.OsEnvSuite.SetUpSuite(c)
-	s.JujuConnSuite.SetUpSuite(c)
-}
-
-func (s *firewallerBaseSuite) TearDownSuite(c *gc.C) {
-	s.JujuConnSuite.TearDownSuite(c)
-	s.OsEnvSuite.TearDownSuite(c)
-}
-
 func (s *firewallerBaseSuite) SetUpTest(c *gc.C) {
-	s.OsEnvSuite.SetUpTest(c)
 	s.JujuConnSuite.SetUpTest(c)
 
 	s.callCtx = context.NewCloudCallContext()
-}
-
-func (s *firewallerBaseSuite) TearDownTest(c *gc.C) {
-	s.JujuConnSuite.TearDownTest(c)
-	s.OsEnvSuite.TearDownTest(c)
 }
 
 var _ worker.Worker = (*firewaller.Firewaller)(nil)
@@ -203,10 +185,6 @@ var _ = gc.Suite(&InstanceModeSuite{})
 
 func (s *InstanceModeSuite) SetUpTest(c *gc.C) {
 	s.firewallerBaseSuite.setUpTest(c, config.FwInstance)
-}
-
-func (s *InstanceModeSuite) TearDownTest(c *gc.C) {
-	s.firewallerBaseSuite.JujuConnSuite.TearDownTest(c)
 }
 
 // mockClock will panic if anything but After is called


### PR DESCRIPTION
When we run 'make test', the machine ends up with a bunch of files and directories left in /tmp.
If these aren't regularly pruned, then tests will start failing - like the centos test machine.

This change introduces an explicit temp dir for the duration of the tests, and it deletes it at the end of a successful run.

## QA steps

* run 'make test' and observe /tmp
