### PR TITLE
model-config: add default spaces

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -241,6 +241,9 @@ const (
 	// list will be comma separated.
 	ContainerInheritPropertiesKey = "container-inherit-properties"
 
+	// Networking spaces
+	DefaultSpace = "default-space"
+
 	//
 	// Deprecated Settings Attributes
 	//
@@ -420,7 +423,7 @@ var defaultConfigValues = map[string]interface{}{
 	IgnoreMachineAddresses:       false,
 	"ssl-hostname-verification":  true,
 	"proxy-ssh":                  false,
-
+	DefaultSpace:                 "_default",
 	// Why is net-bond-reconfigure-delay set to 17 seconds?
 	//
 	// The value represents the amount of time in seconds to sleep
@@ -823,6 +826,11 @@ func (c *Config) Name() string {
 // UUID returns the uuid for the model.
 func (c *Config) UUID() string {
 	return c.mustString(UUIDKey)
+}
+
+// DefaultSpace returns the default-space for the model.
+func (c *Config) DefaultSpace() string {
+	return c.asString(DefaultSpace)
 }
 
 // DefaultSeries returns the configured default Ubuntu series for the environment,
@@ -1515,6 +1523,7 @@ var alwaysOptional = schema.Defaults{
 	CloudInitUserDataKey:          schema.Omit,
 	ContainerInheritPropertiesKey: schema.Omit,
 	BackupDirKey:                  schema.Omit,
+	DefaultSpace:                  schema.Omit,
 }
 
 func allowEmpty(attr string) bool {
@@ -2020,6 +2029,11 @@ data of the store. (default false)`,
 	},
 	BackupDirKey: {
 		Description: "Directory used to store the backup working directory",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
+	DefaultSpace: {
+		Description: "The default network space used for application endpoints in this model",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -571,6 +571,12 @@ var configTests = []configTest{
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"backup-dir": "/foo/bar",
 		}),
+	}, {
+		about:       "Default-space takes a string as valid value",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"default-space": "_bar",
+		}),
 	},
 }
 
@@ -641,6 +647,10 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
 		c.Assert(cfg.FirewallMode(), gc.Equals, m)
+	}
+
+	if m, _ := test.attrs["default-space"].(string); m != "" {
+		c.Assert(cfg.DefaultSpace(), gc.Equals, m)
 	}
 
 	keys, _ := test.attrs["authorized-keys"].(string)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -804,6 +804,20 @@ func AddStatusHistoryPruneSettings(pool *StatePool) error {
 	return nil
 }
 
+// AddDefaultSpaceSetting adds the default space setting
+func AddDefaultSpaceSetting(pool *StatePool) error {
+	st := pool.SystemState()
+	err := applyToAllModelSettings(st, func(doc *settingsDoc) (bool, error) {
+		defaultSettingDefaultSpace := config.ConfigDefaults()[config.DefaultSpace]
+		settingsChanged := maybeUpdateSettings(doc.Settings, config.DefaultSpace, defaultSettingDefaultSpace)
+		return settingsChanged, nil
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // AddActionPruneSettings adds the model settings
 // to control log pruning if they are missing.
 func AddActionPruneSettings(pool *StatePool) error {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -73,6 +73,7 @@ type StateBackend interface {
 	ReplacePortsDocSubnetIDCIDR() error
 	EnsureRelationApplicationSettings() error
 	ConvertAddressSpaceIDs() error
+	AddDefaultSpaceSetting() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -137,6 +138,10 @@ func (s stateBackend) AddControllerLogCollectionsSizeSettings() error {
 
 func (s stateBackend) AddStatusHistoryPruneSettings() error {
 	return state.AddStatusHistoryPruneSettings(s.pool)
+}
+
+func (s stateBackend) AddDefaultSpaceSetting() error {
+	return state.AddDefaultSpaceSetting(s.pool)
 }
 
 func (s stateBackend) AddActionPruneSettings() error {

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -62,5 +62,12 @@ func stateStepsFor27() []Step {
 				return context.State().ConvertAddressSpaceIDs()
 			},
 		},
+		&upgradeStep{
+			description: "adds default value for default_space",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddDefaultSpaceSetting()
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Description of change

 - [x] Adds a model default for spaces
 - [x] Upgrade steps 

## QA steps
- Unit tests
### New Bootstrap
- "juju model-config" should output "...default_spaces=_default" after a new bootstrap
### Upgrade
- 2.6 deployed
- upgrade-controller to current version
- "juju model-config" should output "...default_spaces=_default" 
```
~/golang/src/github.com/juju/juju add_spaces 39s
❯ juju model-config | grep space               
default-space                      default     _default
```