### PR TITLE
Handle BOOTSTRAP_REUSE_LOCAL

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -69,8 +69,14 @@ bootstrap() {
     fi
     bootstrapped_name=$(grep "." "${TEST_DIR}/jujus" | tail -n 1)
     if [ -z "${bootstrapped_name}" ]; then
-        # No bootstrapped juju found, unset the the variable.
-        unset BOOTSTRAP_REUSE
+        if [ -n "${BOOTSTRAP_REUSE_LOCAL}" ]; then
+            bootstrapped_name="${BOOTSTRAP_REUSE_LOCAL}"
+            export BOOTSTRAP_REUSE="true"
+        else
+            # No bootstrapped juju found, unset the the variable.
+            echo "====> Unable to reuse bootstrapped juju"
+            unset BOOTSTRAP_REUSE
+        fi
     fi
 
     version=$(juju_version)
@@ -79,14 +85,14 @@ bootstrap() {
     if [ -n "${BOOTSTRAP_REUSE}" ]; then
         echo "====> Reusing bootstrapped juju ($(green "${version}"))"
 
-        OUT=$(juju models --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
+        OUT=$(juju models -c "${bootstrapped_name}" --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
         if [ -n "${OUT}" ]; then
             echo "${model} already exists. Use the following to clean up the environment:"
             echo "    juju destroy-model --force -y ${model}"
             exit 1
         fi
 
-        add_model "${model}" "${provider}"
+        add_model "${model}" "${provider}" "${bootstrapped_name}"
         name="${bootstrapped_name}"
     else
         echo "====> Bootstrapping juju ($(green "${version}"))"
@@ -102,16 +108,17 @@ bootstrap() {
 # add_model is used to add a model for tracking. This is for internal use only
 # and shouldn't be used by any of the tests directly.
 add_model() {
-    local model provider
+    local model provider controller
 
     model=${1}
     provider=${2}
+    controller=${3}
 
     OUT=$(juju controllers --format=json | jq '.controllers | .["${bootstrapped_name}"] | .cloud' | grep "${provider}" || true)
     if [ -n "${OUT}" ]; then
-        juju add-model "${model}" "${provider}"
+        juju add-model -c "${controller}" "${model}" "${provider}"
     else
-        juju add-model "${model}"
+        juju add-model -c "${controller}" "${model}"
     fi
     echo "${model}" >> "${TEST_DIR}/models"
 }
@@ -133,10 +140,15 @@ juju_bootstrap() {
     output=${1}
     shift
 
+    debug="false"
+    if [ "${VERBOSE}" -gt 1 ]; then
+        debug="true"
+    fi
+
     if [ -n "${output}" ]; then
-        juju bootstrap "${provider}" "${name}" -d "${model}" "$@" 2>&1 | add_date >"${output}"
+        juju bootstrap --debug="${debug}" "${provider}" "${name}" -d "${model}" "$@" 2>&1 | add_date >"${output}"
     else
-        juju bootstrap "${provider}" "${name}" -d "${model}" "$@"
+        juju bootstrap --debug="${debug}" "${provider}" "${name}" -d "${model}" "$@"
     fi
     echo "${name}" >> "${TEST_DIR}/jujus"
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -75,19 +75,20 @@ bootstrap() {
         else
             # No bootstrapped juju found, unset the the variable.
             echo "====> Unable to reuse bootstrapped juju"
-            unset BOOTSTRAP_REUSE
+            export BOOTSTRAP_REUSE="false"
         fi
     fi
 
     version=$(juju_version)
 
     START_TIME=$(date +%s)
-    if [ -n "${BOOTSTRAP_REUSE}" ]; then
+    if [ "${BOOTSTRAP_REUSE}" = "true" ]; then
         echo "====> Reusing bootstrapped juju ($(green "${version}"))"
 
         OUT=$(juju models -c "${bootstrapped_name}" --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
         if [ -n "${OUT}" ]; then
             echo "${model} already exists. Use the following to clean up the environment:"
+            echo "    juju switch ${bootstrapped_name}"
             echo "    juju destroy-model --force -y ${model}"
             exit 1
         fi
@@ -146,7 +147,7 @@ juju_bootstrap() {
     fi
 
     if [ -n "${output}" ]; then
-        juju bootstrap --debug="${debug}" "${provider}" "${name}" -d "${model}" "$@" 2>&1 | add_date >"${output}"
+        juju bootstrap --debug="${debug}" "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
     else
         juju bootstrap --debug="${debug}" "${provider}" "${name}" -d "${model}" "$@"
     fi

--- a/tests/includes/verbose.sh
+++ b/tests/includes/verbose.sh
@@ -1,9 +1,16 @@
 set_verbosity() {
+    # There are three levels of verbosity, both 1 and 2 will fail on any error,
+    # the difference is that 2 will also turn juju debug statements on, but not
+    # the shell debug statements. Turning to 3, turns everything on, in theory
+    # we could also turn on trace statements for juju.
     case "${VERBOSE}" in
     1)
         set -e
         ;;
     2)
+        set -e
+        ;;
+    3)
         set -eux
         ;;
     *)

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -102,6 +102,7 @@ while getopts "h?:vVsaxrp" opt; do
     V)
         VERBOSE=3
         shift
+        alias juju="juju --debug"
         ;;
     s)
         SKIP_LIST="${2}"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -3,6 +3,9 @@
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
 export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005"
+export BOOTSTRAP_REUSE_LOCAL=
+export BOOTSTRAP_REUSE="false"
+export BOOTSTRAP_PROVIDER=
 
 OPTIND=1
 VERBOSE=1
@@ -93,11 +96,11 @@ while getopts "h?:vVsaxrp" opt; do
         show_help
         ;;
     v)
-        VERBOSE=1
+        VERBOSE=2
         shift
         ;;
     V)
-        VERBOSE=2
+        VERBOSE=3
         shift
         ;;
     s)

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -1,16 +1,17 @@
 test_cli() {
-  if [ "$(skip 'test_cli')" ]; then
-    echo "==> TEST SKIPPED: local charms tests"
-    return
-  fi
+    if [ "$(skip 'test_cli')" ]; then
+        echo "==> TEST SKIPPED: CLI tests"
+        return
+    fi
 
-  echo "==> Checking for dependencies"
-  check_dependencies juju
+    echo "==> Checking for dependencies"
+    check_dependencies juju
 
-  file="${TEST_DIR}/test_local_charms.txt"
-  bootstrap "test_local_charms" "${file}"
+    file="${TEST_DIR}/test-local-charms.txt"
 
-  test_local_charms
+    bootstrap "test-local-charms" "${file}"
 
-  destroy_controller "test_local_charms"
+    test_local_charms
+
+    destroy_controller "test-local-charms"
 }

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -4,6 +4,8 @@ test_cli() {
         return
     fi
 
+    set_verbosity
+
     echo "==> Checking for dependencies"
     check_dependencies juju
 

--- a/tests/suites/cli/use_local_charm.sh
+++ b/tests/suites/cli/use_local_charm.sh
@@ -1,5 +1,5 @@
 # Checks whether the cwd is used for the juju local deploy.
-test_deploy_local_charm_revision() {
+run_deploy_local_charm_revision() {
   echo
 
   file="${TEST_DIR}/local-charm-deploy-no-git.txt"
@@ -7,7 +7,7 @@ test_deploy_local_charm_revision() {
   ensure "local-charm-deploy" "${file}"
 
   TMP_NO_GIT=$(mktemp -d -t ci-XXXXXXXXXX)
-  cd "${TMP_CHARM_GIT}" || exit 1
+  cd "${TMP_NO_GIT}" || exit 1
 
   git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
   cd "${TMP_NO_GIT}/ntp" || exit 1
@@ -20,10 +20,11 @@ test_deploy_local_charm_revision() {
 }
 
 # CWD with git, deploy charm with git, but -> check that git describe is correct
-test_deploy_local_charm_revision_invalid_git() {
+run_deploy_local_charm_revision_invalid_git() {
   echo
 
   file="${TEST_DIR}/local-charm-deploy-wrong-git.txt"
+
   ensure "local-charm-deploy-wrong-git" "${file}"
 
   TMP_CHARM_GIT=$(mktemp -d -t ci-XXXXXXXXXX)
@@ -34,7 +35,6 @@ test_deploy_local_charm_revision_invalid_git() {
 
   cd "${TMP_CHARM_GIT}/ntp" || exit 1
   WANTED_CHARM_SHA=\"$(git describe --dirty --always)\"
-
 
   cd "${TMP_NO_CHARM_GIT}" || exit 1
 
@@ -71,7 +71,7 @@ test_local_charms() {
 
         cd .. || exit
 
-        run "test_deploy_local_charm_revision"
-        run "test_deploy_local_charm_revision_invalid_git"
+        run "run_deploy_local_charm_revision"
+        run "run_deploy_local_charm_revision_invalid_git"
     )
 }

--- a/tests/suites/cmr_bundles/task.sh
+++ b/tests/suites/cmr_bundles/task.sh
@@ -4,6 +4,8 @@ test_cmr_bundles() {
         return
     fi
 
+    set_verbosity
+
     echo "==> Checking for dependencies"
     check_dependencies juju
 

--- a/tests/suites/controller/task.sh
+++ b/tests/suites/controller/task.sh
@@ -4,6 +4,8 @@ test_controller() {
         return
     fi
 
+    set_verbosity
+
     echo "==> Checking for dependencies"
     check_dependencies juju
 

--- a/tests/suites/examples/task.sh
+++ b/tests/suites/examples/task.sh
@@ -4,6 +4,8 @@ test_examples() {
         return
     fi
 
+    set_verbosity
+
     echo "==> Checking for dependencies"
     check_dependencies juju
 

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -4,6 +4,8 @@ test_smoke() {
         return
     fi
 
+    set_verbosity
+
     echo "==> Checking for dependencies"
     check_dependencies juju
 

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -4,6 +4,8 @@ test_static_analysis() {
         return
     fi
 
+    set_verbosity
+
     test_copyright
     test_static_analysis_go
     test_static_analysis_shell


### PR DESCRIPTION
## Description of change

The following allows us to completely reuse a local bootstrap,
so much so, that you can now test the integrations on your local
work. This also doesn't destroy your local controller, only the
models that where created whilst running the tests.

Along with these changes, we also get the debug logs out of the
bootstrapping controller, by passing `-V`. This has been an
outstanding issue of mine, so that it becomes easier to debug when
a controller doesn't work correctly.

As a driveby I've made sure that the CLI tests pass again.

## QA steps

```sh
juju deploy lxd test
BOOTSTRAP_REUSE_LOCAL=test ./main.sh cli
```
