### PR TITLE
update charm dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:ed6ef6587e8c42c2cdb227c2e1b164bd131e4c84d420cf725b5fcf97c29e9b19"
+  digest = "1:8632962e0712e94334d716bc1b3b12443b5a5fed420619d72238db34589d0a96"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
+  revision = "f595bfd8a0497d23ea8ae6604d02be42677a9de5"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:8632962e0712e94334d716bc1b3b12443b5a5fed420619d72238db34589d0a96"
+  digest = "1:ccd3f6144f4e55a6786e197d119b879d2b68ff26a489476cbfca7a6f83b6c5f3"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,10 +1502,10 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "f595bfd8a0497d23ea8ae6604d02be42677a9de5"
+  revision = "4e6efee6340bbada7f1e0ce873f33c15254ac2b8"
 
 [[projects]]
-  digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"
+  digest = "1:e4b5e4dc87e06eae6d168f08f9787330aa88164b5f755b92d1a4600960d6c6f9"
   name = "gopkg.in/juju/charmrepo.v3"
   packages = [
     ".",
@@ -1514,7 +1514,7 @@
     "testing",
   ]
   pruneopts = ""
-  revision = "2adcece4e962a51e0793b8562560cf9da874026f"
+  revision = "5ca139ef9e6bd138ab2ff3c59aee3c472d12ac89"
 
 [[projects]]
   digest = "1:74fbfdf0898041a163a696f0a901b6f4740a47ceffb1839d514ba75699a60c3e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
+  revision = "f595bfd8a0497d23ea8ae6604d02be42677a9de5"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,10 +147,10 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "f595bfd8a0497d23ea8ae6604d02be42677a9de5"
+  revision = "4e6efee6340bbada7f1e0ce873f33c15254ac2b8"
 
 [[constraint]]
-  revision = "2adcece4e962a51e0793b8562560cf9da874026f"
+  revision = "5ca139ef9e6bd138ab2ff3c59aee3c472d12ac89"
   name = "gopkg.in/juju/charmrepo.v3"
 
 [[constraint]]

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -458,7 +459,8 @@ func (s *clientSuite) TestOpenCharmMissing(c *gc.C) {
 }
 
 func addLocalCharm(c *gc.C, client *api.Client, name string, force bool) (*charm.URL, *charm.CharmArchive) {
-	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), name)
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().UnixNano()))
+	charmArchive := testcharms.TempRepo(c, path).CharmArchive(path, name)
 	curl := charm.MustParseURL(fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()))
 	_, err := client.AddLocalCharm(curl, charmArchive, force)
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -14,7 +14,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -419,7 +418,8 @@ func (s *clientSuite) TestOpenURIError(c *gc.C) {
 
 func (s *clientSuite) TestOpenCharmFound(c *gc.C) {
 	client := s.APIState.Client()
-	curl, ch := addLocalCharm(c, client, "dummy", false)
+	curl, ch, repoPath := addLocalCharm(c, client, "dummy", false)
+	defer os.Remove(repoPath)
 	c.Logf("added local charm as %v", curl)
 	expected, err := ioutil.ReadFile(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
@@ -435,7 +435,8 @@ func (s *clientSuite) TestOpenCharmFound(c *gc.C) {
 
 func (s *clientSuite) TestOpenCharmFoundWithForceStillSucceeds(c *gc.C) {
 	client := s.APIState.Client()
-	curl, ch := addLocalCharm(c, client, "dummy", true)
+	curl, ch, repoPath := addLocalCharm(c, client, "dummy", true)
+	defer os.Remove(repoPath)
 	expected, err := ioutil.ReadFile(ch.Path)
 	c.Logf("force added local charm as %v", curl)
 	c.Assert(err, jc.ErrorIsNil)
@@ -458,13 +459,13 @@ func (s *clientSuite) TestOpenCharmMissing(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `.*cannot get charm from state: charm "cs:quantal/spam-3" not found`)
 }
 
-func addLocalCharm(c *gc.C, client *api.Client, name string, force bool) (*charm.URL, *charm.CharmArchive) {
-	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().UnixNano()))
-	charmArchive := testcharms.TempRepo(c, path).CharmArchive(path, name)
+func addLocalCharm(c *gc.C, client *api.Client, name string, force bool) (*charm.URL, *charm.CharmArchive, string) {
+	repo := testcharms.TmpRepo(c)
+	charmArchive := repo.CharmArchive(repo.Path(), name)
 	curl := charm.MustParseURL(fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()))
 	_, err := client.AddLocalCharm(curl, charmArchive, force)
 	c.Assert(err, jc.ErrorIsNil)
-	return curl, charmArchive
+	return curl, charmArchive, repo.Path()
 }
 
 func fakeAPIEndpoint(c *gc.C, client *api.Client, address, method string, handle func(http.ResponseWriter, *http.Request)) net.Listener {

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -656,7 +656,10 @@ func (s *charmsSuite) TestGetWorksForControllerMachines(c *gc.C) {
 
 func (s *charmsSuite) TestGetStarReturnsArchiveBytes(c *gc.C) {
 	// Add the dummy charm.
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	charmName := "dummy"
+	repo := testcharms.TmpRepo(c)
+	defer os.Remove(repo.Path())
+	ch := repo.CharmArchive(repo.Path(), charmName)
 	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
 
 	data, err := ioutil.ReadFile(ch.Path)

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -8,6 +8,7 @@ package testcharms
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"github.com/juju/utils/fs"
 	"io"
 	"io/ioutil"
@@ -34,22 +35,22 @@ const localCharmRepo = "charm-repo"
 // Repo provides access to the test charm repository.
 var Repo = testing.NewRepo(localCharmRepo, defaultSeries)
 
-// TempRepo provides access to the a tmp test charm repository. It copies the content from the charm-repo to the given path.
-// With this we can make sure that we use the proper level of isolation. In this case a charm repo which is not under
+// TmpRepo provides access to the a tmp repo repository consisting of one charm. Copied from the
+// repository under juju/juju
+// With this we can make sure that we use the proper level of isolation. In this case the charm repo is not under
 // Juju git versioning.
-// fs.Copy forces to use a path it cannot overwrite existing ones.
-// TODO: problem -> defaultseries is used thus error path
-// SOLUTIONS: own written, copy whole folder. But this would happen each tests...
-func TempRepo(c *gc.C, dst string) *testing.Repo {
+func TmpRepo(c *gc.C) *testing.Repo {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
 		panic("cannot get caller")
 	}
+	dst := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().UnixNano()))
+
+	// With this we ensure only to copy the charm we need
 	src := filepath.Join(filepath.Dir(file), localCharmRepo, defaultSeries)
 	err := fs.Copy(src, dst)
 	c.Assert(err, jc.ErrorIsNil)
-	newRepo := testing.NewRepoFromFullPath(dst, defaultSeries)
-	return newRepo
+	return testing.NewRepoFromFullPath(dst, "")
 }
 
 // RepoForSeries returns a new charm repository for the specified series.


### PR DESCRIPTION

## Description of change

This references to this pr https://github.com/juju/charm/pull/297.
tl;dr change:
- refactoring of the charm version generation code
- only throw a warn on err events, else just log
- generates git version of subdir of git folders
