### PR TITLE
add sorting for instanceTypes by Name (aws, openstack, google, azure)

### DIFF
--- a/environs/instances/instancetype.go
+++ b/environs/instances/instancetype.go
@@ -212,10 +212,10 @@ func (s byMemory) Less(i, j int) bool {
 	return inst0.Cost > inst1.Cost
 }
 
-//by Type is used to sort a slice by name by best effort. As we have different separators for different providers
-//we do it by best effort using "-" and "."
-//A possible sort could be:
-//a1.2xlarge, a1.large, lexical sort would put a1.2xlarge before a1.large -- aws
+// ByName is used to sort a slice by name by best effort. As we have different separators for different providers
+// A possible sort could be:
+// We sort by using a lexical sort for the type, which is before the delimiter,
+// and if they are the same, we sort by using the cost
 
 type ByName []InstanceType
 

--- a/environs/instances/instancetype.go
+++ b/environs/instances/instancetype.go
@@ -6,6 +6,7 @@ package instances
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/juju/juju/core/constraints"
 )
@@ -209,4 +210,30 @@ func (s byMemory) Less(i, j int) bool {
 	// Memory is equal, so use cost as a tie breaker.
 	// Result is in descending order of cost so instance with lowest cost is used.
 	return inst0.Cost > inst1.Cost
+}
+
+//by Type is used to sort a slice by name by best effort. As we have different separators for different providers
+//we do it by best effort using "-" and "."
+//A possible sort could be:
+//a1.2xlarge, a1.large, lexical sort would put a1.2xlarge before a1.large -- aws
+
+type ByName []InstanceType
+
+func (bt ByName) Len() int      { return len(bt) }
+func (bt ByName) Swap(i, j int) { bt[i], bt[j] = bt[j], bt[i] }
+func (bt ByName) Less(i, j int) bool {
+	inst0, inst1 := &bt[i], &bt[j]
+	baseInst0 := strings.FieldsFunc(inst0.Name, splitDelimiters)
+	baseInst1 := strings.FieldsFunc(inst1.Name, splitDelimiters)
+	if baseInst0[0] != baseInst1[0] {
+		return baseInst0[0] < baseInst1[0]
+	}
+	// Name is equal, so use cost as a tie breaker.
+	// Result is in ascending order of cost so instance with lowest cost is first.
+	return inst0.Cost > inst1.Cost
+
+}
+
+func splitDelimiters(r rune) bool {
+	return r == ',' || r == '-' || r == '.'
 }

--- a/environs/instances/instancetype.go
+++ b/environs/instances/instancetype.go
@@ -230,7 +230,7 @@ func (bt ByName) Less(i, j int) bool {
 	}
 	// Name is equal, so use cost as a tie breaker.
 	// Result is in ascending order of cost so instance with lowest cost is first.
