### PR TITLE
vsphere: Stop polling for disk extension

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1145,7 +1145,7 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:e5396b66ff8c90a824413a27fd41ed4413161c949fa681869bd2caf714a155f9"
+  digest = "1:363c7e47cd3449872c15a27a9785900c2af3652a55e17487b1401031cd211202"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -1167,7 +1167,7 @@
     "vim25/xml",
   ]
   pruneopts = ""
-  revision = "05504416e95561e1478196d7058721c827a7bb8c"
+  revision = "40aebf13ba45d8b16d760807fc5e380e7c6f48fb"
 
 [[projects]]
   digest = "1:ad67dfd3799a2c58f6c65871dd141d8b53f61f600aec48ce8d7fa16a4d5476f8"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -452,7 +452,7 @@
 
 [[constraint]]
   name = "github.com/vmware/govmomi"
-  revision = "05504416e95561e1478196d7058721c827a7bb8c"
+  revision = "40aebf13ba45d8b16d760807fc5e380e7c6f48fb"
 
 [[constraint]]
   name = "golang.org/x/crypto"

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -452,104 +452,14 @@ func (s *clientSuite) TestCreateVirtualMachineRootDiskSize(c *gc.C) {
 	args.Constraints.RootDisk = &rootDisk
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	errCh := make(chan error)
-	go func() {
-		_, err := client.CreateVirtualMachine(context.Background(), args)
-		select {
-		case errCh <- err:
-		case <-time.After(coretesting.ShortWait):
-			c.Fatalf("timed out sending error back")
-		}
-	}()
-
-	select {
-	case <-errCh:
-		c.Fatalf("creating virtual machine finished too soon")
-	case <-time.After(coretesting.ShortWait):
-	}
-
-	err := s.clock.WaitAdvance(50*time.Millisecond, coretesting.LongWait, 1)
+	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
-
-	// Report that the disk is big now.
-	s.roundTripper.updateContents("FakeVm1", []types.ObjectContent{{
-		Obj: types.ManagedObjectReference{
-			Type:  "VirtualMachine",
-			Value: "FakeVm1",
-		},
-		PropSet: []types.DynamicProperty{
-			{Name: "name", Val: "vm-1"},
-			{Name: "runtime.powerState", Val: "poweredOn"},
-			{
-				Name: "config.hardware.device",
-				Val: []types.BaseVirtualDevice{
-					&types.VirtualDisk{
-						VirtualDevice: types.VirtualDevice{
-							Backing: &types.VirtualDiskFlatVer2BackingInfo{
-								VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-									FileName: "disk.vmdk",
-								},
-							},
-						},
-						CapacityInKB: 1024 * 1024 * 20, // 20 GiB
-					},
-				},
-			},
-		},
-	}})
-
-	select {
-	case err := <-errCh:
-		c.Assert(err, jc.ErrorIsNil)
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for CreateVirtualMachine")
-	}
 
 	call := findStubCall(c, s.roundTripper.Calls(), "ExtendVirtualDisk")
 	c.Assert(call.Args, jc.DeepEquals, []interface{}{
 		"disk.vmdk",
 		int64(rootDisk) * 1024, // in KiB
 	})
-}
-
-func (s *clientSuite) TestCreateVirtualMachineTimesOut(c *gc.C) {
-	args := baseCreateVirtualMachineParams(c)
-	rootDisk := uint64(1024 * 20) // 20 GiB
-	args.Constraints.RootDisk = &rootDisk
-
-	client := s.newFakeClient(&s.roundTripper, "dc0")
-	errCh := make(chan error)
-	go func() {
-		_, err := client.CreateVirtualMachine(context.Background(), args)
-		select {
-		case errCh <- err:
-		case <-time.After(coretesting.ShortWait):
-			c.Fatalf("timed out sending error back")
-		}
-	}()
-
-	select {
-	case <-errCh:
-		c.Fatalf("creating virtual machine finished too soon")
-	case <-time.After(coretesting.ShortWait):
-	}
-
-	err := s.clock.WaitAdvance(601*time.Second, coretesting.LongWait, 1)
-	c.Assert(err, jc.ErrorIsNil)
-
-	select {
-	case err := <-errCh:
-		c.Assert(err, gc.ErrorMatches, "extending disk failed")
-		c.Assert(err, jc.Satisfies, IsExtendDiskError)
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out waiting for CreateVirtualMachine")
-	}
-
-	// Check that we destroyed the VM if extending the disk timed out.
-	lastCall := len(s.roundTripper.Calls()) - 1
-	s.roundTripper.CheckCall(c, lastCall-3, "Destroy_Task")
-	// (The ones in between are CreatePropertyCollector and CreateFilter.)
-	s.roundTripper.CheckCall(c, lastCall, "WaitForUpdatesEx")
 }
 
 func (s *clientSuite) TestVerifyMAC(c *gc.C) {


### PR DESCRIPTION
## Description of change

Users reported that specifying a non-default root-disk size caused provisioning the VM to fail - it would timeout waiting for the extend disk task (even though the task could be seen to be finished in the UI).

The bug that caused govmomi to hang when waiting for the task extension has been fixed - it will now correctly propagate errors up to the caller. Stop polling the disk size, just wait for the extend task.

The hang was caused by a permission error when trying to get the state of the extend task - this can be avoided by granting the model user the Read-only role on the vcenter instance (with propagate to children turned on). This seems like overkill, and I'm still trying to determine if we can do it with a more specific permission, but I wanted to push this up so @phvalguima can try it out.

Once we determine the right permission I'll add a pre-check for it so we can provide a better error.

## QA steps

* Deploy an application with `--constraints "root-disk=20G"` - it should provision successfully.

## Documentation changes

* We'll need to call out the correct permission in the vsphere provider documentation.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1847245
