### PR TITLE
List tasks command

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -35,6 +35,16 @@ func (c *Client) Actions(arg params.Entities) (params.ActionResults, error) {
 	return results, err
 }
 
+// Tasks fetches the called functions (actions) for specified apps/units.
+func (c *Client) Tasks(arg params.TaskQueryArgs) (params.ActionResults, error) {
+	results := params.ActionResults{}
+	if v := c.BestAPIVersion(); v < 5 {
+		return results, errors.Errorf("Tasks not supported by this version (%d) of Juju", v)
+	}
+	err := c.facade.FacadeCall("Tasks", arg, &results)
+	return results, err
+}
+
 // FindActionTagsByPrefix takes a list of string prefixes and finds
 // corresponding ActionTags that match that prefix.
 func (c *Client) FindActionTagsByPrefix(arg params.FindTags) (params.FindTagsResults, error) {
@@ -127,8 +137,8 @@ func (c *Client) ApplicationCharmActions(arg params.Entity) (map[string]params.A
 // WatchActionProgress returns a watcher that reports on action log messages.
 // The result strings are json formatted core.actions.ActionMessage objects.
 func (c *Client) WatchActionProgress(actionId string) (watcher.StringsWatcher, error) {
-	if c.BestAPIVersion() < 5 {
-		return nil, errors.New("WatchActionProgress not supported by this version of Juju")
+	if v := c.BestAPIVersion(); v < 5 {
+		return nil, errors.Errorf("WatchActionProgress not supported by this version (%d) of Juju", v)
 	}
 	var results params.StringsWatchResults
 	args := params.Entities{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -137,6 +137,17 @@
                         }
                     }
                 },
+                "Tasks": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/TaskQueryArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ActionResults"
+                        }
+                    }
+                },
                 "WatchActionsProgress": {
                     "type": "object",
                     "properties": {
@@ -550,6 +561,36 @@
                     "required": [
                         "results"
                     ]
+                },
+                "TaskQueryArgs": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "status": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
                 }
             }
         }

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -108,6 +108,14 @@ type FindActionsByNames struct {
 	ActionNames []string `json:"names,omitempty"`
 }
 
+// TaskQueryArgs holds args for listing tasks.
+type TaskQueryArgs struct {
+	Applications  []string `json:"applications,omitempty"`
+	Units         []string `json:"units,omitempty"`
+	FunctionNames []string `json:"functions,omitempty"`
+	Status        []string `json:"status,omitempty"`
+}
+
 // ActionExecutionResults holds a slice of ActionExecutionResult for a
 // bulk action API call
 type ActionExecutionResults struct {

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -54,6 +54,9 @@ type APIClient interface {
 	// the ActionReceiver if necessary.
 	Actions(params.Entities) (params.ActionResults, error)
 
+	// Tasks fetches the called functions (actions) for specified apps/units.
+	Tasks(params.TaskQueryArgs) (params.ActionResults, error)
+
 	// FindActionTagsByPrefix takes a list of string prefixes and finds
 	// corresponding ActionTags that match that prefix.
 	FindActionTagsByPrefix(params.FindTags) (params.FindTagsResults, error)

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -435,7 +435,8 @@ mysql/0:
   timing:
     completed: 2015-02-14 08:17:00 +0000 UTC
     enqueued: 2015-02-14 08:13:00 +0000 UTC
-    started: 2015-02-14 08:15:00 +0000 UTC`[1:],
+    started: 2015-02-14 08:15:00 +0000 UTC
+  unit: mysql/0`[1:],
 	}, {
 		should:   "call a basic function with progress logs",
 		withArgs: []string{validUnitId, "some-function", "--utc"},
@@ -535,7 +536,8 @@ mysql/0:
   timing:
     completed: 2015-02-14 08:17:00 +0000 UTC
     enqueued: 2015-02-14 08:13:00 +0000 UTC
-    started: 2015-02-14 08:15:00 +0000 UTC`[1:],
+    started: 2015-02-14 08:15:00 +0000 UTC
+  unit: mysql/0`[1:],
 	}, {
 		should:   "call action on multiple units with stdout for each action",
 		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "yaml"},
@@ -597,6 +599,7 @@ mysql/0:
     completed: 2015-02-14 08:17:00 +0000 UTC
     enqueued: 2015-02-14 08:13:00 +0000 UTC
     started: 2015-02-14 08:15:00 +0000 UTC
+  unit: mysql/0
 mysql/1:
   id: f47ac10b-58cc-4372-a567-0e02b2c3d478
   results:
@@ -607,7 +610,8 @@ mysql/1:
   timing:
     completed: 2015-02-14 08:17:00 +0000 UTC
     enqueued: 2015-02-14 08:13:00 +0000 UTC
-    started: 2015-02-14 08:15:00 +0000 UTC`[1:],
+    started: 2015-02-14 08:15:00 +0000 UTC
+  unit: mysql/1`[1:],
 	}, {
 		should:   "call function on multiple units with plain output selected",
 		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "plain"},

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -6,12 +6,13 @@ package action
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/juju/loggo"
-	"gopkg.in/juju/names.v3"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v3"
+
 	"github.com/juju/juju/apiserver/params"
 	coreactions "github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/watcher"
