### PR TITLE
state: Handle not-found error in force-destroyed relation cleanup

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -243,6 +243,9 @@ func (st *State) cleanupRelationSettings(prefix string) error {
 
 func (st *State) cleanupForceDestroyedRelation(prefix string) (err error) {
 	relation, err := st.KeyRelation(prefix)
+	if errors.IsNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		return errors.Annotatef(err, "getting relation %q", prefix)
 	}


### PR DESCRIPTION
## Description of change

Fix for a bug in #10618: if the relation had already been removed by the last unit correctly
leaving scope, the cleanup would fail because it wasn't checking for not found errors. This would result in it staying in the cleanups collection and spamming errors that the relation couldn't be found.

## QA steps

* Deploy two applications and relate them.
* Force-remove the relation.
* The relation should be removed, and the cleanup should be executed with no errors and removed from the cleanups collection in the database.

## Documentation changes

None

## Bug reference

None