### PR TITLE
Fixes lp#1848104: updating existing credential with invalid value invalidates other credentials

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -212,7 +212,7 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	interfaceInfos, err := netEnviron.NetworkInterfaces(state.CallContext(model.State()), instId)
+	interfaceInfos, err := netEnviron.NetworkInterfaces(state.CallContext(api.st), instId)
 	if errors.IsNotSupported(err) {
 		// It's possible to have a networking environ, but not support
 		// NetworkInterfaces(). In leiu of adding SupportsNetworkInterfaces():

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/environs/context"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 )
@@ -36,7 +35,6 @@ func (s *networkConfigSuite) SetUpTest(c *gc.C) {
 
 	s.networkconfig = networkingcommon.NewNetworkConfigAPI(
 		s.State,
-		context.NewCloudCallContext(),
 		common.AuthAlways(),
 	)
 }

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -51,7 +51,7 @@ func NewMachinerAPI(st *state.State, resources facade.Resources, authorizer faca
 		DeadEnsurer:        common.NewDeadEnsurer(st, getCanModify),
 		AgentEntityWatcher: common.NewAgentEntityWatcher(st, resources, getCanRead),
 		APIAddresser:       common.NewAPIAddresser(st, resources),
-		NetworkConfigAPI:   networkingcommon.NewNetworkConfigAPI(st, state.CallContext(st), getCanModify),
+		NetworkConfigAPI:   networkingcommon.NewNetworkConfigAPI(st, getCanModify),
 		st:                 st,
 		auth:               authorizer,
 		getCanModify:       getCanModify,

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -140,7 +140,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 		ModelWatcher:            common.NewModelWatcher(model, resources, authorizer),
 		ModelMachinesWatcher:    common.NewModelMachinesWatcher(st, resources, authorizer),
 		ControllerConfigAPI:     common.NewStateControllerConfig(st),
-		NetworkConfigAPI:        networkingcommon.NewNetworkConfigAPI(st, callCtx, getCanModify),
+		NetworkConfigAPI:        networkingcommon.NewNetworkConfigAPI(st, getCanModify),
 		st:                      st,
 		m:                       model,
 		resources:               resources,

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 )
@@ -43,7 +42,6 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, nil, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
-		context.NewCloudCallContext(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &applicationoffers.OffersAPIV2{OffersAPI: apiV1}

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -17,9 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -50,7 +48,6 @@ func createOffersAPI(
 	authorizer facade.Authorizer,
 	resources facade.Resources,
 	authContext *commoncrossmodel.AuthContext,
-	callCtx context.ProviderCallContext,
 ) (*OffersAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
@@ -67,7 +64,6 @@ func createOffersAPI(
 			StatePool:            statePool,
 			getEnviron:           getEnviron,
 			getControllerInfo:    getControllerInfo,
-			callContext:          callCtx,
 		},
 	}
 	return api, nil
@@ -98,7 +94,6 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		return common.StateControllerInfo(st)
 	}
 
-	callCtx := state.CallContext(st)
 	authContext := ctx.Resources().Get("offerAccessAuthContext").(common.ValueResource).Value
 	return createOffersAPI(
 		GetApplicationOffers,
@@ -109,7 +104,6 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		ctx.Auth(),
 		ctx.Resources(),
 		authContext.(*commoncrossmodel.AuthContext),
-		callCtx,
 	)
 }
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -21,7 +21,6 @@ import (
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -54,7 +53,6 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
-		context.NewCloudCallContext(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &applicationoffers.OffersAPIV2{OffersAPI: apiV1}
@@ -1077,7 +1075,6 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
-		context.NewCloudCallContext(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = &applicationoffers.OffersAPIV2{OffersAPI: apiV1}

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -543,10 +543,6 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceIDs []string) (map
 		logger.Debugf("cloud provider doesn't support networking, not getting space info")
 		return nil, nil
 	}
-	callContext, err := backend.GetModelCallContext()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	results := make(map[string]params.RemoteSpace)
 	for _, id := range spaceIDs {
@@ -561,7 +557,7 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceIDs []string) (map
 				return nil, errors.Trace(err)
 			}
 		}
-		providerSpace, err := netEnv.ProviderSpaceInfo(callContext, space)
+		providerSpace, err := netEnv.ProviderSpaceInfo(backend.GetModelCallContext(), space)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -19,7 +19,6 @@ import (
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 )
@@ -32,7 +31,6 @@ type BaseAPI struct {
 	StatePool            StatePool
 	getEnviron           environFromModelFunc
 	getControllerInfo    func() (apiAddrs []string, caCert string, _ error)
-	callContext          context.ProviderCallContext
 }
 
 // checkPermission ensures that the logged in user holds the given permission on an entity.
@@ -545,6 +543,10 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceIDs []string) (map
 		logger.Debugf("cloud provider doesn't support networking, not getting space info")
 		return nil, nil
 	}
