### PR TITLE
update-credential ask-or-tell and exclusivity.

### DIFF
--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -164,12 +164,13 @@ func NewSetDefaultRegionCommandForTest(testStore jujuclient.CredentialStore) *se
 	}
 }
 
-func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialAPI) cmd.Command {
-	c := &updateCredentialCommand{
-		api: api,
+func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialAPI) *updateCredentialCommand {
+	return &updateCredentialCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore},
+		updateCredentialAPIFunc: func() (CredentialAPI, error) {
+			return api, nil
+		},
 	}
-	c.SetClientStore(testStore)
-	return modelcmd.WrapController(c)
 }
 
 func NewShowCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialContentAPI) cmd.Command {

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -26,19 +26,27 @@ var usageUpdateCredentialSummary = `
 Updates a controller credential for a cloud.`[1:]
 
 var usageUpdateCredentialDetails = `
-Cloud credentials for controller are used for model operations and manipulations.
+Cloud credentials are used for model operations and manipulations.
 Since it is common to have long-running models, it is also common to 
 have these cloud credentials become invalid during models' lifetime.
 When this happens, a user must update the cloud credential that 
 a model was created with to the new and valid details on controller.
 
 This command allows to update an existing, already-stored, named,
-cloud-specific credential on a controller or the one from this client.
+cloud-specific credential on a controller as well as the one from this client.
+
+If a current controller can be detected, a user will be prompted to confirm 
+if specified cloud needs to be updated on it. 
+If the prompt is not needed and the cloud is always to be updated on
+the current controller if that controller is detected, use --no-prompt option.
+
+Use --controller option to update a cloud on a different controller. 
+
+Use --controller-only option to only update controller copy of the cloud.
 
 If --client-only is used, Juju updates credential only on this client.
-If a user will use a different client, say a different laptop, the update will not affect that 
-client's copy. By extension, when using --client-only, remote credential copies,
-on controllers, will not be affected.
+If a user will use a different client, say a different laptop, 
+the update will not affect that client's (laptop's) copy.
 
 Before credential is updated, the new content is validated. For some providers, 
 cloud credentials are region specific. To validate the credential for a non-default region, 
@@ -48,17 +56,19 @@ Examples:
     juju update-credential aws mysecrets
     juju update-credential -f mine.yaml
     juju update-credential -f mine.yaml --client-only
+    juju update-credential -f mine.yaml --no-prompt --controller-only
     juju update-credential aws -f mine.yaml
     juju update-credential azure --region brazilsouth -f mine.yaml
 
 See also: 
     add-credential
+    remove-credential
     credentials`[1:]
 
 type updateCredentialCommand struct {
-	modelcmd.ControllerCommandBase
+	modelcmd.OptionalControllerCommand
 
-	api CredentialAPI
+	updateCredentialAPIFunc func() (CredentialAPI, error)
 
 	cloud      string
 	credential string
@@ -66,31 +76,26 @@ type updateCredentialCommand struct {
 	// CredentialsFile is the name of the file that contains credentials to update.
 	CredentialsFile string
 
-	// Local stores whether a client side (aka local) copy is requested.
-	Local bool
-
-	// ClientOnly stores whether the command will ONLY operate on a client copy
-	// without affecting controller copy.
-	ClientOnly bool
-
-	// ControllerOnly stores whether the command will ONLY operate on a controller copy
-	// without affecting client copy.
-	ControllerOnly bool
-
 	// Region is the region that credentials will be validated for before an update.
 	Region string
 }
 
 // NewUpdateCredentialCommand returns a command to update credential details.
 func NewUpdateCredentialCommand() cmd.Command {
-	command := updateCredentialCommand{}
-	return modelcmd.WrapController(&command)
+	store := jujuclient.NewFileClientStore()
+	c := &updateCredentialCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store: store,
+		},
+	}
+	c.updateCredentialAPIFunc = c.getAPI
+	return modelcmd.WrapBase(c)
 }
 
 // Init implements Command.Init.
 func (c *updateCredentialCommand) Init(args []string) error {
-	if c.Local && !c.ClientOnly {
-		c.ClientOnly = c.Local
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
 	}
 	argsCount := len(args)
 	if argsCount == 0 {
@@ -122,13 +127,9 @@ func (c *updateCredentialCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *updateCredentialCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ControllerCommandBase.SetFlags(f)
+	c.OptionalControllerCommand.SetFlags(f)
 	f.StringVar(&c.CredentialsFile, "f", "", "The YAML file containing credential details to update")
 	f.StringVar(&c.CredentialsFile, "file", "", "The YAML file containing credential details to update")
-	// TODO (juju3) remove me
-	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client-only instead): Local operation only; controller not affected")
-	f.BoolVar(&c.ClientOnly, "client-only", false, "Client operation only; controller not affected")
-	f.BoolVar(&c.ControllerOnly, "controller-only", false, "Controller operation only; client not affected")
 	f.StringVar(&c.Region, "region", "", "Cloud region that credential is valid for")
 }
 
@@ -140,14 +141,11 @@ type CredentialAPI interface {
 }
 
 func (c *updateCredentialCommand) getAPI() (CredentialAPI, error) {
-	if c.api != nil {
-		return c.api, nil
-	}
-	api, err := c.NewAPIRoot()
+	root, err := c.NewAPIRoot(c.Store, c.ControllerName, "")
 	if err != nil {
-		return nil, errors.Annotate(err, "opening API connection")
+		return nil, errors.Trace(err)
 	}
-	return apicloud.NewClient(api), nil
+	return apicloud.NewClient(root), nil
 }
 
 // Run implements Command.Run
@@ -165,15 +163,36 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 			return errors.Annotatef(err, "could not get credentials from file")
 		}
 	} else {
-		credentials, err = credentialsFromLocalCache(c.ClientStore(), c.cloud, c.credential)
+		credentials, err = credentialsFromLocalCache(c.Store, c.cloud, c.credential)
 		if err != nil {
 			return errors.Annotatef(err, "could not get credentials from local client")
 		}
 	}
