### PR TITLE
update-cloud ask-or-tell and exclusivity.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -80,13 +80,12 @@ func NewUpdatePublicCloudsCommandForTest(publicCloudURL string) *updatePublicClo
 func NewUpdateCloudCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
 	store jujuclient.ClientStore,
-	cloudAPI func(string) (UpdateCloudAPI, error),
+	cloudAPI func() (UpdateCloudAPI, error),
 ) *updateCloudCommand {
 	return &updateCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
 		cloudMetadataStore:        cloudMetadataStore,
 		updateCloudAPIFunc:        cloudAPI,
-		store:                     store,
 	}
 }
 

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -178,7 +178,7 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 				runAction()
 			}
 		} else {
-			return errors.BadRequestf("To update cloud definiton on a controller, a controller name is required.")
+			return errors.BadRequestf("To update cloud definition on a controller, a controller name is required.")
 		}
 	}
 	return returnErr

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -4,6 +4,8 @@
 package cloud
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -13,7 +15,6 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -32,35 +33,41 @@ type updateCloudCommand struct {
 	CloudFile string
 
 	// Used when updating controllers' cloud details
-	controllerName     string
-	store              jujuclient.ClientStore
-	updateCloudAPIFunc func(controllerName string) (updateCloudAPI, error)
+	updateCloudAPIFunc func() (updateCloudAPI, error)
 }
 
 var updateCloudDoc = `
-Update cloud information either on this client or on the controller.
+Update cloud information on this client and/or on a controller.
 
-Updating this client requires a <cloud name> and a yaml file containing the
-cloud details.
+A cloud can be updated from a file. This requires a <cloud name> and a yaml file
+containing the cloud details. 
+This method can be used for cloud updates on the client side and on a controller. 
 
-To update a cloud on the controller you can provide just the <cloud name> which
-will use the cloud defined on this client or you can provide a cloud
-definition yaml file from which to retrieve the cloud details; the current
-controller is used unless the --controller option is specified.
+A cloud on the controller can also be updated just by using a name of a cloud
+from this client.
 
-When <cloud definition file> is provided with <cloud name> and --client-only is
-specified, Juju stores that definition in its internal cache directly after
-validating the contents.
+If a current controller can be detected, a user will be prompted to confirm 
+if specified cloud needs to be updated on it. 
+If the prompt is not needed and the cloud is always to be updated on
+the current controller if that controller is detected, use --no-prompt option.
+
+Use --controller option to update a cloud on a different controller. 
+
+Use --controller-only option to only update controller copy of the cloud.
+
+Use --client-only to update cloud definition on this client.
 
 Examples:
 
     juju update-cloud mymaas -f path/to/maas.yaml
     juju update-cloud mymaas -f path/to/maas.yaml --controller mycontroller
     juju update-cloud mymaas --controller mycontroller
+    juju update-cloud mymaas --no-prompt --controller-only
     juju update-cloud mymaas --client-only -f path/to/maas.yaml
 
 See also:
     add-cloud
+    remove-cloud
     list-clouds
 `
 
@@ -78,19 +85,17 @@ func newUpdateCloudCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &updateCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store:       store,
-			EnabledFlag: feature.MultiCloud,
+			Store: store,
 		},
 		cloudMetadataStore: cloudMetadataStore,
-		store:              store,
 	}
 	c.updateCloudAPIFunc = c.updateCloudAPI
 
 	return modelcmd.WrapBase(c)
 }
 
