### PR TITLE
Set up TERM variable in hook environments

### DIFF
--- a/worker/uniter/runner/context/env.go
+++ b/worker/uniter/runner/context/env.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	jujuos "github.com/juju/os"
+	"github.com/juju/os/series"
 )
 
 // OSDependentEnvVars returns the OS-dependent environment variables that
@@ -22,6 +23,8 @@ func OSDependentEnvVars(paths Paths) []string {
 		return centosEnv(paths)
 	case jujuos.OpenSUSE:
 		return opensuseEnv(paths)
+	case jujuos.GenericLinux:
+		return genericLinuxEnv(paths)
 	}
 	return nil
 }
@@ -39,16 +42,74 @@ func ubuntuEnv(paths Paths) []string {
 		"DEBIAN_FRONTEND=noninteractive",
 		"LANG=C.UTF-8",
 	}
+
 	env = append(env, path...)
+
+	if series.MustHostSeries() == "trusty" {
+		// Trusty is in ESM at the time of writing and it does not have patch 20150502 for ncurses 5.9
+		// with terminal definitions for "tmux" and "tmux-256color"
+		env = append(env, "TERM=screen-256color")
+	} else {
+		env = append(env, "TERM=tmux-256color")
+	}
+
 	return env
 }
 
 func centosEnv(paths Paths) []string {
-	return append(appendPath(paths), "LANG=C.UTF-8")
+	path := appendPath(paths)
+
+	env := []string{
+		"LANG=C.UTF-8",
+	}
+
+	env = append(env, path...)
+
+	// versions older than 7 are not supported and centos7 does not have patch 20150502 for ncurses 5.9
+	// with terminal definitions for "tmux" and "tmux-256color"
+	if series.MustHostSeries() == "centos7" {
+		env = append(env, "TERM=screen-256color")
+	} else {
+		env = append(env, "TERM=tmux-256color")
+	}
+
+	return env
 }
 
 func opensuseEnv(paths Paths) []string {
-	return append(appendPath(paths), "LANG=C.UTF-8")
+	path := appendPath(paths)
+
+	env := []string{
+		"LANG=C.UTF-8",
+	}
+
+	env = append(env, path...)
+
+	// OpenSUSE 42 does not include patch 20150502 for ncurses 5.9 with
+	// with terminal definitions for "tmux" and "tmux-256color"
+	if series.MustHostSeries() == "opensuseleap" {
+		env = append(env, "TERM=screen-256color")
+	} else {
+		env = append(env, "TERM=tmux-256color")
+	}
+
+	return env
+}
+
+func genericLinuxEnv(paths Paths) []string {
+	path := appendPath(paths)
+
+	env := []string{
+		"LANG=C.UTF-8",
+	}
+
+	env = append(env, path...)
+
+	// use the "screen" terminal definition (added to ncurses in 1997) on a generic Linux to avoid
+	// any ncurses version discovery code. tmux documentation suggests that the "screen" terminal is supported.
+	env = append(env, "TERM=screen")
+
+	return env
 }
 
 // windowsEnv adds windows specific environment variables. PSModulePath


### PR DESCRIPTION
## Description of change

In order for a terminal to work properly in a debug-hooks environment, TERM environment variable needs to be set. This change addresses that according to the tmux documentation https://github.com/tmux/tmux/wiki/FAQ in a cross-distribution way.

* `TERM=tmux-256color` is used for distributions that have "ncurses 5.9 - patch 20150502" (https://github.com/mirror/ncurses/commit/be512fa073c00c2d52567c973d16b121414870da).
* `TERM=screen-256color` is used for older distributions.

`tmux-256color` which uses `tmux` (which in turn uses `screen`)
https://github.com/mirror/ncurses/blob/be512fa073c00c2d52567c973d16b121414870da/misc/terminfo.src#L6124-L6129

`screen-256color` which uses `screen`.
https://github.com/mirror/ncurses/blob/be512fa073c00c2d52567c973d16b121414870da/misc/terminfo.src#L5962-L5963

http://man7.org/linux/man-pages/man5/terminfo.5.html (see "Similar Terminals" on that covers the `use` keyword)

## QA steps

```
juju deploy ubuntu
juju debug-hooks ubuntu/0

# once in the hook environment you should see the TERM variable set appropriately to "tmux-256color" or "screen-256color"
printenv TERM

# try to use `less`, it must NOT show this:

less config.yaml
WARNING: terminal is not fully functional
config.yaml  (press RETURN)
```

NOTE: just doing something like `juju run --machine 0 -m controller 'printenv TERM'` will not work because those environment variables are injected by Juju only for hook/action execution environments.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1838772