### PR TITLE
2.6 uniter wrench on idle

### DIFF
--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -72,6 +72,7 @@ func NewTracker(tag names.UnitTag, claimer leadership.Claimer, clock clock.Clock
 			}
 		}()
 		err := t.loop()
+		logger.Debugf("shutting down leadership tracker with err: %v", err)
 		// TODO: jam 2015-04-02 is this the most elegant way to make
 		// sure we shutdown cleanly? Essentially the lowest level sees
 		// that we are dying, and propagates an ErrDying up to us so

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -43,6 +43,7 @@ import (
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	"github.com/juju/juju/worker/uniter/storage"
 	"github.com/juju/juju/worker/uniter/upgradeseries"
+	"github.com/juju/juju/wrench"
 )
 
 var (
@@ -306,6 +307,10 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	}
 
 	onIdle := func() error {
+		logger.Criticalf("looking for wrench 'error-on-idle' for: %q", u.unit.Tag().Id())
+		if wrench.IsActive(u.unit.Tag().Id(), "error-on-idle") {
+			return errors.Errorf("wrench thrown for %s", u.unit.Tag().Id())
+		}
 		opState := u.operationExecutor.State()
 		if opState.Kind != operation.Continue {
 			// We should only set idle status if we're in
@@ -313,6 +318,10 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			// there is nothing to do and we're not in an
 			// error state.
 			return nil
+		}
+		logger.Criticalf("looking for wrench 'error-on-idle' for: %q", u.unit.Tag().Id())
+		if wrench.IsActive(u.unit.Tag().Id(), "error-on-idle") {
+			return errors.Errorf("wrench thrown for %s", u.unit.Tag().Id())
 		}
 		return setAgentStatus(u, status.Idle, "", nil)
 	}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -307,10 +307,6 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	}
 
 	onIdle := func() error {
-		logger.Criticalf("looking for wrench 'error-on-idle' for: %q", u.unit.Tag().Id())
-		if wrench.IsActive(u.unit.Tag().Id(), "error-on-idle") {
-			return errors.Errorf("wrench thrown for %s", u.unit.Tag().Id())
-		}
 		opState := u.operationExecutor.State()
 		if opState.Kind != operation.Continue {
 			// We should only set idle status if we're in
@@ -319,9 +315,8 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			// error state.
 			return nil
 		}
-		logger.Criticalf("looking for wrench 'error-on-idle' for: %q", u.unit.Tag().Id())
-		if wrench.IsActive(u.unit.Tag().Id(), "error-on-idle") {
-			return errors.Errorf("wrench thrown for %s", u.unit.Tag().Id())
+		if wrench.IsActive(u.unit.Tag().String(), "error-on-idle") {
+			return errors.Errorf("wrench thrown for %s", u.unit.Name())
 		}
 		return setAgentStatus(u, status.Idle, "", nil)
 	}

--- a/wrench/wrench.go
+++ b/wrench/wrench.go
@@ -62,7 +62,7 @@ func IsActive(category, feature string) bool {
 
 	wrenchFile, err := os.Open(fileName)
 	if err != nil {
-		logger.Errorf("unable to read wrench data for %s/%s (ignored): %v",
+		logger.Errorf("unable to read wrench data for %s:%s (ignored): %v",
 			category, feature, err)
 		return false
 	}
@@ -71,7 +71,7 @@ func IsActive(category, feature string) bool {
 	for lines.Scan() {
 		line := strings.TrimSpace(lines.Text())
 		if line == feature {
-			logger.Tracef("wrench for %s/%s is active", category, feature)
+			logger.Tracef("wrench for %s:%s is active", category, feature)
 			return true
 		}
 	}
@@ -123,19 +123,19 @@ func checkWrenchDir(dirName string) bool {
 func checkWrenchFile(category, feature, fileName string) bool {
 	fileinfo, err := stat(fileName)
 	if err != nil {
-		logger.Tracef("no wrench data for %s/%s (ignored): %v",
+		logger.Tracef("no wrench data for %s:%s (ignored): %v",
 			category, feature, err)
 		return false
 	}
 	if !isOwnedByJujuUser(fileinfo) {
-		logger.Errorf("wrench file for %s/%s has incorrect ownership "+
+		logger.Errorf("wrench file for %s:%s has incorrect ownership "+
 			"- ignoring %s", category, feature, fileName)
 		return false
 	}
 	// Windows is not fully POSIX compliant
 	if runtime.GOOS != "windows" {
 		if fileinfo.Mode()&0022 != 0 {
-			logger.Errorf("wrench file for %s/%s should only be writable by "+
+			logger.Errorf("wrench file for %s:%s should only be writable by "+
 				"owner - ignoring %s", category, feature, fileName)
 			return false
 		}


### PR DESCRIPTION
## Description of change

When the Uniter goes into Idle state, we allow a '/var/lib/juju/wrench/UNIT' file to indicate that the Uniter should go into an error state if 'error-on-idle' is set. This allows us to test the restart behavior of the Uniter.

Also, this cleans up a bunch of log messages from Wrench. They used to report:
```
  wrench for ubuntu-0/error-on-idle is active
```
However, that looks like a directory path (/var/lib/juju/wrench/ubuntu-0/error-on-idle). However, it is actually not the file that needs to be created but the content of the file. So I switched to ':' as I thought it would be clearer.

## QA steps

```
$ juju bootstrap lxd lxd
$ juju model-config logging-config="<root>=DEBUG;juju.wrench=TRACE"
$ juju deploy cs:~jameinel/ubuntu-lite -n2
$ juju ssh 1
$$ sudo su -
$$ mkdir -p /var/lib/juju/wrench
$$ echo "error-on-idle" > /var/lib/juju/wrench/unit-ubuntu-lite-1
$$ tail -f /var/log/juju/unit-ubuntu-lite-1.log
```

You may need to restart the unit agent to have it go *back* into idle. But when it does, you should end up seeing a message in the error log that 'wrench thrown for ubuntu-lite/1', and `juju status` should report a 'failed' state for that unit.

## Documentation changes

None.

## Bug reference

None.
