### PR TITLE
acceptancetests charm version: add test for cwd no git and for relative path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:ac1a99835ea2a5c4efb01e12f65f5dd1d527b96dcdc9e8589722986477296d9a"
+  digest = "1:905fc6c125b45a9822084a4c76f4238b2a42b3c1449b4bcc8e60f0952638ba30"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "b62f496a731efebe602805523347d4f936a6afb7"
+  revision = "c769faf4c30ef9abde1b7a8c32b6404c8167f999"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "b62f496a731efebe602805523347d4f936a6afb7"
+  revision = "c769faf4c30ef9abde1b7a8c32b6404c8167f999"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"

--- a/tests/suites/cli/use_local_charm.sh
+++ b/tests/suites/cli/use_local_charm.sh
@@ -2,21 +2,122 @@
 run_deploy_local_charm_revision() {
   echo
 
-  file="${TEST_DIR}/local-charm-deploy-no-git.txt"
+  file="${TEST_DIR}/local-charm-deploy-git.txt"
 
   ensure "local-charm-deploy" "${file}"
 
-  TMP_NO_GIT=$(mktemp -d -t ci-XXXXXXXXXX)
-  cd "${TMP_NO_GIT}" || exit 1
+  TMP=$(mktemp -d -t ci-XXXXXXXXXX)
 
+  cd "${TMP}" || exit 1
   git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
-  cd "${TMP_NO_GIT}/ntp" || exit 1
+  cd "${TMP}/ntp" || exit 1
+  SHA_OF_NTP=\"$(git describe --dirty --always)\"
 
   OUTPUT=$(juju deploy . 2>&1)
 
+  wait_for "ntp" ".applications | keys[0]"
+  CURRENT_CHARM_SHA=$(juju status --format=json | jq '.applications.ntp."charm-version"')
+
+  # If a error happens it means it could not use the git sha of the CWD
   check_not_contains "${OUTPUT}" "exit status 128"
 
+  if [ "${SHA_OF_NTP}" != "${CURRENT_CHARM_SHA}" ]; then
+    echo "The expected sha does not equal the ntp SHA"
+    exit 1
+  fi
+
   destroy_model "local-charm-deploy"
+}
+
+# Checks the cwd has no vcs
+run_deploy_local_charm_revision_no_vcs() {
+  echo
+
+  file="${TEST_DIR}/local-charm-deploy-no-vcs.txt"
+
+  ensure "local-charm-deploy-no-vcs" "${file}"
+
+  TMP=$(mktemp -d -t ci-XXXXXXXXXX)
+
+  cd "${TMP}" || exit 1
+  git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+  cd "${TMP}/ntp" || exit 1
+  rm -rf .git
+
+  OUTPUT=$(juju deploy --debug . 2>&1)
+
+  check_contains "${OUTPUT}" "charm is not versioned"
+}
+
+# Checks the cwd has no vcs but a version file
+run_deploy_local_charm_revision_no_vcs_but_version_file() {
+  echo
+
+  file="${TEST_DIR}/local-charm-deploy-version-file.txt"
+
+  ensure "local-charm-deploy-version-file" "${file}"
+
+  TMP=$(mktemp -d -t ci-XXXXXXXXXX)
+
+  cd "${TMP}" || exit 1
+  git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+  cd "${TMP}/ntp" || exit 1
+  rm -rf .git
+  touch version
+  echo 123 >version
+  VERSION_OUTPUT=\""$(cat version)"\"
+
+  DEPLOY_OUTPUT=$(juju deploy --debug . 2>&1)
+
+  wait_for "ntp" ".applications | keys[0]"
+  CURRENT_CHARM_SHA=$(juju status --format=json | jq '.applications.ntp."charm-version"')
+
+  check_contains "${DEPLOY_OUTPUT}" "charm is not in version control and uses a version file"
+
+  if [ "${VERSION_OUTPUT}" != "${CURRENT_CHARM_SHA}" ]; then
+    echo "The expected sha does not equal the ntp SHA. Current sha: ${CURRENT_CHARM_SHA} expected sha: ${VERSION_OUTPUT}"
+    exit 1
+  fi
+}
+
+# Checks whether the cwd is used for the juju local deploy.
+run_deploy_local_charm_revision_relative_path() {
+  echo
+
+  file="${TEST_DIR}/local-charm-deploy-relative-path.txt"
+
+  ensure "relative-path" "${file}"
+
+  TMP=$(mktemp -d -t ci-XXXXXXXXXX)
+
+  cd "${TMP}" || exit 1
+  create_local_git_folder
+  SHA_OF_TMP=\"$(git describe --dirty --always)\"
+  # create ${TMP}/ntp git folder
+  git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+
+  # state: ${TMP} is wrong git ${TMP}/ntp is correct git
+  juju deploy ./ntp 2>&1
+
+  cd "${TMP}/ntp" || exit 1
+  SHA_OF_NTP=\"$(git describe --dirty --always)\"
+
+  wait_for "ntp" ".applications | keys[0]"
+
+  # We still expect the SHA to be the one from the place we deploy and not the CWD, which in this case has no SHA
+  CURRENT_CHARM_SHA=$(juju status --format=json | jq '.applications.ntp."charm-version"')
+
+  if [ "${SHA_OF_TMP}" = "${CURRENT_CHARM_SHA}" ]; then
+    echo "The expected sha should not equal the tmp SHA. Current sha: ${CURRENT_CHARM_SHA}"
+    exit 1
+  fi
+
+  if [ "${SHA_OF_NTP}" != "${CURRENT_CHARM_SHA}" ]; then
+    echo "The expected sha does not equal the ntp SHA. Current sha: ${CURRENT_CHARM_SHA} expected sha: ${SHA_OF_NTP}"
+    exit 1
+  fi
+
+  destroy_model "relative-path"
 }
 
 # CWD with git, deploy charm with git, but -> check that git describe is correct
