### PR TITLE
Add ec2 integration tests for spaces

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -12,10 +12,13 @@ wait_for() {
     name=${1}
     query=${2}
 
-    # shellcheck disable=SC2143
+    attempt=0
+    # shellcheck disable=SC2046,SC2143
     until [ "$(juju status --format=json 2> /dev/null | jq "${query}" | grep "${name}")" ]; do
-        juju status --relations
+        echo "[+] (attempt ${attempt}) polling status"
+        juju status --relations 2>&1 | sed 's/^/    | /g'
         sleep 5
+	let attempt=attempt+1
     done
 }
 
@@ -49,4 +52,52 @@ agent_status() {
     unit=$2
 
     echo ".applications[\"$app\"].units[\"$app/$unit\"][\"juju-status\"]"
+}
+
+# wait_for_machine_agent_status blocks until the machine agent for the specified
+# machine instance ID reports the requested status.
+#
+# ```
+# wait_for_machine_agent_status <instance-id> <status>
+#
+# example:
+# wait_for_machine_agent_status "i-1234" "started"
+# ```
+wait_for_machine_agent_status() {
+    local inst_id status
+
+    inst_id=${1}
+    status=${2}
+
+    attempt=0
+    until [ $(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${inst_id}\"] | .[\"juju-status\"] | .[\"current\"]" | grep "${status}") ]; do
+        echo "[+] (attempt ${attempt}) polling status"
+        juju machines | grep "$inst_id" 2>&1 | sed 's/^/    | /g'
+        sleep 5
+	let attempt=attempt+1
+    done
+}
+
+# wait_for_machine_netif_count blocks until the number of detected network
+# interfaces for the requested machine instance ID becomes equal to the desired
+# value.
+#
+# ```
+# wait_for_machine_netif_count <instance-id> <count>
+#
+# example:
+# wait_for_machine_netif_count "i-1234" "42"
+# ```
+wait_for_machine_netif_count() {
+    local inst_id count
+
+    inst_id=${1}
+    count=${2}
+
+    attempt=0
+    until [ $(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${inst_id}\"] | .[\"network-interfaces\"] | length" | grep "${count}") ]; do
+	echo "[+] (attempt ${attempt}) network interface count for instance ${inst_id} = "$(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${inst_id}\"] | .[\"network-interfaces\"] | length")
+        sleep 5
+	let attempt=attempt+1
+    done
 }

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -18,7 +18,7 @@ wait_for() {
         echo "[+] (attempt ${attempt}) polling status"
         juju status --relations 2>&1 | sed 's/^/    | /g'
         sleep 5
-	let attempt=attempt+1
+        let attempt=attempt+1
     done
 }
 
@@ -70,11 +70,12 @@ wait_for_machine_agent_status() {
     status=${2}
 
     attempt=0
+    # shellcheck disable=SC2046,SC2143
     until [ $(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${inst_id}\"] | .[\"juju-status\"] | .[\"current\"]" | grep "${status}") ]; do
         echo "[+] (attempt ${attempt}) polling status"
         juju machines | grep "$inst_id" 2>&1 | sed 's/^/    | /g'
         sleep 5
-	let attempt=attempt+1
+        let attempt=attempt+1
     done
 }
 
@@ -95,9 +96,11 @@ wait_for_machine_netif_count() {
     count=${2}
 
     attempt=0
+    # shellcheck disable=SC2046,SC2143
     until [ $(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${inst_id}\"] | .[\"network-interfaces\"] | length" | grep "${count}") ]; do
-	echo "[+] (attempt ${attempt}) network interface count for instance ${inst_id} = "$(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${inst_id}\"] | .[\"network-interfaces\"] | length")
+        # shellcheck disable=SC2046,SC2143
+        echo "[+] (attempt ${attempt}) network interface count for instance ${inst_id} = "$(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${inst_id}\"] | .[\"network-interfaces\"] | length")
         sleep 5
-	let attempt=attempt+1
+        let attempt=attempt+1
     done
 }

--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -9,10 +9,10 @@ run_juju_bind() {
     juju reload-spaces
     juju add-space isolated 172.31.254.0/24
 
-    ## Create machine 
+    ## Create machine
     add_multi_nic_machine
     juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-    
+
     # Deploy test charm to dual-nic machine
     juju deploy cs:~juju-qa/bionic/space-defender-1 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
     unit_index=$(get_unit_index "space-defender")

--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -1,0 +1,56 @@
+run_juju_bind() {
+    echo
+
+    file="${TEST_DIR}/test-juju-bind.txt"
+
+    ensure "spaces-juju-bind" "${file}"
+
+    ## Setup spaces
+    juju reload-spaces
+    juju add-space isolated 172.31.254.0/24
+
+    ## Create machine 
+    add_multi_nic_machine
+    juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
+    
+    # Deploy test charm to dual-nic machine
+    juju deploy cs:~juju-qa/bionic/space-defender-1 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
+    unit_index=$(get_unit_index "space-defender")
+    wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
+
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens6"
+
+    assert_endpoint_binding_matches "space-defender" "" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-b" "isolated"
+
+    # Mutate bindings
+    juju bind space-defender defend-a=alpha defend-b=alpha
+
+    # After the upgrade, defend-a should remain attached to ens5 but
+    # defend-b which has now been bound to alpha should also get ens5
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens5"
+
+    assert_endpoint_binding_matches "space-defender" "" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-b" "alpha"
+
+    destroy_model "spaces-juju-bind"
+}
+
+test_juju_bind() {
+    if [ "$(skip 'test_juju_bind')" ]; then
+        echo "==> TEST SKIPPED: juju bind"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_juju_bind"
+    )
+}

