### PR TITLE
ask-or-tell: 'autoload-credentials'. 

### DIFF
--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -412,7 +412,7 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 			continue
 		}
 		if cloud.Type != cred.cloudType {
-			ctxt.Warningf("%v", errors.Errorf("chosen credentials not compatible with %q cloud", cloud.Type))
+			ctxt.Warningf("%v", errors.Errorf("chosen credential not compatible with %q cloud", cloud.Type))
 			continue
 		}
 

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -29,7 +29,6 @@ import (
 
 type detectCredentialsCommand struct {
 	modelcmd.OptionalControllerCommand
-	cmd.CommandBase
 	out cmd.Output
 
 	cloudType string
@@ -38,28 +37,30 @@ type detectCredentialsCommand struct {
 	registeredProvidersFunc func() []string
 
 	// allCloudsFunc is set by tests to return all public and personal clouds
-	allCloudsFunc func() (map[string]jujucloud.Cloud, error)
+	allCloudsFunc func(*cmd.Context) (map[string]jujucloud.Cloud, error)
 
 	// cloudByNameFunc is set by tests to return a named cloud.
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error)
 
 	// These attributes are used when adding credentials to a controller.
-	controllerName    string
 	credentialAPIFunc func() (CredentialAPI, error)
 	remoteClouds      map[string]jujucloud.Cloud
 }
 
-const detectCredentialsSummary = `Attempts to automatically add or replace credentials for a cloud.`
+const detectCredentialsSummary = `Attempts to automatically detect and add credentials for a cloud.`
 
 var detectCredentialsDoc = `
-Well known locations for specific clouds are searched and any found
-information is presented interactively to the user.
+The command searches well known, cloud-specific locations on this client.
+If credential information is found, it is presented to the user
+in a series of prompts to facilitated interactive addition and upload.
 An alternative to this command is ` + "`juju add-credential`" + `.
 
-By default, after validating the contents, credentials are loaded both 
-on the current controller and the current client device. 
-Use --controller option to load credentials to a different controller. 
-Use --local option to load credentials to the current device only.
+By default, after validating the contents, credentials are added to
+this Juju client. If a current controller is detected on the client, the user
+is prompted to confirm if the credentials should be uploaded to it. 
+To skip the prompt and to upload to a detected current controller, use --no-prompt.
+To upload credentials to a different controller, use --controller option. 
+To add credentials to the current client only, use --local option.
 
 Below are the cloud types for which credentials may be autoloaded,
 including the locations searched.
@@ -90,13 +91,16 @@ LXD
 
 Example:
     juju autoload-credentials
+    juju autoload-credentials --local
+    juju autoload-credentials --controller mycontroller
+    juju autoload-credentials --no-prompt
     juju autoload-credentials aws
    
 See also:
-    list-credentials
-    remove-credential
-    default-credential
     add-credential
+    credentials
+    default-credential
+    remove-credential
 `[1:]
 
 // NewDetectCredentialsCommand returns a command to add credential information to credentials.yaml.
@@ -108,8 +112,8 @@ func NewDetectCredentialsCommand() cmd.Command {
 		registeredProvidersFunc: environs.RegisteredProviders,
 		cloudByNameFunc:         jujucloud.CloudByName,
 	}
-	c.allCloudsFunc = func() (map[string]jujucloud.Cloud, error) {
-		return c.allClouds()
+	c.allCloudsFunc = func(ctxt *cmd.Context) (map[string]jujucloud.Cloud, error) {
+		return c.allClouds(ctxt)
 	}
 	c.credentialAPIFunc = c.credentialsAPI
 	return modelcmd.WrapBase(c)
@@ -133,15 +137,6 @@ func (c *detectCredentialsCommand) Init(args []string) (err error) {
 		c.cloudType = strings.ToLower(args[0])
 		return cmd.CheckEmpty(args[1:])
 	}
-	c.ControllerName, err = c.ControllerNameFromArg()
-	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
-		return errors.Trace(err)
-	}
-	if c.ControllerName == "" {
-		// No controller was specified explicitly and we did not detect a current controller,
-		// this operation should be local only.
-		c.Local = true
-	}
 	return cmd.CheckEmpty(args)
 }
 
