### PR TITLE
Ensure pod config values with special characters are quoted

### DIFF
--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -256,6 +256,7 @@ func getBasicPodspec() *caas.PodSpec {
 				"restricted": "'yes'",
 				"bar":        true,
 				"switch":     "on",
+				"brackets":   `'["hello", "world"]'`,
 			},
 		}, {
 			Name:  "test2",
@@ -379,6 +380,7 @@ func (s *K8sSuite) TestMakeUnitSpecConfigPairs(c *gc.C) {
 				WorkingDir: "/path/to/here",
 				Env: []core.EnvVar{
 					{Name: "bar", Value: "true"},
+					{Name: "brackets", Value: `["hello", "world"]`},
 					{Name: "foo", Value: "bar"},
 					{Name: "restricted", Value: "yes"},
 					{Name: "switch", Value: "true"},

--- a/caas/kubernetes/provider/k8stypes_test.go
+++ b/caas/kubernetes/provider/k8stypes_test.go
@@ -74,10 +74,12 @@ containers:
         path: /pingReady
         port: www
     config:
-      attr: foo=bar; name['fred']='blogs';
+      attr: foo=bar; name["fred"]="blogs";
       foo: bar
+      brackets: '["hello", "world"]'
       restricted: 'yes'
       switch: on
+      special: p@ssword's
     files:
       - name: configuration
         mountPath: /var/lib/foo
@@ -117,9 +119,11 @@ initContainers:
     - containerPort: 443
       name: mary
     config:
+      brackets: '["hello", "world"]'
       foo: bar
       restricted: 'yes'
       switch: on
+      special: p@ssword's
 service:
   annotations:
     foo: bar
@@ -203,10 +207,12 @@ echo "do some stuff here for gitlab container"
 				{ContainerPort: 443, Name: "mary"},
 			},
 			Config: map[string]interface{}{
-				"attr":       "foo=bar; name['fred']='blogs';",
+				"attr":       `'foo=bar; name["fred"]="blogs";'`,
 				"foo":        "bar",
 				"restricted": "'yes'",
 				"switch":     true,
+				"brackets":   `'["hello", "world"]'`,
+				"special":    "'p@ssword''s'",
 			},
 			Files: []caas.FileSet{
 				{
@@ -278,6 +284,8 @@ echo "do some stuff here for gitlab-init container"
 				"foo":        "bar",
 				"restricted": "'yes'",
 				"switch":     true,
+				"brackets":   `'["hello", "world"]'`,
+				"special":    "'p@ssword''s'",
 			},
 			ProviderContainer: &provider.K8sContainerSpec{
 				ImagePullPolicy: "Always",

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -80,7 +80,7 @@ containers:
 				{ContainerPort: 443},
 			},
 			Config: map[string]interface{}{
-				"attr": "foo=bar; fred=blogs",
+				"attr": "'foo=bar; fred=blogs'",
 				"foo":  "bar",
 			}},
 		}}


### PR DESCRIPTION
## Description of change

pod spec yaml can contain strings with special characters; these need to be quoted, eg

```
spec:
  containers:
  - env:
    - name: BAR
      value: h'e'llo@world
    - name: FOO
      value: '["hello", "world"]'
```

## QA steps

Deploy a k8s charm with yaml like the above and use kubectl to check pod definition afterwards.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1842691
