### PR TITLE
Systemd uses 'infinity' where ulimit uses 'unlimited'

### DIFF
--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -777,3 +777,40 @@ func (s *initSystemSuite) TestStartCommands(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(commands, jc.DeepEquals, []string{"/bin/systemctl start jujud-machine-0.service"})
 }
+
+func (s *initSystemSuite) TestInstallLimits(c *gc.C) {
+	name := "juju-job"
+	conf := common.Conf{
+		Desc:      "juju agent for juju-job",
+		ExecStart: "/usr/bin/jujud juju-job",
+		Limit: map[string]string{
+			"fsize":   "unlimited",
+			"cpu":     "unlimited",
+			"as":      "12345",
+			"memlock": "unlimited",
+			"nofile":  "64000",
+		},
+	}
+	data, err := systemd.Serialize(name, conf, renderer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(data), gc.Equals, `
+[Unit]
+Description=juju agent for juju-job
+After=syslog.target
+After=network.target
+After=systemd-user-sessions.service
+
+[Service]
+LimitAS=12345
+LimitCPU=infinity
+LimitFSIZE=infinity
+LimitMEMLOCK=infinity
+LimitNOFILE=64000
+ExecStart=/usr/bin/jujud juju-job
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+
+`[1:])
+}


### PR DESCRIPTION
## Description of change

It is unclear why these use a different syntax, and we could just put
'infinity' in our Service definitions. However, this feels like a
'ulimit' vs 'systemd' thing, so lets encode the Systemd knowledge inside
the Systemd service renderer.

To make testing easier, I also sort the limit variables, otherwise we're iterating a map and they appear in random order.

## QA steps

```$ juju bootstrap
$ juju ssh -m controller 0
$$ sudo vim /lib/systemd/system/juju-db/juju-db.service
```
You should see things like:
```
LimitFS=infinity
```
Rather than
```
LimitFS=unlimited
```

You should also be able to verify this by using something like
```
$ ps -C mongod
# get the PID
$ cat /proc/$PID/limits
```

To see what the ulimits for that process is.


## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1845350
