### PR TITLE
Ensure all k8s resources have correct annotations

### DIFF
--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	jujuclock "github.com/juju/clock"
-	testclock "github.com/juju/clock/testclock"
+	"github.com/juju/clock/testclock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
@@ -17,7 +17,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -38,8 +38,6 @@ type BaseSuite struct {
 	k8sRestConfig *rest.Config
 
 	namespace string
-
-	controllerUUID string
 
 	k8sClient                  *mocks.MockInterface
 	mockRestClient             *mocks.MockRestClientInterface
@@ -102,7 +100,6 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.cfg = cfg
 
-	s.controllerUUID = "9bec388c-d264-4cde-8b29-3e675959157a"
 	s.namespace = s.cfg.Name()
 }
 
@@ -144,7 +141,7 @@ func (s *BaseSuite) setupBroker(c *gc.C, ctrl *gomock.Controller,
 	randomPrefixFunc provider.RandomPrefixFunc) *gomock.Controller {
 	s.clock = testclock.NewClock(time.Time{})
 	var err error
-	s.broker, err = provider.NewK8sBroker(s.controllerUUID, s.k8sRestConfig, s.cfg, newK8sRestClientFunc,
+	s.broker, err = provider.NewK8sBroker(testing.ControllerTag.Id(), s.k8sRestConfig, s.cfg, newK8sRestClientFunc,
 		newK8sWatcherFunc, randomPrefixFunc, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	return ctrl
@@ -267,7 +264,7 @@ func (s *BaseSuite) k8sNewFakeWatcher() *watch.RaceFreeFakeWatcher {
 
 func (s *BaseSuite) ensureJujuNamespaceAnnotations(isController bool, ns *core.Namespace) *core.Namespace {
 	annotations := map[string]string{
-		"juju.io/controller": s.controllerUUID,
+		"juju.io/controller": testing.ControllerTag.Id(),
 		"juju.io/model":      s.cfg.UUID(),
 	}
 	if isController {

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -59,8 +59,6 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.cfg = cfg
 
-	s.controllerUUID = "9bec388c-d264-4cde-8b29-3e675959157a"
-
 	s.controllerCfg = testing.FakeControllerConfig()
 	pcfg, err := podcfg.NewBootstrapControllerPodConfig(
 		s.controllerCfg, controllerName, "bionic", constraints.MustParse("root-disk=10000M mem=4000M"))
@@ -113,14 +111,14 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 	existingNs.SetName("controller-1")
 	existingNs.SetAnnotations(map[string]string{
 		"juju.io/model":         s.cfg.UUID(),
-		"juju.io/controller":    s.controllerUUID,
+		"juju.io/controller":    testing.ControllerTag.Id(),
 		"juju.io/is-controller": "true",
 	})
 
 	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller")
 	c.Assert(s.broker.GetAnnotations().ToMap(), jc.DeepEquals, map[string]string{
 		"juju.io/model":      s.cfg.UUID(),
-		"juju.io/controller": s.controllerUUID,
+		"juju.io/controller": testing.ControllerTag.Id(),
 	})
 
 	gomock.InOrder(
@@ -136,7 +134,7 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
 			"juju.io/model":         s.cfg.UUID(),
-			"juju.io/controller":    s.controllerUUID,
+			"juju.io/controller":    testing.ControllerTag.Id(),
 			"juju.io/is-controller": "true",
 		},
 	)
@@ -204,7 +202,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
 			"juju.io/model":      s.cfg.UUID(),
-			"juju.io/controller": s.controllerUUID,
+			"juju.io/controller": testing.ControllerTag.Id(),
 		},
 	)
 
@@ -222,7 +220,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
 			"juju.io/model":         s.cfg.UUID(),
-			"juju.io/controller":    s.controllerUUID,
+			"juju.io/controller":    testing.ControllerTag.Id(),
 			"juju.io/is-controller": "true",
 		},
 	)
@@ -242,9 +240,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	s.ensureJujuNamespaceAnnotations(true, ns)
 	svcNotProvisioned := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-service",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-service",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "juju-controller-test"},
@@ -262,9 +261,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	svcPublicIP := "1.1.1.1"
 	svcProvisioned := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-service",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-service",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "juju-controller-test"},
@@ -282,17 +282,19 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 
 	emptySecret := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-secret",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-secret",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 	}
 	secretWithSharedSecretAdded := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-secret",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-secret",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -301,9 +303,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	}
 	secretWithServerPEMAdded := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-secret",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-secret",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -314,9 +317,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 
 	emptyConfigMap := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-configmap",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-configmap",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 	}
 	bootstrapParamsContent, err := s.pcfg.Bootstrap.StateInitializationParams.Marshal()
