### PR TITLE
Retry all snapcraft run commands

### DIFF
--- a/snap/plugins/x-dep.py
+++ b/snap/plugins/x-dep.py
@@ -42,7 +42,7 @@ import shutil
 
 import snapcraft
 from snapcraft import common
-
+from snapcraft.internal import errors
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +148,16 @@ class DepPlugin(snapcraft.BasePlugin):
 
     def _run(self, cmd, **kwargs):
         env = self._build_environment()
-        return self.run(cmd, cwd=self._path_in_gopath, env=env, **kwargs)
+
+        totalRetries = 3
+        for i in range(0, totalRetries):
+            try:
+                return self.run(cmd, cwd=self._path_in_gopath, env=env, **kwargs)
+            except Exception as e:
+                logger.info("Exception attempting to run: {}".format(e))
+                if i < totalRetries-1:
+                    continue
+                raise
 
     def _build_environment(self):
         env = os.environ.copy()


### PR DESCRIPTION
## Description of change

The following attempts to make installing dependencies for building
snaps more reliable. Essentially we're going to try and retry all
run commands so at least we've not bailed out on the first try.

This should hopefully improve the current ongoing failures we have
when building snaps.
