### PR TITLE
Fixes lp#1844440: update-cloud supports public clouds

### DIFF
--- a/cmd/juju/cloud/cloudsdiff.go
+++ b/cmd/juju/cloud/cloudsdiff.go
@@ -1,0 +1,180 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/juju/collections/set"
+	jujucloud "github.com/juju/juju/cloud"
+)
+
+func diffCloudDetails(cloudName string, new, old jujucloud.Cloud, diff *changes) {
+	sameAuthTypes := func() bool {
+		if len(old.AuthTypes) != len(new.AuthTypes) {
+			return false
+		}
+		newAuthTypes := set.NewStrings()
+		for _, one := range new.AuthTypes {
+			newAuthTypes.Add(string(one))
+		}
+
+		for _, anOldOne := range old.AuthTypes {
+			if !newAuthTypes.Contains(string(anOldOne)) {
+				return false
+			}
+		}
+		return true
+	}
+
+	endpointChanged := new.Endpoint != old.Endpoint
+	identityEndpointChanged := new.IdentityEndpoint != old.IdentityEndpoint
+	storageEndpointChanged := new.StorageEndpoint != old.StorageEndpoint
+
+	if endpointChanged || identityEndpointChanged || storageEndpointChanged || new.Type != old.Type || !sameAuthTypes() {
+		diff.addChange(updateChange, attributeScope, cloudName)
+	}
+
+	formatCloudRegion := func(rName string) string {
+		return fmt.Sprintf("%v/%v", cloudName, rName)
+	}
+
+	oldRegions := mapRegions(old.Regions)
+	newRegions := mapRegions(new.Regions)
+	// added & modified regions
+	for newName, newRegion := range newRegions {
+		oldRegion, ok := oldRegions[newName]
+		if !ok {
+			diff.addChange(addChange, regionScope, formatCloudRegion(newName))
+			continue
+
+		}
+		if (oldRegion.Endpoint != newRegion.Endpoint) || (oldRegion.IdentityEndpoint != newRegion.IdentityEndpoint) || (oldRegion.StorageEndpoint != newRegion.StorageEndpoint) {
+			diff.addChange(updateChange, regionScope, formatCloudRegion(newName))
+		}
+	}
+
+	// deleted regions
+	for oldName := range oldRegions {
+		if _, ok := newRegions[oldName]; !ok {
+			diff.addChange(deleteChange, regionScope, formatCloudRegion(oldName))
+		}
+	}
+}
+
+func mapRegions(regions []jujucloud.Region) map[string]jujucloud.Region {
+	result := make(map[string]jujucloud.Region)
+	for _, region := range regions {
+		result[region.Name] = region
+	}
+	return result
+}
+
+type changeType string
+
+const (
+	addChange    changeType = "added"
+	deleteChange changeType = "deleted"
+	updateChange changeType = "changed"
+)
+
+type scope string
+
+const (
+	cloudScope     scope = "cloud"
+	regionScope    scope = "cloud region"
+	attributeScope scope = "cloud attribute"
+)
+
+type changes struct {
+	all map[changeType]map[scope][]string
+}
+
+func newChanges() *changes {
+	return &changes{make(map[changeType]map[scope][]string)}
+}
+
+func (c *changes) addChange(aType changeType, entity scope, details string) {
+	byType, ok := c.all[aType]
+	if !ok {
+		byType = make(map[scope][]string)
+		c.all[aType] = byType
+	}
+	byType[entity] = append(byType[entity], details)
+}
+
+func (c *changes) summary() string {
+	if len(c.all) == 0 {
+		return ""
+	}
+
+	// Sort by change types
+	types := []string{}
+	for one := range c.all {
+		types = append(types, string(one))
+	}
+	sort.Strings(types)
+
+	msgs := []string{}
+	details := ""
+	tabSpace := "    "
+	detailsSeparator := fmt.Sprintf("\n%v%v- ", tabSpace, tabSpace)
+	for _, aType := range types {
+		typeGroup := c.all[changeType(aType)]
+		entityMsgs := []string{}
+
+		// Sort by change scopes
+		scopes := []string{}
+		for one := range typeGroup {
+			scopes = append(scopes, string(one))
+		}
+		sort.Strings(scopes)
+
+		for _, aScope := range scopes {
+			scopeGroup := typeGroup[scope(aScope)]
+			sort.Strings(scopeGroup)
+			entityMsgs = append(entityMsgs, adjustPlurality(aScope, len(scopeGroup)))
+			details += fmt.Sprintf("\n%v%v %v:%v%v",
+				tabSpace,
+				aType,
+				aScope,
+				detailsSeparator,
+				strings.Join(scopeGroup, detailsSeparator))
+		}
+		typeMsg := formatSlice(entityMsgs, ", ", " and ")
+		msgs = append(msgs, fmt.Sprintf("%v %v", typeMsg, aType))
+	}
+
+	result := formatSlice(msgs, "; ", " as well as ")
+	return fmt.Sprintf("%v:\n%v", result, details)
+}
+
+// TODO(anastasiamac 2014-04-13) Move this to
+// juju/utils (eg. Pluralize). Added tech debt card.
+func adjustPlurality(entity string, count int) string {
+	switch count {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("%d %v", count, entity)
+	default:
+		return fmt.Sprintf("%d %vs", count, entity)
+	}
+}
+
+func formatSlice(slice []string, itemSeparator, lastSeparator string) string {
+	switch len(slice) {
+	case 0:
+		return ""
+	case 1:
+		return slice[0]
+	default:
+		return fmt.Sprintf("%v%v%v",
+			strings.Join(slice[:len(slice)-1], itemSeparator),
+			lastSeparator,
+			slice[len(slice)-1])
+	}
+}

