### PR TITLE
add-cloud exclusivity.

### DIFF
--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -549,11 +549,12 @@ func (s *addSuite) TestAddToControllerBadController(c *gc.C) {
 	store.Credentials = nil
 
 	ctx, err := cmdtesting.RunCommand(c, command, "garage-maas", cloudFileName, "-c", "badcontroller", "--no-prompt")
-	c.Assert(err, gc.ErrorMatches, "controller badcontroller not found")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" successfully added to your local client.\n"+
 		"You will need to add a credential for this cloud (`juju add-credential garage-maas`)\n"+
 		"before you can use it to bootstrap a controller (`juju bootstrap garage-maas`) or\n"+
-		"to create a model (`juju add-model <your model name> garage-maas`).\n\n")
+		"to create a model (`juju add-model <your model name> garage-maas`).\n\n"+
+		"Could not upload cloud to a controller: controller badcontroller not found\n")
 }
 
 func (s *addSuite) TestAddToControllerMissingCredential(c *gc.C) {

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -4,7 +4,6 @@
 package featuretests
 
 import (
-	"flag"
 	"runtime"
 	"testing"
 
@@ -19,22 +18,12 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-var runFeatureTests = flag.Bool("featuretests", true, "Run long-running feature tests.")
-
 func init() {
 	// Required for anything requiring components (e.g. resources).
 	if err := all.RegisterForServer(); err != nil {
 		panic(err)
 	}
 
-	// TODO (go1.13)
-	// This will fail when we go to go 1.13
-	// https://github.com/golang/go/issues/33774
-	flag.Parse()
-
-	if *runFeatureTests == false {
-		return
-	}
 	// Initialize all suites here.
 	gc.Suite(&annotationsSuite{})
 	gc.Suite(&cmdApplicationSuite{})


### PR DESCRIPTION
## Description of change

Occasionally, users may not want to add-k8s to both the client and a controller. In these instances, '--client-only' or '--controller-only' options can be used to filter one or the other.

This PR adds the support for this exclusivity to 'add-cloud'.

As a drive-by, this PR removes the need to flag.Parse() from featuretest package. The way it was implemented there is no longer supported in go 1.13 due to the change of precedence and order of package level and testing init. In addition, the flag that the original code was catering for - 'featuretest' - has never been used. 
