### PR TITLE
Add proxy-update-worker to k8s operator

### DIFF
--- a/apiserver/facades/agent/proxyupdater/proxyupdater.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater.go
@@ -93,7 +93,7 @@ type Backend interface {
 
 // NewAPIBase creates a new server-side API facade with the given Backing.
 func NewAPIBase(backend Backend, resources facade.Resources, authorizer facade.Authorizer) (*APIBase, error) {
-	if !(authorizer.AuthMachineAgent() || authorizer.AuthUnitAgent()) {
+	if !(authorizer.AuthMachineAgent() || authorizer.AuthUnitAgent() || authorizer.AuthApplicationAgent()) {
 		return nil, common.ErrPerm
 	}
 	return &APIBase{

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -48,6 +48,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"migration-fortress",
 		"migration-minion",
 		"migration-inactive-flag",
+		"proxy-config-updater",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate",
 		"upgrade-steps-runner",
@@ -177,6 +178,15 @@ var expectedOperatorManifoldsWithDependencies = map[string][]string{
 		"api-caller",
 		"api-config-watcher",
 		"migration-fortress",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate"},
+
+	"proxy-config-updater": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate"},
 

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -176,6 +176,7 @@ var (
 		"charm-dir",
 		"hook-retry-strategy",
 		"operator",
+		"proxy-config-updater",
 	}
 )
 


### PR DESCRIPTION
## Description of change

Add the proxy-update-worker to the k8s operator so that model config for proxy/no-proxy is set inside the operator when a http client is created. charm operators and the controller operator now use the same worker as on iaas models to internally set the proxy for http clients created inside the operator.

## QA steps

bootstrap controller, add model, deploy charm
exec into operator and run engine report

## Bug reference

https://bugs.launchpad.net/juju/+bug/1829022
