### PR TITLE
'show-cloud' ask-or-tell and exclusivity.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -55,10 +55,9 @@ func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (L
 	}
 }
 
-func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (showCloudAPI, error)) *showCloudCommand {
+func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (showCloudAPI, error)) *showCloudCommand {
 	return &showCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		store:                     store,
 		showCloudAPIFunc:          cloudAPI,
 	}
 }

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -50,7 +50,7 @@ Use --controller option to show a cloud from a different controller.
 
 Use --client-only option to only show a cloud known locally on this client.
 
-Use --controller-only option to only show a cloud known remotely on the controller.
+Use --controller-only option to only show a cloud known on the controller.
 
 Examples:
 
@@ -172,7 +172,7 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 				ctxt.Warningf("%v", remoteErr)
 				displayErr = cmd.ErrSilent
 			} else {
-				ctxt.Infof("No cloud %q exists remotely on the controller.", c.CloudName)
+				ctxt.Infof("No cloud %q exists on the controller.", c.CloudName)
 			}
 		}
 	}

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -17,7 +17,6 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -29,10 +28,9 @@ type showCloudCommand struct {
 
 	includeConfig bool
 
-	// Used when querying a controller for its cloud details
-	controllerName   string
-	store            jujuclient.ClientStore
-	showCloudAPIFunc func(controllerName string) (showCloudAPI, error)
+	showCloudAPIFunc func() (showCloudAPI, error)
+
+	configDisplayed bool
 }
 
 var showCloudDoc = `
@@ -43,19 +41,29 @@ options.
 If ‘--include-config’ is used, additional configuration (key, type, and
 description) specific to the cloud are displayed if available.
 
-The current controller is used unless the --controller option is specified.
-If --client-only is specified, Juju shows the cloud from this client.
+If the current controller can be detected, a user will be prompted to 
+confirm if a cloud known to the controller need to be shown as well. 
+If the prompt is not needed and the cloud from current controller is
+always to be shown, use --no-prompt option.
+
+Use --controller option to show a cloud from a different controller.
+
+Use --client-only option to only show a cloud known locally on this client.
+
+Use --controller-only option to only show a cloud known remotely on the controller.
 
 Examples:
 
     juju show-cloud google
     juju show-cloud azure-china --output ~/azure_cloud_details.txt
-    juju show-cloud myopenstack --controller mycontroller
+    juju show-cloud myopenstack --controller mycontroller --controller-only
     juju show-cloud myopenstack --client-only
+    juju show-cloud myopenstack --no-prompt
 
 See also:
     clouds
-    update-clouds
+    add-cloud
+    update-cloud
 `
 
 type showCloudAPI interface {
@@ -68,16 +76,15 @@ func NewShowCloudCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &showCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store:       store,
-			EnabledFlag: feature.MultiCloud,
+			Store: store,
 		},
 	}
 	c.showCloudAPIFunc = c.cloudAPI
 	return modelcmd.WrapBase(c)
 }
 
-func (c *showCloudCommand) cloudAPI(controllerName string) (showCloudAPI, error) {
-	root, err := c.NewAPIRoot(c.store, controllerName, "")
+func (c *showCloudCommand) cloudAPI() (showCloudAPI, error) {
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -103,11 +110,6 @@ func (c *showCloudCommand) Init(args []string) error {
 	default:
 		return errors.New("no cloud specified")
 	}
-	var err error
-	c.ControllerName, err = c.ControllerNameFromArg()
-	if err != nil {
-		return errors.Wrap(err, errors.New(err.Error()+"\nUse --client-only to query this client."))
-	}
 	return cmd.CheckEmpty(args[1:])
 }
 
@@ -115,44 +117,124 @@ func (c *showCloudCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "show-cloud",
 		Args:    "<cloud name>",
-		Purpose: "Shows detailed information on a cloud.",
+		Purpose: "Shows detailed information for a cloud.",
 		Doc:     showCloudDoc,
 	})
 }
 
 func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 	var (
-		cloud *CloudDetails
-		err   error
+		localCloud *CloudDetails
+		localErr   error
 	)
