### PR TITLE
Make db upgrade worker compatible with k8s controllers

### DIFF
--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	// Profiledir is the directory where the profile script is written.
+	// ProfileDir is the directory where the profile script is written.
 	ProfileDir        = "/etc/profile.d"
 	bashFuncsFilename = "juju-introspection.sh"
 )

--- a/worker/upgradedatabase/manifold.go
+++ b/worker/upgradedatabase/manifold.go
@@ -55,12 +55,12 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			// Determine this machine's agent and tag.
-			var machineAgent agent.Agent
-			if err := context.Get(cfg.AgentName, &machineAgent); err != nil {
+			// Determine this controller's agent and tag.
+			var controllerAgent agent.Agent
+			if err := context.Get(cfg.AgentName, &controllerAgent); err != nil {
 				return nil, errors.Trace(err)
 			}
-			tag := machineAgent.CurrentConfig().Tag()
+			tag := controllerAgent.CurrentConfig().Tag()
 
 			// Wrap the state pool factory to return our implementation.
 			openState := func() (Pool, error) {
@@ -79,7 +79,7 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 			workerCfg := Config{
 				UpgradeComplete: upgradeStepsLock,
 				Tag:             tag,
-				Agent:           machineAgent,
+				Agent:           controllerAgent,
 				Logger:          cfg.Logger,
 				OpenState:       openState,
 				PerformUpgrade:  performUpgrade,

--- a/worker/upgradedatabase/worker.go
+++ b/worker/upgradedatabase/worker.go
@@ -81,7 +81,7 @@ func (cfg Config) Validate() error {
 		return errors.NotValidf("nil machine tag")
 	}
 	k := cfg.Tag.Kind()
-	if k != names.MachineTagKind {
+	if k != names.MachineTagKind && k != names.ControllerAgentTagKind {
 		return errors.NotValidf("%q tag kind", k)
 	}
 	if cfg.Agent == nil {

--- a/worker/upgradedatabase/worker_test.go
+++ b/worker/upgradedatabase/worker_test.go
@@ -76,6 +76,8 @@ func (s *workerSuite) TestValidateConfig(c *gc.C) {
 
 	cfg := s.getConfig()
 	c.Check(cfg.Validate(), jc.ErrorIsNil)
+	cfg.Tag = names.NewControllerAgentTag("0")
+	c.Check(cfg.Validate(), jc.ErrorIsNil)
 
 	cfg.UpgradeComplete = nil
 	c.Check(cfg.Validate(), jc.Satisfies, errors.IsNotValid)


### PR DESCRIPTION
## Description of change

The new db upgrade worker was assuming a machine tag for the controller. For k8s, the tag can also be a controller agent tag.
Also, the check for mongo primary needed tweaking on k8s.

## QA steps

bootstrap a k8s controller
check logs for errors, previously there was log spam

