### PR TITLE
vsphere: Don't expose acquireMutex outside vsphereclient

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -23,7 +23,7 @@ type Client interface {
 	Close(context.Context) error
 	ComputeResources(context.Context) ([]*mo.ComputeResource, error)
 	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
-	CreateVirtualMachine(context.Context, vsphereclient.MutexAcquirer, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
+	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
 	Datastores(context.Context) ([]*mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -245,7 +245,7 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs.ComputeResource = &availZone.r
 	createVMArgs.ResourcePool = availZone.pool.Reference()
 
-	vm, err := env.client.CreateVirtualMachine(env.ctx, vsphereclient.AcquireMutex, createVMArgs)
+	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
 	if vsphereclient.IsExtendDiskError(err) {
 		// Ensure we don't try to make the same extension across
 		// different resource groups.

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -118,12 +118,11 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 
 	s.client.CheckCallNames(c, "ComputeResources", "ResourcePools", "ResourcePools", "CreateVirtualMachine", "Close")
 	call := s.client.Calls()[3]
-	c.Assert(call.Args, gc.HasLen, 3)
+	c.Assert(call.Args, gc.HasLen, 2)
 	c.Assert(call.Args[0], gc.Implements, new(context.Context))
-	c.Assert(call.Args[1], gc.NotNil)
-	c.Assert(call.Args[2], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
+	c.Assert(call.Args[1], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
 
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(createVMArgs.UserData, gc.Not(gc.Equals), "")
 	c.Assert(createVMArgs.ReadOVA, gc.NotNil)
 	readOVA := createVMArgs.ReadOVA
@@ -178,7 +177,7 @@ func (s *environBrokerSuite) TestStartInstanceNetwork(c *gc.C) {
 	c.Assert(result, gc.NotNil)
 
 	call := s.client.Calls()[3]
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(createVMArgs.NetworkDevices, gc.HasLen, 2)
 	c.Assert(createVMArgs.NetworkDevices[0].Network, gc.Equals, "foo")
 	c.Assert(createVMArgs.NetworkDevices[1].Network, gc.Equals, "bar")
@@ -197,7 +196,7 @@ func (s *environBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {
 	_, err = env.StartInstance(s.callCtx, startInstArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	call := s.client.Calls()[3]
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	// The model name in the folder name should be truncated
 	// so that the final part of the model name is 80 characters.
 	c.Assert(path.Base(createVMArgs.Folder), gc.HasLen, 80)
@@ -221,7 +220,7 @@ func (s *environBrokerSuite) TestStartInstanceDiskUUIDDisabled(c *gc.C) {
 	c.Assert(result, gc.NotNil)
 
 	call := s.client.Calls()[3]
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(createVMArgs.EnableDiskUUID, gc.Equals, false)
 }
 
@@ -338,11 +337,11 @@ func (s *environBrokerSuite) TestStartInstanceSelectZone(c *gc.C) {
 
 	s.client.CheckCallNames(c, "ComputeResources", "ResourcePools", "ResourcePools", "CreateVirtualMachine", "Close")
 	call := s.client.Calls()[3]
-	c.Assert(call.Args, gc.HasLen, 3)
+	c.Assert(call.Args, gc.HasLen, 2)
 	c.Assert(call.Args[0], gc.Implements, new(context.Context))
-	c.Assert(call.Args[2], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
+	c.Assert(call.Args[1], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
 
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(createVMArgs.ComputeResource, jc.DeepEquals, s.client.computeResources[1])
 }
 
@@ -354,7 +353,7 @@ func (s *environBrokerSuite) TestStartInstanceFailsWithAvailabilityZone(c *gc.C)
 
 	s.client.CheckCallNames(c, "ComputeResources", "ResourcePools", "ResourcePools", "CreateVirtualMachine", "Close")
 	createVMCall1 := s.client.Calls()[3]
-	createVMArgs1 := createVMCall1.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs1 := createVMCall1.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(createVMArgs1.ComputeResource, jc.DeepEquals, s.client.computeResources[0])
 }
 
@@ -371,7 +370,7 @@ func (s *environBrokerSuite) TestStartInstanceDatastoreDefault(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	call := s.client.Calls()[3]
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(*createVMArgs.Constraints.RootDiskSource, gc.Equals, "datastore0")
 }
 
@@ -393,7 +392,7 @@ func (s *environBrokerSuite) TestStartInstanceRootDiskSource(c *gc.C) {
 	c.Assert(*result.Hardware.RootDiskSource, gc.Equals, "zebras")
 
 	call := s.client.Calls()[3]
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(*createVMArgs.Constraints.RootDiskSource, gc.Equals, "zebras")
 }
 
@@ -479,11 +478,11 @@ func (s *environBrokerSuite) TestStartInstanceNoDatastoreSetting(c *gc.C) {
 
 	s.client.CheckCallNames(c, "ComputeResources", "ResourcePools", "ResourcePools", "CreateVirtualMachine", "Close")
 	call := s.client.Calls()[3]
-	c.Assert(call.Args, gc.HasLen, 3)
+	c.Assert(call.Args, gc.HasLen, 2)
 	c.Assert(call.Args[0], gc.Implements, new(context.Context))
-	c.Assert(call.Args[2], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
+	c.Assert(call.Args[1], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
 
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 
 	var expected *string
 	c.Assert(createVMArgs.Constraints.RootDiskSource, gc.Equals, expected)
@@ -527,11 +526,10 @@ func (s *environBrokerSuite) TestNotBootstrapping(c *gc.C) {
 
 	s.client.CheckCallNames(c, "ComputeResources", "ResourcePools", "ResourcePools", "CreateVirtualMachine", "Close")
 	call := s.client.Calls()[3]
-	c.Assert(call.Args, gc.HasLen, 3)
+	c.Assert(call.Args, gc.HasLen, 2)
 	c.Assert(call.Args[0], gc.Implements, new(context.Context))
-	c.Assert(call.Args[1], gc.NotNil)
-	c.Assert(call.Args[2], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
+	c.Assert(call.Args[1], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
 
-	createVMArgs := call.Args[2].(vsphereclient.CreateVirtualMachineParams)
+	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
 	c.Assert(createVMArgs.IsBootstrap, gc.Equals, false)
 }

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/mutex"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/list"
@@ -56,10 +57,11 @@ func IsExtendDiskError(err error) bool {
 // Client encapsulates a vSphere client, exposing the subset of
 // functionality that we require in the Juju provider.
 type Client struct {
-	client     *govmomi.Client
-	datacenter string
-	logger     loggo.Logger
-	clock      clock.Clock
+	client       *govmomi.Client
+	datacenter   string
+	logger       loggo.Logger
+	clock        clock.Clock
+	acquireMutex func(mutex.Spec) (func(), error)
 }
 
 // Dial dials a new vSphere client connection using the given URL,
@@ -77,10 +79,11 @@ func Dial(
 		return nil, errors.Trace(err)
 	}
 	return &Client{
-		client:     client,
-		datacenter: datacenter,
-		logger:     logger,
-		clock:      clock.WallClock,
+		client:       client,
+		datacenter:   datacenter,
+		logger:       logger,
+		clock:        clock.WallClock,
+		acquireMutex: acquireMutex,
 	}, nil
 }
 

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
+	"github.com/juju/mutex"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/vmware/govmomi"
@@ -530,9 +531,10 @@ func (s *clientSuite) newFakeClient(roundTripper soap.RoundTripper, dc string) *
 			Client:         vimClient,
 			SessionManager: session.NewManager(vimClient),
 		},
-		datacenter: dc,
-		logger:     loggo.GetLogger("vsphereclient"),
-		clock:      s.clock,
+		datacenter:   dc,
+		logger:       loggo.GetLogger("vsphereclient"),
+		clock:        s.clock,
+		acquireMutex: fakeAcquire,
 	}
 }
 
@@ -845,4 +847,8 @@ func (s *clientSuite) TestResourcePools(c *gc.C) {
 	c.Check(result[1].InventoryPath, gc.Equals, "/z0/Resources/parent")
 	c.Check(result[2].InventoryPath, gc.Equals, "/z0/Resources/parent/child")
 	c.Check(result[3].InventoryPath, gc.Equals, "/z0/Resources/other")
+}
+
+func fakeAcquire(spec mutex.Spec) (func(), error) {
+	return func() {}, nil
 }

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -60,7 +60,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusUpdates, jc.DeepEquals, []string{
 		fmt.Sprintf(`creating template VM "juju-template-%s"`, args.OVASHA256),
@@ -154,7 +154,7 @@ func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {
 	args := baseCreateVirtualMachineParams(c)
 	args.EnableDiskUUID = false
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.roundTripper.CheckCall(c, 31, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
@@ -187,7 +187,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreSpecified(c *gc.C) {
 	}}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	//findStubCall(c, s.roundTripper.Calls(), "?")
@@ -207,7 +207,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFound(c *gc.C) {
 	args.Constraints.RootDiskSource = &datastore
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `creating template VM: could not find datastore "datastore3", datastore\(s\) accessible: "datastore2"`)
 }
 
@@ -219,7 +219,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNoneAccessible(c *gc.C) {
 	}}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, "creating template VM: no accessible datastores available")
 }
 
@@ -242,7 +242,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithMultipleAvail
 	)
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `creating template VM: could not find datastore "datastore3", datastore\(s\) accessible: "datastore1", "datastore2"`)
 }
 
@@ -265,7 +265,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithNoAvailable(c
 	)
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `creating template VM: no accessible datastores available`)
 }
 
@@ -277,7 +277,7 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var networkDevice1, networkDevice2 types.VirtualVmxnet3
@@ -345,7 +345,7 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var networkDevice types.VirtualVmxnet3
@@ -398,7 +398,7 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkNotFound(c *gc.C) {
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `cloning template VM: building clone VM config: network "fourtytwo" not found`)
 }
 
@@ -409,7 +409,7 @@ func (s *clientSuite) TestCreateVirtualMachineInvalidMAC(c *gc.C) {
 	}
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches, `cloning template VM: building clone VM config: adding network device 0 - network VM Network: Invalid MAC address: "00:11:22:33:44:55"`)
 }
 
@@ -421,7 +421,7 @@ func (s *clientSuite) TestCreateVirtualMachineRootDiskSize(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	errCh := make(chan error)
 	go func() {
-		_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+		_, err := client.CreateVirtualMachine(context.Background(), args)
 		select {
 		case errCh <- err:
 		case <-time.After(coretesting.ShortWait):
@@ -487,7 +487,7 @@ func (s *clientSuite) TestCreateVirtualMachineTimesOut(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	errCh := make(chan error)
 	go func() {
-		_, err := client.CreateVirtualMachine(context.Background(), fakeAcquire, args)
+		_, err := client.CreateVirtualMachine(context.Background(), args)
 		select {
 		case errCh <- err:
 		case <-time.After(coretesting.ShortWait):
@@ -548,7 +548,8 @@ func (s *clientSuite) TestAcquiresMutexWhenNotBootstrapping(c *gc.C) {
 	}
 	args := baseCreateVirtualMachineParams(c)
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), acquire, args)
+	client.acquireMutex = acquire
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	stub.CheckCallNames(c, "acquire", "release")
@@ -568,7 +569,8 @@ func (s *clientSuite) TestNoAcquireOnBootstrap(c *gc.C) {
 	args := baseCreateVirtualMachineParams(c)
 	args.IsBootstrap = true
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	_, err := client.CreateVirtualMachine(context.Background(), acquire, args)
+	client.acquireMutex = acquire
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCallNames(c)
 }
@@ -655,8 +657,4 @@ func assertNoCall(c *gc.C, calls []testing.StubCall, name string) {
 			c.Fatalf("found call %q", name)
 		}
 	}
-}
-
-func fakeAcquire(spec mutex.Spec) (func(), error) {
-	return func() {}, nil
 }

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -62,10 +62,10 @@ func (c *mockClient) ResourcePools(ctx context.Context, path string) ([]*object.
 	return c.resourcePools[path], c.NextErr()
 }
 
-func (c *mockClient) CreateVirtualMachine(ctx context.Context, acquirer vsphereclient.MutexAcquirer, args vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error) {
+func (c *mockClient) CreateVirtualMachine(ctx context.Context, args vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.MethodCall(c, "CreateVirtualMachine", ctx, acquirer, args)
+	c.MethodCall(c, "CreateVirtualMachine", ctx, args)
 	return c.createdVirtualMachine, c.NextErr()
 }
 


### PR DESCRIPTION
## Description of change

Rather than passing `vsphereclient.AcquireMutex` into CreateVirtualMachine (requiring the provider code to know about it), store it in the client struct, set it to the default acquire function in vsphereclient.Dial and override it in the tests.

This is much cleaner - I'm blaming jetlag for doing it the other way first. Doesn't change the behaviour so it doesn't need to be included in the release - just tidies up the code.

## QA steps

* Bootstrap on vsphere
* Doesn't create a lock file /tmp/juju-vsphere-bionic on the local machine
* Delete the template vm in vsphere
* Deploy and application
* Does create the lock file on the controller machine

## Documentation changes

None

## Bug reference

None