### PR TITLE
Introduce user friendly action ids and capture action stdout and stderr

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1570,11 +1570,11 @@
   revision = "e057c73bd1beb18e9634151a2410c422bd2057f2"
 
 [[projects]]
-  digest = "1:9248d4a0789201f02379a65091cb884e3d92390c69382fce95c44ce3a5c1ed2c"
+  digest = "1:995f0b842e8435ce563c0059d1fb5032ced36c704a45a331a27f42b54a279592"
   name = "gopkg.in/juju/names.v3"
   packages = ["."]
   pruneopts = ""
-  revision = "5ed389481ee8344db732cf8a65a8bbfeb42dc79d"
+  revision = "49183320c914a3413d7c36bfe81906ff2a1f62c0"
 
 [[projects]]
   digest = "1:5081ff05b4471731df7fa7457083397c2663791cd5809858a899306cdfe29b63"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -158,7 +158,7 @@
   name = "gopkg.in/juju/environschema.v1"
 
 [[constraint]]
-  revision = "5ed389481ee8344db732cf8a65a8bbfeb42dc79d"
+  revision = "49183320c914a3413d7c36bfe81906ff2a1f62c0"
   name = "gopkg.in/juju/names.v3"
 
 [[constraint]]

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -345,6 +345,92 @@ outcome: success
 result-map:
   message: hello`[1:],
 	}, {
+		should:   "run a basic action with no params with plain output including stdout, stderr",
+		withArgs: []string{validUnitId, "some-action"},
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{
+				Tag:      validActionTagString,
+				Receiver: names.NewUnitTag(validUnitId).String(),
+				Name:     "some-action",
+			},
+			Status: "completed",
+			Output: map[string]interface{}{
+				"Code":           "0",
+				"Stdout":         "hello",
+				"Stderr":         "world",
+				"StdoutEncoding": "utf-8",
+				"StderrEncoding": "utf-8",
+				"outcome":        "success",
+				"result-map": map[string]interface{}{
+					"message": "hello",
+				},
+			},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
+		}},
+		expectedActionEnqueued: []params.Action{{
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}},
+		expectedOutput: `
+outcome: success
+result-map:
+  message: hello
+
+hello
+world`[1:],
+	}, {
+		should:   "run a basic action with no params with yaml output including stdout, stderr",
+		withArgs: []string{validUnitId, "some-action", "--format", "yaml"},
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+		withActionResults: []params.ActionResult{{
+			Action: &params.Action{
+				Tag:      validActionTagString,
+				Receiver: names.NewUnitTag(validUnitId).String(),
+				Name:     "some-action",
+			},
+			Status: "completed",
+			Output: map[string]interface{}{
+				"Code":           "0",
+				"Stdout":         "hello",
+				"Stderr":         "world",
+				"StdoutEncoding": "utf-8",
+				"StderrEncoding": "utf-8",
+				"outcome":        "success",
+				"result-map": map[string]interface{}{
+					"message": "hello",
+				},
+			},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
+		}},
+		expectedActionEnqueued: []params.Action{{
+			Name:       "some-action",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}},
+		expectedOutput: `
+mysql/0:
+  id: f47ac10b-58cc-4372-a567-0e02b2c3d479
+  results:
+    Code: "0"
+    Stderr: world
+    StderrEncoding: utf-8
+    Stdout: hello
+    StdoutEncoding: utf-8
+    outcome: success
+    result-map:
+      message: hello
+  status: completed
+  timing:
+    completed: 2015-02-14 08:17:00 +0000 UTC
+    enqueued: 2015-02-14 08:13:00 +0000 UTC
+    started: 2015-02-14 08:15:00 +0000 UTC`[1:],
+	}, {
 		should:   "run action on multiple units with stdout for each action",
 		withArgs: []string{validUnitId, validUnitId2, "some-action", "--format", "yaml"},
 		withTags: params.FindTagsResults{Matches: map[string][]params.Entity{

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/feature"
 )
 
@@ -46,7 +45,16 @@ displayed.  This is also the behavior when any negative time is given.
 // Set up the output.
 func (c *showOutputCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ActionCommandBase.SetFlags(f)
-	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+	defaultFormatter := "yaml"
+	if featureflag.Enabled(feature.JujuV3) {
+		defaultFormatter = "plain"
+	}
+	c.out.AddFlags(f, defaultFormatter, map[string]cmd.Formatter{
+		"yaml":  cmd.FormatYaml,
+		"json":  cmd.FormatJson,
+		"plain": printPlainOutput,
+	})
+
 	f.StringVar(&c.wait, "wait", "-1s", "Wait for results")
 }
 
@@ -123,7 +131,13 @@ func (c *showOutputCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	return c.out.Write(ctx, FormatActionResult(result))
+	formatted := FormatActionResult(result)
+	if c.out.Name() != "plain" {
+		return c.out.Write(ctx, formatted)
+	}
+	info := make(map[string]interface{})
+	info[c.requestedId] = formatted
+	return c.out.Write(ctx, info)
 }
 
 // GetActionResult tries to repeatedly fetch an action until it is

--- a/worker/caasoperator/action.go
+++ b/worker/caasoperator/action.go
@@ -230,13 +230,10 @@ func getNewRunnerExecutor(
 				o.ReadFrom(r)
 				return o.Bytes()
 			}
-			if params.ProcessResponse {
-				return &utilexec.ExecResponse{
-					Stdout: readBytes(params.Stdout),
-					Stderr: readBytes(params.Stderr),
-				}, nil
-			}
-			return &utilexec.ExecResponse{}, nil
+			return &utilexec.ExecResponse{
+				Stdout: readBytes(params.Stdout),
+				Stderr: readBytes(params.Stderr),
+			}, nil
 		}
 	}
 }

--- a/worker/common/charmrunner/logger.go
+++ b/worker/common/charmrunner/logger.go
@@ -14,22 +14,28 @@ import (
 
 var logger = loggo.GetLogger("juju.worker.common.runner")
 
+// MessageReceiver instances are fed messages written to stdout/stderr
+// when running hooks/actions.
+type MessageReceiver interface {
+	Messagef(isPrefix bool, message string, args ...interface{})
+}
+
 // NewHookLogger creates a new hook logger.
-func NewHookLogger(logger loggo.Logger, outReader io.ReadCloser) *HookLogger {
+func NewHookLogger(outReader io.ReadCloser, receivers ...MessageReceiver) *HookLogger {
 	return &HookLogger{
-		r:      outReader,
-		done:   make(chan struct{}),
-		logger: logger,
+		r:         outReader,
+		done:      make(chan struct{}),
+		receivers: receivers,
 	}
 }
 
-// HookLogger streams the output from a hook to a logger.
+// HookLogger streams the output from a hook to message receivers.
 type HookLogger struct {
-	r       io.ReadCloser
-	done    chan struct{}
-	mu      sync.Mutex
-	stopped bool
-	logger  loggo.Logger
+	r         io.ReadCloser
+	done      chan struct{}
+	mu        sync.Mutex
+	stopped   bool
+	receivers []MessageReceiver
 }
 
 // Run starts the hook logger.
@@ -38,7 +44,7 @@ func (l *HookLogger) Run() {
 	defer l.r.Close()
 	br := bufio.NewReaderSize(l.r, 4096)
 	for {
-		line, _, err := br.ReadLine()
+		line, isPrefix, err := br.ReadLine()
 		if err != nil {
 			if err != io.EOF {
 				logger.Errorf("cannot read hook output: %v", err)
@@ -50,7 +56,9 @@ func (l *HookLogger) Run() {
 			l.mu.Unlock()
 			return
 		}
-		l.logger.Debugf("%s", line)
+		for _, r := range l.receivers {
+			r.Messagef(isPrefix, "%s", line)
+		}
 		l.mu.Unlock()
 	}
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -77,15 +77,14 @@ func NewRunner(context Context, paths context.Paths, remoteExecutor ExecFunc) Ru
 
 // ExecParams holds all the necessary parameters for ExecFunc.
 type ExecParams struct {
-	Commands        []string
-	Env             []string
-	WorkingDir      string
-	Clock           clock.Clock
-	ProcessSetter   func(context.HookProcess)
-	Cancel          <-chan struct{}
-	Stdout          io.ReadWriter
-	Stderr          io.ReadWriter
-	ProcessResponse bool
+	Commands      []string
+	Env           []string
+	WorkingDir    string
+	Clock         clock.Clock
+	ProcessSetter func(context.HookProcess)
+	Cancel        <-chan struct{}
+	Stdout        io.ReadWriter
+	Stderr        io.ReadWriter
 }
 
 // execOnMachine executes commands on current machine.
@@ -172,15 +171,14 @@ func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Durat
 	}
 	var stdout, stderr bytes.Buffer
 	return executor(ExecParams{
-		Commands:        []string{commands},
-		Env:             env,
-		WorkingDir:      runner.paths.GetCharmDir(),
-		Clock:           clock,
-		ProcessSetter:   runner.context.SetProcess,
-		Cancel:          cancel,
-		Stdout:          &stdout,
-		Stderr:          &stderr,
-		ProcessResponse: true,
+		Commands:      []string{commands},
+		Env:           env,
+		WorkingDir:    runner.paths.GetCharmDir(),
+		Clock:         clock,
+		ProcessSetter: runner.context.SetProcess,
+		Cancel:        cancel,
+		Stdout:        &stdout,
+		Stderr:        &stderr,
 	})
 }
 
@@ -238,8 +236,10 @@ func (runner *runner) updateActionResults(results *utilexec.ExecResponse) error 
 	}
 
 	stdout, encoding := encodeBytes(results.Stdout)
-	if err := runner.context.UpdateActionResults([]string{"Stdout"}, stdout); err != nil {
-		return errors.Trace(err)
+	if stdout != "" {
+		if err := runner.context.UpdateActionResults([]string{"Stdout"}, stdout); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	if encoding != "utf8" {
 		if err := runner.context.UpdateActionResults([]string{"StdoutEncoding"}, encoding); err != nil {
@@ -248,8 +248,10 @@ func (runner *runner) updateActionResults(results *utilexec.ExecResponse) error 
 	}
 
 	stderr, encoding := encodeBytes(results.Stderr)
-	if err := runner.context.UpdateActionResults([]string{"Stderr"}, stderr); err != nil {
-		return errors.Trace(err)
+	if stderr != "" {
+		if err := runner.context.UpdateActionResults([]string{"Stderr"}, stderr); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	if encoding != "utf8" {
 		if err := runner.context.UpdateActionResults([]string{"StderrEncoding"}, encoding); err != nil {
@@ -313,6 +315,40 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 	return runner.runCharmHookOnLocal(hookName, env, charmLocation)
 }
 
+// loggerAdaptor implements MessageReceiver and
+// sends messages to a logger.
+type loggerAdaptor struct {
+	loggo.Logger
+}
+
+func (l *loggerAdaptor) Messagef(isPrefix bool, message string, args ...interface{}) {
+	l.Debugf(message, args...)
+}
+
+// bufferAdaptor implements MessageReceiver and
+// is used with the out writer from os.Pipe().
+// It allows the hook logger to grab console output
+// as well as passing the output to an action result.
+type bufferAdaptor struct {
+	io.ReadWriter
+	outCopy bytes.Buffer
+}
+
+func (b *bufferAdaptor) Read(p []byte) (n int, err error) {
+	return b.outCopy.Read(p)
+}
+
+func (b *bufferAdaptor) Messagef(isPrefix bool, message string, args ...interface{}) {
+	formattedMessage := message
+	if len(args) > 0 {
+		formattedMessage = fmt.Sprintf(message, args...)
+	}
+	if !isPrefix {
+		formattedMessage += "\n"
+	}
+	b.outCopy.WriteString(formattedMessage)
+}
+
 func (runner *runner) runCharmHookOnRemote(hookName string, env []string, charmLocation string) error {
 	charmDir := runner.paths.GetCharmDir()
 	hook := filepath.Join(charmDir, filepath.Join(charmLocation, hookName))
@@ -320,28 +356,63 @@ func (runner *runner) runCharmHookOnRemote(hookName string, env []string, charmL
 	var cancel chan struct{}
 	outReader, outWriter, err := os.Pipe()
 	if err != nil {
-		return errors.Errorf("cannot make logging pipe: %v", err)
+		return errors.Errorf("cannot make stdout logging pipe: %v", err)
 	}
 	defer outWriter.Close()
 
-	hookLogger := charmrunner.NewHookLogger(runner.getLogger(hookName), outReader)
-	defer hookLogger.Stop()
-	go hookLogger.Run()
+	actionOut := &bufferAdaptor{ReadWriter: outWriter}
+	hookOutLogger := charmrunner.NewHookLogger(outReader,
+		&loggerAdaptor{runner.getLogger(hookName)},
+		actionOut,
+	)
+	defer hookOutLogger.Stop()
+	go hookOutLogger.Run()
+
+	// When running an action, We capture stdout and stderr
+	// separately to pass back.
+	var actionErr = actionOut
+	_, err = runner.context.ActionData()
+	runningAction := err == nil
+	if runningAction {
+		errReader, errWriter, err := os.Pipe()
+		if err != nil {
+			return errors.Errorf("cannot make stderr logging pipe: %v", err)
+		}
+		defer errWriter.Close()
+
+		actionErr = &bufferAdaptor{ReadWriter: errWriter}
+		hookErrLogger := charmrunner.NewHookLogger(errReader,
+			&loggerAdaptor{runner.getLogger(hookName)},
+			actionErr,
+		)
+		defer hookErrLogger.Stop()
+		go hookErrLogger.Run()
+	}
 
 	executor, err := runner.getRemoteExecutor(runOnRemote)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = executor(
+	resp, err := executor(
 		ExecParams{
 			Commands:   []string{hook},
 			Env:        env,
 			WorkingDir: charmDir,
-			Stdout:     outWriter,
-			Stderr:     outWriter,
+			Stdout:     actionOut,
+			Stderr:     actionErr,
 			Cancel:     cancel,
 		},
 	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// If we are running an action, record stdout and stderr.
+	if runningAction {
+		if err := runner.updateActionResults(resp); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	return errors.Trace(err)
 }
 
@@ -359,19 +430,65 @@ func (runner *runner) runCharmHookOnLocal(hookName string, env []string, charmLo
 	if err != nil {
 		return errors.Errorf("cannot make logging pipe: %v", err)
 	}
+	defer outWriter.Close()
+
 	ps.Stdout = outWriter
 	ps.Stderr = outWriter
-	hookLogger := charmrunner.NewHookLogger(runner.getLogger(hookName), outReader)
-	go hookLogger.Run()
+	actionOut := &bufferAdaptor{ReadWriter: outWriter}
+	hookOutLogger := charmrunner.NewHookLogger(outReader,
+		&loggerAdaptor{runner.getLogger(hookName)},
+		actionOut,
+	)
+	go hookOutLogger.Run()
+	defer hookOutLogger.Stop()
+
+	// When running an action, We capture stdout and stderr
+	// separately to pass back.
+	var actionErr io.Reader
+	_, err = runner.context.ActionData()
+	runningAction := err == nil
+	if runningAction {
+		errReader, errWriter, err := os.Pipe()
+		if err != nil {
+			return errors.Errorf("cannot make stderr logging pipe: %v", err)
+		}
+		defer errWriter.Close()
+
+		ps.Stderr = errWriter
+		errBuf := &bufferAdaptor{ReadWriter: errWriter}
+		actionErr = errBuf
+		hookErrLogger := charmrunner.NewHookLogger(errReader,
+			&loggerAdaptor{runner.getLogger(hookName)},
+			errBuf,
+		)
+		defer hookErrLogger.Stop()
+		go hookErrLogger.Run()
+	}
+
 	err = ps.Start()
-	outWriter.Close()
 	if err == nil {
 		// Record the *os.Process of the hook
 		runner.context.SetProcess(hookProcess{ps.Process})
 		// Block until execution finishes
 		err = ps.Wait()
 	}
-	hookLogger.Stop()
+
+	// If we are running an action, record stdout and stderr.
+	if runningAction {
+		readBytes := func(r io.Reader) []byte {
+			var o bytes.Buffer
+			o.ReadFrom(r)
+			return o.Bytes()
+		}
+		resp := &utilexec.ExecResponse{
+			Code:   ps.ProcessState.ExitCode(),
+			Stdout: readBytes(actionOut),
+			Stderr: readBytes(actionErr),
+		}
+		if err := runner.updateActionResults(resp); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	return errors.Trace(err)
 }
 

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -266,27 +266,34 @@ func (s *RunMockContextSuite) TestRunHookFlushFailure(c *gc.C) {
 func (s *RunMockContextSuite) TestRunActionFlushSuccess(c *gc.C) {
 	expectErr := errors.New("pew pew pew")
 	ctx := &MockContext{
-		flushResult: expectErr,
-		actionData:  &context.ActionData{},
+		flushResult:   expectErr,
+		actionData:    &context.ActionData{},
+		actionResults: map[string]interface{}{},
 	}
 	makeCharm(c, hookSpec{
-		dir:  "actions",
-		name: hookName,
-		perm: 0700,
+		dir:    "actions",
+		name:   hookName,
+		perm:   0700,
+		stdout: "hello",
+		stderr: "world",
 	}, s.paths.GetCharmDir())
 	actualErr := runner.NewRunner(ctx, s.paths, nil).RunAction("something-happened")
 	c.Assert(actualErr, gc.Equals, expectErr)
 	c.Assert(ctx.flushBadge, gc.Equals, "something-happened")
 	c.Assert(ctx.flushFailure, gc.IsNil)
 	s.assertRecordedPid(c, ctx.expectPid)
+	c.Assert(ctx.actionResults, jc.DeepEquals, map[string]interface{}{
+		"Code": "0", "Stderr": "world\n", "Stdout": "hello\n",
+	})
 }
 
 func (s *RunMockContextSuite) TestRunActionFlushCharmActionsCAASSuccess(c *gc.C) {
 	expectErr := errors.New("pew pew pew")
 	ctx := &MockContext{
-		flushResult: expectErr,
-		actionData:  &context.ActionData{},
-		modelType:   model.CAAS,
+		flushResult:   expectErr,
+		actionData:    &context.ActionData{},
+		actionResults: map[string]interface{}{},
+		modelType:     model.CAAS,
 	}
 	makeCharm(c, hookSpec{
 		dir:  "actions",
@@ -299,7 +306,8 @@ func (s *RunMockContextSuite) TestRunActionFlushCharmActionsCAASSuccess(c *gc.C)
 	execFunc := func(params runner.ExecParams) (*exec.ExecResponse, error) {
 		execFuncCalled = true
 		return &exec.ExecResponse{
-			Stdout: bytes.NewBufferString("1").Bytes(),
+			Stdout: bytes.NewBufferString("hello").Bytes(),
+			Stderr: bytes.NewBufferString("world").Bytes(),
 		}, nil
 	}
 	actualErr := runner.NewRunner(ctx, s.paths, execFunc).RunAction("something-happened")
@@ -307,6 +315,9 @@ func (s *RunMockContextSuite) TestRunActionFlushCharmActionsCAASSuccess(c *gc.C)
 	c.Assert(actualErr, gc.Equals, expectErr)
 	c.Assert(ctx.flushBadge, gc.Equals, "something-happened")
 	c.Assert(ctx.flushFailure, gc.IsNil)
+	c.Assert(ctx.actionResults, jc.DeepEquals, map[string]interface{}{
+		"Code": "0", "Stderr": "world", "Stdout": "hello",
+	})
 }
 
 func (s *RunMockContextSuite) TestRunActionFlushCharmActionsCAASFailed(c *gc.C) {
@@ -329,8 +340,9 @@ func (s *RunMockContextSuite) TestRunActionFlushCharmActionsCAASFailed(c *gc.C) 
 func (s *RunMockContextSuite) TestRunActionFlushFailure(c *gc.C) {
 	expectErr := errors.New("pew pew pew")
 	ctx := &MockContext{
-		flushResult: expectErr,
-		actionData:  &context.ActionData{},
+		flushResult:   expectErr,
+		actionData:    &context.ActionData{},
+		actionResults: map[string]interface{}{},
 	}
 	makeCharm(c, hookSpec{
 		dir:  "actions",
@@ -370,7 +382,7 @@ func (s *RunMockContextSuite) TestRunActionSuccessful(c *gc.C) {
 	c.Assert(ctx.flushFailure, gc.IsNil)
 	c.Assert(ctx.actionResults["Code"], gc.Equals, "0")
 	c.Assert(strings.TrimRight(ctx.actionResults["Stdout"].(string), "\r\n"), gc.Equals, "1")
-	c.Assert(ctx.actionResults["Stderr"], gc.Equals, "")
+	c.Assert(ctx.actionResults["Stderr"], gc.Equals, nil)
 }
 
 func (s *RunMockContextSuite) TestRunActionCancelled(c *gc.C) {
@@ -437,7 +449,7 @@ func (s *RunMockContextSuite) TestRunActionCAASSuccess(c *gc.C) {
 	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
 	c.Assert(ctx.actionResults["Code"], gc.Equals, "0")
 	c.Assert(strings.TrimRight(ctx.actionResults["Stdout"].(string), "\r\n"), gc.Equals, "1")
-	c.Assert(ctx.actionResults["Stderr"], gc.Equals, "")
+	c.Assert(ctx.actionResults["Stderr"], gc.Equals, nil)
 }
 
 func (s *RunMockContextSuite) TestRunActionOnWorkloadIgnoredIAAS(c *gc.C) {
@@ -457,5 +469,5 @@ func (s *RunMockContextSuite) TestRunActionOnWorkloadIgnoredIAAS(c *gc.C) {
 	c.Assert(ctx.flushFailure, gc.IsNil)
 	c.Assert(ctx.actionResults["Code"], gc.Equals, "0")
 	c.Assert(strings.TrimRight(ctx.actionResults["Stdout"].(string), "\r\n"), gc.Equals, "1")
-	c.Assert(ctx.actionResults["Stderr"], gc.Equals, "")
+	c.Assert(ctx.actionResults["Stderr"], gc.Equals, nil)
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1195,7 +1195,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			addAction{"action-log", nil},
 			waitActionResults{[]actionResult{{
 				name:    "action-log",
-				results: map[string]interface{}{},
+				results: map[string]interface{}{"Code": "0"},
 				status:  params.ActionCompleted,
 			}}},
 			waitUnitAgent{status: status.Idle},
@@ -1227,7 +1227,8 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			waitActionResults{[]actionResult{{
 				name: "action-log-fail",
 				results: map[string]interface{}{
-					"foo": "still works",
+					"Code": "0",
+					"foo":  "still works",
 				},
 				message: "I'm afraid I can't let you do that, Dave.",
 				status:  params.ActionFailed,
@@ -1260,7 +1261,9 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			waitActionResults{[]actionResult{{
 				name: "action-log-fail-error",
 				results: map[string]interface{}{
-					"foo": "still works",
+					"Code":   "0",
+					"Stderr": `ERROR unrecognized args: ["many" "arguments"]` + "\n",
+					"foo":    "still works",
 				},
 				message: "A real message",
 				status:  params.ActionFailed,
@@ -1297,6 +1300,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			waitActionResults{[]actionResult{{
 				name: "snapshot",
 				results: map[string]interface{}{
+					"Code": "0",
 					"outfile": map[string]interface{}{
 						"name": "snapshot-01.tar",
 						"size": map[string]interface{}{
@@ -1404,15 +1408,15 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			verifyCharm{},
 			waitActionResults{[]actionResult{{
 				name:    "action-log",
-				results: map[string]interface{}{},
+				results: map[string]interface{}{"Code": "0"},
 				status:  params.ActionCompleted,
 			}, {
 				name:    "action-log",
-				results: map[string]interface{}{},
+				results: map[string]interface{}{"Code": "0"},
 				status:  params.ActionCompleted,
 			}, {
 				name:    "action-log",
-				results: map[string]interface{}{},
+				results: map[string]interface{}{"Code": "0"},
 				status:  params.ActionCompleted,
 			}}},
 			waitUnitAgent{status: status.Idle},
@@ -1469,7 +1473,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			},
 			waitActionResults{[]actionResult{{
 				name:    "action-log",
-				results: map[string]interface{}{},
+				results: map[string]interface{}{"Code": "0"},
 				status:  params.ActionCompleted,
 			}}},
 			waitUnitAgent{
@@ -1600,6 +1604,8 @@ func (s *UniterSuite) TestRebootDisabledInActions(c *gc.C) {
 			waitActionResults{[]actionResult{{
 				name: "action-reboot",
 				results: map[string]interface{}{
+					"Code":           "0",
+					"Stderr":         "ERROR juju-reboot is not supported when running an action.\nERROR juju-reboot is not supported when running an action.\n",
 					"reboot-delayed": "good",
 					"reboot-now":     "good",
 				},


### PR DESCRIPTION
## Description of change

Enhance the local and remote runners in the uniter to capture stdout and stderr when running actions, and ensure this is set on the action result. The output is displayed when calling an action of showing action output. Also add the "plain" formatter as the default for show-operation in Juu v3.

The PR also introduces user friendly action ids instead of UUIDs.

## QA steps

Deploy a charm with an action

```

$ juju call postgresql/1 hello who=world
Running Operation postgresql-6
outcome: success
result-map:
  message: Hello world!
  time-completed: Wed Sep  4 02:33:39 UTC 2019

Goodbye cruel world
This message goes to stderr


$ juju show-operation postgresql-6
outcome: success
result-map:
  message: Hello world!
  time-completed: Wed Sep  4 01:05:58 UTC 2019

Goodbye cruel world
This message goes to stderr
```