### PR TITLE
Don't try to chown on windows.

### DIFF
--- a/core/paths/logfile.go
+++ b/core/paths/logfile.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+// +build !windows
+
+package paths
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+
+	"github.com/juju/errors"
+	jujuos "github.com/juju/os"
+)
+
+// LogfilePermission is the file mode to use for log files.
+const LogfilePermission = os.FileMode(0640)
+
+// SetSyslogOwner sets the owner and group of the file to be the appropriate
+// syslog users as defined by the SyslogUserGroup method.
+func SetSyslogOwner(filename string) error {
+	user, group := SyslogUserGroup()
+	return SetOwnership(filename, user, group)
+}
+
+// SetOwnership sets the ownership of a given file from a path.
+// Searches for the corresponding id's from user, group and uses them to chown.
+func SetOwnership(filePath string, wantedUser string, wantedGroup string) error {
+	group, err := user.LookupGroup(wantedGroup)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	gid, err := strconv.Atoi(group.Gid)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	usr, err := user.Lookup(wantedUser)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	uid, err := strconv.Atoi(usr.Uid)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return Chown(filePath, uid, gid)
+}
+
+// PrimeLogFile ensures that the given log file is created with the
+// correct mode and ownership.
+func PrimeLogFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, LogfilePermission)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := f.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	return SetSyslogOwner(path)
+}
+
+// SyslogUserGroup returns the names of the user and group that own the log files.
+func SyslogUserGroup() (string, string) {
+	switch jujuos.HostOS() {
+	case jujuos.CentOS:
+		return "root", "adm"
+	case jujuos.OpenSUSE:
+		return "root", "root"
+	default:
+		return "syslog", "adm"
+	}
+}

--- a/core/paths/logfile_windows.go
+++ b/core/paths/logfile_windows.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package paths
+
+import (
+	"os"
+
+	"github.com/juju/errors"
+)
+
+// LogfilePermission is the file mode to use for log files.
+// Windows only uses the first byte, 0400 for read-only, 0600 for read/write.
+const LogfilePermission = os.FileMode(0600)
+
+// Windows doesn't have the same issues around ownership. In fact calling
+// Chown on windows always fails.
+
+// SetSyslogOwner is a no-op on windows.
+func SetSyslogOwner(filename string) error {
+	return nil
+}
+
+// SetOwnership is a no-op on windows.
+func SetOwnership(filePath string, wantedUser string, wantedGroup string) error {
+	return nil
+}
+
+// PrimeLogFile ensures that the given log file is created with the
+// correct mode and ownership.
+func PrimeLogFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, LogfilePermission)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(f.Close())
+}
+
+// SyslogUserGroup returns the names of the user and group that own the log files.
+func SyslogUserGroup() (string, string) {
+	return "noone", "noone"
+}


### PR DESCRIPTION
Windows tests were failing due to the `PrimeLogFile` calling `chown`, which always returns an error on Windows.
