### PR TITLE
Fix intermittent failures in httpserver package.

### DIFF
--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -278,7 +278,7 @@ func (s *WorkerSuite) TestHeldListener(c *gc.C) {
 	select {
 	case err := <-quickErr:
 		c.Assert(err, jc.ErrorIsNil)
-	case <-time.After(coretesting.ShortWait):
+	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for quick request")
 	}
 
@@ -308,9 +308,13 @@ attempts:
 	s.mux.ClientDone()
 
 	select {
-	case err := <-quickErr:
+	case <-quickErr:
+		// There is a race in the queueing of the request. It is possible that
+		// the timer will fire a short wait before an unheld request gets to the
+		// phase where it would return nil. However this is only under significant
+		// load, and it isn't easy to synchronise. This is why we don't actually
+		// check the error.
 		// It doesn't really matter what the error is.
-		c.Assert(err, gc.NotNil)
 	case <-time.After(coretesting.ShortWait):
 		c.Fatalf("timed out waiting for 2nd quick request")
 	}

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -287,8 +287,16 @@ func (s *WorkerSuite) TestHeldListener(c *gc.C) {
 
 	// Eventually quick requests get blocked by the held listener.
 	var quickBlocked bool
+	// A very small sleep will allow the kill to be more likely to be processed
+	// by the running loop.
+	time.Sleep(10 * time.Millisecond)
 attempts:
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
+	// We actually try the quick request more than once, on the off chance
+	// that the worker hasn't finished processing the kill signal. Since we have
+	// no other way to check, we just try a quick request, and decide that if
+	// it doesn't respond quickly, the main loop is waithing for the clients to
+	// be done.
+	for i := 0; i < 5; i++ {
 		go request()
 		select {
 		case <-quickErr:


### PR DESCRIPTION
Address two intermittent failures in the httpserver tests.

The first is the wait for the quick request to be processed. Under a machine with heavy load, this sometimes takes longer than 50ms. See https://jenkins.juju.canonical.com/view/unit%20tests/job/RunUnittests-amd64-bionic/1573/testReport/junit/github/com_juju_juju_worker_httpserver/TestPackage/

The second race is where the quick endpoint is hit too soon after the kill that the event is processed successfully, but doesn't return before the 50ms timeout which causes the test to assume that it is in fact blocked.

While there is no way to provide definite synchronisation between the worker and the test without other call back functions, the fix here is twofold: first, add a small sleep before the request check, and secondly, we don't actually care what the error is that was returned.