### PR TITLE
Mechanical Cleanups

### DIFF
--- a/api/backups/restore_test.go
+++ b/api/backups/restore_test.go
@@ -41,8 +41,8 @@ func (s *restoreSuite) TestRestoreFromFileBackupExistsOnController(c *gc.C) {
 	gomock.InOrder(
 		mockBackupFacadeCaller.EXPECT().FacadeCall("PrepareRestore", nil, gomock.Any()),
 		mockBackupFacadeCaller.EXPECT().FacadeCall("List", args, resultBackupList).SetArg(2, testBackupsListResults),
-		mockBackupFacadeCaller.EXPECT().FacadeCall("Restore", gomock.Any(), gomock.Any()).Times(1),
-		mockBackupFacadeCaller.EXPECT().FacadeCall("FinishRestore", gomock.Any(), gomock.Any()).Times(1),
+		mockBackupFacadeCaller.EXPECT().FacadeCall("Restore", gomock.Any(), gomock.Any()),
+		mockBackupFacadeCaller.EXPECT().FacadeCall("FinishRestore", gomock.Any(), gomock.Any()),
 	)
 
 	connFunc := func() (*backups.Client, error) {

--- a/caas/kubernetes/clientconfig/plugins_test.go
+++ b/caas/kubernetes/clientconfig/plugins_test.go
@@ -103,19 +103,19 @@ func (s *k8sRawClientSuite) TestEnsureJujuAdminServiceAccount(c *gc.C) {
 
 	// 1st call of ensuring related resources - CREATE.
 	gomock.InOrder(
-		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).Times(1).
+		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockClusterRoles.EXPECT().Create(cr).Times(1).
+		s.mockClusterRoles.EXPECT().Create(cr).
 			Return(cr, nil),
-		s.mockServiceAccounts.EXPECT().Create(newSa).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(newSa).
 			Return(newSa, nil),
-		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).Times(1).
+		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).
 			Return(newSa, nil),
-		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).Times(1).
+		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).
 			Return(clusterRoleBinding, nil),
-		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).Times(1).
+		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).
 			Return(saWithSecret, nil),
-		s.mockSecrets.EXPECT().Get(saWithSecret.Secrets[0].Name, metav1.GetOptions{}).Times(1).
+		s.mockSecrets.EXPECT().Get(saWithSecret.Secrets[0].Name, metav1.GetOptions{}).
 			Return(secret, nil),
 	)
 	cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(s.k8sClient, cfg, contextName)
@@ -204,17 +204,17 @@ func (s *k8sRawClientSuite) TestEnsureJujuServiceAdminAccountIdempotent(c *gc.C)
 
 	// 2nd call of ensuring related resources - GET.
 	gomock.InOrder(
-		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).Times(1).
+		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).
 			Return(cr, nil),
-		s.mockServiceAccounts.EXPECT().Create(newSa).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(newSa).
 			Return(newSa, nil),
-		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).Times(1).
+		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).
 			Return(newSa, nil),
-		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).Times(1).
+		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).
 			Return(clusterRoleBinding, nil),
-		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).Times(1).
+		s.mockServiceAccounts.EXPECT().Get(newSa.Name, metav1.GetOptions{}).
 			Return(saWithSecret, nil),
-		s.mockSecrets.EXPECT().Get(saWithSecret.Secrets[0].Name, metav1.GetOptions{}).Times(1).
+		s.mockSecrets.EXPECT().Get(saWithSecret.Secrets[0].Name, metav1.GetOptions{}).
 			Return(secret, nil),
 	)
 	cfgOut, err := clientconfig.EnsureJujuAdminServiceAccount(s.k8sClient, cfg, contextName)
@@ -250,7 +250,7 @@ func (s *k8sRawClientSuite) TestEnsureClusterRole(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).Times(1).
+		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).
 			Return(cr, nil),
 	)
 	crOut, err := clientconfig.EnsureClusterRole(s.k8sClient, cr.Name, s.namespace)
@@ -258,9 +258,9 @@ func (s *k8sRawClientSuite) TestEnsureClusterRole(c *gc.C) {
 	c.Assert(crOut, jc.DeepEquals, cr)
 
 	gomock.InOrder(
-		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).Times(1).
+		s.mockClusterRoles.EXPECT().Get(cr.Name, metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockClusterRoles.EXPECT().Create(cr).Times(1).
+		s.mockClusterRoles.EXPECT().Create(cr).
 			Return(cr, nil),
 	)
 	crOut, err = clientconfig.EnsureClusterRole(s.k8sClient, cr.Name, s.namespace)
@@ -281,9 +281,9 @@ func (s *k8sRawClientSuite) TestEnsureServiceAccount(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockServiceAccounts.EXPECT().Create(sa).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(sa).
 			Return(sa, nil),
-		s.mockServiceAccounts.EXPECT().Get(sa.Name, metav1.GetOptions{}).Times(1).
+		s.mockServiceAccounts.EXPECT().Get(sa.Name, metav1.GetOptions{}).
 			Return(sa, nil),
 	)
 	saOut, err := clientconfig.EnsureServiceAccount(s.k8sClient, sa.Name, s.namespace)
@@ -291,9 +291,9 @@ func (s *k8sRawClientSuite) TestEnsureServiceAccount(c *gc.C) {
 	c.Assert(saOut, jc.DeepEquals, sa)
 
 	gomock.InOrder(
-		s.mockServiceAccounts.EXPECT().Create(sa).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(sa).
 			Return(sa, s.k8sAlreadyExistsError()),
-		s.mockServiceAccounts.EXPECT().Get(sa.Name, metav1.GetOptions{}).Times(1).
+		s.mockServiceAccounts.EXPECT().Get(sa.Name, metav1.GetOptions{}).
 			Return(sa, nil),
 	)
 	saOut, err = clientconfig.EnsureServiceAccount(s.k8sClient, sa.Name, s.namespace)
@@ -348,7 +348,7 @@ func (s *k8sRawClientSuite) TestEnsureClusterRoleBinding(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).Times(1).
+		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).
 			Return(clusterRoleBinding, nil),
 	)
 	clusterRoleBindingOut, err := clientconfig.EnsureClusterRoleBinding(s.k8sClient, clusterRoleBinding.Name, sa, cr)
@@ -356,7 +356,7 @@ func (s *k8sRawClientSuite) TestEnsureClusterRoleBinding(c *gc.C) {
 	c.Assert(clusterRoleBindingOut, jc.DeepEquals, clusterRoleBinding)
 
 	gomock.InOrder(
-		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).Times(1).
+		s.mockClusterRoleBinding.EXPECT().Create(clusterRoleBinding).
 			Return(clusterRoleBinding, s.k8sAlreadyExistsError()),
 	)
 	clusterRoleBindingOut, err = clientconfig.EnsureClusterRoleBinding(s.k8sClient, clusterRoleBinding.Name, sa, cr)
@@ -393,7 +393,7 @@ func (s *k8sRawClientSuite) TestGetServiceAccountSecret(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockSecrets.EXPECT().Get(sa.Secrets[0].Name, metav1.GetOptions{}).Times(1).
+		s.mockSecrets.EXPECT().Get(sa.Secrets[0].Name, metav1.GetOptions{}).
 			Return(secret, nil),
 	)
 	secretOut, err := clientconfig.GetServiceAccountSecret(s.k8sClient, sa)

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -124,7 +124,7 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 	})
 
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).
 			Return(&core.NamespaceList{Items: []core.Namespace{existingNs}}, nil),
 	)
 	var err error
