### PR TITLE
Allow add-k8s to work with no undercloud specified

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -171,10 +171,10 @@ func (s *bootstrapSuite) TestGetControllerSvcSpec(c *gc.C) {
 			ServiceType: core.ServiceTypeClusterIP,
 		},
 		"unknown-cloud": {
-			ServiceType: core.ServiceTypeLoadBalancer,
+			ServiceType: core.ServiceTypeClusterIP,
 		},
 	} {
-		spec, _ := s.controllerStackerGetter().GetControllerSvcSpec(cloudType)
+		spec, _ := s.controllerStackerGetter().GetControllerSvcSpec(cloudType, nil)
 		c.Check(spec, jc.DeepEquals, out)
 	}
 }
@@ -211,6 +211,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	s.broker.GetAnnotations().Add("juju.io/is-controller", "true")
 
 	s.pcfg.Bootstrap.Timeout = 10 * time.Minute
+	s.pcfg.Bootstrap.ControllerExternalIPs = []string{"10.0.0.1"}
 
 	controllerStacker := s.controllerStackerGetter()
 	// Broker's namespace should be set to controller name now.
@@ -247,7 +248,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "juju-controller-test"},
-			Type:     core.ServiceType("LoadBalancer"),
+			Type:     core.ServiceType("ClusterIP"),
 			Ports: []core.ServicePort{
 				{
 					Name:       "api-server",
@@ -255,6 +256,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					Port:       int32(APIPort),
 				},
 			},
