### PR TITLE
'remove-cloud' ask-or-tell and exclusivity.

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -60,7 +60,7 @@ The new k8s cloud can then be used to bootstrap into, or it
 can be added to an existing controller.
 
 If the current controller can be detected, a user will be prompted to 
-confirm if the new k8s cloud need to be added to it. 
+confirm if the new k8s cloud needs to be added to it. 
 If the prompt is not needed and the k8s cloud is always to be added to
 the current controller if that controller is detected, use --no-prompt option.
 
@@ -376,7 +376,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 			// The user may have specified the controller via a --controller option.
 			// If not, let's see if there is a current controller that can be detected.
 			var err error
-			c.ControllerName, err = c.MaybePromptCurrentController(ctx, fmt.Sprintf("add k8s cloud %v to the ", c.caasName))
+			c.ControllerName, err = c.MaybePromptCurrentController(ctx, fmt.Sprintf("add k8s cloud %v to", c.caasName))
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -62,10 +62,9 @@ func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (s
 	}
 }
 
-func NewRemoveCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func(string) (removeCloudAPI, error)) *removeCloudCommand {
+func NewRemoveCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (removeCloudAPI, error)) *removeCloudCommand {
 	return &removeCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		store:                     store,
 		removeCloudAPIFunc:        cloudAPI,
 	}
 }

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -43,7 +43,7 @@ Examples:
 
 See also:
     add-cloud
-	update-cloud
+    update-cloud
     list-clouds`
 
 type removeCloudCommand struct {

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -4,6 +4,8 @@
 package cloud
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
@@ -11,27 +13,37 @@ import (
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
 var usageRemoveCloudSummary = `
-Removes a user-defined cloud from Juju.`[1:]
+Removes a cloud from Juju.`[1:]
 
 var usageRemoveCloudDetails = `
-Remove a named, user-defined cloud from Juju's internal cache.
+Remove a cloud from Juju.
 
-If the multi-cloud feature flag is enabled, the cloud is removed from a controller.
-The current controller is used unless the --controller option is specified.
-If --client-only is specified, Juju removes the cloud from this client.
+If --controller is used, also remove the cloud from the specified controller,
+if it is not in use.
+
+If --controller option was not used and the current controller can be detected, 
+a user will be prompted to confirm if specified cloud needs to be removed from it. 
+If the prompt is not needed and the cloud is always to be removed from
+the current controller if that controller is detected, use --no-prompt option.
+
+If you just want to update your controller and not your current client, 
+use the --controller-only option.
+
+If --client-only is specified, Juju removes the cloud from this client only.
 
 Examples:
     juju remove-cloud mycloud
+    juju remove-cloud mycloud --controller-only --no-prompt
     juju remove-cloud mycloud --client-only
     juju remove-cloud mycloud --controller mycontroller
 
 See also:
     add-cloud
+	update-cloud
     list-clouds`
 
 type removeCloudCommand struct {
@@ -41,9 +53,7 @@ type removeCloudCommand struct {
 	Cloud string
 
 	// Used when querying a controller for its cloud details
-	controllerName     string
-	store              jujuclient.ClientStore
-	removeCloudAPIFunc func(controllerName string) (removeCloudAPI, error)
+	removeCloudAPIFunc func() (removeCloudAPI, error)
 }
 
 type removeCloudAPI interface {
@@ -56,17 +66,15 @@ func NewRemoveCloudCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &removeCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store:       store,
-			EnabledFlag: feature.MultiCloud,
+			Store: store,
 		},
-		store: store,
 	}
 	c.removeCloudAPIFunc = c.cloudAPI
 	return modelcmd.WrapBase(c)
 }
 
-func (c *removeCloudCommand) cloudAPI(controllerName string) (removeCloudAPI, error) {
-	root, err := c.NewAPIRoot(c.store, controllerName, "")
+func (c *removeCloudCommand) cloudAPI() (removeCloudAPI, error) {
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -90,22 +98,40 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 		return errors.New("Usage: juju remove-cloud <cloud name>")
 	}
 	c.Cloud = args[0]
-	c.ControllerName, err = c.ControllerNameFromArg()
-	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
-		return errors.Trace(err)
-	}
 	return cmd.CheckEmpty(args[1:])
 }
 
 func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
