### PR TITLE
Run subtests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -47,14 +47,14 @@ echo "failed" | grep -q "passes"   # fails
 To get started, it's best to quickly look at the help command from the runner.
 
 ```sh
-./main.sh -h
+cd tests && ./main.sh -h
 ```
 
 Running a full sweep of the integration tests (which will take a long time), can
 be done by running:
 
 ```sh
-./main.sh
+cd test && ./main.sh
 ```
 
 ### Running tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,46 @@
 
 The following package contains the integration test suite for Juju.
 
+Tests are structured into test suites. Each suite contains a root task (akin
+to a package test) that will setup and run each individual test.
+
+To help break tests down, each test can have a number of subtests. Subtests
+are meant for indivdual units of work, without having to bootstrap a controller
+for every test. Each subtest will just `ensure` that it does have one, failure
+to find a suitable controller, it will create one for you.
+
+### Example of a test suite
+
+```sh
+/suites/deploy/                    # test-suite
+               task.sh             # root/package test (setup)
+               deploy_bundles.sh   # tests
+```
+
+### Example of a test
+
+```sh
+run_deploy_bundles() {             # Subtest
+
+}
+
+test_deploy_bundles() {            # Test
+    run "run_deploy_bundles"       # Run subtest
+}
+```
+
+## Exit codes / Success
+
+All tests will run through until the end of a test/subtest, unless it encounters
+a none zero exit code. In otherwards if you want to assert something passes,
+ensure that the command returns `exit 0`. Failure can then be detected of the
+inverse.
+
+```sh
+echo "passes" | grep -q "passes"   # passes
+echo "failed" | grep -q "passes"   # fails
+```
+
 ## Getting started
 
 To get started, it's best to quickly look at the help command from the runner.
@@ -16,3 +56,19 @@ be done by running:
 ```sh
 ./main.sh
 ```
+
+### Running tests
+
+To run the tests, they can be broken down into steps:
+
+```sh
+./main.sh deploy                     # Runs deploy test suite
+./main.sh deploy test_deploy_bundles # Runs test (and all of the subtests)
+./main.sh deploy run_deploy_bundle   # Runs subtest
+```
+
+Note: running subtests, will also invoke the parent test to ensure that it has
+everything setup correctly.
+
+Running `./main.sh deploy run_deploy_bundle` will also run `test_deploy_bundles`,
+but no other subtests, just `run_deploy_bundle`.

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -50,8 +50,11 @@ bootstrap() {
         "lxd")
             provider="lxd"
             ;;
+        "localhost")
+            provider="lxd"
+            ;;
         *)
