### PR TITLE
Forward port 2.6 test

### DIFF
--- a/state/address_internal_test.go
+++ b/state/address_internal_test.go
@@ -10,6 +10,110 @@ import (
 	"github.com/juju/juju/core/network"
 )
 
+type GetOpsForHostPortsSuite struct {
+	internalStateSuite
+}
+
+var _ = gc.Suite(&GetOpsForHostPortsSuite{})
+
+func (s *GetOpsForHostPortsSuite) TestGetOpsForHostPortsChangeWithSpaces(c *gc.C) {
+	addresses := map[string]network.SpaceHostPorts{
+		"0": {
+			{
+				SpaceAddress: network.SpaceAddress{
+					MachineAddress: network.MachineAddress{
+						Value: "10.144.9.113",
+						Type:  "ipv4",
+						Scope: "local-cloud",
+					},
+					SpaceID: "foo",
+				},
+				NetPort: 17070,
+			}, {
+				SpaceAddress: network.SpaceAddress{
+					MachineAddress: network.MachineAddress{
+						Value: "127.0.0.1",
+						Type:  "ipv4",
+						Scope: "local-machine",
+					},
+				},
+				NetPort: 17070,
+			},
+		},
+		"1": {
+			{
+				SpaceAddress: network.SpaceAddress{
+					MachineAddress: network.MachineAddress{
+						Value: "10.144.9.62",
+						Type:  "ipv4",
+						Scope: "local-cloud",
+					},
+					SpaceID: "foo",
+				},
+				NetPort: 17070,
+			}, {
+				SpaceAddress: network.SpaceAddress{
+					MachineAddress: network.MachineAddress{
+						Value: "127.0.0.1",
+						Type:  "ipv4",
+						Scope: "local-machine",
+					},
+				},
+				NetPort: 17070,
+			},
+		},
+		"2": {
+			{
+				SpaceAddress: network.SpaceAddress{
+					MachineAddress: network.MachineAddress{
+						Value: "10.144.9.56",
+						Type:  "ipv4",
+						Scope: "local-cloud",
+					},
+					SpaceID: "foo",
+				},
+				NetPort: 17070,
+			}, {
+				SpaceAddress: network.SpaceAddress{
+					MachineAddress: network.MachineAddress{
+						Value: "127.0.0.1",
+						Type:  "ipv4",
+						Scope: "local-machine",
+					},
+				},
+				NetPort: 17070,
+			},
+		},
+	}
+	// Iterate the map each time to generate the slice with the machines
+	// in a different order.
+	addressSlice := func() []network.SpaceHostPorts {
+		var result []network.SpaceHostPorts
+		for _, value := range addresses {
+			result = append(result, value)
+		}
+		return result
+	}
+
+	controllers, closer := s.state.db().GetCollection(controllersC)
+	defer closer()
+
+	ops, err := s.state.getOpsForHostPortsChange(controllers, apiHostPortsKey, addressSlice())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(ops), jc.GreaterThan, 0)
+	// Run the ops.
+	err = s.state.db().RunTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now iterate over the map a few times to get different ordering, and assert the
+	// ops to update the host ports is empty.
+	for i := 0; i < 5; i++ {
+		ops, err := s.state.getOpsForHostPortsChange(controllers, apiHostPortsKey, addressSlice())
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ops, gc.HasLen, 0)
+	}
+}
+
 type AddressEqualitySuite struct{}
 
 var _ = gc.Suite(&AddressEqualitySuite{})


### PR DESCRIPTION
Bring the new api host port test from the 2.6 branch. This shows that the problem isn't in the 2.7 branch any more as the network changes have already fixed the problem here.
