### PR TITLE
Protect sends with a check of tomb.Dying()

### DIFF
--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -345,15 +345,18 @@ func (w *pgWorker) watchForControllerChanges() (<-chan struct{}, error) {
 	}
 
 	out := make(chan struct{})
+	var notifyCh chan struct{}
 	go func() {
 		for {
 			select {
 			case <-w.catacomb.Dying():
 				return
 			case <-controllerInfoWatcher.Changes():
-				out <- struct{}{}
+				notifyCh = out
 			case <-controllerStatusWatcher.Changes():
-				out <- struct{}{}
+				notifyCh = out
+			case notifyCh <- struct{}{}:
+				notifyCh = nil
 			}
 		}
 	}()


### PR DESCRIPTION
## Description of change

We were doing bare sends on the out channel if we saw a Changes(), and
if we raced with a tomb.Dying the goroutine could block and never exit.

This was just by inspection, it is unlikely to be visible in the wild,
since you only leak a goroutine if you get a controller change at the
same time you're shutting down.

This is just a drive by cleanup.

## QA steps

None, isn't likely to be an obvservable change.

## Documentation changes

None.

## Bug reference

None.