-	if c.ClientOnly {
-		return c.updateLocalCredentials(ctx, credentials)
+	var returnErr error
+	if c.BothClientAndController || c.ClientOnly {
+		if err := c.updateLocalCredentials(ctx, credentials); err != nil {
+			returnErr = err
+		}
 	}
-	return c.updateRemoteCredentials(ctx, credentials)
+	if c.BothClientAndController || c.ControllerOnly {
+		if c.ControllerName == "" {
+			// The user may have specified the controller via a --controller option.
+			// If not, let's see if there is a current controller that can be detected.
+			var err error
+			c.ControllerName, err = c.MaybePromptCurrentController(ctx, fmt.Sprintf("update credential %q on cloud %q on", c.credential, c.cloud))
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+		if c.ControllerName != "" {
+			if err := c.updateRemoteCredentials(ctx, credentials); err != nil {
+				returnErr = err
+			}
+		} else {
+			return errors.New("To update credential on a controller, a controller name is needed.")
+		}
+	}
+	return returnErr
 }
 
 func credentialsFromFile(credentialsFile, cloudName, credentialName string) (map[string]jujucloud.CloudCredential, error) {
@@ -270,7 +289,7 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 			erred = true
 			continue
 		}
-		storedCredentials, err := c.ClientStore().CredentialForCloud(cloudName)
+		storedCredentials, err := c.Store.CredentialForCloud(cloudName)
 		if errors.IsNotFound(err) {
 			ctx.Warningf("Could not find credentials for cloud %v on this client.", cloudName)
 			ctx.Infof("Use `juju add-credential` to add credentials to this client.")
@@ -308,7 +327,7 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 			}
 			storedCredentials.AuthCredentials[credentialName] = credential
 		}