-func (c *updateCloudCommand) updateCloudAPI(controllerName string) (updateCloudAPI, error) {
-	root, err := c.NewAPIRoot(c.store, controllerName, "")
+func (c *updateCloudCommand) updateCloudAPI() (updateCloudAPI, error) {
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -113,26 +118,6 @@ func (c *updateCloudCommand) Init(args []string) error {
 	if err := cmd.CheckEmpty(args[1:]); err != nil {
 		return err
 	}
-
-	var err error
-	c.ControllerName, err = c.ControllerNameFromArg()
-	if err != nil && errors.Cause(err) != modelcmd.ErrNoControllersDefined {
-		return errors.Trace(err)
-	}
-
-	// Condense arguments into an action,
-	c.commandAction = c.updateLocalCacheFromFile
-	if c.ControllerName != "" {
-		if c.CloudFile != "" && c.Cloud != "" {
-			c.commandAction = c.updateControllerFromFile
-		} else if c.Cloud != "" {
-			c.commandAction = c.updateControllerCacheFromLocalCache
-		} else {
-			return errors.BadRequestf("cloud name and/or cloud definition file required")
-		}
-	} else if c.CloudFile == "" {
-		return errors.BadRequestf("cloud definition file or controller name required")
-	}
 	return nil
 }
 
@@ -151,24 +136,69 @@ func (c *updateCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
-	return c.commandAction(ctxt)
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName == "" {
+			// The user may have specified the controller via a --controller option.
+			// If not, let's see if there is a current controller that can be detected.
+			var err error
+			c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("update cloud %q on", c.Cloud))
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	if c.ControllerName == "" && !c.ClientOnly {
+		ctxt.Infof("To update cloud %q on this client, use the --client-only option.", c.Cloud)
+	}
+	var returnErr error
+	runAction := func() {
+		if err := c.commandAction(ctxt); err != nil {
+			ctxt.Infof("%v", err)
+			returnErr = cmd.ErrSilent
+		}
+	}
+	if c.BothClientAndController || c.ClientOnly {
+		if c.CloudFile == "" {
+			ctxt.Infof("To update cloud %q on this client, a cloud definition file is required.", c.Cloud)
+			returnErr = cmd.ErrSilent
+		} else {
+			c.commandAction = c.updateLocalCacheFromFile
+			runAction()
+		}
+	}
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName != "" {
+			if c.CloudFile != "" {
+				logger.Infof("Updating cloud %q on controller %q from a file.", c.Cloud, c.ControllerName)
+				c.commandAction = c.updateControllerFromFile
+				runAction()
+			} else {
+				logger.Infof("Updating cloud %q on controller %q from a cloud %q on this client.", c.Cloud, c.ControllerName, c.Cloud)
+				c.commandAction = c.updateControllerCacheFromLocalCache
+				runAction()
+			}
+		} else {
+			return errors.BadRequestf("To update cloud definiton on a controller, a controller name is required.")
+		}
+	}
+	return returnErr
 }
 
 func (c *updateCloudCommand) updateLocalCacheFromFile(ctxt *cmd.Context) error {
-	if !c.ClientOnly {
-		ctxt.Infof(
-			"There are no controllers running.\nUpdating cloud on this client so you can use it to bootstrap a controller.\n")
-	}
 	r := &cloudFileReader{
 		cloudMetadataStore: c.cloudMetadataStore,
 		cloudName:          c.Cloud,
 	}
 	newCloud, err := r.readCloudFromFile(c.CloudFile, ctxt)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "could not read cloud definition from file for an update on this client")
 	}
 	c.Cloud = r.cloudName
-	return addLocalCloud(c.cloudMetadataStore, *newCloud)
+	if err := addLocalCloud(c.cloudMetadataStore, *newCloud); err != nil {
+		return err
+	}
+	ctxt.Infof("Cloud %q updated on this client.", c.Cloud)
+	return nil
 }
 
 func (c *updateCloudCommand) updateControllerFromFile(ctxt *cmd.Context) error {
@@ -178,7 +208,7 @@ func (c *updateCloudCommand) updateControllerFromFile(ctxt *cmd.Context) error {
 	}
 	newCloud, err := r.readCloudFromFile(c.CloudFile, ctxt)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "could not read cloud definition from file for an update on a controller")
 	}
 	c.Cloud = r.cloudName
 	return c.updateController(ctxt, newCloud)
