### PR TITLE
vsphere: Fix ineffective assignment in test

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -890,7 +890,7 @@ func (s *clientSuite) TestUserHasRootLevelPrivilege(c *gc.C) {
 	c.Assert(result, gc.Equals, false)
 
 	s.roundTripper.SetErrors(nil, permissionError)
-	result, err = client.UserHasRootLevelPrivilege(context.Background(), "Other.Privilege")
+	_, err = client.UserHasRootLevelPrivilege(context.Background(), "Other.Privilege")
 	c.Assert(err, gc.ErrorMatches, `checking for "Other.Privilege" privilege: ServerFaultCode: Permission to perform this operation was denied.`)
 }
 


### PR DESCRIPTION
## Description of change

This was preventing #10752 from merging. Fixing it here in 2.6 despite strong urges to just fix it over there.

## QA steps

* Ran the test again and it passed.

## Documentation changes

None

## Bug reference

None
