### PR TITLE
vsphere: Check for System.Read privilege if root-disk constraint is set

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -33,6 +33,7 @@ type Client interface {
 	RemoveVirtualMachines(context.Context, string) error
 	UpdateVirtualMachineExtraConfig(context.Context, *mo.VirtualMachine, map[string]string) error
 	VirtualMachines(context.Context, string) ([]*mo.VirtualMachine, error)
+	UserHasRootLevelPrivilege(context.Context, string) (bool, error)
 }
 
 func dialClient(

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -4,10 +4,12 @@
 package vsphere_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/constraints"
@@ -135,4 +137,25 @@ func (s *environPolSuite) TestPrecheckInstanceChecksConstraintDatastore(c *gc.C)
 		Constraints: constraints.MustParse("root-disk-source=bar"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environPolSuite) TestPrecheckInstanceChecksForPrivIfRootDiskSet(c *gc.C) {
+	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{
+		Constraints: constraints.MustParse("root-disk=30G"),
+	})
+	c.Assert(err, gc.ErrorMatches, `the System.Read privilege is required at the root level to extend disks - please grant the ReadOnly role to "user1"`)
+
+	s.client.SetErrors(errors.New("oops"))
+	err = s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{
+		Constraints: constraints.MustParse("root-disk=30G"),
+	})
+	c.Assert(err, gc.ErrorMatches, "oops")
+
+	s.client.hasPrivilege = true
+	err = s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{
+		Constraints: constraints.MustParse("root-disk=30G"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.client.CheckCall(c, 0, "UserHasRootLevelPrivilege", context.Background(), "System.Read")
 }

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -73,6 +73,10 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 			Type:  "SearchIndex",
 			Value: "FakeSearchIndex",
 		},
+		AuthorizationManager: &types.ManagedObjectReference{
+			Type:  "AuthorizationManager",
+			Value: "FakeAuthorizationManager",
+		},
 	}
 	s.roundTripper = mockRoundTripper{
 		collectors: make(map[string]*collector),
@@ -87,6 +91,21 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 			},
 			PropSet: []types.DynamicProperty{
 				{Name: "name", Val: "dc0"},
+			},
+		}},
+		"FakeSessionManager": {{
+			Obj: types.ManagedObjectReference{
+				Type:  "SessionManager",
+				Value: "FakeSessionManager",
+			},
+			PropSet: []types.DynamicProperty{
+				{Name: "name", Val: "sm"},
+				{
+					Name: "currentSession",
+					Val: types.UserSession{
+						Key: "session-key",
+					},
+				},
 			},
 		}},
 		"FakeDatacenter": {{
@@ -848,6 +867,47 @@ func (s *clientSuite) TestResourcePools(c *gc.C) {
 	c.Check(result[2].InventoryPath, gc.Equals, "/z0/Resources/parent/child")
 	c.Check(result[3].InventoryPath, gc.Equals, "/z0/Resources/other")
 }
+
+func (s *clientSuite) TestUserHasRootLevelPrivilege(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	result, err := client.UserHasRootLevelPrivilege(context.Background(), "Some.Privilege")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, true)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeSessionManager"),
+		{"HasPrivilegeOnEntities", []interface{}{
+			"FakeAuthorizationManager",
+			[]types.ManagedObjectReference{s.serviceContent.RootFolder},
+			"session-key",
+			[]string{"Some.Privilege"},
+		}},
+	})
+
+	s.roundTripper.SetErrors(nil, permissionError)
+	result, err = client.UserHasRootLevelPrivilege(context.Background(), "System.Read")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, false)
+
+	s.roundTripper.SetErrors(nil, permissionError)
+	result, err = client.UserHasRootLevelPrivilege(context.Background(), "Other.Privilege")
+	c.Assert(err, gc.ErrorMatches, `checking for "Other.Privilege" privilege: ServerFaultCode: Permission to perform this operation was denied.`)
+}
+
+var permissionError = soap.WrapSoapFault(&soap.Fault{
+	XMLName: xml.Name{Space: "http://schemas.xmlsoap.org/soap/envelope/", Local: "Fault"},
+	Code:    "ServerFaultCode",
+	String:  "Permission to perform this operation was denied.",
+	Detail: struct {
+		Fault types.AnyType "xml:\",any,typeattr\""
+	}{
+		Fault: types.NoPermission{
+			SecurityError: types.SecurityError{},
+			Object:        types.ManagedObjectReference{Type: "Folder", Value: "group-d1"},
+			PrivilegeId:   "System.Read",
+		},
+	},
+})
 
 func fakeAcquire(spec mutex.Spec) (func(), error) {
 	return func() {}, nil

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -114,7 +114,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		{"CreateFilter", nil},
 		{"WaitForUpdatesEx", nil},
 		{"HttpNfcLeaseComplete", []interface{}{"FakeLease"}},
-		{"MarkAsTemplateBody", []interface{}{"FakeVm0"}},
+		{"MarkAsTemplate", []interface{}{"FakeVm0"}},
 		retrievePropertiesStubCall("network-0", "network-1"),
 		retrievePropertiesStubCall("onetwork-0"),
 		retrievePropertiesStubCall("dvportgroup-0"),

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -260,8 +260,21 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		}
 	case *methods.MarkAsTemplateBody:
 		req := req.(*methods.MarkAsTemplateBody).Req
