### PR TITLE
Fix some action test races

### DIFF
--- a/worker/caasoperator/action.go
+++ b/worker/caasoperator/action.go
@@ -224,6 +224,12 @@ func getNewRunnerExecutor(
 				params.Cancel,
 			)
 			exitErr = errors.Cause(exitErr)
+			if params.StdoutLogger != nil {
+				params.StdoutLogger.Stop()
+			}
+			if params.StderrLogger != nil {
+				params.StderrLogger.Stop()
+			}
 
 			readBytes := func(r io.Reader) []byte {
 				var o bytes.Buffer

--- a/worker/caasoperator/mock_test.go
+++ b/worker/caasoperator/mock_test.go
@@ -189,3 +189,11 @@ func (l *mockCharmDirGuard) Lockdown(abort fortress.Abort) error {
 	l.MethodCall(l, "Lockdown", abort)
 	return l.NextErr()
 }
+
+type mockHookLogger struct {
+	stopped bool
+}
+
+func (m *mockHookLogger) Stop() {
+	m.stopped = true
+}

--- a/worker/common/charmrunner/logger.go
+++ b/worker/common/charmrunner/logger.go
@@ -63,8 +63,17 @@ func (l *HookLogger) Run() {
 	}
 }
 
+// Stopper instances can be stopped.
+type Stopper interface {
+	Stop()
+}
+
 // Stop stops the hook logger.
 func (l *HookLogger) Stop() {
+	// Ensure Stop() is idempotent.
+	if l == nil || l.stopped {
+		return
+	}
 	// We can see the process exit before the logger has processed
 	// all its output, so allow a moment for the data buffered
 	// in the pipe to be processed. We don't wait indefinitely though,


### PR DESCRIPTION
## Description of change

Two fixes here: protect the bytes buffer used to record a copy of stdout with a mutex, and ensure hook loggers are stopped prior to reading the stdout buffers.

## QA steps

go test --race
