### PR TITLE
Upgrade Step for Machine Address Space IDs

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -268,10 +268,17 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string)
 		if spaceID != network.DefaultSpaceId && spaceID != "" {
 			space, err := st.SpaceByID(spaceID)
 			if err != nil {
-				return errors.Annotatef(err, "retrieving space for ID %q", spaceID)
+				// TODO (manadart 2019-10-10): This is a temporary softening of
+				// the error condition to prevent blocking upgrades due to the
+				// model-cache and by extension the API server being unable to
+				// start.
+				// A patch is in progress to address this in the upgrade logic.
+				// return errors.Annotatef(err, "retrieving space for ID %q", spaceID)
+				logger.Errorf("retrieving space for ID %q", err)
+			} else {
+				mAddr.SpaceName = space.Name()
+				mAddr.SpaceProviderId = string(space.ProviderId())
 			}
-			mAddr.SpaceName = space.Name()
-			mAddr.SpaceProviderId = string(space.ProviderId())
 		}
 
 		info.Addresses = append(info.Addresses, mAddr)

--- a/state/machine.go
+++ b/state/machine.go
@@ -721,7 +721,7 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 	}
 	// noUnits asserts that the machine has no principal units.
 	noUnits := bson.DocElem{
-		"$or", []bson.D{
+		Name: "$or", Value: []bson.D{
 			{{"principals", bson.D{{"$size", 0}}}},
 			{{"principals", bson.D{{"$exists", false}}}},
 		},
@@ -770,7 +770,7 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 				return nil, errors.Errorf("machine %s is still a controller member", m.Id())
 			}
 			asserts = append(asserts, bson.DocElem{
-				"jobs", bson.D{{"$nin", []MachineJob{JobManageModel}}}})
+				Name: "jobs", Value: bson.D{{Name: "$nin", Value: []MachineJob{JobManageModel}}}})
 			asserts = append(asserts, notDeadDoc...)
 			controllerOp := txn.Op{
 				C:  controllersC,
@@ -846,10 +846,10 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 			}
 			if canDie {
 				checkUnits := bson.DocElem{
-					"$or", []bson.D{
-						{{"principals", principalUnitnames}},
-						{{"principals", bson.D{{"$size", 0}}}},
-						{{"principals", bson.D{{"$exists", false}}}},
+					Name: "$or", Value: []bson.D{
+						{{Name: "principals", Value: principalUnitnames}},
+						{{Name: "principals", Value: bson.D{{"$size", 0}}}},
+						{{Name: "principals", Value: bson.D{{"$exists", false}}}},
 					},
 				}
 				ops[0].Assert = append(asserts, checkUnits)
@@ -929,7 +929,7 @@ func (m *Machine) assertNoPersistentStorage() (bson.D, error) {
 	// but if we're advancing from Alive to Dead then we
 	// must ensure no concurrent attachments are made.
 	noNewVolumes := bson.DocElem{
-		"volumes", bson.D{{
+		Name: "volumes", Value: bson.D{{
 			"$not", bson.D{{
 				"$elemMatch", bson.D{{
 					"$nin", m.doc.Volumes,
@@ -942,7 +942,7 @@ func (m *Machine) assertNoPersistentStorage() (bson.D, error) {
 		// is a subset of the previously known set.
 	}
 	noNewFilesystems := bson.DocElem{
-		"filesystems", bson.D{{
+		Name: "filesystems", Value: bson.D{{
 			"$not", bson.D{{
 				"$elemMatch", bson.D{{
 					"$nin", m.doc.Filesystems,
@@ -1954,7 +1954,7 @@ func (m *Machine) markInvalidContainers() error {
 					Data:    map[string]interface{}{"type": containerType},
 					Since:   &now,
 				}
-				container.SetStatus(s)
+				_ = container.SetStatus(s)
 			} else {
 				logger.Errorf("unsupported container %v has unexpected status %v", containerId, statusInfo.Status)
 			}

--- a/state/upgrade/types.go
+++ b/state/upgrade/types.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrade
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/core/network"
+)
+
+var logger = loggo.GetLogger("juju.state.upgrade")
+
+// The purpose of this module is to house types specific to upgrades,
+// without adding types to the state package.
+// For small upgrade functions closed over types are sufficient,
+// but where that would make steps unwieldy, types can live here.
+
+// OldAddress27 represents the address stored prior to version 2.7 in the
+// collections: machines, cloudservices and cloudcontainers.
+// Note that we can reuse this type for the new form because:
+// - `omitempty` on SpaceName means we can set it as "" to remove.
+// - The bson field `spaceid` is the same for the old SpaceProviderId.
+//   and the new SpaceID.
+type OldAddress27 struct {
+	Value       string `bson:"value"`
+	AddressType string `bson:"addresstype"`
+	Scope       string `bson:"networkscope,omitempty"`
+	Origin      string `bson:"origin,omitempty"`
+	SpaceName   string `bson:"spacename,omitempty"`
+	SpaceID     string `bson:"spaceid,omitempty"`
+}
+
+// convert accepts an address and a name-to-ID space lookup and returns a
+// new address representation based on whether space name/ID are populated.
+// An error is returned if the address has a non-empty space name that we
+// cannot map to an ID.
+func (a OldAddress27) Upgrade(lookup map[string]string) (OldAddress27, error) {
+	// Ignore zero-type addresses.
+	if a.Value == "" {
+		return a, nil
+	}
+
+	if a.SpaceName == "" {
+		// If both fields are empty, populate with the default space ID.
+		if a.SpaceID == "" {
+			a.SpaceID = network.DefaultSpaceId
+		} else {
+			// If we have a space (provider) ID and no name, which should
+			// not be possible in old addresses, then this address *looks*
+			// like one that has already been converted.
+			// Play it safe, leave it alone and log a warning.
+			logger.Warningf("not converting address %q with empty space name and ID %q", a.Value, a.SpaceID)
+		}
+	} else {
+		newID, ok := lookup[a.SpaceName]
+		if !ok {
+			return a, errors.NotFoundf("space with name: %q", a.SpaceName)
+		}
+		a.SpaceID = newID
+		a.SpaceName = ""
+	}
+	return a, nil
+}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state/globalclock"
 	"github.com/juju/juju/state/lease"
+	"github.com/juju/juju/state/upgrade"
 	"github.com/juju/juju/storage/provider"
 )
 
@@ -2594,61 +2595,15 @@ func EnsureRelationApplicationSettings(pool *StatePool) error {
 // Where such addresses include a space name or provider ID,
 // The space is retrieved and these fields are removed in favour of space's ID.
 func ConvertAddressSpaceIDs(pool *StatePool) error {
-	// oldAddress is the type used to represent addresses prior to version 2.7.
-	// Note that we can reuse this type for the new form because:
-	// - `omitempty` on SpaceName means we can set it as "" to remove.
-	// - The bson field `spaceid` is the same for the old SpaceProviderId
-	//   and the new SpaceID.
-	type oldAddress struct {
-		Value       string `bson:"value"`
-		AddressType string `bson:"addresstype"`
-		Scope       string `bson:"networkscope,omitempty"`
-		Origin      string `bson:"origin,omitempty"`
-		SpaceName   string `bson:"spacename,omitempty"`
-		SpaceID     string `bson:"spaceid,omitempty"`
-	}
-
-	// convert accepts an address and a name-to-ID space lookup and returns a
-	// new address representation based on whether space name/ID are populated.
-	// An error is returned if the address has a non-empty space name that we
-	// cannot map to an ID.
-	convert := func(old oldAddress, lookup map[string]string) (oldAddress, error) {
-		// Ignore zero-type addresses.
-		if old.Value == "" {
-			return old, nil
-		}
-
-		if old.SpaceName == "" {
-			// If both fields are empty, populate with the default space ID.
-			if old.SpaceID == "" {
-				old.SpaceID = network.DefaultSpaceId
-			} else {
-				// If we have a space (provider) ID and no name, which should
-				// not be possible in old addresses, then this address *looks*
-				// like one that has already been converted.
-				// Play it safe, leave it alone and log a warning.
-				logger.Warningf("not converting address %q with empty space name and ID %q", old.Value, old.SpaceID)
-			}
-		} else {
-			newID, ok := lookup[old.SpaceName]
-			if !ok {
-				return old, errors.NotFoundf("space with name: %q", old.SpaceName)
-			}
-			old.SpaceID = newID
-			old.SpaceName = ""
-		}
-		return old, nil
-	}
-
 	// machine is a subset of machine document fields that we care about
 	// for updating the address fields.
 	type machine struct {
 		DocID                   string `bson:"_id"`
 		Id                      string `bson:"machineid"`
-		Addresses               []oldAddress
-		MachineAddresses        []oldAddress
-		PreferredPublicAddress  oldAddress `bson:",omitempty"`
-		PreferredPrivateAddress oldAddress `bson:",omitempty"`
+		Addresses               []upgrade.OldAddress27
+		MachineAddresses        []upgrade.OldAddress27
+		PreferredPublicAddress  upgrade.OldAddress27 `bson:",omitempty"`
+		PreferredPrivateAddress upgrade.OldAddress27 `bson:",omitempty"`
 	}
 
 	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
@@ -2667,19 +2622,19 @@ func ConvertAddressSpaceIDs(pool *StatePool) error {
 
 		var ops []txn.Op
 		for _, machine := range machines {
-			allAddrs := [][]oldAddress{machine.Addresses, machine.MachineAddresses}
+			allAddrs := [][]upgrade.OldAddress27{machine.Addresses, machine.MachineAddresses}
 			for i, addrs := range allAddrs {
 				for j, addr := range addrs {
-					if allAddrs[i][j], err = convert(addr, lookup); err != nil {
+					if allAddrs[i][j], err = addr.Upgrade(lookup); err != nil {
 						return errors.Trace(err)
 					}
 				}
 			}
 
-			if machine.PreferredPublicAddress, err = convert(machine.PreferredPublicAddress, lookup); err != nil {
+			if machine.PreferredPublicAddress, err = machine.PreferredPublicAddress.Upgrade(lookup); err != nil {
 				return errors.Trace(err)
 			}
-			if machine.PreferredPrivateAddress, err = convert(machine.PreferredPrivateAddress, lookup); err != nil {
+			if machine.PreferredPrivateAddress, err = machine.PreferredPrivateAddress.Upgrade(lookup); err != nil {
 				return errors.Trace(err)
 			}
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2589,3 +2589,10 @@ func EnsureRelationApplicationSettings(pool *StatePool) error {
 		return errors.Trace(st.db().RunTransaction(ops))
 	}))
 }
+
+// ConvertAddressSpaceIDs interrogates stored addresses.
+// Where such addresses include a space name or provider ID,
+// The space is retrieved and these fields are removed in favour of space's ID.
+func ConvertAddressSpaceIDs(pool *StatePool) error {
+	return nil
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -72,6 +72,7 @@ type StateBackend interface {
 	AddSubnetIdToSubnetDocs() error
 	ReplacePortsDocSubnetIDCIDR() error
 	EnsureRelationApplicationSettings() error
+	ConvertAddressSpaceIDs() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -288,4 +289,8 @@ func (s stateBackend) ReplacePortsDocSubnetIDCIDR() error {
 
 func (s stateBackend) EnsureRelationApplicationSettings() error {
 	return state.EnsureRelationApplicationSettings(s.pool)
+}
+
+func (s stateBackend) ConvertAddressSpaceIDs() error {
+	return state.ConvertAddressSpaceIDs(s.pool)
 }

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -55,5 +55,12 @@ func stateStepsFor27() []Step {
 				return context.State().EnsureRelationApplicationSettings()
 			},
 		},
+		&upgradeStep{
+			description: "ensure stored addresses refer to space by ID, and remove old space name/provider ID",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().ConvertAddressSpaceIDs()
+			},
+		},
 	}
 }

--- a/upgrades/steps_27_test.go
+++ b/upgrades/steps_27_test.go
@@ -59,3 +59,8 @@ func (s *steps27Suite) TestEnsureRelationApplicationSettings(c *gc.C) {
 	step := findStateStep(c, v27, `ensure application settings exist for all relations`)
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps27Suite) TestConvertAddressSpaceIDs(c *gc.C) {
+	step := findStateStep(c, v27, `ensure stored addresses refer to space by ID, and remove old space name/provider ID`)
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/multiwatcher"
 	coretesting "github.com/juju/juju/testing"
@@ -110,19 +108,6 @@ func newUpgradeStep(msg string, targets ...upgrades.Target) *mockUpgradeStep {
 		msg:     msg,
 		targets: targets,
 	}
-}
-
-type mockEnvironUpgradeStep struct {
-	msg string
-	run func() error
-}
-
-func (m *mockEnvironUpgradeStep) Description() string {
-	return m.msg
-}
-
-func (m *mockEnvironUpgradeStep) Run() error {
-	return m.run()
 }
 
 type mockContext struct {
@@ -222,22 +207,6 @@ type mockStateBackend struct {
 func (mock *mockStateBackend) ControllerUUID() string {
 	mock.MethodCall(mock, "ControllerUUID")
 	return "a-b-c-d"
-}
-
-type mockModel struct {
-	testing.Stub
-	config    *config.Config
-	cloudSpec environs.CloudSpec
-}
-
-func (m *mockModel) Config() (*config.Config, error) {
-	m.MethodCall(m, "Config")
-	return m.config, m.NextErr()
-}
-
-func (m *mockModel) CloudSpec() (environs.CloudSpec, error) {
-	m.MethodCall(m, "CloudSpec")
-	return m.cloudSpec, m.NextErr()
 }
 
 func stateUpgradeOperations() []upgrades.Operation {
@@ -582,7 +551,7 @@ func (s *upgradeSuite) checkContextRestriction(c *gc.C, expectedPanic string) {
 	type fakeAgentConfigSetter struct{ agent.ConfigSetter }
 	ctx := upgrades.NewContext(fakeAgentConfigSetter{}, nil, &mockStateBackend{})
 	c.Assert(
-		func() { upgrades.PerformUpgrade(fromVersion, targets(upgrades.Controller), ctx) },
+		func() { _ = upgrades.PerformUpgrade(fromVersion, targets(upgrades.Controller), ctx) },
 		gc.PanicMatches, expectedPanic,
 	)
 }


### PR DESCRIPTION
## Description of change

This patch follows https://github.com/juju/juju/pull/10566 and upgrades addresses in the machines collection to replace space names with space IDs.

Included is temporary logic in the `allwatcher` to work around a situation where the API server fails to start, preventing the upgrade worker from executing the upgrade steps. This will be reverted following work to separate dependency on the API for state-based upgrade steps.

Logic for updating addresses in the `cloudservices` and `cloudcontainers` will also come in a patch to follow.

## QA steps

- Bootstrap to guimaas using the 2.6 branch.
- `juju add-machine --constraints spaces=default,space-alt2` to get a multi-NIC machine.
- Using this branch, run `juju upgrade-model -m controller --build-agent`.
- Connect to Mongo and observe that the `machines` collection addresses have space IDs and not space names.

## Documentation changes

None 

## Bug reference

N/A
