### PR TITLE
vsphere: Don't acquire the mutex when bootstrapping

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -23,7 +23,7 @@ type Client interface {
 	Close(context.Context) error
 	ComputeResources(context.Context) ([]*mo.ComputeResource, error)
 	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
-	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
+	CreateVirtualMachine(context.Context, vsphereclient.MutexAcquirer, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
 	Datastores(context.Context) ([]*mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -232,6 +232,7 @@ func (env *sessionEnviron) newRawInstance(
 		UpdateProgressInterval: updateProgressInterval,
 		Clock:                  clock.WallClock,
 		EnableDiskUUID:         env.ecfg.enableDiskUUID(),
+		IsBootstrap:            args.InstanceConfig.Bootstrap != nil,
 	}
 
 	// Attempt to create a VM in each of the AZs in turn.
@@ -244,7 +245,7 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs.ComputeResource = &availZone.r
 	createVMArgs.ResourcePool = availZone.pool.Reference()
 
-	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
+	vm, err := env.client.CreateVirtualMachine(env.ctx, vsphereclient.AcquireMutex, createVMArgs)
 	if vsphereclient.IsExtendDiskError(err) {
 		// Ensure we don't try to make the same extension across
 		// different resource groups.

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -63,7 +63,7 @@ type Client struct {
 }
 
 // Dial dials a new vSphere client connection using the given URL,
-// scoped to the specified dataceter. The resulting Client's Close
+// scoped to the specified datacenter. The resulting Client's Close
 // method must be called in order to release resources allocated by
 // Dial.
 func Dial(

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -196,7 +196,7 @@ func (c *Client) ensureTemplateVM(
 		// process is updating VMDKs at the same time. We lock around
 		// access to the series directory.
 		release, err := acquireMutex(mutex.Spec{
-			Name:  "juju-vsphere-" + args.Series,
+			Name:  "vsphere-" + args.Series,
 			Clock: args.Clock,
 			Delay: time.Second,
 		})

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -553,7 +553,7 @@ func (s *clientSuite) TestAcquiresMutexWhenNotBootstrapping(c *gc.C) {
 
 	stub.CheckCallNames(c, "acquire", "release")
 	stub.CheckCall(c, 0, "acquire", mutex.Spec{
-		Name:  "juju-vsphere-xenial",
+		Name:  "vsphere-xenial",
 		Clock: args.Clock,
 		Delay: time.Second,
 	})

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/mutex"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -58,7 +60,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusUpdates, jc.DeepEquals, []string{
 		fmt.Sprintf(`creating template VM "juju-template-%s"`, args.OVASHA256),
@@ -152,7 +154,7 @@ func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {
 	args := baseCreateVirtualMachineParams(c)
 	args.EnableDiskUUID = false
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.roundTripper.CheckCall(c, 31, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
@@ -185,7 +187,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreSpecified(c *gc.C) {
 	}}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	//findStubCall(c, s.roundTripper.Calls(), "?")
@@ -205,7 +207,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFound(c *gc.C) {
 	args.Constraints.RootDiskSource = &datastore
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, gc.ErrorMatches, `creating template VM: could not find datastore "datastore3", datastore\(s\) accessible: "datastore2"`)
 }
 
@@ -217,7 +219,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNoneAccessible(c *gc.C) {
 	}}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, gc.ErrorMatches, "creating template VM: no accessible datastores available")
 }
 
@@ -240,7 +242,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithMultipleAvail
 	)
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, gc.ErrorMatches, `creating template VM: could not find datastore "datastore3", datastore\(s\) accessible: "datastore1", "datastore2"`)
 }
 
@@ -263,7 +265,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithNoAvailable(c
 	)
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, gc.ErrorMatches, `creating template VM: no accessible datastores available`)
 }
 
@@ -275,7 +277,7 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var networkDevice1, networkDevice2 types.VirtualVmxnet3
@@ -343,7 +345,7 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var networkDevice types.VirtualVmxnet3
@@ -396,7 +398,7 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkNotFound(c *gc.C) {
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, gc.ErrorMatches, `cloning template VM: building clone VM config: network "fourtytwo" not found`)
 }
 
