### PR TITLE
Passing loggers into workers.

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -769,10 +769,16 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewStore:             leasemanager.NewStore,
 		})),
 
+		// TODO (thumper): It doesn't really make sense in a machine manifold as
+		// not every machine will have credentials. It is here for the
+		// ifCredentialValid function that is used solely for the machine
+		// storage provisioner. It isn't clear to me why we have a storage
+		// provisioner in the machine agent and the model workers.
 		validCredentialFlagName: credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{
 			APICallerName: apiCallerName,
 			NewFacade:     credentialvalidator.NewFacade,
 			NewWorker:     credentialvalidator.NewWorker,
+			Logger:        loggo.GetLogger("juju.worker.credentialvalidator"),
 		}),
 	}
 

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -168,6 +168,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 			NewFacade: lifeflag.NewFacade,
 			NewWorker: lifeflag.NewWorker,
+			// No Logger defined in lifeflag package.
 		}),
 		notAliveFlagName: lifeflag.Manifold(lifeflag.ManifoldConfig{
 			APICallerName: apiCallerName,
@@ -177,6 +178,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 			NewFacade: lifeflag.NewFacade,
 			NewWorker: lifeflag.NewWorker,
+			// No Logger defined in lifeflag package.
 		}),
 		isResponsibleFlagName: singular.Manifold(singular.ManifoldConfig{
 			Clock:         config.Clock,
@@ -187,6 +189,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 			NewFacade: singular.NewFacade,
 			NewWorker: singular.NewWorker,
+			// No Logger defined in singular package.
 		}),
 		// This flag runs on all models, and
 		// indicates if model's cloud credential is valid.
@@ -194,6 +197,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 			NewFacade:     credentialvalidator.NewFacade,
 			NewWorker:     credentialvalidator.NewWorker,
+			Logger:        config.LoggingContext.GetLogger("juju.worker.credentialvalidator"),
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -213,12 +213,15 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// Note that the fortress and flag will only exist while
 		// the model is not dead, and not upgrading; this frees
 		// their dependencies from model-lifetime/upgrade concerns.
-		migrationFortressName: ifNotUpgrading(ifNotDead(fortress.Manifold())),
+		migrationFortressName: ifNotUpgrading(ifNotDead(fortress.Manifold(
+		// No Logger defined in fortress package.
+		))),
 		migrationInactiveFlagName: ifNotUpgrading(ifNotDead(migrationflag.Manifold(migrationflag.ManifoldConfig{
 			APICallerName: apiCallerName,
 			Check:         migrationflag.IsTerminal,
 			NewFacade:     migrationflag.NewFacade,
 			NewWorker:     migrationflag.NewWorker,
+			// No Logger defined in migrationflag package.
 		}))),
 		migrationMasterName: ifNotUpgrading(ifNotDead(migrationmaster.Manifold(migrationmaster.ManifoldConfig{
 			AgentName:     agentName,
@@ -227,6 +230,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Clock:         config.Clock,
 			NewFacade:     migrationmaster.NewFacade,
 			NewWorker:     config.NewMigrationMaster,
+			// No Logger defined in migrationmaster package.
 		}))),
 
 		// Everything else should be wrapped in ifResponsible,
@@ -259,6 +263,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 			NewFacade: charmrevisionmanifold.NewAPIFacade,
 			NewWorker: charmrevision.NewWorker,
+			// No Logger defined in charmrevision or charmrevisionmanifold package.
 		})),
 		remoteRelationsName: ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
 			AgentName:                agentName,

--- a/worker/charmrevision/charmrevisionmanifold/manifold.go
+++ b/worker/charmrevision/charmrevisionmanifold/manifold.go
@@ -16,6 +16,10 @@ import (
 	"github.com/juju/juju/worker/charmrevision"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one passed as manifold config.
+var logger interface{}
+
 // ManifoldConfig describes how to create a worker that checks for updates
 // available to deployed charms in an environment.
 type ManifoldConfig struct {

--- a/worker/charmrevision/worker.go
+++ b/worker/charmrevision/worker.go
@@ -12,6 +12,10 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one in.
+var logger interface{}
+
 // RevisionUpdater exposes the "single" capability required by the worker.
 // As the worker gains more responsibilities, it will likely need more; see
 // storageprovisioner for a helpful model to grow towards.

--- a/worker/credentialvalidator/manifold.go
+++ b/worker/credentialvalidator/manifold.go
@@ -12,6 +12,12 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 )
 
+// Logger represents the methods used by the worker to log details.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
+}
+
 // ManifoldConfig holds the dependencies and configuration for a
 // Worker manifold.
 type ManifoldConfig struct {
@@ -19,6 +25,7 @@ type ManifoldConfig struct {
 
 	NewFacade func(base.APICaller) (Facade, error)
 	NewWorker func(Config) (worker.Worker, error)
+	Logger    Logger
 }
 
 // Validate is called by start to check for bad configuration.
@@ -31,6 +38,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
 	}
 	return nil
 }
