### PR TITLE
'add-credential' ask-or-tell

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -71,10 +71,15 @@ positional argument:
 When <cloud definition file> is provided with <cloud name>,
 Juju stores that definition in the current controller (after
 validating the contents), or the specified controller if
---controller is used. To make use of this multi-cloud feature,
-the controller needs to have the "multi-cloud" feature flag turned on.
+--controller is used. 
 
-If --local is used, Juju stores that definition its internal cache directly.
+If a current controller is detected, Juju will prompt the user to confirm
+whether this new cloud also needs to be uploaded. 
+Use --no-prompt option when this prompt is undesirable, but the upload to 
+the current controller is wanted.
+Use --controller option to upload a cloud to a different controller. 
+
+Use --local option to add cloud to the current device only.
 
 DEPRECATED If <cloud name> already exists in Juju's cache, then the `[1:] + "`--replace`" + ` 
 option is required. Use 'update-credential' instead.
@@ -108,8 +113,9 @@ When a a running controller is updated, the credential for the cloud
 is also uploaded. As with the cloud, the credential needs
 to have been added to the local Juju cache; add-credential is used to
 do that. If there's only one credential for the cloud it will be
-uploaded to the controller. If the cloud has multiple local credentials
-you can specify which to upload with the --credential option.
+uploaded to the controller automatically by add-clloud command. 
+However, if the cloud has multiple local credentials you can specify 
+which to upload with the --credential option.
 
 When adding clouds to a controller, some clouds are whitelisted and can be easily added:
 %v
@@ -166,7 +172,6 @@ type AddCloudCommand struct {
 	cloudMetadataStore CloudMetadataStore
 
 	// These attributes are used when adding a cloud to a controller.
-	controllerName  string
 	credentialName  string
 	addCloudAPIFunc func() (AddCloudAPI, error)
 
@@ -221,6 +226,7 @@ func (c *AddCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Replace, "replace", false, "DEPRECATED: Overwrite any existing cloud information for <cloud name>")
 	f.BoolVar(&c.Force, "force", false, "Force add cloud to the controller")
 	f.StringVar(&c.CloudFile, "f", "", "The path to a cloud definition file")
+	f.StringVar(&c.CloudFile, "file", "", "The path to a cloud definition file")
 	f.StringVar(&c.credentialName, "credential", "", "Credential to use for new cloud")
 }
 

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -620,7 +620,7 @@ func (c *addCredentialCommand) maybeRemoteCloud(ctxt *cmd.Context) error {
 		return err
 	}
 	if remoteCloud, ok := remoteUserClouds[names.NewCloudTag(c.CloudName)]; ok {
-		ctxt.Infof("Using  remote cloud %q from the controller to verify credentials.", c.CloudName)
+		ctxt.Infof("Using cloud %q from the controller to verify credentials.", c.CloudName)
 		c.cloud = &remoteCloud
 		c.remoteCloudFound = true
 	}

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -835,7 +835,7 @@ Credential "blah" added locally for cloud "somecloud".
 
 `[1:]
 	stderr := `
-Using  remote cloud "somecloud" from the controller to verify credentials.
+Using cloud "somecloud" from the controller to verify credentials.
 Controller credential "blah" for user "admin@local" for cloud "somecloud" on controller "controller" added.
 For more information, see ‘juju show-credential somecloud blah’.
 `[1:]
@@ -874,9 +874,9 @@ credentials:
 	stdin := strings.NewReader(fmt.Sprintf("%vblah\n%s\n", expectedStdin, sourceFile))
 
 	ctx, err := s.run(c, stdin, append(args, cloudName)...)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedStdout)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedStderr)
-	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.store.Credentials[cloudName].AuthCredentials["blah"].Attributes()["file"], gc.Not(jc.Contains), expectedContents)
 	c.Assert(s.store.Credentials[cloudName].AuthCredentials["blah"].Attributes()["file"], gc.Equals, sourceFile)
@@ -904,7 +904,7 @@ Credential "blah" added locally for cloud "remote".
 
 `[1:]
 	stderr := `
-Using  remote cloud "remote" from the controller to verify credentials.
+Using cloud "remote" from the controller to verify credentials.
 Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
 For more information, see ‘juju show-credential remote blah’.
 `[1:]
@@ -961,7 +961,7 @@ Credential "blah" added locally for cloud "remote".
 
 `[1:]
 	stderr := `
