### PR TITLE
New ask-or-tell.

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -525,14 +525,12 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !c.Client {
-		if c.ControllerName != "" {
-			ctrlUUID, err := c.ControllerUUID(c.Store, c.ControllerName)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			openParams.ControllerUUID = ctrlUUID
+	if c.ControllerName != "" {
+		ctrlUUID, err := c.ControllerUUID(c.Store, c.ControllerName)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
+		openParams.ControllerUUID = ctrlUUID
 	}
 	return caas.New(openParams)
 }

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -65,17 +65,8 @@ Creates a user-defined cloud based on a k8s cluster.
 The new k8s cloud can then be used to bootstrap into, or it
 can be added to an existing controller.
 
-If the current controller can be detected, a user will be prompted to 
-confirm if the new k8s cloud needs to be added to it. 
-If the prompt is not needed and the k8s cloud is always to be added to
-the current controller if that controller is detected, use --no-prompt option.
-
-Use --controller option to add k8s cloud to a different controller.
-
-Use --controller-only option to only add k8s cloud to a controller.
-
-If you just want to update your current client and not a running controller, use
-the --client-only option.
+Use --controller option to add k8s cloud to a controller.
+Use --client option to add k8s cloud to this client.
 
 Specify a non default kubeconfig file location using $KUBECONFIG
 environment variable or pipe in file content from stdin.
@@ -95,8 +86,8 @@ necessary parameters directly.
 
 Examples:
     juju add-k8s myk8scloud
-    juju add-k8s myk8scloud --client-only
-    juju add-k8s myk8scloud --controller mycontroller --controller-only
+    juju add-k8s myk8scloud --client
+    juju add-k8s myk8scloud --controller mycontroller
     juju add-k8s --context-name mycontext myk8scloud
     juju add-k8s myk8scloud --region <cloudNameOrCloudType>/<someregion>
     juju add-k8s myk8scloud --cloud <cloudNameOrCloudType>
@@ -387,16 +378,8 @@ var noRecommendedStorageErrMsg = `
 
 // Run is defined on the Command interface.
 func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName == "" {
-			// The user may have specified the controller via a --controller option.
-			// If not, let's see if there is a current controller that can be detected.
-			var err error
-			c.ControllerName, err = c.MaybePromptCurrentController(ctx, fmt.Sprintf("add k8s cloud %v to", c.caasName))
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
+	if err := c.MaybePrompt(ctx, fmt.Sprintf("add k8s cloud %v to", c.caasName)); err != nil {
+		return errors.Trace(err)
 	}
 	if err := c.verifyName(c.caasName); err != nil {
 		return errors.Trace(err)
@@ -475,7 +458,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if err := checkCloudRegion(c.givenHostCloudRegion, newCloud.HostCloudRegion); err != nil {
 		return errors.Trace(err)
 	}
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
 			return errors.Trace(err)
 		}
@@ -489,12 +472,12 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	successMsg := fmt.Sprintf("k8s substrate %q added as cloud %q%s", clusterName, c.caasName, storageMsg)
 	var msgDisplayed bool
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		msgDisplayed = true
 		successMsg += fmt.Sprintf("\nYou can now bootstrap to this cloud by running 'juju bootstrap %s'.", c.caasName)
 		fmt.Fprintln(ctx.Stdout, successMsg)
 	}
-	if c.BothClientAndController || c.ControllerOnly {
+	if c.ControllerName != "" {
 		if err := jujuclient.ValidateControllerName(c.ControllerName); err != nil {
 			return errors.Trace(err)
 		}
@@ -542,7 +525,7 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !c.ClientOnly {
+	if !c.Client {
 		if c.ControllerName != "" {
 			ctrlUUID, err := c.ControllerUUID(c.Store, c.ControllerName)
 			if err != nil {

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -104,13 +104,14 @@ func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	if c.ControllerName == "" && !c.Client {
+	if c.ControllerName == "" {
 		ctxt.Infof("There are no controllers running.\nTo remove cloud %q from the current client, use the --client option.", c.cloudName)
 	}
 
-	// TODO(caas): only do RBAC cleanup for removing from both client and controller to less complexity.
-	if err := cleanUpCredentialRBACResources(c.cloudName, c.cloudMetadataStore, c.credentialStoreAPI); err != nil {
-		return errors.Trace(err)
+	if c.ControllerName != "" && c.Client { // TODO(caas): only do RBAC cleanup for removing from both client and controller to less complexity.
+		if err := cleanUpCredentialRBACResources(c.cloudName, c.cloudMetadataStore, c.credentialStoreAPI); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	if c.Client {

--- a/cmd/juju/caas/remove.go
+++ b/cmd/juju/caas/remove.go
@@ -25,21 +25,11 @@ Removes the specified k8s cloud from this client.
 If --controller is used, also removes the cloud 
 from the specified controller (if it is not in use).
 
-If --controller option was not used and the current controller can be detected, 
-a user will be prompted to confirm if the k8s cloud needs to be removed from it. 
-If the prompt is not needed and the k8s cloud is always to be removed from
-the current controller if that controller is detected, use --no-prompt option.
-
-If you just want to update your controller and not
-your current client, use the --controller-only option.
-
-If you just want to update your current client and not
-a running controller, use the --client-only option.
+Use --client option to update your current client.
 
 Examples:
     juju remove-k8s myk8scloud
-    juju remove-k8s myk8scloud --client-only
-    juju remove-k8s myk8scloud --controller-only --no-prompt
+    juju remove-k8s myk8scloud --client
     juju remove-k8s --controller mycontroller myk8scloud
     
 See also:
@@ -110,30 +100,20 @@ func (c *RemoveCAASCommand) Init(args []string) (err error) {
 
 // Run is defined on the Command interface.
 func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName == "" {
-			// The user may have specified the controller via a --controller option.
-			// If not, let's see if there is a current controller that can be detected.
-			var err error
-			c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("remove k8s cloud %v from ", c.cloudName))
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
+	if err := c.MaybePrompt(ctxt, fmt.Sprintf("remove k8s cloud %v from ", c.cloudName)); err != nil {
+		return errors.Trace(err)
 	}
 
-	if c.ControllerName == "" && !c.ClientOnly {
-		ctxt.Infof("There are no controllers running.\nTo remove cloud %q from the current client, use the --client-only option.", c.cloudName)
+	if c.ControllerName == "" && !c.Client {
+		ctxt.Infof("There are no controllers running.\nTo remove cloud %q from the current client, use the --client option.", c.cloudName)
 	}
 
-	if c.BothClientAndController {
-		// TODO(caas): only do RBAC cleanup for removing from both client and controller to less complexity.
-		if err := cleanUpCredentialRBACResources(c.cloudName, c.cloudMetadataStore, c.credentialStoreAPI); err != nil {
-			return errors.Trace(err)
-		}
+	// TODO(caas): only do RBAC cleanup for removing from both client and controller to less complexity.
+	if err := cleanUpCredentialRBACResources(c.cloudName, c.cloudMetadataStore, c.credentialStoreAPI); err != nil {
+		return errors.Trace(err)
 	}
 
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		if err := removeCloudFromLocal(c.cloudName, c.cloudMetadataStore); err != nil {
 			return errors.Annotatef(err, "cannot remove cloud from current client")
 		}
@@ -141,11 +121,8 @@ func (c *RemoveCAASCommand) Run(ctxt *cmd.Context) error {
 		if err := c.Store.UpdateCredential(c.cloudName, cloud.CloudCredential{}); err != nil {
 			return errors.Annotatef(err, "cannot remove credential from current client")
 		}
-		if c.ClientOnly {
-			return nil
-		}
 	}
-	if c.BothClientAndController || c.ControllerOnly {
+	if c.ControllerName != "" {
 		if err := jujuclient.ValidateControllerName(c.ControllerName); err != nil {
 			return errors.Trace(err)
 		}
@@ -173,7 +150,7 @@ func cleanUpCredentialRBACResources(
 	if personalClouds == nil {
 		return nil
 	}
-	cloud, ok := personalClouds[cloudName]
+	pCloud, ok := personalClouds[cloudName]
 	if !ok {
 		return nil
 	}
@@ -186,7 +163,7 @@ func cleanUpCredentialRBACResources(
 		return nil
 	}
 	for _, credential := range cloudCredentials.AuthCredentials {
-		if err := cleanUpCredentialRBAC(cloud, credential); err != nil {
+		if err := cleanUpCredentialRBAC(pCloud, credential); err != nil {
 			logger.Warningf("unable to remove RBAC resources for credential %q", credential.Label)
 		}
 	}

--- a/cmd/juju/caas/remove_test.go
+++ b/cmd/juju/caas/remove_test.go
@@ -130,8 +130,8 @@ func (s *removeCAASSuite) TestRemoveControllerOnly(c *gc.C) {
 	s.fakeCloudAPI.CheckCall(c, 0, "RemoveCloud", "myk8s")
 
 	// client side operations
-	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata")
-	s.store.CheckCallNames(c, "CredentialForCloud")
+	s.cloudMetadataStore.CheckNoCalls(c)
+	s.store.CheckNoCalls(c)
 }
 
 func (s *removeCAASSuite) TestRemoveClientOnly(c *gc.C) {
@@ -143,10 +143,10 @@ func (s *removeCAASSuite) TestRemoveClientOnly(c *gc.C) {
 	s.fakeCloudAPI.CheckNoCalls(c)
 
 	// client side operations
-	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata", "PersonalCloudMetadata", "WritePersonalCloudMetadata")
-	s.cloudMetadataStore.CheckCall(c, 2, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
-	s.store.CheckCallNames(c, "CredentialForCloud", "UpdateCredential")
-	s.store.CheckCall(c, 1, "UpdateCredential", "myk8s", cloud.CloudCredential{})
+	s.cloudMetadataStore.CheckCallNames(c, "PersonalCloudMetadata", "WritePersonalCloudMetadata")
+	s.cloudMetadataStore.CheckCall(c, 1, "WritePersonalCloudMetadata", map[string]cloud.Cloud{})
+	s.store.CheckCallNames(c, "UpdateCredential")
+	s.store.CheckCall(c, 0, "UpdateCredential", "myk8s", cloud.CloudCredential{})
 }
 
 func (s *removeCAASSuite) TestRemoveNotInController(c *gc.C) {
@@ -154,8 +154,7 @@ func (s *removeCAASSuite) TestRemoveNotInController(c *gc.C) {
 	command := s.makeCommand()
 	_, err := s.runCommand(c, command, "myk8s", "-c", "foo")
 	c.Assert(err, gc.ErrorMatches, "cannot remove k8s cloud from controller.*")
-
-	s.store.CheckCallNames(c, "CredentialForCloud")
+	s.store.CheckNoCalls(c)
 }
 
 func (s *removeCAASSuite) TestRemoveNotInLocal(c *gc.C) {

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -351,11 +351,6 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *AddCloudCommand) addRemoteCloud(ctxt *cmd.Context, newCloud *jujucloud.Cloud) error {
-	if c.ControllerName == "" {
-		ctxt.Infof("There are no controllers specified - not adding cloud %q to any controller.", newCloud.Name)
-		return nil
-	}
-
 	// A controller has been specified so upload the cloud details
 	// plus a corresponding credential to the controller.
 	api, err := c.addCloudAPIFunc()

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -72,16 +72,9 @@ When <cloud definition file> is provided with <cloud name>,
 Juju will validate the content of the file and add this cloud 
 to this client as well as upload it to a controller.
 
-If a current controller can be detected, a user will be prompted to confirm 
-if specified cloud needs to be uploaded to it. 
-If the prompt is not needed and the cloud is always to be uploaded to
-the current controller if that controller is detected, use --no-prompt option.
+Use --controller option to upload a cloud to a controller. 
 
-Use --controller option to upload a cloud to a different controller. 
-
-Use --controller-only option to add cloud to a controller only.
-
-Use --client-only option to add cloud to the current client only.
+Use --client option to add cloud to the current client.
 
 DEPRECATED (use 'update-credential' instead) 
 If <cloud name> already exists on this client, then the `[1:] + "`--replace`" + ` 
@@ -131,9 +124,9 @@ Examples:
     juju add-cloud
     juju add-cloud --force
     juju add-cloud mycloud ~/mycloud.yaml
-    juju add-cloud --controller mycontroller mycloud --controller-only
+    juju add-cloud --controller mycontroller mycloud 
     juju add-cloud --controller mycontroller mycloud --credential mycred
-    juju add-cloud --client-only mycloud ~/mycloud.yaml
+    juju add-cloud --client mycloud ~/mycloud.yaml
 
 See also: 
     clouds
@@ -327,6 +320,9 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if err := c.MaybePrompt(ctxt, fmt.Sprintf("add cloud %q to", newCloud.Name)); err != nil {
+		return errors.Trace(err)
+	}
 
 	// All clouds must have at least one default region - lp#1819409.
 	if len(newCloud.Regions) == 0 {
@@ -334,26 +330,18 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	var returnErr error
-	if c.Replace || ((c.BothClientAndController || c.ClientOnly) && !c.existsLocally) {
+	if c.Replace || (c.Client && !c.existsLocally) {
 		returnErr = c.addLocalCloud(ctxt, newCloud)
 	}
-	if !c.Replace && ((c.BothClientAndController || c.ClientOnly) && c.existsLocally) {
-		returnErr = errors.AlreadyExistsf("use `update-cloud %s --client-only` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
+	if !c.Replace && (c.Client && c.existsLocally) {
+		returnErr = errors.AlreadyExistsf("use `update-cloud %s --client` to override known definition: local cloud %q", newCloud.Name, newCloud.Name)
 	}
 
-	if c.BothClientAndController {
+	if c.Client && c.ControllerName != "" {
 		ctxt.Infof("")
 	}
 
-	if c.BothClientAndController || c.ControllerOnly {
-		// At this stage, the user may have specified the controller via a --controller option.
-		// If not, let's see if there is a current controller that can be detected.
-		if c.ControllerName == "" {
-			c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("add cloud %q to", newCloud.Name))
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
+	if c.ControllerName != "" {
 		if err = c.addRemoteCloud(ctxt, newCloud); err != nil {
 			ctxt.Infof("Could not upload cloud to a controller: %v", err)
 			returnErr = cmd.ErrSilent
@@ -797,14 +785,14 @@ func (p *cloudFileReader) verifyName(name string) error {
 		return err
 	}
 	if _, ok := personal[name]; ok {
-		return errors.AlreadyExistsf("use `update-cloud %s --client-only` to replace this cloud locally: %q", name, name)
+		return errors.AlreadyExistsf("use `update-cloud %s --client` to replace this cloud locally: %q", name, name)
 	}
 	msg, err := nameExists(name, public)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if msg != "" {
-		return errors.AlreadyExistsf(msg + "; use `update-cloud --client-only` to override this definition locally")
+		return errors.AlreadyExistsf(msg + "; use `update-cloud --client` to override this definition locally")
 	}
 	return nil
 }

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -92,7 +92,7 @@ provide that functionality.
 
 Use --controller option to upload a credential to a controller. 
 
-Use --client option to add credentials to the current client.
+Use --client option to add a credential to the current client.
 
 Further help:
 Please visit https://discourse.jujucharms.com/t/1508 for cloud-specific

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -942,10 +942,7 @@ func (s *addCredentialSuite) TestAddRemoteCloudPromptForController(c *gc.C) {
 This operation can be applied to both a copy on this client and a controller of your choice.
 Do you want to add a credential to this client? (Y/n): 
 Do you want to add a credential to a controller? (Y/n): 
-Controller Names
-  controller
-
-Select controller name [controller]: 
+Only one controller "controller" is registered. Use it? (Y/n): 
 Enter credential name: 
 Using auth-type "jsonfile".
 

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -98,20 +98,20 @@ func (s *addCredentialSuite) TestBadArgs(c *gc.C) {
 }
 
 func (s *addCredentialSuite) TestBadLocalCloudName(c *gc.C) {
-	ctx, err := s.run(c, nil, "badcloud")
+	ctx, err := s.run(c, nil, "badcloud", "--client")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "To view all available clouds, use 'juju clouds'.\nTo add new cloud, use 'juju add-cloud'.\n")
 	c.Assert(c.GetTestLog(), jc.Contains, "cloud badcloud not valid")
 }
 
 func (s *addCredentialSuite) TestAddFromFileBadFilename(c *gc.C) {
-	_, err := s.run(c, nil, "somecloud", "-f", "somefile.yaml")
+	_, err := s.run(c, nil, "somecloud", "-f", "somefile.yaml", "--client")
 	c.Assert(err, gc.ErrorMatches, ".*open somefile.yaml: .*")
 }
 
 func (s *addCredentialSuite) TestNoCredentialsRequired(c *gc.C) {
 	s.authTypes = nil
-	_, err := s.run(c, nil, "somecloud")
+	_, err := s.run(c, nil, "somecloud", "--client")
 	c.Assert(err, gc.ErrorMatches, `cloud "somecloud" does not require credentials`)
 }
 
@@ -151,13 +151,13 @@ credentials:
 	c.Assert(err, gc.IsNil)
 
 	s.authTypes = []jujucloud.AuthType{jujucloud.InteractiveAuthType}
-	_, err = s.run(c, nil, "somecloud", "-f", sourceFile)
+	_, err = s.run(c, nil, "somecloud", "-f", sourceFile, "--client")
 	c.Assert(err, gc.ErrorMatches, `"credential with spaces" is not a valid credential name`)
 }
 
 func (s *addCredentialSuite) TestAddFromFileNoCredentialsFound(c *gc.C) {
 	sourceFile := s.createTestCredentialData(c)
-	_, err := s.run(c, nil, "anothercloud", "-f", sourceFile)
+	_, err := s.run(c, nil, "anothercloud", "-f", sourceFile, "--client")
 	c.Assert(err, gc.ErrorMatches, `no credentials for cloud anothercloud exist in file.*`)
 }
 
@@ -169,7 +169,7 @@ func (s *addCredentialSuite) TestAddFromFileExisting(c *gc.C) {
 		},
 	}
 	sourceFile := s.createTestCredentialData(c)
-	_, err := s.run(c, nil, "somecloud", "-f", sourceFile)
+	_, err := s.run(c, nil, "somecloud", "-f", sourceFile, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials, jc.DeepEquals, map[string]jujucloud.CloudCredential{
 		"somecloud": {
@@ -185,7 +185,7 @@ func (s *addCredentialSuite) TestAddFromFileExisting(c *gc.C) {
 
 func (s *addCredentialSuite) TestAddInvalidRegionSpecified(c *gc.C) {
 	s.authTypes = []jujucloud.AuthType{jujucloud.AccessKeyAuthType}
-	_, err := s.run(c, nil, "somecloud", "--region", "someregion")
+	_, err := s.run(c, nil, "somecloud", "--region", "someregion", "--client")
 	c.Assert(err, gc.ErrorMatches, `provided region "someregion" for cloud "somecloud" not valid`)
 }
 
@@ -225,19 +225,19 @@ credentials:
 
 func (s *addCredentialSuite) TestAddWithFileRegionSpecified(c *gc.C) {
 	s.setupCloudWithRegions(c)
-	args := []string{"somecloud", "-f", s.createFileForAddCredential(c)}
+	args := []string{"somecloud", "-f", s.createFileForAddCredential(c), "--client"}
 	s.assertCredentialAdded(c, "", args, "specialregion", "specialregion")
 }
 
 func (s *addCredentialSuite) TestAddWithFileNoRegionSpecified(c *gc.C) {
 	s.setupCloudWithRegions(c)
-	args := []string{"somecloud", "-f", s.createFileForAddCredential(c)}
+	args := []string{"somecloud", "-f", s.createFileForAddCredential(c), "--client"}
 	s.assertCredentialAdded(c, "", args, "", "")
 }
 
 func (s *addCredentialSuite) TestAddInteractiveNoRegionSpecified(c *gc.C) {
 	s.setupCloudWithRegions(c)
-	args := []string{"somecloud"}
+	args := []string{"somecloud", "--client"}
 
 	ctxt := s.assertCredentialAdded(c, "fred\n\nuser\npassword\n", args, "", "")
 	c.Assert(cmdtesting.Stdout(ctxt), gc.Equals, `
@@ -254,12 +254,11 @@ Enter password:
 Credential "fred" added locally for cloud "somecloud".
 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "There are no controllers specified - not adding a credential to any controller.\n")
 }
 
 func (s *addCredentialSuite) TestAddInteractiveInvalidRegionEntered(c *gc.C) {
 	s.setupCloudWithRegions(c)
-	args := []string{"somecloud"}
+	args := []string{"somecloud", "--client"}
 
 	ctxt := s.assertCredentialAdded(c, "fred\nnotknownregion\n\nuser\npassword\n", args, "", "")
 	c.Assert(cmdtesting.Stdout(ctxt), gc.Equals, `
@@ -278,12 +277,11 @@ Enter password:
 Credential "fred" added locally for cloud "somecloud".
 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "There are no controllers specified - not adding a credential to any controller.\n")
 }
 
 func (s *addCredentialSuite) TestAddInteractiveRegionSpecified(c *gc.C) {
 	s.setupCloudWithRegions(c)
-	args := []string{"somecloud"}
+	args := []string{"somecloud", "--client"}
 
 	ctxt := s.assertCredentialAdded(c, "fred\nuser\npassword\n", args, "specialregion", "specialregion")
 	c.Assert(cmdtesting.Stdout(ctxt), gc.Equals, `
@@ -297,7 +295,6 @@ Enter password:
 Credential "fred" added locally for cloud "somecloud".
 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "There are no controllers specified - not adding a credential to any controller.\n")
 }
 
 func (s *addCredentialSuite) assertCredentialAdded(c *gc.C, input string, args []string, specifiedRegion, expectedRegion string) *cmd.Context {
@@ -333,7 +330,7 @@ func (s *addCredentialSuite) TestAddFromFileExistingReplace(c *gc.C) {
 		},
 	}
 	sourceFile := s.createTestCredentialData(c)
