### PR TITLE
Check for incorrect endpoint in remove offer url

### DIFF
--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -121,6 +121,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	var invalidOffers []string
 	for i, urlStr := range c.offers {
 		url, err := crossmodel.ParseOfferURL(urlStr)
 		if err != nil {
@@ -136,6 +137,13 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 		if c.offerSource != url.Source {
 			return errors.New("all offer URLs must use the same controller")
 		}
+		if strings.Contains(url.ApplicationName, ":") {
+			invalidOffers = append(invalidOffers, " -"+c.offers[i])
+		}
+	}
+
+	if len(invalidOffers) > 0 {
+		return errors.Errorf("These offers contain endpoints. Only specify the offer name itself.\n%v", strings.Join(invalidOffers, "\n"))
 	}
 
 	if c.offerSource == "" {

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -42,6 +42,14 @@ func (s *removeSuite) TestRemoveURLError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "application offer URL has invalid form.*")
 }
 
+func (s *removeSuite) TestRemoveURLWithEndpoints(c *gc.C) {
+	_, err := s.runRemove(c, "fred/model.db2:db")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err.Error(), gc.Equals, `
+These offers contain endpoints. Only specify the offer name itself.
+ -fred/model.db2:db`[1:])
+}
+
 func (s *removeSuite) TestRemoveInconsistentControllers(c *gc.C) {
 	_, err := s.runRemove(c, "ctrl:fred/model.db2", "ctrl2:fred/model.db2")
 	c.Assert(err, gc.ErrorMatches, "all offer URLs must use the same controller")


### PR DESCRIPTION
## Description of change

Users got confused when running juju-remove offer and included the endpoint in the name. This caused juju to try and remove an offer called "offer:ep" instead of "offer".
Add a check to remove-offer to ensure no endpoint is included.

## QA steps

remove-remove offer mariadb:db mysql
ERROR These offers contain endpoints. Only specify the offer name itself:
 -admin/default.mariadb:db
