### PR TITLE
Mechanical Openstack Refactoring

### DIFF
--- a/provider/openstack/errors.go
+++ b/provider/openstack/errors.go
@@ -17,11 +17,9 @@ func handleCredentialError(err error, ctx context.ProviderCallContext) {
 	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 }
 
-// IsAuthorisationFailure determines if the given error has an authorisation failure.
+// IsAuthorisationFailure determines if the given error has an
+// authorisation failure.
 func IsAuthorisationFailure(err error) bool {
 	// This should cover most cases.
-	if gooseerrors.IsUnauthorised(errors.Cause(err)) {
-		return true
-	}
-	return false
+	return gooseerrors.IsUnauthorised(errors.Cause(err))
 }

--- a/provider/openstack/errors.go
+++ b/provider/openstack/errors.go
@@ -6,7 +6,16 @@ package openstack
 import (
 	"github.com/juju/errors"
 	gooseerrors "gopkg.in/goose.v2/errors"
+
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
 )
+
+// handleCredentialError wraps the common handler,
+// passing the Openstack-specific auth failure detection.
+func handleCredentialError(err error, ctx context.ProviderCallContext) {
+	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+}
 
 // IsAuthorisationFailure determines if the given error has an authorisation failure.
 func IsAuthorisationFailure(err error) bool {

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -112,7 +112,7 @@ func (f *switchingFirewaller) initFirewaller(ctx context.ProviderCallContext) er
 	client := f.env.client()
 	if !client.IsAuthenticated() {
 		if err := authenticateClient(client); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return errors.Trace(err)
 		}
 	}
