### PR TITLE
Verify script clean up

### DIFF
--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -12,79 +12,11 @@ set -e
 VERSION=`go version | awk '{print $3}'`
 echo "go version $VERSION"
 
-FILES=`find * -name '*.go' -not -name '.#*' -not -name '*_mock.go' | grep -v vendor/ | grep -v acceptancetests/`
-
-echo "checking: dependency files ..."
-dep check
-
-echo "checking: copyright notices are in place ..."
-./scripts/copyright.bash
-
-echo "checking: go fmt ..."
-BADFMT=`echo "$FILES" | xargs gofmt -l -s`
-if [ -n "$BADFMT" ]; then
-    BADFMT=`echo "$BADFMT" | sed "s/^/  /"`
-    echo -e "gofmt failed, run the following command(s) to fix:\n"
-    for item in $BADFMT; do
-        echo "gofmt -l -s -w $item"
-    done
-    exit 1
-fi
-
-echo "checking: go vet ..."
-
-# Define additional Printf style functions to check. These add to the
-# default list of standard library functions that go vet already has.
-logging_prints="\
-Tracef
-Debugf
-Infof
-Warningf
-Errorf
-Criticalf
-Annotatef
-"
-
-error_prints="\
-AlreadyExistsf
-BadRequestf
-MethodNotAllowedf
-NotAssignedf
-NotFoundf
-NotImplementedf
-NotProvisionedf
-NotSupportedf
-NotValidf
-Unauthorizedf
-UserNotFoundf
-"
-
-# Under Go 1.6, the vet docs say that -printfuncs takes each print
-# function in "name:N" format. This has changed in Go 1.7 and doesn't
-# actually seem to make a difference under 1.6 either don't bother.
-all_prints=`echo $logging_prints $error_prints | tr " " ,`
-DIRNAMES=$(dirname $FILES | sort -u | xargs -I % echo "github.com/juju/juju/%")
-
-go vet \
-   -all \
-   -composites=false \
-   -printfuncs=$all_prints \
-    $DIRNAMES || [ -n "$IGNORE_VET_WARNINGS" ]
-
-# Allow the ignoring of the golinters
-if [ -n "$INCLUDE_GOLINTERS" ]; then
-    echo "checking: golinters ..."
-    ./scripts/golinters.bash
+STATIC_ANALYSIS="${STATIC_ANALYSIS:-}"
+if [ -n "$STATIC_ANALYSIS" ]; then
+    make static-analysis
 else
-    echo "ignoring: golinters ..."
-fi
-
-INCLUDE_SCHEMA="${INCLUDE_SCHEMA:-1}"
-if [ -n "$INCLUDE_SCHEMA" ]; then
-    echo "checking: schema ..."
-    ./scripts/schema.bash
-else
-    echo "ignoring: schema ..."
+    echo "Ignoring static anaylsis, run again with STATIC_ANALYSIS=1 ..."
 fi
 
 echo "checking: go build ..."

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -127,41 +127,57 @@ test_static_analysis_go() {
     ## Check dependency is correct
     if which dep >/dev/null 2>&1; then
       run "run_dep_check"
+    else
+      echo "dep not found, dep static analysis disabled"
     fi
 
     ## go vet, if it exists
     if go help vet >/dev/null 2>&1; then
       run "run_go_vet" "${FOLDERS}"
+    else
+      echo "vet not found, vet static analysis disabled"
     fi
 
     ## golint
     if which golint >/dev/null 2>&1; then
       run "run_go_lint"
+    else
+      echo "golint not found, golint static analysis disabled"
     fi
 
     ## goimports
     if which goimports >/dev/null 2>&1; then
       run "run_go_imports" "${FOLDERS}"
+    else
+      echo "goimports not found, goimports static analysis disabled"
     fi
 
     ## deadcode
     if which deadcode >/dev/null 2>&1; then
       run "run_deadcode"
+    else
+      echo "deadcode not found, deadcode static analysis disabled"
     fi
 
     ## misspell
     if which misspell >/dev/null 2>&1; then
       run "run_misspell" "${FILES}"
+    else
+      echo "misspell not found, misspell static analysis disabled"
     fi
 
     ## unconvert
     if which unconvert >/dev/null 2>&1; then
       run "run_unconvert"
+    else
+      echo "unconvert not found, unconvert static analysis disabled"
     fi
 
     ## ineffassign
     if which ineffassign >/dev/null 2>&1; then
       run "run_ineffassign"
+    else
+      echo "ineffassign not found, ineffassign static analysis disabled"
     fi
 
     ## go fmt


### PR DESCRIPTION
## Description of change

The following removes all the older static-analysis tools and uses
the new integration test suite. All static-analysis should be done
through the new tools, any other outstanding ones should be correctly
moved over to the new tool.

The jenkins jobs that check the github commit/PR should also now
hook directly into the new integration tests. This should now allow
us to run all these things in parallel.

## QA steps

```sh
make check
STATIC_ANALYSIS=1 make check
```
