### PR TITLE
Introspect controller on destroy

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -152,6 +152,14 @@ destroy_controller() {
         return
     fi
 
+    echo "====> Introspection gathering"
+
+    set +e
+    introspect_controller "${name}" || true
+    set_verbosity
+
+    echo "====> Introspection gathered"
+
     output="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ($(green "${name}"))"
@@ -188,4 +196,13 @@ wait_for() {
         juju status --relations
         sleep 5
     done
+}
+
+introspect_controller() {
+    local name
+
+    name=${1}
+
+    juju ssh -m controller 0 "source /etc/profile.d/juju-introspection.sh && juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_report.txt"
+    juju ssh -m controller 0 "source /etc/profile.d/juju-introspection.sh && juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -203,6 +203,6 @@ introspect_controller() {
 
     name=${1}
 
-    juju ssh -m controller 0 "source /etc/profile.d/juju-introspection.sh && juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_report.txt"
-    juju ssh -m controller 0 "source /etc/profile.d/juju-introspection.sh && juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"
+    juju ssh -m controller 0 bash -lic "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_report.txt"
+    juju ssh -m controller 0 bash -lic "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"
 }


### PR DESCRIPTION
## Description of change

The following attempts to collate as much information about a controller
when destroying it, so that we can better understand how the controller
behaves when under testing.

To run you need to have specified an artifact otherwise the artifact is
cleaned up. You can do this with the following setup:

     ./main.sh -a output.tar.gz smoke

All files will be namespaced per controller.

## QA steps

```sh
./main.sh -a output.tar.gz smoke
```