### PR TITLE
Create Openstack Volumes in Same AZ as Instance

### DIFF
--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -260,6 +260,11 @@ func (s *cinderVolumeSource) createVolume(
 			}
 			if len(aZones) > 0 {
 				az = aZones[0]
+			} else {
+				// All instances should have an availability zone.
+				// The default is "nova" so something is wrong if nothing
+				// is returned from this call.
+				logger.Warningf("no availability zone detected for instance %q", instanceID)
 			}
 		}
 	}

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	envstorage "github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
@@ -35,22 +36,22 @@ func InstanceFloatingIP(inst instances.Instance) *string {
 }
 
 var (
-	NovaListAvailabilityZones   = &novaListAvailabilityZones
-	AvailabilityZoneAllocations = &availabilityZoneAllocations
-	NewOpenstackStorage         = &newOpenstackStorage
+	NovaListAvailabilityZones = &novaListAvailabilityZones
+	NewOpenstackStorage       = &newOpenstackStorage
 )
 
-func NewCinderVolumeSource(s OpenstackStorage) storage.VolumeSource {
-	return NewCinderVolumeSourceForModel(s, testing.ModelTag.Id())
+func NewCinderVolumeSource(s OpenstackStorage, env common.ZonedEnviron) storage.VolumeSource {
+	return NewCinderVolumeSourceForModel(s, testing.ModelTag.Id(), env)
 }
 
-func NewCinderVolumeSourceForModel(s OpenstackStorage, modelUUID string) storage.VolumeSource {
+func NewCinderVolumeSourceForModel(s OpenstackStorage, modelUUID string, env common.ZonedEnviron) storage.VolumeSource {
 	const envName = "testmodel"
 	return &cinderVolumeSource{
 		storageAdapter: s,
 		envName:        envName,
 		modelUUID:      modelUUID,
 		namespace:      fakeNamespace{},
+		zonedEnv:       env,
 	}
 }
 

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -2634,11 +2634,13 @@ func (s *localServerSuite) TestAdoptResourcesNoStorage(c *gc.C) {
 	s.checkGroupController(c, env, newController)
 }
 
-func addVolume(c *gc.C, env environs.Environ, callCtx context.ProviderCallContext, controllerUUID, name string) *storage.Volume {
+func addVolume(
+	c *gc.C, env environs.Environ, callCtx context.ProviderCallContext, controllerUUID, name string,
+) *storage.Volume {
 	storageAdapter, err := (*openstack.NewOpenstackStorage)(env.(*openstack.Environ))
 	c.Assert(err, jc.ErrorIsNil)
 	modelUUID := env.Config().UUID()
-	source := openstack.NewCinderVolumeSourceForModel(storageAdapter, modelUUID)
+	source := openstack.NewCinderVolumeSourceForModel(storageAdapter, modelUUID, env.(common.ZonedEnviron))
 	result, err := source.CreateVolumes(callCtx, []storage.VolumeParams{{
 		Tag: names.NewVolumeTag(name),
 		ResourceTags: tags.ResourceTags(
@@ -2666,7 +2668,7 @@ func (s *localServerSuite) checkInstanceTags(c *gc.C, env environs.Environ, expe
 func (s *localServerSuite) checkVolumeTags(c *gc.C, env environs.Environ, expectedController string) {
 	storage, err := (*openstack.NewOpenstackStorage)(env.(*openstack.Environ))
 	c.Assert(err, jc.ErrorIsNil)
-	source := openstack.NewCinderVolumeSourceForModel(storage, env.Config().UUID())
+	source := openstack.NewCinderVolumeSourceForModel(storage, env.Config().UUID(), s.env.(common.ZonedEnviron))
 	volumeIds, err := source.ListVolumes(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeIds, gc.Not(gc.HasLen), 0)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -75,7 +75,7 @@ var (
 	_ environs.ProviderSchema       = (*EnvironProvider)(nil)
 )
 
-var providerInstance *EnvironProvider = &EnvironProvider{
+var providerInstance = &EnvironProvider{
 	ProviderCredentials: OpenstackCredentials{},
 	Configurator:        &defaultConfigurator{},
 	FirewallerFactory:   &firewallerFactory{},


### PR DESCRIPTION
## Description of change

The Openstack provider to-date has created storage with no availability zone set. This has had the effect of lumping all Juju-created volumes into a single AZ, which defeats the purpose of multi-zoning. If this zone were to become unavailable, so would all attached instances whatever their zone.

This patch ensures that when storage volumes are created, they are created in the same availability zone as the instance (if any) they are attached to.

## QA steps

- Bootstrap to Openstack (I used serverstack, which has "nova" for all AZs).
- `juju deploy postgresql --storage pgdata=10G`
- Check the controller logs for the storage creation. There should be an entry indicating the storage creation in the right zone. For example:
```
machine-0: 15:46:13 DEBUG juju.provider.openstack created volume: &{Attachments:[] AvailabilityZone:nova Bootable:false CreatedAt:2019-11-05T14:46:14.000000 Description: ID:40da4adc-8259-4892-8c36-f1e274c0b6de Links:[{Href:http://10.245.161.160:8776/v2/1297c080b93e4283bff3031d5210ed0c/volumes/40da4adc-8259-4892-8c36-f1e274c0b6de Rel:self} {Href:http://10.245.161.160:8776/1297c080b93e4283bff3031d5210ed0c/volumes/40da4adc-8259-4892-8c36-f1e274c0b6de Rel:bookmark}] Metadata:map[juju-controller-uuid:4cd86c62-9142-4ff4-8f3f-906d3db229dd juju-model-uuid:d11018ef-3f90-4274-84b9-43f5e1bc50f8 juju-storage-instance:pgdata/0 juju-storage-owner:postgresql/0] Name:juju-bc50f8-default-volume-0 Os_Vol_Host_Attr_Host: Os_Vol_Tenant_Attr_TenantID:1297c080b93e4283bff3031d5210ed0c Size:10 SnapshotID:<nil> SourceVolid:<nil> Status:creating VolumeType:}
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1843679
