### PR TITLE
Display action log messages in the CLI when calling an action and also in the action result

### DIFF
--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api/action"
+	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/apiserver/params"
 )
 
@@ -126,4 +127,88 @@ func patchApplicationCharmActions(c *gc.C, apiCli *action.Client, patchResults [
 			return nil
 		},
 	)
+}
+
+func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
+	var called bool
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				called = true
+				c.Assert(request, gc.Equals, "WatchActionsProgress")
+				c.Assert(a, jc.DeepEquals, params.Entities{
+					Entities: []params.Entity{{
+						Tag: "action-666",
+					}},
+				})
+				c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
+				*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+					Results: []params.StringsWatchResult{{
+						Error: &params.Error{Message: "FAIL"},
+					}},
+				}
+				return nil
+			},
+		),
+		BestVersion: 5,
+	}
+	client := action.NewClient(apiCaller)
+	w, err := client.WatchActionProgress("666")
+	c.Assert(w, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *actionSuite) TestWatchActionProgressArity(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Assert(request, gc.Equals, "WatchActionsProgress")
+				c.Assert(a, jc.DeepEquals, params.Entities{
+					Entities: []params.Entity{{
+						Tag: "action-666",
+					}},
+				})
+				c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
+				*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+					Results: []params.StringsWatchResult{{
+						Error: &params.Error{Message: "FAIL"},
+					}, {
+						Error: &params.Error{Message: "ANOTHER"},
+					}},
+				}
+				return nil
+			},
+		),
+		BestVersion: 5,
+	}
+	client := action.NewClient(apiCaller)
+	_, err := client.WatchActionProgress("666")
+	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
+}
+
+func (s *actionSuite) TestWatchActionProgressNotSupported(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				return nil
+			},
+		),
+		BestVersion: 4,
+	}
+	client := action.NewClient(apiCaller)
+	_, err := client.WatchActionProgress("666")
+	c.Assert(err, gc.ErrorMatches, "WatchActionProgress not supported by this version of Juju")
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -11,7 +11,7 @@ package api
 // New facades should start at 1.
 // Facades that existed before versioning start at 0.
 var facadeVersions = map[string]int{
-	"Action":                       4,
+	"Action":                       5,
 	"ActionPruner":                 1,
 	"Agent":                        2,
 	"AgentTools":                   1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -133,6 +133,7 @@ func AllFacades() *facade.Registry {
 	reg("Action", 2, action.NewActionAPIV2)
 	reg("Action", 3, action.NewActionAPIV3)
 	reg("Action", 4, action.NewActionAPIV4)
+	reg("Action", 5, action.NewActionAPIV5)
 	reg("ActionPruner", 1, actionpruner.NewAPI)
 	reg("Agent", 2, agent.NewAgentAPIV2)
 	reg("AgentTools", 1, agenttools.NewFacade)

--- a/apiserver/common/action.go
+++ b/apiserver/common/action.go
@@ -233,7 +233,7 @@ func ConvertActions(ar state.ActionReceiver, fn GetActionsFn) ([]params.ActionRe
 // to params.ActionResult.
 func MakeActionResult(actionReceiverTag names.Tag, action state.Action) params.ActionResult {
 	output, message := action.Results()
-	return params.ActionResult{
+	result := params.ActionResult{
 		Action: &params.Action{
 			Receiver:   actionReceiverTag.String(),
 			Tag:        action.ActionTag().String(),
@@ -247,4 +247,12 @@ func MakeActionResult(actionReceiverTag names.Tag, action state.Action) params.A
 		Started:   action.Started(),
 		Completed: action.Completed(),
 	}
+	for _, m := range action.Messages() {
+		result.Log = append(result.Log, params.ActionMessage{
+			Timestamp: m.Timestamp,
+			Message:   m.Message,
+		})
+	}
+
+	return result
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1,7 +1,7 @@
 [
     {
         "Name": "Action",
-        "Version": 4,
+        "Version": 5,
         "Schema": {
             "type": "object",
             "properties": {
@@ -136,6 +136,17 @@
                             "$ref": "#/definitions/ActionResults"
                         }
                     }
+                },
+                "WatchActionsProgress": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
                 }
             },
             "definitions": {
@@ -168,6 +179,23 @@
                         "name"
                     ]
                 },
+                "ActionMessage": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "timestamp",
+                        "message"
+                    ]
+                },
                 "ActionResult": {
                     "type": "object",
                     "properties": {
@@ -184,6 +212,12 @@
                         },
                         "error": {
                             "$ref": "#/definitions/Error"
+                        },
+                        "log": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionMessage"
+                            }
                         },
                         "message": {
                             "type": "string"
@@ -479,6 +513,42 @@
                     "required": [
                         "commands",
                         "timeout"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 }
             }
@@ -18967,6 +19037,23 @@
                     },
                     "additionalProperties": false
                 },
