### PR TITLE
Show and list cloud commands with ask-or-tell.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -408,7 +408,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 }
 
 func cloudFromLocal(store jujuclient.CredentialGetter, cloudName string) (*jujucloud.Cloud, error) {
-	details, err := listCloudDetails(store)
+	details, err := listLocalCloudDetails(store)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -48,18 +48,24 @@ func NewAddCloudCommandForTest(
 	}
 }
 
-func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (ListCloudsAPI, error)) *listCloudsCommand {
+func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (ListCloudsAPI, error)) *listCloudsCommand {
 	return &listCloudsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
 		listCloudsAPIFunc:         cloudAPI,
 	}
 }
 
-func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (showCloudAPI, error)) *showCloudCommand {
+func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (showCloudAPI, error)) *showCloudCommand {
 	return &showCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		store:                     store,
 		showCloudAPIFunc:          cloudAPI,
+	}
+}
+
+func NewListRegionsCommandForTest(store jujuclient.ClientStore, cloudAPI func() (CloudRegionsAPI, error)) *listRegionsCommand {
+	return &listRegionsCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		cloudAPIFunc:              cloudAPI,
 	}
 }
 
@@ -96,7 +102,7 @@ func NewListCredentialsCommandForTest(
 	testStore jujuclient.ClientStore,
 	personalCloudsFunc func() (map[string]jujucloud.Cloud, error),
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error),
-	apiF func(controllerName string) (ListCredentialsAPI, error),
+	apiF func() (ListCredentialsAPI, error),
 ) *listCredentialsCommand {
 	return &listCredentialsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
@@ -177,7 +183,7 @@ func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api Cre
 
 func NewShowCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialContentAPI) cmd.Command {
 	command := &showCredentialCommand{
-		store: testStore,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore},
 		newAPIFunc: func() (CredentialContentAPI, error) {
 			return api, nil
 		},

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -321,14 +321,12 @@ func formatCloudsTabular(writer io.Writer, value interface{}) error {
 			w.Println(len(info.Regions), defaultRegion, displayCloudType(info.CloudType), description)
 		}
 	}
-	personalColor := ansiterm.Foreground(ansiterm.BrightBlue)
 	if len(clouds.remote) > 0 {
-		printClouds(clouds.remote, ansiterm.Foreground(ansiterm.BrightBlue))
-		personalColor = nil
+		printClouds(clouds.remote, ansiterm.Foreground(ansiterm.BrightGreen))
 	}
 	printClouds(clouds.public, nil)
 	printClouds(clouds.builtin, nil)
