### PR TITLE
Clean up branches on model destroy

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -54,8 +54,9 @@ const (
 	// CAAS models require storage to be cleaned up.
 	cleanupDyingUnitResources cleanupKind = "dyingUnitResources"
 
-	cleanupResourceBlob         cleanupKind = "resourceBlob"
-	cleanupStorageForDyingModel cleanupKind = "modelStorage"
+	cleanupResourceBlob          cleanupKind = "resourceBlob"
+	cleanupStorageForDyingModel  cleanupKind = "modelStorage"
+	cleanupBranchesForDyingModel cleanupKind = "branches"
 )
 
 // cleanupDoc originally represented a set of documents that should be
@@ -195,6 +196,8 @@ func (st *State) Cleanup() (err error) {
 			err = st.cleanupResourceBlob(doc.Prefix)
 		case cleanupStorageForDyingModel:
 			err = st.cleanupStorageForDyingModel(args)
+		case cleanupBranchesForDyingModel:
+			err = st.cleanupBranchesForDyingModel(args)
 		default:
 			err = errors.Errorf("unknown cleanup kind %q", doc.Kind)
 		}
@@ -449,6 +452,14 @@ func (st *State) cleanupStorageForDyingModel(cleanupArgs []bson.Raw) (err error)
 		} else if err != nil {
 			return errors.Trace(err)
 		}