@@ -193,7 +223,7 @@ func (c *updateCloudCommand) updateControllerCacheFromLocalCache(ctxt *cmd.Conte
 }
 
 func (c updateCloudCommand) updateController(ctxt *cmd.Context, cloud *jujucloud.Cloud) error {
-	api, err := c.updateCloudAPIFunc(c.ControllerName)
+	api, err := c.updateCloudAPIFunc()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
@@ -39,27 +40,27 @@ func (s *updateCloudSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *updateCloudSuite) TestBadArgs(c *gc.C) {
-	cmd := cloud.NewUpdateCloudCommandForTest(newFakeCloudMetadataStore(), s.store, nil)
-	_, err := cmdtesting.RunCommand(c, cmd)
+	command := cloud.NewUpdateCloudCommandForTest(newFakeCloudMetadataStore(), s.store, nil)
+	_, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, gc.ErrorMatches, "cloud name required")
 
-	_, err = cmdtesting.RunCommand(c, cmd, "--controller", "blah")
+	_, err = cmdtesting.RunCommand(c, command, "--controller", "blah")
 	c.Assert(err, gc.ErrorMatches, "cloud name required")
 
-	_, err = cmdtesting.RunCommand(c, cmd, "--controller", "blah", "-f", "file/path")
+	_, err = cmdtesting.RunCommand(c, command, "--controller", "blah", "-f", "file/path")
 	c.Assert(err, gc.ErrorMatches, "cloud name required")
 
-	_, err = cmdtesting.RunCommand(c, cmd, "-f", "file/path")
+	_, err = cmdtesting.RunCommand(c, command, "-f", "file/path")
 	c.Assert(err, gc.ErrorMatches, "cloud name required")
 
-	_, err = cmdtesting.RunCommand(c, cmd, "_a", "file/path")
+	_, err = cmdtesting.RunCommand(c, command, "_a", "file/path")
 	c.Assert(err, gc.ErrorMatches, `cloud name "_a" not valid`)
 
-	_, err = cmdtesting.RunCommand(c, cmd, "boo", "boo")
+	_, err = cmdtesting.RunCommand(c, command, "boo", "boo")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["boo"\]`)
 }
 
-func (s *updateCloudSuite) setupCloudFileScenario(c *gc.C, apiFunc func(controllerName string) (cloud.UpdateCloudAPI, error)) (*cloud.UpdateCloudCommand, string) {
+func (s *updateCloudSuite) setupCloudFileScenario(c *gc.C, apiFunc func() (cloud.UpdateCloudAPI, error)) (*cloud.UpdateCloudCommand, string) {
 	cloudfile := prepareTestCloudYaml(c, garageMaasYamlFile)
 	s.AddCleanup(func(_ *gc.C) {
 		defer cloudfile.Close()
@@ -72,9 +73,9 @@ func (s *updateCloudSuite) setupCloudFileScenario(c *gc.C, apiFunc func(controll
 	fake.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]jujucloud.Cloud{}, false, nil)
 	fake.Call("PersonalCloudMetadata").Returns(map[string]jujucloud.Cloud{}, nil)
 	fake.Call("WritePersonalCloudMetadata", mockCloud).Returns(nil)
-	cmd := cloud.NewUpdateCloudCommandForTest(fake, s.store, apiFunc)
+	command := cloud.NewUpdateCloudCommandForTest(fake, s.store, apiFunc)
 
-	return cmd, cloudfile.Name()
+	return command, cloudfile.Name()
 }
 
 func (s *updateCloudSuite) createLocalCacheFile(c *gc.C) {
@@ -83,47 +84,35 @@ func (s *updateCloudSuite) createLocalCacheFile(c *gc.C) {
 }
 
 func (s *updateCloudSuite) TestUpdateLocalCacheFromFile(c *gc.C) {
-	cmd, fileName := s.setupCloudFileScenario(c, func(controllerName string) (cloud.UpdateCloudAPI, error) {
+	command, fileName := s.setupCloudFileScenario(c, func() (cloud.UpdateCloudAPI, error) {
 		return nil, errors.New("")
 	})
-	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName, "--client-only")
+	_, err := cmdtesting.RunCommand(c, command, "garage-maas", "-f", fileName, "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
 }
 
 func (s *updateCloudSuite) TestUpdateFromFileDefaultLocal(c *gc.C) {
 	s.store.Controllers = nil
-	cmd, fileName := s.setupCloudFileScenario(c, func(controllerName string) (cloud.UpdateCloudAPI, error) {
+	command, fileName := s.setupCloudFileScenario(c, func() (cloud.UpdateCloudAPI, error) {
 		return nil, errors.New("")
 	})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName)
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", "-f", fileName, "--client-only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
 	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `There are no controllers running.Updating cloud on this client so you can use it to bootstrap a controller.*`)
-}
-
-func (s *updateCloudSuite) TestUpdateLocalCacheBadFile(c *gc.C) {
-	fake := newFakeCloudMetadataStore()
-	badFileErr := errors.New("")
-	fake.Call("ParseCloudMetadataFile", "somefile.yaml").Returns(map[string]jujucloud.Cloud{}, badFileErr)
-
-	addCmd := cloud.NewUpdateCloudCommandForTest(fake, s.store, nil)
-	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "-f", "somefile.yaml")
-	c.Check(errors.Cause(err), gc.Equals, badFileErr)
+	c.Assert(out, gc.Matches, `Cloud "garage-maas" updated on this client.`)
 }
 
 func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
-	var controllerNameCalled string
-	cmd, fileName := s.setupCloudFileScenario(c, func(controllerName string) (cloud.UpdateCloudAPI, error) {
-		controllerNameCalled = controllerName
+	command, fileName := s.setupCloudFileScenario(c, func() (cloud.UpdateCloudAPI, error) {
 		return s.api, nil
 	})
-	ctx, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "-f", fileName)
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", "-f", fileName, "--no-prompt", "--controller-only")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "UpdateCloud", "Close")
-	c.Assert(controllerNameCalled, gc.Equals, "mycontroller")
+	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	s.api.CheckCall(c, 0, "UpdateCloud", jujucloud.Cloud{
 		Name:        "garage-maas",
 		Type:        "maas",
@@ -138,25 +127,27 @@ func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
 
 func (s *updateCloudSuite) TestUpdateControllerLocalCacheBadFile(c *gc.C) {
 	fake := newFakeCloudMetadataStore()
-	badFileErr := errors.New("")
-	fake.Call("ParseCloudMetadataFile", "somefile.yaml").Returns(map[string]jujucloud.Cloud{}, badFileErr)
+	fake.Call("ParseCloudMetadataFile", "somefile.yaml").Returns(map[string]jujucloud.Cloud{}, errors.New("kaboom"))
 
 	addCmd := cloud.NewUpdateCloudCommandForTest(fake, s.store, nil)
-	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "-f", "somefile.yaml", "--controller", "mycontroller")
-	c.Check(errors.Cause(err), gc.Equals, badFileErr)
+	ctx, err := cmdtesting.RunCommand(c, addCmd, "cloud", "-f", "somefile.yaml", "--controller", "mycontroller")
+	c.Check(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+could not read cloud definition from file for an update on this client: kaboom
+could not read cloud definition from file for an update on a controller: kaboom
+`[1:])
 }
 
 func (s *updateCloudSuite) TestUpdateControllerFromLocalCache(c *gc.C) {
 	s.createLocalCacheFile(c)
-	var controllerNameCalled string
-	cmd, _ := s.setupCloudFileScenario(c, func(controllerName string) (cloud.UpdateCloudAPI, error) {
-		controllerNameCalled = controllerName
+	command, _ := s.setupCloudFileScenario(c, func() (cloud.UpdateCloudAPI, error) {
 		return s.api, nil
 	})
-	_, err := cmdtesting.RunCommand(c, cmd, "garage-maas", "--controller", "mycontroller")
-	c.Assert(err, jc.ErrorIsNil)
+	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", "--controller", "mycontroller")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	s.api.CheckCallNames(c, "UpdateCloud", "Close")
-	c.Assert(controllerNameCalled, gc.Equals, "mycontroller")
+	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	s.api.CheckCall(c, 0, "UpdateCloud", jujucloud.Cloud{
 		Name:        "garage-maas",
 		Type:        "maas",
@@ -164,6 +155,11 @@ func (s *updateCloudSuite) TestUpdateControllerFromLocalCache(c *gc.C) {
 		AuthTypes:   jujucloud.AuthTypes{"oauth1"},
 		Endpoint:    "http://garagemaas",
 	})
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+To update cloud "garage-maas" on this client, a cloud definition file is required.
+Cloud "garage-maas" updated on controller "mycontroller".
+`[1:])
 }
 
 type fakeUpdateCloudAPI struct {

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -102,7 +102,7 @@ func (s *updateCloudSuite) TestUpdateFromFileDefaultLocal(c *gc.C) {
 	c.Assert(s.api.Calls(), gc.HasLen, 0)
 	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `Cloud "garage-maas" updated on this client.`)
+	c.Assert(out, gc.Matches, `Cloud "garage-maas" updated on this client using provided file.`)
 }
 
 func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
@@ -122,7 +122,7 @@ func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
 	})
 	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `Cloud "garage-maas" updated on controller "mycontroller".`)
+	c.Assert(out, gc.Matches, `Cloud "garage-maas" updated on controller "mycontroller" using provided file.`)
 }
 
 func (s *updateCloudSuite) TestUpdateControllerLocalCacheBadFile(c *gc.C) {
@@ -130,13 +130,8 @@ func (s *updateCloudSuite) TestUpdateControllerLocalCacheBadFile(c *gc.C) {
 	fake.Call("ParseCloudMetadataFile", "somefile.yaml").Returns(map[string]jujucloud.Cloud{}, errors.New("kaboom"))
 
 	addCmd := cloud.NewUpdateCloudCommandForTest(fake, s.store, nil)
-	ctx, err := cmdtesting.RunCommand(c, addCmd, "cloud", "-f", "somefile.yaml", "--controller", "mycontroller")
-	c.Check(err, gc.Equals, cmd.ErrSilent)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-could not read cloud definition from file for an update on this client: kaboom
-could not read cloud definition from file for an update on a controller: kaboom
-`[1:])
+	_, err := cmdtesting.RunCommand(c, addCmd, "cloud", "-f", "somefile.yaml", "--controller", "mycontroller")
+	c.Check(err, gc.ErrorMatches, "could not read cloud definition from provided file: kaboom")
 }
 
 func (s *updateCloudSuite) TestUpdateControllerFromLocalCache(c *gc.C) {
@@ -158,7 +153,7 @@ func (s *updateCloudSuite) TestUpdateControllerFromLocalCache(c *gc.C) {
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 To update cloud "garage-maas" on this client, a cloud definition file is required.
-Cloud "garage-maas" updated on controller "mycontroller".
+Cloud "garage-maas" updated on controller "mycontroller" using client cloud definition.
 `[1:])
 }
 


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju update-cloud' command.

* By default, the command operates on both client and controller copies.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only operation but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Occasionally, users may not want to add-k8s to both the client and a controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

## Documentation changes

all of the above