@@ -656,35 +656,35 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 
 	gomock.InOrder(
 		// create namespace.
-		s.mockNamespaces.EXPECT().Create(ns).Times(1).
+		s.mockNamespaces.EXPECT().Create(ns).
 			Return(ns, nil),
 
 		// ensure service
-		s.mockServices.EXPECT().Get("juju-controller-test-service", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("juju-controller-test-service", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(svcNotProvisioned).Times(1).
+		s.mockServices.EXPECT().Update(svcNotProvisioned).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(svcNotProvisioned).Times(1).
+		s.mockServices.EXPECT().Create(svcNotProvisioned).
 			Return(svcNotProvisioned, nil),
 
 		// below calls are for GetService - 1st address no provisioned yet.
-		s.mockServices.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).
 			Return(&core.ServiceList{Items: []core.Service{*svcNotProvisioned}}, nil),
-		s.mockStatefulSets.EXPECT().Get("juju-operator-juju-controller-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-juju-controller-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockDeployments.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
 
 		// below calls are for GetService - 2nd address is ready.
-		s.mockServices.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).
 			Return(&core.ServiceList{Items: []core.Service{*svcProvisioned}}, nil),
-		s.mockStatefulSets.EXPECT().Get("juju-operator-juju-controller-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-juju-controller-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockDeployments.EXPECT().Get("juju-controller-test", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
 
 		// ensure shared-secret secret.
@@ -714,7 +714,7 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			Return(emptyConfigMap, nil),
 		s.mockConfigMaps.EXPECT().Create(configMapWithBootstrapParamsAdded).AnyTimes().
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).Times(1).
+		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).
 			Return(&core.ConfigMapList{Items: []core.ConfigMap{*emptyConfigMap}}, nil),
 		s.mockConfigMaps.EXPECT().Update(configMapWithBootstrapParamsAdded).AnyTimes().
 			Return(configMapWithBootstrapParamsAdded, nil),
@@ -724,17 +724,17 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			Return(configMapWithBootstrapParamsAdded, nil),
 		s.mockConfigMaps.EXPECT().Create(configMapWithAgentConfAdded).AnyTimes().
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).Times(1).
+		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test", IncludeUninitialized: true}).
 			Return(&core.ConfigMapList{Items: []core.ConfigMap{*configMapWithBootstrapParamsAdded}}, nil),
 		s.mockConfigMaps.EXPECT().Update(configMapWithAgentConfAdded).AnyTimes().
 			Return(configMapWithAgentConfAdded, nil),
 
 		// Check the operator storage exists.
 		// first check if <namespace>-<storage-class> exist or not.
