### PR TITLE
List credentials ask-or-tell.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -96,7 +96,7 @@ func NewListCredentialsCommandForTest(
 	testStore jujuclient.ClientStore,
 	personalCloudsFunc func() (map[string]jujucloud.Cloud, error),
 	cloudByNameFunc func(string) (*jujucloud.Cloud, error),
-	apiF func(controllerName string) (ListCredentialsAPI, error),
+	apiF func() (ListCredentialsAPI, error),
 ) *listCredentialsCommand {
 	return &listCredentialsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -58,7 +58,7 @@ will be stored on the controller. It is considered to be controller default.
 
 Recall that when a controller is created a 'default' model is also 
 created. This model will use the controller default credential. 
-To see details of your credentials use "juju show-credentials" command.
+To see details of your credentials use "juju show-credential" command.
 
 When adding a new model, Juju will reuse the controller default credential.
 To add a model that uses a different credential, specify a  credential


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju credentials' command.

* In multi-cloud environment, users are also interested to see what credentials are available to them on the controller. These credentials are now listed first.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only credentials but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Infrequently, users may not want to see both the credentials that are available on the client and the credentials that are available on the controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other part of the list.

* Previous implementation of the output had a pretty coloring for some credentials. Coloring has been removed as it no longer adds clarity to the output - client and controller credentials have been separated into 2 separate tables as per new approach to command output, similar to 'clouds' output.

## Documentation changes

All of the above.
