### PR TITLE
1843219: All watcher missing info status

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -554,19 +554,19 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 		}
 	} else {
 		// The entry already exists, so preserve the current status.
-		oldInfo := oldInfo.(*multiwatcher.ApplicationInfo)
-		info.Constraints = oldInfo.Constraints
-		info.WorkloadVersion = oldInfo.WorkloadVersion
-		if info.CharmURL == oldInfo.CharmURL {
+		appInfo := oldInfo.(*multiwatcher.ApplicationInfo)
+		info.Constraints = appInfo.Constraints
+		info.WorkloadVersion = appInfo.WorkloadVersion
+		if info.CharmURL == appInfo.CharmURL {
 			// The charm URL remains the same - we can continue to
 			// use the same config settings.
-			info.Config = oldInfo.Config
+			info.Config = appInfo.Config
 		} else {
 			// The charm URL has changed - we need to fetch the
 			// settings from the new charm's settings doc.
 			needConfig = true
 		}
-		info.Status = oldInfo.Status
+		info.Status = appInfo.Status
 	}
 	if needConfig {
 		doc, err := readSettingsDoc(st.db(), settingsC, applicationCharmConfigKey(app.Name, app.CharmURL))

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -566,6 +566,7 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 			// settings from the new charm's settings doc.
 			needConfig = true
 		}
+		info.Status = oldInfo.Status
 	}
 	if needConfig {
 		doc, err := readSettingsDoc(st.db(), settingsC, applicationCharmConfigKey(app.Name, app.CharmURL))

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1210,7 +1210,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 
 				_, err = app.AddUnit(AddUnitParams{})
 				c.Assert(err, jc.ErrorIsNil)
-				return 3
+				return 2
 			},
 		}, {
 			about: "relations",
@@ -1224,7 +1224,7 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 				c.Assert(err, jc.ErrorIsNil)
 				_, err = st.AddRelation(eps...)
 				c.Assert(err, jc.ErrorIsNil)
-				return 3
+				return 1
 			},
 		}, {
 			about: "annotations",


### PR DESCRIPTION
## Description of change

The following PR ensures that we set the info.status before
performing a store update if the old info is not nil. In other
words, we need to reuse the data from the old info and set it on
the new info which we'll be saving.

The reason for the tests changes, is now that we have the old
data we don't need to save any changes if the data is the same.

This has been tested with pylibjuju and the status changes are
now populated from the start, allowing you to monitor the changes
of a charm.

## QA steps

Unfortunately there is some work to test this out and requires 
pylibjuju for the quickest turn around...

Checkout 2.6 branch and bootstrap.
```sh
git checkout 2.6
juju bootstrap lxd test --no-gui --build-agent
watch --color -n 1 juju status --color
```

Setup pylibjuju and apply the following changes to pylibjuju 
example/deploy_bundle.py: [print-diff.txt](https://github.com/juju/juju/files/3596102/print-diff.txt)
It requires quite a large bundle to trigger this, so for me a
very basic openstack did this.
```sh
tox -e example -- examples/deploy_bundle.py
```

Notice how some status fields in the print output will be empty 
and has no "since" field:
```json
"status": {"version": "", "current": "", "message": ""}
```
----
To verify the patch, check this branch out and bootstrap:
```sh
juju bootstrap lxd tester --no-gui --build-agent
watch --color -n 1 juju status --color
```

Then run the pylibjuju example again, with the diff applied:
```sh
tox -e example -- examples/deploy_bundle.py
```
The output should be:
```json
"status": {"since": "2019-09-10T13:23:44.99699161Z", "version": "", "current": "waiting", "message": "waiting for machine"}
```