@@ -234,7 +234,7 @@ func (c *firewallerBase) GetSecurityGroups(ctx context.ProviderCallContext, ids 
 			}
 			groups, err := novaClient.GetServerSecurityGroups(string(inst.Id()))
 			if err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				return nil, errors.Trace(err)
 			}
 			for _, group := range groups {
@@ -307,7 +307,7 @@ func deleteSecurityGroup(
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
 			if err := deleteSecurityGroupById(id); err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				return errors.Trace(err)
 			}
 			return nil
@@ -473,7 +473,7 @@ func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, control
 		machineGroup, err = c.ensureGroup(c.globalGroupName(controllerUUID), nil)
 	}
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	groups := []string{jujuGroup.Name, machineGroup.Name}
@@ -696,7 +696,7 @@ func (c *neutronFirewaller) deleteSecurityGroups(ctx context.ProviderCallContext
 	neutronClient := c.environ.neutron()
 	securityGroups, err := neutronClient.ListSecurityGroupsV2()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Annotate(err, "cannot list security groups")
 	}
 	for _, group := range securityGroups {
@@ -733,12 +733,12 @@ func (c *neutronFirewaller) UpdateGroupController(ctx context.ProviderCallContex
 	neutronClient := c.environ.neutron()
 	groups, err := neutronClient.ListSecurityGroupsV2()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	re, err := regexp.Compile(c.jujuGroupRegexp())
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 
@@ -778,7 +778,7 @@ func (c *neutronFirewaller) updateGroupControllerUUID(group *neutron.SecurityGro
 func (c *neutronFirewaller) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
 	err := c.openPorts(ctx, c.openPortsInGroup, rules)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -788,7 +788,7 @@ func (c *neutronFirewaller) OpenPorts(ctx context.ProviderCallContext, rules []n
 func (c *neutronFirewaller) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
 	err := c.closePorts(ctx, c.closePortsInGroup, rules)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -798,7 +798,7 @@ func (c *neutronFirewaller) ClosePorts(ctx context.ProviderCallContext, rules []
 func (c *neutronFirewaller) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
 	rules, err := c.ingressRules(ctx, c.ingressRulesInGroup)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return rules, errors.Trace(err)
 	}
 	return rules, nil
@@ -819,7 +819,7 @@ func (c *neutronFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, i
 	}
 	err := c.openInstancePorts(ctx, c.openPortsInGroup, machineId, ports)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -840,7 +840,7 @@ func (c *neutronFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, 
 	}
 	err := c.closeInstancePorts(ctx, c.closePortsInGroup, machineId, ports)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -861,7 +861,7 @@ func (c *neutronFirewaller) InstanceIngressRules(ctx context.ProviderCallContext
 	}
 	rules, err := c.instanceIngressRules(ctx, c.ingressRulesInGroup, machineId)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return rules, errors.Trace(err)
 	}
 	return rules, err
@@ -878,7 +878,7 @@ func (c *neutronFirewaller) matchingGroup(ctx context.ProviderCallContext, nameR
 	neutronClient := c.environ.neutron()
 	allGroups, err := neutronClient.ListSecurityGroupsV2()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return neutron.SecurityGroupV2{}, err
 	}
 	var matchingGroups []neutron.SecurityGroupV2
@@ -906,7 +906,7 @@ func (c *neutronFirewaller) openPortsInGroup(ctx context.ProviderCallContext, na
 	for _, rule := range ruleInfo {
 		_, err := neutronClient.CreateSecurityGroupRuleV2(rule)
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			// TODO: if err is not rule already exists, raise?
 			logger.Debugf("error creating security group rule: %v", err.Error())
 		}
@@ -957,7 +957,7 @@ func (c *neutronFirewaller) closePortsInGroup(ctx context.ProviderCallContext, n
 			}
 			err := neutronClient.DeleteSecurityGroupRuleV2(p.Id)
 			if err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				return errors.Trace(err)
 			}
 			break

--- a/provider/openstack/legacy_firewaller.go
+++ b/provider/openstack/legacy_firewaller.go
@@ -98,7 +98,7 @@ func (c *legacyNovaFirewaller) ensureGroup(ctx context.ProviderCallContext, name
 	// First attempt to look up an existing group by name.
 	group, err := novaClient.SecurityGroupByName(name)
 	if err == nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		// Group exists, so assume it is correctly set up and return it.
 		// TODO(jam): 2013-09-18 http://pad.lv/121795
 		// We really should verify the group is set up correctly,
@@ -115,7 +115,7 @@ func (c *legacyNovaFirewaller) ensureGroup(ctx context.ProviderCallContext, name
 			// We just tried to create a duplicate group, so load the existing group.
 			group, err = novaClient.SecurityGroupByName(name)
 			if err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				return legacyZeroGroup, err
 			}
 			return *group, nil
@@ -134,7 +134,7 @@ func (c *legacyNovaFirewaller) ensureGroup(ctx context.ProviderCallContext, name
 		}
 		groupRule, err := novaClient.CreateSecurityGroupRule(rule)
 		if err != nil && !gooseerrors.IsDuplicateValue(err) {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return legacyZeroGroup, err
 		}
 		group.Rules[i] = *groupRule
@@ -146,7 +146,7 @@ func (c *legacyNovaFirewaller) deleteSecurityGroups(ctx context.ProviderCallCont
 	novaclient := c.environ.nova()
 	securityGroups, err := novaclient.ListSecurityGroups()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Annotate(err, "cannot list security groups")
 	}
 	for _, group := range securityGroups {
@@ -182,7 +182,7 @@ func (c *legacyNovaFirewaller) UpdateGroupController(ctx context.ProviderCallCon
 	novaClient := c.environ.nova()
 	groups, err := novaClient.ListSecurityGroups()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	re, err := regexp.Compile(c.jujuGroupRegexp())
@@ -218,7 +218,7 @@ func (c *legacyNovaFirewaller) updateGroupControllerUUID(ctx context.ProviderCal
 	}
 	client := c.environ.nova()
 	_, err = client.UpdateSecurityGroup(group.Id, newName, group.Description)
-	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	handleCredentialError(err, ctx)
 	return errors.Trace(err)
 }
 
@@ -260,7 +260,7 @@ func (c *legacyNovaFirewaller) matchingGroup(ctx context.ProviderCallContext, na
 	novaclient := c.environ.nova()
 	allGroups, err := novaclient.ListSecurityGroups()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nova.SecurityGroup{}, err
 	}
 	var matchingGroups []nova.SecurityGroup
@@ -288,7 +288,7 @@ func (c *legacyNovaFirewaller) openPortsInGroup(ctx context.ProviderCallContext,
 	for _, rule := range ruleInfo {
 		_, err := novaclient.CreateSecurityGroupRule(legacyRuleInfo(rule))
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			// TODO: if err is not rule already exists, raise?
 			logger.Debugf("error creating security group rule: %v", err.Error())
 		}
@@ -332,7 +332,7 @@ func (c *legacyNovaFirewaller) closePortsInGroup(ctx context.ProviderCallContext
 			}
 			err := novaclient.DeleteSecurityGroupRule(p.Id)
 			if err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				return errors.Trace(err)
 			}
 			break
@@ -370,7 +370,7 @@ func (c *legacyNovaFirewaller) ingressRulesInGroup(ctx context.ProviderCallConte
 			portRange.ToPort,
 			*sourceCIDRs...)
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, errors.Trace(err)
 		}
 		rules = append(rules, rule)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -230,7 +230,7 @@ func (p EnvironProvider) CloudSchema() *jsonschema.Schema {
 func (p EnvironProvider) Ping(ctx context.ProviderCallContext, endpoint string) error {
 	c := p.ClientFromEndpoint(endpoint)
 	if _, err := c.IdentityAuthOptions(); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Wrap(err, errors.Errorf("No Openstack server running at %s", endpoint))
 	}
 	return nil
@@ -351,7 +351,7 @@ func (inst *openstackInstance) Refresh(ctx context.ProviderCallContext) error {
 	defer inst.mu.Unlock()
 	server, err := inst.e.nova().GetServer(inst.serverDetail.Id)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return err
 	}
 	inst.serverDetail = server
@@ -435,7 +435,7 @@ func (inst *openstackInstance) getAddresses(ctx context.ProviderCallContext) (ma
 	if len(addrs) == 0 {
 		server, err := inst.e.nova().GetServer(string(inst.Id()))
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, err
 		}
 		addrs = server.Addresses
@@ -556,7 +556,7 @@ func (e *Environ) ConstraintsValidator(ctx context.ProviderCallContext) (constra
 	novaClient := e.nova()
 	flavors, err := novaClient.ListFlavorsDetail()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, err
 	}
 	instTypeNames := make([]string, len(flavors))
@@ -594,7 +594,7 @@ func (e *Environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.A
 			return nil, errors.NotImplementedf("availability zones")
 		}
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, err
 		}
 		e.availabilityZones = make([]common.AvailabilityZone, len(zones))
@@ -610,7 +610,7 @@ func (e *Environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.A
 func (e *Environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
 	instances, err := e.Instances(ctx, ids)
 	if err != nil && err != environs.ErrPartialInstances {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, err
 	}
 	zones := make([]string, len(instances))
@@ -631,7 +631,7 @@ type openstackPlacement struct {
 func (e *Environ) DeriveAvailabilityZones(ctx context.ProviderCallContext, args environs.StartInstanceParams) ([]string, error) {
 	availabilityZone, err := e.deriveAvailabilityZone(ctx, args.Placement, args.VolumeAttachments)
 	if err != nil && !errors.IsNotImplemented(err) {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	if availabilityZone != "" {
@@ -650,7 +650,7 @@ func (e *Environ) parsePlacement(ctx context.ProviderCallContext, placement stri
 		availabilityZone := value
 		err := common.ValidateAvailabilityZone(e, ctx, availabilityZone)
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, err
 		}
 		return &openstackPlacement{zoneName: availabilityZone}, nil
@@ -678,7 +678,7 @@ func (e *Environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 		novaClient := e.nova()
 		flavors, err := novaClient.ListFlavorsDetail()
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return err
 		}
 		flavorFound := false
@@ -722,7 +722,7 @@ func (e *Environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerN
 func (e *Environ) Create(ctx context.ProviderCallContext, args environs.CreateParams) error {
 	// Verify credentials.
 	if err := authenticateClient(e.client()); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return err
 	}
 	// TODO(axw) 2016-08-04 #1609643
@@ -735,12 +735,12 @@ func (e *Environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 	// attribute was updated so we need to re-authenticate. This will be a no-op if already authenticated.
 	// An authenticated client is needed for the URL() call below.
 	if err := authenticateClient(e.client()); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, callCtx)
+		handleCredentialError(err, callCtx)
 		return nil, err
 	}
 	result, err := common.Bootstrap(ctx, e, callCtx, args)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, callCtx)
+		handleCredentialError(err, callCtx)
 		return nil, err
 	}
 	return result, nil
@@ -1062,7 +1062,7 @@ func (e *Environ) DistributeInstances(
 ) ([]instance.Id, error) {
 	valid, err := common.DistributeInstances(e, ctx, candidates, distributionGroup, limitZones)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return valid, err
 	}
 	return valid, nil
@@ -1082,15 +1082,15 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		// supports zones; validate the zone.
 		volumeAttachmentsZone, err := e.volumeAttachmentsZone(args.VolumeAttachments)
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, common.ZoneIndependentError(err)
 		}
 		if err := validateAvailabilityZoneConsistency(args.AvailabilityZone, volumeAttachmentsZone); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, common.ZoneIndependentError(err)
 		}
 		if err := common.ValidateAvailabilityZone(e, ctx, args.AvailabilityZone); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, errors.Trace(err)
 		}
 	}
@@ -1104,47 +1104,47 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		Constraints: args.Constraints,
 	}, args.ImageMetadata)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(err)
 	}
 	tools, err := args.Tools.Match(tools.Filter{Arch: spec.Image.Arch})
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(
 			errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches),
 		)
 	}
 
 	if err := args.InstanceConfig.SetTools(tools); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(err)
 	}
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(err)
 	}
 	cloudcfg, err := e.configurator.GetCloudConfig(args)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(err)
 	}
 	userData, err := providerinit.ComposeUserData(args.InstanceConfig, cloudcfg, OpenstackRenderer{})
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(errors.Annotate(err, "cannot make user data"))
 	}
 	logger.Debugf("openstack user data; %d bytes", len(userData))
 
 	networks, err := e.networking.DefaultNetworks()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(errors.Annotate(err, "getting initial networks"))
 	}
 	usingNetwork := e.ecfg().network()
 	networkId, err := e.networking.ResolveNetwork(usingNetwork, false)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		if usingNetwork == "" {
 			// If there is no network configured, we only throw out when the
 			// error reports multiple Openstack networks.
@@ -1175,7 +1175,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		}
 		pt, err := client.CreatePolicyTargetV2(ptArg)
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, errors.Trace(err)
 		}
 		networks = append(networks, nova.ServerNetworks{PortId: pt.PortId})
