### PR TITLE
Refactor track error + update mockgen

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -260,11 +260,14 @@
   revision = "44145f04b68cf362d9c4df2182967c2275eaefed"
 
 [[projects]]
-  digest = "1:718dbab642c6d914aff8fedee621bb4f017acaa75a13dcb84af8ecf354d11585"
+  digest = "1:48448440bcf4465b2aedc1fc92c61beaeffcc056932b4afdcb9a75a059b5211d"
   name = "github.com/golang/mock"
-  packages = ["gomock"]
+  packages = [
+    "gomock",
+    "mockgen/model",
+  ]
   pruneopts = ""
-  revision = "600781dde9cca80734169b9e969d9054ccc57937"
+  revision = "d74b93584564161b2de771089ee697f07d8bd5b5"
 
 [[projects]]
   digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -239,7 +239,7 @@
 
 [[constraint]]
   name = "github.com/golang/mock"
-  revision = "600781dde9cca80734169b9e969d9054ccc57937"
+  revision = "d74b93584564161b2de771089ee697f07d8bd5b5"
 
 [[constraint]]
   name = "github.com/google/go-querystring"

--- a/cmd/juju/model/mocks/abort_mock.go
+++ b/cmd/juju/model/mocks/abort_mock.go
@@ -34,6 +34,7 @@ func (m *MockAbortCommandAPI) EXPECT() *MockAbortCommandAPIMockRecorder {
 
 // AbortBranch mocks base method
 func (m *MockAbortCommandAPI) AbortBranch(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AbortBranch", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -41,11 +42,13 @@ func (m *MockAbortCommandAPI) AbortBranch(arg0 string) error {
 
 // AbortBranch indicates an expected call of AbortBranch
 func (mr *MockAbortCommandAPIMockRecorder) AbortBranch(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AbortBranch", reflect.TypeOf((*MockAbortCommandAPI)(nil).AbortBranch), arg0)
 }
 
 // Close mocks base method
 func (m *MockAbortCommandAPI) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -53,11 +56,13 @@ func (m *MockAbortCommandAPI) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockAbortCommandAPIMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAbortCommandAPI)(nil).Close))
 }
 
 // HasActiveBranch mocks base method
 func (m *MockAbortCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasActiveBranch", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -66,5 +71,6 @@ func (m *MockAbortCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
 
 // HasActiveBranch indicates an expected call of HasActiveBranch
 func (mr *MockAbortCommandAPIMockRecorder) HasActiveBranch(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasActiveBranch", reflect.TypeOf((*MockAbortCommandAPI)(nil).HasActiveBranch), arg0)
 }

--- a/cmd/juju/model/mocks/trackbranch_mock.go
+++ b/cmd/juju/model/mocks/trackbranch_mock.go
@@ -34,6 +34,7 @@ func (m *MockTrackBranchCommandAPI) EXPECT() *MockTrackBranchCommandAPIMockRecor
 
 // Close mocks base method
 func (m *MockTrackBranchCommandAPI) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -41,11 +42,28 @@ func (m *MockTrackBranchCommandAPI) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockTrackBranchCommandAPIMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).Close))
+}
+
+// HasActiveBranch mocks base method
+func (m *MockTrackBranchCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasActiveBranch", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasActiveBranch indicates an expected call of HasActiveBranch
+func (mr *MockTrackBranchCommandAPIMockRecorder) HasActiveBranch(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasActiveBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).HasActiveBranch), arg0)
 }
 
 // TrackBranch mocks base method
 func (m *MockTrackBranchCommandAPI) TrackBranch(arg0 string, arg1 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TrackBranch", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -53,5 +71,6 @@ func (m *MockTrackBranchCommandAPI) TrackBranch(arg0 string, arg1 []string) erro
 
 // TrackBranch indicates an expected call of TrackBranch
 func (mr *MockTrackBranchCommandAPIMockRecorder) TrackBranch(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).TrackBranch), arg0, arg1)
 }

--- a/cmd/juju/model/trackbranch_test.go
+++ b/cmd/juju/model/trackbranch_test.go
@@ -55,6 +55,30 @@ func (s *trackBranchSuite) TestInitInvalid(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid application or unit name "test me"`)
 }
 
+func (s *trackBranchSuite) TestRunCommandValidBranchMissingArg(c *gc.C) {
+	mockController, api := setUpAdvanceMocks(c)
+	defer mockController.Finish()
+
+	api.EXPECT().HasActiveBranch(s.branchName).Return(true, nil)
+
+	_, err := s.runCommand(c, api, s.branchName)
+	c.Assert(err, gc.NotNil)
+	msg := err.Error()
+	c.Assert(msg, gc.Equals, `expected unit and/or application names(s)`)
+}
+
+func (s *trackBranchSuite) TestRunCommandInValidBranchMissingArg(c *gc.C) {
+	mockController, api := setUpAdvanceMocks(c)
+	defer mockController.Finish()
+
+	api.EXPECT().HasActiveBranch("test").Return(false, nil)
+
+	_, err := s.runCommand(c, api, "test")
+	c.Assert(err, gc.NotNil)
+	msg := err.Error()
+	c.Assert(msg, gc.Equals, `branch "test" not found`)
+}
+
 func (s *trackBranchSuite) TestRunCommand(c *gc.C) {
 	mockController, api := setUpAdvanceMocks(c)
 	defer mockController.Finish()


### PR DESCRIPTION
## Description of change

- update mockgen dep to newest release (not commit)
- change error message to be more specific from trackbranches e.g. `juju track bla/0` can either return
  - `bla/0 is not a current branch`
  - or `expected unit and/or application names(s)`
- it now checks if the arg is a branch first, before returning the err msg
## QA steps


`juju deploy ubuntu`
`juju add-branch test`
`juju track ubuntu/0` 
returns: `ERROR branch "ubuntu/0" not found`
`juju track test` 
returns: `expected unit and/or application names(s)`

## Bug reference

https://bugs.launchpad.net/juju/+bug/1834552