### PR TITLE
Fix init container issue upgrading from 2.6

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1320,7 +1320,13 @@ func configureInitContainer(podSpec *core.PodSpec, operatorImagePath string) err
 	if err != nil {
 		return errors.Trace(err)
 	}
-	jujudCmd := fmt.Sprintf("$JUJU_TOOLS_DIR/jujud caas-unit-init --debug --wait")
+	jujudCmd := `
+initCmd=$($JUJU_TOOLS_DIR/jujud help commands | grep caas-unit-init)
+if test -n "$initCmd"; then
+$JUJU_TOOLS_DIR/jujud caas-unit-init --debug --wait;
+else
+exit 0
+fi`[1:]
 	container := core.Container{
 		Name:            caas.InitContainerName,
 		Image:           operatorImagePath,


### PR DESCRIPTION
## Description of change

When upgrading a k8s controller from 2.6, for non controller models we were attempting to run a jujud command in an init container which is not implemented until 2.7, since those models are still using a 2.6 jujud. 

Tweak the init container script to account for this.

## QA steps

juju bootstrap a k8s 2.6 controller
Add a model and deploy a workload
upgrade-controller to 2.7
see that the 2.6 workload pods are ok
upgrade the model to 2.7