### PR TITLE
Ensure Consistent Order of Addresses Returned by Uniter NetworkInfo

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -812,7 +812,7 @@ func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]param
 	var results params.NetworkInfoResults
 	args := params.NetworkInfoParams{
 		Unit:       u.tag.String(),
-		Bindings:   bindings,
+		Endpoints:  bindings,
 		RelationId: relationId,
 	}
 

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -515,7 +515,7 @@ func (s *unitSuite) TestNetworkInfo(c *gc.C) {
 		c.Check(request, gc.Equals, "NetworkInfo")
 		c.Check(arg, gc.DeepEquals, params.NetworkInfoParams{
 			Unit:       "unit-mysql-0",
-			Bindings:   []string{"server"},
+			Endpoints:  []string{"server"},
 			RelationId: &relId,
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.NetworkInfoResults{})

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -297,7 +297,7 @@ func (n *NetworkInfo) NetworksForRelation(
 		egress = n.defaultEgress
 	}
 
-	boundSpace, err = n.unit.GetSpaceForBinding(binding)
+	boundSpace, err = n.spaceForBinding(binding)
 	if err != nil && !errors.IsNotValid(err) {
 		return "", nil, nil, errors.Trace(err)
 	}
@@ -388,6 +388,20 @@ func (n *NetworkInfo) NetworksForRelation(
 		}
 	}
 	return boundSpace, ingress, egress, nil
+}
+
+// spaceForBinding returns the space name
+// associated with the specified endpoint.
+func (n *NetworkInfo) spaceForBinding(endpoint string) (string, error) {
+	boundSpace, known := n.bindings[endpoint]
+	if !known {
+		// If default binding is not explicitly defined we'll use default space
+		if endpoint == "" {
+			return corenetwork.DefaultSpaceName, nil
+		}
+		return "", errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", endpoint))
+	}
+	return boundSpace, nil
 }
 
 func pollForAddress(fetcher func() (corenetwork.SpaceAddress, error)) (corenetwork.SpaceAddress, error) {

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -1,0 +1,405 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+	"github.com/juju/retry"
+	"gopkg.in/juju/names.v3"
+	k8score "k8s.io/api/core/v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/networkingcommon"
+	"github.com/juju/juju/apiserver/params"
+	corenetwork "github.com/juju/juju/core/network"
+)
+
+// TODO (manadart 2019-10-09):
+// This module was pulled together out of the state package and the uniter API.
+// It lacks sufficient coverage with direct unit tests, relying instead on the
+// integration tests that were present at the time of its conception.
+// Over time, the state types should be indirected, mocks generated, and
+// appropriate tests added.
+
+// PreferredAddressRetryArgs returns the retry strategy for getting a unit's
+// preferred address. Override for testing to use a different clock.
+// TODO (manadart 2019-10-09): Pass this as an argument to the NetworkInfo
+// constructor instead of exporting this public type for patching in tests.
+var PreferredAddressRetryArgs = func() retry.CallArgs {
+	return retry.CallArgs{
+		Clock:       clock.WallClock,
+		Delay:       3 * time.Second,
+		MaxDuration: 30 * time.Second,
+	}
+}
+
+// NetworkInfo is responsible for processing
+// a call to the uniter API NetworkGet method.
+type NetworkInfo struct {
+	st            *state.State
+	unit          *state.Unit
+	app           *state.Application
+	defaultEgress []string
+	bindings      map[string]string
+}
+
+// NewNetworkInfo initialises and returns a new NetworkInfo based on the input
+// state and unit tag.
+func NewNetworkInfo(st *state.State, tag names.UnitTag) (*NetworkInfo, error) {
+	netInfo := &NetworkInfo{st: st}
+	err := netInfo.init(tag)
+	return netInfo, errors.Trace(err)
+}
+
+// init uses the member state to initialise NetworkInfo entities in preparation
+// for the retrieval of network information.
+func (n *NetworkInfo) init(tag names.UnitTag) error {
+	var err error
+
+	if n.unit, err = n.st.Unit(tag.Id()); err != nil {
+		return errors.Trace(err)
+	}
+
+	if n.app, err = n.unit.Application(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if n.bindings, err = n.app.EndpointBindings(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if n.defaultEgress, err = n.getModelEgressSubnets(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// getModelEgressSubnets returns model configuration for egress subnets.
+func (n *NetworkInfo) getModelEgressSubnets() ([]string, error) {
+	model, err := n.st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err := model.ModelConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cfg.EgressSubnets(), nil
+}
+
+// ProcessAPIRequest handles a request to the uniter API NetworkInfo method.
+// TODO (manadart 2019-10-09): This method verges on impossible to reason about
+// and should be rewritten.
+func (n *NetworkInfo) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
+	spaces := set.NewStrings()
+	bindings := make(map[string]string)
+	endpointEgressSubnets := make(map[string][]string)
+
+	result := params.NetworkInfoResults{
+		Results: make(map[string]params.NetworkInfoResult),
+	}
+
+	// For each of the endpoints in the request, get the bound space and
+	// initialise the endpoint egress map with the model's configured
+	// egress subnets. Keep track of the spaces that we observe.
+	for _, endpoint := range args.Endpoints {
+		binding, ok := n.bindings[endpoint]
+		if ok {
+			spaces.Add(binding)
+			bindings[endpoint] = binding
+		} else {
+			if endpoint == "" {
+				bindings[endpoint] = corenetwork.DefaultSpaceName
+			} else {
+				err := errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", endpoint))
+				result.Results[endpoint] = params.NetworkInfoResult{Error: common.ServerError(err)}
+			}
+		}
+		endpointEgressSubnets[endpoint] = n.defaultEgress
+	}
+
+	endpointIngressAddresses := make(map[string]corenetwork.SpaceAddresses)
+
+	// If we are working in a relation context, get the network information for
+	// the relation and set it for the relation's binding.
+	if args.RelationId != nil {
+		endpoint, space, ingress, egress, err := n.getRelationNetworkInfo(*args.RelationId)
+		if err != nil {
+			return params.NetworkInfoResults{}, err
+		}
+
+		spaces.Add(space)
+		if len(egress) > 0 {
+			endpointEgressSubnets[endpoint] = egress
+		}
+		endpointIngressAddresses[endpoint] = ingress
+	}
+
+	var (
+		networkInfos            map[string]state.MachineNetworkInfoResult
+		defaultIngressAddresses []string
+	)
+
+	if n.unit.ShouldBeAssigned() {
+		machineID, err := n.unit.AssignedMachineId()
+		if err != nil {
+			return params.NetworkInfoResults{}, err
+		}
+		machine, err := n.st.Machine(machineID)
+		if err != nil {
+			return params.NetworkInfoResults{}, err
+		}
+		networkInfos = machine.GetNetworkInfoForSpaces(spaces)
+	} else {
+		// For CAAS units, we build up a minimal result struct
+		// based on the default space and unit public/private addresses,
+		// ie the addresses of the CAAS service.
+		addr, err := n.unit.AllAddresses()
+		if err != nil {
+			return params.NetworkInfoResults{}, err
+		}
+		corenetwork.SortAddresses(addr)
+
+		// We record the interface addresses as the machine local ones - these
+		// are used later as the binding addresses.
+		// For CAAS models, we need to default ingress addresses to all available
+		// addresses so record those in the default ingress address slice.
+		var interfaceAddr []network.InterfaceAddress
+		for _, a := range addr {
+			if a.Scope == corenetwork.ScopeMachineLocal {
+				interfaceAddr = append(interfaceAddr, network.InterfaceAddress{Address: a.Value})
+			}
+			defaultIngressAddresses = append(defaultIngressAddresses, a.Value)
+		}
+		networkInfos = make(map[string]state.MachineNetworkInfoResult)
+		networkInfos[corenetwork.DefaultSpaceName] = state.MachineNetworkInfoResult{
+			NetworkInfos: []network.NetworkInfo{{Addresses: interfaceAddr}},
+		}
+	}
+
+	for endpoint, space := range bindings {
+		// The binding address information based on link layer devices.
+		info := networkingcommon.MachineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
+
+		// Set egress and ingress address information.
+		info.EgressSubnets = endpointEgressSubnets[endpoint]
+
+		ingressAddrs := make([]string, len(endpointIngressAddresses[endpoint]))
+		for i, addr := range endpointIngressAddresses[endpoint] {
+			ingressAddrs[i] = addr.Value
+		}
+		info.IngressAddresses = ingressAddrs
+
+		// If there is no ingress address explicitly defined for a given
+		// binding, set the ingress addresses to either any defaults set above,
+		// or the binding addresses.
+		if len(info.IngressAddresses) == 0 {
+			info.IngressAddresses = defaultIngressAddresses
+		}
+
+		if len(info.IngressAddresses) == 0 {
+			var ingress corenetwork.SpaceAddresses
+			for _, nwInfo := range info.Info {
+				// We need to construct sortable addresses from link-layer
+				// devices, which unlike machine addresses do not have this
+				// information. We can at least ensure that fan addresses will
+				// be sorted after other addresses.
+				scope := corenetwork.ScopeCloudLocal
+				if strings.HasPrefix(nwInfo.InterfaceName, "fan-") {
+					scope = corenetwork.ScopeFanLocal
+				}
+				for _, addr := range nwInfo.Addresses {
+					ingress = append(ingress, corenetwork.NewScopedSpaceAddress(addr.Address, scope))
+				}
+			}
+			corenetwork.SortAddresses(ingress)
+			info.IngressAddresses = make([]string, len(ingress))
+			for i, addr := range ingress {
+				info.IngressAddresses[i] = addr.Value
+			}
+		}
+
+		// If there is no egress subnet explicitly defined for a given binding,
+		// default to the first ingress address. This matches the behaviour when
+		// there's a relation in place.
+		if len(info.EgressSubnets) == 0 && len(info.IngressAddresses) > 0 {
+			var err error
+			info.EgressSubnets, err = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
+			if err != nil {
+				return result, errors.Trace(err)
+			}
+		}
+
+		result.Results[endpoint] = info
+	}
+
+	return result, nil
+}
+
+// getRelationNetworkInfo returns the endpoint name, network space
+// and ingress/egress addresses for the input relation ID.
+func (n *NetworkInfo) getRelationNetworkInfo(
+	relationId int,
+) (string, string, corenetwork.SpaceAddresses, []string, error) {
+	rel, err := n.st.Relation(relationId)
+	if err != nil {
+		return "", "", nil, nil, errors.Trace(err)
+	}
+	endpoint, err := rel.Endpoint(n.unit.ApplicationName())
+	if err != nil {
+		return "", "", nil, nil, errors.Trace(err)
+	}
+
+	pollPublic := n.unit.ShouldBeAssigned()
+	// For k8s services which may have a public
+	// address, we want to poll in case it's not ready yet.
+	if !pollPublic {
+		cfg, err := n.app.ApplicationConfig()
+		if err != nil {
+			return "", "", nil, nil, errors.Trace(err)
+		}
+		svcType := cfg.GetString(k8sprovider.ServiceTypeConfigKey, "")
+		switch k8score.ServiceType(svcType) {
+		case k8score.ServiceTypeLoadBalancer, k8score.ServiceTypeExternalName:
+			pollPublic = true
+		}
+	}
+
+	space, ingress, egress, err := n.NetworksForRelation(endpoint.Name, rel, pollPublic)
+	return endpoint.Name, space, ingress, egress, errors.Trace(err)
+}
+
+// NetworksForRelation returns the ingress and egress addresses for
+// a relation and unit.
+// The ingress addresses depend on if the relation is cross-model
+// and whether the relation endpoint is bound to a space.
+func (n *NetworkInfo) NetworksForRelation(
+	binding string, rel *state.Relation, pollPublic bool,
+) (boundSpace string, ingress corenetwork.SpaceAddresses, egress []string, _ error) {
+	relEgress := state.NewRelationEgressNetworks(n.st)
+	egressSubnets, err := relEgress.Networks(rel.Tag().Id())
+	if err != nil && !errors.IsNotFound(err) {
+		return "", nil, nil, errors.Trace(err)
+	} else if err == nil {
+		egress = egressSubnets.CIDRS()
+	} else {
+		egress = n.defaultEgress
+	}
+
+	boundSpace, err = n.unit.GetSpaceForBinding(binding)
+	if err != nil && !errors.IsNotValid(err) {
+		return "", nil, nil, errors.Trace(err)
+	}
+
+	fallbackIngressToPrivateAddr := func() error {
+		// TODO(ycliuhw): lp-1830252 retry here once this is fixed.
+		address, err := n.unit.PrivateAddress()
+		if err != nil {
+			logger.Warningf("no private address for unit %q in relation %q", n.unit.Name(), rel)
+		} else if address.Value != "" {
+			ingress = append(ingress, address)
+		}
+		return nil
+	}
+
+	// If the endpoint for this relation is not bound to a space, or
+	// is bound to the default space, we need to look up the ingress
+	// address info which is aware of cross model relations.
+	if boundSpace == corenetwork.DefaultSpaceName || err != nil {
+		_, crossModel, err := rel.RemoteApplication()
+		if err != nil {
+			return "", nil, nil, errors.Trace(err)
+		}
+		if crossModel && (n.unit.ShouldBeAssigned() || pollPublic) {
+			address, err := pollForAddress(n.unit.PublicAddress)
+			if err != nil {
+				logger.Warningf(
+					"no public address for unit %q in cross model relation %q, will use private address",
+					n.unit.Name(), rel,
+				)
+			} else if address.Value != "" {
+				ingress = append(ingress, address)
+			}
+			if len(ingress) == 0 {
+				if err := fallbackIngressToPrivateAddr(); err != nil {
+					return "", nil, nil, errors.Trace(err)
+				}
+			}
+		}
+	}
+
+	if len(ingress) == 0 {
+		if n.unit.ShouldBeAssigned() {
+			// We don't yet have an ingress address, so pick one from the space to
+			// which the endpoint is bound.
+			machineID, err := n.unit.AssignedMachineId()
+			if err != nil {
+				return "", nil, nil, errors.Trace(err)
+			}
+			machine, err := n.st.Machine(machineID)
+			if err != nil {
+				return "", nil, nil, errors.Trace(err)
+			}
+			networkInfos := machine.GetNetworkInfoForSpaces(set.NewStrings(boundSpace))
+			// The binding address information based on link layer devices.
+			for _, nwInfo := range networkInfos[boundSpace].NetworkInfos {
+				// We need to construct sortable addresses from link-layer
+				// devices, which unlike machine addresses do not have this
+				// information. We can at least ensure that fan addresses will
+				// be sorted after other addresses.
+				scope := corenetwork.ScopeCloudLocal
+				if strings.HasPrefix(nwInfo.InterfaceName, "fan-") {
+					scope = corenetwork.ScopeFanLocal
+				}
+
+				for _, addr := range nwInfo.Addresses {
+					ingress = append(ingress, corenetwork.NewScopedSpaceAddress(addr.Address, scope))
+				}
+			}
+		} else {
+			// Be be consistent with IAAS behaviour above, we'll return all addresses.
+			addrs, err := n.unit.AllAddresses()
+			if err != nil {
+				logger.Warningf("no service address for unit %q in relation %q", n.unit.Name(), rel)
+			} else {
+				ingress = append(ingress, addrs...)
+			}
+		}
+	}
+
+	corenetwork.SortAddresses(ingress)
+
+	// If no egress subnets defined, We default to the ingress address.
+	if len(egress) == 0 && len(ingress) > 0 {
+		egress, err = network.FormatAsCIDR([]string{ingress[0].Value})
+		if err != nil {
+			return "", nil, nil, errors.Trace(err)
+		}
+	}
+	return boundSpace, ingress, egress, nil
+}
+
+func pollForAddress(fetcher func() (corenetwork.SpaceAddress, error)) (corenetwork.SpaceAddress, error) {
+	var address corenetwork.SpaceAddress
+	retryArg := PreferredAddressRetryArgs()
+	retryArg.Func = func() error {
+		var err error
+		address, err = fetcher()
+		return err
+	}
+	retryArg.IsFatalError = func(err error) bool {
+		return !network.IsNoAddressError(err)
+	}
+	return address, retry.Call(retryArg)
+}

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -1,0 +1,429 @@
+package uniter_test
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/retry"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/apiserver/facades/agent/uniter"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type ProReqRelation struct {
+	rel                    *state.Relation
+	papp, rapp             *state.Application
+	pu0, pu1, ru0, ru1     *state.Unit
+	pru0, pru1, rru0, rru1 *state.RelationUnit
+}
+
+type RemoteProReqRelation struct {
+	rel                    *state.Relation
+	papp                   *state.RemoteApplication
+	rapp                   *state.Application
+	pru0, pru1, rru0, rru1 *state.RelationUnit
+	ru0, ru1               *state.Unit
+}
+
+type networkInfoSuite struct {
+	testing.JujuConnSuite
+}
+
+var _ = gc.Suite(&networkInfoSuite{})
+
+func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
+	prr := s.newProReqRelation(c, charm.ScopeGlobal)
+	err := prr.pu0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.pu0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	boundSpace, ingress, egress, err := s.newNetworkInfo(c, prr.pu0.UnitTag()).NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(boundSpace, gc.Equals, "")
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
+}
+
+func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machine, addresses ...string) {
+	for _, address := range addresses {
+		name := fmt.Sprintf("e%x", rand.Int31())
+		deviceArgs := state.LinkLayerDeviceArgs{
+			Name: name,
+			Type: network.EthernetDevice,
+		}
+		err := machine.SetLinkLayerDevices(deviceArgs)
+		c.Assert(err, jc.ErrorIsNil)
+		device, err := machine.LinkLayerDevice(name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		addressesArg := state.LinkLayerDeviceAddress{
+			DeviceName:   name,
+			ConfigMethod: state.StaticAddress,
+			CIDRAddress:  address,
+		}
+		err = machine.SetDevicesAddresses(addressesArg)
+		c.Assert(err, jc.ErrorIsNil)
+		deviceAddresses, err := device.Addresses()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(deviceAddresses, gc.HasLen, 1)
+	}
+}
+
+func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
+	subnet1, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "1.2.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("space-1", "pid-1", []string{subnet1.ID()}, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnet2, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "2.2.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("space-2", "pid-2", []string{subnet2.ID()}, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnet3, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "3.2.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("space-3", "pid-3", []string{subnet3.ID()}, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	subnet4, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "4.3.0.0/16"})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("public-4", "pid-4", []string{subnet4.ID()}, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// We want to have all bindings set so that no actual binding is
+	// really set to the default.
+	bindings := map[string]string{
+		"":             "space-3",
+		"server-admin": "space-1",
+		"server":       "space-2",
+	}
+
+	prr := s.newProReqRelationWithBindings(c, charm.ScopeGlobal, bindings, nil)
+	err = prr.pu0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.pu0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addresses := []network.SpaceAddress{
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("2.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("3.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+	}
+	err = machine.SetProviderAddresses(addresses...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.addDevicesWithAddresses(c, machine, "1.2.3.4/16", "2.2.3.4/16", "3.2.3.4/16", "4.3.2.1/16")
+
+	boundSpace, ingress, egress, err := s.newNetworkInfo(c, prr.pu0.UnitTag()).NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(boundSpace, gc.Equals, "space-3")
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("3.2.3.4", network.ScopeCloudLocal)})
+	c.Assert(egress, gc.DeepEquals, []string{"3.2.3.4/32"})
+}
+
+func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
+	prr := s.newRemoteProReqRelation(c)
+	err := prr.ru0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.ru0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	boundSpace, ingress, egress, err := s.newNetworkInfo(c, prr.ru0.UnitTag()).NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(boundSpace, gc.Equals, "")
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
+	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
+}
+
+func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *gc.C) {
+	prr := s.newRemoteProReqRelation(c)
+	err := prr.ru0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.ru0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	boundSpace, ingress, egress, err := s.newNetworkInfo(c, prr.ru0.UnitTag()).NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(boundSpace, gc.Equals, "")
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
+}
+
+func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAddress(c *gc.C) {
+	clk := testclock.NewClock(time.Now())
+	attemptMade := make(chan struct{}, 10)
+	s.PatchValue(&uniter.PreferredAddressRetryArgs, func() retry.CallArgs {
+		return retry.CallArgs{
+			Clock:       clk,
+			Delay:       3 * time.Second,
+			MaxDuration: 30 * time.Second,
+			NotifyFunc: func(lastError error, attempt int) {
+				attemptMade <- struct{}{}
+			},
+		}
+	})
+	prr := s.newRemoteProReqRelation(c)
+	err := prr.ru0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.ru0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Set up a public address after at least one attempt
+	// is made to get it.We record the err for checking later
+	// as gc.C is not thread safe.
+	var funcErr error
+	wg := sync.WaitGroup{}
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		funcErr = clk.WaitAdvance(15*time.Second, time.Second, 1)
+		if funcErr != nil {
+			return
+		}
+		// Ensure we have a failed attempt to get public address.
+		select {
+		case <-attemptMade:
+			funcErr = clk.WaitAdvance(10*time.Second, time.Second, 1)
+			if funcErr != nil {
+				return
+			}
+		case <-time.After(coretesting.LongWait):
+			c.Fatal("waiting for public address attempt")
+		}
+
+		// Now set up the public address.
+		funcErr = machine.SetProviderAddresses(
+			network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+		)
+		if funcErr != nil {
+			return
+		}
+		funcErr = clk.WaitAdvance(10*time.Second, time.Second, 1)
+		if funcErr != nil {
+			return
+		}
+	}()
+
+	boundSpace, ingress, egress, err := s.newNetworkInfo(c, prr.ru0.UnitTag()).NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure there we no errors in the go routine.
+	wg.Wait()
+	c.Assert(funcErr, jc.ErrorIsNil)
+
+	c.Assert(boundSpace, gc.Equals, "")
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
+	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
+}
+
+func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer func() { _ = st.Close() }()
+
+	f := factory.NewFactory(st, s.StatePool)
+	gitlabch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})
+	mysqlch := f.MakeCharm(c, &factory.CharmParams{Name: "mysql", Series: "kubernetes"})
+	gitlab := f.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: gitlabch})
+	mysql := f.MakeApplication(c, &factory.ApplicationParams{Name: "mysql", Charm: mysqlch})
+
+	prr := newProReqRelationForApps(c, st, mysql, gitlab)
+
+	// We need to instantiate this with the new CAAS model state.
+	netInfo, err := uniter.NewNetworkInfo(st, prr.pu0.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// First no address.
+	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(boundSpace, gc.Equals, "")
+	c.Assert(ingress, gc.HasLen, 0)
+	c.Assert(egress, gc.HasLen, 0)
+
+	// Add a application address.
+	err = mysql.UpdateCloudService("", network.SpaceAddresses{
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = prr.pu0.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	boundSpace, ingress, egress, err = netInfo.NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(boundSpace, gc.Equals, "")
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
+}
+
+func (s *networkInfoSuite) newNetworkInfo(c *gc.C, tag names.UnitTag) *uniter.NetworkInfo {
+	ni, err := uniter.NewNetworkInfo(s.State, tag)
+	c.Assert(err, jc.ErrorIsNil)
+	return ni
+}
+
+func (s *networkInfoSuite) newProReqRelationWithBindings(
+	c *gc.C, scope charm.RelationScope, pbindings, rbindings map[string]string,
+) *ProReqRelation {
+	papp := s.AddTestingApplicationWithBindings(c, "mysql", s.AddTestingCharm(c, "mysql"), pbindings)
+	var rapp *state.Application
+	if scope == charm.ScopeGlobal {
+		rapp = s.AddTestingApplicationWithBindings(c, "wordpress", s.AddTestingCharm(c, "wordpress"), rbindings)
+	} else {
+		rapp = s.AddTestingApplicationWithBindings(c, "logging", s.AddTestingCharm(c, "logging"), rbindings)
+	}
+	return newProReqRelationForApps(c, s.State, papp, rapp)
+}
+
+func (s *networkInfoSuite) newProReqRelation(c *gc.C, scope charm.RelationScope) *ProReqRelation {
+	papp := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	var rapp *state.Application
+	if scope == charm.ScopeGlobal {
+		rapp = s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	} else {
+		rapp = s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
+	}
+	return newProReqRelationForApps(c, s.State, papp, rapp)
+}
+
+func (s *networkInfoSuite) newRemoteProReqRelation(c *gc.C) *RemoteProReqRelation {
+	papp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "mysql",
+		SourceModel: coretesting.ModelTag,
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "server",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	rapp := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+
+	eps, err := s.State.InferEndpoints("mysql", "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	prr := &RemoteProReqRelation{rel: rel, papp: papp, rapp: rapp}
+	prr.pru0 = addRemoteRU(c, rel, "mysql/0")
+	prr.pru1 = addRemoteRU(c, rel, "mysql/1")
+	prr.ru0, prr.rru0 = addRU(c, rapp, rel, nil)
+	prr.ru1, prr.rru1 = addRU(c, rapp, rel, nil)
+	return prr
+}
+
+func newProReqRelationForApps(c *gc.C, st *state.State, proApp, reqApp *state.Application) *ProReqRelation {
+	eps, err := st.InferEndpoints(proApp.Name(), reqApp.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := st.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+	prr := &ProReqRelation{rel: rel, papp: proApp, rapp: reqApp}
+	prr.pu0, prr.pru0 = addRU(c, proApp, rel, nil)
+	prr.pu1, prr.pru1 = addRU(c, proApp, rel, nil)
+	if eps[0].Scope == charm.ScopeGlobal {
+		prr.ru0, prr.rru0 = addRU(c, reqApp, rel, nil)
+		prr.ru1, prr.rru1 = addRU(c, reqApp, rel, nil)
+	} else {
+		prr.ru0, prr.rru0 = addRU(c, reqApp, rel, prr.pu0)
+		prr.ru1, prr.rru1 = addRU(c, reqApp, rel, prr.pu1)
+	}
+	return prr
+}
+
+func addRU(
+	c *gc.C, app *state.Application, rel *state.Relation, principal *state.Unit,
+) (*state.Unit, *state.RelationUnit) {
+	// Given the application app in the relation rel, add a unit of app and create
+	// a RelationUnit with rel. If principal is supplied, app is assumed to be
+	// subordinate and the unit will be created by temporarily entering the
+	// relation's scope as the principal.
+	var u *state.Unit
+	if principal == nil {
+		unit, err := app.AddUnit(state.AddUnitParams{})
+		c.Assert(err, jc.ErrorIsNil)
+		u = unit
+	} else {
+		origUnits, err := app.AllUnits()
+		c.Assert(err, jc.ErrorIsNil)
+		pru, err := rel.Unit(principal)
+		c.Assert(err, jc.ErrorIsNil)
+		err = pru.EnterScope(nil) // to create the subordinate
+		c.Assert(err, jc.ErrorIsNil)
+		err = pru.LeaveScope() // to reset to initial expected state
+		c.Assert(err, jc.ErrorIsNil)
+		newUnits, err := app.AllUnits()
+		c.Assert(err, jc.ErrorIsNil)
+		for _, unit := range newUnits {
+			found := false
+			for _, old := range origUnits {
+				if unit.Name() == old.Name() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				u = unit
+				break
+			}
+		}
+		c.Assert(u, gc.NotNil)
+	}
+	ru, err := rel.Unit(u)
+	c.Assert(err, jc.ErrorIsNil)
+	return u, ru
+}
+
+func addRemoteRU(c *gc.C, rel *state.Relation, unitName string) *state.RelationUnit {
+	// Add a remote unit with the given name to rel.
+	ru, err := rel.RemoteUnit(unitName)
+	c.Assert(err, jc.ErrorIsNil)
+	return ru
+}

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package uniter_test
 
 import (

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2399,7 +2399,7 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 	bindingsToSpace := make(map[string]string)
 	bindingsToEgressSubnets := make(map[string][]string)
 
-	for _, binding := range args.Bindings {
+	for _, binding := range args.Endpoints {
 		if boundSpace, err := unit.GetSpaceForBinding(binding); err != nil {
 			result.Results[binding] = params.NetworkInfoResult{Error: common.ServerError(err)}
 		} else {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -601,8 +601,8 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.wordpressUnit.Tag().String(),
-		Bindings: []string{"db"},
+		Unit:      s.wordpressUnit.Tag().String(),
+		Endpoints: []string{"db"},
 	}
 
 	privateAddress, err := s.machine0.PrivateAddress()
@@ -4176,25 +4176,25 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoPermissions(c *gc.C) {
 	}{
 		{
 			"Wrong unit name",
-			params.NetworkInfoParams{Unit: "unit-foo-0", Bindings: []string{"foo"}},
+			params.NetworkInfoParams{Unit: "unit-foo-0", Endpoints: []string{"foo"}},
 			params.NetworkInfoResults{},
 			"permission denied",
 		},
 		{
 			"Invalid tag",
-			params.NetworkInfoParams{Unit: "invalid", Bindings: []string{"db-client"}},
+			params.NetworkInfoParams{Unit: "invalid", Endpoints: []string{"db-client"}},
 			params.NetworkInfoResults{},
 			`"invalid" is not a valid tag`,
 		},
 		{
 			"No access to unit",
-			params.NetworkInfoParams{Unit: "unit-mysql-0", Bindings: []string{"juju-info"}},
+			params.NetworkInfoParams{Unit: "unit-mysql-0", Endpoints: []string{"juju-info"}},
 			params.NetworkInfoResults{},
 			"permission denied",
 		},
 		{
 			"Unknown binding name",
-			params.NetworkInfoParams{Unit: s.wordpressUnit.Tag().String(), Bindings: []string{"unknown"}},
+			params.NetworkInfoParams{Unit: s.wordpressUnit.Tag().String(), Endpoints: []string{"unknown"}},
 			params.NetworkInfoResults{
 				Results: map[string]params.NetworkInfoResult{
 					"unknown": {
@@ -4224,8 +4224,8 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 	s.addRelationAndAssertInScope(c)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.wordpressUnit.Tag().String(),
-		Bindings: []string{"db", "admin-api", "db-client"},
+		Unit:      s.wordpressUnit.Tag().String(),
+		Endpoints: []string{"db", "admin-api", "db-client"},
 	}
 	// For the relation "wordpress:db mysql:server" we expect to see only
 	// ifaces in the "internal" space, where the "db" endpoint itself
@@ -4306,8 +4306,8 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoL2Binding(c *gc.C) {
 	s.addRelationAndAssertInScope(c)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.wordpressUnit.Tag().String(),
-		Bindings: []string{"foo-bar"},
+		Unit:      s.wordpressUnit.Tag().String(),
+		Endpoints: []string{"foo-bar"},
 	}
 
 	expectedInfo := params.NetworkInfoResult{
@@ -4341,8 +4341,8 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForImplicitlyBoundEndpoint(c *gc
 	s.assertInScope(c, mysqlRelUnit, true)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.mysqlUnit.Tag().String(),
-		Bindings: []string{"server"},
+		Unit:      s.mysqlUnit.Tag().String(),
+		Endpoints: []string{"server"},
 	}
 
 	expectedInfo := params.NetworkInfoResult{
@@ -4396,7 +4396,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressNonDefaultBin
 	relId := rel.Id()
 	args := params.NetworkInfoParams{
 		Unit:       s.mysqlUnit.Tag().String(),
-		Bindings:   []string{"server"},
+		Endpoints:  []string{"server"},
 		RelationId: &relId,
 	}
 
@@ -4462,7 +4462,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 	relId := rel.Id()
 	args := params.NetworkInfoParams{
 		Unit:       s.mysqlUnit.Tag().String(),
-		Bindings:   []string{"server"},
+		Endpoints:  []string{"server"},
 		RelationId: &relId,
 	}
 
@@ -4498,8 +4498,8 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoV6Results(c *gc.C) {
 	s.addRelationAndAssertInScope(c)
 
 	args := params.NetworkInfoParams{
-		Unit:     s.wordpressUnit.Tag().String(),
-		Bindings: []string{"db"},
+		Unit:      s.wordpressUnit.Tag().String(),
+		Endpoints: []string{"db"},
 	}
 
 	expectedResult := params.NetworkInfoResultsV6{
@@ -4563,7 +4563,7 @@ func (s *uniterSuite) TestNetworkInfoCAASModelRelation(c *gc.C) {
 	relId := rel.Id()
 	args := params.NetworkInfoParams{
 		Unit:       gitlabUnit.Tag().String(),
-		Bindings:   []string{"db"},
+		Endpoints:  []string{"db"},
 		RelationId: &relId,
 	}
 
@@ -4610,8 +4610,8 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 	c.Assert(wpUnit.Refresh(), jc.ErrorIsNil)
 
 	args := params.NetworkInfoParams{
-		Unit:     wpUnit.Tag().String(),
-		Bindings: []string{"db"},
+		Unit:      wpUnit.Tag().String(),
+		Endpoints: []string{"db"},
 	}
 
 	expectedResult := params.NetworkInfoResult{

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4270,8 +4270,10 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 				},
 			},
 		},
-		EgressSubnets:    []string{"8.8.8.10/32"},
-		IngressAddresses: []string{"8.8.8.10", "8.8.4.10", "8.8.4.11"},
+		// Addresses are sorted, and egress is based on
+		// the first ingress address.
+		EgressSubnets:    []string{"8.8.4.10/32"},
+		IngressAddresses: []string{"8.8.4.10", "8.8.4.11", "8.8.8.10"},
 	}
 
 	// For the "db-client" extra-binding we expect to see interfaces from default

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -827,7 +827,7 @@ type NetworkInfoResultsV6 struct {
 type NetworkInfoParams struct {
 	Unit       string   `json:"unit"`
 	RelationId *int     `json:"relation-id,omitempty"`
-	Bindings   []string `json:"bindings"`
+	Endpoints  []string `json:"bindings"`
 }
 
 // FanConfigEntry holds configuration for a single fan.

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -1146,33 +1146,41 @@ func addAddressToResult(networkInfos []network.NetworkInfo, address *Address) ([
 // GetNetworkInfoForSpaces returns MachineNetworkInfoResult with a list of devices for each space in spaces
 // TODO(wpk): 2017-05-04 This does not work for L2-only devices as it iterates over addresses, needs to be fixed.
 // When changing the method we have to keep the ordering.
-func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string]MachineNetworkInfoResult {
+func (m *Machine) GetNetworkInfoForSpaces(spaces corenetwork.SpaceInfos) map[string]MachineNetworkInfoResult {
 	results := make(map[string]MachineNetworkInfoResult)
 
 	var privateAddress corenetwork.SpaceAddress
 
-	if spaces.Contains(corenetwork.DefaultSpaceName) {
+	if spaces.GetByName(corenetwork.DefaultSpaceName) != nil {
 		var err error
 		privateAddress, err = m.PrivateAddress()
 		if err != nil {
 			results[corenetwork.DefaultSpaceName] = MachineNetworkInfoResult{Error: errors.Annotatef(
 				err, "getting machine %q preferred private address", m.MachineTag())}
-			spaces.Remove(corenetwork.DefaultSpaceName)
+
+			// Remove this space to prevent further processing.
+			var newSpaces corenetwork.SpaceInfos
+			for _, sp := range spaces {
+				if sp.Name != corenetwork.DefaultSpaceName {
+					newSpaces = append(newSpaces, sp)
+				}
+			}
+			spaces = newSpaces
 		}
 	}
 
 	addresses, err := m.AllAddresses()
 	logger.Debugf("Looking for something from spaces %v in %v", spaces, addresses)
 	if err != nil {
-		result := MachineNetworkInfoResult{Error: errors.Annotate(err, "cannot get devices addresses")}
-		for space := range spaces {
-			if _, ok := results[space]; !ok {
-				results[space] = result
+		result := MachineNetworkInfoResult{Error: errors.Annotate(err, "getting devices addresses")}
+		for _, space := range spaces {
+			if _, ok := results[string(space.Name)]; !ok {
+				results[string(space.Name)] = result
 			}
 		}
 		return results
 	}
-	actualSpaces := set.NewStrings()
+
 	for _, addr := range addresses {
 		subnet, err := addr.Subnet()
 		switch {
@@ -1181,18 +1189,17 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string]Machine
 		case err != nil:
 			logger.Errorf("cannot get subnet for address %q - %q", addr, err)
 		default:
-			space := subnet.SpaceName()
-			actualSpaces.Add(space)
-			if spaces.Contains(space) {
-				r := results[space]
+			space := spaces.GetByID(subnet.spaceID)
+			if space != nil {
+				r := results[string(space.Name)]
 				r.NetworkInfos, err = addAddressToResult(r.NetworkInfos, addr)
 				if err != nil {
 					r.Error = err
 				} else {
-					results[space] = r
+					results[string(space.Name)] = r
 				}
 			}
-			if spaces.Contains(corenetwork.DefaultSpaceName) && privateAddress.Value == addr.Value() {
+			if spaces.GetByName(corenetwork.DefaultSpaceName) != nil && privateAddress.Value == addr.Value() {
 				r := results[corenetwork.DefaultSpaceName]
 				r.NetworkInfos, err = addAddressToResult(r.NetworkInfos, addr)
 				if err != nil {
@@ -1206,7 +1213,7 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string]Machine
 
 	// For a spaceless model we won't find a subnet that's linked to privateAddress,
 	// we have to work around that and at least return minimal information.
-	if r, ok := results[corenetwork.DefaultSpaceName]; !ok && spaces.Contains(corenetwork.DefaultSpaceName) {
+	if r, ok := results[corenetwork.DefaultSpaceName]; !ok && spaces.GetByName(corenetwork.DefaultSpaceName) != nil {
 		r.NetworkInfos = []network.NetworkInfo{{
 			Addresses: []network.InterfaceAddress{{
 				Address: privateAddress.Value,
@@ -1214,13 +1221,11 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string]Machine
 		}}
 		results[corenetwork.DefaultSpaceName] = r
 	}
-	actualSpacesStr := network.QuoteSpaceSet(actualSpaces)
 
-	for space := range spaces {
-		if _, ok := results[space]; !ok {
-			results[space] = MachineNetworkInfoResult{
-				Error: errors.Errorf("machine %q has no devices in space %q, only spaces %s",
-					m.doc.Id, space, actualSpacesStr),
+	for _, space := range spaces {
+		if _, ok := results[string(space.Name)]; !ok {
+			results[string(space.Name)] = MachineNetworkInfoResult{
+				Error: errors.Errorf("machine %q has no devices in space %q", m.doc.Id, space.Name),
 			}
 		}
 	}

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -880,7 +880,8 @@ func (s *RelationUnitSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
-	c.Assert(ingress, gc.DeepEquals, []string{"1.2.3.4"})
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -961,7 +962,8 @@ func (s *RelationUnitSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "space-3")
-	c.Assert(ingress, gc.DeepEquals, []string{"3.2.3.4"})
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("3.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"3.2.3.4/32"})
 }
 
@@ -984,7 +986,8 @@ func (s *RelationUnitSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
-	c.Assert(ingress, gc.DeepEquals, []string{"4.3.2.1"})
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -1006,7 +1009,8 @@ func (s *RelationUnitSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c 
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
-	c.Assert(ingress, gc.DeepEquals, []string{"1.2.3.4"})
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -1075,7 +1079,8 @@ func (s *RelationUnitSuite) TestNetworksForRelationRemoteRelationDelayedPublicAd
 	c.Assert(funcErr, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
-	c.Assert(ingress, gc.DeepEquals, []string{"4.3.2.1"})
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -1108,7 +1113,8 @@ func (s *RelationUnitSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(boundSpace, gc.Equals, "")
-	c.Assert(ingress, gc.DeepEquals, []string{"1.2.3.4"})
+	c.Assert(ingress, gc.DeepEquals,
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -3163,7 +3163,7 @@ func (u *Unit) GetSpaceForBinding(bindingName string) (string, error) {
 	boundSpace, known := bindings[bindingName]
 	if !known {
 		// If default binding is not explicitly defined we'll use default space
-		if bindingName == corenetwork.DefaultSpaceName {
+		if bindingName == "" {
 			return corenetwork.DefaultSpaceName, nil
 		}
 		return "", errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", bindingName))

--- a/state/unit.go
+++ b/state/unit.go
@@ -3149,28 +3149,6 @@ func (g *HistoryGetter) StatusHistory(filter status.StatusHistoryFilter) ([]stat
 	return statusHistory(args)
 }
 
-// GetSpaceForBinding returns the space name associated with the specified endpoint.
-func (u *Unit) GetSpaceForBinding(bindingName string) (string, error) {
-	app, err := u.Application()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	bindings, err := app.EndpointBindings()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	boundSpace, known := bindings[bindingName]
-	if !known {
-		// If default binding is not explicitly defined we'll use default space
-		if bindingName == "" {
-			return corenetwork.DefaultSpaceName, nil
-		}
-		return "", errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", bindingName))
-	}
-	return boundSpace, nil
-}
-
 // UpgradeSeriesStatus returns the upgrade status of the units assigned machine.
 func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	machine, err := u.machine()


### PR DESCRIPTION
## Description of change

This patch ensures that calls to the uniter `NetworkInfo` API method return consistently ordered results, and in the case of AWS, favour non-fan addresses as the reported ingress address.

Some binding/relation networking concerns previously residing in state have been relocated to the uniter API server in a new type dedicated to handling unit networking concerns.

In the state package, `machine.GetNetworkInfoForSpaces` now recieves `network.SpaceInfos` instead of a set of space name strings. This was necessary due to subnet spaces now being identified by ID instead of name.

Some accompanying modularisation and efficiency gains are included in the patch, but this particular area of the code is sufficiently nasty as to make an ideal representation of the logic untenable at this point. I have added comments where further performance may be sought, and I believe the new form will make such investigations easier.

## QA steps

- Bootstrap to AWS.
- `juju add-space new-space 172.31.0.0/20`.
- `juju deploy keystone --bind "internal=new-space --constraints spaces=new-space"`.
- Once deployment is complete, `juju run --unit keystone/0 "network-get --ingress-address internal"` multiple times.
- The non-fan address should always be returned.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1844148