-Using  remote cloud "remote" from the controller to verify credentials.
+Using cloud "remote" from the controller to verify credentials.
 Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
 For more information, see ‘juju show-credential remote blah’.
 `[1:]

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -254,7 +254,7 @@ Enter password:
 Credential "fred" added locally for cloud "somecloud".
 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "There are no controllers specified - not adding a credential to any controller.\n")
 }
 
 func (s *addCredentialSuite) TestAddInteractiveInvalidRegionEntered(c *gc.C) {
@@ -278,7 +278,7 @@ Enter password:
 Credential "fred" added locally for cloud "somecloud".
 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "There are no controllers specified - not adding a credential to any controller.\n")
 }
 
 func (s *addCredentialSuite) TestAddInteractiveRegionSpecified(c *gc.C) {
@@ -297,7 +297,7 @@ Enter password:
 Credential "fred" added locally for cloud "somecloud".
 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "There are no controllers specified - not adding a credential to any controller.\n")
 }
 
 func (s *addCredentialSuite) assertCredentialAdded(c *gc.C, input string, args []string, specifiedRegion, expectedRegion string) *cmd.Context {
@@ -836,7 +836,7 @@ Credential "blah" added locally for cloud "somecloud".
 `[1:]
 	stderr := `
 Using  remote cloud "somecloud" from the controller to verify credentials.
-Controller credential "blah" for user "admin@local" on cloud "somecloud" added.
+Controller credential "blah" for user "admin@local" for cloud "somecloud" on controller "controller" added.
 For more information, see ‘juju show-credential somecloud blah’.
 `[1:]
 
@@ -844,6 +844,10 @@ For more information, see ‘juju show-credential somecloud blah’.
 }
 
 func (s *addCredentialSuite) assertAddedCredentialForCloud(c *gc.C, cloudName, expectedStdout, expectedStderr string, uploaded bool) {
+	s.assertAddedCredentialForCloudWithArgs(c, cloudName, expectedStdout, "", expectedStderr, uploaded, "--no-prompt")
+}
+
+func (s *addCredentialSuite) assertAddedCredentialForCloudWithArgs(c *gc.C, cloudName, expectedStdout, expectedStdin, expectedStderr string, uploaded bool, args ...string) {
 	s.setupStore(c)
 	expectedContents := fmt.Sprintf(`
 credentials:
@@ -867,12 +871,12 @@ credentials:
 		return []params.UpdateCredentialResult{{CredentialTag: expectedTag}}, nil
 	}
 
-	stdin := strings.NewReader(fmt.Sprintf("blah\n%s\n", sourceFile))
+	stdin := strings.NewReader(fmt.Sprintf("%vblah\n%s\n", expectedStdin, sourceFile))
 
-	ctx, err := s.run(c, stdin, cloudName)
-	c.Assert(err, jc.ErrorIsNil)
+	ctx, err := s.run(c, stdin, append(args, cloudName)...)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedStdout)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedStderr)
+	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.store.Credentials[cloudName].AuthCredentials["blah"].Attributes()["file"], gc.Not(jc.Contains), expectedContents)
 	c.Assert(s.store.Credentials[cloudName].AuthCredentials["blah"].Attributes()["file"], gc.Equals, sourceFile)
@@ -901,7 +905,7 @@ Credential "blah" added locally for cloud "remote".
 `[1:]
 	stderr := `
 Using  remote cloud "remote" from the controller to verify credentials.
-Controller credential "blah" for user "admin@local" on cloud "remote" added.
+Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
 For more information, see ‘juju show-credential remote blah’.
 `[1:]
 	s.assertAddedCredentialForCloud(c, "remote", stdout, stderr, true)
@@ -933,4 +937,33 @@ Use 'juju clouds -c controller' to see what clouds are available remotely.
 User 'juju add-cloud somecloud -c controller' to add your cloud to the controller.
 `[1:]
 	s.assertAddedCredentialForCloud(c, "somecloud", stdout, "", false)
+}
+
+func (s *addCredentialSuite) TestAddRemoteCloudPromptForController(c *gc.C) {
+	s.api.clouds = func() (map[names.CloudTag]jujucloud.Cloud, error) {
+		return map[names.CloudTag]jujucloud.Cloud{
+			names.NewCloudTag("remote"): {
+				Name:      "remote",
+				Type:      "gce",
+				AuthTypes: []jujucloud.AuthType{jujucloud.JSONFileAuthType},
+			},
+		}, nil
+	}
+	stdout := `
+Do you want to add a credential to current controller "controller"? (Y/n): 
+Enter credential name: 
+Using auth-type "jsonfile".
+
+Enter path to the .json file containing a service account key for your project
+(detailed instructions available at https://discourse.jujucharms.com/t/1508).
+Path: 
+Credential "blah" added locally for cloud "remote".
+
+`[1:]
+	stderr := `
+Using  remote cloud "remote" from the controller to verify credentials.
+Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
+For more information, see ‘juju show-credential remote blah’.
+`[1:]
+	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "\n", stderr, true)
 }

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -932,8 +932,8 @@ Using auth-type "jsonfile".
 Enter path to the credential file: 
 Credential "blah" added locally for cloud "somecloud".
 
-No remote cloud somecloud found on the controller controller: credentials are not added remotely.
-Use 'juju clouds -c controller' to see what clouds are available remotely.
+No cloud "somecloud" found on the controller "controller": credentials are not uploaded.
+Use 'juju clouds -c controller' to see what clouds are available on the controller.
 User 'juju add-cloud somecloud -c controller' to add your cloud to the controller.
 `[1:]
 	s.assertAddedCredentialForCloud(c, "somecloud", stdout, "", false)

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -498,7 +498,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 	if moreCloudInfoNeeded {
 		ctxt.Infof("Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.")
 	}
-	// TODO (anastasiamac 2019-09-04) Local error passd in will eventially be an error from the
+	// TODO (anastasiamac 2019-09-04) Local error passed in will eventually be an error from the
 	// local detection on this client.
 	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results, c.ControllerName, nil)
 }

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -498,7 +498,9 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 	if moreCloudInfoNeeded {
 		ctxt.Infof("Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.")
 	}
-	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results)
+	// TODO (anastasiamac 2019-09-04) Local error passd in will eventially be an error from the
+	// local detection on this client.
+	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results, c.ControllerName, nil)
 }
 
 func (c *detectCredentialsCommand) printCredentialOptions(ctxt *cmd.Context, discovered []discoveredCredential) {

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -405,7 +405,7 @@ Saved credential to cloud test-cloud locally
 1. credential (existing, will overwrite)
 Select a credential to save by number, or type Q to quit: 
 
-Controller credential "blah" for user "admin@local" on cloud "test-cloud" loaded.
+Controller credential "blah" for user "admin@local" for cloud "test-cloud" on controller "controller" loaded.
 For more information, see ‘juju show-credential test-cloud blah’.
 `[1:])
 	c.Assert(called, jc.IsTrue)

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -404,7 +404,7 @@ func (s *updateCredentialSuite) TestUpdateRemote(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, ``)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
-Controller credential "my-credential" for user "admin@local" on cloud "aws" updated.
+Controller credential "my-credential" for user "admin@local" for cloud "aws" on controller "controller" updated.
 For more information, see ‘juju show-credential aws my-credential’.
 `[1:])
 }
