### PR TITLE
configcommand: change key checking logic

### DIFF
--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -301,22 +301,50 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 // get writes the value of a single key or the full output for the model to the cmd.Context.
 func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) error {
 	if len(c.keys) == 1 && certBytes != nil {
-		ctx.Stdout.Write(certBytes)
+		_, _ = ctx.Stdout.Write(certBytes)
 		return nil
 	}
-	attrs, err := client.ModelGetWithMetadata()
+	attrs, err := c.getSkimmedModel(client)
 	if err != nil {
 		return err
 	}
+	attrs, err, finished := c.handleIsKeyOfModel(attrs, ctx)
+	if err != nil {
+		return err
+	} else if attrs != nil && finished {
+		return c.out.Write(ctx, attrs)
+	} else if len(c.keys) > 0 && !finished {
+		if isFileLike(c.keys[0]) {
+			return errors.Errorf("value: %q seems to be a file but not found", c.keys[0])
+		} else {
+			return errors.Errorf("value: %q seems to be neither a file nor a key of the currently targeted model: %q", c.keys[0], attrs["name"])
+		}
+	}
+	return nil
+}
 
+func (c *configCommand) getSkimmedModel(client configCommandAPI) (config.ConfigValues, error) {
+	attrs, err := client.ModelGetWithMetadata()
+	if err != nil {
+		return nil, err
+	}
 	for attrName := range attrs {
-		// We don't want model attributes included, these are available
-		// via show-model.
+		// We don't want model attributes included, these are available via show-model.
 		if c.isModelAttribute(attrName) {
 			delete(attrs, attrName)
 		}
 	}
+	return attrs, nil
+}
 
+func isFileLike(fileLike string) bool {
+	if strings.HasSuffix(fileLike, ".yaml") || strings.HasSuffix(fileLike, ".json") {
+		return true
+	}
+	return false
+}
+
+func (c *configCommand) handleIsKeyOfModel(attrs config.ConfigValues, ctx *cmd.Context) (config.ConfigValues, error, bool) {
 	if len(c.keys) == 1 {
 		key := c.keys[0]
 		if value, found := attrs[key]; found {
@@ -324,20 +352,12 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 				// The user has not specified that they want
 				// YAML or JSON formatting, so we print out
 				// the value unadorned.
-				return c.out.WriteFormatter(
-					ctx,
-					cmd.FormatSmart,
-					value.Value,
-				)
-			}
-			attrs = config.ConfigValues{
-				key: config.ConfigValue{
-					Source: value.Source,
-					Value:  value.Value,
-				},
+				return nil, c.out.WriteFormatter(ctx, cmd.FormatSmart, value.Value), true
+			} else {
+				return config.ConfigValues{key: config.ConfigValue{Source: value.Source, Value: value.Value}}, nil, true
 			}
 		} else {
-			return errors.Errorf("key %q not found in %q model.", key, attrs["name"])
+			return attrs, nil, false
 		}
 	} else {
 		// In tabular format, don't print "cloudinit-userdata" it can be very long,
@@ -347,10 +367,10 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 				value.Value = "<value set, see juju model-config cloudinit-userdata>"
 				attrs["cloudinit-userdata"] = value
 			}
+			return attrs, nil, true
 		}
 	}
-
-	return c.out.Write(ctx, attrs)
+	return attrs, nil, true
 }
 
 // verifyKnownKeys is a helper to validate the keys we are operating with

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -106,7 +106,15 @@ func (s *ConfigCommandSuite) TestSingleValueOutputFile(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {
 	context, err := s.run(c, "unknown")
-	c.Assert(err, gc.ErrorMatches, `key "unknown" not found in {<nil> ""} model.`)
+	c.Assert(err, gc.ErrorMatches, `value: "unknown" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, "")
+}
+
+func (s *ConfigCommandSuite) TestGetProperErrorMessageOnPaths(c *gc.C) {
+	context, err := s.run(c, "bundles/k8s-model-config.yaml")
+	c.Assert(err, gc.ErrorMatches, `value: "bundles/k8s-model-config.yaml" seems to be a file but not found`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -106,7 +106,7 @@ func (s *ConfigCommandSuite) TestSingleValueOutputFile(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {
 	context, err := s.run(c, "unknown")
-	c.Assert(err, gc.ErrorMatches, `value: "unknown" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+	c.Assert(err, gc.ErrorMatches, `"unknown" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")
@@ -114,7 +114,39 @@ func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestGetProperErrorMessageOnPaths(c *gc.C) {
 	context, err := s.run(c, "bundles/k8s-model-config.yaml")
-	c.Assert(err, gc.ErrorMatches, `value: "bundles/k8s-model-config.yaml" seems to be a file but not found`)
+	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config.yaml" seems to be a file but not found`)
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, "")
+}
+
+func (s *ConfigCommandSuite) TestGetFileLike(c *gc.C) {
+	context, err := s.run(c, "bundles/k8s-model-config.json")
+	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config.json" seems to be a file but not found`)
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, "")
+}
+
+func (s *ConfigCommandSuite) TestNotFileLike(c *gc.C) {
+	context, err := s.run(c, "bundles/k8s-model-config--json")
+	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config--json" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, "")
+}
+
+func (s *ConfigCommandSuite) TestNotFileLikeEndsWithDot(c *gc.C) {
+	context, err := s.run(c, "bundles/k8s-model-config.")
+	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config." seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+
+	output := cmdtesting.Stdout(context)
+	c.Assert(output, gc.Equals, "")
+}
+
+func (s *ConfigCommandSuite) TestNotFileLikeEndsTooLong(c *gc.C) {
+	context, err := s.run(c, "bundles/k8s-model-config.fksdkfsd")
+	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config.fksdkfsd" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")


### PR DESCRIPTION
## Description of change
Rewrite error-handling message, as the error message can be too cryptic.
As well as refactoring the methods.

Old check flow:
- is file?
- it is a key of the model -> weird error if neither

Current check flow:
- is file?
- is key of the model?
- is file like?

Wanted check flow:
- is key of model?
- is file like?
- is file?

Problem is that with the current code the order actually matters. To achieve the wanted check flow more changes has to be done.
## QA steps
- added an additional unit test
old output:
```
[14:08:16] nam:juju git:(ede251dd0a) $ juju model-config bundlesk8s-dsds       
ERROR key "bundlesk8s-dsds" not found in {<nil> ""} model.
[14:08:28] nam:juju git:(ede251dd0a) $ juju model-config bundlesk8s-dsds.json
ERROR key "bundlesk8s-dsds.json" not found in {<nil> ""} model.
[14:08:33] nam:juju git:(ede251dd0a) $ juju model-config bundlesk8s-dsds.yaml  
ERROR key "bundlesk8s-dsds.yaml" not found in {<nil> ""} model.

```

new output:
```
[14:06:53] nam:juju git:(model-config-msg) $ juju model-config bundlesk8s-dsds       
ERROR value: "bundlesk8s-dsds" seems to be neither a file nor a key of the currently targeted model: {<nil> ""}
[14:06:56] nam:juju git:(model-config-msg) $ juju model-config bundlesk8s-dsds.yaml
ERROR value: "bundlesk8s-dsds.yaml" seems to be a file but not found
[14:07:03] nam:juju git:(model-config-msg) $ juju model-config bundlesk8s-dsds.json
ERROR value: "bundlesk8s-dsds.json" seems to be a file but not found
```
## Documentation changes

nothing should change
## Bug reference
https://bugs.launchpad.net/juju/+bug/1843456