### PR TITLE
Fix bootstrap reuse.

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -69,7 +69,8 @@ bootstrap() {
     fi
     bootstrapped_name=$(grep "." "${TEST_DIR}/jujus" | tail -n 1)
     if [ -z "${bootstrapped_name}" ]; then
-        if [ -n "${BOOTSTRAP_REUSE_LOCAL}" ]; then
+        # shellcheck disable=SC2236
+        if [ ! -z "${BOOTSTRAP_REUSE_LOCAL}" ]; then
             bootstrapped_name="${BOOTSTRAP_REUSE_LOCAL}"
             export BOOTSTRAP_REUSE="true"
         else

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -3,9 +3,9 @@
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
 export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005"
-export BOOTSTRAP_REUSE_LOCAL=
-export BOOTSTRAP_REUSE="false"
-export BOOTSTRAP_PROVIDER=
+export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
+export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
+export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"
 
 OPTIND=1
 VERBOSE=1
@@ -194,8 +194,6 @@ cleanup() {
 
     echo "==> TEST COMPLETE"
 }
-
-export BOOTSTRAP_PROVIDER="lxd"
 
 TEST_CURRENT=setup
 TEST_RESULT=failure


### PR DESCRIPTION
## Description of change

The following fixes the bootstrap reuse when overriding in a
certain way. The new way sets up better defaults.

## QA steps

```sh
juju deploy lxd test
BOOTSTRAP_REUSE_LOCAL=test ./main.sh cli
```