-		err = c.ClientStore().UpdateCredential(cloudName, *storedCredentials)
+		err = c.Store.UpdateCredential(cloudName, *storedCredentials)
 		if err != nil {
 			logger.Errorf("%v", err)
 			ctx.Warningf("Could not update this client with credentials for cloud %v", cloudName)
@@ -323,11 +342,11 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 }
 
 func (c *updateCredentialCommand) updateRemoteCredentials(ctx *cmd.Context, update map[string]jujucloud.CloudCredential) error {
-	accountDetails, err := c.CurrentAccountDetails()
+	accountDetails, err := c.Store.AccountDetails(c.ControllerName)
 	if err != nil {
 		return err
 	}
-	client, err := c.getAPI()
+	client, err := c.updateCredentialAPIFunc()
 	if err != nil {
 		return err
 	}
@@ -337,10 +356,6 @@ func (c *updateCredentialCommand) updateRemoteCredentials(ctx *cmd.Context, upda
 	remoteUserClouds, err := client.Clouds()
 	if err != nil {
 		return err
-	}
-	controllerName, err := c.ControllerName()
-	if err != nil {
-		return errors.Trace(err)
 	}
 
 	var erred error
@@ -353,7 +368,7 @@ func (c *updateCredentialCommand) updateRemoteCredentials(ctx *cmd.Context, upda
 	for cloudName, cloudCredentials := range update {
 		remoteCloud, ok := remoteUserClouds[names.NewCloudTag(cloudName)]
 		if !ok {
-			ctx.Warningf("No cloud %q available to user %q remotely on controller %q", cloudName, accountDetails.User, controllerName)
+			ctx.Warningf("No cloud %q available to user %q remotely on controller %q", cloudName, accountDetails.User, c.ControllerName)
 			erred = cmd.ErrSilent
 			continue
 		}
@@ -374,10 +389,10 @@ func (c *updateCredentialCommand) updateRemoteCredentials(ctx *cmd.Context, upda
 	results, err := client.UpdateCloudsCredentials(verified)
 	if err != nil {
 		logger.Errorf("%v", err)
-		ctx.Warningf("Could not update credentials remotely, on controller %q", controllerName)
+		ctx.Warningf("Could not update credentials remotely, on controller %q", c.ControllerName)
 		erred = cmd.ErrSilent
 	}
-	return processUpdateCredentialResult(ctx, accountDetails, "updated", results, controllerName, erred)
+	return processUpdateCredentialResult(ctx, accountDetails, "updated", results, c.ControllerName, erred)
 }
 
 func verifyCredentialsForUpload(ctx *cmd.Context, accountDetails *jujuclient.AccountDetails, aCloud *jujucloud.Cloud, region string, all map[string]jujucloud.Credential) (map[string]jujucloud.Credential, error) {

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -401,9 +401,8 @@ func (s *updateCredentialSuite) TestUpdateRemote(c *gc.C) {
 		return []params.UpdateCredentialResult{{CredentialTag: expectedTag}}, nil
 	}
 	s.storeWithCredentials(c)
-	ctx, _ := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--controller-only", "--no-prompt")
-	//ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--controller-only")
-	//c.Assert(err, jc.ErrorIsNil)
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--controller-only", "--no-prompt")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, ``)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
 Controller credential "my-credential" for user "admin@local" for cloud "aws" on controller "controller" updated.

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -344,7 +344,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteCredentialWithFilePath(c *gc.C) 
 		}
 		return nil, nil
 	}
-	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce")
+	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--no-prompt", "--controller-only")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -401,8 +401,9 @@ func (s *updateCredentialSuite) TestUpdateRemote(c *gc.C) {
 		return []params.UpdateCredentialResult{{CredentialTag: expectedTag}}, nil
 	}
 	s.storeWithCredentials(c)
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential")
-	c.Assert(err, jc.ErrorIsNil)
+	ctx, _ := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--controller-only", "--no-prompt")
+	//ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--controller-only")
+	//c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, ``)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
 Controller credential "my-credential" for user "admin@local" for cloud "aws" on controller "controller" updated.
@@ -455,7 +456,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteResultNotUserCloudError(c *gc.C)
 			names.NewCloudTag("somecloud"): {Name: "somecloud", Type: "openstack"},
 		}, nil
 	}
-	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential")
+	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--no-prompt", "--controller-only")
 	c.Assert(err, gc.NotNil)
 	c.Assert(c.GetTestLog(), jc.Contains, `No cloud "aws" available to user "admin@local" remotely on controller "controller"`)
 }
@@ -465,7 +466,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteResultError(c *gc.C) {
 		return nil, errors.New("kaboom")
 	}
 	s.storeWithCredentials(c)
-	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential")
+	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--no-prompt", "--controller-only")
 	c.Assert(err, gc.NotNil)
 	c.Assert(c.GetTestLog(), jc.Contains, ` kaboom`)
 	c.Assert(c.GetTestLog(), jc.Contains, `Could not update credentials remotely, on controller "controller"`)
@@ -500,7 +501,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteWithModels(c *gc.C) {
 	}
 	s.storeWithCredentials(c)
 
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--no-prompt", "--controller-only")
 	c.Assert(err, gc.DeepEquals, jujucmd.ErrSilent)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Credential valid for:

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -71,10 +71,10 @@ clouds:
 		},
 	})
 
-	_, err := s.run(c, "show-credential", "dummy", "cred")
+	_, err := s.run(c, "show-credential", "dummy", "cred", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.run(c, "update-credential", "dummy", "cred")
+	_, err = s.run(c, "update-credential", "dummy", "cred", "--no-prompt")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(c.GetTestLog(), jc.Contains, `ERROR juju.cmd.juju.cloud finalizing "cred" credential for cloud "dummy": unknown key "tenant-name" (value "hrm")`)
 	store.UpdateCredential("dummy", cloud.CloudCredential{
@@ -85,10 +85,11 @@ clouds:
 			}),
 		},
 	})
-	ctx, err := s.run(c, "update-credential", "dummy", "cred")
+	ctx, err := s.run(c, "update-credential", "dummy", "cred", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+Local client was updated successfully with provided credential information.
 Credential valid for:
   controller
 Controller credential "cred" for user "admin" for cloud "dummy" on controller "kontroll" updated.

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -27,6 +27,9 @@ func init() {
 		panic(err)
 	}
 
+	// TODO (go1.13)
+	// This will fail when we go to go 1.13
+	// https://github.com/golang/go/issues/33774
 	flag.Parse()
 
 	if *runFeatureTests == false {


### PR DESCRIPTION
## Description of change

Several changes need to take place with 'juju update-credential' command.

* Ask-or-tell component of the change is applicable when a user did not specify a controller nor explicitly asked for --client-only operation but the presence of a current controller was detected. In that instance, users will be prompted to confirm if the current controller is to be used. For automated environments, --no-prompt option will automatically use a current controller when it's detected.

* Occasionally, users may not want to add-k8s to both the client and a controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

## Documentation changes

as above
