### PR TITLE
Reorganise network/containerizer/bridgepolicy

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1028,10 +1028,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(
 		return errors.Trace(err)
 	}
 
-	bridgePolicy := containerizer.BridgePolicy{
-		NetBondReconfigureDelay:   env.Config().NetBondReconfigureDelay(),
-		ContainerNetworkingMethod: env.Config().ContainerNetworkingMethod(),
-	}
+	bridgePolicy := containerizer.NewBridgePolicy(env)
 
 	// TODO(jam): 2017-01-31 PopulateContainerLinkLayerDevices should really
 	// just be returning the ones we'd like to exist, and then we turn those

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -940,11 +940,15 @@ type perContainerHandler interface {
 	// machine that is hosting the container.
 	// Any errors that are returned from ProcessOneContainer will be turned
 	// into ServerError and handed to SetError
-	ProcessOneContainer(env environs.Environ, callContext context.ProviderCallContext, idx int, host, guest Machine) error
+	ProcessOneContainer(
+		env environs.Environ, callContext context.ProviderCallContext, idx int, host, guest Machine,
+	) error
+
 	// SetError will be called whenever there is a problem with the a given
 	// request. Generally this just does result.Results[i].Error = error
 	// but the Result type is opaque so we can't do it ourselves.
 	SetError(resultIndex int, err error)
+
 	// ConfigType indicates the type of config the handler is getting for
 	// for error messaging.
 	ConfigType() string

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -2055,11 +2055,3 @@ func (s *provisionerMockSuite) setup(c *gc.C) *gomock.Controller {
 
 	return ctrl
 }
-
-type provisionerProfileMockSuite struct {
-	coretesting.BaseSuite
-
-	backend *mocks.MockProfileBackend
-	charm   *mocks.MockProfileCharm
-	machine *mocks.MockProfileMachine
-}

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -42,177 +42,13 @@ type BridgePolicy struct {
 }
 
 // NewBridgePolicy returns a new BridgePolicy for the input environ config
-// getter.
+// getter and state indirection.
 func NewBridgePolicy(cfgGetter environs.ConfigGetter) *BridgePolicy {
 	cfg := cfgGetter.Config()
 
 	return &BridgePolicy{
 		NetBondReconfigureDelay:   cfg.NetBondReconfigureDelay(),
 		ContainerNetworkingMethod: cfg.ContainerNetworkingMethod(),
-	}
-}
-
-// inferContainerSpaces tries to find a valid space for the container to be
-// on. This should only be used when the container itself doesn't have any
-// valid constraints on what spaces it should be in.
-// If ContainerNetworkingMethod is 'local' we fall back to "" and use lxdbr0.
-// If this machine is in a single space, then that space is used. Else, if
-// the machine has the default space, then that space is used.
-// If neither of those conditions is true, then we return an error.
-func (p *BridgePolicy) inferContainerSpaces(m Machine, containerId, defaultSpaceName string) (set.Strings, error) {
-	if p.ContainerNetworkingMethod == "local" {
-		return set.NewStrings(""), nil
-	}
-	hostSpaces, err := m.AllSpaces()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Debugf("container %q not qualified to a space, host machine %q is using spaces %s",
-		containerId, m.Id(), network.QuoteSpaceSet(hostSpaces))
-	if len(hostSpaces) == 1 {
-		return hostSpaces, nil
-	}
-	if defaultSpaceName != "" && hostSpaces.Contains(defaultSpaceName) {
-		return set.NewStrings(defaultSpaceName), nil
-	}
-	if len(hostSpaces) == 0 {
-		logger.Debugf("container has no desired spaces, " +
-			"and host has no known spaces, triggering fallback " +
-			"to bridge all devices")
-		return set.NewStrings(""), nil
-	}
-	return nil, errors.Errorf("no obvious space for container %q, host machine has spaces: %s",
-		containerId, network.QuoteSpaceSet(hostSpaces))
-}
-
-// determineContainerSpaces tries to use the direct information about a
-// container to find what spaces it should be in, and then falls back to what
-// we know about the host machine.
-func (p *BridgePolicy) determineContainerSpaces(
-	m Machine, containerMachine Container, defaultSpaceName string,
-) (set.Strings, error) {
-	containerSpaces, err := containerMachine.DesiredSpaces()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Debugf("for container %q, found desired spaces: %s",
-		containerMachine.Id(), network.QuoteSpaceSet(containerSpaces))
-	if len(containerSpaces) == 0 {
-		// We have determined that the container doesn't have any useful
-		// constraints set on it. So lets see if we can come up with
-		// something useful.
-		containerSpaces, err = p.inferContainerSpaces(m, containerMachine.Id(), defaultSpaceName)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return containerSpaces, nil
-}
-
-// findSpacesAndDevicesForContainer looks up what spaces the container wants
-// to be in, and what spaces the host machine is already in, and tries to
-// find the devices on the host that are useful for the container.
-func (p *BridgePolicy) findSpacesAndDevicesForContainer(
-	m Machine, containerMachine Container,
-) (set.Strings, map[string][]LinkLayerDevice, error) {
-	containerSpaces, err := p.determineContainerSpaces(m, containerMachine, corenetwork.DefaultSpaceName)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	devicesPerSpace, err := m.LinkLayerDevicesForSpaces(containerSpaces.Values())
-	if err != nil {
-		logger.Errorf("findSpacesAndDevicesForContainer(%q) got error looking for host spaces: %v",
-			containerMachine.Id(), err)
-		return nil, nil, errors.Trace(err)
-	}
-	return containerSpaces, devicesPerSpace, nil
-}
-
-func possibleBridgeTarget(dev LinkLayerDevice) (bool, error) {
-	// LoopbackDevices can never be bridged
-	if dev.Type() == corenetwork.LoopbackDevice || dev.Type() == corenetwork.BridgeDevice {
-		return false, nil
-	}
-	// Devices that have no parent entry are direct host devices that can be
-	// bridged.
-	if dev.ParentName() == "" {
-		return true, nil
-	}
-	// TODO(jam): 2016-12-22 This feels dirty, but it falls out of how we are
-	// currently modeling VLAN objects.  see bug https://pad.lv/1652049
-	if dev.Type() != corenetwork.VLAN8021QDevice {
-		// Only VLAN8021QDevice have parents that still allow us to
-		// bridge them.
-		// When anything else has a parent set, it shouldn't be used.
-		return false, nil
-	}
-	parentDevice, err := dev.ParentDevice()
-	if err != nil {
-		// If we got an error here, we have some sort of
-		// database inconsistency error.
-		return false, err
-	}
-	if parentDevice.Type() == corenetwork.EthernetDevice || parentDevice.Type() == corenetwork.BondDevice {
-		// A plain VLAN device with a direct parent
-		// of its underlying ethernet device.
-		return true, nil
-	}
-	return false, nil
-}
-
-func formatDeviceMap(spacesToDevices map[string][]LinkLayerDevice) string {
-	spaceNames := make([]string, len(spacesToDevices))
-	i := 0
-	for spaceName := range spacesToDevices {
-		spaceNames[i] = spaceName
-		i++
-	}
-	sort.Strings(spaceNames)
-	var out []string
-	for _, name := range spaceNames {
-		start := fmt.Sprintf("%q:[", name)
-		devices := spacesToDevices[name]
-		deviceNames := make([]string, len(devices))
-		for i, dev := range devices {
-			deviceNames[i] = dev.Name()
-		}
-		deviceNames = network.NaturallySortDeviceNames(deviceNames...)
-		quotedNames := make([]string, len(deviceNames))
-		for i, name := range deviceNames {
-			quotedNames[i] = fmt.Sprintf("%q", name)
-		}
-		out = append(out, start+strings.Join(quotedNames, ",")+"]")
-	}
-	return "map{" + strings.Join(out, ", ") + "}"
-}
-
-var skippedDeviceNames = set.NewStrings(
-	network.DefaultLXCBridge,
-	network.DefaultLXDBridge,
-	network.DefaultKVMBridge,
-)
-
-// The general policy is to:
-// 1.  Add br- to device name (to keep current behaviour),
-//     if it does not fit in 15 characters then:
-// 2.  Add b- to device name, if it doesn't fit in 15 characters then:
-// 3a. For devices starting in 'en' remove 'en' and add 'b-'
-// 3b. For all other devices
-//     'b-' + 6-char hash of name + '-' + last 6 chars of name
-// 4.  If using the device name directly always replace '.' with '-'
-//     to make sure that bridges from VLANs won't break
-func BridgeNameForDevice(device string) string {
-	device = strings.Replace(device, ".", "-", -1)
-	switch {
-	case len(device) < 13:
-		return fmt.Sprintf("br-%s", device)
-	case len(device) == 13:
-		return fmt.Sprintf("b-%s", device)
-	case device[:2] == "en":
-		return fmt.Sprintf("b-%s", device[2:])
-	default:
-		hash := crc32.Checksum([]byte(device), crc32.IEEETable) & 0xffffff
-		return fmt.Sprintf("b-%0.6x-%s", hash, device[len(device)-6:])
 	}
 }
 
@@ -332,6 +168,144 @@ func (p *BridgePolicy) FindMissingBridgesForContainer(
 	return hostToBridge, reconfigureDelay, nil
 }
 
+// findSpacesAndDevicesForContainer looks up what spaces the container wants
+// to be in, and what spaces the host machine is already in, and tries to
+// find the devices on the host that are useful for the container.
+func (p *BridgePolicy) findSpacesAndDevicesForContainer(
+	m Machine, containerMachine Container,
+) (set.Strings, map[string][]LinkLayerDevice, error) {
+	containerSpaces, err := p.determineContainerSpaces(m, containerMachine, corenetwork.DefaultSpaceName)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	devicesPerSpace, err := m.LinkLayerDevicesForSpaces(containerSpaces.Values())
+	if err != nil {
+		logger.Errorf("findSpacesAndDevicesForContainer(%q) got error looking for host spaces: %v",
+			containerMachine.Id(), err)
+		return nil, nil, errors.Trace(err)
+	}
+	return containerSpaces, devicesPerSpace, nil
+}
+
+// determineContainerSpaces tries to use the direct information about a
+// container to find what spaces it should be in, and then falls back to what
+// we know about the host machine.
+func (p *BridgePolicy) determineContainerSpaces(
+	m Machine, containerMachine Container, defaultSpaceName string,
+) (set.Strings, error) {
+	containerSpaces, err := containerMachine.DesiredSpaces()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("for container %q, found desired spaces: %s",
+		containerMachine.Id(), network.QuoteSpaceSet(containerSpaces))
+	if len(containerSpaces) == 0 {
+		// We have determined that the container doesn't have any useful
+		// constraints set on it. So lets see if we can come up with
+		// something useful.
+		containerSpaces, err = p.inferContainerSpaces(m, containerMachine.Id(), defaultSpaceName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	return containerSpaces, nil
+}
+
+// inferContainerSpaces tries to find a valid space for the container to be
+// on. This should only be used when the container itself doesn't have any
+// valid constraints on what spaces it should be in.
+// If ContainerNetworkingMethod is 'local' we fall back to "" and use lxdbr0.
+// If this machine is in a single space, then that space is used. Else, if
+// the machine has the default space, then that space is used.
+// If neither of those conditions is true, then we return an error.
+func (p *BridgePolicy) inferContainerSpaces(m Machine, containerId, defaultSpaceName string) (set.Strings, error) {
+	if p.ContainerNetworkingMethod == "local" {
+		return set.NewStrings(""), nil
+	}
+	hostSpaces, err := m.AllSpaces()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("container %q not qualified to a space, host machine %q is using spaces %s",
+		containerId, m.Id(), network.QuoteSpaceSet(hostSpaces))
+	if len(hostSpaces) == 1 {
+		return hostSpaces, nil
+	}
+	if defaultSpaceName != "" && hostSpaces.Contains(defaultSpaceName) {
+		return set.NewStrings(defaultSpaceName), nil
+	}
+	if len(hostSpaces) == 0 {
+		logger.Debugf("container has no desired spaces, " +
+			"and host has no known spaces, triggering fallback " +
+			"to bridge all devices")
+		return set.NewStrings(""), nil
+	}
+	return nil, errors.Errorf("no obvious space for container %q, host machine has spaces: %s",
+		containerId, network.QuoteSpaceSet(hostSpaces))
+}
+
+func possibleBridgeTarget(dev LinkLayerDevice) (bool, error) {
+	// LoopbackDevices can never be bridged
+	if dev.Type() == corenetwork.LoopbackDevice || dev.Type() == corenetwork.BridgeDevice {
+		return false, nil
+	}
+	// Devices that have no parent entry are direct host devices that can be
+	// bridged.
+	if dev.ParentName() == "" {
+		return true, nil
+	}
+	// TODO(jam): 2016-12-22 This feels dirty, but it falls out of how we are
+	// currently modeling VLAN objects.  see bug https://pad.lv/1652049
+	if dev.Type() != corenetwork.VLAN8021QDevice {
+		// Only VLAN8021QDevice have parents that still allow us to
+		// bridge them.
+		// When anything else has a parent set, it shouldn't be used.
+		return false, nil
+	}
+	parentDevice, err := dev.ParentDevice()
+	if err != nil {
+		// If we got an error here, we have some sort of
+		// database inconsistency error.
+		return false, err
+	}
+	if parentDevice.Type() == corenetwork.EthernetDevice || parentDevice.Type() == corenetwork.BondDevice {
+		// A plain VLAN device with a direct parent
+		// of its underlying ethernet device.
+		return true, nil
+	}
+	return false, nil
+}
+
+var skippedDeviceNames = set.NewStrings(
+	network.DefaultLXCBridge,
+	network.DefaultLXDBridge,
+	network.DefaultKVMBridge,
+)
+
+// The general policy is to:
+// 1.  Add br- to device name (to keep current behaviour),
+//     if it does not fit in 15 characters then:
+// 2.  Add b- to device name, if it doesn't fit in 15 characters then:
+// 3a. For devices starting in 'en' remove 'en' and add 'b-'
+// 3b. For all other devices
+//     'b-' + 6-char hash of name + '-' + last 6 chars of name
+// 4.  If using the device name directly always replace '.' with '-'
+//     to make sure that bridges from VLANs won't break
+func BridgeNameForDevice(device string) string {
+	device = strings.Replace(device, ".", "-", -1)
+	switch {
+	case len(device) < 13:
+		return fmt.Sprintf("br-%s", device)
+	case len(device) == 13:
+		return fmt.Sprintf("b-%s", device)
+	case device[:2] == "en":
+		return fmt.Sprintf("b-%s", device[2:])
+	default:
+		hash := crc32.Checksum([]byte(device), crc32.IEEETable) & 0xffffff
+		return fmt.Sprintf("b-%0.6x-%s", hash, device[len(device)-6:])
+	}
+}
+
 // PopulateContainerLinkLayerDevices sets the link-layer devices of the given
 // containerMachine, setting each device linked to the corresponding
 // BridgeDevice of the host machine. It also records when one of the
@@ -413,4 +387,30 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(m Machine, containerMac
 
 	logger.Debugf("container %q network config set", containerMachine.Id())
 	return nil
+}
+
+func formatDeviceMap(spacesToDevices map[string][]LinkLayerDevice) string {
+	spaceNames := make([]string, len(spacesToDevices))
+	i := 0
+	for spaceName := range spacesToDevices {
+		spaceNames[i] = spaceName
+		i++
+	}
+	sort.Strings(spaceNames)
+	var out []string
+	for _, name := range spaceNames {
+		start := fmt.Sprintf("%q:[", name)
+		devices := spacesToDevices[name]
+		deviceNames := make([]string, len(devices))
+		for i, dev := range devices {
+			deviceNames[i] = dev.Name()
+		}
+		deviceNames = network.NaturallySortDeviceNames(deviceNames...)
+		quotedNames := make([]string, len(deviceNames))
+		for i, name := range deviceNames {
+			quotedNames[i] = fmt.Sprintf("%q", name)
+		}
+		out = append(out, start+strings.Join(quotedNames, ",")+"]")
+	}
+	return "map{" + strings.Join(out, ", ") + "}"
 }

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
 
-	// Used for some constants and things like LinkLayerDevice[Args]
+	// TODO (manadart 2019-09-25): This package should evolve
+	// so as not to import this package.
 	"github.com/juju/juju/state"
 )
 
@@ -37,6 +39,17 @@ type BridgePolicy struct {
 	//  - provider
 	//  - local
 	ContainerNetworkingMethod string
+}
+
+// NewBridgePolicy returns a new BridgePolicy for the input environ config
+// getter.
+func NewBridgePolicy(cfgGetter environs.ConfigGetter) *BridgePolicy {
+	cfg := cfgGetter.Config()
+
+	return &BridgePolicy{
+		NetBondReconfigureDelay:   cfg.NetBondReconfigureDelay(),
+		ContainerNetworkingMethod: cfg.ContainerNetworkingMethod(),
+	}
 }
 
 // inferContainerSpaces tries to find a valid space for the container to be


### PR DESCRIPTION
## Description of change

This patch is purely mechanical. It does the following:
- Adds a constructor for `BridgePolicy`, so that the provisioner no longer instantiates it directly.
- Reorganises the `bridgepolicy` code to be hierarchical.

## QA steps

No functional change; unit tests pass.

## Documentation changes

None.

## Bug reference

N/A
