### PR TITLE
Removing docs.jujucharms.com references and replacing them with jaas.ai links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Quick links
 Issue tracker: https://bugs.launchpad.net/juju/+bugs
 
 Documentation:
-* https://docs.jujucharms.com/
+* https://jaas.ai/docs
 * [source tree docs](doc/)
 
 Community:

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -589,7 +589,7 @@ for security purposes by allowing only certain configurations and devices. Use
 the '--force' option to bypass this check. Doing so is not recommended as it
 can lead to unexpected behaviour.
 
-Further reading: https://docs.jujucharms.com/stable/charms-deploying
+Further reading: https://jaas.ai/docs/deploying-applications
 
 Examples:
 

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -72,7 +72,7 @@ environment to match the restored database, e.g. no units, relations, nor
 machines will be added or removed during the restore process.
 
 Note: Extra care is needed to restore in an HA environment, please see
-https://docs.jujucharms.com/stable/controllers-backup for more information.
+https://jaas.ai/docs/controller-backups for more information.
 
 If the provided state cannot be restored, this command will fail with
 an explanation.
@@ -174,7 +174,7 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 	}
 	activeCount, _ := controller.ControllerMachineCounts(controllerModelUUID, modelStatus)
 	if activeCount > 1 {
-		return errors.Errorf("unable to restore backup in HA configuration.  For help see https://docs.jujucharms.com/stable/controllers-backup")
+		return errors.Errorf("unable to restore backup in HA configuration.  For help see https://jaas.ai/docs/controller-backups")
 	}
 
 	var archive ArchiveReader

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -260,5 +260,5 @@ func (s *restoreSuite) TestRestoreFromBackupHAFail(c *gc.C) {
 		modelStatusClient.EXPECT().Close(),
 	)
 	_, err := cmdtesting.RunCommand(c, s.wrappedCommand, "restore", "--id", "an_id")
-	c.Assert(err, gc.ErrorMatches, "unable to restore backup in HA configuration.  For help see https://docs.jujucharms.com/stable/controllers-backup")
+	c.Assert(err, gc.ErrorMatches, "unable to restore backup in HA configuration.  For help see https://jaas.ai/docs/controller-backups")
 }

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -62,7 +62,7 @@ var listCloudsDoc = "" +
 	"\n" +
 	"Further reading:\n " +
 	"\n" +
-	"    Documentation:   https://docs.jujucharms.com/stable/clouds\n" +
+	"    Documentation:   https://jaas.ai/docs/clouds\n" +
 	"    microk8s:        https://microk8s.io/\n" +
 	"    LXD hypervisor:  https://linuxcontainers.org/lxd/\n" +
 	listCloudsDocExamples

--- a/doc/logging.txt
+++ b/doc/logging.txt
@@ -9,7 +9,7 @@ Accessing logs as a user
 Please consult the available user documentation for details of how to
 access Juju's logs. Specifically:
 
-  * https://docs.jujucharms.com/stable/en/troubleshooting-logs
+  * https://jaas.ai/docs/logs
   * juju help logging
   * juju help debug-log
   * juju-dumplogs --help

--- a/scripts/jujuman.py
+++ b/scripts/jujuman.py
@@ -175,7 +175,7 @@ Records the UUIDs of all models known to Juju.
 .I "~/.local/share/juju/ssh/"
 A directory containing the SSH credentials for the Juju client.
 .SH "SEE ALSO"
-.UR https://docs.jujucharms.com/
-.BR https://docs.jujucharms.com/
+.UR https://jaas.ai/docs
+.BR https://jaas.ai/docs
 """
 

--- a/scripts/win-installer/README.txt
+++ b/scripts/win-installer/README.txt
@@ -13,8 +13,8 @@ Amazon EC2, Google Compute Engine, or an OpenStack installation.
 in a directory called '.ssh' in your home directory. There are instructions on
 how to generate these keys at:
 
-    https://docs.jujucharms.com/stable/en/getting-started-keygen-win
+    https://jaas.ai/docs/creating-ssh-keypairs-on-windows
 
 To continue, please follow the online documentation at:
 
-    https://docs.jujucharms.com/stable/en/getting-started
+    https://jaas.ai/docs/getting-started-with-juju

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -176,7 +176,7 @@ tmux kill-session -t $JUJU_UNIT_NAME # or, equivalently, CTRL+a d
 4. CTRL+a is tmux prefix.
 
 More help and info is available in the online documentation:
-https://docs.jujucharms.com/stable/en/developer-debugging#the-'debug-hooks'-command
+https://discourse.jujucharms.com/t/debugging-charm-hooks
 
 `
 


### PR DESCRIPTION
## Description of change

It seems like old docs.jujucharms.com fqdn is obsolete and no longer used, so it doesn't make any big sense for me using it in the source code.

## QA steps

N/A

## Documentation changes

N/A

## Bug reference

N/A
