### PR TITLE
Make RBAC rules spec supports ResourceNames and NonResourceURLs;

### DIFF
--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -2661,6 +2661,16 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Resources: []string{"pods"},
 			Verbs:     []string{"get", "watch", "list"},
 		},
+		{
+			NonResourceURLs: []string{"/healthz", "/healthz/*"},
+			Verbs:           []string{"get", "post"},
+		},
+		{
+			APIGroups:     []string{"rbac.authorization.k8s.io"},
+			Resources:     []string{"clusterroles"},
+			Verbs:         []string{"bind"},
+			ResourceNames: []string{"admin", "edit", "view"},
+		},
 	}
 	podSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
@@ -2782,6 +2792,16 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
 				Verbs:     []string{"get", "watch", "list"},
+			},
+			{
+				NonResourceURLs: []string{"/healthz", "/healthz/*"},
+				Verbs:           []string{"get", "post"},
+			},
+			{
+				APIGroups:     []string{"rbac.authorization.k8s.io"},
+				Resources:     []string{"clusterroles"},
+				Verbs:         []string{"bind"},
+				ResourceNames: []string{"admin", "edit", "view"},
 			},
 		},
 	}

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -29,9 +29,11 @@ func (k *kubernetesClient) getRBACLabels(appName string) map[string]string {
 func toK8sRules(rules []specs.PolicyRule) (out []rbacv1.PolicyRule) {
 	for _, r := range rules {
 		out = append(out, rbacv1.PolicyRule{
-			Verbs:     r.Verbs,
-			APIGroups: r.APIGroups,
-			Resources: r.Resources,
+			Verbs:           r.Verbs,
+			APIGroups:       r.APIGroups,
+			Resources:       r.Resources,
+			ResourceNames:   r.ResourceNames,
+			NonResourceURLs: r.NonResourceURLs,
 		})
 	}
 	return out

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -135,6 +135,12 @@ kubernetesResources:
     - apiGroups: [""]
       resources: ["pods"]
       verbs: ["get", "watch", "list"]
+    - nonResourceURLs: ["/healthz", "/healthz/*"] # '*' in a nonResourceURL is a suffix glob match
+      verbs: ["get", "post"]
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      resources: ["clusterroles"]
+      verbs: ["bind"]
+      resourceNames: ["admin","edit","view"]
   pod:
     restartPolicy: OnFailure
     activeDeadlineSeconds: 10
@@ -329,6 +335,16 @@ echo "do some stuff here for gitlab-init container"
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
 				Verbs:     []string{"get", "watch", "list"},
+			},
+			{
+				NonResourceURLs: []string{"/healthz", "/healthz/*"},
+				Verbs:           []string{"get", "post"},
+			},
+			{
+				APIGroups:     []string{"rbac.authorization.k8s.io"},
+				Resources:     []string{"clusterroles"},
+				Verbs:         []string{"bind"},
+				ResourceNames: []string{"admin", "edit", "view"},
 			},
 		}
 		pSpecs.ProviderPod = &k8sspecs.K8sPodSpec{

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -9,9 +9,11 @@ import (
 
 // PolicyRule defines rule spec for creating a role or cluster role.
 type PolicyRule struct {
-	Verbs     []string `yaml:"verbs"`
-	APIGroups []string `yaml:"apiGroups,omitempty"`
-	Resources []string `yaml:"resources,omitempty"`
+	Verbs           []string `yaml:"verbs"`
+	APIGroups       []string `yaml:"apiGroups,omitempty"`
+	Resources       []string `yaml:"resources,omitempty"`
+	ResourceNames   []string `yaml:"resourceNames,omitempty"`
+	NonResourceURLs []string `yaml:"nonResourceURLs,omitempty"`
 }
 
 // RBACSpec defines RBAC related spec.


### PR DESCRIPTION

## Description of change

Make RBAC rules spec supports ResourceNames and NonResourceURLs;

## QA steps

- deploy charms with below RBAC spec;

```yaml
serviceAccount:
  automountServiceAccountToken: true
  global: true
  rules:
    - apiGroups: [""]
      resources: ["pods"]
      verbs: ["get", "watch", "list"]
    - nonResourceURLs: ["*"]
      verbs: ["*"]
```

- check resource created;

```bash
$ mkubectl get clusterrole t1-mariadb-k8s -oyaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  creationTimestamp: "2019-10-18T01:48:11Z"
  labels:
    juju-app: mariadb-k8s
    juju-model: t1
  name: t1-mariadb-k8s
  resourceVersion: "86364"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/t1-mariadb-k8s
  uid: e1f7e68a-2827-4cdf-bc2e-050d8fb41cff
rules:
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - get
  - watch
  - list
- nonResourceURLs:
  - '*'
  verbs:
  - '*'

```


## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1848540