### PR TITLE
state/watcher: Add a timeout to hubwatcher sending

### DIFF
--- a/state/watcher/logger.go
+++ b/state/watcher/logger.go
@@ -6,6 +6,7 @@ package watcher
 // Logger represents methods called by this package to a logging
 // system.
 type Logger interface {
+	Criticalf(format string, values ...interface{})
 	Warningf(format string, values ...interface{})
 	Infof(format string, values ...interface{})
 	Debugf(format string, values ...interface{})
@@ -14,7 +15,8 @@ type Logger interface {
 
 type noOpLogger struct{}
 
-func (noOpLogger) Warningf(format string, values ...interface{}) {}
-func (noOpLogger) Infof(format string, values ...interface{})    {}
-func (noOpLogger) Debugf(format string, values ...interface{})   {}
-func (noOpLogger) Tracef(format string, values ...interface{})   {}
+func (noOpLogger) Criticalf(format string, values ...interface{}) {}
+func (noOpLogger) Warningf(format string, values ...interface{})  {}
+func (noOpLogger) Infof(format string, values ...interface{})     {}
+func (noOpLogger) Debugf(format string, values ...interface{})    {}
+func (noOpLogger) Tracef(format string, values ...interface{})    {}

--- a/state/watcher/watcher.go
+++ b/state/watcher/watcher.go
@@ -115,12 +115,14 @@ type watchInfo struct {
 	ch     chan<- Change
 	revno  int64
 	filter func(interface{}) bool
+	source []byte
 }
 
 type event struct {
-	ch    chan<- Change
-	key   watchKey
-	revno int64
+	ch          chan<- Change
+	key         watchKey
+	revno       int64
+	watchSource []byte
 }
 
 // Period is the delay between each sync.
@@ -138,20 +140,35 @@ func (r reqWatch) Completed() chan error {
 	return r.registeredCh
 }
 
+func (r reqWatch) String() string {
+	r.info.source = nil
+	return fmt.Sprintf("%#v", r)
+}
+
 type reqWatchMulti struct {
 	collection  string
 	ids         []interface{}
 	completedCh chan error
 	watchCh     chan<- Change
+	source      []byte
 }
 
 func (r reqWatchMulti) Completed() chan error {
 	return r.completedCh
 }
 
+func (r reqWatchMulti) String() string {
+	r.source = nil
+	return fmt.Sprintf("%#v", r)
+}
+
 type reqUnwatch struct {
 	key watchKey
 	ch  chan<- Change
+}
+
+func (r reqUnwatch) String() string {
+	return fmt.Sprintf("%#v", r)
 }
 
 type reqSync struct{}


### PR DESCRIPTION
## Description of change

If a state-level watcher doesn't unwatch all of the items it has watched when it stops, all of the other watchers for that model can be blocked behind it. The flush method will sit there not sending any changes out, which has the effect that no watchers will fire. This can be time consuming to track down.

Since the watchers that use the hubwatcher should all be in tight loops receiving changes, add a 10s timeout to the send in flush() so that we can raise an error in the log. Capture the stack for each added watch and report that in the logged error to indicate the misbehaving watcher.

## QA steps

* No behaviour change in the normal case. Bootstrap and check that juju.state.watcher logging is as expected.

## Documentation changes

None

## Bug reference

None
