### PR TITLE
'show-credential' ask-or-tell and exclusivity.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -176,7 +176,7 @@ func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api Cre
 
 func NewShowCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialContentAPI) cmd.Command {
 	command := &showCredentialCommand{
-		store: testStore,
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore},
 		newAPIFunc: func() (CredentialContentAPI, error) {
 			return api, nil
 		},

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -209,8 +209,8 @@ type NamedCredentials map[string]CredentialDetails
 type CloudCredentials map[string]NamedCredentials
 
 type ControllerCredentials struct {
-	Controller CloudCredentials `yaml:"controller-credentials"`
-	Client     CloudCredentials `yaml:"client-credentials"`
+	Controller CloudCredentials `yaml:"controller-credentials,omitempty"`
+	Client     CloudCredentials `yaml:"client-credentials,omitempty"`
 }
 
 func (c *showCredentialCommand) parseContents(ctxt *cmd.Context, in []params.CredentialContentResult) CloudCredentials {

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -209,8 +209,8 @@ type NamedCredentials map[string]CredentialDetails
 type CloudCredentials map[string]NamedCredentials
 
 type ControllerCredentials struct {
-	Client     CloudCredentials `yaml:"client-credentials"`
 	Controller CloudCredentials `yaml:"controller-credentials"`
+	Client     CloudCredentials `yaml:"client-credentials"`
 }
 
 func (c *showCredentialCommand) parseContents(ctxt *cmd.Context, in []params.CredentialContentResult) CloudCredentials {

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -4,6 +4,8 @@
 package cloud
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -18,8 +20,7 @@ import (
 )
 
 type showCredentialCommand struct {
-	modelcmd.CommandBase
-	store jujuclient.ClientStore
+	modelcmd.OptionalControllerCommand
 
 	out cmd.Output
 
@@ -29,46 +30,35 @@ type showCredentialCommand struct {
 	CredentialName string
 
 	ShowSecrets bool
-	// Local stores whether a client side (aka local) copy is requested.
-	Local bool
-
-	// ClientOnly stores whether the command will ONLY operate on a client copy
-	// without affecting controller copy.
-	ClientOnly bool
-
-	// ControllerOnly stores whether the command will ONLY operate on a controller copy
-	// without affecting client copy.
-	ControllerOnly bool
 }
 
 // NewShowCredentialCommand returns a command to show information about
 // credentials stored on the controller.
 func NewShowCredentialCommand() cmd.Command {
-	cmd := &showCredentialCommand{
-		store: jujuclient.NewFileClientStore(),
+	store := jujuclient.NewFileClientStore()
+	command := &showCredentialCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store: store,
+		},
 	}
-	cmd.newAPIFunc = func() (CredentialContentAPI, error) {
-		return cmd.NewCredentialAPI()
+	command.newAPIFunc = func() (CredentialContentAPI, error) {
+		return command.NewCredentialAPI()
 	}
-	return modelcmd.WrapBase(cmd)
+	return modelcmd.WrapBase(command)
 }
 
 func (c *showCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.CommandBase.SetFlags(f)
+	c.OptionalControllerCommand.SetFlags(f)
 	// We only support yaml for display purposes.
 	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
 		"yaml": cmd.FormatYaml,
 	})
 	f.BoolVar(&c.ShowSecrets, "show-secrets", false, "Display credential secret attributes")
-	f.BoolVar(&c.ClientOnly, "client-only", false, "Client operation only; controller not affected")
-	f.BoolVar(&c.ControllerOnly, "controller-only", false, "Controller operation only; client not affected")
-	// TODO (juju3) remove me
-	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client-only): Local operation only; controller not affected")
 }
 
 func (c *showCredentialCommand) Init(args []string) error {
-	if c.Local && !c.ClientOnly {
-		c.ClientOnly = c.Local
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
 	}
 	switch len(args) {
 	case 0:
@@ -96,28 +86,44 @@ func (c *showCredentialCommand) Info() *cmd.Info {
 }
 
 func (c *showCredentialCommand) Run(ctxt *cmd.Context) error {
-	result, err := c.localCredentials(ctxt)
-	if err != nil {
-		ctxt.Infof("local credential content lookup failed: %v", err)
+	all := ControllerCredentials{}
+	if c.BothClientAndController || c.ClientOnly {
+		result, err := c.localCredentials(ctxt)
+		if err != nil {
+			ctxt.Infof("client credential content lookup failed: %v", err)
+		} else {
+			all.Client = c.parseContents(ctxt, result)
+		}
 	}
-	all := ControllerCredentials{Local: c.parseContents(ctxt, result)}
-	if c.ClientOnly {
-		return c.out.Write(ctxt, all)
+	if c.BothClientAndController || c.ControllerOnly {
+		remoteContents, err := c.remoteCredentials(ctxt)
+		if err != nil {
+			ctxt.Infof("credential content lookup on the controller failed: %v", err)
+		} else {
+			all.Controller = c.parseContents(ctxt, remoteContents)
+		}
 	}
-
-	remoteContents, err := c.remoteCredentials()
-	if err != nil {
-		ctxt.Infof("remote credential content lookup failed: %v", err)
-	}
-	all.Controller = c.parseContents(ctxt, remoteContents)
-	if len(all.Local) == 0 && len(all.Controller) == 0 {
+	if len(all.Client) == 0 && len(all.Controller) == 0 {
 		ctxt.Infof("No credentials from this client or from a controller to display.")
 		return nil
 	}
 	return c.out.Write(ctxt, all)
 }
 
-func (c *showCredentialCommand) remoteCredentials() ([]params.CredentialContentResult, error) {
+func (c *showCredentialCommand) remoteCredentials(ctxt *cmd.Context) ([]params.CredentialContentResult, error) {
+	if c.ControllerName == "" {
+		// The user may have specified the controller via a --controller option.
+		// If not, let's see if there is a current controller that can be detected.
+		var err error
+		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("show credential %q for cloud %q from", c.CredentialName, c.CloudName))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	if c.ControllerName == "" {
+		return nil, errors.Errorf("Not showing credential %q for cloud %q from a controller: no controller specified.", c.CredentialName, c.CloudName)
+	}
+
 	client, err := c.newAPIFunc()
 	if err != nil {
 		return nil, err
@@ -126,7 +132,7 @@ func (c *showCredentialCommand) remoteCredentials() ([]params.CredentialContentR
 	defer client.Close()
 
 	if v := client.BestAPIVersion(); v < 2 {
-		return nil, errors.NotSupportedf("remote credential content lookup in Juju v%d", v)
+		return nil, errors.NotSupportedf("credential content lookup on the controller in Juju v%d", v)
 	}
 	remoteContents, err := client.CredentialContents(c.CloudName, c.CredentialName, c.ShowSecrets)
 	if err != nil {
@@ -136,7 +142,7 @@ func (c *showCredentialCommand) remoteCredentials() ([]params.CredentialContentR
 }
 
 func (c *showCredentialCommand) localCredentials(ctxt *cmd.Context) ([]params.CredentialContentResult, error) {
-	locals, err := credentialsFromLocalCache(c.store, c.CloudName, c.CredentialName)
+	locals, err := credentialsFromLocalCache(c.Store, c.CloudName, c.CredentialName)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +150,7 @@ func (c *showCredentialCommand) localCredentials(ctxt *cmd.Context) ([]params.Cr
 	if c.CloudName != "" {
 		_, ok := locals[c.CloudName]
 		if !ok {
-			return nil, errors.NotFoundf("locally stored credentials for cloud %q", c.CloudName)
+			return nil, errors.NotFoundf("client credentials for cloud %q", c.CloudName)
 		}
 	}
 
@@ -180,14 +186,7 @@ type CredentialContentAPI interface {
 }
 
 func (c *showCredentialCommand) NewCredentialAPI() (CredentialContentAPI, error) {
-	currentController, err := modelcmd.DetermineCurrentController(c.store)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, errors.New("there is no active controller")
-		}
-		return nil, errors.Trace(err)
-	}
-	api, err := c.NewAPIRoot(c.store, currentController, "")
+	api, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Annotate(err, "opening API connection")
 	}
@@ -210,7 +209,7 @@ type NamedCredentials map[string]CredentialDetails
 type CloudCredentials map[string]NamedCredentials
 
 type ControllerCredentials struct {
-	Local      CloudCredentials `yaml:"local-credentials"`
+	Client     CloudCredentials `yaml:"client-credentials"`
 	Controller CloudCredentials `yaml:"controller-credentials"`
 }
 
@@ -268,13 +267,27 @@ To see secrets, content attributes marked as hidden, use --show-secrets option.
 
 To see only credentials from this client, use "--client-only" option.
 
+To see only credentials from a controller, use "--controller-only" option.
+
+If the current controller can be detected, a user will be prompted to 
+confirm if a credential known to the controller need to be shown as well. 
+If the prompt is not needed and the credential from current controller is
+always to be shown, use --no-prompt option.
+
+Use --controller option to show a credential from a different controller.
+
 Examples:
 
     juju show-credential google my-admin-credential
     juju show-credentials 
+    juju show-credentials --controller mycontroller --controller-only 
     juju show-credentials --client-only
     juju show-credentials --show-secrets
 
 See also: 
     credentials
+    add-credential
+    update-credential
+    remove-credential
+    autoload-credentials
 `

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -133,7 +133,6 @@ func (s *ShowCredentialSuite) TestShowCredentialOne(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ``)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-client-credentials: {}
 controller-credentials:
   aws:
     credential-name:
@@ -146,6 +145,7 @@ controller-credentials:
         abcmodel: admin
         no-access-model: no access
         xyzmodel: read
+client-credentials: {}
 `[1:])
 	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
 	c.Assert(s.api.inclsecrets, jc.IsTrue)
@@ -206,11 +206,10 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt", "--controller-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "boom\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-client-credentials: {}
 controller-credentials:
   cloud-name:
     one:

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -73,10 +73,10 @@ func (s *ShowCredentialSuite) TestShowCredentialBadArgs(c *gc.C) {
 func (s *ShowCredentialSuite) TestShowCredentialAPIVersion(c *gc.C) {
 	s.api.v = 1
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-remote credential content lookup failed: remote credential content lookup in Juju v1 not supported
+credential content lookup on the controller failed: credential content lookup on the controller in Juju v1 not supported
 No credentials from this client or from a controller to display.
 `[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
@@ -86,10 +86,10 @@ No credentials from this client or from a controller to display.
 func (s *ShowCredentialSuite) TestShowCredentialAPICallError(c *gc.C) {
 	s.api.SetErrors(errors.New("boom"), nil)
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-remote credential content lookup failed: boom
+credential content lookup on the controller failed: boom
 No credentials from this client or from a controller to display.
 `[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
@@ -99,7 +99,7 @@ No credentials from this client or from a controller to display.
 func (s *ShowCredentialSuite) TestShowCredentialNone(c *gc.C) {
 	s.api.contents = []params.CredentialContentResult{}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No credentials from this client or from a controller to display.\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
@@ -129,11 +129,11 @@ func (s *ShowCredentialSuite) TestShowCredentialOne(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ``)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-local-credentials: {}
+client-credentials: {}
 controller-credentials:
   aws:
     credential-name:
@@ -206,11 +206,11 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd)
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "boom\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-local-credentials: {}
+client-credentials: {}
 controller-credentials:
   cloud-name:
     one:

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -106,8 +106,9 @@ func (s *ShowCredentialSuite) TestShowCredentialNone(c *gc.C) {
 	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
 }
 
-func (s *ShowCredentialSuite) TestShowCredentialOne(c *gc.C) {
+func (s *ShowCredentialSuite) TestShowCredentialBothClientAndController(c *gc.C) {
 	_true := true
+	s.putCredentialsInStore(c)
 	s.api.contents = []params.CredentialContentResult{
 		{
 			Result: &params.ControllerCredentialInfo{
@@ -145,13 +146,31 @@ controller-credentials:
         abcmodel: admin
         no-access-model: no access
         xyzmodel: read
-client-credentials: {}
+client-credentials:
+  aws:
+    my-credential:
+      content:
+        auth-type: access-key
+        access-key: key
+        secret-key: secret
+  somecloud:
+    its-another-credential:
+      content:
+        auth-type: access-key
+        access-key: key
+        secret-key: secret
+    its-credential:
+      content:
+        auth-type: access-key
+        access-key: key
+        secret-key: secret
 `[1:])
 	s.api.CheckCallNames(c, "BestAPIVersion", "CredentialContents", "Close")
 	c.Assert(s.api.inclsecrets, jc.IsTrue)
 }
 
 func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
+	s.putCredentialsInStore(c)
 	_true := true
 	_false := false
 	s.api.contents = []params.CredentialContentResult{

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -197,14 +197,12 @@ controller-credentials:
         username: dummy
       models:
         controller: admin
-client-credentials: {}
 `[1:])
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
 	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets", "--no-prompt", "--controller-only")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "client credential content lookup failed: loading credentials: credentials for cloud dummy not found\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 controller-credentials:
   dummy:

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -188,7 +188,6 @@ func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-client-credentials: {}
 controller-credentials:
   dummy:
     cred:
@@ -198,15 +197,15 @@ controller-credentials:
         username: dummy
       models:
         controller: admin
+client-credentials: {}
 `[1:])
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
-	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets", "--no-prompt")
+	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets", "--no-prompt", "--controller-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "client credential content lookup failed: loading credentials: credentials for cloud dummy not found\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-client-credentials: {}
 controller-credentials:
   dummy:
     cred:

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -184,11 +184,11 @@ Changed cloud credential on model "controller" to "newcred".
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
-	ctx, err := s.run(c, "show-credential")
+	ctx, err := s.run(c, "show-credential", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-local-credentials: {}
+client-credentials: {}
 controller-credentials:
   dummy:
     cred:
@@ -202,11 +202,11 @@ controller-credentials:
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
-	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets")
+	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "local credential content lookup failed: loading credentials: credentials for cloud dummy not found\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "client credential content lookup failed: loading credentials: credentials for cloud dummy not found\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-local-credentials: {}
+client-credentials: {}
 controller-credentials:
   dummy:
     cred:


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju show-credential' command.

* In multi-cloud environment, users are interested to see details of the credentials from the controller as well as the client. The details of the credential from the controller are now listed first.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only credential details but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Occasionally, users may not want to see both the credential details from the client and the credential details from the controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

## Documentation changes

All of the above.
