### PR TITLE
Add leadership tracker to uniter worker init for caas only;

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -182,15 +182,18 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 		applicationChannel:   uniterParams.ApplicationChannel,
 	}
 	startFunc := func() (worker.Worker, error) {
-		if err := catacomb.Invoke(catacomb.Plan{
+		plan := catacomb.Plan{
 			Site: &u.catacomb,
 			Work: func() error {
 				return u.loop(uniterParams.UnitTag)
 			},
-			Init: []worker.Worker{
-				u.leadershipTracker,
-			},
-		}); err != nil {
+		}
+		if u.modelType == model.CAAS {
+			// For CAAS models, make sure the leadership tracker is killed when the Uniter
+			// dies.
+			plan.Init = append(plan.Init, u.leadershipTracker)
+		}
+		if err := catacomb.Invoke(plan); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return u, nil


### PR DESCRIPTION
## Description of change

Don't pass leadership tracker to uniter worker init for `IAAS`;

## QA steps

None

## Documentation changes

None

## Bug reference

None
