### PR TITLE
add region gce

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -82,6 +82,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-northeast1:
         endpoint: https://www.googleapis.com
+      asia-northeast2:
+        endpoint: https://www.googleapis.com
       asia-south1:
         endpoint: https://www.googleapis.com
       asia-southeast1:
@@ -97,6 +99,8 @@ clouds:
       europe-west3:
         endpoint: https://www.googleapis.com
       europe-west4:
+        endpoint: https://www.googleapis.com
+      europe-west6:
         endpoint: https://www.googleapis.com
       northamerica-northeast1:
         endpoint: https://www.googleapis.com

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -89,6 +89,8 @@ clouds:
         endpoint: https://www.googleapis.com
       asia-northeast1:
         endpoint: https://www.googleapis.com
+      asia-northeast2:
+        endpoint: https://www.googleapis.com
       asia-south1:
         endpoint: https://www.googleapis.com
       asia-southeast1:
@@ -104,6 +106,8 @@ clouds:
       europe-west3:
         endpoint: https://www.googleapis.com
       europe-west4:
+        endpoint: https://www.googleapis.com
+      europe-west6:
         endpoint: https://www.googleapis.com
       northamerica-northeast1:
         endpoint: https://www.googleapis.com


### PR DESCRIPTION
# Description of change

Adds an additional GCE region as fallback.
Regions are taken from the bug reference

We should update the endpoint where we actually update the regions from.
## QA steps
bootstrap to the new regions gce

```
juju bootstrap google/asia-northeast2
juju bootstrap google/europe-west6
```
```
❯ juju regions google 
Do you want to list regions for cloud "google" from current controller "google-europe-west6"? (Y/n): n

WARNING Not listing regions for cloud "google" from a controller: no controller specified.

Client Cloud Regions
us-east1
us-east4
us-central1
us-west1
us-west2
asia-east1
asia-east2
asia-northeast1
asia-northeast2
asia-south1
asia-southeast1
australia-southeast1
europe-north1
europe-west1
europe-west2
europe-west3
europe-west4
europe-west6
northamerica-northeast1
southamerica-east1
```

europe-west6
```
❯ juju bootstrap google/europe-west6

Creating Juju controller "google-europe-west6" on google/europe-west6
Looking for packaged Juju agent version 2.7-rc1 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on google/europe-west6...
 - juju-571df7-0 (arch=amd64 mem=3.5G cores=4)
Installing Juju agent on bootstrap instance
Fetching Juju GUI 2.15.0
Waiting for address
Attempting to connect to 34.65.168.41:22
Attempting to connect to 10.172.0.2:22
Connected to 34.65.168.41
Running machine configuration script...
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1848433

https://bugs.launchpad.net/juju/+bug/1849509