### PR TITLE
[Dev] environ NetworkInterfaces for multiple instances

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
@@ -212,7 +213,8 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	interfaceInfos, err := netEnviron.NetworkInterfaces(state.CallContext(api.st), instId)
+
+	interfaceInfos, err := netEnviron.NetworkInterfaces(state.CallContext(api.st), []instance.Id{instId})
 	if errors.IsNotSupported(err) {
 		// It's possible to have a networking environ, but not support
 		// NetworkInterfaces(). In leiu of adding SupportsNetworkInterfaces():
@@ -221,12 +223,12 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	} else if err != nil {
 		return nil, errors.Annotatef(err, "cannot get network interfaces of %q", instId)
 	}
-	if len(interfaceInfos) == 0 {
+	if len(interfaceInfos) == 0 || len(interfaceInfos[0]) == 0 {
 		logger.Infof("no provider network interfaces found")
 		return nil, nil
 	}
 
-	providerConfig := NetworkConfigFromInterfaceInfo(interfaceInfos)
+	providerConfig := NetworkConfigFromInterfaceInfo(interfaceInfos[0])
 	logger.Tracef("provider network config instance %q: %+v", instId, providerConfig)
 
 	return providerConfig, nil

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -35,9 +35,13 @@ type Networking interface {
 	// for EC2 VPC.
 	SuperSubnets(ctx context.ProviderCallContext) ([]string, error)
 
-	// NetworkInterfaces requests information about the network
-	// interfaces on the given instance.
-	NetworkInterfaces(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error)
+	// NetworkInterfaces returns a slice with the network interfaces that
+	// correpsond to the given instance IDs. If no instances where found,
+	// but there was no other error, it will return ErrNoInstances. If some
+	// but not all of the instances were found, the returned slice will
+	// have some nil slots, and an ErrPartialInstances error will be
+	// returned.
+	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error)
 
 	// SupportsSpaces returns whether the current environment supports
 	// spaces. The returned error satisfies errors.IsNotSupported(),

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -285,16 +285,19 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		DNSServers:       corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
 		GatewayAddress:   corenetwork.NewProviderAddress("0.30.0.1"),
 	}}
-	info, err := e.NetworkInterfaces(s.callCtx, "i-42")
+	infoList, err := e.NetworkInterfaces(s.callCtx, []instance.Id{instance.Id("i-42")})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infoList, gc.HasLen, 1)
+	info := infoList[0]
+
 	c.Assert(info, jc.DeepEquals, expectInfo)
 	assertInterfaces(c, e, opc, "i-42", expectInfo)
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "NetworkInterfaces")
-	info, err = e.NetworkInterfaces(s.callCtx, "i-any")
+	infoList, err = e.NetworkInterfaces(s.callCtx, []instance.Id{instance.Id("i-any")})
 	c.Assert(err, gc.ErrorMatches, `dummy\.NetworkInterfaces is broken`)
