### PR TITLE
Move add-k8s prompt to after reading config (which could be piped).

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -400,9 +400,6 @@ var noRecommendedStorageErrMsg = `
 
 // Run is defined on the Command interface.
 func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
-	if err := c.MaybePrompt(ctx, fmt.Sprintf("add k8s cloud %v to", c.caasName)); err != nil {
-		return errors.Trace(err)
-	}
 	if err := c.verifyName(c.caasName); err != nil {
 		return errors.Trace(err)
 	}
@@ -440,6 +437,13 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	newcredential, err = ensureCredentialUID(credentialName, credentialUID, newcredential)
 	if err != nil {
+		return errors.Trace(err)
+	}
+	// We need to have c.ControllerName after this, so this si the latest time to
+	// prompt user for client and controller options.
+	// We need to do this later then other commands since
+	// piping is done regularly with add-k8s.
+	if err := c.MaybePrompt(ctx, fmt.Sprintf("add k8s cloud %v to", c.caasName)); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -439,7 +439,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// We need to have c.ControllerName after this, so this si the latest time to
+	// We need to have c.ControllerName after this, so this is the latest time to
 	// prompt user for client and controller options.
 	// We need to do this later then other commands since
 	// piping is done regularly with add-k8s.

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -986,12 +986,31 @@ func (s *addCAASSuite) TestCorrectParseFromStdIn(c *gc.C) {
 
 	command := s.makeCommand(c, true, true, false)
 	stdIn, err := mockStdinPipe(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdIn, gc.NotNil)
 	defer stdIn.Close()
-	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.runCommand(c, stdIn, command, "myk8s", "-c", "foo", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStoreClouds(c, "gce/us-east1")
+}
+
+func (s *addCAASSuite) TestCorrectPromptOrderFromStdIn(c *gc.C) {
+	ctrl := s.setupBroker(c)
+	defer ctrl.Finish()
+
+	command := s.makeCommand(c, true, true, false)
+	stdIn, err := mockStdinPipe(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdIn, gc.NotNil)
+	defer stdIn.Close()
+	ctx, err := s.runCommand(c, stdIn, command, "myk8s")
+	c.Assert(err, gc.ErrorMatches, "EOF")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Do you want to add k8s cloud myk8s to:\n"+
+		"    1. client only (--client)\n"+
+		"    2. controller \"foo\" only (--controller foo)\n"+
+		"    3. both (--client --controller foo)\n"+
+		"Enter your choice, or type Q|q to quit: ")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "This operation can be applied to both a copy on this client and to the one on a controller.\n")
 }
 
 func (s *addCAASSuite) TestAddGkeCluster(c *gc.C) {


### PR DESCRIPTION
## Description of change

'add-k8s' command is regularly piped, specifically to get config, for example

```
microk8s.config | juju add-k8s microk8s1 --debug
```

This PR ensures that the pipe content is read and saved first and then Juju prompts, if needed, with ask-or-tell.

## QA steps

As per linked bug

## Bug reference

https://bugs.launchpad.net/juju/+bug/1849601
