### PR TITLE
Remove openvswitch from linux.kernel_modules

### DIFF
--- a/testcharms/charm-repo/quantal/lxd-profile-alt/lxd-profile.yaml
+++ b/testcharms/charm-repo/quantal/lxd-profile-alt/lxd-profile.yaml
@@ -3,6 +3,6 @@ description: lxd profile for testing nested container profiles
 config:
   security.nesting: "true"
   security.privileged: "true"
-  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+  linux.kernel_modules: nbd,ip_tables,ip6_tables
   environment.http_proxy: ""
 devices: {}


### PR DESCRIPTION
## Description
Remove openvswitch from linux.kernel_modules

Deploy charm --to lxd with openvswitch in the lxd profile has
a non deterministic result.  Some containers start, others do not
within the same deploy setup.  Removed to get consistent CI results.

## QA

https://jenkins.juju.canonical.com/job/nw-deploy-lxd-sub-profile-bundle-lxd/589/
