### PR TITLE
metrics add prometheus endpoint for charmconfig

### DIFF
--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -65,6 +65,9 @@ type ControllerGauges struct {
 	ApplicationHashCacheHit  prometheus.Gauge
 	ApplicationHashCacheMiss prometheus.Gauge
 
+	CharmConfigHashCacheHit  prometheus.Gauge
+	CharmConfigHashCacheMiss prometheus.Gauge
+
 	LXDProfileChangeError        prometheus.Gauge
 	LXDProfileChangeNotification prometheus.Gauge
 	LXDProfileNoChange           prometheus.Gauge
@@ -91,6 +94,20 @@ func createControllerGauges() *ControllerGauges {
 				Namespace: metricsNamespace,
 				Name:      "model_hash_cache_miss",
 				Help:      "The number of times the model config change hash was generated.",
+			},
+		),
+		CharmConfigHashCacheHit: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "charm_config_watcher_hash_hit",
+				Help:      "The number of times a change in master or branch config required no notification to config watcher(s)",
+			},
+		),
+		CharmConfigHashCacheMiss: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "charm_config_watcher_hash_miss",
+				Help:      "The number of times a change in master or branch config required notification to config watcher(s)",
 			},
 		),
 		ApplicationConfigReads: prometheus.NewGauge(
@@ -144,6 +161,9 @@ func (c *ControllerGauges) Describe(ch chan<- *prometheus.Desc) {
 	c.ModelHashCacheHit.Describe(ch)
 	c.ModelHashCacheMiss.Describe(ch)
 
+	c.CharmConfigHashCacheHit.Describe(ch)
+	c.CharmConfigHashCacheMiss.Describe(ch)
+
 	c.ApplicationConfigReads.Describe(ch)
 	c.ApplicationHashCacheHit.Describe(ch)
 	c.ApplicationHashCacheMiss.Describe(ch)
@@ -158,6 +178,9 @@ func (c *ControllerGauges) Collect(ch chan<- prometheus.Metric) {
 	c.ModelConfigReads.Collect(ch)
 	c.ModelHashCacheHit.Collect(ch)
 	c.ModelHashCacheMiss.Collect(ch)
+
+	c.CharmConfigHashCacheHit.Collect(ch)
+	c.CharmConfigHashCacheMiss.Collect(ch)
 
 	c.ApplicationConfigReads.Collect(ch)
 	c.ApplicationHashCacheHit.Collect(ch)

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -153,6 +153,12 @@ func (m *Model) Application(appName string) (Application, error) {
 	return app.copy(), nil
 }
 
+// Metrics returns the metrics of the model
+func (m *Model) Metrics() *ControllerGauges {
+	defer m.doLocked()()
+	return m.metrics
+}
+
 // Units returns all units in the model.
 func (m *Model) Units() map[string]Unit {
 	m.mu.Lock()


### PR DESCRIPTION

## Description of change

adds prometheus scraping endpoints for charmconfigwatcher

## QA steps

https://discourse.jujucharms.com/t/monitoring-juju-controllers/430
- follow the discourse link
   - deploy prometheus 
   - add the controller and its metrics
 - search for the new metric `charm_config_watcher_hash_hit` and `charm_config_watcher_hash_miss`
- see whether they change while you add/remove branches/applications 