-	return inst0.Cost > inst1.Cost
+	return inst0.Cost < inst1.Cost
 
 }
 

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -371,12 +371,11 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (
 	if err != nil {
 		return nil, err
 	}
-	instTypes := convertInstanceTypeMapToSlice(instanceTypes)
-	sort.Sort(instances.ByName(instTypes))
-	instTypeNames := make([]string, len(instTypes))
-	for i, itype := range instTypes {
-		instTypeNames[i] = itype.Name
+	instTypeNames := make([]string, 0, len(instanceTypes))
+	for instTypeName := range instanceTypes {
+		instTypeNames = append(instTypeNames, instTypeName)
 	}
+	sort.Strings(instTypeNames)
 
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported([]string{
@@ -401,14 +400,6 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (
 		},
 	)
 	return validator, nil
-}
-
-func convertInstanceTypeMapToSlice(instanceTypes map[string]instances.InstanceType) []instances.InstanceType {
-	instTypes := make([]instances.InstanceType, 0, len(instanceTypes))
-	for _, instanceType := range instanceTypes {
-		instTypes = append(instTypes, instanceType)
-	}
-	return instTypes
 }
 
 // PrecheckInstance is defined on the environs.InstancePrechecker interface.

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -371,11 +371,12 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (
 	if err != nil {
 		return nil, err
 	}
-	instTypeNames := make([]string, 0, len(instanceTypes))
-	for instTypeName := range instanceTypes {
-		instTypeNames = append(instTypeNames, instTypeName)
+	instTypes := convertInstanceTypeMapToSlice(instanceTypes)
+	sort.Sort(instances.ByName(instTypes))
+	instTypeNames := make([]string, len(instTypes))
+	for i, itype := range instTypes {
+		instTypeNames[i] = itype.Name
 	}
-	sort.Strings(instTypeNames)
 
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported([]string{
@@ -400,6 +401,14 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (
 		},
 	)
 	return validator, nil
+}
+
+func convertInstanceTypeMapToSlice(instanceTypes map[string]instances.InstanceType) []instances.InstanceType {
+	instTypes := make([]instances.InstanceType, 0, len(instanceTypes))
+	for _, instanceType := range instanceTypes {
+		instTypes = append(instTypes, instanceType)
+	}
+	return instTypes
 }
 
 // PrecheckInstance is defined on the environs.InstancePrechecker interface.

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -177,13 +178,16 @@ func (e *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constra
 		[]string{constraints.Mem, constraints.Cores, constraints.CpuPower})
 	validator.RegisterUnsupported(unsupportedConstraints)
 	instanceTypes, err := e.supportedInstanceTypes(ctx)
+
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	sort.Sort(instances.ByName(instanceTypes))
 	instTypeNames := make([]string, len(instanceTypes))
 	for i, itype := range instanceTypes {
 		instTypeNames[i] = itype.Name
 	}
+
 	validator.RegisterVocabulary(constraints.InstanceType, instTypeNames)
 	return validator, nil
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -562,6 +563,7 @@ func (e *Environ) ConstraintsValidator(ctx context.ProviderCallContext) (constra
 	for i, flavor := range flavors {
 		instTypeNames[i] = flavor.Name
 	}
+	sort.Strings(instTypeNames)
 	validator.RegisterVocabulary(constraints.InstanceType, instTypeNames)
 	validator.RegisterVocabulary(constraints.VirtType, []string{"kvm", "lxd"})
 	validator.RegisterVocabulary(constraints.RootDiskSource, []string{rootDiskSourceVolume})


### PR DESCRIPTION
## Description of change

When a nonexistent constraint is given juju-cli returns possible constraint.
Those are unsorted and provider dependent.
This PR addresses this by sorting the output, which should make parsing/human reading easier.

The new sort, type sort `ByType` sorts by the first delimiter, if they are the same it sorts by the cost. Should be seen as best effort. 
Openstack uses its own `instancetypes` kind of struct, which has no cost associated. That`s why a normal lexical sort is used. To have a more fine graned sorting, a own sort has to be implemented which should parse the delimiter and then sort by cpu, ram and finally disk. 

## QA steps
old: `juju bootstrap aws local --constraints "instance-type=foo"` returns unsorted output.
new: `juju bootstrap aws local --constraints "instance-type=foo"` returns sorted output. 

e.g. output:
aws
```
 [a1.4xlarge a1.2xlarge a1.xlarge a1.large a1.medium c1.xlarge c1.medium c3.8xlarge c3.4xlarge c3.2xlarge c3.xlarge c3.large ...]
```
openstack
```
 [cpu1-ram1-disk10 cpu1-ram1-disk20 cpu1-ram1-disk50 cpu1-ram12-disk10 cpu1-ram12-disk20 cpu1-ram12-disk50 cpu1-ram16-disk10 cpu1-ram16-disk20 cpu1-ram16-disk50 cpu1-ram2-disk10 cpu1-ram2-disk20 cpu1-ram2-disk50 cpu1-ram4-disk10 cpu1-ram4-disk20...]
```

## Documentation changes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1764963

