### PR TITLE
Don't use ExitCode() for now; always record action stdout/err even when there's been an error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2169,6 +2169,7 @@
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
     "k8s.io/client-go/tools/remotecommand",
+    "k8s.io/client-go/util/exec",
     "k8s.io/client-go/util/flowcontrol",
   ]
   solver-name = "gps-cdcl"

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -385,6 +385,24 @@ func (s *RunMockContextSuite) TestRunActionSuccessful(c *gc.C) {
 	c.Assert(ctx.actionResults["Stderr"], gc.Equals, nil)
 }
 
+func (s *RunMockContextSuite) TestRunActionError(c *gc.C) {
+	ctx := &MockContext{
+		actionData: &context.ActionData{},
+		actionParams: map[string]interface{}{
+			"command": "echo 1\nexit 3",
+			"timeout": 0,
+		},
+		actionResults: map[string]interface{}{},
+	}
+	err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-run")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.flushFailure, gc.IsNil)
+	c.Assert(ctx.actionResults["Code"], gc.Equals, "3")
+	c.Assert(strings.TrimRight(ctx.actionResults["Stdout"].(string), "\r\n"), gc.Equals, "1")
+	c.Assert(ctx.actionResults["Stderr"], gc.Equals, nil)
+}
+
 func (s *RunMockContextSuite) TestRunActionCancelled(c *gc.C) {
 	timeout := 1 * time.Nanosecond
 	ctx := &MockContext{
@@ -399,7 +417,7 @@ func (s *RunMockContextSuite) TestRunActionCancelled(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
 	c.Assert(ctx.flushFailure, gc.Equals, exec.ErrCancelled)
-	c.Assert(ctx.actionResults["Code"], gc.Equals, nil)
+	c.Assert(ctx.actionResults["Code"], gc.Equals, "0")
 	c.Assert(ctx.actionResults["Stdout"], gc.Equals, nil)
 	c.Assert(ctx.actionResults["Stderr"], gc.Equals, nil)
 }


### PR DESCRIPTION
## Description of change

Don't use ExitCode() to capture an exec return code just now since it's only for Go 1.12.
When running an action, it could exit with an error but we still try to record stdout and stderr if possible. Previously this would not be done.

## QA steps

on k8s and lxd...
run an action with an error
show-operation should record error code and stdout/stderr still
