### PR TITLE
Introduce juju bind command

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -1005,3 +1005,18 @@ func (c *Client) ApplicationsInfo(applications []names.ApplicationTag) ([]params
 	}
 	return out.Results, nil
 }
+
+// MergeBindings merges an operator-defined bindings list with the existing
+// application bindings.
+func (c *Client) MergeBindings(req params.ApplicationMergeBindingsArgs) error {
+	if apiVersion := c.BestAPIVersion(); apiVersion < 11 {
+		return errors.NotSupportedf("MergeBindings for Application facade v%v", apiVersion)
+	}
+
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("MergeBindings", req, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.OneError()
+}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1777,3 +1777,23 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 	app := s.backend.applications["postgresql"]
 	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Series", "Channel", "EndpointBindings", "IsPrincipal", "IsExposed", "IsRemote")
 }
+
+func (s *ApplicationSuite) TestApplicationMergeBindingsErr(c *gc.C) {
+	req := params.ApplicationMergeBindingsArgs{
+		Args: []params.ApplicationMergeBindings{
+			{
+				ApplicationTag: "application-postgresql",
+			},
+		},
+	}
+	app := s.backend.applications["postgresql"]
+	app.SetErrors(
+		errors.Errorf("boom"), // a.MergeBindings() call
+	)
+
+	result, err := s.api.MergeBindings(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, len(req.Args))
+	app.CheckCallNames(c, "MergeBindings")
+	c.Assert(*result.Results[0].Error, gc.ErrorMatches, "boom")
+}

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -93,6 +93,7 @@ type Application interface {
 	SetScale(int, int64, bool) error
 	ChangeScale(int) (int, error)
 	AgentTools() (*tools.Tools, error)
+	MergeBindings(*state.Bindings, bool) error
 }
 
 // Bindings defines a subset of the functionality provided by the

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -265,6 +265,26 @@ func (b *mockBindings) MapWithSpaceNames() (map[string]string, error) {
 	return b.bMap, nil
 }
 
+func (m *mockApplication) MergeBindings(bindings *state.Bindings, force bool) error {
+	m.MethodCall(m, "MergeBindings", bindings, force)
+	return m.NextErr()
+}
+
+type mockNotifyWatcher struct {
+	state.NotifyWatcher
+	jtesting.Stub
+	ch chan struct{}
+}
+
+func (m *mockNotifyWatcher) Changes() <-chan struct{} {
+	m.MethodCall(m, "Changes")
+	return m.ch
+}
+
+func (m *mockNotifyWatcher) Err() error {
+	return m.NextErr()
+}
+
 type mockRemoteApplication struct {
 	jtesting.Stub
 	name           string

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1732,6 +1732,17 @@
                         }
                     }
                 },