-	_, err := s.run(c, nil, "somecloud", "-f", sourceFile, "--replace")
+	_, err := s.run(c, nil, "somecloud", "-f", sourceFile, "--replace", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials, jc.DeepEquals, map[string]jujucloud.CloudCredential{
 		"somecloud": {
@@ -350,7 +347,7 @@ func (s *addCredentialSuite) TestAddFromFileExistingReplace(c *gc.C) {
 func (s *addCredentialSuite) TestAddNewFromFile(c *gc.C) {
 	s.authTypes = []jujucloud.AuthType{jujucloud.AccessKeyAuthType}
 	sourceFile := s.createTestCredentialData(c)
-	_, err := s.run(c, nil, "somecloud", "-f", sourceFile)
+	_, err := s.run(c, nil, "somecloud", "-f", sourceFile, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials, jc.DeepEquals, map[string]jujucloud.CloudCredential{
 		"somecloud": {
@@ -366,7 +363,7 @@ func (s *addCredentialSuite) TestAddNewFromFile(c *gc.C) {
 func (s *addCredentialSuite) TestAddInvalidAuth(c *gc.C) {
 	s.authTypes = []jujucloud.AuthType{jujucloud.AccessKeyAuthType}
 	sourceFile := s.createTestCredentialDataWithAuthType(c, "invalid auth")
-	_, err := s.run(c, nil, "somecloud", "-f", sourceFile)
+	_, err := s.run(c, nil, "somecloud", "-f", sourceFile, "--client")
 	c.Assert(err, gc.ErrorMatches,
 		regexp.QuoteMeta(`credential "me" contains invalid auth type "invalid auth", valid auth types for cloud "somecloud" are [access-key]`))
 }
@@ -374,7 +371,7 @@ func (s *addCredentialSuite) TestAddInvalidAuth(c *gc.C) {
 func (s *addCredentialSuite) TestAddCloudUnsupportedAuth(c *gc.C) {
 	s.authTypes = []jujucloud.AuthType{jujucloud.AccessKeyAuthType}
 	sourceFile := s.createTestCredentialDataWithAuthType(c, fmt.Sprintf("%v", jujucloud.JSONFileAuthType))
-	_, err := s.run(c, nil, "somecloud", "-f", sourceFile)
+	_, err := s.run(c, nil, "somecloud", "-f", sourceFile, "--client")
 	c.Assert(err, gc.ErrorMatches,
 		regexp.QuoteMeta(`credential "me" contains invalid auth type "jsonfile", valid auth types for cloud "somecloud" are [access-key]`))
 }
@@ -390,7 +387,7 @@ func (s *addCredentialSuite) assertAddUserpassCredential(c *gc.C, input string, 
 		},
 	}
 	stdin := strings.NewReader(input)
-	ctx, err := s.run(c, stdin, "somecloud")
+	ctx, err := s.run(c, stdin, "somecloud", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	var cred jujucloud.Credential
 	if expected == nil {
@@ -464,7 +461,7 @@ func (s *addCredentialSuite) TestAddCredentialInteractive(c *gc.C) {
 	}
 
 	stdin := strings.NewReader("bobscreds\nbob\n")
-	ctx, err := s.run(c, stdin, "somecloud")
+	ctx, err := s.run(c, stdin, "somecloud", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// there's an extra line return after Using auth-type because the rest get a
@@ -501,7 +498,7 @@ func (s *addCredentialSuite) TestAddInvalidCredentialInteractive(c *gc.C) {
 	}
 
 	stdin := strings.NewReader("credential name with spaces\n")
-	ctx, err := s.run(c, stdin, "somecloud")
+	ctx, err := s.run(c, stdin, "somecloud", "--client")
 	c.Assert(err, gc.NotNil)
 
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
@@ -525,7 +522,7 @@ func (s *addCredentialSuite) TestAddCredentialCredSchemaInteractive(c *gc.C) {
 	}
 
 	stdin := strings.NewReader("bobscreds\n\nbob\n")
-	ctx, err := s.run(c, stdin, "somecloud")
+	ctx, err := s.run(c, stdin, "somecloud", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// there's an extra line return after Using auth-type because the rest get a
@@ -605,7 +602,7 @@ func (s *addCredentialSuite) assertAddFileCredential(c *gc.C, input, fileKey str
 
 	stdin := strings.NewReader(fmt.Sprintf(input, filename))
 	addCmd := cloud.NewAddCredentialCommandForTest(s.store, s.cloudByNameFunc, s.credentialAPIFunc)
-	err = cmdtesting.InitCommand(addCmd, []string{"somecloud"})
+	err = cmdtesting.InitCommand(addCmd, []string{"somecloud", "--client"})
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.ContextForDir(c, dir)
 	ctx.Stdin = stdin
@@ -669,7 +666,7 @@ func (s *addCredentialSuite) assertAddCredentialWithOptions(c *gc.C, input strin
 	}
 	// Input includes a bad option
 	stdin := strings.NewReader(input)
-	_, err := s.run(c, stdin, "somecloud")
+	_, err := s.run(c, stdin, "somecloud", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials, jc.DeepEquals, map[string]jujucloud.CloudCredential{
 		"somecloud": {
@@ -701,7 +698,7 @@ func (s *addCredentialSuite) TestAddMAASCredential(c *gc.C) {
 		},
 	}
 	stdin := strings.NewReader("fred\nauth:token\n")
-	_, err := s.run(c, stdin, "somecloud")
+	_, err := s.run(c, stdin, "somecloud", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials, jc.DeepEquals, map[string]jujucloud.CloudCredential{
 		"somecloud": {
@@ -730,7 +727,7 @@ func (s *addCredentialSuite) TestAddGCEFileCredentials(c *gc.C) {
 	}
 	sourceFile := s.createTestCredentialDataWithAuthType(c, fmt.Sprintf("%v", jujucloud.JSONFileAuthType))
 	stdin := strings.NewReader(fmt.Sprintf("blah\n%s\n", sourceFile))
-	ctx, err := s.run(c, stdin, "somecloud")
+	ctx, err := s.run(c, stdin, "somecloud", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 Enter credential name: 
@@ -831,8 +828,6 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the credential file: 
-Credential "blah" added locally for cloud "somecloud".
-
 `[1:]
 	stderr := `
 Using cloud "somecloud" from the controller to verify credentials.
@@ -840,11 +835,7 @@ Controller credential "blah" for user "admin@local" for cloud "somecloud" on con
 For more information, see ‘juju show-credential somecloud blah’.
 `[1:]
 
-	s.assertAddedCredentialForCloud(c, "somecloud", stdout, stderr, true)
-}
-
-func (s *addCredentialSuite) assertAddedCredentialForCloud(c *gc.C, cloudName, expectedStdout, expectedStderr string, uploaded bool) {
-	s.assertAddedCredentialForCloudWithArgs(c, cloudName, expectedStdout, "", expectedStderr, uploaded, true, "--no-prompt")
+	s.assertAddedCredentialForCloudWithArgs(c, "somecloud", stdout, "", stderr, true, false, "--c", "controller")
 }
 
 func (s *addCredentialSuite) assertAddedCredentialForCloudWithArgs(c *gc.C, cloudName, expectedStdout, expectedStdin, expectedStderr string, uploaded, added bool, args ...string) {
@@ -902,15 +893,13 @@ Using auth-type "jsonfile".
 Enter path to the .json file containing a service account key for your project
 (detailed instructions available at https://discourse.jujucharms.com/t/1508).
 Path: 
-Credential "blah" added locally for cloud "remote".
-
 `[1:]
 	stderr := `
 Using cloud "remote" from the controller to verify credentials.
 Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
 For more information, see ‘juju show-credential remote blah’.
 `[1:]
-	s.assertAddedCredentialForCloud(c, "remote", stdout, stderr, true)
+	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "", stderr, true, false, "--c", "controller")
 }
 
 func (s *addCredentialSuite) TestAddRemoteNoRemoteCloud(c *gc.C) {
@@ -932,13 +921,11 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the credential file: 
-Credential "blah" added locally for cloud "somecloud".
-
 No cloud "somecloud" found on the controller "controller": credentials are not uploaded.
 Use 'juju clouds -c controller' to see what clouds are available on the controller.
 User 'juju add-cloud somecloud -c controller' to add your cloud to the controller.
 `[1:]
-	s.assertAddedCredentialForCloud(c, "somecloud", stdout, "", false)
+	s.assertAddedCredentialForCloudWithArgs(c, "somecloud", stdout, "", "", false, false, "--c", "controller")
 }
 
 func (s *addCredentialSuite) TestAddRemoteCloudPromptForController(c *gc.C) {
@@ -952,7 +939,13 @@ func (s *addCredentialSuite) TestAddRemoteCloudPromptForController(c *gc.C) {
 		}, nil
 	}
 	stdout := `
-Do you want to add a credential to current controller "controller"? (Y/n): 
+This operation can be applied to both a copy on this client and a controller of your choice.
+Do you want to add a credential to this client? (Y/n): 
+Do you want to add a credential to a controller? (Y/n): 
+Controller Names
+  controller
+
+Select controller name [controller]: 
 Enter credential name: 
 Using auth-type "jsonfile".
 
@@ -967,7 +960,7 @@ Using cloud "remote" from the controller to verify credentials.
 Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
 For more information, see ‘juju show-credential remote blah’.
 `[1:]
-	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "\n", stderr, true, true)
+	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "y\ny\n\n", stderr, true, true)
 }
 
 func (s *addCredentialSuite) TestAddRemoteCloudControllerOnly(c *gc.C) {
@@ -993,5 +986,5 @@ Using cloud "remote" from the controller to verify credentials.
 Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
 For more information, see ‘juju show-credential remote blah’.
 `[1:]
-	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "", stderr, true, false, "--no-prompt", "--controller-only")
+	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "", stderr, true, false, "-c", "controller")
 }

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -171,7 +171,7 @@ func (s *detectCredentialsSuite) assertDetectCredential(c *gc.C, t detectCredent
 	}
 
 	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", t.cloudName))
-	ctx, err := s.run(c, stdin, clouds)
+	ctx, err := s.run(c, stdin, clouds, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	if t.expectedStderr == "" {
 		if t.expectedRegion != "" {
@@ -251,7 +251,7 @@ Select a credential to save by number, or type Q to quit:
 
 func (s *detectCredentialsSuite) TestNewDetectCredentialNoneFound(c *gc.C) {
 	stdin := strings.NewReader("")
-	ctx, err := s.run(c, stdin, nil)
+	ctx, err := s.run(c, stdin, nil, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 	c.Assert(output, gc.Matches, ".*No cloud credentials found.*")
@@ -274,7 +274,7 @@ func (s *detectCredentialsSuite) TestNewDetectCredentialFilter(c *gc.C) {
 	}
 
 	stdin := strings.NewReader("")
-	ctx, err := s.run(c, stdin, clouds, "some-provider")
+	ctx, err := s.run(c, stdin, clouds, "some-provider", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 	c.Assert(output, gc.Matches, ".*No cloud credentials found.*")
@@ -290,7 +290,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialInvalidChoice(c *gc.C) {
 	}
 
 	stdin := strings.NewReader("3\nQ\n")
-	ctx, err := s.run(c, stdin, nil)
+	ctx, err := s.run(c, stdin, nil, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	output := strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1)
 	c.Assert(output, gc.Matches, ".*Invalid choice, enter a number between 1 and 2.*")
@@ -318,7 +318,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialCloudMismatch(c *gc.C) {
 	}
 
 	stdin := strings.NewReader("1\naws\nQ\n")
-	ctx, err := s.run(c, stdin, clouds)
+	ctx, err := s.run(c, stdin, clouds, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 
@@ -344,7 +344,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialQuitOnCloud(c *gc.C) {
 	}
 
 	stdin := strings.NewReader("1\nQ\n")
-	ctx, err := s.run(c, stdin, nil)
+	ctx, err := s.run(c, stdin, nil, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 
@@ -410,7 +410,7 @@ func (s *detectCredentialsSuite) TestRemoteLoad(c *gc.C) {
 		return &remoteTestCloud, nil
 	}
 
-	stdin := strings.NewReader(fmt.Sprintf("\n1\n%s\nQ\n", cloudName))
+	stdin := strings.NewReader(fmt.Sprintf("y\ny\n\n1\n%s\nQ\n", cloudName))
 	ctx, err := s.runWithCloudsFunc(c, stdin, nil, cloudByNameFunc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, `
@@ -431,7 +431,15 @@ Controller credential "blah" for user "admin@local" for cloud "test-cloud" on co
 For more information, see ‘juju show-credential test-cloud blah’.
 `[1:])
 	c.Assert(called, jc.IsTrue)
-	c.Assert(cmdtesting.Stdout(ctx), gc.DeepEquals, "Do you want to add a credential to current controller \"controller\"? (Y/n): \n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.DeepEquals, `
+This operation can be applied to both a copy on this client and a controller of your choice.
+Do you want to add a credential to this client? (Y/n): 
+Do you want to add a credential to a controller? (Y/n): 
+Controller Names
+  controller
+
+Select controller name [controller]: 
+`[1:])
 }
 
 func (s *detectCredentialsSuite) assertAutoloadCredentials(c *gc.C, expectedStderr string, args ...string) {
@@ -486,15 +494,13 @@ func (s *detectCredentialsSuite) TestRemoteLoadNoRemoteCloud(c *gc.C) {
 1. credential (new)
 Select a credential to save by number, or type Q to quit: 
 Select the cloud it belongs to, or type Q to quit [test-cloud]: 
-Saved credential to cloud test-cloud locally
 
-1. credential (existing, will overwrite)
+1. credential (new)
 Select a credential to save by number, or type Q to quit: 
 
 Cloud "test-cloud" does not exist on the controller: not uploading credentials for it...
 Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.
-`[1:],
-		"--no-prompt")
+`[1:], "-c", "controller")
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialClientOnly(c *gc.C) {
@@ -508,7 +514,7 @@ Saved credential to cloud test-cloud locally
 1. credential (existing, will overwrite)
 Select a credential to save by number, or type Q to quit: 
 `[1:],
-		"--client-only")
+		"--client")
 }
 
 func (s *detectCredentialsSuite) TestAddLoadedCredential(c *gc.C) {

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -435,10 +435,7 @@ For more information, see ‘juju show-credential test-cloud blah’.
 This operation can be applied to both a copy on this client and a controller of your choice.
 Do you want to add a credential to this client? (Y/n): 
 Do you want to add a credential to a controller? (Y/n): 
-Controller Names
-  controller
-
-Select controller name [controller]: 
+Only one controller "controller" is registered. Use it? (Y/n): 
 `[1:])
 }
 

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -164,13 +164,14 @@ func NewSetDefaultRegionCommandForTest(testStore jujuclient.CredentialStore) *se
 	}
 }
 
-func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialAPI) *updateCredentialCommand {
-	return &updateCredentialCommand{
+func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialAPI) cmd.Command {
+	command := &updateCredentialCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore},
 		updateCredentialAPIFunc: func() (CredentialAPI, error) {
 			return api, nil
 		},
 	}
+	return modelcmd.WrapBase(command)
 }
 
 func NewShowCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialContentAPI) cmd.Command {

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -41,19 +41,15 @@ var listCloudsDoc = "" +
 	"name, number of regions, number of registered credentials, default region, type, etc...\n" +
 	"\n" +
 	"Clouds known to this client are the clouds known to Juju out of the box \n" +
-	"along with any which have been added with `add-cloud --client-only`. These clouds can be\n" +
-	"used to create a controller and can be exclusively displayed using --client-only option.\n" +
+	"along with any which have been added with `add-cloud --client`. These clouds can be\n" +
+	"used to create a controller and can be displayed using --client option.\n" +
 	"\n" +
 	"Clouds may be listed that are co-hosted with the Juju client.  When the LXD hypervisor\n" +
 	"is detected, the 'localhost' cloud is made available.  When a microk8s installation is\n" +
 	"detected, the 'microk8s' cloud is displayed.\n" +
 	"\n" +
-	"If a current controller is detected, the user is prompted to confirm" +
-	"if the clouds from that controller should be listed as well. " +
-	"If the current controller clouds are always desirable but the prompt is not," +
-	"use --no-prompt option.\n" +
-	"Another controller can specified using the --controller option. \n" +
-	"To list exclusively only clouds known on the controller, use --controller-only option. \n\n" +
+	"Use --controller option to list clouds from a controller. \n" +
+	"Use --client option to list clouds from this client. \n" +
 	"This command's default output format is 'tabular'. Use 'json' and 'yaml' for\n" +
 	"machine-readable output.\n" +
 	"\n" +
@@ -76,9 +72,9 @@ Examples:
 
     juju clouds
     juju clouds --format yaml
-    juju clouds --controller mycontroller --controller-only
-    juju clouds --no-prompt
-    juju clouds --client-only
+    juju clouds --controller mycontroller 
+    juju clouds --controller mycontroller --client
+    juju clouds --client
 
 See also:
     add-cloud
@@ -144,14 +140,14 @@ func (c *listCloudsCommand) getCloudList(ctxt *cmd.Context) (*cloudList, error) 
 		returnErr = cmd.ErrSilent
 	}
 	details := newCloudList()
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		var err error
 		if details, err = listLocalCloudDetails(c.Store); err != nil {
 			warn(err)
 		}
 	}
 
-	if (c.BothClientAndController || c.ControllerOnly) && c.ControllerName != "" {
+	if c.ControllerName != "" {
 		remotes := func() error {
 			api, err := c.listCloudsAPIFunc()
 			if err != nil {
@@ -183,14 +179,8 @@ func (c *listCloudsCommand) getCloudList(ctxt *cmd.Context) (*cloudList, error) 
 }
 
 func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
-	if !c.ClientOnly && c.ControllerName == "" {
-		// The user may have specified the controller via a --controller option.
-		// If not, let's see if there is a current controller that can be detected.
-		var err error
-		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, "list clouds from")
-		if err != nil {
-			return errors.Trace(err)
-		}
+	if err := c.MaybePrompt(ctxt, "list clouds from"); err != nil {
+		return errors.Trace(err)
 	}
 	details, err := c.getCloudList(ctxt)
 	if err != nil {

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -203,9 +203,6 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 		}
 		result = clouds
 	default:
-		if c.ControllerName == "" {
-			ctxt.Infof("No controllers were specified.")
-		}
 		result = details
 	}
 	return c.out.Write(ctxt, result)

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -44,7 +44,6 @@ func (s *listSuite) TestListNoCredentialsRegistered(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Only clouds with registered credentials are shown.
 There are more clouds, use --all to see them.
-No controllers were specified.
 `[1:])
 }
 
@@ -70,10 +69,6 @@ func (s *listSuite) TestListPublicLocalDefault(c *gc.C) {
 	s.store.Controllers = nil
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--all", "--client")
 	c.Assert(err, jc.ErrorIsNil)
-	out := cmdtesting.Stderr(ctx)
-	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Matches, `No controllers were specified.`)
-
 	// Check that we are producing the expected fields
 	s.assertCloudsOutput(c, cmdtesting.Stdout(ctx))
 }

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -39,7 +39,7 @@ func (s *listSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *listSuite) TestListNoCredentialsRegistered(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Only clouds with registered credentials are shown.
@@ -49,7 +49,7 @@ No controllers were specified.
 }
 
 func (s *listSuite) TestListPublic(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--client-only", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--client", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCloudsOutput(c, cmdtesting.Stdout(ctx))
 }
@@ -68,7 +68,7 @@ func (s *listSuite) assertCloudsOutput(c *gc.C, out string) {
 
 func (s *listSuite) TestListPublicLocalDefault(c *gc.C) {
 	s.store.Controllers = nil
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--all")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--all", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -98,7 +98,7 @@ func (s *listSuite) TestListController(c *gc.C) {
 		},
 	}
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "yaml", "--no-prompt", "--all", "--controller-only")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "yaml", "--all", "-c", "mycontroller")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
@@ -135,7 +135,7 @@ func (s *listSuite) TestListKubernetes(c *gc.C) {
 		},
 	}
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "yaml", "--all", "--controller-only")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "yaml", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
@@ -183,7 +183,7 @@ func (s *listSuite) assertListTabular(c *gc.C, expectedOutput string) {
 			return s.api, nil
 		})
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "tabular", "--all", "--controller-only")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "tabular", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
@@ -236,7 +236,7 @@ clouds:
 			return s.api, nil
 		})
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--client-only", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--client", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -257,7 +257,7 @@ clouds:
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client-only", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -268,7 +268,7 @@ clouds:
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client-only", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -277,7 +277,7 @@ func (s *listSuite) TestListYAML(c *gc.C) {
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "json", "--client-only", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "json", "--client", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -286,7 +286,7 @@ func (s *listSuite) TestListJSON(c *gc.C) {
 }
 
 func (s *listSuite) TestListPreservesRegionOrder(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client-only", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client", "--all")
 	c.Assert(err, jc.ErrorIsNil)
 	lines := strings.Split(cmdtesting.Stdout(ctx), "\n")
 	withClouds := "clouds:\n  " + strings.Join(lines, "\n  ")

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -130,8 +130,16 @@ type Credential struct {
 }
 
 type credentialsMap struct {
-	ClientOnly bool                       `yaml:"-" json:"-"`
-	Client     map[string]CloudCredential `yaml:"client-credentials,omitempty" json:"client-credentials,omitempty"`
+	// ClientOnly holds whether the client list was requested or not.
+	// It is needed in the formatter when we get an empty list -
+	// is it that there are no credentials on the client or
+	// is it that we were not even looking on the client for credentials.
+	ClientOnly bool `yaml:"-" json:"-"`
+
+	// Client has a collection of all client credentials keyed on credential name.
+	Client map[string]CloudCredential `yaml:"client-credentials,omitempty" json:"client-credentials,omitempty"`
+
+	// Controller has a collection of all controller credentials keyed on credential name.
 	Controller map[string]CloudCredential `yaml:"controller-credentials,omitempty" json:"controller-credentials,omitempty"`
 }
 

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -4,7 +4,6 @@
 package cloud_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -151,8 +150,14 @@ func (s *regionsSuite) TestListNoController(c *gc.C) {
 	err := cmdtesting.InitCommand(command, []string{"google"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = command.Run(ctx)
-	fmt.Printf("\n%v\n", err)
-	c.Assert(err, gc.ErrorMatches, "registered controllers on this client not found")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+This operation can be applied to both a copy on this client and a controller of your choice.
+Do you want to list regions for cloud "google" from this client? (Y/n): 
+Do you want to list regions for cloud "google" from a controller? (Y/n): 
+
+`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No registered controllers on this client: either bootstrap one or register one.\n")
 }
 
 func (s *regionsSuite) TestListRegionsJson(c *gc.C) {

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -4,7 +4,9 @@
 package cloud_test
 
 import (
+	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
@@ -64,7 +66,7 @@ func (s *regionsSuite) TestListRegionsInvalidArgs(c *gc.C) {
 }
 
 func (s *regionsSuite) TestListRegionsLocalOnly(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "kloud", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "kloud", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, "\nClient Cloud Regions\nlondon\nparis\n\n")
@@ -97,7 +99,7 @@ func (s *regionsSuite) setupControllerData(c *gc.C) cmd.Command {
 
 func (s *regionsSuite) TestListRegions(c *gc.C) {
 	aCommand := s.setupControllerData(c)
-	ctx, err := cmdtesting.RunCommand(c, aCommand, "kloud", "--no-prompt", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, aCommand, "kloud", "-c", "mycontroller", "--client", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
@@ -116,21 +118,21 @@ controller-cloud-regions:
 
 func (s *regionsSuite) TestListRegionsControllerOnly(c *gc.C) {
 	aCommand := s.setupControllerData(c)
-	ctx, err := cmdtesting.RunCommand(c, aCommand, "kloud", "--controller-only", "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, aCommand, "kloud", "-c", "mycontroller")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, "\nController Cloud Regions\nhive  \nmind  \n\n")
 }
 
 func (s *regionsSuite) TestListRegionsBuiltInCloud(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "localhost", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "localhost", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, "\nClient Cloud Regions\nlocalhost\n\n")
 }
 
 func (s *regionsSuite) TestListRegionsYaml(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "kloud", "--format", "yaml", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "kloud", "--format", "yaml", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `
@@ -142,14 +144,19 @@ client-cloud-regions:
 `[1:])
 }
 
-func (s *regionsSuite) TestListNoRegionsOnController(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "google")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
-	c.Assert(c.GetTestLog(), jc.Contains, `Not listing regions for cloud "google" from a controller: no controller specified.`)
+func (s *regionsSuite) TestListNoController(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = strings.NewReader("n\ny\n")
+	command := cloud.NewListRegionsCommand()
+	err := cmdtesting.InitCommand(command, []string{"google"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = command.Run(ctx)
+	fmt.Printf("\n%v\n", err)
+	c.Assert(err, gc.ErrorMatches, "registered controllers on this client not found")
 }
 
 func (s *regionsSuite) TestListRegionsJson(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "kloud", "--format", "json", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListRegionsCommand(), "kloud", "--format", "json", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, "{\"client-cloud-regions\":{\"london\":{\"endpoint\":\"http://london/1.0\"},\"paris\":{\"endpoint\":\"http://paris/1.0\"}}}\n")
 }

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -25,20 +25,11 @@ Remove a cloud from Juju.
 If --controller is used, also remove the cloud from the specified controller,
 if it is not in use.
 
-If --controller option was not used and the current controller can be detected, 
-a user will be prompted to confirm if specified cloud needs to be removed from it. 
-If the prompt is not needed and the cloud is always to be removed from
-the current controller if that controller is detected, use --no-prompt option.
-
-If you just want to update your controller and not your current client, 
-use the --controller-only option.
-
-If --client-only is specified, Juju removes the cloud from this client only.
+If --client is specified, Juju removes the cloud from this client.
 
 Examples:
     juju remove-cloud mycloud
-    juju remove-cloud mycloud --controller-only --no-prompt
-    juju remove-cloud mycloud --client-only
+     juju remove-cloud mycloud --client
     juju remove-cloud mycloud --controller mycontroller
 
 See also:
@@ -102,33 +93,23 @@ func (c *removeCloudCommand) Init(args []string) (err error) {
 }
 
 func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName == "" {
-			// The user may have specified the controller via a --controller option.
-			// If not, let's see if there is a current controller that can be detected.
-			var err error
-			c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("remove cloud %v from", c.Cloud))
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
+	if err := c.MaybePrompt(ctxt, fmt.Sprintf("remove cloud %v from", c.Cloud)); err != nil {
+		return errors.Trace(err)
 	}
-	if c.ControllerName == "" && !c.ClientOnly {
-		ctxt.Infof("To remove cloud %q from this client, use the --client-only option.", c.Cloud)
+	if c.ControllerName == "" && !c.Client {
+		ctxt.Infof("To remove cloud %q from this client, use the --client option.", c.Cloud)
 	}
 	var returnErr error
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		if err := c.removeLocalCloud(ctxt); err != nil {
 			ctxt.Warningf("%v", err)
 			returnErr = cmd.ErrSilent
 		}
 	}
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName == "" {
-			ctxt.Infof("Could not remote a cloud from a controller: no controller was specified.")
+	if c.ControllerName != "" {
+		if err := c.removeControllerCloud(ctxt); err != nil {
+			ctxt.Warningf("%v", err)
 			returnErr = cmd.ErrSilent
-		} else {
-			return c.removeControllerCloud(ctxt)
 		}
 	}
 	return returnErr

--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -96,9 +96,6 @@ func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 	if err := c.MaybePrompt(ctxt, fmt.Sprintf("remove cloud %v from", c.Cloud)); err != nil {
 		return errors.Trace(err)
 	}
-	if c.ControllerName == "" && !c.Client {
-		ctxt.Infof("To remove cloud %q from this client, use the --client option.", c.Cloud)
-	}
 	var returnErr error
 	if c.Client {
 		if err := c.removeLocalCloud(ctxt); err != nil {

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -6,7 +6,6 @@ package cloud_test
 import (
 	"io/ioutil"
 
-	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -38,15 +37,15 @@ func (s *removeSuite) SetUpTest(c *gc.C) {
 
 func (s *removeSuite) TestRemoveBadArgs(c *gc.C) {
 	command := cloud.NewRemoveCloudCommand()
-	_, err := cmdtesting.RunCommand(c, command, "--client-only")
+	_, err := cmdtesting.RunCommand(c, command, "--client")
 	c.Assert(err, gc.ErrorMatches, "Usage: juju remove-cloud <cloud name>")
-	_, err = cmdtesting.RunCommand(c, command, "cloud", "extra", "--client-only")
+	_, err = cmdtesting.RunCommand(c, command, "cloud", "extra", "--client")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
 }
 
 func (s *removeSuite) TestRemoveNotFound(c *gc.C) {
 	command := cloud.NewRemoveCloudCommandForTest(s.store, nil)
-	ctx, err := cmdtesting.RunCommand(c, command, "fnord", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, command, "fnord", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No cloud called \"fnord\" exists on this client\n")
 }
@@ -84,7 +83,7 @@ func (s *removeSuite) TestRemoveCloudLocal(c *gc.C) {
 		})
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of cloud \"homestack\" from the client\n")
 	assertPersonalClouds(c, "homestack2")
@@ -100,14 +99,11 @@ func (s *removeSuite) TestRemoveCloudNoControllers(c *gc.C) {
 		})
 	s.createTestCloudData(c)
 	assertPersonalClouds(c, "homestack", "homestack2")
-	ctx, err := cmdtesting.RunCommand(c, command, "homestack")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--client")
+	c.Assert(err, jc.ErrorIsNil)
 	assertPersonalClouds(c, "homestack2")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Matches,
-		"To remove cloud \"homestack\" from this client, use the --client-only option.\n"+
-			"Removed details of cloud \"homestack\" from the client\n"+
-			"Could not remote a cloud from a controller: no controller was specified.\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, "Removed details of cloud \"homestack\" from the client\n")
 }
 
 func (s *removeSuite) TestRemoveCloudControllerControllerOnly(c *gc.C) {
@@ -117,7 +113,7 @@ func (s *removeSuite) TestRemoveCloudControllerControllerOnly(c *gc.C) {
 			return s.api, nil
 		})
 	s.createTestCloudData(c)
-	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--no-prompt", "--controller-only")
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "-c", "mycontroller")
 	c.Assert(err, jc.ErrorIsNil)
 	assertPersonalClouds(c, "homestack", "homestack2")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
@@ -125,14 +121,14 @@ func (s *removeSuite) TestRemoveCloudControllerControllerOnly(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Removed details of cloud \"homestack\" from controller \"mycontroller\"\n")
 }
 
-func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
+func (s *removeSuite) TestRemoveCloudBoth(c *gc.C) {
 	command := cloud.NewRemoveCloudCommandForTest(
 		s.store,
 		func() (cloud.RemoveCloudAPI, error) {
 			return s.api, nil
 		})
 	s.createTestCloudData(c)
-	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, command, "homestack", "-c", "mycontroller", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	assertPersonalClouds(c, "homestack2")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
@@ -144,8 +140,9 @@ func (s *removeSuite) TestRemoveCloudController(c *gc.C) {
 
 func (s *removeSuite) TestCannotRemovePublicCloud(c *gc.C) {
 	s.createTestCloudData(c)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client-only")
-	c.Assert(err, jc.ErrorIsNil)
+	ctx, _ := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client")
+	//ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client")
+	//c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No cloud called \"prodstack\" exists on this client\n")
 }
 

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -140,9 +140,8 @@ func (s *removeSuite) TestRemoveCloudBoth(c *gc.C) {
 
 func (s *removeSuite) TestCannotRemovePublicCloud(c *gc.C) {
 	s.createTestCloudData(c)
-	ctx, _ := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client")
-	//ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client")
-	//c.Assert(err, jc.ErrorIsNil)
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewRemoveCloudCommand(), "prodstack", "--client")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No cloud called \"prodstack\" exists on this client\n")
 }
 

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -119,9 +119,6 @@ func (c *removeCredentialCommand) Run(ctxt *cmd.Context) error {
 	if err := c.MaybePrompt(ctxt, fmt.Sprintf("remove credential %q for cloud %q from", c.credential, c.cloud)); err != nil {
 		return errors.Trace(err)
 	}
-	if c.ControllerName == "" && !c.Client {
-		ctxt.Infof("To remove credential %q for cloud %q from this client, use the --client option.", c.credential, c.cloud)
-	}
 	var client RemoveCredentialAPI
 	if c.ControllerName != "" {
 		var err error

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -127,25 +127,18 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 		localCloud, localErr = c.getLocalCloud()
 	}
 
-	var (
-		remoteCloud *CloudDetails
-		remoteErr   error
-	)
-	if c.ControllerName != "" {
-		remoteCloud, remoteErr = c.getControllerCloud()
-	}
-
 	var displayErr error
-	showRemoteConfig := c.includeConfig
-	if localCloud != nil && remoteCloud != nil {
-		// It's possible that a local cloud named A is different to
-		// a remote cloud named A. If their types are different and we
-		// need to display config, we'd need to list each cloud type config.
-		// If the clouds' types are the same, we only need to list
-		// config once after the local cloud information.
-		showRemoteConfig = showRemoteConfig && localCloud.CloudType != remoteCloud.CloudType
-	}
 	if c.ControllerName != "" {
+		remoteCloud, remoteErr := c.getControllerCloud()
+		showRemoteConfig := c.includeConfig
+		if localCloud != nil && remoteCloud != nil {
+			// It's possible that a local cloud named A is different to
+			// a remote cloud named A. If their types are different and we
+			// need to display config, we'd need to list each cloud type config.
+			// If the clouds' types are the same, we only need to list
+			// config once after the local cloud information.
+			showRemoteConfig = showRemoteConfig && localCloud.CloudType != remoteCloud.CloudType
+		}
 		if remoteCloud != nil {
 			if err := c.displayCloud(ctxt, remoteCloud, fmt.Sprintf("Cloud %q from controller %q:\n", c.CloudName, c.ControllerName), showRemoteConfig, remoteErr); err != nil {
 				ctxt.Warningf("%v", err)

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -41,24 +41,17 @@ options.
 If ‘--include-config’ is used, additional configuration (key, type, and
 description) specific to the cloud are displayed if available.
 
-If the current controller can be detected, a user will be prompted to 
-confirm if a cloud known to the controller need to be shown as well. 
-If the prompt is not needed and the cloud from current controller is
-always to be shown, use --no-prompt option.
+Use --controller option to show a cloud from a controller.
 
-Use --controller option to show a cloud from a different controller.
-
-Use --client-only option to only show a cloud known on this client.
-
-Use --controller-only option to only show a cloud known on the controller.
+Use --client option to show a cloud known on this client.
 
 Examples:
 
     juju show-cloud google
     juju show-cloud azure-china --output ~/azure_cloud_details.txt
-    juju show-cloud myopenstack --controller mycontroller --controller-only
-    juju show-cloud myopenstack --client-only
-    juju show-cloud myopenstack --no-prompt
+    juju show-cloud myopenstack --controller mycontroller
+    juju show-cloud myopenstack --client
+    juju show-cloud myopenstack --client --controller mycontroller
 
 See also:
     clouds
@@ -123,32 +116,23 @@ func (c *showCloudCommand) Info() *cmd.Info {
 }
 
 func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
+	if err := c.MaybePrompt(ctxt, fmt.Sprintf("show cloud %q from", c.CloudName)); err != nil {
+		return errors.Trace(err)
+	}
 	var (
 		localCloud *CloudDetails
 		localErr   error
 	)
-	if c.BothClientAndController || c.ClientOnly {
-		if localCloud, localErr = c.getLocalCloud(); c.ClientOnly && localErr != nil {
-			return localErr
-		}
+	if c.Client {
+		localCloud, localErr = c.getLocalCloud()
 	}
 
 	var (
 		remoteCloud *CloudDetails
 		remoteErr   error
 	)
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName == "" {
-			// The user may have specified the controller via a --controller option.
-			// If not, let's see if there is a current controller that can be detected.
-			c.ControllerName, remoteErr = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("show cloud %q from", c.CloudName))
-		}
-		if c.ControllerName == "" && remoteErr == nil {
-			remoteErr = errors.New("Not showing a cloud from a controller: no controller specified.")
-		}
-		if remoteErr == nil {
-			remoteCloud, remoteErr = c.getControllerCloud()
-		}
+	if c.ControllerName != "" {
+		remoteCloud, remoteErr = c.getControllerCloud()
 	}
 
 	var displayErr error
@@ -161,7 +145,7 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 		// config once after the local cloud information.
 		showRemoteConfig = showRemoteConfig && localCloud.CloudType != remoteCloud.CloudType
 	}
-	if c.BothClientAndController || c.ControllerOnly {
+	if c.ControllerName != "" {
 		if remoteCloud != nil {
 			if err := c.displayCloud(ctxt, remoteCloud, fmt.Sprintf("Cloud %q from controller %q:\n", c.CloudName, c.ControllerName), showRemoteConfig, remoteErr); err != nil {
 				ctxt.Warningf("%v", err)
@@ -176,7 +160,7 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 			}
 		}
 	}
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		if localCloud != nil {
 			if err := c.displayCloud(ctxt, localCloud, fmt.Sprintf("\nClient cloud %q:\n", c.CloudName), c.includeConfig, localErr); err != nil {
 				ctxt.Warningf("%v", err)

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -51,7 +50,7 @@ func (s *showSuite) assertShowLocal(c *gc.C, expectedOutput string) {
 			c.Fail()
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, command, "aws-china", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, command, "aws-china", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, expectedOutput)
@@ -113,7 +112,7 @@ func (s *showSuite) TestShowKubernetes(c *gc.C) {
 			return s.api, nil
 		})
 	ctx, err := cmdtesting.RunCommand(c, command, "--controller", "mycontroller", "beehive")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Cloud", "Close")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	out := cmdtesting.Stdout(ctx)
@@ -154,8 +153,8 @@ func (s *showSuite) TestShowControllerCloudNoLocal(c *gc.C) {
 		func() (cloud.ShowCloudAPI, error) {
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, command, "beehive", "--no-prompt")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+	ctx, err := cmdtesting.RunCommand(c, command, "beehive", "-c", "mycontroller")
+	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Cloud", "Close")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	out := cmdtesting.Stdout(ctx)
@@ -180,7 +179,7 @@ func (s *showSuite) TestShowControllerAndLocalCloud(c *gc.C) {
 		func() (cloud.ShowCloudAPI, error) {
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, command, "aws-china", "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, command, "aws-china", "-c", "mycontroller", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Cloud", "Close")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
@@ -228,7 +227,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
@@ -297,7 +296,7 @@ clouds:
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, strings.Join([]string{`
@@ -323,7 +322,7 @@ region-config:
 }
 
 func (s *showSuite) TestShowWithRegionConfigAndFlagNoExtraOut(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "joyent", "--include-config", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "joyent", "--include-config", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
@@ -417,7 +416,7 @@ ca-credentials:
 func (s *showSuite) TestShowWithCACertificate(c *gc.C) {
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(yamlWithCert), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, resultWithCert)

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -86,8 +86,11 @@ func (c *showCredentialCommand) Info() *cmd.Info {
 }
 
 func (c *showCredentialCommand) Run(ctxt *cmd.Context) error {
+	if err := c.MaybePrompt(ctxt, fmt.Sprintf("show credential %q for cloud %q from", c.CredentialName, c.CloudName)); err != nil {
+		return errors.Trace(err)
+	}
 	all := ControllerCredentials{}
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		result, err := c.localCredentials(ctxt)
 		if err != nil {
 			ctxt.Infof("client credential content lookup failed: %v", err)
@@ -95,7 +98,7 @@ func (c *showCredentialCommand) Run(ctxt *cmd.Context) error {
 			all.Client = c.parseContents(ctxt, result)
 		}
 	}
-	if c.BothClientAndController || c.ControllerOnly {
+	if c.ControllerName != "" {
 		remoteContents, err := c.remoteCredentials(ctxt)
 		if err != nil {
 			ctxt.Infof("credential content lookup on the controller failed: %v", err)
@@ -111,19 +114,6 @@ func (c *showCredentialCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *showCredentialCommand) remoteCredentials(ctxt *cmd.Context) ([]params.CredentialContentResult, error) {
-	if c.ControllerName == "" {
-		// The user may have specified the controller via a --controller option.
-		// If not, let's see if there is a current controller that can be detected.
-		var err error
-		c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("show credential %q for cloud %q from", c.CredentialName, c.CloudName))
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	if c.ControllerName == "" {
-		return nil, errors.Errorf("Not showing credential %q for cloud %q from a controller: no controller specified.", c.CredentialName, c.CloudName)
-	}
-
 	client, err := c.newAPIFunc()
 	if err != nil {
 		return nil, err
@@ -265,23 +255,17 @@ To see all credentials stored for you, supply no arguments.
 
 To see secrets, content attributes marked as hidden, use --show-secrets option.
 
-To see only credentials from this client, use "--client-only" option.
+To see credentials from this client, use "--client" option.
 
-To see only credentials from a controller, use "--controller-only" option.
-
-If the current controller can be detected, a user will be prompted to 
-confirm if a credential known to the controller need to be shown as well. 
-If the prompt is not needed and the credential from current controller is
-always to be shown, use --no-prompt option.
-
-Use --controller option to show a credential from a different controller.
+To see credentials from a controller, use "--controller" option.
 
 Examples:
 
     juju show-credential google my-admin-credential
     juju show-credentials 
-    juju show-credentials --controller mycontroller --controller-only 
-    juju show-credentials --client-only
+    juju show-credentials --controller mycontroller --client 
+    juju show-credentials --controller mycontroller 
+    juju show-credentials --client
     juju show-credentials --show-secrets
 
 See also: 

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -73,7 +73,7 @@ func (s *ShowCredentialSuite) TestShowCredentialBadArgs(c *gc.C) {
 func (s *ShowCredentialSuite) TestShowCredentialAPIVersion(c *gc.C) {
 	s.api.v = 1
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "-c", "controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 credential content lookup on the controller failed: credential content lookup on the controller in Juju v1 not supported
@@ -86,7 +86,7 @@ No credentials from this client or from a controller to display.
 func (s *ShowCredentialSuite) TestShowCredentialAPICallError(c *gc.C) {
 	s.api.SetErrors(errors.New("boom"), nil)
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "-c", "controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 credential content lookup on the controller failed: boom
@@ -99,7 +99,7 @@ No credentials from this client or from a controller to display.
 func (s *ShowCredentialSuite) TestShowCredentialNone(c *gc.C) {
 	s.api.contents = []params.CredentialContentResult{}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "-c", "controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No credentials from this client or from a controller to display.\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
@@ -130,7 +130,7 @@ func (s *ShowCredentialSuite) TestShowCredentialBothClientAndController(c *gc.C)
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets", "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets", "-c", "controller", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ``)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
@@ -225,7 +225,7 @@ func (s *ShowCredentialSuite) TestShowCredentialMany(c *gc.C) {
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--no-prompt", "--controller-only")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "-c", "controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "boom\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -141,9 +141,6 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 	if err := c.MaybePrompt(ctxt, fmt.Sprintf("update cloud %q on", c.Cloud)); err != nil {
 		return errors.Trace(err)
 	}
-	if c.ControllerName == "" && !c.Client {
-		ctxt.Infof("To update cloud %q on this client, use the --client option.", c.Cloud)
-	}
 	var returnErr error
 	processErr := func(err error, successMsg string) {
 		if err != nil {

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -43,24 +43,17 @@ This method can be used for cloud updates on the client side and on a controller
 A cloud on the controller can also be updated just by using a name of a cloud
 from this client.
 
-If a current controller can be detected, a user will be prompted to confirm 
-if specified cloud needs to be updated on it. 
-If the prompt is not needed and the cloud is always to be updated on
-the current controller if that controller is detected, use --no-prompt option.
+Use --controller option to update a cloud on a controller. 
 
-Use --controller option to update a cloud on a different controller. 
-
-Use --controller-only option to only update controller copy of the cloud.
-
-Use --client-only to update cloud definition on this client.
+Use --client to update cloud definition on this client.
 
 Examples:
 
     juju update-cloud mymaas -f path/to/maas.yaml
     juju update-cloud mymaas -f path/to/maas.yaml --controller mycontroller
     juju update-cloud mymaas --controller mycontroller
-    juju update-cloud mymaas --no-prompt --controller-only
-    juju update-cloud mymaas --client-only -f path/to/maas.yaml
+    juju update-cloud mymaas --client --controller mycontroller
+    juju update-cloud mymaas --client -f path/to/maas.yaml
 
 See also:
     add-cloud
@@ -145,20 +138,11 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 		}
 		c.Cloud = r.cloudName
 	}
-
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName == "" {
-			// The user may have specified the controller via a --controller option.
-			// If not, let's see if there is a current controller that can be detected.
-			var err error
-			c.ControllerName, err = c.MaybePromptCurrentController(ctxt, fmt.Sprintf("update cloud %q on", c.Cloud))
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
+	if err := c.MaybePrompt(ctxt, fmt.Sprintf("update cloud %q on", c.Cloud)); err != nil {
+		return errors.Trace(err)
 	}
-	if c.ControllerName == "" && !c.ClientOnly {
-		ctxt.Infof("To update cloud %q on this client, use the --client-only option.", c.Cloud)
+	if c.ControllerName == "" && !c.Client {
+		ctxt.Infof("To update cloud %q on this client, use the --client option.", c.Cloud)
 	}
 	var returnErr error
 	processErr := func(err error, successMsg string) {
@@ -169,7 +153,7 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 		}
 		ctxt.Infof(successMsg)
 	}
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		if c.CloudFile == "" {
 			ctxt.Infof("To update cloud %q on this client, a cloud definition file is required.", c.Cloud)
 			returnErr = cmd.ErrSilent
@@ -178,17 +162,13 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 			processErr(err, fmt.Sprintf("Cloud %q updated on this client using provided file.", c.Cloud))
 		}
 	}
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName != "" {
-			if c.CloudFile != "" {
-				err := c.updateController(newCloud)
-				processErr(err, fmt.Sprintf("Cloud %q updated on controller %q using provided file.", c.Cloud, c.ControllerName))
-			} else {
-				err := c.updateControllerCacheFromLocalCache()
-				processErr(err, fmt.Sprintf("Cloud %q updated on controller %q using client cloud definition.", c.Cloud, c.ControllerName))
-			}
+	if c.ControllerName != "" {
+		if c.CloudFile != "" {
+			err := c.updateController(newCloud)
+			processErr(err, fmt.Sprintf("Cloud %q updated on controller %q using provided file.", c.Cloud, c.ControllerName))
 		} else {
-			return errors.BadRequestf("To update cloud definition on a controller, a controller name is required.")
+			err := c.updateControllerCacheFromLocalCache()
+			processErr(err, fmt.Sprintf("Cloud %q updated on controller %q using client cloud definition.", c.Cloud, c.ControllerName))
 		}
 	}
 	return returnErr

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -35,9 +35,9 @@ a model was created with to the new and valid details on controller.
 This command allows to update an existing, already-stored, named,
 cloud-specific credential on a controller as well as the one from this client.
 
-Use --controller option to update a cloud on a controller. 
+Use --controller option to update a credential definition on a controller. 
 
-If --client is used, Juju updates credential on this client.
+Use --client to update a credential definition on this client.
 If a user will use a different client, say a different laptop, 
 the update will not affect that client's (laptop's) copy.
 

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -274,7 +274,7 @@ func (c *updateCredentialCommand) updateLocalCredentials(ctx *cmd.Context, updat
 		storedCredentials, err := c.Store.CredentialForCloud(cloudName)
 		if errors.IsNotFound(err) {
 			ctx.Warningf("Could not find credentials for cloud %v on this client.", cloudName)
-			ctx.Infof("Use `juju add-credential` to add credentials to this client.")
+			ctx.Infof("Use `juju add-credential` to add a credential to this client.")
 			erred = true
 			continue
 		} else if err != nil {

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -35,16 +35,9 @@ a model was created with to the new and valid details on controller.
 This command allows to update an existing, already-stored, named,
 cloud-specific credential on a controller as well as the one from this client.
 
-If a current controller can be detected, a user will be prompted to confirm 
-if specified cloud needs to be updated on it. 
-If the prompt is not needed and the cloud is always to be updated on
-the current controller if that controller is detected, use --no-prompt option.
+Use --controller option to update a cloud on a controller. 
 
-Use --controller option to update a cloud on a different controller. 
-
-Use --controller-only option to only update controller copy of the cloud.
-
-If --client-only is used, Juju updates credential only on this client.
+If --client is used, Juju updates credential on this client.
 If a user will use a different client, say a different laptop, 
 the update will not affect that client's (laptop's) copy.
 
@@ -55,8 +48,7 @@ use --region.
 Examples:
     juju update-credential aws mysecrets
     juju update-credential -f mine.yaml
-    juju update-credential -f mine.yaml --client-only
-    juju update-credential -f mine.yaml --no-prompt --controller-only
+    juju update-credential -f mine.yaml --client
     juju update-credential aws -f mine.yaml
     juju update-credential azure --region brazilsouth -f mine.yaml
 
@@ -168,28 +160,18 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 			return errors.Annotatef(err, "could not get credentials from local client")
 		}
 	}
+	if err := c.MaybePrompt(ctx, fmt.Sprintf("update credential %q on cloud %q on", c.credential, c.cloud)); err != nil {
+		return errors.Trace(err)
+	}
 	var returnErr error
-	if c.BothClientAndController || c.ClientOnly {
+	if c.Client {
 		if err := c.updateLocalCredentials(ctx, credentials); err != nil {
 			returnErr = err
 		}
 	}
-	if c.BothClientAndController || c.ControllerOnly {
-		if c.ControllerName == "" {
-			// The user may have specified the controller via a --controller option.
-			// If not, let's see if there is a current controller that can be detected.
-			var err error
-			c.ControllerName, err = c.MaybePromptCurrentController(ctx, fmt.Sprintf("update credential %q on cloud %q on", c.credential, c.cloud))
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
-		if c.ControllerName != "" {
-			if err := c.updateRemoteCredentials(ctx, credentials); err != nil {
-				returnErr = err
-			}
-		} else {
-			return errors.New("To update credential on a controller, a controller name is needed.")
+	if c.ControllerName != "" {
+		if err := c.updateRemoteCredentials(ctx, credentials); err != nil {
+			returnErr = err
 		}
 	}
 	return returnErr

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -264,7 +264,7 @@ func (s *updateCredentialSuite) TestCloudCredentialFromLocalCacheWithCloudAndCre
 }
 
 func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenNoneExists(c *gc.C) {
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client")
 	c.Assert(err, gc.ErrorMatches, "could not get credentials from local client: loading credentials: credentials for cloud somecloud not found")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
@@ -272,7 +272,7 @@ func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenNoneExists(c *gc.C) 
 
 func (s *updateCredentialSuite) TestUpdateLocalWithCloudWhenCredentialDoesNotExists(c *gc.C) {
 	s.storeWithCredentials(c)
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "fluffy-credential", "--client-only")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "fluffy-credential", "--client")
 	c.Assert(err, gc.ErrorMatches, `could not get credentials from local client: credential "fluffy-credential" for cloud "somecloud" in local client not found`)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
@@ -290,7 +290,7 @@ credentials:
 	s.storeWithCredentials(c)
 	before := s.store.Credentials["somecloud"].AuthCredentials["its-credential"].Attributes()["access-key"]
 	c.Assert(before, gc.DeepEquals, "key")
-	ctxt, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client-only", "-f", testFile)
+	ctxt, err := cmdtesting.RunCommand(c, s.testCommand, "somecloud", "its-credential", "--client", "-f", testFile)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctxt), gc.Equals, "Local client was updated successfully with provided credential information.\n")
 	c.Assert(cmdtesting.Stdout(ctxt), gc.Equals, "")
@@ -344,7 +344,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteCredentialWithFilePath(c *gc.C) 
 		}
 		return nil, nil
 	}
-	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--no-prompt", "--controller-only")
+	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "-c", "controller")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -384,7 +384,7 @@ credentials:
       auth-type: jsonfile
       file: %v
 `, tmpFile.Name()))
-	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--client-only", "-f", testFile)
+	_, err = cmdtesting.RunCommand(c, s.testCommand, "google", "gce", "--client", "-f", testFile)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.store.Credentials["google"].AuthCredentials["gce"].Attributes()["file"], gc.Not(jc.Contains), string(contents))
 	c.Assert(s.store.Credentials["google"].AuthCredentials["gce"].Attributes()["file"], gc.Equals, tmpFile.Name())
@@ -401,7 +401,7 @@ func (s *updateCredentialSuite) TestUpdateRemote(c *gc.C) {
 		return []params.UpdateCredentialResult{{CredentialTag: expectedTag}}, nil
 	}
 	s.storeWithCredentials(c)
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--controller-only", "--no-prompt")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "-c", "controller")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, ``)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `
@@ -455,7 +455,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteResultNotUserCloudError(c *gc.C)
 			names.NewCloudTag("somecloud"): {Name: "somecloud", Type: "openstack"},
 		}, nil
 	}
-	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--no-prompt", "--controller-only")
+	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "-c", "controller")
 	c.Assert(err, gc.NotNil)
 	c.Assert(c.GetTestLog(), jc.Contains, `No cloud "aws" available to user "admin@local" remotely on controller "controller"`)
 }
@@ -465,7 +465,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteResultError(c *gc.C) {
 		return nil, errors.New("kaboom")
 	}
 	s.storeWithCredentials(c)
-	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--no-prompt", "--controller-only")
+	_, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "-c", "controller")
 	c.Assert(err, gc.NotNil)
 	c.Assert(c.GetTestLog(), jc.Contains, ` kaboom`)
 	c.Assert(c.GetTestLog(), jc.Contains, `Could not update credentials remotely, on controller "controller"`)
@@ -500,7 +500,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteWithModels(c *gc.C) {
 	}
 	s.storeWithCredentials(c)
 
-	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "--no-prompt", "--controller-only")
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "-c", "controller")
 	c.Assert(err, gc.DeepEquals, jujucmd.ErrSilent)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Credential valid for:

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -500,8 +500,8 @@ func (c *OptionalControllerCommand) queryControllerName(ctxt *cmd.Context, polls
 		defaultController = controllers[0]
 	}
 	cName, err := pollster.SelectVerify(interact.List{
-		Singular: "controller name",
-		Plural:   "controller names",
+		Singular: "controller",
+		Plural:   "controllers",
 		Options:  controllers,
 		Default:  defaultController,
 	}, nameVerify)

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -442,19 +442,20 @@ func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string
 		return errors.Trace(err)
 	}
 	if useController {
-		return c.queryControllerName(pollster)
+		return c.queryControllerName(ctxt, pollster)
 	}
 	return nil
 }
 
-func (c *OptionalControllerCommand) queryControllerName(pollster *interact.Pollster) error {
+func (c *OptionalControllerCommand) queryControllerName(ctxt *cmd.Context, pollster *interact.Pollster) error {
 	all, err := c.Store.AllControllers()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if len(all) == 0 {
 		// No controllers, so nothing to do.
-		return errors.NotFoundf("registered controllers on this client")
+		ctxt.Infof("No registered controllers on this client: either bootstrap one or register one.")
+		return nil
 	}
 
 	controllers := []string{}

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -418,9 +418,7 @@ func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init populates the command with the args from the command line.
 func (c *OptionalControllerCommand) Init(args []string) (err error) {
-	if c.Local && !c.Client {
-		c.Client = c.Local
-	}
+	c.Client = c.Client || c.Local
 	return nil
 }
 

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -458,11 +459,26 @@ func (c *OptionalControllerCommand) queryControllerName(ctxt *cmd.Context, polls
 		return nil
 	}
 
+	if len(all) == 1 {
+		cName := ""
+		for n := range all {
+			cName = n
+			break
+		}
+		useController, err := pollster.YN(fmt.Sprintf("Only one controller %q is registered. Use it", cName), true)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if useController {
+			c.ControllerName = cName
+		}
+		return nil
+	}
 	controllers := []string{}
 	for one := range all {
 		controllers = append(controllers, one)
 	}
-
+	sort.Strings(controllers)
 	knownClouds := interact.VerifyOptions("controller", controllers, true)
 
 	nameVerify := func(s string) (ok bool, errmsg string, err error) {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -408,7 +408,7 @@ type OptionalControllerCommand struct {
 // SetFlags initializes the flags supported by the command.
 func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.Client, "client", false, "Command to operate on or with a copy from this client")
+	f.BoolVar(&c.Client, "client", false, "Client operation")
 	// TODO (juju3) remove me
 	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client-only): Local operation only; controller not affected")
 	f.StringVar(&c.ControllerName, "c", "", "Controller to operate in")

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 
 	"github.com/juju/juju/api"
@@ -397,18 +396,8 @@ type OptionalControllerCommand struct {
 	// Local stores whether a client side (aka local) copy is requested.
 	Local bool
 
-	// ClientOnly stores whether the command will ONLY operate on a client copy
-	// without affecting controller copy.
-	ClientOnly bool
-
-	// ControllerOnly stores whether the command will ONLY operate on a controller copy
-	// without affecting client copy.
-	ControllerOnly bool
-
-	// BothClientAndController indicates that the operation need to take place on
-	// both client and controller. This is the default argument, only selected if
-	// neither ClientOnly nor ControllerOnly specified.
-	BothClientAndController bool
+	// Client stores whether the command will operate on a client copy.
+	Client bool
 
 	ControllerName string
 
@@ -418,8 +407,7 @@ type OptionalControllerCommand struct {
 // SetFlags initializes the flags supported by the command.
 func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.ClientOnly, "client-only", false, "Client operation only; controller not affected")
-	f.BoolVar(&c.ControllerOnly, "controller-only", false, "Controller operation only; client not affected")
+	f.BoolVar(&c.Client, "client", false, "Command to operate on or with a copy from this client")
 	// TODO (juju3) remove me
 	f.BoolVar(&c.Local, "local", false, "DEPRECATED (use --client-only): Local operation only; controller not affected")
 	f.StringVar(&c.ControllerName, "c", "", "Controller to operate in")
@@ -429,74 +417,80 @@ func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init populates the command with the args from the command line.
 func (c *OptionalControllerCommand) Init(args []string) (err error) {
-	if c.Local && !c.ClientOnly {
-		c.ClientOnly = c.Local
+	if c.Local && !c.Client {
+		c.Client = c.Local
 	}
-	c.BothClientAndController = !c.ClientOnly && !c.ControllerOnly
 	return nil
 }
 
-// ControllerNameFromArg returns either a controller name or empty string.
-// A non default controller can be chosen using the --controller option.
-// Use the --local arg to return an empty string, meaning no controller is selected.
-func (c *OptionalControllerCommand) ControllerNameFromArg() (string, error) {
-	requireExplicitController := !featureflag.Enabled(c.EnabledFlag)
-	if c.ClientOnly || (requireExplicitController && c.ControllerName == "") {
-		c.ClientOnly = true
-		return "", nil
+// MaybePrompt checks if the command was give a --client or --controller options.
+// If not, it will prompt user to clarify whether the operation is to take place on
+// a client copy, a controller copy or both.
+func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string) error {
+	if c.Client || c.ControllerName != "" {
+		return nil
 	}
-	controllerName := c.ControllerName
-	if controllerName == "" {
-		all, err := c.Store.AllControllers()
-		if err != nil {
-			return "", errors.Trace(err)
-		}
-		if len(all) == 0 {
-			return "", errors.Trace(ErrNoControllersDefined)
-		}
-		controllerName, err = DetermineCurrentController(c.Store)
-		if err != nil {
-			return "", errors.Trace(err)
-		}
+	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, interact.NewErrWriter(ctxt.Stdout))
+	useClient, err := pollster.YN(fmt.Sprintf("This operation can be applied to both a copy on this client and a controller of your choice.\n"+
+		"Do you want to %v this client", action), true)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	if controllerName == "" {
-		return "", errors.Trace(ErrNoCurrentController)
+	c.Client = useClient
+	useController, err := pollster.YN(fmt.Sprintf("Do you want to %v a controller", action), true)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	return controllerName, nil
+	if useController {
+		return c.queryControllerName(pollster)
+	}
+	return nil
 }
 
-// MaybePromptCurrentController checks if there is a current controller on a client.
-// If there is and the user did not want to be prompted, the current controller will be returned.
-// Otherwise, the user will be prompted if the current controller should be used and
-// based on the answer the current controller may or may not be returned.
-func (c *OptionalControllerCommand) MaybePromptCurrentController(ctxt *cmd.Context, action string) (string, error) {
+func (c *OptionalControllerCommand) queryControllerName(pollster *interact.Pollster) error {
 	all, err := c.Store.AllControllers()
 	if err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
 	if len(all) == 0 {
 		// No controllers, so nothing to do.
-		return "", nil
+		return errors.NotFoundf("registered controllers on this client")
 	}
-	controllerName, err := DetermineCurrentController(c.Store)
+
+	controllers := []string{}
+	for one := range all {
+		controllers = append(controllers, one)
+	}
+
+	knownClouds := interact.VerifyOptions("controller", controllers, true)
+
+	nameVerify := func(s string) (ok bool, errmsg string, err error) {
+		ok, errmsg, err = knownClouds(s)
+		if err != nil {
+			return false, "", errors.Trace(err)
+		}
+		if ok {
+			return true, "", nil
+		}
+		return false, errmsg, nil
+	}
+
+	defaultController, err := DetermineCurrentController(c.Store)
 	if err != nil && !errors.IsNotFound(err) {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
-	if controllerName == "" {
-		return "", nil
+	if defaultController == "" {
+		defaultController = controllers[0]
 	}
-	if c.SkipCurrentControllerPrompt {
-		return controllerName, nil
-	}
-	// Since current controller is detected, user needs to confirm it.
-	errout := interact.NewErrWriter(ctxt.Stdout)
-	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, errout)
-	use, err := pollster.YN(fmt.Sprintf("Do you want to %v current controller %q", action, controllerName), true)
+	cName, err := pollster.SelectVerify(interact.List{
+		Singular: "controller name",
+		Plural:   "controller names",
+		Options:  controllers,
+		Default:  defaultController,
+	}, nameVerify)
 	if err != nil {
-		return "", errors.Trace(err)
+		return err
 	}
-	if use {
-		return controllerName, nil
-	}
-	return "", nil
+	c.ControllerName = cName
+	return nil
 }

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -208,7 +208,7 @@ Select controller name [fred]:
 
 func (s *OptionalControllerCommandSuite) TestPromptNoControllers(c *gc.C) {
 	ctx, command, err := s.assertPrompt(c, jujuclient.NewMemStore(), "n\ny\n")
-	c.Assert(err, gc.ErrorMatches, "registered controllers on this client not found")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(command.ControllerName, gc.Equals, "")
 	c.Assert(command.Client, gc.Equals, false)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
@@ -216,7 +216,7 @@ This operation can be applied to both a copy on this client and a controller of 
 Do you want to  this client? (Y/n): 
 Do you want to  a controller? (Y/n): 
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No registered controllers on this client: either bootstrap one or register one.\n")
 }
 
 func (s *OptionalControllerCommandSuite) TestDetectCurrentControllerNoCurrentController(c *gc.C) {

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -222,10 +222,10 @@ func (s *OptionalControllerCommandSuite) assertManyControllers(c *gc.C,
 This operation can be applied to both a copy on this client and a controller of your choice.
 Do you want to  this client? (Y/n): 
 Do you want to  a controller? (Y/n): 
-Controller Names
+Controllers
   %v
 
-Select controller name [%v]: 
+Select controller [%v]: 
 `[1:],
 		strings.Join(expectedControllerNames, "\n  "),
 		expectedControllerDefault)

--- a/featuretests/cmd_juju_cloud_test.go
+++ b/featuretests/cmd_juju_cloud_test.go
@@ -41,12 +41,12 @@ clouds:
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
 	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll", "--force")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cloud "testdummy" added to controller "kontroll".`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
 	ctx, err = s.run(c, "add-cloud", "testdummy", "-c", "kontroll", "--force")
-	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Cloud "testdummy" already exists on the controller "kontroll".`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -71,10 +71,10 @@ clouds:
 		},
 	})
 
-	_, err := s.run(c, "show-credential", "dummy", "cred", "--no-prompt")
+	_, err := s.run(c, "show-credential", "dummy", "cred", "-c", "kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.run(c, "update-credential", "dummy", "cred", "--no-prompt")
+	_, err = s.run(c, "update-credential", "dummy", "cred", "-c", "kontroll")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(c.GetTestLog(), jc.Contains, `ERROR juju.cmd.juju.cloud finalizing "cred" credential for cloud "dummy": unknown key "tenant-name" (value "hrm")`)
 	store.UpdateCredential("dummy", cloud.CloudCredential{
@@ -85,7 +85,7 @@ clouds:
 			}),
 		},
 	})
-	ctx, err := s.run(c, "update-credential", "dummy", "cred", "--no-prompt")
+	ctx, err := s.run(c, "update-credential", "dummy", "cred", "-c", "kontroll", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
@@ -185,7 +185,7 @@ Changed cloud credential on model "controller" to "newcred".
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandAll(c *gc.C) {
-	ctx, err := s.run(c, "show-credential", "--no-prompt")
+	ctx, err := s.run(c, "show-credential", "-c", "kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
@@ -202,7 +202,7 @@ controller-credentials:
 }
 
 func (s *CmdCredentialSuite) TestShowCredentialCommandWithName(c *gc.C) {
-	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets", "--no-prompt", "--controller-only")
+	ctx, err := s.run(c, "show-credential", "dummy", "cred", "--show-secrets", "-c", "kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 controller-credentials:


### PR DESCRIPTION
## Description of change

This PR changes cloud level commands (CRUD for clouds, credentials and k8s). 
Since these commands can operate on both client and controller copies of the entities, the ambiguity of what user intends needs to be clarified. Thus, when user supplies:
* ***default, i.e. no options supplied***: User will be prompted to confirm whether the operation is to take place on the client and or controller (and if on controller, then which one). Once the answers are obtained, the operation will proceed accordingly;
* ***--client***: the operation will take place on the client;
* ***-c/--controller <controller name>***: the operation will take place on the controller.

This approach also allows the combination of the options, i.e. when both --client and -c options are correctly provided, the operation will take place on both the client and the controller.

For this reason, --client-only option has been renamed to --client.


## Bug reference

https://bugs.launchpad.net/bugs/1849601
