### PR TITLE
Threads context loggers through remaining model workers.

### DIFF
--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -434,6 +434,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade:                    modelupgrader.NewFacade,
 			NewWorker:                    modelupgrader.NewWorker,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
+			Logger:                       config.LoggingContext.GetLogger("juju.worker.modelupgrader"),
 		}))),
 		instanceMutaterName: ifNotMigrating(instancemutater.ModelManifold(instancemutater.ModelManifoldConfig{
 			AgentName:     agentName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -484,6 +484,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 					return caasfirewallerapi.NewClient(caller)
 				},
 				NewWorker: caasfirewaller.NewWorker,
+				Logger:    config.LoggingContext.GetLogger("juju.worker.caasfirewaller"),
 			},
 		)),
 		caasOperatorProvisionerName: ifNotMigrating(caasoperatorprovisioner.Manifold(

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -505,6 +505,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 					return caasunitprovisionerapi.NewClient(caller)
 				},
 				NewWorker: caasunitprovisioner.NewWorker,
+				Logger:    config.LoggingContext.GetLogger("juju.worker.caasunitprovisioner"),
 			},
 		)),
 		modelUpgraderName: caasenvironupgrader.Manifold(caasenvironupgrader.ManifoldConfig{

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -514,6 +514,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ModelTag:      modelTag,
 			NewFacade:     caasenvironupgrader.NewFacade,
 			NewWorker:     caasenvironupgrader.NewWorker,
+			// No Logger defined in caasenvironupgrader package.
 		}),
 		caasStorageProvisionerName: ifNotMigrating(ifCredentialValid(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
 			APICallerName:                apiCallerName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -416,12 +416,14 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}))),
 		metricWorkerName: ifNotMigrating(metricworker.Manifold(metricworker.ManifoldConfig{
 			APICallerName: apiCallerName,
+			Logger:        config.LoggingContext.GetLogger("juju.worker.metricworker"),
 		})),
 		machineUndertakerName: ifNotMigrating(ifCredentialValid(machineundertaker.Manifold(machineundertaker.ManifoldConfig{
 			APICallerName:                apiCallerName,
 			EnvironName:                  environTrackerName,
 			NewWorker:                    machineundertaker.NewWorker,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
+			Logger:                       config.LoggingContext.GetLogger("juju.worker.machineundertaker"),
 		}))),
 		modelUpgraderName: ifNotDead(ifCredentialValid(modelupgrader.Manifold(modelupgrader.ManifoldConfig{
 			APICallerName:                apiCallerName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -472,6 +472,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		caasBrokerTrackerName: ifResponsible(caasbroker.Manifold(caasbroker.ManifoldConfig{
 			APICallerName:          apiCallerName,
 			NewContainerBrokerFunc: config.NewContainerBrokerFunc,
+			Logger:                 config.LoggingContext.GetLogger("juju.worker.caas"),
 		})),
 		caasFirewallerName: ifNotMigrating(caasfirewaller.Manifold(
 			caasfirewaller.ManifoldConfig{

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -494,6 +494,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 				BrokerName:    caasBrokerTrackerName,
 				ClockName:     clockName,
 				NewWorker:     caasoperatorprovisioner.NewProvisionerWorker,
+				Logger:        config.LoggingContext.GetLogger("juju.worker.caasprovisioner"),
 			},
 		)),
 		caasUnitProvisionerName: ifNotMigrating(caasunitprovisioner.Manifold(

--- a/worker/caasbroker/manifold.go
+++ b/worker/caasbroker/manifold.go
@@ -15,10 +15,17 @@ import (
 	"github.com/juju/juju/storage"
 )
 
+// Logger represents the methods used by the worker to log details.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
+}
+
 // ManifoldConfig describes the resources used by a Tracker.
 type ManifoldConfig struct {
 	APICallerName          string
 	NewContainerBrokerFunc caas.NewContainerBrokerFunc
+	Logger                 Logger
 }
 
 // Manifold returns a Manifold that encapsulates a *Tracker and exposes it as
@@ -41,6 +48,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			w, err := NewTracker(Config{
 				ConfigAPI:              api,
 				NewContainerBrokerFunc: config.NewContainerBrokerFunc,
+				Logger:                 config.Logger,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/caasenvironupgrader/worker.go
+++ b/worker/caasenvironupgrader/worker.go
@@ -5,7 +5,6 @@ package caasenvironupgrader
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 
@@ -14,7 +13,9 @@ import (
 	"github.com/juju/juju/worker/gate"
 )
 
-var logger = loggo.GetLogger("juju.worker.modelupgrader")
+// Logger is here to stop the desire of creating a package level Logger.
+// Don't do this, instead use the one passed as manifold config.
+var logger interface{}
 
 // Facade exposes capabilities required by the worker.
 type Facade interface {

--- a/worker/caasfirewaller/application_worker.go
+++ b/worker/caasfirewaller/application_worker.go
@@ -26,6 +26,8 @@ type applicationWorker struct {
 
 	initial           bool
 	previouslyExposed bool
+
+	logger Logger
 }
 
 func newApplicationWorker(
@@ -35,6 +37,7 @@ func newApplicationWorker(
 	applicationGetter ApplicationGetter,
 	applicationExposer ServiceExposer,
 	lifeGetter LifeGetter,
+	logger Logger,
 ) (worker.Worker, error) {
 	w := &applicationWorker{
 		controllerUUID:    controllerUUID,
@@ -44,6 +47,7 @@ func newApplicationWorker(
 		serviceExposer:    applicationExposer,
 		lifeGetter:        lifeGetter,
 		initial:           true,
+		logger:            logger,
 	}
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -68,7 +72,7 @@ func (w *applicationWorker) loop() (err error) {
 	defer func() {
 		// If the application has been deleted, we can return nil.
 		if errors.IsNotFound(err) {
-			logger.Debugf("caas firewaller application %v has been removed", w.application)
+			w.logger.Debugf("caas firewaller application %v has been removed", w.application)
 			err = nil
 		}
 	}()
@@ -99,7 +103,7 @@ func (w *applicationWorker) processApplicationChange() (err error) {
 	defer func() {
 		if errors.IsNotFound(err) {
 			// ignore not found error because the ip could be not ready yet at this stage.
-			logger.Warningf("processing change for application %q, %v", w.application, err)
+			w.logger.Warningf("processing change for application %q, %v", w.application, err)
 			err = nil
 		}
 	}()

--- a/worker/caasfirewaller/manifold.go
+++ b/worker/caasfirewaller/manifold.go
@@ -12,6 +12,13 @@ import (
 	"github.com/juju/juju/caas"
 )
 
+// Logger represents the methods used by the worker to log details.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
 // ManifoldConfig describes the resources used by the firewaller worker.
 type ManifoldConfig struct {
 	APICallerName string
@@ -22,6 +29,7 @@ type ManifoldConfig struct {
 
 	NewClient func(base.APICaller) Client
 	NewWorker func(Config) (worker.Worker, error)
+	Logger    Logger
 }
 
 // Manifold returns a Manifold that encapsulates the firewaller worker.
@@ -55,6 +63,9 @@ func (config ManifoldConfig) Validate() error {
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
 	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
 	return nil
 }
 
@@ -81,6 +92,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ApplicationGetter: client,
 		LifeGetter:        client,
 		ServiceExposer:    broker,
+		Logger:            config.Logger,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/caasfirewaller/manifold_test.go
+++ b/worker/caasfirewaller/manifold_test.go
@@ -5,6 +5,7 @@ package caasfirewaller_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -47,6 +48,7 @@ func (s *ManifoldSuite) validConfig() caasfirewaller.ManifoldConfig {
 		ModelUUID:      coretesting.ModelTag.Id(),
 		NewClient:      s.newClient,
 		NewWorker:      s.newWorker,
+		Logger:         loggo.GetLogger("test"),
 	}
 }
 
@@ -106,6 +108,12 @@ func (s *ManifoldSuite) TestMissingNewWorker(c *gc.C) {
 	s.checkConfigInvalid(c, config, "nil NewWorker not valid")
 }
 
+func (s *ManifoldSuite) TestMissingLogger(c *gc.C) {
+	config := s.validConfig()
+	config.Logger = nil
+	s.checkConfigInvalid(c, config, "nil Logger not valid")
+}
+
 func (s *ManifoldSuite) checkConfigInvalid(c *gc.C, config caasfirewaller.ManifoldConfig, expect string) {
 	err := config.Validate()
 	c.Check(err, gc.ErrorMatches, expect)
@@ -147,5 +155,6 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		ApplicationGetter: &s.client,
 		ServiceExposer:    &s.broker,
 		LifeGetter:        &s.client,
+		Logger:            loggo.GetLogger("test"),
 	})
 }

--- a/worker/caasfirewaller/worker_test.go
+++ b/worker/caasfirewaller/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -63,6 +64,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		ApplicationGetter: &s.applicationGetter,
 		ServiceExposer:    &s.serviceExposer,
 		LifeGetter:        &s.lifeGetter,
+		Logger:            loggo.GetLogger("test"),
 	}
 }
 
@@ -94,6 +96,10 @@ func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
 	s.testValidateConfig(c, func(config *caasfirewaller.Config) {
 		config.LifeGetter = nil
 	}, `missing LifeGetter not valid`)
+
+	s.testValidateConfig(c, func(config *caasfirewaller.Config) {
+		config.Logger = nil
+	}, `missing Logger not valid`)
 }
 
 func (s *WorkerSuite) testValidateConfig(c *gc.C, f func(*caasfirewaller.Config), expect string) {

--- a/worker/caasoperatorprovisioner/manifold.go
+++ b/worker/caasoperatorprovisioner/manifold.go
@@ -15,6 +15,12 @@ import (
 	"github.com/juju/juju/caas"
 )
 
+// Logger represents the methods used by the worker to log details.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
+}
+
 // ManifoldConfig defines a CAAS operator provisioner's dependencies.
 type ManifoldConfig struct {
 	AgentName     string
@@ -23,6 +29,7 @@ type ManifoldConfig struct {
 	ClockName     string
 
 	NewWorker func(Config) (worker.Worker, error)
+	Logger    Logger
 }
 
 // Validate is called by start to check for bad configuration.
@@ -41,6 +48,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
 	}
 	return nil
 }
@@ -83,6 +93,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ModelTag:    modelTag,
 		AgentConfig: agentConfig,
 		Clock:       clock,
+		Logger:      config.Logger,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/caasoperatorprovisioner/manifold_test.go
+++ b/worker/caasoperatorprovisioner/manifold_test.go
@@ -5,6 +5,7 @@ package caasoperatorprovisioner_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -34,6 +35,7 @@ func (s *ManifoldConfigSuite) validConfig() caasoperatorprovisioner.ManifoldConf
 		NewWorker: func(config caasoperatorprovisioner.Config) (worker.Worker, error) {
 			return nil, nil
 		},
+		Logger: loggo.GetLogger("test"),
 	}
 }
 
@@ -64,6 +66,11 @@ func (s *ManifoldConfigSuite) TestMissingClockName(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
 	s.config.NewWorker = nil
 	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	s.checkNotValid(c, "nil Logger not valid")
 }
 
 func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/juju/loggo"
+
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
@@ -74,6 +76,7 @@ func (s *CAASProvisionerSuite) assertWorker(c *gc.C) worker.Worker {
 		ModelTag:    s.modelTag,
 		AgentConfig: s.agentConfig,
 		Clock:       s.clock,
+		Logger:      loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -26,6 +26,7 @@ type deploymentWorker struct {
 	applicationGetter        ApplicationGetter
 	applicationUpdater       ApplicationUpdater
 	provisioningInfoGetter   ProvisioningInfoGetter
+	logger                   Logger
 }
 
 func newDeploymentWorker(
@@ -35,6 +36,7 @@ func newDeploymentWorker(
 	provisioningInfoGetter ProvisioningInfoGetter,
 	applicationGetter ApplicationGetter,
 	applicationUpdater ApplicationUpdater,
+	logger Logger,
 ) (worker.Worker, error) {
 	w := &deploymentWorker{
 		application:              application,
@@ -43,6 +45,7 @@ func newDeploymentWorker(
 		provisioningInfoGetter:   provisioningInfoGetter,
 		applicationGetter:        applicationGetter,
 		applicationUpdater:       applicationUpdater,
+		logger:                   logger,
 	}
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -81,6 +84,7 @@ func (w *deploymentWorker) loop() error {
 	gotSpecNotify := false
 	serviceUpdated := false
 	desiredScale := 0
+	logger := w.logger
 	for {
 		select {
 		case <-w.catacomb.Dying():

--- a/worker/caasunitprovisioner/manifold_test.go
+++ b/worker/caasunitprovisioner/manifold_test.go
@@ -5,6 +5,7 @@ package caasunitprovisioner_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -44,6 +45,7 @@ func (s *ManifoldSuite) validConfig() caasunitprovisioner.ManifoldConfig {
 		BrokerName:    "broker",
 		NewClient:     s.newClient,
 		NewWorker:     s.newWorker,
+		Logger:        loggo.GetLogger("test"),
 	}
 }
 
@@ -91,6 +93,12 @@ func (s *ManifoldSuite) TestMissingNewWorker(c *gc.C) {
 	s.checkConfigInvalid(c, config, "nil NewWorker not valid")
 }
 
+func (s *ManifoldSuite) TestMissingLogger(c *gc.C) {
+	config := s.validConfig()
+	config.Logger = nil
+	s.checkConfigInvalid(c, config, "nil Logger not valid")
+}
+
 func (s *ManifoldSuite) checkConfigInvalid(c *gc.C, config caasunitprovisioner.ManifoldConfig, expect string) {
 	err := config.Validate()
 	c.Check(err, gc.ErrorMatches, expect)
@@ -135,5 +143,6 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		ProvisioningStatusSetter: &s.client,
 		LifeGetter:               &s.client,
 		UnitUpdater:              &s.client,
+		Logger:                   loggo.GetLogger("test"),
 	})
 }

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -6,6 +6,8 @@ package caasunitprovisioner_test
 import (
 	"time"
 
+	"github.com/juju/loggo"
+
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -172,6 +174,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		LifeGetter:               &s.lifeGetter,
 		UnitUpdater:              &s.unitUpdater,
 		ProvisioningStatusSetter: &s.statusSetter,
+		Logger:                   loggo.GetLogger("test"),
 	}
 }
 
@@ -207,9 +210,14 @@ func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
 	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
 		config.LifeGetter = nil
 	}, `missing LifeGetter not valid`)
+
 	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
 		config.ProvisioningStatusSetter = nil
 	}, `missing ProvisioningStatusSetter not valid`)
+
+	s.testValidateConfig(c, func(config *caasunitprovisioner.Config) {
+		config.Logger = nil
+	}, `missing Logger not valid`)
 }
 
 func (s *WorkerSuite) testValidateConfig(c *gc.C, f func(*caasunitprovisioner.Config), expect string) {

--- a/worker/machineundertaker/manifold.go
+++ b/worker/machineundertaker/manifold.go
@@ -15,13 +15,22 @@ import (
 	"github.com/juju/juju/worker/common"
 )
 
+// Logger represents the methods used by the worker to log details.
+type Logger interface {
+	Tracef(string, ...interface{})
+	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
 // ManifoldConfig defines the machine undertaker's configuration and
 // dependencies.
 type ManifoldConfig struct {
 	APICallerName string
 	EnvironName   string
+	Logger        Logger
 
-	NewWorker                    func(Facade, environs.Environ, common.CredentialAPI) (worker.Worker, error)
+	NewWorker                    func(Facade, environs.Environ, common.CredentialAPI, Logger) (worker.Worker, error)
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
 }
 
@@ -49,7 +58,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			w, err := config.NewWorker(api, environ, credentialAPI)
+			w, err := config.NewWorker(api, environ, credentialAPI, config.Logger)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/worker/machineundertaker/manifold_test.go
+++ b/worker/machineundertaker/manifold_test.go
@@ -5,6 +5,7 @@ package machineundertaker_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -81,7 +82,8 @@ func makeManifold(workerResult worker.Worker, workerError error) dependency.Mani
 	return machineundertaker.Manifold(machineundertaker.ManifoldConfig{
 		APICallerName: "the-caller",
 		EnvironName:   "the-environ",
-		NewWorker: func(machineundertaker.Facade, environs.Environ, common.CredentialAPI) (worker.Worker, error) {
+		Logger:        loggo.GetLogger("test"),
+		NewWorker: func(machineundertaker.Facade, environs.Environ, common.CredentialAPI, machineundertaker.Logger) (worker.Worker, error) {
 			return workerResult, workerError
 		},
 		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) {

--- a/worker/metricworker/cleanup.go
+++ b/worker/metricworker/cleanup.go
@@ -6,23 +6,20 @@ package metricworker
 import (
 	"time"
 
-	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/metricsmanager"
 	jworker "github.com/juju/juju/worker"
 )
 
-var cleanupLogger = loggo.GetLogger("juju.worker.metricworker.cleanup")
-
 const cleanupPeriod = time.Hour
 
 // NewCleanup creates a new periodic worker that calls the CleanupOldMetrics api.
-func newCleanup(client metricsmanager.MetricsManagerClient, notify chan string) worker.Worker {
+func newCleanup(client metricsmanager.MetricsManagerClient, notify chan string, logger Logger) worker.Worker {
 	f := func(stopCh <-chan struct{}) error {
 		err := client.CleanupOldMetrics()
 		if err != nil {
-			cleanupLogger.Warningf("failed to cleanup %v - will retry later", err)
+			logger.Warningf("failed to cleanup %v - will retry later", err)
 			return nil
 		}
 		select {

--- a/worker/metricworker/cleanup_test.go
+++ b/worker/metricworker/cleanup_test.go
@@ -6,6 +6,7 @@ package metricworker_test
 import (
 	"time"
 
+	"github.com/juju/loggo"
 	gc "gopkg.in/check.v1"
 
 	coretesting "github.com/juju/juju/testing"
@@ -22,7 +23,7 @@ var _ = gc.Suite(&CleanupSuite{})
 func (s *CleanupSuite) TestCleaner(c *gc.C) {
 	notify := make(chan string, 1)
 	var client mockClient
-	worker := metricworker.NewCleanup(&client, notify)
+	worker := metricworker.NewCleanup(&client, notify, loggo.GetLogger("test"))
 	defer worker.Kill()
 	select {
 	case <-notify:

--- a/worker/metricworker/metricmanager.go
+++ b/worker/metricworker/metricmanager.go
@@ -12,7 +12,7 @@ import (
 )
 
 // NewMetricsManager creates a runner that will run the metricsmanagement workers.
-func newMetricsManager(client metricsmanager.MetricsManagerClient, notify chan string) (*worker.Runner, error) {
+func newMetricsManager(client metricsmanager.MetricsManagerClient, notify chan string, logger Logger) (*worker.Runner, error) {
 	// TODO(fwereade): break this out into separate manifolds (with their own facades).
 
 	// Periodic workers automatically retry so none should return an error. If they do
@@ -25,7 +25,7 @@ func newMetricsManager(client metricsmanager.MetricsManagerClient, notify chan s
 		RestartDelay: jworker.RestartDelay,
 	})
 	err := runner.StartWorker("sender", func() (worker.Worker, error) {
-		return newSender(client, notify), nil
+		return newSender(client, notify, logger), nil
 	})
 
 	if err != nil {
@@ -33,7 +33,7 @@ func newMetricsManager(client metricsmanager.MetricsManagerClient, notify chan s
 	}
 
 	err = runner.StartWorker("cleanup", func() (worker.Worker, error) {
-		return newCleanup(client, notify), nil
+		return newCleanup(client, notify, logger), nil
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/metricworker/metricmanager_test.go
+++ b/worker/metricworker/metricmanager_test.go
@@ -6,6 +6,7 @@ package metricworker_test
 import (
 	"time"
 
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -20,7 +21,7 @@ var _ = gc.Suite(&MetricManagerSuite{})
 func (s *MetricManagerSuite) TestRunner(c *gc.C) {
 	notify := make(chan string, 2)
 	var client mockClient
-	_, err := metricworker.NewMetricsManager(&client, notify)
+	_, err := metricworker.NewMetricsManager(&client, notify, loggo.GetLogger("test"))
 	c.Assert(err, jc.ErrorIsNil)
 	expectedCalls := map[string]bool{}
 	for i := 0; i < 2; i++ {

--- a/worker/metricworker/package_test.go
+++ b/worker/metricworker/package_test.go
@@ -4,11 +4,11 @@
 package metricworker_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
-func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
 }

--- a/worker/metricworker/sender.go
+++ b/worker/metricworker/sender.go
@@ -6,24 +6,21 @@ package metricworker
 import (
 	"time"
 
-	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1"
 
 	"github.com/juju/juju/api/metricsmanager"
 	jworker "github.com/juju/juju/worker"
 )
 
-var senderLogger = loggo.GetLogger("juju.worker.metricworker.sender")
-
 const senderPeriod = 5 * time.Minute
 
 // NewSender creates a new periodic worker that sends metrics
 // to a collection service.
-func newSender(client metricsmanager.MetricsManagerClient, notify chan string) worker.Worker {
+func newSender(client metricsmanager.MetricsManagerClient, notify chan string, logger Logger) worker.Worker {
 	f := func(stopCh <-chan struct{}) error {
 		err := client.SendMetrics()
 		if err != nil {
-			senderLogger.Warningf("failed to send metrics %v - will retry later", err)
+			logger.Warningf("failed to send metrics %v - will retry later", err)
 			return nil
 		}
 		select {

--- a/worker/metricworker/sender_test.go
+++ b/worker/metricworker/sender_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/loggo"
 	gc "gopkg.in/check.v1"
 
 	coretesting "github.com/juju/juju/testing"
@@ -22,7 +23,7 @@ var _ = gc.Suite(&SenderSuite{})
 func (s *SenderSuite) TestSender(c *gc.C) {
 	notify := make(chan string, 1)
 	var client mockClient
-	worker := metricworker.NewSender(&client, notify)
+	worker := metricworker.NewSender(&client, notify, loggo.GetLogger("test"))
 	select {
 	case <-notify:
 	case <-time.After(coretesting.LongWait):

--- a/worker/modelupgrader/manifold.go
+++ b/worker/modelupgrader/manifold.go
@@ -15,6 +15,13 @@ import (
 	"github.com/juju/juju/worker/gate"
 )
 
+// Logger represents the methods used by the worker to log details.
+type Logger interface {
+	Tracef(string, ...interface{})
+	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
+}
+
 // ManifoldConfig describes how to configure and construct a Worker,
 // and what registered resources it may depend upon.
 type ManifoldConfig struct {
@@ -23,6 +30,7 @@ type ManifoldConfig struct {
 	GateName      string
 	ControllerTag names.ControllerTag
 	ModelTag      names.ModelTag
+	Logger        Logger
 
 	NewFacade                    func(base.APICaller) (Facade, error)
 	NewWorker                    func(Config) (worker.Worker, error)
@@ -69,6 +77,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ControllerTag: config.ControllerTag,
 		ModelTag:      config.ModelTag,
 		CredentialAPI: credentialAPI,
+		Logger:        config.Logger,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/modelupgrader/worker_test.go
+++ b/worker/modelupgrader/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -45,6 +46,7 @@ func (*WorkerSuite) TestNewWorker(c *gc.C) {
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
 		CredentialAPI: &credentialAPIForTest{},
+		Logger:        loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckKill(c, w)
@@ -70,6 +72,7 @@ func (*WorkerSuite) TestNewWorkerModelRemovedUninstalls(c *gc.C) {
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
 		CredentialAPI: &credentialAPIForTest{},
+		Logger:        loggo.GetLogger("test"),
 	})
 	c.Assert(errors.Cause(err), gc.ErrorMatches, modelupgrader.ErrModelRemoved.Error())
 	workertest.CheckNilOrKill(c, w)
@@ -91,6 +94,7 @@ func (*WorkerSuite) TestNonUpgradeable(c *gc.C) {
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
 		CredentialAPI: &credentialAPIForTest{},
+		Logger:        loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckKill(c, w)
@@ -143,6 +147,7 @@ func (*WorkerSuite) TestRunUpgradeOperations(c *gc.C) {
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
 		CredentialAPI: &credentialAPIForTest{},
+		Logger:        loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	workertest.CheckKill(c, w)
@@ -190,6 +195,7 @@ func (*WorkerSuite) TestRunUpgradeOperationsStepError(c *gc.C) {
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
 		CredentialAPI: &credentialAPIForTest{},
+		Logger:        loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -220,6 +226,7 @@ func (*WorkerSuite) TestWaitForUpgrade(c *gc.C) {
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
 		CredentialAPI: &credentialAPIForTest{},
+		Logger:        loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -271,6 +278,7 @@ func (*WorkerSuite) TestModelNotFoundWhenRunning(c *gc.C) {
 		ControllerTag: coretesting.ControllerTag,
 		ModelTag:      coretesting.ModelTag,
 		CredentialAPI: &credentialAPIForTest{},
+		Logger:        loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
To keep the size of the branch down, I minimized the amount of refactoring of workers or tests during the threading of the logger through.