### PR TITLE
vsphere: Specify the target datastore when cloning the template

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -459,6 +459,7 @@ func (c *Client) cloneVM(
 	args CreateVirtualMachineParams,
 	srcVM *object.VirtualMachine,
 	vmFolder *object.Folder,
+	datastore *object.Datastore,
 ) (*object.VirtualMachine, error) {
 	taskWaiter := &taskWaiter{
 		args.Clock,
@@ -471,10 +472,12 @@ func (c *Client) cloneVM(
 		return nil, errors.Annotate(err, "building clone VM config")
 	}
 
+	datastoreRef := datastore.Reference()
 	task, err := srcVM.Clone(ctx, vmFolder, args.Name, types.VirtualMachineCloneSpec{
 		Config: vmConfigSpec,
 		Location: types.VirtualMachineRelocateSpec{
-			Pool: &args.ResourcePool,
+			Pool:      &args.ResourcePool,
+			Datastore: &datastoreRef,
 		},
 	})
 	if err != nil {

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -85,13 +85,13 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		retrievePropertiesStubCall("FakeDatacenter"),
 		retrievePropertiesStubCall("FakeVmFolder"),
 		retrievePropertiesStubCall("FakeHostFolder"),
-		retrievePropertiesStubCall("FakeRootFolder"),
-		retrievePropertiesStubCall("FakeRootFolder"),
-		retrievePropertiesStubCall("FakeDatacenter"),
-		retrievePropertiesStubCall("FakeVmFolder"),
-		retrievePropertiesStubCall("FakeVmFolder"),
 		retrievePropertiesStubCall("FakeDatacenter"),
 		retrievePropertiesStubCall("FakeDatastore1", "FakeDatastore2"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeVmFolder"),
 		{"CreateImportSpec", []interface{}{
 			UbuntuOVF,
 			types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
@@ -138,6 +138,10 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 					}},
 				},
 			},
+			types.VirtualMachineRelocateSpec{
+				Pool:      &args.ResourcePool,
+				Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
+			},
 		}},
 		{"CreatePropertyCollector", nil},
 		{"CreateFilter", nil},
@@ -171,6 +175,9 @@ func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {
 				Info:            &types.VAppPropertyInfo{Key: 4, Value: "baz"},
 			}},
 		},
+	}, types.VirtualMachineRelocateSpec{
+		Pool:      &args.ResourcePool,
+		Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
 	})
 }
 
@@ -199,6 +206,26 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreSpecified(c *gc.C) {
 		types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore1"},
 		cisp,
 	)
+
+	s.roundTripper.CheckCall(
+		c, 31, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+			ExtraConfig: []types.BaseOptionValue{
+				&types.OptionValue{Key: "k", Value: "v"},
+			},
+			Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(true)},
+			VAppConfig: &types.VmConfigSpec{
+				Property: []types.VAppPropertySpec{{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+					Info:            &types.VAppPropertyInfo{Key: 1, Value: "vm-0"},
+				}, {
+					ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+					Info:            &types.VAppPropertyInfo{Key: 4, Value: "baz"},
+				}},
+			},
+		}, types.VirtualMachineRelocateSpec{
+			Pool:      &args.ResourcePool,
+			Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore1"},
+		})
 }
 
 func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFound(c *gc.C) {
@@ -208,7 +235,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFound(c *gc.C) {
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	_, err := client.CreateVirtualMachine(context.Background(), args)
-	c.Assert(err, gc.ErrorMatches, `creating template VM: could not find datastore "datastore3", datastore\(s\) accessible: "datastore2"`)
+	c.Assert(err, gc.ErrorMatches, `could not find datastore "datastore3", datastore\(s\) accessible: "datastore2"`)
 }
 
 func (s *clientSuite) TestCreateVirtualMachineDatastoreNoneAccessible(c *gc.C) {
@@ -220,7 +247,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNoneAccessible(c *gc.C) {
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	_, err := client.CreateVirtualMachine(context.Background(), args)
-	c.Assert(err, gc.ErrorMatches, "creating template VM: no accessible datastores available")
+	c.Assert(err, gc.ErrorMatches, "no accessible datastores available")
 }
 
 func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithMultipleAvailable(c *gc.C) {
@@ -243,7 +270,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithMultipleAvail
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	_, err := client.CreateVirtualMachine(context.Background(), args)
-	c.Assert(err, gc.ErrorMatches, `creating template VM: could not find datastore "datastore3", datastore\(s\) accessible: "datastore1", "datastore2"`)
+	c.Assert(err, gc.ErrorMatches, `could not find datastore "datastore3", datastore\(s\) accessible: "datastore1", "datastore2"`)
 }
 
 func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithNoAvailable(c *gc.C) {
@@ -266,7 +293,7 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreNotFoundWithNoAvailable(c
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	_, err := client.CreateVirtualMachine(context.Background(), args)
-	c.Assert(err, gc.ErrorMatches, `creating template VM: no accessible datastores available`)
+	c.Assert(err, gc.ErrorMatches, `no accessible datastores available`)
 }
 
 func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefault(c *gc.C) {
@@ -335,6 +362,9 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 				Info:            &types.VAppPropertyInfo{Key: 4, Value: "baz"},
 			}},
 		},
+	}, types.VirtualMachineRelocateSpec{
+		Pool:      &args.ResourcePool,
+		Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
 	})
 }
 
@@ -388,6 +418,9 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 				Info:            &types.VAppPropertyInfo{Key: 4, Value: "baz"},
 			}},
 		},
+	}, types.VirtualMachineRelocateSpec{
+		Pool:      &args.ResourcePool,
+		Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
 	})
 }
 

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -115,8 +115,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		res.Res = &types.PowerOnVM_TaskResponse{powerOnVMTask}
 	case *methods.CloneVM_TaskBody:
 		req := req.(*methods.CloneVM_TaskBody).Req
-		specConfig := req.Spec.Config
-		r.MethodCall(r, "CloneVM_Task", req.Name, specConfig)
+		r.MethodCall(r, "CloneVM_Task", req.Name, req.Spec.Config, req.Spec.Location)
 		res.Res = &types.CloneVM_TaskResponse{cloneVMTask}
 	case *methods.CreateFolderBody:
 		req := req.(*methods.CreateFolderBody).Req


### PR DESCRIPTION
## Description of change

Cloning a template VM wasn't respecting the root-disk-source constraint. That meant the VM would be created in the same datastore as the template, which could be different from the requested datastore if the template already existed.

Pull the datastore selection up so that the selected datastore can be used when cloning the template.

## QA steps

* Bootstrap a vsphere controller with datastore1.
* Deploy an app with `--constraints "root-disk-source=datastore2" - the deployed VM should be on datastore 2.
* Deploy another one to datastore 3 and ensure that the new VM is in the right datastore.

## Documentation changes

None

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1847278