-	if c.ControllerName == "" {
-		cloud, err = c.getLocalCloud()
-	} else {
-		cloud, err = c.getControllerCloud()
-	}
-	if err != nil {
-		return err
+	if c.BothClientAndController || c.ClientOnly {
+		if localCloud, localErr = c.getLocalCloud(); c.ClientOnly && localErr != nil {
+			return localErr
+		}
 	}
 
-	displayCloud := cloud
-	displayCloud.CloudType = displayCloudType(displayCloud.CloudType)
-	if err := c.out.Write(ctxt, displayCloud); err != nil {
+	var (
+		remoteCloud *CloudDetails
+		remoteErr   error
+	)
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName == "" {
+			// The user may have specified the controller via a --controller option.
+			// If not, let's see if there is a current controller that can be detected.
+			c.ControllerName, remoteErr = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("show cloud %q from", c.CloudName))
+		}
+		if c.ControllerName == "" && remoteErr == nil {
+			remoteErr = errors.New("Not showing a cloud from a controller: no controller specified.")
+		}
+		if remoteErr == nil {
+			remoteCloud, remoteErr = c.getControllerCloud()
+		}
+	}
+
+	var displayErr error
+	showRemoteConfig := c.includeConfig
+	if localCloud != nil && remoteCloud != nil {
+		// It's possible that a local cloud named A is different to
+		// a remote cloud named A. If their types are different and we
+		// need to display config, we'd need to list each cloud type config.
+		// If the clouds' types are the same, we only need to list
+		// config once after the local cloud information.
+		showRemoteConfig = showRemoteConfig && localCloud.CloudType != remoteCloud.CloudType
+	}
+	if c.BothClientAndController || c.ControllerOnly {
+		if remoteCloud != nil {
+			if err := c.displayCloud(ctxt, remoteCloud, fmt.Sprintf("Cloud %q from controller %q:\n", c.CloudName, c.ControllerName), showRemoteConfig, remoteErr); err != nil {
+				ctxt.Warningf("%v", err)
+				displayErr = cmd.ErrSilent
+			}
+		} else {
+			if remoteErr != nil {
+				ctxt.Warningf("%v", remoteErr)
+				displayErr = cmd.ErrSilent
+			} else {
+				ctxt.Infof("No cloud %q exists remotely on the controller.", c.CloudName)
+			}
+		}
+	}
+	if c.BothClientAndController || c.ClientOnly {
+		if localCloud != nil {
+			if err := c.displayCloud(ctxt, localCloud, fmt.Sprintf("\nClient cloud %q:\n", c.CloudName), c.includeConfig, localErr); err != nil {
+				ctxt.Warningf("%v", err)
+				displayErr = cmd.ErrSilent
+			}
+		} else {
+			if localErr != nil {
+				ctxt.Warningf("%v", localErr)
+				displayErr = cmd.ErrSilent
+			} else {
+				ctxt.Infof("No cloud %q exists locally on this client.", c.CloudName)
+			}
+		}
+	}
+
+	// It's possible that a config was desired but was not display because the
+	// remote cloud erred out.
+	if c.includeConfig && !c.configDisplayed && localErr == nil {
+		if err := c.displayConfig(ctxt, localCloud.CloudType); err != nil {
+			ctxt.Warningf("%v", err)
+			displayErr = cmd.ErrSilent
+		}
+	}
+
+	return displayErr
+}
+
+func (c *showCloudCommand) displayCloud(ctxt *cmd.Context, aCloud *CloudDetails, msg string, includeConfig bool, cloudErr error) error {
+	if cloudErr != nil {
+		return cloudErr
+	}
+	fmt.Fprintln(ctxt.Stdout, msg)
+	aCloud.CloudType = displayCloudType(aCloud.CloudType)
+	if err := c.out.Write(ctxt, aCloud); err != nil {
 		return err
 	}
-	if c.includeConfig {
-		config := getCloudConfigDetails(cloud.CloudType)
-		if len(config) > 0 {
-			fmt.Fprintln(
-				ctxt.Stdout,
-				fmt.Sprintf("\nThe available config options specific to %s clouds are:", displayCloud.CloudType))
-			return c.out.Write(ctxt, config)
+	if includeConfig {
+		return c.displayConfig(ctxt, aCloud.CloudType)
+	}
+	return nil
+}
+
+func (c *showCloudCommand) displayConfig(ctxt *cmd.Context, cloudType string) error {
+	config := getCloudConfigDetails(cloudType)
+	if len(config) > 0 {
+		fmt.Fprintln(
+			ctxt.Stdout,
+			fmt.Sprintf("\nThe available config options specific to %s clouds are:", cloudType))
+		if err := c.out.Write(ctxt, config); err != nil {
+			return err
 		}
+		c.configDisplayed = true
 	}
 	return nil
 }
 
 func (c *showCloudCommand) getControllerCloud() (*CloudDetails, error) {
-	api, err := c.showCloudAPIFunc(c.ControllerName)
+	api, err := c.showCloudAPIFunc()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -48,7 +48,7 @@ always to be shown, use --no-prompt option.
 
 Use --controller option to show a cloud from a different controller.
 
-Use --client-only option to only show a cloud known locally on this client.
+Use --client-only option to only show a cloud known on this client.
 
 Use --controller-only option to only show a cloud known on the controller.
 
@@ -187,7 +187,7 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 				ctxt.Warningf("%v", localErr)
 				displayErr = cmd.ErrSilent
 			} else {
-				ctxt.Infof("No cloud %q exists locally on this client.", c.CloudName)
+				ctxt.Infof("No cloud %q exists on this client.", c.CloudName)
 			}
 		}
 	}

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -44,13 +45,13 @@ func (s *showSuite) TestShowBadArgs(c *gc.C) {
 }
 
 func (s *showSuite) assertShowLocal(c *gc.C, expectedOutput string) {
-	cmd := cloud.NewShowCloudCommandForTest(
+	command := cloud.NewShowCloudCommandForTest(
 		s.store,
-		func(controllerName string) (cloud.ShowCloudAPI, error) {
+		func() (cloud.ShowCloudAPI, error) {
 			c.Fail()
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "aws-china", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, command, "aws-china", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, expectedOutput)
@@ -58,6 +59,9 @@ func (s *showSuite) assertShowLocal(c *gc.C, expectedOutput string) {
 
 func (s *showSuite) TestShowLocal(c *gc.C) {
 	s.assertShowLocal(c, `
+
+Client cloud "aws-china":
+
 defined: public
 type: ec2
 description: Amazon China
@@ -73,6 +77,9 @@ regions:
 func (s *showSuite) TestShowLocalWithDefaultCloud(c *gc.C) {
 	s.store.Credentials["aws-china"] = jujucloud.CloudCredential{DefaultRegion: "cn-north-1"}
 	s.assertShowLocal(c, `
+
+Client cloud "aws-china":
+
 defined: public
 type: ec2
 description: Amazon China
@@ -87,7 +94,6 @@ regions:
 }
 
 func (s *showSuite) TestShowKubernetes(c *gc.C) {
-	var controllerAPICalled string
 	s.api.cloud = jujucloud.Cloud{
 		Name:        "beehive",
 		Type:        "kubernetes",
@@ -101,18 +107,19 @@ func (s *showSuite) TestShowKubernetes(c *gc.C) {
 			},
 		},
 	}
-	cmd := cloud.NewShowCloudCommandForTest(
+	command := cloud.NewShowCloudCommandForTest(
 		s.store,
-		func(controllerName string) (cloud.ShowCloudAPI, error) {
-			controllerAPICalled = controllerName
+		func() (cloud.ShowCloudAPI, error) {
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "beehive")
-	c.Assert(err, jc.ErrorIsNil)
+	ctx, err := cmdtesting.RunCommand(c, command, "--controller", "mycontroller", "beehive")
+	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
 	s.api.CheckCallNames(c, "Cloud", "Close")
-	c.Assert(controllerAPICalled, gc.Equals, "mycontroller")
+	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
+Cloud "beehive" from controller "mycontroller":
+
 defined: public
 type: k8s
 description: Bumble Bees
@@ -124,10 +131,9 @@ regions:
 `[1:])
 }
 
-func (s *showSuite) TestShowControllerCloud(c *gc.C) {
-	var controllerAPICalled string
+func (s *showSuite) setupRemoteCloud(cloudName string) {
 	s.api.cloud = jujucloud.Cloud{
-		Name:        "beehive",
+		Name:        cloudName,
 		Type:        "openstack",
 		Description: "Bumble Bees",
 		AuthTypes:   []jujucloud.AuthType{"userpass", "access-key"},
@@ -139,18 +145,23 @@ func (s *showSuite) TestShowControllerCloud(c *gc.C) {
 			},
 		},
 	}
-	cmd := cloud.NewShowCloudCommandForTest(
+}
+
+func (s *showSuite) TestShowControllerCloudNoLocal(c *gc.C) {
+	s.setupRemoteCloud("beehive")
+	command := cloud.NewShowCloudCommandForTest(
 		s.store,
-		func(controllerName string) (cloud.ShowCloudAPI, error) {
-			controllerAPICalled = controllerName
+		func() (cloud.ShowCloudAPI, error) {
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "beehive")
-	c.Assert(err, jc.ErrorIsNil)
+	ctx, err := cmdtesting.RunCommand(c, command, "beehive", "--no-prompt")
+	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
 	s.api.CheckCallNames(c, "Cloud", "Close")
-	c.Assert(controllerAPICalled, gc.Equals, "mycontroller")
+	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
+Cloud "beehive" from controller "mycontroller":
+
 defined: public
 type: openstack
 description: Bumble Bees
@@ -159,6 +170,44 @@ endpoint: http://myopenstack
 regions:
   regionone:
     endpoint: http://boston/1.0
+`[1:])
+}
+
+func (s *showSuite) TestShowControllerAndLocalCloud(c *gc.C) {
+	s.setupRemoteCloud("aws-china")
+	command := cloud.NewShowCloudCommandForTest(
+		s.store,
+		func() (cloud.ShowCloudAPI, error) {
+			return s.api, nil
+		})
+	ctx, err := cmdtesting.RunCommand(c, command, "aws-china", "--no-prompt")
+	c.Assert(err, jc.ErrorIsNil)
+	s.api.CheckCallNames(c, "Cloud", "Close")
+	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, `
+Cloud "aws-china" from controller "mycontroller":
+
+defined: public
+type: openstack
+description: Bumble Bees
+auth-types: [userpass, access-key]
+endpoint: http://myopenstack
+regions:
+  regionone:
+    endpoint: http://boston/1.0
+
+Client cloud "aws-china":
+
+defined: public
+type: ec2
+description: Amazon China
+auth-types: [access-key]
+regions:
+  cn-north-1:
+    endpoint: https://ec2.cn-north-1.amazonaws.com.cn
+  cn-northwest-1:
+    endpoint: https://ec2.cn-northwest-1.amazonaws.com.cn
 `[1:])
 }
 
@@ -183,6 +232,9 @@ clouds:
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
+
+Client cloud "homestack":
+
 defined: local
 type: openstack
 description: Openstack Cloud
@@ -248,7 +300,11 @@ clouds:
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, strings.Join([]string{`defined: local
+	c.Assert(out, gc.Equals, strings.Join([]string{`
+
+Client cloud "homestack":
+
+defined: local
 type: openstack
 description: Openstack Cloud
 auth-types: [userpass, access-key]
@@ -263,7 +319,7 @@ region-config:
   london:
     bootstrap-timeout: 1800
     use-floating-ip: true
-`, openstackProviderConfig}, ""))
+`[1:], openstackProviderConfig}, ""))
 }
 
 func (s *showSuite) TestShowWithRegionConfigAndFlagNoExtraOut(c *gc.C) {
@@ -271,6 +327,9 @@ func (s *showSuite) TestShowWithRegionConfigAndFlagNoExtraOut(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
+
+Client cloud "joyent":
+
 defined: public
 type: joyent
 description: Joyent Cloud
@@ -323,6 +382,9 @@ clouds:
 `[1:]
 
 var resultWithCert = `
+
+Client cloud "homestack":
+
 defined: local
 type: openstack
 description: Openstack Cloud


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju show-cloud' command.

* In multi-cloud environment, users are interested to see details of the clouds from the controller as well as the client. The details of the clouds from the controller are now listed first.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only cloud details but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Occasionally, users may not want to see both the cloud details from the client and the cloud details from the controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

## Documentation changes

All of the above.
