### PR TITLE
Mongo controller integration tests

### DIFF
--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -14,3 +14,39 @@ check_dependencies() {
         exit 1
     fi
 }
+
+check_not_contains() {
+    local input value chk
+
+    input=${1}
+    shift
+
+    value=${1}
+    shift
+
+    chk=$(echo "${input}" | grep "${value}" || true)
+    if [ -n "${chk}" ]; then
+        printf "Unexpected \"${value}\" found\n\n%s\n" "${input}"
+        exit 1
+    else
+        echo "Success: \"${value}\" not found"
+    fi
+}
+
+check_contains() {
+    local input value chk
+
+    input=${1}
+    shift
+
+    value=${1}
+    shift
+
+    chk=$(echo "${input}" | grep "${value}" || true)
+    if [ -z "${chk}" ]; then
+        printf "Expected \"${value}\" not found\n\n%s\n" "${input}"
+        exit 1
+    else
+        echo "Success: \"${value}\" found"
+    fi
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -23,16 +23,22 @@ import_subdir_files includes
 
 # If adding a test suite, then ensure to add it here to be picked up!
 TEST_NAMES="test_static_analysis \
+            test_controller \
             test_smoke \
             test_cmr_bundles"
 
 show_help() {
+    version=$(juju version)
     echo ""
     echo "$(red 'Juju test suite')"
     echo "¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯"
     echo "Juju tests suite expects you to have a Juju available on your \$PATH,"
     echo "so that if a tests needs to bootstrap it can just use that one"
     echo "directly."
+    echo ""
+    echo "Juju Version:"
+    echo "¯¯¯¯¯¯¯¯¯¯¯¯¯"
+    echo "Using juju version: $(green "${version}")"
     echo ""
     echo "Usage:"
     echo "¯¯¯¯¯¯"
@@ -80,7 +86,7 @@ show_help() {
     exit 0
 }
 
-while getopts "h?:vVsax" opt; do
+while getopts "h?:vVsaxrp" opt; do
     case "${opt}" in
     h|\?)
         show_help

--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -1,0 +1,42 @@
+cat_mongo_service() {
+    # shellcheck disable=SC2046
+    echo $(juju run -m controller --machine 0 'cat /lib/systemd/system/juju-db/juju-db.service' | grep "^ExecStart")
+}
+
+run_mongo_memory_profile() {
+    echo
+
+    file="${TEST_DIR}/mongo_memory_profile.txt"
+
+    ensure "mongo-memory-profile" "${file}"
+
+    check_not_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB
+
+    juju controller-config mongo-memory-profile=low
+
+    sleep 5
+
+    check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB
+
+    # Set the value back in case we are reusing a controller
+    juju controller-config mongo-memory-profile=default
+
+    sleep 5
+
+    destroy_model "mongo-memory-profile"
+}
+
+test_mongo_memory_profile() {
+    if [ -n "$(skip 'test_mongo_memory_profile')" ]; then
+        echo "==> SKIP: Asked to skip controller mongo memory profile tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd ../
+
+        run "run_mongo_memory_profile"
+    )
+}

--- a/tests/suites/controller/task.sh
+++ b/tests/suites/controller/task.sh
@@ -1,0 +1,14 @@
+test_controller() {
+    if [ "$(skip 'test_controller')" ]; then
+        echo "==> TEST SKIPPED: controller tests"
+        return
+    fi
+
+    file="${TEST_DIR}/test-controller.txt"
+
+    bootstrap "test-controller" "${file}"
+
+    test_mongo_memory_profile
+
+    destroy_controller "test-controller"
+}


### PR DESCRIPTION
## Description of change

The following adds tests done by @howbazaar to the newly updated
released version of the integration tests.

As a drive by add the juju controller version to the output so it's
very obvious what we're attempting to bootstrap.

See original code [howbazaar:mongo-memory-profile-ci-test](https://github.com/juju/juju/compare/develop...howbazaar:mongo-memory-profile-ci-test#diff-5489f6d8c4bc53fb54a2796393df601b)

## QA steps

```sh
cd tests
./main.sh controller
```
