### PR TITLE
k8s CLI usability fixes

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -268,7 +268,7 @@ type ClusterMetadataChecker interface {
 	CheckDefaultWorkloadStorage(cluster string, storageProvisioner *StorageProvisioner) error
 
 	// EnsureStorageProvisioner creates a storage provisioner with the specified config, or returns an existing one.
-	EnsureStorageProvisioner(cfg StorageProvisioner) (*StorageProvisioner, error)
+	EnsureStorageProvisioner(cfg StorageProvisioner) (*StorageProvisioner, bool, error)
 }
 
 // NamespaceWatcher provides the API to watch caas namespace.

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -213,8 +213,7 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 		// no preferred storage class config but nominated storage found.
 		scName = clusterMetadata.NominatedStorageClass.Name
 	}
-	var sp *caas.StorageProvisioner
-	sp, err = storageParams.MetadataChecker.EnsureStorageProvisioner(caas.StorageProvisioner{
+	sp, existing, err := storageParams.MetadataChecker.EnsureStorageProvisioner(caas.StorageProvisioner{
 		Name:              scName,
 		Provisioner:       provisioner,
 		Parameters:        params,
@@ -231,10 +230,14 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 	} else {
 		storageMsg = " with storage provisioned"
 	}
-	storageMsg += fmt.Sprintf("\nby the existing %q storage class", scName)
+	scExisting := "existing"
+	if !existing {
+		scExisting = "new"
+	}
+	storageMsg += fmt.Sprintf("\nby the %s %q storage class", scExisting, scName)
 	clusterMetadata.NominatedStorageClass = sp
 	clusterMetadata.OperatorStorageClass = sp
-	return
+	return storageMsg, nil
 }
 
 // BaseKubeCloudOpenParams provides a basic OpenParams for a cluster

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -235,7 +235,7 @@ func (api *fakeK8sClusterMetadataChecker) CheckDefaultWorkloadStorage(cluster st
 	return testing.TypeAssertError(results[0])
 }
 
-func (api *fakeK8sClusterMetadataChecker) EnsureStorageProvisioner(cfg caas.StorageProvisioner) (*caas.StorageProvisioner, error) {
+func (api *fakeK8sClusterMetadataChecker) EnsureStorageProvisioner(cfg caas.StorageProvisioner) (*caas.StorageProvisioner, bool, error) {
 	results := api.MethodCall(api, "EnsureStorageProvisioner")
-	return results[0].(*caas.StorageProvisioner), testing.TypeAssertError(results[1])
+	return results[0].(*caas.StorageProvisioner), false, testing.TypeAssertError(results[1])
 }

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -29,13 +29,13 @@ The add-unit is used to scale out an application for improved performance or
 availability.
 
 The usage of this command differs depending on whether it is being used on a
-Kubernetes or cloud model.
+k8s or cloud model.
 
 Many charms will seamlessly support horizontal scaling while others may need
 an additional application support (e.g. a separate load balancer). See the
 documentation for specific charms to check how scale-out is supported.
 
-For Kubernetes models the only valid argument is -n, --num-units.
+For k8s models the only valid argument is -n, --num-units.
 Anything additional will result in an error.
 
 Example:
@@ -105,7 +105,7 @@ type UnitCommandBase struct {
 func (c *UnitCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.NumUnits, "num-units", 1, "")
 	f.StringVar(&c.PlacementSpec, "to", "", "The machine and/or container to deploy the unit in (bypasses constraints)")
-	f.Var(attachStorageFlag{&c.AttachStorage}, "attach-storage", "Existing storage to attach to the deployed unit (not available on kubernetes models)")
+	f.Var(attachStorageFlag{&c.AttachStorage}, "attach-storage", "Existing storage to attach to the deployed unit (not available on k8s models)")
 }
 
 func (c *UnitCommandBase) Init(args []string) error {
@@ -171,20 +171,6 @@ func (c *addUnitCommand) Info() *cmd.Info {
 	})
 }
 
-// IncompatibleModel returns an error if the command is being run against
-// a model with which it is not compatible.
-func (c *addUnitCommand) IncompatibleModel(err error) error {
-	if err == nil {
-		return nil
-	}
-	msg := `
-add-unit is not allowed on Kubernetes models.
-Instead, use juju scale-application.
-See juju help scale-application.
-`[1:]
-	return errors.New(msg)
-}
-
 func (c *addUnitCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.UnitCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "n", 1, "Number of units to add")
@@ -217,7 +203,7 @@ func (c *addUnitCommand) validateArgsByModelType() error {
 	}
 	if modelType == model.CAAS {
 		if c.PlacementSpec != "" || len(c.AttachStorage) != 0 {
-			return errors.New("Kubernetes models only support --num-units")
+			return errors.New("k8s models only support --num-units")
 		}
 	}
 	return nil

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -135,7 +135,7 @@ func (s *AddUnitSuite) TestInitErrorsForCAAS(c *gc.C) {
 	m.ModelType = model.CAAS
 	s.store.Models["arthur"].Models["king/sword"] = m
 	err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake, s.store), []string{"some-application-name", "--to", "lxd:1"})
-	c.Check(err, gc.ErrorMatches, "Kubernetes models only support --num-units")
+	c.Check(err, gc.ErrorMatches, "k8s models only support --num-units")
 }
 
 func (s *AddUnitSuite) runAddUnit(c *gc.C, args ...string) error {
@@ -251,7 +251,7 @@ func (s *AddUnitSuite) TestNameChecks(c *gc.C) {
 }
 
 func (s *AddUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
-	expectedError := "Kubernetes models only support --num-units"
+	expectedError := "k8s models only support --num-units"
 	m := s.store.Models["arthur"].Models["king/sword"]
 	m.ModelType = model.CAAS
 	s.store.Models["arthur"].Models["king/sword"] = m

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -638,11 +638,11 @@ Deploy to a machine that is in the 'dmz' network space but not in either the
 
     juju deploy haproxy -n 2 --constraints spaces=dmz,^cms,^database
 
-Deploy a Kubernetes charm that requires a single Nvidia GPU:
+Deploy a k8s charm that requires a single Nvidia GPU:
 
     juju deploy mycharm --device miner=1,nvidia.com/gpu
 
-Deploy a Kubernetes charm that requires two Nvidia GPUs that have an
+Deploy a k8s charm that requires two Nvidia GPUs that have an
 attribute of 'gpu=nvidia-tesla-p100':
 
     juju deploy mycharm --device \
@@ -811,7 +811,7 @@ func (c *DeployCommand) validateStorageByModelType() error {
 		return nil
 	}
 	if len(c.AttachStorage) > 0 {
-		return errors.New("--attach-storage cannot be used on kubernetes models")
+		return errors.New("--attach-storage cannot be used on k8s models")
 	}
 	return nil
 }
@@ -825,7 +825,7 @@ func (c *DeployCommand) validatePlacementByModelType() error {
 		return nil
 	}
 	if len(c.Placement) > 0 {
-		return errors.New("--to cannot be used on kubernetes models")
+		return errors.New("--to cannot be used on k8s models")
 	}
 	return nil
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -929,9 +929,9 @@ var caasTests = []struct {
 	message string
 }{
 	{[]string{"-m", "caas-model", "some-application-name", "--attach-storage", "foo/0"},
-		"--attach-storage cannot be used on kubernetes models"},
+		"--attach-storage cannot be used on k8s models"},
 	{[]string{"-m", "caas-model", "some-application-name", "--to", "a=b"},
-		regexp.QuoteMeta(`--to cannot be used on kubernetes models`)},
+		regexp.QuoteMeta(`--to cannot be used on k8s models`)},
 }
 
 func (s *CAASDeploySuite) TestCaasModelValidatedAtRun(c *gc.C) {

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -185,10 +185,15 @@ func (s *RemoveUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "removing 0 units not valid")
 
 	_, err = s.runRemoveUnit(c, "some-application-name", "--destroy-storage")
-	c.Assert(err, gc.ErrorMatches, "Kubernetes models only support --num-units")
+	c.Assert(err, gc.ErrorMatches, "k8s models only support --num-units")
 
-	_, err = s.runRemoveUnit(c, "some-application-name/0", "--num-units", "2")
-	c.Assert(err, gc.ErrorMatches, "application name \"some-application-name/0\" not valid")
+	_, err = s.runRemoveUnit(c, "some-application-name/0")
+	c.Assert(err, gc.NotNil)
+	msg := strings.Replace(err.Error(), "\n", "", -1)
+	c.Assert(msg, gc.Matches, "k8s models do not support removing named units.*")
+
+	_, err = s.runRemoveUnit(c, "some-application-name-", "--num-units", "2")
+	c.Assert(err, gc.ErrorMatches, "application name \"some-application-name-\" not valid")
 
 	_, err = s.runRemoveUnit(c, "some-application-name", "another-application", "--num-units", "2")
 	c.Assert(err, gc.ErrorMatches, "only single application supported")

--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -41,7 +41,7 @@ type scaleApplicationCommand struct {
 }
 
 const scaleApplicationDoc = `
-Scale a Kubernetes application by specifying how many units there should be.
+Scale a k8s application by specifying how many units there should be.
 The new number of units can be greater or less than the current number, thus
 allowing both scale up and scale down.
 

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -164,5 +164,5 @@ func ValidateIaasController(c modelcmd.CommandBase, cmdName, controllerName stri
 	if details.ModelType == model.IAAS {
 		return nil
 	}
-	return errors.Errorf("Juju command %q not supported on kubernetes controllers", cmdName)
+	return errors.Errorf("Juju command %q not supported on k8s controllers", cmdName)
 }


### PR DESCRIPTION
## Description of change

There's several small usability fixes for the k8s CLI:
- remove-unit has a better error message when a unit name is supplied
- use "k8s" consistently instead of "kubernetes" or "Kubernetes" in CLI text
- add-k8s reports existing or new storage class correctly
- CLI help text improved
- add-k8s --cloud and --region options improved (dumb cases no longer allowed)

The last change means that:
-- cloud only accepts a cloud name
-- you can't specify just a region with --region unless for gke or aks

There's a slight incompatibility with 2.6 but the logical way to use the options is the what's supported; only the pathological corner cases have been removed. It's now less confusing. Plus using microk8s or GKE/AWS or CDK on a supported cloud it's not an issue anyway; it's only for cases where the undercloud cannot be detected.

## QA steps

juju remove-unit <unitname> and check the error message
add-k8s on a GKE cluster
add-k8s on microk8s
add-k8s on CDK without node labels with and without an existing storage class
(testing the combinations of --cloud and --region)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1847149
