### PR TITLE
Consume initial k8s operator change event

### DIFF
--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -113,6 +113,7 @@ func (aw *applicationWorker) loop() error {
 	// so we only report true changes.
 	lastReportedStatus := make(map[string]status.StatusInfo)
 	lastReportedScale := -1
+	initialOperatorEvent := true
 	logger := aw.logger
 	for {
 		// The caas watcher can just die from underneath so recreate if needed.
@@ -225,6 +226,10 @@ func (aw *applicationWorker) loop() error {
 			logger.Debugf("operator update for %v", aw.application)
 			operator, err := aw.containerBroker.Operator(aw.application)
 			if errors.IsNotFound(err) {
+				if initialOperatorEvent {
+					initialOperatorEvent = false
+					continue
+				}
 				logger.Debugf("pod not found for application %q", aw.application)
 				if err := aw.provisioningStatusSetter.SetOperatorStatus(aw.application, status.Terminated, "", nil); err != nil {
 					return errors.Trace(err)

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -121,6 +121,9 @@ func (m *mockContainerBroker) Units(appName string) ([]caas.Unit, error) {
 
 func (m *mockContainerBroker) Operator(appName string) (*caas.Operator, error) {
 	m.MethodCall(m, "Operator", appName)
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
 	return &caas.Operator{
 		Dying: false,
 		Status: status.StatusInfo{


### PR DESCRIPTION
## Description of change

The initial watcher event from the k8s operator watcher was causing a glitch where the operator status was falsely reported as Terminated.

## QA steps

deploy a k8s charm and immediately watch juju status
observe that status never goes to terminated as the pod is starting up
