### PR TITLE
Save action log messages to state

### DIFF
--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -148,6 +148,22 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	})
 }
 
+func (s *unitSuite) TestLogActionMessage(c *gc.C) {
+	anAction, err := s.wordpressUnit.AddAction("fakeaction", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = anAction.Begin()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.apiUnit.LogActionMessage(anAction.ActionTag(), "hello")
+	c.Assert(err, jc.ErrorIsNil)
+
+	anAction, err = s.Model.Action(anAction.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	messages := anAction.Messages()
+	c.Assert(messages, gc.HasLen, 1)
+	c.Assert(messages[0].Message, gc.Equals, "hello")
+	c.Assert(messages[0].Timestamp, gc.NotNil)
+}
+
 func (s *unitSuite) TestEnsureDead(c *gc.C) {
 	c.Assert(s.wordpressUnit.Life(), gc.Equals, state.Alive)
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -33929,6 +33929,17 @@
                         }
                     }
                 },
+                "LogActionsMessages": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ActionMessageParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
                 "Merge": {
                     "type": "object",
                     "properties": {
@@ -34538,6 +34549,21 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "ActionMessageParams": {
+                    "type": "object",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityString"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "messages"
+                    ]
                 },
                 "ActionResult": {
                     "type": "object",

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -143,3 +143,9 @@ type ActionPruneArgs struct {
 	MaxHistoryTime time.Duration `json:"max-history-time"`
 	MaxHistoryMB   int           `json:"max-history-mb"`
 }
+
+// ActionMessageParams holds the arguments for
+// logging progress messages for some actions.
+type ActionMessageParams struct {
+	Messages []EntityString `json:"messages"`
+}

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -80,7 +80,7 @@ func (c *listCommand) Info() *cmd.Info {
 		Aliases: []string{"list-actions"},
 	})
 	if featureflag.Enabled(feature.JujuV3) {
-		info.Doc = strings.Replace(info.Doc, "run-action", "run", -1)
+		info.Doc = strings.Replace(info.Doc, "run-action", "call", -1)
 	}
 	return info
 }

--- a/cmd/juju/action/show.go
+++ b/cmd/juju/action/show.go
@@ -71,7 +71,7 @@ func (c *showCommand) Info() *cmd.Info {
 		Doc:     showActionDoc,
 	})
 	if featureflag.Enabled(feature.JujuV3) {
-		info.Doc = strings.Replace(info.Doc, "run-action", "run", -1)
+		info.Doc = strings.Replace(info.Doc, "run-action", "call", -1)
 	}
 	return info
 }

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -63,14 +63,12 @@ func (c *showOutputCommand) Info() *cmd.Info {
 		Name:    "show-action-output",
 		Args:    "<action ID>",
 		Purpose: "Show results of an action by ID.",
-		Aliases: []string{"show-operation"},
 		Doc:     showOutputDoc,
 	})
 	if featureflag.Enabled(feature.JujuV3) {
 		info.Name = "show-operation"
 		info.Args = "<operation ID>"
 		info.Purpose = "Show results of an operation by ID."
-		info.Aliases = nil
 	}
 	return info
 }

--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -113,13 +113,15 @@ NOTE: Juju 2 uses "juju run" which is deprecated in favour of "juju exec".
 
 func (c *execCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
-		Name:    "exec",
+		Name:    "run",
 		Args:    "<commands>",
 		Purpose: "Run the commands on the remote targets specified.",
+		Aliases: []string{"exec"},
 		Doc:     execDoc,
 	})
