### PR TITLE
Feature/clusterrolebinding

### DIFF
--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -69,7 +69,6 @@ func boolPtr(b bool) *bool {
 func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 
 	sa := &specs.ServiceAccountSpec{}
-	sa.ClusterRoleNames = []string{"clusterRole1"}
 	sa.AutomountServiceAccountToken = boolPtr(true)
 
 	podSpec := specs.PodSpec{
@@ -2109,204 +2108,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 	}
 }
 
-func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountReferenceExistingClusterRole(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	podSpec := getBasicPodspec()
-	podSpec.ServiceAccount = &specs.ServiceAccountSpec{}
-	podSpec.ServiceAccount.AutomountServiceAccountToken = boolPtr(true)
-	podSpec.ServiceAccount.ClusterRoleNames = []string{
-		"existingClusterRole1",
-		"existingClusterRole2",
-	}
-
-	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec)
-	c.Assert(err, jc.ErrorIsNil)
-
-	deploymentArg := &appsv1.Deployment{
-		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
-			Annotations: map[string]string{
-				"fred": "mary",
-			}},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &numUnits,
-			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
-			},
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					GenerateName: "app-name-",
-					Labels: map[string]string{
-						"juju-app": "app-name",
-					},
-					Annotations: map[string]string{
-						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred": "mary",
-					},
-				},
-				Spec: provider.PodSpec(workloadSpec),
-			},
-		},
-	}
-	serviceArg := &core.Service{
-		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
-			Annotations: map[string]string{
-				"fred": "mary",
-				"a":    "b",
-			}},
-		Spec: core.ServiceSpec{
-			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
-			Ports: []core.ServicePort{
-				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
-				{Port: 8080, Protocol: "TCP", Name: "fred"},
-			},
-			LoadBalancerIP: "10.0.0.1",
-			ExternalName:   "ext-name",
-		},
-	}
-
-	svcAccount := &core.ServiceAccount{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
-		},
-		AutomountServiceAccountToken: boolPtr(true),
-	}
-	existingClusterRole1 := &rbacv1.ClusterRole{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "existingClusterRole1",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "watch", "list"},
-			},
-		},
-	}
-	existingClusterRole2 := &rbacv1.ClusterRole{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "existingClusterRole2",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "watch", "list"},
-			},
-		},
-	}
-	rb1 := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name-existingClusterRole1",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Name: "existingClusterRole1",
-			Kind: "ClusterRole",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "app-name",
-				Namespace: "test",
-			},
-		},
-	}
-	rbUID1 := rb1.GetUID()
-	rb2 := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name-existingClusterRole2",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Name: "existingClusterRole2",
-			Kind: "ClusterRole",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "app-name",
-				Namespace: "test",
-			},
-		},
-	}
-	rbUID2 := rb2.GetUID()
-
-	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
-	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockClusterRoles.EXPECT().Get("existingClusterRole1", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(existingClusterRole1, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
-			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{*rb1}}, nil),
-		s.mockRoleBindings.EXPECT().Delete("app-name-existingClusterRole1", s.deleteOptions(v1.DeletePropagationForeground, &rbUID1)).Times(1).Return(nil),
-		s.mockRoleBindings.EXPECT().Get("app-name-existingClusterRole1", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(rb1, nil),
-		s.mockRoleBindings.EXPECT().Get("app-name-existingClusterRole1", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(nil, s.k8sNotFoundError()),
-		s.mockRoleBindings.EXPECT().Create(rb1).Times(1).Return(rb1, nil),
-		s.mockClusterRoles.EXPECT().Get("existingClusterRole2", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(existingClusterRole2, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
-			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{*rb2}}, nil),
-		s.mockRoleBindings.EXPECT().Delete("app-name-existingClusterRole2", s.deleteOptions(v1.DeletePropagationForeground, &rbUID2)).Times(1).Return(nil),
-		s.mockRoleBindings.EXPECT().Get("app-name-existingClusterRole2", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(rb2, nil),
-		s.mockRoleBindings.EXPECT().Get("app-name-existingClusterRole2", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(nil, s.k8sNotFoundError()),
-		s.mockRoleBindings.EXPECT().Create(rb2).Times(1).Return(rb1, nil),
-		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
-			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
-			Return(nil, nil),
-	)
-
-	params := &caas.ServiceParams{
-		PodSpec:      podSpec,
-		ResourceTags: map[string]string{"fred": "mary"},
-	}
-
-	errChan := make(chan error)
-	go func() {
-		errChan <- s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-			"kubernetes-service-type":            "nodeIP",
-			"kubernetes-service-loadbalancer-ip": "10.0.0.1",
-			"kubernetes-service-externalname":    "ext-name",
-			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
-		})
-	}()
-	// checking app-name-existingClusterRole1 has already been deleted.
-	err = s.clock.WaitAdvance(2*time.Second, testing.ShortWait, 1)
-	c.Assert(err, jc.ErrorIsNil)
-	// checking app-name-existingClusterRole2 has already been deleted.
-	err = s.clock.WaitAdvance(2*time.Second, testing.ShortWait, 1)
-	c.Assert(err, jc.ErrorIsNil)
-
-	select {
-	case err := <-errChan:
-		c.Assert(err, jc.ErrorIsNil)
-	case <-time.After(testing.LongWait):
-		c.Fatalf("timed out waiting for EnsureService return")
-	}
-}
-
 func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
