### PR TITLE
Use model owner and name for model logfile name on controller

### DIFF
--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -331,7 +331,7 @@ func (a *ActionAPI) Tasks(arg params.TaskQueryArgs) (params.ActionResults, error
 	}
 
 	var entities params.Entities
-	for _, unitTag := range unitTags.Values() {
+	for _, unitTag := range unitTags.SortedValues() {
 		entities.Entities = append(entities.Entities, params.Entity{Tag: unitTag})
 	}
 
@@ -340,7 +340,7 @@ func (a *ActionAPI) Tasks(arg params.TaskQueryArgs) (params.ActionResults, error
 		statusSet = set.NewStrings(params.ActionPending, params.ActionRunning, params.ActionCompleted)
 	}
 	var extractorFuncs []extractorFn
-	for _, status := range statusSet.Values() {
+	for _, status := range statusSet.SortedValues() {
 		switch status {
 		case params.ActionPending:
 			extractorFuncs = append(extractorFuncs, pendingActions)

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
 
@@ -892,11 +893,7 @@ func (s *actionSuite) TestTasksAppFilter(c *gc.C) {
 	c.Assert(actions.Results, gc.HasLen, 2)
 	result0 := actions.Results[0]
 	result1 := actions.Results[1]
-	if result0.Status == "running" {
-		r := result0
-		result0 = result1
-		result1 = r
-	}
+
 	c.Assert(result0.Action, gc.NotNil)
 	if result0.Enqueued.IsZero() {
 		c.Fatal("enqueued time not set")
@@ -948,28 +945,26 @@ func (s *actionSuite) TestTasksAppAndUnitFilter(c *gc.C) {
 	})
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(actions.Results, gc.HasLen, 2)
-	result0 := actions.Results[0]
-	result1 := actions.Results[1]
-	if result0.Status == "running" {
-		r := result0
-		result0 = result1
-		result1 = r
-	}
-	c.Assert(result0.Action, gc.NotNil)
-	if result0.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	c.Assert(result0.Status, gc.Equals, "pending")
-	c.Assert(result0.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result0.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result0.Action.Tag, gc.Equals, "action-3")
+	mysqlAction := actions.Results[0]
+	wordpressAction := actions.Results[1]
+	c.Log(pretty.Sprint(actions.Results))
 
-	c.Assert(result1.Action, gc.NotNil)
-	if result1.Enqueued.IsZero() {
+	c.Assert(mysqlAction.Action, gc.NotNil)
+	if mysqlAction.Enqueued.IsZero() {
 		c.Fatal("enqueued time not set")
 	}
-	c.Assert(result1.Status, gc.Equals, "pending")
-	c.Assert(result1.Action.Name, gc.Equals, "anotherfakeaction")
-	c.Assert(result1.Action.Receiver, gc.Equals, "unit-mysql-0")
-	c.Assert(result1.Action.Tag, gc.Equals, "action-4")
+	c.Assert(mysqlAction.Status, gc.Equals, "pending")
+	c.Assert(mysqlAction.Action.Name, gc.Equals, "anotherfakeaction")
+	c.Assert(mysqlAction.Action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(mysqlAction.Action.Tag, gc.Equals, "action-4")
+
+	c.Assert(wordpressAction.Action, gc.NotNil)
+	if wordpressAction.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	c.Assert(wordpressAction.Status, gc.Equals, "pending")
+	c.Assert(wordpressAction.Action.Name, gc.Equals, "fakeaction")
+	c.Assert(wordpressAction.Action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(wordpressAction.Action.Tag, gc.Equals, "action-3")
+
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1060,7 +1060,8 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 	if agentModelUUID == cfg.ModelUUID {
 		writer = a.ctx.Stderr
 	} else {
-		logFilename := filepath.Join(currentConfig.LogDir(), "models", cfg.ModelUUID+".log")
+		filename := cfg.ModelName + "-" + cfg.ModelUUID[:6] + ".log"
+		logFilename := filepath.Join(currentConfig.LogDir(), "models", filename)
 		writer = &lumberjack.Logger{
 			Filename:   logFilename,
 			MaxSize:    cfg.ControllerConfig.ModelLogfileMaxSizeMB(),

--- a/core/paths/paths.go
+++ b/core/paths/paths.go
@@ -194,6 +194,10 @@ func SetSyslogOwner(filename string) error {
 	return SetOwnership(filename, user, group)
 }
 
+// Chown is a variable here so it can be mocked out in tests to a no-op.
+// Agents run as root, but users don't.
+var Chown = os.Chown
+
 // SetOwnership sets the ownership of a given file from a path.
 // Searches for the corresponding id's from user, group and uses them to chown.
 func SetOwnership(filePath string, wantedUser string, wantedGroup string) error {
@@ -213,7 +217,7 @@ func SetOwnership(filePath string, wantedUser string, wantedGroup string) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return os.Chown(filePath, uid, gid)
+	return Chown(filePath, uid, gid)
 }
 
 // PrimeLogFile ensures that the given log file is created with the

--- a/core/paths/paths.go
+++ b/core/paths/paths.go
@@ -33,6 +33,7 @@ const (
 	cloudInitCfgDir
 	curtinInstallConfig
 
+	// LogfilePermission is the file mode to use for log files.
 	LogfilePermission = os.FileMode(0640)
 )
 
@@ -40,7 +41,7 @@ const (
 	// NixDataDir is location for agent binaries on *nix operating systems.
 	NixDataDir = "/var/lib/juju"
 
-	// NixDataDir is location for Juju logs on *nix operating systems.
+	// NixLogDir is location for Juju logs on *nix operating systems.
 	NixLogDir = "/var/log"
 )
 
@@ -186,9 +187,16 @@ func MustSucceed(s string, e error) string {
 	return s
 }
 
-// Sets the ownership of a given file from a path.
-// Searches for the corresponding id's from user, group and uses them to chown
-func SetOwnerShip(filePath string, wantedUser string, wantedGroup string) error {
+// SetSyslogOwner sets the owner and group of the file to be the appropriate
+// syslog users as defined by the SyslogUserGroup method.
+func SetSyslogOwner(filename string) error {
+	user, group := SyslogUserGroup()
+	return SetOwnership(filename, user, group)
+}
+
+// SetOwnership sets the ownership of a given file from a path.
+// Searches for the corresponding id's from user, group and uses them to chown.
+func SetOwnership(filePath string, wantedUser string, wantedGroup string) error {
 	group, err := user.LookupGroup(wantedGroup)
 	if err != nil {
 		return errors.Trace(err)
@@ -218,8 +226,7 @@ func PrimeLogFile(path string) error {
 	if err := f.Close(); err != nil {
 		return errors.Trace(err)
 	}
-	wantedOwner, wantedGroup := SyslogUserGroup()
-	return SetOwnerShip(path, wantedOwner, wantedGroup)
+	return SetSyslogOwner(path)
 }
 
 // SyslogUserGroup returns the names of the user and group that own the log files.

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -152,6 +153,7 @@ func (s *JujuConnSuite) SetUpSuite(c *gc.C) {
 	s.PatchValue(&utils.OutgoingAccessAllowed, false)
 	s.PatchValue(&cert.NewCA, testing.NewCA)
 	s.PatchValue(&cert.NewLeafKeyBits, 512)
+	s.PatchValue(&paths.Chown, func(name string, uid, gid int) error { return nil })
 }
 
 func (s *JujuConnSuite) TearDownSuite(c *gc.C) {

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -115,7 +115,7 @@ func setJujuFolderPermissionsToAdm(dir string) error {
 			return nil
 		}
 		fullPath := dir + string(os.PathSeparator) + info.Name()
-		if err := paths.SetOwnerShip(fullPath, wantedOwner, wantedGroup); err != nil {
+		if err := paths.SetOwnership(fullPath, wantedOwner, wantedGroup); err != nil {
 			return errors.Trace(err)
 		}
 		if err := os.Chmod(fullPath, paths.LogfilePermission); err != nil {

--- a/worker/modelworkermanager/modelworkermanager_test.go
+++ b/worker/modelworkermanager/modelworkermanager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/workertest"
 	"gopkg.in/tomb.v2"
@@ -332,6 +333,14 @@ func (m *mockModel) MigrationMode() state.MigrationMode {
 
 func (m *mockModel) Type() state.ModelType {
 	return m.modelType
+}
+
+func (m *mockModel) Name() string {
+	return "doesn't matter for this test"
+}
+
+func (m *mockModel) Owner() names.UserTag {
+	return names.NewUserTag("anyone-is-fine")
 }
 
 type mockEnvWatcher struct {


### PR DESCRIPTION
Instead of just having the model's log in the controller's log directory just using the model UUID, use the owner and name of the model, and a short part of the UUID just in case the operator is looking for the model-uuid.