@@ -407,7 +409,7 @@ func (s *clientSuite) TestCreateVirtualMachineInvalidMAC(c *gc.C) {
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), args)
+	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 	c.Assert(err, gc.ErrorMatches, `cloning template VM: building clone VM config: adding network device 0 - network VM Network: Invalid MAC address: "00:11:22:33:44:55"`)
 }
 
@@ -419,7 +421,7 @@ func (s *clientSuite) TestCreateVirtualMachineRootDiskSize(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	errCh := make(chan error)
 	go func() {
-		_, err := client.CreateVirtualMachine(context.Background(), args)
+		_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 		select {
 		case errCh <- err:
 		case <-time.After(coretesting.ShortWait):
@@ -485,7 +487,7 @@ func (s *clientSuite) TestCreateVirtualMachineTimesOut(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	errCh := make(chan error)
 	go func() {
-		_, err := client.CreateVirtualMachine(context.Background(), args)
+		_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
 		select {
 		case errCh <- err:
 		case <-time.After(coretesting.ShortWait):
@@ -538,6 +540,39 @@ func (s *clientSuite) TestVerifyMAC(c *gc.C) {
 	}
 }
 
+func (s *clientSuite) TestAcquiresMutexWhenNotBootstrapping(c *gc.C) {
+	var stub testing.Stub
+	acquire := func(spec mutex.Spec) (func(), error) {
+		stub.AddCall("acquire", spec)
+		return func() { stub.AddCall("release") }, nil
+	}
+	args := baseCreateVirtualMachineParams(c)
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), acquire, args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	stub.CheckCallNames(c, "acquire", "release")
+	stub.CheckCall(c, 0, "acquire", mutex.Spec{
+		Name:  "juju-vsphere-xenial",
+		Clock: args.Clock,
+		Delay: time.Second,
+	})
+}
+
+func (s *clientSuite) TestNoAcquireOnBootstrap(c *gc.C) {
+	var stub testing.Stub
+	acquire := func(spec mutex.Spec) (func(), error) {
+		stub.AddCall("acquire")
+		return nil, errors.Errorf("boom")
+	}
+	args := baseCreateVirtualMachineParams(c)
+	args.IsBootstrap = true
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), acquire, args)
+	c.Assert(err, jc.ErrorIsNil)
+	stub.CheckCallNames(c)
+}
+
 func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
 	readOVA := func() (string, io.ReadCloser, error) {
 		r := bytes.NewReader(ovatest.FakeOVAContents())
@@ -588,6 +623,7 @@ func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
 		UpdateProgressInterval: time.Second,
 		Clock:                  testclock.NewClock(time.Time{}),
 		EnableDiskUUID:         true,
+		IsBootstrap:            false,
 	}
 }
 
@@ -619,4 +655,8 @@ func assertNoCall(c *gc.C, calls []testing.StubCall, name string) {
 			c.Fatalf("found call %q", name)
 		}
 	}
+}
+
+func fakeAcquire(spec mutex.Spec) (func(), error) {
+	return func() {}, nil
 }

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -62,10 +62,10 @@ func (c *mockClient) ResourcePools(ctx context.Context, path string) ([]*object.
 	return c.resourcePools[path], c.NextErr()
 }
 
-func (c *mockClient) CreateVirtualMachine(ctx context.Context, args vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error) {
+func (c *mockClient) CreateVirtualMachine(ctx context.Context, acquirer vsphereclient.MutexAcquirer, args vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.MethodCall(c, "CreateVirtualMachine", ctx, args)
+	c.MethodCall(c, "CreateVirtualMachine", ctx, acquirer, args)
 	return c.createdVirtualMachine, c.NextErr()
 }
 


### PR DESCRIPTION
## Description of change

The mutex in vsphereclient is designed to prevent multiple models' provisioners from clobbering each other when creating template VMs - it doesn't need to be done on the local machine when creating the initial bootstrap instance.

## QA steps

* Bootstrap on vsphere.
* Ensure that no lock file named `juju-juju-vsphere-bionic` or `juju-vsphere-bionic` is created under `/tmp`.

## Documentation changes
None

## Bug reference
None