### PR TITLE
Feature/podspec v2 cm secrets rbac

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -440,7 +440,7 @@ func (c *controllerStack) createControllerSecretSharedSecret() error {
 	logger.Debugf("ensuring shared secret: \n%+v", secret)
 	c.addCleanUp(func() {
 		logger.Debugf("deleting %q shared-secret", secret.Name)
-		c.broker.deleteSecret(secret.GetName(), secret.GetUID())
+		c.broker.deleteSecret(secret.GetName(), &secret.UID)
 	})
 	return c.broker.updateSecret(secret)
 }
@@ -461,7 +461,7 @@ func (c *controllerStack) createControllerSecretServerPem() error {
 	logger.Debugf("ensuring server.pem secret: \n%+v", secret)
 	c.addCleanUp(func() {
 		logger.Debugf("deleting %q server.pem", secret.Name)
-		c.broker.deleteSecret(secret.GetName(), secret.GetUID())
+		c.broker.deleteSecret(secret.GetName(), &secret.UID)
 	})
 	return c.broker.updateSecret(secret)
 }

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -704,19 +704,29 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 		s.mockSecrets.EXPECT().Update(secretWithServerPEMAdded).AnyTimes().
 			Return(secretWithServerPEMAdded, nil),
 
-		// ensure bootstrap-params configmap.
+		// initialize the empty configmap.
 		s.mockConfigMaps.EXPECT().Get("juju-controller-test-configmap", v1.GetOptions{IncludeUninitialized: true}).AnyTimes().
 			Return(nil, s.k8sNotFoundError()),
 		s.mockConfigMaps.EXPECT().Create(emptyConfigMap).AnyTimes().
 			Return(emptyConfigMap, nil),
+
+		// ensure bootstrap-params configmap.
 		s.mockConfigMaps.EXPECT().Get("juju-controller-test-configmap", v1.GetOptions{IncludeUninitialized: true}).AnyTimes().
 			Return(emptyConfigMap, nil),
+		s.mockConfigMaps.EXPECT().Create(configMapWithBootstrapParamsAdded).AnyTimes().
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).Times(1).
+			Return(&core.ConfigMapList{Items: []core.ConfigMap{*emptyConfigMap}}, nil),
 		s.mockConfigMaps.EXPECT().Update(configMapWithBootstrapParamsAdded).AnyTimes().
 			Return(configMapWithBootstrapParamsAdded, nil),
 
 		// ensure agent.conf configmap.
 		s.mockConfigMaps.EXPECT().Get("juju-controller-test-configmap", v1.GetOptions{IncludeUninitialized: true}).AnyTimes().
 			Return(configMapWithBootstrapParamsAdded, nil),