-	if c.ControllerName == "" {
-		if c.ControllerName == "" && !c.ClientOnly {
-			return errors.Errorf(
-				"There are no controllers running.\nTo remove cloud %q from this client, use the --client-only option.", c.Cloud)
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName == "" {
+			// The user may have specified the controller via a --controller option.
+			// If not, let's see if there is a current controller that can be detected.
+			var err error
+			c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("remove cloud %v from", c.Cloud))
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
-		return c.removeLocalCloud(ctxt)
 	}
-	return c.removeControllerCloud(ctxt)
+	if c.ControllerName == "" && !c.ClientOnly {
+		ctxt.Infof("To remove cloud %q from this client, use the --client-only option.", c.Cloud)
+	}
+	var returnErr error
+	if c.BothClientAndController || c.ClientOnly {
+		if err := c.removeLocalCloud(ctxt); err != nil {
+			ctxt.Warningf("%v", err)
+			returnErr = cmd.ErrSilent
+		}
+	}
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName == "" {
+			ctxt.Infof("Could not remote a cloud from a controller: no controller was specified.")
+			returnErr = cmd.ErrSilent
+		} else {
+			return c.removeControllerCloud(ctxt)
+		}
+	}
+	return returnErr
 }
 
 func (c *removeCloudCommand) removeLocalCloud(ctxt *cmd.Context) error {
@@ -114,19 +140,19 @@ func (c *removeCloudCommand) removeLocalCloud(ctxt *cmd.Context) error {
 		return err
 	}
 	if _, ok := personalClouds[c.Cloud]; !ok {
-		ctxt.Infof("No personal cloud called %q exists", c.Cloud)
+		ctxt.Infof("No cloud called %q exists on this client", c.Cloud)
 		return nil
 	}
 	delete(personalClouds, c.Cloud)
 	if err := cloud.WritePersonalCloudMetadata(personalClouds); err != nil {
 		return errors.Trace(err)
 	}
-	ctxt.Infof("Removed details of personal cloud %q", c.Cloud)
+	ctxt.Infof("Removed details of cloud %q from the client", c.Cloud)
 	return nil
 }
 
 func (c *removeCloudCommand) removeControllerCloud(ctxt *cmd.Context) error {
-	api, err := c.removeCloudAPIFunc(c.ControllerName)
+	api, err := c.removeCloudAPIFunc()
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -161,6 +161,6 @@ func (c *removeCloudCommand) removeControllerCloud(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	ctxt.Infof("Cloud %q on controller %q removed", c.Cloud, c.ControllerName)
+	ctxt.Infof("Removed details of cloud %q from controller %q", c.Cloud, c.ControllerName)
 	return nil
 }

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -5,8 +5,8 @@ package cloud_test
 
 import (
 	"io/ioutil"
-	"strings"
 
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -37,18 +37,18 @@ func (s *removeSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *removeSuite) TestRemoveBadArgs(c *gc.C) {
-	cmd := cloud.NewRemoveCloudCommand()
-	_, err := cmdtesting.RunCommand(c, cmd, "--client-only")
+	command := cloud.NewRemoveCloudCommand()
+	_, err := cmdtesting.RunCommand(c, command, "--client-only")
 	c.Assert(err, gc.ErrorMatches, "Usage: juju remove-cloud <cloud name>")
-	_, err = cmdtesting.RunCommand(c, cmd, "cloud", "extra", "--client-only")
+	_, err = cmdtesting.RunCommand(c, command, "cloud", "extra", "--client-only")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *removeSuite) TestRemoveNotFound(c *gc.C) {
-	cmd := cloud.NewRemoveCloudCommandForTest(s.store, nil)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "fnord", "--client-only")
+	command := cloud.NewRemoveCloudCommandForTest(s.store, nil)
+	ctx, err := cmdtesting.RunCommand(c, command, "fnord", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"fnord\" exists\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No cloud called \"fnord\" exists on this client\n")
 }
 
 func (s *removeSuite) createTestCloudData(c *gc.C) {
@@ -76,57 +76,77 @@ clouds:
 }
 
 func (s *removeSuite) TestRemoveCloudLocal(c *gc.C) {
-	cmd := cloud.NewRemoveCloudCommandForTest(
+	command := cloud.NewRemoveCloudCommandForTest(
 		s.store,
-		func(controllerName string) (cloud.RemoveCloudAPI, error) {
+		func() (cloud.RemoveCloudAPI, error) {
 			c.Fail()
 			return s.api, nil
 		})
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	ctx, err := cmdtesting.RunCommand(c, cmd, "homestack", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of personal cloud \"homestack\"\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of cloud \"homestack\" from the client\n")
 	assertPersonalClouds(c, "homestack2")
 }
 
 func (s *removeSuite) TestRemoveCloudNoControllers(c *gc.C) {
 	s.store.Controllers = nil
-	cmd := cloud.NewRemoveCloudCommandForTest(
+	command := cloud.NewRemoveCloudCommandForTest(
 		s.store,
-		func(controllerName string) (cloud.RemoveCloudAPI, error) {
+		func() (cloud.RemoveCloudAPI, error) {
 			c.Fail()
 			return s.api, nil
 		})
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	_, err := cmdtesting.RunCommand(c, cmd, "homestack")
-	c.Assert(err, gc.NotNil)
-	msg := err.Error()
-	msg = strings.Replace(msg, "\n", "", -1)
-	c.Assert(msg, gc.Matches, `There are no controllers running.To remove cloud "homestack" from this client, use the --client-only option.*`)
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	assertPersonalClouds(c, "homestack2")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches,
+		"To remove cloud \"homestack\" from this client, use the --client-only option.\n"+
+			"Removed details of cloud \"homestack\" from the client\n"+
+			"Could not remote a cloud from a controller: no controller was specified.\n")
+}
+
+func (s *removeSuite) TestRemoveCloudControllerControllerOnly(c *gc.C) {
+	command := cloud.NewRemoveCloudCommandForTest(
+		s.store,
+		func() (cloud.RemoveCloudAPI, error) {
+			return s.api, nil
+		})
+	s.createTestCloudData(c)
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--no-prompt", "--controller-only")
+	c.Assert(err, jc.ErrorIsNil)
+	assertPersonalClouds(c, "homestack", "homestack2")
+	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
+	s.api.CheckCallNames(c, "RemoveCloud", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"homestack\" on controller \"mycontroller\" removed\n")
 }
 
 func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
-	var controllerAPICalled string
-	cmd := cloud.NewRemoveCloudCommandForTest(
+	command := cloud.NewRemoveCloudCommandForTest(
 		s.store,
-		func(controllerName string) (cloud.RemoveCloudAPI, error) {
-			controllerAPICalled = controllerName
+		func() (cloud.RemoveCloudAPI, error) {
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "homestack")
+	s.createTestCloudData(c)
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(controllerAPICalled, gc.Equals, "mycontroller")
+	assertPersonalClouds(c, "homestack2")
+	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	s.api.CheckCallNames(c, "RemoveCloud", "Close")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"homestack\" on controller \"mycontroller\" removed\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals,
+		"Removed details of cloud \"homestack\" from the client\n"+
+			"Cloud \"homestack\" on controller \"mycontroller\" removed\n")
 }
 
 func (s *removeSuite) TestCannotRemovePublicCloud(c *gc.C) {
 	s.createTestCloudData(c)
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No personal cloud called \"prodstack\" exists\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No cloud called \"prodstack\" exists on this client\n")
 }
 
 func assertPersonalClouds(c *gc.C, names ...string) {

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -122,7 +122,7 @@ func (s *removeSuite) TestRemoveCloudControllerControllerOnly(c *gc.C) {
 	assertPersonalClouds(c, "homestack", "homestack2")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	s.api.CheckCallNames(c, "RemoveCloud", "Close")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"homestack\" on controller \"mycontroller\" removed\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of cloud \"homestack\" from controller \"mycontroller\"\n")
 }
 
 func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
@@ -139,7 +139,7 @@ func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
 	s.api.CheckCallNames(c, "RemoveCloud", "Close")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals,
 		"Removed details of cloud \"homestack\" from the client\n"+
-			"Cloud \"homestack\" on controller \"mycontroller\" removed\n")
+			"Removed details of cloud \"homestack\" from controller \"mycontroller\"\n")
 }
 
 func (s *removeSuite) TestCannotRemovePublicCloud(c *gc.C) {


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju remove-cloud' command.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only operation but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Occasionally, users may not want to add-k8s to both the client and a controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

Drive-by:
* fix typos in 'add-k8s' help;
* removed multi-cloud feature flag;
* remove redundant duplicate variables that do not work.

## Documentation changes

all of the above.
