### PR TITLE
Fix race+test with actions blocked and snapshot.

### DIFF
--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -109,8 +109,9 @@ func NewWatcher(config WatcherConfig) (*RemoteStateWatcher, error) {
 		// so that we coalesce events while the observer is busy.
 		out: make(chan struct{}, 1),
 		current: Snapshot{
-			Relations: make(map[int]RelationSnapshot),
-			Storage:   make(map[names.StorageTag]StorageSnapshot),
+			Relations:      make(map[int]RelationSnapshot),
+			Storage:        make(map[names.StorageTag]StorageSnapshot),
+			ActionsBlocked: config.RunningStatusFunc != nil,
 		},
 	}
 	err := catacomb.Invoke(catacomb.Plan{

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -142,11 +142,20 @@ func (s *WatcherSuite) TearDownTest(c *gc.C) {
 	}
 }
 
-func (s *WatcherSuite) TestInitialSnapshot(c *gc.C) {
+func (s *WatcherSuiteIAAS) TestInitialSnapshot(c *gc.C) {
 	snap := s.watcher.Snapshot()
 	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{},
 		Storage:   map[names.StorageTag]remotestate.StorageSnapshot{},
+	})
+}
+
+func (s *WatcherSuiteCAAS) TestInitialSnapshot(c *gc.C) {
+	snap := s.watcher.Snapshot()
+	c.Assert(snap, jc.DeepEquals, remotestate.Snapshot{
+		Relations:      map[int]remotestate.RelationSnapshot{},
+		Storage:        map[names.StorageTag]remotestate.StorageSnapshot{},
+		ActionsBlocked: true,
 	})
 }
 


### PR DESCRIPTION
## Description of change

Fix non-critical race condition with actions blocked and Snapshot.
If Snapshot is called too quickly it wouldn't return the expected state.

## QA steps

Run tests for github.com/juju/juju/worker/uniter/remotestate

## Documentation changes

N/A

## Bug reference

N/A