@@ -2326,10 +2127,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		Name: "k8sRBAC1",
 	}
 	k8sSASpec.AutomountServiceAccountToken = boolPtr(true)
-	k8sSASpec.ClusterRoleNames = []string{
-		"someClusterRole1",
-		"someClusterRole2",
-	}
 	k8sSASpec.Rules = []specs.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -2479,68 +2276,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		},
 	}
 
-	clusterRole1 := &rbacv1.ClusterRole{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "someClusterRole1",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		},
-	}
-	clusterRole2 := &rbacv1.ClusterRole{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "someClusterRole2",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		},
-	}
-	rb3 := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "k8sRBAC1-someClusterRole1",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Name: "someClusterRole1",
-			Kind: "ClusterRole",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "k8sRBAC1",
-				Namespace: "test",
-			},
-		},
-	}
-
-	rb4 := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "k8sRBAC1-someClusterRole2",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Name: "someClusterRole2",
-			Kind: "ClusterRole",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "k8sRBAC1",
-				Namespace: "test",
-			},
-		},
-	}
-
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
@@ -2557,16 +2292,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
 		s.mockRoleBindings.EXPECT().Create(rb2).Times(1).Return(rb2, nil),
-
-		s.mockClusterRoles.EXPECT().Get("someClusterRole1", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(clusterRole1, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
-			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb3).Times(1).Return(rb3, nil),
-
-		s.mockClusterRoles.EXPECT().Get("someClusterRole2", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(clusterRole2, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
-			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb4).Times(1).Return(rb4, nil),
 
 		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -88,7 +88,7 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 				return cleanups, errors.Trace(err)
 			}
 
-			// ensure rolebindings for Role.
+			// ensure RoleBindings for Role.
 			_, rBCleanups, err := k.ensureRoleBinding(&rbacv1.RoleBinding{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      rbacStackName,
@@ -126,7 +126,7 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 			if err != nil {
 				return cleanups, errors.Trace(err)
 			}
-			// ensure rolebindings for ClusterRole.
+			// ensure ClusterRoleBindings for ClusterRole.
 			_, cRBCleanups, err := k.ensureClusterRoleBinding(&rbacv1.ClusterRoleBinding{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      rbacStackName,

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -112,36 +112,6 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 			return cleanups, errors.Trace(err)
 		}
 	}
-
-	for _, clusterRoleName := range caasSpec.ClusterRoleNames {
-		// check if ClusterRoles exist.
-		cR, err := k.getClusterRole(clusterRoleName)
-		if err != nil {
-			return cleanups, errors.Trace(err)
-		}
-		_, cRBCleanups, err := k.ensureRoleBinding(&rbacv1.RoleBinding{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      getBindingName(sa, cR),
-				Namespace: k.namespace,
-				Labels:    labels,
-			},
-			RoleRef: rbacv1.RoleRef{
-				Name: cR.GetName(),
-				Kind: "ClusterRole",
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      rbacv1.ServiceAccountKind,
-					Name:      sa.GetName(),
-					Namespace: sa.GetNamespace(),
-				},
-			},
-		})
-		cleanups = append(cleanups, cRBCleanups...)
-		if err != nil {
-			return cleanups, errors.Trace(err)
-		}
-	}
 	return cleanups, nil
 }
 

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -121,7 +121,6 @@ service:
     foo: bar
 serviceAccount:
   automountServiceAccountToken: true
-  clusterRoleNames: [someClusterRole1, someClusterRole2]
   rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -130,7 +129,6 @@ kubernetesResources:
   serviceAccounts:
   - name: k8sServiceAccount1
     automountServiceAccountToken: true
-    clusterRoleNames: [someClusterRole1, someClusterRole2]
     rules:
     - apiGroups: [""]
       resources: ["pods"]
@@ -197,9 +195,6 @@ foo: bar
 
 	sa1 := &specs.ServiceAccountSpec{}
 	sa1.AutomountServiceAccountToken = boolPtr(true)
-	sa1.ClusterRoleNames = []string{
-		"someClusterRole1", "someClusterRole2",
-	}
 	sa1.Rules = []specs.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -325,9 +320,6 @@ echo "do some stuff here for gitlab-init container"
 			Name: "k8sServiceAccount1",
 		}
 		sa2.AutomountServiceAccountToken = boolPtr(true)
