### PR TITLE
Err when neither client nor controller specified.

### DIFF
--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -150,12 +150,11 @@ func (s *regionsSuite) TestListNoController(c *gc.C) {
 	err := cmdtesting.InitCommand(command, []string{"google"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = command.Run(ctx)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, "Neither client nor controller specified - nothing to do.")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 This operation can be applied to both a copy on this client and a controller of your choice.
 Do you want to list regions for cloud "google" from this client? (Y/n): 
 Do you want to list regions for cloud "google" from a controller? (Y/n): 
-
 `[1:])
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No registered controllers on this client: either bootstrap one or register one.\n")
 }

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -441,7 +441,12 @@ func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string
 		return errors.Trace(err)
 	}
 	if useController {
-		return c.queryControllerName(ctxt, pollster)
+		if err := c.queryControllerName(ctxt, pollster); err != nil {
+			return err
+		}
+	}
+	if !c.Client && c.ControllerName == "" {
+		return errors.New("Neither client nor controller specified - nothing to do.")
 	}
 	return nil
 }

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -245,7 +245,7 @@ func (s *OptionalControllerCommandSuite) TestPromptManyControllers(c *gc.C) {
 
 func (s *OptionalControllerCommandSuite) TestPromptNoControllers(c *gc.C) {
 	ctx, command, err := s.assertPrompt(c, jujuclient.NewMemStore(), "n\ny\n")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, "Neither client nor controller specified - nothing to do.")
 	c.Assert(command.ControllerName, gc.Equals, "")
 	c.Assert(command.Client, gc.Equals, false)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
@@ -254,6 +254,19 @@ Do you want to  this client? (Y/n):
 Do you want to  a controller? (Y/n): 
 `[1:])
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No registered controllers on this client: either bootstrap one or register one.\n")
+}
+
+func (s *OptionalControllerCommandSuite) TestPromptNothingPicked(c *gc.C) {
+	ctx, command, err := s.assertPrompt(c, jujuclient.NewMemStore(), "n\nn\n")
+	c.Assert(err, gc.ErrorMatches, "Neither client nor controller specified - nothing to do.")
+	c.Assert(command.ControllerName, gc.Equals, "")
+	c.Assert(command.Client, gc.Equals, false)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+This operation can be applied to both a copy on this client and a controller of your choice.
+Do you want to  this client? (Y/n): 
+Do you want to  a controller? (Y/n): 
+`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *OptionalControllerCommandSuite) TestDetectCurrentControllerNoCurrentController(c *gc.C) {
@@ -303,7 +316,7 @@ func (s *OptionalControllerCommandSuite) TestPrompt(c *gc.C) {
 }
 
 func (s *OptionalControllerCommandSuite) TestPromptDeny(c *gc.C) {
-	s.assertDetectCurrentControllerPrompt(c, "n\nn\n", "", false, testShortOutput)
+	s.assertDetectCurrentControllerPrompt(c, "y\nn\n", "", true, testShortOutput)
 }
 
 func (s *OptionalControllerCommandSuite) TestPromptUseNonDefaultController(c *gc.C) {


### PR DESCRIPTION
## Description of change

When neither --client nor valid controller is supplied, commands that can operate on both copies can err out early.

