### PR TITLE
Remove redundant getEffectiveBindingsForCharmMeta().

### DIFF
--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -226,32 +226,6 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *DeployLocalSuite) TestDeployWithInvalidBinding(c *gc.C) {
-	wordpressCharm := s.addWordpressCharm(c)
-	publicSpace, err := s.State.AddSpace("public", "", nil, false)
-	c.Assert(err, jc.ErrorIsNil)
-	internalSpace, err := s.State.AddSpace("internal", "", nil, false)
-	c.Assert(err, jc.ErrorIsNil)
-
-	app, err := application.DeployApplication(stateDeployer{s.State},
-		application.DeployApplicationParams{
-			ApplicationName: "bob",
-			Charm:           wordpressCharm,
-			EndpointBindings: map[string]string{
-				"":      publicSpace.Id(),
-				"bd":    internalSpace.Id(), // typo 'bd'
-				"pubic": publicSpace.Id(),   // typo 'pubic'
-			},
-		})
-	c.Assert(err, gc.ErrorMatches,
-		`invalid binding\(s\) supplied "bd", "pubic", valid binding names are "admin-api", .* "url"`)
-	c.Check(app, gc.IsNil)
-	// The application should not have been added
-	_, err = s.State.Application("bob")
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-
-}
-
 func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
 	var f fakeDeployer
 

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -850,7 +850,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidBinding(c *gc.C) {
                 bindings:
                   noturl: public
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot deploy application "wp": invalid binding\(s\) supplied "noturl", valid binding names are "admin-api",.* "url"`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot deploy application "wp": cannot add application "wp": unknown endpoint "noturl" not valid`)
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidSpace(c *gc.C) {


### PR DESCRIPTION
## Description of change

Remove redundant getEffectiveBindingsForCharmMeta(),  duplication of
Bindings.merge() functionality used by AddApplication.
validateGivenBindings() only used by getEffectiveBindingsForCharmMeta().

## QA steps

Bootstrap guimaas
juju deploy mysql --binding "db=space-alt2"   -- success
juju show-application mysql  - review EP
juju deploy mysql --binding "default db=space-alt2"   -- success
juju show-application mysql  - review EP
juju deploy mysql --binding "testme=space-alt2"   -- expect failure

