### PR TITLE
Use numeric action ids; use task instead of operation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1570,11 +1570,11 @@
   revision = "e057c73bd1beb18e9634151a2410c422bd2057f2"
 
 [[projects]]
-  digest = "1:995f0b842e8435ce563c0059d1fb5032ced36c704a45a331a27f42b54a279592"
+  digest = "1:f30cf5494ed1ee42a972a17d1b66e3831a7f5dff9fe403ab87ad3fdfa35c3767"
   name = "gopkg.in/juju/names.v3"
   packages = ["."]
   pruneopts = ""
-  revision = "49183320c914a3413d7c36bfe81906ff2a1f62c0"
+  revision = "8d2f241f8a5d0e3a16baf52a5f31be80636ee12d"
 
 [[projects]]
   digest = "1:5081ff05b4471731df7fa7457083397c2663791cd5809858a899306cdfe29b63"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -158,7 +158,7 @@
   name = "gopkg.in/juju/environschema.v1"
 
 [[constraint]]
-  revision = "49183320c914a3413d7c36bfe81906ff2a1f62c0"
+  revision = "8d2f241f8a5d0e3a16baf52a5f31be80636ee12d"
   name = "gopkg.in/juju/names.v3"
 
 [[constraint]]

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -160,6 +160,7 @@ func (a *ActionAPI) Actions(arg params.Entities) (params.ActionResults, error) {
 
 // FindActionTagsByPrefix takes a list of string prefixes and finds
 // corresponding ActionTags that match that prefix.
+// TODO(juju3) - rename API method since we only need prefix matching for UUIDs
 func (a *ActionAPI) FindActionTagsByPrefix(arg params.FindTags) (params.FindTagsResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.FindTagsResults{}, errors.Trace(err)
@@ -171,7 +172,7 @@ func (a *ActionAPI) FindActionTagsByPrefix(arg params.FindTags) (params.FindTags
 		if err != nil {
 			return params.FindTagsResults{}, errors.Trace(err)
 		}
-		found := m.FindActionTagsByPrefix(prefix)
+		found := m.FindActionTagsById(prefix)
 		matches := make([]params.Entity, len(found))
 		for i, tag := range found {
 			matches[i] = params.Entity{Tag: tag.String()}

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -146,7 +146,7 @@ func (s *actionSuite) TestFindActionTagsByPrefix(c *gc.C) {
 
 	actionTag, err := names.ParseActionTag(r.Results[0].Action.Tag)
 	c.Assert(err, gc.Equals, nil)
-	prefix := actionTag.Id()[:7]
+	prefix := actionTag.Id()
 	tags, err := s.action.FindActionTagsByPrefix(params.FindTags{Prefixes: []string{prefix}})
 	c.Assert(err, gc.Equals, nil)
 

--- a/cmd/juju/action/call.go
+++ b/cmd/juju/action/call.go
@@ -93,7 +93,7 @@ Examples:
     juju call mysql/3 backup --format yaml
     juju call mysql/3 backup
     juju call mysql/leader backup
-    juju show-operation <ID>
+    juju show-task <ID>
     juju call mysql/3 backup --params parameters.yml
     juju call mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
     juju call mysql/3 backup --params p.yml file.kind=xz file.quality=high
@@ -268,7 +268,7 @@ func (c *callCommand) Run(ctx *cmd.Context) error {
 		}
 
 		if !c.background {
-			ctx.Infof("Running Operation %s", actionTag.Id())
+			ctx.Infof("Running Task %s", actionTag.Id())
 			continue
 		}
 		unitTag, err := names.ParseUnitTag(result.Action.Receiver)
@@ -281,12 +281,12 @@ func (c *callCommand) Run(ctx *cmd.Context) error {
 	}
 	if c.background {
 		if len(results.Results) == 1 {
-			ctx.Infof("Scheduled Operation %s", actionTag.Id())
-			ctx.Infof("Check status with 'juju show-operation %s'", actionTag.Id())
+			ctx.Infof("Scheduled Task %s", actionTag.Id())
+			ctx.Infof("Check status with 'juju show-task %s'", actionTag.Id())
 		} else {
-			ctx.Infof("Scheduled Operations:")
+			ctx.Infof("Scheduled Tasks:")
 			cmd.FormatYaml(ctx.Stderr, info)
-			ctx.Infof("Check status with 'juju show-operation <id>'")
+			ctx.Infof("Check status with 'juju show-task <id>'")
 		}
 		return nil
 	}
@@ -376,7 +376,7 @@ func printPlainOutput(writer io.Writer, value interface{}) error {
 				actionOutput[k] = fmt.Sprintf("%v", resultDataCopy)
 			}
 		} else {
-			actionOutput[k] = fmt.Sprintf("Operation %v complete\n", resultMetadata["id"])
+			actionOutput[k] = fmt.Sprintf("Task %v complete\n", resultMetadata["id"])
 		}
 		actionInfo[k] = map[string]interface{}{
 			"id":     resultMetadata["id"],

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -745,8 +745,8 @@ mysql/1:
 
 						// Make sure the CLI responded with the expected tag
 						c.Assert(outString, gc.Equals, fmt.Sprintf(`
-Scheduled Operation %s
-Check status with 'juju show-operation %s'`[1:],
+Scheduled Task %s
+Check status with 'juju show-task %s'`[1:],
 							expectedTag.Id(), expectedTag.Id()))
 					} else {
 						outputResult := ctx.Stdout.(*bytes.Buffer).Bytes()

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -66,9 +66,9 @@ func (c *showOutputCommand) Info() *cmd.Info {
 		Doc:     showOutputDoc,
 	})
 	if featureflag.Enabled(feature.JujuV3) {
-		info.Name = "show-operation"
-		info.Args = "<operation ID>"
-		info.Purpose = "Show results of an operation by ID."
+		info.Name = "show-task"
+		info.Args = "<task ID>"
+		info.Purpose = "Show results of a task by ID."
 	}
 	return info
 }
@@ -78,7 +78,7 @@ func (c *showOutputCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
 		if featureflag.Enabled(feature.JujuV3) {
-			return errors.New("no operation ID specified")
+			return errors.New("no task ID specified")
 		}
 		return errors.New("no action ID specified")
 	case 1:

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -44,7 +44,7 @@ func (s *ShowOutputSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d: it should %s: juju show-operation %s", i,
+			c.Logf("test %d: it should %s: juju show-task %s", i,
 				t.should, strings.Join(t.args, " "))
 			cmd, _ := action.NewShowOutputCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -630,7 +630,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"call", "show-operation",
+	"call", "show-task",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -282,7 +282,7 @@ func (s *ActionSuite) TestActionMessages(c *gc.C) {
 
 	// Cannot log messages until action is running.
 	err = anAction.Log("hello")
-	c.Assert(err, gc.ErrorMatches, `cannot log message to operation "dummy-1" with status pending`)
+	c.Assert(err, gc.ErrorMatches, `cannot log message to task "1" with status pending`)
 
 	anAction, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -305,7 +305,7 @@ func (s *ActionSuite) TestActionMessages(c *gc.C) {
 	_, err = anAction.Finish(state.ActionResults{Status: state.ActionCompleted})
 	c.Assert(err, jc.ErrorIsNil)
 	err = anAction.Log("hello")
-	c.Assert(err, gc.ErrorMatches, `cannot log message to operation "dummy-1" with status completed`)
+	c.Assert(err, gc.ErrorMatches, `cannot log message to task "1" with status completed`)
 }
 
 func (s *ActionSuite) TestActionLogMessageRace(c *gc.C) {
@@ -326,7 +326,7 @@ func (s *ActionSuite) TestActionLogMessageRace(c *gc.C) {
 	})()
 
 	err = anAction.Log("hello")
-	c.Assert(err, gc.ErrorMatches, `cannot log message to operation "dummy-1" with status completed`)
+	c.Assert(err, gc.ErrorMatches, `cannot log message to task "1" with status completed`)
 }
 
 // makeUnits prepares units with given Action schemas
@@ -540,7 +540,7 @@ func (s *ActionSuite) TestComplete(c *gc.C) {
 	c.Assert(len(actions), gc.Equals, 0)
 }
 
-func (s *ActionSuite) TestFindActionTagsByPrefix(c *gc.C) {
+func (s *ActionSuite) TestFindActionTagsById(c *gc.C) {
 	actions := []struct {
 		Name       string
 		Parameters map[string]interface{}
@@ -556,14 +556,10 @@ func (s *ActionSuite) TestFindActionTagsByPrefix(c *gc.C) {
 		c.Assert(err, gc.Equals, nil)
 	}
 
-	tags := s.model.FindActionTagsByPrefix(s.application.Name())
+	tags := s.model.FindActionTagsById("1")
 
-	c.Assert(len(tags), gc.Equals, len(actions))
-	for i, tag := range tags {
-		appName := s.application.Name()
-		c.Logf("check %q against %d:%q", appName, i, tag)
-		c.Check(tag.Id()[:len(appName)], gc.Equals, appName)
-	}
+	c.Assert(len(tags), gc.Equals, 1)
+	c.Check(tags[0].Id(), gc.Equals, "1")
 }
 
 func (s *ActionSuite) TestFindActionsByName(c *gc.C) {

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -119,7 +119,7 @@ func PatchCachedStatus(ctx jujuc.Context, status, info string, data map[string]i
 
 func WithActionContext(ctx *HookContext, in map[string]interface{}) {
 	ctx.actionData = &ActionData{
-		Tag:        names.NewActionTag("u-1"),
+		Tag:        names.NewActionTag("1"),
 		ResultsMap: in,
 	}
 }


### PR DESCRIPTION
## Description of change

Use numeric ids when running actions.
Rename the artefacts of running an action "task" instead of "operation".

## QA steps

Deploy a charm with actions
juju call an action and observe output
juju show-task to see the output