### PR TITLE
Deprecate --local in favor of --client.

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -60,8 +60,8 @@ Creates a user-defined cloud based on a k8s cluster.
 The new k8s cloud can then be used to bootstrap into, or it
 can be added to an existing controller; the current controller
 is used unless the --controller option is specified. If you just
-want to update the local cache and not a running controller, use
-the --local option.
+want to update your current client and not a running controller, use
+the --client option.
 
 Specify a non default kubeconfig file location using $KUBECONFIG
 environment variable or pipe in file content from stdin.
@@ -81,7 +81,7 @@ necessary parameters directly.
 
 Examples:
     juju add-k8s myk8scloud
-    juju add-k8s myk8scloud --local
+    juju add-k8s myk8scloud --client
     juju add-k8s myk8scloud --controller mycontroller
     juju add-k8s --context-name mycontext myk8scloud
     juju add-k8s myk8scloud --region <cloudNameOrCloudType>/<someregion>

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -812,7 +812,7 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 	cloudRegion := "gce/us-east1"
 
 	command := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--local")
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `k8s substrate "mrcloud2" added as cloud "myk8s".You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
 	c.Assert(strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1), gc.Equals, expected)

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -46,7 +46,6 @@ func NewRemoveCAASCommandForTest(
 	command := &RemoveCAASCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
 		cloudMetadataStore:        cloudMetadataStore,
-		store:                     store,
 		apiFunc:                   removeCloudAPIFunc,
 	}
 	return command

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -122,7 +122,7 @@ func (s *removeCAASSuite) TestRemove(c *gc.C) {
 
 func (s *removeCAASSuite) TestRemoveLocalOnly(c *gc.C) {
 	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s", "--local")
+	_, err := s.runCommand(c, cmd, "myk8s", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.fakeCloudAPI.CheckNoCalls(c)
@@ -143,7 +143,7 @@ func (s *removeCAASSuite) TestRemoveNoController(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	msg := err.Error()
 	msg = strings.Replace(msg, "\n", "", -1)
-	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from the local cache, use the --local option.*`)
+	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from the current client, use the --client option.*`)
 
 	s.fakeCloudAPI.CheckNoCalls(c)
 	s.cloudMetadataStore.CheckNoCalls(c)

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -79,7 +79,7 @@ Use --no-prompt option when this prompt is undesirable, but the upload to
 the current controller is wanted.
 Use --controller option to upload a cloud to a different controller. 
 
-Use --local option to add cloud to the current device only.
+Use --client option to add cloud to the current client only.
 
 DEPRECATED If <cloud name> already exists in Juju's cache, then the `[1:] + "`--replace`" + ` 
 option is required. Use 'update-credential' instead.
@@ -111,11 +111,11 @@ clouds:                           # mandatory
 
 When a a running controller is updated, the credential for the cloud
 is also uploaded. As with the cloud, the credential needs
-to have been added to the local Juju cache; add-credential is used to
+to have been added to the current client; add-credential is used to
 do that. If there's only one credential for the cloud it will be
 uploaded to the controller automatically by add-clloud command. 
-However, if the cloud has multiple local credentials you can specify 
-which to upload with the --credential option.
+However, if the cloud has multiple credentials on this client
+you can specify which to upload with the --credential option.
 
 When adding clouds to a controller, some clouds are whitelisted and can be easily added:
 %v
@@ -133,7 +133,7 @@ If the "multi-cloud" feature flag is turned on in the controller:
 
     juju add-cloud --controller mycontroller mycloud
     juju add-cloud --controller mycontroller mycloud --credential mycred
-    juju add-cloud --local mycloud ~/mycloud.yaml
+    juju add-cloud --client mycloud ~/mycloud.yaml
 
 See also: 
     clouds
@@ -349,7 +349,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		}
 	}
 	if !c.Replace && c.existsLocally {
-		returnErr = errors.AlreadyExistsf("use `update-cloud %s --local` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
+		returnErr = errors.AlreadyExistsf("use `update-cloud %s --client` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
 	}
 	if c.Local {
 		return returnErr
@@ -780,14 +780,14 @@ func (p *cloudFileReader) verifyName(name string) error {
 		return err
 	}
 	if _, ok := personal[name]; ok {
-		return errors.AlreadyExistsf("use `update-cloud %s --local` to replace this cloud locally: %q", name, name)
+		return errors.AlreadyExistsf("use `update-cloud %s --client` to replace this cloud locally: %q", name, name)
 	}
 	msg, err := nameExists(name, public)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if msg != "" {
-		return errors.AlreadyExistsf(msg + "; use `update-cloud --local` to override this definition locally")
+		return errors.AlreadyExistsf(msg + "; use `update-cloud --client` to override this definition locally")
 	}
 	return nil
 }

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -176,7 +176,7 @@ func (*addSuite) TestAddBadFilename(c *gc.C) {
 	fake.Call("ParseCloudMetadataFile", "somefile.yaml").Returns(map[string]jujucloud.Cloud{}, badFileErr)
 
 	addCmd := cloud.NewAddCloudCommand(fake)
-	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "somefile.yaml", "--local")
+	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "somefile.yaml", "--client")
 	c.Check(errors.Cause(err), gc.Equals, badFileErr)
 }
 
@@ -212,7 +212,7 @@ func (s *addSuite) TestAddExisting(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(mockCloud, nil)
 
 	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud homestack --local` to override known definition: local cloud \"homestack\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud homestack --client` to override known definition: local cloud \"homestack\" already exists")
 }
 
 func (s *addSuite) TestAddExistingReplace(c *gc.C) {
@@ -230,7 +230,7 @@ func (s *addSuite) TestAddExistingReplace(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name(), "--replace", "--local")
+	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name(), "--replace", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(numCallsToWrite(), gc.Equals, 1)
@@ -251,7 +251,7 @@ func (s *addSuite) TestAddExistingPublic(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "aws", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud aws --local` to override known definition: local cloud \"aws\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud aws --client` to override known definition: local cloud \"aws\" already exists")
 }
 
 func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