+                "MergeBindings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationMergeBindingsArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
                 "ResolveUnitErrors": {
                     "type": "object",
                     "properties": {
@@ -2341,6 +2352,46 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "ApplicationMergeBindings": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "force": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag",
+                        "bindings",
+                        "force"
+                    ]
+                },
+                "ApplicationMergeBindingsArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationMergeBindings"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
                     ]
                 },
                 "ApplicationMetricCredential": {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -419,6 +419,20 @@ type ApplicationUnitParams struct {
 	Data           map[string]interface{}     `json:"data,omitempty"`
 }
 
+// ApplicationMergeBindingsArgs holds the parameters for updating application
+// bindings.
+type ApplicationMergeBindingsArgs struct {
+	Args []ApplicationMergeBindings `json:"args"`
+}
+
+// ApplicationMergeBindings holds a list of operator-defined bindings to be
+// merged with the current application bindings.
+type ApplicationMergeBindings struct {
+	ApplicationTag string            `json:"application-tag"`
+	Bindings       map[string]string `json:"bindings"`
+	Force          bool              `json:"force"`
+}
+
 // DestroyApplicationUnits holds parameters for the deprecated
 // Application.DestroyUnits call.
 type DestroyApplicationUnits struct {

--- a/cmd/juju/application/bind.go
+++ b/cmd/juju/application/bind.go
@@ -1,0 +1,238 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/api/spaces"
+	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// NewBindCommand returns a command which changes the bindings for an application.
+func NewBindCommand() cmd.Command {
+	cmd := &bindCommand{
+		NewApplicationClient: func(conn base.APICallCloser) ApplicationBindClient {
+			return application.NewClient(conn)
+		},
+		NewModelConfigGetter: func(conn base.APICallCloser) ModelConfigGetter {
+			return modelconfig.NewClient(conn)
+		},
+		NewSpacesClient: func(conn base.APICallCloser) SpacesAPI {
+			return spaces.NewAPI(conn)
+		},
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+// ApplicationBindClient defines a subset of the application facade that deals with
+// querying and updating application bindings.
+type ApplicationBindClient interface {
+	Get(string, string) (*params.ApplicationGetResults, error)
+	MergeBindings(req params.ApplicationMergeBindingsArgs) error
+}
+
+// Bind is responsible for changing the bindings for an application.
+type bindCommand struct {
+	modelcmd.ModelCommandBase
+
+	NewApplicationClient func(base.APICallCloser) ApplicationBindClient
+	NewModelConfigGetter func(base.APICallCloser) ModelConfigGetter
+	NewSpacesClient      func(base.APICallCloser) SpacesAPI
+
+	ApplicationName string
+	BindExpression  string
+	Bindings        map[string]string
+	Force           bool
+}
+
+const bindCmdDoc = `
+When no bind expression is specified, the command will print out the currently
+assigned bindings for the application.
+
+To update the default binding for the application and automatically update all
+existing endpoint bindings that were referencing the old default, you can use 
+the following syntax:
+
+  juju bind foo new-default
+
+To bind individual endpoints to a space you can use the following syntax:
+
+  juju bind foo endpoint-1=space-1 endpoint-2=space-2
+
+Finally, the above commands can be combined to update both the default space
+and individual endpoints in one go:
+
+  juju bind foo new-default endpoint-1=space-1
+
+In order to be able to bind any endpoint to a space, all machines where the
+application units are deployed to are required to be configured with an address
+in that space. However, you can use the --force option to bypass this check.
+`
+
+func (c *bindCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "bind",
+		Args:    "<application> [<default-space>] [<endpoint-name>=<space> ...]",
+		Purpose: "Change bindings for a deployed application.",
+		Doc:     bindCmdDoc,
+	})
+}
+
+func (c *bindCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	f.BoolVar(&c.Force, "force", false, "Allow endpoints to be bound to spaces that might not be available to all existing units")
+}
+
+func (c *bindCommand) Init(args []string) error {
+	nArgs := len(args)
+	if nArgs == 0 {
+		return errors.Errorf("no application specified")
+	}
+
+	if !names.IsValidApplication(args[0]) {
+		return errors.Errorf("invalid application name %q", args[0])
+	}
+	c.ApplicationName = args[0]
+	c.BindExpression = strings.Join(args[1:], " ")
+	return nil
+}
+
+// Run connects to the specified environment and applies the requested binding
+// changes.
+func (c *bindCommand) Run(ctx *cmd.Context) error {
+	apiRoot, err := c.NewAPIRoot()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer func() { _ = apiRoot.Close() }()
+
+	if err = c.checkApplicationFacadeSupport(apiRoot, "changing application bindings", 11); err != nil {
+		return err
+	}
+
+	if err = c.parseBindExpression(apiRoot); err != nil {
+		return err
+	}
+
+	modelConfigGetter := c.NewModelConfigGetter(apiRoot)
+	modelConfig, err := getModelConfig(modelConfigGetter)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	generation, err := c.ActiveBranch()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	applicationClient := c.NewApplicationClient(apiRoot)
+	applicationInfo, err := applicationClient.Get(generation, c.ApplicationName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Validate endpoints and merge operator-defined bindings
+	curBindings := applicationInfo.EndpointBindings
+	var epList []string
+	for epName := range curBindings {
+		if epName == "" {
+			continue
+		}
+		epList = append(epList, epName)
+	}
+	curCharmEndpoints := set.NewStrings(epList...)
+
+	if err := c.validateEndpointNames(curCharmEndpoints, curBindings, c.Bindings); err != nil {
+		return errors.Trace(err)
+	}
+
+	appDefaultSpace := detectDefaultSpace(modelConfig, curBindings)
+
+	var bindingsChangelog []string
+	c.Bindings, bindingsChangelog = mergeBindings(curCharmEndpoints, curBindings, c.Bindings, appDefaultSpace)
+
+	err = applicationClient.MergeBindings(params.ApplicationMergeBindingsArgs{
+		Args: []params.ApplicationMergeBindings{
+			{
+				ApplicationTag: names.NewApplicationTag(c.ApplicationName).String(),
+				Bindings:       c.Bindings,
+				Force:          c.Force,
+			},
+		},
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Emit binding changelog after a successful call to MergeBindings.
+	for _, change := range bindingsChangelog {
+		ctx.Infof(change)
+	}
+	return nil
+}
+
+func (c *bindCommand) validateEndpointNames(newCharmEndpoints set.Strings, oldEndpointsMap, userBindings map[string]string) error {
+	for epName := range userBindings {
+		if _, exists := oldEndpointsMap[epName]; exists || epName == "" {
+			continue
+		}
+
+		if !newCharmEndpoints.Contains(epName) {
+			return errors.NotFoundf("endpoint %q", epName)
+		}
+	}
+	return nil
+}
+
+func (c *bindCommand) parseBindExpression(apiRoot base.APICallCloser) error {
+	if c.BindExpression == "" {
+		return nil
+	}
+
+	// Fetch known spaces from server
+	knownSpaceList, err := c.NewSpacesClient(apiRoot).ListSpaces()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	knownSpaces := make([]string, 0, len(knownSpaceList))
+	for _, sp := range knownSpaceList {
+		knownSpaces = append(knownSpaces, sp.Name)
+	}
+
+	// Parse expression
+	bindings, err := parseBindExpr(c.BindExpression, knownSpaces)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	c.Bindings = bindings
+	return nil
+}
+
+func (c *bindCommand) checkApplicationFacadeSupport(verQuerier versionQuerier, action string, minVersion int) error {
+	if verQuerier.BestFacadeVersion("Application") >= minVersion {
+		return nil
+	}
+
+	suffix := "this server"
+	if version, ok := verQuerier.ServerVersion(); ok {
+		suffix = fmt.Sprintf("server version %s", version)
+	}
+
+	return errors.New(action + " is not supported by " + suffix)
+}

--- a/cmd/juju/application/bind_test.go
+++ b/cmd/juju/application/bind_test.go
@@ -1,0 +1,219 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/jujuclient"
+)
+
+type BindSuite struct {
+	testing.IsolationSuite
+	testing.Stub
+
+	apiConnection     mockAPIConnection
+	applicationClient mockApplicationBindClient
+	modelConfigGetter mockModelConfigGetter
+	spacesClient      mockSpacesClient
+	cmd               cmd.Command
+}
+
+var _ = gc.Suite(&BindSuite{})
+
+func (s *BindSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.Stub.ResetCalls()
+
+	// Create persistent cookies in a temporary location.
+	cookieFile := filepath.Join(c.MkDir(), "cookies")
+	s.PatchEnvironment("JUJU_COOKIEFILE", cookieFile)
+
+	s.apiConnection = mockAPIConnection{
+		bestFacadeVersion: 2,
+		serverVersion: &version.Number{
+			Major: 1,
+			Minor: 2,
+			Patch: 3,
+		},
+	}
+	s.applicationClient = mockApplicationBindClient{}
+	s.modelConfigGetter = mockModelConfigGetter{}
+	s.spacesClient = mockSpacesClient{
+		spaceList: []params.Space{
+			{Id: "0", Name: ""}, // default
+			{Id: "1", Name: "sp1"},
+		},
+	}
+
+	store := jujuclient.NewMemStore()
+	store.CurrentControllerName = "foo"
+	store.Controllers["foo"] = jujuclient.ControllerDetails{
+		APIEndpoints: []string{"0.1.2.3:1234"},
+	}
+	store.Models["foo"] = &jujuclient.ControllerModels{
+		CurrentModel: "admin/bar",
+		Models:       map[string]jujuclient.ModelDetails{"admin/bar": {ActiveBranch: model.GenerationMaster}},
+	}
+	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
+		s.AddCall("OpenAPI")
+		return &s.apiConnection, nil
+	}
+
+	s.cmd = NewBindCommandForTest(
+		store,
+		apiOpen,
+		func(conn base.APICallCloser) ApplicationBindClient {
+			s.AddCall("NewApplicationClient", conn)
+			return &s.applicationClient
+		},
+		func(conn base.APICallCloser) ModelConfigGetter {
+			s.AddCall("NewModelConfigGetter", conn)
+			return &s.modelConfigGetter
+		},
+		func(conn base.APICallCloser) SpacesAPI {
+			s.AddCall("NewSpacesClient", conn)
+			return &s.spacesClient
+		},
+	)
+}
+
+func (s *BindSuite) runBind(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, s.cmd, args...)
+}
+
+func (s *BindSuite) TestBind(c *gc.C) {
+	s.apiConnection = mockAPIConnection{
+		bestFacadeVersion: 11,
+		serverVersion: &version.Number{
+			Major: 1,
+			Minor: 2,
+			Patch: 3,
+		},
+	}
+
+	s.applicationClient.getResults = &params.ApplicationGetResults{
+		EndpointBindings: map[string]string{
+			"ep1": network.DefaultSpaceName,
+			"ep2": "sp2",
+		},
+	}
+
+	_, err := s.runBind(c, "foo", "ep1=sp1")
+	c.Assert(err, jc.ErrorIsNil)
+	s.spacesClient.CheckCallNames(c, "ListSpaces")
+	s.applicationClient.CheckCallNames(c, "Get", "MergeBindings")
+	s.applicationClient.CheckCall(c, 1, "MergeBindings", params.ApplicationMergeBindingsArgs{
+		Args: []params.ApplicationMergeBindings{
+			{
+				ApplicationTag: names.NewApplicationTag("foo").String(),
+				Bindings: map[string]string{
+					"ep1": "sp1",
+					"ep2": "sp2",
+				},
+			},
+		},
+	})
+}
+
+func (s *BindSuite) TestBindWithNoBindings(c *gc.C) {
+	s.apiConnection = mockAPIConnection{
+		bestFacadeVersion: 11,
+		serverVersion: &version.Number{
+			Major: 1,
+			Minor: 2,
+			Patch: 3,
+		},
+	}
+
+	s.applicationClient.getResults = &params.ApplicationGetResults{
+		EndpointBindings: map[string]string{
+			"ep1": network.DefaultSpaceName,
+			"ep2": "sp2",
+		},
+	}
+
+	// If the operator specifies no bindings, juju bind will simply print
+	// out the current bindings and make a no-op call to the server.
+	_, err := s.runBind(c, "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	s.spacesClient.CheckNoCalls(c)
+	s.applicationClient.CheckCallNames(c, "Get", "MergeBindings")
+	s.applicationClient.CheckCall(c, 1, "MergeBindings", params.ApplicationMergeBindingsArgs{
+		Args: []params.ApplicationMergeBindings{
+			{
+				ApplicationTag: names.NewApplicationTag("foo").String(),
+				Bindings: map[string]string{
+					"ep1": network.DefaultSpaceName,
+					"ep2": "sp2",
+				},
+			},
+		},
+	})
+}
+
+func (s *BindSuite) TestBindUnknownEndpoint(c *gc.C) {
+	s.apiConnection = mockAPIConnection{
+		bestFacadeVersion: 11,
+		serverVersion: &version.Number{
+			Major: 1,
+			Minor: 2,
+			Patch: 3,
+		},
+	}
+
+	s.applicationClient.getResults = &params.ApplicationGetResults{
+		EndpointBindings: map[string]string{
+			"ep1": network.DefaultSpaceName,
+			"ep2": "sp2",
+		},
+	}
+
+	_, err := s.runBind(c, "foo", "unknown=sp1")
+	c.Assert(err, gc.ErrorMatches, `endpoint "unknown" not found`)
+}
+
+func (s *BindSuite) TestBindWithOlderController(c *gc.C) {
+	s.apiConnection = mockAPIConnection{
+		bestFacadeVersion: 10,
+		serverVersion: &version.Number{
+			Major: 1,
+			Minor: 2,
+			Patch: 3,
+		},
+	}
+
+	_, err := s.runBind(c, "foo", "unknown=sp1")
+	c.Assert(err, gc.ErrorMatches, `changing application bindings is not supported by server version.*`)
+}
+
+type mockApplicationBindClient struct {
+	ApplicationBindClient
+	testing.Stub
+
+	getResults *params.ApplicationGetResults
+}
+
+func (m *mockApplicationBindClient) Get(generation string, app string) (*params.ApplicationGetResults, error) {
+	m.MethodCall(m, "Get", generation, app)
+	return m.getResults, m.NextErr()
+}
+
+func (m *mockApplicationBindClient) MergeBindings(p params.ApplicationMergeBindingsArgs) error {
+	m.MethodCall(m, "MergeBindings", p)
+	return m.NextErr()
+}

--- a/cmd/juju/application/binding.go
+++ b/cmd/juju/application/binding.go
@@ -55,7 +55,7 @@ func parseBindExpr(expr string, knownSpaces []string) (map[string]string, error)
 		spaceName = strings.Trim(spaceName, `"`)
 
 		if _, exists := knownSpaceMap[spaceName]; !exists {
-			return nil, errors.NotFoundf("Space with name %q", spaceName)
+			return nil, errors.NotFoundf("space %q", spaceName)
 		}
 
 		parsedBindings[endpoint] = spaceName

--- a/cmd/juju/application/binding_test.go
+++ b/cmd/juju/application/binding_test.go
@@ -66,16 +66,16 @@ func (s *ParseBindSuite) TestParseWithEmptyQuotedDefaultSpace(c *gc.C) {
 }
 
 func (s *ParseBindSuite) TestParseFailsWithSpaceNameButNoEndpoint(c *gc.C) {
-	s.checkParseFailsForExpr(c, "=bad", nil, "Found = without endpoint name. Use a lone space name to set the default.")
+	s.checkParseFailsForExpr(c, "=bad", nil, parseBindErrorPrefix+"Found = without endpoint name. Use a lone space name to set the default.")
 }
 
 func (s *ParseBindSuite) TestParseFailsWithTooManyEqualsSignsInArgs(c *gc.C) {
-	s.checkParseFailsForExpr(c, "foo=bar=baz", nil, "Found multiple = in binding. Did you forget to space-separate the binding list?")
+	s.checkParseFailsForExpr(c, "foo=bar=baz", nil, parseBindErrorPrefix+"Found multiple = in binding. Did you forget to space-separate the binding list?")
 }
 
 func (s *ParseBindSuite) TestParseFailsWithUnknownSpaceName(c *gc.C) {
 	_, err := parseBindExpr("rel1=bogus", nil)
-	c.Check(err.Error(), gc.Equals, `Space with name "bogus" not found`)
+	c.Check(err.Error(), gc.Equals, `space "bogus" not found`)
 }
 
 func (s *ParseBindSuite) TestMergeBindingsNewBindingsInheritDefaultSpace(c *gc.C) {
@@ -108,6 +108,6 @@ func (s *ParseBindSuite) checkParseOKForExpr(c *gc.C, expr string, knownSpaces [
 
 func (s *ParseBindSuite) checkParseFailsForExpr(c *gc.C, expr string, knownSpaces []string, expectedErrorSuffix string) {
 	parsedBindings, err := parseBindExpr(expr, knownSpaces)
-	c.Check(err.Error(), gc.Equals, parseBindErrorPrefix+expectedErrorSuffix)
+	c.Check(err.Error(), gc.Equals, expectedErrorSuffix)
 	c.Check(parsedBindings, gc.IsNil)
 }

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -154,6 +154,23 @@ func NewUpgradeCharmCommandForTest(
 	return modelcmd.Wrap(cmd)
 }
 
+func NewBindCommandForTest(
+	store jujuclient.ClientStore,
+	apiOpen api.OpenFunc,
+	newApplicationClient func(base.APICallCloser) ApplicationBindClient,
+	newModelConfigGetter func(base.APICallCloser) ModelConfigGetter,
+	newSpacesClient func(base.APICallCloser) SpacesAPI,
+) cmd.Command {
+	cmd := &bindCommand{
+		NewApplicationClient: newApplicationClient,
+		NewModelConfigGetter: newModelConfigGetter,
+		NewSpacesClient:      newSpacesClient,
+	}
+	cmd.SetClientStore(store)
+	cmd.SetAPIOpen(apiOpen)
+	return modelcmd.Wrap(cmd)
+}
+
 // NewResolvedCommandForTest returns a ResolvedCommand with the api provided as specified.
 func NewResolvedCommandForTest(applicationResolveAPI applicationResolveAPI, clientAPI clientAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
 	cmd := &resolvedCommand{applicationResolveAPI: applicationResolveAPI, clientAPI: clientAPI}

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -444,7 +444,7 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 
 func (c *upgradeCharmCommand) validateEndpointNames(newCharmEndpoints set.Strings, oldEndpointsMap, userBindings map[string]string) error {
 	for epName := range userBindings {
-		if _, exists := oldEndpointsMap[epName]; exists {
+		if _, exists := oldEndpointsMap[epName]; exists || epName == "" {
 			continue
 		}
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -310,6 +310,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(newUpgradeControllerCommand())
 	r.Register(application.NewUpgradeCharmCommand())
 	r.Register(application.NewSetSeriesCommand())
+	r.Register(application.NewBindCommand())
 
 	// Charm tool commands.
 	r.Register(newHelpToolCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -444,6 +444,7 @@ var commandNames = []string{
 	"attach-storage",
 	"autoload-credentials",
 	"backups",
+	"bind",
 	"bootstrap",
 	"budget",
 	"cached-images",

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -162,7 +162,7 @@ func (suite *PluginSuite) TestHelpPluginNameAsPathIsNotAPlugin(c *gc.C) {
 	expectedHelp := `ERROR juju: "/foo" is not a juju command. See "juju --help".
 
 Did you mean:
-	exec
+	bind
 `
 	c.Assert(output, gc.Matches, expectedHelp)
 }
@@ -172,7 +172,7 @@ func (suite *PluginSuite) TestHelpPluginNameWithSpecialPrefixWhichIsNotAPathAndP
 	expectedHelp := `ERROR juju: ".foo" is not a juju command. See "juju --help".
 
 Did you mean:
-	exec
+	bind
 `
 	c.Assert(output, gc.Matches, expectedHelp)
 }

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -141,7 +141,7 @@ func (b *Bindings) Merge(mergeWith map[string]string, meta *charm.Meta) (bool, e
 		// miss an entry. Either they have identical keys and we check all the values, or there is an identical
 		// number of new keys and missing keys and we'll notice a missing key.
 		for key, val := range updated {
-			if oldVal, existed := mergeMap[key]; !existed || oldVal != val {
+			if oldVal, existed := b.bindingsMap[key]; !existed || oldVal != val {
 				isModified = true
 				break
 			}


### PR DESCRIPTION
## Description of change

This PR introduces a new CLI command which allows operators to change the bindings for a deployed application's endpoints and/or to change the default space for the application.

## QA steps

```
# Bootstrap guimaas
$ juju bootstrap guimaas guimaas --credential guimaas --no-gui

# Add a machine with two NICs
$ juju add-machine --constraints spaces=default,space-alt2

# Deploy charms (important: don't wait for machine too boot)
$ juju deploy  cs:~juju-qa/bionic/space-defender-0 --to lxd:0 --bind "default defend-b=space-alt2"
$ juju deploy  cs:~juju-qa/bionic/space-invader-1 --to lxd:0 --bind "invade-a=default invade-b=space-alt2"

# On a new terminal
$ juju debug-log --include space-defender --level INFO

# On a new terminal
$ juju debug-log --include space-invader --level INFO

# Back to the first terminal; relate the charms and notice the "relation-changed" events
# in the logs
$ juju relate space-defender:defend-a space-invader:invade-a
$ juju relate space-defender:defend-b space-invader:invade-b

# Change the bindings for space-defender. In all examples:
#  - the *space-defender* should receive a "config-changed" hook while
#  - the *space-invader* should receive a "relation-changed" hook for "invade-a"

# Run these *BEFORE* the machine for space-defender boots up
$ juju bind space-defender space-alt2
ERROR merging application bindings: changing default space to "space-alt2" is not feasible: one or more deployed machines lack an address in this space

$ juju bind space-defender defend-a=space-alt2
ERROR merging application bindings: binding endpoint "defend-b" to space "space-alt2" is not feasible: one or more deployed machines lack an address in this space

# I know better... Make it so!!!
$ juju bind space-defender defend-a=space-alt2 --force
Updating endpoint "defend-a" from "default" to "space-alt2"
Leaving endpoint in "space-alt2": defend-b

# Now WAIT for the units to go online before running the following

# juju bind with no args
$ juju bind space-defender
Leaving endpoints in "space-alt2": defend-a, defend-b

$ juju bind space-defender defend-a=default
Updating endpoint "defend-a" from "space-alt2" to "default"
Updating endpoint "defend-b" from "space-alt2" to "default"

# Change default space for application
$ juju bind space-defender space-alt2
Updating endpoint "defend-a" from "default" to "space-alt2"
Updating endpoint "defend-b" from "default" to "space-alt2"
```

## Documentation changes

This PR introduces a new juju command.