### PR TITLE
Use model config default-space to configure default endpoint binding space

### DIFF
--- a/cmd/juju/application/bind.go
+++ b/cmd/juju/application/bind.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/api/spaces"
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
@@ -27,9 +26,6 @@ func NewBindCommand() cmd.Command {
 	cmd := &bindCommand{
 		NewApplicationClient: func(conn base.APICallCloser) ApplicationBindClient {
 			return application.NewClient(conn)
-		},
-		NewModelConfigGetter: func(conn base.APICallCloser) ModelConfigGetter {
-			return modelconfig.NewClient(conn)
 		},
 		NewSpacesClient: func(conn base.APICallCloser) SpacesAPI {
 			return spaces.NewAPI(conn)
@@ -50,7 +46,6 @@ type bindCommand struct {
 	modelcmd.ModelCommandBase
 
 	NewApplicationClient func(base.APICallCloser) ApplicationBindClient
-	NewModelConfigGetter func(base.APICallCloser) ModelConfigGetter
 	NewSpacesClient      func(base.APICallCloser) SpacesAPI
 
 	ApplicationName string
@@ -131,12 +126,6 @@ func (c *bindCommand) Run(ctx *cmd.Context) error {
 		return errors.New("no bindings specified")
 	}
 
-	modelConfigGetter := c.NewModelConfigGetter(apiRoot)
-	modelConfig, err := getModelConfig(modelConfigGetter)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	generation, err := c.ActiveBranch()
 	if err != nil {
 		return errors.Trace(err)
@@ -163,7 +152,7 @@ func (c *bindCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	appDefaultSpace := detectDefaultSpace(modelConfig, curBindings)
+	appDefaultSpace := curBindings[""]
 
 	var bindingsChangelog []string
 	c.Bindings, bindingsChangelog = mergeBindings(curCharmEndpoints, curBindings, c.Bindings, appDefaultSpace)

--- a/cmd/juju/application/bind_test.go
+++ b/cmd/juju/application/bind_test.go
@@ -52,11 +52,12 @@ func (s *BindSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	s.applicationClient = mockApplicationBindClient{}
-	s.modelConfigGetter = mockModelConfigGetter{}
+	s.modelConfigGetter = newMockModelConfigGetter()
 	s.spacesClient = mockSpacesClient{
 		spaceList: []params.Space{
-			{Id: "0", Name: ""}, // default
+			{Id: "0", Name: network.AlphaSpaceName},
 			{Id: "1", Name: "sp1"},
+			{Id: "4", Name: "sp4"},
 		},
 	}
 

--- a/cmd/juju/application/bind_test.go
+++ b/cmd/juju/application/bind_test.go
@@ -28,7 +28,6 @@ type BindSuite struct {
 
 	apiConnection     mockAPIConnection
 	applicationClient mockApplicationBindClient
-	modelConfigGetter mockModelConfigGetter
 	spacesClient      mockSpacesClient
 	cmd               cmd.Command
 }
@@ -52,12 +51,12 @@ func (s *BindSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	s.applicationClient = mockApplicationBindClient{}
-	s.modelConfigGetter = newMockModelConfigGetter()
 	s.spacesClient = mockSpacesClient{
 		spaceList: []params.Space{
 			{Id: "0", Name: network.AlphaSpaceName},
 			{Id: "1", Name: "sp1"},
 			{Id: "4", Name: "sp4"},
+			{Id: "5", Name: "testing"},
 		},
 	}
 
@@ -81,10 +80,6 @@ func (s *BindSuite) SetUpTest(c *gc.C) {
 		func(conn base.APICallCloser) ApplicationBindClient {
 			s.AddCall("NewApplicationClient", conn)
 			return &s.applicationClient
-		},
-		func(conn base.APICallCloser) ModelConfigGetter {
-			s.AddCall("NewModelConfigGetter", conn)
-			return &s.modelConfigGetter
 		},
 		func(conn base.APICallCloser) SpacesAPI {
 			s.AddCall("NewSpacesClient", conn)

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -158,12 +158,10 @@ func NewBindCommandForTest(
 	store jujuclient.ClientStore,
 	apiOpen api.OpenFunc,
 	newApplicationClient func(base.APICallCloser) ApplicationBindClient,
-	newModelConfigGetter func(base.APICallCloser) ModelConfigGetter,
 	newSpacesClient func(base.APICallCloser) SpacesAPI,
 ) cmd.Command {
 	cmd := &bindCommand{
 		NewApplicationClient: newApplicationClient,
-		NewModelConfigGetter: newModelConfigGetter,
 		NewSpacesClient:      newSpacesClient,
 	}
 	cmd.SetClientStore(store)

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -747,16 +747,20 @@ func allEndpoints(ci *charms.CharmInfo) set.Strings {
 	return epSet
 }
 
+// detectDefaultSpace returns the current default space for the bindings provided.
+// The default space is determined via the following sequence.
+// 1. the space of the default endpoint in the bindings provided.
+// 2. the "default-space" from the model-config.
+// 3. AlphaSpaceName
 func detectDefaultSpace(modelConfig *config.Config, curBindings map[string]string) string {
 	if curBindings != nil {
 		if defaultSpace, defined := curBindings[""]; defined {
 			return defaultSpace
 		}
 	}
-
-	// TODO(achilleasa): When we introduce a model config parameter for
-	// specifying the default space we should check whether it is set and
-	// use its value as the default before falling-back to the global
-	// default below.
+	configSpaceName := modelConfig.DefaultSpace()
+	if configSpaceName != "" {
+		return configSpaceName
+	}
 	return network.AlphaSpaceName
 }

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -34,7 +34,6 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourceadapters"
@@ -402,7 +401,7 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 		}
 
 		curBindings := applicationInfo.EndpointBindings
-		appDefaultSpace := detectDefaultSpace(modelConfig, curBindings)
+		appDefaultSpace := curBindings[""]
 		newCharmEndpoints := allEndpoints(charmInfo)
 		if err := c.validateEndpointNames(newCharmEndpoints, curBindings, c.Bindings); err != nil {
 			return errors.Trace(err)
@@ -745,22 +744,4 @@ func allEndpoints(ci *charms.CharmInfo) set.Strings {
 	}
 
 	return epSet
-}
-
-// detectDefaultSpace returns the current default space for the bindings provided.
-// The default space is determined via the following sequence.
-// 1. the space of the default endpoint in the bindings provided.
-// 2. the "default-space" from the model-config.
-// 3. AlphaSpaceName
-func detectDefaultSpace(modelConfig *config.Config, curBindings map[string]string) string {
-	if curBindings != nil {
-		if defaultSpace, defined := curBindings[""]; defined {
-			return defaultSpace
-		}
-	}
-	configSpaceName := modelConfig.DefaultSpace()
-	if configSpaceName != "" {
-		return configSpaceName
-	}
-	return network.AlphaSpaceName
 }

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -78,6 +78,16 @@ applications:
       logging-directory: alpha
   wordpress:
     charm: cs:quantal/wordpress-23
+    bindings:
+      "": alpha
+      admin-api: alpha
+      cache: alpha
+      db: alpha
+      db-client: alpha
+      foo-bar: alpha
+      logging-dir: alpha
+      monitoring-port: alpha
+      url: alpha
 relations:
 - - wordpress:juju-info
   - logging:info

--- a/state/application.go
+++ b/state/application.go
@@ -2576,7 +2576,7 @@ func (a *Application) defaultEndpointBindings() (map[string]string, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return DefaultEndpointBindingsForCharm(appCharm.Meta()), nil
+	return DefaultEndpointBindingsForCharm(a.st, appCharm.Meta())
 }
 
 // MetricCredentials returns any metric credentials associated with this application.

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3513,7 +3513,8 @@ func (s *ApplicationSuite) assertApplicationHasOnlyDefaultEndpointBindings(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 
 	knownEndpoints := set.NewStrings("")
-	allBindings := state.DefaultEndpointBindingsForCharm(charm.Meta())
+	allBindings, err := state.DefaultEndpointBindingsForCharm(s.State, charm.Meta())
+	c.Assert(err, jc.ErrorIsNil)
 	for endpoint := range allBindings {
 		knownEndpoints.Add(endpoint)
 	}

--- a/state/mocks/endpointbinding_mock.go
+++ b/state/mocks/endpointbinding_mock.go
@@ -5,10 +5,9 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	state "github.com/juju/juju/state"
+	reflect "reflect"
 )
 
 // MockEndpointBinding is a mock of EndpointBinding interface
@@ -32,6 +31,19 @@ func NewMockEndpointBinding(ctrl *gomock.Controller) *MockEndpointBinding {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockEndpointBinding) EXPECT() *MockEndpointBindingMockRecorder {
 	return m.recorder
+}
+
+// DefaultEndpointBindingSpace mocks base method
+func (m *MockEndpointBinding) DefaultEndpointBindingSpace() (string, error) {
+	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace
+func (mr *MockEndpointBindingMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockEndpointBinding)(nil).DefaultEndpointBindingSpace))
 }
 
 // Space mocks base method


### PR DESCRIPTION
## Description of change

Use the model config default-space value to determine the default endpoint binding to use.  If it's an empty string, use the AlphaSpaceName.  

## QA steps

Test with AWS, maas, and no space aware configs.
1. juju deploy mysql --bind db:<space>
2. juju show-application mysql   <-- binding show assigned to alpha, except db
3. juju remove-application mysql
3. juju model-config default-space <space>
2. juju show-application mysql --bind db:<space2>  <-- binding show assigned to <space>, except db
3. test with the bindings command
3. test with upgrade charm getting new bindings.

## Documentation changes

Maybe, this is adding on top of the new default-space model-config option.