@@ -513,7 +513,7 @@ Credential invalid for:
 Failed models may require a different credential.
 Use ‘juju set-credential’ to change credential for these models before repeating this update.
 `[1:])
-	c.Assert(c.GetTestLog(), jc.Contains, `Controller credential "my-credential" for user "admin@local" on cloud "aws" not updated: models issues`)
+	c.Assert(c.GetTestLog(), jc.Contains, `Controller credential "my-credential" for user "admin@local" for cloud "aws" on controller "controller" not updated: models issues`)
 }
 
 type fakeUpdateCredentialAPI struct {

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -91,7 +91,7 @@ clouds:
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Credential valid for:
   controller
-Controller credential "cred" for user "admin" on cloud "dummy" updated.
+Controller credential "cred" for user "admin" for cloud "dummy" on controller "kontroll" updated.
 For more information, see ‘juju show-credential dummy cred’.
 `[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")


### PR DESCRIPTION
## Description of change

In previous iteration, 'add-credential' command has been upgraded to operate on both local client and on controller. This PR ensures that a user is prompted to confirm to upload a credential to the current controller if one is detected.

Drive-by:
(*) File can be specified with an -f or --file option for both add-cloud and add-credential commands.

## QA steps

(*) Add credential interactively (local since no current nor specified controller)
```
$ juju add-credential aws
Enter credential name: sample

Regions
  us-east-1
  us-east-2
  us-west-1
  us-west-2
  ca-central-1
  eu-west-1
  eu-west-2
  eu-west-3
  eu-central-1
  ap-south-1
  ap-southeast-1
  ap-southeast-2
  ap-northeast-1
  ap-northeast-2
  sa-east-1

Select region [any region, credential is not region specific]: 

Using auth-type "access-key".

Enter access-key: 7efgugfygr

Enter secret-key: 

Credential "sample" added locally for cloud "aws".
```
(*) Add credential with file (local since no current nor specified controller)
```
$ juju add-credential aws -f ~/creds.yaml
WARNING credential "sample" for cloud "aws" already exists locally, use 'juju update-credential aws sample' to update it
No local credentials for cloud "aws" changed.

$ juju add-credential aws -f ~/creds.yaml                                                                                         
Credentials "example" added locally for cloud "aws".                       
```
(*) Add credential to a specified controller with file
```
$ juju add-credential aws -f ~/creds.yaml -c mycontroller                                                                         
Using  remote cloud "aws" from the controller to verify credentials.                                                                                                                                         
Credential "special" added locally for cloud "aws".                                                                                                                                                          
                                                                                                                                                                                                             
Controller credential "special" for user "admin" for cloud "aws" on controller "mycontroller" added.                                                                                                                                       
For more information, see ‘juju show-credential aws special’.               
```
(*) Add credential to a current controller with file (prompt)
```
$ juju add-credential aws -f ~/creds.yaml                                                                                         
Do you want to add a credential to current controller "mycontroller"? (Y/n):                                                                                                                                 

Using  remote cloud "aws" from the controller to verify credentials.
Credential "news" added locally for cloud "aws".

Controller credential "news" for user "admin" for cloud "aws" on controller "mycontroller" added.
For more information, see ‘juju show-credential aws news’.
```
(*) Add credential to a current controller with file (skip prompt)
```
$ juju add-credential aws -f ~/creds.yaml --no-prompt
Using  remote cloud "aws" from the controller to verify credentials.
Credential "again" added locally for cloud "aws".

Controller credential "again" for user "admin" for cloud "aws" on controller "mycontroller" added.
For more information, see ‘juju show-credential aws again’.
```
(*) Add credential (remote since credential exists locally)
```
$ juju add-credential aws -f ~/creds.yaml -c mycontroller
Using  remote cloud "aws" from the controller to verify credentials.
WARNING credential "trial" for cloud "aws" already exists locally, use 'juju update-credential aws trial' to update it
No local credentials for cloud "aws" changed.
Controller credential "trial" for user "admin" for cloud "aws" on controller "mycontroller" added.
For more information, see ‘juju show-credential aws trial’.
```
(*) Add credential to a specified controller interactively
```
$ juju add-credential aws -c mycontroller
Using  remote cloud "aws" from the controller to verify credentials.
Enter credential name: okay

Regions
  ap-northeast-1
  ap-northeast-2
  ap-south-1
  ap-southeast-1
  ap-southeast-2
  ca-central-1
  eu-central-1
  eu-west-1
  eu-west-2
  eu-west-3
  sa-east-1
  us-east-1
  us-east-2
  us-west-1
  us-west-2

Select region [any region, credential is not region specific]: 

Using auth-type "access-key".

Enter access-key: dscsc

Enter secret-key: 

Credential "okay" added locally for cloud "aws".

Controller credential "okay" for user "admin" for cloud "aws" on controller "mycontroller" added.
For more information, see ‘juju show-credential aws okay’.
```
(*) Add credential to a current controller interactively (prompt)
```
$ juju add-credential aws
Do you want to add a credential to current controller "mycontroller"? (Y/n): 

Using  remote cloud "aws" from the controller to verify credentials.
Enter credential name: fuunny

Regions
  ap-northeast-1
  ap-northeast-2
  ap-south-1
  ap-southeast-1
  ap-southeast-2
  ca-central-1
  eu-central-1
  eu-west-1
  eu-west-2
  eu-west-3
  sa-east-1
  us-east-1
  us-east-2
  us-west-1
  us-west-2

Select region [any region, credential is not region specific]: 

Using auth-type "access-key".

Enter access-key: asdsds

Enter secret-key: 

Credential "fuunny" added locally for cloud "aws".

Controller credential "fuunny" for user "admin" for cloud "aws" on controller "mycontroller" added.
For more information, see ‘juju show-credential aws fuunny’.
```
(*) Add credential to a current controller interactively (skip prompt)
```
$ juju add-credential aws --no-prompt
Using  remote cloud "aws" from the controller to verify credentials.
Enter credential name: buteme 

Regions
  ap-northeast-1
  ap-northeast-2
  ap-south-1
  ap-southeast-1
  ap-southeast-2
  ca-central-1
  eu-central-1
  eu-west-1
  eu-west-2
  eu-west-3
  sa-east-1
  us-east-1
  us-east-2
  us-west-1
  us-west-2

Select region [any region, credential is not region specific]: 

Using auth-type "access-key".

Enter access-key: dfcdv

Enter secret-key: 

Credential "buteme" added locally for cloud "aws".

Controller credential "buteme" for user "admin" for cloud "aws" on controller "mycontroller" added.
For more information, see ‘juju show-credential aws buteme’.
```
(*) Add credential exists both locally and remotely
```
$ juju add-credential aws -f ~/creds.yaml -c mycontroller
Using  remote cloud "aws" from the controller to verify credentials.
WARNING credential "amtest" for cloud "aws" already exists locally, use 'juju update-credential aws amtest' to update it
No local credentials for cloud "aws" changed.
No remote credentials for cloud "aws" added.
```