-	if !featureflag.Enabled(feature.JujuV3) {
-		info.Aliases = []string{"run"}
+	if featureflag.Enabled(feature.JujuV3) {
+		info.Name = "exec"
+		info.Aliases = nil
 	}
 	return info
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -386,8 +386,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(action.NewListCommand())
 	r.Register(action.NewShowCommand())
 	r.Register(action.NewCancelCommand())
-	r.Register(action.NewCallCommand())
-	if !featureflag.Enabled(feature.JujuV3) {
+	if featureflag.Enabled(feature.JujuV3) {
+		r.Register(action.NewCallCommand())
+	} else {
 		r.Register(action.NewRunActionCommand())
 		r.Register(action.NewStatusCommand())
 	}

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -447,7 +447,6 @@ var commandNames = []string{
 	"bootstrap",
 	"budget",
 	"cached-images",
-	"call",
 	"cancel-action",
 	"change-user-password",
 	"charm",
@@ -585,7 +584,6 @@ var commandNames = []string{
 	"show-machine",
 	"show-model",
 	"show-offer",
-	"show-operation",
 	"show-status",
 	"show-status-log",
 	"show-storage",
@@ -632,7 +630,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-// Currently no commands behind feature flags.
+	"call", "show-operation",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {

--- a/state/interface.go
+++ b/state/interface.go
@@ -221,6 +221,12 @@ type Action interface {
 	// Finish removes action from the pending queue and captures the output
 	// and end state of the action.
 	Finish(results ActionResults) (Action, error)
+
+	// Log adds message to the action's progress message array.
+	Log(message string) error
+
+	// Messages returns the action's progress messages.
+	Messages() []ActionMessage
 }
 
 // ApplicationEntity represents a local or remote application.

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -722,6 +722,7 @@ func (s *MigrationSuite) TestActionDocFields(c *gc.C) {
 		"Results",
 		"Message",
 		"Status",
+		"Logs",
 	)
 	s.AssertExportedFields(c, actionDoc{}, migrated.Union(ignored))
 }

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -335,7 +335,8 @@ func (s *InterfaceSuite) TestUpdateActionResults(c *gc.C) {
 
 	for i, t := range tests {
 		c.Logf("UpdateActionResults test %d: %#v: %#v", i, t.keys, t.value)
-		hctx := context.GetStubActionContext(t.initial)
+		hctx := s.getHookContext(c, s.State.ModelUUID(), -1, "")
+		context.WithActionContext(hctx, t.initial)
 		err := hctx.UpdateActionResults(t.keys, t.value)
 		c.Assert(err, jc.ErrorIsNil)
 		actionData, err := hctx.ActionData()
@@ -346,7 +347,8 @@ func (s *InterfaceSuite) TestUpdateActionResults(c *gc.C) {
 
 // TestSetActionFailed ensures SetActionFailed works properly.
 func (s *InterfaceSuite) TestSetActionFailed(c *gc.C) {
-	hctx := context.GetStubActionContext(nil)
+	hctx := s.getHookContext(c, s.State.ModelUUID(), -1, "")
+	context.WithActionContext(hctx, nil)
 	err := hctx.SetActionFailed()
 	c.Assert(err, jc.ErrorIsNil)
 	actionData, err := hctx.ActionData()
@@ -356,7 +358,8 @@ func (s *InterfaceSuite) TestSetActionFailed(c *gc.C) {
 
 // TestSetActionMessage ensures SetActionMessage works properly.
 func (s *InterfaceSuite) TestSetActionMessage(c *gc.C) {
-	hctx := context.GetStubActionContext(nil)
+	hctx := s.getHookContext(c, s.State.ModelUUID(), -1, "")
+	context.WithActionContext(hctx, nil)
 	err := hctx.SetActionMessage("because reasons")
 	c.Assert(err, jc.ErrorIsNil)
 	actionData, err := hctx.ActionData()
@@ -366,9 +369,20 @@ func (s *InterfaceSuite) TestSetActionMessage(c *gc.C) {
 
 // TestLogActionMessage ensures LogActionMessage works properly.
 func (s *InterfaceSuite) TestLogActionMessage(c *gc.C) {
-	hctx := context.GetStubActionContext(nil)
-	err := hctx.LogActionMessage("hello world")
+	action, err := s.unit.AddAction("fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
+	_, err = action.Begin()
+	c.Assert(err, jc.ErrorIsNil)
+
+	hctx := s.getHookContext(c, s.State.ModelUUID(), -1, "")
+	context.WithActionContext(hctx, nil)
+	err = hctx.LogActionMessage("hello world")
+	c.Assert(err, jc.ErrorIsNil)
+	a, err := s.Model.Action(action.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	messages := a.Messages()
+	c.Assert(messages, gc.HasLen, 1)
+	c.Assert(messages[0].Message, gc.Equals, "hello world")
 }
 
 func (s *InterfaceSuite) TestRequestRebootAfterHook(c *gc.C) {

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -117,11 +117,10 @@ func PatchCachedStatus(ctx jujuc.Context, status, info string, data map[string]i
 	}
 }
 
-func GetStubActionContext(in map[string]interface{}) *HookContext {
-	return &HookContext{
-		actionData: &ActionData{
-			ResultsMap: in,
-		},
+func WithActionContext(ctx *HookContext, in map[string]interface{}) {
+	ctx.actionData = &ActionData{
+		Tag:        names.NewActionTag("u-1"),
+		ResultsMap: in,
 	}
 }
 

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -128,8 +128,8 @@ func (s *HookContextSuite) GetContext(
 	return s.getHookContext(c, uuid.String(), relId, remoteName)
 }
 
-func (s *HookContextSuite) addUnit(c *gc.C, svc *state.Application) *state.Unit {
-	unit, err := svc.AddUnit(state.AddUnitParams{})
+func (s *HookContextSuite) addUnit(c *gc.C, app *state.Application) *state.Unit {
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	if s.machine != nil {
 		err = unit.AssignToMachine(s.machine)
@@ -152,8 +152,8 @@ func (s *HookContextSuite) addUnit(c *gc.C, svc *state.Application) *state.Unit 
 	return unit
 }
 
-func (s *HookContextSuite) AddUnit(c *gc.C, svc *state.Application) *state.Unit {
-	unit := s.addUnit(c, svc)
+func (s *HookContextSuite) AddUnit(c *gc.C, app *state.Application) *state.Unit {
+	unit := s.addUnit(c, app)
 	name := strings.Replace(unit.Name(), "/", "-", 1)
 	privateAddr := network.NewScopedAddress(name+".testing.invalid", network.ScopeCloudLocal)
 	err := s.machine.SetProviderAddresses(privateAddr)


### PR DESCRIPTION
## Description of change

Hook up the uniter facade api to record action progress log messages.
As a driveby, move the new action commands behind the juju-v3 flag; even though the new ones can co-exist, we'll keep the power dry until later.

## QA steps

Run an action with action-log calls.
juju dump-db to see that the messages have been saved.