-		r.MethodCall(r, "MarkAsTemplateBody", req.This.Value)
+		r.MethodCall(r, "MarkAsTemplate", req.This.Value)
 		res.Res = &types.MarkAsTemplateResponse{}
+
+	case *methods.HasPrivilegeOnEntitiesBody:
+		req := req.(*methods.HasPrivilegeOnEntitiesBody).Req
+		r.MethodCall(r, "HasPrivilegeOnEntities", req.This.Value, req.Entity, req.SessionId, req.PrivId)
+		res.Res = &types.HasPrivilegeOnEntitiesResponse{
+			Returnval: []types.EntityPrivilege{{
+				Entity: req.Entity[0],
+				PrivAvailability: []types.PrivilegeAvailability{{
+					PrivId:    req.PrivId[0],
+					IsGranted: true,
+				}},
+			}},
+		}
 
 	default:
 		logger.Debugf("mockRoundTripper: unknown res type %T", res)

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -39,6 +39,7 @@ type mockClient struct {
 	virtualMachines       []*mo.VirtualMachine
 	datastores            []*mo.Datastore
 	vmFolder              *object.Folder
+	hasPrivilege          bool
 }
 
 func (c *mockClient) Close(ctx context.Context) error {
@@ -123,6 +124,13 @@ func (c *mockClient) UpdateVirtualMachineExtraConfig(ctx context.Context, vm *mo
 	defer c.mu.Unlock()
 	c.MethodCall(c, "UpdateVirtualMachineExtraConfig", ctx, vm, attrs)
 	return c.NextErr()
+}
+
+func (c *mockClient) UserHasRootLevelPrivilege(ctx context.Context, privilege string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.MethodCall(c, "UserHasRootLevelPrivilege", ctx, privilege)
+	return c.hasPrivilege, c.NextErr()
 }
 
 func (c *mockClient) VirtualMachines(ctx context.Context, path string) ([]*mo.VirtualMachine, error) {


### PR DESCRIPTION
## Description of change

If a machine has a non-default root-disk constraint, we'll need the global System.Read privilege to wait for the extend task to complete. Check that we have it in PrecheckInstance so that we can give early feedback to the user, rather than failing and retrying in the provisioner.

## QA steps

* Ensure the juju user doesn't have System.Read for the vsphere root (i.e. it hasn't been granted Administrator or ReadOnly)
* Deploy an application without a root-disk constraint - it works.
* Deploy one with root-disk - it's rejected with an error explaining what privilege should be granted.
* Grant ReadOnly to the juju user.
* Try the root-disk deploy again - it's accepted and the unit deploys successfully with the expanded disk.

## Documentation changes

* We should add a note to the vsphere provider docs explaining the privilege needed.

## Bug reference

Rest of the fix for: https://bugs.launchpad.net/juju/+bug/1847245