@@ -1195,7 +1195,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 			}
 			net, err := client.GetNetworkV2(n.NetworkId)
 			if err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				return nil, common.ZoneIndependentError(err)
 			}
 			if net.PortSecurityEnabled != nil &&
@@ -1218,7 +1218,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		}
 		groupNames, err := e.firewaller.SetUpGroups(ctx, args.ControllerUUID, args.InstanceConfig.MachineId, apiPort)
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, common.ZoneIndependentError(errors.Annotate(err, "cannot set up groups"))
 		}
 		novaGroupNames = make([]nova.SecurityGroupName, len(groupNames))
@@ -1256,7 +1256,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 			},
 		})
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, err
 		}
 		return server, nil
@@ -1270,7 +1270,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		for a := attempts.Start(); a.Next(); {
 			server, err = client.RunServer(instanceOpts)
 			if err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				break
 			}
 			if server == nil {
@@ -1322,7 +1322,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 
 	server, err := tryStartNovaInstance(shortAttempt, e.nova(), opts)
 	if err != nil || server == nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		// 'No valid host available' is typically a resource error,
 		// let the provisioner know it is a good idea to try another
 		// AZ if available.
@@ -1336,7 +1336,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 
 	detail, err := e.nova().GetServer(server.Id)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, common.ZoneIndependentError(errors.Annotate(err, "cannot get started instance"))
 	}
 
