### PR TITLE
Fix permission error for k8s unit peer relations

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1833,6 +1833,11 @@ func (u *UniterAPI) checkRemoteUnit(relUnit *state.RelationUnit, remoteUnitTag s
 			return "", common.ErrPerm
 		}
 	case names.ApplicationTag:
+		endpoints := relUnit.Relation().Endpoints()
+		isPeerRelation := len(endpoints) == 1 && endpoints[0].Role == charm.RolePeer
+		if isPeerRelation {
+			break
+		}
 		// If called by an application agent, we need
 		// to check the units of the application.
 		app, err := u.st.Application(tag.Name)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -183,7 +183,7 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.State, *state.CAAS
 	s.CleanupSuite.AddCleanup(func(*gc.C) { _ = apiState.Close() })
 
 	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag: unit.Tag(),
+		Tag: app.Tag(),
 	}
 	u, err := apiState.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2340,6 +2340,42 @@ func (s *uniterSuite) TestReadRemoteSettingsWithNonStringValuesFails(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.SettingsResults{
 		Results: []params.SettingsResult{
 			{Error: &params.Error{Message: expectErr}},
+		},
+	})
+}
+
+func (s *uniterSuite) TestReadRemoteSettingsForCAASApplicationInPeerRelation(c *gc.C) {
+	_, cm, app, unit := s.setupCAASModel(c)
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+
+	unit2, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	ep, err := app.Endpoint("ring")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := cm.State().EndpointsRelation(ep)
+	c.Assert(err, jc.ErrorIsNil)
+
+	relUnit, err := rel.Unit(unit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = relUnit.EnterScope(map[string]interface{}{
+		"black midi": "ducter",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	uniterAPI := s.newUniterAPI(c, cm.State(), s.authorizer)
+
+	args := params.RelationUnitPairs{RelationUnitPairs: []params.RelationUnitPair{{
+		Relation:   rel.Tag().String(),
+		LocalUnit:  unit2.Tag().String(),
+		RemoteUnit: unit.Tag().String(),
+	}}}
+	result, err := uniterAPI.ReadRemoteSettings(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.SettingsResults{
+		Results: []params.SettingsResult{
+			{Settings: params.Settings{
+				"black midi": "ducter",
+			}},
 		},
 	})
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -162,7 +162,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 		"mariadb": {charm: "cs:kubernetes/mariadb-42", config: mysqlch.Config().DefaultSettings()},
 		"gitlab":  {charm: "cs:kubernetes/gitlab-47", config: wpch.Config().DefaultSettings(), scale: 1},
 	})
-	s.assertRelationsEstablished(c, "gitlab:db mariadb:server")
+	s.assertRelationsEstablished(c, "gitlab:ring", "gitlab:db mariadb:server")
 }
 
 func (s *BundleDeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -209,11 +209,11 @@ func (s *ApplicationSuite) TestCAASSetCharm(c *gc.C) {
 	})
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
-	ch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})
-	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: ch})
+	ch := f.MakeCharm(c, &factory.CharmParams{Name: "mysql", Series: "kubernetes"})
+	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "mysql", Charm: ch})
 
 	// Add a compatible charm and force it.
-	sch := state.AddCustomCharm(c, st, "gitlab", "metadata.yaml", metaBase, "kubernetes", 2)
+	sch := state.AddCustomCharm(c, st, "mysql", "metadata.yaml", metaBase, "kubernetes", 2)
 
 	cfg := state.SetCharmConfig{
 		Charm:      sch,

--- a/testcharms/charm-repo/kubernetes/gitlab/metadata.yaml
+++ b/testcharms/charm-repo/kubernetes/gitlab/metadata.yaml
@@ -14,6 +14,9 @@ provides:
     interface: http
 requires:
   db:
-    interface: mysql    
+    interface: mysql
+peers:
+  ring:
+    interface: gitlab
 series:
   - kubernetes


### PR DESCRIPTION
## Description of change

k8s charms were unable to read peer relation settings due to a logic error in checking permissions.
Also a drive by fix of the uniter test authoriser used for caas models.

## QA steps

deploy a k8s charm with a peer relation

## Bug reference

https://bugs.launchpad.net/juju/+bug/1818230
