### PR TITLE
Remove max-logs-age and max-logs-size Controller Config Articles

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -131,15 +131,6 @@ const (
 	// session. If the user needs more information, perhaps debug-log isn't the right source.
 	MaxDebugLogDuration = "max-debug-log-duration"
 
-	// TODO(thumper): remove max-logs-age and max-logs-size in 2.7 branch.
-
-	// MaxLogsAge is the maximum age for log entries, eg "72h"
-	MaxLogsAge = "max-logs-age"
-
-	// MaxLogsSize is the maximum size the log collection can grow to
-	// before it is pruned, eg "4M"
-	MaxLogsSize = "max-logs-size"
-
 	// ModelLogfileMaxSize is the maximum size of the log file written out by the
 	// controller on behalf of workers running for a model.
 	ModelLogfileMaxSize = "model-logfile-max-size"
@@ -217,15 +208,6 @@ const (
 	// can run before being terminated by the API server.
 	DefaultMaxDebugLogDuration = 24 * time.Hour
 
-	// TODO(thumper): remove DefaultMaxLogsAgeDays and DefaultMaxLogCollectionMB in 2.7 branch.
-
-	// DefaultMaxLogsAgeDays is the maximum age in days of log entries.
-	DefaultMaxLogsAgeDays = 3
-
-	// DefaultMaxLogCollectionMB is the maximum size the log collection can
-	// grow to before being pruned.
-	DefaultMaxLogCollectionMB = 4 * 1024 // 4 GB
-
 	// DefaultMaxTxnLogCollectionMB is the maximum size the txn log collection.
 	DefaultMaxTxnLogCollectionMB = 10 // 10 MB
 
@@ -299,9 +281,6 @@ var (
 		StatePort,
 		MongoMemoryProfile,
 		MaxDebugLogDuration,
-		// TODO(thumper): remove MaxLogsAge and MaxLogsSize in 2.7 branch.
-		MaxLogsSize,
-		MaxLogsAge,
 		MaxTxnLogSize,
 		MaxPruneTxnBatchSize,
 		MaxPruneTxnPasses,
@@ -337,9 +316,6 @@ var (
 		MaxDebugLogDuration,
 		MaxPruneTxnBatchSize,
 		MaxPruneTxnPasses,
-		// TODO(thumper): remove MaxLogsAge and MaxLogsSize in 2.7 branch.
-		MaxLogsSize,
-		MaxLogsAge,
 		ModelLogfileMaxBackups,
 		ModelLogfileMaxSize,
 		ModelLogsSize,
@@ -766,18 +742,6 @@ func Validate(c Config) error {
 			return errors.Errorf("%s cannot be zero", MaxDebugLogDuration)
 		}
 	}
-	// TODO(thumper): remove MaxLogsAge and MaxLogsSize validation in 2.7 branch.
-	if v, ok := c[MaxLogsAge].(string); ok {
-		if _, err := time.ParseDuration(v); err != nil {
-			return errors.Annotate(err, "invalid logs prune interval in configuration")
-		}
-	}
-
-	if v, ok := c[MaxLogsSize].(string); ok {
-		if _, err := utils.ParseSize(v); err != nil {
-			return errors.Annotate(err, "invalid max logs size in configuration")
-		}
-	}
 
 	if v, ok := c[ModelLogsSize].(string); ok {
 		mb, err := utils.ParseSize(v)
@@ -966,8 +930,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AllowModelAccessKey:     schema.Bool(),
 	MongoMemoryProfile:      schema.String(),
 	MaxDebugLogDuration:     schema.TimeDuration(),
-	MaxLogsAge:              schema.String(),
-	MaxLogsSize:             schema.String(),
 	MaxTxnLogSize:           schema.String(),
 	MaxPruneTxnBatchSize:    schema.ForceInt(),
 	MaxPruneTxnPasses:       schema.ForceInt(),
@@ -1001,8 +963,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AllowModelAccessKey:     schema.Omit,
 	MongoMemoryProfile:      DefaultMongoMemoryProfile,
 	MaxDebugLogDuration:     DefaultMaxDebugLogDuration,
-	MaxLogsAge:              fmt.Sprintf("%vh", DefaultMaxLogsAgeDays*24),
-	MaxLogsSize:             fmt.Sprintf("%vM", DefaultMaxLogCollectionMB),
 	MaxTxnLogSize:           fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),
 	MaxPruneTxnBatchSize:    DefaultMaxPruneTxnBatchSize,
 	MaxPruneTxnPasses:       DefaultMaxPruneTxnPasses,
@@ -1099,14 +1059,6 @@ they don't have any access rights to the controller itself`,
 	MaxDebugLogDuration: {
 		Type:        environschema.Tstring,
 		Description: `The maximum amout of time a debug-log session is allowed to run`,
-	},
-	MaxLogsAge: {
-		Type:        environschema.Tstring,
-		Description: `The maximum age for log entries`,
-	},
-	MaxLogsSize: {
-		Type:        environschema.Tstring,
-		Description: `The maximum size the log collection can grow to before it is pruned`,
 	},
 	MaxTxnLogSize: {
 		Type:        environschema.Tstring,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -333,16 +333,10 @@ func (s *ConfigSuite) TestAPIPortDefaults(c *gc.C) {
 func (s *ConfigSuite) TestLogConfigDefaults(c *gc.C) {
 	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(thumper): remove max-logs-age and max-logs-size in 2.7 branch.
-	c.Assert(cfg["max-logs-age"], gc.Equals, "72h")
-	c.Assert(cfg["max-logs-size"], gc.Equals, "4096M")
 	c.Assert(cfg.ModelLogsSizeMB(), gc.Equals, 20)
 }
 
 func (s *ConfigSuite) TestLogConfigValues(c *gc.C) {
-	// TODO(thumper): remove MaxLogsAge and MaxLogsSize in 2.7 branch.
-	c.Assert(controller.AllowedUpdateConfigAttributes.Contains(controller.MaxLogsAge), jc.IsTrue)
-	c.Assert(controller.AllowedUpdateConfigAttributes.Contains(controller.MaxLogsSize), jc.IsTrue)
 	c.Assert(controller.AllowedUpdateConfigAttributes.Contains(controller.ModelLogsSize), jc.IsTrue)
 
 	cfg, err := controller.NewConfig(

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -38,10 +38,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.JujuHASpace,
 		controller.JujuManagementSpace,
 		controller.AuditLogExcludeMethods,
-		// TODO(thumper): remove MaxLogsAge and MaxLogsSize in 2.7 branch.
 		controller.MaxDebugLogDuration,
-		controller.MaxLogsAge,
-		controller.MaxLogsSize,
 		controller.MaxPruneTxnBatchSize,
 		controller.MaxPruneTxnPasses,
 		controller.ModelLogfileMaxBackups,

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -75,6 +75,7 @@ type StateBackend interface {
 	ConvertAddressSpaceIDs() error
 	ReplaceSpaceNameWithIDEndpointBindings() error
 	EnsureDefaultSpaceSetting() error
+	RemoveControllerConfigMaxLogAgeAndSize() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -303,4 +304,7 @@ func (s stateBackend) ReplaceSpaceNameWithIDEndpointBindings() error {
 
 func (s stateBackend) EnsureDefaultSpaceSetting() error {
 	return state.EnsureDefaultSpaceSetting(s.pool)
+}
+func (s stateBackend) RemoveControllerConfigMaxLogAgeAndSize() error {
+	return state.RemoveControllerConfigMaxLogAgeAndSize(s.pool)
 }

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -90,6 +90,13 @@ func stateStepsFor27() []Step {
 				return context.State().EnsureDefaultSpaceSetting()
 			},
 		},
+		&upgradeStep{
+			description: "remove controller config for max-logs-age and max-logs-size if set",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveControllerConfigMaxLogAgeAndSize()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_27_test.go
+++ b/upgrades/steps_27_test.go
@@ -76,6 +76,11 @@ func (s *steps27Suite) TestReplaceSpaceNameWithIDEndpointBindings(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
+func (s *steps27Suite) TestRemoveControllerConfigMaxLogAgeAndSize(c *gc.C) {
+	step := findStateStep(c, v27, `remove controller config for max-logs-age and max-logs-size if set`)
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 func (s *steps27Suite) TestLogfilePermissions(c *gc.C) {
 	// This test is to primarily test the walking of the log directory and the
 	// calling of the SetOwnership call. Skipped on windows because this will


### PR DESCRIPTION
## Description of change

This patch addresses a _TODO_ for the 2.7 branch, removing the controller configuration items `max-logs-age` and `max-logs-size`. These are no longer required.

## QA steps

Bootstrap a 2.6 controller, upgrade to this patch, and check that there are no controller log errors.

## Documentation changes

Yes.

## Bug reference

N/A