-            echo "Unexpected bootstrap provider."
+            echo "Unexpected bootstrap provider (${BOOTSTRAP_PROVIDER})."
             exit 1
     esac
 

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -2,6 +2,7 @@ run() {
   CMD="${1}"
 
   if [ -n "${RUN_SUBTEST}" ]; then
+    # shellcheck disable=SC2143
     if [ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]; then
         echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
         exit 0

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -1,5 +1,13 @@
 run() {
   CMD="${1}"
+
+  if [ -n "${RUN_SUBTEST}" ]; then
+    if [ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]; then
+        echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
+        exit 0
+    fi
+  fi
+
   DESC=$(echo "${1}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
 
   echo -n "===> [   ] Running: ${DESC}"

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -14,7 +14,7 @@ wait_for() {
 
     attempt=0
     # shellcheck disable=SC2046,SC2143
-    until [ "$(juju status --format=json 2> /dev/null | jq "${query}" | grep "${name}")" ]; do
+    until [ "$(juju status --format=json 2> /dev/null | jq -S "${query}" | grep "${name}")" ]; do
         echo "[+] (attempt ${attempt}) polling status"
         juju status --relations 2>&1 | sed 's/^/    | /g'
         sleep 5

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -151,7 +151,8 @@ while getopts "hH?:vVAsaxrlp" opt; do
     l)
         export BOOTSTRAP_REUSE_LOCAL="${2}"
         export BOOTSTRAP_REUSE="true"
-        export BOOTSTRAP_PROVIDER=$(juju show-controller "${2}" --format=json | jq -r ".[\"${2}\"] | .details | .cloud")
+        CLOUD=$(juju show-controller "${2}" --format=json | jq -r ".[\"${2}\"] | .details | .cloud")
+        export BOOTSTRAP_PROVIDER="${CLOUD}"
         shift 2
         ;;
     p)
@@ -269,6 +270,7 @@ run_test() {
 
 # allow for running a specific set of tests
 if [ "$#" -gt 0 ]; then
+    # shellcheck disable=SC2143
     if [ "$(echo "${2}" | grep -E "^run_")" ]; then
         TEST="$(grep -lr "run \"${2}\"" "suites/${1}" | xargs sed -rn 's/.*(test_\w+)\s+?\(\)\s+?\{/\1/p')"
         if [ -z "${TEST}" ]; then

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -62,6 +62,8 @@ show_help() {
     echo ""
     echo "Usage:"
     echo "¯¯¯¯¯¯"
+    echo "Flags should appear $(red 'before') arguments."
+    echo ""
     echo "cmd [-h] [-vV] [-s test] [-a file] [-x file] [-r] [-l controller] [-p provider type <lxd|aws>]"
     echo ""
     echo "    $(green 'cmd -h')        Display this help message"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -145,6 +145,7 @@ while getopts "hH?:vVsaxrlp" opt; do
     l)
         export BOOTSTRAP_REUSE_LOCAL="${2}"
         export BOOTSTRAP_REUSE="true"
+        export BOOTSTRAP_PROVIDER=$(juju show-controller "${2}" --format=json | jq -r ".[\"${2}\"] | .details | .cloud")
         shift 2
         ;;
     p)

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,14 +1,3 @@
-run_func_vet() {
-  OUT=$(grep -Rrn --include=\*.go --exclude-dir=vendor "^$" -B1 . | \
-      grep "func " | grep -v "}$" | \
-      sed -E "s/^(.+\\.go)-([0-9]+)-(.+)$/\1:\2 \3/" \
-      || true)
-  if [ -n "${OUT}" ]; then
-    printf "\\nERROR: Functions must not start with an empty line: \\n%s\\n" "${OUT}"
-    exit 1
-  fi
-}
-
 run_dep_check() {
   OUT=$(dep check 2>&1 || true)
   if [ -n "${OUT}" ]; then

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -30,6 +30,30 @@ run_trailing_whitespace() {
   fi
 }
 
+run_test_setup() {
+  # shellcheck disable=SC2038
+  OUT=$(find tests/suites -iname '*.sh' | xargs grep -rEoh '^run_\w+\s?[^\(]' | sort)
+  echo "${OUT}" | while read -r subtest; do
+    S=$(grep -owr "${subtest}" tests/suites)
+    COUNT=$(echo "${S}" | wc -l)
+    TEST_FILE=$(echo "${S}" | cut -f1 -d":")
+    if [ "${COUNT}" -ne 2 ]; then
+      echo ""
+      echo "$(red 'Found some issues:')"
+      echo "Expected subtest (${subtest}) to be in the same file as test (${TEST_FILE})."
+      exit 1
+    fi
+    H=$(echo "${S}" | head -n 1)
+    T=$(echo "${S}" | tail -n 1)
+    if [ "${H}" != "${T}" ]; then
+      echo ""
+      echo "$(red 'Found some issues:')"
+      echo "Expected subtest (${subtest}) to be in the same file as test (${TEST_FILE})."
+      exit 1
+    fi
+  done
+}
+
 test_static_analysis_shell() {
   if [ "$(skip 'test_static_analysis_shell')" ]; then
       echo "==> TEST SKIPPED: static shell analysis"
@@ -53,5 +77,8 @@ test_static_analysis_shell() {
 
     ## Trailing whitespace in scripts
     run "run_trailing_whitespace"
+
+    ## Tests are wired up
+    run "run_test_setup"
   )
 }


### PR DESCRIPTION
## Description of change

Every person seems to hit the same issue, in that they attempt to run
a subtest directly. This wasn't originally the main idea, instead they
where meant to run the test that runs the subtests and then see if they
broke anything whilst doing that.

I've been persuaded otherwise, a subtest should be able be run as you
want to iterate hard on that and instead of blocking people from doing
fast iterations we should enable it.

## QA steps

```sh
./main.sh deploy run_deploy_bundle
```
