### PR TITLE
Fix caasoperator id watcher test race condition

### DIFF
--- a/apiserver/facades/agent/caasoperator/watcher.go
+++ b/apiserver/facades/agent/caasoperator/watcher.go
@@ -25,6 +25,7 @@ type watcherModelInterface interface {
 }
 
 // newUnitIDWatcher watches a StringsWatcher and converts ProviderIDs into UnitIDs and re-emits them.
+// If the ProviderID does not match any Units, then the ProviderID is ignored.
 func newUnitIDWatcher(model watcherModelInterface, src corewatcher.StringsWatcher) (*unitIDWatcher, error) {
 	w := &unitIDWatcher{
 		out:   make(chan []string),

--- a/apiserver/facades/agent/caasoperator/watcher_test.go
+++ b/apiserver/facades/agent/caasoperator/watcher_test.go
@@ -26,17 +26,18 @@ func (s *IDWatcherSuite) TestWatcher(c *gc.C) {
 		&mockCloudContainer{unit: "A", providerID: "a"},
 		&mockCloudContainer{unit: "C", providerID: "c"},
 	}
-	wc := make(chan []string, 4)
+	wc := make(chan []string, 3)
 	wc <- []string{"a"}
+	// b should be ignored because the model has no CloudContainer
+	// that matches.
 	wc <- []string{"b"}
-	wc <- []string{"c"}
-	wc <- []string{"d"}
 	srcWatcher := watchertest.NewMockStringsWatcher(wc)
 	idWatcher, err := caasoperator.NewUnitIDWatcher(m, srcWatcher)
 	c.Assert(err, jc.ErrorIsNil)
 
 	testWatcher := testing.NewStringsWatcherC(c, s, idWatcher)
 	testWatcher.AssertChangeInSingleEvent("A")
+	wc <- []string{"c"}
 	testWatcher.AssertChangeInSingleEvent("C")
 
 	err = idWatcher.Stop()


### PR DESCRIPTION
## Description of change

Fix caasoperator id watcher test race condition.

## QA steps

Run the tests.

## Documentation changes

N/A

## Bug reference

N/A
