### PR TITLE
Address Space ID Upgrade for CAAS

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2699,7 +2699,7 @@ func convertCloudServiceAddressSpaceIDs(db Database) ([]txn.Op, error) {
 		for i := range doc.Addresses {
 			// CAAS addresses at this point in time are space-less.
 			// We just need to ensure that they all have the zero ID.
-			doc.Addresses[i].SpaceID = "0"
+			doc.Addresses[i].SpaceID = network.DefaultSpaceId
 		}
 
 		ops = append(ops, txn.Op{
@@ -2737,7 +2737,7 @@ func convertCloudContainerAddressSpaceIDs(db Database) ([]txn.Op, error) {
 
 		// CAAS addresses at this point in time are space-less.
 		// We just need to ensure that they all have the zero ID.
-		doc.Address.SpaceID = "0"
+		doc.Address.SpaceID = network.DefaultSpaceId
 
 		ops = append(ops, txn.Op{
 			C:  cloudContainersC,


### PR DESCRIPTION
## Description of change

This patch augments the upgrade step for updating addresses to use space ID instead of name and provider ID.

The addresses in collections _cloudservices_ and _cloudcontainers_ are now updated. These will not have space names as CAAS is currently space-less, but they have the "0" space ID added.

## QA steps

- Bootstrap a CAAS model and deploy any unit(s)/bundle.
- Update the operator image using the make job from this patch.
- Run `juju upgrade-controller` and observe success without error.

## Documentation changes

None.

## Bug reference

N/A