@@ -1358,7 +1358,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		var publicIP *string
 		logger.Debugf("allocating public IP address for openstack node")
 		if fip, err := e.networking.AllocatePublicIP(inst.Id()); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, common.ZoneIndependentError(errors.Annotate(err, "cannot allocate a public IP as needed"))
 		} else {
 			publicIP = fip
@@ -1366,7 +1366,7 @@ func (e *Environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		}
 		if err := e.assignPublicIP(publicIP, string(inst.Id())); err != nil {
 			if err := e.terminateInstances(ctx, []instance.Id{inst.Id()}); err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				// ignore the failure at this stage, just log it
 				logger.Debugf("failed to terminate instance %q: %v", inst.Id(), err)
 			}
@@ -1428,7 +1428,7 @@ func (e *Environ) deriveAvailabilityZone(
 ) (string, error) {
 	volumeAttachmentsZone, err := e.volumeAttachmentsZone(volumeAttachments)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return "", errors.Trace(err)
 	}
 	if placement == "" {
@@ -1507,17 +1507,17 @@ func (e *Environ) StopInstances(ctx context.ProviderCallContext, ids ...instance
 		return nil
 	}
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return err
 	}
 	logger.Debugf("terminating instances %v", ids)
 	if err := e.terminateInstances(ctx, ids); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return err
 	}
 	if securityGroupNames != nil {
 		if err := e.firewaller.DeleteGroups(ctx, securityGroupNames...); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return err
 		}
 	}
