### PR TITLE
vsphere: Change extend disk polling to investigate bug 1847245

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -29,7 +29,7 @@ import (
 const (
 	// maxExtendWait is the longest we'll wait for a disk to be
 	// extended.
-	maxExtendWait = 30 * time.Second
+	maxExtendWait = 10 * time.Minute
 
 	// extendInitialDelay is the shortest time we'll wait for a disk
 	// extend to succeed.
@@ -37,7 +37,7 @@ const (
 
 	// extendMaxDelay is the longest we'll wait before checking
 	// again whether the disk extend has succeeded.
-	extendMaxDelay = 5 * time.Second
+	extendMaxDelay = 30 * time.Second
 
 	// extendBackoffFactor is the multiple the delay will grow by each
 	// attempt.
@@ -651,6 +651,17 @@ func (c *Client) extendDisk(
 		MaxDelay: extendMaxDelay,
 		Jitter:   true,
 	})
+
+	var lastLog time.Time
+	maybeLog := func(currentKB int64) {
+		now := c.clock.Now()
+		if now.Sub(lastLog) > extendMaxDelay {
+			c.logger.Debugf("waiting for disk size >= %d kB - currently %d kB",
+				capacityKB, currentKB)
+			lastLog = now
+		}
+	}
+
 	a := retry.StartWithCancel(strategy, c.clock, ctx.Done())
 	for a.Next() {
 		disk, _, err := c.getDiskWithFileBacking(ctx, vm)
@@ -658,8 +669,10 @@ func (c *Client) extendDisk(
 			return errors.Trace(err)
 		}
 		if disk.CapacityInKB >= capacityKB {
+			c.logger.Debugf("disk extended to %d kB", disk.CapacityInKB)
 			return nil
 		}
+		maybeLog(disk.CapacityInKB)
 	}
 	return errors.Trace(ErrExtendDisk)
 }

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -501,7 +501,7 @@ func (s *clientSuite) TestCreateVirtualMachineTimesOut(c *gc.C) {
 	case <-time.After(coretesting.ShortWait):
 	}
 
-	err := s.clock.WaitAdvance(35*time.Second, coretesting.LongWait, 1)
+	err := s.clock.WaitAdvance(601*time.Second, coretesting.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {

--- a/scripts/golinters.bash
+++ b/scripts/golinters.bash
@@ -24,7 +24,6 @@ $GOPATH/bin/golangci-lint run \
     --enable=goimports \
     --enable=misspell \
     --enable=unconvert \
-    --deadline=10m \
     &> $OUTPUT_FILE
 
 # go through each golangci-lint error and check to see if it's related 


### PR DESCRIPTION
## Description of change

We're getting reports that provisioning machines on vsphere fails if the root disk is extended.

I haven't been able to reproduce this locally, so making some changes in the hope that we can get the users hitting the problem to try it. 

* Bump up the timeout to 10m in case 30s isn't sufficient - we'll check much more frequently initially anyway. 
* Log of the current size on each failed check so we can see whether there's a problem with the way we're getting the disk size.

## QA steps

* Deploy a machine with a bigger root disk than the default 10G, make sure it still extends and check logging.


## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1847245
