### PR TITLE
Fixes lp#1840470: bootstrap help displays available config keys.

### DIFF
--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -82,14 +82,14 @@ func (c *configCommand) Info() *cmd.Info {
 		Args:    "[<attribute key>[=<value>] ...]",
 		Purpose: "Displays or sets configuration settings for a controller.",
 	}
-	if details, err := c.controllerConfigDetails(); err == nil {
-		if output, err := common.FormatConfigSchema(details); err == nil {
+	if details, err := ConfigDetails(); err == nil {
+		if formattedDetails, err := common.FormatConfigSchema(details); err == nil {
 			info.Doc = fmt.Sprintf("%s%s\n%s%s",
 				configCommandHelpDocPart1,
 				controllerConfigHelpDocKeys,
-				output,
+				formattedDetails,
 				configCommandHelpDocPart2)
-			return info
+			return jujucmd.Info(info)
 		}
 	}
 	info.Doc = strings.TrimSpace(fmt.Sprintf("%s%s",
@@ -227,7 +227,8 @@ func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error 
 	return errors.Trace(client.ConfigSet(attrs))
 }
 
-func (c *configCommand) controllerConfigDetails() (map[string]interface{}, error) {
+// ConfigDetails gets information about controller config attributes.
+func ConfigDetails() (map[string]interface{}, error) {
 	specifics := make(map[string]interface{})
 	for key, attr := range controller.ConfigSchema {
 		if !controller.AllowedUpdateConfigAttributes.Contains(key) {

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -38,7 +38,7 @@ func (s *ConfigCommandSuite) TestInit(c *gc.C) {
 			// Test reset
 			desc:       "reset requires arg",
 			args:       []string{"--reset"},
-			errorMatch: "flag needs an argument: --reset",
+			errorMatch: "option needs an argument: --reset",
 		}, {
 			desc:       "cannot set and retrieve at the same time",
 			args:       []string{"--reset", "something", "weird"},
@@ -72,8 +72,8 @@ func (s *ConfigCommandSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d: %s", i, test.desc)
-		cmd := model.NewConfigCommandForTest(s.fake)
-		err := cmdtesting.InitCommand(cmd, test.args)
+		command := model.NewConfigCommandForTest(s.fake)
+		err := cmdtesting.InitCommand(command, test.args)
 		if test.nilErr {
 			c.Check(err, jc.ErrorIsNil)
 			continue


### PR DESCRIPTION
## Description of change

Bootstrap command help has been pointing to stale docs site.
Rather than changing the links to point to the newer site that is going to be obsolete soon as well, this PR goes to the source of truth - the code - to list available config keys.

Drive-by: fixes to some variables that conflict with import names.

## QA steps

run 'juju help bootstrap' to see newer help.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1840470
