### PR TITLE
add "let" to check_dependencies

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -158,7 +158,7 @@ export SKIP_LIST="${SKIP_LIST}"
 echo ""
 
 echo "==> Checking for dependencies"
-check_dependencies curl jq shellcheck
+check_dependencies curl jq shellcheck let
 
 if [ "${USER:-'root'}" = "root" ]; then
     echo "The testsuite must not be run as root." >&2


### PR DESCRIPTION
## Description of change

Let is not installed by default on all versions of ubuntu.  As it's in the test helpers, add to the overall dependency check.

## QA steps

(cd tests && ./main.sh -A)  on a machine where let isn't installed.