-	c.Assert(info, gc.HasLen, 0)
+	c.Assert(infoList, gc.HasLen, 0)
 }
 
 func (s *suite) TestSubnets(c *gc.C) {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -979,18 +979,132 @@ func (e *environ) gatherInstances(
 
 // NetworkInterfaces implements NetworkingEnviron.NetworkInterfaces.
 func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error) {
-	var (
-		infos = make([][]network.InterfaceInfo, len(ids))
-		err   error
-	)
-
-	for idx, id := range ids {
-		if infos[idx], err = e.networkInterfacesForInstance(ctx, id); err != nil {
+	switch len(ids) {
+	case 0:
+		return nil, environs.ErrNoInstances
+	case 1: // short-cut for single instance
+		ifList, err := e.networkInterfacesForInstance(ctx, ids[0])
+		if err != nil {
 			return nil, err
+		}
+		return [][]network.InterfaceInfo{ifList}, nil
+	}
+
+	// Collect all available subnets into a map where keys are subnet IDs
+	// and values are subnets. We will use this map to resolve subnets
+	// for the bulk network interface info requests below.
+	subMap, err := e.subnetMap()
+	if err != nil {
+		return nil, errors.Annotate(maybeConvertCredentialError(err, ctx), "failed to retrieve subnet info")
+	}
+
+	infos := make([][]network.InterfaceInfo, len(ids))
+	idToInfosIndex := make(map[string]int)
+	for idx, id := range ids {
+		idToInfosIndex[string(id)] = idx
+	}
+
+	// Make a series of requests to cope with eventual consistency.  Each
+	// request will attempt to add more network interface queries to the
+	// requested set till we eventually obtain the full set of data.
+	for a := shortAttempt.Start(); a.Next(); {
+		var need []string
+		for idx, info := range infos {
+			if info == nil {
+				need = append(need, string(ids[idx]))
+			}
+		}
+
+		// Network interfaces are not currently tagged so we cannot
+		// use a model filter here.
+		filter := ec2.NewFilter()
+		filter.Add("attachment.instance-id", need...)
+		logger.Tracef("retrieving NICs for instances %v", need)
+		err = e.gatherNetworkInterfaceInfo(ctx, filter, infos, idToInfosIndex, subMap)
+		if err == nil || err != environs.ErrPartialInstances {
+			break
 		}
 	}
 
+	if err == environs.ErrPartialInstances {
+		for _, info := range infos {
+			if info != nil {
+				return infos, environs.ErrPartialInstances
+			}
+		}
+		return nil, environs.ErrNoInstances
+	}
+	if err != nil {
+		return nil, err
+	}
 	return infos, nil
+}
+
+// subnetMap returns a map with all known ec2.Subnets and their IDs as keys.
+func (e *environ) subnetMap() (map[string]ec2.Subnet, error) {
+	subnetsResp, err := e.ec2.Subnets(nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	subMap := make(map[string]ec2.Subnet, len(subnetsResp.Subnets))
+	for _, sub := range subnetsResp.Subnets {
+		subMap[sub.Id] = sub
+	}
+	return subMap, nil
+}
+
+// gatherNetworkInterfaceInfo executes a filtered network interface lookup,
+// parses the results and appends them to the correct infos slot based on
+// the attachment instance ID information for each result.
+//
+// This method returns environs.ErrPartialInstances if the infos slice contains
+// any nil entries.
+func (e *environ) gatherNetworkInterfaceInfo(
+	ctx context.ProviderCallContext,
+	filter *ec2.Filter,
+	infos [][]network.InterfaceInfo,
+	idToInfosIndex map[string]int,
+	subMap map[string]ec2.Subnet,
+) error {
+	// Check how many queries have already been answered; machines must
+	// have at least one network interface attached to them.
+	pending := len(infos)
+	for _, info := range infos {
+		if len(info) != 0 {
+			pending--
+		}
+	}
+
+	// Run query
+	networkInterfacesResp, err := e.ec2.NetworkInterfaces(nil, filter)
+	if err != nil {
+		return maybeConvertCredentialError(err, ctx)
+	}
+
+	for _, netIfSpec := range networkInterfacesResp.Interfaces {
+		idx, found := idToInfosIndex[netIfSpec.Attachment.InstanceId]
+		if !found {
+			continue
+		} else if infos[idx] == nil {
+			// This is the first (and perhaps only) interface that
+			// we obtained for this instance. Decrement the number
+			// of pending queries.
+			pending--
+		}
+
+		subnet, found := subMap[netIfSpec.SubnetId]
+		if !found {
+			return errors.NotFoundf("info for subnet %q", netIfSpec.SubnetId)
+		}
+
+		infos[idx] = append(infos[idx], mapNetworkInterface(netIfSpec, subnet))
+	}
+
+	if pending != 0 {
+		return environs.ErrPartialInstances
+	}
+	return nil
 }
 
 func (e *environ) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
@@ -1033,27 +1147,29 @@ func (e *environ) networkInterfacesForInstance(ctx context.ProviderCallContext, 
 		if len(resp.Subnets) != 1 {
 			return nil, errors.Errorf("expected 1 subnet, got %d", len(resp.Subnets))
 		}
-		subnet := resp.Subnets[0]
-		cidr := subnet.CIDRBlock
 
-		result[i] = network.InterfaceInfo{
-			DeviceIndex:       iface.Attachment.DeviceIndex,
-			MACAddress:        iface.MACAddress,
-			CIDR:              cidr,
-			ProviderId:        corenetwork.Id(iface.Id),
-			ProviderSubnetId:  corenetwork.Id(iface.SubnetId),
-			AvailabilityZones: []string{subnet.AvailZone},
-			VLANTag:           0, // Not supported on EC2.
-			// Getting the interface name is not supported on EC2, so fake it.
-			InterfaceName: fmt.Sprintf("unsupported%d", iface.Attachment.DeviceIndex),
-			Disabled:      false,
-			NoAutoStart:   false,
-			ConfigType:    network.ConfigDHCP,
-			InterfaceType: network.EthernetInterface,
-			Address:       corenetwork.NewScopedProviderAddress(iface.PrivateIPAddress, corenetwork.ScopeCloudLocal),
-		}
+		result[i] = mapNetworkInterface(iface, resp.Subnets[0])
 	}
 	return result, nil
+}
+
+func mapNetworkInterface(iface ec2.NetworkInterface, subnet ec2.Subnet) network.InterfaceInfo {
+	return network.InterfaceInfo{
+		DeviceIndex:       iface.Attachment.DeviceIndex,
+		MACAddress:        iface.MACAddress,
+		CIDR:              subnet.CIDRBlock,
+		ProviderId:        corenetwork.Id(iface.Id),
+		ProviderSubnetId:  corenetwork.Id(iface.SubnetId),
+		AvailabilityZones: []string{subnet.AvailZone},
+		VLANTag:           0, // Not supported on EC2.
+		// Getting the interface name is not supported on EC2, so fake it.
+		InterfaceName: fmt.Sprintf("unsupported%d", iface.Attachment.DeviceIndex),
+		Disabled:      false,
+		NoAutoStart:   false,
+		ConfigType:    network.ConfigDHCP,
+		InterfaceType: network.EthernetInterface,
+		Address:       corenetwork.NewScopedProviderAddress(iface.PrivateIPAddress, corenetwork.ScopeCloudLocal),
+	}
 }
 
 func makeSubnetInfo(

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1609,8 +1609,10 @@ func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.Networ
 
 func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
-	interfaces, err := env.NetworkInterfaces(t.callCtx, instId)
+	interfaceList, err := env.NetworkInterfaces(t.callCtx, []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(interfaceList, gc.HasLen, 1)
+	interfaces := interfaceList[0]
 
 	// The CIDR isn't predictable, but it is in the 10.10.x.0/24 format
 	// The subnet ID is in the form "subnet-x", where x matches the same
@@ -1658,16 +1660,20 @@ func (t *localServerSuite) TestSubnetsWithInstanceId(c *gc.C) {
 	c.Assert(subnets, gc.HasLen, 1)
 	validateSubnets(c, subnets, "")
 
-	interfaces, err := env.NetworkInterfaces(t.callCtx, instId)
+	interfaceList, err := env.NetworkInterfaces(t.callCtx, []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(interfaceList, gc.HasLen, 1)
+	interfaces := interfaceList[0]
 	c.Assert(interfaces, gc.HasLen, 1)
 	c.Assert(interfaces[0].ProviderSubnetId, gc.Equals, subnets[0].ProviderId)
 }
 
 func (t *localServerSuite) TestSubnetsWithInstanceIdAndSubnetId(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
-	interfaces, err := env.NetworkInterfaces(t.callCtx, instId)
+	interfaceList, err := env.NetworkInterfaces(t.callCtx, []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(interfaceList, gc.HasLen, 1)
+	interfaces := interfaceList[0]
 	c.Assert(interfaces, gc.HasLen, 1)
 
 	subnets, err := env.Subnets(t.callCtx, instId, []corenetwork.Id{interfaces[0].ProviderSubnetId})

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1607,20 +1607,78 @@ func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.Networ
 	return env, instanceIds[0]
 }
 
+func (t *localServerSuite) TestNetworkInterfacesForMultipleInstances(c *gc.C) {
+	// Start three instances
+	env := t.prepareEnviron(c)
+	testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "1")
+	testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "2")
+	testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "3")
+
+	// Get a list of running instance IDs
+	instances, err := env.AllInstances(t.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	var ids = make([]instance.Id, len(instances))
+	for i, inst := range instances {
+		ids[i] = inst.Id()
+	}
+
+	ifLists, err := env.NetworkInterfaces(t.callCtx, ids)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that each entry in the list contains the right set of interfaces
+	for i, id := range ids {
+		c.Logf("comparing entry %d in result list with network interface list for instance %v", i, id)
+
+		list, err := env.NetworkInterfaces(t.callCtx, []instance.Id{id})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(list, gc.HasLen, 1)
+		instIfList := list[0]
+		c.Assert(instIfList, gc.HasLen, 1)
+
+		c.Assert(instIfList, gc.DeepEquals, ifLists[i], gc.Commentf("inconsistent result for entry %d in multi-instance result list", i))
+		for devIdx, iface := range instIfList {
+			t.assertInterfaceLooksValid(c, i+devIdx, devIdx, iface)
+		}
+	}
+}
+
+func (t *localServerSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
+	// Start three instances
+	env := t.prepareEnviron(c)
+	inst, _ := testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "1")
+
+	infoLists, err := env.NetworkInterfaces(t.callCtx, []instance.Id{inst.Id(), instance.Id("bogus")})
+	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
+	c.Assert(infoLists, gc.HasLen, 2)
+
+	// Check interfaces for first instance
+	list := infoLists[0]
+	c.Assert(list, gc.HasLen, 1)
+	t.assertInterfaceLooksValid(c, 0, 0, list[0])
+
+	// Check that the slot for the second instance is nil
+	c.Assert(infoLists[1], gc.IsNil, gc.Commentf("expected slot for unknown instance to be nil"))
+}
+
 func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
-	interfaceList, err := env.NetworkInterfaces(t.callCtx, []instance.Id{instId})
+	infoLists, err := env.NetworkInterfaces(t.callCtx, []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(interfaceList, gc.HasLen, 1)
-	interfaces := interfaceList[0]
+	c.Assert(infoLists, gc.HasLen, 1)
 
+	list := infoLists[0]
+	c.Assert(list, gc.HasLen, 1)
+
+	t.assertInterfaceLooksValid(c, 0, 0, list[0])
+}
+
+func (t *localServerSuite) assertInterfaceLooksValid(c *gc.C, expIfaceID, expDevIndex int, iface network.InterfaceInfo) {
 	// The CIDR isn't predictable, but it is in the 10.10.x.0/24 format
 	// The subnet ID is in the form "subnet-x", where x matches the same
 	// number from the CIDR. The interfaces address is part of the CIDR.
 	// For these reasons we check that the CIDR is in the expected format
 	// and derive the expected values for ProviderSubnetId and Address.
-	c.Assert(interfaces, gc.HasLen, 1)
-	cidr := interfaces[0].CIDR
+	cidr := iface.CIDR
 	re := regexp.MustCompile(`10\.10\.(\d+)\.0/24`)
 	c.Assert(re.Match([]byte(cidr)), jc.IsTrue)
 	index := re.FindStringSubmatch(cidr)[1]
@@ -1630,16 +1688,16 @@ func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 	// AvailabilityZones will either contain "test-available",
 	// "test-impaired" or "test-unavailable" depending on which subnet is
 	// picked. Any of these is fine.
-	zones := interfaces[0].AvailabilityZones
+	zones := iface.AvailabilityZones
 	c.Assert(zones, gc.HasLen, 1)
 	re = regexp.MustCompile("test-available|test-unavailable|test-impaired")
 	c.Assert(re.Match([]byte(zones[0])), jc.IsTrue)
 
-	expectedInterfaces := []network.InterfaceInfo{{
-		DeviceIndex:       0,
-		MACAddress:        "20:01:60:cb:27:37",
+	expectedInterface := network.InterfaceInfo{
+		DeviceIndex:       expDevIndex,
+		MACAddress:        iface.MACAddress,
 		CIDR:              cidr,
-		ProviderId:        "eni-0",
+		ProviderId:        corenetwork.Id(fmt.Sprintf("eni-%d", expIfaceID)),
 		ProviderSubnetId:  subnetId,
 		VLANTag:           0,
 		InterfaceName:     "unsupported0",
@@ -1649,8 +1707,8 @@ func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 		InterfaceType:     network.EthernetInterface,
 		Address:           corenetwork.NewScopedProviderAddress(addr, corenetwork.ScopeCloudLocal),
 		AvailabilityZones: zones,
-	}}
-	c.Assert(interfaces, jc.DeepEquals, expectedInterfaces)
+	}
+	c.Assert(iface, gc.DeepEquals, expectedInterface)
 }
 
 func (t *localServerSuite) TestSubnetsWithInstanceId(c *gc.C) {

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -198,8 +198,10 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 	s.cannedData()
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
 
-	infos, err := s.NetEnv.NetworkInterfaces(s.CallCtx, instance.Id("moana"))
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infoList, gc.HasLen, 1)
+	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:       0,
@@ -238,7 +240,7 @@ func (s *environNetSuite) TestNetworkInterfaceInvalidCredentialError(c *gc.C) {
 	})
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	_, err := s.NetEnv.NetworkInterfaces(s.CallCtx, instance.Id("moana"))
+	_, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
 	c.Check(err, gc.NotNil)
 	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
@@ -262,8 +264,10 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 	})
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	infos, err := s.NetEnv.NetworkInterfaces(s.CallCtx, instance.Id("moana"))
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infoList, gc.HasLen, 1)
+	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:       0,
@@ -312,8 +316,10 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 	}}
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	infos, err := s.NetEnv.NetworkInterfaces(s.CallCtx, instance.Id("moana"))
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infoList, gc.HasLen, 1)
+	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:       0,
@@ -350,8 +356,10 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 	})
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	infos, err := s.NetEnv.NetworkInterfaces(s.CallCtx, instance.Id("moana"))
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infoList, gc.HasLen, 1)
+	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, []network.InterfaceInfo{{
 		DeviceIndex:       0,

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -245,6 +245,127 @@ func (s *environNetSuite) TestNetworkInterfaceInvalidCredentialError(c *gc.C) {
 	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
 
+func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
+	s.cannedData()
+	baseInst1 := s.NewBaseInstance(c, "i-1")
+
+	// Create a second instance and patch its interface list
+	baseInst2 := s.NewBaseInstance(c, "i-2")
+	b2summary := &baseInst2.InstanceSummary
+	b2summary.NetworkInterfaces = []*compute.NetworkInterface{
+		{
+			Name:       "netif-0",
+			NetworkIP:  "10.0.10.42",
+			Network:    "https://www.googleapis.com/compute/v1/projects/sonic-youth/global/networks/go-team",
+			Subnetwork: "https://www.googleapis.com/compute/v1/projects/sonic-youth/regions/asia-east1/subnetworks/go-team",
+			AccessConfigs: []*compute.AccessConfig{{
+				Type:  "ONE_TO_ONE_NAT",
+				Name:  "ExternalNAT",
+				NatIP: "25.185.142.227",
+			}},
+		},
+		{
+			Name:       "netif-1",
+			NetworkIP:  "10.0.20.42",
+			Network:    "https://www.googleapis.com/compute/v1/projects/sonic-youth/global/networks/shellac",
+			Subnetwork: "https://www.googleapis.com/compute/v1/projects/sonic-youth/regions/asia-east1/subnetworks/shellac",
+			AccessConfigs: []*compute.AccessConfig{{
+				Type:  "ONE_TO_ONE_NAT",
+				Name:  "ExternalNAT",
+				NatIP: "25.185.142.227",
+			}},
+		},
+	}
+	s.FakeEnviron.Insts = []instances.Instance{
+		s.NewInstanceFromBase(baseInst1),
+		s.NewInstanceFromBase(baseInst2),
+	}
+
+	infoLists, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{
+		instance.Id("i-1"),
+		instance.Id("i-2"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(infoLists, gc.HasLen, 2)
+
+	// Check interfaces for first instance
+	infos := infoLists[0]
+	c.Assert(infos, gc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:       0,
+		CIDR:              "10.0.10.0/24",
+		ProviderId:        "i-1/somenetif",
+		ProviderSubnetId:  "go-team",
+		ProviderNetworkId: "go-team1",
+		AvailabilityZones: []string{"a-zone", "b-zone"},
+		InterfaceName:     "somenetif",
+		InterfaceType:     network.EthernetInterface,
+		Disabled:          false,
+		NoAutoStart:       false,
+		ConfigType:        network.ConfigDHCP,
+		Address:           corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
+	}})
+
+	// Check interfaces for second instance
+	infos = infoLists[1]
+	c.Assert(infos, gc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:       0,
+		CIDR:              "10.0.10.0/24",
+		ProviderId:        "i-2/netif-0",
+		ProviderSubnetId:  "go-team",
+		ProviderNetworkId: "go-team1",
+		AvailabilityZones: []string{"a-zone", "b-zone"},
+		InterfaceName:     "netif-0",
+		InterfaceType:     network.EthernetInterface,
+		Disabled:          false,
+		NoAutoStart:       false,
+		ConfigType:        network.ConfigDHCP,
+		Address:           corenetwork.NewScopedProviderAddress("10.0.10.42", corenetwork.ScopeCloudLocal),
+	}, {
+		DeviceIndex:       1,
+		CIDR:              "10.0.20.0/24",
+		ProviderId:        "i-2/netif-1",
+		ProviderSubnetId:  "shellac",
+		ProviderNetworkId: "albini",
+		AvailabilityZones: []string{"a-zone", "b-zone"},
+		InterfaceName:     "netif-1",
+		InterfaceType:     network.EthernetInterface,
+		Disabled:          false,
+		NoAutoStart:       false,
+		ConfigType:        network.ConfigDHCP,
+		Address:           corenetwork.NewScopedProviderAddress("10.0.20.42", corenetwork.ScopeCloudLocal),
+	}})
+}
+
+func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
+	s.cannedData()
+	baseInst1 := s.NewBaseInstance(c, "i-1")
+	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst1)}
+
+	infoLists, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("i-1"), instance.Id("bogus")})
+	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
+	c.Assert(infoLists, gc.HasLen, 2)
+
+	// Check interfaces for first instance
+	infos := infoLists[0]
+	c.Assert(infos, gc.DeepEquals, []network.InterfaceInfo{{
+		DeviceIndex:       0,
+		CIDR:              "10.0.10.0/24",
+		ProviderId:        "i-1/somenetif",
+		ProviderSubnetId:  "go-team",
+		ProviderNetworkId: "go-team1",
+		AvailabilityZones: []string{"a-zone", "b-zone"},
+		InterfaceName:     "somenetif",
+		InterfaceType:     network.EthernetInterface,
+		Disabled:          false,
+		NoAutoStart:       false,
+		ConfigType:        network.ConfigDHCP,
+		Address:           corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
+	}})
+
+	// Check that the slot for the second instance is nil
+	c.Assert(infoLists[1], gc.IsNil, gc.Commentf("expected slot for unknown instance to be nil"))
+}
+
 func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 	s.cannedData()
 	baseInst := s.NewBaseInstance(c, "moana")

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -87,7 +87,22 @@ type maasSubnet struct {
 }
 
 // NetworkInterfaces implements Environ.NetworkInterfaces.
