### PR TITLE
Sort instance IDs to fix intermittent test failure in ec2 provider

### DIFF
--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1622,6 +1622,9 @@ func (t *localServerSuite) TestNetworkInterfacesForMultipleInstances(c *gc.C) {
 		ids[i] = inst.Id()
 	}
 
+	// Sort instance list so we always get consistent results
+	sort.Slice(ids, func(l, r int) bool { return ids[l] < ids[r] })
+
 	ifLists, err := env.NetworkInterfaces(t.callCtx, ids)
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
## Description of change

Fix for an intermittent failure for test introduced to the ec2 provider in #10805.