--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -1,0 +1,37 @@
+test_spaces_ec2() {
+    if [ "$(skip 'test_spaces_ec2')" ]; then
+        echo "==> TEST SKIPPED: space tests (EC2)"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju aws
+
+    echo "==> Checking for EC2 prerequisites"
+    check_prerequisites_for_space_tests
+
+    file="${TEST_DIR}/test-spaces-ec2.txt"
+
+    bootstrap "test-spaces-ec2" "${file}"
+
+    test_upgrade_charm_with_bind
+    test_juju_bind
+
+    destroy_controller "test-spaces-ec2"
+}
+
+check_prerequisites_for_space_tests() {
+  match_count=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24 | jq '.Subnets | length')
+  if [[ "$match_count" != "1" ]]; then
+	  echo $(red "To run these tests you need to create a subnet with name \"isolated\" and CIDR \"172.31.254/24\"")
+	  exit 1
+  fi
+  	
+  if_count=$(aws ec2 describe-network-interfaces --filters Name=tag:nic-type,Values=hotpluggable | jq '.NetworkInterfaces[] | select(.["PrivateIpAddress"] | startswith("172.31.254.")) | .NetworkInterfaceId')
+  if [[ -z "$if_count" ]]; then
+	  echo $(red "To run these tests you need to create a network interface on the isolated subnet (CIDR \"172.31.254/24\") and tag it with \"nic-type:hotpluggable\"")
+	  exit 1
+  fi
+}

