### PR TITLE
state: Clean up apps stuck in dying state if the model is force-destroyed

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -527,9 +527,14 @@ func (st *State) removeApplicationsForDyingModel(args DestroyModelParams) (err e
 	//  it doesn't cause applications that are Dying to finish progressing to Dead.
 	application := Application{st: st}
 	sel := bson.D{{"life", Alive}}
+	force := args.Force != nil && *args.Force
+	if force {
+		// If we're forcing, propagate down to even dying
+		// applications, just in case they weren't originally forced.
+		sel = nil
+	}
 	iter := applications.Find(sel).Iter()
 	defer closeIter(iter, &err, "reading application document")
-	force := args.Force != nil && *args.Force
 	for iter.Next(&application.doc) {
 		op := application.DestroyOperation()
 		op.RemoveOffers = true


### PR DESCRIPTION
## Description of change

If a model is force-destroyed while an application is stuck in a dying state (for example if there's a bug in CMR that means that a remote unit is still in scope for a relation), ensure that we correctly propagate the destruction down to the dying application in the cleanup.

## QA steps
I haven't come up with a simple way to reproduce this situation, other than commenting out the leave scope code in the remote relations worker facade and in the remote application terminate operation method.
* Create a cross-model relation.
* Remove the consuming application - because of the broken leave-scope logic it won't go away.
* Destroy the model with --force - it will successfully remove it.

## Documentation changes
None

## Bug reference
None