@@ -324,9 +328,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 
 	configMapWithBootstrapParamsAdded := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-configmap",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-configmap",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Data: map[string]string{
 			"bootstrap-params": string(bootstrapParamsContent),
@@ -334,9 +339,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	}
 	configMapWithAgentConfAdded := &core.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test-configmap",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test-configmap",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Data: map[string]string{
 			"bootstrap-params": string(bootstrapParamsContent),
@@ -348,9 +354,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	fileMode := int32(256)
 	statefulSetSpec := &apps.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "juju-controller-test",
-			Labels:    map[string]string{"juju-app": "juju-controller-test"},
-			Namespace: s.getNamespace(),
+			Name:        "juju-controller-test",
+			Namespace:   s.getNamespace(),
+			Labels:      map[string]string{"juju-app": "juju-controller-test"},
+			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apps.StatefulSetSpec{
 			ServiceName: "juju-controller-test-service",
@@ -361,8 +368,9 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			VolumeClaimTemplates: []core.PersistentVolumeClaim{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:   "storage",
-						Labels: map[string]string{"juju-app": "juju-controller-test"},
+						Name:        "storage",
+						Labels:      map[string]string{"juju-app": "juju-controller-test"},
+						Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 					},
 					Spec: core.PersistentVolumeClaimSpec{
 						StorageClassName: &scName,
@@ -377,9 +385,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "controller-0",
-					Labels:    map[string]string{"juju-app": "juju-controller-test"},
-					Namespace: s.getNamespace(),
+					Name:        "controller-0",
+					Namespace:   s.getNamespace(),
+					Labels:      map[string]string{"juju-app": "juju-controller-test"},
+					Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 				},
 				Spec: core.PodSpec{
 					RestartPolicy: core.RestartPolicyAlways,

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -19,13 +19,18 @@ func (k *kubernetesClient) getConfigMapLabels(appName string) map[string]string 
 	}
 }
 
-func (k *kubernetesClient) ensureConfigMaps(appName string, cms map[string]specs.ConfigMap) (cleanUps []func(), _ error) {
+func (k *kubernetesClient) ensureConfigMaps(
+	appName string,
+	annotations map[string]string,
+	cms map[string]specs.ConfigMap,
+) (cleanUps []func(), _ error) {
 	for name, v := range cms {
 		spec := &core.ConfigMap{
 			ObjectMeta: v1.ObjectMeta{
-				Name:      name,
-				Namespace: k.namespace,
-				Labels:    k.getConfigMapLabels(appName),
+				Name:        name,
+				Namespace:   k.namespace,
+				Labels:      k.getConfigMapLabels(appName),
+				Annotations: annotations,
 			},
 			Data: v,
 		}

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -20,9 +20,13 @@ func (k *kubernetesClient) getCRDLabels(appName string) map[string]string {
 }
 
 // ensureCustomResourceDefinitions creates or updates a custom resource definition resource.
-func (k *kubernetesClient) ensureCustomResourceDefinitions(appName string, crds map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec) (cleanUps []func(), _ error) {
+func (k *kubernetesClient) ensureCustomResourceDefinitions(
+	appName string,
+	annotations map[string]string,
+	crds map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec,
+) (cleanUps []func(), _ error) {
 	for name, crd := range crds {
-		crd, err := k.ensureCustomResourceDefinition(name, k.getCRDLabels(appName), crd)
+		crd, err := k.ensureCustomResourceDefinition(name, k.getCRDLabels(appName), annotations, crd)
 		if err != nil {
 			return cleanUps, errors.Annotate(err, fmt.Sprintf("ensure custom resource definition %q", name))
 		}
@@ -34,13 +38,15 @@ func (k *kubernetesClient) ensureCustomResourceDefinitions(appName string, crds 
 
 func (k *kubernetesClient) ensureCustomResourceDefinition(
 	name string, labels map[string]string,
+	annotations map[string]string,
 	spec apiextensionsv1beta1.CustomResourceDefinitionSpec,
 ) (crd *apiextensionsv1beta1.CustomResourceDefinition, err error) {
 	crdIn := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: k.namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   k.namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: spec,
 	}

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -33,14 +33,14 @@ func processSecretData(in map[string]string) (_ map[string][]byte, err error) {
 	return out, nil
 }
 
-func (k *kubernetesClient) ensureSecrets(appName string, secrets []k8sspecs.Secret) (cleanUps []func(), err error) {
+func (k *kubernetesClient) ensureSecrets(appName string, annotations k8sannotations.Annotation, secrets []k8sspecs.Secret) (cleanUps []func(), err error) {
 	for _, v := range secrets {
 		spec := &core.Secret{
 			ObjectMeta: v1.ObjectMeta{
 				Name:        v.Name,
 				Namespace:   k.namespace,
 				Labels:      k.getSecretLabels(appName),
-				Annotations: v.Annotations,
+				Annotations: annotations.Merge(v.Annotations),
 			},
 			Type:       v.Type,
 			StringData: v.StringData,


### PR DESCRIPTION
## Description of change

When creating k8s resources, ensure that the annotations contain the controller uuid.
Also, any resource tags set in model config should be included in the annotations. This was done for some things but not all.

## QA steps

bootstrap k8s and deploy workload
kubectl describe the pods, services, service accounts etc to ensure juju.io/controller is set