### PR TITLE
updates charm pkg ref

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:905fc6c125b45a9822084a4c76f4238b2a42b3c1449b4bcc8e60f0952638ba30"
+  digest = "1:ed6ef6587e8c42c2cdb227c2e1b164bd131e4c84d420cf725b5fcf97c29e9b19"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "c769faf4c30ef9abde1b7a8c32b6404c8167f999"
+  revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "c769faf4c30ef9abde1b7a8c32b6404c8167f999"
+  revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"


### PR DESCRIPTION
## Description of change

adds https://github.com/juju/charm/commit/780719c3e4a68329408cfecf46ed1ee84b530287
reasons:
- The log level was too high
- Charmdir can get read quite a lot of time, by inversing the logging place we can reduce this
## QA steps

run a test suite which reads charms a lot e.g. 
`cd worker/uniter; go test -check.vv -check.f UniterRelations`


the expected level of output
`INFO juju.charm charm is not versioned,` only comes after each part of the unit test directly under each other. 

Like here: 
```
uniter_test.quickStartRelation{}
uniter_test.quickStart{minion:false}
uniter_test.createCharm{revision:0, badHooks:[]string(nil), customize:(func(*check.C, *uniter_test.context, string))(nil)}
uniter_test.addCharm{dir:(*charm.CharmDir)(0xc000ba65f0), curl:(*charm.URL)(0xc000ba6820)}
[LOG] 0:00.185 INFO juju.charm charm is not versioned, charm path "/tmp/check-8543309850409549887/9/wordpress"
uniter_test.serveCharm{}
[LOG] 0:00.218 DEBUG juju.storage resource catalog entry created with id "a3d0577fddd881e3db8cee679bbb7b6a1c761cabceacfc003767b719c76e4f53e18afba56d2dde6c1fa8b65f7bc6e14d"
...
```
https://pastebin.canonical.com/p/XXxdSPDxnZ/ for longer version.
The test should do something with a `mysql` charm, outputs a lot and then changes to a `wordpress` charm.
There should be no duplicate info message regarding the charm versioning.

and not that many times like here:
http://paste.ubuntu.com/p/76Phr48KH7/    -- 20x in a row


## Bug reference
too much logging output
http://paste.ubuntu.com/p/76Phr48KH7/