### PR TITLE
Remove cloud-utils from cloud-init

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -238,39 +238,6 @@ var ctests = []struct {
 		cfg.AddPackage("ubuntu")
 	},
 }, {
-	"Packages on precise, needing cloud-tools",
-	map[string]interface{}{"packages": []string{
-		// Regular packages (not needing the cloud-tools archive)
-		"juju",
-		"curl",
-		// The following need to be among the list of cloud-tools
-		// packages (see cloudArchivePackagesUbuntu in juju/utils
-		// repo).
-		"--target-release", "precise-updates/cloud-tools", "cloud-utils",
-		// Other regular packages.
-		"ubuntu",
-	}},
-	func(cfg cloudinit.CloudConfig) {
-		cfg.AddPackage("juju")
-		cfg.AddPackage("curl")
-		// cloud-tools packages need to appear in the list of packages
-		// after the "--target-release" and
-		// "precise-updates/cloud-tools" lines to work around the
-		// broken 0.6.3 cloud-init on precise. cloud-init 0.6.3
-		// concatenates all space-separated arguments for each entry
-		// in the packages list, and then escapes the result in single
-		// quotes, which in turn leads to incorrectly rendered apt-get
-		// command (e.g. instead of "apt-get install --target-release
-		// foo/bar package" 0.6.3 will try to execute "apt-get install
-		// '--target-release foo/bar package'".). See bug #1424777 for
-		// more info.
-		cfg.AddPackage("--target-release")
-		cfg.AddPackage("precise-updates/cloud-tools")
-		cfg.AddPackage("cloud-utils")
-
-		cfg.AddPackage("ubuntu")
-	},
-}, {
 	"BootCmd",
 	map[string]interface{}{"bootcmd": []string{
 		"ls > /dev",

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -272,7 +272,6 @@ func (cfg *ubuntuCloudConfig) addRequiredPackages() {
 		// Don't install bridge-utils in cloud-init;
 		// leave it to the networker worker.
 		"bridge-utils",
-		"cloud-utils",
 		"tmux",
 		// TODO(wpk) 2017-07-23 maybe we should do it in fanconfigurer?
 		"ubuntu-fan",


### PR DESCRIPTION
## Description of change

The following removes cloud-utils from cloud-init, as we no longer
need it because we no longer cache the LXD images directly and instead
use LXD itself to do that for us.

Also considering we're not supporting precise in 2.7, it should also
be safe to remove.

## QA steps

```sh
juju bootstrap lxd test --bootstrap-series=xenial
juju bootstrap lxd test --bootstrap-series=bionic
juju bootstrap lxd test --bootstrap-series=eoan
```

Additionally bootstrap to aws and then deploy with `--to` directive.

```sh
juju bootstrap aws/eu-west-2 test
juju deploy redis --to lxd:0
```
