### PR TITLE
Fix/configmap label conflict

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1291,7 +1291,7 @@ func (k *kubernetesClient) configurePodFiles(podSpec *core.PodSpec, containers [
 		for _, fileSet := range container.Files {
 			cfgName := cfgMapName(fileSet.Name)
 			vol := core.Volume{Name: cfgName}
-			if _, err := k.ensureConfigMap(filesetConfigMap(cfgName, &fileSet)); err != nil {
+			if _, err := k.ensureConfigMapLegacy(filesetConfigMap(cfgName, &fileSet)); err != nil {
 				return errors.Annotatef(err, "creating or updating ConfigMap for file set %v", cfgName)
 			}
 			vol.ConfigMap = &core.ConfigMapVolumeSource{

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -182,7 +182,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 			return errors.Annotatef(err, "config map for %q should already exist", appName)
 		}
 	} else {
-		cmCleanUp, err := k.ensureConfigMap(operatorConfigMap(appName, cmName, k.getConfigMapLabels(appName), config))
+		cmCleanUp, err := k.ensureConfigMapLegacy(operatorConfigMap(appName, cmName, k.getConfigMapLabels(appName), config))
 		cleanups = append(cleanups, cmCleanUp)
 		if err != nil {
 			return errors.Annotate(err, "creating or updating ConfigMap")

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -426,6 +426,8 @@ func (s *K8sBrokerSuite) TestEnsureOperatorCreate(c *gc.C) {
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
 		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
 
+		s.mockConfigMaps.EXPECT().Update(configMapArg).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockConfigMaps.EXPECT().Create(configMapArg).
 			Return(configMapArg, nil),
 		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).
@@ -544,7 +546,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorUpdate(c *gc.C) {
 		s.mockRoleBindings.EXPECT().Get("test-operator", v1.GetOptions{IncludeUninitialized: true}).Return(nil, s.k8sNotFoundError()),
 		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
 
-		s.mockConfigMaps.EXPECT().Create(configMapArg).
+		s.mockConfigMaps.EXPECT().Update(configMapArg).
 			Return(configMapArg, nil),
 		s.mockStorageClass.EXPECT().Get("test-operator-storage", v1.GetOptions{IncludeUninitialized: false}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "test-operator-storage"}}, nil),


### PR DESCRIPTION

## Description of change

Ignore labels check for podfile configmap and operator configmap to fix upgrade broken to 2.7;

## QA steps

- bootstrap and deploy workloads to 2.6;

- upgrade to 2.7

``` bash
$ juju upgrade-juju --agent-version 2.7-rc1 -m controller
```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1849744
