### PR TITLE
Feature/add pod asddresses2bind addresses

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -55,7 +55,7 @@ def check_app_healthy(url, timeout=300, success_hook=lambda: None, fail_hook=lam
                 log.info('timeout in %ss', remaining)
     log.error('HTTP health check failed -> %s, status_code -> %s !', url, status_code)
     fail_hook()
-    raise JujuAssertionError('gitlab is not healthy')
+    raise JujuAssertionError('%s is not healthy' % url)
 
 
 def get_app_endpoint(caas_client, model_name, app_name, svc_type, timeout=120):

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4664,7 +4664,9 @@ func (s *uniterSuite) TestNetworkInfoCAASModelRelation(c *gc.C) {
 	expectedResult := params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
 			{
-				Addresses: []params.InterfaceAddress{},
+				Addresses: []params.InterfaceAddress{
+					{Address: "10.0.0.1"},
+				},
 			},
 		},
 		EgressSubnets:    []string{"54.32.1.2/32"},
@@ -4711,7 +4713,9 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 	expectedResult := params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
 			{
-				Addresses: []params.InterfaceAddress{},
+				Addresses: []params.InterfaceAddress{
+					{Address: "10.0.0.1"},
+				},
 			},
 		},
 		EgressSubnets:    []string{"54.32.1.2/32"},

--- a/state/unit.go
+++ b/state/unit.go
@@ -1161,7 +1161,11 @@ func (u *Unit) PublicAddress() (corenetwork.SpaceAddress, error) {
 // PrivateAddress returns the private address of the unit.
 func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
 	if !u.ShouldBeAssigned() {
-		return u.scopedAddress("private")
+		addr, err := u.scopedAddress("private")
+		if network.IsNoAddressError(err) {
+			return u.containerAddress()
+		}
+		return addr, errors.Trace(err)
 	}
 	m, err := u.machine()
 	if err != nil {
@@ -1171,41 +1175,25 @@ func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
 	return m.PrivateAddress()
 }
 
-func (u *Unit) scopedAddress(scope string) (corenetwork.SpaceAddress, error) {
-	addr, err := u.serviceAddress(scope)
-	if err == nil {
-		return addr, nil
-	}
-	if network.IsNoAddressError(err) {
-		return u.containerAddress()
-	}
-	return corenetwork.SpaceAddress{}, errors.Trace(err)
-}
-
 // AllAddresses returns the public and private addresses
 // plus the container address of the unit (if known).
 // Only relevant for CAAS models - will return an empty
 // slice for IAAS models.
 func (u *Unit) AllAddresses() (addrs corenetwork.SpaceAddresses, _ error) {
 	if u.ShouldBeAssigned() {
-		return nil, nil
+		return addrs, nil
 	}
 
 	// First the addresses of the service.
-	app, err := u.Application()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	serviceInfo, err := app.ServiceInfo()
+	serviceAddrs, err := u.serviceAddresses()
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
 	if err == nil {
-		addrs = append(addrs, serviceInfo.Addresses()...)
+		addrs = append(addrs, serviceAddrs...)
 	}
 
-	// If there's no service deployed then it's ok
-	// to fallback to the container address.
+	// Then the container address.
 	containerAddr, err := u.containerAddress()
 	if network.IsNoAddressError(err) {
 		return addrs, nil
@@ -1215,6 +1203,20 @@ func (u *Unit) AllAddresses() (addrs corenetwork.SpaceAddresses, _ error) {
 	}
 	addrs = append(addrs, containerAddr)
 	return addrs, nil
+}
+
+// serviceAddresses returns the addresses of the service
+// managing the pods in which the unit workload is running.
+func (u *Unit) serviceAddresses() (corenetwork.SpaceAddresses, error) {
+	app, err := u.Application()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	serviceInfo, err := app.ServiceInfo()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return serviceInfo.Addresses(), nil
 }
 
 // containerAddress returns the address of the pod's container.
@@ -1233,9 +1235,7 @@ func (u *Unit) containerAddress() (corenetwork.SpaceAddress, error) {
 	return addr.networkAddress(), nil
 }
 
-// serviceAddress returns the address of the service
-// managing the pods in which the unit workload is running.
-func (u *Unit) serviceAddress(scope string) (corenetwork.SpaceAddress, error) {
+func (u *Unit) scopedAddress(scope string) (corenetwork.SpaceAddress, error) {
 	addresses, err := u.AllAddresses()
 	if err != nil {
 		return corenetwork.SpaceAddress{}, errors.Trace(err)

--- a/state/unit.go
+++ b/state/unit.go
@@ -1186,7 +1186,7 @@ func (u *Unit) scopedAddress(scope string) (corenetwork.SpaceAddress, error) {
 // plus the container address of the unit (if known).
 // Only relevant for CAAS models - will return an empty
 // slice for IAAS models.
-func (u *Unit) AllAddresses() (corenetwork.SpaceAddresses, error) {
+func (u *Unit) AllAddresses() (addrs corenetwork.SpaceAddresses, _ error) {
 	if u.ShouldBeAssigned() {
 		return nil, nil
 	}
@@ -1201,19 +1201,20 @@ func (u *Unit) AllAddresses() (corenetwork.SpaceAddresses, error) {
 		return nil, errors.Trace(err)
 	}
 	if err == nil {
-		return serviceInfo.Addresses(), nil
+		addrs = append(addrs, serviceInfo.Addresses()...)
 	}
 
 	// If there's no service deployed then it's ok
 	// to fallback to the container address.
-	addr, err := u.containerAddress()
+	containerAddr, err := u.containerAddress()
 	if network.IsNoAddressError(err) {
-		return nil, nil
+		return addrs, nil
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return corenetwork.SpaceAddresses{addr}, nil
+	addrs = append(addrs, containerAddr)
+	return addrs, nil
 }
 
 // containerAddress returns the address of the pod's container.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2537,11 +2537,12 @@ func (s *CAASUnitSuite) TestAllAddresses(c *gc.C) {
 	err = s.application.UpdateUnits(&updateUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addr, err := existingUnit.AllAddresses()
+	addrs, err := existingUnit.AllAddresses()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, corenetwork.SpaceAddresses{
+	c.Assert(addrs, jc.DeepEquals, corenetwork.SpaceAddresses{
 		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
 		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.0.0.1", corenetwork.ScopeMachineLocal),
 	})
 }
 


### PR DESCRIPTION

## Description of change

Make `network-get` returns container addresses in binding addresses for `CaaS`;

## QA steps

- deploy mediawiki and mariadb, then relate them;

```bash
$ juju deploy cs:~juju/mariadb-k8s-0 
$ juju deploy cs:~juju/mediawiki-k8s-3
$ juju relate mediawiki-k8s:db mariadb-k8s:server
```

- run `network-get`;

```bash
$ juju run --unit mediawiki-k8s/0 --timeout=30s "network-get db" --operator=false
bind-addresses:
- macaddress: ""
  interfacename: ""
  addresses:
  - hostname: ""
    address: 10.1.26.40
    cidr: ""
egress-subnets:
- 10.152.183.7/32
ingress-addresses:
- 10.152.183.7

$ juju run --unit mariadb-k8s/0 --timeout=30s "network-get server" --operator=false
bind-addresses:
- macaddress: ""
  interfacename: ""
  addresses:
  - hostname: ""
    address: 10.1.26.39
    cidr: ""
egress-subnets:
- 10.152.183.236/32
ingress-addresses:
- 10.152.183.236
```

## Documentation changes

No

## Bug reference

No