+	callContext, err := backend.GetModelCallContext()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	results := make(map[string]params.RemoteSpace)
 	for _, id := range spaceIDs {
@@ -559,7 +561,7 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceIDs []string) (map
 				return nil, errors.Trace(err)
 			}
 		}
-		providerSpace, err := netEnv.ProviderSpaceInfo(api.callContext, space)
+		providerSpace, err := netEnv.ProviderSpaceInfo(callContext, space)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -377,6 +377,10 @@ func (m *mockState) OfferConnections(offerUUID string) ([]applicationoffers.Offe
 	return m.connections, nil
 }
 
+func (m *mockState) GetModelCallContext() (context.ProviderCallContext, error) {
+	return context.NewCloudCallContext(), nil
+}
+
 func (m *mockState) User(tag names.UserTag) (applicationoffers.User, error) {
 	user, ok := m.users[tag.Id()]
 	if !ok {

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -377,8 +377,8 @@ func (m *mockState) OfferConnections(offerUUID string) ([]applicationoffers.Offe
 	return m.connections, nil
 }
 
-func (m *mockState) GetModelCallContext() (context.ProviderCallContext, error) {
-	return context.NewCloudCallContext(), nil
+func (m *mockState) GetModelCallContext() context.ProviderCallContext {
+	return context.NewCloudCallContext()
 }
 
 func (m *mockState) User(tag names.UserTag) (applicationoffers.User, error) {

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -69,7 +69,7 @@ type Backend interface {
 	GetOfferUsers(offerUUID string) (map[string]permission.Access, error)
 
 	// GetModelCallContext gets everything that is needed to make cloud calls on behalf of the state current model.
-	GetModelCallContext() (context.ProviderCallContext, error)
+	GetModelCallContext() context.ProviderCallContext
 }
 
 var GetStateAccess = func(st *state.State) Backend {
@@ -110,12 +110,8 @@ func (s *stateShim) Model() (Model, error) {
 	return &modelShim{m}, err
 }
 
-func (s *stateShim) GetModelCallContext() (context.ProviderCallContext, error) {
-	m, err := s.st.Model()
-	if err != nil {
-		return nil, err
-	}
-	return state.CallContext(m.State()), nil
+func (s *stateShim) GetModelCallContext() context.ProviderCallContext {
+	return state.CallContext(s.st)
 }
 
 type stateCharmShim struct {

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -105,11 +105,7 @@ func (s statePoolShim) GetModelCallContext(modelUUID string) (credentialcommon.P
 		return nil, nil, err
 	}
 	defer modelState.Release()
-	m, err := modelState.Model()
-	if err != nil {
-		return nil, nil, err
-	}
-	return credentialcommon.NewPersistentBackend(m.State()), state.CallContext(m.State()), err
+	return credentialcommon.NewPersistentBackend(modelState.State), state.CallContext(modelState.State), err
 }
 
 type User interface {

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -75,6 +75,7 @@ func (s stateShim) Model() (Model, error) {
 }
 
 type Model interface {
+	UUID() string
 	Cloud() string
 	CloudCredential() (names.CloudCredentialTag, bool)
 	CloudRegion() string

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -94,28 +94,25 @@ func (s *cloudSuiteV2) SetUpTest(c *gc.C) {
 	}
 
 	s.setTestAPIForUser(c, owner)
-	newModel := func(uuid string) *mockPooledModel {
-		return &mockPooledModel{
-			model: &mockModelBackend{
-				uuid: uuid,
-				model: &mockModel{
-					cloud:       "dummy",
-					cloudRegion: "nether",
-					cfg:         coretesting.ModelConfig(c),
-				},
-				cloud: cloud.Cloud{
-					Name:      "dummy",
-					Type:      "dummy",
-					AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
-					Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
-				},
+	modelBackend := func(uuid string) *mockModelBackend {
+		return &mockModelBackend{
+			uuid: uuid,
+			model: &mockModel{
+				cloud:       "dummy",
+				cloudRegion: "nether",
+				cfg:         coretesting.ModelConfig(c),
 			},
-			release: true,
+			cloud: cloud.Cloud{
+				Name:      "dummy",
+				Type:      "dummy",
+				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+				Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+			},
 		}
 	}
 	s.statePool = &mockStatePool{
-		getF: func(modelUUID string) (cloudfacade.PooledModelBackend, error) {
-			return newModel(modelUUID), nil
+		getF: func(modelUUID string) (credentialcommon.PersistentBackend, context.ProviderCallContext, error) {
+			return modelBackend(modelUUID), context.NewCloudCallContext(), nil
 		},
 	}
 }
@@ -124,7 +121,7 @@ func (s *cloudSuiteV2) setTestAPIForUser(c *gc.C, user names.UserTag) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag: user,
 	}
-	client, err := cloudfacade.NewCloudAPI(s.backend, s.backend, s.statePool, s.authorizer, context.NewCloudCallContext())
+	client, err := cloudfacade.NewCloudAPI(s.backend, s.backend, s.statePool, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.apiv2 = &cloudfacade.CloudAPIV2{&cloudfacade.CloudAPIV3{&cloudfacade.CloudAPIV4{&cloudfacade.CloudAPIV5{client}}}}
 }

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -98,6 +98,7 @@ func (s *cloudSuiteV2) SetUpTest(c *gc.C) {
 		return &mockModelBackend{
 			uuid: uuid,
 			model: &mockModel{
+				uuid:        coretesting.ModelTag.Id(),
 				cloud:       "dummy",
 				cloudRegion: "nether",
 				cfg:         coretesting.ModelConfig(c),

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -98,6 +98,7 @@ func newModelBackend(c *gc.C, aCloud cloud.Cloud, uuid string) *mockModelBackend
 	return &mockModelBackend{
 		uuid: uuid,
 		model: &mockModel{
+			uuid:        coretesting.ModelTag.Id(),
 			cloud:       "dummy",
 			cloudRegion: "nether",
 			cfg:         coretesting.ModelConfig(c),
@@ -1379,6 +1380,7 @@ func (st *mockBackend) ControllerConfig() (controller.Config, error) {
 func (st *mockBackend) Model() (cloudfacade.Model, error) {
 	st.MethodCall(st, "Model")
 	return &mockModel{
+		uuid:  coretesting.ModelTag.Id(),
 		cloud: st.cloud.Name,
 	}, st.NextErr()
 }
@@ -1517,6 +1519,7 @@ func (m *mockUser) DisplayName() string {
 }
 
 type mockModel struct {
+	uuid               string
 	cloud              string
 	cloudRegion        string
 	cloudCredentialTag names.CloudCredentialTag
@@ -1545,6 +1548,10 @@ func (m *mockModel) Config() (*config.Config, error) {
 
 func (m *mockModel) Type() state.ModelType {
 	return state.ModelType("")
+}
+
+func (m *mockModel) UUID() string {
+	return m.uuid
 }
 
 type mockStatePool struct {

--- a/apiserver/facades/client/cloud/export_test.go
+++ b/apiserver/facades/client/cloud/export_test.go
@@ -3,17 +3,7 @@
 
 package cloud
 
-import "github.com/juju/juju/apiserver/facade"
-
 var (
 	InstanceTypes                     = instanceTypes
 	ValidateNewCredentialForModelFunc = &validateNewCredentialForModelFunc
 )
-
-func NewCloudTestingAPI(backend, ctlrBackend Backend, authorizer facade.Authorizer) *CloudAPI {
-	return &CloudAPI{
-		backend:     backend,
-		ctlrBackend: ctlrBackend,
-		authorizer:  authorizer,
-	}
-}

--- a/apiserver/facades/client/cloud/instance_information.go
+++ b/apiserver/facades/client/cloud/instance_information.go
@@ -49,11 +49,7 @@ func instanceTypes(api *CloudAPI,
 	if err != nil {
 		return params.InstanceTypesResults{}, errors.Trace(err)
 	}
-	modelCfg, err := api.ctlrBackend.ModelConfig()
-	if err != nil {
-		return params.InstanceTypesResults{}, errors.Trace(err)
-	}
-	_, callContext, err := api.pool.GetModelCallContext(modelCfg.UUID())
+	_, callContext, err := api.pool.GetModelCallContext(m.UUID())
 	if err != nil {
 		return params.InstanceTypesResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/cloud/instance_information.go
+++ b/apiserver/facades/client/cloud/instance_information.go
@@ -49,6 +49,14 @@ func instanceTypes(api *CloudAPI,
 	if err != nil {
 		return params.InstanceTypesResults{}, errors.Trace(err)
 	}
+	modelCfg, err := api.ctlrBackend.ModelConfig()
+	if err != nil {
+		return params.InstanceTypesResults{}, errors.Trace(err)
+	}
+	_, callContext, err := api.pool.GetModelCallContext(modelCfg.UUID())
+	if err != nil {
+		return params.InstanceTypesResults{}, errors.Trace(err)
+	}
 
 	result := make([]params.InstanceTypesResult, len(cons.Constraints))
 	// TODO(perrito666) Cache the results to avoid excessive querying of the cloud.
@@ -76,10 +84,9 @@ func instanceTypes(api *CloudAPI,
 		if err != nil {
 			return params.InstanceTypesResults{}, errors.Trace(err)
 		}
-
 		itCons := common.NewInstanceTypeConstraints(
 			env,
-			api.callContext,
+			callContext,
 			value,
 		)
 		it, err := common.InstanceTypes(itCons)

--- a/apiserver/facades/client/cloud/instance_information_test.go
+++ b/apiserver/facades/client/cloud/instance_information_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/state"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type instanceTypesSuite struct{}
@@ -103,9 +102,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 }
 
 func (*mockBackend) ModelConfig() (*config.Config, error) {
-	attrs := coretesting.FakeConfig()
-	attrs["uuid"] = coretesting.ModelTag.Id()
-	return config.New(config.UseDefaults, attrs)
+	return nil, nil
 }
 
 func (b *mockBackend) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -75,10 +75,10 @@ func (s *Suite) SetUpTest(c *gc.C) {
 }
 
 func (s *Suite) TestFacadeRegistered(c *gc.C) {
-	factory, err := apiserver.AllFacades().GetFactory("MigrationTarget", 1)
+	aFactory, err := apiserver.AllFacades().GetFactory("MigrationTarget", 1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	api, err := factory(&facadetest.Context{
+	api, err := aFactory(&facadetest.Context{
 		State_:     s.State,
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
@@ -306,7 +306,10 @@ func (s *Suite) TestAdoptIAASResources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(env.Stub.Calls(), gc.HasLen, 1)
-	env.Stub.CheckCall(c, 0, "AdoptResources", s.callContext, st.ControllerUUID(), version.MustParse("3.2.1"))
+	aCall := env.Stub.Calls()[0]
+	c.Assert(aCall.FuncName, gc.Equals, "AdoptResources")
+	c.Assert(aCall.Args[1], gc.Equals, st.ControllerUUID())
+	c.Assert(aCall.Args[2], gc.Equals, version.MustParse("3.2.1"))
 }
 
 func (s *Suite) TestAdoptCAASResources(c *gc.C) {
@@ -332,7 +335,10 @@ func (s *Suite) TestAdoptCAASResources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(broker.Stub.Calls(), gc.HasLen, 1)
-	broker.Stub.CheckCall(c, 0, "AdoptResources", s.callContext, st.ControllerUUID(), version.MustParse("3.2.1"))
+	aCall := broker.Stub.Calls()[0]
+	c.Assert(aCall.FuncName, gc.Equals, "AdoptResources")
+	c.Assert(aCall.Args[1], gc.Equals, st.ControllerUUID())
+	c.Assert(aCall.Args[2], gc.Equals, version.MustParse("3.2.1"))
 }
 
 func (s *Suite) TestCheckMachinesSuccess(c *gc.C) {
@@ -414,7 +420,7 @@ func (s *Suite) TestCheckMachinesHandlesManual(c *gc.C) {
 }
 
 func (s *Suite) newAPI(environFunc stateenvirons.NewEnvironFunc, brokerFunc stateenvirons.NewCAASBrokerFunc) (*migrationtarget.API, error) {
-	api, err := migrationtarget.NewAPI(&s.facadeContext, environFunc, brokerFunc, s.callContext)
+	api, err := migrationtarget.NewAPI(&s.facadeContext, environFunc, brokerFunc)
 	return api, err
 }
 
@@ -472,8 +478,8 @@ func (e *mockEnv) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 func (e *mockEnv) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
 	e.MethodCall(e, "AllInstances", ctx)
 	results := make([]instances.Instance, len(e.instances))
-	for i, instance := range e.instances {
-		results[i] = instance
+	for i, anInstance := range e.instances {
+		results[i] = anInstance
 	}
 	return results, e.NextErr()
 }


### PR DESCRIPTION
## Description of change

On the controller facades, creating cloud call context in the facade construction makes no sense since call context is model specific. 

This PR changes the creation of the context to be in the actual facade call methods. All context creation has been moved to the calls that use context rather than forcing it to happen too early and for every call. 

## QA steps

steps in bug report do not result in the controller model cloud credential to be invalidated. 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1848104