-		s.mockStorageClass.EXPECT().Get("controller-1-some-storage", v1.GetOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().Get("controller-1-some-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		// not found, fallback to <storage-class>.
-		s.mockStorageClass.EXPECT().Get("some-storage", v1.GetOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().Get("some-storage", v1.GetOptions{}).
 			Return(&sc, nil),
 
 		// ensure statefulset.
@@ -746,7 +746,7 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			},
 		).
 			Return(podWatcher, nil),
-		s.mockStatefulSets.EXPECT().Create(statefulSetSpec).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetSpec).
 			Return(statefulSetSpec, nil),
 		s.mockEvents.EXPECT().Watch(
 			v1.ListOptions{

--- a/caas/kubernetes/provider/exec/copy_test.go
+++ b/caas/kubernetes/provider/exec/copy_test.go
@@ -192,23 +192,19 @@ func (s *execSuite) TestCopyToPod(c *gc.C) {
 	var stderr bytes.Buffer
 	gomock.InOrder(
 		// check remote path is dir or not.
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-0", metav1.GetOptions{}).
-			Times(1).
-			Return(&pod, nil),
-		s.restClient.EXPECT().Post().Times(1).Return(checkRemotePathRequest),
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-0", metav1.GetOptions{}).Return(&pod, nil),
+		s.restClient.EXPECT().Post().Return(checkRemotePathRequest),
 		s.mockRemoteCmdExecutor.EXPECT().Stream(
 			remotecommand.StreamOptions{
 				Stdout: &stdout,
 				Stderr: &stderr,
 				Tty:    false,
 			},
-		).Times(1).Return(nil),
+		).Return(nil),
 
 		// copy files.
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-0", metav1.GetOptions{}).
-			Times(1).
-			Return(&pod, nil),
-		s.restClient.EXPECT().Post().Times(1).Return(copyRequest),
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-0", metav1.GetOptions{}).Return(&pod, nil),
+		s.restClient.EXPECT().Post().Return(copyRequest),
 		s.mockRemoteCmdExecutor.EXPECT().Stream(
 			remotecommand.StreamOptions{
 				Stdin:  s.pipReader,
@@ -216,7 +212,7 @@ func (s *execSuite) TestCopyToPod(c *gc.C) {
 				Stderr: &stderr,
 				Tty:    false,
 			},
-		).Times(1).Return(nil),
+		).Return(nil),
 	)
 
 	cancel := make(<-chan struct{}, 1)

--- a/caas/kubernetes/provider/exec/exec_test.go
+++ b/caas/kubernetes/provider/exec/exec_test.go
@@ -103,9 +103,9 @@ func (s *execSuite) TestExecParamsValidatePodContainerExistence(c *gc.C) {
 		Phase: core.PodSucceeded,
 	}
 	gomock.InOrder(
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 	c.Assert(params.Validate(s.mockPodGetter), gc.ErrorMatches, "cannot exec into a container within a Succeeded pod")
@@ -122,9 +122,9 @@ func (s *execSuite) TestExecParamsValidatePodContainerExistence(c *gc.C) {
 		Phase: core.PodFailed,
 	}
 	gomock.InOrder(
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 	c.Assert(params.Validate(s.mockPodGetter), gc.ErrorMatches, "cannot exec into a container within a Failed pod")
@@ -143,9 +143,9 @@ func (s *execSuite) TestExecParamsValidatePodContainerExistence(c *gc.C) {
 	pod.SetUID("gitlab-k8s-uid")
 	pod.SetName("gitlab-k8s-0")
 	gomock.InOrder(
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 	c.Assert(params.Validate(s.mockPodGetter), gc.ErrorMatches, `container "non-existing-container-name" not found`)
@@ -169,9 +169,9 @@ func (s *execSuite) TestExecParamsValidatePodContainerExistence(c *gc.C) {
 	pod.SetUID("gitlab-k8s-uid")
 	pod.SetName("gitlab-k8s-0")
 	gomock.InOrder(
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 	c.Assert(params.Validate(s.mockPodGetter), jc.ErrorIsNil)
@@ -195,9 +195,9 @@ func (s *execSuite) TestExecParamsValidatePodContainerExistence(c *gc.C) {
 	pod.SetUID("gitlab-k8s-uid")
 	pod.SetName("gitlab-k8s-0")
 	gomock.InOrder(
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 	c.Assert(params.Validate(s.mockPodGetter), jc.ErrorIsNil)
@@ -221,9 +221,9 @@ func (s *execSuite) TestExecParamsValidatePodContainerExistence(c *gc.C) {
 	pod.SetUID("gitlab-k8s-uid")
 	pod.SetName("gitlab-k8s-0")
 	gomock.InOrder(
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 	)
 	c.Assert(params.Validate(s.mockPodGetter), jc.ErrorIsNil)
@@ -277,9 +277,9 @@ func (s *execSuite) TestExec(c *gc.C) {
 			TTY:       false,
 		}, scheme.ParameterCodec)
 	gomock.InOrder(
-		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().Get("gitlab-k8s-uid", metav1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).Times(1).
+		s.mockPodGetter.EXPECT().List(metav1.ListOptions{}).
 			Return(&core.PodList{Items: []core.Pod{pod}}, nil),
 
 		s.restClient.EXPECT().Post().Return(request),
@@ -290,7 +290,7 @@ func (s *execSuite) TestExec(c *gc.C) {
 				Stderr: &stderr,
 				Tty:    false,
 			},
-		).Times(1).Return(nil),
+		).Return(nil),
 	)
 
 	cancel := make(<-chan struct{}, 1)

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -10,6 +10,8 @@ import (
 	"github.com/juju/juju/caas"
 )
 
+const volBindModeWaitFirstConsumer = "WaitForFirstConsumer"
+
 var k8sCloudCheckers map[string][]k8slabels.Selector
 var jujuPreferredWorkloadStorage map[string]caas.PreferredStorage
 var jujuPreferredOperatorStorage map[string]caas.PreferredStorage
@@ -30,27 +32,27 @@ func init() {
 		caas.K8sCloudMicrok8s: {
 			Name:              "hostpath",
 			Provisioner:       "microk8s.io/hostpath",
-			VolumeBindingMode: "WaitForFirstConsumer",
+			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudGCE: {
 			Name:              "GCE Persistent Disk",
 			Provisioner:       "kubernetes.io/gce-pd",
-			VolumeBindingMode: "WaitForFirstConsumer",
+			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudAzure: {
 			Name:              "Azure Disk",
 			Provisioner:       "kubernetes.io/azure-disk",
-			VolumeBindingMode: "WaitForFirstConsumer",
+			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudEC2: {
 			Name:              "EBS Volume",
 			Provisioner:       "kubernetes.io/aws-ebs",
-			VolumeBindingMode: "WaitForFirstConsumer",
+			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudOpenStack: {
 			Name:              "Cinder Disk",
 			Provisioner:       "csi-cinderplugin",
-			VolumeBindingMode: "WaitForFirstConsumer",
+			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 	}
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -395,7 +395,7 @@ func (s *K8sBrokerSuite) TestAPIVersion(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockDiscovery.EXPECT().ServerVersion().Times(1).Return(&k8sversion.Info{
+		s.mockDiscovery.EXPECT().ServerVersion().Return(&k8sversion.Info{
 			Major: "1", Minor: "16",
 		}, nil),
 	)
@@ -460,9 +460,9 @@ func (s *K8sBrokerSuite) TestBootstrap(c *gc.C) {
 	}
 	gomock.InOrder(
 		// Check the operator storage exists.
-		s.mockStorageClass.EXPECT().Get("test-some-storage", v1.GetOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-some-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().Get("some-storage", v1.GetOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().Get("some-storage", v1.GetOptions{}).
 			Return(sc, nil),
 	)
 	result, err := s.broker.Bootstrap(ctx, callCtx, bootstrapParams)
@@ -498,13 +498,13 @@ func (s *K8sBrokerSuite) TestPrepareForBootstrap(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().Get("controller-ctrl-1", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("controller-ctrl-1", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).
 			Return(&core.NamespaceList{Items: []core.Namespace{}}, nil),
-		s.mockStorageClass.EXPECT().Get("controller-ctrl-1-some-storage", v1.GetOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().Get("controller-ctrl-1-some-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().Get("some-storage", v1.GetOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().Get("some-storage", v1.GetOptions{}).
 			Return(sc, nil),
 	)
 	ctx := envtesting.BootstrapContext(c)
@@ -521,7 +521,7 @@ func (s *K8sBrokerSuite) TestPrepareForBootstrapAlreadyExistNamespaceError(c *gc
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "controller-ctrl-1"}}
 	s.ensureJujuNamespaceAnnotations(true, ns)
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().Get("controller-ctrl-1", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("controller-ctrl-1", v1.GetOptions{IncludeUninitialized: true}).
 			Return(ns, nil),
 	)
 	ctx := envtesting.BootstrapContext(c)
@@ -537,9 +537,9 @@ func (s *K8sBrokerSuite) TestPrepareForBootstrapAlreadyExistControllerAnnotation
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "controller-ctrl-1"}}
 	s.ensureJujuNamespaceAnnotations(true, ns)
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().Get("controller-ctrl-1", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("controller-ctrl-1", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).
 			Return(&core.NamespaceList{Items: []core.Namespace{*ns}}, nil),
 	)
 	ctx := envtesting.BootstrapContext(c)
@@ -555,7 +555,7 @@ func (s *K8sBrokerSuite) TestGetNamespace(c *gc.C) {
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}}
 	s.ensureJujuNamespaceAnnotations(false, ns)
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(ns, nil),
 	)
 
@@ -569,7 +569,7 @@ func (s *K8sBrokerSuite) TestGetNamespaceNotFound(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().Get("unknown-namespace", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("unknown-namespace", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 	)
 
@@ -585,7 +585,7 @@ func (s *K8sBrokerSuite) TestNamespaces(c *gc.C) {
 	ns1 := s.ensureJujuNamespaceAnnotations(false, &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}})
 	ns2 := s.ensureJujuNamespaceAnnotations(false, &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test2"}})
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().List(v1.ListOptions{IncludeUninitialized: true}).
 			Return(&core.NamespaceList{Items: []core.Namespace{*ns1, *ns2}}, nil),
 	)
 
@@ -611,20 +611,20 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 			},
 		).
 			Return(namespaceWatcher, nil),
-		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(ns, nil),
-		s.mockNamespaces.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockNamespaces.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(nil),
 		s.mockStorageClass.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-model==test"},
-		).Times(1).
+		).
 			Return(s.k8sNotFoundError()),
 		// still terminating.
-		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(ns, nil),
 		// terminated, not found returned.
-		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 	)
 
@@ -664,7 +664,7 @@ func (s *K8sBrokerSuite) TestCreate(c *gc.C) {
 
 	ns := s.ensureJujuNamespaceAnnotations(false, &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}})
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().Create(ns).Times(1).
+		s.mockNamespaces.EXPECT().Create(ns).
 			Return(ns, nil),
 	)
 
@@ -681,7 +681,7 @@ func (s *K8sBrokerSuite) TestCreateAlreadyExists(c *gc.C) {
 
 	ns := s.ensureJujuNamespaceAnnotations(false, &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: "test"}})
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().Create(ns).Times(1).
+		s.mockNamespaces.EXPECT().Create(ns).
 			Return(nil, s.k8sAlreadyExistsError()),
 	)
 
@@ -744,55 +744,55 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 
 	// Delete operations below return a not found to ensure it's treated as a no-op.
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 
-		s.mockServices.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockServices.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockStatefulSets.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Delete("test-endpoints", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockServices.EXPECT().Delete("test-endpoints", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockDeployments.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
 
 		// delete secrets.
 		s.mockSecrets.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 
 		// delete configmaps.
 		s.mockConfigMaps.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 
 		// delete RBAC resources.
 		s.mockRoleBindings.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 		s.mockClusterRoleBindings.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 		s.mockRoles.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 		s.mockClusterRoles.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 		s.mockServiceAccounts.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 		s.mockCustomResourceDefinition.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-app==test,juju-model==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 	)
 
 	err := s.broker.DeleteService("test")
@@ -809,13 +809,13 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoUnits(c *gc.C) {
 	emptyDc := dc
 	emptyDc.Spec.Replicas = &zero
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockDeployments.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(dc, nil),
-		s.mockDeployments.EXPECT().Update(emptyDc).Times(1).
+		s.mockDeployments.EXPECT().Update(emptyDc).
 			Return(nil, nil),
 	)
 
@@ -884,21 +884,21 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 
 	ociImageSecret := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -1050,32 +1050,32 @@ password: shhhh`[1:],
 
 	ociImageSecret := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 
 		// ensure configmaps.
-		s.mockConfigMaps.EXPECT().Create(cm).Times(1).
+		s.mockConfigMaps.EXPECT().Create(cm).
 			Return(cm, nil),
 
 		// ensure secrets.
-		s.mockSecrets.EXPECT().Create(secrets1).Times(1).
+		s.mockSecrets.EXPECT().Create(secrets1).
 			Return(secrets1, nil),
-		s.mockSecrets.EXPECT().Create(secrets2).Times(1).
+		s.mockSecrets.EXPECT().Create(secrets2).
 			Return(secrets2, nil),
 
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -1098,7 +1098,7 @@ func (s *K8sBrokerSuite) TestVersion(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockDiscovery.EXPECT().ServerVersion().Times(1).Return(&k8sversion.Info{
+		s.mockDiscovery.EXPECT().ServerVersion().Return(&k8sversion.Info{
 			Major: "1", Minor: "15+",
 		}, nil),
 	)
@@ -1242,44 +1242,44 @@ password: shhhh`[1:],
 
 	ociImageSecret := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 
 		// ensure configmaps.
-		s.mockConfigMaps.EXPECT().Create(cm).Times(1).
+		s.mockConfigMaps.EXPECT().Create(cm).
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockConfigMaps.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&core.ConfigMapList{Items: []core.ConfigMap{*cm}}, nil),
-		s.mockConfigMaps.EXPECT().Update(cm).Times(1).
+		s.mockConfigMaps.EXPECT().Update(cm).
 			Return(cm, nil),
 
 		// ensure secrets.
-		s.mockSecrets.EXPECT().Create(secrets1).Times(1).
+		s.mockSecrets.EXPECT().Create(secrets1).
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockSecrets.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockSecrets.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&core.SecretList{Items: []core.Secret{*secrets1}}, nil),
-		s.mockSecrets.EXPECT().Update(secrets1).Times(1).
+		s.mockSecrets.EXPECT().Update(secrets1).
 			Return(secrets1, nil),
-		s.mockSecrets.EXPECT().Create(secrets2).Times(1).
+		s.mockSecrets.EXPECT().Create(secrets2).
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockSecrets.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockSecrets.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&core.SecretList{Items: []core.Secret{*secrets2}}, nil),
-		s.mockSecrets.EXPECT().Update(secrets2).Times(1).
+		s.mockSecrets.EXPECT().Update(secrets2).
 			Return(secrets2, nil),
 
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -1341,27 +1341,27 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 	serviceArg.Spec.Type = core.ServiceTypeClusterIP
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(&serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(&serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(&serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(&serviceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(statefulSetArg, nil),
 	)
 
@@ -1420,27 +1420,27 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 	serviceArg.Spec.Type = core.ServiceTypeExternalName
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(&serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(&serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(&serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(&serviceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(statefulSetArg, nil),
 	)
 
@@ -1466,13 +1466,13 @@ func (s *K8sBrokerSuite) TestEnsureServiceServiceWithoutPortsNotValid(c *gc.C) {
 	serviceArg.Spec.Type = core.ServiceTypeExternalName
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
-		s.mockSecrets.EXPECT().Delete("app-name-test-secret", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockSecrets.EXPECT().Delete("app-name-test-secret", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(nil),
 	)
 	caasPodSpec := getBasicPodspec()
@@ -1549,7 +1549,7 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds map[str
 
 	assertCalls = append(
 		[]*gomock.Call{
-			s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+			s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 				Return(nil, s.k8sNotFoundError()),
 		},
 		assertCalls...,
@@ -1557,25 +1557,25 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds map[str
 
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	assertCalls = append(assertCalls, []*gomock.Call{
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(&serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(&serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(&serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(&serviceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
 	}...)
 	gomock.InOrder(assertCalls...)
@@ -1699,7 +1699,7 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionCreate(c *gc.C) {
 
 	s.assertCustomerResourceDefinitions(
 		c, crds,
-		s.mockCustomResourceDefinition.EXPECT().Create(crd).Times(1).Return(crd, nil),
+		s.mockCustomResourceDefinition.EXPECT().Create(crd).Return(crd, nil),
 	)
 }
 
@@ -1808,9 +1808,9 @@ func (s *K8sBrokerSuite) TestEnsureCustomResourceDefinitionUpdate(c *gc.C) {
 
 	s.assertCustomerResourceDefinitions(
 		c, crds,
-		s.mockCustomResourceDefinition.EXPECT().Create(crd).Times(1).Return(crd, s.k8sAlreadyExistsError()),
-		s.mockCustomResourceDefinition.EXPECT().Get("tfjobs.kubeflow.org", v1.GetOptions{}).Times(1).Return(crd, nil),
-		s.mockCustomResourceDefinition.EXPECT().Update(crd).Times(1).Return(crd, nil),
+		s.mockCustomResourceDefinition.EXPECT().Create(crd).Return(crd, s.k8sAlreadyExistsError()),
+		s.mockCustomResourceDefinition.EXPECT().Get("tfjobs.kubeflow.org", v1.GetOptions{}).Return(crd, nil),
+		s.mockCustomResourceDefinition.EXPECT().Update(crd).Return(crd, nil),
 	)
 }
 
@@ -1924,25 +1924,25 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockRoles.EXPECT().Create(role).Times(1).Return(role, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(svcAccount, nil),
+		s.mockRoles.EXPECT().Create(role).Return(role, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb).Times(1).Return(rb, nil),
-		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
+		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -2071,34 +2071,34 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockServiceAccounts.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&core.ServiceAccountList{Items: []core.ServiceAccount{*svcAccount}}, nil),
-		s.mockServiceAccounts.EXPECT().Update(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockRoles.EXPECT().Create(role).Times(1).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockRoles.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Update(svcAccount).Return(svcAccount, nil),
+		s.mockRoles.EXPECT().Create(role).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockRoles.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleList{Items: []rbacv1.Role{*role}}, nil),
-		s.mockRoles.EXPECT().Update(role).Times(1).Return(role, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockRoles.EXPECT().Update(role).Return(role, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{*rb}}, nil),
-		s.mockRoleBindings.EXPECT().Delete("app-name", s.deleteOptions(v1.DeletePropagationForeground, &rbUID)).Times(1).Return(nil),
-		s.mockRoleBindings.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(rb, nil),
-		s.mockRoleBindings.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(nil, s.k8sNotFoundError()),
-		s.mockRoleBindings.EXPECT().Create(rb).Times(1).Return(rb, nil),
-		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockRoleBindings.EXPECT().Delete("app-name", s.deleteOptions(v1.DeletePropagationForeground, &rbUID)).Return(nil),
+		s.mockRoleBindings.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Return(rb, nil),
+		s.mockRoleBindings.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Return(nil, s.k8sNotFoundError()),
+		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
+		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -2239,25 +2239,25 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockClusterRoles.EXPECT().Create(cr).Times(1).Return(cr, nil),
-		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(svcAccount, nil),
+		s.mockClusterRoles.EXPECT().Create(cr).Return(cr, nil),
+		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Create(crb).Times(1).Return(crb, nil),
-		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockClusterRoleBindings.EXPECT().Create(crb).Return(crb, nil),
+		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -2387,34 +2387,34 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockServiceAccounts.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&core.ServiceAccountList{Items: []core.ServiceAccount{*svcAccount}}, nil),
-		s.mockServiceAccounts.EXPECT().Update(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockClusterRoles.EXPECT().Create(cr).Times(1).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockClusterRoles.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Update(svcAccount).Return(svcAccount, nil),
+		s.mockClusterRoles.EXPECT().Create(cr).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockClusterRoles.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*cr}}, nil),
-		s.mockClusterRoles.EXPECT().Update(cr).Times(1).Return(cr, nil),
-		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockClusterRoles.EXPECT().Update(cr).Return(cr, nil),
+		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*crb}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Delete("test-app-name", s.deleteOptions(v1.DeletePropagationForeground, &crbUID)).Times(1).Return(nil),
-		s.mockClusterRoleBindings.EXPECT().Get("test-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(crb, nil),
-		s.mockClusterRoleBindings.EXPECT().Get("test-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(nil, s.k8sNotFoundError()),
-		s.mockClusterRoleBindings.EXPECT().Create(crb).Times(1).Return(crb, nil),
-		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockClusterRoleBindings.EXPECT().Delete("test-app-name", s.deleteOptions(v1.DeletePropagationForeground, &crbUID)).Return(nil),
+		s.mockClusterRoleBindings.EXPECT().Get("test-app-name", v1.GetOptions{IncludeUninitialized: true}).Return(crb, nil),
+		s.mockClusterRoleBindings.EXPECT().Get("test-app-name", v1.GetOptions{IncludeUninitialized: true}).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Create(crb).Return(crb, nil),
+		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -2614,33 +2614,33 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 
-		s.mockServiceAccounts.EXPECT().Create(svcAccount1).Times(1).Return(svcAccount1, nil),
-		s.mockRoles.EXPECT().Create(role1).Times(1).Return(role1, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount1).Return(svcAccount1, nil),
+		s.mockRoles.EXPECT().Create(role1).Return(role1, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb1).Times(1).Return(rb1, nil),
+		s.mockRoleBindings.EXPECT().Create(rb1).Return(rb1, nil),
 
-		s.mockServiceAccounts.EXPECT().Create(svcAccount2).Times(1).Return(svcAccount2, nil),
-		s.mockRoles.EXPECT().Create(role2).Times(1).Return(role2, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount2).Return(svcAccount2, nil),
+		s.mockRoles.EXPECT().Create(role2).Return(role2, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb2).Times(1).Return(rb2, nil),
+		s.mockRoleBindings.EXPECT().Create(rb2).Return(rb2, nil),
 
-		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -2849,33 +2849,33 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 
-		s.mockServiceAccounts.EXPECT().Create(svcAccount1).Times(1).Return(svcAccount1, nil),
-		s.mockRoles.EXPECT().Create(role1).Times(1).Return(role1, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount1).Return(svcAccount1, nil),
+		s.mockRoles.EXPECT().Create(role1).Return(role1, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb1).Times(1).Return(rb1, nil),
+		s.mockRoleBindings.EXPECT().Create(rb1).Return(rb1, nil),
 
-		s.mockServiceAccounts.EXPECT().Create(svcAccount2).Times(1).Return(svcAccount2, nil),
-		s.mockClusterRoles.EXPECT().Create(clusterrole2).Times(1).Return(clusterrole2, nil),
-		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount2).Return(svcAccount2, nil),
+		s.mockClusterRoles.EXPECT().Create(clusterrole2).Return(clusterrole2, nil),
+		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test", IncludeUninitialized: true}).
 			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Create(crb2).Times(1).Return(crb2, nil),
+		s.mockClusterRoleBindings.EXPECT().Create(crb2).Return(crb2, nil),
 
-		s.mockSecrets.EXPECT().Create(secretArg).Times(1).Return(secretArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(serviceArg).Times(1).
+		s.mockServices.EXPECT().Update(serviceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(serviceArg).Times(1).
+		s.mockServices.EXPECT().Create(serviceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -2920,31 +2920,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
 	)
 
@@ -3024,21 +3024,21 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 	}
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicServiceArg).
 			Return(nil, nil),
-		s.mockDeployments.EXPECT().Update(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Update(deploymentArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Create(deploymentArg).Times(1).
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -3087,31 +3087,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(statefulSetArg, nil),
 	)
 
@@ -3167,31 +3167,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(statefulSetArg, nil),
 	)
 
@@ -3254,31 +3254,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
 	)
 
@@ -3333,31 +3333,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockSecrets.EXPECT().Create(ociImageSecret).Times(1).
+		s.mockSecrets.EXPECT().Create(ociImageSecret).
 			Return(ociImageSecret, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
-		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("app-name-endpoints", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(basicHeadlessServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(basicHeadlessServiceArg).
 			Return(nil, nil),
-		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
 	)
 
@@ -3531,9 +3531,9 @@ func (s *K8sBrokerSuite) TestUpgradeController(c *gc.C) {
 	updated.Spec.Template.Annotations["juju-version"] = "6.6.6"
 	updated.Spec.Template.Spec.Containers[1].Image = "juju-operator:6.6.6"
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("controller", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("controller", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&ss, nil),
-		s.mockStatefulSets.EXPECT().Update(&updated).Times(1).
+		s.mockStatefulSets.EXPECT().Update(&updated).
 			Return(nil, nil),
 	)
 
@@ -3546,9 +3546,9 @@ func (s *K8sBrokerSuite) TestUpgradeNotSupported(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 	)
 

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -186,9 +186,9 @@ func (s *K8sMetadataSuite) TestListHostCloudRegions(c *gc.C) {
 	for i, v := range hostRegionsTestCases {
 		c.Logf("test %d", i)
 		gomock.InOrder(
-			s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+			s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 				Return(v.nodes, nil),
-			s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+			s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 				Return(&storagev1.StorageClassList{}, nil),
 		)
 		metadata, err := s.broker.GetClusterMetadata("")
@@ -203,9 +203,9 @@ func (s *K8sMetadataSuite) TestNoDefaultStorageClasses(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				Provisioner: "a-provisioner",
 				Parameters:  map[string]string{"foo": "bar"},
@@ -224,9 +224,9 @@ func (s *K8sMetadataSuite) TestNoDefaultStorageClassesTooMany(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				Provisioner: "a-provisioner",
 				Parameters:  map[string]string{"foo": "bar"},
@@ -245,9 +245,9 @@ func (s *K8sMetadataSuite) TestPreferDefaultStorageClass(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
 				Provisioner: "a-provisioner",
@@ -270,9 +270,9 @@ func (s *K8sMetadataSuite) TestBetaDefaultStorageClass(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.beta.kubernetes.io/is-default-class": "true"}},
 				Provisioner: "a-provisioner",
@@ -295,17 +295,17 @@ func (s *K8sMetadataSuite) TestUserSpecifiedStorageClasses(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
 				Labels: map[string]string{"manufacturer": "amazon_ec2"},
 			}}}}, nil),
-		s.mockStorageClass.EXPECT().Get("foo", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStorageClass.EXPECT().Get("foo", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&storagev1.StorageClass{
 				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
 				Provisioner: "a-provisioner",
 				Parameters:  map[string]string{"foo": "bar"},
 			}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				Provisioner: "kubernetes.io/aws-ebs",
 			}}}, nil),
@@ -326,11 +326,11 @@ func (s *K8sMetadataSuite) TestOperatorStorageClassNoDefault(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
 				Labels: map[string]string{"manufacturer": "amazon_ec2"},
 			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				Provisioner: "kubernetes.io/aws-ebs",
 			}, {
@@ -353,11 +353,11 @@ func (s *K8sMetadataSuite) TestOperatorStorageClassPrefersDefault(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
 				Labels: map[string]string{"manufacturer": "amazon_ec2"},
 			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				Provisioner: "kubernetes.io/aws-ebs",
 			}, {
@@ -383,11 +383,11 @@ func (s *K8sMetadataSuite) TestAnnotatedWorkloadStorageClass(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
 				Labels: map[string]string{"manufacturer": "amazon_ec2"},
 			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "juju-preferred-workload-storage",
@@ -418,11 +418,11 @@ func (s *K8sMetadataSuite) TestAnnotatedWorkloadAndOperatorStorageClass(c *gc.C)
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).Times(1).
+		s.mockNodes.EXPECT().List(v1.ListOptions{Limit: 5}).
 			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
 				Labels: map[string]string{"manufacturer": "amazon_ec2"},
 			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockStorageClass.EXPECT().List(v1.ListOptions{}).
 			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{
 				{
 					ObjectMeta: v1.ObjectMeta{

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -199,30 +199,30 @@ func (s *K8sBrokerSuite) TestDeleteOperator(c *gc.C) {
 
 	// Delete operations below return a not found to ensure it's treated as a no-op.
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 
 		// delete RBAC resources.
 		s.mockRoleBindings.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 		s.mockRoles.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 		s.mockServiceAccounts.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, nil),
 			v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true},
-		).Times(1).Return(nil),
+		).Return(nil),
 
-		s.mockConfigMaps.EXPECT().Delete("test-operator-config", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockConfigMaps.EXPECT().Delete("test-operator-config", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockConfigMaps.EXPECT().Delete("test-configurations-config", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockConfigMaps.EXPECT().Delete("test-configurations-config", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockServices.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockStatefulSets.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
 		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test"}).
 			Return(&core.PodList{Items: []core.Pod{{
@@ -238,13 +238,13 @@ func (s *K8sBrokerSuite) TestDeleteOperator(c *gc.C) {
 					}},
 				},
 			}}}, nil),
-		s.mockSecrets.EXPECT().Delete("test-jujud-secret", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockSecrets.EXPECT().Delete("test-jujud-secret", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockPersistentVolumeClaims.EXPECT().Delete("test-operator-volume", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockPersistentVolumeClaims.EXPECT().Delete("test-operator-volume", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockPersistentVolumes.EXPECT().Delete("test-operator-volume", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockPersistentVolumes.EXPECT().Delete("test-operator-volume", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockDeployments.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
 	)
 
@@ -303,31 +303,31 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfig(c *gc.C) {
 	}
 	statefulSetArg := operatorStatefulSetArg(1, "test-operator-storage", "test-operator")
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(operatorServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(operatorServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&core.Service{Spec: core.ServiceSpec{ClusterIP: "10.1.2.3"}}, nil),
 
 		// ensure RBAC resources.
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockRoles.EXPECT().Create(role).Times(1).Return(role, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(svcAccount, nil),
+		s.mockRoles.EXPECT().Create(role).Return(role, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb).Times(1).Return(rb, nil),
+		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
 
-		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, nil),
-		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "test-operator-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(statefulSetArg, nil),
 	)
 
@@ -408,31 +408,31 @@ func (s *K8sBrokerSuite) TestEnsureOperatorCreate(c *gc.C) {
 	statefulSetArg := operatorStatefulSetArg(1, "test-operator-storage", "test-operator")
 
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(operatorServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(operatorServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&core.Service{Spec: core.ServiceSpec{ClusterIP: "10.1.2.3"}}, nil),
 
 		// ensure RBAC resources.
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockRoles.EXPECT().Create(role).Times(1).Return(role, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(svcAccount, nil),
+		s.mockRoles.EXPECT().Create(role).Return(role, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb).Times(1).Return(rb, nil),
+		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
 
-		s.mockConfigMaps.EXPECT().Create(configMapArg).Times(1).
+		s.mockConfigMaps.EXPECT().Create(configMapArg).
 			Return(configMapArg, nil),
-		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "test-operator-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Create(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(statefulSetArg, nil),
 	)
 
@@ -517,42 +517,42 @@ func (s *K8sBrokerSuite) TestEnsureOperatorUpdate(c *gc.C) {
 	statefulSetArg := operatorStatefulSetArg(1, "test-operator-storage", "test-operator")
 
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(operatorServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(operatorServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&core.Service{Spec: core.ServiceSpec{ClusterIP: "10.1.2.3"}}, nil),
 
 		// ensure RBAC resources.
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockServiceAccounts.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).
 			Return(&core.ServiceAccountList{Items: []core.ServiceAccount{*svcAccount}}, nil),
-		s.mockServiceAccounts.EXPECT().Update(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockRoles.EXPECT().Create(role).Times(1).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockRoles.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Update(svcAccount).Return(svcAccount, nil),
+		s.mockRoles.EXPECT().Create(role).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockRoles.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleList{Items: []rbacv1.Role{*role}}, nil),
-		s.mockRoles.EXPECT().Update(role).Times(1).Return(role, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).Times(1).
+		s.mockRoles.EXPECT().Update(role).Return(role, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{*rb}}, nil),
-		s.mockRoleBindings.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &rbUID)).Times(1).Return(nil),
-		s.mockRoleBindings.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(rb, nil),
-		s.mockRoleBindings.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).Return(nil, s.k8sNotFoundError()),
-		s.mockRoleBindings.EXPECT().Create(rb).Times(1).Return(rb, nil),
+		s.mockRoleBindings.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &rbUID)).Return(nil),
+		s.mockRoleBindings.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Return(rb, nil),
+		s.mockRoleBindings.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Return(nil, s.k8sNotFoundError()),
+		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
 
-		s.mockConfigMaps.EXPECT().Create(configMapArg).Times(1).
+		s.mockConfigMaps.EXPECT().Create(configMapArg).
 			Return(configMapArg, nil),
-		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "test-operator-storage"}}, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).Times(1).
+		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(statefulSetArg, nil),
 	)
 
@@ -636,35 +636,35 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfigMissingConfigMap(c *gc.C
 	}
 	rbUID := rb.GetUID()
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Update(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Update(operatorServiceArg).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockServices.EXPECT().Create(operatorServiceArg).Times(1).
+		s.mockServices.EXPECT().Create(operatorServiceArg).
 			Return(nil, nil),
-		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).Times(1).
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&core.Service{Spec: core.ServiceSpec{ClusterIP: "10.1.2.3"}}, nil),
 
 		// ensure RBAC resources.
-		s.mockServiceAccounts.EXPECT().Create(svcAccount).Times(1).Return(svcAccount, nil),
-		s.mockRoles.EXPECT().Create(role).Times(1).Return(role, nil),
-		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).Times(1).
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(svcAccount, nil),
+		s.mockRoles.EXPECT().Create(role).Return(role, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test", IncludeUninitialized: true}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
-		s.mockRoleBindings.EXPECT().Create(rb).Times(1).Return(rb, nil),
+		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
 
-		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
 
 		// clean up steps.
-		s.mockServices.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockServices.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
 
 		// delete RBAC resources.
-		s.mockRoleBindings.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &rbUID)).Times(1).Return(nil),
-		s.mockRoles.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &roleUID)).Times(1).Return(nil),
-		s.mockServiceAccounts.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &svcAccountUID)).Times(1).Return(nil),
+		s.mockRoleBindings.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &rbUID)).Return(nil),
+		s.mockRoles.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &roleUID)).Return(nil),
+		s.mockServiceAccounts.EXPECT().Delete("test-operator", s.deleteOptions(v1.DeletePropagationForeground, &svcAccountUID)).Return(nil),
 	)
 
 	err := s.broker.EnsureOperator("test", "path/to/agent", &caas.OperatorConfig{
@@ -715,13 +715,13 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 		},
 	}
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&ss, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test"}).Times(1).
+		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test"}).
 			Return(&core.PodList{Items: []core.Pod{opPod}}, nil),
-		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockConfigMaps.EXPECT().Get("test-operator-config", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&cm, nil),
 	)
 
@@ -758,11 +758,11 @@ func (s *K8sBrokerSuite) TestOperatorNoPodFound(c *gc.C) {
 		},
 	}
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&ss, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test"}).Times(1).
+		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator==test"}).
 			Return(&core.PodList{Items: []core.Pod{}}, nil),
 	)
 
@@ -803,11 +803,11 @@ func (s *K8sBrokerSuite) TestUpgradeOperator(c *gc.C) {
 	updated.Spec.Template.Annotations["juju-version"] = "6.6.6"
 	updated.Spec.Template.Spec.Containers[1].Image = "juju-operator:6.6.6"
 	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{IncludeUninitialized: true}).
 			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&ss, nil),
-		s.mockStatefulSets.EXPECT().Update(&updated).Times(1).
+		s.mockStatefulSets.EXPECT().Update(&updated).
 			Return(nil, nil),
 	)
 

--- a/caas/kubernetes/provider/resources_test.go
+++ b/caas/kubernetes/provider/resources_test.go
@@ -29,44 +29,44 @@ func (s *ResourcesSuite) TestAdoptResources(c *gc.C) {
 	modelSelector := "juju-model-uuid==" + testing.ModelTag.Id()
 
 	gomock.InOrder(
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).Times(1).
+		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{}}},
 			}}, nil),
 		s.mockPods.EXPECT().Update(&core.Pod{ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).Times(1).
+			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).
 			Return(nil, nil),
 