@@ -24,11 +125,10 @@ run_deploy_local_charm_revision_invalid_git() {
   echo
 
   file="${TEST_DIR}/local-charm-deploy-wrong-git.txt"
-
   ensure "local-charm-deploy-wrong-git" "${file}"
 
   TMP_CHARM_GIT=$(mktemp -d -t ci-XXXXXXXXXX)
-  TMP_NO_CHARM_GIT=$(mktemp -d -t ci-XXXXXXXXXX)
+  TMP=$(mktemp -d -t ci-XXXXXXXXXX)
 
   cd "${TMP_CHARM_GIT}" || exit 1
   git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
@@ -36,17 +136,18 @@ run_deploy_local_charm_revision_invalid_git() {
   cd "${TMP_CHARM_GIT}/ntp" || exit 1
   WANTED_CHARM_SHA=\"$(git describe --dirty --always)\"
 
-  cd "${TMP_NO_CHARM_GIT}" || exit 1
+  # We cd into a folder without git and deploy from the folder without git.
+  cd "${TMP}" || exit 1
 
   create_local_git_folder
 
   juju deploy "${TMP_CHARM_GIT}"/ntp ntp
 
   wait_for "ntp" ".applications | keys[0]"
-
+  # We still expect the SHA to be the one from the place we deploy and not the CWD, which in this case has no SHA
   CURRENT_CHARM_SHA=$(juju status --format=json | jq '.applications.ntp."charm-version"')
   if [ "${WANTED_CHARM_SHA}" != "${CURRENT_CHARM_SHA}" ]; then
-    echo "The expected sha does not equal the current SHA"
+    echo "The expected sha does not equal the ntp SHA. Current sha: ${CURRENT_CHARM_SHA} expected sha: ${WANTED_CHARM_SHA}"
     exit 1
   fi
 
@@ -61,17 +162,20 @@ create_local_git_folder() {
 }
 
 test_local_charms() {
-    if [ "$(skip 'test_local_charms')" ]; then
-        echo "==> TEST SKIPPED: deploy local charm tests"
-        return
-    fi
+  if [ "$(skip 'test_local_charms')" ]; then
+    echo "==> TEST SKIPPED: deploy local charm tests"
+    return
+  fi
 
-    (
-        set_verbosity
+  (
+    set_verbosity
 
-        cd .. || exit
+    cd .. || exit
 
-        run "run_deploy_local_charm_revision"
-        run "run_deploy_local_charm_revision_invalid_git"
-    )
+    run "run_deploy_local_charm_revision"
+    run "run_deploy_local_charm_revision_no_vcs"
+    run "run_deploy_local_charm_revision_no_vcs_but_version_file"
+    run "run_deploy_local_charm_revision_relative_path"
+    run "run_deploy_local_charm_revision_invalid_git"
+  )
 }


### PR DESCRIPTION
## Tests still needed to be added
[x] local charm with version file

## Related CHARM PR 
https://github.com/juju/charm/pull/294

## Description of change
add test for cwd no git and for relative path

If the charm folder does not contain git it will do the following:
```
else {
		logger.Debugf("charm is not in revision control directory")
		// Return empty string.
		return "", "", nil <--- which corresponds to the charm version 
	}
```
## QA steps

run the acceptance tests

## Bug reference

https://bugs.launchpad.net/juju/+bug/1848149 

regarding this bug we would need to make further changes as currently a file with a "version" does not get parsed correctly (not at all). The current acceptancetests should add some confidence to the cases except the one I just mentioned. 

Another separate PR should add the fix + another acceptancetest