@@ -1539,7 +1539,7 @@ func (e *Environ) listServers(ctx context.ProviderCallContext, ids []instance.Id
 		var maybeServer *nova.ServerDetail
 		maybeServer, err := e.nova().GetServer(string(ids[0]))
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, err
 		}
 		// Only return server details if it is currently alive
@@ -1551,7 +1551,7 @@ func (e *Environ) listServers(ctx context.ProviderCallContext, ids []instance.Id
 	// List all instances in the environment.
 	instances, err := e.AllRunningInstances(ctx)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, err
 	}
 	// Return only servers with the wanted ids that are currently alive
@@ -1577,7 +1577,7 @@ func (e *Environ) listServers(ctx context.ProviderCallContext, ids []instance.Id
 func (e *Environ) updateFloatingIPAddresses(ctx context.ProviderCallContext, instances map[string]instances.Instance) error {
 	servers, err := e.nova().ListServersDetail(jujuMachineFilter())
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return err
 	}
 	for _, server := range servers {
@@ -1611,7 +1611,7 @@ func (e *Environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 		if err != nil {
 			logger.Debugf("error listing servers: %v", err)
 			if !IsNotFoundError(err) {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				handleCredentialError(err, ctx)
 				return nil, err
 			}
 		}
@@ -1660,7 +1660,7 @@ func (e *Environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 
 	instances, err := e.AllInstances(ctx)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	for _, instance := range instances {
@@ -1677,14 +1677,14 @@ func (e *Environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 
 	failedVolumes, err := e.adoptVolumes(controllerTag, ctx)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	failed = append(failed, failedVolumes...)
 
 	err = e.firewaller.UpdateGroupController(ctx, controllerUUID)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	if len(failed) != 0 {
@@ -1700,7 +1700,7 @@ func (e *Environ) adoptVolumes(controllerTag map[string]string, ctx context.Prov
 		return nil, nil
 	}
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	// TODO(axw): fix the storage API.
@@ -1710,12 +1710,12 @@ func (e *Environ) adoptVolumes(controllerTag map[string]string, ctx context.Prov
 	}
 	volumeSource, err := cinder.VolumeSource(storageConfig)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	volumeIds, err := volumeSource.ListVolumes(ctx)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -1739,7 +1739,7 @@ func (e *Environ) AllInstances(ctx context.ProviderCallContext) ([]instances.Ins
 	tagFilter := tagValue{tags.JujuModel, e.ecfg().UUID()}
 	instances, err := e.allInstances(ctx, tagFilter, e.ecfg().useFloatingIP())
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return instances, err
 	}
 	return instances, nil
@@ -1758,7 +1758,7 @@ func (e *Environ) allControllerManagedInstances(ctx context.ProviderCallContext,
 	tagFilter := tagValue{tags.JujuController, controllerUUID}
 	instances, err := e.allInstances(ctx, tagFilter, updateFloatingIPAddresses)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return instances, err
 	}
 	return instances, nil
@@ -1773,7 +1773,7 @@ type tagValue struct {
 func (e *Environ) allInstances(ctx context.ProviderCallContext, tagFilter tagValue, updateFloatingIPAddresses bool) ([]instances.Instance, error) {
 	servers, err := e.nova().ListServersDetail(jujuMachineFilter())
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, err
 	}
 	instsById := make(map[string]instances.Instance)
@@ -1789,7 +1789,7 @@ func (e *Environ) allInstances(ctx context.ProviderCallContext, tagFilter tagVal
 	}
 	if updateFloatingIPAddresses {
 		if err := e.updateFloatingIPAddresses(ctx, instsById); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return nil, err
 		}
 	}
@@ -1803,12 +1803,12 @@ func (e *Environ) allInstances(ctx context.ProviderCallContext, tagFilter tagVal
 func (e *Environ) Destroy(ctx context.ProviderCallContext) error {
 	err := common.Destroy(e, ctx)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	// Delete all security groups remaining in the model.
 	if err := e.firewaller.DeleteAllModelGroups(ctx); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -1817,18 +1817,18 @@ func (e *Environ) Destroy(ctx context.ProviderCallContext) error {
 // DestroyController implements the Environ interface.
 func (e *Environ) DestroyController(ctx context.ProviderCallContext, controllerUUID string) error {
 	if err := e.Destroy(ctx); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Annotate(err, "destroying controller model")
 	}
 	// In case any hosted environment hasn't been cleaned up yet,
 	// we also attempt to delete their resources when the controller
 	// environment is destroyed.
 	if err := e.destroyControllerManagedEnvirons(ctx, controllerUUID); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Annotate(err, "destroying managed models")
 	}
 	if err := e.firewaller.DeleteAllControllerGroups(ctx, controllerUUID); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -1847,7 +1847,7 @@ func (e *Environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 		instIds[i] = inst.Id()
 	}
 	if err := e.terminateInstances(ctx, instIds); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Annotate(err, "terminating instances")
 	}
 
@@ -1856,7 +1856,7 @@ func (e *Environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 	if err == nil {
 		volumes, err := controllerCinderVolumes(cinder.storageAdapter, controllerUUID)
 		if err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return errors.Annotate(err, "listing volumes")
 		}
 		volIds := volumeInfoToVolumeIds(cinderToJujuVolumeInfos(volumes))
@@ -1865,11 +1865,11 @@ func (e *Environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 			if err == nil {
 				continue
 			}
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			handleCredentialError(err, ctx)
 			return errors.Annotatef(err, "destroying volume %q", volIds[i])
 		}
 	} else if !errors.IsNotSupported(err) {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 
@@ -1916,7 +1916,7 @@ func rulesToRuleInfo(groupId string, rules []network.IngressRule) []neutron.Rule
 
 func (e *Environ) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
 	if err := e.firewaller.OpenPorts(ctx, rules); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -1924,7 +1924,7 @@ func (e *Environ) OpenPorts(ctx context.ProviderCallContext, rules []network.Ing
 
 func (e *Environ) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
 	if err := e.firewaller.ClosePorts(ctx, rules); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
 	return nil
@@ -1933,7 +1933,7 @@ func (e *Environ) ClosePorts(ctx context.ProviderCallContext, rules []network.In
 func (e *Environ) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
 	rules, err := e.firewaller.IngressRules(ctx)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return rules, errors.Trace(err)
 	}
 	return rules, nil
@@ -1997,7 +1997,7 @@ func (e *Environ) cloudSpec(region string) (simplestreams.CloudSpec, error) {
 // TagInstance implements environs.InstanceTagger.
 func (e *Environ) TagInstance(ctx context.ProviderCallContext, id instance.Id, tags map[string]string) error {
 	if err := e.nova().SetServerMetadata(string(id), tags); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return errors.Annotate(err, "setting server metadata")
 	}
 	return nil
@@ -2040,7 +2040,7 @@ func (e *Environ) Subnets(
 ) ([]corenetwork.SubnetInfo, error) {
 	subnets, err := e.networking.Subnets(instId, subnetIds)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return subnets, errors.Trace(err)
 	}
 	return subnets, nil
@@ -2050,7 +2050,7 @@ func (e *Environ) Subnets(
 func (e *Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error) {
 	infos, err := e.networking.NetworkInterfaces(ids)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return infos, errors.Trace(err)
 	}
 
@@ -2081,7 +2081,7 @@ func (e *Environ) SupportsContainerAddresses(ctx context.ProviderCallContext) (b
 func (e *Environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
 	subnets, err := e.networking.Subnets("", nil)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		handleCredentialError(err, ctx)
 		return nil, err
 	}
 	cidrs := make([]string, len(subnets))


### PR DESCRIPTION
## Description of change

This patch consists of minor mechanical changes to DRY up the Openstack provider a little.
- Credential error handling now has a wrapper that applies the Openstack-specific detection.
- A couple of methods are broken out of `StartInstance` in order to shorten it.

## QA steps

No functional changes; tests continue to pass.

## Documentation changes

None.

## Bug reference

N/A
