### PR TITLE
Introducing client-only and controller-only options for cloud commands.

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -211,6 +211,9 @@ func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init populates the command with the args from the command line.
 func (c *AddCAASCommand) Init(args []string) (err error) {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	if len(args) == 0 {
 		return errors.Errorf("missing k8s name.")
 	}
@@ -441,7 +444,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if clusterName == "" {
 		clusterName = newCloud.HostCloudRegion
 	}
-	if c.Local {
+	if c.ClientOnly {
 		successMsg := fmt.Sprintf("k8s substrate %q added as cloud %q%s", clusterName, c.caasName, storageMsg)
 		successMsg += fmt.Sprintf("\nYou can now bootstrap to this cloud by running 'juju bootstrap %s'.", c.caasName)
 		fmt.Fprintln(ctx.Stdout, successMsg)
@@ -491,7 +494,7 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !c.Local {
+	if !c.ClientOnly {
 		ctrlUUID, err := c.ControllerUUID(c.Store, c.ControllerName)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -61,7 +61,7 @@ The new k8s cloud can then be used to bootstrap into, or it
 can be added to an existing controller; the current controller
 is used unless the --controller option is specified. If you just
 want to update your current client and not a running controller, use
-the --client option.
+the --client-only option.
 
 Specify a non default kubeconfig file location using $KUBECONFIG
 environment variable or pipe in file content from stdin.
@@ -81,7 +81,7 @@ necessary parameters directly.
 
 Examples:
     juju add-k8s myk8scloud
-    juju add-k8s myk8scloud --client
+    juju add-k8s myk8scloud --client-only
     juju add-k8s myk8scloud --controller mycontroller
     juju add-k8s --context-name mycontext myk8scloud
     juju add-k8s myk8scloud --region <cloudNameOrCloudType>/<someregion>

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -812,7 +812,7 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 	cloudRegion := "gce/us-east1"
 
 	command := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--client")
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `k8s substrate "mrcloud2" added as cloud "myk8s".You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
 	c.Assert(strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1), gc.Equals, expected)
@@ -834,6 +834,7 @@ func mockStdinPipe(content string) (*os.File, error) {
 func (s *addCAASSuite) TestCorrectParseFromStdIn(c *gc.C) {
 	command := s.makeCommand(c, true, true, false)
 	stdIn, err := mockStdinPipe(kubeConfigStr)
+	c.Assert(stdIn, gc.NotNil)
 	defer stdIn.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.runCommand(c, stdIn, command, "myk8s", "-c", "foo")

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -55,7 +55,7 @@ type RemoveCAASCommand struct {
 // NewRemoveCAASCommand returns a command to add caas information.
 func NewRemoveCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
-	cmd := &RemoveCAASCommand{
+	command := &RemoveCAASCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
 			Store:       store,
 			EnabledFlag: feature.MultiCloud,
@@ -63,14 +63,14 @@ func NewRemoveCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 
 		cloudMetadataStore: cloudMetadataStore,
 	}
-	cmd.apiFunc = func() (RemoveCloudAPI, error) {
-		root, err := cmd.NewAPIRoot(cmd.Store, cmd.ControllerName, "")
+	command.apiFunc = func() (RemoveCloudAPI, error) {
+		root, err := command.NewAPIRoot(command.Store, command.ControllerName, "")
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return cloudapi.NewClient(root), nil
 	}
-	return modelcmd.WrapBase(cmd)
+	return modelcmd.WrapBase(command)
 }
 
 // Info returns help information about the command.
@@ -85,6 +85,9 @@ func (c *RemoveCAASCommand) Info() *cmd.Info {
 
 // Init populates the command with the args from the command line.
 func (c *RemoveCAASCommand) Init(args []string) (err error) {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	if len(args) == 0 {
 		return errors.Errorf("missing k8s name.")
 	}
@@ -98,7 +101,7 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 
 // Run is defined on the Command interface.
 func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
-	if c.ControllerName == "" && !c.Local {
+	if c.ControllerName == "" && !c.ClientOnly {
 		return errors.Errorf(
 			"There are no controllers running.\nTo remove cloud %q from the current client, use the --client option.", c.cloudName)
 	}

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -24,11 +24,11 @@ If --controller is used, also removes the cloud
 from the specified controller (if it is not in use).
 
 If you just want to update your current client and not
-a running controller, use the --client option.
+a running controller, use the --client-only option.
 
 Examples:
     juju remove-k8s myk8scloud
-    juju remove-k8s myk8scloud --client
+    juju remove-k8s myk8scloud --client-only
     juju remove-k8s --controller mycontroller myk8scloud
     
 See also:
@@ -103,7 +103,7 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
 	if c.ControllerName == "" && !c.ClientOnly {
 		return errors.Errorf(
-			"There are no controllers running.\nTo remove cloud %q from the current client, use the --client option.", c.cloudName)
+			"There are no controllers running.\nTo remove cloud %q from the current client, use the --client-only option.", c.cloudName)
 	}
 	if err := removeCloudFromLocal(c.cloudMetadataStore, c.cloudName); err != nil {
 		return errors.Annotatef(err, "cannot remove cloud from current client")

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -94,20 +94,20 @@ func (s *removeCAASSuite) runCommand(c *gc.C, cmd cmd.Command, args ...string) (
 }
 
 func (s *removeCAASSuite) TestExtraArg(c *gc.C) {
-	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "k8sname", "extra")
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "k8sname", "extra")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *removeCAASSuite) TestMissingName(c *gc.C) {
-	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd)
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command)
 	c.Assert(err, gc.ErrorMatches, `missing k8s name.`)
 }
 
 func (s *removeCAASSuite) TestRemove(c *gc.C) {
-	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s", "-c", "foo")
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "myk8s", "-c", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.fakeCloudAPI.CheckCallNames(c, "RemoveCloud")
@@ -121,8 +121,8 @@ func (s *removeCAASSuite) TestRemove(c *gc.C) {
 }
 
 func (s *removeCAASSuite) TestRemoveLocalOnly(c *gc.C) {
-	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s", "--client")
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "myk8s", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.fakeCloudAPI.CheckNoCalls(c)
@@ -136,10 +136,10 @@ func (s *removeCAASSuite) TestRemoveLocalOnly(c *gc.C) {
 
 func (s *removeCAASSuite) TestRemoveNoController(c *gc.C) {
 	s.store.Controllers = nil
-	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s")
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "myk8s")
 	c.Assert(err, gc.NotNil)
-	_, err = cmdtesting.RunCommand(c, cmd, "homestack")
+	_, err = cmdtesting.RunCommand(c, command, "homestack")
 	c.Assert(err, gc.NotNil)
 	msg := err.Error()
 	msg = strings.Replace(msg, "\n", "", -1)
@@ -152,16 +152,16 @@ func (s *removeCAASSuite) TestRemoveNoController(c *gc.C) {
 
 func (s *removeCAASSuite) TestRemoveNotInController(c *gc.C) {
 	s.fakeCloudAPI.SetErrors(errors.NotFoundf("cloud"))
-	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "myk8s", "-c", "foo")
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "myk8s", "-c", "foo")
 	c.Assert(err, gc.ErrorMatches, "cannot remove k8s cloud from controller.*")
 
 	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
 }
 
 func (s *removeCAASSuite) TestRemoveNotInLocal(c *gc.C) {
-	cmd := s.makeCommand()
-	_, err := s.runCommand(c, cmd, "yourk8s", "-c", "foo")
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "yourk8s", "-c", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.fakeCloudAPI.CheckCallNames(c, "RemoveCloud")

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -143,7 +143,7 @@ func (s *removeCAASSuite) TestRemoveNoController(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	msg := err.Error()
 	msg = strings.Replace(msg, "\n", "", -1)
-	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from the current client, use the --client option.*`)
+	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from the current client, use the --client-only option.*`)
 
 	s.fakeCloudAPI.CheckNoCalls(c)
 	s.cloudMetadataStore.CheckNoCalls(c)

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -232,6 +232,9 @@ func (c *AddCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init populates the command with the args from the command line.
 func (c *AddCloudCommand) Init(args []string) (err error) {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	if len(args) > 0 {
 		c.Cloud = args[0]
 		if ok := names.IsValidCloud(c.Cloud); !ok {
@@ -351,7 +354,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	if !c.Replace && c.existsLocally {
 		returnErr = errors.AlreadyExistsf("use `update-cloud %s --client` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
 	}
-	if c.Local {
+	if c.ClientOnly {
 		return returnErr
 	}
 	ctxt.Infof("")

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -79,7 +79,7 @@ Use --no-prompt option when this prompt is undesirable, but the upload to
 the current controller is wanted.
 Use --controller option to upload a cloud to a different controller. 
 
-Use --client option to add cloud to the current client only.
+Use --client-only option to add cloud to the current client only.
 
 DEPRECATED If <cloud name> already exists in Juju's cache, then the `[1:] + "`--replace`" + ` 
 option is required. Use 'update-credential' instead.
@@ -133,7 +133,7 @@ If the "multi-cloud" feature flag is turned on in the controller:
 
     juju add-cloud --controller mycontroller mycloud
     juju add-cloud --controller mycontroller mycloud --credential mycred
-    juju add-cloud --client mycloud ~/mycloud.yaml
+    juju add-cloud --client-only mycloud ~/mycloud.yaml
 
 See also: 
     clouds
@@ -352,7 +352,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		}
 	}
 	if !c.Replace && c.existsLocally {
-		returnErr = errors.AlreadyExistsf("use `update-cloud %s --client` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
+		returnErr = errors.AlreadyExistsf("use `update-cloud %s --client-only` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
 	}
 	if c.ClientOnly {
 		return returnErr
@@ -783,14 +783,14 @@ func (p *cloudFileReader) verifyName(name string) error {
 		return err
 	}
 	if _, ok := personal[name]; ok {
-		return errors.AlreadyExistsf("use `update-cloud %s --client` to replace this cloud locally: %q", name, name)
+		return errors.AlreadyExistsf("use `update-cloud %s --client-only` to replace this cloud locally: %q", name, name)
 	}
 	msg, err := nameExists(name, public)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if msg != "" {
-		return errors.AlreadyExistsf(msg + "; use `update-cloud --client` to override this definition locally")
+		return errors.AlreadyExistsf(msg + "; use `update-cloud --client-only` to override this definition locally")
 	}
 	return nil
 }

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -212,7 +212,7 @@ func (s *addSuite) TestAddExisting(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(mockCloud, nil)
 
 	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud homestack --client` to override known definition: local cloud \"homestack\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud homestack --client-only` to override known definition: local cloud \"homestack\" already exists")
 }
 
 func (s *addSuite) TestAddExistingReplace(c *gc.C) {
@@ -251,7 +251,7 @@ func (s *addSuite) TestAddExistingPublic(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "aws", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud aws --client` to override known definition: local cloud \"aws\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud aws --client-only` to override known definition: local cloud \"aws\" already exists")
 }
 
 func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
@@ -269,7 +269,7 @@ func (s *addSuite) TestAddExistingBuiltin(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 
 	_, err = s.runCommand(c, fake, "localhost", cloudFile.Name())
-	c.Assert(err, gc.ErrorMatches, "use `update-cloud localhost --client` to override known definition: local cloud \"localhost\" already exists")
+	c.Assert(err, gc.ErrorMatches, "use `update-cloud localhost --client-only` to override known definition: local cloud \"localhost\" already exists")
 }
 
 func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -176,7 +176,7 @@ func (*addSuite) TestAddBadFilename(c *gc.C) {
 	fake.Call("ParseCloudMetadataFile", "somefile.yaml").Returns(map[string]jujucloud.Cloud{}, badFileErr)
 
 	addCmd := cloud.NewAddCloudCommand(fake)
-	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "somefile.yaml", "--client")
+	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "somefile.yaml", "--client-only")
 	c.Check(errors.Cause(err), gc.Equals, badFileErr)
 }
 
