### PR TITLE
Pass logger into storage provisioner worker

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -933,6 +933,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:                    agentName,
 			APICallerName:                apiCallerName,
 			Clock:                        config.Clock,
+			Logger:                       loggo.GetLogger("juju.worker.storageprovisioner"),
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
 		}))),
 		brokerTrackerName: ifNotMigrating(lxdbroker.Manifold(lxdbroker.ManifoldConfig{

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -364,7 +364,8 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}))),
 		storageProvisionerName: ifNotMigrating(ifCredentialValid(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName:                apiCallerName,
-			ClockName:                    clockName,
+			Clock:                        config.Clock,
+			Logger:                       config.LoggingContext.GetLogger("juju.worker.storageprovisioner"),
 			StorageRegistryName:          environTrackerName,
 			Model:                        modelTag,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
@@ -492,7 +493,8 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 		caasStorageProvisionerName: ifNotMigrating(ifCredentialValid(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName:                apiCallerName,
-			ClockName:                    clockName,
+			Clock:                        config.Clock,
+			Logger:                       config.LoggingContext.GetLogger("juju.worker.storageprovisioner"),
 			StorageRegistryName:          caasBrokerTrackerName,
 			Model:                        modelTag,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -244,7 +244,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"caas-broker-tracker",
-		"clock",
 		"is-responsible-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
@@ -594,7 +593,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	"storage-provisioner": {
 		"agent",
 		"api-caller",
-		"clock",
 		"environ-tracker",
 		"is-responsible-flag",
 		"migration-fortress",

--- a/worker/storageprovisioner/blockdevices.go
+++ b/worker/storageprovisioner/blockdevices.go
@@ -68,7 +68,7 @@ func machineBlockDevicesChanged(ctx *context) error {
 // previously observed block devices.
 func processPendingVolumeBlockDevices(ctx *context) error {
 	if len(ctx.pendingVolumeBlockDevices) == 0 {
-		logger.Tracef("no pending volume block devices")
+		ctx.config.Logger.Tracef("no pending volume block devices")
 		return nil
 	}
 	volumeTags := make([]names.VolumeTag, len(ctx.pendingVolumeBlockDevices))
@@ -87,7 +87,7 @@ func refreshVolumeBlockDevices(ctx *context, volumeTags []names.VolumeTag) error
 	if !ok {
 		// This function should only be called by machine-scoped
 		// storage provisioners.
-		logger.Warningf("refresh block devices, expected machine tag, got %v", ctx.config.Scope)
+		ctx.config.Logger.Warningf("refresh block devices, expected machine tag, got %v", ctx.config.Scope)
 		return nil
 	}
 	ids := make([]params.MachineStorageId, len(volumeTags))

--- a/worker/storageprovisioner/caasworker.go
+++ b/worker/storageprovisioner/caasworker.go
@@ -123,11 +123,11 @@ func (p *provisioner) loop() error {
 			for i, appId := range apps {
 				appLifeResult := appsLife[i]
 				if appLifeResult.Error != nil && params.IsCodeNotFound(appLifeResult.Error) {
-					logger.Debugf("app %v not found", appId)
+					p.config.Logger.Debugf("app %v not found", appId)
 					_, ok := p.getApplicationWorker(appId)
 					if ok {
 						if err := worker.Stop(w); err != nil {
-							logger.Errorf("stopping application storage worker for %v: %v", appId, err)
+							p.config.Logger.Errorf("stopping application storage worker for %v: %v", appId, err)
 						}
 						p.deleteApplicationWorker(appId)
 					}

--- a/worker/storageprovisioner/caasworker_test.go
+++ b/worker/storageprovisioner/caasworker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -53,6 +54,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		Life:             s.lifeGetter,
 		Status:           &mockStatusSetter{},
 		Clock:            &mockClock{},
+		Logger:           loggo.GetLogger("test"),
 		Registry:         storage.StaticProviderRegistry{},
 		CloudCallContext: context.NewCloudCallContext(),
 	}

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -82,7 +82,7 @@ func removeEntities(ctx *context, tags []names.Tag) error {
 	if len(tags) == 0 {
 		return nil
 	}
-	logger.Debugf("removing entities: %v", tags)
+	ctx.config.Logger.Debugf("removing entities: %v", tags)
 	errorResults, err := ctx.config.Life.Remove(tags)
 	if err != nil {
 		return errors.Annotate(err, "removing storage entities")
@@ -121,7 +121,7 @@ func removeAttachments(ctx *context, ids []params.MachineStorageId) error {
 func setStatus(ctx *context, statuses []params.EntityStatusArgs) {
 	if len(statuses) > 0 {
 		if err := ctx.config.Status.SetStatus(statuses); err != nil {
-			logger.Errorf("failed to set status: %v", err)
+			ctx.config.Logger.Errorf("failed to set status: %v", err)
 		}
 	}
 }

--- a/worker/storageprovisioner/config.go
+++ b/worker/storageprovisioner/config.go
@@ -12,6 +12,14 @@ import (
 	"github.com/juju/juju/storage"
 )
 
+// Logger represents the methods used by the worker to log details.
+type Logger interface {
+	Tracef(string, ...interface{})
+	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
 // Config holds configuration and dependencies for a storageprovisioner worker.
 type Config struct {
 	Model            names.ModelTag
@@ -25,6 +33,7 @@ type Config struct {
 	Machines         MachineAccessor
 	Status           StatusSetter
 	Clock            clock.Clock
+	Logger           Logger
 	CloudCallContext environscontext.ProviderCallContext
 }
 
@@ -71,6 +80,9 @@ func (config Config) Validate() error {
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("nil Clock")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
 	}
 	if config.CloudCallContext == nil {
 		return errors.NotValidf("nil CloudCallContext")

--- a/worker/storageprovisioner/config_test.go
+++ b/worker/storageprovisioner/config_test.go
@@ -102,6 +102,11 @@ func (s *ConfigSuite) TestNilClock(c *gc.C) {
 	s.checkNotValid(c, "nil Clock not valid")
 }
 
+func (s *ConfigSuite) TestNilLogger(c *gc.C) {
+	s.config.Logger = nil
+	s.checkNotValid(c, "nil Logger not valid")
+}
+
 func (s *ConfigSuite) checkNotValid(c *gc.C, match string) {
 	err := s.config.Validate()
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
@@ -152,6 +157,9 @@ func almostValidConfig() storageprovisioner.Config {
 		}{},
 		Clock: struct {
 			clock.Clock
+		}{},
+		Logger: struct {
+			storageprovisioner.Logger
 		}{},
 	}
 }

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -34,7 +34,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 	var filesystems []storage.Filesystem
 	var statuses []params.EntityStatusArgs
 	for sourceName, filesystemParams := range paramsBySource {
-		logger.Debugf("creating filesystems: %v", filesystemParams)
+		ctx.config.Logger.Debugf("creating filesystems: %v", filesystemParams)
 		filesystemSource := filesystemSources[sourceName]
 		validFilesystemParams, validationErrors := validateFilesystemParams(
 			filesystemSource, filesystemParams,
@@ -48,7 +48,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
-			logger.Debugf(
+			ctx.config.Logger.Debugf(
 				"failed to validate parameters for %s: %v",
 				names.ReadableString(filesystemParams[i].Tag), err,
 			)
@@ -77,7 +77,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 				// status to "error" for permanent errors.
 				entityStatus.Status = status.Pending.String()
 				entityStatus.Info = result.Error.Error()
-				logger.Debugf(
+				ctx.config.Logger.Debugf(
 					"failed to create %s: %v",
 					names.ReadableString(filesystemParams[i].Tag),
 					result.Error,
@@ -102,7 +102,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 	}
 	for i, result := range errorResults {
 		if result.Error != nil {
-			logger.Errorf(
+			ctx.config.Logger.Errorf(
 				"publishing filesystem %s to state: %v",
 				filesystems[i].Tag.Id(),
 				result.Error,
@@ -139,7 +139,7 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 	var filesystemAttachments []storage.FilesystemAttachment
 	var statuses []params.EntityStatusArgs
 	for sourceName, filesystemAttachmentParams := range paramsBySource {
-		logger.Debugf("attaching filesystems: %+v", filesystemAttachmentParams)
+		ctx.config.Logger.Debugf("attaching filesystems: %+v", filesystemAttachmentParams)
 		filesystemSource := filesystemSources[sourceName]
 		results, err := filesystemSource.AttachFilesystems(ctx.config.CloudCallContext, filesystemAttachmentParams)
 		if err != nil {
@@ -166,7 +166,7 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 				// set the status to "error" for permanent errors.
 				entityStatus.Status = status.Attaching.String()
 				entityStatus.Info = result.Error.Error()
-				logger.Debugf(
+				ctx.config.Logger.Debugf(
 					"failed to attach %s to %s: %v",
 					names.ReadableString(p.Filesystem),
 					names.ReadableString(p.Machine),
@@ -241,7 +241,7 @@ func removeFilesystems(ctx *context, ops map[names.FilesystemTag]*removeFilesyst
 		return nil
 	}
 	for sourceName, filesystemParams := range paramsBySource {
-		logger.Debugf("removing filesystems from %q: %v", sourceName, filesystemParams)
+		ctx.config.Logger.Debugf("removing filesystems from %q: %v", sourceName, filesystemParams)
 		filesystemSource := filesystemSources[sourceName]
 		removeTags := make([]names.FilesystemTag, len(filesystemParams))
 		removeParams := make([]params.RemoveFilesystemParams, len(filesystemParams))
@@ -306,7 +306,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 	var statuses []params.EntityStatusArgs
 	var remove []params.MachineStorageId
 	for sourceName, filesystemAttachmentParams := range paramsBySource {
-		logger.Debugf("detaching filesystems: %+v", filesystemAttachmentParams)
+		ctx.config.Logger.Debugf("detaching filesystems: %+v", filesystemAttachmentParams)
 		filesystemSource, ok := filesystemSources[sourceName]
 		if !ok && ctx.isApplicationKind() {
 			continue
@@ -334,7 +334,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 				reschedule = append(reschedule, ops[id])
 				entityStatus.Status = status.Detaching.String()
 				entityStatus.Info = err.Error()
-				logger.Debugf(
+				ctx.config.Logger.Debugf(
 					"failed to detach %s from %s: %v",
 					names.ReadableString(p.Filesystem),
 					names.ReadableString(p.Machine),

--- a/worker/storageprovisioner/manifold_machine.go
+++ b/worker/storageprovisioner/manifold_machine.go
@@ -25,14 +25,17 @@ type MachineManifoldConfig struct {
 	AgentName                    string
 	APICallerName                string
 	Clock                        clock.Clock
+	Logger                       Logger
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
 }
 
 func (config MachineManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	if config.Clock == nil {
-		return nil, dependency.ErrMissing
+		return nil, errors.NotValidf("missing Clock")
 	}
-
+	if config.Logger == nil {
+		return nil, errors.NotValidf("missing Logger")
+	}
 	cfg := a.CurrentConfig()
 	api, err := storageprovisioner.NewState(apiCaller)
 	if err != nil {
@@ -60,6 +63,7 @@ func (config MachineManifoldConfig) newWorker(a agent.Agent, apiCaller base.APIC
 		Machines:         api,
 		Status:           api,
 		Clock:            config.Clock,
+		Logger:           config.Logger,
 		CloudCallContext: common.NewCloudCallContext(credentialAPI, nil),
 	})
 	if err != nil {

--- a/worker/storageprovisioner/manifold_model_test.go
+++ b/worker/storageprovisioner/manifold_model_test.go
@@ -26,33 +26,17 @@ var _ = gc.Suite(&ManifoldSuite{})
 func (s *ManifoldSuite) TestManifold(c *gc.C) {
 	manifold := storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 		APICallerName:       "grenouille",
-		ClockName:           "bustopher",
 		StorageRegistryName: "environ",
 	})
-	c.Check(manifold.Inputs, jc.DeepEquals, []string{"grenouille", "bustopher", "environ"})
+	c.Check(manifold.Inputs, jc.DeepEquals, []string{"grenouille", "environ"})
 	c.Check(manifold.Output, gc.IsNil)
 	c.Check(manifold.Start, gc.NotNil)
 	// ...Start is *not* well-tested, in common with many manifold configs.
 }
 
-func (s *ManifoldSuite) TestMissingClock(c *gc.C) {
-	manifold := storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
-		APICallerName:       "api-caller",
-		ClockName:           "clock",
-		StorageRegistryName: "environ",
-	})
-	_, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{
-		"api-caller": struct{ base.APICaller }{},
-		"clock":      dependency.ErrMissing,
-		"environ":    struct{ environs.Environ }{},
-	}))
-	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
-}
-
 func (s *ManifoldSuite) TestMissingAPICaller(c *gc.C) {
 	manifold := storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 		APICallerName:       "api-caller",
-		ClockName:           "clock",
 		StorageRegistryName: "environ",
 	})
 	_, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{
@@ -66,7 +50,6 @@ func (s *ManifoldSuite) TestMissingAPICaller(c *gc.C) {
 func (s *ManifoldSuite) TestMissingEnviron(c *gc.C) {
 	manifold := storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 		APICallerName:       "api-caller",
-		ClockName:           "clock",
 		StorageRegistryName: "environ",
 	})
 	_, err := manifold.Start(dt.StubContext(nil, map[string]interface{}{

--- a/worker/storageprovisioner/storageprovisioner.go
+++ b/worker/storageprovisioner/storageprovisioner.go
@@ -28,7 +28,6 @@ package storageprovisioner
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
@@ -40,7 +39,9 @@ import (
 	"github.com/juju/juju/worker/storageprovisioner/internal/schedule"
 )
 
-var logger = loggo.GetLogger("juju.worker.storageprovisioner")
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead use the one passed as manifold config.
+var logger interface{}
 
 var newManagedFilesystemSource = provider.NewManagedFilesystemSource
 

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
@@ -67,6 +68,7 @@ func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
 		Machines:         newMockMachineAccessor(c),
 		Status:           &mockStatusSetter{},
 		Clock:            &mockClock{},
+		Logger:           loggo.GetLogger("test"),
 		CloudCallContext: context.NewCloudCallContext(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2069,6 +2071,7 @@ func newStorageProvisioner(c *gc.C, args *workerArgs) worker.Worker {
 		Machines:         args.machines,
 		Status:           args.statusSetter,
 		Clock:            args.clock,
+		Logger:           loggo.GetLogger("test"),
 		CloudCallContext: context.NewCloudCallContext(),
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -30,7 +30,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 	var volumeAttachments []storage.VolumeAttachment
 	var statuses []params.EntityStatusArgs
 	for sourceName, volumeParams := range paramsBySource {
-		logger.Debugf("creating volumes: %v", volumeParams)
+		ctx.config.Logger.Debugf("creating volumes: %v", volumeParams)
 		volumeSource := volumeSources[sourceName]
 		validVolumeParams, validationErrors := validateVolumeParams(volumeSource, volumeParams)
 		for i, err := range validationErrors {
@@ -42,7 +42,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 				Status: status.Error.String(),
 				Info:   err.Error(),
 			})
-			logger.Debugf(
+			ctx.config.Logger.Debugf(
 				"failed to validate parameters for %s: %v",
 				names.ReadableString(volumeParams[i].Tag), err,
 			)
@@ -71,7 +71,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 				// status to "error" for permanent errors.
 				entityStatus.Status = status.Pending.String()
 				entityStatus.Info = result.Error.Error()
-				logger.Debugf(
+				ctx.config.Logger.Debugf(
 					"failed to create %s: %v",
 					names.ReadableString(volumeParams[i].Tag),
 					result.Error,
@@ -100,7 +100,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 	}
 	for i, result := range errorResults {
 		if result.Error != nil {
-			logger.Errorf(
+			ctx.config.Logger.Errorf(
 				"publishing volume %s to state: %v",
 				volumes[i].Tag.Id(),
 				result.Error,
@@ -138,7 +138,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 	var volumeAttachments []storage.VolumeAttachment
 	var statuses []params.EntityStatusArgs
 	for sourceName, volumeAttachmentParams := range paramsBySource {
-		logger.Debugf("attaching volumes: %+v", volumeAttachmentParams)
+		ctx.config.Logger.Debugf("attaching volumes: %+v", volumeAttachmentParams)
 		volumeSource := volumeSources[sourceName]
 		if volumeSource == nil {
 			// The storage provider does not support dynamic
@@ -172,7 +172,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 				// set the status to "error" for permanent errors.
 				entityStatus.Status = status.Attaching.String()
 				entityStatus.Info = result.Error.Error()
-				logger.Debugf(
+				ctx.config.Logger.Debugf(
 					"failed to attach %s to %s: %v",
 					names.ReadableString(p.Volume),
 					names.ReadableString(p.Machine),
@@ -300,7 +300,7 @@ func removeVolumes(ctx *context, ops map[names.VolumeTag]*removeVolumeOp) error 
 		return nil
 	}
 	for sourceName, volumeParams := range paramsBySource {
-		logger.Debugf("removing volumes from %q: %v", sourceName, volumeParams)
+		ctx.config.Logger.Debugf("removing volumes from %q: %v", sourceName, volumeParams)
 		volumeSource := volumeSources[sourceName]
 		removeTags := make([]names.VolumeTag, len(volumeParams))
 		removeParams := make([]params.RemoveVolumeParams, len(volumeParams))
@@ -361,7 +361,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 	var statuses []params.EntityStatusArgs
 	var remove []params.MachineStorageId
 	for sourceName, volumeAttachmentParams := range paramsBySource {
-		logger.Debugf("detaching volumes: %+v", volumeAttachmentParams)
+		ctx.config.Logger.Debugf("detaching volumes: %+v", volumeAttachmentParams)
 		volumeSource := volumeSources[sourceName]
 		if volumeSource == nil {
 			// The storage provider does not support dynamic
@@ -392,7 +392,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 				reschedule = append(reschedule, ops[id])
 				entityStatus.Status = status.Detaching.String()
 				entityStatus.Info = err.Error()
-				logger.Debugf(
+				ctx.config.Logger.Debugf(
 					"failed to detach %s from %s: %v",
 					names.ReadableString(p.Volume),
 					names.ReadableString(p.Machine),


### PR DESCRIPTION
Update the storage provisioner worker to get the clock and logger from the manifold config. This means we have the logger from the right logging context when operating in the controller.
