### PR TITLE
Fix Intermittent Uniter Test Failure

### DIFF
--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -230,7 +230,6 @@ func (s *InterfaceSuite) TestConfigCaching(c *gc.C) {
 }
 
 func (s *InterfaceSuite) TestGoalState(c *gc.C) {
-
 	timestamp := time.Date(2200, time.November, 5, 0, 0, 0, 0, time.UTC)
 	mockUnitSince := func(inUnits application.UnitsGoalState) application.UnitsGoalState {
 		outUnits := application.UnitsGoalState{}


### PR DESCRIPTION
## Description of change

This patch addresses an intermittent failure in the `InterfaceSuite.TestConfigCaching` uniter test.

`SetUpTest` in the `HookContextSuite` (embedded in `InterfaceSuite`) previously set the unit's charm URL directly in state, which exposed potential races with the model cache.

Using the API to set the charm URL, which includes cache synchronisation, ensures that this does not happen.

## QA steps

Previously failing test passes consistently in a loop.

## Documentation changes

None.

## Bug reference

N/A