@@ -230,7 +230,7 @@ func (s *addSuite) TestAddExistingReplace(c *gc.C) {
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name(), "--replace", "--client")
+	_, err = s.runCommand(c, fake, "homestack", cloudFile.Name(), "--replace", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(numCallsToWrite(), gc.Equals, 1)
@@ -286,7 +286,7 @@ func (s *addSuite) TestAddExistingPublicReplace(c *gc.C) {
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 	writeCall := fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "aws", cloudFile.Name(), "--replace", "--client")
+	_, err = s.runCommand(c, fake, "aws", cloudFile.Name(), "--replace", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(writeCall(), gc.Equals, 1)
 }
@@ -318,7 +318,7 @@ func (s *addSuite) TestAddNew(c *gc.C) {
 	// but here mockCloud should have a region attached...
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "garage-maas", cloudFile.Name(), "--client")
+	_, err = s.runCommand(c, fake, "garage-maas", cloudFile.Name(), "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(numCallsToWrite(), gc.Equals, 1)
 }
@@ -513,7 +513,7 @@ func (s *addSuite) TestAddLocal(c *gc.C) {
 	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenario(c)
 
 	_, err := cmdtesting.RunCommand(
-		c, command, "garage-maas", cloudFileName, "--client")
+		c, command, "garage-maas", cloudFileName, "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	api.CheckNoCalls(c)
 
@@ -522,7 +522,7 @@ func (s *addSuite) TestAddLocal(c *gc.C) {
 
 func (s *addSuite) TestAddLocalNoCloudName(c *gc.C) {
 	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenario(c)
-	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--client")
+	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	api.CheckNoCalls(c)
 	c.Check(numCalls(), gc.Equals, 1)
@@ -534,7 +534,8 @@ func (s *addSuite) TestAddLocalNoCloudName(c *gc.C) {
 
 func (s *addSuite) TestAddLocalNoCloudNameButManyCloudsInFile(c *gc.C) {
 	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenarioWithFile(c, manyCloudsYamlFile)
-	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--client")
+	ctx, err := cmdtesting.RunCommand(c, command, "-f", cloudFileName, "--client-only")
+	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), jc.Contains, "there is more than one cloud defined in file")
 	api.CheckNoCalls(c)
 	c.Check(numCalls(), gc.Equals, 0)
@@ -590,7 +591,7 @@ func (s *addSuite) TestAddToControllerAmbiguousCredential(c *gc.C) {
 
 func (*addSuite) TestInteractive(c *gc.C) {
 	command := cloud.NewAddCloudCommand(nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := &bytes.Buffer{}
@@ -631,7 +632,7 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(m1Metadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := &bytes.Buffer{}
@@ -670,7 +671,7 @@ func (*addSuite) TestInteractiveManual(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	out := &bytes.Buffer{}
@@ -715,7 +716,7 @@ func (*addSuite) TestInteractiveManualInvalidName(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -764,7 +765,7 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(vsphereMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	var stdout bytes.Buffer
@@ -809,7 +810,7 @@ func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(manMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
@@ -846,7 +847,7 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(compoundCloudMetadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	var out bytes.Buffer
@@ -946,7 +947,7 @@ clouds:
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	fake.Call("WritePersonalCloudMetadata", addDefaultRegion(mockCloud)).Returns(nil)
 
-	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--client")
+	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--client-only")
 	c.Check(err, jc.ErrorIsNil)
 
 	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{})
@@ -981,7 +982,7 @@ clouds:
 		logWriter.Clear()
 	}()
 
-	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--client")
+	_, err = s.runCommand(c, fake, "foundations", cloudFile.Name(), "--client-only")
 	c.Check(err, jc.ErrorIsNil)
 
 	c.Check(logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
@@ -1221,7 +1222,7 @@ func testInteractiveOpenstack(c *gc.C, myOpenstack jujucloud.Cloud, expectedYAML
 	numCallsToWrite := fake.Call("WritePersonalCloudMetadata", addDefaultRegion(m1Metadata)).Returns(nil)
 
 	command := cloud.NewAddCloudCommandForTest(fake, jujuclient.NewMemStore(), nil)
-	err := cmdtesting.InitCommand(command, []string{"--client"})
+	err := cmdtesting.InitCommand(command, []string{"--client-only"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := cmdtesting.Context(c)

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -172,6 +172,9 @@ func (c *addCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *addCredentialCommand) Init(args []string) (err error) {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	if len(args) < 1 {
 		return errors.New("Usage: juju add-credential <cloud-name> [-f <credentials.yaml>]")
 	}
@@ -187,7 +190,7 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	var err error
-	if !c.Local && c.ControllerName == "" {
+	if !c.ClientOnly && c.ControllerName == "" {
 		// The user may have specified the controller via a --controller option.
 		// If not, let's see if there is a current controller that can be detected.
 		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, "add a credential to")
@@ -197,7 +200,7 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	// Check that the supplied cloud is valid.
-	if !c.Local && c.ControllerName != "" {
+	if !c.ClientOnly && c.ControllerName != "" {
 		if err := c.maybeRemoteCloud(ctxt); err != nil {
 			if !errors.IsNotFound(err) {
 				logger.Errorf("%v", err)
@@ -330,7 +333,7 @@ func (c *addCredentialCommand) internalAddCredential(ctxt *cmd.Context, verb str
 		}
 	}
 	// Remote processing.
-	if !c.Local {
+	if !c.ClientOnly {
 		if c.ControllerName != "" {
 			return c.addRemoteCredentials(ctxt, added, err)
 		} else {

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -75,11 +75,11 @@ overwritten. This option is DEPRECATED, use 'juju update-credential' instead.
 
 Examples:
     juju add-credential google
-    juju add-credential google --client
+    juju add-credential google --client-only
     juju add-credential google -c mycontroller
     juju add-credential aws -f ~/credentials.yaml -c mycontroller
     juju add-credential aws -f ~/credentials.yaml
-    juju add-credential aws -f ~/credentials.yaml --client
+    juju add-credential aws -f ~/credentials.yaml --client-only
     juju add-credential aws -f ~/credentials.yaml --no-prompt
 
 Notes:
@@ -100,7 +100,7 @@ Use --no-prompt option when this prompt is undesirable, but the upload to
 the current controller is wanted.
 Use --controller option to upload a credential to a different controller. 
 
-Use --client option to add credentials to the current client only.
+Use --client-only option to add credentials to the current client only.
 
 Further help:
 Please visit https://discourse.jujucharms.com/t/1508 for cloud-specific

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -133,6 +133,9 @@ func (c *detectCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *detectCredentialsCommand) Init(args []string) (err error) {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	if len(args) > 0 {
 		c.cloudType = strings.ToLower(args[0])
 		return cmd.CheckEmpty(args[1:])
@@ -178,7 +181,7 @@ func (c *detectCredentialsCommand) allClouds(ctxt *cmd.Context) (map[string]juju
 	for k, v := range personalClouds {
 		clouds[k] = v
 	}
-	if !c.Local && c.ControllerName != "" {
+	if !c.ClientOnly && c.ControllerName != "" {
 		ctxt.Infof("\nLooking for cloud information on controller %q...", c.ControllerName)
 		// If there is a cloud definition for the same cloud both
 		// on the controller and on the client and they conflict,
@@ -204,7 +207,7 @@ func (c *detectCredentialsCommand) allClouds(ctxt *cmd.Context) (map[string]juju
 
 func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
 	var err error
-	if !c.Local && c.ControllerName == "" {
+	if !c.ClientOnly && c.ControllerName == "" {
 		// The user may have specified the controller via a --controller option.
 		// If not, let's see if there is a current controller that can be detected.
 		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, "add a credential to")
@@ -443,7 +446,7 @@ func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Contex
 		}
 	}
 upload:
-	if !c.Local && c.ControllerName != "" {
+	if !c.ClientOnly && c.ControllerName != "" {
 		fmt.Fprintln(ctxt.Stderr)
 		return c.addRemoteCredentials(ctxt, clouds, loaded, localErr)
 	}

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -60,7 +60,7 @@ this Juju client. If a current controller is detected on the client, the user
 is prompted to confirm if the credentials should be uploaded to it. 
 To skip the prompt and to upload to a detected current controller, use --no-prompt.
 To upload credentials to a different controller, use --controller option. 
-To add credentials to the current client only, use --client option.
+To add credentials to the current client only, use --client-only option.
 
 Below are the cloud types for which credentials may be autoloaded,
 including the locations searched.
@@ -91,7 +91,7 @@ LXD
 
 Example:
     juju autoload-credentials
-    juju autoload-credentials --client
+    juju autoload-credentials --client-only
     juju autoload-credentials --controller mycontroller
     juju autoload-credentials --no-prompt
     juju autoload-credentials aws

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -43,10 +43,10 @@ var listCloudsDoc = "" +
 	"\n" +
 	"The default behaviour is to show clouds available on the current controller.\n" +
 	"Another controller can specified using the --controller option. When no controllers\n" +
-	"are available, --client is implied.\n" +
+	"are available, --client-only is implied.\n" +
 	"\n" +
-	"If --client is specified, the public clouds known to Juju out of the box are displayed,\n" +
-	"along with any which have been added with `add-cloud --client`. These clouds can be\n" +
+	"If --client-only is specified, the public clouds known to Juju out of the box are displayed,\n" +
+	"along with any which have been added with `add-cloud --client-only`. These clouds can be\n" +
 	"used to create a controller.\n" +
 	"\n" +
 	"Clouds may be listed that are co-hosted with the Juju client.  When the LXD hypervisor\n" +
@@ -79,7 +79,7 @@ Examples:
     juju clouds
     juju clouds --format yaml
     juju clouds --controller mycontroller
-    juju clouds --client
+    juju clouds --client-only
 
 See also:
     add-cloud

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -140,6 +140,9 @@ func (c *listCloudsCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init populates the command with the args from the command line.
 func (c *listCloudsCommand) Init(args []string) (err error) {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
 		return errors.Trace(err)
@@ -189,7 +192,7 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 		}
 		result = clouds
 	default:
-		if c.ControllerName == "" && !c.Local {
+		if c.ControllerName == "" && !c.ClientOnly {
 			ctxt.Infof(
 				"There are no controllers running.\nYou can bootstrap a new controller using one of these clouds:\n")
 		}

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -39,7 +39,7 @@ func (s *listSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *listSuite) TestListPublic(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -225,7 +225,7 @@ clouds:
 			return s.api, nil
 		})
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--client")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -246,7 +246,7 @@ clouds:
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -257,7 +257,7 @@ clouds:
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -266,7 +266,7 @@ func (s *listSuite) TestListYAML(c *gc.C) {
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "json", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "json", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -275,7 +275,7 @@ func (s *listSuite) TestListJSON(c *gc.C) {
 }
 
 func (s *listSuite) TestListPreservesRegionOrder(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	lines := strings.Split(cmdtesting.Stdout(ctx), "\n")
 	withClouds := "clouds:\n  " + strings.Join(lines, "\n  ")

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -180,6 +180,9 @@ func (c *listCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *listCredentialsCommand) Init(args []string) error {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	cloudName, err := cmd.ZeroOrOneArgs(args)
 	if err != nil {
 		return errors.Trace(err)
@@ -234,8 +237,8 @@ func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	credentials := credentialsMap{Local: local, LocalOnly: c.Local}
-	if c.Local {
+	credentials := credentialsMap{Local: local, LocalOnly: c.ClientOnly}
+	if c.ClientOnly {
 		return c.out.Write(ctxt, credentials)
 	}
 
@@ -390,6 +393,10 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 				} else {
 					credentialNames = append(credentialNames, credentialName)
 				}
+			}
+			if len(credentialNames) == 0 {
+				w.Println(fmt.Sprintf("No credentials for cloud %v to display", cloudName))
+				continue
 			}
 			if haveDefault {
 				sort.Strings(credentialNames[1:])

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -395,7 +395,7 @@ func formatCredentialsTabular(writer io.Writer, value interface{}) error {
 				}
 			}
 			if len(credentialNames) == 0 {
-				w.Println(fmt.Sprintf("No credentials for cloud %v to display", cloudName))
+				w.Println(fmt.Sprintf("No credentials to display for cloud %v", cloudName))
 				continue
 			}
 			if haveDefault {

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -218,7 +218,7 @@ aws    down*, bob
 }
 
 func (s *listCredentialsSuite) TestListCredentialsTabularFilteredLocalOnly(c *gc.C) {
-	out := s.listCredentials(c, "aws", "--client")
+	out := s.listCredentials(c, "aws", "--client-only")
 	c.Assert(out, gc.Equals, `
 Cloud  Credentials
 aws    down*, bob  

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -23,11 +23,11 @@ Remove a named, user-defined cloud from Juju's internal cache.
 
 If the multi-cloud feature flag is enabled, the cloud is removed from a controller.
 The current controller is used unless the --controller option is specified.
-If --client is specified, Juju removes the cloud from this client.
+If --client-only is specified, Juju removes the cloud from this client.
 
 Examples:
     juju remove-cloud mycloud
-    juju remove-cloud mycloud --client
+    juju remove-cloud mycloud --client-only
     juju remove-cloud mycloud --controller mycontroller
 
 See also:
@@ -101,7 +101,7 @@ func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.ControllerName == "" {
 		if c.ControllerName == "" && !c.ClientOnly {
 			return errors.Errorf(
-				"There are no controllers running.\nTo remove cloud %q from this client, use the --client option.", c.Cloud)
+				"There are no controllers running.\nTo remove cloud %q from this client, use the --client-only option.", c.Cloud)
 		}
 		return c.removeLocalCloud(ctxt)
 	}

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -83,6 +83,9 @@ func (c *removeCloudCommand) Info() *cmd.Info {
 }
 
 func (c *removeCloudCommand) Init(args []string) (err error) {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	if len(args) < 1 {
 		return errors.New("Usage: juju remove-cloud <cloud name>")
 	}
@@ -96,7 +99,7 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 
 func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 	if c.ControllerName == "" {
-		if c.ControllerName == "" && !c.Local {
+		if c.ControllerName == "" && !c.ClientOnly {
 			return errors.Errorf(
 				"There are no controllers running.\nTo remove cloud %q from this client, use the --client option.", c.Cloud)
 		}

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -104,7 +104,7 @@ func (s *removeSuite) TestRemoveCloudNoControllers(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	msg := err.Error()
 	msg = strings.Replace(msg, "\n", "", -1)
-	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from this client, use the --client option.*`)
+	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from this client, use the --client-only option.*`)
 }
 
 func (s *removeSuite) TestRemoveCloudController(c *gc.C) {

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -38,15 +38,15 @@ func (s *removeSuite) SetUpTest(c *gc.C) {
 
 func (s *removeSuite) TestRemoveBadArgs(c *gc.C) {
 	cmd := cloud.NewRemoveCloudCommand()
-	_, err := cmdtesting.RunCommand(c, cmd, "--client")
+	_, err := cmdtesting.RunCommand(c, cmd, "--client-only")
 	c.Assert(err, gc.ErrorMatches, "Usage: juju remove-cloud <cloud name>")
-	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "extra", "--client")
+	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "extra", "--client-only")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *removeSuite) TestRemoveNotFound(c *gc.C) {
 	cmd := cloud.NewRemoveCloudCommandForTest(s.store, nil)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "fnord", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "fnord", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"fnord\" exists\n")
 }
@@ -84,7 +84,7 @@ func (s *removeSuite) TestRemoveCloudLocal(c *gc.C) {
 		})
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	ctx, err := cmdtesting.RunCommand(c, cmd, "homestack", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "homestack", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of personal cloud \"homestack\"\n")
 	assertPersonalClouds(c, "homestack2")
@@ -124,7 +124,7 @@ func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
 
 func (s *removeSuite) TestCannotRemovePublicCloud(c *gc.C) {
 	s.createTestCloudData(c)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"prodstack\" exists\n")
 }

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -57,11 +57,11 @@ material, can be listed with `[1:] + "`juju credentials`" + `.
 By default, after validating the contents, credentials are removed
 from both the current controller and the current client device. 
 Use --controller option to remove credentials from a different controller. 
-Use --client option to remove credentials from the current client only.
+Use --client-only option to remove credentials from the current client only.
 
 Examples:
     juju remove-credential rackspace credential_name
-    juju remove-credential rackspace credential_name --client
+    juju remove-credential rackspace credential_name --client-only
     juju remove-credential rackspace credential_name -c another_controller
 
 See also: 

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -131,7 +131,7 @@ func (s *removeCredentialSuite) TestGettingApiClientErrorButLocal(c *gc.C) {
 	store := s.setupStore(c)
 	s.clientF = func() (cloud.RemoveCredentialAPI, error) { return s.fakeClient, errors.New("kaboom") }
 	command := cloud.NewRemoveCredentialCommandForTest(store, s.cloudByNameFunc, s.clientF)
-	_, err := cmdtesting.RunCommand(c, command, "aws", "foo", "--client")
+	_, err := cmdtesting.RunCommand(c, command, "aws", "foo", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeClient.CheckNoCalls(c)
 }

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -94,6 +94,9 @@ func (c *showCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *showCloudCommand) Init(args []string) error {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	switch len(args) {
 	case 1:
 		c.CloudName = args[0]

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -44,14 +44,14 @@ If ‘--include-config’ is used, additional configuration (key, type, and
 description) specific to the cloud are displayed if available.
 
 The current controller is used unless the --controller option is specified.
-If --client is specified, Juju shows the cloud from this client.
+If --client-only is specified, Juju shows the cloud from this client.
 
 Examples:
 
     juju show-cloud google
     juju show-cloud azure-china --output ~/azure_cloud_details.txt
     juju show-cloud myopenstack --controller mycontroller
-    juju show-cloud myopenstack --client
+    juju show-cloud myopenstack --client-only
 
 See also:
     clouds
@@ -106,7 +106,7 @@ func (c *showCloudCommand) Init(args []string) error {
 	var err error
 	c.ControllerName, err = c.ControllerNameFromArg()
 	if err != nil {
-		return errors.Wrap(err, errors.New(err.Error()+"\nUse --client to query this client."))
+		return errors.Wrap(err, errors.New(err.Error()+"\nUse --client-only to query this client."))
 	}
 	return cmd.CheckEmpty(args[1:])
 }

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -50,7 +50,7 @@ func (s *showSuite) assertShowLocal(c *gc.C, expectedOutput string) {
 			c.Fail()
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "aws-china", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "aws-china", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, expectedOutput)
@@ -179,7 +179,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
@@ -245,7 +245,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, strings.Join([]string{`defined: local
@@ -267,7 +267,7 @@ region-config:
 }
 
 func (s *showSuite) TestShowWithRegionConfigAndFlagNoExtraOut(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "joyent", "--include-config", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "joyent", "--include-config", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
@@ -355,7 +355,7 @@ ca-credentials:
 func (s *showSuite) TestShowWithCACertificate(c *gc.C) {
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(yamlWithCert), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, resultWithCert)

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -99,6 +99,9 @@ func (c *updateCloudCommand) updateCloudAPI(controllerName string) (updateCloudA
 
 // Init populates the command with the args from the command line.
 func (c *updateCloudCommand) Init(args []string) error {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
 	if len(args) < 1 {
 		return errors.BadRequestf("cloud name required")
 	}
@@ -152,7 +155,7 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *updateCloudCommand) updateLocalCacheFromFile(ctxt *cmd.Context) error {
-	if !c.Local {
+	if !c.ClientOnly {
 		ctxt.Infof(
 			"There are no controllers running.\nUpdating cloud on this client so you can use it to bootstrap a controller.\n")
 	}

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -48,7 +48,7 @@ will use the cloud defined on this client or you can provide a cloud
 definition yaml file from which to retrieve the cloud details; the current
 controller is used unless the --controller option is specified.
 
-When <cloud definition file> is provided with <cloud name> and --client is
+When <cloud definition file> is provided with <cloud name> and --client-only is
 specified, Juju stores that definition in its internal cache directly after
 validating the contents.
 
@@ -57,7 +57,7 @@ Examples:
     juju update-cloud mymaas -f path/to/maas.yaml
     juju update-cloud mymaas -f path/to/maas.yaml --controller mycontroller
     juju update-cloud mymaas --controller mycontroller
-    juju update-cloud mymaas --client -f path/to/maas.yaml
+    juju update-cloud mymaas --client-only -f path/to/maas.yaml
 
 See also:
     add-cloud

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -86,7 +86,7 @@ func (s *updateCloudSuite) TestUpdateLocalCacheFromFile(c *gc.C) {
 	cmd, fileName := s.setupCloudFileScenario(c, func(controllerName string) (cloud.UpdateCloudAPI, error) {
 		return nil, errors.New("")
 	})
-	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName, "--client")
+	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName, "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
 }

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -35,9 +35,9 @@ a model was created with to the new and valid details on controller.
 This command allows to update an existing, already-stored, named,
 cloud-specific credential on a controller or the one from this client.
 
-If --client is used, Juju updates credential only on this client.
+If --client-only is used, Juju updates credential only on this client.
 If a user will use a different client, say a different laptop, the update will not affect that 
-client's copy. By extension, when using --client, remote credential copies,
+client's copy. By extension, when using --client-only, remote credential copies,
 on controllers, will not be affected.
 
 Before credential is updated, the new content is validated. For some providers, 
@@ -47,7 +47,7 @@ use --region.
 Examples:
     juju update-credential aws mysecrets
     juju update-credential -f mine.yaml
-    juju update-credential -f mine.yaml --client
+    juju update-credential -f mine.yaml --client-only
     juju update-credential aws -f mine.yaml
     juju update-credential azure --region brazilsouth -f mine.yaml
 

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -66,8 +66,16 @@ type updateCredentialCommand struct {
 	// CredentialsFile is the name of the file that contains credentials to update.
 	CredentialsFile string
 
-	// Local determines if only local credentials are updated.
+	// Local stores whether a client side (aka local) copy is requested.
 	Local bool
+
+	// ClientOnly stores whether the command will ONLY operate on a client copy
+	// without affecting controller copy.
+	ClientOnly bool
+
+	// ControllerOnly stores whether the command will ONLY operate on a controller copy
+	// without affecting client copy.
+	ControllerOnly bool
 
 	// Region is the region that credentials will be validated for before an update.
 	Region string
@@ -81,6 +89,9 @@ func NewUpdateCredentialCommand() cmd.Command {
 
 // Init implements Command.Init.
 func (c *updateCredentialCommand) Init(args []string) error {
+	if c.Local && !c.ClientOnly {
+		c.ClientOnly = c.Local
+	}
 	argsCount := len(args)
 	if argsCount == 0 {
 		// We are either in the interactive mode or updating from a file.
@@ -115,8 +126,9 @@ func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.CredentialsFile, "f", "", "The YAML file containing credential details to update")
 	f.StringVar(&c.CredentialsFile, "file", "", "The YAML file containing credential details to update")
 	// TODO (juju3) remove me
-	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client instead): Local operation only; controller not affected")
-	f.BoolVar(&c.Local, "client", false, "Client operation only; controller not affected")
+	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client-only instead): Local operation only; controller not affected")
+	f.BoolVar(&c.ClientOnly, "client-only", false, "Client operation only; controller not affected")
+	f.BoolVar(&c.ControllerOnly, "controller-only", false, "Controller operation only; client not affected")
 	f.StringVar(&c.Region, "region", "", "Cloud region that credential is valid for")
 }
 
@@ -158,7 +170,7 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 			return errors.Annotatef(err, "could not get credentials from local client")
 		}
 	}
-	if c.Local {
+	if c.ClientOnly {
 		return c.updateLocalCredentials(ctx, credentials)
 	}
 	return c.updateRemoteCredentials(ctx, credentials)

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -61,6 +61,7 @@ func (s *updateCredentialSuite) TestNoArgs(c *gc.C) {
 
 func (s *updateCredentialSuite) TestBadFileSpecified(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "-f", "somefile.yaml")
+	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), jc.Contains, "could not get credentials from file: reading credentials file: open somefile.yaml")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
@@ -263,7 +264,7 @@ func (s *updateCredentialSuite) TestCloudCredentialFromLocalCacheWithCloudAndCre
 }
 
 func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenNoneExists(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client-only")
 	c.Assert(err, gc.ErrorMatches, "could not get credentials from local client: loading credentials: credentials for cloud somecloud not found")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
@@ -271,7 +272,7 @@ func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenNoneExists(c *gc.C) 
 
 func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenCredentialDoesNotExists(c *gc.C) {
 	s.storeWithCredentials(c)
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "fluffy-credential", "--client")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "fluffy-credential", "--client-only")
 	c.Assert(err, gc.ErrorMatches, `could not get credentials from local client: credential "fluffy-credential" for cloud "somecloud" in local client not found`)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
@@ -289,7 +290,7 @@ credentials:
 	s.storeWithCredentials(c)
 	before := s.store.Credentials["somecloud"].AuthCredentials["its-credential"].Attributes()["access-key"]
 	c.Assert(before, gc.DeepEquals, "key")
-	ctxt, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client", "-f", testFile)
+	ctxt, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client-only", "-f", testFile)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "Local client was updated successfully with provided credential information.\n")
 	c.Assert(cmdtesting.Stdout(ctxt), gc.Equals, "")
@@ -383,7 +384,7 @@ credentials:
       auth-type: jsonfile
       file: %v
 `, tmpFile.Name()))
-	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--client", "-f", testFile)
+	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--client-only", "-f", testFile)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials["google"].AuthCredentials["gce"].Attributes()["file"], gc.Not(jc.Contains), string(contents))
 	c.Assert(s.store.Credentials["google"].AuthCredentials["gce"].Attributes()["file"], gc.Equals, tmpFile.Name())

--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -103,7 +103,7 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	if sameCloudInfo {
-		fmt.Fprintln(ctxt.Stderr, "This client's list of public clouds is up to date, see `juju clouds --client`.")
+		fmt.Fprintln(ctxt.Stderr, "This client's list of public clouds is up to date, see `juju clouds --client-only`.")
 		return nil
 	}
 	if err := jujucloud.WritePublicCloudMetadata(newPublicClouds); err != nil {

--- a/cmd/juju/cloud/updatepublicclouds_test.go
+++ b/cmd/juju/cloud/updatepublicclouds_test.go
@@ -131,7 +131,7 @@ func (s *updatePublicCloudsSuite) TestNoNewData(c *gc.C) {
 	defer ts.Close()
 
 	msg := s.run(c, ts.URL, "")
-	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...This client's list of public clouds is up to date, see `juju clouds --client`.")
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...This client's list of public clouds is up to date, see `juju clouds --client-only`.")
 }
 
 func (s *updatePublicCloudsSuite) TestFirstRun(c *gc.C) {


### PR DESCRIPTION
## Description of change

Newly introduced --client option if not enough for cloud based commands - CRUD for clouds, credentials and CAAS add and remove. We need the ability to allow operators to manage both client and controller copies of information as well as the ability to manage either one or the other without affecting the copy that was not explicitly stated.

This means that by default the commands will operate on both copies. However, when --client-only or --controller-only options are specified, the command will only deal with desired copy.

Since --client-copy is a simple rename of an existing option, it's fully functional. As --controller-only is a new option it's only introduced here, with full functionality taking affect as each command that requires it is modified to support it.

