### PR TITLE
Add a script/tool that allows introspection of our blobstore and cleaning up unreferenced blobs.

### DIFF
--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -42,6 +42,7 @@ var loggingConfig = gnuflag.String("logging-config", defaultLoggingConfig, "spec
 var human = gnuflag.Bool("h", false, "print human readable values")
 var verbose = gnuflag.Bool("v", false, "print more detailed information about found references")
 var dryRun = gnuflag.Bool("dry-run", true, "use --dry-run=false to actually cleanup references")
+var noChunks = gnuflag.Bool("no-chunks", false, "disable looking for chunks that have no corresponding file")
 
 func main() {
 	gnuflag.Usage = func() {
@@ -308,6 +309,9 @@ func (b *BlobstoreCleaner) findResourcelessFiles() {
 }
 
 func (b *BlobstoreCleaner) findFilelessChunks() {
+	if *noChunks {
+		return
+	}
 	// must be called after findResourcelessFiles as that populates foundBlobstoreIds
 	var chunkDoc blobstoreChunk
 	filesIter := b.blobstoreChunks.Find(nil).Select(blobstoreChunkNoDataFieldSelector).Iter()

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -291,7 +291,7 @@ func (b *BlobstoreCleaner) findModellessManagedResources() {
 			var resourceDoc storedResourceDoc
 			err := b.storedResources.FindId(managedDoc.ResourceId).One(&resourceDoc)
 			if err == mgo.ErrNotFound {
-				logger.Warningf("Managed Resource %q points to missing storedResource: %q", managedDoc.ResourceId)
+				logger.Warningf("Managed Resource %q points to missing storedResource: %v", managedDoc.ResourceId, err)
 				continue
 			} else {
 				checkErr(err, "reading stored resource")
@@ -459,7 +459,7 @@ func (b *BlobstoreCleaner) findFilelessChunks() {
 		err := b.blobstoreChunks.FindId(chunkDoc.ID).One(&dataDoc)
 		if err != nil {
 			if err == mgo.ErrNotFound {
-				logger.Warningf("chunk doc %s went missing")
+				logger.Warningf("chunk doc %s went missing", chunkDoc.ID)
 				continue
 			}
 		}

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -273,9 +273,10 @@ func (b *BlobstoreCleaner) findModellessManagedResources() {
 		// take just the bucket local path and build the longer path.
 		// make sure it conforms to our expectation, and then strip off the
 		// prefix in preparation for deleting.
-		bucketPrefix := fmt.Sprintf("buckets/%s/.*", managedDoc.BucketUUID)
+		bucketPrefix := fmt.Sprintf("buckets/%s/", managedDoc.BucketUUID)
 		if !strings.HasPrefix(managedDoc.Path, bucketPrefix) {
 			logger.Warningf("bucket has unexpected prefix, skipping: %q", managedDoc.Path)
+			continue
 		}
 		b.modellessResources = append(b.modellessResources, ManagedResource{
 			BucketUUID: managedDoc.BucketUUID,

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"gopkg.in/juju/blobstore.v2"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	jujutxn "github.com/juju/txn"
+	"gopkg.in/juju/blobstore.v2"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -475,7 +475,7 @@ func (b *BlobstoreCleaner) findFilelessChunks() {
 
 func (b *BlobstoreCleaner) cleanupChunks() {
 	if *dryRun {
-		fmt.Printf("Not removing %d dangling files\n\n", len(b.unreferencedFiles))
+		fmt.Printf("Not removing %d dangling chunks\n\n", len(b.unreferencedChunks))
 		return
 	}
 	fmt.Printf("Removing %d dangling files\n", len(b.unreferencedFiles))

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -1,0 +1,325 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/juju/clock"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.blobstorecleanup")
+
+const (
+	defaultLoggingConfig = "<root>=WARNING"
+	dataDir              = "/var/lib/juju"
+	managedResourceC     = "managedStoredResources"
+	resourceCatalogC     = "storedResources"
+	//resourceC            = "resources"
+	blobstoreFilesC  = "blobstore.files"
+	blobstoreChunksC = "blobstore.chunks"
+)
+
+type ContentType string
+
+var loggingConfig = gnuflag.String("logging-config", defaultLoggingConfig, "specify log levels for modules")
+var human = gnuflag.Bool("h", false, "print human readable values")
+var verbose = gnuflag.Bool("v", false, "print more detailed information about found references")
+var dryRun = gnuflag.Bool("dry-run", true, "use --dry-run=false to actually cleanup references")
+
+func main() {
+	gnuflag.Usage = func() {
+		fmt.Printf("Usage: %s\n", os.Args[0])
+		gnuflag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	gnuflag.Parse(true)
+
+	args := gnuflag.Args()
+	if len(args) < 0 {
+		gnuflag.Usage()
+	}
+	checkErr("logging config", loggo.ConfigureLoggers(*loggingConfig))
+
+	cleaner := NewBlobstoreCleaner()
+	cleaner.findModellessManagedResources()
+	cleaner.findUnmanagedResources()
+	cleaner.findResourcelessFiles()
+	cleaner.findFilelessChunks()
+}
+
+func checkErr(label string, err error) {
+	if err != nil {
+		logger.Errorf("%s: %s", label, err)
+		os.Exit(1)
+	}
+}
+
+// getState returns a StatePool and the underlying Session.
+// callers are responsible for calling session.Close() if there is no error
+func getState() (*state.StatePool, *mgo.Session, error) {
+	tag, err := getCurrentMachineTag(dataDir)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "finding machine tag")
+	}
+
+	logger.Infof("current machine tag: %s", tag)
+
+	config, err := getConfig(tag)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "loading agent config")
+	}
+
+	mongoInfo, available := config.MongoInfo()
+	if !available {
+		return nil, nil, errors.New("mongo info not available from agent config")
+	}
+	session, err := mongo.DialWithInfo(*mongoInfo, mongo.DefaultDialOpts())
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	pool, err := state.OpenStatePool(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      config.Controller(),
+		ControllerModelTag: config.Model(),
+		MongoSession:       session,
+	})
+	if err != nil {
+		session.Close()
+		return nil, nil, errors.Annotate(err, "opening state connection")
+	}
+	return pool, session, nil
+}
+
+func getCurrentMachineTag(datadir string) (names.MachineTag, error) {
+	var empty names.MachineTag
+	values, err := filepath.Glob(filepath.Join(datadir, "agents", "machine-*"))
+	if err != nil {
+		return empty, errors.Annotate(err, "problem globbing")
+	}
+	switch len(values) {
+	case 0:
+		return empty, errors.Errorf("no machines found")
+	case 1:
+		return names.ParseMachineTag(filepath.Base(values[0]))
+	default:
+		return empty, errors.Errorf("too many possible machine agents: %v", values)
+	}
+}
+
+func getConfig(tag names.MachineTag) (agent.ConfigSetterWriter, error) {
+	diskPath := agent.ConfigPath(dataDir, tag)
+	return agent.ReadConfig(diskPath)
+}
+
+func lengthToSize(length uint64) string {
+	if *human {
+		return humanize.Bytes(length)
+	}
+	return fmt.Sprintf("%d", length)
+}
+
+func NewBlobstoreCleaner() *BlobstoreCleaner {
+	statePool, session, err := getState()
+	// Some of the chunks queries take a long time
+	session.SetSocketTimeout(10 * time.Minute)
+	checkErr("getting state connection", err)
+	jujuDB := session.DB("juju")
+	managedResources := jujuDB.C(managedResourceC)
+	storedResources := jujuDB.C(resourceCatalogC)
+	blobstoreDB := session.DB("blobstore")
+	blobstoreFiles := blobstoreDB.C(blobstoreFilesC)
+	blobstoreChunks := blobstoreDB.C(blobstoreChunksC)
+	return &BlobstoreCleaner{
+		pool:    statePool,
+		session: session,
+		system:  statePool.SystemState(),
+
+		managedResources: managedResources,
+		storedResources:  storedResources,
+		blobstoreChunks:  blobstoreChunks,
+		blobstoreFiles:   blobstoreFiles,
+
+		foundResourceIDs:    set.NewStrings(),
+		foundBlobstorePaths: set.NewStrings(),
+		foundBlobstoreIDs:   set.NewStrings(),
+	}
+}
+
+type BlobstoreCleaner struct {
+	pool    *state.StatePool
+	session *mgo.Session
+	system  *state.State
+
+	managedResources *mgo.Collection
+	storedResources  *mgo.Collection
+	blobstoreFiles   *mgo.Collection
+	blobstoreChunks  *mgo.Collection
+
+	foundResourceIDs    set.Strings
+	foundBlobstorePaths set.Strings
+	foundBlobstoreIDs   set.Strings
+
+	modellessResources []string
+	unmanagedResources []string
+	unreferencedFiles  []string
+	unreferencedChunks []string
+}
+
+func (b *BlobstoreCleaner) Close() {
+	b.pool.Close()
+	b.session.Close()
+}
+
+// managedResourceDoc is the persistent representation of a ManagedResource.
+// copied from gopkg.in/juju/blobstore.v2/managedstorage.go
+type managedResourceDoc struct {
+	ID         string `bson:"_id"`
+	BucketUUID string `bson:"bucketuuid"`
+	User       string `bson:"user"`
+	Path       string `bson:"path"`
+	ResourceId string `bson:"resourceid"`
+}
+
+// storedResourceDoc is the persistent representation of a Resource.
+// copied from gopkg.in/juju/blobstore.v2/resourcecatalog.go
+type storedResourceDoc struct {
+	ID string `bson:"_id"`
+	// Path is the storage path of the resource, which will be
+	// the empty string until the upload has been completed.
+	Path       string `bson:"path"`
+	SHA384Hash string `bson:"sha384hash"`
+	Length     int64  `bson:"length"`
+	RefCount   int64  `bson:"refcount"`
+}
+
+type blobstoreChunk struct {
+	ID      bson.ObjectId `bson:"_id"`
+	FilesID bson.ObjectId `bson:"files_id"`
+	N       int           `bson:"n"`
+	Data    []byte        `bson:"data"`
+}
+
+var blobstoreChunkNoDataFieldSelector = bson.M{"_id": 1, "files_id": 1}
+
+type blobstoreFile struct {
+	ID       bson.ObjectId `bson:"_id"`
+	Filename string        `bson:"filename"`
+	Length   int64         `bson:"length"`
+}
+
+var blobstoreFileFieldSelector = bson.M{"_id": 1, "filename": 1, "length": 1}
+
+func (b *BlobstoreCleaner) findModellessManagedResources() {
+	modelUUIDs, err := b.system.AllModelUUIDs()
+	checkErr("AllModelUUIDS", err)
+	allModels := set.NewStrings(modelUUIDs...)
+
+	var managedDoc managedResourceDoc
+	var managedBytes uint64
+	managedIter := b.managedResources.Find(nil).Iter()
+	for managedIter.Next(&managedDoc) {
+		alreadyFound := b.foundResourceIDs.Contains(managedDoc.ResourceId)
+		b.foundResourceIDs.Add(managedDoc.ResourceId)
+		if allModels.Contains(managedDoc.BucketUUID) {
+			continue
+		}
+		b.modellessResources = append(b.modellessResources, managedDoc.ID)
+
+		if alreadyFound {
+			if *verbose {
+				fmt.Printf("%s: (repeat)\n", managedDoc.Path)
+			}
+		} else {
+			var resourceDoc storedResourceDoc
+			err := b.storedResources.FindId(managedDoc.ResourceId).One(&resourceDoc)
+			if err == mgo.ErrNotFound {
+				logger.Warningf("Managed Resource %q points to missing storedResource: %q", managedDoc.ResourceId)
+				continue
+			} else {
+				checkErr("reading stored resource", err)
+			}
+			managedBytes += uint64(resourceDoc.Length)
+			if *verbose {
+				fmt.Printf("%s: %d\n", managedDoc.Path, lengthToSize(uint64(resourceDoc.Length)))
+			}
+		}
+	}
+	checkErr("listing managed stored resources", managedIter.Close())
+	fmt.Printf("Found %d managed resource documents without models totaling %s bytes\n", len(b.modellessResources), lengthToSize(managedBytes))
+}
+
+func (b *BlobstoreCleaner) findUnmanagedResources() {
+	// must be called after findModellessManagedResources because that populates foundResourceIDs
+	var resourceDoc storedResourceDoc
+	storedResourceIter := b.storedResources.Find(nil).Iter()
+	var unmanagedBytes uint64
+	for storedResourceIter.Next(&resourceDoc) {
+		b.foundBlobstorePaths.Add(resourceDoc.Path)
+		if b.foundResourceIDs.Contains(resourceDoc.ID) {
+			continue
+		}
+		b.unmanagedResources = append(b.unmanagedResources, resourceDoc.ID)
+		unmanagedBytes += uint64(resourceDoc.Length)
+		if *verbose {
+			fmt.Printf("%s: %d\n", resourceDoc.ID, lengthToSize(uint64(resourceDoc.Length)))
+		}
+	}
+	checkErr("listing stored resources", storedResourceIter.Close())
+	fmt.Printf("Found %d unreferenced resource documents totaling %s bytes\n", len(b.unmanagedResources), lengthToSize(unmanagedBytes))
+}
+
+func (b *BlobstoreCleaner) findResourcelessFiles() {
+	// must be called after findUnmanagedResources because that populates foundBlobstorePaths
+	var fileDoc blobstoreFile
+	var unreferencedFileBytes uint64
+	filesIter := b.blobstoreFiles.Find(nil).Select(blobstoreFileFieldSelector).Iter()
+	for filesIter.Next(&fileDoc) {
+		b.foundBlobstoreIDs.Add(string(fileDoc.ID))
+		if b.foundBlobstorePaths.Contains(fileDoc.Filename) {
+			continue
+		}
+		b.foundBlobstorePaths.Add(fileDoc.Filename)
+		b.unreferencedFiles = append(b.unreferencedFiles, fileDoc.Filename)
+		unreferencedFileBytes += uint64(fileDoc.Length)
+		if *verbose {
+			fmt.Printf("%s: %d\n", fileDoc.Filename, lengthToSize(uint64(fileDoc.Length)))
+		}
+	}
+	checkErr("listing blobstore files", filesIter.Close())
+	fmt.Printf("Found %d unreferenced blobstore files totaling %s bytes\n", len(b.unreferencedFiles), lengthToSize(unreferencedFileBytes))
+}
+
+func (b *BlobstoreCleaner) findFilelessChunks() {
+	// must be called after findResourcelessFiles as that populates foundBlobstoreIds
+	var chunkDoc blobstoreChunk
+	filesIter := b.blobstoreChunks.Find(nil).Select(blobstoreChunkNoDataFieldSelector).Iter()
+	for filesIter.Next(&chunkDoc) {
+		if b.foundBlobstoreIDs.Contains(string(chunkDoc.FilesID)) {
+			continue
+		}
+		b.unreferencedChunks = append(b.unreferencedChunks, string(chunkDoc.ID))
+		if *verbose {
+			fmt.Printf("%s: ?\n", chunkDoc.ID)
+		}
+	}
+	checkErr("listing blobstore chunks", filesIter.Close())
+	fmt.Printf("Found %d unreferenced blobstore chunks totaling ? bytes\n", len(b.unreferencedChunks))
+}

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -125,8 +125,8 @@ func NewBlobStoreChecker() *BlobStoreChecker {
 }
 
 func (b *BlobStoreChecker) Close() {
-	b.session.Close()
 	b.pool.Close()
+	b.session.Close()
 }
 
 func checkErr(label string, err error) {
@@ -191,13 +191,6 @@ func getCurrentMachineTag(datadir string) (names.MachineTag, error) {
 func getConfig(tag names.MachineTag) (agent.ConfigSetterWriter, error) {
 	diskPath := agent.ConfigPath(dataDir, tag)
 	return agent.ReadConfig(diskPath)
-}
-
-func shortModelUUID(modelUUID string) string {
-	if len(modelUUID) > 6 {
-		return modelUUID[:6]
-	}
-	return modelUUID
 }
 
 // managedResourceDoc is the persistent representation of a ManagedResource.

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/dustin/go-humanize"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -20,7 +21,6 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/dustin/go-humanize"
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
@@ -40,7 +40,6 @@ var human = gnuflag.Bool("h", false, "print human readable values")
 var verbose = gnuflag.Bool("v", false, "print more detailed information about found references")
 
 func main() {
-	loggo.GetLogger("").SetLogLevel(loggo.TRACE)
 	gnuflag.Usage = func() {
 		fmt.Printf("Usage: %s\n", os.Args[0])
 		os.Exit(1)

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -454,14 +454,14 @@ func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string,
 		for _, resourceId := range notReferenced {
 			length := sizes[resourceId]
 			charmURL := resourceToCharmURLs[resourceId][0]
-			fmt.Fprintf(os.Stdout, "  %v: %s %s...\n",
+			fmt.Fprintf(os.Stdout, "   %v: %s %s...\n",
 				charmURL, lengthToSize(length), resourceId[:8])
 			for _, curl := range resourceToCharmURLs[resourceId] {
 				if curl != charmURL {
-					fmt.Fprintf(os.Stdout, "    %v:\n", curl)
+					fmt.Fprintf(os.Stdout, "     %v:\n", curl)
 				}
 				for _, unit := range unitReferencedCharms[curl] {
-					fmt.Fprintf(os.Stdout, "    - %v\n", unit)
+					fmt.Fprintf(os.Stdout, "     - %v\n", unit)
 				}
 			}
 		}
@@ -492,7 +492,7 @@ func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string,
 		for _, resourceId := range unknownResourceIdToManaged.KeysBySortedValues() {
 			length := sizes[resourceId]
 			unrefResourceBytes += length
-			fmt.Fprintf(os.Stdout, "    %v: %s\n", resourceId, lengthToSize(length))
+			fmt.Fprintf(os.Stdout, "    %v...: %s\n", resourceId[:8], lengthToSize(length))
 			for _, path := range unknownResourceIdToManaged[resourceId] {
 				fmt.Fprintf(os.Stdout, "      %v\n", path)
 			}

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -230,6 +230,9 @@ func inspectAgentBinaries(st *state.State, session *mgo.Session, foundHashes map
 		toolPath := path.Join("tools", fmt.Sprintf("%s-%s", metadata.Version, metadata.SHA256))
 		bucketPath := path.Join("buckets", modelUUID, toolPath)
 		res := lookupResource(managedResources, resources, bucketPath, metadata.Version)
+		if res.Id == "" {
+			continue
+		}
 		soFar, found := seen[res.SHA384Hash]
 		seen[res.SHA384Hash] = append(soFar, binary)
 		sizes[res.SHA384Hash] = res.Length
@@ -314,6 +317,9 @@ func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string,
 	for _, charm := range charms {
 		bucketPath := path.Join("buckets", modelUUID, charm.StoragePath())
 		res := lookupResource(managedResources, resources, bucketPath, charm.String())
+		if res.Id == "" {
+			continue
+		}
 		foundHashes[res.SHA384Hash] = struct{}{}
 		_, found := seen[res.Id]
 		seen[res.Id] = res.Length

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -1082,5 +1082,5 @@ func (b *BlobStoreChecker) checkUnreferencedChunks() {
 		}
 	}
 	fmt.Fprintf(os.Stdout, "  total unreferenced chunks %d, bytes: %s\n", unreferencedChunkCount, lengthToSize(unreferencedBytes))
-	fmt.Fprint(os.Stdout, "  read %d blobstore chunks\n", chunkCount)
+	fmt.Fprintf(os.Stdout, "  read %d blobstore chunks\n", chunkCount)
 }

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -949,7 +949,7 @@ func (b *BlobStoreChecker) checkUnreferencedResources() {
 	}
 	size := fmt.Sprintf("%d", totalBytes)
 	if *human {
-		size = humanize.Bytes(uint64(totalBytes))
+		size = humanize.Bytes(totalBytes)
 	}
 	fmt.Fprintf(os.Stdout, "total: %s\n\n", size)
 }
@@ -1068,7 +1068,7 @@ func (b *BlobStoreChecker) checkUnreferencedChunks() {
 			chunkCount++
 			if *verbose {
 				chunkValues = append(chunkValues, fmt.Sprintf("%s: %s",
-					bson.ObjectId(chunkDataDoc.ID).Hex(), lengthToSize(chunkLen)))
+					chunkDataDoc.ID.Hex(), lengthToSize(chunkLen)))
 			}
 		}
 		checkErr("iterating chunk data", chunkDataIter.Close())

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -1,0 +1,267 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"github.com/juju/version"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/dustin/go-humanize"
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.listblobstore")
+
+const (
+	defaultLoggingConfig = "<root>=WARNING"
+	dataDir              = "/var/lib/juju"
+	managedResourceC     = "managedStoredResources"
+	resourceCatalogC     = "storedResources"
+)
+
+var loggingConfig = gnuflag.String("logging-config", defaultLoggingConfig, "specify log levels for modules")
+var human = gnuflag.Bool("h", false, "print human readable values")
+
+func checkErr(label string, err error) {
+	if err != nil {
+		logger.Errorf("%s: %s", label, err)
+		os.Exit(1)
+	}
+}
+
+// getState returns a StatePool and the underlying Session.
+// callers are responsible for calling session.Close() if there is no error
+func getState() (*state.StatePool, *mgo.Session, error) {
+	tag, err := getCurrentMachineTag(dataDir)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "finding machine tag")
+	}
+
+	logger.Infof("current machine tag: %s", tag)
+
+	config, err := getConfig(tag)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "loading agent config")
+	}
+
+	mongoInfo, available := config.MongoInfo()
+	if !available {
+		return nil, nil, errors.New("mongo info not available from agent config")
+	}
+	session, err := mongo.DialWithInfo(*mongoInfo, mongo.DefaultDialOpts())
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	pool, err := state.OpenStatePool(state.OpenParams{
+		Clock:              clock.WallClock,
+		ControllerTag:      config.Controller(),
+		ControllerModelTag: config.Model(),
+		MongoSession:       session,
+	})
+	if err != nil {
+		session.Close()
+		return nil, nil, errors.Annotate(err, "opening state connection")
+	}
+	return pool, session, nil
+}
+
+func getCurrentMachineTag(datadir string) (names.MachineTag, error) {
+	var empty names.MachineTag
+	values, err := filepath.Glob(filepath.Join(datadir, "agents", "machine-*"))
+	if err != nil {
+		return empty, errors.Annotate(err, "problem globbing")
+	}
+	switch len(values) {
+	case 0:
+		return empty, errors.Errorf("no machines found")
+	case 1:
+		return names.ParseMachineTag(filepath.Base(values[0]))
+	default:
+		return empty, errors.Errorf("too many possible machine agents: %v", values)
+	}
+}
+
+func getConfig(tag names.MachineTag) (agent.ConfigSetterWriter, error) {
+	diskPath := agent.ConfigPath(dataDir, tag)
+	return agent.ReadConfig(diskPath)
+}
+
+func shortModelUUID(modelUUID string) string {
+	if len(modelUUID) > 6 {
+		return modelUUID[:6]
+	}
+	return modelUUID
+}
+
+// managedResourceDoc is the persistent representation of a ManagedResource.
+// copied from gopkg.in/juju/blobstore.v2/managedstorage.go
+type managedResourceDoc struct {
+	Id         string `bson:"_id"`
+	BucketUUID string `bson:"bucketuuid"`
+	User       string `bson:"user"`
+	Path       string `bson:"path"`
+	ResourceId string `bson:"resourceid"`
+}
+
+// resourceDoc is the persistent representation of a Resource.
+// copied from gopkg.in/juju/blobstore.v2/resourcecatalog.go
+type resourceDoc struct {
+	Id string `bson:"_id"`
+	// Path is the storage path of the resource, which will be
+	// the empty string until the upload has been completed.
+	Path       string `bson:"path"`
+	SHA384Hash string `bson:"sha384hash"`
+	Length     int64  `bson:"length"`
+	RefCount   int64  `bson:"refcount"`
+}
+
+func inspectAgentBinaries(st *state.State, session *mgo.Session) {
+	toolsStorage, err := st.ToolsStorage()
+	checkErr("tools storage", err)
+	defer toolsStorage.Close()
+	var totalBytes uint64
+
+	fmt.Fprintf(os.Stdout, "Agent Binaries\n")
+	modelUUID := st.ModelUUID()
+	jujuDB := session.DB("juju")
+	managedResources := jujuDB.C(managedResourceC)
+	resources := jujuDB.C(resourceCatalogC)
+	// managedStore := blobstore.NewManagedStorage(jujuDB, blobstore.NewGridFS("blobstore", "blobstore", session))
+	toolsMetadata, err := toolsStorage.AllMetadata()
+	checkErr("tools metadata", err)
+	logger.Debugf("found %d tools", len(toolsMetadata))
+	seen := make(map[version.Number]int, 0)
+	seenResources := make(map[string]int64)
+	for _, metadata := range toolsMetadata {
+		// internally we store a metadata.Path for each object, we really need that here.. :(
+		binary, err := version.ParseBinary(metadata.Version)
+		if err != nil {
+			logger.Warningf("Unknown Binary Version: %q", metadata.Version)
+			continue
+		}
+		count := seen[binary.Number]
+		seen[binary.Number] = count + 1
+		// This assumes we aren't reading from a fallback storage
+		// These queries aren't exposed via the ToolsStorage interface nor via the ManagedStorage interface
+		toolPath := path.Join("tools", fmt.Sprintf("%s-%s", metadata.Version, metadata.SHA256))
+		bucketPath := path.Join("buckets", modelUUID, toolPath)
+		resource := lookupResource(managedResources, resources, bucketPath, metadata.Version)
+		_, found := seenResources[resource.Id]
+		seenResources[resource.Id] = resource.Length
+		if !found {
+			totalBytes += uint64(resource.Length)
+			size := fmt.Sprint(resource.Length)
+			if *human {
+				size = humanize.Bytes(uint64(resource.Length))
+			}
+			fmt.Fprintf(os.Stdout, "%v: %s refcount %d %s...\n",
+				binary.Number, size, resource.RefCount, resource.SHA384Hash[:8])
+		}
+	}
+	size := fmt.Sprintf("%d", totalBytes)
+	if *human {
+		size = humanize.Bytes(totalBytes)
+	}
+	fmt.Fprintf(os.Stdout, "total: %s\n\n", size)
+}
+
+func lookupResource(managedResources, resources *mgo.Collection, bucketPath, description string) resourceDoc {
+	var manageDoc managedResourceDoc
+	var resource resourceDoc
+	err := managedResources.Find(bson.M{"path": bucketPath}).One(&manageDoc)
+	if err == mgo.ErrNotFound {
+		logger.Warningf("could not find managed resource doc for %q", description)
+		return resource
+	}
+	checkErr("managed resource doc", err)
+	err = resources.FindId(manageDoc.ResourceId).One(&resource)
+	if err == mgo.ErrNotFound {
+		logger.Warningf("could not find resource doc for %q", description)
+		return resource
+	}
+	checkErr("resource doc", err)
+	if resource.Id != resource.SHA384Hash {
+		logger.Warningf("resource with id != sha384: %q != %q", resource.Id, resource.SHA384Hash)
+	}
+	return resource
+}
+
+func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string) {
+	model, helper, err := pool.GetModel(modelUUID)
+	defer helper.Release()
+	shortUID := shortModelUUID(modelUUID)
+	checkErr(fmt.Sprintf("reading model %s", shortUID), err)
+	charms, err := model.State().AllCharms()
+	checkErr("AllCharms", err)
+	logger.Debugf("[%s] checking model", shortUID)
+	name := model.Name()
+	fmt.Fprintf(os.Stdout, "Model: %q\n", name)
+	jujuDB := session.DB("juju")
+	managedResources := jujuDB.C(managedResourceC)
+	resources := jujuDB.C(resourceCatalogC)
+	var totalBytes uint64
+	seen := make(map[string]int64)
+	for _, charm := range charms {
+		bucketPath := path.Join("buckets", modelUUID, charm.StoragePath())
+		resource := lookupResource(managedResources, resources, bucketPath, charm.String())
+		_, found := seen[resource.Id]
+		seen[resource.Id] = resource.Length
+		if !found {
+			totalBytes += uint64(resource.Length)
+			size := fmt.Sprint(resource.Length)
+			if *human {
+				size = humanize.Bytes(uint64(resource.Length))
+			}
+			fmt.Fprintf(os.Stdout, "%v: %s refcount %d %s...\n",
+				charm.String(), size, resource.RefCount, resource.Id[:8])
+		}
+	}
+	size := fmt.Sprintf("%d", totalBytes)
+	if *human {
+		size = humanize.Bytes(totalBytes)
+	}
+	fmt.Fprintf(os.Stdout, "total: %s\n\n", size)
+}
+
+func main() {
+	loggo.GetLogger("").SetLogLevel(loggo.TRACE)
+	gnuflag.Usage = func() {
+		fmt.Printf("Usage: %s\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	gnuflag.Parse(true)
+
+	args := gnuflag.Args()
+	if len(args) < 0 {
+		gnuflag.Usage()
+	}
+	checkErr("logging config", loggo.ConfigureLoggers(*loggingConfig))
+
+	statePool, session, err := getState()
+	checkErr("getting state connection", err)
+	defer statePool.Close()
+	defer session.Close()
+	system := statePool.SystemState()
+	inspectAgentBinaries(system, session)
+	modelUUIDs, err := system.AllModelUUIDs()
+	checkErr("listing model UUIDs", err)
+	logger.Debugf("Found models: %s", modelUUIDs)
+	for _, modelUUID := range modelUUIDs {
+		inspectModel(statePool, session, modelUUID)
+	}
+}

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"github.com/juju/version"
+	"gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -35,6 +37,38 @@ const (
 
 var loggingConfig = gnuflag.String("logging-config", defaultLoggingConfig, "specify log levels for modules")
 var human = gnuflag.Bool("h", false, "print human readable values")
+var verbose = gnuflag.Bool("v", false, "print more detailed information about found references")
+
+func main() {
+	loggo.GetLogger("").SetLogLevel(loggo.TRACE)
+	gnuflag.Usage = func() {
+		fmt.Printf("Usage: %s\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	gnuflag.Parse(true)
+
+	args := gnuflag.Args()
+	if len(args) < 0 {
+		gnuflag.Usage()
+	}
+	checkErr("logging config", loggo.ConfigureLoggers(*loggingConfig))
+
+	statePool, session, err := getState()
+	checkErr("getting state connection", err)
+	defer statePool.Close()
+	defer session.Close()
+	system := statePool.SystemState()
+	foundHashes := make(map[string]struct{})
+	inspectAgentBinaries(system, session, foundHashes)
+	modelUUIDs, err := system.AllModelUUIDs()
+	checkErr("listing model UUIDs", err)
+	logger.Debugf("Found models: %s", modelUUIDs)
+	for _, modelUUID := range modelUUIDs {
+		inspectModel(statePool, session, modelUUID, foundHashes)
+	}
+	checkMissing(system, session, foundHashes)
+}
 
 func checkErr(label string, err error) {
 	if err != nil {
@@ -129,7 +163,45 @@ type resourceDoc struct {
 	RefCount   int64  `bson:"refcount"`
 }
 
-func inspectAgentBinaries(st *state.State, session *mgo.Session) {
+type sortableBinaries []version.Binary
+
+func (s sortableBinaries) Len() int      { return len(s) }
+func (s sortableBinaries) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s sortableBinaries) Less(i, j int) bool {
+	cmp := s[i].Compare(s[j].Number)
+	switch {
+	case cmp < 0:
+		return true
+	case cmp > 0:
+		return false
+	default: // cmp == 0
+		// Technically we could compare Series and then Arch as strings
+		// individually, but this still gives the right answer.
+		return s[i].String() < s[j].String()
+	}
+}
+
+type binaryInfo struct {
+	Version version.Binary
+	Hash    string
+}
+type binariesInfo []binaryInfo
+
+func (bi binariesInfo) Len() int      { return len(bi) }
+func (bi binariesInfo) Swap(i, j int) { bi[i], bi[j] = bi[j], bi[i] }
+func (bi binariesInfo) Less(i, j int) bool {
+	cmp := bi[i].Version.Compare(bi[j].Version.Number)
+	switch {
+	case cmp < 0:
+		return true
+	case cmp > 0:
+		return false
+	default: // cmp == 0
+		return bi[i].Version.String() < bi[j].Version.String()
+	}
+}
+
+func inspectAgentBinaries(st *state.State, session *mgo.Session, foundHashes map[string]struct{}) {
 	toolsStorage, err := st.ToolsStorage()
 	checkErr("tools storage", err)
 	defer toolsStorage.Close()
@@ -144,8 +216,9 @@ func inspectAgentBinaries(st *state.State, session *mgo.Session) {
 	toolsMetadata, err := toolsStorage.AllMetadata()
 	checkErr("tools metadata", err)
 	logger.Debugf("found %d tools", len(toolsMetadata))
-	seen := make(map[version.Number]int, 0)
-	seenResources := make(map[string]int64)
+	// map from SHA384 to the list of agent versions that match it
+	seen := make(map[string][]version.Binary, 0)
+	sizes := make(map[string]int64)
 	for _, metadata := range toolsMetadata {
 		// internally we store a metadata.Path for each object, we really need that here.. :(
 		binary, err := version.ParseBinary(metadata.Version)
@@ -153,23 +226,47 @@ func inspectAgentBinaries(st *state.State, session *mgo.Session) {
 			logger.Warningf("Unknown Binary Version: %q", metadata.Version)
 			continue
 		}
-		count := seen[binary.Number]
-		seen[binary.Number] = count + 1
 		// This assumes we aren't reading from a fallback storage
 		// These queries aren't exposed via the ToolsStorage interface nor via the ManagedStorage interface
 		toolPath := path.Join("tools", fmt.Sprintf("%s-%s", metadata.Version, metadata.SHA256))
 		bucketPath := path.Join("buckets", modelUUID, toolPath)
-		resource := lookupResource(managedResources, resources, bucketPath, metadata.Version)
-		_, found := seenResources[resource.Id]
-		seenResources[resource.Id] = resource.Length
+		res := lookupResource(managedResources, resources, bucketPath, metadata.Version)
+		soFar, found := seen[res.SHA384Hash]
+		seen[res.SHA384Hash] = append(soFar, binary)
+		sizes[res.SHA384Hash] = res.Length
+		foundHashes[res.SHA384Hash] = struct{}{}
 		if !found {
-			totalBytes += uint64(resource.Length)
-			size := fmt.Sprint(resource.Length)
-			if *human {
-				size = humanize.Bytes(uint64(resource.Length))
+			totalBytes += uint64(res.Length)
+		}
+	}
+	firstKeys := make(binariesInfo, 0, len(seen))
+	for key := range seen {
+		binaries := seen[key]
+		if len(binaries) == 0 {
+			// How could it be seen but have no entries?
+			continue
+		}
+		sort.Sort(sortableBinaries(binaries))
+		seen[key] = binaries
+		firstKeys = append(firstKeys, binaryInfo{
+			Version: binaries[0],
+			Hash:    key,
+		})
+	}
+	sort.Sort(firstKeys)
+	for _, info := range firstKeys {
+		length := sizes[info.Hash]
+		size := fmt.Sprint(length)
+		if *human {
+			size = humanize.Bytes(uint64(length))
+		}
+		fmt.Fprintf(os.Stdout, "%v: %s %d %s...\n",
+			info.Version.Number, size, len(seen[info.Hash]), info.Hash[:8])
+		if *verbose {
+			binaries := seen[info.Hash]
+			for _, binary := range binaries {
+				fmt.Fprintf(os.Stdout, "  %s\n", binary)
 			}
-			fmt.Fprintf(os.Stdout, "%v: %s refcount %d %s...\n",
-				binary.Number, size, resource.RefCount, resource.SHA384Hash[:8])
 		}
 	}
 	size := fmt.Sprintf("%d", totalBytes)
@@ -181,26 +278,26 @@ func inspectAgentBinaries(st *state.State, session *mgo.Session) {
 
 func lookupResource(managedResources, resources *mgo.Collection, bucketPath, description string) resourceDoc {
 	var manageDoc managedResourceDoc
-	var resource resourceDoc
+	var res resourceDoc
 	err := managedResources.Find(bson.M{"path": bucketPath}).One(&manageDoc)
 	if err == mgo.ErrNotFound {
 		logger.Warningf("could not find managed resource doc for %q", description)
-		return resource
+		return res
 	}
 	checkErr("managed resource doc", err)
-	err = resources.FindId(manageDoc.ResourceId).One(&resource)
+	err = resources.FindId(manageDoc.ResourceId).One(&res)
 	if err == mgo.ErrNotFound {
 		logger.Warningf("could not find resource doc for %q", description)
-		return resource
+		return res
 	}
 	checkErr("resource doc", err)
-	if resource.Id != resource.SHA384Hash {
-		logger.Warningf("resource with id != sha384: %q != %q", resource.Id, resource.SHA384Hash)
+	if res.Id != res.SHA384Hash {
+		logger.Warningf("resource with id != sha384: %q != %q", res.Id, res.SHA384Hash)
 	}
-	return resource
+	return res
 }
 
-func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string) {
+func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string, foundHashes map[string]struct{}) {
 	model, helper, err := pool.GetModel(modelUUID)
 	defer helper.Release()
 	shortUID := shortModelUUID(modelUUID)
@@ -208,8 +305,8 @@ func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string)
 	charms, err := model.State().AllCharms()
 	checkErr("AllCharms", err)
 	logger.Debugf("[%s] checking model", shortUID)
-	name := model.Name()
-	fmt.Fprintf(os.Stdout, "Model: %q\n", name)
+	modelName := model.Name()
+	fmt.Fprintf(os.Stdout, "Model: %q\n", modelName)
 	jujuDB := session.DB("juju")
 	managedResources := jujuDB.C(managedResourceC)
 	resources := jujuDB.C(resourceCatalogC)
@@ -217,17 +314,32 @@ func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string)
 	seen := make(map[string]int64)
 	for _, charm := range charms {
 		bucketPath := path.Join("buckets", modelUUID, charm.StoragePath())
-		resource := lookupResource(managedResources, resources, bucketPath, charm.String())
-		_, found := seen[resource.Id]
-		seen[resource.Id] = resource.Length
+		res := lookupResource(managedResources, resources, bucketPath, charm.String())
+		foundHashes[res.SHA384Hash] = struct{}{}
+		_, found := seen[res.Id]
+		seen[res.Id] = res.Length
 		if !found {
-			totalBytes += uint64(resource.Length)
-			size := fmt.Sprint(resource.Length)
+			totalBytes += uint64(res.Length)
+			size := fmt.Sprint(res.Length)
 			if *human {
-				size = humanize.Bytes(uint64(resource.Length))
+				size = humanize.Bytes(uint64(res.Length))
 			}
-			fmt.Fprintf(os.Stdout, "%v: %s refcount %d %s...\n",
-				charm.String(), size, resource.RefCount, resource.Id[:8])
+			fmt.Fprintf(os.Stdout, "%v: %s %d %s...\n",
+				charm.String(), size, res.RefCount, res.Id[:8])
+		}
+	}
+	charmResources, err := model.State().Resources()
+	checkErr("resources", err)
+	applications, err := model.State().AllApplications()
+	checkErr("applications", err)
+	for _, app := range applications {
+		resources, err := charmResources.ListResources(app.Name())
+		if err != nil {
+			logger.Warningf("%v: error listing resources for app %q", modelName, app.Name())
+		}
+		for _, res := range resources.Resources {
+			if res.Type == resource.TypeFile {
+			}
 		}
 	}
 	size := fmt.Sprintf("%d", totalBytes)
@@ -237,31 +349,41 @@ func inspectModel(pool *state.StatePool, session *mgo.Session, modelUUID string)
 	fmt.Fprintf(os.Stdout, "total: %s\n\n", size)
 }
 
-func main() {
-	loggo.GetLogger("").SetLogLevel(loggo.TRACE)
-	gnuflag.Usage = func() {
-		fmt.Printf("Usage: %s\n", os.Args[0])
-		os.Exit(1)
+func checkMissing(st *state.State, session *mgo.Session, foundHashes map[string]struct{}) {
+	jujuDB := session.DB("juju")
+	managedResources := jujuDB.C(managedResourceC)
+	resources := jujuDB.C(resourceCatalogC)
+	allResources := resources.Find(nil).Iter()
+	var res resourceDoc
+	missingResources := make(map[string]resourceDoc)
+	missingIds := make([]string, 0)
+	for allResources.Next(&res) {
+		if _, found := foundHashes[res.Id]; found {
+			continue
+		}
+		missingResources[res.SHA384Hash] = res
+		missingIds = append(missingIds, res.Id)
 	}
-
-	gnuflag.Parse(true)
-
-	args := gnuflag.Args()
-	if len(args) < 0 {
-		gnuflag.Usage()
+	checkErr("missingResources", allResources.Close())
+	if len(missingResources) == 0 {
+		return
 	}
-	checkErr("logging config", loggo.ConfigureLoggers(*loggingConfig))
-
-	statePool, session, err := getState()
-	checkErr("getting state connection", err)
-	defer statePool.Close()
-	defer session.Close()
-	system := statePool.SystemState()
-	inspectAgentBinaries(system, session)
-	modelUUIDs, err := system.AllModelUUIDs()
-	checkErr("listing model UUIDs", err)
-	logger.Debugf("Found models: %s", modelUUIDs)
-	for _, modelUUID := range modelUUIDs {
-		inspectModel(statePool, session, modelUUID)
+	resourceRefs := make(map[string][]managedResourceDoc, len(missingResources))
+	// Note, there isn't an index on resourceid, otherwise we'd just do a reverse lookup
+	var manageDoc managedResourceDoc
+	managedRefs := managedResources.Find(bson.M{"resourceid": bson.M{"$in": missingIds}}).Iter()
+	for managedRefs.Next(&manageDoc) {
+		// if _, missing := missingResources[manageDoc.ResourceId]; !missing {
+		// 	continue
+		// }
+		resourceRefs[manageDoc.ResourceId] = append(resourceRefs[manageDoc.ResourceId], manageDoc)
 	}
+	fmt.Fprint(os.Stderr, "Unknown Resources\n")
+	for _, key := range missingIds {
+		fmt.Fprintf(os.Stderr, "%v:\n", key)
+		for _, doc := range resourceRefs[key] {
+			fmt.Fprintf(os.Stdout, "  %v\n", doc.Path)
+		}
+	}
+	fmt.Fprint(os.Stdout, "\n")
 }

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -385,14 +385,14 @@ func checkMissing(st *state.State, session *mgo.Session, foundHashes map[string]
 		// }
 		resourceRefs[manageDoc.ResourceId] = append(resourceRefs[manageDoc.ResourceId], manageDoc)
 	}
-	fmt.Fprint(os.Stderr, "Unknown Resources\n")
+	fmt.Fprint(os.Stdout, "Unknown Resources\n")
 	for _, key := range missingIds {
 		res := missingResources[key]
 		size := fmt.Sprintf("%d", res.Length)
 		if *human {
 			size = humanize.Bytes(uint64(res.Length))
 		}
-		fmt.Fprintf(os.Stderr, "%v: %s\n", key, size)
+		fmt.Fprintf(os.Stdout, "%v: %s\n", key, size)
 		for _, doc := range resourceRefs[key] {
 			fmt.Fprintf(os.Stdout, "  %v\n", doc.Path)
 		}

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -804,7 +804,7 @@ func (b *BlobStoreChecker) checkUnreferencedFiles() {
 		unreferencedBytes += length
 	}
 	if wroteHeader {
-		fmt.Fprint(os.Stdout, "\n  total unreferenced blobstore file bytes: %s\n", lengthToSize(unreferencedBytes))
+		fmt.Fprintf(os.Stdout, "\n  total unreferenced blobstore file bytes: %s\n", lengthToSize(unreferencedBytes))
 	} else {
 		fmt.Fprint(os.Stdout, "\nNo Unknown Blobstore Files\n")
 	}


### PR DESCRIPTION
## Description of change

This adds 2 tools into the 'scripts/' directory. The first is "juju-list-blobstore", which starts by listing all models, and looking for references from the model to "resources". That includes Agent Binaries, Charm Archives, and Charm Resources (TBD, backups and images). It then walks the managedStoredResources collection to find other managed resources that have a bucketUUID that matches the modelUUID, but aren't actually referenced. After walking all models, it then iterates through:
 1. all managedStoredResources for any bucketUUIDs that aren't an active modelUUID
 2. all storedResources for anything that isn't referenced by *any* managed stored resource
 3. all blobstore.blobstore.files objects that aren't referenced by any storedResource
 4. all blobstore.blobstore.chunks objects that don't have an associated file.

This generates a report of what data is stored, how much of it is properly referenced, and how much is waste.

The other new tool is "juju-blobstore-cleanup". This defaults to '--dry-run', but with '--dry-run=false' will actively remove resources from the database. The algorithm we use is:

 1. Find managedStoredResources that don't belong to any active model. Since we know these can't actually be acted upon. When we remove these, we only remove the reference count, so if the resource is still referenced by an active model, it won't actually free up space. But that is fine, it still makes the database cleaner, and it means when an active model stops referencing it (say by upgrading a charm), then it will free up space.
 2. Find resources that are unreferenced. Since there are no references, the refcount is clearly wrong, but was just not cleaned up properly. Looking at the ManagedStorage code, the ManagedResource is removed before we remove the refcount. Which means that if the first step succeeded, but the second failed, we would end up with a dangling reference. These get pruned, along with their associated blobstore file.
 3. Find blobstore.blobstore.files that are unreferenced. I audited our codebase, and all references to GridFS were behind some sort of ManagedStorage. So we shouldn't have any blobstore.files that don't have an associated storedResources document. These are Removed. This also has the same issue in (2), where the reference is removed before the file, but if anything interrupts it, nothing will come by later and clean it up.
 4. Find blobstore.blobstore.chunks that don't refer to a files object. Likely this is either a partial upload, or possibly a partial delete. Either way, we know that we don't need them anymore.

I submitted https://bugs.launchpad.net/juju/+bug/1846310 to track the idea that we should be doing better at making sure we clean up even in the face of failures/errors. And https://bugs.launchpad.net/juju/+bug/1846311 to track cleaning up more resources that are no longer actually referenced.

## QA steps

Once this is built, you can use:
```
$ juju scp -m controller $GOPATH/bin/juju-list-blobstore 0:.
$ juju ssh -m controller 0
$$ sudo -i
$$ ~ubuntu/juju-list-blobstore
```

And it should print out the known blobstore usage like:
```
# ~ubuntu/juju-list-blobstore -h
Model: "controller"
  Referenced By Apps
  app referenced charm bytes: 0B
  total charm bytes: 0B
  No Referenced Resources

  total unreferenced model bytes: 0B
  total model bytes: 0B

Model: "default"
  Referenced By Apps
  - cs:postgresql-199: 5.0MB 30baf18b...
  - local:bionic/dummy-fat-sink-13: 105MB b7ccd9f8...
  - local:bionic/dummy-fat-sink-15: 105MB cde4cebe...
  app referenced charm bytes: 215MB
  Referenced By Units
  - local:bionic/dummy-fat-sink-14: 105MB 3f602fdc...
     - dummy-fat-sink/1
  unit referenced charm bytes: 105MB
  total charm bytes: 320MB
  Referenced Resources
  - application-postgresql/resources/wal-e: 105MB 725734d7...
  total resource bytes: 105MB

  total unreferenced model bytes: 0B
  total model bytes: 424MB

Model: "new"
  Referenced By Apps
  - cs:postgresql-199: 5.0MB 30baf18b...
  app referenced charm bytes: 5.0MB
  total charm bytes: 5.0MB
  No Referenced Resources

  total unreferenced model bytes: 0B
  total model bytes: 5.0MB

Model Summary
  app referenced charm bytes: 220MB
  unit referenced charm bytes: 105MB
  unreferenced charm bytes: 0B
  referenced resource bytes: 105MB
  unreferenced misc bytes: 0B
  total unreferenced bytes: 0B
  total model bytes: 430MB

Agent Binaries
  - 2.7-beta1.4: 49MB 66b90ef5...
  - 2.7-beta1.6: 49MB 3f2811da...
  referenced agent bytes: 98MB

Unreferenced Agent Binaries
  2.7-beta1.1-artful-amd64: 49MB 16 88f8d368...
  2.7-beta1.2-artful-amd64: 49MB 16 5edeea86...
  2.7-beta1.3-artful-amd64: 49MB 16 78bc724f...
  2.7-beta1.5-artful-amd64: 49MB 16 f6c2af0b...
  2.7-beta1.7-artful-amd64: 49MB 16 2d8aa5b6...
  unreferenced agent bytes: 246MB
total agent bytes: 344MB

No Unknown Resources

No Unknown Blobstore Files
  read 12 blobstore files

No Unknown Blobstore Chunks
  read 2951 blobstore chunks
```

You can also use `-v` to see details about who is referencing the various objects (what agents are running particular agent binaries, etc.)

For `juju-blobstore-cleanup` it defaults to --dry-run, so is safe to run. Using:
```
# ~ubuntu/juju-blobstore-cleanup -h -v --dry-run
Found 0 managed resource documents without models totaling 0B

Not removing 0 managed resources

Found 0 unreferenced resource documents totaling 0B

Not removing 0 dangling resources

Found 0 unreferenced blobstore files totaling 0B

Not removing 0 dangling files

Found 0 unreferenced blobstore chunks totaling 0B

Not removing 0 dangling chunks

total bytes: 0B
```
Passing --dry-run=false should remove anything.


## Documentation changes

None.

## Bug reference

None.
