### PR TITLE
Add a Restart Strategy for the All-Watcher to the Model-Cache Worker

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -88,7 +88,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 		},
 		PrometheusRegisterer: noopRegisterer{},
 		Cleanup:              func() {},
-	})
+	}.WithDefaultRestartStrategy())
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, modelCache) })
 

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -48,7 +48,7 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 		},
 		PrometheusRegisterer: noopRegisterer{},
 		Cleanup:              func() {},
-	})
+	}.WithDefaultRestartStrategy())
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, modelCache) })
 	c.Assert(err, jc.ErrorIsNil)
 	var controller *cache.Controller

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -524,7 +524,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	}
 	s.CreateUserHome(c, &userHomeParams)
 
-	cfg, err := config.New(config.UseDefaults, (map[string]interface{})(s.sampleConfig()))
+	cfg, err := config.New(config.UseDefaults, s.sampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := cmdtesting.Context(c)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -936,7 +936,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 				},
 				PrometheusRegisterer: noopRegisterer{},
 				Cleanup:              func() {},
-			})
+			}.WithDefaultRestartStrategy())
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/worker/modelcache/manifold.go
+++ b/worker/modelcache/manifold.go
@@ -4,9 +4,6 @@
 package modelcache
 
 import (
-	"time"
-
-	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1"
@@ -90,15 +87,12 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	}
 
 	w, err := config.NewWorker(Config{
-		InitializedGate:        unlocker,
-		Logger:                 config.Logger,
-		WatcherFactory:         func() BackingWatcher { return pool.SystemState().WatchAllModels(pool) },
-		PrometheusRegisterer:   config.PrometheusRegisterer,
-		Cleanup:                func() { _ = stTracker.Done() },
-		WatcherRestartDelayMin: 10 * time.Millisecond,
-		WatcherRestartDelayMax: time.Second,
-		Clock:                  clock.WallClock,
-	})
+		InitializedGate:      unlocker,
+		Logger:               config.Logger,
+		WatcherFactory:       func() BackingWatcher { return pool.SystemState().WatchAllModels(pool) },
+		PrometheusRegisterer: config.PrometheusRegisterer,
+		Cleanup:              func() { _ = stTracker.Done() },
+	}.WithDefaultRestartStrategy())
 	if err != nil {
 		_ = stTracker.Done()
 		return nil, errors.Trace(err)

--- a/worker/modelcache/manifold.go
+++ b/worker/modelcache/manifold.go
@@ -4,6 +4,9 @@
 package modelcache
 
 import (
+	"time"
+
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/juju/worker.v1"
@@ -87,11 +90,14 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	}
 
 	w, err := config.NewWorker(Config{
-		InitializedGate:      unlocker,
-		Logger:               config.Logger,
-		WatcherFactory:       func() BackingWatcher { return pool.SystemState().WatchAllModels(pool) },
-		PrometheusRegisterer: config.PrometheusRegisterer,
-		Cleanup:              func() { _ = stTracker.Done() },
+		InitializedGate:        unlocker,
+		Logger:                 config.Logger,
+		WatcherFactory:         func() BackingWatcher { return pool.SystemState().WatchAllModels(pool) },
+		PrometheusRegisterer:   config.PrometheusRegisterer,
+		Cleanup:                func() { _ = stTracker.Done() },
+		WatcherRestartDelayMin: 10 * time.Millisecond,
+		WatcherRestartDelayMax: time.Second,
+		Clock:                  clock.WallClock,
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -88,18 +88,18 @@ func (s *WorkerSuite) TestConfigMissingCleanup(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "missing cleanup func not valid")
 }
 
-func (s *WorkerSuite) TestConfigNegativeMinRestartDelay(c *gc.C) {
+func (s *WorkerSuite) TestConfigNonPositiveMinRestartDelay(c *gc.C) {
 	s.config.WatcherRestartDelayMin = -10 * time.Second
 	err := s.config.Validate()
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, "negative watcher min restart delay not valid")
+	c.Check(err, gc.ErrorMatches, "non-positive watcher min restart delay not valid")
 }
 
-func (s *WorkerSuite) TestConfigNegativeMaxRestartDelay(c *gc.C) {
-	s.config.WatcherRestartDelayMax = -10 * time.Second
+func (s *WorkerSuite) TestConfigNonPositiveMaxRestartDelay(c *gc.C) {
+	s.config.WatcherRestartDelayMax = 0
 	err := s.config.Validate()
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, "negative watcher max restart delay not valid")
+	c.Check(err, gc.ErrorMatches, "non-positive watcher max restart delay not valid")
 }
 
 func (s *WorkerSuite) TestConfigMissingClock(c *gc.C) {
@@ -623,7 +623,7 @@ func (s *WorkerSuite) TestWatcherErrorRestartBackoff(c *gc.C) {
 	s.config.Clock = clk
 
 	// 7 times through the loop will double the timeout (starting at 2s) until
-	// we get two times though with the max delay (1m).
+	// we get two times through with the max delay (1m).
 	maxErrors := 7
 
 	var errCount int


### PR DESCRIPTION
## Description of change

This patch prevents a flood of all-watcher restarts in the model-cache worker when the all-watcher is returning persistent errors. Such a flood can spam the logs heavily, causing them to roll quickly and losing the original error context.

The delay in restarting the all-watcher starts at 10 milliseconds and tops out a 1 second.

## QA steps

Bootstrap and deploy a unit. Observe that there are no errors.

## Documentation changes

None. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1847030