@@ -269,7 +269,7 @@ func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "localhost", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud localhost --local` to override known definition: local cloud \"localhost\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud localhost --client` to override known definition: local cloud \"localhost\" already exists")
 }
 
 func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {
@@ -286,7 +286,7 @@ func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 	writeCall := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "aws", cloudFile.Name(), "--replace", "--local")
+	_, err = s.runCommand(c, fake, "aws", cloudFile.Name(), "--replace", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(writeCall(), gc.Equals, 1)
 }
@@ -318,7 +318,7 @@ func (s *addSuite) TestAddNew(c *gc.C) {
 	// but here mockCloud should have a region attached...
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "garage-maas", cloudFile.Name(), "--local")
+	_, err = s.runCommand(c, fake, "garage-maas", cloudFile.Name(), "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(numCallsToWrite(), gc.Equals, 1)
 }
@@ -513,7 +513,7 @@ func (s *addSuite) TestAddLocal(c *gc.C) {
 	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenario(c)
 
 	_, err := cmdtesting.RunCommand(
-		c, command, "garage-maas", cloudFileName, "--local")
+		c, command, "garage-maas", cloudFileName, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	api.CheckNoCalls(c)
 
@@ -522,7 +522,7 @@ func (s *addSuite) TestAddLocal(c *gc.C) {
 
 func (s *addSuite) TestAddLocalNoCloudName(c *gc.C) {
 	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenario(c)
-	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--local")
+	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	api.CheckNoCalls(c)
 	c.Check(numCalls(), gc.Equals, 1)
@@ -534,7 +534,7 @@ func (s *addSuite) TestAddLocalNoCloudName(c *gc.C) {
 
 func (s *addSuite) TestAddLocalNoCloudNameButManyCloudsInFile(c *gc.C) {
 	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenarioWithFile(c, manyCloudsYamlFile)
-	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--local")
+	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--client")
 	c.Assert(err.Error(), jc.Contains, "there is more than one cloud defined in file")
 	api.CheckNoCalls(c)
 	c.Check(numCalls(), gc.Equals, 0)
@@ -590,7 +590,7 @@ func (s *addSuite) TestAddToControllerAmbiguousCredential(c *gc.C) {
 
 func (*addSuite) TestInteractive(c *gc.C) {
 	command := cloud.NewAddCloudCommand(nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := &bytes.Buffer{}
@@ -631,7 +631,7 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(m1Metadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := &bytes.Buffer{}
@@ -670,7 +670,7 @@ func (*addSuite) TestInteractiveManual(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := &bytes.Buffer{}
@@ -715,7 +715,7 @@ func (*addSuite) TestInteractiveManualInvalidName(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -764,7 +764,7 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(vsphereMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	var stdout bytes.Buffer
@@ -809,7 +809,7 @@ func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -846,7 +846,7 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(compoundCloudMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	var out bytes.Buffer
@@ -946,7 +946,7 @@ clouds:
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--local")
+	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--client")
 	c.Check(err, jc.ErrorIsNil)
 
 	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{})
@@ -981,7 +981,7 @@ clouds:
 		logWriter.Clear()
 	}()
 
-	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--local")
+	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--client")
 	c.Check(err, jc.ErrorIsNil)
 
 	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
@@ -1221,7 +1221,7 @@ func testInteractiveOpenstack(c *gc.C, myOpenstack jujucloud.Cloud, expectedYAML
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(m1Metadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--local"})
+	err := cmdtesting.InitCommand(command, []string{"--client"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := cmdtesting.Context(c)

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -75,11 +75,11 @@ overwritten. This option is DEPRECATED, use 'juju update-credential' instead.
 
 Examples:
     juju add-credential google
-    juju add-credential google --local
+    juju add-credential google --client
     juju add-credential google -c mycontroller
     juju add-credential aws -f ~/credentials.yaml -c mycontroller
     juju add-credential aws -f ~/credentials.yaml
-    juju add-credential aws -f ~/credentials.yaml --local
+    juju add-credential aws -f ~/credentials.yaml --client
     juju add-credential aws -f ~/credentials.yaml --no-prompt
 
 Notes:
@@ -100,7 +100,7 @@ Use --no-prompt option when this prompt is undesirable, but the upload to
 the current controller is wanted.
 Use --controller option to upload a credential to a different controller. 
 
-Use --local option to add credentials to the current device only.
+Use --client option to add credentials to the current client only.
 
 Further help:
 Please visit https://discourse.jujucharms.com/t/1508 for cloud-specific

--- a/cmd/juju/cloud/defaultcredential.go
+++ b/cmd/juju/cloud/defaultcredential.go
@@ -17,7 +17,7 @@ import (
 )
 
 var usageSetDefaultCredentialSummary = `
-Sets local default credentials for a cloud.`[1:]
+Sets local default credentials for a cloud on this client.`[1:]
 
 var usageSetDefaultCredentialDetails = `
 The default credentials are specified with a "credential name". 

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -60,7 +60,7 @@ this Juju client. If a current controller is detected on the client, the user
 is prompted to confirm if the credentials should be uploaded to it. 
 To skip the prompt and to upload to a detected current controller, use --no-prompt.
 To upload credentials to a different controller, use --controller option. 
-To add credentials to the current client only, use --local option.
+To add credentials to the current client only, use --client option.
 
 Below are the cloud types for which credentials may be autoloaded,
 including the locations searched.
@@ -91,7 +91,7 @@ LXD
 
 Example:
     juju autoload-credentials
-    juju autoload-credentials --local
+    juju autoload-credentials --client
     juju autoload-credentials --controller mycontroller
     juju autoload-credentials --no-prompt
     juju autoload-credentials aws

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -43,10 +43,10 @@ var listCloudsDoc = "" +
 	"\n" +
 	"The default behaviour is to show clouds available on the current controller.\n" +
 	"Another controller can specified using the --controller option. When no controllers\n" +
-	"are available, --local is implied.\n" +
+	"are available, --client is implied.\n" +
 	"\n" +
-	"If --local is specified, the public clouds known to Juju out of the box are displayed,\n" +
-	"along with any which have been added with `add-cloud --local`. These clouds can be\n" +
+	"If --client is specified, the public clouds known to Juju out of the box are displayed,\n" +
+	"along with any which have been added with `add-cloud --client`. These clouds can be\n" +
 	"used to create a controller.\n" +
 	"\n" +
 	"Clouds may be listed that are co-hosted with the Juju client.  When the LXD hypervisor\n" +
@@ -79,7 +79,7 @@ Examples:
     juju clouds
     juju clouds --format yaml
     juju clouds --controller mycontroller
-    juju clouds --local
+    juju clouds --client
 
 See also:
     add-cloud

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -39,7 +39,7 @@ func (s *listSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *listSuite) TestListPublic(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -225,7 +225,7 @@ clouds:
 			return s.api, nil
 		})
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--local")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -246,7 +246,7 @@ clouds:
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -257,7 +257,7 @@ clouds:
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -266,7 +266,7 @@ func (s *listSuite) TestListYAML(c *gc.C) {
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "json", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "json", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -275,7 +275,7 @@ func (s *listSuite) TestListJSON(c *gc.C) {
 }
 
 func (s *listSuite) TestListPreservesRegionOrder(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	lines := strings.Split(cmdtesting.Stdout(ctx), "\n")
 	withClouds := "clouds:\n  " + strings.Join(lines, "\n  ")

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -361,7 +361,7 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 		fmt.Fprintln(writer, "No credentials from this client to display.")
 	}
 	if !credentials.LocalOnly && len(credentials.Remote) == 0 {
-		fmt.Fprintln(writer, "No credentials from a controller to display.")
+		fmt.Fprintln(writer, "No credentials from any controller to display.")
 	}
 	if len(credentials.Remote) == 0 && len(credentials.Local) == 0 {
 		return nil

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -29,7 +29,8 @@ var usageListCredentialsSummary = `
 Lists Juju credentials for a cloud.`[1:]
 
 var usageListCredentialsDetails = `
-This command list locally or remotely stored Juju credentials.
+This command list credentials from this client and credentials
+from a controller.
 
 Locally stored credentials are client specific and 
 are used with `[1:] + "`juju bootstrap`" + `  
@@ -61,8 +62,8 @@ created. This model will use the controller default credential. To see all your
 credentials on the controller use "juju show-credentials" command.
 
 When adding a new model, Juju will reuse the controller default credential.
-To add a model that uses a different credential, specify a locally
-stored credential using --credential option. See ` + "`juju help add-model`" + ` 
+To add a model that uses a different credential, specify a  credential
+from this client using --credential option. See ` + "`juju help add-model`" + ` 
 for more information.
 
 Credentials denoted with an asterisk '*' are currently set as the user default
@@ -357,10 +358,10 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 	}
 
 	if len(credentials.Local) == 0 {
-		fmt.Fprintln(writer, "No locally stored credentials to display.")
+		fmt.Fprintln(writer, "No credentials from this client to display.")
 	}
 	if !credentials.LocalOnly && len(credentials.Remote) == 0 {
-		fmt.Fprintln(writer, "No remotely stored credentials to display.")
+		fmt.Fprintln(writer, "No credentials from a controller to display.")
 	}
 	if len(credentials.Remote) == 0 && len(credentials.Local) == 0 {
 		return nil

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -131,7 +131,7 @@ func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
 	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
-No remotely stored credentials to display.
+No credentials from a controller to display.
 Cloud    Credentials
 aws      down*, bob  
 azure    azhja       
@@ -160,7 +160,7 @@ func (s *listCredentialsSuite) TestListCredentialsTabularInvalidCredential(c *gc
 
 	ctx := s.listCredentialsWithStore(c, store)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-No remotely stored credentials to display.
+No credentials from a controller to display.
 Cloud   Credentials
 aws     down*, bob  
 azure   azhja       
@@ -180,7 +180,7 @@ func (s *listCredentialsSuite) TestListCredentialsTabularShowsNoSecrets(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "secrets are not shown in tabular format\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-No remotely stored credentials to display.
+No credentials from a controller to display.
 Cloud    Credentials
 aws      down*, bob  
 azure    azhja       
@@ -197,7 +197,7 @@ func (s *listCredentialsSuite) TestListCredentialsTabularMissingCloud(c *gc.C) {
 The following clouds have been removed and are omitted from the results to avoid leaking secrets.
 Run with --show-secrets to display these clouds' credentials: missingcloud
 
-No remotely stored credentials to display.
+No credentials from a controller to display.
 Cloud    Credentials
 aws      down*, bob  
 azure    azhja       
@@ -210,7 +210,7 @@ mycloud  me
 func (s *listCredentialsSuite) TestListCredentialsTabularFiltered(c *gc.C) {
 	out := s.listCredentials(c, "aws")
 	c.Assert(out, gc.Equals, `
-No remotely stored credentials to display.
+No credentials from a controller to display.
 Cloud  Credentials
 aws    down*, bob  
 
@@ -218,7 +218,7 @@ aws    down*, bob
 }
 
 func (s *listCredentialsSuite) TestListCredentialsTabularFilteredLocalOnly(c *gc.C) {
-	out := s.listCredentials(c, "aws", "--local")
+	out := s.listCredentials(c, "aws", "--client")
 	c.Assert(out, gc.Equals, `
 Cloud  Credentials
 aws    down*, bob  
@@ -507,7 +507,7 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 		},
 	}
 	out := strings.Replace(s.listCredentials(c), "\n", "", -1)
-	c.Assert(out, gc.Equals, "No remotely stored credentials to display.Cloud  Credentialsaws    bob  ")
+	c.Assert(out, gc.Equals, "No credentials from a controller to display.Cloud  Credentialsaws    bob  ")
 
 	out = strings.Replace(s.listCredentials(c, "--format", "yaml"), "\n", "", -1)
 	c.Assert(out, gc.Equals, "local-credentials:  aws:    bob:      auth-type: oauth2")
@@ -522,7 +522,7 @@ func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out := strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, "No locally stored credentials to display.No remotely stored credentials to display.")
+	c.Assert(out, gc.Equals, "No credentials from this client to display.No credentials from a controller to display.")
 
 	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -131,7 +131,7 @@ func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
 	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
-No credentials from a controller to display.
+No credentials from any controller to display.
 Cloud    Credentials
 aws      down*, bob  
 azure    azhja       
@@ -160,7 +160,7 @@ func (s *listCredentialsSuite) TestListCredentialsTabularInvalidCredential(c *gc
 
 	ctx := s.listCredentialsWithStore(c, store)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-No credentials from a controller to display.
+No credentials from any controller to display.
 Cloud   Credentials
 aws     down*, bob  
 azure   azhja       
@@ -180,7 +180,7 @@ func (s *listCredentialsSuite) TestListCredentialsTabularShowsNoSecrets(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "secrets are not shown in tabular format\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-No credentials from a controller to display.
+No credentials from any controller to display.
 Cloud    Credentials
 aws      down*, bob  
 azure    azhja       
@@ -197,7 +197,7 @@ func (s *listCredentialsSuite) TestListCredentialsTabularMissingCloud(c *gc.C) {
 The following clouds have been removed and are omitted from the results to avoid leaking secrets.
 Run with --show-secrets to display these clouds' credentials: missingcloud
 
-No credentials from a controller to display.
+No credentials from any controller to display.
 Cloud    Credentials
 aws      down*, bob  
 azure    azhja       
@@ -210,7 +210,7 @@ mycloud  me
 func (s *listCredentialsSuite) TestListCredentialsTabularFiltered(c *gc.C) {
 	out := s.listCredentials(c, "aws")
 	c.Assert(out, gc.Equals, `
-No credentials from a controller to display.
+No credentials from any controller to display.
 Cloud  Credentials
 aws    down*, bob  
 
@@ -507,7 +507,7 @@ func (s *listCredentialsSuite) TestListCredentialsEmpty(c *gc.C) {
 		},
 	}
 	out := strings.Replace(s.listCredentials(c), "\n", "", -1)
-	c.Assert(out, gc.Equals, "No credentials from a controller to display.Cloud  Credentialsaws    bob  ")
+	c.Assert(out, gc.Equals, "No credentials from any controller to display.Cloud  Credentialsaws    bob  ")
 
 	out = strings.Replace(s.listCredentials(c, "--format", "yaml"), "\n", "", -1)
 	c.Assert(out, gc.Equals, "local-credentials:  aws:    bob:      auth-type: oauth2")
@@ -522,7 +522,7 @@ func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	out := strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1)
-	c.Assert(out, gc.Equals, "No credentials from this client to display.No credentials from a controller to display.")
+	c.Assert(out, gc.Equals, "No credentials from this client to display.No credentials from any controller to display.")
 
 	ctx, err = cmdtesting.RunCommand(c, listCmd, "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -23,11 +23,11 @@ Remove a named, user-defined cloud from Juju's internal cache.
 
 If the multi-cloud feature flag is enabled, the cloud is removed from a controller.
 The current controller is used unless the --controller option is specified.
-If --local is specified, Juju removes the cloud from internal cache.
+If --client is specified, Juju removes the cloud from this client.
 
 Examples:
     juju remove-cloud mycloud
-    juju remove-cloud mycloud --local
+    juju remove-cloud mycloud --client
     juju remove-cloud mycloud --controller mycontroller
 
 See also:
@@ -98,7 +98,7 @@ func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.ControllerName == "" {
 		if c.ControllerName == "" && !c.Local {
 			return errors.Errorf(
-				"There are no controllers running.\nTo remove cloud %q from the local cache, use the --local option.", c.Cloud)
+				"There are no controllers running.\nTo remove cloud %q from this client, use the --client option.", c.Cloud)
 		}
 		return c.removeLocalCloud(ctxt)
 	}

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -38,15 +38,15 @@ func (s *removeSuite) SetUpTest(c *gc.C) {
 
 func (s *removeSuite) TestRemoveBadArgs(c *gc.C) {
 	cmd := cloud.NewRemoveCloudCommand()
-	_, err := cmdtesting.RunCommand(c, cmd, "--local")
+	_, err := cmdtesting.RunCommand(c, cmd, "--client")
 	c.Assert(err, gc.ErrorMatches, "Usage: juju remove-cloud <cloud name>")
-	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "extra", "--local")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "extra", "--client")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *removeSuite) TestRemoveNotFound(c *gc.C) {
 	cmd := cloud.NewRemoveCloudCommandForTest(s.store, nil)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "fnord", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "fnord", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"fnord\" exists\n")
 }
@@ -84,7 +84,7 @@ func (s *removeSuite) TestRemoveCloudLocal(c *gc.C) {
 		})
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	ctx, err := cmdtesting.RunCommand(c, cmd, "homestack", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of personal cloud \"homestack\"\n")
 	assertPersonalClouds(c, "homestack2")
@@ -104,7 +104,7 @@ func (s *removeSuite) TestRemoveCloudNoControllers(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	msg := err.Error()
 	msg = strings.Replace(msg, "\n", "", -1)
-	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from the local cache, use the --local option.*`)
+	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from this client, use the --client option.*`)
 }
 
 func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
@@ -124,7 +124,7 @@ func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
 
 func (s *removeSuite) TestCannotRemovePublicCloud(c *gc.C) {
 	s.createTestCloudData(c)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"prodstack\" exists\n")
 }

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -57,11 +57,11 @@ material, can be listed with `[1:] + "`juju credentials`" + `.
 By default, after validating the contents, credentials are removed
 from both the current controller and the current client device. 
 Use --controller option to remove credentials from a different controller. 
-Use --local option to remove credentials from the current device only.
+Use --client option to remove credentials from the current client only.
 
 Examples:
     juju remove-credential rackspace credential_name
-    juju remove-credential rackspace credential_name --local
+    juju remove-credential rackspace credential_name --client
     juju remove-credential rackspace credential_name -c another_controller
 
 See also: 
@@ -153,7 +153,7 @@ func (c *removeCredentialCommand) checkCloud(ctxt *cmd.Context, client RemoveCre
 			if !errors.IsNotFound(err) {
 				logger.Errorf("%v", err)
 			}
-			ctxt.Infof("Cloud %q is not found remotely on the controller, looking for a locally stored cloud.", c.cloud)
+			ctxt.Infof("Cloud %q is not found on the controller, looking for it locally on this client.", c.cloud)
 		}
 	}
 	if err := c.maybeLocalCloud(ctxt); err != nil {
@@ -210,7 +210,7 @@ func (c *removeCredentialCommand) removeFromController(ctxt *cmd.Context, client
 
 func (c *removeCredentialCommand) removeFromLocal(ctxt *cmd.Context) error {
 	if !c.localCloudFound {
-		ctxt.Infof("No locally stored credentials exist since cloud %q is not found locally.", c.cloud)
+		ctxt.Infof("No credentials exist on this client since cloud %q is not found locally.", c.cloud)
 		return nil
 	}
 	cred, err := c.Store.CredentialForCloud(c.cloud)
@@ -221,13 +221,13 @@ func (c *removeCredentialCommand) removeFromLocal(ctxt *cmd.Context) error {
 		return err
 	}
 	if _, ok := cred.AuthCredentials[c.credential]; !ok {
-		ctxt.Infof("No local credential called %q exists for cloud %q", c.credential, c.cloud)
+		ctxt.Infof("No credential called %q exists for cloud %q on this client", c.credential, c.cloud)
 		return nil
 	}
 	delete(cred.AuthCredentials, c.credential)
 	if err := c.Store.UpdateCredential(c.cloud, *cred); err != nil {
-		return errors.Annotate(err, "could not remove local credential")
+		return errors.Annotate(err, "could not remove credential from this client")
 	}
-	ctxt.Infof("Local credential %q for cloud %q has been deleted.", c.credential, c.cloud)
+	ctxt.Infof("Credential %q for cloud %q has been deleted from this client.", c.credential, c.cloud)
 	return nil
 }

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -62,7 +62,7 @@ func (s *removeCredentialSuite) TestMissingLocalCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, `Found  local cloud "aws" on this client.No local credential called "foo" exists for cloud "aws"`)
+	c.Assert(output, gc.Equals, `Found  local cloud "aws" on this client.No credential called "foo" exists for cloud "aws" on this client`)
 }
 
 func (s *removeCredentialSuite) TestBadLocalCloudName(c *gc.C) {
@@ -93,7 +93,7 @@ func (s *removeCredentialSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := cmdtesting.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, `Found  local cloud "aws" on this client.Local credential "my-credential" for cloud "aws" has been deleted.`)
+	c.Assert(output, gc.Equals, `Found  local cloud "aws" on this client.Credential "my-credential" for cloud "aws" has been deleted from this client.`)
 	_, stillThere := store.Credentials["aws"].AuthCredentials["my-credential"]
 	c.Assert(stillThere, jc.IsFalse)
 	c.Assert(store.Credentials["aws"].AuthCredentials, gc.HasLen, 1)
@@ -131,7 +131,7 @@ func (s *removeCredentialSuite) TestGettingApiClientErrorButLocal(c *gc.C) {
 	store := s.setupStore(c)
 	s.clientF = func() (cloud.RemoveCredentialAPI, error) { return s.fakeClient, errors.New("kaboom") }
 	command := cloud.NewRemoveCredentialCommandForTest(store, s.cloudByNameFunc, s.clientF)
-	_, err := cmdtesting.RunCommand(c, command, "aws", "foo", "--local")
+	_, err := cmdtesting.RunCommand(c, command, "aws", "foo", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeClient.CheckNoCalls(c)
 }
@@ -157,7 +157,7 @@ func (s *removeCredentialSuite) TestBadRemoteCloudName(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, command, "other", "foo")
 	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-Cloud "other" is not found remotely on the controller, looking for a locally stored cloud.
+Cloud "other" is not found on the controller, looking for it locally on this client.
 Cloud "other" is not found locally on this client.
 To view all available clouds, use 'juju clouds'.
 To add new cloud, use 'juju add-cloud'.
@@ -177,7 +177,7 @@ func (s *removeCredentialSuite) TestRemoveRemoteCredential(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Found  remote cloud "somecloud" from the controller.
 Cloud "somecloud" is not found locally on this client.
-No locally stored credentials exist since cloud "somecloud" is not found locally.
+No credentials exist on this client since cloud "somecloud" is not found locally.
 Credential "foo" removed from the controller "controller".
 `[1:])
 }

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -43,17 +43,15 @@ options.
 If ‘--include-config’ is used, additional configuration (key, type, and
 description) specific to the cloud are displayed if available.
 
-If the multi-cloud feature flag is enabled, Juju shows a cloud on a controller,
-otherwise Juju shows the cloud from internal cache.
 The current controller is used unless the --controller option is specified.
-If --local is specified, Juju shows the cloud from internal cache.
+If --client is specified, Juju shows the cloud from this client.
 
 Examples:
 
     juju show-cloud google
     juju show-cloud azure-china --output ~/azure_cloud_details.txt
     juju show-cloud myopenstack --controller mycontroller
-    juju show-cloud myopenstack --local
+    juju show-cloud myopenstack --client
 
 See also:
     clouds
@@ -105,7 +103,7 @@ func (c *showCloudCommand) Init(args []string) error {
 	var err error
 	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil {
-		return errors.Wrap(err, errors.New(err.Error()+"\nUse --local to query the local cache."))
+		return errors.Wrap(err, errors.New(err.Error()+"\nUse --client to query this client."))
 	}
 	return cmd.CheckEmpty(args[1:])
 }

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -50,7 +50,7 @@ func (s *showSuite) assertShowLocal(c *gc.C, expectedOutput string) {
 			c.Fail()
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "aws-china", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws-china", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, expectedOutput)
@@ -179,7 +179,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
@@ -245,7 +245,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, strings.Join([]string{`defined: local
@@ -267,7 +267,7 @@ region-config:
 }
 
 func (s *showSuite) TestShowWithRegionConfigAndFlagNoExtraOut(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "joyent", "--include-config", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "joyent", "--include-config", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
@@ -355,7 +355,7 @@ ca-credentials:
 func (s *showSuite) TestShowWithCACertificate(c *gc.C) {
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(yamlWithCert), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--local")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, resultWithCert)

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -51,6 +51,7 @@ func (c *showCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 		"yaml": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.ShowSecrets, "show-secrets", false, "Display credential secret attributes")
+	// TODO (juju3) remove me
 	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client instead): Local operation only; controller credentials not shown")
 	f.BoolVar(&c.Local, "client", false, "Client operation only; controller credentials not shown")
 }

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -52,8 +52,8 @@ func (c *showCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 	f.BoolVar(&c.ShowSecrets, "show-secrets", false, "Display credential secret attributes")
 	// TODO (juju3) remove me
-	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client instead): Local operation only; controller credentials not shown")
-	f.BoolVar(&c.Local, "client", false, "Client operation only; controller credentials not shown")
+	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client instead): Local operation only; controller credential not shown")
+	f.BoolVar(&c.Local, "client", false, "Client operation only; controller credential not shown")
 }
 
 func (c *showCredentialCommand) Init(args []string) error {

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -51,7 +51,8 @@ func (c *showCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 		"yaml": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.ShowSecrets, "show-secrets", false, "Display credential secret attributes")
-	f.BoolVar(&c.Local, "local", false, "Local operation only; controller credentials not shown")
+	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client instead): Local operation only; controller credentials not shown")
+	f.BoolVar(&c.Local, "client", false, "Client operation only; controller credentials not shown")
 }
 
 func (c *showCredentialCommand) Init(args []string) error {
@@ -74,7 +75,7 @@ func (c *showCredentialCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "show-credential",
 		Args:    "[<cloud name> <credential name>]",
-		Purpose: "Shows credential information stored either locally or on a controller.",
+		Purpose: "Shows credential information stored either on this client or on a controller.",
 		Doc:     showCredentialDoc,
 		Aliases: []string{"show-credentials"},
 	})
@@ -96,7 +97,7 @@ func (c *showCredentialCommand) Run(ctxt *cmd.Context) error {
 	}
 	all.Controller = c.parseContents(ctxt, remoteContents)
 	if len(all.Local) == 0 && len(all.Controller) == 0 {
-		ctxt.Infof("No local or remote credentials to display.")
+		ctxt.Infof("No credentials from this client or from a controller to display.")
 		return nil
 	}
 	return c.out.Write(ctxt, all)
@@ -244,19 +245,20 @@ func (c *showCredentialCommand) parseContents(ctxt *cmd.Context, in []params.Cre
 
 var showCredentialDoc = `
 This command displays information about cloud credential(s) stored 
-either locally or on a controller for this user.
+either on this client or on a controller for this user.
 
 To see the contents of a specific credential, supply its cloud and name.
 To see all credentials stored for you, supply no arguments.
 
 To see secrets, content attributes marked as hidden, use --show-secrets option.
 
-To see only locally stored credentials, use "--local" option.
+To see only credentials from this client, use "--client" option.
 
 Examples:
 
     juju show-credential google my-admin-credential
     juju show-credentials 
+    juju show-credentials --client
     juju show-credentials --show-secrets
 
 See also: 

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -77,7 +77,7 @@ func (s *ShowCredentialSuite) TestShowCredentialAPIVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 remote credential content lookup failed: remote credential content lookup in Juju v1 not supported
-No local or remote credentials to display.
+No credentials from this client or from a controller to display.
 `[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	s.api.CheckCallNames(c, "BestAPIVersion", "Close")
@@ -90,7 +90,7 @@ func (s *ShowCredentialSuite) TestShowCredentialAPICallError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 remote credential content lookup failed: boom
-No local or remote credentials to display.
+No credentials from this client or from a controller to display.
 `[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
@@ -101,7 +101,7 @@ func (s *ShowCredentialSuite) TestShowCredentialNone(c *gc.C) {
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
 	ctx, err := cmdtesting.RunCommand(c, cmd)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No local or remote credentials to display.\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No credentials from this client or from a controller to display.\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
 }

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -38,17 +38,17 @@ type updateCloudCommand struct {
 }
 
 var updateCloudDoc = `
-Update cloud information either locally or on the controller.
+Update cloud information either on this client or on the controller.
 
-Updating the local cache requires a <cloud name> and a yaml file containing the
+Updating this client requires a <cloud name> and a yaml file containing the
 cloud details.
 
 To update a cloud on the controller you can provide just the <cloud name> which
-will use the cloud defined in the local cache or you can provide a cloud
+will use the cloud defined on this client or you can provide a cloud
 definition yaml file from which to retrieve the cloud details; the current
 controller is used unless the --controller option is specified.
 
-When <cloud definition file> is provided with <cloud name> and --local is
+When <cloud definition file> is provided with <cloud name> and --client is
 specified, Juju stores that definition in its internal cache directly after
 validating the contents.
 
@@ -57,7 +57,7 @@ Examples:
     juju update-cloud mymaas -f path/to/maas.yaml
     juju update-cloud mymaas -f path/to/maas.yaml --controller mycontroller
     juju update-cloud mymaas --controller mycontroller
-    juju update-cloud mymaas --local -f path/to/maas.yaml
+    juju update-cloud mymaas --client -f path/to/maas.yaml
 
 See also:
     add-cloud
@@ -154,7 +154,7 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 func (c *updateCloudCommand) updateLocalCacheFromFile(ctxt *cmd.Context) error {
 	if !c.Local {
 		ctxt.Infof(
-			"There are no controllers running.\nUpdating cloud in local cache so you can use it to bootstrap a controller.\n")
+			"There are no controllers running.\nUpdating cloud on this client so you can use it to bootstrap a controller.\n")
 	}
 	r := &cloudFileReader{
 		cloudMetadataStore: c.cloudMetadataStore,

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -86,7 +86,7 @@ func (s *updateCloudSuite) TestUpdateLocalCacheFromFile(c *gc.C) {
 	cmd, fileName := s.setupCloudFileScenario(c, func(controllerName string) (cloud.UpdateCloudAPI, error) {
 		return nil, errors.New("")
 	})
-	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName, "--local")
+	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
 }
@@ -101,7 +101,7 @@ func (s *updateCloudSuite) TestUpdateFromFileDefaultLocal(c *gc.C) {
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
 	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `There are no controllers running.Updating cloud in local cache so you can use it to bootstrap a controller.*`)
+	c.Assert(out, gc.Matches, `There are no controllers running.Updating cloud on this client so you can use it to bootstrap a controller.*`)
 }
 
 func (s *updateCloudSuite) TestUpdateLocalCacheBadFile(c *gc.C) {

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -114,6 +114,7 @@ func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	f.StringVar(&c.CredentialsFile, "f", "", "The YAML file containing credential details to update")
 	f.StringVar(&c.CredentialsFile, "file", "", "The YAML file containing credential details to update")
+	// TODO (juju3) remove me
 	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client instead): Local operation only; controller not affected")
 	f.BoolVar(&c.Local, "client", false, "Client operation only; controller not affected")
 	f.StringVar(&c.Region, "region", "", "Cloud region that credential is valid for")

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -33,11 +33,11 @@ When this happens, a user must update the cloud credential that
 a model was created with to the new and valid details on controller.
 
 This command allows to update an existing, already-stored, named,
-cloud-specific credential on controller or the one stored locally.
+cloud-specific credential on a controller or the one from this client.
 
-If --local is used, Juju updates credential in its internal cache directly but only on this client.
+If --client is used, Juju updates credential only on this client.
 If a user will use a different client, say a different laptop, the update will not affect that 
-client's copy. By extension, when using --local, remote credential copies,
+client's copy. By extension, when using --client, remote credential copies,
 on controllers, will not be affected.
 
 Before credential is updated, the new content is validated. For some providers, 
@@ -47,6 +47,7 @@ use --region.
 Examples:
     juju update-credential aws mysecrets
     juju update-credential -f mine.yaml
+    juju update-credential -f mine.yaml --client
     juju update-credential aws -f mine.yaml
     juju update-credential azure --region brazilsouth -f mine.yaml
 
@@ -113,7 +114,8 @@ func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	f.StringVar(&c.CredentialsFile, "f", "", "The YAML file containing credential details to update")
 	f.StringVar(&c.CredentialsFile, "file", "", "The YAML file containing credential details to update")
-	f.BoolVar(&c.Local, "local", false, "Local operation only; controller not affected")
+	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client instead): Local operation only; controller not affected")
+	f.BoolVar(&c.Local, "client", false, "Client operation only; controller not affected")
 	f.StringVar(&c.Region, "region", "", "Cloud region that credential is valid for")
 }
 
@@ -152,7 +154,7 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 	} else {
 		credentials, err = credentialsFromLocalCache(c.ClientStore(), c.cloud, c.credential)
 		if err != nil {
-			return errors.Annotatef(err, "could not get credentials from local client cache")
+			return errors.Annotatef(err, "could not get credentials from local client")
 		}
 	}
 	if c.Local {
@@ -238,7 +240,7 @@ func credentialsFromLocalCache(store jujuclient.ClientStore, cloudName, credenti
 			}
 		}
 	}
-	return nil, errors.NotFoundf("credential %q for cloud %q in local client cache", credentialName, cloudName)
+	return nil, errors.NotFoundf("credential %q for cloud %q in local client", credentialName, cloudName)
 }
 
 func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, update map[string]jujucloud.CloudCredential) error {
@@ -257,13 +259,13 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 		}
 		storedCredentials, err := c.ClientStore().CredentialForCloud(cloudName)
 		if errors.IsNotFound(err) {
-			ctx.Warningf("Could not find local credentials for cloud %v.", cloudName)
-			ctx.Infof("Use `juju add-credential` to add credentials locally.")
+			ctx.Warningf("Could not find credentials for cloud %v on this client.", cloudName)
+			ctx.Infof("Use `juju add-credential` to add credentials to this client.")
 			erred = true
 			continue
 		} else if err != nil {
 			logger.Errorf("%v", err)
-			ctx.Warningf("Could not get local credentials for cloud %v.", cloudName)
+			ctx.Warningf("Could not get credentials for cloud %v from this client.", cloudName)
 			erred = true
 			continue
 		}
@@ -285,7 +287,7 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 				newCredential, err := finalizeProvider(ctx, aCloud, c.Region, cloudCredentials.DefaultRegion, credential.AuthType(), credential.Attributes())
 				if err != nil {
 					logger.Errorf("%v", err)
-					logger.Warningf("Could not verify credential %v for cloud %v locally", credentialName, aCloud.Name)
+					logger.Warningf("Could not verify credential %v for cloud %v on this client", credentialName, aCloud.Name)
 					erred = true
 					continue
 				}
@@ -296,7 +298,7 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 		err = c.ClientStore().UpdateCredential(cloudName, *storedCredentials)
 		if err != nil {
 			logger.Errorf("%v", err)
-			ctx.Warningf("Could not update local client store with credentials for cloud %v", cloudName)
+			ctx.Warningf("Could not update this client with credentials for cloud %v", cloudName)
 			erred = true
 		}
 	}
@@ -378,7 +380,7 @@ func verifyCredentialsForUpload(ctx *cmd.Context, accountDetails *jujuclient.Acc
 		verifiedCredential, err := modelcmd.VerifyCredentials(ctx, aCloud, &aCredential, credentialName, region)
 		if err != nil {
 			logger.Errorf("%v", err)
-			ctx.Warningf("Could not verify credential %v for cloud %v locally", credentialName, aCloud.Name)
+			ctx.Warningf("Could not verify credential %v for cloud %v on this client", credentialName, aCloud.Name)
 			erred = cmd.ErrSilent
 			continue
 		}

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -263,16 +263,16 @@ func (s *updateCredentialSuite) TestCloudCredentialFromLocalCacheWithCloudAndCre
 }
 
 func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenNoneExists(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--local")
-	c.Assert(err, gc.ErrorMatches, "could not get credentials from local client cache: loading credentials: credentials for cloud somecloud not found")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client")
+	c.Assert(err, gc.ErrorMatches, "could not get credentials from local client: loading credentials: credentials for cloud somecloud not found")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }
 
 func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenCredentialDoesNotExists(c *gc.C) {
 	s.storeWithCredentials(c)
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "fluffy-credential", "--local")
-	c.Assert(err, gc.ErrorMatches, `could not get credentials from local client cache: credential "fluffy-credential" for cloud "somecloud" in local client cache not found`)
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "fluffy-credential", "--client")
+	c.Assert(err, gc.ErrorMatches, `could not get credentials from local client: credential "fluffy-credential" for cloud "somecloud" in local client not found`)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }
@@ -289,7 +289,7 @@ credentials:
 	s.storeWithCredentials(c)
 	before := s.store.Credentials["somecloud"].AuthCredentials["its-credential"].Attributes()["access-key"]
 	c.Assert(before, gc.DeepEquals, "key")
