### PR TITLE
GitHub actions - Client side testing with mongo

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -8,7 +8,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        # macOS-latest is disabled because there is an issue of the tests timing
+        # out. No effort has been done to work out why they currently timeout
+        # on macOS, but we should investigate that to improve our coverage on
+        # other clients.
+        # To turn on macOS, just update the os to include it.
+        # os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
 
     steps:
 

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -3,8 +3,12 @@ on: [push, pull_request]
 jobs:
 
   test-client-ubuntu:
-    name: "Client Tests: Ubuntu"
-    runs-on: ubuntu-latest
+    name: "Client Tests"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
 
@@ -22,20 +26,34 @@ jobs:
         echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
       shell: bash
 
-    - name: Check out code
+    - name: Checkout
       uses: actions/checkout@v1
       with:
         path: src/github.com/juju/juju
 
-    - name: Install mongo dependencies
+    - name: "Install Mongo Dependencies: ubuntu-latest"
+      if: (matrix.os == 'ubuntu-latest')
       run: |
         make install-mongo-dependencies
 
-    - name: Install vendor dependencies
+    - name: "Install Mongo Dependencies: macOS-latest"
+      if: (matrix.os == 'macOS-latest')
+      run: |
+        curl -o mongodb-3.6.14.tgz https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.14.tgz
+        tar xzvf mongodb-3.6.14.tgz
+        sudo mkdir -p /usr/local/mongodb
+        sudo mv mongodb-osx-x86_64-3.6.14/bin/* /usr/local/mongodb
+        sudo mkdir -p /user/local/bin
+        sudo ln -s /usr/local/mongodb/mongod /usr/local/bin/mongod
+      shell: bash
+
+    - name: Install Vendor Dependencies
       run: |
         make dep
       shell: bash
 
     - name: Test client
       run: |
-        go test -v ./cmd/... -check.v
+        # Jenkins can perform the full jujud testing.
+        go test -v ./cmd/juju/... -check.v
+        go test -v ./cmd/plugins/... -check.v

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,0 +1,41 @@
+name: "Client Tests"
+on: [push, pull_request]
+jobs:
+
+  test-client-ubuntu:
+    name: "Client Tests: Ubuntu"
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Set GOPATH
+      # temporary fix
+      # see https://github.com/actions/setup-go/issues/14
+      run: |
+        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
+        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+      shell: bash
+
+    - name: Check out code
+      uses: actions/checkout@v1
+      with:
+        path: src/github.com/juju/juju
+
+    - name: Install mongo dependencies
+      run: |
+        make install-mongo-dependencies
+
+    - name: Install vendor dependencies
+      run: |
+        make dep
+      shell: bash
+
+    - name: Test client
+      run: |
+        go test -v ./cmd/... -check.v

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,9 +1,9 @@
-name: Go
-on: [push]
+name: "Static Analysis"
+on: [push, pull_request]
 jobs:
 
   lint:
-    name: Static Analysis
+    name: Lint
     runs-on: ubuntu-latest
     steps:
 
@@ -85,3 +85,4 @@ jobs:
       run: |
         STATIC_ANALYSIS_JOB=test_schema make static-analysis
       shell: bash
+

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,17 +21,17 @@ jobs:
         echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
       shell: bash
 
-    - name: Check out code
+    - name: Checkout
       uses: actions/checkout@v1
       with:
         path: src/github.com/juju/juju
 
-    - name: Install vendor dependencies
+    - name: Install Vendor dependencies
       run: |
         make dep
       shell: bash
 
-    - name: Install dependencies
+    - name: Install Dependencies
       run: |
         go get -u github.com/client9/misspell/cmd/misspell
         go get -u github.com/tsenart/deadcode
@@ -71,12 +71,12 @@ jobs:
         echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
       shell: bash
 
-    - name: Check out code
+    - name: Checkout
       uses: actions/checkout@v1
       with:
         path: src/github.com/juju/juju
 
-    - name: Install vendor dependencies
+    - name: Install Vendor Dependencies
       run: |
         make dep
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,11 @@ endif
 
 # Install packages required to develop Juju and run tests. The stable
 # PPA includes the required mongodb-server binaries.
-install-dependencies:
+install-snap-dependencies:
 	@echo Installing go-1.12 snap
 	@sudo snap install go --channel=1.12/stable --classic
+
+install-mongo-dependencies:
 	@echo Adding juju PPA for mongodb
 	@sudo apt-add-repository --yes ppa:juju/stable
 	@sudo apt-get update
@@ -157,6 +159,9 @@ install-dependencies:
 	@sudo apt-get --yes install  \
 	$(strip $(DEPENDENCIES)) \
 	$(shell apt-cache madison mongodb-server-core juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
+
+install-dependencies: install-snap-dependencies install-mongo-dependencies
+	@echo "Installing dependencies"
 
 # Install bash_completion
 install-etc:


### PR DESCRIPTION
## Description of change

The following commits add ubuntu and macOS client tests to the github
actions setup. Unfortunately windows isn't as simple as I first thought, so
some serious thinking about how to do it efficiently is going to be needed.

I've split the tests up so we have pre-checking aka "static analysis", this
should be fine to run concurrently and gives you need feedback.

The other file `client-tests.yml` will check if the clients have been broken
at any point. We could and probably should prevent concurrent running
of these and allow github to cancel these if there is a new PR. I'll look into
that next week.