@@ -129,8 +130,7 @@ func decodeLogMessage(encodedMessage string, utc bool) (string, error) {
 	return formatLogMessage(actionMessage, true, utc), nil
 }
 
-func formatLogMessage(actionMessage coreactions.ActionMessage, progressFormat, utc bool) string {
-	timestamp := actionMessage.Timestamp
+func formatTimestamp(timestamp time.Time, progressFormat, utc bool) string {
 	if utc {
 		timestamp = timestamp.UTC()
 	} else {
@@ -140,7 +140,11 @@ func formatLogMessage(actionMessage coreactions.ActionMessage, progressFormat, u
 	if progressFormat {
 		timestampFormat = watchTimestampFormat
 	}
-	return fmt.Sprintf("%v %v", timestamp.Format(timestampFormat), actionMessage.Message)
+	return timestamp.Format(timestampFormat)
+}
+
+func formatLogMessage(actionMessage coreactions.ActionMessage, progressFormat, utc bool) string {
+	return fmt.Sprintf("%v %v", formatTimestamp(actionMessage.Timestamp, progressFormat, utc), actionMessage.Message)
 }
 
 // processLogMessages starts a go routine to decode and handle any incoming

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -107,6 +107,10 @@ func (c *ShowCommand) ActionName() string {
 	return c.functionName
 }
 
+type ListTasksCommand struct {
+	*listTasksCommand
+}
+
 func NewShowOutputCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ShowOutputCommand) {
 	c := &showOutputCommand{}
 	c.SetClientStore(store)
@@ -153,4 +157,10 @@ func NewRunActionCommandForTest(store jujuclient.ClientStore) (cmd.Command, *Run
 
 func ActionResultsToMap(results []params.ActionResult) map[string]interface{} {
 	return resultsToMap(results)
+}
+
+func NewListTasksCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ListTasksCommand) {
+	c := &listTasksCommand{}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ListTasksCommand{c}
 }

--- a/cmd/juju/action/listtasks.go
+++ b/cmd/juju/action/listtasks.go
@@ -1,0 +1,254 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/output"
+	"gopkg.in/juju/names.v3"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+func NewListTasksCommand() cmd.Command {
+	return modelcmd.Wrap(&listTasksCommand{})
+}
+
+// listTasksCommand fetches the results of an action by ID.
+type listTasksCommand struct {
+	ActionCommandBase
+	out              cmd.Output
+	utc              bool
+	applicationNames []string
+	unitNames        []string
+	functionNames    []string
+	statusValues     []string
+}
+
+const listTasksDoc = `
+List the tasks with the specified query criteria.
+With no query arguments, any completed tasks will be listed.
+A completed task is one that has run successfully, been cancelled, or failed.
+
+When an application is specified, all units from that application are relevant.
+
+Examples:
+    juju tasks
+    juju tasks --format yaml
+    juju tasks --functions backup,restore
+    juju tasks --apps mysql,mediawiki
+    juju tasks --units mysql/0,mediawiki/1
+    juju tasks --status pending,completed
+    juju tasks --apps mysql --units mediawiki/0 --status running --functions backup
+
+See also:
+    call
+    show-task
+`
+
+// Set up the output.
+func (c *listTasksCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ActionCommandBase.SetFlags(f)
+	defaultFormatter := "plain"
+	c.out.AddFlags(f, defaultFormatter, map[string]cmd.Formatter{
+		"yaml":  cmd.FormatYaml,
+		"json":  cmd.FormatJson,
+		"plain": c.formatTabular,
+	})
+
+	f.BoolVar(&c.utc, "utc", false, "Show times in UTC")
+	f.Var(cmd.NewStringsValue(nil, &c.applicationNames), "applications", "Comma separated list of applications to filter on")
+	f.Var(cmd.NewStringsValue(nil, &c.applicationNames), "apps", "Comma separated list of applications to filter on")
+	f.Var(cmd.NewStringsValue(nil, &c.unitNames), "units", "Comma separated list of units to filter on")
+	f.Var(cmd.NewStringsValue(nil, &c.functionNames), "functions", "Comma separated list of function names to filter on")
+	f.Var(cmd.NewStringsValue([]string{params.ActionCompleted}, &c.statusValues), "status", "Comma separated list of task status values to filter on")
+}
+
+func (c *listTasksCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "tasks",
+		Purpose: "Lists pending, running, or completed tasks for specified application, units, or all.",
+		Doc:     listTasksDoc,
+		Aliases: []string{"list-tasks"},
+	})
+}
+
+// Init implements Command.
+func (c *listTasksCommand) Init(args []string) error {
+	var nameErrors []string
+	for _, application := range c.applicationNames {
+		if !names.IsValidApplication(application) {
+			nameErrors = append(nameErrors, fmt.Sprintf("invalid application name %q", application))
+		}
+	}
+	for _, unit := range c.unitNames {
+		if !names.IsValidUnit(unit) {
+			nameErrors = append(nameErrors, fmt.Sprintf("invalid unit name %q", unit))
+		}
+	}
+	for _, status := range c.statusValues {
+		switch status {
+		case params.ActionPending,
+			params.ActionRunning,
+			params.ActionCompleted:
+		default:
+			nameErrors = append(nameErrors,
+				fmt.Sprintf("%q is not a valid function status, want one of %v",
+					status,
+					[]string{params.ActionPending, params.ActionRunning, params.ActionCompleted}))
+		}
+	}
+	if len(nameErrors) > 0 {
+		return errors.New(strings.Join(nameErrors, "\n"))
+	}
+	return cmd.CheckEmpty(args)
+}
+
+// Run implements Command.
+func (c *listTasksCommand) Run(ctx *cmd.Context) error {
+	api, err := c.NewActionAPIClient()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	args := params.TaskQueryArgs{
+		Applications:  c.applicationNames,
+		Units:         c.unitNames,
+		FunctionNames: c.functionNames,
+		Status:        c.statusValues,
+	}
+	results, err := api.Tasks(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	out := make(map[string]interface{})
+	var actionResults byId = results.Results
+	if len(actionResults) == 0 {
+		fmt.Fprintln(ctx.Stderr, "no matching tasks")
+		return nil
+	}
+
+	sort.Sort(actionResults)
+	for _, result := range actionResults {
+		if result.Error != nil {
+			continue
+		}
+		tag, err := names.ParseActionTag(result.Action.Tag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		out[tag.Id()] = FormatActionResult(result, c.utc)
+	}
+	if c.out.Name() != "plain" {
+		return c.out.Write(ctx, out)
+	}
+	return c.out.Write(ctx, actionResults)
+}
+
+type taskLine struct {
+	timestamp time.Time
+	id        string
+	task      string
+	status    string
+	unit      string
+}
+
+func (c *listTasksCommand) formatTabular(writer io.Writer, value interface{}) error {
+	results, ok := value.(byId)
+	if !ok {
+		return errors.Errorf("expected value of type %T, got %T", results, value)
+	}
+	tw := output.TabWriter(writer)
+	w := output.Wrapper{tw}
+	w.SetColumnAlignRight(1)
+
+	printTasks := func(tasks []taskLine, utc bool) {
+		for _, line := range tasks {
+			w.Print(formatTimestamp(line.timestamp, false, c.utc))
+			w.Println(line.id, line.task, line.status, line.unit)
+		}
+	}
+	w.Println("Time", "Id", "Task", "Status", "Unit")
+	printTasks(actionTaskLinesFromResults(results), c.utc)
+	return tw.Flush()
+}
+
+func taskDisplayTime(r params.ActionResult) time.Time {
+	timestamp := r.Completed
+	if timestamp.IsZero() {
+		timestamp = r.Started
+	}
+	if timestamp.IsZero() {
+		timestamp = r.Enqueued
+	}
+	return timestamp
+}
+
+func actionTaskLinesFromResults(results []params.ActionResult) []taskLine {
+	sort.Sort(byTimestamp(results))
+
+	var taskLines []taskLine
+	for _, r := range results {
+		if r.Action == nil {
+			continue
+		}
+		line := taskLine{
+			timestamp: taskDisplayTime(r),
+			status:    r.Status,
+			task:      r.Action.Name,
+		}
+		if at, err := names.ParseActionTag(r.Action.Tag); err == nil {
+			line.id = at.Id()
+		}
+		if ut, err := names.ParseUnitTag(r.Action.Receiver); err == nil {
+			line.unit = ut.Id()
+		}
+		taskLines = append(taskLines, line)
+	}
+	return taskLines
+}
+
+type byTimestamp []params.ActionResult
+
+func (s byTimestamp) Len() int {
+	return len(s)
+}
+
+func (s byTimestamp) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byTimestamp) Less(i, j int) bool {
+	return taskDisplayTime(s[i]).UnixNano() < taskDisplayTime(s[j]).UnixNano()
+}
+
+type byId []params.ActionResult
+
+func (s byId) Len() int {
+	return len(s)
+}
+func (s byId) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s byId) Less(i, j int) bool {
+	if s[i].Action == nil {
+		return true
+	}
+	if s[j].Action == nil {
+		return false
+	}
+	return s[i].Action.Tag < s[j].Action.Tag
+}

--- a/cmd/juju/action/listtasks_test.go
+++ b/cmd/juju/action/listtasks_test.go
@@ -1,0 +1,208 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action_test
+
+import (
+	"bytes"
+	"strings"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/juju/apiserver/params"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/action"
+)
+
+type ListTasksSuite struct {
+	BaseActionSuite
+	wrappedCommand cmd.Command
+	command        *action.ListTasksCommand
+}
+
+var _ = gc.Suite(&ListTasksSuite{})
+
+func (s *ListTasksSuite) SetUpTest(c *gc.C) {
+	s.BaseActionSuite.SetUpTest(c)
+	s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
+}
+
+func (s *ListTasksSuite) TestInit(c *gc.C) {
+	tests := []struct {
+		should      string
+		args        []string
+		expectedErr string
+	}{{
+		should:      "fail with invalid application name",
+		args:        []string{"--apps", "valid," + invalidApplicationId},
+		expectedErr: "invalid application name \"" + invalidApplicationId + "\"",
+	}, {
+		should:      "fail with invalid unit name",
+		args:        []string{"--units", "valid/0," + invalidUnitId},
+		expectedErr: "invalid unit name \"" + invalidUnitId + "\"",
+	}, {
+		should:      "fail with invalid status value",
+		args:        []string{"--status", "pending," + "error"},
+		expectedErr: `"error" is not a valid function status, want one of \[pending running completed\]`,
+	}, {
+		should:      "fail with multiple errors",
+		args:        []string{"--units", "valid/0," + invalidUnitId, "--apps", "valid," + invalidApplicationId},
+		expectedErr: "invalid application name \"" + invalidApplicationId + "\"\ninvalid unit name \"" + invalidUnitId + "\"",
+	}, {
+		should:      "fail with too many args",
+		args:        []string{"any"},
+		expectedErr: `unrecognized args: \["any"\]`,
+	}}
+
+	for i, t := range tests {
+		for _, modelFlag := range s.modelFlags {
+			c.Logf("test %d should %s: juju tasks defined %s", i,
+				t.should, strings.Join(t.args, " "))
+			s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
+			args := append([]string{modelFlag, "admin"}, t.args...)
+			err := cmdtesting.InitCommand(s.wrappedCommand, args)
+			if t.expectedErr == "" {
+				c.Check(err, jc.ErrorIsNil)
+			} else {
+				c.Check(err, gc.ErrorMatches, t.expectedErr)
+			}
+		}
+	}
+}
+
+func (s *ListTasksSuite) TestRunQueryArgs(c *gc.C) {
+	fakeClient := &fakeAPIClient{}
+	restore := s.patchAPIClient(fakeClient)
+	defer restore()
+
+	s.wrappedCommand, _ = action.NewListTasksCommandForTest(s.store)
+	args := []string{
+		"--apps", "mysql,mediawiki",
+		"--units", "mysql/1,mediawiki/0",
+		"--functions", "backup",
+		"--status", "completed,pending",
+	}
+	for _, modelFlag := range s.modelFlags {
+		s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
+		args = append([]string{modelFlag, "admin"}, args...)
+
+		_, err := cmdtesting.RunCommand(c, s.wrappedCommand, args...)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(fakeClient.taskQueryArgs, jc.DeepEquals, params.TaskQueryArgs{
+			Applications:  []string{"mysql", "mediawiki"},
+			Units:         []string{"mysql/1", "mediawiki/0"},
+			FunctionNames: []string{"backup"},
+			Status:        []string{"completed", "pending"},
+		})
+	}
+}
+
+var listTaskResults = []params.ActionResult{
+	{
+		Action: &params.Action{
+			Tag:      "action-1",
+			Receiver: "unit-mysql-0",
+			Name:     "backup",
+		},
+		Enqueued:  time.Time{},
+		Started:   time.Date(2015, time.February, 14, 6, 6, 6, 0, time.UTC),
+		Completed: time.Time{},
+		Status:    "completed",
+	}, {
+		Action: &params.Action{
+			Tag:      "action-2",
+			Receiver: "unit-mysql-1",
+			Name:     "restore",
+		},
+		Enqueued:  time.Time{},
+		Started:   time.Time{},
+		Completed: time.Date(2014, time.February, 14, 6, 6, 6, 0, time.UTC),
+		Status:    "running",
+	}, {
+		Action: &params.Action{
+			Tag:      "action-3",
+			Receiver: "unit-mysql-1",
+			Name:     "vacuum",
+		},
+		Enqueued:  time.Date(2013, time.February, 14, 6, 6, 6, 0, time.UTC),
+		Started:   time.Time{},
+		Completed: time.Time{},
+		Status:    "pending",
+	}, {
+		Error: &params.Error{Message: "boom"},
+	},
+}
+
+func (s *ListTasksSuite) TestRunNoResults(c *gc.C) {
+	fakeClient := &fakeAPIClient{}
+	restore := s.patchAPIClient(fakeClient)
+	defer restore()
+
+	s.wrappedCommand, _ = action.NewListTasksCommandForTest(s.store)
+	for _, modelFlag := range s.modelFlags {
+		s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
+		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, "")
+		c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "no matching tasks\n")
+	}
+}
+
+func (s *ListTasksSuite) TestRunPlain(c *gc.C) {
+	fakeClient := &fakeAPIClient{
+		actionResults: listTaskResults,
+	}
+	restore := s.patchAPIClient(fakeClient)
+	defer restore()
+
+	s.wrappedCommand, _ = action.NewListTasksCommandForTest(s.store)
+	for _, modelFlag := range s.modelFlags {
+		s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
+		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--utc")
+		c.Assert(err, jc.ErrorIsNil)
+		expected := `
+Time                 Id  Task     Status     Unit
+2013-02-14 06:06:06   3  vacuum   pending    mysql/1
+2014-02-14 06:06:06   2  restore  running    mysql/1
+2015-02-14 06:06:06   1  backup   completed  mysql/0
+
+`[1:]
+		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expected)
+	}
+}
+
+func (s *ListTasksSuite) TestRunYaml(c *gc.C) {
+	fakeClient := &fakeAPIClient{
+		actionResults: listTaskResults,
+	}
+	restore := s.patchAPIClient(fakeClient)
+	defer restore()
+
+	s.wrappedCommand, _ = action.NewListTasksCommandForTest(s.store)
+	for _, modelFlag := range s.modelFlags {
+		s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
+		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--format", "yaml")
+		c.Assert(err, jc.ErrorIsNil)
+		expected := `
+"1":
+  status: completed
+  timing:
+    started: 2015-02-14 06:06:06 +0000 UTC
+  unit: mysql/0
+"2":
+  status: running
+  timing:
+    completed: 2014-02-14 06:06:06 +0000 UTC
+  unit: mysql/1
+"3":
+  status: pending
+  timing:
+    enqueued: 2013-02-14 06:06:06 +0000 UTC
+  unit: mysql/1
+`[1:]
+		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expected)
+	}
+}

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -140,6 +140,7 @@ type fakeAPIClient struct {
 	delay              *time.Timer
 	timeout            *time.Timer
 	actionResults      []params.ActionResult
+	taskQueryArgs      params.TaskQueryArgs
 	enqueuedActions    params.Actions
 	actionsByReceivers []params.ActionsByReceiver
 	actionTagMatches   params.FindTagsResults
@@ -264,4 +265,11 @@ func (c *fakeAPIClient) FindActionsByNames(args params.FindActionsByNames) (para
 
 func (c *fakeAPIClient) WatchActionProgress(actionId string) (watcher.StringsWatcher, error) {
 	return watchertest.NewMockStringsWatcher(c.logMessageCh), nil
+}
+
+func (c *fakeAPIClient) Tasks(args params.TaskQueryArgs) (params.ActionResults, error) {
+	c.taskQueryArgs = args
+	return params.ActionResults{
+		Results: c.actionResults,
+	}, c.apiErr
 }

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -278,13 +278,8 @@ func (c *runActionCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		unitTag, err := names.ParseUnitTag(result.Action.Receiver)
-		if err != nil {
-			return err
-		}
 		d := FormatActionResult(result, false)
-		d["id"] = tag.Id()       // Action ID is required in case we timed out.
-		d["unit"] = unitTag.Id() // Formatted unit is nice to have.
+		d["id"] = tag.Id() // Action ID is required in case we timed out.
 		out[result.Action.Receiver] = d
 	}
 	return c.out.Write(ctx, out)

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/featureflag"
+	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
@@ -237,6 +238,12 @@ func fetchResult(api APIClient, requestedId string) (params.ActionResult, error)
 // write in an easy-to-read format.
 func FormatActionResult(result params.ActionResult, utc bool) map[string]interface{} {
 	response := map[string]interface{}{"status": result.Status}
+	if result.Action != nil {
+		ut, err := names.ParseUnitTag(result.Action.Receiver)
+		if err == nil {
+			response["unit"] = ut.Id()
+		}
+	}
 	if result.Message != "" {
 		response["message"] = result.Message
 	}

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -121,7 +121,7 @@ var debugHooksTests = []struct {
 }, {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
-	error: `unit "mysql/0" contains neither hook nor action "invalid-hook", valid actions are [fakeaction] and valid hooks are [collect-metrics config-changed install juju-info-relation-broken juju-info-relation-changed juju-info-relation-departed juju-info-relation-joined leader-deposed leader-elected leader-settings-changed meter-status-changed metrics-client-relation-broken metrics-client-relation-changed metrics-client-relation-departed metrics-client-relation-joined post-series-upgrade pre-series-upgrade server-admin-relation-broken server-admin-relation-changed server-admin-relation-departed server-admin-relation-joined server-relation-broken server-relation-changed server-relation-departed server-relation-joined start stop update-status upgrade-charm]`,
+	error: `unit "mysql/0" contains neither hook nor action "invalid-hook", valid actions are [anotherfakeaction fakeaction] and valid hooks are [collect-metrics config-changed install juju-info-relation-broken juju-info-relation-changed juju-info-relation-departed juju-info-relation-joined leader-deposed leader-elected leader-settings-changed meter-status-changed metrics-client-relation-broken metrics-client-relation-changed metrics-client-relation-departed metrics-client-relation-joined post-series-upgrade pre-series-upgrade server-admin-relation-broken server-admin-relation-changed server-admin-relation-departed server-admin-relation-joined server-relation-broken server-relation-changed server-relation-departed server-relation-joined start stop update-status upgrade-charm]`,
 }, {
 	info:  `no args at all`,
 	args:  nil,

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -388,6 +388,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(action.NewCancelCommand())
 	if featureflag.Enabled(feature.JujuV3) {
 		r.Register(action.NewCallCommand())
+		r.Register(action.NewListTasksCommand())
 	} else {
 		r.Register(action.NewRunActionCommand())
 		r.Register(action.NewStatusCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -630,7 +630,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"call", "show-task", "functions", "list-functions", "show-function",
+	"call", "show-task", "functions", "list-functions", "show-function", "tasks", "list-tasks",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {

--- a/testcharms/charm-repo/quantal/mysql/actions.yaml
+++ b/testcharms/charm-repo/quantal/mysql/actions.yaml
@@ -1,1 +1,2 @@
 fakeaction:
+anotherfakeaction:


### PR DESCRIPTION
## Description of change

Add a new lists-tasks command. This command will display any tasks resulting from calling a charm function. Filtering can be done on target (application, unit), function name, and status.

Commit 1 is the api server facade implementation
Commit 2 is the action facade client
Commit 3 is the list-tasks CLI

## QA steps

deploy a charm with an action and add some units
set the juju-v3 feature flag
call the charm action a few times
use juju tasks with plain and yaml format with combinations of filter params
