### PR TITLE
Track branch with -n Option

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -75,7 +75,7 @@ var facadeVersions = map[string]int{
 	"MigrationStatusWatcher":       1,
 	"MigrationTarget":              1,
 	"ModelConfig":                  2,
-	"ModelGeneration":              2,
+	"ModelGeneration":              3,
 	"ModelManager":                 8,
 	"ModelUpgrader":                1,
 	"NotifyWatcher":                1,

--- a/api/modelgeneration/modelgeneration.go
+++ b/api/modelgeneration/modelgeneration.go
@@ -71,10 +71,11 @@ func (c *Client) CommitBranch(branchName string) (int, error) {
 
 // TrackBranch sets the input units and/or applications
 // to track changes made under the input branch name.
-func (c *Client) TrackBranch(branchName string, entities []string) error {
+func (c *Client) TrackBranch(branchName string, entities []string, numUnits int) error {
 	var result params.ErrorResults
 	arg := params.BranchTrackArg{
 		BranchName: branchName,
+		NumUnits:   numUnits,
 	}
 	if len(entities) == 0 {
 		return errors.New("no units or applications specified")

--- a/api/modelgeneration/modelgeneration_test.go
+++ b/api/modelgeneration/modelgeneration_test.go
@@ -86,7 +86,7 @@ func (s *modelGenerationSuite) TestTrackBranchSuccess(c *gc.C) {
 	s.fCaller.EXPECT().FacadeCall("TrackBranch", arg, gomock.Any()).SetArg(2, resultsSource).Return(nil)
 
 	api := modelgeneration.NewStateFromCaller(s.fCaller)
-	err := api.TrackBranch(s.branchName, []string{"mysql/0", "mysql"})
+	err := api.TrackBranch(s.branchName, []string{"mysql/0", "mysql"}, 0)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -94,7 +94,7 @@ func (s *modelGenerationSuite) TestTrackBranchError(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
 	api := modelgeneration.NewStateFromCaller(s.fCaller)
-	err := api.TrackBranch(s.branchName, []string{"mysql/0", "mysql", "machine-3"})
+	err := api.TrackBranch(s.branchName, []string{"mysql/0", "mysql", "machine-3"}, 0)
 	c.Assert(err, gc.ErrorMatches, `"machine-3" is not an application or a unit`)
 }
 

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -251,6 +251,7 @@ func AllFacades() *facade.Registry {
 	reg("ModelConfig", 2, modelconfig.NewFacadeV2)
 	reg("ModelGeneration", 1, modelgeneration.NewModelGenerationFacade)
 	reg("ModelGeneration", 2, modelgeneration.NewModelGenerationFacadeV2)
+	reg("ModelGeneration", 3, modelgeneration.NewModelGenerationFacadeV3)
 	reg("ModelManager", 2, modelmanager.NewFacadeV2)
 	reg("ModelManager", 3, modelmanager.NewFacadeV3)
 	reg("ModelManager", 4, modelmanager.NewFacadeV4)

--- a/apiserver/facades/client/modelgeneration/interface.go
+++ b/apiserver/facades/client/modelgeneration/interface.go
@@ -39,6 +39,7 @@ type Generation interface {
 	Created() int64
 	CreatedBy() string
 	AssignAllUnits(string) error
+	AssignUnits(string, int) error
 	AssignUnit(string) error
 	AssignedUnits() map[string][]string
 	Commit(string) (int, error)

--- a/apiserver/facades/client/modelgeneration/mocks/package_mock.go
+++ b/apiserver/facades/client/modelgeneration/mocks/package_mock.go
@@ -207,6 +207,18 @@ func (mr *MockGenerationMockRecorder) AssignUnit(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignUnit", reflect.TypeOf((*MockGeneration)(nil).AssignUnit), arg0)
 }
 
+// AssignUnits mocks base method
+func (m *MockGeneration) AssignUnits(arg0 string, arg1 int) error {
+	ret := m.ctrl.Call(m, "AssignUnits", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AssignUnits indicates an expected call of AssignUnits
+func (mr *MockGenerationMockRecorder) AssignUnits(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignUnits", reflect.TypeOf((*MockGeneration)(nil).AssignUnits), arg0, arg1)
+}
+
 // AssignedUnits mocks base method
 func (m *MockGeneration) AssignedUnits() map[string][]string {
 	ret := m.ctrl.Call(m, "AssignedUnits")

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -143,7 +143,7 @@ func (api *API) TrackBranch(arg params.BranchTrackArg) (params.ErrorResults, err
 		}
 		switch tag.Kind() {
 		case names.ApplicationTagKind:
-			result.Results[i].Error = common.ServerError(branch.AssignAllUnits(tag.Id()))
+			result.Results[i].Error = common.ServerError(branch.AssignUnits(tag.Id(), arg.NumUnits))
 		case names.UnitTagKind:
 			result.Results[i].Error = common.ServerError(branch.AssignUnit(tag.Id()))
 		default:

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -152,7 +152,7 @@ func (api *API) TrackBranch(arg params.BranchTrackArg) (params.ErrorResults, err
 	// topographically distribute between all the applications and units,
 	// especially if an error occurs whilst assigning the units.
 	if arg.NumUnits > 0 && len(arg.Entities) > 1 {
-		return params.ErrorResults{}, errors.Errorf("num of units allowed when specifying multiple entities")
+		return params.ErrorResults{}, errors.Errorf("number of units and unit IDs can not be specified at the same time")
 	}
 
 	branch, err := api.model.Branch(arg.BranchName)

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -110,6 +110,22 @@ func (s *modelGenerationSuite) TestTrackBranchSuccess(c *gc.C) {
 	})
 }
 
+func (s *modelGenerationSuite) TestTrackBranchWithTooManyNumUnits(c *gc.C) {
+	defer s.setupModelGenerationAPI(c).Finish()
+
+	arg := params.BranchTrackArg{
+		BranchName: s.newBranchName,
+		Entities: []params.Entity{
+			{Tag: names.NewUnitTag("mysql/0").String()},
+			{Tag: names.NewApplicationTag("ghost").String()},
+		},
+		NumUnits: 1,
+	}
+	result, err := s.api.TrackBranch(arg)
+	c.Assert(err, gc.ErrorMatches, "num of units allowed when specifying multiple entities")
+	c.Check(result.Results, gc.DeepEquals, []params.ErrorResult(nil))
+}
+
 func (s *modelGenerationSuite) TestCommitBranchSuccess(c *gc.C) {
 	defer s.setupModelGenerationAPI(c).Finish()
 	s.expectCommit()

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -68,7 +68,7 @@ func (s *modelGenerationSuite) TestAddBranchSuccess(c *gc.C) {
 
 func (s *modelGenerationSuite) TestTrackBranchEntityTypeError(c *gc.C) {
 	defer s.setupModelGenerationAPI(c).Finish()
-	s.expectAssignAllUnits("ghost")
+	s.expectAssignUnits("ghost", 0)
 	s.expectAssignUnit("mysql/0")
 	s.expectBranch()
 
@@ -91,7 +91,7 @@ func (s *modelGenerationSuite) TestTrackBranchEntityTypeError(c *gc.C) {
 
 func (s *modelGenerationSuite) TestTrackBranchSuccess(c *gc.C) {
 	defer s.setupModelGenerationAPI(c).Finish()
-	s.expectAssignAllUnits("ghost")
+	s.expectAssignUnits("ghost", 0)
 	s.expectAssignUnit("mysql/0")
 	s.expectBranch()
 
@@ -261,6 +261,10 @@ func (s *modelGenerationSuite) expectHasActiveBranch(err error) {
 
 func (s *modelGenerationSuite) expectAssignAllUnits(appName string) {
 	s.mockGen.EXPECT().AssignAllUnits(appName).Return(nil)
+}
+
+func (s *modelGenerationSuite) expectAssignUnits(appName string, numUnits int) {
+	s.mockGen.EXPECT().AssignUnits(appName, numUnits).Return(nil)
 }
 
 func (s *modelGenerationSuite) expectAssignUnit(unitName string) {

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -122,7 +122,7 @@ func (s *modelGenerationSuite) TestTrackBranchWithTooManyNumUnits(c *gc.C) {
 		NumUnits: 1,
 	}
 	result, err := s.api.TrackBranch(arg)
-	c.Assert(err, gc.ErrorMatches, "num of units allowed when specifying multiple entities")
+	c.Assert(err, gc.ErrorMatches, "number of units and unit IDs can not be specified at the same time")
 	c.Check(result.Results, gc.DeepEquals, []params.ErrorResult(nil))
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -23037,7 +23037,7 @@
     },
     {
         "Name": "ModelGeneration",
-        "Version": 2,
+        "Version": 3,
         "Schema": {
             "type": "object",
             "properties": {
@@ -23166,6 +23166,9 @@
                             "items": {
                                 "$ref": "#/definitions/Entity"
                             }
+                        },
+                        "num-units": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1198,6 +1198,7 @@ type BranchInfoArgs struct {
 type BranchTrackArg struct {
 	BranchName string   `json:"branch"`
 	Entities   []Entity `json:"entities"`
+	NumUnits   int      `json:"num-units,omitempty"`
 }
 
 // GenerationApplication represents changes to an application

--- a/cmd/juju/model/mocks/abort_mock.go
+++ b/cmd/juju/model/mocks/abort_mock.go
@@ -34,7 +34,6 @@ func (m *MockAbortCommandAPI) EXPECT() *MockAbortCommandAPIMockRecorder {
 
 // AbortBranch mocks base method
 func (m *MockAbortCommandAPI) AbortBranch(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AbortBranch", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -42,13 +41,11 @@ func (m *MockAbortCommandAPI) AbortBranch(arg0 string) error {
 
 // AbortBranch indicates an expected call of AbortBranch
 func (mr *MockAbortCommandAPIMockRecorder) AbortBranch(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AbortBranch", reflect.TypeOf((*MockAbortCommandAPI)(nil).AbortBranch), arg0)
 }
 
 // Close mocks base method
 func (m *MockAbortCommandAPI) Close() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -56,13 +53,11 @@ func (m *MockAbortCommandAPI) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockAbortCommandAPIMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAbortCommandAPI)(nil).Close))
 }
 
 // HasActiveBranch mocks base method
 func (m *MockAbortCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasActiveBranch", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -71,6 +66,5 @@ func (m *MockAbortCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
 
 // HasActiveBranch indicates an expected call of HasActiveBranch
 func (mr *MockAbortCommandAPIMockRecorder) HasActiveBranch(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasActiveBranch", reflect.TypeOf((*MockAbortCommandAPI)(nil).HasActiveBranch), arg0)
 }

--- a/cmd/juju/model/mocks/trackbranch_mock.go
+++ b/cmd/juju/model/mocks/trackbranch_mock.go
@@ -34,7 +34,6 @@ func (m *MockTrackBranchCommandAPI) EXPECT() *MockTrackBranchCommandAPIMockRecor
 
 // Close mocks base method
 func (m *MockTrackBranchCommandAPI) Close() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -42,13 +41,11 @@ func (m *MockTrackBranchCommandAPI) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockTrackBranchCommandAPIMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).Close))
 }
 
 // HasActiveBranch mocks base method
 func (m *MockTrackBranchCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasActiveBranch", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -57,20 +54,17 @@ func (m *MockTrackBranchCommandAPI) HasActiveBranch(arg0 string) (bool, error) {
 
 // HasActiveBranch indicates an expected call of HasActiveBranch
 func (mr *MockTrackBranchCommandAPIMockRecorder) HasActiveBranch(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasActiveBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).HasActiveBranch), arg0)
 }
 
 // TrackBranch mocks base method
-func (m *MockTrackBranchCommandAPI) TrackBranch(arg0 string, arg1 []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TrackBranch", arg0, arg1)
+func (m *MockTrackBranchCommandAPI) TrackBranch(arg0 string, arg1 []string, arg2 int) error {
+	ret := m.ctrl.Call(m, "TrackBranch", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TrackBranch indicates an expected call of TrackBranch
-func (mr *MockTrackBranchCommandAPIMockRecorder) TrackBranch(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).TrackBranch), arg0, arg1)
+func (mr *MockTrackBranchCommandAPIMockRecorder) TrackBranch(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackBranch", reflect.TypeOf((*MockTrackBranchCommandAPI)(nil).TrackBranch), arg0, arg1, arg2)
 }

--- a/cmd/juju/model/trackbranch_test.go
+++ b/cmd/juju/model/trackbranch_test.go
@@ -99,6 +99,17 @@ func (s *trackBranchSuite) TestRunCommandNumUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *trackBranchSuite) TestRunCommandNumUnitsWithInvalidNumber(c *gc.C) {
+	mockController, api := setUpAdvanceMocksWithoutAPI(c)
+	defer mockController.Finish()
+
+	_, err := s.runCommand(c, api, s.branchName, "-n", "0", "redis")
+	c.Assert(err, gc.ErrorMatches, "expected a valid number of units to track")
+
+	_, err = s.runCommand(c, api, s.branchName, "-n", "-1", "redis")
+	c.Assert(err, gc.ErrorMatches, "expected a valid number of units to track")
+}
+
 func (s *trackBranchSuite) TestRunCommandFail(c *gc.C) {
 	ctrl, api := setUpAdvanceMocks(c)
 	defer ctrl.Finish()

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -245,7 +245,7 @@ func (g *Generation) AssignUnits(appName string, numUnits int) error {
 			}
 		}
 		// If there are no units to add to the generation, quit here.
-		if len(ops) == 0 {
+		if assigned == 0 {
 			return nil, jujutxn.ErrNoOperations
 		}
 		return ops, nil

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -191,6 +191,14 @@ func (s *generationSuite) TestAssignNumUnitsSuccessRemaining(c *gc.C) {
 	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected)
 }
 
+func (s *generationSuite) TestAssignUnitsNoOperations(c *gc.C) {
+	gen := s.setupAssignUnits(c)
+
+	c.Assert(gen.AssignUnits("riak", 1), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), gc.HasLen, 0)
+}
+
 func (s *generationSuite) TestAssignNumUnitsSelectAll(c *gc.C) {
 	gen := s.setupAssignAllUnits(c)
 
@@ -512,6 +520,18 @@ options:
 		_, err := riak.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 	}
+
+	return s.addBranch(c)
+}
+
+func (s *generationSuite) setupAssignUnits(c *gc.C) *state.Generation {
+	var cfgYAML = `
+options:
+  http_port: {default: 8089, description: HTTP Port, type: int}
+`
+	s.ch = s.AddConfigCharm(c, "riak", cfgYAML, 666)
+
+	s.AddTestingApplication(c, "riak", s.ch)
 
 	return s.addBranch(c)
 }

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -164,6 +164,50 @@ func (s *generationSuite) TestAssignAllUnitsSuccessRemaining(c *gc.C) {
 	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected)
 }
 
+func (s *generationSuite) TestAssignNumUnitsSuccessRemaining(c *gc.C) {
+	gen := s.setupAssignAllUnits(c)
+
+	expected := []string{"riak/0", "riak/1", "riak/2", "riak/3"}
+
+	c.Assert(gen.AssignUnits("riak", 1), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), gc.HasLen, 1)
+	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected[:1])
+
+	c.Assert(gen.AssignUnits("riak", 2), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), gc.HasLen, 1)
+	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected[:3])
+
+	c.Assert(gen.AssignUnits("riak", 1), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), gc.HasLen, 1)
+	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected)
+
+	// Idempotent.
+	c.Assert(gen.AssignAllUnits("riak"), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), gc.HasLen, 1)
+	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected)
+}
+
+func (s *generationSuite) TestAssignNumUnitsSelectAll(c *gc.C) {
+	gen := s.setupAssignAllUnits(c)
+
+	expected := []string{"riak/0", "riak/1", "riak/2", "riak/3"}
+
+	c.Assert(gen.AssignUnits("riak", 100), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), gc.HasLen, 1)
+	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected)
+
+	// Idempotent.
+	c.Assert(gen.AssignAllUnits("riak"), jc.ErrorIsNil)
+	c.Assert(gen.Refresh(), jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), gc.HasLen, 1)
+	c.Check(gen.AssignedUnits()["riak"], jc.SameContents, expected)
+}
+
 func (s *generationSuite) TestAssignAllUnitsCompletedError(c *gc.C) {
 	s.setupTestingClock(c)
 	gen := s.setupAssignAllUnits(c)


### PR DESCRIPTION
## Description of change

Track branch with -n allows us to specify the number of units to
track when tracking a branch.

The -n can only be used when tracking application tags, as unit
tags only track 1 thing, so it's not valid to do so. I've added some
validation around this to ensure we don't accidentally allow this to
happen.


## QA steps

```sh
juju track-branch xxx redis -n 2
```

