### PR TITLE
change permissions: let group members read logs as well

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -353,7 +353,7 @@ echo 'Installing Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(service jujud-machine-0\)'.*
-cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
+cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0640 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-0
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-precise-amd64\.sha256
 `,
@@ -406,7 +406,7 @@ cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(service jujud-machine-99\)'.*
-cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0600 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
+cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:syslog /var/log/juju/machine-99\.log\\n  chmod 0640 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-99
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 `,
@@ -459,7 +459,7 @@ mkdir -p '/var/lib/juju/agents/machine-2-lxd-1'
 cat > '/var/lib/juju/agents/machine-2-lxd-1/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-2-lxd-1/agent\.conf'
 ln -s 1\.2\.3-quantal-amd64 '/var/lib/juju/tools/machine-2-lxd-1'
-cat > /etc/init/jujud-machine-2-lxd-1\.conf << 'EOF'\\ndescription "juju agent for machine-2-lxd-1"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxd-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxd-1\.log\\n  chmod 0600 /var/log/juju/machine-2-lxd-1\.log\\n\\n  exec '/var/lib/juju/tools/machine-2-lxd-1/jujud' machine --data-dir '/var/lib/juju' --machine-id 2/lxd/1 --debug >> /var/log/juju/machine-2-lxd-1\.log 2>&1\\nend script\\nEOF\\n
+cat > /etc/init/jujud-machine-2-lxd-1\.conf << 'EOF'\\ndescription "juju agent for machine-2-lxd-1"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-2-lxd-1\.log\\n  chown syslog:syslog /var/log/juju/machine-2-lxd-1\.log\\n  chmod 0640 /var/log/juju/machine-2-lxd-1\.log\\n\\n  exec '/var/lib/juju/tools/machine-2-lxd-1/jujud' machine --data-dir '/var/lib/juju' --machine-id 2/lxd/1 --debug >> /var/log/juju/machine-2-lxd-1\.log 2>&1\\nend script\\nEOF\\n
 start jujud-machine-2-lxd-1
 `,
 	},

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -68,7 +68,7 @@ func normalize(name string, conf common.Conf, scriptPath string, renderer confRe
 		// is syslog.
 		user, group := syslogUserGroup()
 		cmds = append(cmds, renderer.Chown(filename, user, group)...)
-		cmds = append(cmds, renderer.Chmod(filename, 0600)...)
+		cmds = append(cmds, renderer.Chmod(filename, 0640)...)
 		cmds = append(cmds, renderer.RedirectOutput(filename)...)
 		cmds = append(cmds, renderer.RedirectFD("out", "err")...)
 		cmds = append(cmds,

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -191,7 +191,7 @@ func (s *initSystemSuite) TestNewServiceLogfile(c *gc.C) {
 # Set up logging.
 touch '/var/log/juju/machine-0.log'
 chown `[1:] + user + `:` + group + ` '/var/log/juju/machine-0.log'
-chmod 0600 '/var/log/juju/machine-0.log'
+chmod 0640 '/var/log/juju/machine-0.log'
 exec >> '/var/log/juju/machine-0.log'
 exec 2>&1
 

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -350,7 +350,7 @@ script
   # Ensure log files are properly protected
   touch {{.Logfile}}
   chown syslog:syslog {{.Logfile}}
-  chmod 0600 {{.Logfile}}
+  chmod 0640 {{.Logfile}}
 {{end}}
   exec {{.ExecStart}}{{if .Logfile}} >> {{.Logfile}} 2>&1{{end}}
 end script


### PR DESCRIPTION
## Description of change

Adds read rights to group users. This should be seen as a complement PR to #10696, which adds the logs to the `adm` group.

## QA steps
- unit test updated
- should PR #10696  be merged first I can add an additional acceptance test
- manual:
  - bootstrap new controller
  - deploy something (ubuntu)
```
[17:35:40] nam:juju git:(add_read_rights) $ juju ssh 0 -- ls -la /var/log/juju                                                     
total 172
drwxr-xr-x  2 syslog adm     4096 Oct  8 15:35 .
drwxrwxr-x 10 root   syslog  4096 Oct  8 15:35 ..
-rw-r-----  1 syslog syslog 27701 Oct  8 15:35 machine-0.log
-rw-r--r--  1 root   root     861 Oct  8 15:36 machine-lock.log
-rw-r-----  1 syslog syslog 73491 Oct  8 15:36 unit-ntp-0.log
-rw-r-----  1 syslog syslog 60788 Oct  8 15:35 unit-ubuntu-0.log
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1679479