### PR TITLE
Address Space ID Migration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -492,11 +492,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:2800a04445584891c21d3a8a92464ead850096e415e75a6fd02fad4d5844f80b"
+  digest = "1:ee86bcdc9520c404f5b994d770c321a80ad5bdbd61a15a79e4905f5942308872"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "ef199d6ad38cb2f3c5e32cf9006624e22ee66002"
+  revision = "518c591d8576f28b31d46e90ee00536418690345"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "ef199d6ad38cb2f3c5e32cf9006624e22ee66002"
+  revision = "518c591d8576f28b31d46e90ee00536418690345"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -706,7 +706,7 @@ func (e *exporter) readAllStorageConstraints() error {
 	storageConstraints := make(map[string]storageConstraintsDoc)
 	var doc storageConstraintsDoc
 	iter := coll.Find(nil).Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		storageConstraints[e.st.localID(doc.DocID)] = doc
 	}
@@ -1710,7 +1710,7 @@ func (e *exporter) readAllStatusHistory() error {
 	// underconstrained - include document id for deterministic
 	// ordering in those cases.
 	iter := statuses.Find(nil).Sort("-updated", "-_id").Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		history := e.statusHistory[doc.GlobalKey]
 		e.statusHistory[doc.GlobalKey] = append(history, doc)
@@ -2017,7 +2017,7 @@ func (e *exporter) volumes() error {
 
 	var doc volumeDoc
 	iter := coll.Find(nil).Sort("_id").Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		vol := &volume{e.st, doc}
 		plan := attachmentPlans[doc.Name]
@@ -2141,7 +2141,7 @@ func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, er
 	var doc volumeAttachmentDoc
 	var count int
 	iter := coll.Find(nil).Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		result[doc.Volume] = append(result[doc.Volume], doc)
 		count++
@@ -2161,7 +2161,7 @@ func (e *exporter) readVolumeAttachmentPlans() (map[string][]volumeAttachmentPla
 	var doc volumeAttachmentPlanDoc
 	var count int
 	iter := coll.Find(nil).Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		result[doc.Volume] = append(result[doc.Volume], doc)
 		count++
@@ -2183,7 +2183,7 @@ func (e *exporter) filesystems() error {
 	}
 	var doc filesystemDoc
 	iter := coll.Find(nil).Sort("_id").Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		fs := &filesystem{e.st, doc}
 		if err := e.addFilesystem(fs, attachments[doc.FilesystemId]); err != nil {
@@ -2263,7 +2263,7 @@ func (e *exporter) readFilesystemAttachments() (map[string][]filesystemAttachmen
 	var doc filesystemAttachmentDoc
 	var count int
 	iter := coll.Find(nil).Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		result[doc.Filesystem] = append(result[doc.Filesystem], doc)
 		count++
@@ -2289,7 +2289,7 @@ func (e *exporter) storageInstances() error {
 	}
 	var doc storageInstanceDoc
 	iter := coll.Find(nil).Sort("_id").Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		instance := &storageInstance{sb, doc}
 		if err := e.addStorage(instance, attachments[doc.Id]); err != nil {
@@ -2328,7 +2328,7 @@ func (e *exporter) readStorageAttachments() (map[string][]names.UnitTag, error) 
 	var doc storageAttachmentDoc
 	var count int
 	iter := coll.Find(nil).Iter()
-	defer iter.Close()
+	defer func() { _ = iter.Close() }()
 	for iter.Next(&doc) {
 		unit := names.NewUnitTag(doc.Unit)
 		result[doc.StorageInstance] = append(result[doc.StorageInstance], unit)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -43,7 +43,7 @@ import (
 // one and each migration step will add itself to that and Run for completion.
 //
 // Whilst we're creating these steps, it is expected to create the unit tests
-// and suppliment all of these tests with existing tests, to ensure that no
+// and supplement all of these tests with existing tests, to ensure that no
 // gaps are missing. In the future the integration tests should be replaced with
 // the new shell tests to ensure a full end to end test is performed.
 
@@ -562,19 +562,20 @@ func (e *exporter) openedPortsArgsForMachine(machineId string, portsData []ports
 }
 
 func (e *exporter) newAddressArgsSlice(a []address) []description.AddressArgs {
-	result := []description.AddressArgs{}
-	for _, addr := range a {
-		result = append(result, e.newAddressArgs(addr))
+	result := make([]description.AddressArgs, len(a))
+	for i, addr := range a {
+		result[i] = e.newAddressArgs(addr)
 	}
 	return result
 }
 
 func (e *exporter) newAddressArgs(a address) description.AddressArgs {
 	return description.AddressArgs{
-		Value:  a.Value,
-		Type:   a.AddressType,
-		Scope:  a.Scope,
-		Origin: a.Origin,
+		Value:   a.Value,
+		Type:    a.AddressType,
+		Scope:   a.Scope,
+		Origin:  a.Origin,
+		SpaceID: a.SpaceID,
 	}
 }
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -303,11 +303,16 @@ func (s *MigrationExportSuite) TestMachinesWithRootDiskSourceConstraint(c *gc.C)
 func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.Value) {
 	// Add a machine with an LXC container.
 	source := "vashti"
+
+	addr := network.NewSpaceAddress("1.1.1.1")
+	addr.SpaceID = "0"
+
 	machine1 := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: cons,
 		Characteristics: &instance.HardwareCharacteristics{
 			RootDiskSource: &source,
 		},
+		Addresses: network.SpaceAddresses{addr},
 	})
 	nested := s.Factory.MakeMachineNested(c, machine1.Id(), nil)
 
@@ -358,6 +363,11 @@ func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.
 	instance := exported.Instance()
 	c.Assert(instance.ModificationStatus().Value(), gc.Equals, "idle")
 	c.Assert(instance.RootDiskSource(), gc.Equals, "vashti")
+
+	c.Assert(exported.ProviderAddresses(), gc.HasLen, 1)
+	exAddr := exported.ProviderAddresses()[0]
+	c.Assert(exAddr.Value(), gc.Equals, "1.1.1.1")
+	c.Assert(exAddr.SpaceID(), gc.Equals, "0")
 }
 
 func (s *MigrationExportSuite) TestMachineDevices(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -713,12 +713,21 @@ func (i *importer) makeAddress(addr description.Address) address {
 	if addr == nil {
 		return address{}
 	}
-	return address{
+
+	newAddr := address{
 		Value:       addr.Value(),
 		AddressType: addr.Type(),
 		Scope:       addr.Scope(),
 		Origin:      addr.Origin(),
+		SpaceID:     addr.SpaceID(),
 	}
+
+	// Addresses are placed in the default space if no space ID is set.
+	if newAddr.SpaceID == "" {
+		newAddr.SpaceID = "0"
+	}
+
+	return newAddr
 }
 
 func (i *importer) makeAddresses(addrs []description.Address) []address {

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -341,14 +341,19 @@ func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachin
 }
 
 func (s *MigrationImportSuite) TestMachines(c *gc.C) {
-	// Let's add a machine with an LXC container.
+	// Add a machine with an LXC container.
 	cons := constraints.MustParse("arch=amd64 mem=8G root-disk-source=bunyan")
 	source := "bunyan"
+
+	addr := network.NewSpaceAddress("1.1.1.1")
+	addr.SpaceID = "9"
+
 	machine1 := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: cons,
 		Characteristics: &instance.HardwareCharacteristics{
 			RootDiskSource: &source,
 		},
+		Addresses: corenetwork.SpaceAddresses{addr},
 	})
 	err := s.Model.SetAnnotations(machine1, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
@@ -662,6 +667,7 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	err = caasModel.SetPodSpec(application.ApplicationTag(), "pod spec")
 	c.Assert(err, jc.ErrorIsNil)
 	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal)
+	addr.SpaceID = "0"
 	err = application.UpdateCloudService("provider-id", []network.SpaceAddress{addr})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -948,6 +954,7 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, st *state.State, con
 		c.Assert(containerInfo.ProviderId(), gc.Equals, "provider-id")
 		c.Assert(containerInfo.Ports(), jc.DeepEquals, []string{"80"})
 		addr := network.NewScopedSpaceAddress("192.168.1.2", network.ScopeMachineLocal)
+		addr.SpaceID = "0"
 		c.Assert(containerInfo.Address(), jc.DeepEquals, &addr)
 	}
 


### PR DESCRIPTION
## Description of change

This patch ensures that migrations include address space IDs.

Unfortunately, addresses were never migrated with the old space data (`SpaceName`, `ProviderSpaceID`). This means that no conversion between these is possible. We either get space IDs as set in the current Juju version, or they get the "0" space ID if migrating from old to new.

## QA steps

Same version:
- Bootstrap to MAAS and add a machine.
- Bootstrap another MAAS controller and migrate the model.
- Check that machine address space IDs are preserved.

Upgrade:
- Bootstrap a controller from the 2.6 branch and add a machine.
- Bootstrap a new controller with this patch and migrate the old model.
- Check that machine address space IDs are "0".

## Documentation changes

None.

## Bug reference

N/A