-		sa2.ClusterRoleNames = []string{
-			"someClusterRole1", "someClusterRole2",
-		}
 		sa2.Rules = []specs.PolicyRule{
 			{
 				APIGroups: []string{""},
@@ -509,7 +501,7 @@ serviceAccount:
 `[1:]
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, gc.ErrorMatches, `rules or clusterRoleNames are required`)
+	c.Assert(err, gc.ErrorMatches, `rules is required`)
 }
 
 func (s *v2SpecsSuite) TestValidateCustomResourceDefinitions(c *gc.C) {

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -121,6 +121,7 @@ service:
     foo: bar
 serviceAccount:
   automountServiceAccountToken: true
+  global: true
   rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -129,6 +130,7 @@ kubernetesResources:
   serviceAccounts:
   - name: k8sServiceAccount1
     automountServiceAccountToken: true
+    global: true
     rules:
     - apiGroups: [""]
       resources: ["pods"]
@@ -195,6 +197,7 @@ foo: bar
 
 	sa1 := &specs.ServiceAccountSpec{}
 	sa1.AutomountServiceAccountToken = boolPtr(true)
+	sa1.Global = true
 	sa1.Rules = []specs.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -319,6 +322,7 @@ echo "do some stuff here for gitlab-init container"
 		sa2 := k8sspecs.K8sServiceAccountSpec{
 			Name: "k8sServiceAccount1",
 		}
+		sa2.Global = true
 		sa2.AutomountServiceAccountToken = boolPtr(true)
 		sa2.Rules = []specs.PolicyRule{
 			{

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -16,9 +16,9 @@ type PolicyRule struct {
 
 // RBACSpec defines RBAC related spec.
 type RBACSpec struct {
-	AutomountServiceAccountToken *bool `yaml:"automountServiceAccountToken,omitempty"`
-
-	Rules []PolicyRule `yaml:"rules,omitempty"`
+	AutomountServiceAccountToken *bool        `yaml:"automountServiceAccountToken,omitempty"`
+	Global                       bool         `yaml:"global,omitempty"`
+	Rules                        []PolicyRule `yaml:"rules,omitempty"`
 }
 
 // Validate returns an error if the spec is not valid.

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -16,16 +16,15 @@ type PolicyRule struct {
 
 // RBACSpec defines RBAC related spec.
 type RBACSpec struct {
-	AutomountServiceAccountToken *bool    `yaml:"automountServiceAccountToken,omitempty"`
-	ClusterRoleNames             []string `yaml:"ClusterRoleNames,omitempty"`
+	AutomountServiceAccountToken *bool `yaml:"automountServiceAccountToken,omitempty"`
 
 	Rules []PolicyRule `yaml:"rules,omitempty"`
 }
 
 // Validate returns an error if the spec is not valid.
 func (rs RBACSpec) Validate() error {
-	if len(rs.ClusterRoleNames) == 0 && len(rs.Rules) == 0 {
-		return errors.NewNotValid(nil, "rules or clusterRoleNames are required")
+	if len(rs.Rules) == 0 {
+		return errors.NewNotValid(nil, "rules is required")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

add cluster scope role/rolebinding for podspecV2;

## QA steps

- deploy charms `without` `global` rbac scope;

```yaml
serviceAccount:
  automountServiceAccountToken: true
  rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["get", "watch", "list"]
kubernetesResources:
  serviceAccounts:
    - name: rbac-foo
      automountServiceAccountToken: true
      rules:
        - apiGroups: [""]
          resources: ["pods"]
          verbs: ["get", "watch", "list"]
```

- check role and  role binding created;

```bash
mkubectl get sa,roles,rolebindings,clusterroles,clusterrolebindings -nt1

NAME                                  SECRETS   AGE
serviceaccount/mariadb-k8s            1         11s
serviceaccount/rbac-foo               1         11s

NAME                                                  AGE
role.rbac.authorization.k8s.io/mariadb-k8s            11s
role.rbac.authorization.k8s.io/rbac-foo               11s

NAME                                                         AGE
rolebinding.rbac.authorization.k8s.io/mariadb-k8s            11s
rolebinding.rbac.authorization.k8s.io/rbac-foo

```


- deploy charms with `global` rbac scope;

```yaml
serviceAccount:
  automountServiceAccountToken: true
  global: true
  rules:
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["get", "watch", "list"]
kubernetesResources:
  serviceAccounts:
    - name: rbac-foo
      global: true
      automountServiceAccountToken: true
      rules:
        - apiGroups: [""]
          resources: ["pods"]
          verbs: ["get", "watch", "list"]
```

- check `cluster` role and `cluster` role binding created;

```bash
$ mkubectl get sa,roles,rolebindings,clusterroles,clusterrolebindings -nt1

NAME                                  SECRETS   AGE
serviceaccount/mariadb-k8s            1         36s
serviceaccount/rbac-foo               1         36s

NAME                                                                       AGE
clusterrole.rbac.authorization.k8s.io/t1-mariadb-k8s                       36s
clusterrole.rbac.authorization.k8s.io/t1-rbac-foo                          36s


NAME                                                                  AGE
clusterrolebinding.rbac.authorization.k8s.io/t1-mariadb-k8s           36s
clusterrolebinding.rbac.authorization.k8s.io/t1-rbac-foo              36s
```


## Documentation changes

No

## Bug reference

None