-		s.mockPersistentVolumeClaims.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).Times(1).
+		s.mockPersistentVolumeClaims.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).
 			Return(&core.PersistentVolumeClaimList{Items: []core.PersistentVolumeClaim{
 				{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{}}},
 			}}, nil),
 		s.mockPersistentVolumeClaims.EXPECT().Update(&core.PersistentVolumeClaim{ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).Times(1).
+			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).
 			Return(nil, nil),
 
-		s.mockPersistentVolumes.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).Times(1).
+		s.mockPersistentVolumes.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).
 			Return(&core.PersistentVolumeList{Items: []core.PersistentVolume{
 				{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{}}},
 			}}, nil),
 		s.mockPersistentVolumes.EXPECT().Update(&core.PersistentVolume{ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).Times(1).
+			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).
 			Return(nil, nil),
 
-		s.mockStatefulSets.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).Times(1).
+		s.mockStatefulSets.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).
 			Return(&apps.StatefulSetList{Items: []apps.StatefulSet{
 				{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{}}},
 			}}, nil),
 		s.mockStatefulSets.EXPECT().Update(&apps.StatefulSet{ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).Times(1).
+			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).
 			Return(nil, nil),
 
-		s.mockDeployments.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).Times(1).
+		s.mockDeployments.EXPECT().List(v1.ListOptions{LabelSelector: modelSelector}).
 			Return(&apps.DeploymentList{Items: []apps.Deployment{
 				{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{}}},
 			}}, nil),
 		s.mockDeployments.EXPECT().Update(&apps.Deployment{ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).Times(1).
+			Labels: map[string]string{"juju-controller-uuid": "uuid"}}}).
 			Return(nil, nil),
 	)
 

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -98,14 +98,14 @@ func (s *storageSuite) TestDestroyVolumes(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockPersistentVolumes.EXPECT().Get("vol-1", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockPersistentVolumes.EXPECT().Get("vol-1", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&core.PersistentVolume{
 				Spec: core.PersistentVolumeSpec{
 					ClaimRef: &core.ObjectReference{Namespace: "test", Name: "vol-1-pvc"},
 				}}, nil),
-		s.mockPersistentVolumeClaims.EXPECT().Delete("vol-1-pvc", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockPersistentVolumeClaims.EXPECT().Delete("vol-1-pvc", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockPersistentVolumes.EXPECT().Delete("vol-1", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockPersistentVolumes.EXPECT().Delete("vol-1", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(nil),
 	)
 
@@ -123,14 +123,14 @@ func (s *storageSuite) TestDestroyVolumesNotFoundIgnored(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockPersistentVolumes.EXPECT().Get("vol-1", v1.GetOptions{IncludeUninitialized: true}).Times(1).
+		s.mockPersistentVolumes.EXPECT().Get("vol-1", v1.GetOptions{IncludeUninitialized: true}).
 			Return(&core.PersistentVolume{
 				Spec: core.PersistentVolumeSpec{
 					ClaimRef: &core.ObjectReference{Namespace: "test", Name: "vol-1-pvc"},
 				}}, nil),
-		s.mockPersistentVolumeClaims.EXPECT().Delete("vol-1-pvc", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockPersistentVolumeClaims.EXPECT().Delete("vol-1-pvc", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
-		s.mockPersistentVolumes.EXPECT().Delete("vol-1", s.deleteOptions(v1.DeletePropagationForeground, nil)).Times(1).
+		s.mockPersistentVolumes.EXPECT().Delete("vol-1", s.deleteOptions(v1.DeletePropagationForeground, nil)).
 			Return(s.k8sNotFoundError()),
 	)
 
@@ -148,7 +148,7 @@ func (s *storageSuite) TestListVolumes(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockPersistentVolumes.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockPersistentVolumes.EXPECT().List(v1.ListOptions{}).
 			Return(&core.PersistentVolumeList{Items: []core.PersistentVolume{
 				{ObjectMeta: v1.ObjectMeta{Name: "vol-1"}}}}, nil),
 	)
@@ -167,7 +167,7 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockPersistentVolumes.EXPECT().List(v1.ListOptions{}).Times(1).
+		s.mockPersistentVolumes.EXPECT().List(v1.ListOptions{}).
 			Return(&core.PersistentVolumeList{Items: []core.PersistentVolume{
 				{ObjectMeta: v1.ObjectMeta{Name: "vol-id"},
 					Spec: core.PersistentVolumeSpec{

--- a/cmd/juju/caas/aks_test.go
+++ b/cmd/juju/caas/aks_test.go
@@ -51,7 +51,7 @@ func (s *aksSuite) TestGetKubeConfig(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks get-credentials --name mycluster --resource-group resourceGroup --overwrite-existing -f " + configFile,
 			Environment: []string{"KUBECONFIG=" + configFile, "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code: 0,
 			}, nil),
@@ -105,7 +105,7 @@ func (s *aksSuite) TestInteractiveParam(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(clusterJSONResp),
@@ -115,7 +115,7 @@ func (s *aksSuite) TestInteractiveParam(c *gc.C) {
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(resourcegroupJSONResp),
@@ -178,7 +178,7 @@ func (s *aksSuite) TestInteractiveParamResourceGroupDefined(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json --resource-group " + resourceGroup,
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(clusterJSONResp),
@@ -188,7 +188,7 @@ func (s *aksSuite) TestInteractiveParamResourceGroupDefined(c *gc.C) {
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(resourcegroupJSONResp),
@@ -255,7 +255,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedSingleResourceGr
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(clusterJSONResp),
@@ -265,7 +265,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedSingleResourceGr
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(resourcegroupJSONResp),
@@ -332,7 +332,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGro
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(clusterJSONResp),
@@ -342,7 +342,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGro
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(resourcegroupJSONResp),
@@ -408,7 +408,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(clusterJSONResp),
@@ -418,7 +418,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(namedResourcegroupJSONResp),
@@ -498,7 +498,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(clusterJSONResp),
@@ -506,7 +506,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    `az group list --output json --query "[?properties.provisioningState=='Succeeded']"`,
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(resourcegroupJSONResp),
@@ -516,7 +516,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(namedResourcegroupJSONResp),
@@ -573,7 +573,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedResourceGroupSpecified(c
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(namedResourcegroupJSONResp),
@@ -613,7 +613,7 @@ func (s *aksSuite) TestEnsureExecutablePicksAZ(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which az",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(""),
@@ -621,7 +621,7 @@ func (s *aksSuite) TestEnsureExecutablePicksAZ(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az account show",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte(""),
@@ -642,7 +642,7 @@ func (s *aksSuite) TestEnsureExecutableNotFound(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which az",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code: 1,
 			}, nil),

--- a/cmd/juju/caas/gke_test.go
+++ b/cmd/juju/caas/gke_test.go
@@ -44,7 +44,7 @@ func (s *gkeSuite) TestInteractiveParams(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud auth list --format value\\(account,status\\)",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte("mysecret\ndefaultSecret *"),
@@ -52,7 +52,7 @@ func (s *gkeSuite) TestInteractiveParams(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud projects list --account mysecret --filter lifecycleState:ACTIVE --format value\\(projectId\\)",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte("myproject"),
@@ -60,7 +60,7 @@ func (s *gkeSuite) TestInteractiveParams(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters list --filter status:RUNNING --account mysecret --project myproject --format value\\(name,zone\\)",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte("mycluster asia-southeast1-a"),
@@ -114,7 +114,7 @@ func (s *gkeSuite) TestInteractiveParamsProjectSpecified(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters list --filter status:RUNNING --account mysecret --project myproject --format value\\(name,zone\\)",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte("mycluster asia-southeast1-a"),
@@ -162,7 +162,7 @@ func (s *gkeSuite) TestInteractiveParamsProjectAndRegionSpecified(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters list --filter status:RUNNING --account mysecret --project myproject --format value\\(name,zone\\)",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
 				Stdout: []byte("mycluster asia-southeast1-a"),
@@ -216,7 +216,7 @@ func (s *gkeSuite) TestGetKubeConfig(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters get-credentials mycluster --account mysecret --project myproject --zone asia-southeast1-a",
 			Environment: []string{"KUBECONFIG=" + configFile, "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code: 0,
 			}, nil),
@@ -248,7 +248,7 @@ func (s *gkeSuite) TestEnsureExecutableGcloudFound(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which gcloud",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code: 0,
 			}, nil),
@@ -268,7 +268,7 @@ func (s *gkeSuite) TestEnsureExecutableGcloudNotFound(c *gc.C) {
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which gcloud",
 			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
-		}).Times(1).
+		}).
 			Return(&exec.ExecResponse{
 				Code: 1,
 			}, nil),

--- a/worker/caasoperator/action_test.go
+++ b/worker/caasoperator/action_test.go
@@ -81,9 +81,9 @@ func (s *actionSuite) assertRunnerExecFunc(c *gc.C, errMsg string) {
 		expectedCode = 3
 	}
 	gomock.InOrder(
-		s.unitAPI.EXPECT().Refresh().Times(1).Return(nil),
-		s.unitAPI.EXPECT().ProviderID().Times(1).Return("gitlab-xxxx"),
-		s.unitAPI.EXPECT().Name().Times(1).Return("gitlab-k8s/0"),
+		s.unitAPI.EXPECT().Refresh().Return(nil),
+		s.unitAPI.EXPECT().ProviderID().Return("gitlab-xxxx"),
+		s.unitAPI.EXPECT().Name().Return("gitlab-k8s/0"),
 		s.executor.EXPECT().Exec(
 			exec.ExecParams{
 				PodName:  "gitlab-xxxx",
@@ -92,7 +92,7 @@ func (s *actionSuite) assertRunnerExecFunc(c *gc.C, errMsg string) {
 				Stdout:   stdout,
 				Stderr:   stderr,
 			}, cancel,
-		).Times(1).DoAndReturn(func(...interface{}) error {
+		).DoAndReturn(func(...interface{}) error {
 			stdout.WriteString("some message")
 			stderr.WriteString("some err message")
 			return exitErr

--- a/worker/caasunitinit/initializer_test.go
+++ b/worker/caasunitinit/initializer_test.go
@@ -69,7 +69,7 @@ func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
 			ContainerName: "juju-pod-init",
 			Stdout:        &bytes.Buffer{},
 			Stderr:        &bytes.Buffer{},
-		}, gomock.Any()).Return(nil).Times(1),
+		}, gomock.Any()).Return(nil),
 		mockExecClient.EXPECT().Copy(exec.CopyParam{
 			Src: exec.FileResource{
 				Path: "dir/charm",
@@ -79,7 +79,7 @@ func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
 				PodName:       "gitlab-ffff",
 				ContainerName: "juju-pod-init",
 			},
-		}, gomock.Any()).Return(nil).Times(1),
+		}, gomock.Any()).Return(nil),
 		mockExecClient.EXPECT().Copy(exec.CopyParam{
 			Src: exec.FileResource{
 				Path: filepath.Join(os.TempDir(), "unit-gitlab-0-random/ca.crt"),
@@ -89,7 +89,7 @@ func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
 				PodName:       "gitlab-ffff",
 				ContainerName: "juju-pod-init",
 			},
-		}, gomock.Any()).Return(nil).Times(1),
+		}, gomock.Any()).Return(nil),
 		mockExecClient.EXPECT().Copy(exec.CopyParam{
 			Src: exec.FileResource{
 				Path: "/var/lib/juju/agents/unit-gitlab-0/operator-client-cache.yaml",
@@ -99,7 +99,7 @@ func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
 				PodName:       "gitlab-ffff",
 				ContainerName: "juju-pod-init",
 			},
-		}, gomock.Any()).Return(nil).Times(1),
+		}, gomock.Any()).Return(nil),
 		mockExecClient.EXPECT().Exec(exec.ExecParams{
 			Commands: []string{"/var/lib/juju/tools/jujud", "caas-unit-init",
 				"--send", "--unit", "unit-gitlab-0",
@@ -115,7 +115,7 @@ func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
 			ContainerName: "juju-pod-init",
 			Stdout:        &bytes.Buffer{},
 			Stderr:        &bytes.Buffer{},
-		}, gomock.Any()).Return(nil).Times(1),
+		}, gomock.Any()).Return(nil),
 	)
 
 	cancel := make(chan struct{})
@@ -195,7 +195,7 @@ func (s *UnitInitializerSuite) TestInitializeContainerMissing(c *gc.C) {
 			ContainerName: "juju-pod-init",
 			Stdout:        &bytes.Buffer{},
 			Stderr:        &bytes.Buffer{},
-		}, gomock.Any()).Return(nil).Times(1),
+		}, gomock.Any()).Return(nil),
 		mockExecClient.EXPECT().Copy(exec.CopyParam{
 			Src: exec.FileResource{
 				Path: "dir/charm",
@@ -205,7 +205,7 @@ func (s *UnitInitializerSuite) TestInitializeContainerMissing(c *gc.C) {
 				PodName:       "gitlab-ffff",
 				ContainerName: "juju-pod-init",
 			},
-		}, gomock.Any()).Return(errors.NotFoundf("container")).Times(1),
+		}, gomock.Any()).Return(errors.NotFoundf("container")),
 	)
 
 	cancel := make(chan struct{})


### PR DESCRIPTION
## Description of change

This is a purely mechanical patch that:
- Introduces a constant for "WaitForFirstConsumer".
- Removes all implicit `.Times(1)` from mock expectations.

## QA steps

No functional changes. Unit tests continue to pass.

## Documentation changes

None.

## Bug reference

N/A
