### PR TITLE
cmd plugin: fix bug where a path-error was not interpreted as such

### DIFF
--- a/cmd/juju/commands/plugin.go
+++ b/cmd/juju/commands/plugin.go
@@ -68,9 +68,10 @@ func RunPlugin(callback cmd.MissingCallback) cmd.MissingCallback {
 		}
 		err := plugin.Run(ctx)
 		_, execError := err.(*exec.Error)
-		// exec.Error results are for when the executable isn't found, in
-		// those cases, drop through.
-		if !execError {
+		_, pathError := err.(*os.PathError)
+		// exec.Error and pathError results are for when the executable isn't found, in
+		// those cases, let's test whether we have a similar command available.
+		if !execError && !pathError {
 			return err
 		}
 

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -157,6 +157,26 @@ Did you mean:
 	c.Assert(output, gc.Matches, expectedHelp)
 }
 
+func (suite *PluginSuite) TestHelpPluginNameAsPathIsNotAPlugin(c *gc.C) {
+	output := badrun(c, 0, "help", "/foo")
+	expectedHelp := `ERROR juju: "/foo" is not a juju command. See "juju --help".
+
+Did you mean:
+	exec
+`
+	c.Assert(output, gc.Matches, expectedHelp)
+}
+
+func (suite *PluginSuite) TestHelpPluginNameWithSpecialPrefixWhichIsNotAPathAndPlugin(c *gc.C) {
+	output := badrun(c, 0, "help", ".foo")
+	expectedHelp := `ERROR juju: ".foo" is not a juju command. See "juju --help".
+
+Did you mean:
+	exec
+`
+	c.Assert(output, gc.Matches, expectedHelp)
+}
+
 func (suite *PluginSuite) TestHelpAsArg(c *gc.C) {
 	suite.makeFullPlugin(PluginParams{Name: "foo"})
 	output := badrun(c, 0, "foo", "--help")


### PR DESCRIPTION
## Description of change

If one runs a juju command with is unknown command we will try to find a similar command.
But if we run a command which contains a path separator golang tries to interpret it as such and thus returns and "fork/exec".

This only happens if this can be interpreted as a path, thus having a separator
By checking whether the error is of this kind and handling it correctly leads to the same help message. 

## QA steps
- The unit test should contain the QA Test
- Manual tests steps
no path
```shell
[11:47:47] nam:juju git:(fix-plugin-load*) $ juju foo       
ERROR juju: "foo" is not a juju command. See "juju --help".

Did you mean:
        gui

```
with path
```shell
[11:47:44] nam:juju git:(fix-plugin-load*) $ juju /foo      
ERROR juju: "/foo" is not a juju command. See "juju --help".

Did you mean:
        exec

```
with a not path special char
```shell
[11:57:45] nam:juju git:(develop) $ juju .foo 
ERROR juju: ".foo" is not a juju command. See "juju --help".

Did you mean:
        exec

```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1747040