### PR TITLE
Dev fix incorrect handling of endpoint bindings when migrating

### DIFF
--- a/state/endpoint_bindings_test.go
+++ b/state/endpoint_bindings_test.go
@@ -221,7 +221,7 @@ func (s *bindingsSuite) TestMergeBindings(c *gc.C) {
 			"":          s.appsSpace.Id(),
 			"foo1":      s.appsSpace.Id(),
 			"bar1":      s.dbSpace.Id(),
-			"self":      "",
+			"self":      network.DefaultSpaceId,
 			"one-extra": s.barbSpace.Id(),
 		},
 		meta: s.newMeta,
@@ -231,7 +231,7 @@ func (s *bindingsSuite) TestMergeBindings(c *gc.C) {
 			"foo2": s.clientSpace.Id(),
 			"bar2": s.clientSpace.Id(),
 			"bar3": s.barbSpace.Id(),
-			"self": "",
+			"self": network.DefaultSpaceId,
 			"me":   s.clientSpace.Id(),
 		},
 		modified: true,
@@ -244,7 +244,7 @@ func (s *bindingsSuite) TestMergeBindings(c *gc.C) {
 			"":          s.appsSpace.Id(),
 			"foo1":      s.appsSpace.Id(),
 			"bar1":      s.dbSpace.Id(),
-			"self":      "",
+			"self":      network.DefaultSpaceId,
 			"one-extra": s.clientSpace.Id(),
 		},
 		meta: s.oldMeta,
@@ -262,7 +262,7 @@ func (s *bindingsSuite) TestMergeBindings(c *gc.C) {
 		currentMap: map[string]string{
 			"":          s.appsSpace.Id(),
 			"bar1":      s.dbSpace.Id(),
-			"self":      "",
+			"self":      network.DefaultSpaceId,
 			"lost":      s.clientSpace.Id(),
 			"one-extra": s.clientSpace.Id(),
 		},
@@ -271,7 +271,7 @@ func (s *bindingsSuite) TestMergeBindings(c *gc.C) {
 			"":          s.appsSpace.Id(),
 			"foo1":      s.appsSpace.Id(),
 			"bar1":      s.dbSpace.Id(),
-			"self":      "",
+			"self":      network.DefaultSpaceId,
 			"one-extra": s.clientSpace.Id(),
 		},
 		modified: true,
@@ -320,7 +320,7 @@ func (s *bindingsMockSuite) TestNewBindingsByID(c *gc.C) {
 	initial := map[string]string{
 		"db":      "2",
 		"testing": "5",
-		"empty":   "",
+		"empty":   network.DefaultSpaceId,
 	}
 
 	binding, err := state.NewBindings(s.endpointBinding, initial)
@@ -347,7 +347,7 @@ func (s *bindingsMockSuite) TestNewBindingsByName(c *gc.C) {
 	expected := map[string]string{
 		"db":      "2",
 		"testing": "5",
-		"empty":   "",
+		"empty":   network.DefaultSpaceId,
 	}
 	c.Logf("%+v", binding.Map())
 	c.Assert(binding.Map(), jc.DeepEquals, expected)
@@ -375,7 +375,7 @@ func (s *bindingsMockSuite) TestMapWithSpaceNames(c *gc.C) {
 	initial := map[string]string{
 		"db":      "2",
 		"testing": "3",
-		"empty":   "",
+		"empty":   network.DefaultSpaceId,
 	}
 
 	binding, err := state.NewBindings(s.endpointBinding, initial)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -927,6 +927,12 @@ func (i *importer) parseBindings(bindingsMap map[string]string) (*Bindings, erro
 		}
 	}
 
+	// 2.6 controllers only populate the default space key if set to the
+	// non-default space whereas 2.7 controllers always set it.
+	if _, exists := bindingsMap[defaultEndpointName]; !exists {
+		bindingsMap[defaultEndpointName] = network.DefaultSpaceName
+	}
+
 	return NewBindings(i.st, bindingsMap)
 }
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -850,7 +850,7 @@ func (i *importer) application(a description.Application) error {
 		return errors.Trace(err)
 	}
 
-	bindings, err := NewBindings(i.st, a.EndpointBindings())
+	bindings, err := i.parseBindings(a.EndpointBindings())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -907,6 +907,27 @@ func (i *importer) application(a description.Application) error {
 	}
 
 	return nil
+}
+
+// parseBindings converts a bindings map from a 2.6.x or 2.7+ migration export
+// into a Bindings object.
+//
+// When migrating from a 2.6.x controller, the bindings in the description
+// output are encoded as {endpoint name => space name} with "" representing
+// the "default" (now called alpha) space. The empty spaces must be remapped
+// to the correct default space name for the new controller.
+//
+// On the other hand, migration exports from 2.7+ are using space IDs instead
+// of space names as the map values and can safely be passed to the NewBindings
+// c-tor.
+func (i *importer) parseBindings(bindingsMap map[string]string) (*Bindings, error) {
+	for epName, spNameOrID := range bindingsMap {
+		if spNameOrID == "" {
+			bindingsMap[epName] = network.DefaultSpaceName
+		}
+	}
+
+	return NewBindings(i.st, bindingsMap)
 }
 
 func (i *importer) appResourceOps(app description.Application) []txn.Op {


### PR DESCRIPTION
## Description of change

When migrating from a 2.6 -> 2.7 controller, we must be careful to properly re-map the endpoint bindings from the 2.6 application description so the 2.7 code can properly parse them into a Bindings object. 

If a 2.6 application had **all** its bindings assigned to the default space (represented as `""` in 2.6 controllers), the NewBindings c-tor would get confused and treat the map as if it contained space IDs instead of space names and thus preventing the operator from adding new units (the endpoint bindings document would contain `""` values instead of the default space ID)

Note: when the DefaultAlphaSpaceName changes land, we should update the code in import_migration to re-map the 2.6 default space (`""`) to the alpha space name.

## QA steps

```console
# bootstrap 2.6 controller on lxd
$ juju add-model test
$ juju deploy cs:~jameinel/ubuntu-lite-7
# wait for the unit machine to boot...

# bootstrap 2.7 controller on lxd
$ juju switch 2.6
$ juju migrate test 2.7
$ juju switch 2.7
$ juju add-unit ubuntu-lite
```

If you peek into the DB, the endpointbindings document for the application should map all endpoints to "0" **and include a key "" with value "0"** (2.6 only sets the key for the default space if different than network.DefaultSpaceName whereas 2.7 always sets it)

## Bug reference

Tentative fix for https://bugs.launchpad.net/juju/+bug/1850589
