### PR TITLE
Don't try to run transactions with empty slices.

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1268,6 +1268,9 @@ func (i ImportRemoteApplications) Execute(src RemoteApplicationsDescription,
 	runner TransactionRunner,
 ) error {
 	remoteApplications := src.RemoteApplications()
+	if len(remoteApplications) == 0 {
+		return nil
+	}
 	ops := make([]txn.Op, 0)
 	for _, app := range remoteApplications {
 		appDoc := src.MakeRemoteApplicationDoc(app)
@@ -1534,6 +1537,9 @@ type ImportRemoteEntities struct{}
 // the dependencies we have.
 func (ImportRemoteEntities) Execute(src RemoteEntitiesDescription, runner TransactionRunner) error {
 	remoteEntities := src.RemoteEntities()
+	if len(remoteEntities) == 0 {
+		return nil
+	}
 	ops := make([]txn.Op, len(remoteEntities))
 	for i, entity := range remoteEntities {
 		docID := src.DocID(entity.ID())
@@ -1587,6 +1593,9 @@ type ImportRelationNetworks struct{}
 // the dependencies we have.
 func (ImportRelationNetworks) Execute(src RelationNetworksDescription, runner TransactionRunner) error {
 	relationNetworks := src.RelationNetworks()
+	if len(relationNetworks) == 0 {
+		return nil
+	}
 	ops := make([]txn.Op, len(relationNetworks))
 	for i, entity := range relationNetworks {
 		docID := src.DocID(entity.ID())
@@ -1659,8 +1668,10 @@ func (i *importer) linklayerdevices() error {
 		ops = append(ops, incrementDeviceNumChildrenOp(parentDocID))
 
 	}
-	if err := i.st.db().RunTransaction(ops); err != nil {
-		return errors.Trace(err)
+	if len(ops) > 0 {
+		if err := i.st.db().RunTransaction(ops); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	i.logger.Debugf("importing linklayerdevices succeeded")
 	return nil

--- a/state/migration_import_unit_test.go
+++ b/state/migration_import_unit_test.go
@@ -158,7 +158,7 @@ func (s *MigrationImportSuite) TestImportRemoteEntitiesWithNoEntities(c *gc.C) {
 	model.EXPECT().RemoteEntities().Return(entities)
 
 	runner := NewMockTransactionRunner(ctrl)
-	runner.EXPECT().RunTransaction([]txn.Op{})
+	// No call to RunTransaction if there are no operations.
 
 	m := ImportRemoteEntities{}
 	err := m.Execute(model, runner)
@@ -260,7 +260,7 @@ func (s *MigrationImportSuite) TestImportRelationNetworksWithNoEntities(c *gc.C)
 	model.EXPECT().RelationNetworks().Return(entities)
 
 	runner := NewMockTransactionRunner(ctrl)
-	runner.EXPECT().RunTransaction([]txn.Op{}).Return(nil)
+	// No call to RunTransaction if there are no operations.
 
 	m := ImportRelationNetworks{}
 	err := m.Execute(model, runner)


### PR DESCRIPTION
When migrating a model from 2.6 to 2.7 there were a number of warning lines written like this:
```
2019-10-30 19:55:11 WARNING juju.state txns.go:89 Running no-op transaction - called by /home/tim/go/src/github.com/juju/juju/state/database.go:386 /home/tim/go/src/github.com/juju/juju/state/migration_import.go:1290 /home/tim/go/src/github.com/juju/juju/state/migration_import.go:1201 /home/tim/go/src/github.com/juju/juju/state/migration_import.go:259 /home/tim/go/src/github.com/juju/juju/state/migration_import.go:1209 /home/tim/go/src/github.com/juju/juju/state/migration_import.go:191 /home/tim/go/src/github.com/juju/juju/migration/migration.go:71 /home/tim/go/src/github.com/juju/juju/apiserver/facades/controller/migrationtarget/migrationtarget.go:115 /snap/go/4678/src/reflect/value.go:447 /snap/go/4678/src/reflect/value.go:308 /home/tim/go/src/github.com/juju/juju/vendor/github.com/juju/rpcreflect/type.go:327 /home/tim/go/src/github.com/juju/juju/apiserver/root.go:171 /home/tim/go/src/github.com/juju/juju/rpc/server.go:571 /home/tim/go/src/github.com/juju/juju/rpc/server.go:475
```
This PR addresses those no-op run transaction calls.
