### PR TITLE
Fix instance mutator test

### DIFF
--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -4,6 +4,8 @@
 package instancemutater
 
 import (
+	"sync"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
@@ -174,9 +176,12 @@ type mutaterWorker struct {
 }
 
 func (w *mutaterWorker) loop() error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	m := &mutater{
 		context:     w.getRequiredContextFunc(w),
 		logger:      w.logger,
+		wg:          &wg,
 		machines:    make(map[names.MachineTag]chan struct{}),
 		machineDead: make(chan instancemutater.MutaterMachine),
 	}

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -61,14 +61,14 @@ func (s *workerConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 		{
 			description: "Test no api",
 			config: instancemutater.Config{
-				Logger: mocks.NewMockLogger(ctrl),
+				Logger: loggo.GetLogger("test"),
 			},
 			err: "nil Facade not valid",
 		},
 		{
 			description: "Test no environ",
 			config: instancemutater.Config{
-				Logger: mocks.NewMockLogger(ctrl),
+				Logger: loggo.GetLogger("test"),
 				Facade: mocks.NewMockInstanceMutaterAPI(ctrl),
 			},
 			err: "nil Broker not valid",
@@ -76,7 +76,7 @@ func (s *workerConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 		{
 			description: "Test no agent",
 			config: instancemutater.Config{
-				Logger: mocks.NewMockLogger(ctrl),
+				Logger: loggo.GetLogger("test"),
 				Facade: mocks.NewMockInstanceMutaterAPI(ctrl),
 				Broker: mocks.NewMockLXDProfiler(ctrl),
 			},
@@ -85,7 +85,7 @@ func (s *workerConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 		{
 			description: "Test no tag",
 			config: instancemutater.Config{
-				Logger:      mocks.NewMockLogger(ctrl),
+				Logger:      loggo.GetLogger("test"),
 				Facade:      mocks.NewMockInstanceMutaterAPI(ctrl),
 				Broker:      mocks.NewMockLXDProfiler(ctrl),
 				AgentConfig: mocks.NewMockConfig(ctrl),
@@ -95,7 +95,7 @@ func (s *workerConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 		{
 			description: "Test no GetMachineWatcher",
 			config: instancemutater.Config{
-				Logger:      mocks.NewMockLogger(ctrl),
+				Logger:      loggo.GetLogger("test"),
 				Facade:      mocks.NewMockInstanceMutaterAPI(ctrl),
 				Broker:      mocks.NewMockLXDProfiler(ctrl),
 				AgentConfig: mocks.NewMockConfig(ctrl),
@@ -106,7 +106,7 @@ func (s *workerConfigSuite) TestInvalidConfigValidate(c *gc.C) {
 		{
 			description: "Test no GetRequiredLXDProfiles",
 			config: instancemutater.Config{
-				Logger:            mocks.NewMockLogger(ctrl),
+				Logger:            loggo.GetLogger("test"),
 				Facade:            mocks.NewMockInstanceMutaterAPI(ctrl),
 				Broker:            mocks.NewMockLXDProfiler(ctrl),
 				AgentConfig:       mocks.NewMockConfig(ctrl),
@@ -133,7 +133,7 @@ func (s *workerConfigSuite) TestValidConfigValidate(c *gc.C) {
 
 	config := instancemutater.Config{
 		Facade:                 mocks.NewMockInstanceMutaterAPI(ctrl),
-		Logger:                 mocks.NewMockLogger(ctrl),
+		Logger:                 loggo.GetLogger("test"),
 		Broker:                 mocks.NewMockLXDProfiler(ctrl),
 		AgentConfig:            mocks.NewMockConfig(ctrl),
 		Tag:                    names.MachineTag{},
@@ -148,8 +148,9 @@ func (s *workerConfigSuite) TestValidConfigValidate(c *gc.C) {
 }
 
 type workerSuite struct {
-	loggerSuite
+	testing.IsolationSuite
 
+	logger                 loggo.Logger
 	facade                 *mocks.MockInstanceMutaterAPI
 	broker                 *mocks.MockLXDProfiler
 	agentConfig            *mocks.MockConfig
@@ -172,6 +173,9 @@ var _ = gc.Suite(&workerSuite{})
 func (s *workerSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
+	s.logger = loggo.GetLogger("workerSuite")
+	s.logger.SetLogLevel(loggo.TRACE)
+
 	s.newWorkerFunc = instancemutater.NewEnvironTestWorker
 	s.machineTag = names.NewMachineTag("0")
 	s.getRequiredLXDProfiles = func(modelName string) []string {
@@ -191,7 +195,6 @@ var _ = gc.Suite(&workerEnvironSuite{})
 func (s *workerEnvironSuite) TestFullWorkflow(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyMachines([][]string{{"0"}})
 	s.expectFacadeMachineTag(0)
 	s.notifyMachineAppLXDProfile(0, 1)
@@ -208,7 +211,6 @@ func (s *workerEnvironSuite) TestFullWorkflow(c *gc.C) {
 func (s *workerEnvironSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyMachines([][]string{{"0"}})
 	s.expectFacadeMachineTag(0)
 	s.notifyMachineAppLXDProfile(0, 1)
@@ -223,7 +225,6 @@ func (s *workerEnvironSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
 func (s *workerEnvironSuite) TestRemoveAllCharmProfiles(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyMachines([][]string{{"0"}})
 	s.expectFacadeMachineTag(0)
 	s.notifyMachineAppLXDProfile(0, 1)
@@ -243,7 +244,6 @@ func (s *workerEnvironSuite) TestMachineNotifyTwice(c *gc.C) {
 	// machine notifications are sent.  The 2nd group must
 	// be after machine 0 gets Life() == Alive.
 	var group sync.WaitGroup
-	s.ignoreLogging(c)
 	s.notifyMachinesWaitGroup([][]string{{"0", "1"}, {"0"}}, &group)
 	s.expectFacadeMachineTag(0)
 	s.expectFacadeMachineTag(1)
@@ -262,7 +262,6 @@ func (s *workerEnvironSuite) TestMachineNotifyTwice(c *gc.C) {
 func (s *workerEnvironSuite) TestNoChangeFoundOne(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyMachines([][]string{{"0"}})
 	s.expectFacadeMachineTag(0)
 	s.notifyMachineAppLXDProfile(0, 1)
@@ -274,7 +273,6 @@ func (s *workerEnvironSuite) TestNoChangeFoundOne(c *gc.C) {
 func (s *workerEnvironSuite) TestNoMachineFound(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyMachines([][]string{{"0"}})
 	s.expectFacadeReturnsNoMachine()
 
@@ -299,7 +297,6 @@ func (s *workerEnvironSuite) TestNoMachineFound(c *gc.C) {
 func (s *workerEnvironSuite) TestCharmProfilingInfoNotProvisioned(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyMachines([][]string{{"0"}})
 	s.expectFacadeMachineTag(0)
 	s.notifyMachineAppLXDProfile(0, 1)
@@ -312,7 +309,6 @@ func (s *workerEnvironSuite) TestCharmProfilingInfoNotProvisioned(c *gc.C) {
 func (s *workerEnvironSuite) TestCharmProfilingInfoError(c *gc.C) {
 	defer s.setup(c, 1).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyMachines([][]string{{"0"}})
 	s.expectFacadeMachineTag(0)
 	s.notifyMachineAppLXDProfile(0, 1)
@@ -326,7 +322,6 @@ func (s *workerEnvironSuite) TestCharmProfilingInfoError(c *gc.C) {
 func (s *workerSuite) setup(c *gc.C, machineCount int) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
-	s.logger = mocks.NewMockLogger(ctrl)
 	s.facade = mocks.NewMockInstanceMutaterAPI(ctrl)
 	s.broker = mocks.NewMockLXDProfiler(ctrl)
 	s.agentConfig = mocks.NewMockConfig(ctrl)
@@ -365,11 +360,9 @@ func (s *workerSuite) workerForScenario(c *gc.C) worker.Worker {
 }
 
 func (s *workerSuite) workerForScenarioWithContext(c *gc.C) worker.Worker {
-	logger := loggo.GetLogger("workertest")
-	logger.SetLogLevel(loggo.TRACE)
 	config := instancemutater.Config{
 		Facade:                 s.facade,
-		Logger:                 logger,
+		Logger:                 s.logger,
 		Broker:                 s.broker,
 		AgentConfig:            s.agentConfig,
 		Tag:                    s.machineTag,
@@ -657,42 +650,6 @@ func (s *workerSuite) waitDone(c *gc.C) {
 	}
 }
 
-type loggerSuite struct {
-	testing.IsolationSuite
-
-	logger *mocks.MockLogger
-}
-
-var _ = gc.Suite(&loggerSuite{})
-
-// ignoreLogging turns the suite's mock Logger into a sink, with no validation.
-// Logs are still emitted via the test Logger.
-func (s *loggerSuite) ignoreLogging(c *gc.C) {
-	warnIt := func(message string, args ...interface{}) { logIt(c, loggo.WARNING, message, args) }
-	debugIt := func(message string, args ...interface{}) { logIt(c, loggo.DEBUG, message, args) }
-	errorIt := func(message string, args ...interface{}) { logIt(c, loggo.ERROR, message, args) }
-	traceIt := func(message string, args ...interface{}) { logIt(c, loggo.TRACE, message, args) }
-
-	e := s.logger.EXPECT()
-	e.Warningf(gomock.Any(), gomock.Any()).AnyTimes().Do(warnIt)
-	e.Debugf(gomock.Any(), gomock.Any()).AnyTimes().Do(debugIt)
-	e.Errorf(gomock.Any(), gomock.Any()).AnyTimes().Do(errorIt)
-	e.Tracef(gomock.Any(), gomock.Any()).AnyTimes().Do(traceIt)
-
-}
-
-func logIt(c *gc.C, level loggo.Level, message string, args interface{}) {
-	var nArgs []interface{}
-	var ok bool
-	if nArgs, ok = args.([]interface{}); ok {
-		nArgs = append([]interface{}{level}, nArgs...)
-	} else {
-		nArgs = append([]interface{}{level}, args)
-	}
-
-	c.Logf("%s "+message, nArgs...)
-}
-
 type workerContainerSuite struct {
 	workerSuite
 
@@ -721,7 +678,6 @@ func (s *workerContainerSuite) SetUpTest(c *gc.C) {
 func (s *workerContainerSuite) TestFullWorkflow(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.ignoreLogging(c)
 	s.notifyContainers(0, [][]string{{"0/lxd/0", "0/kvm/0"}})
 	s.expectFacadeMachineTag(0)
 	s.expectFacadeContainerTags()


### PR DESCRIPTION
Fix a few intermittent test failures in the instance mutater.

Since the goroutines that were being created were ensured to be complete before the catacomb loop function terminated, there was a race in the setting of the errors, and the mock controlled test runners.

The test would progress after all the expected calls had been called, and would kill and wait for the worker. The race is that the loop could well finish, and wait on the worker return before the inner goroutine had called catacomb.Kill with the error, giving the intermititent failure of nil.

This is the same reason one of the other tests was also intermittently failing. This has now also been updated.

I also removed the mocking of the logging as it is unnecessary code.

## QA steps

Run the tests with the stress script. Without the change it would fail after several thousand attempts.
With the fix the test run successfully passed 200k runs.