-	ctxt, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--local", "-f", testFile)
+	ctxt, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client", "-f", testFile)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "Local client was updated successfully with provided credential information.\n")
 	c.Assert(cmdtesting.Stdout(ctxt), gc.Equals, "")
@@ -383,7 +383,7 @@ credentials:
       auth-type: jsonfile
       file: %v
 `, tmpFile.Name()))
-	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--local", "-f", testFile)
+	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--client", "-f", testFile)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials["google"].AuthCredentials["gce"].Attributes()["file"], gc.Not(jc.Contains), string(contents))
 	c.Assert(s.store.Credentials["google"].AuthCredentials["gce"].Attributes()["file"], gc.Equals, tmpFile.Name())

--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -103,7 +103,7 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	if sameCloudInfo {
-		fmt.Fprintln(ctxt.Stderr, "This client's list of public clouds is up to date, see `juju clouds --local`.")
+		fmt.Fprintln(ctxt.Stderr, "This client's list of public clouds is up to date, see `juju clouds --client`.")
 		return nil
 	}
 	if err := jujucloud.WritePublicCloudMetadata(newPublicClouds); err != nil {

--- a/cmd/juju/cloud/updatepublicclouds_test.go
+++ b/cmd/juju/cloud/updatepublicclouds_test.go
@@ -131,7 +131,7 @@ func (s *updatePublicCloudsSuite) TestNoNewData(c *gc.C) {
 	defer ts.Close()
 
 	msg := s.run(c, ts.URL, "")
-	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...This client's list of public clouds is up to date, see `juju clouds --local`.")
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...This client's list of public clouds is up to date, see `juju clouds --client`.")
 }
 
 func (s *updatePublicCloudsSuite) TestFirstRun(c *gc.C) {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -402,6 +402,7 @@ type OptionalControllerCommand struct {
 // SetFlags initializes the flags supported by the command.
 func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
+	// TODO (juju3) remove me
 	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client): Local operation only; controller not affected")
 	f.BoolVar(&c.Local, "client", false, "Client operation only; controller not affected")
 	f.StringVar(&c.ControllerName, "c", "", "Controller to operate in")

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -402,7 +402,8 @@ type OptionalControllerCommand struct {
 // SetFlags initializes the flags supported by the command.
 func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.Local, "local", false, "Local operation only; controller not affected")
+	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client): Local operation only; controller not affected")
+	f.BoolVar(&c.Local, "client", false, "Client operation only; controller not affected")
 	f.StringVar(&c.ControllerName, "c", "", "Controller to operate in")
 	f.StringVar(&c.ControllerName, "controller", "", "")
 	f.BoolVar(&c.SkipCurrentControllerPrompt, "no-prompt", false, "Skip prompting for confirmation to use current controller, always use it when detected")


### PR DESCRIPTION
## Description of change

--local option doe snot provide enough clarity to differentiate between client-side information and controller-side information when dealing with clouds, regions and credentials.

This PR deprecates --local and introduces --client option. In Juju 3, --local will be removed.

As a drive-by, fix local command variables overwritting values in caas/remove.