@@ -163,7 +158,8 @@ func (c *detectCredentialsCommand) credentialsAPI() (CredentialAPI, error) {
 	return apicloud.NewClient(root), nil
 }
 
-func (c *detectCredentialsCommand) allClouds() (map[string]jujucloud.Cloud, error) {
+func (c *detectCredentialsCommand) allClouds(ctxt *cmd.Context) (map[string]jujucloud.Cloud, error) {
+	ctxt.Infof("\nLooking for cloud and credential information on local client...")
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
 		return nil, err
@@ -182,7 +178,8 @@ func (c *detectCredentialsCommand) allClouds() (map[string]jujucloud.Cloud, erro
 	for k, v := range personalClouds {
 		clouds[k] = v
 	}
-	if !c.Local {
+	if !c.Local && c.ControllerName != "" {
+		ctxt.Infof("\nLooking for cloud information on controller %q...", c.ControllerName)
 		// If there is a cloud definition for the same cloud both
 		// on the controller and on the client and they conflict,
 		// we want definition from the controller to take precedence.
@@ -206,9 +203,17 @@ func (c *detectCredentialsCommand) allClouds() (map[string]jujucloud.Cloud, erro
 }
 
 func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
-	fmt.Fprintln(ctxt.Stderr, "\nLooking for cloud and credential information locally...")
+	var err error
+	if !c.Local && c.ControllerName == "" {
+		// The user may have specified the controller via a --controller option.
+		// If not, let's see if there is a current controller that can be detected.
+		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, "add a credential to")
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
 
-	clouds, err := c.allCloudsFunc()
+	clouds, err := c.allCloudsFunc(ctxt)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -362,6 +367,7 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 	quit := func(in string) bool {
 		return strings.ToLower(in) == "q"
 	}
+	var localErr error
 	for {
 		// Prompt for a credential to save.
 		c.printCredentialOptions(ctxt, discovered)
@@ -389,7 +395,7 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 		// Prompt for the cloud for which to save the credential.
 		cloudName, err := c.promptCloudName(ctxt.Stderr, ctxt.Stdin, cred.defaultCloudName)
 		if err != nil {
-			fmt.Fprintln(ctxt.Stderr, err.Error())
+			ctxt.Warningf("%v", err.Error())
 			continue
 		}
 		if quit(cloudName) {
@@ -402,11 +408,11 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 		}
 		cloud, err := common.CloudOrProvider(cloudName, c.cloudByNameFunc)
 		if err != nil {
-			fmt.Fprintln(ctxt.Stderr, err.Error())
+			ctxt.Warningf("%v", err)
 			continue
 		}
 		if cloud.Type != cred.cloudType {
-			fmt.Fprintln(ctxt.Stderr, errors.Errorf("chosen credentials not compatible with a %s cloud", cloud.Type))
+			ctxt.Warningf("%v", errors.Errorf("chosen credentials not compatible with %q cloud", cloud.Type))
 			continue
 		}
 
@@ -427,7 +433,8 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 		existing.AuthCredentials[cred.credentialName] = cred.credential
 		addLoadedCredential(loaded, cloudName, cred)
 		if err := c.Store.UpdateCredential(cloudName, *existing); err != nil {
-			fmt.Fprintf(ctxt.Stderr, "error saving credential locally: %v\n", err)
+			ctxt.Warningf("error saving credential locally: %v\n", err)
+			localErr = err
 		} else {
 			// Update so we display correctly next time list is printed.
 			cred.isNew = false
@@ -436,9 +443,9 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 		}
 	}
 upload:
-	if !c.Local {
+	if !c.Local && c.ControllerName != "" {
 		fmt.Fprintln(ctxt.Stderr)
-		return c.addRemoteCredentials(ctxt, clouds, loaded)
+		return c.addRemoteCredentials(ctxt, clouds, loaded, localErr)
 	}
 	return nil
 }
@@ -457,9 +464,9 @@ func addLoadedCredential(all map[string]map[string]map[string]jujucloud.Credenti
 	byRegion[cred.credentialName] = cred.credential
 }
 
-func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, clouds map[string]jujucloud.Cloud, all map[string]map[string]map[string]jujucloud.Credential) error {
+func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, clouds map[string]jujucloud.Cloud, all map[string]map[string]map[string]jujucloud.Credential, localErr error) error {
 	if len(all) == 0 {
-		fmt.Fprintf(ctxt.Stdout, "No credentials loaded remotely.\n")
+		ctxt.Infof("No credentials loaded to controller %v.\n", c.ControllerName)
 		return nil
 	}
 	accountDetails, err := c.Store.AccountDetails(c.ControllerName)
@@ -490,7 +497,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 			result, err := client.UpdateCloudsCredentials(verified)
 			if err != nil {
 				logger.Errorf("%v", err)
-				ctxt.Warningf("Could not add credentials remotely, on controller %q", c.ControllerName)
+				ctxt.Warningf("Could not upload credentials to controller %q", c.ControllerName)
 			}
 			results = append(results, result...)
 		}
@@ -498,9 +505,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 	if moreCloudInfoNeeded {
 		ctxt.Infof("Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.")
 	}
-	// TODO (anastasiamac 2019-09-04) Local error passed in will eventually be an error from the
-	// local detection on this client.
-	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results, c.ControllerName, nil)
+	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results, c.ControllerName, localErr)
 }
 
 func (c *detectCredentialsCommand) printCredentialOptions(ctxt *cmd.Context, discovered []discoveredCredential) {

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -6,7 +6,6 @@ package cloud_test
 import (
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -119,7 +118,7 @@ func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *detectCredentialsSuite) run(c *gc.C, stdin io.Reader, clouds map[string]jujucloud.Cloud, args ...string) (*cmd.Context, error) {
-	allCloudsFunc := func() (map[string]jujucloud.Cloud, error) {
+	allCloudsFunc := func(*cmd.Context) (map[string]jujucloud.Cloud, error) {
 		return clouds, nil
 	}
 	cloudByNameFunc := func(cloudName string) (*jujucloud.Cloud, error) {
@@ -132,21 +131,17 @@ func (s *detectCredentialsSuite) run(c *gc.C, stdin io.Reader, clouds map[string
 }
 
 func (s *detectCredentialsSuite) runWithCloudsFunc(c *gc.C, stdin io.Reader,
-	cloudsFunc func() (map[string]jujucloud.Cloud, error),
+	cloudsFunc func(*cmd.Context) (map[string]jujucloud.Cloud, error),
 	cloudByNameFunc func(cloudName string) (*jujucloud.Cloud, error),
 	args ...string) (*cmd.Context, error) {
 	registeredProvidersFunc := func() []string {
 		return []string{"mock-provider"}
 	}
-	cloudType := ""
-	if len(args) > 0 {
-		cloudType = args[0]
-	}
-	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, cloudsFunc, cloudByNameFunc, cloudType, s.credentialAPIFunc)
-	err := cmdtesting.InitCommand(command, nil)
-	c.Assert(err, jc.ErrorIsNil)
+	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, cloudsFunc, cloudByNameFunc, s.credentialAPIFunc)
 	ctx := cmdtesting.Context(c)
 	ctx.Stdin = stdin
+	err := cmdtesting.InitCommand(command, args)
+	c.Assert(err, jc.ErrorIsNil)
 	return ctx, command.Run(ctx)
 }
 
@@ -156,7 +151,11 @@ func (s *detectCredentialsSuite) credentialWithLabel(authType jujucloud.AuthType
 	return cred
 }
 
-func (s *detectCredentialsSuite) assertDetectCredential(c *gc.C, cloudName, expectedRegion, errText string) {
+type detectCredentialTestExpectations struct {
+	cloudName, expectedRegion, expectedStderr, expectedWarn string
+}
+
+func (s *detectCredentialsSuite) assertDetectCredential(c *gc.C, t detectCredentialTestExpectations) {
 	s.aCredential = jujucloud.CloudCredential{
 		DefaultRegion: "default region",
 		AuthCredentials: map[string]jujucloud.Credential{
@@ -171,22 +170,24 @@ func (s *detectCredentialsSuite) assertDetectCredential(c *gc.C, cloudName, expe
 		},
 	}
 
-	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", cloudName))
+	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", t.cloudName))
 	ctx, err := s.run(c, stdin, clouds)
 	c.Assert(err, jc.ErrorIsNil)
-	if errText == "" {
-		if expectedRegion != "" {
-			s.aCredential.DefaultRegion = expectedRegion
+	if t.expectedStderr == "" {
+		if t.expectedRegion != "" {
+			s.aCredential.DefaultRegion = t.expectedRegion
 		}
 		c.Assert(s.store.Credentials["test-cloud"], jc.DeepEquals, s.aCredential)
 	} else {
-		output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
-		c.Assert(output, gc.Matches, ".*"+regexp.QuoteMeta(errText)+".*")
+		c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, t.expectedStderr)
+	}
+	if t.expectedWarn != "" {
+		c.Assert(c.GetTestLog(), jc.Contains, t.expectedWarn)
 	}
 }
 
 func (s *detectCredentialsSuite) TestDetectNewCredential(c *gc.C) {
-	s.assertDetectCredential(c, "test-cloud", "", "")
+	s.assertDetectCredential(c, detectCredentialTestExpectations{cloudName: "test-cloud"})
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialOverwrites(c *gc.C) {
@@ -197,7 +198,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialOverwrites(c *gc.C) {
 			},
 		},
 	}
-	s.assertDetectCredential(c, "test-cloud", "", "")
+	s.assertDetectCredential(c, detectCredentialTestExpectations{cloudName: "test-cloud"})
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialKeepsExistingRegion(c *gc.C) {
@@ -209,19 +210,43 @@ func (s *detectCredentialsSuite) TestDetectCredentialKeepsExistingRegion(c *gc.C
 			},
 		},
 	}
-	s.assertDetectCredential(c, "test-cloud", "west", "")
+	s.assertDetectCredential(c, detectCredentialTestExpectations{cloudName: "test-cloud", expectedRegion: "west"})
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialDefaultCloud(c *gc.C) {
-	s.assertDetectCredential(c, "", "", "")
+	s.assertDetectCredential(c, detectCredentialTestExpectations{})
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialUnknownCloud(c *gc.C) {
-	s.assertDetectCredential(c, "foo", "", "cloud foo not valid")
+	s.assertDetectCredential(c, detectCredentialTestExpectations{
+		cloudName: "foo",
+		expectedStderr: `
+
+1. credential (new)
+Select a credential to save by number, or type Q to quit: 
+Select the cloud it belongs to, or type Q to quit [test-cloud]: 
+
+1. credential (new)
+Select a credential to save by number, or type Q to quit: 
+`[1:],
+		expectedWarn: "cloud foo not valid",
+	})
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialInvalidCloud(c *gc.C) {
-	s.assertDetectCredential(c, "another-cloud", "", "chosen credentials not compatible with a another-provider cloud")
+	s.assertDetectCredential(c, detectCredentialTestExpectations{
+		cloudName: "another-cloud",
+		expectedStderr: `
+
+1. credential (new)
+Select a credential to save by number, or type Q to quit: 
+Select the cloud it belongs to, or type Q to quit [test-cloud]: 
+
+1. credential (new)
+Select a credential to save by number, or type Q to quit: 
+`[1:],
+		expectedWarn: `chosen credentials not compatible with "another-provider" cloud`,
+	})
 }
 
 func (s *detectCredentialsSuite) TestNewDetectCredentialNoneFound(c *gc.C) {
@@ -297,18 +322,16 @@ func (s *detectCredentialsSuite) TestDetectCredentialCloudMismatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 
-Looking for cloud and credential information locally...
-
 1. credential 2 (new)
 2. credential 1 (new)
 Select a credential to save by number, or type Q to quit: 
 Select the cloud it belongs to, or type Q to quit []: 
-chosen credentials not compatible with a aws cloud
 
 1. credential 2 (new)
 2. credential 1 (new)
 Select a credential to save by number, or type Q to quit: 
 `[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	c.Assert(s.store.Credentials, gc.HasLen, 0)
 }
 
@@ -324,8 +347,6 @@ func (s *detectCredentialsSuite) TestDetectCredentialQuitOnCloud(c *gc.C) {
 	ctx, err := s.run(c, stdin, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-
-Looking for cloud and credential information locally...
 
 1. credential a (new)
 2. credential b (new)
@@ -389,13 +410,14 @@ func (s *detectCredentialsSuite) TestRemoteLoad(c *gc.C) {
 		return &remoteTestCloud, nil
 	}
 
-	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", cloudName))
+	stdin := strings.NewReader(fmt.Sprintf("\n1\n%s\nQ\n", cloudName))
 	ctx, err := s.runWithCloudsFunc(c, stdin, nil, cloudByNameFunc)
 	c.Assert(err, jc.ErrorIsNil)
-
 	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, `
 
-Looking for cloud and credential information locally...
+Looking for cloud and credential information on local client...
+
+Looking for cloud information on controller "controller"...
 
 1. credential (new)
 Select a credential to save by number, or type Q to quit: 
@@ -409,6 +431,7 @@ Controller credential "blah" for user "admin@local" for cloud "test-cloud" on co
 For more information, see ‘juju show-credential test-cloud blah’.
 `[1:])
 	c.Assert(called, jc.IsTrue)
+	c.Assert(cmdtesting.Stdout(ctx), gc.DeepEquals, "Do you want to add a credential to current controller \"controller\"? (Y/n): \n")
 }
 
 func (s *detectCredentialsSuite) TestRemoteLoadNoRemoteCloud(c *gc.C) {
@@ -428,7 +451,7 @@ func (s *detectCredentialsSuite) TestRemoteLoadNoRemoteCloud(c *gc.C) {
 	}
 
 	clouds := map[string]jujucloud.Cloud{
-		"test-cloud": {
+		cloudName: {
 			Name:             cloudName,
 			Type:             "mock-provider",
 			AuthTypes:        []jujucloud.AuthType{jujucloud.AccessKeyAuthType},
@@ -450,12 +473,10 @@ func (s *detectCredentialsSuite) TestRemoteLoadNoRemoteCloud(c *gc.C) {
 	}
 
 	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", cloudName))
-	ctx, err := s.run(c, stdin, clouds)
+	ctx, err := s.run(c, stdin, clouds, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, `
-
-Looking for cloud and credential information locally...
 
 1. credential (new)
 Select a credential to save by number, or type Q to quit: 

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -245,7 +245,7 @@ Select the cloud it belongs to, or type Q to quit [test-cloud]:
 1. credential (new)
 Select a credential to save by number, or type Q to quit: 
 `[1:],
-		expectedWarn: `chosen credentials not compatible with "another-provider" cloud`,
+		expectedWarn: `chosen credential not compatible with "another-provider" cloud`,
 	})
 }
 

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -111,16 +111,14 @@ func NewListCredentialsCommandForTest(
 func NewDetectCredentialsCommandForTest(
 	testStore jujuclient.ClientStore,
 	registeredProvidersFunc func() []string,
-	allCloudsFunc func() (map[string]jujucloud.Cloud, error),
+	allCloudsFunc func(*cmd.Context) (map[string]jujucloud.Cloud, error),
 	cloudsByNameFunc func(string) (*jujucloud.Cloud, error),
-	cloudType string,
 	f func() (CredentialAPI, error),
 ) *detectCredentialsCommand {
 	command := &detectCredentialsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore},
 		registeredProvidersFunc:   registeredProvidersFunc,
 		cloudByNameFunc:           jujucloud.CloudByName,
-		cloudType:                 cloudType,
 		credentialAPIFunc:         f,
 	}
 	if allCloudsFunc != nil {


### PR DESCRIPTION
## Description of change

If Juju detects current controller, instead of using it by default, it will prompt the user to confirm whether detected credentials should be uploaded to it or not. If the upload is always desirable, but the prompt is not, the user can use ''-no-prompt" option.

As a drive-by, this PR updates command help doc.
