### PR TITLE
Add integration test for export bundles

### DIFF
--- a/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
@@ -1,7 +1,7 @@
 series: bionic
 saas:
   mysql:
-    url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/cmr-bundles-test-deploy.mysql
+    url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/test-cmr-bundles-deploy.mysql
 applications:
   wordpress:
     charm: wordpress

--- a/tests/suites/deploy/bundles/telegraf-bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf-bundle.yaml
@@ -1,0 +1,22 @@
+series: bionic
+applications:
+  influxdb:
+    charm: cs:influxdb-22
+    num_units: 1
+    to:
+    - "0"
+  telegraf:
+    charm: cs:telegraf-29
+  ubuntu:
+    charm: cs:ubuntu-12
+    num_units: 1
+    to:
+    - "1"
+machines:
+  "0": {}
+  "1": {}
+relations:
+- - telegraf:juju-info
+  - ubuntu:juju-info
+- - telegraf:influxdb-api
+  - influxdb:query

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -27,12 +27,12 @@ run_deploy_cmr_bundle() {
 
     juju switch other
 
-    bundle=./suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+    bundle=./tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
     sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" > "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
     juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 
     destroy_model "test-cmr-bundles-deploy"
-    destroy_mode "other"
+    destroy_model "other"
 }
 
 run_deploy_exported_bundle() {
@@ -42,13 +42,13 @@ run_deploy_exported_bundle() {
 
     ensure "test-export-bundles-deploy" "${file}"
 
-    bundle=./suites/deploy/bundles/telegraf-bundle.yaml
+    bundle=./tests/suites/deploy/bundles/telegraf-bundle.yaml
     juju deploy ${bundle}
 
     # no need to wait for the bundle to finish deploying to
     # check the export.
-    juju export-bundle --filename ${TEST_DIR}/exported-bundle.yaml
-    diff ${bundle} ${TEST_DIR}/exported-bundle.yaml | wc -l | grep -q "0"
+    juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
+    diff ${bundle} "${TEST_DIR}/exported-bundle.yaml"
 
     destroy_model test-export-bundles-deploy
 }

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -27,11 +27,12 @@ run_deploy_cmr_bundle() {
 
     juju switch other
 
-    bundle=./tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+    bundle=./suites/deploy/bundles/cmr_bundles_test_deploy.yaml
     sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" > "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
     juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 
     destroy_model "test-cmr-bundles-deploy"
+    destroy_mode "other"
 }
 
 run_deploy_exported_bundle() {

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -34,6 +34,24 @@ run_deploy_cmr_bundle() {
     destroy_model "test-cmr-bundles-deploy"
 }
 
+run_deploy_exported_bundle() {
+    echo
+
+    file="${TEST_DIR}/test-export-bundles-deploy.txt"
+
+    ensure "test-export-bundles-deploy" "${file}"
+
+    bundle=./suites/deploy/bundles/telegraf-bundle.yaml
+    juju deploy ${bundle}
+
+    # no need to wait for the bundle to finish deploying to
+    # check the export.
+    juju export-bundle --filename ${TEST_DIR}/exported-bundle.yaml
+    diff ${bundle} ${TEST_DIR}/exported-bundle.yaml | wc -l | grep -q "0"
+
+    destroy_model test-export-bundles-deploy
+}
+
 test_deploy_bundles() {
     if [ "$(skip 'test_deploy_bundles')" ]; then
         echo "==> TEST SKIPPED: deploy bundles"
@@ -47,5 +65,6 @@ test_deploy_bundles() {
 
         run "run_deploy_bundle"
         run "run_deploy_cmr_bundle"
+        run "run_deploy_exported_bundle"
     )
 }

--- a/tests/suites/deploy/export_overlay.sh
+++ b/tests/suites/deploy/export_overlay.sh
@@ -35,6 +35,7 @@ EOT
     echo "${OUT}" | grep "raw: my-include"
 
     destroy_model "cmr-bundles-test-export-overlay"
+    destroy_model "test1"
 }
 
 test_cmr_bundles_export_overlay() {


### PR DESCRIPTION
## Description of change

Adds deploy integration test for export bundle.

Update cmr bundle test:
- Destroy "other" model, left behind when reusing a controller.
- Update location of bundle.yaml.
- Update name of offer in bundle.yaml.

## QA steps

Run with and without existing controllers (export BOOTSTRAP_REUSE_LOCAL=<controller)
With existing controllers, verify that all test models are destroyed.
1. cd tests && ./main.sh -r deploy

