### PR TITLE
Check the model version to decide the action ID type;

### DIFF
--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -783,7 +783,19 @@ func stringify(r params.ActionResult) string {
 	return fmt.Sprintf("%s-%s-%#v-%s-%s-%#v", a.Tag, a.Name, a.Parameters, r.Status, r.Message, r.Output)
 }
 
+func (s *actionSuite) toSupportNewActionID(c *gc.C) {
+	ver, err := s.Model.AgentVersion()
+	c.Assert(err, jc.ErrorIsNil)
+
+	if !state.IsNewActionIDSupported(ver) {
+		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
 func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
+	s.toSupportNewActionID(c)
+
 	unit, err := s.State.Unit("mysql/0")
 	c.Assert(err, jc.ErrorIsNil)
 	assertReadyToTest(c, unit)
@@ -829,6 +841,8 @@ func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
 }
 
 func (s *actionSuite) setupTasks(c *gc.C) {
+	s.toSupportNewActionID(c)
+
 	arg := params.Actions{
 		Actions: []params.Action{
 			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},

--- a/state/action.go
+++ b/state/action.go
@@ -332,10 +332,13 @@ func newAction(st *State, adoc actionDoc) Action {
 	}
 }
 
-var newActionIDFirstSupportedVersion = version.MustParse("2.7.0")
+// MinVersionSupportNewActionID should be un-exposed after 2.7 released.
+// TODO(action): un-expose MinVersionSupportNewActionID and IsNewActionIDSupported and remove those helper functions using these two vars in tests from 2.7.0.
+var MinVersionSupportNewActionID = version.MustParse("2.7.0")
 
-func newActionIDSupported(ver version.Number) bool {
-	return ver.Compare(newActionIDFirstSupportedVersion) >= 0
+// IsNewActionIDSupported checks if new action ID is supported for the specified version.
+func IsNewActionIDSupported(ver version.Number) bool {
+	return ver.Compare(MinVersionSupportNewActionID) >= 0
 }
 
 // newActionDoc builds the actionDoc with the given name and parameters.
@@ -347,7 +350,7 @@ func newActionDoc(mb modelBackend, receiverTag names.Tag, actionName string, par
 
 	// we support machine actions anymore.
 	var actionId string
-	if receiverTag.Kind() == names.UnitTagKind && newActionIDSupported(modelAgentVersion) {
+	if receiverTag.Kind() == names.UnitTagKind && IsNewActionIDSupported(modelAgentVersion) {
 		id, err := sequence(mb, "task")
 		if err != nil {
 			return actionDoc{}, actionNotificationDoc{}, err

--- a/state/action.go
+++ b/state/action.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
+	"github.com/juju/version"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -331,15 +332,22 @@ func newAction(st *State, adoc actionDoc) Action {
 	}
 }
 
+var newActionIDFirstSupportedVersion = version.MustParse("2.7.0")
+
+func newActionIDSupported(ver version.Number) bool {
+	return ver.Compare(newActionIDFirstSupportedVersion) >= 0
+}
+
 // newActionDoc builds the actionDoc with the given name and parameters.
-func newActionDoc(mb modelBackend, receiverTag names.Tag, actionName string, parameters map[string]interface{}) (actionDoc, actionNotificationDoc, error) {
+func newActionDoc(mb modelBackend, receiverTag names.Tag, actionName string, parameters map[string]interface{}, modelAgentVersion version.Number) (actionDoc, actionNotificationDoc, error) {
 	prefix := ensureActionMarker(receiverTag.Id())
 	// For actions run on units, we want to use a user friendly action id.
 	// Theoretically, an action receiver could also be a machine, but for
 	// now we'll continue to use a UUID for that case, since I don't think
+
 	// we support machine actions anymore.
 	var actionId string
-	if receiverTag.Kind() == names.UnitTagKind {
+	if receiverTag.Kind() == names.UnitTagKind && newActionIDSupported(modelAgentVersion) {
 		id, err := sequence(mb, "task")
 		if err != nil {
 			return actionDoc{}, actionNotificationDoc{}, err
@@ -462,7 +470,7 @@ func (m *Model) FindActionsByName(name string) ([]Action, error) {
 	return results, errors.Trace(iter.Close())
 }
 
-// EnqueueAction
+// EnqueueAction caches the action doc to the database.
 func (m *Model) EnqueueAction(receiver names.Tag, actionName string, payload map[string]interface{}) (Action, error) {
 	if len(actionName) == 0 {
 		return nil, errors.New("action name required")
@@ -472,8 +480,11 @@ func (m *Model) EnqueueAction(receiver names.Tag, actionName string, payload map
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	doc, ndoc, err := newActionDoc(m.st, receiver, actionName, payload)
+	agentVersion, err := m.AgentVersion()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	doc, ndoc, err := newActionDoc(m.st, receiver, actionName, payload, agentVersion)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -373,8 +374,19 @@ func (s *InterfaceSuite) TestSetActionMessage(c *gc.C) {
 	c.Check(actionData.ResultsMessage, gc.Equals, "because reasons")
 }
 
+func (s *InterfaceSuite) toSupportNewActionID(c *gc.C) {
+	ver, err := s.Model.AgentVersion()
+	c.Assert(err, jc.ErrorIsNil)
+
+	if !state.IsNewActionIDSupported(ver) {
+		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
 // TestLogActionMessage ensures LogActionMessage works properly.
 func (s *InterfaceSuite) TestLogActionMessage(c *gc.C) {
+	s.toSupportNewActionID(c)
 	action, err := s.unit.AddAction("fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = action.Begin()


### PR DESCRIPTION
## Description of change

Use `UUID` for the actionID if the model agent version < 2.7;

## QA steps

## CaaS

```console
# controller version 2.7
$ juju controllers
Controller  Model  User   Access     Cloud/Region        Models  Nodes  HA  Version
k1*         t1     admin  superuser  microk8s/localhost       2      1   -  2.7.0


# model version 2.6
$ juju status --relations --color --storage -m k1:t1                                                                        
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.6.11   unsupported  13:47:03+11:00

# run action got errors, that's ok because 2.6 doesnot support k8s actions yet.
$ juju run --unit mariadb-k8s/0 --timeout=30s "network-get server" --operator=false
ERROR timed out waiting for result from: unit mariadb-k8s/0

# check actionID in DB - it's `UUID`
juju:PRIMARY> db.actions.find().pretty()
{
	"_id" : "146d3193-4756-4492-872c-db9ba112be6f:b27e5bcc-9b7e-4817-8b14-632ba7715a94",
	"model-uuid" : "146d3193-4756-4492-872c-db9ba112be6f",
	"receiver" : "mariadb-k8s/0",
	"name" : "juju-run",
	"parameters" : {
		"workload-context" : true,
		"command" : "network-get server",
		"timeout" : NumberLong("30000000000")
	},
	"enqueued" : ISODate("2019-11-01T02:43:35Z"),
	"started" : ISODate("0001-01-01T00:00:00Z"),
	"completed" : ISODate("0001-01-01T00:00:00Z"),
	"status" : "pending",
	"message" : "",
	"results" : {

	},
	"messages" : [ ],
	"txn-revno" : NumberLong(2),
	"txn-queue" : [
		"5dbb9bd6fe5c050008b25e02_d6a87d84"
	]
}

# upgrade model;
$ juju upgrade-juju --agent-version 2.7.0 -m t1
best version:
    2.7.0
started upgrade to 2.7.0

# run action again
$ juju run --unit mariadb-k8s/0 --timeout=30s "network-get server" --operator=false

# check actionID in DB - it's `number`
juju:PRIMARY> db.actions.find().pretty()
{
	"_id" : "146d3193-4756-4492-872c-db9ba112be6f:4",
	"model-uuid" : "146d3193-4756-4492-872c-db9ba112be6f",
	"receiver" : "mariadb-k8s/0",
	"name" : "juju-run",
	"parameters" : {
		"command" : "network-get server",
		"timeout" : NumberLong("30000000000"),
		"workload-context" : true
	},
	"enqueued" : ISODate("2019-11-01T03:29:54Z"),
	"started" : ISODate("0001-01-01T00:00:00Z"),
	"completed" : ISODate("0001-01-01T00:00:00Z"),
	"status" : "pending",
	"message" : "",
	"results" : {

	},
	"messages" : [ ],
	"txn-revno" : NumberLong(2),
	"txn-queue" : [
		"5dbba6b1fe5c0500085bb340_86016a6f"
	]
}

```

## IaaS

```console
# 2.7 controller
$ juju controllers

Controller  Model    User   Access     Cloud/Region         Models  Nodes    HA  Version
k1*         default  admin  superuser  localhost/localhost       2      1  none  2.7.0.1

# 2.6 model
$ juju status --relations --color  --storage -m k1:default
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  k1          localhost/localhost  2.6.11.1  unsupported  16:58:48+11:00

# run action - `UUID` format of action ID;
$ juju run-action  postgresql/1 wal-e-list-backups
Action queued with id: 8ee87083-6a85-4477-8483-515f741218ba

# upgrade model to 2.7
$ juju upgrade-juju -m default
best version:
    2.7.0.1
started upgrade to 2.7.0.1

# run action - `number` format of action ID;
$ juju run-action  postgresql/1 wal-e-list-backups
Action queued with id: "1"
```

## Documentation changes

None

## Bug reference

None