--- a/cmd/juju/cloud/cloudsdiff_internal_test.go
+++ b/cmd/juju/cloud/cloudsdiff_internal_test.go
@@ -10,42 +10,42 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type cloudChangesSuite struct {
+type cloudDiffSuite struct {
 	testing.BaseSuite
 }
 
-var _ = gc.Suite(&cloudChangesSuite{})
+var _ = gc.Suite(&cloudDiffSuite{})
 
-func (s *cloudChangesSuite) TestPluralityNone(c *gc.C) {
+func (s *cloudDiffSuite) TestPluralityNone(c *gc.C) {
 	c.Assert(adjustPlurality("item", 0), gc.Equals, "")
 }
 
-func (s *cloudChangesSuite) TestPluralitySingular(c *gc.C) {
+func (s *cloudDiffSuite) TestPluralitySingular(c *gc.C) {
 	c.Assert(adjustPlurality("item", 1), gc.Equals, "1 item")
 }
 
-func (s *cloudChangesSuite) TestPluralityPlural(c *gc.C) {
+func (s *cloudDiffSuite) TestPluralityPlural(c *gc.C) {
 	c.Assert(adjustPlurality("item", 2), gc.Equals, "2 items")
 }
 
-func (s *cloudChangesSuite) TestFormatSliceEmpty(c *gc.C) {
+func (s *cloudDiffSuite) TestFormatSliceEmpty(c *gc.C) {
 	c.Assert(formatSlice(nil, "", ""), gc.Equals, "")
 	c.Assert(formatSlice([]string{}, "", ""), gc.Equals, "")
 }
 
-func (s *cloudChangesSuite) TestFormatSliceOne(c *gc.C) {
+func (s *cloudDiffSuite) TestFormatSliceOne(c *gc.C) {
 	c.Assert(formatSlice([]string{"one"}, "", ""), gc.Equals, "one")
 }
 
-func (s *cloudChangesSuite) TestFormatSliceTwo(c *gc.C) {
+func (s *cloudDiffSuite) TestFormatSliceTwo(c *gc.C) {
 	c.Assert(formatSlice([]string{"one", "two"}, "", " and "), gc.Equals, "one and two")
 }
 
-func (s *cloudChangesSuite) TestFormatSliceMany(c *gc.C) {
+func (s *cloudDiffSuite) TestFormatSliceMany(c *gc.C) {
 	c.Assert(formatSlice([]string{"one", "two", "three"}, ", ", " and "), gc.Equals, "one, two and three")
 }
 
-func (s *cloudChangesSuite) TestFormatSlices(c *gc.C) {
+func (s *cloudDiffSuite) TestFormatSlices(c *gc.C) {
 	c.Assert(formatSlice(
 		[]string{"one add", "two and three updates", "four, five and seven deletes"}, "; ", " as well as "),
 		gc.Equals,
@@ -426,7 +426,7 @@ var diffCloudsTests = []struct {
 	},
 }
 
-func (s *cloudChangesSuite) TestDiffClouds(c *gc.C) {
+func (s *cloudDiffSuite) TestDiffClouds(c *gc.C) {
 	for i, test := range diffCloudsTests {
 		c.Logf("%d: %v", i, test.description)
 		c.Check(diffClouds(test.new, test.old), gc.Equals, test.expected)

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -71,9 +71,11 @@ func NewRemoveCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() 
 
 func NewUpdatePublicCloudsCommandForTest(publicCloudURL string) *updatePublicCloudsCommand {
 	return &updatePublicCloudsCommand{
-		// TODO(wallyworld) - move testing key elsewhere
-		publicSigningKey: sstesting.SignedMetadataPublicKey,
-		publicCloudURL:   publicCloudURL,
+		config: publicCloudsConfig{
+			// TODO(wallyworld) - move testing key elsewhere
+			publicSigningKey: sstesting.SignedMetadataPublicKey,
+			publicCloudURL:   publicCloudURL,
+		},
 	}
 }
 
@@ -81,11 +83,17 @@ func NewUpdateCloudCommandForTest(
 	cloudMetadataStore CloudMetadataStore,
 	store jujuclient.ClientStore,
 	cloudAPI func() (UpdateCloudAPI, error),
+	publicCloudURL string,
 ) *updateCloudCommand {
 	return &updateCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
 		cloudMetadataStore:        cloudMetadataStore,
 		updateCloudAPIFunc:        cloudAPI,
+		publicCloudFetchConfig: publicCloudsConfig{
+			// TODO(wallyworld) - move testing key elsewhere
+			publicSigningKey: sstesting.SignedMetadataPublicKey,
+			publicCloudURL:   publicCloudURL,
+		},
 	}
 }
 

--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -4,34 +4,23 @@
 package cloud
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"sort"
-	"strings"
 
 	"github.com/juju/cmd"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/utils"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/clearsign"
 
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/juju/keys"
 )
 
 type updatePublicCloudsCommand struct {
 	cmd.CommandBase
-
-	publicSigningKey string
-	publicCloudURL   string
+	config publicCloudsConfig
 }
 
 var updatePublicCloudsDoc = `
+DEPRECATED COMMAND Use 'update-cloud' instead. 
+
 If any new information for public clouds (such as regions and connection
 endpoints) are available this command will update Juju accordingly. It is
 suggested to run this command periodically.
@@ -51,8 +40,7 @@ var NewUpdatePublicCloudsCommand = func() cmd.Command {
 
 func newUpdatePublicCloudsCommand() cmd.Command {
 	return &updatePublicCloudsCommand{
-		publicSigningKey: keys.JujuPublicKey,
-		publicCloudURL:   "https://streams.canonical.com/juju/public-clouds.syaml",
+		config: newPublicCloudsConfig(),
 	}
 }
 
@@ -60,38 +48,15 @@ func (c *updatePublicCloudsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "update-public-clouds",
 		Aliases: []string{"update-clouds"},
-		Purpose: "Updates public cloud information available to Juju.",
+		Purpose: "DEPRECATED (use 'update-cloud' instead): Updates public cloud information available to Juju.",
 		Doc:     updatePublicCloudsDoc,
 	})
 }
 
 func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
-	fmt.Fprint(ctxt.Stderr, "Fetching latest public cloud list...\n")
-	client := utils.GetHTTPClient(utils.VerifySSLHostnames)
-	resp, err := client.Get(c.publicCloudURL)
+	newPublicClouds, err := getPublishedPublicClouds(ctxt, c.config)
 	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		switch resp.StatusCode {
-		case http.StatusNotFound:
-			fmt.Fprintln(ctxt.Stderr, "Public cloud list is unavailable right now.")
-			return nil
-		case http.StatusUnauthorized:
-			return errors.Unauthorizedf("unauthorised access to URL %q", c.publicCloudURL)
-		}
-		return errors.Errorf("cannot read public cloud information at URL %q, %q", c.publicCloudURL, resp.Status)
-	}
-
-	cloudData, err := decodeCheckSignature(resp.Body, c.publicSigningKey)
-	if err != nil {
-		return errors.Annotate(err, "error receiving updated cloud data")
-	}
-	newPublicClouds, err := jujucloud.ParseCloudMetadata(cloudData)
-	if err != nil {
-		return errors.Annotate(err, "invalid cloud data received when updating clouds")
+		return errors.Trace(err)
 	}
 	currentPublicClouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
@@ -112,27 +77,6 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 	updateDetails := diffClouds(newPublicClouds, currentPublicClouds)
 	fmt.Fprintln(ctxt.Stderr, fmt.Sprintf("Updated your list of public clouds with %s", updateDetails))
 	return nil
-}
-
-func decodeCheckSignature(r io.Reader, publicKey string) ([]byte, error) {
-	data, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-	b, _ := clearsign.Decode(data)
-	if b == nil {
-		return nil, errors.New("no PGP signature embedded in plain text data")
-	}
-	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewBufferString(publicKey))
-	if err != nil {
-		return nil, errors.Errorf("failed to parse public key: %v", err)
-	}
-
-	_, err = openpgp.CheckDetachedSignature(keyring, bytes.NewBuffer(b.Bytes), b.ArmoredSignature.Body)
-	if err != nil {
-		return nil, err
-	}
-	return b.Plaintext, nil
 }
 
 func diffClouds(newClouds, oldClouds map[string]jujucloud.Cloud) string {
@@ -157,180 +101,4 @@ func diffClouds(newClouds, oldClouds map[string]jujucloud.Cloud) string {
 		}
 	}
 	return diff.summary()
-}
-
-func cloudChanged(cloudName string, new, old jujucloud.Cloud) bool {
-	same, _ := jujucloud.IsSameCloudMetadata(
-		map[string]jujucloud.Cloud{cloudName: new},
-		map[string]jujucloud.Cloud{cloudName: old},
-	)
-	// If both old and new version are the same the cloud is not changed.
-	return !same
-}
-
-func diffCloudDetails(cloudName string, new, old jujucloud.Cloud, diff *changes) {
-	sameAuthTypes := func() bool {
-		if len(old.AuthTypes) != len(new.AuthTypes) {
-			return false
-		}
-		newAuthTypes := set.NewStrings()
-		for _, one := range new.AuthTypes {
-			newAuthTypes.Add(string(one))
-		}
-
-		for _, anOldOne := range old.AuthTypes {
-			if !newAuthTypes.Contains(string(anOldOne)) {
-				return false
-			}
-		}
-		return true
-	}
-
-	endpointChanged := new.Endpoint != old.Endpoint
-	identityEndpointChanged := new.IdentityEndpoint != old.IdentityEndpoint
-	storageEndpointChanged := new.StorageEndpoint != old.StorageEndpoint
-
-	if endpointChanged || identityEndpointChanged || storageEndpointChanged || new.Type != old.Type || !sameAuthTypes() {
-		diff.addChange(updateChange, attributeScope, cloudName)
-	}
-
-	formatCloudRegion := func(rName string) string {
-		return fmt.Sprintf("%v/%v", cloudName, rName)
-	}
-
-	oldRegions := mapRegions(old.Regions)
-	newRegions := mapRegions(new.Regions)
-	// added & modified regions
-	for newName, newRegion := range newRegions {
-		oldRegion, ok := oldRegions[newName]
-		if !ok {
-			diff.addChange(addChange, regionScope, formatCloudRegion(newName))
-			continue
-
-		}
-		if (oldRegion.Endpoint != newRegion.Endpoint) || (oldRegion.IdentityEndpoint != newRegion.IdentityEndpoint) || (oldRegion.StorageEndpoint != newRegion.StorageEndpoint) {
-			diff.addChange(updateChange, regionScope, formatCloudRegion(newName))
-		}
-	}
-
-	// deleted regions
-	for oldName := range oldRegions {
-		if _, ok := newRegions[oldName]; !ok {
-			diff.addChange(deleteChange, regionScope, formatCloudRegion(oldName))
-		}
-	}
-}
-
-func mapRegions(regions []jujucloud.Region) map[string]jujucloud.Region {
-	result := make(map[string]jujucloud.Region)
-	for _, region := range regions {
-		result[region.Name] = region
-	}
-	return result
-}
-
-type changeType string
-
-const (
-	addChange    changeType = "added"
-	deleteChange changeType = "deleted"
-	updateChange changeType = "changed"
-)
-
-type scope string
-
-const (
-	cloudScope     scope = "cloud"
-	regionScope    scope = "cloud region"
-	attributeScope scope = "cloud attribute"
-)
-
-type changes struct {
-	all map[changeType]map[scope][]string
-}
-
-func newChanges() *changes {
-	return &changes{make(map[changeType]map[scope][]string)}
-}
-
-func (c *changes) addChange(aType changeType, entity scope, details string) {
-	byType, ok := c.all[aType]
-	if !ok {
-		byType = make(map[scope][]string)
-		c.all[aType] = byType
-	}
-	byType[entity] = append(byType[entity], details)
-}
-
-func (c *changes) summary() string {
-	if len(c.all) == 0 {
-		return ""
-	}
-
-	// Sort by change types
-	types := []string{}
-	for one := range c.all {
-		types = append(types, string(one))
-	}
-	sort.Strings(types)
-
-	msgs := []string{}
-	details := ""
-	tabSpace := "    "
-	detailsSeparator := fmt.Sprintf("\n%v%v- ", tabSpace, tabSpace)
-	for _, aType := range types {
-		typeGroup := c.all[changeType(aType)]
-		entityMsgs := []string{}
-
-		// Sort by change scopes
-		scopes := []string{}
-		for one := range typeGroup {
-			scopes = append(scopes, string(one))
-		}
-		sort.Strings(scopes)
-
-		for _, aScope := range scopes {
-			scopeGroup := typeGroup[scope(aScope)]
-			sort.Strings(scopeGroup)
-			entityMsgs = append(entityMsgs, adjustPlurality(aScope, len(scopeGroup)))
-			details += fmt.Sprintf("\n%v%v %v:%v%v",
-				tabSpace,
-				aType,
-				aScope,
-				detailsSeparator,
-				strings.Join(scopeGroup, detailsSeparator))
-		}
-		typeMsg := formatSlice(entityMsgs, ", ", " and ")
-		msgs = append(msgs, fmt.Sprintf("%v %v", typeMsg, aType))
-	}
-
-	result := formatSlice(msgs, "; ", " as well as ")
-	return fmt.Sprintf("%v:\n%v", result, details)
-}
-
-// TODO(anastasiamac 2014-04-13) Move this to
-// juju/utils (eg. Pluralize). Added tech debt card.
-func adjustPlurality(entity string, count int) string {
-	switch count {
-	case 0:
-		return ""
-	case 1:
-		return fmt.Sprintf("%d %v", count, entity)
-	default:
-		return fmt.Sprintf("%d %vs", count, entity)
-	}
-}
-
-func formatSlice(slice []string, itemSeparator, lastSeparator string) string {
-	switch len(slice) {
-	case 0:
-		return ""
-	case 1:
-		return slice[0]
-	default:
-		return fmt.Sprintf("%v%v%v",
-			strings.Join(slice[:len(slice)-1], itemSeparator),
-			lastSeparator,
-			slice[len(slice)-1])
-	}
 }


### PR DESCRIPTION
## Description of change

'update-public-clouds' command is being deprecated in this PR in favor of 'update-cloud' command. 'update-cloud' now supports updating public clouds too where for the client, we'd query single point of truth (in simplestreams) and for the controller, we'd still use local copy of a  public copy.

The advantages of this approach is that we are now collapsing 2-steps required to update public cloud on a controller into 1 -  'update-cloud aws --client --controller mycontroller' 

As a drive-by, the functionality shared between 'update-public-clouds' and now 'update-cloud' has been moved to ensure that the file with update-public-cloud command can be easily removed when the time comes. 

## QA steps

1. Public cloud definition has changed:
```
$ juju update-cloud aws --client
Fetching latest public cloud list...
Updated public cloud "aws" on this client, 5 cloud regions added:

    added cloud region:
        - aws/ap-northeast-1
        - aws/ap-northeast-2
        - aws/ap-northeast-3
        - aws/me-south-1
        - aws/sa-east-1
```
2. Public cloud definition is the same (no-op):
```
$ juju update-cloud aws --client
Fetching latest public cloud list...
No new details for cloud "aws" have been published.
```

## Documentation changes

'update-public-clouds' command is deprecated in favor of 'update-cloud'

## Bug reference

https://bugs.launchpad.net/juju/+bug/1844440
