### PR TITLE
Fix k8s controller config validation

### DIFF
--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -130,8 +130,13 @@ func (c Config) Validate() error {
 	if c.BootstrapAddressesDelay <= 0 {
 		return errors.NotValidf("%s of %s", BootstrapAddressesDelayKey, c.BootstrapAddressesDelay)
 	}
-	if len(c.ControllerExternalIPs) > 0 && c.ControllerServiceType != string(caas.ServiceExternal) {
-		return errors.NewNotValid(nil, fmt.Sprintf("external IPs require a service type of %q", caas.ServiceExternal))
+	if len(c.ControllerExternalIPs) > 0 &&
+		c.ControllerServiceType != string(caas.ServiceExternal) &&
+		c.ControllerServiceType != string(caas.ServiceLoadBalancer) {
+		return errors.NewNotValid(nil, fmt.Sprintf("external IPs require a service type of %q or %q", caas.ServiceExternal, caas.ServiceLoadBalancer))
+	}
+	if len(c.ControllerExternalIPs) > 1 && c.ControllerServiceType == string(caas.ServiceLoadBalancer) {
+		return errors.NewNotValid(nil, fmt.Sprintf("only 1 external IP is allowed with service type %q", caas.ServiceLoadBalancer))
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

When validation k8s controller config, "loadbalancer" services are also allowed to have external ips, not just "external" services. Also, "loadbalancer" services can just specify 1 external IP.

## QA steps

$ juju bootstrap microk8s test
  --config controller-service-type=loadbalancer
  --config controller-external-ips=[10.0.0.1]