+	}
+	return nil
+}
+
+func (st *State) cleanupBranchesForDyingModel(cleanupArgs []bson.Raw) (err error) {
+	change := branchesCleanupChange{}
+	if err := Apply(st.database, change); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -313,6 +313,41 @@ func (s *CleanupSuite) TestCleanupRelationSettings(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot read settings for unit "riak/0" in relation "riak:ring": unit "riak/0": settings not found`)
 }
 
+func (s *CleanupSuite) TestCleanupModelBranches(c *gc.C) {
+	s.assertDoesNotNeedCleanup(c)
+
+	// Create a branch.
+	c.Assert(s.Model.AddBranch(newBranchName, newBranchCreator), jc.ErrorIsNil)
+	branches, err := s.State.Branches()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(branches, gc.HasLen, 1)
+	s.assertDoesNotNeedCleanup(c)
+
+	// Destroy the model and check the branches unaffected, but a cleanup for
+	// the branches has been scheduled.
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.Destroy(state.DestroyModelParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertNeedsCleanup(c)
+	s.assertCleanupCount(c, 1)
+
+	s.assertCleanupRuns(c)
+	err = model.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertCleanupCount(c, 0)
+
+	_, err = s.Model.Branch(newBranchName)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	branches, err = s.State.Branches()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(branches, gc.HasLen, 0)
+
+	// Now we should have all the cleanups done
+	s.assertDoesNotNeedCleanup(c)
+}
+
 func (s *CleanupSuite) TestDestroyControllerMachineErrors(c *gc.C) {
 	manager, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/model.go
+++ b/state/model.go
@@ -1343,6 +1343,8 @@ func (m *Model) destroyOps(
 			ops = append(ops, newCleanupOp(cleanupStorageForDyingModel, modelUUID, args))
 		}
 	}
+	// Ensure we clean up the branches upon clean up of a model.
+	ops = append(ops, newCleanupOp(cleanupBranchesForDyingModel, modelUUID, args))
 	return append(prereqOps, ops...), nil
 }
 

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -432,6 +432,30 @@ func (s *generationSuite) TestApplicationBranches(c *gc.C) {
 	c.Assert(appBranchesATake2, gc.DeepEquals, appBranchesA)
 }
 
+func (s *generationSuite) TestDestroyCleansupBranches(c *gc.C) {
+	s.setupTestingClock(c)
+
+	branches, err := s.State.Branches()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(branches, gc.HasLen, 0)
+
+	_ = s.addBranch(c)
+
+	branches, err = s.State.Branches()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(branches, gc.HasLen, 1)
+	c.Check(branches[0].BranchName(), gc.Equals, newBranchName)
+
+	c.Assert(s.Model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+	c.Assert(s.Model.Refresh(), jc.ErrorIsNil)
+	assertNeedsCleanup(c, s.State)
+	assertCleanupRuns(c, s.State)
+
+	branches, err = s.State.Branches()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(branches, gc.HasLen, 0)
+}
+
 func (s *generationSuite) setupAssignAllUnits(c *gc.C) *state.Generation {
 	var cfgYAML = `
 options:

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -263,6 +263,17 @@ wait_for() {
     done
 }
 
+idle_condition() {
+    local name app_index unit_index
+
+    name=${1}
+    app_index=${2:-0}
+    unit_index=${3:-0}
+
+    echo ".applications | select(.$name | .units | .[\"$name/$unit_index\"] | .[\"juju-status\"] | .current == \"idle\") | keys[$app_index]"
+    exit 0
+}
+
 introspect_controller() {
     local name
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -26,11 +26,12 @@ import_subdir_files includes
 
 # If adding a test suite, then ensure to add it here to be picked up!
 TEST_NAMES="test_static_analysis \
+            test_branches \
+            test_cli \
             test_controller \
-            test_smoke \
             test_cmr_bundles \
             test_machine \
-            test_cli"
+            test_smoke"
 
 show_help() {
     version=$(juju version)

--- a/tests/suites/branches/README.md
+++ b/tests/suites/branches/README.md
@@ -1,0 +1,1 @@
+# Branches test suite

--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -1,0 +1,44 @@
+run_branch() {
+    # Echo out to ensure nice output to the test suite.
+    echo
+
+    # The following ensures that a bootstrap juju exists
+    file="${TEST_DIR}/test-branches.txt"
+    ensure "branches" "${file}"
+
+    juju branch | grep -q 'Active branch is "master"'
+
+    juju deploy redis
+
+    wait_for "redis" ".applications | select(.redis | .units | .[\"redis/0\"] | .[\"juju-status\"] | .current == \"idle\") | keys[0]"
+
+    set -ux
+
+    juju add-branch test-branch
+    juju branch | grep -q 'Active branch is "test-branch"'
+
+    juju config redis password=pass --branch test-branch
+    juju config redis password --branch test-branch | grep -q "pass"
+    juju config redis password --branch master | wc -c | grep -q "0"
+
+    juju commit test-branch | grep -q 'Active branch set to "master"'
+    juju config redis password | grep -q "pass"
+
+    # Clean up!
+    destroy_model "branches"
+}
+
+test_branch() {
+    if [ -n "$(skip 'test_branch')" ]; then
+        echo "==> SKIP: Asked to skip branch tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_branch"
+    )
+}

--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -10,9 +10,7 @@ run_branch() {
 
     juju deploy redis
 
-    wait_for "redis" ".applications | select(.redis | .units | .[\"redis/0\"] | .[\"juju-status\"] | .current == \"idle\") | keys[0]"
-
-    set -ux
+    wait_for "redis" "$(idle_condition "redis")"
 
     juju add-branch test-branch
     juju branch | grep -q 'Active branch is "test-branch"'

--- a/tests/suites/branches/task.sh
+++ b/tests/suites/branches/task.sh
@@ -1,0 +1,21 @@
+test_branches() {
+    if [ "$(skip 'test_branches')" ]; then
+        echo "==> TEST SKIPPED: branches tests"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju
+
+    file="${TEST_DIR}/test-branch.txt"
+
+    export JUJU_DEV_FEATURE_FLAGS=generations
+
+    bootstrap "test-branch" "${file}"
+
+    test_branch
+
+    destroy_controller "test-branch"
+}


### PR DESCRIPTION
## Description of change

The following cleans up any branches associated with a model, when
the model is destroyed. Ensuring two things:

 1. We remove any orphaned branch models from the db
 2. We ensure that there won't be any conflicts from leaving any
    branches around.

The code attempts to use the latest Apply change strategy, which
applies a visitor pattern to a change operation to clean up the
branches.

It would be nice for these strategies to be moved out from state
and fully mocked, but probably not today!

## QA steps

TBA

