### PR TITLE
Add action logs to model export

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -492,11 +492,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:1866c86d7f96f4949e0a952413b919a3a0720ec69033fdced75ffba6cdffb996"
+  digest = "1:2800a04445584891c21d3a8a92464ead850096e415e75a6fd02fad4d5844f80b"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "303c0a2ac03fb315309324f8a1f7164b27c8193f"
+  revision = "ef199d6ad38cb2f3c5e32cf9006624e22ee66002"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "303c0a2ac03fb315309324f8a1f7164b27c8193f"
+  revision = "ef199d6ad38cb2f3c5e32cf9006624e22ee66002"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -160,8 +160,8 @@ func (s *unitSuite) TestLogActionMessage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	messages := anAction.Messages()
 	c.Assert(messages, gc.HasLen, 1)
-	c.Assert(messages[0].Message, gc.Equals, "hello")
-	c.Assert(messages[0].Timestamp, gc.NotNil)
+	c.Assert(messages[0].Message(), gc.Equals, "hello")
+	c.Assert(messages[0].Timestamp(), gc.NotNil)
 }
 
 func (s *unitSuite) TestEnsureDead(c *gc.C) {

--- a/apiserver/common/action.go
+++ b/apiserver/common/action.go
@@ -249,8 +249,8 @@ func MakeActionResult(actionReceiverTag names.Tag, action state.Action) params.A
 	}
 	for _, m := range action.Messages() {
 		result.Log = append(result.Log, params.ActionMessage{
-			Timestamp: m.Timestamp,
-			Message:   m.Message,
+			Timestamp: m.Timestamp(),
+			Message:   m.Message(),
 		})
 	}
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1151,8 +1151,8 @@ func (s *uniterSuite) TestLogActionMessage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	messages := anAction.Messages()
 	c.Assert(messages, gc.HasLen, 1)
-	c.Assert(messages[0].Message, gc.Equals, "hello")
-	c.Assert(messages[0].Timestamp, gc.NotNil)
+	c.Assert(messages[0].Message(), gc.Equals, "hello")
+	c.Assert(messages[0].Timestamp(), gc.NotNil)
 }
 
 func (s *uniterSuite) TestWatchActionNotifications(c *gc.C) {

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/action"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/actions"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -816,7 +817,11 @@ func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
 	a, err := s.Model.Action("1")
 	c.Assert(err, jc.ErrorIsNil)
 	logged := a.Messages()
-	expected, err := json.Marshal(logged[0])
+	c.Assert(logged, gc.HasLen, 1)
+	expected, err := json.Marshal(actions.ActionMessage{
+		Message:   logged[0].Message(),
+		Timestamp: logged[0].Timestamp(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(string(expected))

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1411,7 +1411,7 @@ func (e *exporter) actions() error {
 	e.logger.Debugf("read %d actions", len(actions))
 	for _, action := range actions {
 		results, message := action.Results()
-		e.model.AddAction(description.ActionArgs{
+		arg := description.ActionArgs{
 			Receiver:   action.Receiver(),
 			Name:       action.Name(),
 			Parameters: action.Parameters(),
@@ -1422,7 +1422,13 @@ func (e *exporter) actions() error {
 			Results:    results,
 			Message:    message,
 			Id:         action.Id(),
-		})
+		}
+		messages := action.Messages()
+		arg.Messages = make([]description.ActionMessage, len(messages))
+		for i, m := range messages {
+			arg.Messages[i] = m
+		}
+		e.model.AddAction(arg)
 	}
 	return nil
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	corenetwork "github.com/juju/juju/core/network"
@@ -2486,8 +2487,10 @@ func (w *actionLogsWatcher) messages() ([]string, error) {
 	}
 	var changes []string
 	for _, m := range doc.Messages {
-		m.Timestamp = m.Timestamp.UTC()
-		mjson, err := json.Marshal(m)
+		mjson, err := json.Marshal(actions.ActionMessage{
+			Message:   m.MessageValue,
+			Timestamp: m.TimestampValue.UTC(),
+		})
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -388,7 +388,7 @@ func (s *InterfaceSuite) TestLogActionMessage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	messages := a.Messages()
 	c.Assert(messages, gc.HasLen, 1)
-	c.Assert(messages[0].Message, gc.Equals, "hello world")
+	c.Assert(messages[0].Message(), gc.Equals, "hello world")
 }
 
 func (s *InterfaceSuite) TestRequestRebootAfterHook(c *gc.C) {


### PR DESCRIPTION
## Description of change

Add action logs to model export.
Also, as a driveby, limit the log count just in case an action wants to misbehave.

## QA steps

run a charm with an action which logs messages
juju dump-model and look at the yaml to see the logs included