### PR TITLE
Add test for upgrade step and handle nested directories.

### DIFF
--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -8,6 +8,8 @@ import "github.com/juju/juju/environs"
 var (
 	UpgradeOperations      = &upgradeOperations
 	StateUpgradeOperations = &stateUpgradeOperations
+
+	SetJujuFolderPermissionsToAdm = setJujuFolderPermissionsToAdm
 )
 
 type ModelConfigUpdater environConfigUpdater

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -114,11 +114,10 @@ func setJujuFolderPermissionsToAdm(dir string) error {
 		if info.IsDir() {
 			return nil
 		}
-		fullPath := dir + string(os.PathSeparator) + info.Name()
-		if err := paths.SetOwnership(fullPath, wantedOwner, wantedGroup); err != nil {
+		if err := paths.SetOwnership(path, wantedOwner, wantedGroup); err != nil {
 			return errors.Trace(err)
 		}
-		if err := os.Chmod(fullPath, paths.LogfilePermission); err != nil {
+		if err := os.Chmod(path, paths.LogfilePermission); err != nil {
 			return errors.Trace(err)
 		}
 		return nil

--- a/upgrades/steps_27_test.go
+++ b/upgrades/steps_27_test.go
@@ -4,10 +4,16 @@
 package upgrades_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
 )
@@ -68,4 +74,40 @@ func (s *steps27Suite) TestConvertAddressSpaceIDs(c *gc.C) {
 func (s *steps27Suite) TestReplaceSpaceNameWithIDEndpointBindings(c *gc.C) {
 	step := findStateStep(c, v27, `replace space name in endpointBindingDoc bindings with an space ID`)
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
+func (s *steps27Suite) TestLogfilePermissions(c *gc.C) {
+	// This test is to primarily test the walking of the log directory and the
+	// calling of the SetOwnership call. Skipped on windows because this will
+	// never be run there.
+	if runtime.GOOS == "windows" {
+		c.Skip("never running upgrade steps on windows")
+	}
+
+	// Set up a test directory, with a few files, and a directory within with a few
+	// files. We aren't actually able to test that the files do get changed ownership
+	// to "syslog:adm" because normal users running these tests don't have permission
+	// to do that. What we are testing here is the path that is passed into the Chown
+	// command.
+
+	var calls []string
+	s.PatchValue(&paths.Chown, func(name string, uid, gid int) error {
+		calls = append(calls, name)
+		return nil
+	})
+
+	base := c.MkDir()
+	c.Assert(ioutil.WriteFile(filepath.Join(base, "one"), []byte("test"), 0600), jc.ErrorIsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(base, "two"), []byte("test"), 0600), jc.ErrorIsNil)
+	c.Assert(os.Mkdir(filepath.Join(base, "nested"), 0755), jc.ErrorIsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(base, "nested", "three"), []byte("test"), 0600), jc.ErrorIsNil)
+
+	err := upgrades.SetJujuFolderPermissionsToAdm(base)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(calls, jc.SameContents, []string{
+		filepath.Join(base, "one"),
+		filepath.Join(base, "two"),
+		filepath.Join(base, "nested", "three"),
+	})
 }


### PR DESCRIPTION
There was an idempotency issue with the upgrade step to set the ownership and permissions of the log file.

In 2.7 we now have a nested "models" directory which holds the logs for the workers run on the controller on behalf of the models. The walking of the files in the /var/log/juju directory wasn't taking this into account when creating the path to use. Luckily this is actually one of the parameters to the walk function.