@@ -50,6 +60,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	}
 	w, err := config.NewWorker(Config{
 		Facade: facade,
+		Logger: config.Logger,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/credentialvalidator/manifold_test.go
+++ b/worker/credentialvalidator/manifold_test.go
@@ -79,6 +79,12 @@ func (*ManifoldSuite) TestStartMissingNewWorker(c *gc.C) {
 	checkManifoldNotValid(c, config, "nil NewWorker not valid")
 }
 
+func (*ManifoldSuite) TestStartMissingLogger(c *gc.C) {
+	config := validManifoldConfig()
+	config.Logger = nil
+	checkManifoldNotValid(c, config, "nil Logger not valid")
+}
+
 func (*ManifoldSuite) TestStartMissingAPICaller(c *gc.C) {
 	context := dt.StubContext(nil, map[string]interface{}{
 		"api-caller": dependency.ErrMissing,

--- a/worker/credentialvalidator/util_test.go
+++ b/worker/credentialvalidator/util_test.go
@@ -5,6 +5,7 @@ package credentialvalidator_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -80,6 +81,7 @@ func panicWorker(credentialvalidator.Config) (worker.Worker, error) {
 func validConfig() credentialvalidator.Config {
 	return credentialvalidator.Config{
 		Facade: struct{ credentialvalidator.Facade }{},
+		Logger: loggo.GetLogger("test"),
 	}
 }
 
@@ -106,6 +108,7 @@ func validManifoldConfig() credentialvalidator.ManifoldConfig {
 		APICallerName: "api-caller",
 		NewFacade:     panicFacade,
 		NewWorker:     panicWorker,
+		Logger:        loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/credentialvalidator/validate_test.go
+++ b/worker/credentialvalidator/validate_test.go
@@ -26,3 +26,9 @@ func (*ValidateSuite) TestNilFacade(c *gc.C) {
 	config.Facade = nil
 	checkNotValid(c, config, "nil Facade not valid")
 }
+
+func (*ValidateSuite) TestNilLogger(c *gc.C) {
+	config := validConfig()
+	config.Logger = nil
+	checkNotValid(c, config, "nil Logger not valid")
+}

--- a/worker/credentialvalidator/worker_test.go
+++ b/worker/credentialvalidator/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -50,6 +51,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 
 	s.config = credentialvalidator.Config{
 		Facade: s.facade,
+		Logger: loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/lifeflag/manifold.go
+++ b/worker/lifeflag/manifold.go
@@ -14,6 +14,10 @@ import (
 	"github.com/juju/juju/core/life"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one passed as manifold config.
+var logger interface{}
+
 // ManifoldConfig describes how to configure and construct a Worker,
 // and what registered resources it may depend upon.
 type ManifoldConfig struct {

--- a/worker/migrationflag/manifold.go
+++ b/worker/migrationflag/manifold.go
@@ -12,6 +12,10 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one passed as manifold config.
+var logger interface{}
+
 // ManifoldConfig holds the dependencies and configuration for a
 // Worker manifold.
 type ManifoldConfig struct {

--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -16,6 +16,10 @@ import (
 	"github.com/juju/juju/worker/fortress"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one passed as manifold config.
+var logger interface{}
+
 // ManifoldConfig defines the names of the manifolds on which a
 // Worker manifold will depend.
 type ManifoldConfig struct {

--- a/worker/singular/manifold.go
+++ b/worker/singular/manifold.go
@@ -16,6 +16,10 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 )
 
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead pass one passed as manifold config.
+var logger interface{}
+
 // ManifoldConfig holds the information necessary to run a FlagWorker in
 // a dependency.Engine.
 type ManifoldConfig struct {


### PR DESCRIPTION
The continuing work of passing loggers into the model workers. For those packages that didn't define a logger, a preventative declaration is added.

The credential validator worker didn't actually use the package level logger, but I didn't notice until I had already threaded it through, so I added a log line.
