### PR TITLE
Fix the recording of api host ports in controller collection.

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -395,22 +395,24 @@ func networkAddresses(addrs []address) []network.Address {
 // stuff at some point. We want to use juju-specific network names
 // that point to existing documents in the networks collection.
 type hostPort struct {
-	Value       string `bson:"value"`
-	AddressType string `bson:"addresstype"`
-	Scope       string `bson:"networkscope,omitempty"`
-	Port        int    `bson:"port"`
-	SpaceName   string `bson:"spacename,omitempty"`
+	Value           string `bson:"value"`
+	AddressType     string `bson:"addresstype"`
+	Scope           string `bson:"networkscope,omitempty"`
+	Port            int    `bson:"port"`
+	SpaceName       string `bson:"spacename,omitempty"`
+	SpaceProviderId string `bson:"spaceprovider,omitempty"`
 }
 
 // fromNetworkHostPort is a convenience helper to create a state type
 // out of the network type, here for HostPort.
 func fromNetworkHostPort(netHostPort network.HostPort) hostPort {
 	return hostPort{
-		Value:       netHostPort.Value,
-		AddressType: string(netHostPort.Type),
-		Scope:       string(netHostPort.Scope),
-		Port:        netHostPort.Port,
-		SpaceName:   string(netHostPort.SpaceName),
+		Value:           netHostPort.Value,
+		AddressType:     string(netHostPort.Type),
+		Scope:           string(netHostPort.Scope),
+		Port:            netHostPort.Port,
+		SpaceName:       string(netHostPort.SpaceName),
+		SpaceProviderId: string(netHostPort.SpaceProviderId),
 	}
 }
 
@@ -419,10 +421,11 @@ func fromNetworkHostPort(netHostPort network.HostPort) hostPort {
 func (hp *hostPort) networkHostPort() network.HostPort {
 	return network.HostPort{
 		Address: network.Address{
-			Value:     hp.Value,
-			Type:      network.AddressType(hp.AddressType),
-			Scope:     network.Scope(hp.Scope),
-			SpaceName: network.SpaceName(hp.SpaceName),
+			Value:           hp.Value,
+			Type:            network.AddressType(hp.AddressType),
+			Scope:           network.Scope(hp.Scope),
+			SpaceName:       network.SpaceName(hp.SpaceName),
+			SpaceProviderId: network.Id(hp.SpaceProviderId),
 		},
 		Port: hp.Port,
 	}

--- a/state/address_internal_test.go
+++ b/state/address_internal_test.go
@@ -10,6 +10,101 @@ import (
 	"github.com/juju/juju/network"
 )
 
+type GetOpsForHostPortsSuite struct {
+	internalStateSuite
+}
+
+var _ = gc.Suite(&GetOpsForHostPortsSuite{})
+
+func (s *GetOpsForHostPortsSuite) TestGetOpsForHostPortsChangeWithSpaces(c *gc.C) {
+	addresses := map[string][]network.HostPort{
+		"0": {
+			{
+				Address: network.Address{
+					Value:           "10.144.9.113",
+					Type:            "ipv4",
+					Scope:           "local-cloud",
+					SpaceName:       "default",
+					SpaceProviderId: "foo",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		},
+		"1": {
+			{
+				Address: network.Address{
+					Value:           "10.144.9.62",
+					Type:            "ipv4",
+					Scope:           "local-cloud",
+					SpaceName:       "default",
+					SpaceProviderId: "foo",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		},
+		"2": {
+			{
+				Address: network.Address{
+					Value:           "10.144.9.56",
+					Type:            "ipv4",
+					Scope:           "local-cloud",
+					SpaceName:       "default",
+					SpaceProviderId: "foo",
+				},
+				Port: 17070,
+			}, {
+				Address: network.Address{
+					Value: "127.0.0.1",
+					Type:  "ipv4",
+					Scope: "local-machine",
+				},
+				Port: 17070,
+			},
+		},
+	}
+	// Iterate the map each time to generate the slice with the machines
+	// in a different order.
+	addressSlice := func() [][]network.HostPort {
+		var result [][]network.HostPort
+		for _, value := range addresses {
+			result = append(result, value)
+		}
+		return result
+	}
+
+	controllers, closer := s.state.db().GetCollection(controllersC)
+	defer closer()
+
+	ops, err := s.state.getOpsForHostPortsChange(controllers, apiHostPortsKey, addressSlice())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(ops), jc.GreaterThan, 0)
+	// Run the ops.
+	err = s.state.db().RunTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now iterate over the map a few times to get different ordering, and assert the
+	// ops to update the host ports is empty.
+	for i := 0; i < 5; i++ {
+		ops, err := s.state.getOpsForHostPortsChange(controllers, apiHostPortsKey, addressSlice())
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ops, gc.HasLen, 0)
+	}
+}
+
 type AddressEqualitySuite struct{}
 
 var _ = gc.Suite(&AddressEqualitySuite{})


### PR DESCRIPTION
For any provider that understands spaces, and records spaces with the network addresses, the recording of the controller api host ports became broken in 2.6.2 with the addition of the space provider id to the addresses stored with the machines. Since the space provider id wasn't stored with the api host ports, the sorting method that is used for equality never had items match as it uses the stringified network host port, which has ip@space if no id is present and id@(space:id) if it is.

This means that every minute this gets updated by the peer grouper (because of a separate bug). The peergrouper should only be telling the DB when it changes, but the peergrouper is iterating over a dict in random order every minute, so for a single node, nothing changes, but in HA, the machines are likely to have a different order every minute causing the call to the state package to record them. Since the arrays never match, they are recorded every minute.

When this document is updated it triggers updates for the ProxyUpdater to update as the controller host addresses are added to the noproxy values.

On a large deployment this causes every agent to call back every minute, and this puts a lot of load on the controllers, which may also be why we are seeing mongo elections mid openstack deploy on maas. 

## QA steps

* bootstrap into guimaas with 2.6.8
* enable-ha
* juju model-config -m controller logging-config="juju=info;juju.state.txn=trace"

Observe that the apiHostPorts is being updated every minute

* upgrade the controller with the built agent

Observe the host ports are no longer being updated every minute.

