### PR TITLE
machine.GetNetworkInfoForSpaces arg change.

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -384,12 +384,7 @@ func (n *NetworkInfo) machineNetworkInfos(spaces ...string) (map[string]state.Ma
 		return nil, err
 	}
 
-	spInfos, err := n.lookupSpaces(spaces...)
-	if err != nil {
-		return nil, err
-	}
-
-	return machine.GetNetworkInfoForSpaces(spInfos), nil
+	return machine.GetNetworkInfoForSpaces(set.NewStrings(spaces...)), nil
 }
 
 // spaceForBinding returns the space id
@@ -405,22 +400,6 @@ func (n *NetworkInfo) spaceForBinding(endpoint string) (string, error) {
 		return "", errors.NewNotValid(nil, fmt.Sprintf("binding id %q not defined by the unit's charm", endpoint))
 	}
 	return boundSpace, nil
-}
-
-func (n *NetworkInfo) lookupSpaces(ids ...string) (corenetwork.SpaceInfos, error) {
-	allInfos, err := n.st.SpaceInfosByID()
-	if err != nil {
-		return nil, err
-	}
-	spaceInfos := make(corenetwork.SpaceInfos, len(ids))
-	for i, id := range ids {
-		info, found := allInfos[id]
-		if !found {
-			return nil, errors.NotFoundf("space with id %q", id)
-		}
-		spaceInfos[i] = info
-	}
-	return spaceInfos, nil
 }
 
 // spaceAddressesFromNetworkInfo returns a SpaceAddresses collection


### PR DESCRIPTION
## Description of change

Follow on from PR 10718 comments.  Use set of SpaceIDs instead of 
corenetwork.SpaceInfos as arg for GetNetworkInfoForSpaces.  Only 
need the IDs not the entire SpaceInfo.

## QA steps

This change should have no discernible impact to juju functionality.  Please run thru normal bootstrap and deploy.

