### PR TITLE
state: Ensure units leave scope if the relation is force-destroyed

### DIFF
--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -743,3 +743,19 @@ func unitNameFromScopeKey(key string) string {
 	parts := strings.Split(key, "#")
 	return parts[len(parts)-1]
 }
+
+// unpackScopeKey returns the scope, role and unitname from the
+// relation scope key.
+func unpackScopeKey(key string) (string, string, string, error) {
+	if _, localID, ok := splitDocID(key); ok {
+		key = localID
+	}
+	parts := strings.Split(key, "#")
+	if len(parts) < 4 {
+		return "", "", "", errors.Errorf("%q has too few parts to be a relation scope key", key)
+	}
+	unitName := parts[len(parts)-1]
+	role := parts[len(parts)-2]
+	scope := strings.Join(parts[:len(parts)-2], "#")
+	return scope, role, unitName, nil
+}


### PR DESCRIPTION
## Description of change

We've seen some cases with cross-model relations where the relation can't be removed because there are remaining relation scope docs (either because of a network problem or a bug in CMR) that means the the relation has a nonzero unit count. This change adds a fallback cleanup when the relation is force-destroyed that leaves scope on any that are left behind. Because the unit might not exist we construct the RelationUnit directly rather than trying to get a unit first.

## QA steps

* Bootstrap a controller
* Deploy two applications and relate them
* Stop one of the unit agents
* Remove the relation with force - eventually it will be removed, even though the unit agent wasn't running to leave.

## Documentation changes

None

## Bug reference

None