### PR TITLE
Expose GetChangesMapArgs for clients to use

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -455,11 +455,11 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:3bf45368929d01a44755247cee64f93057c8a0f012ade9a227e4a60a6d2b85ff"
+  digest = "1:ebbd30a06de5bc3933e34d426cfaa69a0cefa10f575d520e6597acbf37e4d132"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "2ab5b6004f111b9f4792a67b14e2f03c37e0af1d"
+  revision = "3ef4201dfd2495d7a56be07a4d095fa624167067"
 
 [[projects]]
   digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/hashicorp/raft-boltdb"
 
 [[constraint]]
-  revision = "2ab5b6004f111b9f4792a67b14e2f03c37e0af1d"
+  revision = "3ef4201dfd2495d7a56be07a4d095fa624167067"
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]

--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -30,6 +30,37 @@ func NewClient(st base.APICallCloser) *Client {
 		facade:       backend}
 }
 
+// GetChanges returns back the changes for a given bundle that need to be
+// applied.
+// GetChanges is superseded by GetChangesMapArgs, use that where possible, by
+// detecting the BestAPIVersion to use.
+func (c *Client) GetChanges(bundleURL, bundleDataYAML string) (params.BundleChangesResults, error) {
+	var result params.BundleChangesResults
+	if err := c.facade.FacadeCall("GetChanges", params.BundleChangesParams{
+		BundleURL:      bundleURL,
+		BundleDataYAML: bundleDataYAML,
+	}, &result); err != nil {
+		return result, errors.Trace(err)
+	}
+	return result, nil
+}
+
+// GetChangesMapArgs returns back the changes for a given bundle that need to be
+// applied, with the args of a method as a map.
+func (c *Client) GetChangesMapArgs(bundleURL, bundleDataYAML string) (params.BundleChangesMapArgsResults, error) {
+	var result params.BundleChangesMapArgsResults
+	if bestVer := c.BestAPIVersion(); bestVer < 4 {
+		return result, errors.Errorf("this controller version does not support bundle get changes as map args feature.")
+	}
+	if err := c.facade.FacadeCall("GetChangesMapArgs", params.BundleChangesParams{
+		BundleURL:      bundleURL,
+		BundleDataYAML: bundleDataYAML,
+	}, &result); err != nil {
+		return result, errors.Trace(err)
+	}
+	return result, nil
+}
+
 // ExportBundle exports the current model configuration.
 func (c *Client) ExportBundle() (string, error) {
 	var result params.StringResult

--- a/api/bundle/client_test.go
+++ b/api/bundle/client_test.go
@@ -26,6 +26,248 @@ func newClient(f basetesting.APICallerFunc, ver int) *bundle.Client {
 	return bundle.NewClient(basetesting.BestVersionCaller{f, ver})
 }
 
+func (s *bundleMockSuite) TestGetChanges(c *gc.C) {
+	bundleURL := "cs:bundle-url"
+	bundleYAML := `applications:
+	ubuntu:
+		charm: cs:trusty/ubuntu
+		series: trusty
+		num_units: 1
+		options:
+			key: value
+			series: xenial
+		relations:
+			- []`
+	changes := []*params.BundleChange{
+		{
+			Id:       "addCharm-0",
+			Method:   "addCharm",
+			Args:     []interface{}{"cs:trusty/ubuntu", "trusty", ""},
+			Requires: []string{},
+		},
+		{
+			Id:     "deploy-1",
+			Method: "deploy",
+			Args: []interface{}{
+				"$addCharm-0",
+				"trusty",
+				"ubuntu",
+				map[string]interface{}{
+					"key":    "value",
+					"series": "xenial",
+				},
+				"",
+				map[string]string{},
+				map[string]string{},
+				map[string]int{},
+				1,
+			},
+			Requires: []string{"$addCharm-0"},
+		},
+	}
+	client := newClient(
+		func(objType string,
+			version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "GetChanges")
+			c.Assert(args, gc.Equals, params.BundleChangesParams{
+				BundleDataYAML: bundleYAML,
+				BundleURL:      bundleURL,
+			})
+			result := response.(*params.BundleChangesResults)
+			result.Changes = changes
+			return nil
+		}, 2,
+	)
+	result, err := client.GetChanges(bundleURL, bundleYAML)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Errors, gc.DeepEquals, []string(nil))
+	c.Assert(result.Changes, gc.DeepEquals, changes)
+}
+
+func (s *bundleMockSuite) TestGetChangesReturnsErrors(c *gc.C) {
+	bundleURL := "cs:bundle-url"
+	bundleYAML := `applications:
+	ubuntu:
+		charm: cs:trusty/ubuntu
+		series: trusty
+		num_units: 1
+		options:
+			key: value
+			series: xenial`
+	client := newClient(
+		func(objType string,
+			version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "GetChanges")
+			c.Assert(args, gc.Equals, params.BundleChangesParams{
+				BundleDataYAML: bundleYAML,
+				BundleURL:      bundleURL,
+			})
+			result := response.(*params.BundleChangesResults)
+			result.Errors = []string{
+				"Error returned from request",
+			}
+			return nil
+		}, 2,
+	)
+	result, err := client.GetChanges(bundleURL, bundleYAML)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Errors, gc.DeepEquals, []string{"Error returned from request"})
+	c.Assert(result.Changes, gc.DeepEquals, []*params.BundleChange(nil))
+}
+
+func (s *bundleMockSuite) TestGetChangesMapArgs(c *gc.C) {
+	bundleURL := "cs:bundle-url"
+	bundleYAML := `applications:
+	ubuntu:
+		charm: cs:trusty/ubuntu
+		series: trusty
+		num_units: 1
+		options:
+			key: value
+			series: xenial`
+	changes := []*params.BundleChangesMapArgs{
+		{
+			Id:     "addCharm-0",
+			Method: "addCharm",
+			Args: map[string]interface{}{
+				"charm":  "cs:trusty/ubuntu",
+				"series": "trusty",
+			},
+			Requires: []string{},
+		},
+		{
+			Id:     "deploy-1",
+			Method: "deploy",
+			Args: map[string]interface{}{
+				"charm":     "$addCharm-0",
+				"series":    "trusty",
+				"num_units": "1",
+				"options": map[string]interface{}{
+					"key":    "value",
+					"series": "xenial",
+				},
+			},
+			Requires: []string{"$addCharm-0"},
+		},
+	}
+	client := newClient(
+		func(objType string,
+			version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "GetChangesMapArgs")
+			c.Assert(args, gc.Equals, params.BundleChangesParams{
+				BundleDataYAML: bundleYAML,
+				BundleURL:      bundleURL,
+			})
+			result := response.(*params.BundleChangesMapArgsResults)
+			result.Changes = changes
+			return nil
+		}, 4,
+	)
+	result, err := client.GetChangesMapArgs(bundleURL, bundleYAML)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Errors, gc.DeepEquals, []string(nil))
+	c.Assert(result.Changes, gc.DeepEquals, changes)
+}
+
+func (s *bundleMockSuite) TestGetChangesMapArgsReturnsErrors(c *gc.C) {
+	bundleURL := "cs:bundle-url"
+	bundleYAML := `applications:
+	ubuntu:
+		charm: cs:trusty/ubuntu
+		series: trusty
+		num_units: 1
+		options:
+			key: value
+			series: xenial
+		relations:
+			- []`
+	client := newClient(
+		func(objType string,
+			version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "GetChangesMapArgs")
+			c.Assert(args, gc.Equals, params.BundleChangesParams{
+				BundleDataYAML: bundleYAML,
+				BundleURL:      bundleURL,
+			})
+			result := response.(*params.BundleChangesMapArgsResults)
+			result.Errors = []string{
+				"Error returned from request",
+			}
+			return nil
+		}, 4,
+	)
+	result, err := client.GetChangesMapArgs(bundleURL, bundleYAML)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Errors, gc.DeepEquals, []string{"Error returned from request"})
+	c.Assert(result.Changes, gc.DeepEquals, []*params.BundleChangesMapArgs(nil))
+}
+
+func (s *bundleMockSuite) TestGetChangesMapArgsV3(c *gc.C) {
+	bundleURL := "cs:bundle-url"
+	bundleYAML := `applications:
+	ubuntu:
+		charm: cs:trusty/ubuntu
+		series: trusty
+		num_units: 1
+		options:
+			key: value
+			series: xenial
+		relations:
+			- []`
+	client := newClient(
+		func(objType string,
+			version int,
+			id,
+			request string,
+			args,
+			response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Bundle")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "GetChangesMapArgs")
+			c.Assert(args, gc.Equals, params.BundleChangesParams{
+				BundleDataYAML: bundleYAML,
+				BundleURL:      bundleURL,
+			})
+			result := response.(*params.BundleChangesMapArgsResults)
+			result.Errors = []string{
+				"Error returned from request",
+			}
+			return nil
+		}, 3,
+	)
+	_, err := client.GetChangesMapArgs(bundleURL, bundleYAML)
+	c.Assert(err, gc.ErrorMatches, "this controller version does not support bundle get changes as map args feature.")
+}
+
 func (s *bundleMockSuite) TestFailExportBundlev1(c *gc.C) {
 	client := newClient(
 		func(objType string,
@@ -51,6 +293,18 @@ func (s *bundleMockSuite) TestFailExportBundlev1(c *gc.C) {
 }
 
 func (s *bundleMockSuite) TestExportBundlev2(c *gc.C) {
+	bundle := `applications:
+	ubuntu:
+		charm: cs:trusty/ubuntu
+		series: trusty
+		num_units: 1
+		to:
+			- \"0\"
+		options:
+			key: value
+			series: xenial
+		relations:
+			- []`
 	client := newClient(
 		func(objType string, version int,
 			id,
@@ -59,35 +313,13 @@ func (s *bundleMockSuite) TestExportBundlev2(c *gc.C) {
 			response interface{},
 		) error {
 			result := response.(*params.StringResult)
-			result.Result = "applications:\n  " +
-				"ubuntu:\n    " +
-				"charm: cs:trusty/ubuntu\n    " +
-				"series: trusty\n    " +
-				"num_units: 1\n    " +
-				"to:\n    " +
-				"- \"0\"\n    " +
-				"options:\n      " +
-				"key: value\n" +
-				"series: xenial\n" +
-				"relations:\n" +
-				"- []\n"
+			result.Result = bundle
 			return nil
 		}, 2,
 	)
 	result, err := client.ExportBundle()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, "applications:\n  "+
-		"ubuntu:\n    "+
-		"charm: cs:trusty/ubuntu\n    "+
-		"series: trusty\n    "+
-		"num_units: 1\n    "+
-		"to:\n    "+
-		"- \"0\"\n    "+
-		"options:\n      "+
-		"key: value\n"+
-		"series: xenial\n"+
-		"relations:\n"+
-		"- []\n")
+	c.Assert(result, jc.DeepEquals, bundle)
 }
 
 func (s *bundleMockSuite) TestExportBundleNotNilParamsErrorv2(c *gc.C) {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -23,7 +23,7 @@ var facadeVersions = map[string]int{
 	"ApplicationScaler":            1,
 	"Backups":                      2,
 	"Block":                        2,
-	"Bundle":                       3,
+	"Bundle":                       4,
 	"CAASAgent":                    1,
 	"CAASFirewaller":               1,
 	"CAASOperator":                 1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -161,6 +161,7 @@ func AllFacades() *facade.Registry {
 	reg("Bundle", 1, bundle.NewFacadeV1)
 	reg("Bundle", 2, bundle.NewFacadeV2)
 	reg("Bundle", 3, bundle.NewFacadeV3)
+	reg("Bundle", 4, bundle.NewFacadeV4)
 	reg("CharmRevisionUpdater", 2, charmrevisionupdater.NewCharmRevisionUpdaterAPI)
 	reg("Charms", 2, charms.NewFacade)
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4816,7 +4816,7 @@
     },
     {
         "Name": "Bundle",
-        "Version": 3,
+        "Version": 4,
         "Schema": {
             "type": "object",
             "properties": {
@@ -4836,6 +4836,17 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/BundleChangesResults"
+                        }
+                    }
+                },
+                "GetChangesMapArgs": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BundleChangesParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BundleChangesMapArgsResults"
                         }
                     }
                 }
@@ -4871,6 +4882,57 @@
                         "args",
                         "requires"
                     ]
+                },
+                "BundleChangesMapArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "method": {
+                            "type": "string"
+                        },
+                        "requires": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "method",
+                        "args",
+                        "requires"
+                    ]
+                },
+                "BundleChangesMapArgsResults": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BundleChangesMapArgs"
+                            }
+                        },
+                        "errors": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
                 },
                 "BundleChangesParams": {
                     "type": "object",

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -903,6 +903,31 @@ type BundleChange struct {
 	Requires []string `json:"requires"`
 }
 
+// BundleChangesMapArgsResults holds results of the Bundle.GetChanges call.
+type BundleChangesMapArgsResults struct {
+	// Changes holds the list of changes required to deploy the bundle.
+	// It is omitted if the provided bundle YAML has verification errors.
+	Changes []*BundleChangesMapArgs `json:"changes,omitempty"`
+	// Errors holds possible bundle verification errors.
+	Errors []string `json:"errors,omitempty"`
+}
+
+// BundleChangesMapArgs holds a single change required to deploy a bundle.
+// BundleChangesMapArgs has Args represented as a map of arguments rather
+// than a series.
+type BundleChangesMapArgs struct {
+	// Id is the unique identifier for this change.
+	Id string `json:"id"`
+	// Method is the action to be performed to apply this change.
+	Method string `json:"method"`
+	// Args holds a list of arguments to pass to the method.
+	Args map[string]interface{} `json:"args"`
+	// Requires holds a list of dependencies for this change. Each dependency
+	// is represented by the corresponding change id, and must be applied
+	// before this change is applied.
+	Requires []string `json:"requires"`
+}
+
 type MongoVersion struct {
 	Major         int    `json:"major"`
 	Minor         int    `json:"minor"`

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -389,6 +389,17 @@ func (h *bundleHandler) getChanges() error {
 	if h.bundleURL != nil {
 		bundleURL = h.bundleURL.String()
 	}
+	// TODO(stickupkid): The following should use the new
+	// Bundle.getChangesMapArgs, with the fallback to Bundle.getChanges and
+	// with controllers without a Bundle facade should use the bundlechanges
+	// library.
+	// The real sticking point is that all the code below uses the bundlechanges
+	// library directly and that's just not cricket. Instead there should be
+	// some normalisation for all entry points, either that be a API or a
+	// library. Then walk over that normalised AST of changes to execute the
+	// changes required. That unfortunately is some re-factoring and would take
+	// some time to do that, hence why we're still using the library directly
+	// unlike other clients.
 	changes, err := bundlechanges.FromData(
 		bundlechanges.ChangesConfig{
 			Bundle:    h.data,


### PR DESCRIPTION
## Description of change

The following exposes GetChangesMapArgs on the Bundle api server,
including adding the methods to the Bundle client. The changes in
the cmd/.../bundle.go requires a LOT of changes, which requires
more time than I've currently got. So instead of doing it in one
stage, I've updated it to make it better than before and left a
very large TODO. Either I'll get time to finish it off at some
point, or someone else will...

In an ideal world, most of the overlay bundle changes would also
be put on the server, again this is a multi-day effort to get it
working and tested, so that again is left as an exercise of the
reader.

What do work at the moment is getting a map of arguments from the
api server, so clients like pylib can work without jumping through
hoops and crashing everytime someone updates bundlechanges.

Note: bundlechanges is a minefield to clients :o

## QA steps

TBA: Will need pylibjuju to get it working for QA steps.
