### PR TITLE
List controller clouds irrespective of their credential count.

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -161,12 +161,6 @@ func (c *listCloudsCommand) getCloudList(ctxt *cmd.Context) (*cloudList, error) 
 			}
 			for _, cloud := range controllerClouds {
 				cloudDetails := makeCloudDetails(c.Store, cloud)
-				if !c.all {
-					if cloudDetails.CredentialCount == 0 {
-						c.showAllMessage = true
-						continue
-					}
-				}
 				details.remote[cloud.Name] = cloudDetails
 			}
 			return nil

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -93,7 +93,7 @@ func (s *listSuite) TestListController(c *gc.C) {
 		},
 	}
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "yaml", "--all", "-c", "mycontroller")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--format", "yaml", "-c", "mycontroller")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
@@ -130,7 +130,7 @@ func (s *listSuite) TestListKubernetes(c *gc.C) {
 		},
 	}
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "yaml", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
@@ -178,7 +178,7 @@ func (s *listSuite) assertListTabular(c *gc.C, expectedOutput string) {
 			return s.api, nil
 		})
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "tabular", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--controller", "mycontroller", "--format", "tabular")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Clouds", "Close")
 	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
@@ -231,14 +231,14 @@ clouds:
 			return s.api, nil
 		})
 
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--client", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	// local clouds are last.
 	// homestack should abut localhost and hence come last in the output.
-	c.Assert(out, jc.Contains, `homestack       1        london           openstack   0            local     Openstack Cloud`)
+	c.Assert(out, jc.Contains, `homestack  1        london     openstack  0            local     Openstack Cloud`)
 }
 
 func (s *listSuite) TestListPublicAndPersonalSameName(c *gc.C) {
@@ -252,7 +252,7 @@ clouds:
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client", "--all")
+	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)


### PR DESCRIPTION
## Description of change

'clouds' output can be fairly verbose. 
From Juju 2.7*, we wanted to present a humanly readable list and changed the default output to only display clouds that have at least one credential registered. 

However, when this was trialed in beta versions, it took users by surprise since most of the time built-in (lxd and microk8s) as well as personal (maas, opesntack, etc type) clouds became invisible unless the user asked for --all. So in the latest versions, Juju counts credentials only for public clouds on client side. 

However, the same behavior is still surprising to users when viewing controller clouds. This PR relaxes the restriction for controller clouds too - all controller clouds will be shown irrespective of whether there are any known credentials. 

## QA steps

1. bootstrap on lxd
2. 'juju clouds --controller YOUR_CONTROLLER_NAME' should have your cloud.

