### PR TITLE
Add logging context for workers.

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -221,17 +221,19 @@ LXC_BRIDGE="ignored"`[1:])
 	controllerCfg, err = st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerCfg, jc.DeepEquals, controller.Config{
-		"controller-uuid":         testing.ControllerTag.Id(),
-		"ca-cert":                 testing.CACert,
-		"state-port":              1234,
-		"api-port":                17777,
-		"set-numa-control-policy": false,
-		"max-txn-log-size":        "10M",
-		"model-logs-size":         "1M",
-		"auditing-enabled":        false,
-		"audit-log-capture-args":  true,
-		"audit-log-max-size":      "200M",
-		"audit-log-max-backups":   5,
+		"controller-uuid":           testing.ControllerTag.Id(),
+		"ca-cert":                   testing.CACert,
+		"state-port":                1234,
+		"api-port":                  17777,
+		"set-numa-control-policy":   false,
+		"max-txn-log-size":          "10M",
+		"model-logfile-max-backups": 1,
+		"model-logfile-max-size":    "1M",
+		"model-logs-size":           "1M",
+		"auditing-enabled":          false,
+		"audit-log-capture-args":    true,
+		"audit-log-max-size":        "200M",
+		"audit-log-max-backups":     5,
 	})
 
 	// Check that controller model configuration has been added, and

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -40,6 +40,7 @@ var (
 		"firewaller",
 		"instance-mutater",
 		"instance-poller",
+		"logging-config-updater",  // tertiary dependency: will be inactive because migration workers will be inactive
 		"machine-undertaker",      // tertiary dependency: will be inactive because migration workers will be inactive
 		"metric-worker",           // tertiary dependency: will be inactive because migration workers will be inactive
 		"migration-fortress",      // secondary dependency: will be inactive because depends on model-upgrader
@@ -63,6 +64,7 @@ var (
 		"instance-mutater",
 		"instance-poller",
 		"log-forwarder",
+		"logging-config-updater",
 		"machine-undertaker",
 		"metric-worker",
 		"migration-fortress",

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1019,6 +1019,7 @@ func (a *MachineAgent) initState(agentConfig agent.Config) (*state.StatePool, er
 	if err != nil {
 		return nil, err
 	}
+	logger.Infof("juju database opened")
 
 	reportOpenedState(pool.SystemState())
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -80,6 +81,7 @@ import (
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/logsender/logsendermetrics"
 	"github.com/juju/juju/worker/migrationmaster"
+	"github.com/juju/juju/worker/modelworkermanager"
 	"github.com/juju/juju/worker/provisioner"
 	psworker "github.com/juju/juju/worker/pubsub"
 	"github.com/juju/juju/worker/upgradesteps"
@@ -359,6 +361,7 @@ func (a *MachineAgent) registerPrometheusCollectors() error {
 type MachineAgent struct {
 	AgentConfigWriter
 
+	ctx              *cmd.Context
 	dead             chan struct{}
 	errReason        error
 	agentTag         names.Tag
@@ -460,8 +463,9 @@ func upgradeCertificateDNSNames(config agent.ConfigSetter) error {
 }
 
 // Run runs a machine agent.
-func (a *MachineAgent) Run(*cmd.Context) (err error) {
+func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 	defer a.Done(err)
+	a.ctx = ctx
 	useMultipleCPUs()
 	if err := a.ReadConfig(a.Tag().String()); err != nil {
 		return errors.Errorf("cannot read agent configuration: %v", err)
@@ -1023,9 +1027,13 @@ func (a *MachineAgent) initState(agentConfig agent.Config) (*state.StatePool, er
 
 // startModelWorkers starts the set of workers that run for every model
 // in each controller, both IAAS and CAAS.
-func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.ModelType) (worker.Worker, error) {
-	controllerUUID := a.CurrentConfig().Controller().Id()
-	modelAgent, err := model.WrapAgent(a, controllerUUID, modelUUID)
+func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) (worker.Worker, error) {
+	currentConfig := a.CurrentConfig()
+	controllerUUID := currentConfig.Controller().Id()
+	// We look at the model in the agent.conf file to see if we are starting workers
+	// for our model.
+	agentModelUUID := currentConfig.Model().Id()
+	modelAgent, err := model.WrapAgent(a, controllerUUID, cfg.ModelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1038,10 +1046,35 @@ func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.Model
 		return nil, errors.Trace(err)
 	}
 
+	// Send model logging to a different file on disk to the controller logging
+	// for all models except the controller model.
+	loggingContext := loggo.NewContext(loggo.INFO)
+	var writer io.Writer
+	if agentModelUUID == cfg.ModelUUID {
+		writer = a.ctx.Stderr
+	} else {
+		logFilename := filepath.Join(currentConfig.LogDir(), "models", cfg.ModelUUID+".log")
+		writer = &lumberjack.Logger{
+			Filename:   logFilename,
+			MaxSize:    cfg.ControllerConfig.ModelLogfileMaxSizeMB(),
+			MaxBackups: cfg.ControllerConfig.ModelLogfileMaxBackups(),
+			Compress:   true,
+		}
+	}
+	if err := loggingContext.AddWriter(
+		"file", loggo.NewSimpleWriter(writer, loggo.DefaultFormatter)); err != nil {
+		logger.Errorf("unable to configure file logging for model: %v", err)
+	}
+	// Use a standard state logger for the right model.
+	if err := loggingContext.AddWriter("db", cfg.ModelLogger); err != nil {
+		logger.Errorf("unable to configure db logging for model: %v", err)
+	}
+
 	manifoldsCfg := model.ManifoldsConfig{
 		Agent:                       modelAgent,
 		AgentConfigChanged:          a.configChangedVal,
 		Clock:                       clock.WallClock,
+		LoggingContext:              loggingContext,
 		RunFlagDuration:             time.Minute,
 		CharmRevisionUpdateInterval: 24 * time.Hour,
 		InstPollerAggregationDelay:  3 * time.Second,
@@ -1052,7 +1085,7 @@ func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.Model
 		NewMigrationMaster:          migrationmaster.NewWorker,
 	}
 	var manifolds dependency.Manifolds
-	if modelType == state.ModelTypeIAAS {
+	if cfg.ModelType == state.ModelTypeIAAS {
 		manifolds = iaasModelManifolds(manifoldsCfg)
 	} else {
 		manifolds = caasModelManifolds(manifoldsCfg)
@@ -1063,7 +1096,26 @@ func (a *MachineAgent) startModelWorkers(modelUUID string, modelType state.Model
 		}
 		return nil, errors.Trace(err)
 	}
-	return engine, nil
+	return &modelWorker{
+		Engine:    engine,
+		logger:    cfg.ModelLogger,
+		modelUUID: cfg.ModelUUID,
+	}, nil
+}
+
+type modelWorker struct {
+	*dependency.Engine
+	logger    modelworkermanager.ModelLogger
+	modelUUID string
+}
+
+// Wait is the last thing that is called on the worker as it is being
+// removed.
+func (m *modelWorker) Wait() error {
+	err := m.Engine.Wait()
+	logger.Debugf("closing db logger for %q", m.modelUUID)
+	m.logger.Close()
+	return err
 }
 
 // stateWorkerDialOpts is a mongo.DialOpts suitable

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -239,7 +239,7 @@ type ManifoldsConfig struct {
 
 	// NewModelWorker returns a new worker for managing the model with
 	// the specified UUID and type.
-	NewModelWorker func(modelUUID string, modelType state.ModelType) (worker.Worker, error)
+	NewModelWorker modelworkermanager.NewModelWorkerFunc
 
 	// MachineLock is a central source for acquiring the machine lock.
 	// This is used by a number of workers to ensure serialisation of actions
@@ -667,9 +667,12 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		modelWorkerManagerName: ifFullyUpgraded(modelworkermanager.Manifold(modelworkermanager.ManifoldConfig{
+			AgentName:      agentName,
 			StateName:      stateName,
+			Clock:          config.Clock,
 			NewWorker:      modelworkermanager.New,
 			NewModelWorker: config.NewModelWorker,
+			Logger:         loggo.GetLogger("juju.workers.modelworkermanager"),
 		})),
 
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{

--- a/cmd/jujud/agent/machine_charms_test.go
+++ b/cmd/jujud/agent/machine_charms_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
@@ -57,7 +58,8 @@ func (s *MachineWithCharmsSuite) TestManageModelRunsCharmRevisionUpdater(c *gc.C
 
 	a := s.newAgent(c, m)
 	go func() {
-		c.Check(a.Run(nil), jc.ErrorIsNil)
+		ctx := cmdtesting.Context(c)
+		c.Check(a.Run(ctx), jc.ErrorIsNil)
 	}()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
+	"github.com/juju/loggo"
 	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -1076,6 +1077,7 @@ func (s *MachineLegacyLeasesSuite) TestWorkersForHostedModelWithInvalidCredentia
 	// The dummy provider blows up in the face of multi-model
 	// scenarios so patch in a minimal environs.Environ that's good
 	// enough to allow the model workers to run.
+	loggo.GetLogger("juju.worker.dependency").SetLogLevel(loggo.TRACE)
 	s.PatchValue(&newEnvirons, func(environs.OpenParams) (environs.Environ, error) {
 		return &minModelWorkersEnviron{}, nil
 	})
@@ -1120,6 +1122,7 @@ func (s *MachineLegacyLeasesSuite) TestWorkersForHostedModelWithDeletedCredentia
 	// The dummy provider blows up in the face of multi-model
 	// scenarios so patch in a minimal environs.Environ that's good
 	// enough to allow the model workers to run.
+	loggo.GetLogger("juju.worker.dependency").SetLogLevel(loggo.TRACE)
 	s.PatchValue(&newEnvirons, func(environs.OpenParams) (environs.Environ, error) {
 		return &minModelWorkersEnviron{}, nil
 	})
@@ -1134,6 +1137,7 @@ func (s *MachineLegacyLeasesSuite) TestWorkersForHostedModelWithDeletedCredentia
 			"max-status-history-size": "4M",
 			"max-action-results-age":  "2h",
 			"max-action-results-size": "4M",
+			"logging-config":          "juju=debug;juju.worker.dependency=trace",
 		},
 		CloudCredential: credentialTag,
 	})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -261,7 +261,7 @@ func (s *MachineLegacyLeasesSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	a := s.newAgent(c, m)
 	defer a.Stop()
 	go func() {
-		c.Check(a.Run(nil), jc.ErrorIsNil)
+		c.Check(a.Run(cmdtesting.Context(c)), jc.ErrorIsNil)
 	}()
 
 	// Add one unit to an application;
@@ -352,7 +352,7 @@ func (s *MachineLegacyLeasesSuite) testUpgradeRequest(c *gc.C, agent runner, tag
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)[0]
 	err := s.State.SetModelAgentVersion(newVers.Number, true)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runWithTimeout(agent)
+	err = runWithTimeout(c, agent)
 	envtesting.CheckUpgraderReadyError(c, err, &upgrader.UpgradeReadyError{
 		AgentName: tag,
 		OldTools:  currentTools.Version,
@@ -372,7 +372,7 @@ func (s *MachineLegacyLeasesSuite) TestNoUpgradeRequired(c *gc.C) {
 	m, _, _ := s.primeAgent(c, state.JobManageModel, state.JobHostUnits)
 	a := s.newAgent(c, m)
 	done := make(chan error)
-	go func() { done <- a.Run(nil) }()
+	go func() { done <- a.Run(cmdtesting.Context(c)) }()
 	select {
 	case <-a.initialUpgradeCheckComplete.Unlocked():
 	case <-time.After(coretesting.LongWait):
@@ -446,7 +446,7 @@ func (s *MachineLegacyLeasesSuite) waitForOpenState(c *gc.C, a *MachineAgent) (*
 
 	done := make(chan error)
 	go func() {
-		done <- a.Run(nil)
+		done <- a.Run(cmdtesting.Context(c))
 	}()
 
 	select {
@@ -571,8 +571,13 @@ func (s *MachineLegacyLeasesSuite) assertAgentSetsToolsVersion(c *gc.C, job stat
 	vers.Minor++
 	m, _, _ := s.primeAgentVersion(c, vers, job)
 	a := s.newAgent(c, m)
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
-	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+	ctx := cmdtesting.Context(c)
+	go func() { c.Check(a.Run(ctx), jc.ErrorIsNil) }()
+	defer func() {
+		logger.Infof("stopping machine agent")
+		c.Check(a.Stop(), jc.ErrorIsNil)
+		logger.Infof("stopped machine agent")
+	}()
 
 	timeout := time.After(coretesting.LongWait)
 	for done := false; !done; {
@@ -766,7 +771,7 @@ func (s *MachineLegacyLeasesSuite) TestMachineAgentUninstall(c *gc.C) {
 
 	// Wait for the agent to become alive, then run EnsureDead and wait
 	// for the agent to exit
-	err := s.WithAliveAgent(m, a, m.EnsureDead)
+	err := s.WithAliveAgent(c, m, a, m.EnsureDead)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// juju-* symlinks should have been removed on termination.
@@ -904,7 +909,7 @@ func (s *MachineLegacyLeasesSuite) testCertificateDNSUpdated(c *gc.C, a *Machine
 	})
 
 	// Start the agent.
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	go func() { c.Check(a.Run(cmdtesting.Context(c)), jc.ErrorIsNil) }()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 
 	// Wait for State to be opened. Once this occurs we know that the
@@ -1019,7 +1024,7 @@ func (s *MachineSuite) TestMachineWorkers(c *gc.C) {
 
 	m, _, _ := s.primeAgent(c, state.JobHostUnits)
 	a := s.newAgent(c, m)
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	go func() { c.Check(a.Run(cmdtesting.Context(c)), jc.ErrorIsNil) }()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 
 	// Wait for it to stabilise, running as normal.

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -146,7 +146,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Filter:        apiConnectFilter,
 		}),
 
-		// The logging config updater listents for logging config updates
+		// The logging config updater listens for logging config updates
 		// for the model and configures the logging context appropriately.
 		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
 			AgentName:      agentName,

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -223,7 +223,7 @@ func (s *UnitSuite) TestUpgrade(c *gc.C) {
 	// Set the machine agent version to trigger an upgrade.
 	err = machine.SetAgentVersion(newVers)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runWithTimeout(agent)
+	err = runWithTimeout(c, agent)
 	envtesting.CheckUpgraderReadyError(c, err, &upgrader.UpgradeReadyError{
 		AgentName: unit.Tag().String(),
 		OldTools:  currentTools.Version,
@@ -243,7 +243,7 @@ func (s *UnitSuite) TestUpgradeFailsWithoutTools(c *gc.C) {
 	newVers.Patch++
 	err := machine.SetAgentVersion(newVers)
 	c.Assert(err, jc.ErrorIsNil)
-	err = runWithTimeout(agent)
+	err = runWithTimeout(c, agent)
 	c.Assert(err, gc.ErrorMatches, "timed out waiting for agent to finish.*")
 }
 
@@ -252,14 +252,14 @@ func (s *UnitSuite) TestWithDeadUnit(c *gc.C) {
 	err := unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	a := s.newAgent(c, unit)
-	err = runWithTimeout(a)
+	err = runWithTimeout(c, a)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// try again when the unit has been removed.
 	err = unit.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 	a = s.newAgent(c, unit)
-	err = runWithTimeout(a)
+	err = runWithTimeout(c, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/collections/set"
 	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
@@ -261,14 +262,15 @@ func (s *commonMachineSuite) setFakeMachineAddresses(c *gc.C, machine *state.Mac
 // the agent either exits or exceeds its run timeout. In both cases, any error
 // returned by the agent's Run method will be captured and returned to the
 // caller.
-func (s *commonMachineSuite) WithAliveAgent(m *state.Machine, a *MachineAgent, cb func() error) error {
+func (s *commonMachineSuite) WithAliveAgent(c *gc.C, m *state.Machine, a *MachineAgent, cb func() error) error {
 	// achilleasa: the agent usually takes a around 30 seconds
 	waitTime := coretesting.LongWait * 3
 
+	ctx := cmdtesting.Context(c)
 	errCh := make(chan error, 1)
 	go func() {
 		select {
-		case errCh <- a.Run(nil):
+		case errCh <- a.Run(ctx):
 		case <-time.After(waitTime):
 			errCh <- fmt.Errorf("time out waiting for agent to complete its run")
 		}
@@ -375,10 +377,10 @@ type runner interface {
 
 // runWithTimeout runs an agent and waits
 // for it to complete within a reasonable time.
-func runWithTimeout(r runner) error {
+func runWithTimeout(c *gc.C, r runner) error {
 	done := make(chan error)
 	go func() {
-		done <- r.Run(nil)
+		done <- r.Run(cmdtesting.Context(c))
 	}()
 	select {
 	case err := <-done:

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -460,7 +460,7 @@ func (e *minModelWorkersEnviron) AllRunningInstances(context.ProviderCallContext
 }
 
 func (e *minModelWorkersEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
-	return nil, nil
+	return nil, environs.ErrNoInstances
 }
 
 func (env *minModelWorkersEnviron) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -95,7 +95,8 @@ func waitForApplicationActive(c *gc.C, dataDir, appTag string) {
 func (s *CAASOperatorSuite) TestRunStop(c *gc.C) {
 	app, config, _ := s.primeAgent(c)
 	a := s.newAgent(c, app)
-	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	ctx := cmdtesting.Context(c)
+	go func() { c.Check(a.Run(ctx), gc.IsNil) }()
 	defer func() { c.Check(a.Stop(), gc.IsNil) }()
 	waitForApplicationActive(c, config.DataDir(), app.Tag().String())
 }
@@ -103,7 +104,8 @@ func (s *CAASOperatorSuite) TestRunStop(c *gc.C) {
 func (s *CAASOperatorSuite) TestOpenStateFails(c *gc.C) {
 	app, config, _ := s.primeAgent(c)
 	a := s.newAgent(c, app)
-	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	ctx := cmdtesting.Context(c)
+	go func() { c.Check(a.Run(ctx), gc.IsNil) }()
 	defer func() { c.Check(a.Stop(), gc.IsNil) }()
 	waitForApplicationActive(c, config.DataDir(), app.Tag().String())
 
@@ -174,7 +176,7 @@ func (s *CAASOperatorSuite) TestWorkers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.InitAgent(c, a, "--application-name", app.Name())
 
-	go func() { c.Check(a.Run(nil), gc.IsNil) }()
+	go func() { c.Check(a.Run(ctx), gc.IsNil) }()
 	defer func() { c.Check(a.Stop(), gc.IsNil) }()
 
 	matcher := agenttest.NewWorkerMatcher(c, tracker, a.Tag().String(),

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -6,6 +6,7 @@ package featuretests
 import (
 	"time"
 
+	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/juju/controller"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
@@ -98,7 +99,8 @@ func (s *dblogSuite) assertAgentLogsGoToDB(c *gc.C, tag names.Tag, isCaas bool) 
 	c.Assert(s.getLogCount(c, tag), gc.Equals, 0)
 
 	// Start the agent.
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	ctx := cmdtesting.Context(c)
+	go func() { c.Check(a.Run(ctx), jc.ErrorIsNil) }()
 	defer a.Stop()
 
 	foundLogs := s.waitForLogs(c, tag)
@@ -119,7 +121,8 @@ func (s *dblogSuite) TestUnitAgentLogsGoToDB(c *gc.C) {
 	c.Assert(s.getLogCount(c, u.Tag()), gc.Equals, 0)
 
 	// Start the agent.
-	go func() { c.Assert(a.Run(nil), jc.ErrorIsNil) }()
+	ctx := cmdtesting.Context(c)
+	go func() { c.Assert(a.Run(ctx), jc.ErrorIsNil) }()
 	defer a.Stop()
 
 	foundLogs := s.waitForLogs(c, u.Tag())

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -117,7 +117,8 @@ func (s *introspectionSuite) startAgent(
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Start the agent.
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	ctx := cmdtesting.Context(c)
+	go func() { c.Check(a.Run(ctx), jc.ErrorIsNil) }()
 
 	// Wait for the agent to start serving on the introspection socket.
 	var conn net.Conn

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/os/series"
 	pacman "github.com/juju/packaging/manager"
@@ -131,7 +132,8 @@ func (s *upgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	s.PatchValue(&upgradesteps.PerformUpgrade, fakePerformUpgrade)
 
 	a := s.newAgent(c, machine)
-	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	ctx := cmdtesting.Context(c)
+	go func() { c.Check(a.Run(ctx), jc.ErrorIsNil) }()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 
 	c.Assert(waitForUpgradeToStart(upgradeCh), jc.IsTrue)
@@ -203,8 +205,9 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 	agent := s.newAgent(c, machineA)
 	defer agent.Stop()
 	agentDone := make(chan error)
+	ctx := cmdtesting.Context(c)
 	go func() {
-		agentDone <- agent.Run(nil)
+		agentDone <- agent.Run(ctx)
 	}()
 
 	select {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -44,6 +44,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MaxLogsSize,
 		controller.MaxPruneTxnBatchSize,
 		controller.MaxPruneTxnPasses,
+		controller.ModelLogfileMaxBackups,
+		controller.ModelLogfileMaxSize,
 		controller.PruneTxnQueryCount,
 		controller.PruneTxnSleepTime,
 		controller.CAASOperatorImagePath,

--- a/state/logdb/buf.go
+++ b/state/logdb/buf.go
@@ -17,16 +17,13 @@ import (
 type Logger interface {
 	// Log writes the given log records to the logger's storage.
 	Log([]state.LogRecord) error
-	Close()
 }
 
 // BufferedLogger wraps a Logger, providing a buffer that
 // accumulates log messages, flushing them to the underlying logger
 // when enough messages have been accumulated.
 type BufferedLogger struct {
-	// Use struct embedding to get the Close method.
-	Logger
-
+	l             Logger
 	clock         clock.Clock
 	flushInterval time.Duration
 
@@ -44,7 +41,7 @@ func NewBufferedLogger(
 	clock clock.Clock,
 ) *BufferedLogger {
 	return &BufferedLogger{
-		Logger:        l,
+		l:             l,
 		buf:           make([]state.LogRecord, 0, bufferSize),
 		clock:         clock,
 		flushInterval: flushInterval,
@@ -103,7 +100,7 @@ func (b *BufferedLogger) flush() error {
 		b.flushTimer = nil
 	}
 	if len(b.buf) > 0 {
-		if err := b.Logger.Log(b.buf); err != nil {
+		if err := b.l.Log(b.buf); err != nil {
 			return errors.Trace(err)
 		}
 		b.buf = b.buf[:0]

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -49,17 +49,19 @@ var ControllerTag = names.NewControllerTag("deadbeef-1bad-500d-9000-4b1d0d06f00d
 // that is expected to be found in state for a fake controller.
 func FakeControllerConfig() controller.Config {
 	return controller.Config{
-		"controller-uuid":         ControllerTag.Id(),
-		"ca-cert":                 CACert,
-		"state-port":              1234,
-		"api-port":                17777,
-		"set-numa-control-policy": false,
-		"model-logs-size":         "1M",
-		"max-txn-log-size":        "10M",
-		"auditing-enabled":        false,
-		"audit-log-capture-args":  true,
-		"audit-log-max-size":      "200M",
-		"audit-log-max-backups":   5,
+		"controller-uuid":           ControllerTag.Id(),
+		"ca-cert":                   CACert,
+		"state-port":                1234,
+		"api-port":                  17777,
+		"set-numa-control-policy":   false,
+		"model-logfile-max-backups": 1,
+		"model-logfile-max-size":    "1M",
+		"model-logs-size":           "1M",
+		"max-txn-log-size":          "10M",
+		"auditing-enabled":          false,
+		"audit-log-capture-args":    true,
+		"audit-log-max-size":        "200M",
+		"audit-log-max-backups":     5,
 	}
 }
 

--- a/worker/logsender/worker.go
+++ b/worker/logsender/worker.go
@@ -18,7 +18,7 @@ import (
 const loggerName = "juju.worker.logsender"
 
 // New starts a logsender worker which reads log message structs from
-// a channel and sends them to the JES via the logsink API.
+// a channel and sends them to the controller via the logsink API.
 func New(logs LogRecordCh, logSenderAPI *logsender.API) worker.Worker {
 	loop := func(stop <-chan struct{}) error {
 		// It has been observed that sometimes the logsender.API gets wedged

--- a/worker/modelworkermanager/dblogger.go
+++ b/worker/modelworkermanager/dblogger.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelworkermanager
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/logdb"
+)
+
+// newModelLogger returns a buffered database logger that uses the name
+// specified as the entity doing the logging.
+func newModelLogger(
+	name string,
+	modelUUID string,
+	base logdb.Logger,
+	clock clock.Clock,
+	logger Logger,
+) *dbLogger {
+
+	// Write to the database every second, or 1024 entries, whichever comes first.
+	buffered := logdb.NewBufferedLogger(base, 1024, time.Second, clock)
+
+	return &dbLogger{
+		Logger:    buffered,
+		name:      name,
+		modelUUID: modelUUID,
+		logger:    logger,
+	}
+}
+
+type dbLogger struct {
+	// Use struct embedding to get the Close method.
+	logdb.Logger
+	// "controller-0" for machine-0 in the controller model.
+	name      string
+	modelUUID string
+	logger    Logger
+}
+
+func (l *dbLogger) Write(entry loggo.Entry) {
+	err := l.Logger.Log([]state.LogRecord{{
+		Time:     entry.Timestamp,
+		Entity:   l.name,
+		Module:   entry.Module,
+		Location: fmt.Sprintf("%s:%d", filepath.Base(entry.Filename), entry.Line),
+		Level:    entry.Level,
+		Message:  entry.Message,
+	}})
+
+	if err != nil {
+		l.logger.Warningf("logging to DB failed for model %q, %v", l.modelUUID, err)
+	}
+}

--- a/worker/modelworkermanager/manifold.go
+++ b/worker/modelworkermanager/manifold.go
@@ -4,25 +4,39 @@
 package modelworkermanager
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/dependency"
 
+	"github.com/juju/juju/agent"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/common"
 	workerstate "github.com/juju/juju/worker/state"
 )
 
+// Logger defines the logging methods used by the worker.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
+}
+
 // ManifoldConfig holds the information necessary to run a model worker manager
 // in a dependency.Engine.
 type ManifoldConfig struct {
+	AgentName      string
 	StateName      string
+	Clock          clock.Clock
 	NewWorker      func(Config) (worker.Worker, error)
 	NewModelWorker NewModelWorkerFunc
+	Logger         Logger
 }
 
 // Validate validates the manifold configuration.
 func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
 	if config.StateName == "" {
 		return errors.NotValidf("empty StateName")
 	}
@@ -32,13 +46,16 @@ func (config ManifoldConfig) Validate() error {
 	if config.NewModelWorker == nil {
 		return errors.NotValidf("nil NewModelWorker")
 	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
 	return nil
 }
 
 // Manifold returns a dependency.Manifold that will run a model worker manager.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{config.StateName},
+		Inputs: []string{config.AgentName, config.StateName},
 		Start:  config.start,
 	}
 }
@@ -46,6 +63,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 // start is a method on ManifoldConfig because it's more readable than a closure.
 func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -58,9 +79,14 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
+	machineID := agent.CurrentConfig().Tag().Id()
+
 	w, err := config.NewWorker(Config{
+		Clock:          config.Clock,
+		Logger:         config.Logger,
+		MachineID:      machineID,
 		ModelWatcher:   statePool.SystemState(),
-		ModelGetter:    StatePoolModelGetter{statePool},
+		Controller:     StatePoolController{statePool},
 		NewModelWorker: config.NewModelWorker,
 		ErrorDelay:     jworker.RestartDelay,
 	})

--- a/worker/modelworkermanager/manifold_test.go
+++ b/worker/modelworkermanager/manifold_test.go
@@ -105,7 +105,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 
 	c.Assert(config, jc.DeepEquals, modelworkermanager.Config{
 		ModelWatcher: s.State,
-		ModelGetter:  modelworkermanager.StatePoolModelGetter{s.StatePool},
+		Controller:   modelworkermanager.StatePoolController{s.StatePool},
 		ErrorDelay:   jworker.RestartDelay,
 	})
 }

--- a/worker/modelworkermanager/modelworkermanager.go
+++ b/worker/modelworkermanager/modelworkermanager.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/logdb"
 )
 
 // ModelWatcher provides an interface for watching the additiona and
@@ -31,7 +30,7 @@ type ModelWatcher interface {
 type Controller interface {
 	Config() (controller.Config, error)
 	Model(modelUUID string) (Model, func(), error)
-	DBLogger(modelUUID string) (logdb.Logger, error)
+	DBLogger(modelUUID string) (DBLogger, error)
 }
 
 // Model represents a model.
@@ -40,10 +39,17 @@ type Model interface {
 	Type() state.ModelType
 }
 
+// DBLogger writes into the log collections.
+type DBLogger interface {
+	// Log writes the given log records to the logger's storage.
+	Log([]state.LogRecord) error
+	Close()
+}
+
 // ModelLogger is a database backed loggo Writer.
 type ModelLogger interface {
 	loggo.Writer
-	Close()
+	Close() error
 }
 
 // NewModelConfig holds the information required by the NewModelWorkerFunc

--- a/worker/modelworkermanager/modelworkermanager.go
+++ b/worker/modelworkermanager/modelworkermanager.go
@@ -6,15 +6,17 @@ package modelworkermanager
 import (
 	"time"
 
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/logdb"
 )
-
-var logger = loggo.GetLogger("juju.workers.modelworkermanager")
 
 // ModelWatcher provides an interface for watching the additiona and
 // removal of models.
@@ -22,11 +24,14 @@ type ModelWatcher interface {
 	WatchModels() state.StringsWatcher
 }
 
-// ModelGetter provides an interface for getting models by UUID.
+// Controller provides an interface for getting models by UUID,
+// and other details needed to pass into the function to start workers for a model.
 // Once a model is no longer required, the returned function must
 // be called to dispose of the model.
-type ModelGetter interface {
+type Controller interface {
+	Config() (controller.Config, error)
 	Model(modelUUID string) (Model, func(), error)
+	DBLogger(modelUUID string) (logdb.Logger, error)
 }
 
 // Model represents a model.
@@ -35,16 +40,34 @@ type Model interface {
 	Type() state.ModelType
 }
 
+// ModelLogger is a database backed loggo Writer.
+type ModelLogger interface {
+	loggo.Writer
+	Close()
+}
+
+// NewModelConfig holds the information required by the NewModelWorkerFunc
+// to start the workers for the specified model
+type NewModelConfig struct {
+	ModelUUID        string
+	ModelType        state.ModelType
+	ModelLogger      ModelLogger
+	ControllerConfig controller.Config
+}
+
 // NewModelWorkerFunc should return a worker responsible for running
 // all a model's required workers; and for returning nil when there's
 // no more model to manage.
-type NewModelWorkerFunc func(modelUUID string, modelType state.ModelType) (worker.Worker, error)
+type NewModelWorkerFunc func(config NewModelConfig) (worker.Worker, error)
 
 // Config holds the dependencies and configuration necessary to run
 // a model worker manager.
 type Config struct {
+	Clock          clock.Clock
+	Logger         Logger
+	MachineID      string
 	ModelWatcher   ModelWatcher
-	ModelGetter    ModelGetter
+	Controller     Controller
 	NewModelWorker NewModelWorkerFunc
 	ErrorDelay     time.Duration
 }
@@ -52,11 +75,20 @@ type Config struct {
 // Validate returns an error if config cannot be expected to drive
 // a functional model worker manager.
 func (config Config) Validate() error {
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.MachineID == "" {
+		return errors.NotValidf("empty MachineID")
+	}
 	if config.ModelWatcher == nil {
 		return errors.NotValidf("nil ModelWatcher")
 	}
-	if config.ModelGetter == nil {
-		return errors.NotValidf("nil ModelGetter")
+	if config.Controller == nil {
+		return errors.NotValidf("nil Controller")
 	}
 	if config.NewModelWorker == nil {
 		return errors.NotValidf("nil NewModelWorker")
@@ -67,6 +99,7 @@ func (config Config) Validate() error {
 	return nil
 }
 
+// New starts a new model worker manager.
 func New(config Config) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
@@ -102,6 +135,10 @@ func (m *modelWorkerManager) Wait() error {
 }
 
 func (m *modelWorkerManager) loop() error {
+	controllerConfig, err := m.config.Controller.Config()
+	if err != nil {
+		return errors.Annotate(err, "unable to get controller config")
+	}
 	m.runner = worker.NewRunner(worker.RunnerParams{
 		IsFatal:       neverFatal,
 		MoreImportant: neverImportant,
@@ -116,9 +153,16 @@ func (m *modelWorkerManager) loop() error {
 	}
 
 	modelChanged := func(modelUUID string) error {
-		model, release, err := m.config.ModelGetter.Model(modelUUID)
+		model, release, err := m.config.Controller.Model(modelUUID)
 		if errors.IsNotFound(err) {
 			// Model was removed, ignore it.
+			// The reason we ignore it here is that one of the embedded
+			// workers is also responding to the model life changes and
+			// when it returns a NotFound error, which is determined as a
+			// fatal error for the model worker engine. This causes it to be
+			// removed from the runner above. However since the runner itself
+			// has neverFatal as an error handler, the runner itself doesn't
+			// propagate the error.
 			return nil
 		} else if err != nil {
 			return errors.Trace(err)
@@ -132,7 +176,12 @@ func (m *modelWorkerManager) loop() error {
 			// https://bugs.launchpad.net/juju/+bug/1646310
 			return nil
 		}
-		return errors.Trace(m.ensure(modelUUID, model.Type()))
+		cfg := NewModelConfig{
+			ModelUUID:        modelUUID,
+			ModelType:        model.Type(),
+			ControllerConfig: controllerConfig,
+		}
+		return errors.Trace(m.ensure(cfg))
 	}
 
 	for {
@@ -152,19 +201,32 @@ func (m *modelWorkerManager) loop() error {
 	}
 }
 
-func (m *modelWorkerManager) ensure(modelUUID string, modelType state.ModelType) error {
-	starter := m.starter(modelUUID, modelType)
-	if err := m.runner.StartWorker(modelUUID, starter); err != nil {
+func (m *modelWorkerManager) ensure(cfg NewModelConfig) error {
+	starter := m.starter(cfg)
+	if err := m.runner.StartWorker(cfg.ModelUUID, starter); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
 }
 
-func (m *modelWorkerManager) starter(modelUUID string, modelType state.ModelType) func() (worker.Worker, error) {
+func (m *modelWorkerManager) starter(cfg NewModelConfig) func() (worker.Worker, error) {
 	return func() (worker.Worker, error) {
-		logger.Debugf("starting workers for model %q", modelUUID)
-		worker, err := m.config.NewModelWorker(modelUUID, modelType)
+		modelUUID := cfg.ModelUUID
+		m.config.Logger.Debugf("starting workers for model %q", modelUUID)
+		dbLogger, err := m.config.Controller.DBLogger(modelUUID)
 		if err != nil {
+			return nil, errors.Annotatef(err, "unable to create db logger for %q", modelUUID)
+		}
+		cfg.ModelLogger = newModelLogger(
+			"controller-"+m.config.MachineID,
+			modelUUID,
+			dbLogger,
+			m.config.Clock,
+			m.config.Logger,
+		)
+		worker, err := m.config.NewModelWorker(cfg)
+		if err != nil {
+			cfg.ModelLogger.Close()
 			return nil, errors.Annotatef(err, "cannot manage model %q", modelUUID)
 		}
 		return worker, nil

--- a/worker/modelworkermanager/modelworkermanager_test.go
+++ b/worker/modelworkermanager/modelworkermanager_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/logdb"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/modelworkermanager"
 )
@@ -314,10 +313,10 @@ func (mock *mockController) Model(uuid string) (modelworkermanager.Model, func()
 }
 
 type fakeLogger struct {
-	logdb.Logger
+	modelworkermanager.DBLogger
 }
 
-func (mock *mockController) DBLogger(uuid string) (logdb.Logger, error) {
+func (mock *mockController) DBLogger(uuid string) (modelworkermanager.DBLogger, error) {
 	mock.MethodCall(mock, "DBLogger", uuid)
 	return &fakeLogger{}, nil
 }

--- a/worker/modelworkermanager/shim.go
+++ b/worker/modelworkermanager/shim.go
@@ -35,5 +35,9 @@ func (g StatePoolController) DBLogger(modelUUID string) (DBLogger, error) {
 
 // Config is part of the Controller interface.
 func (g StatePoolController) Config() (controller.Config, error) {
-	return g.StatePool.SystemState().ControllerConfig()
+	sys := g.StatePool.SystemState()
+	if sys == nil {
+		return nil, errors.New("state pool closed")
+	}
+	return sys.ControllerConfig()
 }

--- a/worker/modelworkermanager/shim.go
+++ b/worker/modelworkermanager/shim.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/logdb"
 )
 
 // StatePoolController implements Controller in terms of a *state.StatePool.
@@ -25,7 +24,7 @@ func (g StatePoolController) Model(modelUUID string) (Model, func(), error) {
 }
 
 // DBLogger returns a database logger for the specified model.
-func (g StatePoolController) DBLogger(modelUUID string) (logdb.Logger, error) {
+func (g StatePoolController) DBLogger(modelUUID string) (DBLogger, error) {
 	ps, err := g.StatePool.Get(modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/modelworkermanager/shim.go
+++ b/worker/modelworkermanager/shim.go
@@ -4,19 +4,37 @@ package modelworkermanager
 
 import (
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/logdb"
 )
 
-// StatePoolModelGetter implements ModelGetter in terms of a *state.StatePool.
-type StatePoolModelGetter struct {
+// StatePoolController implements Controller in terms of a *state.StatePool.
+type StatePoolController struct {
 	*state.StatePool
 }
 
-// Model is part of the ModelGetter interface.
-func (g StatePoolModelGetter) Model(modelUUID string) (Model, func(), error) {
+// Model is part of the Controller interface.
+func (g StatePoolController) Model(modelUUID string) (Model, func(), error) {
 	model, ph, err := g.StatePool.GetModel(modelUUID)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
 	return model, func() { ph.Release() }, nil
+}
+
+// DBLogger returns a database logger for the specified model.
+func (g StatePoolController) DBLogger(modelUUID string) (logdb.Logger, error) {
+	ps, err := g.StatePool.Get(modelUUID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer ps.Release()
+	return state.NewDbLogger(ps), nil
+}
+
+// Config is part of the Controller interface.
+func (g StatePoolController) Config() (controller.Config, error) {
+	return g.StatePool.SystemState().ControllerConfig()
 }


### PR DESCRIPTION
In the past workers that ran on the controller had all the logging go into the log collection of the controller model. That information was also written into the machine-x.log file.

This PR adds a new logging context for model workers started by the controller on behalf of a model.

This logging context has two log writers:
 * a file based writer that goes to /var/log/juju/models/<uuid>.log
 * a db log writer that writes into the model's log collection

## QA steps

 * Bootstrap a controller
 * deploy something into the default model, I used ubuntu-lite
 * add a few models and deploy things into those models too

SSH into the controller machine and check the /var/log/juju directory. Look at the logs in the appropriate model's log files.

Use the debug-log command on the client to see that the log entries ended up in the right model's collection.

## Documentation changes

No real documentation changes needed.

## Bug reference

I'm sure there is one somewhere.