### PR TITLE
Tests can expect a numeric action id

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1876,8 +1876,8 @@ class ModelClient:
         args = (unit, action) + args
 
         output = self.get_juju_output("run-action", *args)
-        action_id_pattern = re.compile(
-            'Action queued with id: ((?:[a-f0-9\-]{36})|(?:(?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*)-(?:0|[1-9][0-9]*)))')
+        idRegexp = '([0-9]+|((?:[a-f0-9\-]{36})|(?:(?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*)-(?:0|[1-9][0-9]*))))'
+        action_id_pattern = re.compile('Action queued with id: ' + idRegexp)
         match = action_id_pattern.search(output)
         if match is None:
             raise Exception("Action id not found in output: %s" %

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -2837,9 +2837,9 @@ class TestModelClient(ClientTest):
                              '1.23-series-arch', None)
         with patch.object(ModelClient, 'get_juju_output') as mock:
             mock.return_value = \
-                "Action queued with id: 5a92ec93-d4be-4399-82dc-7431dbfd08f9"
+                "Action queued with id: 666"
             id = client.action_do("foo/0", "myaction", "param=5")
-            self.assertEqual(id, "5a92ec93-d4be-4399-82dc-7431dbfd08f9")
+            self.assertEqual(id, "666")
         mock.assert_called_once_with(
             'run-action', 'foo/0', 'myaction', "param=5"
         )
@@ -2886,7 +2886,7 @@ class TestModelClient(ClientTest):
             # setting side_effect to an iterable will return the next value
             # from the list each time the function is called.
             mock.side_effect = [
-                "Action queued with id: 5a92ec93-d4be-4399-82dc-7431dbfd08f9",
+                "Action queued with id: 666",
                 ret]
             out = client.action_do_fetch("foo/0", "myaction", "param=5")
             self.assertEqual(out, ret)


### PR DESCRIPTION
## Description of change

The network health CI tests were failing because they were checking for an action id that is a UUID. Juju now produces numeric action ids.

## QA steps

Run the network health test on AWS and LXD.