+			ExternalIPs: []string{"10.0.0.1"},
 		},
 	}
 

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -51,7 +51,7 @@ type ControllerStackerForTest interface {
 	GetAgentConfigContent(*gc.C) string
 	GetSharedSecretAndSSLKey(*gc.C) (string, string)
 	GetStorageSize() resource.Quantity
-	GetControllerSvcSpec(string) (*controllerServiceSpec, error)
+	GetControllerSvcSpec(string, *podcfg.BootstrapConfig) (*controllerServiceSpec, error)
 }
 
 func (cs *controllerStack) GetAgentConfigContent(c *gc.C) string {
@@ -70,8 +70,8 @@ func (cs *controllerStack) GetStorageSize() resource.Quantity {
 	return cs.storageSize
 }
 
-func (cs *controllerStack) GetControllerSvcSpec(cloudType string) (*controllerServiceSpec, error) {
-	return cs.getControllerSvcSpec(cloudType)
+func (cs *controllerStack) GetControllerSvcSpec(cloudType string, cfg *podcfg.BootstrapConfig) (*controllerServiceSpec, error) {
+	return cs.getControllerSvcSpec(cloudType, cfg)
 }
 
 func NewcontrollerStackForTest(

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -243,6 +243,15 @@ type BootstrapConfig struct {
 	// JujuDbSnapAssertions is a path to a .assert file that will be used
 	// to verify the .snap at JujuDbSnapPath
 	JujuDbSnapAssertionsPath string
+
+	// ControllerServiceType is the service type of a k8s controller.
+	ControllerServiceType string
+
+	// ControllerExternalName is the external name of a k8s controller.
+	ControllerExternalName string
+
+	// ControllerExternalIPs is the list of external ips for a k8s controller.
+	ControllerExternalIPs []string
 }
 
 // SSHHostKeys contains the SSH host keys to configure for a bootstrap host.

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -57,11 +57,6 @@ type ControllerPodConfig struct {
 	// ControllerName is the controller name.
 	ControllerName string
 
-	// TODO(bootstrap): remove me.
-	// PodNonce is set at provisioning/bootstrap time and used to
-	// ensure the agent is running on the correct instance.
-	PodNonce string
-
 	// JujuVersion is the juju version.
 	JujuVersion version.Number
 
@@ -207,7 +202,7 @@ func (cfg *ControllerPodConfig) verifyBootstrapConfig() (err error) {
 		return errors.New(`
 host cloud region is missing.
 The k8s cloud definition might be stale, please try to re-import the k8s cloud using
-    juju add-k8s <cloud-name> --cluster-name <cluster-name> --local
+    juju add-k8s <cloud-name> --cluster-name <cluster-name> --client
 
 See juju help add-k8s for more information.
 `[1:])

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -391,6 +391,11 @@ var unknownClusterErrMsg = `
 	Run add-k8s again, using --storage=<name> to specify the storage class to use.
 `[1:]
 
+var noClusterSpecifiedErrMsg = `
+	Juju needs to know what storage class to use to provision workload and operator storage.
+	Run add-k8s again, using --storage=<name> to specify the storage class to use.
+`[1:]
+
 var noRecommendedStorageErrMsg = `
 	No recommended storage configuration is defined on this cluster.
 	Run add-k8s again with --storage=<name> and Juju will use the
@@ -470,19 +475,28 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 			return errors.Errorf(noRecommendedStorageErrMsg, err.(provider.NoRecommendedStorageError).StorageProvider())
 		}
 		if provider.IsUnknownClusterError(err) {
-			return errors.Errorf(unknownClusterErrMsg, err.(provider.UnknownClusterError).CloudName)
+			cloudName := err.(provider.UnknownClusterError).CloudName
+			if cloudName == "" {
+				return errors.New(noClusterSpecifiedErrMsg)
+			}
+			return errors.Errorf(unknownClusterErrMsg, cloudName)
 		}
 		return errors.Trace(err)
 	}
 
-	newCloud.HostCloudRegion, err = c.validateCloudRegion(ctx, newCloud.HostCloudRegion)
-	if err != nil {
-		return errors.Trace(err)
+	if newCloud.HostCloudRegion != "" {
+		newCloud.HostCloudRegion, err = c.validateCloudRegion(ctx, newCloud.HostCloudRegion)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 	// By this stage, we know if cloud name/type and/or region input is needed from the user.
 	// If we could not detect it, check what was provided.
 	if err := checkCloudRegion(c.givenHostCloudRegion, newCloud.HostCloudRegion); err != nil {
 		return errors.Trace(err)
+	}
+	if newCloud.HostCloudRegion == "" {
+		newCloud.HostCloudRegion = caas.K8sCloudOther
 	}
 	if c.Client {
 		if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
@@ -493,10 +507,13 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 		}
 	}
 
-	if clusterName == "" {
+	if clusterName == "" && newCloud.HostCloudRegion != caas.K8sCloudOther {
 		clusterName = newCloud.HostCloudRegion
 	}
-	successMsg := fmt.Sprintf("k8s substrate %q added as cloud %q%s", clusterName, c.caasName, storageMsg)
+	if clusterName != "" {
+		clusterName = fmt.Sprintf("%q ", clusterName)
+	}
+	successMsg := fmt.Sprintf("k8s substrate %sadded as cloud %q%s", clusterName, c.caasName, storageMsg)
 	var msgDisplayed bool
 	if c.Client {
 		msgDisplayed = true

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -644,6 +644,14 @@ to create a new model to deploy k8s workloads.
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if !isCAASController {
+		if bootstrapCfg.bootstrap.ControllerServiceType != "" ||
+			bootstrapCfg.bootstrap.ControllerExternalName != "" ||
+			len(bootstrapCfg.bootstrap.ControllerExternalIPs) > 0 {
+			return errors.Errorf("%q, %q and %q\nare only allowed for kubernetes controllers",
+				bootstrap.ControllerServiceType, bootstrap.ControllerExternalName, bootstrap.ControllerExternalIPs)
+		}
+	}
 
 	// Read existing current controller so we can clean up on error.
 	var oldCurrentController string
@@ -709,6 +717,9 @@ to create a new model to deploy k8s workloads.
 		RegionInheritedConfig:     cloud.RegionConfig,
 		AdminSecret:               bootstrapCfg.bootstrap.AdminSecret,
 		CAPrivateKey:              bootstrapCfg.bootstrap.CAPrivateKey,
+		ControllerServiceType:     bootstrapCfg.bootstrap.ControllerServiceType,
+		ControllerExternalName:    bootstrapCfg.bootstrap.ControllerExternalName,
+		ControllerExternalIPs:     append([]string(nil), bootstrapCfg.bootstrap.ControllerExternalIPs...),
 		JujuDbSnapPath:            c.JujuDbSnapPath,
 		JujuDbSnapAssertionsPath:  c.JujuDbSnapAssertionsPath,
 		DialOpts: environs.BootstrapDialOpts{

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -461,6 +461,10 @@ var bootstrapTests = []bootstrapTest{{
 	info: "specifying controller attribute as model-default",
 	args: []string{"--model-default", "api-port=12345"},
 	err:  `"api-port" is a controller attribute, and cannot be set as a model-default`,
+}, {
+	info: "k8s config on iaas controller",
+	args: []string{"--config", "controller-service-type=loadbalancer"},
+	err:  `"controller-service-type", "controller-external-name" and "controller-external-ips"are only allowed for kubernetes controllers`,
 }}
 
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *gc.C) {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -149,6 +149,15 @@ type BootstrapParams struct {
 	// CAPrivateKey is the controller's CA certificate private key.
 	CAPrivateKey string
 
+	// ControllerServiceType is the service type of a k8s controller.
+	ControllerServiceType string
+
+	// ControllerExternalName is the external name of a k8s controller.
+	ControllerExternalName string
+
+	// ControllerExternalIPs is the list of external ips for a k8s controller.
+	ControllerExternalIPs []string
+
 	// DialOpts contains the bootstrap dial options.
 	DialOpts environs.BootstrapDialOpts
 
@@ -722,6 +731,9 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
 	pcfg.Bootstrap.HostedModelConfig = args.HostedModelConfig
 	pcfg.Bootstrap.Timeout = args.DialOpts.Timeout
+	pcfg.Bootstrap.ControllerServiceType = args.ControllerServiceType
+	pcfg.Bootstrap.ControllerExternalName = args.ControllerExternalName
+	pcfg.Bootstrap.ControllerExternalIPs = append([]string(nil), args.ControllerExternalIPs...)
 	return nil
 }
 

--- a/environs/bootstrap/config_test.go
+++ b/environs/bootstrap/config_test.go
@@ -44,6 +44,9 @@ func (*ConfigSuite) TestConfigValuesSpecified(c *gc.C) {
 		"bootstrap-timeout":         1,
 		"bootstrap-retry-delay":     2,
 		"bootstrap-addresses-delay": 3,
+		"controller-service-type":   "external",
+		"controller-external-name":  "externalName",
+		"controller-external-ips":   []string{"10.0.0.1", "10.0.0.2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -54,6 +57,9 @@ func (*ConfigSuite) TestConfigValuesSpecified(c *gc.C) {
 		BootstrapTimeout:        time.Second * 1,
 		BootstrapRetryDelay:     time.Second * 2,
 		BootstrapAddressesDelay: time.Second * 3,
+		ControllerServiceType:   "external",
+		ControllerExternalName:  "externalName",
+		ControllerExternalIPs:   []string{"10.0.0.1", "10.0.0.2"},
 	})
 }
 
@@ -165,6 +171,12 @@ func (*ConfigSuite) TestValidateBootstrapAddressesDelay(c *gc.C) {
 	c.Assert(cfg.Validate(), gc.ErrorMatches, "bootstrap-addresses-delay of -2m0s not valid")
 }
 
+func (*ConfigSuite) TestValidateExternalIpsAndServiceType(c *gc.C) {
+	cfg := validConfig()
+	cfg.ControllerServiceType = "cluster"
+	c.Assert(cfg.Validate(), gc.ErrorMatches, `external IPs require a service type of "external"`)
+}
+
 func validConfig() bootstrap.Config {
 	return bootstrap.Config{
 		AdminSecret:             "sekrit",
@@ -173,6 +185,8 @@ func validConfig() bootstrap.Config {
 		BootstrapTimeout:        time.Second * 1,
 		BootstrapRetryDelay:     time.Second * 2,
 		BootstrapAddressesDelay: time.Second * 3,
+		ControllerServiceType:   "external",
+		ControllerExternalIPs:   []string{"10.0.0.1", "10.0.0.2"},
 	}
 }
 

--- a/environs/bootstrap/export_test.go
+++ b/environs/bootstrap/export_test.go
@@ -4,10 +4,11 @@
 package bootstrap
 
 var (
-	ValidateUploadAllowed    = validateUploadAllowed
-	GetBootstrapToolsVersion = getBootstrapToolsVersion
-	FindTools                = &findTools
-	FindBootstrapTools       = findBootstrapTools
-	FindPackagedTools        = findPackagedTools
-	GUIFetchMetadata         = &guiFetchMetadata
+	FinalizePodBootstrapConfig = finalizePodBootstrapConfig
+	ValidateUploadAllowed      = validateUploadAllowed
+	GetBootstrapToolsVersion   = getBootstrapToolsVersion
+	FindTools                  = &findTools
+	FindBootstrapTools         = findBootstrapTools
+	FindPackagedTools          = findPackagedTools
+	GUIFetchMetadata           = &guiFetchMetadata
 )


### PR DESCRIPTION
## Description of change

There's a need to use add-k8s without specify any underlying cloud.
This PR supports that case, and records the cloud type as "other".
The cloud type is used internally by Juju when creating the controller service type. The service type for "other" is now "ClusterIP" instead of "LoadBalancer" as we can't always be sure a load balancer service is supported. To allow bootstrapping in more cases, two new boostrap config params are added:
controller-service-type (cluster, external, loadbalancer)
controller-external-ips

This fixes another bug preventing bootstrap to a remote microk8s, plus allows the user to control what type of controller service is created by Juju to cover more scenarios on bespoke k8s clusters.
Known clusters like GKE etc still work out of the box.

Note - add-k8s will use a default storage class if one is found if no undercloud is specified. So most times just "juju add-k8s" is sufficient.

## QA steps

add-k8s on a cluster with no undercloud
bootstrap to that cluster using --config controller-service-type=blah

## Bug reference

https://bugs.launchpad.net/bugs/1850877
https://bugs.launchpad.net/juju/+bug/1841960
