### PR TITLE
State Package Method Name Consistency for Spaces and Subnets

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -125,7 +125,7 @@ type NetworkBacking interface {
 	// AllSubnets returns all backing subnets.
 	AllSubnets() ([]BackingSubnet, error)
 
-	Subnet(cidr string) (BackingSubnet, error)
+	SubnetByCIDR(cidr string) (BackingSubnet, error)
 
 	// ModelTag returns the tag of the model this state is associated to.
 	ModelTag() names.ModelTag

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -274,7 +274,7 @@ func (api *ProvisionerAPI) machineSubnetsAndZones(m *state.Machine) (map[string]
 			spaceName, m.Id(), includeSpaces[1:],
 		)
 	}
-	space, err := api.st.Space(spaceName)
+	space, err := api.st.SpaceByName(spaceName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -441,7 +441,7 @@ func (m *mockBackend) SpaceNamesByID() (map[string]string, error) {
 	return nil, nil
 }
 
-func (m *mockBackend) SpaceByID(_ string) (*state.Space, error) {
+func (m *mockBackend) Space(_ string) (*state.Space, error) {
 	return nil, nil
 }
 

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -550,7 +550,7 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceIDs []string) (map
 	for _, id := range spaceIDs {
 		space := environs.DefaultSpaceInfo
 		if id != network.DefaultSpaceId {
-			dbSpace, err := backend.SpaceByID(id)
+			dbSpace, err := backend.Space(id)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -333,7 +333,7 @@ func (m *mockState) ApplicationOffer(name string) (*jujucrossmodel.ApplicationOf
 	return &offer, nil
 }
 
-func (m *mockState) SpaceByID(id string) (applicationoffers.Space, error) {
+func (m *mockState) Space(id string) (applicationoffers.Space, error) {
 	space, ok := m.spaces[id]
 	if !ok {
 		return nil, errors.NotFoundf("space %q", id)

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -97,7 +97,7 @@ func (s stateShim) GetOfferUsers(offerUUID string) (map[string]permission.Access
 }
 
 func (s *stateShim) SpaceByID(id string) (Space, error) {
-	sp, err := s.st.Space(id)
+	sp, err := s.st.SpaceByName(id)
 	return &spaceShim{sp}, err
 }
 

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -59,7 +59,7 @@ type Backend interface {
 	ApplicationOffer(name string) (*crossmodel.ApplicationOffer, error)
 	Model() (Model, error)
 	OfferConnections(string) ([]OfferConnection, error)
-	SpaceByID(string) (Space, error)
+	Space(string) (Space, error)
 	User(names.UserTag) (User, error)
 
 	CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
@@ -96,8 +96,8 @@ func (s stateShim) GetOfferUsers(offerUUID string) (map[string]permission.Access
 	return s.st.GetOfferUsers(offerUUID)
 }
 
-func (s *stateShim) SpaceByID(id string) (Space, error) {
-	sp, err := s.st.SpaceByName(id)
+func (s *stateShim) Space(id string) (Space, error) {
+	sp, err := s.st.Space(id)
 	return &spaceShim{sp}, err
 }
 

--- a/apiserver/facades/client/bundle/mock_test.go
+++ b/apiserver/facades/client/bundle/mock_test.go
@@ -51,7 +51,7 @@ func (m *mockState) SpaceIDsByName() (map[string]string, error) {
 	return idsByName, nil
 }
 
-func (m *mockState) SpaceByID(_ string) (*state.Space, error) {
+func (m *mockState) Space(_ string) (*state.Space, error) {
 	return nil, nil
 }
 

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -53,7 +53,7 @@ func (s *stateShim) AllSpaces() ([]networkingcommon.BackingSpace, error) {
 }
 
 func (s *stateShim) Subnet(cidr string) (networkingcommon.BackingSubnet, error) {
-	result, err := s.State.Subnet(cidr)
+	result, err := s.State.SubnetByCIDR(cidr)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -52,7 +52,7 @@ func (s *stateShim) AllSpaces() ([]networkingcommon.BackingSpace, error) {
 	return spaces, nil
 }
 
-func (s *stateShim) Subnet(cidr string) (networkingcommon.BackingSubnet, error) {
+func (s *stateShim) SubnetByCIDR(cidr string) (networkingcommon.BackingSubnet, error) {
 	result, err := s.State.SubnetByCIDR(cidr)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -35,7 +35,7 @@ type Backing interface {
 	// ModelTag returns the tag of this model.
 	ModelTag() names.ModelTag
 
-	// Subnet return a subnet based on the given cidr.
+	// SubnetByCIDR return a subnet based on the given cidr.
 	Subnet(cidr string) (networkingcommon.BackingSubnet, error)
 
 	// AddSpace creates a space.

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -35,8 +35,8 @@ type Backing interface {
 	// ModelTag returns the tag of this model.
 	ModelTag() names.ModelTag
 
-	// SubnetByCIDR return a subnet based on the given cidr.
-	Subnet(cidr string) (networkingcommon.BackingSubnet, error)
+	// SubnetByCIDR returns a subnet based on the input CIDR.
+	SubnetByCIDR(cidr string) (networkingcommon.BackingSubnet, error)
 
 	// AddSpace creates a space.
 	AddSpace(Name string, ProviderId network.Id, Subnets []string, Public bool) error
@@ -219,7 +219,7 @@ func (api *API) createOneSpace(args params.CreateSpaceParams) error {
 		if !network.IsValidCidr(cidr) {
 			return errors.New(fmt.Sprintf("%q is not a valid CIDR", cidr))
 		}
-		subnet, err := api.backing.Subnet(cidr)
+		subnet, err := api.backing.SubnetByCIDR(cidr)
 		if err != nil {
 			return err
 		}

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -152,10 +152,10 @@ func (s *SpacesSuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 		apiservertesting.ZonedNetworkingEnvironCall("SupportsSpaces", s.callContext),
 	}
 
-	// If we have an expected error, no calls to Subnet() nor
+	// If we have an expected error, no calls to SubnetByCIDR() nor
 	// AddSpace() should be made.  Check the methods called and
 	// return.  The exception is TestAddSpacesAPIError cause an
-	// error after Subnet() is called.
+	// error after SubnetByCIDR() is called.
 	if p.Error != "" && !subnetCallMade() {
 		apiservertesting.CheckMethodCalls(c, apiservertesting.SharedStub, baseCalls...)
 		return
@@ -164,7 +164,7 @@ func (s *SpacesSuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 	allCalls := baseCalls
 	subnetIDs := []string{}
 	for _, cidr := range p.Subnets {
-		allCalls = append(allCalls, apiservertesting.BackingCall("Subnet", cidr))
+		allCalls = append(allCalls, apiservertesting.BackingCall("SubnetByCIDR", cidr))
 		for _, fakeSN := range apiservertesting.BackingInstance.Subnets {
 			if fakeSN.CIDR() == cidr {
 				subnetIDs = append(subnetIDs, fakeSN.ID())
@@ -182,7 +182,7 @@ func (s *SpacesSuite) checkAddSpaces(c *gc.C, p checkAddSpacesParams) {
 
 func subnetCallMade() bool {
 	for _, call := range apiservertesting.SharedStub.Calls() {
-		if call.FuncName == "Subnet" {
+		if call.FuncName == "SubnetByCIDR" {
 			return true
 		}
 	}

--- a/apiserver/facades/client/subnets/shims.go
+++ b/apiserver/facades/client/subnets/shims.go
@@ -59,7 +59,7 @@ func (s *stateShim) AllSubnets() ([]networkingcommon.BackingSubnet, error) {
 	return subnets, nil
 }
 
-func (s *stateShim) Subnet(cidr string) (networkingcommon.BackingSubnet, error) {
+func (s *stateShim) SubnetByCIDR(cidr string) (networkingcommon.BackingSubnet, error) {
 	result, err := s.State.SubnetByCIDR(cidr)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/subnets/shims.go
+++ b/apiserver/facades/client/subnets/shims.go
@@ -60,7 +60,7 @@ func (s *stateShim) AllSubnets() ([]networkingcommon.BackingSubnet, error) {
 }
 
 func (s *stateShim) Subnet(cidr string) (networkingcommon.BackingSubnet, error) {
-	result, err := s.State.Subnet(cidr)
+	result, err := s.State.SubnetByCIDR(cidr)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -43,7 +43,7 @@ type Backing interface {
 	// AllSubnets returns all backing subnets.
 	AllSubnets() ([]networkingcommon.BackingSubnet, error)
 
-	Subnet(cidr string) (networkingcommon.BackingSubnet, error)
+	SubnetByCIDR(cidr string) (networkingcommon.BackingSubnet, error)
 
 	// AllSpaces returns all known Juju network spaces.
 	AllSpaces() ([]networkingcommon.BackingSpace, error)

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -118,11 +118,11 @@ func (st *mockState) FirewallRule(service state.WellKnownServiceType) (*state.Fi
 	return r, nil
 }
 
-func (st *mockState) Subnet(cidr string) (firewaller.Subnet, error) {
+func (st *mockState) SubnetByCIDR(cidr string) (firewaller.Subnet, error) {
 	return nil, errors.NotImplementedf("SubnetByCIDR")
 }
 
-func (st *mockState) SubnetByID(id string) (firewaller.Subnet, error) {
+func (st *mockState) Subnet(id string) (firewaller.Subnet, error) {
 	return nil, errors.NotImplementedf("Subnet")
 }
 

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -119,11 +119,11 @@ func (st *mockState) FirewallRule(service state.WellKnownServiceType) (*state.Fi
 }
 
 func (st *mockState) Subnet(cidr string) (firewaller.Subnet, error) {
-	return nil, errors.NotImplementedf("Subnet")
+	return nil, errors.NotImplementedf("SubnetByCIDR")
 }
 
 func (st *mockState) SubnetByID(id string) (firewaller.Subnet, error) {
-	return nil, errors.NotImplementedf("SubnetByID")
+	return nil, errors.NotImplementedf("Subnet")
 }
 
 type mockWatcher struct {

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -26,9 +26,9 @@ type State interface {
 
 	FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error)
 
-	SubnetByID(id string) (Subnet, error)
+	Subnet(id string) (Subnet, error)
 
-	Subnet(cidr string) (Subnet, error)
+	SubnetByCIDR(cidr string) (Subnet, error)
 }
 
 // TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
@@ -58,8 +58,8 @@ func (st stateShim) WatchOpenedPorts() state.StringsWatcher {
 	return st.st.WatchOpenedPorts()
 }
 
-func (s stateShim) FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error) {
-	api := state.NewFirewallRules(s.st)
+func (st stateShim) FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error) {
+	api := state.NewFirewallRules(st.st)
 	return api.Rule(service)
 }
 
@@ -68,10 +68,10 @@ type Subnet interface {
 	CIDR() string
 }
 
-func (s stateShim) SubnetByID(id string) (Subnet, error) {
-	return s.st.Subnet(id)
+func (st stateShim) Subnet(id string) (Subnet, error) {
+	return st.st.Subnet(id)
 }
 
-func (s stateShim) Subnet(cidr string) (Subnet, error) {
-	return s.st.SubnetByCIDR(cidr)
+func (st stateShim) SubnetByCIDR(cidr string) (Subnet, error) {
+	return st.st.SubnetByCIDR(cidr)
 }

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -69,9 +69,9 @@ type Subnet interface {
 }
 
 func (s stateShim) SubnetByID(id string) (Subnet, error) {
-	return s.st.SubnetByID(id)
+	return s.st.Subnet(id)
 }
 
 func (s stateShim) Subnet(cidr string) (Subnet, error) {
-	return s.st.Subnet(cidr)
+	return s.st.SubnetByCIDR(cidr)
 }

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -165,7 +165,7 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 		providerId := network.Id("provider-" + subnetId)
 
 		// Pick the third element of the IP address and use this to
-		// decide how we construct the SubnetByCIDR. It provides variation of
+		// decide how we construct the Subnet. It provides variation of
 		// test data.
 		first, err := strconv.Atoi(strings.Split(subnetId, ".")[2])
 		if err != nil {
@@ -558,7 +558,7 @@ func (sb *StubBacking) AllSubnets() ([]networkingcommon.BackingSubnet, error) {
 	return output, nil
 }
 
-func (sb *StubBacking) Subnet(cidr string) (networkingcommon.BackingSubnet, error) {
+func (sb *StubBacking) SubnetByCIDR(cidr string) (networkingcommon.BackingSubnet, error) {
 	sb.MethodCall(sb, "SubnetByCIDR", cidr)
 	if err := sb.NextErr(); err != nil {
 		return nil, err

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -165,7 +165,7 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 		providerId := network.Id("provider-" + subnetId)
 
 		// Pick the third element of the IP address and use this to
-		// decide how we construct the Subnet. It provides variation of
+		// decide how we construct the SubnetByCIDR. It provides variation of
 		// test data.
 		first, err := strconv.Atoi(strings.Split(subnetId, ".")[2])
 		if err != nil {
@@ -559,7 +559,7 @@ func (sb *StubBacking) AllSubnets() ([]networkingcommon.BackingSubnet, error) {
 }
 
 func (sb *StubBacking) Subnet(cidr string) (networkingcommon.BackingSubnet, error) {
-	sb.MethodCall(sb, "Subnet", cidr)
+	sb.MethodCall(sb, "SubnetByCIDR", cidr)
 	if err := sb.NextErr(); err != nil {
 		return nil, err
 	}

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -139,7 +139,7 @@ func (s *cmdSpaceSuite) TestSpaceCreateNoSubnets(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, jc.Contains, "added space \"myspace\" with no subnets\n")
 
-	space, err := s.State.Space("myspace")
+	space, err := s.State.SpaceByName("myspace")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(space.Name(), gc.Equals, "myspace")
 	subnets, err := space.Subnets()
@@ -160,7 +160,7 @@ func (s *cmdSpaceSuite) TestSpaceCreateWithSubnets(c *gc.C) {
 		"added space \"myspace\" with subnets 10.10.0.0/16, 10.11.0.0/16\n",
 	)
 
-	space, err := s.State.Space("myspace")
+	space, err := s.State.SpaceByName("myspace")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(space.Name(), gc.Equals, "myspace")
 	subnets, err := space.Subnets()

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -107,7 +107,7 @@ func (s *cmdSubnetSuite) TestSubnetAddWithoutZonesWhenProviderHasZones(c *gc.C) 
 		"added subnet with CIDR \"0.10.0.0/24\" in space \"myspace\"\n",
 	)
 
-	subnet, err := s.State.Subnet("0.10.0.0/24")
+	subnet, err := s.State.SubnetByCIDR("0.10.0.0/24")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnet.CIDR(), gc.Equals, "0.10.0.0/24")
 	c.Assert(subnet.SpaceName(), gc.Equals, "myspace")
@@ -131,7 +131,7 @@ func (s *cmdSubnetSuite) TestSubnetAddWithZonesWithNoProviderZones(c *gc.C) {
 		"added subnet with ProviderId \"dummy-public\" in space \"myspace\"\n",
 	)
 
-	subnet, err := s.State.Subnet("0.20.0.0/24")
+	subnet, err := s.State.SubnetByCIDR("0.20.0.0/24")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnet.CIDR(), gc.Equals, "0.20.0.0/24")
 	c.Assert(subnet.SpaceName(), gc.Equals, "myspace")

--- a/network/containerizer/bridgepolicy_mock_test.go
+++ b/network/containerizer/bridgepolicy_mock_test.go
@@ -5,14 +5,13 @@
 package containerizer
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	set "github.com/juju/collections/set"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
+	reflect "reflect"
 )
 
 // MockContainer is a mock of Container interface
@@ -352,17 +351,17 @@ func (mr *MockAddressMockRecorder) DeviceName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeviceName", reflect.TypeOf((*MockAddress)(nil).DeviceName))
 }
 
-// SubnetByCIDR mocks base method
+// Subnet mocks base method
 func (m *MockAddress) Subnet() (Subnet, error) {
-	ret := m.ctrl.Call(m, "SubnetByCIDR")
+	ret := m.ctrl.Call(m, "Subnet")
 	ret0, _ := ret[0].(Subnet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SubnetByCIDR indicates an expected call of SubnetByCIDR
+// Subnet indicates an expected call of Subnet
 func (mr *MockAddressMockRecorder) Subnet() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetByCIDR", reflect.TypeOf((*MockAddress)(nil).Subnet))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockAddress)(nil).Subnet))
 }
 
 // MockSubnet is a mock of Subnet interface

--- a/network/containerizer/bridgepolicy_mock_test.go
+++ b/network/containerizer/bridgepolicy_mock_test.go
@@ -5,13 +5,14 @@
 package containerizer
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	set "github.com/juju/collections/set"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
-	reflect "reflect"
 )
 
 // MockContainer is a mock of Container interface
@@ -351,17 +352,17 @@ func (mr *MockAddressMockRecorder) DeviceName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeviceName", reflect.TypeOf((*MockAddress)(nil).DeviceName))
 }
 
-// Subnet mocks base method
+// SubnetByCIDR mocks base method
 func (m *MockAddress) Subnet() (Subnet, error) {
-	ret := m.ctrl.Call(m, "Subnet")
+	ret := m.ctrl.Call(m, "SubnetByCIDR")
 	ret0, _ := ret[0].(Subnet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Subnet indicates an expected call of Subnet
+// SubnetByCIDR indicates an expected call of SubnetByCIDR
 func (mr *MockAddressMockRecorder) Subnet() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockAddress)(nil).Subnet))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetByCIDR", reflect.TypeOf((*MockAddress)(nil).Subnet))
 }
 
 // MockSubnet is a mock of Subnet interface

--- a/network/containerizer/shim.go
+++ b/network/containerizer/shim.go
@@ -138,7 +138,7 @@ func (a *addressShim) Subnet() (Subnet, error) {
 	return a.Address.Subnet()
 }
 
-// Subnet is an indirection for state.Subnet
+// SubnetByCIDR is an indirection for state.SubnetByCIDR
 type Subnet interface {
 	SpaceID() string
 }

--- a/network/containerizer/shim.go
+++ b/network/containerizer/shim.go
@@ -138,7 +138,7 @@ func (a *addressShim) Subnet() (Subnet, error) {
 	return a.Address.Subnet()
 }
 
-// SubnetByCIDR is an indirection for state.SubnetByCIDR
+// Subnet is an indirection for state.Subnet
 type Subnet interface {
 	SpaceID() string
 }

--- a/state/address.go
+++ b/state/address.go
@@ -193,7 +193,7 @@ func (st *State) filterHostPortsForManagementSpace(
 
 	var hostPortsForAgents []network.SpaceHostPorts
 	if mgmtSpace := config.JujuManagementSpace(); mgmtSpace != network.DefaultSpaceName {
-		sp, err := st.Space(mgmtSpace)
+		sp, err := st.SpaceByName(mgmtSpace)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -525,7 +525,7 @@ func (st *State) ConvertSpaceHostPort(sHP network.SpaceHostPort) (network.Provid
 		NetPort:         sHP.NetPort,
 	}
 	if sHP.SpaceID != "" {
-		space, err := st.SpaceByID(sHP.SpaceID)
+		space, err := st.Space(sHP.SpaceID)
 		if err != nil {
 			return hp, errors.Trace(err)
 		}

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -264,7 +264,7 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string)
 
 		spaceID := addr.SpaceID
 		if spaceID != network.DefaultSpaceId && spaceID != "" {
-			space, err := st.SpaceByID(spaceID)
+			space, err := st.Space(spaceID)
 			if err != nil {
 				return errors.Annotatef(err, "retrieving space for ID %q", spaceID)
 			}

--- a/state/controller.go
+++ b/state/controller.go
@@ -162,7 +162,7 @@ func (st *State) checkSpaceIsAvailableToAllControllers(spaceName string) error {
 		return errors.Annotate(err, "cannot get controller info")
 	}
 
-	space, err := st.Space(spaceName)
+	space, err := st.SpaceByName(spaceName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -233,7 +233,7 @@ func (b *Bindings) updateOps(txnRevno int64, newMap map[string]string, newMeta *
 
 	// Ensure that the spaceIDs needed for the bindings exist.
 	for _, spID := range b.Map() {
-		sp, err := b.st.SpaceByID(spID)
+		sp, err := b.st.Space(spID)
 		if err != nil {
 			return ops, errors.Trace(err)
 		}
@@ -339,7 +339,7 @@ func (b *Bindings) validateForMachines() error {
 }
 
 func (b *Bindings) spaceNotFeasibleError(msg, id string) error {
-	space, err := b.st.SpaceByID(id)
+	space, err := b.st.Space(id)
 	if err != nil {
 		logger.Errorf(msg, id)
 		return errors.Annotatef(err, "cannot get space name for id %q", id)
@@ -445,7 +445,7 @@ func DefaultEndpointBindingsForCharm(charmMeta *charm.Meta) map[string]string {
 //
 //go:generate mockgen -package mocks -destination mocks/endpointbinding_mock.go github.com/juju/juju/state EndpointBinding
 type EndpointBinding interface {
-	SpaceByID(id string) (*Space, error)
+	Space(id string) (*Space, error)
 	SpaceIDsByName() (map[string]string, error)
 	SpaceNamesByID() (map[string]string, error)
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -223,7 +223,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	c.Assert(refCount, gc.Equals, 1)
 
 	// Check that the default space is created.
-	_, err = s.State.Space("")
+	_, err = s.State.SpaceByName("")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -162,7 +162,7 @@ func (s *ipAddressesStateSuite) TestSubnetMethodReturnsSubnet(c *gc.C) {
 
 func (s *ipAddressesStateSuite) TestSubnetMethodReturnsNotFoundErrorWhenMissing(c *gc.C) {
 	_, addresses := s.addNamedDeviceWithAddresses(c, "eth0", "10.20.30.41/16")
-	subnet, err := s.State.Subnet("10.20.0.0/16")
+	subnet, err := s.State.SubnetByCIDR("10.20.0.0/16")
 	c.Assert(err, jc.ErrorIsNil)
 	s.ensureEntityDeadAndRemoved(c, subnet)
 
@@ -350,7 +350,7 @@ func resetSubnet(c *gc.C, st *state.State, subnetInfo corenetwork.SubnetInfo) {
 	// We currently don't allow updating a subnet's information, so remove it
 	// and add it with the new value.
 	// XXX(jam): We should add mutation operations instead of this ugly hack
-	subnet, err := st.Subnet(subnetInfo.CIDR)
+	subnet, err := st.SubnetByCIDR(subnetInfo.CIDR)
 	c.Assert(err, jc.ErrorIsNil)
 	err = subnet.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
@@ -514,7 +514,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesOKWhenCIDRAddressDoesNotM
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenCIDRAddressMatchesDeadSubnet(c *gc.C) {
 	s.addNamedDevice(c, "eth0")
 	subnetCIDR := "10.20.0.0/16"
-	subnet, err := s.State.Subnet(subnetCIDR)
+	subnet, err := s.State.SubnetByCIDR(subnetCIDR)
 	c.Assert(err, jc.ErrorIsNil)
 	err = subnet.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -161,7 +161,7 @@ func (addr *Address) SubnetCIDR() string {
 // errors.NotFoundError if the address comes from an unknown subnet (i.e.
 // machine-local one).
 func (addr *Address) Subnet() (*Subnet, error) {
-	return addr.st.Subnet(addr.doc.SubnetCIDR)
+	return addr.st.SubnetByCIDR(addr.doc.SubnetCIDR)
 }
 
 // ConfigMethod returns the AddressConfigMethod used for this IP address.

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -736,7 +736,7 @@ func (m *Machine) newIPAddressDocFromArgs(args *LinkLayerDeviceAddress) (*ipAddr
 	}
 	addressValue := ip.String()
 	subnetCIDR := ipNet.String()
-	subnet, err := m.st.Subnet(subnetCIDR)
+	subnet, err := m.st.SubnetByCIDR(subnetCIDR)
 	if errors.IsNotFound(err) {
 		logger.Debugf(
 			"address %q on machine %q uses unknown or machine-local subnet %q",
@@ -834,7 +834,7 @@ func (m *Machine) setDevicesAddressesFromDocsOps(newDocs []ipAddressDoc) ([]txn.
 }
 
 func (m *Machine) maybeAssertSubnetAliveOps(newDoc *ipAddressDoc, opsSoFar []txn.Op) ([]txn.Op, error) {
-	subnet, err := m.st.Subnet(newDoc.SubnetCIDR)
+	subnet, err := m.st.SubnetByCIDR(newDoc.SubnetCIDR)
 	if errors.IsNotFound(err) {
 		// Subnet is machine-local, no need to assert whether it's alive.
 		return opsSoFar, nil

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -534,7 +534,7 @@ func (i *importer) machinePortsOps(m description.Machine) ([]txn.Op, error) {
 		if network.IsValidCidr(subnetID) {
 			// If we're migrating from a controller which has cidrs for
 			// subnetIDs, there can be only 1 of that cidr in the model.
-			subnet, err := i.st.Subnet(subnetID)
+			subnet, err := i.st.SubnetByCIDR(subnetID)
 			if err != nil {
 				return []txn.Op{}, errors.Trace(err)
 			}
@@ -1762,7 +1762,7 @@ func (i *importer) addSubnet(id string, args network.SubnetInfo) error {
 		}
 		subnet := &Subnet{st: i.st, doc: subnetDoc}
 		if attempt != 0 {
-			if _, err = i.st.SubnetByID(id); err == nil {
+			if _, err = i.st.Subnet(id); err == nil {
 				return nil, errors.AlreadyExistsf("subnet %q", args.CIDR)
 			}
 			if err := subnet.Refresh(); err != nil {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1730,7 +1730,7 @@ func (i *importer) subnets() error {
 		info.SetFan(subnet.FanLocalUnderlay(), subnet.FanOverlay())
 
 		if info.SpaceID == "" && info.SpaceName != "" {
-			space, err := i.st.Space(subnet.SpaceName())
+			space, err := i.st.SpaceByName(subnet.SpaceName())
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1308,7 +1308,7 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 		}
 	})
 
-	subnet, err := newSt.SubnetByID(original.ID())
+	subnet, err := newSt.Subnet(original.ID())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
@@ -1321,7 +1321,7 @@ func (s *MigrationImportSuite) TestSubnets(c *gc.C) {
 	c.Assert(subnet.FanOverlay(), gc.Equals, "")
 	c.Assert(subnet.IsPublic(), gc.Equals, true)
 
-	imported, err := newSt.Subnet(originalNoID.CIDR())
+	imported, err := newSt.SubnetByCIDR(originalNoID.CIDR())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(imported, gc.Not(gc.Equals), "")
 }
@@ -1348,7 +1348,7 @@ func (s *MigrationImportSuite) TestSubnetsWithFan(c *gc.C) {
 
 	_, newSt := s.importModel(c, s.State)
 
-	subnet, err = newSt.Subnet(original.CIDR())
+	subnet, err = newSt.SubnetByCIDR(original.CIDR())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1165,7 +1165,7 @@ func (s *MigrationImportSuite) TestSpaces(c *gc.C) {
 		}
 	})
 
-	imported, err := newSt.Space(space.Name())
+	imported, err := newSt.SpaceByName(space.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(imported.Id(), gc.Equals, space.Id())
@@ -1173,7 +1173,7 @@ func (s *MigrationImportSuite) TestSpaces(c *gc.C) {
 	c.Check(imported.ProviderId(), gc.Equals, space.ProviderId())
 	c.Check(imported.IsPublic(), gc.Equals, space.IsPublic())
 
-	imported, err = newSt.Space(spaceNoID.Name())
+	imported, err = newSt.SpaceByName(spaceNoID.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(imported.Id(), gc.Not(gc.Equals), "")
 }

--- a/state/mocks/endpointbinding_mock.go
+++ b/state/mocks/endpointbinding_mock.go
@@ -5,9 +5,10 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	state "github.com/juju/juju/state"
-	reflect "reflect"
 )
 
 // MockEndpointBinding is a mock of EndpointBinding interface
@@ -33,17 +34,17 @@ func (m *MockEndpointBinding) EXPECT() *MockEndpointBindingMockRecorder {
 	return m.recorder
 }
 
-// SpaceByID mocks base method
-func (m *MockEndpointBinding) SpaceByID(arg0 string) (*state.Space, error) {
-	ret := m.ctrl.Call(m, "SpaceByID", arg0)
+// Space mocks base method
+func (m *MockEndpointBinding) Space(arg0 string) (*state.Space, error) {
+	ret := m.ctrl.Call(m, "Space", arg0)
 	ret0, _ := ret[0].(*state.Space)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SpaceByID indicates an expected call of SpaceByID
-func (mr *MockEndpointBindingMockRecorder) SpaceByID(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceByID", reflect.TypeOf((*MockEndpointBinding)(nil).SpaceByID), arg0)
+// Space indicates an expected call of Space
+func (mr *MockEndpointBindingMockRecorder) Space(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Space", reflect.TypeOf((*MockEndpointBinding)(nil).Space), arg0)
 }
 
 // SpaceIDsByName mocks base method

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -335,7 +335,7 @@ func (s *ModelSuite) TestNewModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the default model was created.
-	_, err = st.Space(network.DefaultSpaceName)
+	_, err = st.SpaceByName(network.DefaultSpaceName)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/ports.go
+++ b/state/ports.go
@@ -259,7 +259,7 @@ func (p *Ports) verifySubnetAliveWhenSet() error {
 		return nil
 	}
 
-	subnet, err := p.st.SubnetByID(p.doc.SubnetID)
+	subnet, err := p.st.Subnet(p.doc.SubnetID)
 	if err != nil {
 		return errors.Trace(err)
 	} else if subnet.Life() != Alive {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -119,7 +119,7 @@ func (st *State) AddSpace(
 		}
 
 		for _, subnetId := range subnetIDs {
-			subnet, err := st.SubnetByID(subnetId)
+			subnet, err := st.Subnet(subnetId)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -456,7 +456,7 @@ func (s *SpacesSuite) TestSubnetsReturnsExpectedSubnets(c *gc.C) {
 
 	var expected []*state.Subnet
 	for _, cidr := range args.SubnetCIDRs {
-		subnet, err := s.State.Subnet(cidr)
+		subnet, err := s.State.SubnetByCIDR(cidr)
 		c.Assert(err, jc.ErrorIsNil)
 		expected = append(expected, subnet)
 	}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -75,7 +75,7 @@ func (s *SpacesSuite) assertSpaceNotFound(c *gc.C, name string) {
 }
 
 func (s *SpacesSuite) assertSpaceNotFoundForState(c *gc.C, name string, st *state.State) {
-	_, err := st.Space(name)
+	_, err := st.SpaceByName(name)
 	s.assertSpaceNotFoundError(c, err, name)
 }
 
@@ -466,7 +466,7 @@ func (s *SpacesSuite) TestSubnetsReturnsExpectedSubnets(c *gc.C) {
 }
 
 func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
-	defaultSpace, err := s.State.Space("")
+	defaultSpace, err := s.State.SpaceByName("")
 	c.Assert(err, jc.ErrorIsNil)
 
 	spaces, err := s.State.AllSpaces()
@@ -490,12 +490,12 @@ func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
 }
 
 func (s *SpacesSuite) TestSpaceByID(c *gc.C) {
-	_, err := s.State.SpaceByID(network.DefaultSpaceId)
+	_, err := s.State.Space(network.DefaultSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *SpacesSuite) TestSpaceByIDNotFound(c *gc.C) {
-	_, err := s.State.SpaceByID("42")
+	_, err := s.State.Space("42")
 	c.Assert(err, gc.ErrorMatches, "space id \"42\" not found")
 }
 
@@ -565,7 +565,7 @@ func (s *SpacesSuite) TestRemoveSucceedsWhenCalledTwice(c *gc.C) {
 
 func (s *SpacesSuite) TestRefreshUpdatesStaleDocData(c *gc.C) {
 	space := s.addAliveSpace(c, "original")
-	spaceCopy, err := s.State.Space(space.Name())
+	spaceCopy, err := s.State.SpaceByName(space.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.ensureDeadAndAssertLifeIsDead(c, space)

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -155,7 +155,7 @@ func (s *Subnet) SpaceName() string {
 	if s.spaceID == "" {
 		return network.DefaultSpaceName
 	}
-	sp, err := s.st.SpaceByID(s.spaceID)
+	sp, err := s.st.Space(s.spaceID)
 	if err != nil {
 		logger.Errorf("error finding space %q: %s", s.spaceID, err)
 		return network.DefaultSpaceName
@@ -247,7 +247,7 @@ func (s *Subnet) Update(args network.SubnetInfo) error {
 		if makeSpaceNameUpdate {
 			// TODO (hml) 2019-07-25
 			// Update for SpaceID once SubnetInfo Updated
-			sp, err := s.st.Space(args.SpaceName)
+			sp, err := s.st.SpaceByName(args.SpaceName)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -278,7 +278,7 @@ func (s *Subnet) Update(args network.SubnetInfo) error {
 
 func (s *Subnet) updateSpaceName(spaceName string) (bool, error) {
 	var spaceNameChange bool
-	sp, err := s.st.SpaceByID(s.doc.SpaceID)
+	sp, err := s.st.Space(s.doc.SpaceID)
 	switch {
 	case err != nil && !errors.IsNotFound(err):
 		return false, errors.Trace(err)

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -49,7 +49,7 @@ func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
 	s.assertSubnetMatchesInfo(c, subnet, subnetInfo)
 
 	// check it's been stored in state by fetching it back again
-	subnetFromDB, err := s.State.Subnet("192.168.1.0/24")
+	subnetFromDB, err := s.State.SubnetByCIDR("192.168.1.0/24")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSubnetMatchesInfo(c, subnetFromDB, subnetInfo)
 }
@@ -245,7 +245,7 @@ func (s *SubnetSuite) removeSubnetAndAssertNotFound(c *gc.C, subnet *state.Subne
 }
 
 func (s *SubnetSuite) assertSubnetWithCIDRNotFound(c *gc.C, cidr string) {
-	_, err := s.State.Subnet(cidr)
+	_, err := s.State.SubnetByCIDR(cidr)
 	s.assertSubnetNotFoundError(c, err)
 }
 
@@ -265,7 +265,7 @@ func (s *SubnetSuite) TestRemoveSucceedsWhenCalledTwice(c *gc.C) {
 
 func (s *SubnetSuite) TestRefreshUpdatesStaleDocData(c *gc.C) {
 	subnet := s.addAliveSubnet(c, "fc00::/64")
-	subnetCopy, err := s.State.Subnet("fc00::/64")
+	subnetCopy, err := s.State.SubnetByCIDR("fc00::/64")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.ensureDeadAndAssertLifeIsDead(c, subnet)

--- a/state/unit.go
+++ b/state/unit.go
@@ -1444,7 +1444,7 @@ func (u *Unit) checkSubnetAliveWhenSet(subnetID string) error {
 		return errors.Errorf("invalid subnet ID %q", subnetID)
 	}
 
-	subnet, err := u.st.SubnetByID(subnetID)
+	subnet, err := u.st.Subnet(subnetID)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Annotatef(err, "getting subnet %q", subnetID)
 	} else if errors.IsNotFound(err) || subnet.Life() != Alive {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2428,7 +2428,7 @@ func ChangeSubnetSpaceNameToSpaceID(pool *StatePool) (err error) {
 			if sDoc.SpaceName == network.DefaultSpaceName {
 				id = network.DefaultSpaceId
 			} else {
-				space, err := st.Space(sDoc.SpaceName)
+				space, err := st.SpaceByName(sDoc.SpaceName)
 				if err != nil {
 					return errors.Trace(err)
 				}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2535,7 +2535,7 @@ func ReplacePortsDocSubnetIDCIDR(pool *StatePool) (err error) {
 
 			// If we're upgrading from a model which has cidrs for
 			// subnetIDs, there can be only 1 of that cidr in the model.
-			subnet, err := st.Subnet(oldDoc.SubnetID)
+			subnet, err := st.SubnetByCIDR(oldDoc.SubnetID)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -46,7 +46,7 @@ func (s StateShim) RemoveControllerReference(c ControllerNode) error {
 }
 
 func (s StateShim) Space(name string) (Space, error) {
-	return s.State.Space(name)
+	return s.State.SpaceByName(name)
 }
 
 // cloudServiceShim stubs out functionality not yet


### PR DESCRIPTION
## Description of change

During the network model refactoring work, two new methods were added to the `state` package:
- `SpaceByID`
- `SubnetByID`

This patch is simple mechanical changes to rename methods so they are consistent with expectations:
- `Space` -> `SpaceByName`
- `SpaceByID` -> `Space`
- `Subnet` -> `SubnetByCIDR`
- `SubnetByID` -> `Subnet`

Where possible generated mocks are edited in-place. They work, so I saw no reason to re-create them.

## QA steps

No functional changes; tests pass.

## Documentation changes

None.

## Bug reference

N/A
