### PR TITLE
Handle HA controllers for introspection

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -203,7 +203,10 @@ introspect_controller() {
 
     name=${1}
 
-    idents=$(juju machines -m ${name}:controller --format=json | jq ".machines | keys | .[]")
+    idents=$(juju machines -m "${name}:controller" --format=json | jq ".machines | keys | .[]")
+    if [ -z "${idents}" ]; then
+        return
+    fi
 
     echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_reports.txt"
     echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -203,6 +203,8 @@ introspect_controller() {
 
     name=${1}
 
-    juju ssh -m controller 0 bash -lic "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_report.txt"
-    juju ssh -m controller 0 bash -lic "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"
+    idents=$(juju machines -m ${name}:controller --format=json | jq ".machines | keys | .[]")
+
+    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_reports.txt"
+    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"
 }


### PR DESCRIPTION
## Description of change

@howbazaar correctly pointed out https://github.com/juju/juju/pull/10676#discussion_r331238735 that we don't
support HA mode or the fact that it might not have a machine 0.
Instead we now query for the machines that are controllers and then
inspect the code correctly.

The following updates the introspection code to ensure that we
enable HA querying for controllers.

Also we now use the correct namespace for controllers in case we're
in the wrong juju context.


## QA steps

```sh
./main.sh -a output.tar.gz smoke
```