### PR TITLE
cmd status: show active branch and created By

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1449,6 +1449,7 @@ func (c *statusContext) processBranches() map[string]params.BranchStatus {
 		branchMap[name] = params.BranchStatus{
 			AssignedUnits: branch.AssignedUnits(),
 			Created:       branch.Created(),
+			CreatedBy:     branch.CreatedBy(),
 		}
 	}
 	return branchMap

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9409,12 +9409,16 @@
                         },
                         "created": {
                             "type": "integer"
+                        },
+                        "created-by": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
                         "assigned-units",
-                        "created"
+                        "created",
+                        "created-by"
                     ]
                 },
                 "BundleChange": {

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -337,4 +337,5 @@ const (
 type BranchStatus struct {
 	AssignedUnits map[string][]string `json:"assigned-units"`
 	Created       int64               `json:"created"`
+	CreatedBy     string              `json:"created-by"`
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -325,6 +325,8 @@ type relationStatus struct {
 }
 
 type branchStatus struct {
-	Ref     string `json:"ref,omitempty" yaml:"ref,omitempty"`
-	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+	Ref       string `json:"ref,omitempty" yaml:"ref,omitempty"`
+	Created   string `json:"created,omitempty" yaml:"created,omitempty"`
+	CreatedBy string `json:"created-by,omitempty" yaml:"created-by,omitempty"`
+	Active    bool   `json:"active,omitempty" yaml:"active,omitempty"`
 }

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -265,10 +265,13 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 }
 
 func printBranches(tw *ansiterm.TabWriter, branches map[string]branchStatus) {
-	w := startSection(tw, false, "Branch", "Ref", "Created")
+	w := startSection(tw, false, "Branch", "Ref", "Created", "Created By")
 	for _, branchName := range naturalsort.Sort(stringKeysFromMap(branches)) {
 		b := branches[branchName]
-		w.Println(branchName, b.Ref, b.Created)
+		if b.Active {
+			branchName = branchName + "*"
+		}
+		w.Println(branchName, b.Ref, b.Created, b.CreatedBy)
 	}
 }
 

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -283,6 +283,10 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	activeBranch, err := c.ActiveBranch()
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	showRelations := c.relations
 	showStorage := c.storage
@@ -307,6 +311,7 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		outputName:     c.out.Name(),
 		isoTime:        c.isoTime,
 		showRelations:  showRelations,
+		activeBranch:   activeBranch,
 	}
 	if showStorage {
 		storageInfo, err := c.getStorageInfo(ctx)

--- a/tests/suites/branches/active_branch.sh
+++ b/tests/suites/branches/active_branch.sh
@@ -1,0 +1,79 @@
+# Checks juju that juju shows no branches output.
+run_indicate_active_branch_no_active() {
+  echo
+
+  file="${TEST_DIR}/indicate-active-branch-no-active.txt"
+
+  ensure "indicate-active-branch-no-active" "${file}"
+
+  juju deploy ubuntu
+
+  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+  check_not_contains "$(juju status)" "Branch"
+
+  if [ "$(juju status --format=json | jq '.branches')" != null ]; then
+    echo "The status shows branches even though we do not use them yet"
+    exit 1
+  fi
+
+  destroy_model "indicate-active-branch-no-active"
+}
+
+# Checks juju that juju shows branches output as we are using it
+run_indicate_active_branch_active() {
+  echo
+
+  file="${TEST_DIR}/indicate-active-branch-active.txt"
+
+  ensure "indicate-active-branch-active" "${file}"
+
+  juju deploy ubuntu
+
+  juju add-branch bla
+  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+  check_contains "$(juju status)" "bla\*"
+
+  if [ "$(juju status --format=json | jq '.branches.bla.active')" != true ]; then
+    echo "The status does not show active branch"
+    exit 1
+  fi
+
+  juju add-branch testtest
+  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+  check_contains "$(juju status)" "testtest\*"
+  check_not_contains "$(juju status)" "bla\*"
+
+  STATUS_UNACTIVE=$(juju status --format=json | jq '.branches.bla.active')
+  STATUS_ACTIVE=$(juju status --format=json | jq '.branches.testtest.active')
+
+  if [ "${STATUS_UNACTIVE}" != null ]; then
+    echo "The status shows active branch"
+    exit 1
+  fi
+
+  if [ "${STATUS_ACTIVE}" != true ]; then
+    echo "The status shows active branch"
+    exit 1
+  fi
+
+  destroy_model "indicate-active-branch-active"
+}
+
+test_active_branch_output() {
+  if [ "$(skip 'test_active_branch_output')" ]; then
+    echo "==> TEST SKIPPED: test_active_branch_outputtests"
+    return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    run "run_indicate_active_branch_no_active"
+    run "run_indicate_active_branch_active"
+  )
+}

--- a/tests/suites/branches/task.sh
+++ b/tests/suites/branches/task.sh
@@ -16,6 +16,7 @@ test_branches() {
     bootstrap "test-branch" "${file}"
 
     test_branch
+    test_active_branch_output
 
     destroy_controller "test-branch"
 }


### PR DESCRIPTION
## Description of change

- Shows Created By in  status 
- Indicates current Branch in status with a "*"
- json and yaml output has new key-value indicating current branch
- Only shows if branches are in use

## QA steps
activate generations: `export JUJU_DEV_FEATURE_FLAGS=generations`

tl;dr:
```
- deploy ubuntu
- add-branches test and bla
- switch between them
- check if status is correct each time (* indicating current one + createdBy output)
- check status --format=yaml only shows branches if we use branches
- check status --format=yaml shows active=True for the current targeted branch, if branches are used 
```

long version:

```
do after every step `juju status` to ensure output that looks reasonable
```

```
juju deploy ubuntu
```

```
juju add-branch test
```

```
juju status
```

expected juju output
```
❯ juju status         
Model    Controller    Cloud/Region       Version    SLA          Timestamp
default  testbranches  localhost/default  2.7-rc1.1  unsupported  18:47:39+02:00

Branch  Ref  Created        Created By
test*   #1   3 seconds ago  admin

App     Version  Status  Scale  Charm   Store       Rev  OS      Notes
ubuntu  18.04    active      1  ubuntu  jujucharms   12  ubuntu  

Unit       Workload  Agent  Machine  Public address  Ports    Message
ubuntu/0*  active    idle   0        10.75.147.14             ready

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.75.147.14  juju-f0e3fc-0  bionic      Running
```

add new branch bla, now should be the active one
```
~/Workspace/canonical/clouds-unsigned
❯ juju add-branch bla 
Created branch "bla" and set active

~/Workspace/canonical/clouds-unsigned
❯ juju status        
Model    Controller    Cloud/Region       Version    SLA          Timestamp
default  testbranches  localhost/default  2.7-rc1.1  unsupported  18:50:02+02:00

Branch  Ref  Created        Created By
bla*    #1   2 seconds ago  admin
test    #2   2 minutes ago  admin

App     Version  Status  Scale  Charm   Store       Rev  OS      Notes
ubuntu  18.04    active      1  ubuntu  jujucharms   12  ubuntu  

Unit       Workload  Agent  Machine  Public address  Ports    Message
ubuntu/0*  active    idle   0        10.75.147.14             ready

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.75.147.14  juju-f0e3fc-0  bionic      Running
```

test switch branch to test again

```
juju branch test
````

The same tests for `juju status --format=yaml` for above cases

## Bug reference

https://github.com/juju/juju/pull/10383#issuecomment-506565941