### PR TITLE
Update some model workers to use the logging context.

### DIFF
--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -122,6 +122,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
 			AgentName:          agentName,
 			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             loggo.GetLogger("juju.worker.apiconfigwatcher"),
 		}),
 
 		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -415,6 +415,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
 			AgentName:          agentName,
 			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             loggo.GetLogger("juju.worker.apiconfigwatcher"),
 		}),
 
 		// The certificate-watcher manifold monitors the API server

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -263,7 +263,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
 			APICallerName: apiCallerName,
-			ClockName:     clockName,
+			Clock:         config.Clock,
+			Logger:        config.LoggingContext.GetLogger("juju.worker.cleaner"),
 		})),
 		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
 			APICallerName: apiCallerName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -138,6 +138,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
 			AgentName:          agentName,
 			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.apiconfigwatcher"),
 		}),
 		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
 			AgentName:     agentName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -267,17 +267,19 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
 			APICallerName: apiCallerName,
-			ClockName:     clockName,
+			Clock:         config.Clock,
 			NewWorker:     statushistorypruner.New,
 			NewFacade:     statushistorypruner.NewFacade,
 			PruneInterval: config.StatusHistoryPrunerInterval,
+			Logger:        config.LoggingContext.GetLogger("juju.worker.pruner.statushistory"),
 		})),
 		actionPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
 			APICallerName: apiCallerName,
-			ClockName:     clockName,
+			Clock:         config.Clock,
 			NewWorker:     actionpruner.New,
 			NewFacade:     actionpruner.NewFacade,
 			PruneInterval: config.ActionPrunerInterval,
+			Logger:        config.LoggingContext.GetLogger("juju.worker.pruner.action"),
 		})),
 		logForwarderName: ifNotDead(logforwarder.Manifold(logforwarder.ManifoldConfig{
 			APICallerName: apiCallerName,

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -202,7 +202,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"action-pruner": {
 		"agent",
 		"api-caller",
-		"clock",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
@@ -355,7 +354,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"status-history-pruner": {
 		"agent",
 		"api-caller",
-		"clock",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
@@ -381,7 +379,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	"action-pruner": {
 		"agent",
 		"api-caller",
-		"clock",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
@@ -588,7 +585,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	"status-history-pruner": {
 		"agent",
 		"api-caller",
-		"clock",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -343,7 +343,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"state-cleaner": {
 		"agent",
 		"api-caller",
-		"clock",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
@@ -574,7 +573,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	"state-cleaner": {
 		"agent",
 		"api-caller",
-		"clock",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -138,6 +138,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
 			AgentName:          agentName,
 			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             loggo.GetLogger("juju.worker.apiconfigwatcher"),
 		}),
 
 		// The api caller is a thin concurrent wrapper around a connection

--- a/worker/actionpruner/worker.go
+++ b/worker/actionpruner/worker.go
@@ -16,6 +16,10 @@ import (
 	"github.com/juju/juju/worker/pruner"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one through as config to the worker.
+var logger interface{}
+
 // Worker prunes status history records at regular intervals.
 type Worker struct {
 	pruner.PrunerWorker

--- a/worker/apiconfigwatcher/manifold_test.go
+++ b/worker/apiconfigwatcher/manifold_test.go
@@ -6,6 +6,7 @@ package apiconfigwatcher_test
 import (
 	"sync"
 
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/voyeur"
@@ -41,6 +42,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.manifold = apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
 		AgentName:          "agent",
 		AgentConfigChanged: s.agentConfigChanged,
+		Logger:             loggo.GetLogger("test"),
 	})
 }
 

--- a/worker/pruner/config.go
+++ b/worker/pruner/config.go
@@ -10,11 +10,17 @@ import (
 	"github.com/juju/errors"
 )
 
+// Logger defines the methods used by the pruner worker for logging.
+type Logger interface {
+	Infof(string, ...interface{})
+}
+
 // Config holds all necessary attributes to start a pruner worker.
 type Config struct {
 	Facade        Facade
 	PruneInterval time.Duration
 	Clock         clock.Clock
+	Logger        Logger
 }
 
 // Validate will err unless basic requirements for a valid
@@ -25,6 +31,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Clock == nil {
 		return errors.New("missing Clock")
+	}
+	if c.Logger == nil {
+		return errors.New("missing Logger")
 	}
 	return nil
 }

--- a/worker/pruner/manifold_test.go
+++ b/worker/pruner/manifold_test.go
@@ -4,7 +4,9 @@
 package pruner_test
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -35,9 +37,10 @@ func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
 func (s *ManifoldConfigSuite) validConfig() pruner.ManifoldConfig {
 	return pruner.ManifoldConfig{
 		APICallerName: "api-caller",
-		ClockName:     "clock",
+		Clock:         clock.WallClock,
 		NewWorker:     func(pruner.Config) (worker.Worker, error) { return nil, nil },
 		NewFacade:     func(caller base.APICaller) pruner.Facade { return nil },
+		Logger:        loggo.GetLogger("test"),
 	}
 }
 
@@ -50,9 +53,9 @@ func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
 	s.checkNotValid(c, "empty APICallerName not valid")
 }
 
-func (s *ManifoldConfigSuite) TestMissingClockName(c *gc.C) {
-	s.config.ClockName = ""
-	s.checkNotValid(c, "empty ClockName not valid")
+func (s *ManifoldConfigSuite) TestMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	s.checkNotValid(c, "nil Clock not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
@@ -63,6 +66,11 @@ func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingNewFacade(c *gc.C) {
 	s.config.NewFacade = nil
 	s.checkNotValid(c, "nil NewFacade not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	s.checkNotValid(c, "nil Logger not valid")
 }
 
 func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {

--- a/worker/pruner/worker_test.go
+++ b/worker/pruner/worker_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/worker.v1"
@@ -40,6 +41,7 @@ func (s *PrunerSuite) setupPruner(c *gc.C) (*fakeFacade, *testclock.Clock) {
 		Facade:        facade,
 		PruneInterval: coretesting.ShortWait,
 		Clock:         testClock,
+		Logger:        loggo.GetLogger("test"),
 	}
 
 	// an example pruner
@@ -54,7 +56,7 @@ func (s *PrunerSuite) setupPruner(c *gc.C) (*fakeFacade, *testclock.Clock) {
 	select {
 	case <-facade.gotConfig:
 	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out waiting for model configr")
+		c.Fatal("timed out waiting for model config")
 	}
 
 	return facade, testClock

--- a/worker/statushistorypruner/worker.go
+++ b/worker/statushistorypruner/worker.go
@@ -16,6 +16,10 @@ import (
 	"github.com/juju/juju/worker/pruner"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one through as config to the worker.
+var logger interface{}
+
 // Worker prunes status history records at regular intervals.
 type Worker struct {
 	pruner.PrunerWorker


### PR DESCRIPTION
Now we have a logging context for the model workers, the worker implementations need to be updated to accept a logger as part of the manifold config. This branch continues this work with three workers fixed.

## QA steps

* The logging for the workers now appears in the model logs, not the controller logs.
