### PR TITLE
'add-k8s' ask-or-tell and exclusivity.

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -27,7 +27,6 @@ import (
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -58,9 +57,18 @@ var usageAddCAASDetails = `
 Creates a user-defined cloud based on a k8s cluster.
 
 The new k8s cloud can then be used to bootstrap into, or it
-can be added to an existing controller; the current controller
-is used unless the --controller option is specified. If you just
-want to update your current client and not a running controller, use
+can be added to an existing controller.
+
+If the current controller can be detected, a user will be prompted to 
+confirm if the new k8s cloud need to be added to it. 
+If the prompt is not needed and the k8s cloud is always to be added to
+the current controller if that controller is detected, use --no-prompt option.
+
+Use --controller option to add k8s cloud to a different controller.
+
+Use --controller-only option to only add k8s cloud to a controller.
+
+If you just want to update your current client and not a running controller, use
 the --client-only option.
 
 Specify a non default kubeconfig file location using $KUBECONFIG
@@ -82,7 +90,7 @@ necessary parameters directly.
 Examples:
     juju add-k8s myk8scloud
     juju add-k8s myk8scloud --client-only
-    juju add-k8s myk8scloud --controller mycontroller
+    juju add-k8s myk8scloud --controller mycontroller --controller-only
     juju add-k8s --context-name mycontext myk8scloud
     juju add-k8s myk8scloud --region <cloudNameOrCloudType>/<someregion>
     juju add-k8s myk8scloud --cloud <cloudNameOrCloudType>
@@ -112,7 +120,7 @@ type AddCAASCommand struct {
 	credentialName  string
 	addCloudAPIFunc func() (AddCloudAPI, error)
 
-	// caasName is the name of the caas to add.
+	// caasName is the name of the CAAS to add.
 	caasName string
 
 	// caasType is the type of CAAS being added.
@@ -121,7 +129,7 @@ type AddCAASCommand struct {
 	// clusterName is the name of the cluster (k8s) or credential to import.
 	clusterName string
 
-	// contextName is the name of the contex to import.
+	// contextName is the name of the context to import.
 	contextName string
 
 	// project is the project id for the cluster.
@@ -145,7 +153,7 @@ type AddCAASCommand struct {
 	// workloadStorage is a storage class specified by the user.
 	workloadStorage string
 
-	// brokerGetter returns caas broker instance.
+	// brokerGetter returns CAAS broker instance.
 	brokerGetter BrokerGetter
 
 	gke        bool
@@ -158,13 +166,12 @@ type AddCAASCommand struct {
 	getAllCloudDetails func(jujuclient.CredentialGetter) (map[string]*jujucmdcloud.CloudDetails, error)
 }
 
-// NewAddCAASCommand returns a command to add caas information.
+// NewAddCAASCommand returns a command to add CAAS information.
 func NewAddCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	command := &AddCAASCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store:       store,
-			EnabledFlag: feature.MultiCloud,
+			Store: store,
 		},
 		cloudMetadataStore: cloudMetadataStore,
 		newClientConfigReader: func(caasType string) (clientconfig.ClientConfigFunc, error) {
@@ -263,11 +270,6 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 				return errors.Trace(err)
 			}
 		}
-	}
-
-	c.ControllerName, err = c.ControllerNameFromArg()
-	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
-		return errors.Trace(err)
 	}
 	return cmd.CheckEmpty(args[1:])
 }
@@ -369,6 +371,17 @@ var noRecommendedStorageErrMsg = `
 
 // Run is defined on the Command interface.
 func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName == "" {
+			// The user may have specified the controller via a --controller option.
+			// If not, let's see if there is a current controller that can be detected.
+			var err error
+			c.ControllerName, err = c.MaybePromptCurrentController(ctx, fmt.Sprintf("add k8s cloud %v to the ", c.caasName))
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
 	if err := c.verifyName(c.caasName); err != nil {
 		return errors.Trace(err)
 	}
@@ -432,40 +445,42 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if err := checkCloudRegion(c.givenHostCloudRegion, newCloud.HostCloudRegion); err != nil {
 		return errors.Trace(err)
 	}
-
-	if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := c.addCredentialToLocal(c.caasName, credential, credentialName); err != nil {
-		return errors.Trace(err)
+	if c.BothClientAndController || c.ClientOnly {
+		if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
+			return errors.Trace(err)
+		}
+		if err := c.addCredentialToLocal(c.caasName, credential, credentialName); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	if clusterName == "" {
 		clusterName = newCloud.HostCloudRegion
 	}
-	if c.ClientOnly {
-		successMsg := fmt.Sprintf("k8s substrate %q added as cloud %q%s", clusterName, c.caasName, storageMsg)
+	successMsg := fmt.Sprintf("k8s substrate %q added as cloud %q%s", clusterName, c.caasName, storageMsg)
+	var msgDisplayed bool
+	if c.BothClientAndController || c.ClientOnly {
+		msgDisplayed = true
 		successMsg += fmt.Sprintf("\nYou can now bootstrap to this cloud by running 'juju bootstrap %s'.", c.caasName)
 		fmt.Fprintln(ctx.Stdout, successMsg)
-		return nil
 	}
+	if c.BothClientAndController || c.ControllerOnly {
+		cloudClient, err := c.addCloudAPIFunc()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer cloudClient.Close()
 
-	cloudClient, err := c.addCloudAPIFunc()
-	if err != nil {
-		return errors.Trace(err)
+		if err := addCloudToController(cloudClient, newCloud); err != nil {
+			return errors.Trace(err)
+		}
+		if err := c.addCredentialToController(cloudClient, credential, credentialName); err != nil {
+			return errors.Trace(err)
+		}
+		if !msgDisplayed {
+			fmt.Fprintln(ctx.Stdout, successMsg)
+		}
 	}
-	defer cloudClient.Close()
-
-	if err := addCloudToController(cloudClient, newCloud); err != nil {
-		return errors.Trace(err)
-	}
-	if err := c.addCredentialToController(cloudClient, credential, credentialName); err != nil {
-		return errors.Trace(err)
-	}
-	successMsg := fmt.Sprintf("k8s substrate %q added as cloud %q%s", clusterName, c.caasName, storageMsg)
-	fmt.Fprintln(ctx.Stdout, successMsg)
-
 	return nil
 }
 
@@ -495,11 +510,13 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 		return nil, errors.Trace(err)
 	}
 	if !c.ClientOnly {
-		ctrlUUID, err := c.ControllerUUID(c.Store, c.ControllerName)
-		if err != nil {
-			return nil, errors.Trace(err)
+		if c.ControllerName != "" {
+			ctrlUUID, err := c.ControllerUUID(c.Store, c.ControllerName)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			openParams.ControllerUUID = ctrlUUID
 		}
-		openParams.ControllerUUID = ctrlUUID
 	}
 	return caas.New(openParams)
 }
@@ -715,6 +732,9 @@ func (c *AddCAASCommand) addCredentialToLocal(cloudName string, newCredential ju
 }
 
 func (c *AddCAASCommand) addCredentialToController(apiClient AddCloudAPI, newCredential jujucloud.Credential, credentialName string) error {
+	if c.ControllerName == "" {
+		return errors.New("Not adding k8s to the controller: no controller was specified.")
+	}
 	_, err := c.Store.ControllerByName(c.ControllerName)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -733,7 +733,7 @@ func (c *AddCAASCommand) addCredentialToLocal(cloudName string, newCredential ju
 
 func (c *AddCAASCommand) addCredentialToController(apiClient AddCloudAPI, newCredential jujucloud.Credential, credentialName string) error {
 	if c.ControllerName == "" {
-		return errors.New("Not adding k8s to the controller: no controller was specified.")
+		return errors.New("Not adding k8s cloud to the controller: no controller was specified.")
 	}
 	_, err := c.Store.ControllerByName(c.ControllerName)
 	if err != nil {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -362,13 +362,13 @@ func (s *addCAASSuite) TestAddExtraArg(c *gc.C) {
 
 func (s *addCAASSuite) TestEmptyKubeConfigFileWithoutStdin(c *gc.C) {
 	command := s.makeCommand(c, true, true, true)
-	_, err := s.runCommand(c, nil, command, "k8sname")
+	_, err := s.runCommand(c, nil, command, "k8sname", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, `No k8s cluster definitions found in config`)
 }
 
 func (s *addCAASSuite) TestAddNameClash(c *gc.C) {
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "mrcloud1")
+	_, err := s.runCommand(c, nil, command, "mrcloud1", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, `"mrcloud1" is the name of a public cloud`)
 }
 
@@ -386,7 +386,7 @@ func (s *addCAASSuite) TestMissingArgs(c *gc.C) {
 
 func (s *addCAASSuite) TestNonExistClusterName(c *gc.C) {
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "non existing cluster name")
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "non existing cluster name", "--client-only")
 	c.Assert(err, gc.ErrorMatches, `context for cluster name "non existing cluster name" not found`)
 }
 
@@ -574,10 +574,16 @@ func (s *addCAASSuite) TestGatherClusterRegionMetaRegionNoMatchesThenIgnored(c *
 	)
 }
 
+type testData struct {
+	both           bool
+	clientOnly     bool
+	controllerOnly bool
+}
+
 func (s *addCAASSuite) assertAddCloudResult(
 	c *gc.C,
 	cloudRegion, workloadStorage, operatorStorage string,
-	localOnly bool,
+	t testData,
 ) {
 	_, region, err := jujucloud.SplitHostCloudRegion(cloudRegion)
 	c.Assert(err, jc.ErrorIsNil)
@@ -598,41 +604,42 @@ func (s *addCAASSuite) assertAddCloudResult(
 	if region != "" {
 		expectedCloudToAdd.Regions = []cloud.Region{{Name: region, Endpoint: "fakeendpoint2"}}
 	}
-
-	if localOnly {
+	if t.clientOnly {
 		s.fakeCloudAPI.CheckNoCalls(c)
 	} else {
 		s.fakeCloudAPI.CheckCall(c, 0, "AddCloud", expectedCloudToAdd, false)
 	}
-	s.cloudMetadataStore.CheckCall(c, 2, "WritePersonalCloudMetadata",
-		map[string]cloud.Cloud{
-			"mrcloud1": {
-				Name:             "mrcloud1",
-				Type:             "kubernetes",
-				Description:      "",
-				AuthTypes:        cloud.AuthTypes(nil),
-				Endpoint:         "",
-				IdentityEndpoint: "",
-				StorageEndpoint:  "",
-				Regions:          []cloud.Region(nil),
-				Config:           map[string]interface{}(nil),
-				RegionConfig:     cloud.RegionConfig(nil),
+	if t.both || t.clientOnly {
+		s.cloudMetadataStore.CheckCall(c, 2, "WritePersonalCloudMetadata",
+			map[string]cloud.Cloud{
+				"mrcloud1": {
+					Name:             "mrcloud1",
+					Type:             "kubernetes",
+					Description:      "",
+					AuthTypes:        cloud.AuthTypes(nil),
+					Endpoint:         "",
+					IdentityEndpoint: "",
+					StorageEndpoint:  "",
+					Regions:          []cloud.Region(nil),
+					Config:           map[string]interface{}(nil),
+					RegionConfig:     cloud.RegionConfig(nil),
+				},
+				"mrcloud2": {
+					Name:             "mrcloud2",
+					Type:             "kubernetes",
+					Description:      "",
+					AuthTypes:        cloud.AuthTypes(nil),
+					Endpoint:         "",
+					IdentityEndpoint: "",
+					StorageEndpoint:  "",
+					Regions:          []cloud.Region(nil),
+					Config:           map[string]interface{}(nil),
+					RegionConfig:     cloud.RegionConfig(nil),
+				},
+				"myk8s": expectedCloudToAdd,
 			},
-			"mrcloud2": {
-				Name:             "mrcloud2",
-				Type:             "kubernetes",
-				Description:      "",
-				AuthTypes:        cloud.AuthTypes(nil),
-				Endpoint:         "",
-				IdentityEndpoint: "",
-				StorageEndpoint:  "",
-				Regions:          []cloud.Region(nil),
-				Config:           map[string]interface{}(nil),
-				RegionConfig:     cloud.RegionConfig(nil),
-			},
-			"myk8s": expectedCloudToAdd,
-		},
-	)
+		)
+	}
 }
 
 func (s *addCAASSuite) TestGatherClusterRegionMetaRegionMatchesAndPassThrough(c *gc.C) {
@@ -640,10 +647,11 @@ func (s *addCAASSuite) TestGatherClusterRegionMetaRegionMatchesAndPassThrough(c 
 	cloudRegion := "gce/us-east1"
 
 	command := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s".`)
-	s.assertAddCloudResult(c, cloudRegion, "", "operator-sc", false)
+	c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s".
+You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+	s.assertAddCloudResult(c, cloudRegion, "", "operator-sc", testData{both: true})
 }
 
 func (s *addCAASSuite) TestGatherClusterMetadataError(c *gc.C) {
@@ -667,7 +675,7 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRegions(c *gc.C) {
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(&result, nil)
 
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2")
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--no-prompt")
 	expectedErr := `
 	Juju needs to query the k8s cluster to ensure that the recommended
 	storage defaults are available and to detect the cluster's cloud/region.
@@ -687,7 +695,7 @@ func (s *addCAASSuite) TestGatherClusterMetadataUnknownError(c *gc.C) {
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("foo"))
 
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2")
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--no-prompt")
 	expectedErr := `
 	Juju needs to query the k8s cluster to ensure that the recommended
 	storage defaults are available and to detect the cluster's cloud/region.
@@ -702,7 +710,7 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRecommendedStorageError(c *gc.
 		&jujucaas.NonPreferredStorageError{PreferredStorage: jujucaas.PreferredStorage{Name: "disk"}})
 
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2")
+	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--no-prompt")
 	expectedErr := `
 	No recommended storage configuration is defined on this cluster.
 	Run add-k8s again with --storage=<name> and Juju will use the
@@ -726,15 +734,15 @@ func (s *addCAASSuite) TestUnknownClusterExistingStorageClass(c *gc.C) {
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
-	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class.`)
-	s.assertAddCloudResult(c, cloudRegion, "mystorage", "mystorage", false)
+	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+	s.assertAddCloudResult(c, cloudRegion, "mystorage", "mystorage", testData{both: true})
 }
 
-func (s *addCAASSuite) TestCreateDefaultStorageProvisioner(c *gc.C) {
+func (s *addCAASSuite) assertCreateDefaultStorageProvisioner(c *gc.C, expectedMsg string, t testData, additionalArgs ...string) {
 	s.fakeCloudAPI.isCloudRegionRequired = true
 	cloudRegion := "gce/us-east1"
 
@@ -752,12 +760,36 @@ func (s *addCAASSuite) TestCreateDefaultStorageProvisioner(c *gc.C) {
 	}).Returns(storageProvisioner, nil)
 
 	command := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage")
+	args := []string{"myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage"}
+	if len(additionalArgs) > 0 {
+		args = append(args, additionalArgs...)
+	}
+	ctx, err := s.runCommand(c, nil, command, args...)
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
-	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class.`)
-	s.assertAddCloudResult(c, cloudRegion, "mystorage", "mystorage", false)
+	c.Assert(result, gc.Equals, expectedMsg)
+	s.assertAddCloudResult(c, cloudRegion, "mystorage", "mystorage", t)
+}
+
+func (s *addCAASSuite) TestCreateDefaultStorageProvisionerBoth(c *gc.C) {
+	s.assertCreateDefaultStorageProvisioner(c,
+		`k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
+		testData{both: true})
+}
+
+func (s *addCAASSuite) TestCreateDefaultStorageProvisionerClientOnly(c *gc.C) {
+	s.assertCreateDefaultStorageProvisioner(c,
+		`k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
+		testData{clientOnly: true},
+		"--client-only")
+}
+
+func (s *addCAASSuite) TestCreateDefaultStorageProvisionerControllerOnly(c *gc.C) {
+	s.assertCreateDefaultStorageProvisioner(c,
+		`k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class.`,
+		testData{controllerOnly: true},
+		"--controller-only")
 }
 
 func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
@@ -779,8 +811,8 @@ func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
-	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class.`)
-	s.assertAddCloudResult(c, cloudRegion, "mystorage", "mystorage", false)
+	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+	s.assertAddCloudResult(c, cloudRegion, "mystorage", "mystorage", testData{both: true})
 }
 
 func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStorageOptionProvided(c *gc.C) {
@@ -803,8 +835,8 @@ func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStora
 	c.Assert(err, jc.ErrorIsNil)
 	result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	result = strings.Replace(result, "\n", " ", -1)
-	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class.`)
-	s.assertAddCloudResult(c, "maas", "mystorage", "mystorage", false)
+	c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+	s.assertAddCloudResult(c, "maas", "mystorage", "mystorage", testData{both: true})
 }
 
 func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
@@ -816,7 +848,7 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `k8s substrate "mrcloud2" added as cloud "myk8s".You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
 	c.Assert(strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1), gc.Equals, expected)
-	s.assertAddCloudResult(c, cloudRegion, "", "operator-sc", true)
+	s.assertAddCloudResult(c, cloudRegion, "", "operator-sc", testData{clientOnly: true})
 }
 
 func mockStdinPipe(content string) (*os.File, error) {


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju add-k8s' command.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only operation but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Occasionally, users may not want to add-k8s to both the client and a controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

Drive-by:
Removed multi-cloud feature flag.

## Documentation changes

all of the above.