### PR TITLE
configcommand: change key checking logic

### DIFF
--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -153,13 +153,13 @@ func (c *configCommand) handleZeroArgs() error {
 // handleOneArg handles the case where there is one positional arg.
 func (c *configCommand) handleOneArg(arg string) error {
 	// We may have a single config.yaml file
+	// If we are not setting a value, then we are retrieving one so we need to
+	// make sure that we are not resetting because it is not valid to get and
+	// reset simultaneously.
 	_, err := os.Stat(arg)
 	if err == nil || strings.Contains(arg, "=") {
 		return c.parseSetKeys([]string{arg})
 	}
-	// If we are not setting a value, then we are retrieving one so we need to
-	// make sure that we are not resetting because it is not valid to get and
-	// reset simultaneously.
 	if len(c.reset) > 0 {
 		return errors.New("cannot set and retrieve model values simultaneously")
 	}
@@ -301,22 +301,50 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 // get writes the value of a single key or the full output for the model to the cmd.Context.
 func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) error {
 	if len(c.keys) == 1 && certBytes != nil {
-		ctx.Stdout.Write(certBytes)
+		_, _ = ctx.Stdout.Write(certBytes)
 		return nil
 	}
-	attrs, err := client.ModelGetWithMetadata()
+	attrs, err := c.getSkimmedModel(client)
 	if err != nil {
 		return err
 	}
+	attrs, err, finished := c.handleIsKeyOfModel(attrs, ctx)
+	if err != nil {
+		return err
+	} else if attrs != nil && finished {
+		return c.out.Write(ctx, attrs)
+	} else if len(c.keys) > 0 && !finished {
+		if isFileLike(c.keys[0]) {
+			return errors.Errorf("value: %q seems to be a file but not found", c.keys[0])
+		} else {
+			return errors.Errorf("value: %q seems to be neither a file nor a key of the currently targeted model: %q", c.keys[0], attrs["name"])
+		}
+	}
+	return nil
+}
 
+func (c *configCommand) getSkimmedModel(client configCommandAPI) (config.ConfigValues, error) {
+	attrs, err := client.ModelGetWithMetadata()
+	if err != nil {
+		return nil, err
+	}
 	for attrName := range attrs {
-		// We don't want model attributes included, these are available
-		// via show-model.
+		// We don't want model attributes included, these are available via show-model.
 		if c.isModelAttribute(attrName) {
 			delete(attrs, attrName)
 		}
 	}
+	return attrs, nil
+}
 
+func isFileLike(fileLike string) bool {
+	if strings.HasSuffix(fileLike, ".yaml") || strings.HasSuffix(fileLike, ".json") {
+		return true
+	}
+	return false
+}
+
+func (c *configCommand) handleIsKeyOfModel(attrs config.ConfigValues, ctx *cmd.Context) (config.ConfigValues, error, bool) {
 	if len(c.keys) == 1 {
 		key := c.keys[0]
 		if value, found := attrs[key]; found {
@@ -324,20 +352,12 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 				// The user has not specified that they want
 				// YAML or JSON formatting, so we print out
 				// the value unadorned.
-				return c.out.WriteFormatter(
-					ctx,
-					cmd.FormatSmart,
-					value.Value,
-				)
-			}
-			attrs = config.ConfigValues{
-				key: config.ConfigValue{
-					Source: value.Source,
-					Value:  value.Value,
-				},
+				return nil, c.out.WriteFormatter(ctx, cmd.FormatSmart, value.Value), true
+			} else {
+				return config.ConfigValues{key: config.ConfigValue{Source: value.Source, Value: value.Value}}, nil, true
 			}
 		} else {
-			return errors.Errorf("key %q not found in %q model.", key, attrs["name"])
+			return attrs, nil, false
 		}
 	} else {
 		// In tabular format, don't print "cloudinit-userdata" it can be very long,
@@ -347,10 +367,10 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 				value.Value = "<value set, see juju model-config cloudinit-userdata>"
 				attrs["cloudinit-userdata"] = value
 			}
+			return attrs, nil, true
 		}
 	}
-
-	return c.out.Write(ctx, attrs)
+	return attrs, nil, true
 }
 
 // verifyKnownKeys is a helper to validate the keys we are operating with
@@ -363,7 +383,7 @@ func (c *configCommand) verifyKnownKeys(client configCommandAPI, keys []string) 
 
 	allKeys := keys[:]
 	for _, key := range allKeys {
-		// check if the key exists in the known config
+		// isKeyOfModelConfig if the key exists in the known config
 		// and warn the user if the key is not defined
 		if _, exists := known[key]; !exists {
 			logger.Warningf(

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -106,7 +106,15 @@ func (s *ConfigCommandSuite) TestSingleValueOutputFile(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {
 	context, err := s.run(c, "unknown")
-	c.Assert(err, gc.ErrorMatches, `key "unknown" not found in {<nil> ""} model.`)
+	c.Assert(err, gc.ErrorMatches, `value: "unknown" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, "")
+}
+
+func (s *ConfigCommandSuite) TestGetProperErrorMessageOnPaths(c *gc.C) {
+	context, err := s.run(c, "bundles/k8s-model-config.yaml")
+	c.Assert(err, gc.ErrorMatches, `value: "bundles/k8s-model-config.yaml" seems to be a file but not found`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")


### PR DESCRIPTION
## Description of change
Rewrite error-handling message, as the error message can be too cryptic.
As well as refactoring the methods.

Old check flow:
- is file?
- it is a key of the model -> weird error if neither

Current check flow:
- is file?
- is key of the model?
- is file like?

Wanted check flow:
- is key of model?
- is file like?
- is file?

Problem is that with the current code the order actually matters. To achieve the wanted check flow more changes has to be done.
## QA steps
- added an additional unit test
old output:
```
[14:08:16] nam:juju git:(ede251dd0a) $ juju model-config bundlesk8s-dsds       
ERROR key "bundlesk8s-dsds" not found in {<nil> ""} model.
[14:08:28] nam:juju git:(ede251dd0a) $ juju model-config bundlesk8s-dsds.json
ERROR key "bundlesk8s-dsds.json" not found in {<nil> ""} model.
[14:08:33] nam:juju git:(ede251dd0a) $ juju model-config bundlesk8s-dsds.yaml  
ERROR key "bundlesk8s-dsds.yaml" not found in {<nil> ""} model.

```

new output:
```
[14:06:53] nam:juju git:(model-config-msg) $ juju model-config bundlesk8s-dsds       
ERROR value: "bundlesk8s-dsds" seems to be neither a file nor a key of the currently targeted model: {<nil> ""}
[14:06:56] nam:juju git:(model-config-msg) $ juju model-config bundlesk8s-dsds.yaml
ERROR value: "bundlesk8s-dsds.yaml" seems to be a file but not found
[14:07:03] nam:juju git:(model-config-msg) $ juju model-config bundlesk8s-dsds.json
ERROR value: "bundlesk8s-dsds.json" seems to be a file but not found
```
## Documentation changes

nothing should change
## Bug reference
https://bugs.launchpad.net/juju/+bug/1843456