### PR TITLE
For jujuv3, actions are called functions

### DIFF
--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -62,7 +62,7 @@ func (s *CallSuite) TestInit(c *gc.C) {
 		args                 []string
 		expectMaxWait        time.Duration
 		expectUnits          []string
-		expectAction         string
+		expectFunction       string
 		expectParamsYamlPath string
 		expectParseStrings   bool
 		expectKVArgs         [][]string
@@ -74,113 +74,113 @@ func (s *CallSuite) TestInit(c *gc.C) {
 		expectError: "no unit specified",
 	}, {
 		should:      "fail with both --background and --max-wait",
-		args:        []string{"--background", "--max-wait=60s", validUnitId, "action"},
+		args:        []string{"--background", "--max-wait=60s", validUnitId, "function"},
 		expectError: "cannot specify both --max-wait and --background",
 	}, {
-		should:      "fail with no action specified",
+		should:      "fail with no function specified",
 		args:        []string{validUnitId},
-		expectError: "no action specified",
+		expectError: "no function specified",
 	}, {
 		should:      "fail with invalid unit ID",
-		args:        []string{invalidUnitId, "valid-action-name"},
-		expectError: "invalid unit or action name \"something-strange-\"",
+		args:        []string{invalidUnitId, "valid-function-name"},
+		expectError: "invalid unit or function name \"something-strange-\"",
 	}, {
 		should:      "fail with invalid unit ID first",
-		args:        []string{validUnitId, invalidUnitId, "valid-action-name"},
-		expectError: "invalid unit or action name \"something-strange-\"",
+		args:        []string{validUnitId, invalidUnitId, "valid-function-name"},
+		expectError: "invalid unit or function name \"something-strange-\"",
 	}, {
 		should:      "fail with invalid unit ID second",
-		args:        []string{invalidUnitId, validUnitId, "valid-action-name"},
-		expectError: "invalid unit or action name \"something-strange-\"",
+		args:        []string{invalidUnitId, validUnitId, "valid-function-name"},
+		expectError: "invalid unit or function name \"something-strange-\"",
 	}, {
-		should:       "work with multiple valid units",
-		args:         []string{validUnitId, validUnitId2, "valid-action-name"},
-		expectUnits:  []string{validUnitId, validUnitId2},
-		expectAction: "valid-action-name",
-		expectKVArgs: [][]string{},
+		should:         "work with multiple valid units",
+		args:           []string{validUnitId, validUnitId2, "valid-function-name"},
+		expectUnits:    []string{validUnitId, validUnitId2},
+		expectFunction: "valid-function-name",
+		expectKVArgs:   [][]string{},
 	}, {
-		should:      "fail with invalid action name",
+		should:      "fail with invalid function name",
 		args:        []string{validUnitId, "BadName"},
-		expectError: "invalid unit or action name \"BadName\"",
+		expectError: "invalid unit or function name \"BadName\"",
 	}, {
-		should:      "fail with invalid action name ending in \"-\"",
+		should:      "fail with invalid function name ending in \"-\"",
 		args:        []string{validUnitId, "name-end-with-dash-"},
-		expectError: "invalid unit or action name \"name-end-with-dash-\"",
+		expectError: "invalid unit or function name \"name-end-with-dash-\"",
 	}, {
 		should:      "fail with wrong formatting of k-v args",
-		args:        []string{validUnitId, "valid-action-name", "uh"},
+		args:        []string{validUnitId, "valid-function-name", "uh"},
 		expectError: "argument \"uh\" must be of the form key.key.key...=value",
 	}, {
 		should:      "fail with wrong formatting of k-v args",
-		args:        []string{validUnitId, "valid-action-name", "foo.Baz=3"},
+		args:        []string{validUnitId, "valid-function-name", "foo.Baz=3"},
 		expectError: "key \"Baz\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens",
 	}, {
 		should:      "fail with wrong formatting of k-v args",
-		args:        []string{validUnitId, "valid-action-name", "no-go?od=3"},
+		args:        []string{validUnitId, "valid-function-name", "no-go?od=3"},
 		expectError: "key \"no-go\\?od\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens",
 	}, {
-		should:        "use max-wait if specified",
-		args:          []string{validUnitId, "action", "--max-wait", "20s"},
-		expectUnits:   []string{validUnitId},
-		expectAction:  "action",
-		expectMaxWait: 20 * time.Second,
+		should:         "use max-wait if specified",
+		args:           []string{validUnitId, "function", "--max-wait", "20s"},
+		expectUnits:    []string{validUnitId},
+		expectFunction: "function",
+		expectMaxWait:  20 * time.Second,
 	}, {
-		should:       "work with action name ending in numeric values",
-		args:         []string{validUnitId, "action-01"},
-		expectUnits:  []string{validUnitId},
-		expectAction: "action-01",
+		should:         "work with function name ending in numeric values",
+		args:           []string{validUnitId, "function-01"},
+		expectUnits:    []string{validUnitId},
+		expectFunction: "function-01",
 	}, {
-		should:       "work with numeric values within action name",
-		args:         []string{validUnitId, "action-00-foo"},
-		expectUnits:  []string{validUnitId},
-		expectAction: "action-00-foo",
+		should:         "work with numeric values within function name",
+		args:           []string{validUnitId, "function-00-foo"},
+		expectUnits:    []string{validUnitId},
+		expectFunction: "function-00-foo",
 	}, {
-		should:       "work with action name starting with numeric values",
-		args:         []string{validUnitId, "00-action"},
-		expectUnits:  []string{validUnitId},
-		expectAction: "00-action",
+		should:         "work with function name starting with numeric values",
+		args:           []string{validUnitId, "00-function"},
+		expectUnits:    []string{validUnitId},
+		expectFunction: "00-function",
 	}, {
-		should:       "work with empty values",
-		args:         []string{validUnitId, "valid-action-name", "ok="},
-		expectUnits:  []string{validUnitId},
-		expectAction: "valid-action-name",
-		expectKVArgs: [][]string{{"ok", ""}},
+		should:         "work with empty values",
+		args:           []string{validUnitId, "valid-function-name", "ok="},
+		expectUnits:    []string{validUnitId},
+		expectFunction: "valid-function-name",
+		expectKVArgs:   [][]string{{"ok", ""}},
 	}, {
 		should:             "handle --parse-strings",
-		args:               []string{validUnitId, "valid-action-name", "--string-args"},
+		args:               []string{validUnitId, "valid-function-name", "--string-args"},
 		expectUnits:        []string{validUnitId},
-		expectAction:       "valid-action-name",
+		expectFunction:     "valid-function-name",
 		expectParseStrings: true,
 	}, {
-		// cf. worker/uniter/runner/jujuc/action-set_test.go per @fwereade
-		should:       "work with multiple '=' signs",
-		args:         []string{validUnitId, "valid-action-name", "ok=this=is=weird="},
-		expectUnits:  []string{validUnitId},
-		expectAction: "valid-action-name",
-		expectKVArgs: [][]string{{"ok", "this=is=weird="}},
+		// cf. worker/uniter/runner/jujuc/function-set_test.go per @fwereade
+		should:         "work with multiple '=' signs",
+		args:           []string{validUnitId, "valid-function-name", "ok=this=is=weird="},
+		expectUnits:    []string{validUnitId},
+		expectFunction: "valid-function-name",
+		expectKVArgs:   [][]string{{"ok", "this=is=weird="}},
 	}, {
-		should:       "init properly with no params",
-		args:         []string{validUnitId, "valid-action-name"},
-		expectUnits:  []string{validUnitId},
-		expectAction: "valid-action-name",
+		should:         "init properly with no params",
+		args:           []string{validUnitId, "valid-function-name"},
+		expectUnits:    []string{validUnitId},
+		expectFunction: "valid-function-name",
 	}, {
 		should:               "handle --params properly",
-		args:                 []string{validUnitId, "valid-action-name", "--params=foo.yml"},
+		args:                 []string{validUnitId, "valid-function-name", "--params=foo.yml"},
 		expectUnits:          []string{validUnitId},
-		expectAction:         "valid-action-name",
+		expectFunction:       "valid-function-name",
 		expectParamsYamlPath: "foo.yml",
 	}, {
 		should: "handle --params and key-value args",
 		args: []string{
 			validUnitId,
-			"valid-action-name",
+			"valid-function-name",
 			"--params=foo.yml",
 			"foo.bar=2",
 			"foo.baz.bo=3",
 			"bar.foo=hello",
 		},
 		expectUnits:          []string{validUnitId},
-		expectAction:         "valid-action-name",
+		expectFunction:       "valid-function-name",
 		expectParamsYamlPath: "foo.yml",
 		expectKVArgs: [][]string{
 			{"foo", "bar", "2"},
@@ -191,36 +191,36 @@ func (s *CallSuite) TestInit(c *gc.C) {
 		should: "handle key-value args with no --params",
 		args: []string{
 			validUnitId,
-			"valid-action-name",
+			"valid-function-name",
 			"foo.bar=2",
 			"foo.baz.bo=y",
 			"bar.foo=hello",
 		},
-		expectUnits:  []string{validUnitId},
-		expectAction: "valid-action-name",
+		expectUnits:    []string{validUnitId},
+		expectFunction: "valid-function-name",
 		expectKVArgs: [][]string{
 			{"foo", "bar", "2"},
 			{"foo", "baz", "bo", "y"},
 			{"bar", "foo", "hello"},
 		},
 	}, {
-		should:       "work with leader identifier",
-		args:         []string{"mysql/leader", "valid-action-name"},
-		expectUnits:  []string{"mysql/leader"},
-		expectAction: "valid-action-name",
-		expectKVArgs: [][]string{},
+		should:         "work with leader identifier",
+		args:           []string{"mysql/leader", "valid-function-name"},
+		expectUnits:    []string{"mysql/leader"},
+		expectFunction: "valid-function-name",
+		expectKVArgs:   [][]string{},
 	}}
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
 			wrappedCommand, command := action.NewCallCommandForTest(s.store)
-			c.Logf("test %d: should %s:\n$ juju run (action) %s\n", i,
+			c.Logf("test %d: should %s:\n$ juju run (function) %s\n", i,
 				t.should, strings.Join(t.args, " "))
 			args := append([]string{modelFlag, "admin"}, t.args...)
 			err := cmdtesting.InitCommand(wrappedCommand, args)
 			if t.expectError == "" {
 				c.Check(command.UnitNames(), gc.DeepEquals, t.expectUnits)
-				c.Check(command.ActionName(), gc.Equals, t.expectAction)
+				c.Check(command.FunctionName(), gc.Equals, t.expectFunction)
 				c.Check(command.ParamsYAML().Path, gc.Equals, t.expectParamsYamlPath)
 				c.Check(command.Args(), jc.DeepEquals, t.expectKVArgs)
 				c.Check(command.ParseStrings(), gc.Equals, t.expectParseStrings)
@@ -238,91 +238,91 @@ func (s *CallSuite) TestInit(c *gc.C) {
 
 func (s *CallSuite) TestRun(c *gc.C) {
 	tests := []struct {
-		should                 string
-		clientSetup            func(client *fakeAPIClient)
-		withArgs               []string
-		withAPIErr             error
-		withActionResults      []params.ActionResult
-		withTags               params.FindTagsResults
-		expectedActionEnqueued []params.Action
-		expectedOutput         string
-		expectedErr            string
+		should                   string
+		clientSetup              func(client *fakeAPIClient)
+		withArgs                 []string
+		withAPIErr               error
+		withFunctionResults      []params.ActionResult
+		withTags                 params.FindTagsResults
+		expectedFunctionEnqueued []params.Action
+		expectedOutput           string
+		expectedErr              string
 	}{{
 		should:   "fail with multiple results",
-		withArgs: []string{validUnitId, "some-action"},
-		withActionResults: []params.ActionResult{
+		withArgs: []string{validUnitId, "some-function"},
+		withFunctionResults: []params.ActionResult{
 			{Action: &params.Action{Tag: validActionTagString}},
 			{Action: &params.Action{Tag: validActionTagString}},
 		},
 		expectedErr: "illegal number of results returned",
 	}, {
 		should:   "fail with API error",
-		withArgs: []string{validUnitId, "some-action"},
-		withActionResults: []params.ActionResult{{
+		withArgs: []string{validUnitId, "some-function"},
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{Tag: validActionTagString}},
 		},
 		withAPIErr:  errors.New("something wrong in API"),
 		expectedErr: "something wrong in API",
 	}, {
 		should:   "fail with error in result",
-		withArgs: []string{validUnitId, "some-action"},
-		withActionResults: []params.ActionResult{{
+		withArgs: []string{validUnitId, "some-function"},
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{Tag: validActionTagString},
 			Error:  common.ServerError(errors.New("database error")),
 		}},
 		expectedErr: "database error",
 	}, {
 		should:   "fail with invalid tag in result",
-		withArgs: []string{validUnitId, "some-action"},
-		withActionResults: []params.ActionResult{{
+		withArgs: []string{validUnitId, "some-function"},
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{Tag: invalidActionTagString},
 		}},
 		expectedErr: "\"" + invalidActionTagString + "\" is not a valid action tag",
 	}, {
 		should: "fail with missing file passed",
-		withArgs: []string{validUnitId, "some-action",
+		withArgs: []string{validUnitId, "some-function",
 			"--params", s.dir + "/" + "missing.yml",
 		},
 		expectedErr: "open .*missing.yml: " + utils.NoSuchFileErrRegexp,
 	}, {
 		should: "fail with invalid yaml in file",
-		withArgs: []string{validUnitId, "some-action",
+		withArgs: []string{validUnitId, "some-function",
 			"--params", s.dir + "/" + "invalidParams.yml",
 		},
 		expectedErr: "yaml: line 4: mapping values are not allowed in this context",
 	}, {
 		should: "fail with invalid UTF in file",
-		withArgs: []string{validUnitId, "some-action",
+		withArgs: []string{validUnitId, "some-function",
 			"--params", s.dir + "/" + "invalidUTF.yml",
 		},
 		expectedErr: "yaml: invalid leading UTF-8 octet",
 	}, {
 		should:      "fail with invalid YAML passed as arg and no --string-args",
-		withArgs:    []string{validUnitId, "some-action", "foo.bar=\""},
+		withArgs:    []string{validUnitId, "some-function", "foo.bar=\""},
 		expectedErr: "yaml: found unexpected end of stream",
 	}, {
-		should:   "enqueue a basic action with no params",
-		withArgs: []string{validUnitId, "some-action", "--background"},
-		withActionResults: []params.ActionResult{{
+		should:   "enqueue a basic function with no params",
+		withArgs: []string{validUnitId, "some-function", "--background"},
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
 			},
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:       "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
 	}, {
-		should:   "run a basic action with no params with output set to action-set data",
-		withArgs: []string{validUnitId, "some-action"},
+		should:   "run a basic function with no params with output set to function-set data",
+		withArgs: []string{validUnitId, "some-function"},
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
-				Name:     "some-action",
+				Name:     "some-function",
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
@@ -335,8 +335,8 @@ func (s *CallSuite) TestRun(c *gc.C) {
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:       "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
@@ -345,14 +345,14 @@ outcome: success
 result-map:
   message: hello`[1:],
 	}, {
-		should:   "run a basic action with no params with plain output including stdout, stderr",
-		withArgs: []string{validUnitId, "some-action"},
+		should:   "run a basic function with no params with plain output including stdout, stderr",
+		withArgs: []string{validUnitId, "some-function"},
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
-				Name:     "some-action",
+				Name:     "some-function",
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
@@ -370,8 +370,8 @@ result-map:
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:       "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
@@ -383,14 +383,14 @@ result-map:
 hello
 world`[1:],
 	}, {
-		should:   "run a basic action with no params with yaml output including stdout, stderr",
-		withArgs: []string{validUnitId, "some-action", "--format", "yaml"},
+		should:   "run a basic function with no params with yaml output including stdout, stderr",
+		withArgs: []string{validUnitId, "some-function", "--format", "yaml"},
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
-				Name:     "some-action",
+				Name:     "some-function",
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
@@ -408,8 +408,8 @@ world`[1:],
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:       "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}},
@@ -431,17 +431,17 @@ mysql/0:
     enqueued: 2015-02-14 08:13:00 +0000 UTC
     started: 2015-02-14 08:15:00 +0000 UTC`[1:],
 	}, {
-		should:   "run action on multiple units with stdout for each action",
-		withArgs: []string{validUnitId, validUnitId2, "some-action", "--format", "yaml"},
+		should:   "run function on multiple units with stdout for each function",
+		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "yaml"},
 		withTags: params.FindTagsResults{Matches: map[string][]params.Entity{
 			validActionId:  {{Tag: validActionTagString}},
 			validActionId2: {{Tag: validActionTagString2}},
 		}},
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
-				Name:     "some-action",
+				Name:     "some-function",
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
@@ -457,7 +457,7 @@ mysql/0:
 			Action: &params.Action{
 				Tag:      validActionTagString2,
 				Receiver: names.NewUnitTag(validUnitId2).String(),
-				Name:     "some-action",
+				Name:     "some-function",
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
@@ -470,12 +470,12 @@ mysql/0:
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
 			Completed: time.Date(2015, time.February, 14, 8, 17, 0, 0, time.UTC),
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:       "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}, {
-			Name:       "some-action",
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId2).String(),
 		}},
@@ -503,17 +503,17 @@ mysql/1:
     enqueued: 2015-02-14 08:13:00 +0000 UTC
     started: 2015-02-14 08:15:00 +0000 UTC`[1:],
 	}, {
-		should:   "run action on multiple units with plain output selected",
-		withArgs: []string{validUnitId, validUnitId2, "some-action", "--format", "plain"},
+		should:   "run function on multiple units with plain output selected",
+		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "plain"},
 		withTags: params.FindTagsResults{Matches: map[string][]params.Entity{
 			validActionId:  {{Tag: validActionTagString}},
 			validActionId2: {{Tag: validActionTagString2}},
 		}},
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
-				Name:     "some-action",
+				Name:     "some-function",
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
@@ -526,7 +526,7 @@ mysql/1:
 			Action: &params.Action{
 				Tag:      validActionTagString2,
 				Receiver: names.NewUnitTag(validUnitId2).String(),
-				Name:     "some-action",
+				Name:     "some-function",
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
@@ -536,12 +536,12 @@ mysql/1:
 				},
 			},
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:       "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId).String(),
 		}, {
-			Name:       "some-action",
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   names.NewUnitTag(validUnitId2).String(),
 		}},
@@ -559,21 +559,21 @@ mysql/1:
     result-map:
       message: hello2`[1:],
 	}, {
-		should: "enqueue an action with some explicit params",
-		withArgs: []string{validUnitId, "some-action", "--background",
+		should: "enqueue an function with some explicit params",
+		withArgs: []string{validUnitId, "some-function", "--background",
 			"out.name=bar",
 			"out.kind=tmpfs",
 			"out.num=3",
 			"out.boolval=y",
 		},
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
 			},
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:     "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:     "some-function",
 			Receiver: names.NewUnitTag(validUnitId).String(),
 			Parameters: map[string]interface{}{
 				"out": map[string]interface{}{
@@ -585,21 +585,21 @@ mysql/1:
 			},
 		}},
 	}, {
-		should: "enqueue an action with some raw string params",
-		withArgs: []string{validUnitId, "some-action", "--background", "--string-args",
+		should: "enqueue an function with some raw string params",
+		withArgs: []string{validUnitId, "some-function", "--background", "--string-args",
 			"out.name=bar",
 			"out.kind=tmpfs",
 			"out.num=3",
 			"out.boolval=y",
 		},
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
 			},
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:     "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:     "some-function",
 			Receiver: names.NewUnitTag(validUnitId).String(),
 			Parameters: map[string]interface{}{
 				"out": map[string]interface{}{
@@ -611,20 +611,20 @@ mysql/1:
 			},
 		}},
 	}, {
-		should: "enqueue an action with file params plus CLI args",
-		withArgs: []string{validUnitId, "some-action", "--background",
+		should: "enqueue an function with file params plus CLI args",
+		withArgs: []string{validUnitId, "some-function", "--background",
 			"--params", s.dir + "/" + "validParams.yml",
 			"compression.kind=gz",
 			"compression.fast=true",
 		},
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
 			},
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:     "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:     "some-function",
 			Receiver: names.NewUnitTag(validUnitId).String(),
 			Parameters: map[string]interface{}{
 				"out": "name",
@@ -636,22 +636,22 @@ mysql/1:
 			},
 		}},
 	}, {
-		should: "enqueue an action with file params and explicit params",
-		withArgs: []string{validUnitId, "some-action", "--background",
+		should: "enqueue an function with file params and explicit params",
+		withArgs: []string{validUnitId, "some-function", "--background",
 			"out.name=bar",
 			"out.kind=tmpfs",
 			"compression.quality.speed=high",
 			"compression.quality.size=small",
 			"--params", s.dir + "/" + "validParams.yml",
 		},
-		withActionResults: []params.ActionResult{{
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
 			},
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:     "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:     "some-function",
 			Receiver: names.NewUnitTag(validUnitId).String(),
 			Parameters: map[string]interface{}{
 				"out": map[string]interface{}{
@@ -669,8 +669,8 @@ mysql/1:
 		}},
 	}, {
 		should:   "fail with not implemented Leaders method",
-		withArgs: []string{"mysql/leader", "some-action", "--background"},
-		withActionResults: []params.ActionResult{{
+		withArgs: []string{"mysql/leader", "some-function", "--background"},
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
@@ -680,17 +680,17 @@ mysql/1:
 			"\nleader determination is unsupported by this API" +
 			"\neither upgrade your controller, or explicitly specify a unit",
 	}, {
-		should:      "enqueue a basic action on the leader",
+		should:      "enqueue a basic function on the leader",
 		clientSetup: func(api *fakeAPIClient) { api.apiVersion = 3 },
-		withArgs:    []string{"mysql/leader", "some-action", "--background"},
-		withActionResults: []params.ActionResult{{
+		withArgs:    []string{"mysql/leader", "some-function", "--background"},
+		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
 				Receiver: names.NewUnitTag(validUnitId).String(),
 			},
 		}},
-		expectedActionEnqueued: []params.Action{{
-			Name:       "some-action",
+		expectedFunctionEnqueued: []params.Action{{
+			Name:       "some-function",
 			Parameters: map[string]interface{}{},
 			Receiver:   "mysql/leader",
 		},
@@ -700,10 +700,10 @@ mysql/1:
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
 			func() {
-				c.Logf("test %d: should %s:\n$ juju actions do %s\n", i, t.should, strings.Join(t.withArgs, " "))
+				c.Logf("test %d: should %s:\n$ juju functions do %s\n", i, t.should, strings.Join(t.withArgs, " "))
 
 				fakeClient := &fakeAPIClient{
-					actionResults:    t.withActionResults,
+					actionResults:    t.withFunctionResults,
 					actionTagMatches: t.withTags,
 					apiVersion:       2,
 				}
@@ -725,22 +725,22 @@ mysql/1:
 					c.Assert(err, gc.IsNil)
 					// Before comparing, double-check to avoid
 					// panics in malformed tests.
-					c.Assert(len(t.withActionResults), gc.Not(gc.Equals), 0)
-					// Make sure the test's expected Actions were
+					c.Assert(len(t.withFunctionResults), gc.Not(gc.Equals), 0)
+					// Make sure the test's expected Functions were
 					// non-nil and correct.
-					for i := range t.withActionResults {
-						c.Assert(t.withActionResults[i].Action, gc.NotNil)
+					for i := range t.withFunctionResults {
+						c.Assert(t.withFunctionResults[i].Action, gc.NotNil)
 					}
-					// Make sure the Action sent to the API to be
+					// Make sure the Function sent to the API to be
 					// enqueued was indeed the expected map
 					enqueued := fakeClient.EnqueuedActions()
-					c.Assert(enqueued.Actions, jc.DeepEquals, t.expectedActionEnqueued)
+					c.Assert(enqueued.Actions, jc.DeepEquals, t.expectedFunctionEnqueued)
 
 					if t.expectedOutput == "" {
 						outputResult := ctx.Stderr.(*bytes.Buffer).Bytes()
 						outString := strings.Trim(string(outputResult), "\n")
 
-						expectedTag, err := names.ParseActionTag(t.withActionResults[0].Action.Tag)
+						expectedTag, err := names.ParseActionTag(t.withFunctionResults[0].Action.Tag)
 						c.Assert(err, gc.IsNil)
 
 						// Make sure the CLI responded with the expected tag

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -39,8 +39,8 @@ func (c *CallCommand) UnitNames() []string {
 	return c.unitReceivers
 }
 
-func (c *CallCommand) ActionName() string {
-	return c.actionName
+func (c *CallCommand) FunctionName() string {
+	return c.functionName
 }
 
 func (c *CallCommand) ParseStrings() bool {
@@ -104,7 +104,7 @@ func (c *ShowCommand) ApplicationTag() names.ApplicationTag {
 }
 
 func (c *ShowCommand) ActionName() string {
-	return c.actionName
+	return c.functionName
 }
 
 func NewShowOutputCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ShowOutputCommand) {

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -80,7 +80,11 @@ func (c *listCommand) Info() *cmd.Info {
 		Aliases: []string{"list-actions"},
 	})
 	if featureflag.Enabled(feature.JujuV3) {
+		info.Name = "functions"
+		info.Aliases = []string{"list-functions"}
 		info.Doc = strings.Replace(info.Doc, "run-action", "call", -1)
+		info.Doc = strings.Replace(info.Doc, "action", "function", -1)
+		info.Purpose = strings.Replace(info.Purpose, "action", "function", -1)
 	}
 	return info
 }
@@ -149,7 +153,11 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		output = shortOutput
 	default:
 		if len(sortedNames) == 0 {
-			ctx.Infof("No actions defined for %s.", c.applicationTag.Id())
+			functions := "functions"
+			if !featureflag.Enabled(feature.JujuV3) {
+				functions = "actions"
+			}
+			ctx.Infof("No %s defined for %s.", functions, c.applicationTag.Id())
 			return nil
 		}
 		var list []listOutput
@@ -180,7 +188,11 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 	}
 
 	tw := output.TabWriter(writer)
-	fmt.Fprintf(tw, "%s\t%s\n", "Action", "Description")
+	if featureflag.Enabled(feature.JujuV3) {
+		fmt.Fprintf(tw, "%s\t%s\n", "Function", "Description")
+	} else {
+		fmt.Fprintf(tw, "%s\t%s\n", "Action", "Description")
+	}
 	for _, value := range list {
 		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.TrimSpace(value.description))
 	}

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -5,6 +5,7 @@ package action
 
 import (
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd"
@@ -32,10 +33,10 @@ type showOutputCommand struct {
 }
 
 const showOutputDoc = `
-Show the results returned by an action with the given ID.  A partial ID may
-also be used.  To block until the result is known completed or failed, use
-the --wait option with a duration, as in --wait 5s or --wait 1h.  Use --wait 0
-to wait indefinitely.  If units are left off, seconds are assumed.
+Show the results returned by an action with the given ID.  
+To block until the result is known completed or failed, use
+the --wait option with a duration, as in --wait 5s or --wait 1h.
+Use --wait 0 to wait indefinitely.  If units are left off, seconds are assumed.
 
 The default behavior without --wait is to immediately check and return; if
 the results are "pending" then only the available information will be
@@ -69,6 +70,7 @@ func (c *showOutputCommand) Info() *cmd.Info {
 		info.Name = "show-task"
 		info.Args = "<task ID>"
 		info.Purpose = "Show results of a task by ID."
+		info.Doc = strings.Replace(info.Doc, "an action", "a function call", -1)
 	}
 	return info
 }
@@ -208,11 +210,15 @@ func fetchResult(api APIClient, requestedId string) (params.ActionResult, error)
 	}
 	actionResults := actions.Results
 	numActionResults := len(actionResults)
+	task := "task"
+	if !featureflag.Enabled(feature.JujuV3) {
+		task = "action"
+	}
 	if numActionResults == 0 {
-		return none, errors.Errorf("no results for action %s", requestedId)
+		return none, errors.Errorf("no results for %s %s", task, requestedId)
 	}
 	if numActionResults != 1 {
-		return none, errors.Errorf("too many results for action %s", requestedId)
+		return none, errors.Errorf("too many results for %s %s", task, requestedId)
 	}
 
 	result := actionResults[0]

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -630,7 +630,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"call", "show-task",
+	"call", "show-task", "functions", "list-functions", "show-function",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {
@@ -643,8 +643,11 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	// since they are not enabled.
 	cmdSet := set.NewStrings(commandNames...)
 	if !featureflag.Enabled(feature.JujuV3) {
+		cmdSet.Add("actions")
+		cmdSet.Add("list-actions")
 		cmdSet.Add("run-action")
 		cmdSet.Add("run")
+		cmdSet.Add("show-action")
 		cmdSet.Add("show-action-status")
 		cmdSet.Add("show-action-output")
 	}
@@ -666,7 +669,7 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	c.Assert(unknown, jc.DeepEquals, set.NewStrings())
 	missing = cmdSet.Difference(registered)
 	c.Assert(missing, jc.DeepEquals, set.NewStrings(
-		"run", "run-action", "show-action-status", "show-action-output"))
+		"actions", "list-actions", "run", "run-action", "show-action", "show-action-status", "show-action-output"))
 }
 
 func getHelpCommandNames(c *gc.C) set.Strings {


### PR DESCRIPTION
## Description of change

Behind the juju-v3 feature flag, adjust the actions CLI to refer instead to functions.
This includes command names and output.

## QA steps

Run juju help 'cmdname'
Run the commands and checkout output