### PR TITLE
Add proxy update worker to caas controllers

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -602,6 +602,7 @@ func (a *MachineAgent) makeEngineCreator(agentName string, previousAgentVersion 
 			MuxShutdownWait:                   1 * time.Minute,
 			NewContainerBrokerFunc:            newCAASBroker,
 			NewBrokerFunc:                     newBroker,
+			IsCaasConfig:                      a.isCaasAgent,
 		}
 		manifolds := iaasMachineManifolds(manifoldsCfg)
 		if a.isCaasAgent {

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -165,6 +165,7 @@ func (ms *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
 			"model-worker-manager",
 			"peer-grouper",
 			"presence",
+			"proxy-config-updater",
 			"pubsub-forwarder",
 			"raft",
 			"raft-backstop",

--- a/worker/proxyupdater/manifold.go
+++ b/worker/proxyupdater/manifold.go
@@ -25,13 +25,14 @@ type Logger interface {
 
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
 type ManifoldConfig struct {
-	AgentName       string
-	APICallerName   string
-	Logger          Logger
-	WorkerFunc      func(Config) (worker.Worker, error)
-	ExternalUpdate  func(proxy.Settings) error
-	InProcessUpdate func(proxy.Settings) error
-	RunFunc         func(string, string, ...string) (string, error)
+	AgentName           string
+	APICallerName       string
+	Logger              Logger
+	WorkerFunc          func(Config) (worker.Worker, error)
+	SupportLegacyValues bool
+	ExternalUpdate      func(proxy.Settings) error
+	InProcessUpdate     func(proxy.Settings) error
+	RunFunc             func(string, string, ...string) (string, error)
 }
 
 // Manifold returns a dependency manifold that runs a proxy updater worker,
@@ -64,14 +65,15 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, err
 			}
 			w, err := config.WorkerFunc(Config{
-				SystemdFiles:    []string{"/etc/juju-proxy-systemd.conf"},
-				EnvFiles:        []string{"/etc/juju-proxy.conf"},
-				RegistryPath:    `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
-				API:             proxyAPI,
-				ExternalUpdate:  config.ExternalUpdate,
-				InProcessUpdate: config.InProcessUpdate,
-				Logger:          config.Logger,
-				RunFunc:         config.RunFunc,
+				SystemdFiles:        []string{"/etc/juju-proxy-systemd.conf"},
+				EnvFiles:            []string{"/etc/juju-proxy.conf"},
+				RegistryPath:        `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`,
+				API:                 proxyAPI,
+				SupportLegacyValues: config.SupportLegacyValues,
+				ExternalUpdate:      config.ExternalUpdate,
+				InProcessUpdate:     config.InProcessUpdate,
+				Logger:              config.Logger,
+				RunFunc:             config.RunFunc,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/proxyupdater/manifold_test.go
+++ b/worker/proxyupdater/manifold_test.go
@@ -46,8 +46,9 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 			}
 			return &dummyWorker{config: cfg}, nil
 		},
-		ExternalUpdate:  MakeUpdateFunc("external"),
-		InProcessUpdate: MakeUpdateFunc("in-process"),
+		SupportLegacyValues: true,
+		ExternalUpdate:      MakeUpdateFunc("external"),
+		InProcessUpdate:     MakeUpdateFunc("in-process"),
 	}
 }
 
@@ -121,6 +122,7 @@ func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
 	c.Check(dummy.config.SystemdFiles, gc.DeepEquals, []string{"/etc/juju-proxy-systemd.conf"})
 	c.Check(dummy.config.EnvFiles, gc.DeepEquals, []string{"/etc/juju-proxy.conf"})
 	c.Check(dummy.config.RegistryPath, gc.Equals, `HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings`)
+	c.Check(dummy.config.SupportLegacyValues, jc.IsTrue)
 	c.Check(dummy.config.API, gc.NotNil)
 	// Checking function equality is problematic, use the errors they
 	// return.

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -24,14 +24,15 @@ import (
 )
 
 type Config struct {
-	RegistryPath    string
-	EnvFiles        []string
-	SystemdFiles    []string
-	API             API
-	ExternalUpdate  func(proxy.Settings) error
-	InProcessUpdate func(proxy.Settings) error
-	RunFunc         func(string, string, ...string) (string, error)
-	Logger          Logger
+	SupportLegacyValues bool
+	RegistryPath        string
+	EnvFiles            []string
+	SystemdFiles        []string
+	API                 API
+	ExternalUpdate      func(proxy.Settings) error
+	InProcessUpdate     func(proxy.Settings) error
+	RunFunc             func(string, string, ...string) (string, error)
+	Logger              Logger
 }
 
 // Validate ensures that all the required fields have values.
@@ -186,7 +187,7 @@ func (w *proxyWorker) handleProxyValues(legacyProxySettings, jujuProxySettings p
 	}
 
 	// Here we write files to disk. This is done only for legacyProxySettings.
-	if legacyProxySettings != w.proxy || w.first {
+	if w.config.SupportLegacyValues && (legacyProxySettings != w.proxy || w.first) {
 		w.config.Logger.Debugf("saving new legacy proxy settings %#v", legacyProxySettings)
 		w.proxy = legacyProxySettings
 		if err := w.saveProxySettings(); err != nil {

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -92,9 +92,10 @@ func (s *ProxyUpdaterSuite) SetUpTest(c *gc.C) {
 	logger := loggo.GetLogger("test.proxyupdater")
 	logger.SetLogLevel(loggo.TRACE)
 	s.config = proxyupdater.Config{
-		SystemdFiles: []string{s.proxySystemdFile},
-		EnvFiles:     []string{s.proxyEnvFile},
-		API:          s.api,
+		SupportLegacyValues: true,
+		SystemdFiles:        []string{s.proxySystemdFile},
+		EnvFiles:            []string{s.proxyEnvFile},
+		API:                 s.api,
 		InProcessUpdate: func(newSettings proxy.Settings) error {
 			select {
 			case s.inProcSettings <- newSettings:


### PR DESCRIPTION
## Description of change

Move the proxy update worker manifold from IAAS only to the common set for machine agents.
When run on a k8s controller, the worker ignores legacy non-Juju proxy values and also only updates in-memory use; it doesn't write out any systemd files etc.

## QA steps

bootstrap a k8s controller with a test value for the https proxy
$ juju bootstrap microk8s --config juju-https-proxy=10.0.0.1:8888 --debug

Try and add a model and it fails because it tries to use the proxy
Look at logs files to see that proxy is being set up

Also bootstrap an IAAS controller to check that proxy worker is fine there as well.
