### PR TITLE
Fix k8s controller upgrades

### DIFF
--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -62,8 +62,8 @@ func (api *API) UpgradeOperator(arg params.KubernetesUpgradeArg) (params.ErrorRe
 	}
 	appName := tag.Id()
 
-	// Machines representing controllers really mean the controller operator.
-	if tag.Kind() == names.MachineTagKind {
+	// Nodes representing controllers really mean the controller operator.
+	if tag.Kind() == names.MachineTagKind || tag.Kind() == names.ControllerAgentTagKind {
 		appName = bootstrap.ControllerModelName
 	}
 	logger.Debugf("upgrading caas app %v", appName)

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
@@ -58,9 +58,9 @@ func (s *CAASProvisionerSuite) TestUpgradeOperator(c *gc.C) {
 	s.broker.CheckCall(c, 0, "Upgrade", "app", vers)
 }
 
-func (s *CAASProvisionerSuite) TestUpgradeController(c *gc.C) {
+func (s *CAASProvisionerSuite) assertUpgradeController(c *gc.C, tag names.Tag) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{
-		Tag:        names.NewMachineTag("0"),
+		Tag:        tag,
 		Controller: true,
 	}
 
@@ -75,6 +75,14 @@ func (s *CAASProvisionerSuite) TestUpgradeController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	s.broker.CheckCall(c, 0, "Upgrade", "controller", vers)
+}
+
+func (s *CAASProvisionerSuite) TestUpgradeLegacyController(c *gc.C) {
+	s.assertUpgradeController(c, names.NewMachineTag("0"))
+}
+
+func (s *CAASProvisionerSuite) TestUpgradeController(c *gc.C) {
+	s.assertUpgradeController(c, names.NewControllerAgentTag("0"))
 }
 
 type mockBroker struct {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -757,7 +757,7 @@ func (a *noopStatusSetter) SetStatus(setableStatus status.Status, info string, d
 }
 
 func (a *MachineAgent) statusSetter(apiConn api.Connection) (upgradesteps.StatusSetter, error) {
-	if a.agentTag.Kind() != names.MachineTagKind {
+	if a.isCaasAgent || a.agentTag.Kind() != names.MachineTagKind {
 		// TODO - support set status for controller agents
 		return &noopStatusSetter{}, nil
 	}
@@ -857,7 +857,7 @@ func (a *MachineAgent) validateMigration(apiCaller base.APICaller) error {
 	// TODO(mjs) - more extensive checks to come.
 	var err error
 	// TODO(controlleragent) - add k8s controller check.
-	if a.agentTag.Kind() == names.MachineTagKind {
+	if !a.isCaasAgent {
 		facade := apimachiner.NewState(apiCaller)
 		_, err = facade.Machine(a.agentTag.(names.MachineTag))
 	}

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -157,7 +157,7 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 		addr := server.TCPAddr().String()
 		c, err := net.DialTimeout("tcp", addr, opts.Timeout)
 		if err != nil {
-			logger.Warningf("mongodb connection failed, will retry: %v", err)
+			logger.Debugf("mongodb connection failed, will retry: %v", err)
 			return nil, err
 		}
 		if tlsConfig != nil {

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -45,7 +45,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.New("missing PreUpgradeSteps in config")
 			}
 
-			// Get machine agent.
+			// Get the agent.
 			var agent agent.Agent
 			if err := context.Get(config.AgentName, &agent); err != nil {
 				return nil, errors.Trace(err)
@@ -72,7 +72,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			// application tag for CAAS operator, controller, machine or unit tag for agents.
+			// application tag for CAAS operator; controller, machine or unit tag for agents.
 			isOperator := agent.CurrentConfig().Tag().Kind() == names.ApplicationTagKind
 			if isOperator {
 				return NewWorker(

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -193,16 +193,19 @@ func (w *upgradesteps) run() error {
 		}
 		defer func() { _ = w.pool.Close() }()
 
-		if w.isMaster, err = IsMachineMaster(w.pool, w.tag.Id()); err != nil {
-			return errors.Trace(err)
-		}
-
 		st := w.pool.SystemState()
 		model, err := st.Model()
 		if err != nil {
 			return errors.Trace(err)
 		}
 		w.isCaas = model.Type() == state.ModelTypeCAAS
+		w.isMaster = w.isCaas
+		if !w.isCaas {
+			// TODO(caas) - will need fixing when we support HA controllers
+			if w.isMaster, err = IsMachineMaster(w.pool, w.tag.Id()); err != nil {
+				return errors.Trace(err)
+			}
+		}
 	}
 
 	if err := w.runUpgrades(); err != nil {


### PR DESCRIPTION
## Description of change

There were some issues upgrading a k8s controller from 2.6.9 to 2.7:
- 2.6.9 uses a machine tag and not a controller tag so the checks that just looked at the tag type needed tweaking
- the upgrade steps worker assumed the tag was a machine tag when doing the isMaster check

## QA steps

bootstrap a 2.6.9 k8s controller
juju upgrade-controller --agent-version 2.7-rc1

check that status works, deploys work etc;
show-controller should indicate the controller is not upgrading