-	printClouds(clouds.personal, personalColor)
+	printClouds(clouds.personal, ansiterm.Foreground(ansiterm.BrightBlue))
 	tw.Flush()
 	return nil
 }

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -154,12 +154,12 @@ func (c *listCloudsCommand) getCloudList(ctxt *cmd.Context) (*cloudList, error) 
 		remotes := func() error {
 			api, err := c.listCloudsAPIFunc()
 			if err != nil {
-				return err
+				return errors.Trace(err)
 			}
 			defer api.Close()
 			controllerClouds, err := api.Clouds()
 			if err != nil {
-				return err
+				return errors.Trace(err)
 			}
 			for _, cloud := range controllerClouds {
 				cloudDetails := makeCloudDetails(c.Store, cloud)
@@ -187,7 +187,7 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	}
 	details, err := c.getCloudList(ctxt)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	var result interface{}
 	switch c.out.Name() {
@@ -245,7 +245,7 @@ func (c *cloudList) all() map[string]*CloudDetails {
 func listCloudDetails(store jujuclient.CredentialGetter) (*cloudList, error) {
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	details := newCloudList()
 	for name, cloud := range clouds {
@@ -266,7 +266,7 @@ func listCloudDetails(store jujuclient.CredentialGetter) (*cloudList, error) {
 
 	personalClouds, err := jujucloud.PersonalCloudMetadata()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	for name, cloud := range personalClouds {
 		cloudDetails := makeCloudDetails(store, cloud)

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -145,7 +145,7 @@ func (c *listCloudsCommand) getCloudList(ctxt *cmd.Context) (*cloudList, error) 
 		ctxt.Warningf("%v", anErr)
 		returnErr = cmd.ErrSilent
 	}
-	details, err := listCloudDetails(c.Store)
+	details, err := listLocalCloudDetails(c.Store)
 	if err != nil {
 		warn(err)
 	}
@@ -242,7 +242,7 @@ func (c *cloudList) all() map[string]*CloudDetails {
 	return result
 }
 
-func listCloudDetails(store jujuclient.CredentialGetter) (*cloudList, error) {
+func listLocalCloudDetails(store jujuclient.CredentialGetter) (*cloudList, error) {
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -209,7 +209,7 @@ func (c *listCredentialsCommand) cloudNames() ([]string, error) {
 	}
 	personalClouds, err := c.personalClouds()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	publicClouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
@@ -277,7 +277,7 @@ func (c *listCredentialsCommand) remoteCredentials(ctxt *cmd.Context) (map[strin
 	defer client.Close()
 	remotes, err := client.CredentialContents("", "", c.showSecrets)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	byCloud := map[string]CloudCredential{}
@@ -352,17 +352,17 @@ func (c *listCredentialsCommand) localCredentials(ctxt *cmd.Context) (map[string
 func removeSecrets(cloudName string, cloudCred *jujucloud.CloudCredential, cloudFinder func(string) (*jujucloud.Cloud, error)) error {
 	cloud, err := common.CloudOrProvider(cloudName, cloudFinder)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	provider, err := environs.Provider(cloud.Type)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	schemas := provider.CredentialSchemas()
 	for name, cred := range cloudCred.AuthCredentials {
 		sanitisedCred, err := jujucloud.RemoveSecrets(cred, schemas)
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		cloudCred.AuthCredentials[name] = *sanitisedCred
 	}

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -422,8 +422,8 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 			w.Println()
 		}
 	}
-	printGroup(credentials.Remote, ansiterm.Foreground(ansiterm.BrightBlue))
-	printGroup(credentials.Local, nil)
+	printGroup(credentials.Remote, ansiterm.Foreground(ansiterm.BrightGreen))
+	printGroup(credentials.Local, ansiterm.Foreground(ansiterm.BrightBlue))
 
 	tw.Flush()
 	return nil

--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -7,26 +7,51 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v3"
 	"gopkg.in/yaml.v2"
 
+	cloudapi "github.com/juju/juju/api/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/jujuclient"
 )
 
 type listRegionsCommand struct {
-	cmd.CommandBase
+	modelcmd.OptionalControllerCommand
 	out       cmd.Output
 	cloudName string
+
+	cloudAPIFunc func() (CloudRegionsAPI, error)
+	found        *FoundRegions
 }
 
 var listRegionsDoc = `
+List regions for a given cloud.
+
+If the current controller can be detected, a user will be prompted to 
+confirm if regions for the cloud known to the controller need to be 
+listed as well. If the prompt is not needed and the regions from 
+current controller's cloud are always to be listed, use --no-prompt option.
+
+Use --controller option to list regions from the cloud from a different controller.
+
+Use --local option to only list regions known locally on this client.
+
+Regions for a cloud known locally on this client are always listed.
+
 Examples:
 
     juju regions aws
+    juju regions aws --controller mycontroller
+    juju regions aws --local
+    juju regions aws --no-prompt
 
 See also:
     add-cloud
@@ -35,9 +60,29 @@ See also:
     update-clouds
 `
 
+type CloudRegionsAPI interface {
+	Cloud(tag names.CloudTag) (jujucloud.Cloud, error)
+	Close() error
+}
+
 // NewListRegionsCommand returns a command to list cloud region information.
 func NewListRegionsCommand() cmd.Command {
-	return &listRegionsCommand{}
+	store := jujuclient.NewFileClientStore()
+	c := &listRegionsCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store: store,
+		},
+	}
+	c.cloudAPIFunc = c.cloudAPI
+	return modelcmd.WrapBase(c)
+}
+
+func (c *listRegionsCommand) cloudAPI() (CloudRegionsAPI, error) {
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cloudapi.NewClient(root), nil
 }
 
 // Info implements Command.Info.
@@ -53,7 +98,7 @@ func (c *listRegionsCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *listRegionsCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.CommandBase.SetFlags(f)
+	c.OptionalControllerCommand.SetFlags(f)
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
@@ -72,60 +117,123 @@ func (c *listRegionsCommand) Init(args []string) error {
 	return cmd.CheckEmpty(args[1:])
 }
 
+type FoundRegions struct {
+	Local  interface{} `yaml:"local-cloud-regions,omitempty" json:"local-cloud-regions,omitempty"`
+	Remote interface{} `yaml:"controller-cloud-regions,omitempty" json:"controller-cloud-regions,omitempty"`
+}
+
 // Run implements Command.Run.
 func (c *listRegionsCommand) Run(ctxt *cmd.Context) error {
+	c.found = &FoundRegions{}
+	var returnErr error
+	if err := c.findLocalRegions(ctxt); err != nil {
+		ctxt.Warningf("%v", err)
+		returnErr = cmd.ErrSilent
+	}
+
+	if !c.Local {
+		if err := c.findRemoteRegions(ctxt); err != nil {
+			ctxt.Warningf("%v", err)
+			returnErr = cmd.ErrSilent
+		}
+	}
+	if err := c.out.Write(ctxt, *c.found); err != nil {
+		ctxt.Warningf("%v", err)
+		returnErr = cmd.ErrSilent
+	}
+	return returnErr
+}
+
+func (c *listRegionsCommand) findRemoteRegions(ctxt *cmd.Context) error {
+	if c.ControllerName == "" {
+		// The user may have specified the controller via a --controller option.
+		// If not, let's see if there is a current controller that can be detected.
+		var err error
+		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("list regions for cloud %q from", c.cloudName))
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if c.ControllerName == "" {
+		return errors.Errorf("Not listing regions for cloud %q from a controller: no controller specified.", c.cloudName)
+	}
+
+	api, err := c.cloudAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+	aCloud, err := api.Cloud(names.NewCloudTag(c.cloudName))
+	if err != nil {
+		return errors.Annotatef(err, "on controller %q", c.ControllerName)
+	}
+
+	if len(aCloud.Regions) == 0 {
+		fmt.Fprintf(ctxt.GetStdout(), "Cloud %q has no regions defined on controller %q.\n", c.cloudName, c.ControllerName)
+		return nil
+	}
+	c.found.Remote = c.parseRegions(aCloud)
+	return nil
+}
+
+func (c *listRegionsCommand) findLocalRegions(ctxt *cmd.Context) error {
 	cloud, err := common.CloudByName(c.cloudName)
 	if err != nil {
 		return errors.Trace(err)
 	}
-
 	if len(cloud.Regions) == 0 {
-		fmt.Fprintf(ctxt.GetStdout(), "Cloud %q has no regions defined.\n", c.cloudName)
+		fmt.Fprintf(ctxt.GetStdout(), "Cloud %q has no regions defined locally on this client.\n", c.cloudName)
 		return nil
 	}
-	var regions interface{}
+	c.found.Local = c.parseRegions(*cloud)
+	return nil
+}
+
+func (c *listRegionsCommand) parseRegions(aCloud jujucloud.Cloud) interface{} {
 	if c.out.Name() == "json" {
 		details := make(map[string]RegionDetails)
-		for _, r := range cloud.Regions {
+		for _, r := range aCloud.Regions {
 			details[r.Name] = RegionDetails{
 				Endpoint:         r.Endpoint,
 				IdentityEndpoint: r.IdentityEndpoint,
 				StorageEndpoint:  r.StorageEndpoint,
 			}
 		}
-		regions = details
-	} else {
-		details := make(yaml.MapSlice, len(cloud.Regions))
-		for i, r := range cloud.Regions {
-			details[i] = yaml.MapItem{r.Name, RegionDetails{
-				Name:             r.Name,
-				Endpoint:         r.Endpoint,
-				IdentityEndpoint: r.IdentityEndpoint,
-				StorageEndpoint:  r.StorageEndpoint,
-			}}
-		}
-		regions = details
+		return details
 	}
-	err = c.out.Write(ctxt, regions)
-	if err != nil {
-		return err
+	details := make(yaml.MapSlice, len(aCloud.Regions))
+	for i, r := range aCloud.Regions {
+		details[i] = yaml.MapItem{r.Name, RegionDetails{
+			Name:             r.Name,
+			Endpoint:         r.Endpoint,
+			IdentityEndpoint: r.IdentityEndpoint,
+			StorageEndpoint:  r.StorageEndpoint,
+		}}
 	}
-	return nil
+	return details
 }
 
 func (c *listRegionsCommand) formatRegionsListTabular(writer io.Writer, value interface{}) error {
-	regions, ok := value.(yaml.MapSlice)
+	regions, ok := value.(FoundRegions)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", regions, value)
 	}
 	return formatRegionsTabular(writer, regions)
 }
 
-func formatRegionsTabular(writer io.Writer, regions yaml.MapSlice) error {
+func formatRegionsTabular(writer io.Writer, regions FoundRegions) error {
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	for _, r := range regions {
-		w.Println(r.Key)
+	if locals, ok := regions.Local.(yaml.MapSlice); ok {
+		for _, r := range locals {
+			w.Println(r.Key)
+		}
+	}
+	if remotes, ok := regions.Remote.(yaml.MapSlice); ok {
+		for _, r := range remotes {
+			w.PrintColor(ansiterm.Foreground(ansiterm.BrightBlue), r.Key)
+			w.Println()
+		}
 	}
 	tw.Flush()
 	return nil

--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -160,7 +160,7 @@ func (c *listRegionsCommand) findRemoteRegions(ctxt *cmd.Context) error {
 
 	api, err := c.cloudAPIFunc()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer api.Close()
 	aCloud, err := api.Cloud(names.NewCloudTag(c.cloudName))

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -332,7 +332,7 @@ func getCloudConfigDetails(cloudType string) map[string]interface{} {
 
 // GetAllCloudDetails returns a list of all cloud details.
 func GetAllCloudDetails(store jujuclient.CredentialGetter) (map[string]*CloudDetails, error) {
-	result, err := listCloudDetails(store)
+	result, err := listLocalCloudDetails(store)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -189,7 +189,7 @@ func (c *showCloudCommand) displayCloud(ctxt *cmd.Context, aCloud *CloudDetails,
 	fmt.Fprintln(ctxt.Stdout, msg)
 	aCloud.CloudType = displayCloudType(aCloud.CloudType)
 	if err := c.out.Write(ctxt, aCloud); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if includeConfig {
 		return c.displayConfig(ctxt, aCloud.CloudType)
@@ -204,7 +204,7 @@ func (c *showCloudCommand) displayConfig(ctxt *cmd.Context, cloudType string) er
 			ctxt.Stdout,
 			fmt.Sprintf("\nThe available config options specific to %s clouds are:", cloudType))
 		if err := c.out.Write(ctxt, config); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 		c.configDisplayed = true
 	}
@@ -214,12 +214,12 @@ func (c *showCloudCommand) displayConfig(ctxt *cmd.Context, cloudType string) er
 func (c *showCloudCommand) getControllerCloud() (*CloudDetails, error) {
 	api, err := c.showCloudAPIFunc()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	defer api.Close()
 	controllerCloud, err := api.Cloud(names.NewCloudTag(c.CloudName))
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	cloud := makeCloudDetails(c.Store, controllerCloud)
 	return cloud, nil
@@ -228,7 +228,7 @@ func (c *showCloudCommand) getControllerCloud() (*CloudDetails, error) {
 func (c *showCloudCommand) getLocalCloud() (*CloudDetails, error) {
 	details, err := GetAllCloudDetails(c.Store)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	cloud, ok := details[c.CloudName]
 	if !ok {

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -36,15 +36,15 @@ type showCredentialCommand struct {
 // credentials stored on the controller.
 func NewShowCredentialCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
-	cmd := &showCredentialCommand{
+	command := &showCredentialCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
 			Store: store,
 		},
 	}
-	cmd.newAPIFunc = func() (CredentialContentAPI, error) {
-		return cmd.NewCredentialAPI()
+	command.newAPIFunc = func() (CredentialContentAPI, error) {
+		return command.NewCredentialAPI()
 	}
-	return modelcmd.WrapBase(cmd)
+	return modelcmd.WrapBase(command)
 }
 
 func (c *showCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -120,7 +120,7 @@ func (c *showCredentialCommand) remoteCredentials(ctxt *cmd.Context) ([]params.C
 
 	client, err := c.newAPIFunc()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	defer client.Close()
@@ -130,7 +130,7 @@ func (c *showCredentialCommand) remoteCredentials(ctxt *cmd.Context) ([]params.C
 	}
 	remoteContents, err := client.CredentialContents(c.CloudName, c.CredentialName, c.ShowSecrets)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return remoteContents, nil
 }
@@ -138,7 +138,7 @@ func (c *showCredentialCommand) remoteCredentials(ctxt *cmd.Context) ([]params.C
 func (c *showCredentialCommand) localCredentials(ctxt *cmd.Context) ([]params.CredentialContentResult, error) {
 	locals, err := credentialsFromLocalCache(c.Store, c.CloudName, c.CredentialName)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	if c.CloudName != "" {

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -73,7 +73,7 @@ func (s *ShowCredentialSuite) TestShowCredentialBadArgs(c *gc.C) {
 func (s *ShowCredentialSuite) TestShowCredentialAPIVersion(c *gc.C) {
 	s.api.v = 1
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 remote credential content lookup failed: remote credential content lookup in Juju v1 not supported
@@ -86,7 +86,7 @@ No local or remote credentials to display.
 func (s *ShowCredentialSuite) TestShowCredentialAPICallError(c *gc.C) {
 	s.api.SetErrors(errors.New("boom"), nil)
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 remote credential content lookup failed: boom
@@ -99,7 +99,7 @@ No local or remote credentials to display.
 func (s *ShowCredentialSuite) TestShowCredentialNone(c *gc.C) {
 	s.api.contents = []params.CredentialContentResult{}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No local or remote credentials to display.\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
@@ -129,7 +129,7 @@ func (s *ShowCredentialSuite) TestShowCredentialOne(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ``)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
@@ -206,7 +206,7 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "boom\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -184,7 +184,7 @@ Changed cloud credential on model "controller" to "newcred".
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
-	ctx, err := s.run(c, "show-credential")
+	ctx, err := s.run(c, "show-credential", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
@@ -202,7 +202,7 @@ controller-credentials:
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
-	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets")
+	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "local credential content lookup failed: loading credentials: credentials for cloud dummy not found\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `


### PR DESCRIPTION
## Description of change

This PR changes:
* 'juju clouds';
* 'juju regions';
* 'juju credentials';
* 'juju show-clouds'; 
* 'juju show-credential';

to prompt user if the detected current controller needs to be used when listing/showing information.

As a drive-by, ensure that 'juju regions' command works on remote clouds, bug https://bugs.launchpad.net/juju/+bug/1843455

