### PR TITLE
Ensure volumeBindingMode sets to WaitForFirstConsumer for Juju prefer…

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -206,9 +206,12 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 	}
 	var sp *caas.StorageProvisioner
 	sp, err = storageParams.MetadataChecker.EnsureStorageProvisioner(caas.StorageProvisioner{
-		Name:              scName,
-		Provisioner:       provisioner,
-		Parameters:        params,
+		Name:        scName,
+		Provisioner: provisioner,
+		Parameters:  params,
+		// WaitForFirstConsumer mode which will delay the binding and provisioning of a PersistentVolume until a
+		// Pod using the PersistentVolumeClaim is created.
+		// https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
 		VolumeBindingMode: string(k8sstorage.VolumeBindingWaitForFirstConsumer),
 	})
 	if errors.IsNotFound(err) {

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/exec"
 	"gopkg.in/yaml.v2"
+	k8sstorage "k8s.io/api/storage/v1"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
@@ -205,9 +206,10 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 	}
 	var sp *caas.StorageProvisioner
 	sp, err = storageParams.MetadataChecker.EnsureStorageProvisioner(caas.StorageProvisioner{
-		Name:        scName,
-		Provisioner: provisioner,
-		Parameters:  params,
+		Name:              scName,
+		Provisioner:       provisioner,
+		Parameters:        params,
+		VolumeBindingMode: string(k8sstorage.VolumeBindingWaitForFirstConsumer),
 	})
 	if errors.IsNotFound(err) {
 		return "", errors.Wrap(err, errors.NotFoundf("storage class %q", scName))

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -24,25 +24,33 @@ func init() {
 	// jujuPreferredWorkloadStorage defines the opinionated storage
 	// that Juju requires to be available on supported clusters.
 	jujuPreferredWorkloadStorage = map[string]caas.PreferredStorage{
+		// WaitForFirstConsumer mode which will delay the binding and provisioning of a PersistentVolume until a
+		// Pod using the PersistentVolumeClaim is created.
+		// https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
 		caas.K8sCloudMicrok8s: {
-			Name:        "hostpath",
-			Provisioner: "microk8s.io/hostpath",
+			Name:              "hostpath",
+			Provisioner:       "microk8s.io/hostpath",
+			VolumeBindingMode: "WaitForFirstConsumer",
 		},
 		caas.K8sCloudGCE: {
-			Name:        "GCE Persistent Disk",
-			Provisioner: "kubernetes.io/gce-pd",
+			Name:              "GCE Persistent Disk",
+			Provisioner:       "kubernetes.io/gce-pd",
+			VolumeBindingMode: "WaitForFirstConsumer",
 		},
 		caas.K8sCloudAzure: {
-			Name:        "Azure Disk",
-			Provisioner: "kubernetes.io/azure-disk",
+			Name:              "Azure Disk",
+			Provisioner:       "kubernetes.io/azure-disk",
+			VolumeBindingMode: "WaitForFirstConsumer",
 		},
 		caas.K8sCloudEC2: {
-			Name:        "EBS Volume",
-			Provisioner: "kubernetes.io/aws-ebs",
+			Name:              "EBS Volume",
+			Provisioner:       "kubernetes.io/aws-ebs",
+			VolumeBindingMode: "WaitForFirstConsumer",
 		},
 		caas.K8sCloudOpenStack: {
-			Name:        "Cinder Disk",
-			Provisioner: "csi-cinderplugin",
+			Name:              "Cinder Disk",
+			Provisioner:       "csi-cinderplugin",
+			VolumeBindingMode: "WaitForFirstConsumer",
 		},
 	}
 

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -569,25 +569,10 @@ func (k *kubernetesClient) getStorageClass(name string) (*k8sstorage.StorageClas
 
 // EnsureStorageProvisioner creates a storage class with the specified config, or returns an existing one.
 func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner) (*caas.StorageProvisioner, error) {
-	toCaaSSC := func(sc *k8sstorage.StorageClass) *caas.StorageProvisioner {
-		csc := &caas.StorageProvisioner{
-			Name:        sc.Name,
-			Provisioner: sc.Provisioner,
-			Parameters:  sc.Parameters,
-		}
-		if sc.VolumeBindingMode != nil {
-			csc.VolumeBindingMode = string(*sc.VolumeBindingMode)
-		}
-		if sc.ReclaimPolicy != nil {
-			csc.ReclaimPolicy = string(*sc.ReclaimPolicy)
-		}
-		return csc
-	}
-
 	// First see if the named storage class exists.
 	sc, err := k.getStorageClass(cfg.Name)
 	if err == nil {
-		return toCaaSSC(sc), nil
+		return toCaaSStorageProvisioner(*sc), nil
 	}
 	if !k8serrors.IsNotFound(err) {
 		return nil, errors.Annotatef(err, "getting storage class %q", cfg.Name)
@@ -623,7 +608,7 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner)
 	if err != nil {
 		return nil, errors.Annotatef(err, "creating storage class %q", cfg.Name)
 	}
-	return toCaaSSC(sc), nil
+	return toCaaSStorageProvisioner(*sc), nil
 }
 
 func getLoadBalancerAddress(svc *core.Service) string {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -569,14 +569,22 @@ func (k *kubernetesClient) getStorageClass(name string) (*k8sstorage.StorageClas
 
 // EnsureStorageProvisioner creates a storage class with the specified config, or returns an existing one.
 func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner) (*caas.StorageProvisioner, error) {
-	// First see if the named storage class exists.
-	sc, err := k.getStorageClass(cfg.Name)
-	if err == nil {
-		return &caas.StorageProvisioner{
+	toCaaSSC := func(sc *k8sstorage.StorageClass) *caas.StorageProvisioner {
+		csc := &caas.StorageProvisioner{
 			Name:        sc.Name,
 			Provisioner: sc.Provisioner,
 			Parameters:  sc.Parameters,
-		}, nil
+		}
+		if sc.VolumeBindingMode != nil {
+			csc.VolumeBindingMode = string(*sc.VolumeBindingMode)
+		}
+		return csc
+	}
+
+	// First see if the named storage class exists.
+	sc, err := k.getStorageClass(cfg.Name)
+	if err == nil {
+		return toCaaSSC(sc), nil
 	}
 	if !k8serrors.IsNotFound(err) {
 		return nil, errors.Annotatef(err, "getting storage class %q", cfg.Name)
@@ -590,32 +598,29 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner)
 	}
 
 	// Create the storage class with the specified provisioner.
-	var reclaimPolicy *core.PersistentVolumeReclaimPolicy
-	if cfg.ReclaimPolicy != "" {
-		policy := core.PersistentVolumeReclaimPolicy(cfg.ReclaimPolicy)
-		reclaimPolicy = &policy
-	}
-	storageClasses := k.client().StorageV1().StorageClasses()
 	sc = &k8sstorage.StorageClass{
 		ObjectMeta: v1.ObjectMeta{
 			Name: qualifiedStorageClassName(cfg.Namespace, cfg.Name),
 		},
-		Provisioner:   cfg.Provisioner,
-		ReclaimPolicy: reclaimPolicy,
-		Parameters:    cfg.Parameters,
+		Provisioner: cfg.Provisioner,
+		Parameters:  cfg.Parameters,
+	}
+	if cfg.ReclaimPolicy != "" {
+		policy := core.PersistentVolumeReclaimPolicy(cfg.ReclaimPolicy)
+		sc.ReclaimPolicy = &policy
+	}
+	if cfg.VolumeBindingMode != "" {
+		bindMode := k8sstorage.VolumeBindingMode(cfg.VolumeBindingMode)
+		sc.VolumeBindingMode = &bindMode
 	}
 	if cfg.Namespace != "" {
 		sc.Labels = map[string]string{labelModel: k.namespace}
 	}
-	_, err = storageClasses.Create(sc)
+	_, err = k.client().StorageV1().StorageClasses().Create(sc)
 	if err != nil {
 		return nil, errors.Annotatef(err, "creating storage class %q", cfg.Name)
 	}
-	return &caas.StorageProvisioner{
-		Name:        sc.Name,
-		Provisioner: sc.Provisioner,
-		Parameters:  sc.Parameters,
-	}, nil
+	return toCaaSSC(sc), nil
 }
 
 func getLoadBalancerAddress(svc *core.Service) string {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -578,6 +578,9 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner)
 		if sc.VolumeBindingMode != nil {
 			csc.VolumeBindingMode = string(*sc.VolumeBindingMode)
 		}
+		if sc.ReclaimPolicy != nil {
+			csc.ReclaimPolicy = string(*sc.ReclaimPolicy)
+		}
 		return csc
 	}
 

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -72,11 +72,14 @@ const (
 	workloadStorageClassAnnotationKey = "juju.io/workload-storage"
 )
 
-func caasStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner {
+func toCaaSStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner {
 	caasSc := &caas.StorageProvisioner{
 		Name:        sc.Name,
 		Provisioner: sc.Provisioner,
 		Parameters:  sc.Parameters,
+	}
+	if sc.VolumeBindingMode != nil {
+		caasSc.VolumeBindingMode = string(*sc.VolumeBindingMode)
 	}
 	if sc.ReclaimPolicy != nil {
 		caasSc.ReclaimPolicy = string(*sc.ReclaimPolicy)
@@ -100,7 +103,7 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 		}
 		if err == nil {
 			logger.Debugf("Use %q for nominated storage class", sc.Name)
-			result.NominatedStorageClass = caasStorageProvisioner(*sc)
+			result.NominatedStorageClass = toCaaSStorageProvisioner(*sc)
 		}
 	}
 
@@ -161,7 +164,7 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 		if result.OperatorStorageClass != nil && result.NominatedStorageClass != nil {
 			break
 		}
-		maybeStorage := caasStorageProvisioner(sc)
+		maybeStorage := toCaaSStorageProvisioner(sc)
 		pickOperatorSC(sc, maybeStorage)
 		pickWorkloadSC(sc, maybeStorage)
 	}

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -47,9 +47,10 @@ const (
 // PreferredStorage defines preferred storage
 // attributes on a given cluster.
 type PreferredStorage struct {
-	Name        string
-	Provisioner string
-	Parameters  map[string]string
+	Name              string
+	Provisioner       string
+	Parameters        map[string]string
+	VolumeBindingMode string
 }
 
 // StorageProvisioner defines the a storage provisioner available on a cluster.

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -54,11 +54,12 @@ type PreferredStorage struct {
 
 // StorageProvisioner defines the a storage provisioner available on a cluster.
 type StorageProvisioner struct {
-	Name          string
-	Provisioner   string
-	Parameters    map[string]string
-	Namespace     string
-	ReclaimPolicy string
+	Name              string
+	Provisioner       string
+	Parameters        map[string]string
+	Namespace         string
+	ReclaimPolicy     string
+	VolumeBindingMode string
 }
 
 // ClusterMetadata defines metadata about a cluster.

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -722,8 +722,7 @@ func (s *addCAASSuite) TestUnknownClusterExistingStorageClass(c *gc.C) {
 		Provisioner: "kubernetes.io/gce-pd",
 	}
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name:              "mystorage",
-		VolumeBindingMode: "WaitForFirstConsumer",
+		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
@@ -748,9 +747,8 @@ func (s *addCAASSuite) TestCreateDefaultStorageProvisioner(c *gc.C) {
 		Provisioner: "kubernetes.io/gce-pd",
 	}
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name:              "mystorage",
-		Provisioner:       "kubernetes.io/gce-pd",
-		VolumeBindingMode: "WaitForFirstConsumer",
+		Name:        "mystorage",
+		Provisioner: "kubernetes.io/gce-pd",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
@@ -773,8 +771,7 @@ func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
 		Provisioner: "my disk provisioner",
 	}
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name:              "mystorage",
-		VolumeBindingMode: "WaitForFirstConsumer",
+		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
@@ -798,8 +795,7 @@ func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStora
 	}, nil)
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("no sc config for this cloud type"))
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name:              "mystorage",
-		VolumeBindingMode: "WaitForFirstConsumer",
+		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -722,7 +722,8 @@ func (s *addCAASSuite) TestUnknownClusterExistingStorageClass(c *gc.C) {
 		Provisioner: "kubernetes.io/gce-pd",
 	}
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name: "mystorage",
+		Name:              "mystorage",
+		VolumeBindingMode: "WaitForFirstConsumer",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
@@ -747,8 +748,9 @@ func (s *addCAASSuite) TestCreateDefaultStorageProvisioner(c *gc.C) {
 		Provisioner: "kubernetes.io/gce-pd",
 	}
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name:        "mystorage",
-		Provisioner: "kubernetes.io/gce-pd",
+		Name:              "mystorage",
+		Provisioner:       "kubernetes.io/gce-pd",
+		VolumeBindingMode: "WaitForFirstConsumer",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
@@ -771,7 +773,8 @@ func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
 		Provisioner: "my disk provisioner",
 	}
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name: "mystorage",
+		Name:              "mystorage",
+		VolumeBindingMode: "WaitForFirstConsumer",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
@@ -795,7 +798,8 @@ func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStora
 	}, nil)
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("no sc config for this cloud type"))
 	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", jujucaas.StorageProvisioner{
-		Name: "mystorage",
+		Name:              "mystorage",
+		VolumeBindingMode: "WaitForFirstConsumer",
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)


### PR DESCRIPTION
## Description of change

Ensure volumeBindingMode sets to WaitForFirstConsumer for Juju preferred storage classes;

## QA steps

- run add-k8s with --storage;

```bash
$ mkubectl delete sc microk8s-hostpath
$ microk8s.config | juju add-k8s microk8s1 --debug --storage=sctest1
```

- check created sc (`volumeBindingMode` sets to `WaitForFirstConsumer`);

```bash
$ mkubectl get sc sctest1 -o yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2019-10-15T05:13:45Z"
  name: sctest1
  resourceVersion: "296816"
  selfLink: /apis/storage.k8s.io/v1/storageclasses/sctest1
  uid: c4f1b52a-5eaf-4913-88d3-2ee47f569378
provisioner: microk8s.io/hostpath
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```

## Documentation changes

None

## Bug reference

None
