### PR TITLE
CAAS unit init container for hook ctx and juju-run

### DIFF
--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -151,12 +151,13 @@ type DeploymentInfo struct {
 
 // ProvisioningInfo holds unit provisioning info.
 type ProvisioningInfo struct {
-	DeploymentInfo DeploymentInfo
-	PodSpec        string
-	Constraints    constraints.Value
-	Filesystems    []storage.KubernetesFilesystemParams
-	Devices        []devices.KubernetesDeviceParams
-	Tags           map[string]string
+	DeploymentInfo    DeploymentInfo
+	PodSpec           string
+	Constraints       constraints.Value
+	Filesystems       []storage.KubernetesFilesystemParams
+	Devices           []devices.KubernetesDeviceParams
+	Tags              map[string]string
+	OperatorImagePath string
 }
 
 // ProvisioningInfo returns the provisioning info for the specified CAAS
@@ -180,9 +181,10 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 	}
 	result := results.Results[0].Result
 	info := &ProvisioningInfo{
-		PodSpec:     result.PodSpec,
-		Constraints: result.Constraints,
-		Tags:        result.Tags,
+		PodSpec:           result.PodSpec,
+		Constraints:       result.Constraints,
+		Tags:              result.Tags,
+		OperatorImagePath: result.OperatorImagePath,
 	}
 	if result.DeploymentInfo != nil {
 		info.DeploymentInfo = DeploymentInfo{

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -46,9 +46,10 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 		*(result.(*params.KubernetesProvisioningInfoResults)) = params.KubernetesProvisioningInfoResults{
 			Results: []params.KubernetesProvisioningInfoResult{{
 				Result: &params.KubernetesProvisioningInfo{
-					PodSpec:     "foo",
-					Tags:        map[string]string{"foo": "bar"},
-					Constraints: constraints.MustParse("mem=4G"),
+					PodSpec:           "foo",
+					Tags:              map[string]string{"foo": "bar"},
+					Constraints:       constraints.MustParse("mem=4G"),
+					OperatorImagePath: "operator/image-path",
 					DeploymentInfo: &params.KubernetesDeploymentInfo{
 						DeploymentType: "stateful",
 						ServiceType:    "loadbalancer",
@@ -82,9 +83,10 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 	info, err := client.ProvisioningInfo("gitlab")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &caasunitprovisioner.ProvisioningInfo{
-		PodSpec:     "foo",
-		Tags:        map[string]string{"foo": "bar"},
-		Constraints: constraints.MustParse("mem=4G"),
+		PodSpec:           "foo",
+		Tags:              map[string]string{"foo": "bar"},
+		Constraints:       constraints.MustParse("mem=4G"),
+		OperatorImagePath: "operator/image-path",
 		DeploymentInfo: caasunitprovisioner.DeploymentInfo{
 			DeploymentType: "stateful",
 			ServiceType:    "loadbalancer",

--- a/apiserver/facades/agent/caasoperator/export_test.go
+++ b/apiserver/facades/agent/caasoperator/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+var NewUnitIDWatcher = newUnitIDWatcher

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -35,6 +35,7 @@ type Model interface {
 	UUID() string
 	Type() state.ModelType
 	ModelConfig() (*config.Config, error)
+	Containers(providerIds ...string) ([]state.CloudContainer, error)
 }
 
 // Application provides the subset of application state

--- a/apiserver/facades/agent/caasoperator/watcher.go
+++ b/apiserver/facades/agent/caasoperator/watcher.go
@@ -1,0 +1,105 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/catacomb"
+
+	corewatcher "github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/state"
+)
+
+type unitIDWatcher struct {
+	catacomb catacomb.Catacomb
+	out      chan []string
+	src      corewatcher.StringsWatcher
+	model    watcherModelInterface
+}
+
+type watcherModelInterface interface {
+	Containers(providerIds ...string) ([]state.CloudContainer, error)
+}
+
+// newUnitIDWatcher watches a StringsWatcher and converts ProviderIDs into UnitIDs and re-emits them.
+func newUnitIDWatcher(model watcherModelInterface, src corewatcher.StringsWatcher) (*unitIDWatcher, error) {
+	w := &unitIDWatcher{
+		out:   make(chan []string),
+		src:   src,
+		model: model,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{src},
+	})
+	return w, err
+}
+
+func (w *unitIDWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *unitIDWatcher) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *unitIDWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *unitIDWatcher) Changes() <-chan []string {
+	return w.out
+}
+
+func (w *unitIDWatcher) Err() error {
+	return w.catacomb.Err()
+}
+
+func (w *unitIDWatcher) loop() error {
+	defer close(w.out)
+
+	var out chan []string
+	var result []string
+
+	// initial event is sent regardless of if it's
+	// empty.
+	sendInitial := true
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case providerIDs, ok := <-w.src.Changes():
+			if !ok {
+				return errors.Errorf("event watcher closed")
+			}
+			uniqueIDs := set.NewStrings(providerIDs...)
+			containers, err := w.model.Containers(uniqueIDs.Values()...)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			providerIDToUnitName := map[string]string{}
+			for _, containerInfo := range containers {
+				providerIDToUnitName[containerInfo.ProviderId()] = containerInfo.Unit()
+			}
+			for _, providerID := range providerIDs {
+				if unitName, ok := providerIDToUnitName[providerID]; ok {
+					result = append(result, unitName)
+				}
+			}
+			if len(result) == 0 && !sendInitial {
+				continue
+			}
+			out = w.out
+		case out <- result:
+			out = nil
+			result = nil
+			sendInitial = false
+		}
+	}
+}

--- a/apiserver/facades/agent/caasoperator/watcher_test.go
+++ b/apiserver/facades/agent/caasoperator/watcher_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasoperator_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
+	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&IDWatcherSuite{})
+
+type IDWatcherSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *IDWatcherSuite) TestWatcher(c *gc.C) {
+	m := &mockModel{}
+	m.containers = []state.CloudContainer{
+		&mockCloudContainer{unit: "A", providerID: "a"},
+		&mockCloudContainer{unit: "C", providerID: "c"},
+	}
+	wc := make(chan []string, 4)
+	wc <- []string{"a"}
+	wc <- []string{"b"}
+	wc <- []string{"c"}
+	wc <- []string{"d"}
+	srcWatcher := watchertest.NewMockStringsWatcher(wc)
+	idWatcher, err := caasoperator.NewUnitIDWatcher(m, srcWatcher)
+	c.Assert(err, jc.ErrorIsNil)
+
+	testWatcher := testing.NewStringsWatcherC(c, s, idWatcher)
+	testWatcher.AssertChangeInSingleEvent("A")
+	testWatcher.AssertChangeInSingleEvent("C")
+
+	err = idWatcher.Stop()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// StartSync fulfills testing.StartSync interface.
+func (s *IDWatcherSuite) StartSync() {
+}

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type mockState struct {
@@ -104,6 +105,7 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
 	attrs := coretesting.FakeConfig()
 	attrs["workload-storage"] = "k8s-storage"
+	attrs["agent-version"] = jujuversion.Current.String()
 	return config.New(config.UseDefaults, attrs)
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package caasunitprovisioner_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/clock"
@@ -26,6 +27,7 @@ import (
 	statetesting "github.com/juju/juju/state/testing"
 	storageprovider "github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&CAASProvisionerSuite{})
@@ -198,6 +200,7 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 			DeploymentType: "stateful",
 			ServiceType:    "loadbalancer",
 		},
+		OperatorImagePath: fmt.Sprintf("jujusolutions/jujud-operator:%s", jujuversion.Current.String()),
 		Devices: []params.KubernetesDeviceParams{
 			{
 				Type:       "nvidia.com/gpu",
@@ -243,9 +246,12 @@ func (s *CAASProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 				MountPoint: "/var/lib/juju/storage/logs/0",
 			},
 		}}
+	c.Assert(results.Results[0].Error, gc.IsNil)
 	obtained := results.Results[0].Result
+	c.Assert(obtained, gc.NotNil)
 	c.Assert(obtained.PodSpec, jc.DeepEquals, expectedResult.PodSpec)
 	c.Assert(obtained.DeploymentInfo, jc.DeepEquals, expectedResult.DeploymentInfo)
+	c.Assert(obtained.OperatorImagePath, gc.Equals, expectedResult.OperatorImagePath)
 	c.Assert(len(obtained.Filesystems), gc.Equals, len(expectedFileSystems))
 	for _, fs := range obtained.Filesystems {
 		c.Assert(fs, gc.DeepEquals, expectedFileSystems[fs.StorageName])

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -5899,6 +5899,17 @@
                         }
                     }
                 },
+                "WatchUnitStart": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
                 "WatchUnits": {
                     "type": "object",
                     "properties": {
@@ -7653,6 +7664,9 @@
                             "items": {
                                 "$ref": "#/definitions/KubernetesFilesystemParams"
                             }
+                        },
+                        "operator-image-path": {
+                            "type": "string"
                         },
                         "pod-spec": {
                             "type": "string"

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -17,13 +17,14 @@ type KubernetesDeploymentInfo struct {
 
 // KubernetesProvisioningInfo holds unit provisioning info.
 type KubernetesProvisioningInfo struct {
-	DeploymentInfo *KubernetesDeploymentInfo    `json:"deployment-info,omitempty"`
-	PodSpec        string                       `json:"pod-spec"`
-	Constraints    constraints.Value            `json:"constraints"`
-	Tags           map[string]string            `json:"tags,omitempty"`
-	Filesystems    []KubernetesFilesystemParams `json:"filesystems,omitempty"`
-	Volumes        []KubernetesVolumeParams     `json:"volumes,omitempty"`
-	Devices        []KubernetesDeviceParams     `json:"devices,omitempty"`
+	DeploymentInfo    *KubernetesDeploymentInfo    `json:"deployment-info,omitempty"`
+	PodSpec           string                       `json:"pod-spec"`
+	Constraints       constraints.Value            `json:"constraints"`
+	Tags              map[string]string            `json:"tags,omitempty"`
+	Filesystems       []KubernetesFilesystemParams `json:"filesystems,omitempty"`
+	Volumes           []KubernetesVolumeParams     `json:"volumes,omitempty"`
+	Devices           []KubernetesDeviceParams     `json:"devices,omitempty"`
+	OperatorImagePath string                       `json:"operator-image-path,omitempty"`
 }
 
 // KubernetesProvisioningInfoResult holds unit provisioning info or an error.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -120,6 +120,9 @@ type ServiceParams struct {
 
 	// Devices is a set of parameters for Devices that is required.
 	Devices []devices.KubernetesDeviceParams
+
+	// OperatorImagePath is the path to the OCI image shared by the operator and pod init.
+	OperatorImagePath string
 }
 
 // OperatorState is returned by the OperatorExists call.
@@ -158,6 +161,11 @@ type Broker interface {
 	// of the specified application. Filesystems are mounted
 	// via volumes bound to the unit.
 	Units(appName string) ([]Unit, error)
+
+	// WatchUnitStart returns a watcher which notifies when units
+	// in an application is starting/restarting. Each string represents
+	// the provider id for the unit.
+	WatchUnitStart(appName string) (watcher.StringsWatcher, error)
 
 	// WatchOperator returns a watcher which notifies when there
 	// are changes to the operator of the specified application.

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -72,7 +72,7 @@ type BaseSuite struct {
 
 	mockDiscovery *mocks.MockDiscoveryInterface
 
-	watchers []*provider.KubernetesWatcher
+	watchers []*provider.KubernetesNotifyWatcher
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
@@ -126,8 +126,8 @@ func (s *BaseSuite) getNamespace() string {
 func (s *BaseSuite) setupController(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	newK8sRestClientFunc := s.setupK8sRestClient(c, ctrl, s.getNamespace())
-	newK8sWatcherForTest := func(wi watch.Interface, name string, clock jujuclock.Clock) (*provider.KubernetesWatcher, error) {
-		w, err := provider.NewKubernetesWatcher(wi, name, clock)
+	newK8sWatcherForTest := func(wi watch.Interface, name string, clock jujuclock.Clock) (*provider.KubernetesNotifyWatcher, error) {
+		w, err := provider.NewKubernetesNotifyWatcher(wi, name, clock)
 		c.Assert(err, jc.ErrorIsNil)
 		s.watchers = append(s.watchers, w)
 		return w, err

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -187,8 +187,8 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	// Eventually the namespace wil be set to controllerName.
 	// So we have to specify the final namespace(controllerName) for later use.
 	newK8sRestClientFunc := s.setupK8sRestClient(c, ctrl, s.pcfg.ControllerName)
-	newK8sWatcherForTest := func(wi watch.Interface, name string, clock jujuclock.Clock) (*provider.KubernetesWatcher, error) {
-		w, err := provider.NewKubernetesWatcher(wi, name, clock)
+	newK8sWatcherForTest := func(wi watch.Interface, name string, clock jujuclock.Clock) (*provider.KubernetesNotifyWatcher, error) {
+		w, err := provider.NewKubernetesNotifyWatcher(wi, name, clock)
 		c.Assert(err, jc.ErrorIsNil)
 		<-w.Changes() // Consume initial event for testing.
 		s.watchers = append(s.watchers, w)

--- a/caas/kubernetes/provider/exec/exec.go
+++ b/caas/kubernetes/provider/exec/exec.go
@@ -234,13 +234,21 @@ func getValidatedPodContainer(
 		return "", "", errors.NotFoundf("pod %q", podName)
 	}
 
-	if pod.Status.Phase != core.PodRunning {
+	switch pod.Status.Phase {
+	case core.PodPending:
+	case core.PodRunning:
+	default:
 		return "", "", errors.New(fmt.Sprintf(
 			"cannot exec into a container within a %s pod", pod.Status.Phase,
 		))
 	}
 
 	checkContainerExists := func(name string) error {
+		for _, c := range pod.Spec.InitContainers {
+			if c.Name == name {
+				return nil
+			}
+		}
 		for _, c := range pod.Spec.Containers {
 			if c.Name == name {
 				return nil

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -20,28 +20,28 @@ import (
 )
 
 var (
-	PrepareWorkloadSpec      = prepareWorkloadSpec
-	OperatorPod              = operatorPod
-	ExtractRegistryURL       = extractRegistryURL
-	CreateDockerConfigJSON   = createDockerConfigJSON
-	NewStorageConfig         = newStorageConfig
-	NewKubernetesWatcher     = newKubernetesWatcher
-	CompileK8sCloudCheckers  = compileK8sCloudCheckers
-	CloudSpecToK8sRestConfig = cloudSpecToK8sRestConfig
-	ControllerCorelation     = controllerCorelation
-	GetLocalMicroK8sConfig   = getLocalMicroK8sConfig
-	AttemptMicroK8sCloud     = attemptMicroK8sCloud
-	EnsureMicroK8sSuitable   = ensureMicroK8sSuitable
-	NewK8sBroker             = newK8sBroker
-	ToYaml                   = toYaml
-	Indent                   = indent
-	ProcessSecretData        = processSecretData
+	PrepareWorkloadSpec        = prepareWorkloadSpec
+	OperatorPod                = operatorPod
+	ExtractRegistryURL         = extractRegistryURL
+	CreateDockerConfigJSON     = createDockerConfigJSON
+	NewStorageConfig           = newStorageConfig
+	NewKubernetesNotifyWatcher = newKubernetesNotifyWatcher
+	CompileK8sCloudCheckers    = compileK8sCloudCheckers
+	CloudSpecToK8sRestConfig   = cloudSpecToK8sRestConfig
+	ControllerCorelation       = controllerCorelation
+	GetLocalMicroK8sConfig     = getLocalMicroK8sConfig
+	AttemptMicroK8sCloud       = attemptMicroK8sCloud
+	EnsureMicroK8sSuitable     = ensureMicroK8sSuitable
+	NewK8sBroker               = newK8sBroker
+	ToYaml                     = toYaml
+	Indent                     = indent
+	ProcessSecretData          = processSecretData
 )
 
 type (
-	KubernetesClient      = kubernetesClient
-	KubernetesWatcher     = kubernetesWatcher
-	ControllerServiceSpec = controllerServiceSpec
+	KubernetesClient        = kubernetesClient
+	KubernetesNotifyWatcher = kubernetesNotifyWatcher
+	ControllerServiceSpec   = controllerServiceSpec
 )
 
 type ControllerStackerForTest interface {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -72,6 +72,8 @@ const (
 
 	operatorContainerName = "juju-operator"
 
+	dataDirVolumeName = "juju-data-dir"
+
 	// OperatorPodIPEnvName is the environment name for operator pod IP.
 	OperatorPodIPEnvName = "JUJU_OPERATOR_POD_IP"
 
@@ -135,7 +137,7 @@ type kubernetesClient struct {
 type NewK8sClientFunc func(c *rest.Config) (kubernetes.Interface, apiextensionsclientset.Interface, error)
 
 // NewK8sWatcherFunc defines a function which returns a k8s watcher based on the supplied config.
-type NewK8sWatcherFunc func(wi watch.Interface, name string, clock jujuclock.Clock) (*kubernetesWatcher, error)
+type NewK8sWatcherFunc func(wi watch.Interface, name string, clock jujuclock.Clock) (*kubernetesNotifyWatcher, error)
 
 // RandomPrefixFunc defines a function used to generate a random hex string.
 type RandomPrefixFunc func() (string, error)
@@ -921,7 +923,8 @@ func (k *kubernetesClient) EnsureService(
 		}
 	}()
 
-	workloadSpec, err := prepareWorkloadSpec(appName, deploymentName, params.PodSpec)
+	workloadSpec, err := prepareWorkloadSpec(appName, deploymentName, params.PodSpec,
+		params.OperatorImagePath)
 	if err != nil {
 		return errors.Annotatef(err, "parsing unit spec for %s", appName)
 	}
@@ -1303,6 +1306,67 @@ func (k *kubernetesClient) configurePodFiles(podSpec *core.PodSpec, containers [
 				MountPath: fileSet.MountPath,
 			})
 		}
+	}
+	return nil
+}
+
+func configureInitContainer(podSpec *core.PodSpec, operatorImagePath string) error {
+	dataDir, err := paths.DataDir(CAASProviderType)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	jujudCmd := fmt.Sprintf("$JUJU_TOOLS_DIR/jujud caas-unit-init --debug --wait")
+	container := core.Container{
+		Name:            caas.InitContainerName,
+		Image:           operatorImagePath,
+		ImagePullPolicy: core.PullIfNotPresent,
+		VolumeMounts: []core.VolumeMount{{
+			Name:      dataDirVolumeName,
+			MountPath: dataDir,
+		}},
+		WorkingDir: dataDir,
+		Command: []string{
+			"/bin/sh",
+		},
+		Args: []string{
+			"-c",
+			fmt.Sprintf(
+				caas.JujudStartUpSh,
+				dataDir,
+				"tools",
+				jujudCmd,
+			),
+		},
+	}
+	podSpec.InitContainers = append(podSpec.InitContainers, container)
+	return configureDataDir(podSpec)
+}
+
+func configureDataDir(podSpec *core.PodSpec) error {
+	podSpec.Volumes = append(podSpec.Volumes, core.Volume{
+		Name: dataDirVolumeName,
+		VolumeSource: core.VolumeSource{
+			EmptyDir: &core.EmptyDirVolumeSource{},
+		},
+	})
+	dataDir, err := paths.DataDir(CAASProviderType)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	jujuRun, err := paths.JujuRun(CAASProviderType)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for i := range podSpec.Containers {
+		container := &podSpec.Containers[i]
+		container.VolumeMounts = append(container.VolumeMounts, core.VolumeMount{
+			Name:      dataDirVolumeName,
+			MountPath: dataDir,
+		}, core.VolumeMount{
+			Name:      dataDirVolumeName,
+			MountPath: jujuRun,
+			SubPath:   "tools/jujud",
+		})
 	}
 	return nil
 }
@@ -1740,6 +1804,74 @@ func (k *kubernetesClient) WatchUnits(appName string) (watcher.NotifyWatcher, er
 	return k.newWatcher(w, appName, k.clock)
 }
 
+// WatchUnitStart returns a watcher which notifies when units
+// in an application is starting/restarting. Each string represents
+// the provider id for the unit.
+func (k *kubernetesClient) WatchUnitStart(appName string) (watcher.StringsWatcher, error) {
+	pods := k.client().CoreV1().Pods(k.namespace)
+	selector := applicationSelector(appName)
+	logger.Debugf("selecting units %q to watch", selector)
+	w, err := pods.Watch(v1.ListOptions{
+		LabelSelector:        selector,
+		Watch:                true,
+		IncludeUninitialized: true,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	podsList, err := pods.List(v1.ListOptions{
+		LabelSelector:        applicationSelector(appName),
+		IncludeUninitialized: true,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	podInInit := func(pod *core.Pod) bool {
+		for _, cs := range pod.Status.InitContainerStatuses {
+			if cs.Name == caas.InitContainerName {
+				if cs.State.Running != nil {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	podInitState := map[string]struct{}{}
+	var initialEvents []string
+	for _, pod := range podsList.Items {
+		if podInInit(&pod) {
+			podInitState[string(pod.GetUID())] = struct{}{}
+			initialEvents = append(initialEvents, providerID(&pod))
+		}
+	}
+
+	filterEvent := func(evt watch.Event) (string, bool) {
+		pod, ok := evt.Object.(*core.Pod)
+		if !ok {
+			return "", false
+		}
+		key := string(pod.GetUID())
+		if evt.Type == watch.Deleted {
+			delete(podInitState, key)
+			return "", false
+		}
+		if podInInit(pod) {
+			if _, ok := podInitState[key]; !ok {
+				podInitState[key] = struct{}{}
+				return providerID(pod), true
+			}
+		} else {
+			delete(podInitState, key)
+		}
+		return "", false
+	}
+
+	return newKubernetesStringsWatcher(w, appName, k.clock, initialEvents, filterEvent)
+}
+
 // WatchService returns a watcher which notifies when there
 // are changes to the deployment of the specified application.
 func (k *kubernetesClient) WatchService(appName string) (watcher.NotifyWatcher, error) {
@@ -1808,19 +1940,9 @@ func (k *kubernetesClient) Units(appName string) ([]caas.Unit, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		providerId := string(p.GetUID())
 		stateful := false
-
-		// Pods managed by a stateful set use the pod name
-		// as the provider id as this is stable across pod restarts.
-		for _, ref := range p.OwnerReferences {
-			if stateful = ref.Kind == "StatefulSet"; stateful {
-				providerId = p.Name
-				break
-			}
-		}
 		unitInfo := caas.Unit{
-			Id:       providerId,
+			Id:       providerID(&p),
 			Address:  p.Status.PodIP,
 			Ports:    ports,
 			Dying:    terminated,
@@ -1890,7 +2012,10 @@ func (k *kubernetesClient) getPod(podName string) (*core.Pod, error) {
 }
 
 func (k *kubernetesClient) volumeInfoForEmptyDir(vol core.Volume, volMount core.VolumeMount, now time.Time) (*caas.FilesystemInfo, error) {
-	size := uint64(vol.EmptyDir.SizeLimit.Size())
+	size := uint64(0)
+	if vol.EmptyDir.SizeLimit != nil {
+		size = uint64(vol.EmptyDir.SizeLimit.Size())
+	}
 	return &caas.FilesystemInfo{
 		Size:         size,
 		FilesystemId: vol.Name,
@@ -2186,11 +2311,15 @@ func processContainers(deploymentName string, podSpec *specs.PodSpec, spec *core
 	return nil
 }
 
-func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec) (*workloadSpec, error) {
+func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
+	operatorImagePath string) (*workloadSpec, error) {
 	var spec workloadSpec
 	if err := processContainers(deploymentName, podSpec, &spec.Pod); err != nil {
 		logger.Errorf("unable to parse %q pod spec: \n%+v", appName, *podSpec)
 		return nil, errors.Annotatef(err, "processing container specs for app %q", appName)
+	}
+	if err := configureInitContainer(&spec.Pod, operatorImagePath); err != nil {
+		return nil, errors.Annotatef(err, "adding init container for app %q", appName)
 	}
 
 	spec.Service = podSpec.Service
@@ -2245,21 +2374,22 @@ func defaultSecurityContext() *core.SecurityContext {
 
 func populateContainerDetails(deploymentName string, pod *core.PodSpec, podContainers []core.Container, containers []specs.ContainerSpec) error {
 	for i, c := range containers {
+		pc := &podContainers[i]
 		if c.Image != "" {
 			logger.Warningf("Image parameter deprecated, use ImageDetails")
-			podContainers[i].Image = c.Image
+			pc.Image = c.Image
 		} else {
-			podContainers[i].Image = c.ImageDetails.ImagePath
+			pc.Image = c.ImageDetails.ImagePath
 		}
 		if c.ImageDetails.Password != "" {
 			pod.ImagePullSecrets = append(pod.ImagePullSecrets, core.LocalObjectReference{Name: appSecretName(deploymentName, c.Name)})
 		}
 		if c.ImagePullPolicy != "" {
-			podContainers[i].ImagePullPolicy = core.PullPolicy(c.ImagePullPolicy)
+			pc.ImagePullPolicy = core.PullPolicy(c.ImagePullPolicy)
 		}
 
+		pc.SecurityContext = defaultSecurityContext()
 		if c.ProviderContainer == nil {
-			podContainers[i].SecurityContext = defaultSecurityContext()
 			continue
 		}
 		spec, ok := c.ProviderContainer.(*k8sspecs.K8sContainerSpec)
@@ -2267,15 +2397,13 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 			return errors.Errorf("unexpected kubernetes container spec type %T", c.ProviderContainer)
 		}
 		if spec.LivenessProbe != nil {
-			podContainers[i].LivenessProbe = spec.LivenessProbe
+			pc.LivenessProbe = spec.LivenessProbe
 		}
 		if spec.ReadinessProbe != nil {
-			podContainers[i].ReadinessProbe = spec.ReadinessProbe
+			pc.ReadinessProbe = spec.ReadinessProbe
 		}
 		if spec.SecurityContext != nil {
-			podContainers[i].SecurityContext = spec.SecurityContext
-		} else {
-			podContainers[i].SecurityContext = defaultSecurityContext()
+			pc.SecurityContext = spec.SecurityContext
 		}
 	}
 	return nil
@@ -2413,4 +2541,15 @@ func getNodeSelectorFromDeviceConstraints(devices []devices.KubernetesDevicePara
 
 func headlessServiceName(deploymentName string) string {
 	return fmt.Sprintf("%s-endpoints", deploymentName)
+}
+
+func providerID(pod *core.Pod) string {
+	// Pods managed by a stateful set use the pod name
+	// as the provider id as this is stable across pod restarts.
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == "StatefulSet" {
+			return pod.Name
+		}
+	}
+	return string(pod.GetUID())
 }

--- a/caas/kubernetes/provider/k8swatcher.go
+++ b/caas/kubernetes/provider/k8swatcher.go
@@ -16,12 +16,12 @@ import (
 	"github.com/juju/juju/core/watcher"
 )
 
-// kubernetesWatcher reports changes to kubernetes
+// kubernetesNotifyWatcher reports changes to kubernetes
 // resources. A native kubernetes watcher is passed
 // in to generate change events from the kubernetes
 // model. These events are consolidated into a Juju
 // notification watcher event.
-type kubernetesWatcher struct {
+type kubernetesNotifyWatcher struct {
 	clock    jujuclock.Clock
 	catacomb catacomb.Catacomb
 
@@ -30,8 +30,8 @@ type kubernetesWatcher struct {
 	k8watcher watch.Interface
 }
 
-func newKubernetesWatcher(wi watch.Interface, name string, clock jujuclock.Clock) (*kubernetesWatcher, error) {
-	w := &kubernetesWatcher{
+func newKubernetesNotifyWatcher(wi watch.Interface, name string, clock jujuclock.Clock) (*kubernetesNotifyWatcher, error) {
+	w := &kubernetesNotifyWatcher{
 		clock:     clock,
 		out:       make(chan struct{}),
 		name:      name,
@@ -46,7 +46,7 @@ func newKubernetesWatcher(wi watch.Interface, name string, clock jujuclock.Clock
 
 const sendDelay = 1 * time.Second
 
-func (w *kubernetesWatcher) loop() error {
+func (w *kubernetesNotifyWatcher) loop() error {
 	defer close(w.out)
 	defer w.k8watcher.Stop()
 
@@ -87,17 +87,108 @@ func (w *kubernetesWatcher) loop() error {
 }
 
 // Changes returns the event channel for this watcher.
-func (w *kubernetesWatcher) Changes() watcher.NotifyChannel {
+func (w *kubernetesNotifyWatcher) Changes() watcher.NotifyChannel {
 	return w.out
 }
 
 // Kill asks the watcher to stop without waiting for it do so.
-func (w *kubernetesWatcher) Kill() {
+func (w *kubernetesNotifyWatcher) Kill() {
 	w.catacomb.Kill(nil)
 }
 
 // Wait waits for the watcher to die and returns any
 // error encountered when it was running.
-func (w *kubernetesWatcher) Wait() error {
+func (w *kubernetesNotifyWatcher) Wait() error {
+	return w.catacomb.Wait()
+}
+
+type kubernetesStringsWatcher struct {
+	clock    jujuclock.Clock
+	catacomb catacomb.Catacomb
+
+	out           chan []string
+	name          string
+	k8watcher     watch.Interface
+	initialEvents []string
+	filterFunc    k8sStringsWatcherFilterFunc
+}
+
+type k8sStringsWatcherFilterFunc func(evt watch.Event) (string, bool)
+
+func newKubernetesStringsWatcher(wi watch.Interface, name string, clock jujuclock.Clock,
+	initialEvents []string, filterFunc k8sStringsWatcherFilterFunc) (*kubernetesStringsWatcher, error) {
+	w := &kubernetesStringsWatcher{
+		clock:         clock,
+		out:           make(chan []string),
+		name:          name,
+		k8watcher:     wi,
+		initialEvents: initialEvents,
+		filterFunc:    filterFunc,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	return w, err
+}
+
+func (w *kubernetesStringsWatcher) loop() error {
+	defer close(w.out)
+	defer w.k8watcher.Stop()
+
+	select {
+	case <-w.catacomb.Dying():
+		return w.catacomb.ErrDying()
+	case w.out <- w.initialEvents:
+	}
+	w.initialEvents = nil
+
+	// Set out now so that initial event is sent.
+	var out chan []string
+	var delayCh <-chan time.Time
+	var pendingEvents []string
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case evt, ok := <-w.k8watcher.ResultChan():
+			// This can happen if the k8s API connection drops.
+			if !ok {
+				return errors.Errorf("k8s event watcher closed, restarting")
+			}
+			if evt.Type == watch.Error {
+				return errors.Errorf("kubernetes watcher error: %v", k8serrors.FromObject(evt.Object))
+			}
+			logger.Tracef("received k8s event: %+v", evt.Type)
+			if emittedEvent, ok := w.filterFunc(evt); ok {
+				pendingEvents = append(pendingEvents, emittedEvent)
+				if delayCh == nil {
+					delayCh = w.clock.After(sendDelay)
+				}
+			}
+		case <-delayCh:
+			delayCh = nil
+			out = w.out
+		case out <- pendingEvents:
+			out = nil
+			pendingEvents = nil
+		}
+	}
+}
+
+// Changes returns the event channel for this watcher.
+func (w *kubernetesStringsWatcher) Changes() watcher.StringsChannel {
+	return w.out
+}
+
+// Kill asks the watcher to stop without waiting for it do so.
+func (w *kubernetesStringsWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait waits for the watcher to die and returns any
+// error encountered when it was running.
+func (w *kubernetesStringsWatcher) Wait() error {
 	return w.catacomb.Wait()
 }

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -106,7 +106,7 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 		return nil, errors.Trace(err)
 	}
 	broker, err := newK8sBroker(
-		args.ControllerUUID, k8sRestConfig, args.Config, newK8sClient, newKubernetesWatcher, randomPrefix, jujuclock.WallClock,
+		args.ControllerUUID, k8sRestConfig, args.Config, newK8sClient, newKubernetesNotifyWatcher, randomPrefix, jujuclock.WallClock,
 	)
 	if err != nil {
 		return nil, err

--- a/caas/operator.go
+++ b/caas/operator.go
@@ -22,6 +22,9 @@ const (
 
 	// CACertFile is the file containing the cluster CA.
 	CACertFile = "ca.crt"
+
+	// InitContainerName is the name of the init container on workloads pods.
+	InitContainerName = "juju-pod-init"
 )
 
 // OperatorInfo contains information needed by CAAS operators

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -52,6 +52,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrade-steps-gate",
 		"upgrade-steps-runner",
 		"upgrader",
+		"unit-init-worker",
 		// TODO(caas)
 		//"metric-spool",
 		//"meter-status",
@@ -62,7 +63,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	for k := range manifolds {
 		keys = append(keys, k)
 	}
-	c.Assert(expectedKeys, jc.SameContents, keys)
+	c.Assert(keys, jc.SameContents, expectedKeys)
 }
 
 func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
@@ -209,5 +210,17 @@ var expectedOperatorManifoldsWithDependencies = map[string][]string{
 		"migration-fortress",
 		"migration-inactive-flag",
 		"upgrade-steps-flag",
-		"upgrade-steps-gate"},
+		"upgrade-steps-gate",
+	},
+
+	"unit-init-worker": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"clock",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 }

--- a/cmd/jujud/agent/caasunitinit.go
+++ b/cmd/jujud/agent/caasunitinit.go
@@ -1,0 +1,212 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/caas"
+	jujucmd "github.com/juju/juju/cmd"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/juju/sockets"
+	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+// CAASUnitInitCommand represents a jujud bootstrap command.
+type CAASUnitInitCommand struct {
+	cmd.CommandBase
+
+	Wait bool
+	Send bool
+	Args struct {
+		Unit               string `json:"unit"`
+		OperatorFile       string `json:"operator-file"`
+		OperatorCACertFile string `json:"operator-ca-cert-file"`
+		CharmDir           string `json:"charm-dir"`
+	}
+
+	socketName    string
+	copyFunc      func(string, string) error
+	symlinkFunc   func(string, string) error
+	removeAllFunc func(string) error
+	mkdirAllFunc  func(string, os.FileMode) error
+	listenFunc    func(sockets.Socket) (net.Listener, error)
+	stdErr        io.Writer
+}
+
+// NewCAASUnitInitCommand returns a new CAASUnitInitCommand that has been initialized.
+func NewCAASUnitInitCommand() *CAASUnitInitCommand {
+	return &CAASUnitInitCommand{
+		socketName:    "@jujud-caas-unit-init",
+		copyFunc:      copy,
+		symlinkFunc:   os.Symlink,
+		removeAllFunc: os.RemoveAll,
+		mkdirAllFunc:  os.MkdirAll,
+		listenFunc:    sockets.Listen,
+		stdErr:        os.Stderr,
+	}
+}
+
+// Info returns a description of the command.
+func (c *CAASUnitInitCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "caas-unit-init",
+		Purpose: "initialize caas unit filesystem",
+	})
+}
+
+func (c *CAASUnitInitCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.Wait, "wait", false, "wait for args init via socket")
+	f.BoolVar(&c.Send, "send", false, "send args for init via socket")
+	f.StringVar(&c.Args.Unit, "unit", "", "unit name")
+	f.StringVar(&c.Args.OperatorFile, "operator-file", "", "operator client info file")
+	f.StringVar(&c.Args.OperatorCACertFile, "operator-ca-cert-file", "", "ca cert for operator")
+	f.StringVar(&c.Args.CharmDir, "charm-dir", "", "directory containing the charm")
+}
+
+func (c *CAASUnitInitCommand) Init(args []string) error {
+	if c.Wait && c.Send {
+		return errors.New("only one or none of --wait/--send can be specified")
+	}
+	return nil
+}
+
+func (c *CAASUnitInitCommand) Run(ctx *cmd.Context) (errOut error) {
+	sock := sockets.Socket{
+		Network: "unix",
+		Address: c.socketName,
+	}
+	// The waiting process waits for arguments to be sent by the
+	// sending process. If neither wait or send is specified,
+	// continue with the arguments already specified.
+	if c.Wait {
+		l, err := c.listenFunc(sock)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer l.Close()
+		conn, err := l.Accept()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer conn.Close()
+		err = json.NewDecoder(conn).Decode(&c.Args)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		// Write logs back to the sender.
+		w := loggo.NewSimpleWriter(conn, loggo.DefaultFormatter)
+		err = loggo.RegisterWriter("socket", w)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else if c.Send {
+		conn, err := net.Dial(sock.Network, sock.Address)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = json.NewEncoder(conn).Encode(c.Args)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		// Read logs from the waiter.
+		_, err = io.Copy(c.stdErr, conn)
+		return err
+	}
+
+	defer func() {
+		if errOut != nil {
+			logger.Errorf("%v", errOut)
+		}
+	}()
+
+	if c.Args.Unit == "" {
+		return errors.New("missing unit arg")
+	}
+
+	unitTag, err := names.ParseUnitTag(c.Args.Unit)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	jujudPath := filepath.Join(tools.ToolsDir(cmdutil.DataDir, ""), "jujud")
+	unitPaths := uniter.NewPaths(cmdutil.DataDir, unitTag, nil)
+	if err = c.removeAllFunc(unitPaths.ToolsDir); err != nil && !os.IsNotExist(err) {
+		return errors.Annotatef(err, "failed to remove unit tools dir %s",
+			unitPaths.ToolsDir)
+	}
+	if err = c.mkdirAllFunc(unitPaths.ToolsDir, 0775); err != nil {
+		return errors.Annotatef(err, "failed to make unit tools dir %s",
+			unitPaths.ToolsDir)
+	}
+	if err = c.removeAllFunc(unitPaths.State.BaseDir); err != nil && !os.IsNotExist(err) {
+		return errors.Annotatef(err, "failed to remove unit base dir %s",
+			unitPaths.State.BaseDir)
+	}
+	if err = c.mkdirAllFunc(unitPaths.State.BaseDir, 0775); err != nil {
+		return errors.Annotatef(err, "failed to make unit base dir %s",
+			unitPaths.State.BaseDir)
+	}
+
+	commandNames := append([]string{"jujud"}, jujuc.CommandNames()...)
+	for _, cmdName := range commandNames {
+		ln := filepath.Join(unitPaths.ToolsDir, cmdName)
+		logger.Infof("link %s => %s", ln, jujudPath)
+		if err = c.symlinkFunc(jujudPath, ln); err != nil {
+			return errors.Annotatef(err, "failed to link %s to %s",
+				ln, jujudPath)
+		}
+	}
+
+	var copies []srcDest
+	if c.Args.OperatorFile != "" {
+		operatorFile := filepath.Join(unitPaths.State.BaseDir, caas.OperatorClientInfoFile)
+		copies = append(copies, srcDest{c.Args.OperatorFile, operatorFile})
+	}
+	if c.Args.OperatorCACertFile != "" {
+		caCertFile := filepath.Join(unitPaths.State.BaseDir, caas.CACertFile)
+		copies = append(copies, srcDest{c.Args.OperatorCACertFile, caCertFile})
+	}
+	if c.Args.CharmDir != "" {
+		copies = append(copies, srcDest{c.Args.CharmDir, unitPaths.State.CharmDir})
+	}
+
+	for _, op := range copies {
+		logger.Infof("copy %s => %s", op.src, op.dst)
+		if err = c.copyFunc(op.src, op.dst); err != nil {
+			return errors.Annotatef(err, "failed to copy %s to %s", op.src, op.dst)
+		}
+	}
+
+	return nil
+}
+
+func copy(src, dst string) error {
+	logger.Infof("copy %s => %s", src, dst)
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("cp -Rf %q %q", src, dst))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Annotatef(err, "output: %s", string(out))
+	}
+	return nil
+}
+
+type srcDest struct {
+	src string
+	dst string
+}

--- a/cmd/jujud/agent/caasunitinit_test.go
+++ b/cmd/jujud/agent/caasunitinit_test.go
@@ -1,0 +1,145 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"bytes"
+	"math/rand"
+	"net"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/juju/juju/sockets"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+	"github.com/juju/testing"
+)
+
+type CAASUnitInitSuite struct {
+	coretesting.BaseSuite
+
+	rootDir string
+}
+
+var _ = gc.Suite(&CAASUnitInitSuite{})
+
+func (s *CAASUnitInitSuite) SetUpTest(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("unsupported")
+	}
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *CAASUnitInitSuite) newCommand(c *gc.C, st *testing.Stub) *CAASUnitInitCommand {
+	cmd := NewCAASUnitInitCommand()
+	cmd.copyFunc = func(src, dst string) error {
+		st.AddCall("Copy", src, dst)
+		return st.NextErr()
+	}
+	cmd.symlinkFunc = func(src, dst string) error {
+		st.AddCall("Symlink", src, dst)
+		return st.NextErr()
+	}
+	cmd.removeAllFunc = func(path string) error {
+		st.AddCall("RemoveAll", path)
+		return st.NextErr()
+	}
+	cmd.mkdirAllFunc = func(path string, mode os.FileMode) error {
+		st.AddCall("MkdirAll", path, mode)
+		return st.NextErr()
+	}
+	return cmd
+}
+
+func (s *CAASUnitInitSuite) checkCommand(c *gc.C, cmd *CAASUnitInitCommand, args []string,
+	unit string, operatorFile string,
+	operatorCACertFile string, charmDir string) []testing.StubCall {
+	ctx, err := cmdtesting.RunCommand(c, cmd, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx, gc.NotNil)
+
+	toolsPath := "/var/lib/juju/tools/" + unit
+	agentPath := "/var/lib/juju/agents/" + unit
+
+	calls := []testing.StubCall{
+		{FuncName: "RemoveAll", Args: []interface{}{toolsPath}},
+		{FuncName: "MkdirAll", Args: []interface{}{toolsPath, os.FileMode(0775)}},
+		{FuncName: "RemoveAll", Args: []interface{}{agentPath}},
+		{FuncName: "MkdirAll", Args: []interface{}{agentPath, os.FileMode(0775)}},
+		{FuncName: "Symlink", Args: []interface{}{"/var/lib/juju/tools/jujud", toolsPath + "/jujud"}},
+	}
+	for _, cmdName := range jujuc.CommandNames() {
+		_ = cmdName
+		calls = append(calls,
+			testing.StubCall{FuncName: "Symlink", Args: []interface{}{"/var/lib/juju/tools/jujud", toolsPath + "/" + cmdName}})
+	}
+
+	calls = append(calls,
+		testing.StubCall{FuncName: "Copy", Args: []interface{}{operatorFile, agentPath + "/operator-client.yaml"}},
+		testing.StubCall{FuncName: "Copy", Args: []interface{}{operatorCACertFile, agentPath + "/ca.crt"}},
+		testing.StubCall{FuncName: "Copy", Args: []interface{}{charmDir, agentPath + "/charm"}})
+
+	return calls
+}
+
+func (s *CAASUnitInitSuite) TestInitUnit(c *gc.C) {
+	args := []string{"--unit", "unit-wow-0",
+		"--operator-file", "operator/file/path",
+		"--operator-ca-cert-file", "operator/cert/file/path",
+		"--charm-dir", "charm/dir"}
+	st := &testing.Stub{}
+	cmd := s.newCommand(c, st)
+	calls := s.checkCommand(c, cmd, args, "unit-wow-0",
+		"operator/file/path", "operator/cert/file/path", "charm/dir")
+	st.CheckCalls(c, calls)
+}
+
+func (s *CAASUnitInitSuite) TestInitUnitWaitSend(c *gc.C) {
+	socketName := "@" + string(rand.Int63())
+	listening := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		st := &testing.Stub{}
+		cmd := s.newCommand(c, st)
+		cmd.socketName = socketName
+		cmd.listenFunc = func(s sockets.Socket) (net.Listener, error) {
+			l, err := sockets.Listen(s)
+			close(listening)
+			return l, err
+		}
+		calls := s.checkCommand(c, cmd, []string{"--wait"}, "unit-wow-0",
+			"operator/file/path", "operator/cert/file/path", "charm/dir")
+		st.CheckCalls(c, calls)
+	}()
+
+	select {
+	case <-listening:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("failed to listen")
+	}
+
+	stdErr := &bytes.Buffer{}
+	args := []string{"--send", "--unit", "unit-wow-0",
+		"--operator-file", "operator/file/path",
+		"--operator-ca-cert-file", "operator/cert/file/path",
+		"--charm-dir", "charm/dir"}
+	st := &testing.Stub{}
+	cmd := s.newCommand(c, st)
+	cmd.stdErr = stdErr
+	cmd.socketName = socketName
+	ctx, err := cmdtesting.RunCommand(c, cmd, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx, gc.NotNil)
+	c.Assert(stdErr.Bytes(), gc.Not(gc.HasLen), 0)
+
+	wg.Wait()
+}

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -219,6 +219,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	}
 
 	jujud.Register(agentcmd.NewBootstrapCommand())
+	jujud.Register(agentcmd.NewCAASUnitInitCommand())
 
 	// TODO(katco-): AgentConf type is doing too much. The
 	// MachineAgent type has called out the separate concerns; the

--- a/worker/caasoperator/action.go
+++ b/worker/caasoperator/action.go
@@ -6,205 +6,15 @@ package caasoperator
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
 	utilexec "github.com/juju/utils/exec"
 
 	"github.com/juju/juju/caas"
-	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/caas/kubernetes/provider/exec"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/runner"
-	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
-
-func ensurePath(
-	client exec.Executor,
-	podName string,
-	path string,
-	stdout io.Writer,
-	stderr io.Writer,
-	cancel <-chan struct{},
-) error {
-	logger.Debugf("ensuring %q", path)
-	err := client.Exec(
-		exec.ExecParams{
-			PodName:  podName,
-			Commands: []string{"test", "-d", path, "||", "mkdir", "-p", path},
-			Stdout:   stdout,
-			Stderr:   stderr,
-		},
-		cancel,
-	)
-	return errors.Trace(err)
-}
-
-func ensureSymlink(
-	client exec.Executor,
-	podName string,
-	oldName, newName string,
-	stdout io.Writer,
-	stderr io.Writer,
-	cancel <-chan struct{},
-) error {
-	logger.Debugf("making symlink %v->%v", newName, oldName)
-	err := client.Exec(
-		exec.ExecParams{
-			PodName:  podName,
-			Commands: []string{"test", "-f", newName, "||", "ln", "-s", oldName, newName},
-			Stdout:   stdout,
-			Stderr:   stderr,
-		},
-		cancel,
-	)
-	return errors.Trace(err)
-}
-
-type workloadPathSpec struct {
-	src, dest string
-}
-
-func workloadFilesToCopy(operatorPaths Paths, unitPaths uniter.Paths) []workloadPathSpec {
-	return []workloadPathSpec{{
-		src:  operatorPaths.GetCharmDir(),
-		dest: unitPaths.State.BaseDir,
-	}, {
-		src:  filepath.Join(operatorPaths.GetToolsDir(), "jujud"),
-		dest: unitPaths.ToolsDir,
-	}}
-}
-
-func prepare(
-	client exec.Executor,
-	podName string,
-	serviceAddress string,
-	operatorPaths Paths,
-	unitPaths uniter.Paths,
-	operatorInfo caas.OperatorInfo,
-	stdout io.ReadWriter,
-	stderr io.Writer,
-	cancel <-chan struct{},
-) error {
-	// TODO(caas) - quick check to see if files have already been copied across.
-	// upgrade-charm and upgrade-juju will need to ensure files are up-to-date.
-	operatorFile := filepath.Join(unitPaths.State.BaseDir, caas.OperatorClientInfoFile)
-	err := client.Exec(
-		exec.ExecParams{
-			PodName:  podName,
-			Commands: []string{"test", "-f", operatorFile},
-			Stdout:   stdout,
-			Stderr:   stderr,
-		},
-		cancel,
-	)
-	if exitErr, ok := errors.Cause(err).(exec.ExitError); ok {
-		if exitErr.ExitStatus() != 1 {
-			return errors.Trace(err)
-		}
-	} else if err != nil {
-		return errors.Trace(err)
-	} else {
-		return nil
-	}
-
-	// Copy the core charm files and jujud binary.
-	for _, pathSpec := range workloadFilesToCopy(operatorPaths, unitPaths) {
-		_, err := os.Stat(pathSpec.src)
-		if os.IsNotExist(err) {
-			return errors.NotFoundf("file or path %q", pathSpec.src)
-		}
-		if err != nil {
-			return errors.Trace(err)
-		}
-		logger.Debugf("copy path %q to %q", pathSpec.src, pathSpec.dest)
-		if err := ensurePath(client, podName, pathSpec.dest, stdout, stderr, cancel); err != nil {
-			return errors.Trace(err)
-		}
-
-		if err := client.Copy(exec.CopyParam{
-			Src: exec.FileResource{
-				Path: pathSpec.src,
-			},
-			Dest: exec.FileResource{
-				Path:    pathSpec.dest,
-				PodName: podName,
-			},
-		}, cancel); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	// set up the symlinks to jujud (hook commands and juju-run etc).
-	jujudPath := filepath.Join(unitPaths.ToolsDir, "jujud")
-	for _, slk := range jujudSymlinks {
-		if err := ensureSymlink(client, podName, jujudPath, slk, stdout, stderr, cancel); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	for _, cmdName := range jujuc.CommandNames() {
-		slk := filepath.Join(unitPaths.ToolsDir, cmdName)
-		if err := ensureSymlink(client, podName, jujudPath, slk, stdout, stderr, cancel); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	// Ensure unit dir exists for operator-client.yaml and ca.crt file.
-	if err := ensurePath(client, podName, unitPaths.State.BaseDir, stdout, stderr, cancel); err != nil {
-		return errors.Trace(err)
-	}
-
-	// Create the ca.crt file containing the cluster's CA cert.
-	tempCACertFile := filepath.Join(os.TempDir(), caas.CACertFile)
-	if err := ioutil.WriteFile(tempCACertFile, []byte(operatorInfo.CACert), 0644); err != nil {
-		return errors.Trace(err)
-	}
-	if err := client.Copy(exec.CopyParam{
-		Src: exec.FileResource{
-			Path: tempCACertFile,
-		},
-		Dest: exec.FileResource{
-			Path:    filepath.Join(unitPaths.State.BaseDir, caas.CACertFile),
-			PodName: podName,
-		},
-	}, cancel); err != nil {
-		return errors.Trace(err)
-	}
-
-	// Create the operator.yaml file containing the operator service address and token.
-	token, err := utils.RandomPassword()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	clientInfo := caas.OperatorClientInfo{
-		ServiceAddress: serviceAddress,
-		Token:          token,
-	}
-	data, err := clientInfo.Marshal()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	operatorCacheFile := filepath.Join(unitPaths.State.BaseDir, caas.OperatorClientInfoCacheFile)
-	if err := ioutil.WriteFile(operatorCacheFile, data, 0644); err != nil {
-		return errors.Trace(err)
-	}
-	if err := client.Copy(exec.CopyParam{
-		Src: exec.FileResource{
-			Path: operatorCacheFile,
-		},
-		Dest: exec.FileResource{
-			Path:    operatorFile,
-			PodName: podName,
-		},
-	}, cancel); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
-}
 
 //go:generate mockgen -package mocks -destination mocks/exec_mock.go github.com/juju/juju/caas/kubernetes/provider/exec Executor
 //go:generate mockgen -package mocks -destination mocks/uniter_mock.go github.com/juju/juju/worker/uniter ProviderIDGetter
@@ -223,17 +33,6 @@ func getNewRunnerExecutor(
 			logger.Debugf("exec on pod %q for unit %q, cmd %v", podNameOrID, unitName, params.Commands)
 			if podNameOrID == "" {
 				return nil, errors.NotFoundf("pod for %q", unitName)
-			}
-
-			serviceAddress := os.Getenv(provider.OperatorServiceIPEnvName)
-			logger.Debugf("operator service address: %v", serviceAddress)
-			if err := prepare(
-				execClient, podNameOrID, serviceAddress,
-				operatorPaths, unitPaths, operatorInfo,
-				params.Stdout, params.Stderr, params.Cancel,
-			); err != nil {
-				logger.Errorf("ensuring dirs and syncing files %v", err)
-				return nil, errors.Trace(err)
 			}
 
 			// juju run - return stdout and stderr to ExecResponse.

--- a/worker/caasoperator/action_test.go
+++ b/worker/caasoperator/action_test.go
@@ -5,15 +5,12 @@ package caasoperator_test
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/juju/caas"
-	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	utilexec "github.com/juju/utils/exec"
@@ -43,16 +40,6 @@ func (s *actionSuite) setupExecClient(c *gc.C) *gomock.Controller {
 	s.executor = mocks.NewMockExecutor(ctrl)
 	s.unitAPI = mocks.NewMockProviderIDGetter(ctrl)
 	return ctrl
-}
-
-func (s *actionSuite) symlinkJujudCommand(out *bytes.Buffer, baseDir string, file string) exec.ExecParams {
-	cmd := fmt.Sprintf("test -f %s || ln -s "+baseDir+"/tools/unit-gitlab-k8s-0/jujud %s", file, file)
-	return exec.ExecParams{
-		PodName:  "gitlab-xxxx",
-		Commands: strings.Split(cmd, " "),
-		Stdout:   out,
-		Stderr:   out,
-	}
 }
 
 func (s *actionSuite) TestRunnerExecFunc(c *gc.C) {
@@ -86,115 +73,17 @@ func (s *actionSuite) assertRunnerExecFunc(c *gc.C, errMsg string) {
 	runnerExecFunc := caasoperator.GetNewRunnerExecutor(s.executor, operatorPaths, caas.OperatorInfo{})(s.unitAPI, unitPaths)
 	cancel := make(<-chan struct{}, 1)
 	stdout := bytes.NewBufferString("")
-
-	calls := []*gomock.Call{
-		s.unitAPI.EXPECT().Refresh().Times(1).Return(nil),
-		s.unitAPI.EXPECT().ProviderID().Times(1).Return("gitlab-xxxx"),
-		s.unitAPI.EXPECT().Name().Times(1).Return("gitlab-k8s/0"),
-
-		s.executor.EXPECT().Exec(
-			exec.ExecParams{
-				PodName:  "gitlab-xxxx",
-				Commands: []string{"test", "-f", baseDir + "/agents/unit-gitlab-k8s-0/operator-client.yaml"},
-				Stdout:   stdout,
-				Stderr:   stdout,
-			}, cancel,
-		).Times(1).DoAndReturn(func(...interface{}) error {
-			return exitError{code: 1, err: "file not found"}
-		}),
-
-		s.executor.EXPECT().Exec(
-			exec.ExecParams{
-				PodName:  "gitlab-xxxx",
-				Commands: []string{"test", "-d", baseDir + "/agents/unit-gitlab-k8s-0", "||", "mkdir", "-p", baseDir + "/agents/unit-gitlab-k8s-0"},
-				Stdout:   stdout,
-				Stderr:   stdout,
-			}, cancel,
-		).Times(1).Return(nil),
-		s.executor.EXPECT().Copy(
-			exec.CopyParam{
-				Src: exec.FileResource{
-					Path: baseDir + "/agents/application-gitlab-k8s/charm",
-				},
-				Dest: exec.FileResource{
-					Path:    baseDir + "/agents/unit-gitlab-k8s-0",
-					PodName: "gitlab-xxxx",
-				},
-			}, cancel,
-		).Times(1).Return(nil),
-
-		s.executor.EXPECT().Exec(
-			exec.ExecParams{
-				PodName:  "gitlab-xxxx",
-				Commands: []string{"test", "-d", baseDir + "/tools/unit-gitlab-k8s-0", "||", "mkdir", "-p", baseDir + "/tools/unit-gitlab-k8s-0"},
-				Stdout:   stdout,
-				Stderr:   stdout,
-			}, cancel,
-		).Times(1).Return(nil),
-		s.executor.EXPECT().Copy(
-			exec.CopyParam{
-				Src: exec.FileResource{
-					Path: baseDir + "/tools/jujud",
-				},
-				Dest: exec.FileResource{
-					Path:    baseDir + "/tools/unit-gitlab-k8s-0",
-					PodName: "gitlab-xxxx",
-				},
-			}, cancel,
-		).Times(1).Return(nil),
-	}
-
-	calls = append(calls,
-		s.executor.EXPECT().Exec(s.symlinkJujudCommand(stdout, baseDir, "/usr/bin/juju-run"),
-			cancel).Times(1).Return(nil),
-		s.executor.EXPECT().Exec(s.symlinkJujudCommand(stdout, baseDir, "/usr/bin/juju-dumplogs"),
-			cancel).Times(1).Return(nil),
-		s.executor.EXPECT().Exec(s.symlinkJujudCommand(stdout, baseDir, "/usr/bin/juju-introspect"),
-			cancel).Times(1).Return(nil),
-	)
-	for _, cmdName := range jujuc.CommandNames() {
-		s.executor.EXPECT().Exec(s.symlinkJujudCommand(stdout, baseDir, baseDir+"/tools/unit-gitlab-k8s-0/"+cmdName),
-			cancel).Times(1).Return(nil)
-	}
-
+	stderr := bytes.NewBufferString("")
 	expectedCode := 0
 	var exitErr error
 	if errMsg != "" {
 		exitErr = errors.Trace(k8sexec.CodeExitError{Code: 3, Err: errors.New(errMsg)})
 		expectedCode = 3
 	}
-	stderr := bytes.NewBufferString("")
-	calls = append(calls,
-		s.executor.EXPECT().Exec(
-			exec.ExecParams{
-				PodName:  "gitlab-xxxx",
-				Commands: []string{"test", "-d", baseDir + "/agents/unit-gitlab-k8s-0", "||", "mkdir", "-p", baseDir + "/agents/unit-gitlab-k8s-0"},
-				Stdout:   stdout,
-				Stderr:   stdout,
-			}, cancel,
-		).Times(1).Return(nil),
-		s.executor.EXPECT().Copy(
-			exec.CopyParam{
-				Src: exec.FileResource{
-					Path: filepath.Join(os.TempDir(), "ca.crt"),
-				},
-				Dest: exec.FileResource{
-					Path:    baseDir + "/agents/unit-gitlab-k8s-0/ca.crt",
-					PodName: "gitlab-xxxx",
-				},
-			}, cancel,
-		).Times(1).Return(nil),
-		s.executor.EXPECT().Copy(
-			exec.CopyParam{
-				Src: exec.FileResource{
-					Path: baseDir + "/agents/unit-gitlab-k8s-0/operator-client-cache.yaml",
-				},
-				Dest: exec.FileResource{
-					Path:    baseDir + "/agents/unit-gitlab-k8s-0/operator-client.yaml",
-					PodName: "gitlab-xxxx",
-				},
-			}, cancel,
-		).Times(1).Return(nil),
+	gomock.InOrder(
+		s.unitAPI.EXPECT().Refresh().Times(1).Return(nil),
+		s.unitAPI.EXPECT().ProviderID().Times(1).Return("gitlab-xxxx"),
+		s.unitAPI.EXPECT().Name().Times(1).Return("gitlab-k8s/0"),
 		s.executor.EXPECT().Exec(
 			exec.ExecParams{
 				PodName:  "gitlab-xxxx",
@@ -209,8 +98,6 @@ func (s *actionSuite) assertRunnerExecFunc(c *gc.C, errMsg string) {
 			return exitErr
 		}),
 	)
-
-	gomock.InOrder(calls...)
 
 	outLogger := &mockHookLogger{}
 	errLogger := &mockHookLogger{}

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -194,7 +194,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 			loadOperatorInfoFunc := config.LoadOperatorInfo
 			if loadOperatorInfoFunc == nil {
-				loadOperatorInfoFunc = loadOperatorInfo
+				loadOperatorInfoFunc = LoadOperatorInfo
 			}
 			operatorInfo, err := loadOperatorInfoFunc(wCfg.getPaths())
 			if err != nil {
@@ -259,7 +259,8 @@ func socketConfig(info *caas.OperatorInfo) (*uniter.SocketConfig, error) {
 	return sc, nil
 }
 
-func loadOperatorInfo(paths Paths) (*caas.OperatorInfo, error) {
+// LoadOperatorInfo loads the operator info file from the state dir.
+func LoadOperatorInfo(paths Paths) (*caas.OperatorInfo, error) {
 	filepath := path.Join(paths.State.BaseDir, caas.OperatorInfoFile)
 	data, err := ioutil.ReadFile(filepath)
 	if err != nil {

--- a/worker/caasunitinit/initializer.go
+++ b/worker/caasunitinit/initializer.go
@@ -1,0 +1,197 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/juju/worker.v1/catacomb"
+
+	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/caas/kubernetes/provider/exec"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/worker/caasoperator"
+	"github.com/juju/juju/worker/uniter"
+)
+
+type unitInitializer struct {
+	catacomb catacomb.Catacomb
+
+	config  InitializeUnitParams
+	unitTag names.UnitTag
+}
+
+// InitializeUnitParams contains parameters and dependencies for initializing
+// a unit.
+type InitializeUnitParams struct {
+	// UnitTag of the unit being initialized.
+	UnitTag names.UnitTag
+
+	// Logger for the worker.
+	Logger Logger
+
+	// UnitProviderIDFunc returns the ProviderID for the given unit.
+	UnitProviderIDFunc func(unit names.UnitTag) (string, error)
+
+	// Paths provides CAAS operator paths.
+	Paths caasoperator.Paths
+
+	// OperatorInfo contains serving information such as Certs and PrivateKeys.
+	OperatorInfo caas.OperatorInfo
+
+	// ExecClient is used for initilizing units.
+	ExecClient exec.Executor
+
+	// WriteFile is used to write files to the local state.
+	WriteFile func(string, []byte, os.FileMode) error
+
+	// TempDir is used for creating a temporary directory.
+	TempDir func(string, string) (string, error)
+}
+
+// Validate InitializeUnitParams
+func (p InitializeUnitParams) Validate() error {
+	if p.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	if p.UnitProviderIDFunc == nil {
+		return errors.NotValidf("missing UnitProviderIDFunc")
+	}
+	if p.ExecClient == nil {
+		return errors.NotValidf("missing ExecClient")
+	}
+	if p.WriteFile == nil {
+		return errors.NotValidf("missing WriteFile")
+	}
+	if p.TempDir == nil {
+		return errors.NotValidf("missing TempDir")
+	}
+	return nil
+}
+
+// InitializeUnit with the charm and configuration.
+func InitializeUnit(params InitializeUnitParams, cancel <-chan struct{}) error {
+	if err := params.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+
+	params.Logger.Infof("started pod init on %q", params.UnitTag.Id())
+	providerID, err := params.UnitProviderIDFunc(params.UnitTag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	rootToolsDir := tools.ToolsDir(cmdutil.DataDir, "")
+	jujudPath := filepath.Join(rootToolsDir, "jujud")
+	unitPaths := uniter.NewPaths(cmdutil.DataDir, params.UnitTag, nil)
+	operatorPaths := params.Paths
+	tempDir, err := params.TempDir(os.TempDir(), params.UnitTag.String())
+	if err != nil {
+		return errors.Annotatef(err, "creating temp directory")
+	}
+
+	err = params.ExecClient.Exec(exec.ExecParams{
+		Commands:      []string{"mkdir", "-p", tempDir},
+		PodName:       providerID,
+		ContainerName: caas.InitContainerName,
+		Stdout:        &bytes.Buffer{},
+		Stderr:        &bytes.Buffer{},
+	}, cancel)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	tempCharmDir := filepath.Join(tempDir, "charm")
+	err = params.ExecClient.Copy(exec.CopyParam{
+		Src: exec.FileResource{
+			Path: operatorPaths.State.CharmDir,
+		},
+		Dest: exec.FileResource{
+			Path:          tempDir,
+			PodName:       providerID,
+			ContainerName: caas.InitContainerName,
+		},
+	}, cancel)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	tempCACertFile := filepath.Join(tempDir, caas.CACertFile)
+	if err := params.WriteFile(tempCACertFile, []byte(params.OperatorInfo.CACert), 0644); err != nil {
+		return errors.Trace(err)
+	}
+	err = params.ExecClient.Copy(exec.CopyParam{
+		Src: exec.FileResource{
+			Path: tempCACertFile,
+		},
+		Dest: exec.FileResource{
+			Path:          tempCACertFile,
+			PodName:       providerID,
+			ContainerName: caas.InitContainerName,
+		},
+	}, cancel)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	serviceAddress := os.Getenv(provider.OperatorServiceIPEnvName)
+	params.Logger.Debugf("operator service address: %v", serviceAddress)
+	token, err := utils.RandomPassword()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	clientInfo := caas.OperatorClientInfo{
+		ServiceAddress: serviceAddress,
+		Token:          token,
+	}
+	data, err := clientInfo.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	operatorCacheFile := filepath.Join(unitPaths.State.BaseDir, caas.OperatorClientInfoCacheFile)
+	if err := params.WriteFile(operatorCacheFile, data, 0644); err != nil {
+		return errors.Trace(err)
+	}
+	tempOperatorCacheFile := filepath.Join(tempDir, caas.OperatorClientInfoCacheFile)
+	err = params.ExecClient.Copy(exec.CopyParam{
+		Src: exec.FileResource{
+			Path: operatorCacheFile,
+		},
+		Dest: exec.FileResource{
+			Path:          tempOperatorCacheFile,
+			PodName:       providerID,
+			ContainerName: caas.InitContainerName,
+		},
+	}, cancel)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	stdout := &bytes.Buffer{}
+	err = params.ExecClient.Exec(exec.ExecParams{
+		Commands: []string{jujudPath, "caas-unit-init", "--send",
+			"--unit", params.UnitTag.String(),
+			"--charm-dir", tempCharmDir,
+			"--operator-file", tempOperatorCacheFile,
+			"--operator-ca-cert-file", tempCACertFile,
+		},
+		PodName:       providerID,
+		ContainerName: caas.InitContainerName,
+		WorkingDir:    cmdutil.DataDir,
+		Stdout:        stdout,
+		Stderr:        stdout,
+	}, cancel)
+	if err != nil {
+		return errors.Annotatef(err, "caas-unit-init failed: %s", string(stdout.Bytes()))
+	}
+
+	return nil
+}

--- a/worker/caasunitinit/initializer_test.go
+++ b/worker/caasunitinit/initializer_test.go
@@ -1,0 +1,214 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider/exec"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasoperator"
+	"github.com/juju/juju/worker/caasoperator/mocks"
+	"github.com/juju/juju/worker/caasunitinit"
+)
+
+type UnitInitializerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&UnitInitializerSuite{})
+
+func (s *UnitInitializerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockExecClient := mocks.NewMockExecutor(ctrl)
+
+	params := caasunitinit.InitializeUnitParams{
+		UnitTag: names.NewUnitTag("gitlab/0"),
+		Logger:  loggo.GetLogger("test"),
+		Paths: caasoperator.Paths{
+			State: caasoperator.StatePaths{
+				CharmDir: "dir/charm",
+			},
+		},
+		ExecClient: mockExecClient,
+		OperatorInfo: caas.OperatorInfo{
+			CACert: "ca-cert",
+		},
+		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
+			return "gitlab-ffff", nil
+		},
+		TempDir: func(dir string, prefix string) (string, error) {
+			return filepath.Join(dir, prefix+"-random"), nil
+		},
+		WriteFile: func(path string, data []byte, perm os.FileMode) error {
+			return nil
+		},
+	}
+
+	gomock.InOrder(
+		mockExecClient.EXPECT().Exec(exec.ExecParams{
+			Commands:      []string{"mkdir", "-p", filepath.Join(os.TempDir(), "unit-gitlab-0-random")},
+			PodName:       "gitlab-ffff",
+			ContainerName: "juju-pod-init",
+			Stdout:        &bytes.Buffer{},
+			Stderr:        &bytes.Buffer{},
+		}, gomock.Any()).Return(nil).Times(1),
+		mockExecClient.EXPECT().Copy(exec.CopyParam{
+			Src: exec.FileResource{
+				Path: "dir/charm",
+			},
+			Dest: exec.FileResource{
+				Path:          filepath.Join(os.TempDir(), "unit-gitlab-0-random"),
+				PodName:       "gitlab-ffff",
+				ContainerName: "juju-pod-init",
+			},
+		}, gomock.Any()).Return(nil).Times(1),
+		mockExecClient.EXPECT().Copy(exec.CopyParam{
+			Src: exec.FileResource{
+				Path: filepath.Join(os.TempDir(), "unit-gitlab-0-random/ca.crt"),
+			},
+			Dest: exec.FileResource{
+				Path:          filepath.Join(os.TempDir(), "unit-gitlab-0-random/ca.crt"),
+				PodName:       "gitlab-ffff",
+				ContainerName: "juju-pod-init",
+			},
+		}, gomock.Any()).Return(nil).Times(1),
+		mockExecClient.EXPECT().Copy(exec.CopyParam{
+			Src: exec.FileResource{
+				Path: "/var/lib/juju/agents/unit-gitlab-0/operator-client-cache.yaml",
+			},
+			Dest: exec.FileResource{
+				Path:          filepath.Join(os.TempDir(), "unit-gitlab-0-random/operator-client-cache.yaml"),
+				PodName:       "gitlab-ffff",
+				ContainerName: "juju-pod-init",
+			},
+		}, gomock.Any()).Return(nil).Times(1),
+		mockExecClient.EXPECT().Exec(exec.ExecParams{
+			Commands: []string{"/var/lib/juju/tools/jujud", "caas-unit-init",
+				"--send", "--unit", "unit-gitlab-0",
+				"--charm-dir",
+				filepath.Join(os.TempDir(), "unit-gitlab-0-random/charm"),
+				"--operator-file",
+				filepath.Join(os.TempDir(), "unit-gitlab-0-random/operator-client-cache.yaml"),
+				"--operator-ca-cert-file",
+				filepath.Join(os.TempDir(), "unit-gitlab-0-random/ca.crt"),
+			},
+			WorkingDir:    "/var/lib/juju",
+			PodName:       "gitlab-ffff",
+			ContainerName: "juju-pod-init",
+			Stdout:        &bytes.Buffer{},
+			Stderr:        &bytes.Buffer{},
+		}, gomock.Any()).Return(nil).Times(1),
+	)
+
+	cancel := make(chan struct{})
+	err := caasunitinit.InitializeUnit(params, cancel)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UnitInitializerSuite) TestInitializeUnitMissing(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockExecClient := mocks.NewMockExecutor(ctrl)
+
+	params := caasunitinit.InitializeUnitParams{
+		UnitTag: names.NewUnitTag("gitlab/0"),
+		Logger:  loggo.GetLogger("test"),
+		Paths: caasoperator.Paths{
+			State: caasoperator.StatePaths{
+				CharmDir: "dir/charm",
+			},
+		},
+		ExecClient: mockExecClient,
+		OperatorInfo: caas.OperatorInfo{
+			CACert: "ca-cert",
+		},
+		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
+			return "", errors.NotFoundf("unit")
+		},
+		TempDir: func(dir string, prefix string) (string, error) {
+			return filepath.Join(dir, prefix+"-random"), nil
+		},
+		WriteFile: func(path string, data []byte, perm os.FileMode) error {
+			return nil
+		},
+	}
+
+	gomock.InOrder()
+
+	cancel := make(chan struct{})
+	err := caasunitinit.InitializeUnit(params, cancel)
+	c.Assert(err, gc.ErrorMatches, "unit not found")
+}
+
+func (s *UnitInitializerSuite) TestInitializeContainerMissing(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockExecClient := mocks.NewMockExecutor(ctrl)
+
+	params := caasunitinit.InitializeUnitParams{
+		UnitTag: names.NewUnitTag("gitlab/0"),
+		Logger:  loggo.GetLogger("test"),
+		Paths: caasoperator.Paths{
+			State: caasoperator.StatePaths{
+				CharmDir: "dir/charm",
+			},
+		},
+		ExecClient: mockExecClient,
+		OperatorInfo: caas.OperatorInfo{
+			CACert: "ca-cert",
+		},
+		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
+			return "gitlab-ffff", nil
+		},
+		TempDir: func(dir string, prefix string) (string, error) {
+			return filepath.Join(dir, prefix+"-random"), nil
+		},
+		WriteFile: func(path string, data []byte, perm os.FileMode) error {
+			return nil
+		},
+	}
+
+	gomock.InOrder(
+		mockExecClient.EXPECT().Exec(exec.ExecParams{
+			Commands:      []string{"mkdir", "-p", filepath.Join(os.TempDir(), "unit-gitlab-0-random")},
+			PodName:       "gitlab-ffff",
+			ContainerName: "juju-pod-init",
+			Stdout:        &bytes.Buffer{},
+			Stderr:        &bytes.Buffer{},
+		}, gomock.Any()).Return(nil).Times(1),
+		mockExecClient.EXPECT().Copy(exec.CopyParam{
+			Src: exec.FileResource{
+				Path: "dir/charm",
+			},
+			Dest: exec.FileResource{
+				Path:          filepath.Join(os.TempDir(), "unit-gitlab-0-random"),
+				PodName:       "gitlab-ffff",
+				ContainerName: "juju-pod-init",
+			},
+		}, gomock.Any()).Return(errors.NotFoundf("container")).Times(1),
+	)
+
+	cancel := make(chan struct{})
+	err := caasunitinit.InitializeUnit(params, cancel)
+	c.Assert(err, gc.ErrorMatches, "container not found")
+}

--- a/worker/caasunitinit/manifold.go
+++ b/worker/caasunitinit/manifold.go
@@ -1,0 +1,145 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit
+
+import (
+	"os"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	apiuniter "github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/caas/kubernetes/provider/exec"
+	"github.com/juju/juju/worker/caasoperator"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	Logger Logger
+
+	AgentName     string
+	APICallerName string
+	ClockName     string
+
+	NewWorker func(Config) (worker.Worker, error)
+	NewClient func(base.APICaller) Client
+
+	NewExecClient func(namespace string) (exec.Executor, error)
+
+	LoadOperatorInfo func(paths caasoperator.Paths) (*caas.OperatorInfo, error)
+}
+
+// Validate checks that all required configuration is provided.
+func (config ManifoldConfig) Validate() error {
+	if config.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.ClockName == "" {
+		return errors.NotValidf("empty ClockName")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("missing NewWorker")
+	}
+	if config.NewClient == nil {
+		return errors.NotValidf("missing NewClient")
+	}
+	if config.NewExecClient == nil {
+		return errors.NotValidf("missing NewExecClient")
+	}
+	if config.LoadOperatorInfo == nil {
+		return errors.NotValidf("missing LoadOperatorInfo")
+	}
+	return nil
+}
+
+// Manifold returns a dependency manifold that runs a caasoperator worker,
+// using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.ClockName,
+		},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			if err := config.Validate(); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			var agent agent.Agent
+			if err := context.Get(config.AgentName, &agent); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			var apiCaller base.APICaller
+			if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+				return nil, errors.Trace(err)
+			}
+			client := config.NewClient(apiCaller)
+
+			var clock clock.Clock
+			if err := context.Get(config.ClockName, &clock); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			// Configure and start the caasoperator worker.
+			agentConfig := agent.CurrentConfig()
+			tag := agentConfig.Tag()
+			applicationTag, ok := tag.(names.ApplicationTag)
+			if !ok {
+				return nil, errors.Errorf("expected an application tag, got %v", tag)
+			}
+			unitProviderID := func(unitTag names.UnitTag) (string, error) {
+				unit, err := apiuniter.NewState(apiCaller, unitTag).Unit(unitTag)
+				if err != nil {
+					return "", errors.Trace(err)
+				}
+				return unit.ProviderID(), nil
+			}
+
+			execClient, err := config.NewExecClient(os.Getenv(provider.OperatorNamespaceEnvName))
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			cfg := Config{
+				Logger:             config.Logger,
+				Application:        applicationTag.Id(),
+				Clock:              clock,
+				DataDir:            agentConfig.DataDir(),
+				UnitStartWatcher:   client,
+				UnitProviderIDFunc: unitProviderID,
+				ExecClient:         execClient,
+				InitializeUnit:     InitializeUnit,
+			}
+			cfg.Paths = caasoperator.NewPaths(cfg.DataDir, names.NewApplicationTag(cfg.Application))
+
+			operatorInfo, err := config.LoadOperatorInfo(cfg.Paths)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			cfg.OperatorInfo = *operatorInfo
+
+			w, err := config.NewWorker(cfg)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return w, nil
+		},
+	}
+}

--- a/worker/caasunitinit/manifold_test.go
+++ b/worker/caasunitinit/manifold_test.go
@@ -1,0 +1,192 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit_test
+
+import (
+	"os"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	dt "gopkg.in/juju/worker.v1/dependency/testing"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider/exec"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasoperator"
+	"github.com/juju/juju/worker/caasoperator/mocks"
+	"github.com/juju/juju/worker/caasunitinit"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	manifold  dependency.Manifold
+	context   dependency.Context
+	agent     fakeAgent
+	apiCaller fakeAPICaller
+	client    fakeClient
+	clock     *testclock.Clock
+	dataDir   string
+	stub      testing.Stub
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	os.Setenv("JUJU_OPERATOR_SERVICE_IP", "127.0.0.1")
+	os.Setenv("JUJU_OPERATOR_POD_IP", "127.0.0.2")
+
+	s.dataDir = c.MkDir()
+	s.agent = fakeAgent{
+		config: fakeAgentConfig{
+			tag:     names.NewApplicationTag("gitlab"),
+			dataDir: s.dataDir,
+		},
+	}
+	s.clock = testclock.NewClock(time.Time{})
+	s.stub.ResetCalls()
+
+	s.context = s.newContext(nil)
+}
+
+func (s *ManifoldSuite) TearDownTest(c *gc.C) {
+	os.Setenv("JUJU_OPERATOR_SERVICE_IP", "")
+	os.Setenv("JUJU_OPERATOR_POD_IP", "")
+
+	s.IsolationSuite.TearDownTest(c)
+}
+
+func (s *ManifoldSuite) setupManifold(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.manifold = caasunitinit.Manifold(caasunitinit.ManifoldConfig{
+		Logger:        loggo.GetLogger("test"),
+		AgentName:     "agent",
+		APICallerName: "api-caller",
+		ClockName:     "clock",
+		NewWorker:     s.newWorker,
+		NewClient:     s.newClient,
+		NewExecClient: func(modelName string) (exec.Executor, error) {
+			return mocks.NewMockExecutor(ctrl), nil
+		},
+		LoadOperatorInfo: func(paths caasoperator.Paths) (*caas.OperatorInfo, error) {
+			return &caas.OperatorInfo{
+				CACert:     coretesting.CACert,
+				Cert:       coretesting.ServerCert,
+				PrivateKey: coretesting.ServerKey,
+			}, nil
+		},
+	})
+	return ctrl
+}
+
+func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"agent":      &s.agent,
+		"api-caller": &s.apiCaller,
+		"clock":      s.clock,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *ManifoldSuite) newWorker(config caasunitinit.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	w := worker.NewRunner(worker.RunnerParams{})
+	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, w) })
+	return w, nil
+}
+
+func (s *ManifoldSuite) newClient(caller base.APICaller) caasunitinit.Client {
+	s.stub.MethodCall(s, "NewClient", caller)
+	return &s.client
+}
+
+var expectedInputs = []string{"agent", "api-caller", "clock"}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	ctrl := s.setupManifold(c)
+	defer ctrl.Finish()
+
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *ManifoldSuite) TestMissingInputs(c *gc.C) {
+	ctrl := s.setupManifold(c)
+	defer ctrl.Finish()
+
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	w := s.startWorkerClean(c)
+	workertest.CleanKill(c, w)
+
+	s.stub.CheckCallNames(c, "NewClient", "NewWorker")
+	s.stub.CheckCall(c, 0, "NewClient", &s.apiCaller)
+
+	args := s.stub.Calls()[1].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, caasunitinit.Config{})
+	config := args[0].(caasunitinit.Config)
+
+	// Don't care about some helper funcs.
+	c.Assert(config.UnitProviderIDFunc, gc.NotNil)
+	config.UnitProviderIDFunc = nil
+	c.Assert(config.Logger, gc.NotNil)
+	config.Logger = nil
+	c.Assert(config.UnitStartWatcher, gc.NotNil)
+	config.UnitStartWatcher = nil
+	c.Assert(config.ExecClient, gc.NotNil)
+	config.ExecClient = nil
+	c.Assert(config.InitializeUnit, gc.NotNil)
+	config.InitializeUnit = nil
+	c.Assert(config.Paths.ToolsDir, gc.Not(gc.Equals), "")
+	c.Assert(config.Paths.State.BaseDir, gc.Not(gc.Equals), "")
+	config.Paths = caasoperator.Paths{}
+
+	c.Assert(config, jc.DeepEquals, caasunitinit.Config{
+		Application: "gitlab",
+		DataDir:     s.dataDir,
+		Clock:       s.clock,
+		OperatorInfo: caas.OperatorInfo{
+			CACert:     coretesting.CACert,
+			Cert:       coretesting.ServerCert,
+			PrivateKey: coretesting.ServerKey,
+		},
+	})
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	ctrl := s.setupManifold(c)
+	defer ctrl.Finish()
+
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	workertest.CheckAlive(c, w)
+	return w
+}

--- a/worker/caasunitinit/mock_test.go
+++ b/worker/caasunitinit/mock_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit_test
+
+import (
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasunitinit"
+)
+
+type fakeAgent struct {
+	agent.Agent
+	config fakeAgentConfig
+}
+
+func (a *fakeAgent) CurrentConfig() agent.Config {
+	return &a.config
+}
+
+type fakeAgentConfig struct {
+	agent.Config
+	dataDir string
+	tag     names.Tag
+}
+
+func (c *fakeAgentConfig) Tag() names.Tag {
+	return c.tag
+}
+
+func (c *fakeAgentConfig) Model() names.ModelTag {
+	return coretesting.ModelTag
+}
+
+func (c *fakeAgentConfig) DataDir() string {
+	return c.dataDir
+}
+
+type fakeAPICaller struct {
+	base.APICaller
+}
+
+type fakeClient struct {
+	testing.Stub
+	caasunitinit.Client
+	unitStartWatcher *watchertest.MockStringsWatcher
+}
+
+func (c *fakeClient) WatchUnitStart(application string) (watcher.StringsWatcher, error) {
+	c.MethodCall(c, "WatchUnits", application)
+	if err := c.NextErr(); err != nil {
+		return nil, err
+	}
+	return c.unitStartWatcher, nil
+}

--- a/worker/caasunitinit/package_test.go
+++ b/worker/caasunitinit/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasunitinit/worker.go
+++ b/worker/caasunitinit/worker.go
@@ -1,0 +1,172 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit
+
+import (
+	"io/ioutil"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/catacomb"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider/exec"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/worker/caasoperator"
+)
+
+type Logger interface {
+	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+// Client provides an interface for interacting
+// with the CAASOperator API. Subsets of this
+// should be passed to the CAASUnitInit worker.
+type Client interface {
+	UnitStartWatcher
+}
+
+// UnitStartWatcher provides an interface for watching
+// for unit starts.
+type UnitStartWatcher interface {
+	WatchUnitStart(string) (watcher.StringsWatcher, error)
+}
+
+// Config for a caasUnitInitWorker and unitInitializer
+type Config struct {
+	// Logger for the worker.
+	Logger Logger
+
+	// Clock holds the clock to be used by the CAAS operator
+	// for time-related operations.
+	Clock clock.Clock
+
+	// Application holds the name of the application that
+	// this CAAS operator manages.
+	Application string
+
+	// DataDir holds the path to the Juju "data directory",
+	// i.e. "/var/lib/juju" (by default). The CAAS operator
+	// expects to find the jujud binary at <data-dir>/tools/jujud.
+	DataDir string
+
+	// UnitStartWatcher is an interface for watching unit startup.
+	UnitStartWatcher UnitStartWatcher
+
+	// UnitProviderIDFunc returns the ProviderID for the given unit.
+	UnitProviderIDFunc func(unit names.UnitTag) (string, error)
+
+	// Paths provides CAAS operator paths.
+	Paths caasoperator.Paths
+
+	// OperatorInfo contains serving information such as Certs and PrivateKeys.
+	OperatorInfo caas.OperatorInfo
+
+	// ExecClient is used for initilizing units.
+	ExecClient exec.Executor
+
+	// InitializeUnit with the charm and configuration.
+	InitializeUnit InitializeUnitFunc
+}
+
+func (config Config) Validate() error {
+	if !names.IsValidApplication(config.Application) {
+		return errors.NotValidf("application name %q", config.Application)
+	}
+	if config.UnitStartWatcher == nil {
+		return errors.NotValidf("missing UnitStartWatcher")
+	}
+	if config.UnitProviderIDFunc == nil {
+		return errors.NotValidf("missing UnitProviderIDFunc")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("missing Clock")
+	}
+	if config.DataDir == "" {
+		return errors.NotValidf("missing DataDir")
+	}
+	if config.ExecClient == nil {
+		return errors.NotValidf("missing ExecClient")
+	}
+	if config.InitializeUnit == nil {
+		return errors.NotValidf("missing InitializeUnit")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	return nil
+}
+
+// InitializeUnitFunc returns a new worker start function to initilize the Unit.
+type InitializeUnitFunc func(params InitializeUnitParams, cancel <-chan struct{}) error
+
+type caasUnitInitWorker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+}
+
+// NewWorker returns a new CAAS unit init worker.
+func NewWorker(config Config) (worker.Worker, error) {
+	w := &caasUnitInitWorker{
+		config: config,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+func (w *caasUnitInitWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *caasUnitInitWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *caasUnitInitWorker) loop() error {
+	unitStartWatcher, err := w.config.UnitStartWatcher.WatchUnitStart(w.config.Application)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(unitStartWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case units, ok := <-unitStartWatcher.Changes():
+			if !ok {
+				return errors.Errorf("watcher closed channel")
+			}
+			for _, unit := range units {
+				params := InitializeUnitParams{
+					UnitTag:            names.NewUnitTag(unit),
+					Logger:             w.config.Logger,
+					UnitProviderIDFunc: w.config.UnitProviderIDFunc,
+					Paths:              w.config.Paths,
+					OperatorInfo:       w.config.OperatorInfo,
+					ExecClient:         w.config.ExecClient,
+					WriteFile:          ioutil.WriteFile,
+					TempDir:            ioutil.TempDir,
+				}
+				err = w.config.InitializeUnit(params, w.catacomb.Dying())
+				if errors.IsNotFound(err) {
+					w.config.Logger.Infof("unit %q went away, skipping initialization", unit)
+				} else if err != nil {
+					return errors.Annotatef(err, "initializing unit %q", unit)
+				}
+			}
+		}
+	}
+}

--- a/worker/caasunitinit/worker_test.go
+++ b/worker/caasunitinit/worker_test.go
@@ -1,0 +1,137 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitinit_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/watcher/watchertest"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasoperator/mocks"
+	"github.com/juju/juju/worker/caasunitinit"
+)
+
+type UnitInitWorkerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&UnitInitWorkerSuite{})
+
+func (s *UnitInitWorkerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *UnitInitWorkerSuite) TestWorker(c *gc.C) {
+	startChan := make(chan []string, 1)
+	startChan <- []string{"gitlab/0"}
+	close(startChan)
+	client := &fakeClient{
+		unitStartWatcher: watchertest.NewMockStringsWatcher(startChan),
+	}
+
+	st := &testing.Stub{}
+	cfg := caasunitinit.Config{
+		Logger:     loggo.GetLogger("test"),
+		ExecClient: &mocks.MockExecutor{},
+		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
+			return "", errors.NotImplementedf("not required")
+		},
+		InitializeUnit: func(params caasunitinit.InitializeUnitParams, cancel <-chan struct{}) error {
+			st.AddCall("InitializeUnit", params.UnitTag)
+			return nil
+		},
+		UnitStartWatcher: client,
+	}
+
+	w, err := caasunitinit.NewWorker(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-worker.Dead(w):
+	case <-time.After(coretesting.LongWait):
+	}
+	err = workertest.CheckKill(c, w)
+	c.Assert(err, gc.ErrorMatches, "watcher closed channel")
+
+	st.CheckCall(c, 0, "InitializeUnit", names.NewUnitTag("gitlab/0"))
+}
+
+func (s *UnitInitWorkerSuite) TestUnitDeadGraceful(c *gc.C) {
+	startChan := make(chan []string, 1)
+	startChan <- []string{"gitlab/0"}
+	close(startChan)
+	client := &fakeClient{
+		unitStartWatcher: watchertest.NewMockStringsWatcher(startChan),
+	}
+
+	st := &testing.Stub{}
+	cfg := caasunitinit.Config{
+		Logger:     loggo.GetLogger("test"),
+		ExecClient: &mocks.MockExecutor{},
+		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
+			return "", errors.NotImplementedf("not required")
+		},
+		InitializeUnit: func(params caasunitinit.InitializeUnitParams, cancel <-chan struct{}) error {
+			st.AddCall("InitializeUnit", params.UnitTag)
+			return errors.NotFoundf("unit sadly died")
+		},
+		UnitStartWatcher: client,
+	}
+
+	w, err := caasunitinit.NewWorker(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-worker.Dead(w):
+	case <-time.After(coretesting.LongWait):
+	}
+	err = workertest.CheckKill(c, w)
+	c.Assert(err, gc.ErrorMatches, "watcher closed channel")
+
+	st.CheckCall(c, 0, "InitializeUnit", names.NewUnitTag("gitlab/0"))
+}
+
+func (s *UnitInitWorkerSuite) TestInitializeFailed(c *gc.C) {
+	startChan := make(chan []string, 1)
+	startChan <- []string{"gitlab/0"}
+	close(startChan)
+	client := &fakeClient{
+		unitStartWatcher: watchertest.NewMockStringsWatcher(startChan),
+	}
+
+	st := &testing.Stub{}
+	cfg := caasunitinit.Config{
+		Logger:     loggo.GetLogger("test"),
+		ExecClient: &mocks.MockExecutor{},
+		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
+			return "", errors.NotImplementedf("not required")
+		},
+		InitializeUnit: func(params caasunitinit.InitializeUnitParams, cancel <-chan struct{}) error {
+			st.AddCall("InitializeUnit", params.UnitTag)
+			return errors.Errorf("something bad happened")
+		},
+		UnitStartWatcher: client,
+	}
+
+	w, err := caasunitinit.NewWorker(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-worker.Dead(w):
+	case <-time.After(coretesting.LongWait):
+	}
+	err = workertest.CheckKill(c, w)
+	c.Assert(err, gc.ErrorMatches, `initializing unit "gitlab/0": something bad happened`)
+
+	st.CheckCall(c, 0, "InitializeUnit", names.NewUnitTag("gitlab/0"))
+}

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -157,11 +157,12 @@ func (w *deploymentWorker) loop() error {
 		}
 
 		serviceParams := &caas.ServiceParams{
-			PodSpec:      spec,
-			Constraints:  info.Constraints,
-			ResourceTags: info.Tags,
-			Filesystems:  info.Filesystems,
-			Devices:      info.Devices,
+			PodSpec:           spec,
+			Constraints:       info.Constraints,
+			ResourceTags:      info.Tags,
+			Filesystems:       info.Filesystems,
+			Devices:           info.Devices,
+			OperatorImagePath: info.OperatorImagePath,
 			Deployment: caas.DeploymentParams{
 				DeploymentType: caas.DeploymentType(info.DeploymentInfo.DeploymentType),
 				ServiceType:    caas.ServiceType(info.DeploymentInfo.ServiceType),


### PR DESCRIPTION
## CAAS unit init container for hook ctx and juju-run

This work moves the prepare logic outside of the command runner
for k8s into an init container that initializes the pod's /var/lib/juju for the
hook context and juju-run.

The init container shares /var/lib/juju and /usr/bin/juju-run via an
emptyDir volume with the workload containers. When the init container
starts it waits on an abstract domain socket for context to be delivered
via the caas-unit-init worker.

The caas-unit-init worker watches on the k8s api for the juju-init-pod to
enter the running state. It then uses the exec framework to copy over various
required files such as the charm and config then finally invokes the
command to complete the init.

## QA steps

- Bootstrap microk8s
- Deploy a workload with a test action
- Enable the developer-mode feature flag
- Test the action runs
- kubectl into the pod and test juju-run

## Documentation changes

N/A

## Bug reference

N/A
