### PR TITLE
Reset azure Suite state in SetUpTest.

### DIFF
--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -47,6 +47,7 @@ func (s *environUpgradeSuite) SetUpTest(c *gc.C) {
 		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.env = openEnviron(c, s.provider, &s.sender)
+	s.invalidCredential = false
 	s.callCtx = &context.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true


### PR DESCRIPTION
## Description of change

If you ran the azure test suite with -count=2 (or more) then the second
time through the Suite object would already have invalidCredential set
to true.
This change ensures that this test doesn't leave mutated state around
for other tests to see.

## QA steps

```
$ cd provider/azure
$ go test -count=2
# would fail reliably
```

## Documentation changes

None.

## Bug reference

None.
