### PR TITLE
Ensure user is in microk8s group before bootstrapping

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
@@ -322,20 +323,44 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 }
 
 func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {
+	resp, err := cmdRunner.RunCommands(exec.RunParams{
+		Commands: `id -nG "$(whoami)" | grep -qw "microk8s"`,
+	})
+	if err != nil {
+		return errors.Annotate(err, "checking microk8s setup")
+	}
+	if resp.Code != 0 {
+		user, _ := utils.OSUsername()
+		if user == "" {
+			user = "<username>"
+		}
+		return errors.Errorf(`
+The microk8s user group is created during the microk8s snap installation.
+Users in that group are granted access to microk8s commands and this
+is needed for Juju to be able to interact with microk8s.
+
+Add yourself to that group before trying again:
+  sudo usermod -a -G microk8s %s
+`[1:], user)
+	}
+
 	status, err := microK8sStatus(cmdRunner)
 	if err != nil {
 		return errors.Trace(err)
 	}
-
+	var requiredAddons []string
 	if storageStatus, ok := status.Addons["storage"]; ok {
 		if storageStatus != "enabled" {
-			return errors.New("storage is not enabled for microk8s, run 'microk8s.enable storage'")
+			requiredAddons = append(requiredAddons, "storage")
 		}
 	}
 	if dns, ok := status.Addons["dns"]; ok {
 		if dns != "enabled" {
-			return errors.New("dns is not enabled for microk8s, run 'microk8s.enable dns'")
+			requiredAddons = append(requiredAddons, "dns")
 		}
+	}
+	if len(requiredAddons) > 0 {
+		return errors.Errorf("required addons not enabled for microk8s, run 'microk8s.enable %s'", strings.Join(requiredAddons, " "))
 	}
 	return nil
 }

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -5,6 +5,7 @@ package provider_test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
@@ -125,6 +126,10 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 
 	s.runner.Call(
 		"RunCommands",
+		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "microk8s"`}).Returns(
+		&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
 		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
@@ -160,6 +165,10 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 
 	s.runner.Call(
 		"RunCommands",
+		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "microk8s"`}).Returns(
+		&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
 		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
@@ -191,6 +200,10 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
 	s.runner.Call(
 		"RunCommands",
+		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "microk8s"`}).Returns(
+		&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
 		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), jc.ErrorIsNil)
@@ -199,17 +212,36 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
 func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
 	s.runner.Call(
 		"RunCommands",
+		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "microk8s"`}).Returns(
+		&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
 		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusStorageDisabled)}, nil)
-	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `storage is not enabled for microk8s, run 'microk8s.enable storage'`)
+	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s.enable storage'`)
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
 	s.runner.Call(
 		"RunCommands",
+		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "microk8s"`}).Returns(
+		&exec.ExecResponse{Code: 0}, nil)
+	s.runner.Call(
+		"RunCommands",
 		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDNSDisabled)}, nil)
-	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `dns is not enabled for microk8s, run 'microk8s.enable dns'`)
+	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s.enable dns'`)
+}
+
+func (s *cloudSuite) TestEnsureMicroK8sSuitableNotInGroup(c *gc.C) {
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "microk8s"`}).Returns(
+		&exec.ExecResponse{Code: 1}, nil)
+	err := provider.EnsureMicroK8sSuitable(s.runner)
+	c.Assert(err, gc.NotNil)
+	c.Assert(strings.Replace(err.Error(), "\n", "", -1),
+		gc.Matches, `The microk8s user group is created during the microk8s snap installation.*`)
 }
 
 type mockContext struct {


### PR DESCRIPTION
## Description of change

Improve the checks done when bootstrapping to microk8s.
1. Ensure user is in the microk8s group
2. Include all missing required addons in the one error message

## QA steps

juju bootstrap microk8s
when
- user is not in microk8s group
- microk8s storage is disabled
- microk8s storage and dns is disabled
