### PR TITLE
Update juju/os dependency to the latest version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -641,14 +641,14 @@
   revision = "5b81707e882b8293e6cf77854b4cd49f29776e11"
 
 [[projects]]
-  digest = "1:35d597b18d97dbc59d70e250bbcab9d7dd0bd6ed0e82343620eb0a70f44a9f61"
+  digest = "1:d8ec1fe408feff29f06246bbd4f262b66c6b1dcfabe14c9d6e843b6b8f5bfa36"
   name = "github.com/juju/os"
   packages = [
     ".",
     "series",
   ]
   pruneopts = ""
-  revision = "31722624f15a324ca554ef01285a92e6e89ac7df"
+  revision = "44115a59837dd6cddf93ee4cfb51e48c7ba8bb73"
 
 [[projects]]
   digest = "1:294998b796d446415dd45401c62501b2ed97f215a3a25249ad5017848d223322"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,7 +90,7 @@
   name = "github.com/juju/naturalsort"
 
 [[constraint]]
-  revision = "31722624f15a324ca554ef01285a92e6e89ac7df"
+  revision = "44115a59837dd6cddf93ee4cfb51e48c7ba8bb73"
   name = "github.com/juju/os"
 
 [[constraint]]


### PR DESCRIPTION
## Description of change

Mac users on Catalina who tried to build Juju were getting an error when generating the facade schema. For example, comment number 17 on https://bugs.launchpad.net/juju/+bug/1847245.

This adds the catalina series for macOS.

## QA steps

* Build juju on macOS 10.15 - schema generation should succeed. (I haven't done this.)

## Documentation changes

None.

## Bug reference

None.