--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -25,13 +25,15 @@ test_spaces_ec2() {
 check_prerequisites_for_space_tests() {
   match_count=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24 | jq '.Subnets | length')
   if [[ "$match_count" != "1" ]]; then
-	  echo $(red "To run these tests you need to create a subnet with name \"isolated\" and CIDR \"172.31.254/24\"")
-	  exit 1
+      # shellcheck disable=SC2046
+      echo $(red "To run these tests you need to create a subnet with name \"isolated\" and CIDR \"172.31.254/24\"")
+      exit 1
   fi
-  	
+
   if_count=$(aws ec2 describe-network-interfaces --filters Name=tag:nic-type,Values=hotpluggable | jq '.NetworkInterfaces[] | select(.["PrivateIpAddress"] | startswith("172.31.254.")) | .NetworkInterfaceId')
   if [[ -z "$if_count" ]]; then
-	  echo $(red "To run these tests you need to create a network interface on the isolated subnet (CIDR \"172.31.254/24\") and tag it with \"nic-type:hotpluggable\"")
-	  exit 1
+      # shellcheck disable=SC2046
+      echo $(red "To run these tests you need to create a network interface on the isolated subnet (CIDR \"172.31.254/24\") and tag it with \"nic-type:hotpluggable\"")
+      exit 1
   fi
 }

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -1,0 +1,57 @@
+run_upgrade_charm_with_bind() {
+    echo
+
+    file="${TEST_DIR}/test-upgrade-charm-with-bind-ec2.txt"
+
+    ensure "spaces-upgrade-charm-with-bind-ec2" "${file}"
+
+    ## Setup spaces
+    juju reload-spaces
+    juju add-space isolated 172.31.254.0/24
+
+    ## Create machine 
+    add_multi_nic_machine
+    juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
+    
+    # Deploy test charm to dual-nic machine
+    juju deploy cs:~juju-qa/bionic/space-defender-0 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
+    unit_index=$(get_unit_index "space-defender")
+    wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
+
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens6"
+
+    assert_endpoint_binding_matches "space-defender" "" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-b" "isolated"
+
+    # Upgrade the space-defender charm and modify its bindings
+    juju upgrade-charm space-defender --bind "defend-a=alpha defend-b=alpha"
+    wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
+
+    # After the upgrade, defend-a should remain attached to ens5 but
+    # defend-b which has now been bound to alpha should also get ens5
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-a" "ens5"
+    assert_net_iface_for_endpoint_matches "space-defender" "defend-b" "ens5"
+
+    assert_endpoint_binding_matches "space-defender" "" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-a" "alpha"
+    assert_endpoint_binding_matches "space-defender" "defend-b" "alpha"
+
+    destroy_model "spaces-upgrade-charm-with-bind-ec2"
+}
+
+test_upgrade_charm_with_bind() {
+    if [ "$(skip 'test_upgrade_charm_with_bind')" ]; then
+        echo "==> TEST SKIPPED: upgrade charm with --bind"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_upgrade_charm_with_bind"
+    )
+}

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -9,10 +9,10 @@ run_upgrade_charm_with_bind() {
     juju reload-spaces
     juju add-space isolated 172.31.254.0/24
 
-    ## Create machine 
+    ## Create machine
     add_multi_nic_machine
     juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
-    
+
     # Deploy test charm to dual-nic machine
     juju deploy cs:~juju-qa/bionic/space-defender-0 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
     unit_index=$(get_unit_index "space-defender")

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -1,0 +1,79 @@
+# add_multi_nic_machine()
+#
+# Create a new machine, wait for it to boot and hotplug a pre-allocated
+# network interface which has been tagged: "nic-type: hotpluggable".
+#
+# Then, patch the netplan settings for the new interface, apply the new plan,
+# restart the machine agent and wait for juju to detect the new interface 
+# before returning.
+add_multi_nic_machine() {
+  juju add-machine
+  juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
+  echo "[+] waiting for machine ${juju_machine_id} to start..."
+  
+  wait_for_machine_agent_status "$juju_machine_id" "started"
+
+  # Hotplug the second network device to the machine
+  echo "[+] hotplugging second NIC to machine ${juju_machine_id}..."
+  aws ec2 attach-network-interface --device-index 1 \
+  	--network-interface-id $(aws ec2 describe-network-interfaces --filters Name=tag:nic-type,Values=hotpluggable | jq -r '.NetworkInterfaces[0].NetworkInterfaceId') \
+  	--instance-id $(juju show-machine --format json | jq -r ".[\"machines\"] | .[\"${juju_machine_id}\"] | .[\"instance-id\"]")
+  
+  # Add an entry to netplan and apply it so the second interface comes online
+  echo "[+] updating netplan and restarting machine agent"
+  juju ssh ${juju_machine_id} 'sudo sh -c "echo \"            gateway4: `ip route | grep default | cut -d\" \" -f3`\n        ens6:\n            dhcp4: true\n\" >> /etc/netplan/50-cloud-init.yaml"'
+  juju ssh ${juju_machine_id} 'sudo netplan apply'
+  juju ssh ${juju_machine_id} 'sudo systemctl restart jujud-machine-*'
+  
+  # Wait for the interface to be detected by juju
+  echo "[+] waiting for juju to detect added NIC"
+  wait_for_machine_netif_count "$juju_machine_id" "3"
+}
+
+# assert_net_iface_for_endpoint_matches(app_name, endpoint_name, exp_if_name)
+#
+# Verify that the (non-fan) network adapter assigned to the specified endpoint
+# matches the provided value.
+assert_net_iface_for_endpoint_matches() {
+    local app_name endpoint_name exp_if_name
+
+    app_name=${1}
+    endpoint_name=${2}
+    exp_if_name=${3}
+
+    got_if=$(juju run -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
+    if [[ "$got_if" != "$exp_if_name" ]]; then
+	    echo $(red "Expected network interface for ${app_name}:${endpoint_name} to be ${exp_if_name}; got ${got_if}")
+	    exit 1
+    fi
+}
+
+# assert_endpoint_binding_matches(app_name, endpoint_name, exp_space_name)
+#
+# Verify that show-application shows that the specified endpoint is bound to
+# the provided space name.
+assert_endpoint_binding_matches() {
+    local app_name endpoint_name exp_space_name
+
+    app_name=${1}
+    endpoint_name=${2}
+    exp_space_name=${3}
+
+    got=$(juju show-application ${app_name} --format json | jq -r ".[\"${app_name}\"] | .[\"endpoint-bindings\"] | .[\"${endpoint_name}\"]")
+    if [[ "$got" != "$exp_space_name" ]]; then
+	    echo $(red "Expected endpoint \"${endpoint_name}\" in juju show-application ${app_name} to be ${exp_space_name}; got ${got}")
+	    exit 1
+    fi
+}
+
+# get_unit_index(app_name)
+#
+# Lookup and return the unit index for app_name.
+get_unit_index() {
+    local app_name
+
+    app_name=${1}
+
+    index=$(juju status | grep "${app_name}/" | cut -d' ' -f1 | cut -d'/' -f2 | cut -d'*' -f1)
+    echo $index
+}


### PR DESCRIPTION
## Description of change

This PR adds some rudimentary integration tests for spaces on EC2. To run these tests, you need to setup:

- A subnet with name `isolated` and CIDR `172.31.0.254` (us-east-1; though any AZ will work)
- A network interface on the `isolated` space and tagged as `nic-type:hotpluggable`.

The tests include a preflight check which will abort the test (with a helpful message) if the above prerequisites are missing. Note: I have **already** set these up for our QA account.

The tests create a new machine (juju add-machine) and then manually hot-plug the above NIC instance (appears as `esn6`). As a result, the machine now has two spaces (alpha, isolated) which can be used for the following tests: 

- juju deploy X; juju show-application; juju upgrade-charm X --bind Y; juju show-application
- juju deploy X; juju show-application; juju bind Y; juju show-application

## QA steps

Install the AWS cli, create the required resources and:

```console
cd tests
./main.sh spaces_ec2
```