### PR TITLE
During Uniter teardown, don't wait for BlockUntilLeadershipReleased

### DIFF
--- a/worker/leadership/tracker_test.go
+++ b/worker/leadership/tracker_test.go
@@ -112,6 +112,17 @@ func (s *TrackerSuite) TestOnLeaderFailure(c *gc.C) {
 	// Check the ticket fails.
 	assertClaimLeader(c, tracker, false)
 
+	// wait for calls to stabilize before killing the worker and inspecting the calls.
+	timeout := time.After(testing.LongWait)
+	next := time.After(0)
+	for len(s.claimer.Stub.Calls()) < 2 {
+		select {
+		case <-next:
+			next = time.After(testing.ShortWait)
+		case <-timeout:
+			c.Fatalf("timed out waiting %s for 2 calls", testing.LongWait)
+		}
+	}
 	// Stop the tracker before trying to look at its mocks.
 	workertest.CleanKill(c, tracker)
 


### PR DESCRIPTION
## Description of change

The APIServer isn't tearing down, and the cancel channel doesn't work on
API calls. Instead, we just let the goroutine die on its own.

This only triggers when we have an application with multiple units, and
the Uniter agent for a unit that is not the leader wants to restart.

## QA steps

I'm still working on adding a 'wrench' that will let us kill the uniter on demand.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1843376
