### PR TITLE
Fix Block Device Matching and Device Path regex

### DIFF
--- a/apiserver/common/storagecommon/blockdevices.go
+++ b/apiserver/common/storagecommon/blockdevices.go
@@ -4,6 +4,8 @@
 package storagecommon
 
 import (
+	"strings"
+
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/state"
@@ -16,17 +18,18 @@ var logger = loggo.GetLogger("juju.apiserver.storagecommon")
 // storage.BlockDevice.
 func BlockDeviceFromState(in state.BlockDeviceInfo) storage.BlockDevice {
 	return storage.BlockDevice{
-		in.DeviceName,
-		in.DeviceLinks,
-		in.Label,
-		in.UUID,
-		in.HardwareId,
-		in.WWN,
-		in.BusAddress,
-		in.Size,
-		in.FilesystemType,
-		in.InUse,
-		in.MountPoint,
+		DeviceName:     in.DeviceName,
+		DeviceLinks:    in.DeviceLinks,
+		Label:          in.Label,
+		UUID:           in.UUID,
+		HardwareId:     in.HardwareId,
+		WWN:            in.WWN,
+		BusAddress:     in.BusAddress,
+		Size:           in.Size,
+		FilesystemType: in.FilesystemType,
+		InUse:          in.InUse,
+		MountPoint:     in.MountPoint,
+		SerialId:       in.SerialId,
 	}
 }
 
@@ -74,6 +77,14 @@ func MatchingBlockDevice(
 				return &dev, true
 			}
 			logger.Tracef("no match for block device hardware id: %v", dev.HardwareId)
+			continue
+		}
+		if volumeInfo.VolumeId != "" && dev.SerialId != "" {
+			if strings.HasPrefix(volumeInfo.VolumeId, dev.SerialId) {
+				logger.Tracef("serial id %v match on volume id %v", dev.SerialId, volumeInfo.VolumeId)
+				return &dev, true
+			}
+			logger.Tracef("no match for block device serial id: %v", dev.SerialId)
 			continue
 		}
 		if attachmentInfo.BusAddress != "" {

--- a/apiserver/common/storagecommon/blockdevices_test.go
+++ b/apiserver/common/storagecommon/blockdevices_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storagecommon_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common/storagecommon"
+	"github.com/juju/juju/state"
+)
+
+type BlockDeviceSuite struct {
+}
+
+var _ = gc.Suite(&BlockDeviceSuite{})
+
+func (s *BlockDeviceSuite) TestBlockDeviceMatchingSerialID(c *gc.C) {
+	blockDevices := []state.BlockDeviceInfo{
+		{
+			DeviceName: "sdb",
+			SerialId:   "543554ff-3b88-4",
+		},
+		{
+			DeviceName: "sdc",
+			WWN:        "wow",
+		},
+	}
+	volumeInfo := state.VolumeInfo{
+		VolumeId: "543554ff-3b88-43b9-83fc-4d69de28490b",
+	}
+	atachmentInfo := state.VolumeAttachmentInfo{}
+	planBlockInfo := state.BlockDeviceInfo{}
+	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(blockDevices, volumeInfo, atachmentInfo, planBlockInfo)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
+		DeviceName: "sdb",
+		SerialId:   "543554ff-3b88-4",
+	})
+}
+
+func (s *BlockDeviceSuite) TestBlockDeviceMatchingHardwareID(c *gc.C) {
+	blockDevices := []state.BlockDeviceInfo{
+		{
+			DeviceName: "sdb",
+			HardwareId: "ide-543554ff-3b88-4",
+		},
+		{
+			DeviceName: "sdc",
+		},
+	}
+	volumeInfo := state.VolumeInfo{
+		HardwareId: "ide-543554ff-3b88-4",
+	}
+	atachmentInfo := state.VolumeAttachmentInfo{}
+	planBlockInfo := state.BlockDeviceInfo{}
+	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(blockDevices, volumeInfo, atachmentInfo, planBlockInfo)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
+		DeviceName: "sdb",
+		HardwareId: "ide-543554ff-3b88-4",
+	})
+}

