### PR TITLE
Dev support binding arg for juju upgradecharm

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -315,6 +315,10 @@ type SetCharmConfig struct {
 	// update during the upgrade. This field is only understood by Application
 	// facade version 2 and greater.
 	StorageConstraints map[string]storage.Constraints `json:"storage-constraints,omitempty"`
+
+	// EndpointBindings is a map of operator-defined endpoint names to
+	// space names to be merged with any existing endpoint bindings.
+	EndpointBindings map[string]string
 }
 
 // SetCharm sets the charm for a given application.
@@ -349,6 +353,7 @@ func (c *Client) SetCharm(branchName string, cfg SetCharmConfig) error {
 		ForceUnits:         cfg.ForceUnits,
 		ResourceIDs:        cfg.ResourceIDs,
 		StorageConstraints: storageConstraints,
+		EndpointBindings:   cfg.EndpointBindings,
 		Generation:         branchName,
 	}
 	return c.facade.FacadeCall("SetCharm", args, nil)

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  10,
+	"Application":                  11,
 	"ApplicationOffers":            2,
 	"ApplicationScaler":            1,
 	"Backups":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -151,6 +151,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 8, application.NewFacadeV8)
 	reg("Application", 9, application.NewFacadeV9)   // ApplicationInfo; generational config; Force on App, Relation and Unit Removal.
 	reg("Application", 10, application.NewFacadeV10) // --force and --no-wait parameters
