### PR TITLE
remove-k8s ask-or-tell and exclusivity.

### DIFF
--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -21,11 +21,12 @@ Removes a k8s cloud from Juju.`[1:]
 
 var usageRemoveCAASDetails = `
 Removes the specified k8s cloud from this client.
+
 If --controller is used, also removes the cloud 
 from the specified controller (if it is not in use).
 
 If --controller option was not used and the current controller can be detected, 
-a user will be prompted to confirm if the new k8s cloud need to be removed from it. 
+a user will be prompted to confirm if the k8s cloud needs to be removed from it. 
 If the prompt is not needed and the k8s cloud is always to be removed from
 the current controller if that controller is detected, use --no-prompt option.
 

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -4,6 +4,8 @@
 package caas
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
@@ -11,17 +13,24 @@ import (
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
 var usageRemoveCAASSummary = `
-Removes a k8s endpoint from Juju.`[1:]
+Removes a k8s cloud from Juju.`[1:]
 
 var usageRemoveCAASDetails = `
 Removes the specified k8s cloud from this client.
 If --controller is used, also removes the cloud 
 from the specified controller (if it is not in use).
+
+If --controller option was not used and the current controller can be detected, 
+a user will be prompted to confirm if the new k8s cloud need to be removed from it. 
+If the prompt is not needed and the k8s cloud is always to be removed from
+the current controller if that controller is detected, use --no-prompt option.
+
+If you just want to update your controller and not
+your current client, use the --controller-only option.
 
 If you just want to update your current client and not
 a running controller, use the --client-only option.
@@ -29,6 +38,7 @@ a running controller, use the --client-only option.
 Examples:
     juju remove-k8s myk8scloud
     juju remove-k8s myk8scloud --client-only
+    juju remove-k8s myk8scloud --controller-only --no-prompt
     juju remove-k8s --controller mycontroller myk8scloud
     
 See also:
@@ -57,8 +67,7 @@ func NewRemoveCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	command := &RemoveCAASCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store:       store,
-			EnabledFlag: feature.MultiCloud,
+			Store: store,
 		},
 
 		cloudMetadataStore: cloudMetadataStore,
@@ -89,41 +98,53 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 		return err
 	}
 	if len(args) == 0 {
-		return errors.Errorf("missing k8s name.")
+		return errors.Errorf("missing k8s cloud name.")
 	}
 	c.cloudName = args[0]
-	c.ControllerName, err = c.ControllerNameFromArg()
-	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
-		return errors.Trace(err)
-	}
 	return cmd.CheckEmpty(args[1:])
 }
 
 // Run is defined on the Command interface.
 func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName == "" {
+			// The user may have specified the controller via a --controller option.
+			// If not, let's see if there is a current controller that can be detected.
+			var err error
+			c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("remove k8s cloud %v from ", c.cloudName))
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
 	if c.ControllerName == "" && !c.ClientOnly {
-		return errors.Errorf(
-			"There are no controllers running.\nTo remove cloud %q from the current client, use the --client-only option.", c.cloudName)
+		ctxt.Infof("There are no controllers running.\nTo remove cloud %q from the current client, use the --client-only option.", c.cloudName)
 	}
-	if err := removeCloudFromLocal(c.cloudMetadataStore, c.cloudName); err != nil {
-		return errors.Annotatef(err, "cannot remove cloud from current client")
-	}
+	if c.BothClientAndController || c.ClientOnly {
+		if err := removeCloudFromLocal(c.cloudMetadataStore, c.cloudName); err != nil {
+			return errors.Annotatef(err, "cannot remove cloud from current client")
+		}
 
-	if err := c.Store.UpdateCredential(c.cloudName, cloud.CloudCredential{}); err != nil {
-		return errors.Annotatef(err, "cannot remove credential from current client")
+		if err := c.Store.UpdateCredential(c.cloudName, cloud.CloudCredential{}); err != nil {
+			return errors.Annotatef(err, "cannot remove credential from current client")
+		}
+		if c.ClientOnly {
+			return nil
+		}
 	}
 	if c.ControllerName == "" {
-		return nil
+		return errors.New("No controller was specified: cannot remove k8s cloud from a controller.")
 	}
+	if c.BothClientAndController || c.ControllerOnly {
+		cloudAPI, err := c.apiFunc()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer cloudAPI.Close()
 
-	cloudAPI, err := c.apiFunc()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer cloudAPI.Close()
-
-	if err := cloudAPI.RemoveCloud(c.cloudName); err != nil {
-		return errors.Annotatef(err, "cannot remove k8s cloud from controller")
+		if err := cloudAPI.RemoveCloud(c.cloudName); err != nil {
+			return errors.Annotatef(err, "cannot remove k8s cloud from controller")
+		}
 	}
 	return nil
 }

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -102,7 +102,7 @@ func (s *removeCAASSuite) TestExtraArg(c *gc.C) {
 func (s *removeCAASSuite) TestMissingName(c *gc.C) {
 	command := s.makeCommand()
 	_, err := s.runCommand(c, command)
-	c.Assert(err, gc.ErrorMatches, `missing k8s name.`)
+	c.Assert(err, gc.ErrorMatches, `missing k8s cloud name.`)
 }
 
 func (s *removeCAASSuite) TestRemove(c *gc.C) {

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -120,16 +120,31 @@ func (s *removeCAASSuite) TestRemove(c *gc.C) {
 	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
 }
 
+func (s *removeCAASSuite) TestRemoveControllerOnly(c *gc.C) {
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "myk8s", "-c", "foo", "--controller-only")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// controller side operations
+	s.fakeCloudAPI.CheckCallNames(c, "RemoveCloud")
+	s.fakeCloudAPI.CheckCall(c, 0, "RemoveCloud", "myk8s")
+
+	// client side operations
+	s.cloudMetadataStore.CheckNoCalls(c)
+	s.store.CheckNoCalls(c)
+}
+
 func (s *removeCAASSuite) TestRemoveLocalOnly(c *gc.C) {
 	command := s.makeCommand()
 	_, err := s.runCommand(c, command, "myk8s", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 
+	// controller side operations
 	s.fakeCloudAPI.CheckNoCalls(c)
 
+	// client side operations
 	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata", "WritePersonalCloudMetadata")
 	s.cloudMetadataStore.CheckCall(c, 1, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
-
 	s.store.CheckCallNames(c, "UpdateCredential")
 	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
 }
@@ -143,11 +158,16 @@ func (s *removeCAASSuite) TestRemoveNoController(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	msg := err.Error()
 	msg = strings.Replace(msg, "\n", "", -1)
-	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from the current client, use the --client-only option.*`)
+	c.Assert(msg, gc.Matches, `No controller was specified: cannot remove k8s cloud from a controller.`)
 
+	// controller side operations
 	s.fakeCloudAPI.CheckNoCalls(c)
-	s.cloudMetadataStore.CheckNoCalls(c)
-	s.store.CheckNoCalls(c)
+
+	// client side operations
+	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata", "WritePersonalCloudMetadata", "PersonalCloudMetadata")
+	s.cloudMetadataStore.CheckCall(c, 1, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
+	s.store.CheckCallNames(c, "UpdateCredential", "UpdateCredential")
+	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
 }
 
 func (s *removeCAASSuite) TestRemoveNotInController(c *gc.C) {


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju remove-k8s' command.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only operation but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Occasionally, users may not want to add-k8s to both the client and a controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

Drive-by:
Removed multi-cloud feature flag.

## Documentation changes

all of the above