-func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
+func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error) {
+	var (
+		infos = make([][]network.InterfaceInfo, len(ids))
+		err   error
+	)
+
+	for idx, id := range ids {
+		if infos[idx], err = env.networkInterfacesForInstance(ctx, id); err != nil {
+			return nil, err
+		}
+	}
+
+	return infos, nil
+}
+
+func (env *maasEnviron) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
 	inst, err := env.getInstance(ctx, instId)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/network"
 )
@@ -88,18 +89,67 @@ type maasSubnet struct {
 
 // NetworkInterfaces implements Environ.NetworkInterfaces.
 func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error) {
-	var (
-		infos = make([][]network.InterfaceInfo, len(ids))
-		err   error
-	)
-
-	for idx, id := range ids {
-		if infos[idx], err = env.networkInterfacesForInstance(ctx, id); err != nil {
+	switch len(ids) {
+	case 0:
+		return nil, environs.ErrNoInstances
+	case 1: // short-cut
+		ifList, err := env.networkInterfacesForInstance(ctx, ids[0])
+		if err != nil {
 			return nil, err
+		}
+		return [][]network.InterfaceInfo{ifList}, nil
+	}
+
+	// Fetch instance information for the IDs we are interested in.
+	insts, err := env.Instances(ctx, ids)
+	partialInfo := err == environs.ErrPartialInstances
+	if err != nil && err != environs.ErrPartialInstances {
+		if err == environs.ErrNoInstances {
+			return nil, err
+		}
+		return nil, errors.Trace(err)
+	}
+
+	subnetsMap, err := env.subnetToSpaceIds(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	infos := make([][]network.InterfaceInfo, len(ids))
+	if env.usingMAAS2() {
+		dnsSearchDomains, err := env.Domains(ctx)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		for idx, inst := range insts {
+			if inst == nil {
+				continue // unknown instance ID
+			}
+
+			ifList, err := maas2NetworkInterfaces(ctx, inst.(*maas2Instance), subnetsMap, dnsSearchDomains...)
+			if err != nil {
+				return nil, errors.Annotatef(err, "obtaining network interfaces for instance %v", ids[idx])
+			}
+			infos[idx] = ifList
+		}
+	} else {
+		for idx, inst := range insts {
+			if inst == nil {
+				continue // unknown instance ID
+			}
+			ifList, err := maasObjectNetworkInterfaces(ctx, inst.(*maas1Instance).maasObject, subnetsMap)
+			if err != nil {
+				return nil, errors.Annotatef(err, "obtaining network interfaces for instance %v", ids[idx])
+			}
+			infos[idx] = ifList
 		}
 	}
 
-	return infos, nil
+	if partialInfo {
+		err = environs.ErrPartialInstances
+	}
+	return infos, err
 }
 
 func (env *maasEnviron) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -1047,7 +1047,22 @@ func (e *Environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, er
 	return nil, errors.NotSupportedf("super subnets")
 }
 
-func (e *Environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
+func (e *Environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error) {
+	var (
+		infos = make([][]network.InterfaceInfo, len(ids))
+		err   error
+	)
+
+	for idx, id := range ids {
+		if infos[idx], err = e.networkInterfacesForInstance(ctx, id); err != nil {
+			return nil, err
+		}
+	}
+
+	return infos, nil
+}
+
+func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
 	oInst, err := e.getOCIInstance(ctx, instId)
 	if err != nil {
 		providerCommon.HandleCredentialError(err, ctx)

--- a/provider/oci/networking_test.go
+++ b/provider/oci/networking_test.go
@@ -238,8 +238,11 @@ func (n *networkingSuite) TestNetworkInterfaces(c *gc.C) {
 
 	n.setupNetworkInterfacesExpectations(vnicID, vcnID)
 
-	info, err := n.env.NetworkInterfaces(nil, instance.Id(n.testInstanceID))
+	infoList, err := n.env.NetworkInterfaces(nil, []instance.Id{instance.Id(n.testInstanceID)})
 	c.Assert(err, gc.IsNil)
+	c.Assert(infoList, gc.HasLen, 1)
+	info := infoList[0]
+
 	c.Assert(info, gc.HasLen, 1)
 	c.Assert(info[0].Address, gc.Equals, corenetwork.NewScopedProviderAddress("1.1.1.1", corenetwork.ScopeCloudLocal))
 	c.Assert(info[0].InterfaceName, gc.Equals, "unsupported0")

--- a/provider/openstack/legacy_networking.go
+++ b/provider/openstack/legacy_networking.go
@@ -88,6 +88,6 @@ func (n *LegacyNovaNetworking) Subnets(
 }
 
 // NetworkInterfaces is part of the Networking interface.
-func (n *LegacyNovaNetworking) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
+func (n *LegacyNovaNetworking) NetworkInterfaces(ids []instance.Id) ([][]network.InterfaceInfo, error) {
 	return nil, errors.NotSupportedf("nova network interfaces")
 }

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -42,9 +42,9 @@ type Networking interface {
 	Subnets(instance.Id, []corenetwork.Id) ([]corenetwork.SubnetInfo, error)
 
 	// NetworkInterfaces requests information about the network
-	// interfaces on the given instance.
+	// interfaces on the given list of instances.
 	// Needed for Environ.Networking
-	NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error)
+	NetworkInterfaces(ids []instance.Id) ([][]network.InterfaceInfo, error)
 }
 
 // NetworkingDecorator is an interface that provides a means of overriding
@@ -124,11 +124,11 @@ func (n *switchingNetworking) Subnets(
 }
 
 // NetworkInterfaces is part of the Networking interface
-func (n *switchingNetworking) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
+func (n *switchingNetworking) NetworkInterfaces(ids []instance.Id) ([][]network.InterfaceInfo, error) {
 	if err := n.initNetworking(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return n.networking.NetworkInterfaces(instId)
+	return n.networking.NetworkInterfaces(ids)
 }
 
 type networkingBase struct {
@@ -425,6 +425,6 @@ func noNetConfigMsg(err error) string {
 		err.Error())
 }
 
-func (n *NeutronNetworking) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo, error) {
+func (n *NeutronNetworking) NetworkInterfaces(ids []instance.Id) ([][]network.InterfaceInfo, error) {
 	return nil, errors.NotSupportedf("neutron network interfaces")
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2048,26 +2048,12 @@ func (e *Environ) Subnets(
 
 // NetworkInterfaces is specified on environs.Networking.
 func (e *Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error) {
-	var (
-		infos = make([][]network.InterfaceInfo, len(ids))
-		err   error
-	)
-
-	for idx, id := range ids {
-		if infos[idx], err = e.networkInterfacesForInstance(ctx, id); err != nil {
-			return nil, err
-		}
-	}
-
-	return infos, nil
-}
-
-func (e *Environ) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
-	infos, err := e.networking.NetworkInterfaces(instId)
+	infos, err := e.networking.NetworkInterfaces(ids)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return infos, errors.Trace(err)
 	}
+
 	return infos, nil
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2047,7 +2047,22 @@ func (e *Environ) Subnets(
 }
 
 // NetworkInterfaces is specified on environs.Networking.
-func (e *Environ) NetworkInterfaces(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
+func (e *Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error) {
+	var (
+		infos = make([][]network.InterfaceInfo, len(ids))
+		err   error
+	)
+
+	for idx, id := range ids {
+		if infos[idx], err = e.networkInterfacesForInstance(ctx, id); err != nil {
+			return nil, err
+		}
+	}
+
+	return infos, nil
+}
+
+func (e *Environ) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]network.InterfaceInfo, error) {
 	infos, err := e.networking.NetworkInterfaces(instId)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)

--- a/provider/oracle/network/environ_test.go
+++ b/provider/oracle/network/environ_test.go
@@ -168,9 +168,10 @@ func (e *environSuite) TestNetworkInterfacesWithEmptyParams(c *gc.C) {
 	netEnv := network.NewEnviron(&fakeNetworkingAPI{}, env)
 	c.Assert(netEnv, gc.NotNil)
 
-	info, err := netEnv.NetworkInterfaces(e.callCtx, instance.Id("0"))
-	c.Assert(info, jc.DeepEquals, []jujunetwork.InterfaceInfo{})
+	infoList, err := netEnv.NetworkInterfaces(e.callCtx, []instance.Id{instance.Id("0")})
 	c.Assert(err, gc.IsNil)
+	c.Assert(infoList, gc.HasLen, 1)
+	c.Assert(infoList[0], jc.DeepEquals, []jujunetwork.InterfaceInfo{})
 }
 
 func (e *environSuite) TestSpaces(c *gc.C) {


### PR DESCRIPTION
## Description of change

This PR is part of the work for enabling the refactored instance poller [#10750] to collect both the instance address information and the network interfaces reported by the provider (for the ones supporting environs.Networking) and the combined information to the controller where it then will be possible to resolve space IDs for non-MAAS providers.

To collect this information in an efficient manner, this PR modifies the signature for `environs.Networking.NetworkInterfaces` to accept a `[]instance.Id` instead of a single `instance.Id`. This change will allow us to get all the information we need with two calls instead of a call per machine when going through the machiner worker.

The following providers implement `environs.Networking` and were modified to use the new signature: 

- dummy.
- ec2. A filtering query is used to fetch all the complete interface list with a single API call (+ 1 extra call to get the shared subnet information)
- gce. The original code was fetching the information from a call to `Instances()` with a single instance ID. The updated code simply gets all the required instance information by passing the ID list to `Instances`.
- maas.  Similar to gce; the required information is obtained through the `Instances()` call.
- openstack. None of the network implementations (legacy, switching or nova) support the NetworkInterfaces call at the moment. The method signatures have been updated in preparation of adding support for this call in the future.
- oci and oracle. Emulated by looping over the requested IDs and calling the old code.

Note: the `NetworkInterfaces` method is only invoked by the networkingcommon code in the juju code-base.

## QA steps

Bootstrapping using the above providers should work without any issue.