+                "ActionMessage": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "timestamp",
+                        "message"
+                    ]
+                },
                 "ActionResult": {
                     "type": "object",
                     "properties": {
@@ -18983,6 +19070,12 @@
                         },
                         "error": {
                             "$ref": "#/definitions/Error"
+                        },
+                        "log": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionMessage"
+                            }
                         },
                         "message": {
                             "type": "string"
@@ -34730,6 +34823,23 @@
                     },
                     "additionalProperties": false
                 },
+                "ActionMessage": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "timestamp",
+                        "message"
+                    ]
+                },
                 "ActionMessageParams": {
                     "type": "object",
                     "properties": {
@@ -34761,6 +34871,12 @@
                         },
                         "error": {
                             "$ref": "#/definitions/Error"
+                        },
+                        "log": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionMessage"
+                            }
                         },
                         "message": {
                             "type": "string"

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -45,6 +45,12 @@ type ActionResults struct {
 	Results []ActionResult `json:"results,omitempty"`
 }
 
+// ActionMessage represents a logged message on an action.
+type ActionMessage struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message"`
+}
+
 // ActionResult describes an Action that will be or has been completed.
 type ActionResult struct {
 	Action    *Action                `json:"action,omitempty"`
@@ -53,6 +59,7 @@ type ActionResult struct {
 	Completed time.Time              `json:"completed,omitempty"`
 	Status    string                 `json:"status,omitempty"`
 	Message   string                 `json:"message,omitempty"`
+	Log       []ActionMessage        `json:"log,omitempty"`
 	Output    map[string]interface{} `json:"output,omitempty"`
 	Error     *Error                 `json:"error,omitempty"`
 }

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -28,6 +28,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"CredentialValidator",
 	"CrossController",
 	"CrossModelRelations",
+	"ExternalControllerUpdater",
 	"FilesystemAttachmentsWatcher",
 	"LeadershipService",
 	"LifeFlag",
@@ -43,6 +44,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"NotifyWatcher",
 	"OfferStatusWatcher",
 	"Pinger",
+	"ProxyUpdater",
 	"Resources",
 	"GetResource",
 	"GetResourceInfo",
@@ -50,6 +52,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"RelationUnitsWatcher",
 	"ResourcesHookContext",
 	"RemoteRelations",
+	"Resumer",
 	"RetryStrategy",
 	"Singular",
 	"StatusHistory",
@@ -60,16 +63,6 @@ var commonModelFacadeNames = set.NewStrings(
 	"Uniter",
 	"Upgrader",
 	"VolumeAttachmentsWatcher",
-
-	// for caas controller.
-	// TODO(bootstrap): revisit here to ensure unneeded items are removed.
-	"Provisioner",
-	"Resumer",
-	"MachineActions",
-	"ProxyUpdater",
-	"Machiner",
-	"ExternalControllerUpdater",
-	"FanConfigurer",
 )
 
 // caasModelFacadeNames lists facades that are only used with CAAS

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -162,7 +162,7 @@ func newStringsWatcher(context facade.Context) (facade.Facade, error) {
 
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
-	if auth.GetAuthTag() != nil && !isAgent(auth) {
+	if auth.GetAuthTag() != nil && !isAgentOrUser(auth) {
 		return nil, common.ErrPerm
 	}
 	watcher, ok := resources.Get(id).(cache.StringsWatcher)

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/action"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/watcher"
 )
 
 // type APIClient represents the action API functionality.
@@ -60,6 +61,9 @@ type APIClient interface {
 	// FindActionsByNames takes a list of names and finds a corresponding list of
 	// Actions for every name.
 	FindActionsByNames(params.FindActionsByNames) (params.ActionsByNames, error)
+
+	// WatchActionProgress reports on logged action progress messages.
+	WatchActionProgress(actionId string) (watcher.StringsWatcher, error)
 }
 
 // ActionCommandBase is the base type for action sub-commands.

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -5,11 +5,14 @@ package action_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 	"unicode/utf8"
 
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -20,6 +23,8 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
+	"github.com/juju/juju/core/actions"
+	"github.com/juju/juju/testing"
 )
 
 var (
@@ -213,8 +218,8 @@ func (s *CallSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			wrappedCommand, command := action.NewCallCommandForTest(s.store)
-			c.Logf("test %d: should %s:\n$ juju run (function) %s\n", i,
+			wrappedCommand, command := action.NewCallCommandForTest(s.store, nil)
+			c.Logf("test %d: should %s:\n$ juju call (function) %s\n", i,
 				t.should, strings.Join(t.args, " "))
 			args := append([]string{modelFlag, "admin"}, t.args...)
 			err := cmdtesting.InitCommand(wrappedCommand, args)
@@ -236,7 +241,7 @@ func (s *CallSuite) TestInit(c *gc.C) {
 	}
 }
 
-func (s *CallSuite) TestRun(c *gc.C) {
+func (s *CallSuite) TestCall(c *gc.C) {
 	tests := []struct {
 		should                   string
 		clientSetup              func(client *fakeAPIClient)
@@ -247,6 +252,7 @@ func (s *CallSuite) TestRun(c *gc.C) {
 		expectedFunctionEnqueued []params.Action
 		expectedOutput           string
 		expectedErr              string
+		expectedLogs             []string
 	}{{
 		should:   "fail with multiple results",
 		withArgs: []string{validUnitId, "some-function"},
@@ -315,7 +321,7 @@ func (s *CallSuite) TestRun(c *gc.C) {
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 	}, {
-		should:   "run a basic function with no params with output set to function-set data",
+		should:   "call a basic function with no params with output set to action-set data",
 		withArgs: []string{validUnitId, "some-function"},
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
 		withFunctionResults: []params.ActionResult{{
@@ -345,7 +351,7 @@ outcome: success
 result-map:
   message: hello`[1:],
 	}, {
-		should:   "run a basic function with no params with plain output including stdout, stderr",
+		should:   "call a basic function with no params with plain output including stdout, stderr",
 		withArgs: []string{validUnitId, "some-function"},
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
 		withFunctionResults: []params.ActionResult{{
@@ -383,7 +389,7 @@ result-map:
 hello
 world`[1:],
 	}, {
-		should:   "run a basic function with no params with yaml output including stdout, stderr",
+		should:   "call a basic function with no params with yaml output including stdout, stderr",
 		withArgs: []string{validUnitId, "some-function", "--format", "yaml"},
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
 		withFunctionResults: []params.ActionResult{{
@@ -431,7 +437,107 @@ mysql/0:
     enqueued: 2015-02-14 08:13:00 +0000 UTC
     started: 2015-02-14 08:15:00 +0000 UTC`[1:],
 	}, {
-		should:   "run function on multiple units with stdout for each function",
+		should:   "call a basic function with progress logs",
+		withArgs: []string{validUnitId, "some-function", "--utc"},
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+
+		withFunctionResults: []params.ActionResult{{
+			Action: &params.Action{
+				Tag:      validActionTagString,
+				Receiver: names.NewUnitTag(validUnitId).String(),
+				Name:     "some-function",
+			},
+			Status: "completed",
+			Output: map[string]interface{}{
+				"Code":           "0",
+				"Stdout":         "hello",
+				"Stderr":         "world",
+				"StdoutEncoding": "utf-8",
+				"StderrEncoding": "utf-8",
+				"outcome":        "success",
+				"result-map": map[string]interface{}{
+					"message": "hello",
+				},
+			},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
+		}},
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}},
+		expectedLogs: []string{"log line 1", "log line 2"},
+		expectedOutput: `
+outcome: success
+result-map:
+  message: hello
+
+hello
+world`[1:],
+	}, {
+		should:   "call a basic action with progress logs with yaml output",
+		withArgs: []string{validUnitId, "some-function", "--format", "yaml", "--utc"},
+		withTags: tagsForIdPrefix(validActionId, validActionTagString),
+
+		withFunctionResults: []params.ActionResult{{
+			Action: &params.Action{
+				Tag:      validActionTagString,
+				Receiver: names.NewUnitTag(validUnitId).String(),
+				Name:     "some-function",
+			},
+			Log: []params.ActionMessage{{
+				Timestamp: time.Date(2015, time.February, 14, 6, 6, 6, 0, time.UTC),
+				Message:   "log line 1",
+			}, {
+				Timestamp: time.Date(2015, time.February, 14, 6, 6, 6, 0, time.UTC),
+				Message:   "log line 2",
+			}},
+			Status: "completed",
+			Output: map[string]interface{}{
+				"Code":           "0",
+				"Stdout":         "hello",
+				"Stderr":         "world",
+				"StdoutEncoding": "utf-8",
+				"StderrEncoding": "utf-8",
+				"outcome":        "success",
+				"result-map": map[string]interface{}{
+					"message": "hello",
+				},
+			},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
+		}},
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
+			Parameters: map[string]interface{}{},
+			Receiver:   names.NewUnitTag(validUnitId).String(),
+		}},
+		expectedLogs: []string{"log line 1", "log line 2"},
+		expectedOutput: `
+mysql/0:
+  id: f47ac10b-58cc-4372-a567-0e02b2c3d479
+  log:
+  - 2015-02-14 06:06:06 log line 1
+  - 2015-02-14 06:06:06 log line 2
+  results:
+    Code: "0"
+    Stderr: world
+    StderrEncoding: utf-8
+    Stdout: hello
+    StdoutEncoding: utf-8
+    outcome: success
+    result-map:
+      message: hello
+  status: completed
+  timing:
+    completed: 2015-02-14 08:17:00 +0000 UTC
+    enqueued: 2015-02-14 08:13:00 +0000 UTC
+    started: 2015-02-14 08:15:00 +0000 UTC`[1:],
+	}, {
+		should:   "call action on multiple units with stdout for each action",
 		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "yaml"},
 		withTags: params.FindTagsResults{Matches: map[string][]params.Entity{
 			validActionId:  {{Tag: validActionTagString}},
@@ -503,7 +609,7 @@ mysql/1:
     enqueued: 2015-02-14 08:13:00 +0000 UTC
     started: 2015-02-14 08:15:00 +0000 UTC`[1:],
 	}, {
-		should:   "run function on multiple units with plain output selected",
+		should:   "call function on multiple units with plain output selected",
 		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "plain"},
 		withTags: params.FindTagsResults{Matches: map[string][]params.Entity{
 			validActionId:  {{Tag: validActionTagString}},
@@ -668,8 +774,9 @@ mysql/1:
 			},
 		}},
 	}, {
-		should:   "fail with not implemented Leaders method",
-		withArgs: []string{"mysql/leader", "some-function", "--background"},
+		should:      "fail with not implemented Leaders method",
+		clientSetup: func(api *fakeAPIClient) { api.apiVersion = 2 },
+		withArgs:    []string{"mysql/leader", "some-function", "--background"},
 		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
@@ -705,7 +812,11 @@ mysql/1:
 				fakeClient := &fakeAPIClient{
 					actionResults:    t.withFunctionResults,
 					actionTagMatches: t.withTags,
-					apiVersion:       2,
+					apiVersion:       5,
+					logMessageCh:     make(chan []string, len(t.expectedLogs)),
+				}
+				if len(t.expectedLogs) > 0 {
+					fakeClient.waitForResults = make(chan bool)
 				}
 				if t.clientSetup != nil {
 					t.clientSetup(fakeClient)
@@ -715,9 +826,43 @@ mysql/1:
 				restore := s.patchAPIClient(fakeClient)
 				defer restore()
 
-				wrappedCommand, _ := action.NewCallCommandForTest(s.store)
+				if len(t.expectedLogs) > 0 {
+					go func() {
+						encodedLogs := make([]string, len(t.expectedLogs))
+						for n, log := range t.expectedLogs {
+							msg := actions.ActionMessage{
+								Message:   log,
+								Timestamp: time.Date(2015, time.February, 14, 6, 6, 6, 0, time.UTC),
+							}
+							msgData, err := json.Marshal(msg)
+							c.Assert(err, jc.ErrorIsNil)
+							encodedLogs[n] = string(msgData)
+						}
+						fakeClient.logMessageCh <- encodedLogs
+					}()
+				}
+
+				var receivedMessages []string
+				var expectedLogs []string
+				for _, msg := range t.expectedLogs {
+					expectedLogs = append(expectedLogs, "06:06:06 "+msg)
+				}
+				wrappedCommand, _ := action.NewCallCommandForTest(s.store, func(_ *cmd.Context, msg string) {
+					receivedMessages = append(receivedMessages, msg)
+					if reflect.DeepEqual(receivedMessages, expectedLogs) {
+						close(fakeClient.waitForResults)
+					}
+				})
 				args := append([]string{modelFlag, "admin"}, t.withArgs...)
 				ctx, err := cmdtesting.RunCommand(c, wrappedCommand, args...)
+
+				if len(t.expectedLogs) > 0 {
+					select {
+					case <-fakeClient.waitForResults:
+					case <-time.After(testing.LongWait):
+						c.Fatal("waiting for log messages to be consumed")
+					}
+				}
 
 				if t.expectedErr != "" || t.withAPIErr != nil {
 					c.Check(err, gc.ErrorMatches, t.expectedErr)

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -4,11 +4,17 @@
 package action
 
 import (
-	"github.com/juju/errors"
+	"encoding/json"
+	"fmt"
+
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v3"
 
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
+	coreactions "github.com/juju/juju/core/actions"
+	"github.com/juju/juju/core/watcher"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.action")
@@ -107,4 +113,60 @@ func addValueToMap(keys []string, value interface{}, target map[string]interface
 		next[keys[i]] = m
 		next = m
 	}
+}
+
+const (
+	watchTimestampFormat  = "15:04:05"
+	resultTimestampFormat = "2006-01-02 15:04:05"
+)
+
+func decodeLogMessage(encodedMessage string, utc bool) (string, error) {
+	var actionMessage coreactions.ActionMessage
+	err := json.Unmarshal([]byte(encodedMessage), &actionMessage)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return formatLogMessage(actionMessage, true, utc), nil
+}
+
+func formatLogMessage(actionMessage coreactions.ActionMessage, progressFormat, utc bool) string {
+	timestamp := actionMessage.Timestamp
+	if utc {
+		timestamp = timestamp.UTC()
+	} else {
+		timestamp = timestamp.Local()
+	}
+	timestampFormat := resultTimestampFormat
+	if progressFormat {
+		timestampFormat = watchTimestampFormat
+	}
+	return fmt.Sprintf("%v %v", timestamp.Format(timestampFormat), actionMessage.Message)
+}
+
+// processLogMessages starts a go routine to decode and handle any incoming
+// action log messages received via the string watcher.
+func processLogMessages(
+	w watcher.StringsWatcher, done chan struct{}, ctx *cmd.Context, utc bool, handler func(*cmd.Context, string),
+) {
+	go func() {
+		defer w.Kill()
+		for {
+			select {
+			case <-done:
+				return
+			case messages, ok := <-w.Changes():
+				if !ok {
+					return
+				}
+				for _, msg := range messages {
+					logMsg, err := decodeLogMessage(msg, utc)
+					if err != nil {
+						logger.Warningf("badly formatted action log message: %v\n%v", err, msg)
+						continue
+					}
+					handler(ctx, logMsg)
+				}
+			}
+		}
+	}()
 }

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -137,8 +137,10 @@ func NewShowCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ShowComm
 	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ShowCommand{c}
 }
 
-func NewCallCommandForTest(store jujuclient.ClientStore) (cmd.Command, *CallCommand) {
-	c := &callCommand{}
+func NewCallCommandForTest(store jujuclient.ClientStore, logMessage func(*cmd.Context, string)) (cmd.Command, *CallCommand) {
+	c := &callCommand{
+		logMessageHandler: logMessage,
+	}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &CallCommand{c}
 }

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/action"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -145,6 +147,8 @@ type fakeAPIClient struct {
 	charmActions       map[string]params.ActionSpec
 	apiVersion         int
 	apiErr             error
+	logMessageCh       chan []string
+	waitForResults     chan bool
 }
 
 var _ action.APIClient = (*fakeAPIClient)(nil)
@@ -218,15 +222,24 @@ func (c *fakeAPIClient) Actions(args params.Entities) (params.ActionResults, err
 	// to prevent the test hanging.  If the given wait is up, then return
 	// the results; otherwise, return a pending status.
 
-	if c.delay == nil {
+	if c.delay == nil && c.waitForResults == nil {
 		// No delay requested, just return immediately.
 		return c.getActionResults(args.Entities), c.apiErr
 	}
+	var delayChan, timeoutChan <-chan time.Time
+	if c.delay != nil {
+		delayChan = c.delay.C
+	}
+	if c.timeout != nil {
+		timeoutChan = c.timeout.C
+	}
 	select {
-	case _ = <-c.delay.C:
+	case <-c.waitForResults:
+		return c.getActionResults(args.Entities), c.apiErr
+	case _ = <-delayChan:
 		// The API delay timer is up.
 		return c.getActionResults(args.Entities), c.apiErr
-	case _ = <-c.timeout.C:
+	case _ = <-timeoutChan:
 		// Timeout to prevent tests from hanging.
 		return params.ActionResults{}, errors.New("test timed out before wait time")
 	default:
@@ -247,4 +260,8 @@ func (c *fakeAPIClient) FindActionTagsByPrefix(arg params.FindTags) (params.Find
 
 func (c *fakeAPIClient) FindActionsByNames(args params.FindActionsByNames) (params.ActionsByNames, error) {
 	return c.actionsByNames, c.apiErr
+}
+
+func (c *fakeAPIClient) WatchActionProgress(actionId string) (watcher.StringsWatcher, error) {
+	return watchertest.NewMockStringsWatcher(c.logMessageCh), nil
 }

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -282,7 +282,7 @@ func (c *runActionCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		d := FormatActionResult(result)
+		d := FormatActionResult(result, false)
 		d["id"] = tag.Id()       // Action ID is required in case we timed out.
 		d["unit"] = unitTag.Id() // Formatted unit is nice to have.
 		out[result.Action.Receiver] = d

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1287,7 +1287,6 @@ func (a *MachineAgent) createJujudSymlinks(dataDir string) error {
 	if a.isCaasAgent {
 		// For IAAS, this is done in systemd for for caas we need to do it here.
 		caasJujud := filepath.Join(tools.ToolsDir(dataDir, ""), jujunames.Jujud)
-		logger.Criticalf("creating %v to %v", jujud, caasJujud)
 		if err := a.createSymlink(caasJujud, jujud); err != nil {
 			return errors.Annotatef(err, "failed to create %s symlink", jujud)
 		}

--- a/core/actions/message.go
+++ b/core/actions/message.go
@@ -1,0 +1,12 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package actions
+
+import "time"
+
+// ActionMessage is a timestamped message logged by a running action.
+type ActionMessage struct {
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/core/watcher/watchertest/strings.go
+++ b/core/watcher/watchertest/strings.go
@@ -30,7 +30,7 @@ func NewMockStringsWatcher(ch <-chan []string) *MockStringsWatcher {
 }
 
 func (w *MockStringsWatcher) Changes() watcher.StringsChannel {
-	return watcher.StringsChannel(w.ch)
+	return w.ch
 }
 
 func (w *MockStringsWatcher) Stop() error {


### PR DESCRIPTION
## Description of change

Implement the facade call to watch and report on action progress messages, and wire this up to the CLI. When calling an action synchronously, the log messages are printed as they occur. When showing an action result, the log messages are included in the yaml.

## QA steps

deploy a charm with an action where the action calls action-log
juju call action

observe the log messages while the action runs

juju call action --format yaml

observe the log messages in the yaml output