+		s.mockConfigMaps.EXPECT().Create(configMapWithAgentConfAdded).AnyTimes().
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).Times(1).
+			Return(&core.ConfigMapList{Items: []core.ConfigMap{*configMapWithBootstrapParamsAdded}}, nil),
 		s.mockConfigMaps.EXPECT().Update(configMapWithAgentConfAdded).AnyTimes().
 			Return(configMapWithAgentConfAdded, nil),
 

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -1,0 +1,118 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/errors"
+	core "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/juju/juju/caas/specs"
+)
+
+func (k *kubernetesClient) getConfigMapLabels(appName string) map[string]string {
+	return map[string]string{
+		labelApplication: appName,
+		labelModel:       k.namespace,
+	}
+}
+
+func (k *kubernetesClient) ensureConfigMaps(appName string, cms map[string]specs.ConfigMap) (cleanUps []func(), _ error) {
+	for name, v := range cms {
+		spec := &core.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: k.namespace,
+				Labels:    k.getConfigMapLabels(appName),
+			},
+			Data: v,
+			// BinaryData: // TODO: do we need support binanry data????????????
+		}
+		cmCleanup, err := k.ensureConfigMap(spec)
+		cleanUps = append(cleanUps, cmCleanup)
+		if err != nil {
+			return cleanUps, errors.Trace(err)
+		}
+	}
+	return cleanUps, nil
+}
+
+// ensureConfigMap ensures a ConfigMap resource.
+func (k *kubernetesClient) ensureConfigMap(cm *core.ConfigMap) (cleanUp func(), _ error) {
+	out, err := k.createConfigMap(cm)
+	if err == nil {
+		logger.Debugf("configmap %q created", out.GetName())
+		cleanUp = func() { k.deleteConfigMap(out.GetName(), out.GetUID()) }
+		return cleanUp, nil
+	}
+	if !errors.IsAlreadyExists(err) {
+		return cleanUp, errors.Trace(err)
+	}
+	_, err = k.listConfigMaps(cm.GetLabels())
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// cm.Name is already used for an existing secret.
+			return cleanUp, errors.AlreadyExistsf("configmap %q", cm.GetName())
+		}
+		return cleanUp, errors.Trace(err)
+	}
+	err = k.updateConfigMap(cm)
+	logger.Debugf("updating configmap %q", cm.GetName())
+	return cleanUp, errors.Trace(err)
+}
+
+func (k *kubernetesClient) updateConfigMap(cm *core.ConfigMap) error {
+	_, err := k.client().CoreV1().ConfigMaps(k.namespace).Update(cm)
+	if k8serrors.IsNotFound(err) {
+		return errors.NotFoundf("configmap %q", cm.GetName())
+	}
+	return errors.Trace(err)
+}
+
+// getConfigMap returns a ConfigMap resource.
+func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) {
+	cm, err := k.client().CoreV1().ConfigMaps(k.namespace).Get(cmName, v1.GetOptions{IncludeUninitialized: true})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, errors.NotFoundf("configmap %q", cmName)
+		}
+		return nil, errors.Trace(err)
+	}
+	return cm, nil
+}
+
+// createConfigMap creates a ConfigMap resource.
+func (k *kubernetesClient) createConfigMap(cm *core.ConfigMap) (*core.ConfigMap, error) {
+	out, err := k.client().CoreV1().ConfigMaps(k.namespace).Create(cm)
+	if k8serrors.IsAlreadyExists(err) {
+		return nil, errors.AlreadyExistsf("configmap %q", out.GetName())
+	}
+	return out, errors.Trace(err)
+}
+
+// deleteConfigMap deletes a ConfigMap resource.
+func (k *kubernetesClient) deleteConfigMap(name string, uid types.UID) error {
+	err := k.client().CoreV1().ConfigMaps(k.namespace).Delete(name, newPreconditionDeleteOptions(uid))
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) listConfigMaps(labels map[string]string) ([]core.ConfigMap, error) {
+	listOps := v1.ListOptions{
+		LabelSelector:        labelsToSelector(labels),
+		IncludeUninitialized: true,
+	}
+	cmList, err := k.client().CoreV1().ConfigMaps(k.namespace).List(listOps)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(cmList.Items) == 0 {
+		return nil, errors.NotFoundf("configmap with labels %v", labels)
+	}
+	return cmList.Items, nil
+}

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/caas/specs"

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -86,7 +86,7 @@ func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) 
 
 // createConfigMap creates a ConfigMap resource.
 func (k *kubernetesClient) createConfigMap(cm *core.ConfigMap) (*core.ConfigMap, error) {
-	k.purifyResourceForCreate(cm)
+	k.purifyResource(cm)
 	out, err := k.client().CoreV1().ConfigMaps(k.namespace).Create(cm)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("configmap %q", cm.GetName())

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -16,6 +16,7 @@ import (
 func (k *kubernetesClient) getConfigMapLabels(appName string) map[string]string {
 	return map[string]string{
 		labelApplication: appName,
+		labelModel:       k.namespace,
 	}
 }
 
@@ -73,11 +74,11 @@ func (k *kubernetesClient) updateConfigMap(cm *core.ConfigMap) error {
 }
 
 // getConfigMap returns a ConfigMap resource.
-func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) {
-	cm, err := k.client().CoreV1().ConfigMaps(k.namespace).Get(cmName, v1.GetOptions{IncludeUninitialized: true})
+func (k *kubernetesClient) getConfigMap(name string) (*core.ConfigMap, error) {
+	cm, err := k.client().CoreV1().ConfigMaps(k.namespace).Get(name, v1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, errors.NotFoundf("configmap %q", cmName)
+			return nil, errors.NotFoundf("configmap %q", name)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -16,7 +16,6 @@ import (
 func (k *kubernetesClient) getConfigMapLabels(appName string) map[string]string {
 	return map[string]string{
 		labelApplication: appName,
-		labelModel:       k.namespace,
 	}
 }
 
@@ -88,7 +87,7 @@ func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) 
 func (k *kubernetesClient) createConfigMap(cm *core.ConfigMap) (*core.ConfigMap, error) {
 	out, err := k.client().CoreV1().ConfigMaps(k.namespace).Create(cm)
 	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("configmap %q", out.GetName())
+		return nil, errors.AlreadyExistsf("configmap %q", cm.GetName())
 	}
 	return out, errors.Trace(err)
 }

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/caas/specs"

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -116,3 +116,16 @@ func (k *kubernetesClient) listConfigMaps(labels map[string]string) ([]core.Conf
 	}
 	return cmList.Items, nil
 }
+
+func (k *kubernetesClient) deleteConfigMaps(appName string) error {
+	err := k.client().CoreV1().ConfigMaps(k.namespace).DeleteCollection(&v1.DeleteOptions{
+		PropagationPolicy: &defaultPropagationPolicy,
+	}, v1.ListOptions{
+		LabelSelector:        labelsToSelector(k.getConfigMapLabels(appName)),
+		IncludeUninitialized: true,
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -29,7 +29,6 @@ func (k *kubernetesClient) ensureConfigMaps(appName string, cms map[string]specs
 				Labels:    k.getConfigMapLabels(appName),
 			},
 			Data: v,
-			// BinaryData: // TODO: do we need support binanry data????????????
 		}
 		cmCleanup, err := k.ensureConfigMap(spec)
 		cleanUps = append(cleanUps, cmCleanup)
@@ -55,7 +54,7 @@ func (k *kubernetesClient) ensureConfigMap(cm *core.ConfigMap) (func(), error) {
 	_, err = k.listConfigMaps(cm.GetLabels())
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// cm.Name is already used for an existing secret.
+			// configmap name is already used for an existing secret.
 			return cleanUp, errors.AlreadyExistsf("configmap %q", cm.GetName())
 		}
 		return cleanUp, errors.Trace(err)
@@ -87,7 +86,7 @@ func (k *kubernetesClient) getConfigMap(name string) (*core.ConfigMap, error) {
 
 // createConfigMap creates a ConfigMap resource.
 func (k *kubernetesClient) createConfigMap(cm *core.ConfigMap) (*core.ConfigMap, error) {
-	k.purifyResource(cm)
+	purifyResource(cm)
 	out, err := k.client().CoreV1().ConfigMaps(k.namespace).Create(cm)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("configmap %q", cm.GetName())

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -40,7 +40,8 @@ func (k *kubernetesClient) ensureConfigMaps(appName string, cms map[string]specs
 }
 
 // ensureConfigMap ensures a ConfigMap resource.
-func (k *kubernetesClient) ensureConfigMap(cm *core.ConfigMap) (cleanUp func(), _ error) {
+func (k *kubernetesClient) ensureConfigMap(cm *core.ConfigMap) (func(), error) {
+	cleanUp := func() {}
 	out, err := k.createConfigMap(cm)
 	if err == nil {
 		logger.Debugf("configmap %q created", out.GetName())
@@ -85,6 +86,7 @@ func (k *kubernetesClient) getConfigMap(cmName string) (*core.ConfigMap, error) 
 
 // createConfigMap creates a ConfigMap resource.
 func (k *kubernetesClient) createConfigMap(cm *core.ConfigMap) (*core.ConfigMap, error) {
+	k.purifyResourceForCreate(cm)
 	out, err := k.client().CoreV1().ConfigMaps(k.namespace).Create(cm)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("configmap %q", cm.GetName())

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -1,0 +1,82 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kubernetesClient) getCRDLabels(appName string) map[string]string {
+	return map[string]string{
+		labelApplication: appName,
+		labelModel:       k.namespace,
+	}
+}
+
+// ensureCustomResourceDefinitions creates or updates a custom resource definition resource.
+func (k *kubernetesClient) ensureCustomResourceDefinitions(appName string, crds map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec) (cleanUps []func(), _ error) {
+	for name, crd := range crds {
+		crd, err := k.ensureCustomResourceDefinition(name, k.getCRDLabels(appName), crd)
+		if err != nil {
+			return cleanUps, errors.Annotate(err, fmt.Sprintf("ensure custom resource definition %q", name))
+		}
+		logger.Debugf("ensured custom resource definition %q", crd.ObjectMeta.Name)
+		cleanUps = append(cleanUps, func() { k.deleteCustomResourceDefinition(name) })
+	}
+	return cleanUps, nil
+}
+
+func (k *kubernetesClient) ensureCustomResourceDefinition(name string, labels map[string]string, spec apiextensionsv1beta1.CustomResourceDefinitionSpec) (
+	crd *apiextensionsv1beta1.CustomResourceDefinition, err error) {
+	crdIn := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: k.namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+	apiextensionsV1beta1 := k.extendedCient().ApiextensionsV1beta1()
+	logger.Debugf("creating crd %#v", crdIn)
+	crd, err = apiextensionsV1beta1.CustomResourceDefinitions().Create(crdIn)
+	if k8serrors.IsAlreadyExists(err) {
+		crd, err = apiextensionsV1beta1.CustomResourceDefinitions().Get(name, v1.GetOptions{})
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		resourceVersion := crd.ObjectMeta.GetResourceVersion()
+		crdIn.ObjectMeta.SetResourceVersion(resourceVersion)
+		logger.Debugf("existing crd with resource version %q found, so update it %#v", resourceVersion, crdIn)
+		crd, err = apiextensionsV1beta1.CustomResourceDefinitions().Update(crdIn)
+	}
+	return
+}
+
+func (k *kubernetesClient) deleteCustomResourceDefinition(name string) error {
+	err := k.extendedCient().ApiextensionsV1beta1().CustomResourceDefinitions().Delete(name, &v1.DeleteOptions{
+		PropagationPolicy: &defaultPropagationPolicy,
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) deleteCustomResourceDefinitions(appName string) error {
+	err := k.extendedCient().ApiextensionsV1beta1().CustomResourceDefinitions().DeleteCollection(&v1.DeleteOptions{
+		PropagationPolicy: &defaultPropagationPolicy,
+	}, v1.ListOptions{
+		LabelSelector:        labelsToSelector(k.getCRDLabels(appName)),
+		IncludeUninitialized: true,
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -208,8 +208,8 @@ type resourcePurifier interface {
 	SetResourceVersion(string)
 }
 
-// purifyResourceForCreate purifies read only fields before creating the resources.
-func (k *kubernetesClient) purifyResourceForCreate(resource resourcePurifier) {
+// purifyResource purifies read only fields before creating/updating the resource.
+func (k *kubernetesClient) purifyResource(resource resourcePurifier) {
 	resource.SetResourceVersion("")
 }
 
@@ -2699,6 +2699,7 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 func (k *kubernetesClient) legacyAppName(appName string) bool {
 	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	legacyName := "juju-operator-" + appName
+	logger.Criticalf("legacyAppName appName -> %q, legacyName -> %q", appName, legacyName)
 	_, err := statefulsets.Get(legacyName, v1.GetOptions{IncludeUninitialized: true})
 	return err == nil
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -532,7 +532,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 			return errors.Annotatef(err, "config map for %q should already exist", appName)
 		}
 	} else {
-		cmCleanUp, err := k.ensureConfigMap(operatorConfigMap(appName, operatorName, config))
+		cmCleanUp, err := k.ensureConfigMap(operatorConfigMap(appName, operatorName, k.getConfigMapLabels(appName), config))
 		cleanups = append(cleanups, cmCleanUp)
 		if err != nil {
 			return errors.Annotate(err, "creating or updating ConfigMap")
@@ -2524,11 +2524,13 @@ func operatorPod(podName, appName, operatorServiceIP, agentPath, operatorImagePa
 
 // operatorConfigMap returns a *core.ConfigMap for the operator pod
 // of the specified application, with the specified configuration.
-func operatorConfigMap(appName, operatorName string, config *caas.OperatorConfig) *core.ConfigMap {
+func operatorConfigMap(appName, operatorName string, labels map[string]string, config *caas.OperatorConfig) *core.ConfigMap {
 	configMapName := operatorConfigMapName(operatorName)
 	return &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name: configMapName,
+			// TODO: properly labling operator resources could ensure all resources get deleted when application is removed.
+			Labels: labels,
 		},
 		Data: map[string]string{
 			appName + "-agent.conf": string(config.AgentConf),

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -532,7 +532,6 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	}
 
 	cmName := operatorConfigMapName(operatorName)
-	logger.Criticalf("operatorConfigMapName -> %q", cmName)
 	// TODO(caas) use secrets for storing agent password?
 	if config.AgentConf == nil {
 		// We expect that the config map already exists,
@@ -2650,7 +2649,6 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 func (k *kubernetesClient) legacyAppName(appName string) bool {
 	statefulsets := k.client().AppsV1().StatefulSets(k.namespace)
 	legacyName := "juju-operator-" + appName
-	logger.Criticalf("legacyAppName appName -> %q, legacyName -> %q", appName, legacyName)
 	_, err := statefulsets.Get(legacyName, v1.GetOptions{IncludeUninitialized: true})
 	return err == nil
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -835,7 +835,7 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 		// Delete secrets.
 		for _, c := range p.Spec.Containers {
 			secretName := appSecretName(deploymentName, c.Name)
-			if err := k.deleteSecretByName(secretName); err != nil {
+			if err := k.deleteSecret(secretName, nil); err != nil {
 				return errors.Annotatef(err, "deleting %s secret for container %s", appName, c.Name)
 			}
 		}
@@ -1273,7 +1273,7 @@ func (k *kubernetesClient) EnsureService(
 		if err := k.ensureOCIImageSecret(imageSecretName, appName, &c.ImageDetails, annotations.Copy()); err != nil {
 			return errors.Annotatef(err, "creating secrets for container: %s", c.Name)
 		}
-		cleanups = append(cleanups, func() { k.deleteSecretByName(imageSecretName) })
+		cleanups = append(cleanups, func() { k.deleteSecret(imageSecretName, nil) })
 	}
 
 	// Add a deployment controller or stateful set configured to create the specified number of units/pods.

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1003,6 +1003,9 @@ func (k *kubernetesClient) DeleteService(appName string) (err error) {
 	if err := k.deleteSecrets(appName); err != nil {
 		return errors.Trace(err)
 	}
+	if err := k.deleteConfigMaps(appName); err != nil {
+		return errors.Trace(err)
+	}
 	if err := k.deleteServiceAccountsRolesBindings(appName); err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -204,6 +204,15 @@ func (k *kubernetesClient) client() kubernetes.Interface {
 	return client
 }
 
+type resourcePurifier interface {
+	SetResourceVersion(string)
+}
+
+// purifyResourceForCreate purifies read only fields before creating the resources.
+func (k *kubernetesClient) purifyResourceForCreate(resource resourcePurifier) {
+	resource.SetResourceVersion("")
+}
+
 func (k *kubernetesClient) extendedCient() apiextensionsclientset.Interface {
 	k.lock.Lock()
 	defer k.lock.Unlock()

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2629,7 +2629,6 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec)
 				spec.Pod.ActiveDeadlineSeconds = k8sResources.Pod.ActiveDeadlineSeconds
 				spec.Pod.TerminationGracePeriodSeconds = k8sResources.Pod.TerminationGracePeriodSeconds
 				spec.Pod.DNSPolicy = k8sResources.Pod.DNSPolicy
-				spec.Pod.Priority = k8sResources.Pod.Priority
 				spec.Pod.SecurityContext = k8sResources.Pod.SecurityContext
 				spec.Pod.RestartPolicy = k8sResources.Pod.RestartPolicy
 				spec.Pod.ReadinessGates = k8sResources.Pod.ReadinessGates

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -209,7 +209,7 @@ type resourcePurifier interface {
 }
 
 // purifyResource purifies read only fields before creating/updating the resource.
-func (k *kubernetesClient) purifyResource(resource resourcePurifier) {
+func purifyResource(resource resourcePurifier) {
 	resource.SetResourceVersion("")
 }
 
@@ -2493,11 +2493,10 @@ func operatorPod(podName, appName, operatorServiceIP, agentPath, operatorImagePa
 
 // operatorConfigMap returns a *core.ConfigMap for the operator pod
 // of the specified application, with the specified configuration.
-func operatorConfigMap(appName, cmName string, labels map[string]string, config *caas.OperatorConfig) *core.ConfigMap {
+func operatorConfigMap(appName, name string, labels map[string]string, config *caas.OperatorConfig) *core.ConfigMap {
 	return &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			Name: cmName,
-			// TODO: properly labling operator resources could ensure all resources get deleted when application is removed.
+			Name:   name,
 			Labels: labels,
 		},
 		Data: map[string]string{

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1672,14 +1672,11 @@ func (k *kubernetesClient) configureStatefulSet(
 
 func (k *kubernetesClient) ensureStatefulSet(spec *apps.StatefulSet, existingPodSpec core.PodSpec) error {
 	api := k.client().AppsV1().StatefulSets(k.namespace)
-	_, err := api.Update(spec)
-	if k8serrors.IsNotFound(err) {
-		_, err = api.Create(spec)
-	}
 
+	_, err := api.Update(spec)
 	if err != nil {
-		if k8serrors.IsInvalid(err) {
-			return errors.NewNotValid(err, "ensuring statefulset")
+		if k8serrors.IsNotFound(err) {
+			_, err = api.Create(spec)
 		}
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1038,7 +1038,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfigMissingConfigMap(c *gc.C
 			Provider: "kubernetes",
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, `config map for "test" should already exist:  "test" not found`)
+	c.Assert(err, gc.ErrorMatches, `config map for "test" should already exist: configmap "test-operator-config" not found`)
 }
 
 func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
@@ -1425,8 +1425,6 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds map[str
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Logf("workloadSpec.Secrets -> %+v", workloadSpec.Secrets)
-	c.Logf("workloadSpec.ConfigMaps -> %+v", workloadSpec.ConfigMaps)
 	podSpec := provider.PodSpec(workloadSpec)
 
 	numUnits := int32(2)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -395,7 +395,7 @@ func (s *K8sBrokerSuite) getOCIImageSecret(c *gc.C, annotations map[string]strin
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "app-name-test-secret",
 			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name"},
+			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: annotations,
 		},
 		Type: "kubernetes.io/dockerconfigjson",
@@ -925,7 +925,7 @@ func (s *K8sBrokerSuite) TestEnsureOperator(c *gc.C) {
 	configMapArg := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "test-operator-config",
-			Labels: map[string]string{"juju-app": "test"},
+			Labels: map[string]string{"juju-app": "test", "juju-model": "test"},
 		},
 		Data: map[string]string{
 			"test-agent.conf": "agent-conf-data",
@@ -1062,13 +1062,13 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 		// delete secrets.
 		s.mockSecrets.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
-			v1.ListOptions{LabelSelector: "juju-app==test", IncludeUninitialized: true},
+			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
 		).Times(1).Return(nil),
 
 		// delete configmaps.
 		s.mockConfigMaps.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
-			v1.ListOptions{LabelSelector: "juju-app==test", IncludeUninitialized: true},
+			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
 		).Times(1).Return(nil),
 
 		// delete RBAC resources.
@@ -1089,6 +1089,10 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
 		).Times(1).Return(nil),
 		s.mockServiceAccounts.EXPECT().DeleteCollection(
+			s.deleteOptions(v1.DeletePropagationForeground, nil),
+			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
+		).Times(1).Return(nil),
+		s.mockCustomResourceDefinition.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
 		).Times(1).Return(nil),
@@ -1559,6 +1563,7 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionCreate(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfjobs.kubeflow.org",
 			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -1667,6 +1672,7 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionUpdate(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfjobs.kubeflow.org",
 			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1735,10 +1735,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 	podSpec := getBasicPodspec()
 	podSpec.ServiceAccount = &specs.ServiceAccountSpec{
 		AutomountServiceAccountToken: boolPtr(true),
-		Rules: &rbacv1.PolicyRule{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"get", "watch", "list"},
+		Rules: []specs.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
 		},
 	}
 
@@ -1879,10 +1881,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 	podSpec := getBasicPodspec()
 	podSpec.ServiceAccount = &specs.ServiceAccountSpec{
 		AutomountServiceAccountToken: boolPtr(true),
-		Rules: &rbacv1.PolicyRule{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"get", "watch", "list"},
+		Rules: []specs.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
 		},
 	}
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -85,7 +85,6 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 					RunAsNonRoot:       boolPtr(true),
 					SupplementalGroups: []int64{1, 2},
 				},
-				Priority: int32Ptr(30),
 				ReadinessGates: []core.PodReadinessGate{
 					{ConditionType: core.PodInitialized},
 				},
@@ -130,7 +129,6 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 			RunAsNonRoot:       boolPtr(true),
 			SupplementalGroups: []int64{1, 2},
 		},
-		Priority: int32Ptr(30),
 		ReadinessGates: []core.PodReadinessGate{
 			{ConditionType: core.PodInitialized},
 		},

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -70,7 +70,7 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 				Kind: "Role",
 			},
 			Subjects: []rbacv1.Subject{
-				rbacv1.Subject{
+				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      sa.GetName(),
 					Namespace: sa.GetNamespace(),
@@ -101,7 +101,7 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 				Kind: "ClusterRole",
 			},
 			Subjects: []rbacv1.Subject{
-				rbacv1.Subject{
+				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      sa.GetName(),
 					Namespace: sa.GetNamespace(),

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -9,7 +9,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/caas/specs"
 )

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -444,12 +444,15 @@ func (k *kubernetesClient) ensureRoleBinding(rb *rbacv1.RoleBinding) (out *rbacv
 		logger.Debugf("role binding %q deleted", v.GetName())
 	}
 	out, err = k.createRoleBinding(rb)
+	if err != nil {
+		return nil, cleanups, errors.Trace(err)
+	}
 	if isFirstDeploy {
 		// only do cleanup for the first time, don't do this for existing deployments.
 		cleanups = append(cleanups, func() { k.deleteRoleBinding(out.GetName(), out.GetUID()) })
 	}
 	logger.Debugf("role binding %q created", rb.GetName())
-	return out, cleanups, errors.Trace(err)
+	return out, cleanups, nil
 }
 
 func (k *kubernetesClient) getRoleBinding(name string) (*rbacv1.RoleBinding, error) {
@@ -529,11 +532,14 @@ func (k *kubernetesClient) ensureClusterRoleBinding(crb *rbacv1.ClusterRoleBindi
 		logger.Debugf("cluster role binding %q deleted", v.GetName())
 	}
 	out, err = k.createClusterRoleBinding(crb)
+	if err != nil {
+		return nil, cleanups, errors.Trace(err)
+	}
 	if isFirstDeploy {
 		cleanups = append(cleanups, func() { k.deleteClusterRoleBinding(out.GetName(), out.GetUID()) })
 	}
 	logger.Debugf("cluster role binding %q created", crb.GetName())
-	return out, cleanups, errors.Trace(err)
+	return out, cleanups, nil
 }
 
 func (k *kubernetesClient) getClusterRoleBinding(name string) (*rbacv1.ClusterRoleBinding, error) {

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -415,10 +415,12 @@ func (k *kubernetesClient) ensureRoleBinding(rb *rbacv1.RoleBinding) (out *rbacv
 	}
 
 	for _, v := range rbs {
-		if err := k.deleteRoleBinding(v.GetName(), v.GetUID()); err != nil {
-			return nil, cleanups, errors.Trace(err)
+		if v.GetName() == rb.GetName() {
+			if err := k.deleteRoleBinding(v.GetName(), v.GetUID()); err != nil {
+				return nil, cleanups, errors.Trace(err)
+			}
+			logger.Debugf("role binding %q deleted", v.GetName())
 		}
-		logger.Debugf("role binding %q deleted", v.GetName())
 	}
 	out, err = k.createRoleBinding(rb)
 	if err != nil {

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -136,7 +136,7 @@ func (k *kubernetesClient) deleteAllServiceAccountResources(appName string) erro
 }
 
 func (k *kubernetesClient) createServiceAccount(sa *core.ServiceAccount) (*core.ServiceAccount, error) {
-	k.purifyResourceForCreate(sa)
+	k.purifyResource(sa)
 	out, err := k.client().CoreV1().ServiceAccounts(k.namespace).Create(sa)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("service account %q", sa.GetName())
@@ -220,7 +220,7 @@ func (k *kubernetesClient) listServiceAccount(labels map[string]string) ([]core.
 }
 
 func (k *kubernetesClient) createRole(role *rbacv1.Role) (*rbacv1.Role, error) {
-	k.purifyResourceForCreate(role)
+	k.purifyResource(role)
 	out, err := k.client().RbacV1().Roles(k.namespace).Create(role)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("role %q", role.GetName())
@@ -304,7 +304,7 @@ func (k *kubernetesClient) listRoles(labels map[string]string) ([]rbacv1.Role, e
 }
 
 func (k *kubernetesClient) createClusterRole(cRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	k.purifyResourceForCreate(cRole)
+	k.purifyResource(cRole)
 	out, err := k.client().RbacV1().ClusterRoles().Create(cRole)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("cluster role %q", cRole.GetName())
@@ -388,7 +388,7 @@ func (k *kubernetesClient) listClusterRoles(labels map[string]string) ([]rbacv1.
 }
 
 func (k *kubernetesClient) createRoleBinding(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-	k.purifyResourceForCreate(rb)
+	k.purifyResource(rb)
 	out, err := k.client().RbacV1().RoleBindings(k.namespace).Create(rb)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("role binding %q", rb.GetName())
@@ -479,7 +479,7 @@ func (k *kubernetesClient) listRoleBindings(labels map[string]string) ([]rbacv1.
 }
 
 func (k *kubernetesClient) createClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-	k.purifyResourceForCreate(crb)
+	k.purifyResource(crb)
 	out, err := k.client().RbacV1().ClusterRoleBindings().Create(crb)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("cluster role binding %q", crb.GetName())

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -136,6 +136,7 @@ func (k *kubernetesClient) deleteAllServiceAccountResources(appName string) erro
 }
 
 func (k *kubernetesClient) createServiceAccount(sa *core.ServiceAccount) (*core.ServiceAccount, error) {
+	k.purifyResourceForCreate(sa)
 	out, err := k.client().CoreV1().ServiceAccounts(k.namespace).Create(sa)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("service account %q", sa.GetName())
@@ -219,6 +220,7 @@ func (k *kubernetesClient) listServiceAccount(labels map[string]string) ([]core.
 }
 
 func (k *kubernetesClient) createRole(role *rbacv1.Role) (*rbacv1.Role, error) {
+	k.purifyResourceForCreate(role)
 	out, err := k.client().RbacV1().Roles(k.namespace).Create(role)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("role %q", role.GetName())
@@ -302,6 +304,7 @@ func (k *kubernetesClient) listRoles(labels map[string]string) ([]rbacv1.Role, e
 }
 
 func (k *kubernetesClient) createClusterRole(cRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	k.purifyResourceForCreate(cRole)
 	out, err := k.client().RbacV1().ClusterRoles().Create(cRole)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("cluster role %q", cRole.GetName())
@@ -385,6 +388,7 @@ func (k *kubernetesClient) listClusterRoles(labels map[string]string) ([]rbacv1.
 }
 
 func (k *kubernetesClient) createRoleBinding(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+	k.purifyResourceForCreate(rb)
 	out, err := k.client().RbacV1().RoleBindings(k.namespace).Create(rb)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("role binding %q", rb.GetName())
@@ -473,6 +477,7 @@ func (k *kubernetesClient) listRoleBindings(labels map[string]string) ([]rbacv1.
 }
 
 func (k *kubernetesClient) createClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+	k.purifyResourceForCreate(crb)
 	out, err := k.client().RbacV1().ClusterRoleBindings().Create(crb)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("cluster role binding %q", crb.GetName())

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -18,6 +18,7 @@ import (
 func (k *kubernetesClient) getSecretLabels(appName string) map[string]string {
 	return map[string]string{
 		labelApplication: appName,
+		labelModel:       k.namespace,
 	}
 }
 
@@ -170,7 +171,7 @@ func (k *kubernetesClient) deleteSecrets(appName string) error {
 	err := k.client().CoreV1().Secrets(k.namespace).DeleteCollection(&v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	}, v1.ListOptions{
-		LabelSelector:        labelsToSelector(k.getConfigMapLabels(appName)),
+		LabelSelector:        labelsToSelector(k.getSecretLabels(appName)),
 		IncludeUninitialized: true,
 	})
 	if k8serrors.IsNotFound(err) {

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -18,7 +18,6 @@ import (
 func (k *kubernetesClient) getSecretLabels(appName string) map[string]string {
 	return map[string]string{
 		labelApplication: appName,
-		labelModel:       k.namespace,
 	}
 }
 
@@ -70,7 +69,7 @@ func (k *kubernetesClient) ensureOCIImageSecret(
 		ObjectMeta: v1.ObjectMeta{
 			Name:        imageSecretName,
 			Namespace:   k.namespace,
-			Labels:      map[string]string{labelApplication: appName},
+			Labels:      k.getSecretLabels(appName),
 			Annotations: annotations.ToMap()},
 		Type: core.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
@@ -130,7 +129,7 @@ func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
 func (k *kubernetesClient) createSecret(secret *core.Secret) (*core.Secret, error) {
 	out, err := k.client().CoreV1().Secrets(k.namespace).Create(secret)
 	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("secret %q", out.GetName())
+		return nil, errors.AlreadyExistsf("secret %q", secret.GetName())
 	}
 	return out, errors.Trace(err)
 }

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -129,7 +129,7 @@ func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
 
 // createSecret creates a secret resource.
 func (k *kubernetesClient) createSecret(secret *core.Secret) (*core.Secret, error) {
-	k.purifyResource(secret)
+	purifyResource(secret)
 	out, err := k.client().CoreV1().Secrets(k.namespace).Create(secret)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("secret %q", secret.GetName())

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -81,7 +81,8 @@ func (k *kubernetesClient) ensureOCIImageSecret(
 	return errors.Trace(err)
 }
 
-func (k *kubernetesClient) ensureSecret(sec *core.Secret) (cleanUp func(), _ error) {
+func (k *kubernetesClient) ensureSecret(sec *core.Secret) (func(), error) {
+	cleanUp := func() {}
 	out, err := k.createSecret(sec)
 	if err == nil {
 		logger.Debugf("secret %q created", out.GetName())
@@ -127,6 +128,7 @@ func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
 
 // createSecret creates a secret resource.
 func (k *kubernetesClient) createSecret(secret *core.Secret) (*core.Secret, error) {
+	k.purifyResourceForCreate(secret)
 	out, err := k.client().CoreV1().Secrets(k.namespace).Create(secret)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("secret %q", secret.GetName())

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -1,0 +1,188 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/errors"
+	core "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
+	"github.com/juju/juju/caas/specs"
+	k8sannotations "github.com/juju/juju/core/annotations"
+)
+
+func (k *kubernetesClient) getSecretLabels(appName string) map[string]string {
+	return map[string]string{
+		labelApplication: appName,
+		labelModel:       k.namespace,
+	}
+}
+
+func (k *kubernetesClient) ensureSecrets(appName string, secrets []k8sspecs.Secret) (cleanUps []func(), _ error) {
+	processData := func(in map[string]string) map[string][]byte {
+		out := make(map[string][]byte)
+		for k, v := range in {
+			out[k] = []byte(v)
+		}
+		return out
+	}
+	for _, v := range secrets {
+		spec := &core.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:        v.Name,
+				Namespace:   k.namespace,
+				Labels:      k.getSecretLabels(appName),
+				Annotations: v.Annotations,
+			},
+			Type:       v.Type,
+			Data:       processData(v.Data),
+			StringData: v.StringData,
+		}
+		secretCleanup, err := k.ensureSecret(spec)
+		cleanUps = append(cleanUps, secretCleanup)
+		if err != nil {
+			return cleanUps, errors.Trace(err)
+		}
+	}
+	return cleanUps, nil
+}
+
+// ensureOCIImageSecret ensures a secret exists for use with retrieving images from private registries
+func (k *kubernetesClient) ensureOCIImageSecret(
+	imageSecretName,
+	appName string,
+	imageDetails *specs.ImageDetails,
+	annotations k8sannotations.Annotation,
+) error {
+	if imageDetails.Password == "" {
+		return errors.New("attempting to create a secret with no password")
+	}
+	secretData, err := createDockerConfigJSON(imageDetails)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	newSecret := &core.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        imageSecretName,
+			Namespace:   k.namespace,
+			Labels:      map[string]string{labelApplication: appName},
+			Annotations: annotations.ToMap()},
+		Type: core.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			core.DockerConfigJsonKey: secretData,
+		},
+	}
+	logger.Debugf("ensuring docker secret %q", imageSecretName)
+	_, err = k.ensureSecret(newSecret)
+	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) ensureSecret(sec *core.Secret) (cleanUp func(), _ error) {
+	out, err := k.createSecret(sec)
+	if err == nil {
+		logger.Debugf("secret %q created", out.GetName())
+		cleanUp = func() { k.deleteSecret(out.GetName(), out.GetUID()) }
+		return cleanUp, nil
+	}
+	if !errors.IsAlreadyExists(err) {
+		return cleanUp, errors.Trace(err)
+	}
+	_, err = k.listSecrets(sec.GetLabels())
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// sec.Name is already used for an existing secret.
+			return cleanUp, errors.AlreadyExistsf("secret %q", sec.GetName())
+		}
+		return cleanUp, errors.Trace(err)
+	}
+	err = k.updateSecret(sec)
+	logger.Debugf("updating secret %q", sec.GetName())
+	return cleanUp, errors.Trace(err)
+}
+
+// updateSecret updates a secret resource.
+func (k *kubernetesClient) updateSecret(sec *core.Secret) error {
+	_, err := k.client().CoreV1().Secrets(k.namespace).Update(sec)
+	if k8serrors.IsNotFound(err) {
+		return errors.NotFoundf("secret %q", sec.GetName())
+	}
+	return errors.Trace(err)
+}
+
+// getSecret return a secret resource.
+func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
+	secret, err := k.client().CoreV1().Secrets(k.namespace).Get(secretName, v1.GetOptions{IncludeUninitialized: true})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, errors.NotFoundf("secret %q", secretName)
+		}
+		return nil, errors.Trace(err)
+	}
+	return secret, nil
+}
+
+// createSecret creates a secret resource.
+func (k *kubernetesClient) createSecret(secret *core.Secret) (*core.Secret, error) {
+	out, err := k.client().CoreV1().Secrets(k.namespace).Create(secret)
+	if k8serrors.IsAlreadyExists(err) {
+		return nil, errors.AlreadyExistsf("secret %q", out.GetName())
+	}
+	return out, errors.Trace(err)
+}
+
+// deleteSecret deletes a secret resource.
+func (k *kubernetesClient) deleteSecret(secretName string, uid types.UID) error {
+	secrets := k.client().CoreV1().Secrets(k.namespace)
+	err := secrets.Delete(secretName, newPreconditionDeleteOptions(uid))
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}
+
+// deleteSecret deletes a secret resource(try to use the deleteSecret if possible).
+func (k *kubernetesClient) deleteSecretByName(secretName string) error {
+	secrets := k.client().CoreV1().Secrets(k.namespace)
+	err := secrets.Delete(secretName, &v1.DeleteOptions{
+		PropagationPolicy: &defaultPropagationPolicy,
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) listSecrets(labels map[string]string) ([]core.Secret, error) {
+	listOps := v1.ListOptions{
+		LabelSelector:        labelsToSelector(labels),
+		IncludeUninitialized: true,
+	}
+	secList, err := k.client().CoreV1().Secrets(k.namespace).List(listOps)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(secList.Items) == 0 {
+		return nil, errors.NotFoundf("secret with labels %v", labels)
+	}
+	return secList.Items, nil
+}
+
+func (k *kubernetesClient) deleteSecrets(appName string) error {
+	secretList, err := k.client().CoreV1().Secrets(k.namespace).List(v1.ListOptions{
+		LabelSelector: applicationSelector(appName),
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, s := range secretList.Items {
+		if err := k.deleteSecret(s.Name, s.GetUID()); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -128,7 +128,7 @@ func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
 
 // createSecret creates a secret resource.
 func (k *kubernetesClient) createSecret(secret *core.Secret) (*core.Secret, error) {
-	k.purifyResourceForCreate(secret)
+	k.purifyResource(secret)
 	out, err := k.client().CoreV1().Secrets(k.namespace).Create(secret)
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("secret %q", secret.GetName())

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -89,7 +89,6 @@ func (p podSpecLegacy) ToLatest() *specs.PodSpec {
 		ActiveDeadlineSeconds:         p.k8sSpec.ActiveDeadlineSeconds,
 		TerminationGracePeriodSeconds: p.k8sSpec.TerminationGracePeriodSeconds,
 		SecurityContext:               p.k8sSpec.SecurityContext,
-		Priority:                      p.k8sSpec.Priority,
 		ReadinessGates:                p.k8sSpec.ReadinessGates,
 		DNSPolicy:                     p.k8sSpec.DNSPolicy,
 	}

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -80,10 +80,8 @@ func (p podSpecLegacy) ToLatest() *specs.PodSpec {
 	}
 
 	if p.k8sSpec.ServiceAccountName != "" {
-		pSpec.ServiceAccount = &specs.ServiceAccountSpec{
-			Name:                         p.k8sSpec.ServiceAccountName,
-			AutomountServiceAccountToken: p.k8sSpec.AutomountServiceAccountToken,
-		}
+		// we ignore service account stuff in legacy version.
+		logger.Warningf("service account support is dropped in legacy version, please use v2.")
 	}
 
 	iPodSpec := &PodSpec{

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -156,12 +156,7 @@ foo: bar
 `[1:]
 
 	getExpectedPodSpecBase := func() *specs.PodSpec {
-		pSpecs := &specs.PodSpec{
-			ServiceAccount: &specs.ServiceAccountSpec{
-				Name:                         "serviceAccountFoo",
-				AutomountServiceAccountToken: boolPtr(true),
-			},
-		}
+		pSpecs := &specs.PodSpec{}
 		// always parse to latest version.
 		pSpecs.Version = specs.CurrentVersion
 		pSpecs.OmitServiceFrontend = true

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -33,7 +33,6 @@ serviceAccountName: serviceAccountFoo
 securityContext:
   runAsNonRoot: true
   supplementalGroups: [1,2]
-priority: 30
 dnsPolicy: ClusterFirstWithHostNet
 readinessGates:
   - conditionType: PodScheduled
@@ -278,7 +277,6 @@ echo "do some stuff here for gitlab-init container"
 						RunAsNonRoot:       boolPtr(true),
 						SupplementalGroups: []int64{1, 2},
 					},
-					Priority: int32Ptr(30),
 					ReadinessGates: []core.PodReadinessGate{
 						{ConditionType: core.PodScheduled},
 					},

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -87,7 +87,6 @@ type PodSpec struct {
 	ActiveDeadlineSeconds         *int64                   `json:"activeDeadlineSeconds,omitempty"`
 	TerminationGracePeriodSeconds *int64                   `json:"terminationGracePeriodSeconds,omitempty"`
 	SecurityContext               *core.PodSecurityContext `json:"securityContext,omitempty"`
-	Priority                      *int32                   `json:"priority,omitempty"`
 	ReadinessGates                []core.PodReadinessGate  `json:"readinessGates,omitempty"`
 	DNSPolicy                     core.DNSPolicy           `json:"dnsPolicy,omitempty"`
 }
@@ -98,7 +97,6 @@ func (ps PodSpec) IsEmpty() bool {
 		ps.ActiveDeadlineSeconds == nil &&
 		ps.TerminationGracePeriodSeconds == nil &&
 		ps.SecurityContext == nil &&
-		ps.Priority == nil &&
 		len(ps.ReadinessGates) == 0 &&
 		ps.DNSPolicy == ""
 }

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -222,7 +222,7 @@ foo: bar
 		pSpecs.Service = &specs.ServiceSpec{
 			Annotations: map[string]string{"foo": "bar"},
 		}
-		pSpecs.ConfigMaps = map[string]map[string]string{
+		pSpecs.ConfigMaps = map[string]specs.ConfigMap{
 			"mydata": {
 				"foo":   "bar",
 				"hello": "world",

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -134,7 +134,6 @@ kubernetesResources:
     securityContext:
       runAsNonRoot: true
       supplementalGroups: [1,2]
-    priority: 30
     readinessGates:
       - conditionType: PodScheduled
     dnsPolicy: ClusterFirstWithHostNet
@@ -327,7 +326,6 @@ echo "do some stuff here for gitlab-init container"
 						RunAsNonRoot:       boolPtr(true),
 						SupplementalGroups: []int64{1, 2},
 					},
-					Priority: int32Ptr(30),
 					ReadinessGates: []core.PodReadinessGate{
 						{ConditionType: core.PodScheduled},
 					},

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -8,105 +8,29 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-// RBACType describes Role/Binding type.
-type RBACType string
-
-const (
-	// Role is the single namespace based.
-	Role RBACType = "Role"
-	// ClusterRole is the all namespaces based.
-	ClusterRole RBACType = "ClusterRole"
-
-	// RoleBinding is the single namespace based.
-	RoleBinding RBACType = "RoleBinding"
-	// ClusterRoleBinding is the all namespaces based.
-	ClusterRoleBinding RBACType = "ClusterRoleBinding"
-)
-
-var (
-	// RoleTypes defines supported role types.
-	RoleTypes = []RBACType{
-		Role, ClusterRole,
-	}
-	// RoleBindingTypes defines supported role binding types.
-	RoleBindingTypes = []RBACType{
-		RoleBinding, ClusterRoleBinding,
-	}
-)
-
-// RoleSpec defines config for referencing to or creating a Role or Cluster resource.
-type RoleSpec struct {
-	Name string   `yaml:"name"`
-	Type RBACType `yaml:"type"`
-	// We assume this is an existing Role/ClusterRole if Rules is empty.
-	// Existing Role/ClusterRoles can be only referenced but will never be deleted or updated by Juju.
-	// Role/ClusterRoles are created by Juju will be properly labeled.
-	Rules []rbacv1.PolicyRule `yaml:"rules"`
-}
-
-// Validate returns an error if the spec is not valid.
-func (r RoleSpec) Validate() error {
-	for _, v := range RoleTypes {
-		if r.Type == v {
-			return nil
-		}
-	}
-	return errors.NotSupportedf("%q", r.Type)
-}
-
-// RoleBindingSpec defines config for referencing to or creating a RoleBinding or ClusterRoleBinding resource.
-type RoleBindingSpec struct {
-	Name string   `yaml:"name"`
-	Type RBACType `yaml:"type"`
-}
-
-// Validate returns an error if the spec is not valid.
-func (rb RoleBindingSpec) Validate() error {
-	for _, v := range RoleBindingTypes {
-		if rb.Type == v {
-			return nil
-		}
-	}
-	return errors.NotSupportedf("%q", rb.Type)
-}
-
-// Capabilities defines RBAC related config.
-type Capabilities struct {
-	Role        *RoleSpec        `yaml:"role"`
-	RoleBinding *RoleBindingSpec `yaml:"roleBinding"`
-}
-
-// Validate returns an error if the spec is not valid.
-func (c Capabilities) Validate() error {
-	if c.Role == nil {
-		return errors.New("role is required for capabilities")
-	}
-	if c.RoleBinding == nil {
-		return errors.New("roleBinding is required for capabilities")
-	}
-	if err := c.Role.Validate(); err != nil {
-		return errors.Trace(err)
-	}
-	if err := c.RoleBinding.Validate(); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
 // ServiceAccountSpec defines spec for referencing to or creating a service account.
 type ServiceAccountSpec struct {
-	Name                         string        `yaml:"name"`
-	AutomountServiceAccountToken *bool         `yaml:"automountServiceAccountToken,omitempty"`
-	Capabilities                 *Capabilities `yaml:"capabilities"`
+	name                         string
+	AutomountServiceAccountToken *bool    `yaml:"automountServiceAccountToken,omitempty"`
+	ClusterRoleNames             []string `yaml:"ClusterRoleNames,omitempty"`
+
+	Rules *rbacv1.PolicyRule `yaml:"rules,omitempty"` // TODO: still think we either need to model further or move rbac to k8specs level!!!!!!!!!!!!!
+}
+
+// GetName returns the service accout name.
+func (sa ServiceAccountSpec) GetName() string {
+	return sa.name
+}
+
+// SetName sets the service accout name.
+func (sa *ServiceAccountSpec) SetName(name string) {
+	sa.name = name
 }
 
 // Validate returns an error if the spec is not valid.
 func (sa ServiceAccountSpec) Validate() error {
-	if sa.Capabilities == nil {
-		return errors.New("capabilities is required for service account")
-	}
-	if err := sa.Capabilities.Validate(); err != nil {
-		return errors.Trace(err)
+	if len(sa.ClusterRoleNames) == 0 && sa.Rules == nil {
+		return errors.NotValidf("rules or clusterRoleNames are required")
 	}
 	return nil
 }

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -5,8 +5,14 @@ package specs
 
 import (
 	"github.com/juju/errors"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
+
+// PolicyRule defines rule spec for creating a role or cluster role.
+type PolicyRule struct {
+	Verbs     []string `yaml:"verbs"`
+	APIGroups []string `yaml:"apiGroups,omitempty"`
+	Resources []string `yaml:"resources,omitempty"`
+}
 
 // ServiceAccountSpec defines spec for referencing to or creating a service account.
 type ServiceAccountSpec struct {
@@ -14,7 +20,7 @@ type ServiceAccountSpec struct {
 	AutomountServiceAccountToken *bool    `yaml:"automountServiceAccountToken,omitempty"`
 	ClusterRoleNames             []string `yaml:"ClusterRoleNames,omitempty"`
 
-	Rules *rbacv1.PolicyRule `yaml:"rules,omitempty"` // TODO: still think we either need to model further or move rbac to k8specs level!!!!!!!!!!!!!
+	Rules []PolicyRule `yaml:"rules,omitempty"` // TODO: still think we either need to model further or move rbac to k8specs level!!!!!!!!!!!!!
 }
 
 // GetName returns the service accout name.
@@ -29,8 +35,8 @@ func (sa *ServiceAccountSpec) SetName(name string) {
 
 // Validate returns an error if the spec is not valid.
 func (sa ServiceAccountSpec) Validate() error {
-	if len(sa.ClusterRoleNames) == 0 && sa.Rules == nil {
-		return errors.NotValidf("rules or clusterRoleNames are required")
+	if len(sa.ClusterRoleNames) == 0 && len(sa.Rules) == 0 {
+		return errors.NewNotValid(nil, "rules or clusterRoleNames are required")
 	}
 	return nil
 }

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -49,6 +49,7 @@ type ImageDetails struct {
 	Password  string `yaml:"password,omitempty" json:"password,omitempty"`
 }
 
+// PullPolicy describes a policy for if/when to pull a container image.
 type PullPolicy string
 
 // ContainerSpec defines the data values used to configure
@@ -112,6 +113,9 @@ type PodSpecVersion struct {
 	Version Version `json:"version,omitempty"`
 }
 
+// ConfigMap describes the format of configmap resource.
+type ConfigMap map[string]string
+
 // podSpecBase defines the data values used to configure
 // a pod on the CAAS substrate.
 type podSpecBase struct {
@@ -121,8 +125,8 @@ type podSpecBase struct {
 	// Keep it for now because we have to combine it with the ServerType (from metadata.yaml).
 	OmitServiceFrontend bool `json:"omitServiceFrontend" yaml:"omitServiceFrontend"`
 
-	Service    *ServiceSpec                 `json:"service,omitempty" yaml:"service,omitempty"`
-	ConfigMaps map[string]map[string]string `json:"configmaps,omitempty" yaml:"configmaps,omitempty"`
+	Service    *ServiceSpec         `json:"service,omitempty" yaml:"service,omitempty"`
+	ConfigMaps map[string]ConfigMap `json:"configmaps,omitempty" yaml:"configmaps,omitempty"`
 
 	Containers []ContainerSpec `json:"containers" yaml:"containers"`
 

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -536,7 +536,6 @@ func (ctx *HookContext) SetPodSpec(specYaml string) error {
 		logger.Errorf("%v is not the leader but is setting application pod spec", entityName)
 		return ErrIsNotLeader
 	}
-	logger.Criticalf("HookContext.SetPodSpec specYaml -> %q", specYaml)
 	_, err = k8sspecs.ParsePodSpec(specYaml)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -536,6 +536,7 @@ func (ctx *HookContext) SetPodSpec(specYaml string) error {
 		logger.Errorf("%v is not the leader but is setting application pod spec", entityName)
 		return ErrIsNotLeader
 	}
+	logger.Criticalf("HookContext.SetPodSpec specYaml -> %q", specYaml)
 	_, err = k8sspecs.ParsePodSpec(specYaml)
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/uniter/runner/jujuc/pod-spec-set.go
+++ b/worker/uniter/runner/jujuc/pod-spec-set.go
@@ -94,10 +94,12 @@ func (c *PodSpecSetCommand) handleSpecFile(ctx *cmd.Context) (string, error) {
 }
 
 func (c *PodSpecSetCommand) handleK8sResources(ctx *cmd.Context) (string, error) {
+	logger.Criticalf("handleK8sResources c.k8sResources -> %+v, c.k8sResources.IsStdin() -> %b", c.k8sResources, c.k8sResources.IsStdin())
 	if c.k8sResources.Path == "" {
 		return "", nil
 	}
 	k8sResourcesData, err := c.k8sResources.Read(ctx)
+	logger.Criticalf("handleK8sResources k8sResourcesData -> \n%q", string(k8sResourcesData))
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/pod-spec-set.go
+++ b/worker/uniter/runner/jujuc/pod-spec-set.go
@@ -4,6 +4,8 @@
 package jujuc
 
 import (
+	"bytes"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -16,7 +18,8 @@ type PodSpecSetCommand struct {
 	cmd.CommandBase
 	ctx Context
 
-	specFile cmd.FileVar
+	specFile     cmd.FileVar
+	k8sResources cmd.FileVar
 }
 
 // NewPodSpecSetCommand makes a pod-spec-set command.
@@ -31,7 +34,7 @@ The spec applies to all units for the application.
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "pod-spec-set",
-		Args:    "--file <pod spec file>",
+		Args:    "--file <pod spec file> [--k8s-resources <k8s pod spec file>]",
 		Purpose: "set pod spec information",
 		Doc:     doc,
 	})
@@ -41,6 +44,7 @@ func (c *PodSpecSetCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.specFile.SetStdin()
 	c.specFile.Path = "-"
 	f.Var(&c.specFile, "file", "file containing pod spec")
+	f.Var(&c.k8sResources, "k8s-resources", "file containing k8s pod spec")
 }
 
 func (c *PodSpecSetCommand) Init(args []string) error {
@@ -48,11 +52,34 @@ func (c *PodSpecSetCommand) Init(args []string) error {
 }
 
 func (c *PodSpecSetCommand) Run(ctx *cmd.Context) error {
-	specData, err := c.handleSpecFile(ctx)
+	specData, err := c.mergePodSpec(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	return c.ctx.SetPodSpec(specData)
+}
+
+func (c *PodSpecSetCommand) mergePodSpec(ctx *cmd.Context) (string, error) {
+	caasSpecData, err := c.handleSpecFile(ctx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	k8sSpecData, err := c.handleK8sResources(ctx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return mergeFileContent(caasSpecData, k8sSpecData), nil
+}
+
+func mergeFileContent(contents ...string) string {
+	var buffer bytes.Buffer
+	for _, v := range contents {
+		if v == "" {
+			continue
+		}
+		buffer.WriteString(v)
+	}
+	return buffer.String()
 }
 
 func (c *PodSpecSetCommand) handleSpecFile(ctx *cmd.Context) (string, error) {
@@ -64,4 +91,15 @@ func (c *PodSpecSetCommand) handleSpecFile(ctx *cmd.Context) (string, error) {
 		return "", errors.New("no pod spec specified: pipe pod spec to command, or specify a file with --file")
 	}
 	return string(specData), nil
+}
+
+func (c *PodSpecSetCommand) handleK8sResources(ctx *cmd.Context) (string, error) {
+	if c.k8sResources.Path == "" {
+		return "", nil
+	}
+	k8sResourcesData, err := c.k8sResources.Read(ctx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return string(k8sResourcesData), nil
 }

--- a/worker/uniter/runner/jujuc/pod-spec-set.go
+++ b/worker/uniter/runner/jujuc/pod-spec-set.go
@@ -44,7 +44,7 @@ func (c *PodSpecSetCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.specFile.SetStdin()
 	c.specFile.Path = "-"
 	f.Var(&c.specFile, "file", "file containing pod spec")
-	f.Var(&c.k8sResources, "k8s-resources", "file containing k8s pod spec")
+	f.Var(&c.k8sResources, "k8s-resources", "file containing k8s specific resources not yet modelled by Juju")
 }
 
 func (c *PodSpecSetCommand) Init(args []string) error {

--- a/worker/uniter/runner/jujuc/pod-spec-set.go
+++ b/worker/uniter/runner/jujuc/pod-spec-set.go
@@ -94,12 +94,10 @@ func (c *PodSpecSetCommand) handleSpecFile(ctx *cmd.Context) (string, error) {
 }
 
 func (c *PodSpecSetCommand) handleK8sResources(ctx *cmd.Context) (string, error) {
-	logger.Criticalf("handleK8sResources c.k8sResources -> %+v, c.k8sResources.IsStdin() -> %b", c.k8sResources, c.k8sResources.IsStdin())
 	if c.k8sResources.Path == "" {
 		return "", nil
 	}
 	k8sResourcesData, err := c.k8sResources.Read(ctx)
-	logger.Criticalf("handleK8sResources k8sResourcesData -> \n%q", string(k8sResourcesData))
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/pod-spec-set_test.go
+++ b/worker/uniter/runner/jujuc/pod-spec-set_test.go
@@ -22,10 +22,37 @@ type ContainerspecSetSuite struct {
 
 var _ = gc.Suite(&ContainerspecSetSuite{})
 
-var containerSpecYaml = `
+var (
+	containerSpecYaml = `
 containerspec:
   foo: bar
 `[1:]
+
+	k8sResourcesYaml = `
+kubernetesResources:
+  pod:
+    restartPolicy: OnFailure
+    activeDeadlineSeconds: 10
+    terminationGracePeriodSeconds: 20
+    securityContext:
+      runAsNonRoot: true
+      supplementalGroups: [1,2]
+    priority: 30
+    readinessGates:
+      - conditionType: PodScheduled
+    dnsPolicy: ClusterFirstWithHostNet
+  secrets:
+    - name: build-robot-secret
+      annotations:
+          kubernetes.io/service-account.name: build-robot
+      type: kubernetes.io/service-account-token
+      stringData:
+          config.yaml: |-
+              apiUrl: "https://my.api.com/api/v1"
+              username: fred
+              password: shhhh
+`[1:]
+)
 
 var containerSpecSetInitTests = []struct {
 	args []string
@@ -52,7 +79,7 @@ func (s *ContainerspecSetSuite) TestHelp(c *gc.C) {
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	expectedHelp := "" +
-		"Usage: pod-spec-set [options] --file <pod spec file>\n" +
+		"Usage: pod-spec-set [options] --file <pod spec file> [--k8s-resources <k8s pod spec file>]\n" +
 		"\n" +
 		"Summary:\n" +
 		"set pod spec information\n" +
@@ -60,6 +87,8 @@ func (s *ContainerspecSetSuite) TestHelp(c *gc.C) {
 		"Options:\n" +
 		"--file  (= -)\n" +
 		"    file containing pod spec\n" +
+		"--k8s-resources  (= )\n" +
+		"    file containing k8s pod spec\n" +
 		"\n" +
 		"Details:\n" +
 		"Sets configuration data to use for a pod.\n" +
@@ -84,25 +113,37 @@ func (s *ContainerspecSetSuite) TestContainerSpecSetNoData(c *gc.C) {
 }
 
 func (s *ContainerspecSetSuite) TestContainerSpecSet(c *gc.C) {
-	s.assertContainerSpecSet(c, "specfile.yaml")
+	s.assertContainerSpecSet(c, "specfile.yaml", false)
 }
 
 func (s *ContainerspecSetSuite) TestContainerSpecSetStdIn(c *gc.C) {
-	s.assertContainerSpecSet(c, "-")
+	s.assertContainerSpecSet(c, "-", false)
 }
 
-func (s *ContainerspecSetSuite) assertContainerSpecSet(c *gc.C, filename string) {
+func (s *ContainerspecSetSuite) TestContainerSpecSetWithK8sResource(c *gc.C) {
+	s.assertContainerSpecSet(c, "specfile.yaml", true)
+}
+
+func (s *ContainerspecSetSuite) TestContainerSpecSetStdInWithK8sResource(c *gc.C) {
+	s.assertContainerSpecSet(c, "-", true)
+}
+
+func (s *ContainerspecSetSuite) assertContainerSpecSet(c *gc.C, filename string, withK8sResource bool) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, args, ctx := s.initCommand(c, hctx, containerSpecYaml, filename)
+	com, args, ctx := s.initCommand(c, hctx, containerSpecYaml, filename, withK8sResource)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)
 	c.Check(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-	c.Assert(hctx.info.ContainerSpec, gc.Equals, containerSpecYaml)
+	expectedSpecYaml := containerSpecYaml
+	if withK8sResource {
+		expectedSpecYaml += k8sResourcesYaml
+	}
+	c.Assert(hctx.info.ContainerSpec, gc.Equals, expectedSpecYaml)
 }
 
 func (s *ContainerspecSetSuite) initCommand(
-	c *gc.C, hctx jujuc.Context, yaml string, filename string,
+	c *gc.C, hctx jujuc.Context, yaml string, filename string, withK8sResource bool,
 ) (cmd.Command, []string, *cmd.Context) {
 	com, err := jujuc.NewCommand(hctx, "pod-spec-set")
 	c.Assert(err, jc.ErrorIsNil)
@@ -113,9 +154,16 @@ func (s *ContainerspecSetSuite) initCommand(
 		ctx.Stdin = bytes.NewBufferString(yaml)
 	} else if filename != "" {
 		filename = filepath.Join(c.MkDir(), filename)
-		args = append(args, "--file", filename)
 		err := ioutil.WriteFile(filename, []byte(yaml), 0644)
 		c.Assert(err, jc.ErrorIsNil)
+		args = append(args, "--file", filename)
+	}
+	if withK8sResource {
+		k8sResourceFileName := "k8sresources.yaml"
+		k8sResourceFileName = filepath.Join(c.MkDir(), k8sResourceFileName)
+		err := ioutil.WriteFile(k8sResourceFileName, []byte(k8sResourcesYaml), 0644)
+		c.Assert(err, jc.ErrorIsNil)
+		args = append(args, "--k8s-resources", k8sResourceFileName)
 	}
 	return jujuc.NewJujucCommandWrappedForTest(com), args, ctx
 }

--- a/worker/uniter/runner/jujuc/pod-spec-set_test.go
+++ b/worker/uniter/runner/jujuc/pod-spec-set_test.go
@@ -88,7 +88,7 @@ func (s *ContainerspecSetSuite) TestHelp(c *gc.C) {
 		"--file  (= -)\n" +
 		"    file containing pod spec\n" +
 		"--k8s-resources  (= )\n" +
-		"    file containing k8s pod spec\n" +
+		"    file containing k8s specific resources not yet modelled by Juju\n" +
 		"\n" +
 		"Details:\n" +
 		"Sets configuration data to use for a pod.\n" +


### PR DESCRIPTION

## Description of change

a few new features and enhancements for `podspecV2`:
- Added `secrets`, `configmap` support
- Changed `RBAC` logic a bit for the new spec;

## QA steps

- deploy some a charm using podspec v2(has `RBAC`, `secrets` and `configmap`);


## Documentation changes

Yes

## Bug reference

None
