### PR TITLE
Add PodManagementPolicy statefulset config to podspecV2;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1632,7 +1632,10 @@ func (k *kubernetesClient) configureStatefulSet(
 	cfgName := func(fileSetName string) string {
 		return applicationConfigMapName(deploymentName, fileSetName)
 	}
-
+	podManagementPolicy := apps.ParallelPodManagement
+	if workloadSpec.Service != nil && workloadSpec.Service.PodManagementPolicy != "" {
+		podManagementPolicy = workloadSpec.Service.PodManagementPolicy
+	}
 	statefulset := &apps.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name: deploymentName,
@@ -1651,7 +1654,7 @@ func (k *kubernetesClient) configureStatefulSet(
 					Annotations: podAnnotations(annotations.Copy()).ToMap(),
 				},
 			},
-			PodManagementPolicy: apps.ParallelPodManagement,
+			PodManagementPolicy: apps.PodManagementPolicyType(podManagementPolicy),
 			ServiceName:         headlessServiceName(deploymentName),
 		},
 	}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1660,6 +1660,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
+	basicPodSpec.Service = &specs.ServiceSpec{
+		PodManagementPolicy: "OrderedReady",
+	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.PodSpec(workloadSpec)
@@ -1687,7 +1690,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 				},
 				Spec: podSpec,
 			},
-			PodManagementPolicy: apps.ParallelPodManagement,
+			PodManagementPolicy: apps.PodManagementPolicyType("OrderedReady"),
 			ServiceName:         "app-name-endpoints",
 		},
 	}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1661,7 +1661,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 
 	basicPodSpec := getBasicPodspec()
 	basicPodSpec.Service = &specs.ServiceSpec{
-		PodManagementPolicy: "OrderedReady",
+		ScalePolicy: "serial",
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec)
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -116,6 +116,7 @@ configMaps:
     foo: bar
     hello: world
 service:
+  podManagementPolicy: OrderedReady
   annotations:
     foo: bar
 serviceAccount:
@@ -203,7 +204,8 @@ foo: bar
 			},
 		}
 		pSpecs.Service = &specs.ServiceSpec{
-			Annotations: map[string]string{"foo": "bar"},
+			PodManagementPolicy: "OrderedReady",
+			Annotations:         map[string]string{"foo": "bar"},
 		}
 		pSpecs.ConfigMaps = map[string]specs.ConfigMap{
 			"mydata": {

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -116,7 +116,7 @@ configMaps:
     foo: bar
     hello: world
 service:
-  podManagementPolicy: OrderedReady
+  scalePolicy: serial
   annotations:
     foo: bar
 serviceAccount:
@@ -204,8 +204,8 @@ foo: bar
 			},
 		}
 		pSpecs.Service = &specs.ServiceSpec{
-			PodManagementPolicy: "OrderedReady",
-			Annotations:         map[string]string{"foo": "bar"},
+			ScalePolicy: "serial",
+			Annotations: map[string]string{"foo": "bar"},
 		}
 		pSpecs.ConfigMaps = map[string]specs.ConfigMap{
 			"mydata": {

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -102,7 +102,8 @@ func (spec *ContainerSpec) Validate() error {
 // ServiceSpec contains attributes to be set on v1.Service when
 // the application is deployed.
 type ServiceSpec struct {
-	Annotations map[string]string `json:"annotations,omitempty"`
+	PodManagementPolicy string            `json:"podManagementPolicy,omitempty"`
+	Annotations         map[string]string `json:"annotations,omitempty"`
 }
 
 // Version describes pod spec version type.

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -99,11 +99,50 @@ func (spec *ContainerSpec) Validate() error {
 	return nil
 }
 
+// ScalePolicyType defines the policy for creating or terminating pods under a service.
+type ScalePolicyType string
+
+// Validate returns an error if the spec is not valid.
+func (spt ScalePolicyType) Validate() error {
+	if spt == "" {
+		return nil
+	}
+	for _, v := range supportedPolicies {
+		if spt == v {
+			return nil
+		}
+	}
+	return errors.NotSupportedf("%v", spt)
+}
+
+const (
+	// ParallelScale will create and delete pods as soon as the
+	// replica count is changed, and will not wait for pods to be ready or complete
+	// termination.
+	ParallelScale ScalePolicyType = "parallel"
+
+	// SerialScale will create pods in strictly increasing order on
+	// scale up and strictly decreasing order on scale down, progressing only when
+	// the previous pod is ready or terminated. At most one pod will be changed
+	// at any time.
+	SerialScale = "serial"
+)
+
+var supportedPolicies = []ScalePolicyType{
+	ParallelScale,
+	SerialScale,
+}
+
 // ServiceSpec contains attributes to be set on v1.Service when
 // the application is deployed.
 type ServiceSpec struct {
-	PodManagementPolicy string            `json:"podManagementPolicy,omitempty"`
-	Annotations         map[string]string `json:"annotations,omitempty"`
+	ScalePolicy ScalePolicyType   `json:"scalePolicy,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// Validate returns an error if the spec is not valid.
+func (ss ServiceSpec) Validate() error {
+	return errors.Trace(ss.ScalePolicy.Validate())
 }
 
 // Version describes pod spec version type.
@@ -117,8 +156,7 @@ type PodSpecVersion struct {
 // ConfigMap describes the format of configmap resource.
 type ConfigMap map[string]string
 
-// podSpecBase defines the data values used to configure
-// a pod on the CAAS substrate.
+// podSpecBase defines the data values used to configure a pod on the CAAS substrate.
 type podSpecBase struct {
 	PodSpecVersion `yaml:",inline"`
 
@@ -144,6 +182,12 @@ type ProviderPod interface {
 func (spec *podSpecBase) Validate(ver Version) error {
 	if spec.Version != ver {
 		return errors.NewNotValid(nil, fmt.Sprintf("expected version %d, but found %d", ver, spec.Version))
+	}
+
+	if spec.Service != nil {
+		if err := spec.Service.Validate(); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	for _, c := range spec.Containers {

--- a/caas/specs/types_test.go
+++ b/caas/specs/types_test.go
@@ -84,6 +84,23 @@ func (s *typesSuite) TestValidateFileSet(c *gc.C) {
 	}
 }
 
+func (s *typesSuite) TestValidateServiceSpec(c *gc.C) {
+	spec := specs.ServiceSpec{
+		ScalePolicy: "foo",
+	}
+	c.Assert(spec.Validate(), gc.ErrorMatches, `foo not supported`)
+
+	spec = specs.ServiceSpec{
+		ScalePolicy: "parallel",
+	}
+	c.Assert(spec.Validate(), jc.ErrorIsNil)
+
+	spec = specs.ServiceSpec{
+		ScalePolicy: "serial",
+	}
+	c.Assert(spec.Validate(), jc.ErrorIsNil)
+}
+
 func (s *typesSuite) TestValidateContainerSpec(c *gc.C) {
 	for i, tc := range []validateTc{
 		{


### PR DESCRIPTION
## Description of change

Add `PodManagementPolicy` statefulset config support in `podspecV2`;

## QA steps

- deploy a statefulset application with below service section in podspec;

```yaml
# podspec.yaml
version: 2
service:
  podManagementPolicy: OrderedReady
...
```

```yaml
# metadata.yaml
deployment:
  type: stateful
...
```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1834481