### PR TITLE
Revert Default Model Config Setting for "default-space"

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -423,7 +423,7 @@ var defaultConfigValues = map[string]interface{}{
 	IgnoreMachineAddresses:       false,
 	"ssl-hostname-verification":  true,
 	"proxy-ssh":                  false,
-	DefaultSpace:                 "_default",
+	DefaultSpace:                 "",
 	// Why is net-bond-reconfigure-delay set to 17 seconds?
 	//
 	// The value represents the amount of time in seconds to sleep

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -575,7 +575,7 @@ var configTests = []configTest{
 		about:       "Default-space takes a string as valid value",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-space": "_bar",
+			"default-space": "bar",
 		}),
 	},
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1058,66 +1058,6 @@ func (s *upgradesSuite) TestAddActionPruneSettings(c *gc.C) {
 	s.checkAddPruneSettings(c, "max-action-results-age", "max-action-results-size", config.DefaultActionResultsAge, config.DefaultActionResultsSize, AddActionPruneSettings)
 }
 
-func (s *upgradesSuite) TestAddDefaultSpaceSetting(c *gc.C) {
-	defaultSpaceValue := config.ConfigDefaults()[config.DefaultSpace]
-	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
-	defer settingsCloser()
-	_, err := settingsColl.RemoveAll(nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// should not be changed, because we already have a value
-	m1 := s.makeModel(c, "m1", coretesting.Attrs{
-		config.DefaultSpace: "something",
-	})
-	defer m1.Close()
-
-	// should be changed to default, because we do not have a value yet
-	m2 := s.makeModel(c, "m2", coretesting.Attrs{})
-	defer m2.Close()
-
-	err = settingsColl.Insert(bson.M{
-		"_id": "someothersettingshouldnotbetouched",
-		// non-model setting: should not be touched
-		"settings": bson.M{"key": "value"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	model1, err := m1.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	cfg1, err := model1.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	expected1 := cfg1.AllAttrs()
-	expected1["resource-tags"] = ""
-
-	model2, err := m2.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	cfg2, err := model2.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	expected2 := cfg2.AllAttrs()
-	expected2[config.DefaultSpace] = defaultSpaceValue
-	expected2["resource-tags"] = ""
-
-	expectedSettings := bsonMById{
-		{
-			"_id":        m1.ModelUUID() + ":e",
-			"settings":   bson.M(expected1),
-			"model-uuid": m1.ModelUUID(),
-		}, {
-			"_id":        m2.ModelUUID() + ":e",
-			"settings":   bson.M(expected2),
-			"model-uuid": m2.ModelUUID(),
-		}, {
-			"_id":      "someothersettingshouldnotbetouched",
-			"settings": bson.M{"key": "value"},
-		},
-	}
-	sort.Sort(expectedSettings)
-
-	s.assertUpgradedData(c, AddDefaultSpaceSetting,
-		upgradedData(settingsColl, expectedSettings),
-	)
-}
-
 func (s *upgradesSuite) TestAddUpdateStatusHookSettings(c *gc.C) {
 	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()
@@ -4129,6 +4069,75 @@ func (s *upgradesSuite) TestReplaceSpaceNameWithIDEndpointBindings(c *gc.C) {
 
 	sort.Sort(expected)
 	s.assertUpgradedData(c, ReplaceSpaceNameWithIDEndpointBindings, upgradedData(col, expected))
+}
+
+func (s *upgradesSuite) TestEnsureDefaultSpaceSetting(c *gc.C) {
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Should not be changed because we already have a value.
+	m1 := s.makeModel(c, "m1", coretesting.Attrs{
+		config.DefaultSpace: "something",
+	})
+	defer func() { _ = m1.Close() }()
+
+	// Should be set to "" because we do not have a value yet.
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{})
+	defer func() { _ = m2.Close() }()
+
+	// Should be set to "" because it has the old default value "_default".
+	m3 := s.makeModel(c, "m3", coretesting.Attrs{
+		config.DefaultSpace: "_default",
+	})
+	defer func() { _ = m3.Close() }()
+
+	err = settingsColl.Insert(bson.M{
+		"_id":      "someothersettingshouldnotbetouched",
+		"settings": bson.M{"key": "value"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	getCfg := func(st *State) map[string]interface{} {
+		m, err := st.Model()
+		c.Assert(err, jc.ErrorIsNil)
+		cfg, err := m.ModelConfig()
+		c.Assert(err, jc.ErrorIsNil)
+		exp := cfg.AllAttrs()
+		exp["resource-tags"] = ""
+		return exp
+	}
+
+	exp1 := getCfg(m1)
+
+	exp2 := getCfg(m2)
+	exp2[config.DefaultSpace] = ""
+
+	exp3 := getCfg(m3)
+	exp3[config.DefaultSpace] = ""
+
+	expectedSettings := bsonMById{
+		{
+			"_id":        m1.ModelUUID() + ":e",
+			"settings":   bson.M(exp1),
+			"model-uuid": m1.ModelUUID(),
+		}, {
+			"_id":        m2.ModelUUID() + ":e",
+			"settings":   bson.M(exp2),
+			"model-uuid": m2.ModelUUID(),
+		}, {
+			"_id":        m3.ModelUUID() + ":e",
+			"settings":   bson.M(exp3),
+			"model-uuid": m3.ModelUUID(),
+		}, {
+			"_id":      "someothersettingshouldnotbetouched",
+			"settings": bson.M{"key": "value"},
+		},
+	}
+	sort.Sort(expectedSettings)
+
+	s.assertUpgradedData(c, EnsureDefaultSpaceSetting, upgradedData(settingsColl, expectedSettings))
 }
 
 func (s *upgradesSuite) makeMachine(c *gc.C, uuid, id string, life Life) {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -73,8 +73,8 @@ type StateBackend interface {
 	ReplacePortsDocSubnetIDCIDR() error
 	EnsureRelationApplicationSettings() error
 	ConvertAddressSpaceIDs() error
-	AddDefaultSpaceSetting() error
 	ReplaceSpaceNameWithIDEndpointBindings() error
+	EnsureDefaultSpaceSetting() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -139,10 +139,6 @@ func (s stateBackend) AddControllerLogCollectionsSizeSettings() error {
 
 func (s stateBackend) AddStatusHistoryPruneSettings() error {
 	return state.AddStatusHistoryPruneSettings(s.pool)
-}
-
-func (s stateBackend) AddDefaultSpaceSetting() error {
-	return state.AddDefaultSpaceSetting(s.pool)
 }
 
 func (s stateBackend) AddActionPruneSettings() error {
@@ -303,4 +299,8 @@ func (s stateBackend) ConvertAddressSpaceIDs() error {
 
 func (s stateBackend) ReplaceSpaceNameWithIDEndpointBindings() error {
 	return state.ReplaceSpaceNameWithIDEndpointBindings(s.pool)
+}
+
+func (s stateBackend) EnsureDefaultSpaceSetting() error {
+	return state.EnsureDefaultSpaceSetting(s.pool)
 }

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -77,17 +77,17 @@ func stateStepsFor27() []Step {
 			},
 		},
 		&upgradeStep{
-			description: "adds default value for default_space",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return context.State().AddDefaultSpaceSetting()
-			},
-		},
-		&upgradeStep{
 			description: "replace space name in endpointBindingDoc bindings with an space ID",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return context.State().ReplaceSpaceNameWithIDEndpointBindings()
+			},
+		},
+		&upgradeStep{
+			description: `remove model config for default-space if set to "_default"`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureDefaultSpaceSetting()
 			},
 		},
 	}

--- a/upgrades/steps_27.go
+++ b/upgrades/steps_27.go
@@ -84,7 +84,7 @@ func stateStepsFor27() []Step {
 			},
 		},
 		&upgradeStep{
-			description: `remove model config for default-space if set to "_default"`,
+			description: `ensure model config for default-space is "" if either absent or is set to "_default"`,
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return context.State().EnsureDefaultSpaceSetting()


### PR DESCRIPTION
## Description of change

- Reverts model config default setting for "default-space".
- The old upgrade step to set it to "_default" is removed.
- A new upgrade step ensures that if unset or set to the old "_default" value, it is set to "".

**Edit:** It appears that the original addition of "default-space" as a model-config item was not released with 2.7-beta1, so checking for "_default" is not strictly necessary.

## QA steps

- Bootstrap 2.6.
- Build this patch and `juju upgrade-controller --build-agent`.
- Check that `juju model-config default-space` has the value "".

## Documentation changes

None.

## Bug reference

N/A