+	reg("Application", 11, application.NewFacadeV11) // Get call returns the endpoint bindings
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -81,6 +81,12 @@ type APIv9 struct {
 // APIv10 provides the Application API facade for version 10.
 // It adds --force and --max-wait parameters to remove-saas.
 type APIv10 struct {
+	*APIv11
+}
+
+// APIv11 provides the Application API facade for version 11.
+// The Get call also returns the endpoint bindings
+type APIv11 struct {
 	*APIBase
 }
 
@@ -171,11 +177,19 @@ func NewFacadeV9(ctx facade.Context) (*APIv9, error) {
 }
 
 func NewFacadeV10(ctx facade.Context) (*APIv10, error) {
-	api, err := newFacadeBase(ctx)
+	api, err := NewFacadeV11(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &APIv10{api}, nil
+}
+
+func NewFacadeV11(ctx facade.Context) (*APIv11, error) {
+	api, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv11{api}, nil
 }
 
 type caasBrokerInterface interface {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -85,7 +85,8 @@ type APIv10 struct {
 }
 
 // APIv11 provides the Application API facade for version 11.
-// The Get call also returns the endpoint bindings
+// The Get call also returns the current endpoint bindings while the SetCharm
+// call access a map of operator-defined bindings.
 type APIv11 struct {
 	*APIBase
 }
@@ -786,6 +787,7 @@ type setCharmParams struct {
 	ConfigSettingsYAML    string
 	ResourceIDs           map[string]string
 	StorageConstraints    map[string]params.StorageConstraints
+	EndpointBindings      map[string]string
 	Force                 forceParams
 }
 
@@ -961,6 +963,7 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 			ConfigSettingsYAML:    args.ConfigSettingsYAML,
 			ResourceIDs:           args.ResourceIDs,
 			StorageConstraints:    args.StorageConstraints,
+			EndpointBindings:      args.EndpointBindings,
 			Force: forceParams{
 				ForceSeries: args.ForceSeries,
 				ForceUnits:  args.ForceUnits,
@@ -1063,6 +1066,7 @@ func (api *APIBase) applicationSetCharm(
 		Force:              force.Force,
 		ResourceIDs:        params.ResourceIDs,
 		StorageConstraints: stateStorageConstraints,
+		EndpointBindings:   params.EndpointBindings,
 	}
 	return params.Application.SetCharm(cfg)
 }

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -50,7 +50,7 @@ type applicationSuite struct {
 	apiservertesting.CharmStoreSuite
 	commontesting.BlockHelper
 
-	applicationAPI *application.APIv10
+	applicationAPI *application.APIv11
 	application    *state.Application
 	authorizer     *apiservertesting.FakeAuthorizer
 }
@@ -87,7 +87,7 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 	s.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv10 {
+func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv11 {
 	resources := common.NewResources()
 	c.Assert(resources.RegisterNamed("dataDir", common.StringResource(c.MkDir())), jc.ErrorIsNil)
 	storageAccess, err := application.GetStorageState(s.State)
@@ -111,7 +111,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv10 {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	return &application.APIv10{api}
+	return &application.APIv11{api}
 }
 
 func (s *applicationSuite) TestCharmConfig(c *gc.C) {
@@ -134,7 +134,9 @@ func (s *applicationSuite) TestCharmConfigV8(c *gc.C) {
 	s.setUpConfigTest(c)
 	api := &application.APIv8{
 		APIv9: &application.APIv9{
-			APIv10: s.applicationAPI,
+			APIv10: &application.APIv10{
+				APIv11: s.applicationAPI,
+			},
 		},
 	}
 	results, err := api.CharmConfig(params.Entities{

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -55,7 +55,7 @@ type ApplicationSuite struct {
 	env          environs.Environ
 	blockChecker mockBlockChecker
 	authorizer   apiservertesting.FakeAuthorizer
-	api          *application.APIv10
+	api          *application.APIv11
 	deployParams map[string]application.DeployApplicationParams
 }
 
@@ -85,7 +85,7 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		s.caasBroker,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api = &application.APIv10{api}
+	s.api = &application.APIv11{api}
 }
 
 func (s *ApplicationSuite) SetUpTest(c *gc.C) {
@@ -1724,7 +1724,7 @@ func (s *ApplicationSuite) TestApplicationsInfoOne(c *gc.C) {
 		},
 	})
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "Series", "Channel", "EndpointBindings", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Series", "Channel", "EndpointBindings", "IsPrincipal", "IsExposed", "IsRemote")
 }
 
 func (s *ApplicationSuite) TestApplicationsInfoDetailsErr(c *gc.C) {
@@ -1775,5 +1775,5 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 	c.Assert(result.Results[1].Error, gc.ErrorMatches, `application "wordpress" not found`)
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"unit-postgresql-0" is not a valid application tag`)
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "Series", "Channel", "EndpointBindings", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Series", "Channel", "EndpointBindings", "IsPrincipal", "IsExposed", "IsRemote")
 }

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -15,6 +15,6 @@ func GetState(st *state.State) Backend {
 	return stateShim{st}
 }
 
-func SetModelType(api *APIv10, modelType state.ModelType) {
+func SetModelType(api *APIv11, modelType state.ModelType) {
 	api.modelType = modelType
 }

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -28,6 +28,7 @@ func (api *APIv5) Get(args params.ApplicationGet) (params.ApplicationGetResults,
 		return params.ApplicationGetResults{}, err
 	}
 	results.ApplicationConfig = nil
+	results.EndpointBindings = nil
 	return results, nil
 }
 
@@ -40,6 +41,7 @@ func (api *APIv4) Get(args params.ApplicationGet) (params.ApplicationGetResults,
 		return params.ApplicationGetResults{}, err
 	}
 	results.ApplicationConfig = nil
+	results.EndpointBindings = nil
 	return results, nil
 }
 
@@ -89,6 +91,10 @@ func (api *APIBase) getConfig(
 			return params.ApplicationGetResults{}, err
 		}
 	}
+	endpoints, err := app.EndpointBindings()
+	if err != nil {
+		return params.ApplicationGetResults{}, err
+	}
 	return params.ApplicationGetResults{
 		Application:       args.ApplicationName,
 		Charm:             ch.Meta().Name,
@@ -97,6 +103,7 @@ func (api *APIBase) getConfig(
 		Constraints:       cons,
 		Series:            app.Series(),
 		Channel:           string(app.Channel()),
+		EndpointBindings:  endpoints,
 	}, nil
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2368,6 +2368,14 @@
                         "config-settings-yaml": {
                             "type": "string"
                         },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "force": {
                             "type": "boolean"
                         },

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1431,7 +1431,7 @@
     },
     {
         "Name": "Application",
-        "Version": 10,
+        "Version": 11,
         "Schema": {
             "type": "object",
             "properties": {
@@ -2138,6 +2138,14 @@
                         },
                         "constraints": {
                             "$ref": "#/definitions/Value"
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "series": {
                             "type": "string"

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -144,6 +144,11 @@ type ApplicationSetCharm struct {
 	// update during the upgrade. This field is only understood by Application
 	// facade version 2 and greater.
 	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
+
+	// EndpointBindings is a map of operator-defined endpoint names to
+	// space names to be merged with any existing endpoint bindings. This
+	// field is only understood by Application facade version 10 and greater.
+	EndpointBindings map[string]string `json:"endpoint-bindings,omitempty"`
 }
 
 // ApplicationExpose holds the parameters for making the application Expose call.

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -201,6 +201,7 @@ type ApplicationGetResults struct {
 	Constraints       constraints.Value      `json:"constraints"`
 	Series            string                 `json:"series"`
 	Channel           string                 `json:"channel"`
+	EndpointBindings  map[string]string      `json:"endpoint-bindings,omitempty"`
 }
 
 // ApplicationConfigSetArgs holds the parameters for

--- a/cmd/juju/application/binding.go
+++ b/cmd/juju/application/binding.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
+
+const parseBindErrorPrefix = "--bind must be in the form '[<default-space>] [<endpoint-name>=<space> ...]'. "
+
+// parseBindExpr parses the --bind option and returns back a map where keys
+// are endpoint names and values are space names. Valid forms are:
+// * relation-name=space-name
+// * extra-binding-name=space-name
+// * space-name (equivalent to binding all endpoints to the same space, i.e. application-default)
+// * The above in a space separated list to specify multiple bindings,
+//   e.g. "rel1=space1 ext1=space2 space3"
+func parseBindExpr(expr string, knownSpaces []string) (map[string]string, error) {
+	if expr == "" {
+		return nil, nil
+	}
+
+	knownSpaceMap := make(map[string]struct{})
+	for _, spaceName := range knownSpaces {
+		knownSpaceMap[spaceName] = struct{}{}
+	}
+
+	parsedBindings := make(map[string]string)
+	for _, s := range strings.Fields(expr) {
+		v := strings.Split(s, "=")
+		var endpoint, spaceName string
+		switch len(v) {
+		case 1:
+			endpoint = ""
+			spaceName = v[0]
+		case 2:
+			if v[0] == "" {
+				return nil, errors.New(parseBindErrorPrefix + "Found = without endpoint name. Use a lone space name to set the default.")
+			}
+			endpoint = v[0]
+			spaceName = v[1]
+		default:
+			return nil, errors.New(parseBindErrorPrefix + "Found multiple = in binding. Did you forget to space-separate the binding list?")
+		}
+
+		// This is a temporary hack to allow us to bind endpoints to the
+		// default spaceName which is currently represented as a blank string.
+		// It will be removed when the work for properly naming the
+		// default spaceName lands.
+		spaceName = strings.Trim(spaceName, `"`)
+
+		if _, exists := knownSpaceMap[spaceName]; !exists {
+			return nil, errors.NotFoundf("Space with name %q", spaceName)
+		}
+
+		parsedBindings[endpoint] = spaceName
+	}
+	return parsedBindings, nil
+}
+
+// mergeBindings is invoked when upgrading a charm to merge the existing set of
+// endpoint to space assignments for a deployed application and the user-defined
+// bindings passed to the upgrade-charm command.
+func mergeBindings(newCharmEndpoints set.Strings, oldEndpointsMap, userBindings map[string]string, oldDefaultSpace string) (map[string]string, error) {
+	if oldEndpointsMap == nil {
+		oldEndpointsMap = make(map[string]string)
+	}
+	if userBindings == nil {
+		userBindings = make(map[string]string)
+	}
+
+	newDefaultSpace, newDefaultBindingDefined := userBindings[""]
+	changeDefaultSpace := newDefaultBindingDefined && oldDefaultSpace != newDefaultSpace
+	mergedBindings := make(map[string]string)
+	unmodifiedEndpoints := make(map[string][]string)
+	for _, epName := range newCharmEndpoints.SortedValues() {
+		newSpaceAssignment, newBindingDefined := userBindings[epName]
+
+		// If this is a new endpoint and it is not specified, assign it to the default space
+		oldSpaceAssignment, isOldEndpoint := oldEndpointsMap[epName]
+		if !isOldEndpoint {
+			// If not explicitly defined, it inherits the default space for the application
+			if !newBindingDefined {
+				mergedBindings[epName] = oldDefaultSpace
+				logger.Infof("Adding endpoint %q to default space %q", epName, oldDefaultSpace)
+			} else {
+				mergedBindings[epName] = newSpaceAssignment
+				logger.Infof("Adding endpoint %q to space %q", epName, newSpaceAssignment)
+			}
+			continue
+		}
+
+		// This is an existing endpoint. Check whether the operator
+		// specified a different space for it.
+		if newBindingDefined && oldSpaceAssignment != newSpaceAssignment {
+			mergedBindings[epName] = newSpaceAssignment
+			logger.Infof("Updating endpoint %q from %q to %q", epName, oldSpaceAssignment, newSpaceAssignment)
+			continue
+		}
+
+		// Next, check whether the endpoint is bound to the old default
+		// space and override it to the new default space.
+		if !newBindingDefined && changeDefaultSpace && oldSpaceAssignment == oldDefaultSpace {
+			mergedBindings[epName] = newDefaultSpace
+			logger.Infof("Updating endpoint %q from %q to %q", epName, oldSpaceAssignment, newDefaultSpace)
+			continue
+		}
+
+		// Retain the existing binding
+		mergedBindings[epName] = oldSpaceAssignment
+		unmodifiedEndpoints[oldSpaceAssignment] = append(unmodifiedEndpoints[oldSpaceAssignment], epName)
+	}
+
+	for spName, epList := range unmodifiedEndpoints {
+		var pluralSuffix string
+		if len(epList) > 1 {
+			pluralSuffix = "s"
+		}
+
+		logger.Infof("Leaving endpoint%s in %q: %s", pluralSuffix, spName, strings.Join(epList, ", "))
+	}
+
+	if changeDefaultSpace {
+		mergedBindings[""] = newDefaultSpace
+	}
+	return mergedBindings, nil
+}

--- a/cmd/juju/application/binding_test.go
+++ b/cmd/juju/application/binding_test.go
@@ -5,9 +5,9 @@ package application
 
 import (
 	"github.com/juju/collections/set"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/testing"
 
+	"github.com/juju/juju/core/network"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -96,8 +96,7 @@ func (s *ParseBindSuite) TestMergeBindingsNewBindingsInheritDefaultSpace(c *gc.C
 		"ep3": "sp1",
 	}
 
-	mergedBindings, err := mergeBindings(newCharmEndpoints, oldEndpointsMap, userBindings, network.DefaultSpaceName)
-	c.Assert(err, gc.IsNil)
+	mergedBindings, _ := mergeBindings(newCharmEndpoints, oldEndpointsMap, userBindings, network.DefaultSpaceName)
 	c.Assert(mergedBindings, gc.DeepEquals, expMergedBindings)
 }
 

--- a/cmd/juju/application/binding_test.go
+++ b/cmd/juju/application/binding_test.go
@@ -1,0 +1,114 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/collections/set"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type ParseBindSuite struct {
+	testing.LoggingSuite
+}
+
+var _ = gc.Suite(&ParseBindSuite{})
+
+func (s *ParseBindSuite) SetUpSuite(c *gc.C) {
+	s.LoggingSuite.SetUpSuite(c)
+}
+
+func (s *ParseBindSuite) TearDownSuite(c *gc.C) {
+	s.LoggingSuite.TearDownSuite(c)
+}
+
+func (s *ParseBindSuite) TestParseSuccessWithEmptyArgs(c *gc.C) {
+	s.checkParseOKForExpr(c, "", nil, nil)
+}
+
+func (s *ParseBindSuite) TestParseSuccessWithEndpointsOnly(c *gc.C) {
+	knownSpaces := []string{"a", "b"}
+	s.checkParseOKForExpr(c, "foo=a bar=b", knownSpaces, map[string]string{"foo": "a", "bar": "b"})
+}
+
+func (s *ParseBindSuite) TestParseSuccessWithApplicationDefaultSpaceOnly(c *gc.C) {
+	knownSpaces := []string{"application-default"}
+	s.checkParseOKForExpr(c, "application-default", knownSpaces, map[string]string{"": "application-default"})
+}
+
+func (s *ParseBindSuite) TestBindingsOrderForDefaultSpaceAndEndpointsDoesNotMatter(c *gc.C) {
+	knownSpaces := []string{"sp3", "sp1", "sp2"}
+	expectedBindings := map[string]string{
+		"ep1": "sp1",
+		"ep2": "sp2",
+		"":    "sp3",
+	}
+	s.checkParseOKForExpr(c, "ep1=sp1 ep2=sp2 sp3", knownSpaces, expectedBindings)
+	s.checkParseOKForExpr(c, "ep1=sp1 sp3 ep2=sp2", knownSpaces, expectedBindings)
+	s.checkParseOKForExpr(c, "ep2=sp2 ep1=sp1 sp3", knownSpaces, expectedBindings)
+	s.checkParseOKForExpr(c, "ep2=sp2 sp3 ep1=sp1", knownSpaces, expectedBindings)
+	s.checkParseOKForExpr(c, "sp3 ep1=sp1 ep2=sp2", knownSpaces, expectedBindings)
+	s.checkParseOKForExpr(c, "sp3 ep2=sp2 ep1=sp1", knownSpaces, expectedBindings)
+}
+
+func (s *ParseBindSuite) TestParseWithEmptyQuotedDefaultSpace(c *gc.C) {
+	knownSpaces := []string{"", "sp1"}
+	expectedBindings := map[string]string{
+		"ep1": "sp1",
+		"ep2": "",
+		"":    "",
+	}
+	s.checkParseOKForExpr(c, `"" ep2="" ep1=sp1`, knownSpaces, expectedBindings)
+}
+
+func (s *ParseBindSuite) TestParseFailsWithSpaceNameButNoEndpoint(c *gc.C) {
+	s.checkParseFailsForExpr(c, "=bad", nil, "Found = without endpoint name. Use a lone space name to set the default.")
+}
+
+func (s *ParseBindSuite) TestParseFailsWithTooManyEqualsSignsInArgs(c *gc.C) {
+	s.checkParseFailsForExpr(c, "foo=bar=baz", nil, "Found multiple = in binding. Did you forget to space-separate the binding list?")
+}
+
+func (s *ParseBindSuite) TestParseFailsWithUnknownSpaceName(c *gc.C) {
+	_, err := parseBindExpr("rel1=bogus", nil)
+	c.Check(err.Error(), gc.Equals, `Space with name "bogus" not found`)
+}
+
+func (s *ParseBindSuite) TestMergeBindingsNewBindingsInheritDefaultSpace(c *gc.C) {
+	newCharmEndpoints := set.NewStrings("ep1", "ep2", "ep3")
+	oldEndpointsMap := map[string]string{
+		"":    network.DefaultSpaceName,
+		"ep1": "sp1",
+	}
+
+	userBindings := map[string]string{
+		"ep1": "sp-foo", // overwrite existing space assignment
+		"ep3": "sp1",    // set space for new endpoint
+	}
+
+	expMergedBindings := map[string]string{
+		"ep1": "sp-foo",
+		"ep2": network.DefaultSpaceName, // new endpoint ep2 inherits the default space
+		"ep3": "sp1",
+	}
+
+	mergedBindings, err := mergeBindings(newCharmEndpoints, oldEndpointsMap, userBindings, network.DefaultSpaceName)
+	c.Assert(err, gc.IsNil)
+	c.Assert(mergedBindings, gc.DeepEquals, expMergedBindings)
+}
+
+func (s *ParseBindSuite) checkParseOKForExpr(c *gc.C, expr string, knownSpaces []string, expectedBindings map[string]string) {
+	parsedBindings, err := parseBindExpr(expr, knownSpaces)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(parsedBindings, jc.DeepEquals, expectedBindings)
+}
+
+func (s *ParseBindSuite) checkParseFailsForExpr(c *gc.C, expr string, knownSpaces []string, expectedErrorSuffix string) {
+	parsedBindings, err := parseBindExpr(expr, knownSpaces)
+	c.Check(err.Error(), gc.Equals, parseBindErrorPrefix+expectedErrorSuffix)
+	c.Check(parsedBindings, gc.IsNil)
+}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2124,66 +2124,6 @@ func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) 
 	c.Check(err, gc.ErrorMatches, "IsMetered")
 }
 
-type ParseBindSuite struct {
-}
-
-var _ = gc.Suite(&ParseBindSuite{})
-
-func (s *ParseBindSuite) TestParseSuccessWithEmptyArgs(c *gc.C) {
-	s.checkParseOKForArgs(c, "", nil)
-}
-
-func (s *ParseBindSuite) TestParseSuccessWithEndpointsOnly(c *gc.C) {
-	s.checkParseOKForArgs(c, "foo=a bar=b", map[string]string{"foo": "a", "bar": "b"})
-}
-
-func (s *ParseBindSuite) TestParseSuccessWithApplicationDefaultSpaceOnly(c *gc.C) {
-	s.checkParseOKForArgs(c, "application-default", map[string]string{"": "application-default"})
-}
-
-func (s *ParseBindSuite) TestBindingsOrderForDefaultSpaceAndEndpointsDoesNotMatter(c *gc.C) {
-	expectedBindings := map[string]string{
-		"ep1": "sp1",
-		"ep2": "sp2",
-		"":    "sp3",
-	}
-	s.checkParseOKForArgs(c, "ep1=sp1 ep2=sp2 sp3", expectedBindings)
-	s.checkParseOKForArgs(c, "ep1=sp1 sp3 ep2=sp2", expectedBindings)
-	s.checkParseOKForArgs(c, "ep2=sp2 ep1=sp1 sp3", expectedBindings)
-	s.checkParseOKForArgs(c, "ep2=sp2 sp3 ep1=sp1", expectedBindings)
-	s.checkParseOKForArgs(c, "sp3 ep1=sp1 ep2=sp2", expectedBindings)
-	s.checkParseOKForArgs(c, "sp3 ep2=sp2 ep1=sp1", expectedBindings)
-}
-
-func (s *ParseBindSuite) TestParseFailsWithSpaceNameButNoEndpoint(c *gc.C) {
-	s.checkParseFailsForArgs(c, "=bad", "Found = without endpoint name. Use a lone space name to set the default.")
-}
-
-func (s *ParseBindSuite) TestParseFailsWithTooManyEqualsSignsInArgs(c *gc.C) {
-	s.checkParseFailsForArgs(c, "foo=bar=baz", "Found multiple = in binding. Did you forget to space-separate the binding list?")
-}
-
-func (s *ParseBindSuite) TestParseFailsWithBadSpaceName(c *gc.C) {
-	s.checkParseFailsForArgs(c, "rel1=spa#ce1", "Space name invalid.")
-}
-
-func (s *ParseBindSuite) runParseBindWithArgs(args string) (error, map[string]string) {
-	deploy := &DeployCommand{BindToSpaces: args}
-	return deploy.parseBind(), deploy.Bindings
-}
-
-func (s *ParseBindSuite) checkParseOKForArgs(c *gc.C, args string, expectedBindings map[string]string) {
-	err, parsedBindings := s.runParseBindWithArgs(args)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(parsedBindings, jc.DeepEquals, expectedBindings)
-}
-
-func (s *ParseBindSuite) checkParseFailsForArgs(c *gc.C, args string, expectedErrorSuffix string) {
-	err, parsedBindings := s.runParseBindWithArgs(args)
-	c.Check(err.Error(), gc.Equals, parseBindErrorPrefix+expectedErrorSuffix)
-	c.Check(parsedBindings, gc.IsNil)
-}
-
 type ParseMachineMapSuite struct{}
 
 var _ = gc.Suite(&ParseMachineMapSuite{})

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -136,6 +136,7 @@ func NewUpgradeCharmCommandForTest(
 	newModelConfigGetter func(base.APICallCloser) ModelConfigGetter,
 	newResourceLister func(base.APICallCloser) (ResourceLister, error),
 	charmStoreURLGetter func(base.APICallCloser) (string, error),
+	newSpacesClient func(base.APICallCloser) SpacesAPI,
 ) cmd.Command {
 	cmd := &upgradeCharmCommand{
 		DeployResources:       deployResources,
@@ -146,6 +147,7 @@ func NewUpgradeCharmCommandForTest(
 		NewModelConfigGetter:  newModelConfigGetter,
 		NewResourceLister:     newResourceLister,
 		CharmStoreURLGetter:   charmStoreURLGetter,
+		NewSpacesClient:       newSpacesClient,
 	}
 	cmd.SetClientStore(store)
 	cmd.SetAPIOpen(apiOpen)

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -258,6 +258,20 @@ func (st *State) SpaceIDsByName() (map[string]string, error) {
 }
 
 // SpaceNamesByID (core/network.SpaceLookup)
+// returns a map of space IDs to space names.
+func (st *State) SpaceNamesByID() (map[string]string, error) {
+	spaces, err := st.AllSpaces()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	lookup := make(map[string]string, len(spaces))
+	for _, space := range spaces {
+		lookup[space.Id()] = space.Name()
+	}
+	return lookup, nil
+}
+
+// SpaceNamesByID (core/network.SpaceLookup)
 // returns a map of space IDs to SpaceInfos.
 func (st *State) SpaceInfosByID() (map[string]network.SpaceInfo, error) {
 	spaces, err := st.AllSpaces()


### PR DESCRIPTION
## Description of change

This PR brings support for `--bind` to the juju CLI `upgrade-charm` command. This change will allow operators to (optionally) specify space bindings for any new endpoints defined in an upgraded charm version. In the future, the same binding syntax will also allow operators to override both the _default_ space for the application as well as the endpoint bindings for existing endpoints.

As the bind flag parser is now shared between the deploy and upgrade-charm commands, I have extracted it into a standalone function and enhanced it by adding client-side validation for any space names provided by the operator. Note that the server already validates this but this enhancement allows us to error early.

The upgrade-charm code will fetch the existing application bindings and merge them (client-side) into the final set of bindings that will get passed to the server. This allows us to display useful endpoint-related information to the operator:

- Adding endpoint "XXX" to space "YYY" (new endpoints defined by the upgraded charm)
- Updating endpoint "XXX" from "YYY" to "ZZZ"
- Leaving endpoints in "XXX": foo, bar, baz

To get back the list of current bindings from the server and to send the updated endpoint bindings
back to the server I had to modify the `Get` and `SetCharm` methods of the `Application` facade. To this end, the PR also bumps the `Application` facade version.

The introduced `--bind` changes are not compatible with older controllers. The client uses version sniffing and will display an error to the operator if they try to use the `--bind` flag with an older controller while upgrading a charm.

## QA steps

For the following QA steps you will either need to use MAAS with spaces OR follow [this](https://discourse.jujucharms.com/t/how-to-create-and-use-spaces-on-aws/2115/4) guide to setup the `isolated` space on AWS. If running the QA steps on AWS, **don't forget to delete the NAT gateway and release the elastic IP associated with it**.

### Check --bind flag with newer controllers

```console
$ juju deploy ./testcharms/charm-repo/bionic/mysql --constraints spaces=isolated
$ juju show-application mysql
mysql:
  charm: mysql
  series: bionic
  constraints:
    spaces:
    - isolated
  principal: true
  exposed: false
  remote: false
  endpoint-bindings:
    metrics-client: ""
    server: ""
    server-admin: ""

# Add an extra binding called "foo" and remove "server-admin"
echo 'diff --git a/testcharms/charm-repo/bionic/mysql/metadata.yaml b/testcharms/charm-repo/bionic/mysql/metadata.yaml
index 58a640c817..5d80d7d627 100644
--- a/testcharms/charm-repo/bionic/mysql/metadata.yaml
+++ b/testcharms/charm-repo/bionic/mysql/metadata.yaml
@@ -4,8 +4,8 @@ description: "A pretty popular database"
 provides:
   server:
     interface: mysql
-  server-admin:
-    interface: mysql-root
 requires:
   metrics-client:
     interface: metrics
+extra-bindings:
+  foo:' | git apply

# Upgrading without binding should automatically assign "foo" to the app's default space
$ juju upgrade-charm mysql --path ./testcharms/charm-repo/bionic/mysql
Added charm "local:bionic/mysql-2" to the model.
Adding endpoint "foo" to default space ""
Leaving endpoints in "": metrics-client, server

$ juju show-application mysql
mysql:
  charm: mysql
  series: bionic
  constraints:
    spaces:
    - isolated
  principal: true
  exposed: false
  remote: false
  endpoint-bindings:
    foo: ""
    metrics-client: ""
    server: ""

# Notice that the "server-admin" endpoint has been removed and that "foo" is assigned to the default space.

# Add a new binding call "bar"
$ echo 'index 5d80d7d627..7a5713ac00 100644
--- a/testcharms/charm-repo/bionic/mysql/metadata.yaml
+++ b/testcharms/charm-repo/bionic/mysql/metadata.yaml
@@ -9,3 +9,4 @@ requires:
     interface: metrics
 extra-bindings:
   foo:
+  bar:' | git apply 

# Upgrade and this time assign "bar" to the isolated space
$  juju upgrade-charm mysql --path ./testcharms/charm-repo/bionic/mysql --bind bar=isolated
Added charm "local:bionic/mysql-3" to the model.
Adding endpoint "bar" to space "isolated"
Leaving endpoints in "": foo, metrics-client, server

$ juju show-application mysql
mysql:
  charm: mysql
  series: bionic
  constraints:
    spaces:
    - isolated
  principal: true
  exposed: false
  remote: false
  endpoint-bindings:
    bar: isolated
    foo: ""
    metrics-client: ""
    server: ""

# Notice that "bar" is now assigned to "isolated"

# Try to upgrade again while attempting to change the default binding OR an existing binding.
# In both cases we will get back an error; this will be addressed in a separate PR

$ juju upgrade-charm mysql --path ./testcharms/charm-repo/bionic/mysql --bind isolated
Added charm "local:bionic/mysql-4" to the model.
ERROR cannot upgrade application "mysql" to charm "local:bionic/mysql-4": changing the default application space while upgrading charms not supported (not supported)

$ juju upgrade-charm mysql --path ./testcharms/charm-repo/bionic/mysql --bind server=isolated
Added charm "local:bionic/mysql-5" to the model.
ERROR cannot upgrade application "mysql" to charm "local:bionic/mysql-5": changing existing endpoint bindings while upgrading charms not supported (not supported)
```

### Using the client with older controllers 

```console
$ juju upgrade-charm mysql --path ./testcharms/charm-repo/bionic/mysql --bind server=isolated
ERROR specifying bindings at upgrade-charm time is not supported by server version 2.6.9
```

## Documentation changes

@mitechie We probably need to update the CLI usage texts for both deploy and upgrade-charm to include a section about the --bind argument.