### PR TITLE
Thread logger through remote relations worker.

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -271,6 +271,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewControllerConnection:  apicaller.NewExternalControllerConnection,
 			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
 			NewWorker:                remoterelations.NewWorker,
+			Logger:                   config.LoggingContext.GetLogger("juju.worker.remoterelations"),
 		})),
 		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
 			APICallerName: apiCallerName,

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -5,6 +5,7 @@ package remoterelations_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -34,6 +35,7 @@ func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
 		NewControllerConnection:  func(*api.Info) (api.Connection, error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) (remoterelations.RemoteRelationsFacade, error) { return nil, nil },
 		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
+		Logger:                   loggo.GetLogger("test"),
 	}
 }
 
@@ -64,6 +66,11 @@ func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingNewControllerConnection(c *gc.C) {
 	s.config.NewControllerConnection = nil
 	s.checkNotValid(c, "nil NewControllerConnection not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	s.checkNotValid(c, "nil Logger not valid")
 }
 
 func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -54,7 +55,8 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 		NewRemoteModelFacadeFunc: func(*api.Info) (remoterelations.RemoteModelRelationsFacadeCloser, error) {
 			return s.remoteRelationsFacade, nil
 		},
-		Clock: testclock.NewClock(time.Time{}),
+		Clock:  testclock.NewClock(time.Time{}),
+		Logger: loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -22,6 +22,7 @@ type remoteRelationsWorker struct {
 	applicationToken    string
 	relationsWatcher    watcher.RelationStatusWatcher
 	changes             chan<- params.RemoteRelationChangeEvent
+	logger              Logger
 }
 
 func newRemoteRelationsWorker(
@@ -30,6 +31,7 @@ func newRemoteRelationsWorker(
 	remoteRelationToken string,
 	relationsWatcher watcher.RelationStatusWatcher,
 	changes chan<- params.RemoteRelationChangeEvent,
+	logger Logger,
 ) (*remoteRelationsWorker, error) {
 	w := &remoteRelationsWorker{
 		relationsWatcher:    relationsWatcher,
@@ -37,6 +39,7 @@ func newRemoteRelationsWorker(
 		remoteRelationToken: remoteRelationToken,
 		applicationToken:    applicationToken,
 		changes:             changes,
+		logger:              logger,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -72,12 +75,12 @@ func (w *remoteRelationsWorker) loop() error {
 				return w.catacomb.ErrDying()
 			}
 			if len(relChanges) == 0 {
-				logger.Warningf("relation status watcher event with no changes")
+				w.logger.Warningf("relation status watcher event with no changes")
 				continue
 			}
 			// We only care about the most recent change.
 			change := relChanges[len(relChanges)-1]
-			logger.Debugf("relation status changed for %v: %v", w.relationTag, change)
+			w.logger.Debugf("relation status changed for %v: %v", w.relationTag, change)
 			suspended := change.Suspended
 			event = params.RemoteRelationChangeEvent{
 				RelationToken:    w.remoteRelationToken,


### PR DESCRIPTION
Next in the line of model workers to get the logger from the right logging context.