### PR TITLE
rework track branch err message

### DIFF
--- a/cmd/juju/model/mocks/trackbranch_mock.go
+++ b/cmd/juju/model/mocks/trackbranch_mock.go
@@ -5,14 +5,28 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockTrackBranchCommandAPI is a mock of TrackBranchCommandAPI interface
 type MockTrackBranchCommandAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockTrackBranchCommandAPIMockRecorder
+}
+
+// HasActiveBranch mocks base method
+func (m *MockTrackBranchCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
+	ret := m.ctrl.Call(m, "HasActiveBranch", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasActiveBranch indicates an expected call of HasActiveBranch
+func (mr *MockTrackBranchCommandAPIMockRecorder) HasActiveBranch(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasActiveBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).HasActiveBranch), arg0)
 }
 
 // MockTrackBranchCommandAPIMockRecorder is the mock recorder for MockTrackBranchCommandAPI

--- a/cmd/juju/model/trackbranch_test.go
+++ b/cmd/juju/model/trackbranch_test.go
@@ -55,6 +55,30 @@ func (s *trackBranchSuite) TestInitInvalid(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid application or unit name "test me"`)
 }
 
+func (s *trackBranchSuite) TestRunCommandValidBranchMissingArg(c *gc.C) {
+	mockController, api := setUpAdvanceMocks(c)
+	defer mockController.Finish()
+
+	api.EXPECT().HasActiveBranch(s.branchName).Return(true, nil)
+
+	_, err := s.runCommand(c, api, s.branchName)
+	c.Assert(err, gc.NotNil)
+	msg := err.Error()
+	c.Assert(msg, gc.Equals, `expected unit and/or application names(s)`)
+}
+
+func (s *trackBranchSuite) TestRunCommandInValidBranchMissingArg(c *gc.C) {
+	mockController, api := setUpAdvanceMocks(c)
+	defer mockController.Finish()
+
+	api.EXPECT().HasActiveBranch("test").Return(false, nil)
+
+	_, err := s.runCommand(c, api, "test")
+	c.Assert(err, gc.NotNil)
+	msg := err.Error()
+	c.Assert(msg, gc.Equals, `branch "test" not found`)
+}
+
 func (s *trackBranchSuite) TestRunCommand(c *gc.C) {
 	mockController, api := setUpAdvanceMocks(c)
 	defer mockController.Finish()


### PR DESCRIPTION
## Description of change

- change error message to be more specific from trackbranches e.g. `juju track bla/0` can either return
  - `bla/0 is not a current branch`
  - or `expected unit and/or application names(s)`
- it now checks if the arg is a branch first, before returning the err msg
## QA steps


`juju deploy ubuntu`
`juju add-branch test`
`juju track ubuntu/0` 
returns: `ERROR branch "ubuntu/0" not found`
`juju track test` 
returns: `expected unit and/or application names(s)`

e.g. output

```
~/golang/src/github.com/juju/juju 2.6 ⇡
❯ juju track branch
ERROR branch "branch" not found

~/golang/src/github.com/juju/juju 2.6 ⇡
❯ juju track test  
ERROR expected unit and/or application names(s)

~/golang/src/github.com/juju/juju 2.6 ⇡
❯ juju track test ubuntu/0

~/golang/src/github.com/juju/juju 2.6 ⇡
❯ juju status             
Model    Controller    Cloud/Region       Version    SLA          Timestamp
default  testbranches  localhost/default  2.7-rc1.1  unsupported  10:48:44+01:00

Branch  Ref  Created
bla     #1   2019-10-24
test    #2   2019-10-24

App     Version  Status  Scale  Charm   Store       Rev  OS      Notes
ntp     3.2      active      1  ntp     jujucharms   35  ubuntu  
ubuntu  18.04    active      1  ubuntu  jujucharms   12  ubuntu  

Unit          Workload  Agent  Machine  Public address  Ports    Message
ubuntu/0* #2  active    idle   0        10.75.147.14             ready
  ntp/0*      active    idle            10.75.147.14    123/udp  chrony: Ready, time sync disabled in container

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.75.147.14  juju-f0e3fc-0  bionic      Running


```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1834552