### PR TITLE
ask-or-tell: one question

### DIFF
--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -939,11 +939,11 @@ func (s *addCredentialSuite) TestAddRemoteCloudPromptForController(c *gc.C) {
 		}, nil
 	}
 	stdout := `
-This operation can be applied to both a copy on this client and a controller of your choice.
-Do you want to add a credential to this client? (Y/n): 
-Do you want to add a credential to a controller? (Y/n): 
-Only one controller "controller" is registered. Use it? (Y/n): 
-Enter credential name: 
+Do you want to add a credential to:
+    1. client only (--client)
+    2. controller "controller" only (--controller controller)
+    3. both (--client --controller controller)
+Enter your choice, or type Q|q to quit: Enter credential name: 
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
@@ -953,11 +953,12 @@ Credential "blah" added locally for cloud "remote".
 
 `[1:]
 	stderr := `
+This operation can be applied to both a copy on this client and to the one on a controller.
 Using cloud "remote" from the controller to verify credentials.
 Controller credential "blah" for user "admin@local" for cloud "remote" on controller "controller" added.
 For more information, see ‘juju show-credential remote blah’.
 `[1:]
-	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "y\ny\n\n", stderr, true, true)
+	s.assertAddedCredentialForCloudWithArgs(c, "remote", stdout, "3\n", stderr, true, true)
 }
 
 func (s *addCredentialSuite) TestAddRemoteCloudControllerOnly(c *gc.C) {

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -410,10 +410,11 @@ func (s *detectCredentialsSuite) TestRemoteLoad(c *gc.C) {
 		return &remoteTestCloud, nil
 	}
 
-	stdin := strings.NewReader(fmt.Sprintf("y\ny\n\n1\n%s\nQ\n", cloudName))
+	stdin := strings.NewReader(fmt.Sprintf("3\n1\n%s\nQ\n", cloudName))
 	ctx, err := s.runWithCloudsFunc(c, stdin, nil, cloudByNameFunc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, `
+This operation can be applied to both a copy on this client and to the one on a controller.
 
 Looking for cloud and credential information on local client...
 
@@ -432,11 +433,11 @@ For more information, see ‘juju show-credential test-cloud blah’.
 `[1:])
 	c.Assert(called, jc.IsTrue)
 	c.Assert(cmdtesting.Stdout(ctx), gc.DeepEquals, `
-This operation can be applied to both a copy on this client and a controller of your choice.
-Do you want to add a credential to this client? (Y/n): 
-Do you want to add a credential to a controller? (Y/n): 
-Only one controller "controller" is registered. Use it? (Y/n): 
-`[1:])
+Do you want to add a credential to:
+    1. client only (--client)
+    2. controller "controller" only (--controller controller)
+    3. both (--client --controller controller)
+Enter your choice, or type Q|q to quit: `[1:])
 }
 
 func (s *detectCredentialsSuite) assertAutoloadCredentials(c *gc.C, expectedStderr string, args ...string) {

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -50,14 +50,14 @@ func NewAddCloudCommandForTest(
 
 func NewListCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (ListCloudsAPI, error)) *listCloudsCommand {
 	return &listCloudsCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store, ReadOnly: true},
 		listCloudsAPIFunc:         cloudAPI,
 	}
 }
 
 func NewShowCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() (showCloudAPI, error)) *showCloudCommand {
 	return &showCloudCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store, ReadOnly: true},
 		showCloudAPIFunc:          cloudAPI,
 	}
 }
@@ -97,7 +97,8 @@ func NewListCredentialsCommandForTest(
 ) *listCredentialsCommand {
 	return &listCredentialsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store: testStore,
+			Store:    testStore,
+			ReadOnly: true,
 		},
 		personalCloudsFunc:     personalCloudsFunc,
 		cloudByNameFunc:        cloudByNameFunc,
@@ -176,7 +177,7 @@ func NewUpdateCredentialCommandForTest(testStore jujuclient.ClientStore, api Cre
 
 func NewShowCredentialCommandForTest(testStore jujuclient.ClientStore, api CredentialContentAPI) cmd.Command {
 	command := &showCredentialCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore},
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: testStore, ReadOnly: true},
 		newAPIFunc: func() (CredentialContentAPI, error) {
 			return api, nil
 		},
@@ -200,7 +201,7 @@ func AddLoadedCredentialForTest(
 
 func NewListRegionsCommandForTest(store jujuclient.ClientStore, cloudAPI func() (CloudRegionsAPI, error)) *listRegionsCommand {
 	return &listRegionsCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store, ReadOnly: true},
 		cloudAPIFunc:              cloudAPI,
 	}
 }

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -97,7 +97,8 @@ func NewListCloudsCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &listCloudsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store: store,
+			Store:    store,
+			ReadOnly: true,
 		},
 	}
 	c.listCloudsAPIFunc = c.cloudAPI

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -153,7 +153,8 @@ func NewListCredentialsCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &listCredentialsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store: store,
+			Store:    store,
+			ReadOnly: true,
 		},
 		cloudByNameFunc: jujucloud.CloudByName,
 	}

--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -64,7 +64,8 @@ func NewListRegionsCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &listRegionsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store: store,
+			Store:    store,
+			ReadOnly: true,
 		},
 	}
 	c.cloudAPIFunc = c.cloudAPI

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -151,12 +151,9 @@ func (s *regionsSuite) TestListNoController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = command.Run(ctx)
 	c.Assert(err, gc.ErrorMatches, "Neither client nor controller specified - nothing to do.")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-This operation can be applied to both a copy on this client and a controller of your choice.
-Do you want to list regions for cloud "google" from this client? (Y/n): 
-Do you want to list regions for cloud "google" from a controller? (Y/n): 
-`[1:])
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "No registered controllers on this client: either bootstrap one or register one.\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Do you ONLY want to list regions for cloud \"google\" from this client? (Y/n): \n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "This operation can be applied to both a copy on this client and to the one on a controller.\n"+
+		"No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.\n")
 }
 
 func (s *regionsSuite) TestListRegionsJson(c *gc.C) {

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -147,14 +147,18 @@ func (s *regionsSuite) TestListNoController(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	ctx.Stdin = strings.NewReader("n\ny\n")
 	command := cloud.NewListRegionsCommand()
-	err := cmdtesting.InitCommand(command, []string{"google"})
+	err := cmdtesting.InitCommand(command, []string{"kloud"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Do you ONLY want to list regions for cloud \"google\" from this client? (Y/n): \n\n")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "This operation can be applied to both a copy on this client and to the one on a controller.\n"+
-		"No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.\n"+
-		"Neither client nor controller specified - nothing to do.\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+
+Client Cloud Regions
+london
+paris
+
+`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *regionsSuite) TestListRegionsJson(c *gc.C) {

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -150,10 +150,11 @@ func (s *regionsSuite) TestListNoController(c *gc.C) {
 	err := cmdtesting.InitCommand(command, []string{"google"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, "Neither client nor controller specified - nothing to do.")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Do you ONLY want to list regions for cloud \"google\" from this client? (Y/n): \n")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Do you ONLY want to list regions for cloud \"google\" from this client? (Y/n): \n\n")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "This operation can be applied to both a copy on this client and to the one on a controller.\n"+
-		"No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.\n")
+		"No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.\n"+
+		"Neither client nor controller specified - nothing to do.\n")
 }
 
 func (s *regionsSuite) TestListRegionsJson(c *gc.C) {

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -69,7 +69,8 @@ func NewShowCloudCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	c := &showCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store: store,
+			Store:    store,
+			ReadOnly: true,
 		},
 	}
 	c.showCloudAPIFunc = c.cloudAPI

--- a/cmd/juju/cloud/showcredential.go
+++ b/cmd/juju/cloud/showcredential.go
@@ -38,7 +38,8 @@ func NewShowCredentialCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
 	command := &showCredentialCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
-			Store: store,
+			Store:    store,
+			ReadOnly: true,
 		},
 	}
 	command.newAPIFunc = func() (CredentialContentAPI, error) {

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -462,9 +462,9 @@ func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string
 			return errors.Trace(err)
 		}
 		if !useClient {
-			return errors.New("Neither client nor controller specified - nothing to do.")
+			ctxt.Infof("Neither client nor controller specified - nothing to do.")
 		}
-		c.Client = true
+		c.Client = useClient
 		return nil
 	}
 
@@ -498,7 +498,7 @@ func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string
 	}
 quit:
 	if !c.Client && c.ControllerName == "" {
-		return errors.New("Neither client nor controller specified - nothing to do.")
+		ctxt.Infof("Neither client nor controller specified - nothing to do.")
 	}
 	return nil
 }

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sort"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -425,92 +425,80 @@ func (c *OptionalControllerCommand) Init(args []string) (err error) {
 // MaybePrompt checks if the command was give a --client or --controller options.
 // If not, it will prompt user to clarify whether the operation is to take place on
 // a client copy, a controller copy or both.
+// When neither client nor controller is specified on the command,
+// several scenarios need to be catered for when prompting:
+// 1. there is a current controller to prompt user with;
+// 2. there is no current controller but there are other controllers, so inform users how to use -c;
+// 3. there is no current controller and there are no registered controllers, so inform users to bootstrap or register.
+// When there is no current controller, the prompt becomes a Y/N client question instead of a multi-choice
+// client/controller.
 func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string) error {
 	if c.Client || c.ControllerName != "" {
 		return nil
 	}
-	pollster := interact.New(ctxt.Stdin, ctxt.Stdout, interact.NewErrWriter(ctxt.Stdout))
-	useClient, err := pollster.YN(fmt.Sprintf("This operation can be applied to both a copy on this client and a controller of your choice.\n"+
-		"Do you want to %v this client", action), true)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	c.Client = useClient
-	useController, err := pollster.YN(fmt.Sprintf("Do you want to %v a controller", action), true)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if useController {
-		if err := c.queryControllerName(ctxt, pollster); err != nil {
-			return err
-		}
-	}
-	if !c.Client && c.ControllerName == "" {
-		return errors.New("Neither client nor controller specified - nothing to do.")
-	}
-	return nil
-}
 
-func (c *OptionalControllerCommand) queryControllerName(ctxt *cmd.Context, pollster *interact.Pollster) error {
-	all, err := c.Store.AllControllers()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(all) == 0 {
-		// No controllers, so nothing to do.
-		ctxt.Infof("No registered controllers on this client: either bootstrap one or register one.")
-		return nil
-	}
+	ctxt.Infof("This operation can be applied to both a copy on this client and to the one on a controller.")
 
-	if len(all) == 1 {
-		cName := ""
-		for n := range all {
-			cName = n
-			break
-		}
-		useController, err := pollster.YN(fmt.Sprintf("Only one controller %q is registered. Use it", cName), true)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if useController {
-			c.ControllerName = cName
-		}
-		return nil
-	}
-	controllers := []string{}
-	for one := range all {
-		controllers = append(controllers, one)
-	}
-	sort.Strings(controllers)
-	knownClouds := interact.VerifyOptions("controller", controllers, true)
-
-	nameVerify := func(s string) (ok bool, errmsg string, err error) {
-		ok, errmsg, err = knownClouds(s)
-		if err != nil {
-			return false, "", errors.Trace(err)
-		}
-		if ok {
-			return true, "", nil
-		}
-		return false, errmsg, nil
-	}
-
-	defaultController, err := DetermineCurrentController(c.Store)
+	currentController, err := DetermineCurrentController(c.Store)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
-	if defaultController == "" {
-		defaultController = controllers[0]
+
+	if currentController == "" {
+		msg := "No current controller was detected"
+		all, err := c.Store.AllControllers()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(all) == 0 {
+			msg += " and there are no registered controllers on this client: either bootstrap one or register one."
+		} else {
+			msg += " but there are other controllers registered: use -c or --controller to specify a controller if needed."
+		}
+		ctxt.Infof(msg)
+		pollster := interact.New(ctxt.Stdin, ctxt.Stdout, interact.NewErrWriter(ctxt.Stdout))
+		useClient, err := pollster.YN(fmt.Sprintf("Do you ONLY want to %v this client", action), true)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !useClient {
+			return errors.New("Neither client nor controller specified - nothing to do.")
+		}
+		c.Client = true
+		return nil
 	}
-	cName, err := pollster.SelectVerify(interact.List{
-		Singular: "controller",
-		Plural:   "controllers",
-		Options:  controllers,
-		Default:  defaultController,
-	}, nameVerify)
-	if err != nil {
-		return err
+
+	fmt.Fprintf(ctxt.Stdout, fmt.Sprintf("Do you want to %v:\n", action))
+	fmt.Fprintf(ctxt.Stdout, "    1. client only (--client)\n")
+	fmt.Fprintf(ctxt.Stdout, fmt.Sprintf("    2. controller %q only (--controller %s)\n", currentController, currentController))
+	fmt.Fprintf(ctxt.Stdout, fmt.Sprintf("    3. both (--client --controller %s)\n", currentController))
+	fmt.Fprint(ctxt.Stdout, "Enter your choice, or type Q|q to quit: ")
+	for {
+		input, err := readLine(ctxt.Stdin)
+		if err != nil {
+			return err
+		}
+		input = strings.TrimSpace(input)
+		switch input {
+		case "q":
+			goto quit
+		case "1":
+			c.Client = true
+			return nil
+		case "2":
+			c.ControllerName = currentController
+			return nil
+		case "3":
+			c.ControllerName = currentController
+			c.Client = true
+			return nil
+		default:
+			ctxt.Infof("Invalid choice, enter a number between 1 and 3 or quit Q|q")
+		}
 	}
-	c.ControllerName = cName
+quit:
+	if !c.Client && c.ControllerName == "" {
+		return errors.New("Neither client nor controller specified - nothing to do.")
+	}
 	return nil
 }

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -478,7 +478,7 @@ func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string
 		if err != nil {
 			return err
 		}
-		input = strings.TrimSpace(input)
+		input = strings.ToLower(strings.TrimSpace(input))
 		switch input {
 		case "q":
 			goto quit

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -198,7 +198,6 @@ type testData struct {
 }
 
 func (s *OptionalControllerCommandSuite) assertPrompted(c *gc.C, store jujuclient.ClientStore, t testData) {
-	//ctx, command, _ := s.assertPrompt(c, store, t.action, t.userAnswer, t.args...)
 	ctx, command, err := s.assertPrompt(c, store, t.action, t.userAnswer, t.args...)
 	if t.expectedErr == "" {
 		c.Assert(err, jc.ErrorIsNil)
@@ -260,20 +259,22 @@ func setupTestStore() jujuclient.ClientStore {
 }
 
 func (s *OptionalControllerCommandSuite) TestPromptDenyClientAndCurrent(c *gc.C) {
-	s.assertPrompted(c, setupTestStore(), testData{
-		action:       "build a snowman on",
-		expectedInfo: "This operation can be applied to both a copy on this client and to the one on a controller.\n",
-		expectedPrompt: `
+	for _, input := range []string{"q\n", "Q\n"} {
+		s.assertPrompted(c, setupTestStore(), testData{
+			action:       "build a snowman on",
+			expectedInfo: "This operation can be applied to both a copy on this client and to the one on a controller.\n",
+			expectedPrompt: `
 Do you want to build a snowman on:
     1. client only (--client)
     2. controller "fred" only (--controller fred)
     3. both (--client --controller fred)
 Enter your choice, or type Q|q to quit: `[1:],
-		userAnswer:              "q\n",
-		expectedErr:             "Neither client nor controller specified - nothing to do.",
-		expectedControllerName:  "",
-		expectedClientOperation: false,
-	})
+			userAnswer:              input,
+			expectedErr:             "Neither client nor controller specified - nothing to do.",
+			expectedControllerName:  "",
+			expectedClientOperation: false,
+		})
+	}
 }
 
 func (s *OptionalControllerCommandSuite) TestPromptInvalidChoice(c *gc.C) {

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -338,6 +338,29 @@ Enter your choice, or type Q|q to quit: `[1:],
 	})
 }
 
+func (s *OptionalControllerCommandSuite) assertNoPromptForReadOnlyCommands(c *gc.C, store jujuclient.ClientStore, expectedErr, expectedOut, expectedController string) {
+	command := &testOptionalControllerCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store, ReadOnly: true},
+	}
+	ctx, err := cmdtesting.RunCommand(c, command)
+	c.Assert(err, jc.ErrorIsNil)
+	err = command.MaybePrompt(ctx, "add a cloud")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedOut)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedErr)
+	c.Assert(command.ControllerName, gc.Equals, expectedController)
+	c.Assert(command.Client, jc.IsTrue)
+
+}
+
+func (s *OptionalControllerCommandSuite) TestNoPromptForReadOnlyNoCurrentController(c *gc.C) {
+	s.assertNoPromptForReadOnlyCommands(c, jujuclient.NewMemStore(), "", "", "")
+}
+
+func (s *OptionalControllerCommandSuite) TestNoPromptForReadOnlyWithCurrentController(c *gc.C) {
+	s.assertNoPromptForReadOnlyCommands(c, setupTestStore(), "", "", "fred")
+}
+
 type testOptionalControllerCommand struct {
 	modelcmd.OptionalControllerCommand
 }


### PR DESCRIPTION
## Description of change

Ask-or-tell PR to cater for different cases when neither --client nor --controller is specified on a cloud level command:

1. There is no current controller and no controllers registered on a client: confirm (Y/n) whether the operation is to be run on the client but also inform the user that a controller can be registered or bootstrapped;

2. There is no current controller but other controllers are registered: confirm (Y/n) whether the operation is to be run on the client and also inform the user that a controller can be specified;

3. There is a current controller:  multi-choice prompt to operate (1) on a client; (2) on a controller, (3) on both. This option caters for invalid input as well as for a quit for prompt.