--- a/apiserver/facades/agent/diskmanager/diskmanager.go
+++ b/apiserver/facades/agent/diskmanager/diskmanager.go
@@ -90,17 +90,18 @@ func stateBlockDeviceInfo(devices []storage.BlockDevice) []state.BlockDeviceInfo
 	result := make([]state.BlockDeviceInfo, len(devices))
 	for i, dev := range devices {
 		result[i] = state.BlockDeviceInfo{
-			dev.DeviceName,
-			dev.DeviceLinks,
-			dev.Label,
-			dev.UUID,
-			dev.HardwareId,
-			dev.WWN,
-			dev.BusAddress,
-			dev.Size,
-			dev.FilesystemType,
-			dev.InUse,
-			dev.MountPoint,
+			DeviceName:     dev.DeviceName,
+			DeviceLinks:    dev.DeviceLinks,
+			Label:          dev.Label,
+			UUID:           dev.UUID,
+			HardwareId:     dev.HardwareId,
+			WWN:            dev.WWN,
+			BusAddress:     dev.BusAddress,
+			Size:           dev.Size,
+			FilesystemType: dev.FilesystemType,
+			InUse:          dev.InUse,
+			MountPoint:     dev.MountPoint,
+			SerialId:       dev.SerialId,
 		}
 	}
 	return result

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14631,6 +14631,9 @@
                         "MountPoint": {
                             "type": "string"
                         },
+                        "SerialId": {
+                            "type": "string"
+                        },
                         "Size": {
                             "type": "integer"
                         },
@@ -14653,7 +14656,8 @@
                         "Size",
                         "FilesystemType",
                         "InUse",
-                        "MountPoint"
+                        "MountPoint",
+                        "SerialId"
                     ]
                 },
                 "Error": {
@@ -31864,6 +31868,9 @@
                         "MountPoint": {
                             "type": "string"
                         },
+                        "SerialId": {
+                            "type": "string"
+                        },
                         "Size": {
                             "type": "integer"
                         },
@@ -31886,7 +31893,8 @@
                         "Size",
                         "FilesystemType",
                         "InUse",
-                        "MountPoint"
+                        "MountPoint",
+                        "SerialId"
                     ]
                 },
                 "BlockDeviceResult": {

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -44,6 +44,7 @@ type BlockDeviceInfo struct {
 	FilesystemType string   `bson:"fstype,omitempty"`
 	InUse          bool     `bson:"inuse"`
 	MountPoint     string   `bson:"mountpoint,omitempty"`
+	SerialId       string   `bson:"serialid,omitempty"`
 }
 
 // WatchBlockDevices returns a new NotifyWatcher watching for

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -630,6 +630,7 @@ func (s *MigrationSuite) TestBlockDeviceFields(c *gc.C) {
 		"FilesystemType",
 		"InUse",
 		"MountPoint",
+		"SerialId",
 	)
 	s.AssertExportedFields(c, BlockDeviceInfo{}, migrated)
 }

--- a/storage/blockdevice.go
+++ b/storage/blockdevice.go
@@ -63,4 +63,7 @@ type BlockDevice struct {
 
 	// MountPoint is the path at which the block devices is mounted.
 	MountPoint string `yaml:"mountpoint,omitempty"`
+
+	// SerialId is the block devices serial id used for matching.
+	SerialId string `yaml:"serialid,omitempty"`
 }

--- a/worker/diskmanager/lsblk.go
+++ b/worker/diskmanager/lsblk.go
@@ -234,6 +234,9 @@ func addHardwareInfo(dev *storage.BlockDevice) error {
 		// and together they make up the symlink in /dev/disk/by-id.
 		dev.HardwareId = idBus + "-" + idSerial
 	}
+	if idSerial != "" {
+		dev.SerialId = idSerial
+	}
 
 	// For devices on the SCSI bus, we include the address. This is to
 	// support storage providers where the SCSI address may be specified,
@@ -241,7 +244,7 @@ func addHardwareInfo(dev *storage.BlockDevice) error {
 	if idBus == "scsi" && devpath != "" {
 		// DEVPATH will be "<uninteresting stuff>/<SCSI address>/block/<device>".
 		re := regexp.MustCompile(fmt.Sprintf(
-			`^.*/(\d+):(\d+):(\d+):(\d+)/block/%s$`,
+			`^.*/(\d+):(\d+):(\d+):(\d+)/block/(?:\w+/|)%s$`,
 			regexp.QuoteMeta(dev.DeviceName),
 		))
 		submatch := re.FindStringSubmatch(devpath)


### PR DESCRIPTION
# Description of change

LP1790728: Match on just block device serial when bus id is missing.
LP1830326: Extend device path regex to match against partitions.

## QA steps

Bootstrap OpenStack and Deploy postgresql charm with storage. Application should have storage attached successfully.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1790728
https://bugs.launchpad.net/juju/+bug/1830326