### PR TITLE
Add state watcher for action messages

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -264,7 +264,15 @@ func (a *action) removeAndLog(finalStatus ActionStatus, results map[string]inter
 
 // Messages returns the action's progress messages.
 func (a *action) Messages() []ActionMessage {
-	return append([]ActionMessage(nil), a.doc.Logs...)
+	// Timestamps are not decoded as UTC, so we need to convert :-(
+	result := make([]ActionMessage, len(a.doc.Logs))
+	for i, m := range a.doc.Logs {
+		result[i] = ActionMessage{
+			Message:   m.Message,
+			Timestamp: m.Timestamp.UTC(),
+		}
+	}
+	return result
 }
 
 // Log adds message to the action's progress message array.
@@ -290,7 +298,7 @@ func (a *action) Log(message string) error {
 				Id:     a.doc.DocId,
 				Assert: bson.D{{"status", ActionRunning}},
 				Update: bson.D{{"$push", bson.D{
-					{"messages", ActionMessage{Message: message, Timestamp: a.st.nowToTheSecond()}},
+					{"messages", ActionMessage{Message: message, Timestamp: a.st.nowToTheSecond().UTC()}},
 				}}},
 			}}
 		return ops, nil

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -2430,6 +2431,111 @@ type actionStatusWatcher struct {
 	sink           chan []string
 	receiverFilter bson.D
 	statusFilter   bson.D
+}
+
+// WatchActionLogs starts and returns a StringsWatcher that
+// notifies on new log messages for a specified action being added.
+// The strings are json encoded action messages.
+func (st *State) WatchActionLogs(actionId string) StringsWatcher {
+	return newActionLogsWatcher(st, actionId)
+}
+
+// actionLogsWatcher reports new action progress messages.
+type actionLogsWatcher struct {
+	commonWatcher
+	coll func() (mongo.Collection, func())
+	out  chan []string
+
+	actionId string
+}
+
+var _ Watcher = (*actionLogsWatcher)(nil)
+
+func newActionLogsWatcher(st *State, actionId string) StringsWatcher {
+	w := &actionLogsWatcher{
+		commonWatcher: newCommonWatcher(st),
+		coll:          collFactory(st.db(), actionsC),
+		out:           make(chan []string),
+		actionId:      actionId,
+	}
+	w.tomb.Go(func() error {
+		defer close(w.out)
+		return w.loop()
+	})
+	return w
+}
+
+// Changes returns the event channel for w.
+func (w *actionLogsWatcher) Changes() <-chan []string {
+	return w.out
+}
+
+func (w *actionLogsWatcher) messages() ([]string, error) {
+	// Get the initial logs.
+	type messagesDoc struct {
+		Messages []ActionMessage `bson:"messages"`
+	}
+	coll, closer := w.coll()
+	defer closer()
+	var doc messagesDoc
+	err := coll.FindId(w.backend.docID(w.actionId)).Select(bson.D{{"messages", 1}}).One(&doc)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var changes []string
+	for _, m := range doc.Messages {
+		m.Timestamp = m.Timestamp.UTC()
+		mjson, err := json.Marshal(m)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		changes = append(changes, string(mjson))
+	}
+	return changes, nil
+}
+
+func (w *actionLogsWatcher) loop() error {
+	in := make(chan watcher.Change)
+	filter := func(id interface{}) bool {
+		k, err := w.backend.strictLocalID(id.(string))
+		if err != nil {
+			return false
+		}
+		return k == w.actionId
+	}
+
+	w.watcher.WatchCollectionWithFilter(actionsC, in, filter)
+	defer w.watcher.UnwatchCollection(actionsC, in)
+
+	changes, err := w.messages()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Record how many messages already sent so we
+	// only send new ones.
+	var reportedCount int
+	out := w.out
+
+	for {
+		select {
+		case <-w.watcher.Dead():
+			return stateWatcherDeadError(w.watcher.Err())
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-in:
+			messages, err := w.messages()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if len(messages) > reportedCount {
+				out = w.out
+				changes = messages[reportedCount:]
+			}
+		case out <- changes:
+			reportedCount = len(changes)
+			out = nil
+		}
+	}
 }
 
 var _ StringsWatcher = (*actionStatusWatcher)(nil)


### PR DESCRIPTION
## Description of change

Add a state watcher to report on new action log messages.

As a drive by, fix timestamps to make sure they are recorded as UTC.