### PR TITLE
Use Assigned Unit's Application Bindings As Space Constraints for New Machines

### DIFF
--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -214,23 +214,20 @@ func (p *BridgePolicy) findSpacesAndDevicesForContainer(
 func (p *BridgePolicy) determineContainerSpaces(
 	host Machine, guest Container, defaultSpaceName string,
 ) (corenetwork.SpaceInfos, error) {
-	spaces := set.NewStrings()
-
 	// Gather any *positive* space constraints for the guest.
 	cons, err := guest.Constraints()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if cons.Spaces != nil {
-		for _, space := range *cons.Spaces {
-			if !strings.HasPrefix(space, "^") {
-				spaces.Add(space)
-			}
-		}
-	}
+	spaces := set.NewStrings(cons.IncludeSpaces()...)
 
 	// Gather any space bindings for application endpoints
-	// that apply to units the the container will host.
+	// that apply to units that the container will host.
+	// TODO (manadart 2019-10-08): This is not necessary now that we convert
+	// endpoint bindings into machine space constraints when placing units.
+	// However it remains in case we fix that logic properly to do machine
+	// creation and assignment in a single transaction.
+	// See `state.AssignUnitWithPlacement`.
 	units, err := guest.Units()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/state.go
+++ b/state/state.go
@@ -1802,7 +1802,12 @@ func (st *State) addMachineWithPlacement(unit *Unit, data *placementData) (*Mach
 	}
 	spaces := set.NewStrings()
 	for _, space := range bindings {
-		spaces.Add(space)
+		// TODO (manadart 2019-10-08): "" is not a valid space name and so
+		// can not be used as a constraint. This condition will be removed with
+		// the institution of universal mutable spaces.
+		if space != network.DefaultSpaceName {
+			spaces.Add(space)
+		}
 	}
 	spaceCons := constraints.MustParse("spaces=" + strings.Join(spaces.Values(), ","))
 	cons, err := constraints.Merge(*unitCons, spaceCons)

--- a/state/state.go
+++ b/state/state.go
@@ -1782,7 +1782,32 @@ func (st *State) parsePlacement(placement *instance.Placement) (*placementData, 
 func (st *State) addMachineWithPlacement(unit *Unit, data *placementData) (*Machine, error) {
 	unitCons, err := unit.Constraints()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
+	}
+
+	// Turn any endpoint bindings for the unit's application into machine
+	// constraints. This prevents a possible race condition where the
+	// provisioner can act on a newly created container before the unit is
+	// assigned to it, missing the required spaces for bridging based on
+	// endpoint bindings.
+	// TODO (manadart 2019-10-08): This step is not necessary when a single
+	// transaction is used based on the comment below.
+	app, err := unit.Application()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	bindings, err := app.EndpointBindings()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	spaces := set.NewStrings()
+	for _, space := range bindings {
+		spaces.Add(space)
+	}
+	spaceCons := constraints.MustParse("spaces=" + strings.Join(spaces.Values(), ","))
+	cons, err := constraints.Merge(*unitCons, spaceCons)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	// Create any new machine marked as dirty so that
@@ -1825,14 +1850,15 @@ func (st *State) addMachineWithPlacement(unit *Unit, data *placementData) (*Mach
 			Series:      unit.Series(),
 			Jobs:        []MachineJob{JobHostUnits},
 			Dirty:       true,
-			Constraints: *unitCons,
+			Constraints: cons,
 		}
 		if mId != "" {
 			return st.AddMachineInsideMachine(template, mId, data.containerType)
 		}
 		return st.AddMachineInsideNewMachine(template, template, data.containerType)
 	case directivePlacement:
-		return nil, errors.NotSupportedf("programming error: directly adding a machine for %s with a non-machine placement directive", unit.Name())
+		return nil, errors.NotSupportedf(
+			"programming error: directly adding a machine for %s with a non-machine placement directive", unit.Name())
 	default:
 		return machine, nil
 	}

--- a/state/unit_assignment.go
+++ b/state/unit_assignment.go
@@ -4,7 +4,7 @@
 package state
 
 // assignUnitDoc is a document that temporarily stores unit assignment
-// information created during srevice creation until the unitassigner worker can
+// information created during service creation until the unitassigner worker can
 // come along and use it.
 type assignUnitDoc struct {
 	// DocId is the unique id of the document, which is also the unit id of the


### PR DESCRIPTION
## Description of change

In `state.AssignUnitWithPlacement`, there is logic that creates a machine for unit placement then assigns the unit in two separate transactions.

It is possible that the provisioner can act on a new container before the unit assignment has occurred, meaning that the unit's application endpoints are not considered when determination of which host devices to bridge is made.

This patch interrogates the unit's application endpoint bindings and adds them as positive space constraints to the template for any associated machine creation, eliminating the possibility that we will incorrectly determine which spaces a target container should be in.

## QA steps

MAAS:
- Bootstrap to guimaas with `--build-agent`.
- `juju deploy keystone --bind "public=default internal=space-alt2 admin=default shared-db=space-alt2"`
- `juju add-unit keystone --to lxd:0`.
- `juju show-machine 0` indicates the machine and container got the two bindings as constraints.
- `juju deploy postgresql` works (no bindings).
- `juju add-unit postgresql -- to lxd:1` works (no bindings).

AWS:
- Bootstrap to aws with `--build-agent`.
- `juju add-space new-space 172.31.0.0/20`.
- `juju deploy keystone --bind "new-space" --to lxd`.
- `juju show-machine 0` indicates the machine and container got the two bindings as constraints.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1845392 is possibly a manifestation of this issue, and there are likely other associated live bugs.
