### PR TITLE
CMR Migration: integration SAAS apps 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -492,11 +492,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:ee86bcdc9520c404f5b994d770c321a80ad5bdbd61a15a79e4905f5942308872"
+  digest = "1:12e9d8a3a8f87f24295b14721ae5a222b06db2c3215d0015b7766a3ddb559095"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "518c591d8576f28b31d46e90ee00536418690345"
+  revision = "4a2d8e1a91c9355889febe294accbbcfb3a1a656"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "518c591d8576f28b31d46e90ee00536418690345"
+  revision = "4a2d8e1a91c9355889febe294accbbcfb3a1a656"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -70,7 +70,7 @@ var facadeVersions = map[string]int{
 	"MetricsDebug":                 2,
 	"MetricsManager":               1,
 	"MigrationFlag":                1,
-	"MigrationMaster":              1,
+	"MigrationMaster":              2,
 	"MigrationMinion":              1,
 	"MigrationStatusWatcher":       1,
 	"MigrationTarget":              1,

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -190,6 +190,12 @@ func (c *Client) Export() (migration.SerializedModel, error) {
 	}, nil
 }
 
+// ProcessRelations runs a series of processes to ensure that the relations
+// of a given model are correct after a migrated model.
+func (c *Client) ProcessRelations(controllerAlias string) error {
+	return nil
+}
+
 // OpenResource downloads the named resource for an application.
 func (c *Client) OpenResource(application, name string) (io.ReadCloser, error) {
 	httpClient, err := c.httpClientFactory()

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -193,6 +193,17 @@ func (c *Client) Export() (migration.SerializedModel, error) {
 // ProcessRelations runs a series of processes to ensure that the relations
 // of a given model are correct after a migrated model.
 func (c *Client) ProcessRelations(controllerAlias string) error {
+	param := params.ProcessReleations{
+		ControllerAlias: controllerAlias,
+	}
+	var result params.ErrorResult
+	err := c.caller.FacadeCall("ProcessRelations", param, &result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
 	return nil
 }
 

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -193,7 +193,7 @@ func (c *Client) Export() (migration.SerializedModel, error) {
 // ProcessRelations runs a series of processes to ensure that the relations
 // of a given model are correct after a migrated model.
 func (c *Client) ProcessRelations(controllerAlias string) error {
-	param := params.ProcessReleations{
+	param := params.ProcessRelations{
 		ControllerAlias: controllerAlias,
 	}
 	var result params.ErrorResult

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -215,6 +215,16 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 	})
 }
 
+func (s *ClientSuite) TestProcessRelations(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+
+	client := migrationmaster.NewClient(apiCaller, nil)
+	err := client.ProcessRelations("")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *ClientSuite) TestExport(c *gc.C) {
 	var stub jujutesting.Stub
 

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -216,13 +216,24 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 }
 
 func (s *ClientSuite) TestProcessRelations(c *gc.C) {
+	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, id, arg)
 		return nil
 	})
 
 	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.ProcessRelations("")
+	err := client.ProcessRelations("foo")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ClientSuite) TestProcessRelationsError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, interface{}, interface{}) error {
+		return errors.New("blam")
+	})
+	client := migrationmaster.NewClient(apiCaller, nil)
+	err := client.ProcessRelations("foo")
+	c.Assert(err, gc.ErrorMatches, "blam")
 }
 
 func (s *ClientSuite) TestExport(c *gc.C) {

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -170,7 +170,7 @@ func (s *stateSuite) TestLoginToMigratedModel(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	phases := []migration.Phase{migration.IMPORT, migration.VALIDATION, migration.SUCCESS, migration.LOGTRANSFER, migration.REAP, migration.DONE}
+	phases := []migration.Phase{migration.IMPORT, migration.PROCESSRELATIONS, migration.VALIDATION, migration.SUCCESS, migration.LOGTRANSFER, migration.REAP, migration.DONE}
 	for _, phase := range phases {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
 	}

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -170,7 +170,15 @@ func (s *stateSuite) TestLoginToMigratedModel(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	phases := []migration.Phase{migration.IMPORT, migration.PROCESSRELATIONS, migration.VALIDATION, migration.SUCCESS, migration.LOGTRANSFER, migration.REAP, migration.DONE}
+	phases := []migration.Phase{
+		migration.IMPORT,
+		migration.PROCESSRELATIONS,
+		migration.VALIDATION,
+		migration.SUCCESS,
+		migration.LOGTRANSFER,
+		migration.REAP,
+		migration.DONE,
+	}
 	for _, phase := range phases {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -770,7 +770,15 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	phases := []migration.Phase{migration.IMPORT, migration.VALIDATION, migration.SUCCESS, migration.LOGTRANSFER, migration.REAP, migration.DONE}
+	phases := []migration.Phase{
+		migration.IMPORT,
+		migration.PROCESSRELATIONS,
+		migration.VALIDATION,
+		migration.SUCCESS,
+		migration.LOGTRANSFER,
+		migration.REAP,
+		migration.DONE,
+	}
 	for _, phase := range phases {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
 	}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -243,7 +243,8 @@ func AllFacades() *facade.Registry {
 	reg("MetricsManager", 1, metricsmanager.NewFacade)
 
 	reg("MigrationFlag", 1, migrationflag.NewFacade)
-	reg("MigrationMaster", 1, migrationmaster.NewFacade)
+	reg("MigrationMaster", 1, migrationmaster.NewMigrationMasterFacade)
+	reg("MigrationMaster", 2, migrationmaster.NewMigrationMasterFacadeV2)
 	reg("MigrationMinion", 1, migrationminion.NewFacade)
 	reg("MigrationTarget", 1, migrationtarget.NewFacade)
 

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1639,7 +1639,15 @@ func (s *modelManagerStateSuite) TestModelInfoForMigratedModel(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	phases := []migration.Phase{migration.IMPORT, migration.VALIDATION, migration.SUCCESS, migration.LOGTRANSFER, migration.REAP, migration.DONE}
+	phases := []migration.Phase{
+		migration.IMPORT,
+		migration.PROCESSRELATIONS,
+		migration.VALIDATION,
+		migration.SUCCESS,
+		migration.LOGTRANSFER,
+		migration.REAP,
+		migration.DONE,
+	}
 	for _, phase := range phases {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
 	}

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -249,7 +249,7 @@ func (api *APIV1) ProcessRelations(_, _ struct{}) {}
 
 // ProcessRelations processes any relations that need updating after an export.
 // This should help fix any remoteApplications that have been migrated.
-func (api *API) ProcessRelations(args params.ProcessReleations) error {
+func (api *API) ProcessRelations(args params.ProcessRelations) error {
 	return nil
 }
 

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -191,7 +191,7 @@ func (s *Suite) TestPrechecks(c *gc.C) {
 
 func (s *Suite) TestProcessRelations(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	err := api.ProcessRelations(params.ProcessReleations{
+	err := api.ProcessRelations(params.ProcessRelations{
 		ControllerAlias: "foo",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -189,6 +189,14 @@ func (s *Suite) TestPrechecks(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "retrieving model: boom")
 }
 
+func (s *Suite) TestProcessRelations(c *gc.C) {
+	api := s.mustMakeAPI(c)
+	err := api.ProcessRelations(params.ProcessReleations{
+		ControllerAlias: "foo",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *Suite) TestExportIAAS(c *gc.C) {
 	s.assertExport(c, "iaas")
 }

--- a/apiserver/facades/controller/migrationmaster/shim.go
+++ b/apiserver/facades/controller/migrationmaster/shim.go
@@ -8,28 +8,8 @@ import (
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v3"
 
-	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
-
-// NewFacade exists to provide the required signature for API
-// registration, converting st to backend.
-func NewFacade(ctx facade.Context) (*API, error) {
-	controllerState := ctx.StatePool().SystemState()
-	precheckBackend, err := migration.PrecheckShim(ctx.State(), controllerState)
-	if err != nil {
-		return nil, errors.Annotate(err, "creating precheck backend")
-	}
-	return NewAPI(
-		&backendShim{ctx.State()},
-		precheckBackend,
-		migration.PoolShim(ctx.StatePool()),
-		ctx.Resources(),
-		ctx.Auth(),
-		ctx.Presence(),
-	)
-}
 
 // backendShim wraps a *state.State to implement Backend. It is
 // untested, but is simple enough to be verified by inspection.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21899,7 +21899,7 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/ProcessReleations"
+                            "$ref": "#/definitions/ProcessRelations"
                         }
                     }
                 },
@@ -22151,7 +22151,7 @@
                         "Build"
                     ]
                 },
-                "ProcessReleations": {
+                "ProcessRelations": {
                     "type": "object",
                     "properties": {
                         "controller-alias": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21856,7 +21856,7 @@
     },
     {
         "Name": "MigrationMaster",
-        "Version": 1,
+        "Version": 2,
         "Schema": {
             "type": "object",
             "properties": {
@@ -21894,6 +21894,14 @@
                 },
                 "Prechecks": {
                     "type": "object"
+                },
+                "ProcessRelations": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ProcessReleations"
+                        }
+                    }
                 },
                 "Reap": {
                     "type": "object"
@@ -22141,6 +22149,18 @@
                         "Tag",
                         "Patch",
                         "Build"
+                    ]
+                },
+                "ProcessReleations": {
+                    "type": "object",
+                    "properties": {
+                        "controller-alias": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "controller-alias"
                     ]
                 },
                 "SerializedModel": {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -166,6 +166,12 @@ type RelationSuspendedArg struct {
 	Suspended  bool   `json:"suspended"`
 }
 
+// ProcessReleations holds the information required to process series of
+// relations during a model migration.
+type ProcessReleations struct {
+	ControllerAlias string `json:"controller-alias"`
+}
+
 // AddCharm holds the arguments for making an AddCharm API call.
 type AddCharm struct {
 	URL     string `json:"url"`

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -166,9 +166,9 @@ type RelationSuspendedArg struct {
 	Suspended  bool   `json:"suspended"`
 }
 
-// ProcessReleations holds the information required to process series of
+// ProcessRelations holds the information required to process series of
 // relations during a model migration.
-type ProcessReleations struct {
+type ProcessRelations struct {
 	ControllerAlias string `json:"controller-alias"`
 }
 

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -12,6 +12,7 @@ const (
 	NONE
 	QUIESCE
 	IMPORT
+	PROCESSRELATIONS
 	VALIDATION
 	SUCCESS
 	LOGTRANSFER
@@ -27,6 +28,7 @@ var phaseNames = []string{
 	"NONE",    // For watchers to indicate there's never been a migration attempt.
 	"QUIESCE",
 	"IMPORT",
+	"PROCESSRELATIONS",
 	"VALIDATION",
 	"SUCCESS",
 	"LOGTRANSFER",
@@ -81,7 +83,7 @@ func (p Phase) IsRunning() bool {
 		return false
 	}
 	switch p {
-	case QUIESCE, IMPORT, VALIDATION, SUCCESS:
+	case QUIESCE, IMPORT, PROCESSRELATIONS, VALIDATION, SUCCESS:
 		return true
 	default:
 		return false
@@ -93,13 +95,14 @@ func (p Phase) IsRunning() bool {
 // The keys are the "from" states and the values enumerate the
 // possible "to" states.
 var validTransitions = map[Phase][]Phase{
-	QUIESCE:     {IMPORT, ABORT},
-	IMPORT:      {VALIDATION, ABORT},
-	VALIDATION:  {SUCCESS, ABORT},
-	SUCCESS:     {LOGTRANSFER},
-	LOGTRANSFER: {REAP},
-	REAP:        {DONE, REAPFAILED},
-	ABORT:       {ABORTDONE},
+	QUIESCE:          {IMPORT, ABORT},
+	IMPORT:           {PROCESSRELATIONS, ABORT},
+	PROCESSRELATIONS: {VALIDATION, ABORT},
+	VALIDATION:       {SUCCESS, ABORT},
+	SUCCESS:          {LOGTRANSFER},
+	LOGTRANSFER:      {REAP},
+	REAP:             {DONE, REAPFAILED},
+	ABORT:            {ABORTDONE},
 }
 
 var terminalPhases []Phase

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -61,6 +61,7 @@ func (s *PhaseSuite) TestIsRunning(c *gc.C) {
 
 	c.Check(migration.QUIESCE.IsRunning(), jc.IsTrue)
 	c.Check(migration.IMPORT.IsRunning(), jc.IsTrue)
+	c.Check(migration.PROCESSRELATIONS.IsRunning(), jc.IsTrue)
 	c.Check(migration.SUCCESS.IsRunning(), jc.IsTrue)
 
 	c.Check(migration.LOGTRANSFER.IsRunning(), jc.IsFalse)
@@ -75,6 +76,7 @@ func (s *PhaseSuite) TestCanTransitionTo(c *gc.C) {
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.SUCCESS), jc.IsFalse)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.ABORT), jc.IsTrue)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.IMPORT), jc.IsTrue)
+	c.Check(migration.QUIESCE.CanTransitionTo(migration.PROCESSRELATIONS), jc.IsFalse)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.Phase(-1)), jc.IsFalse)
 	c.Check(migration.ABORT.CanTransitionTo(migration.QUIESCE), jc.IsFalse)
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1370,7 +1370,7 @@ func (i ImportRemoteApplications) addRemoteApplicationOps(src RemoteApplications
 	return ops, nil
 }
 
-func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) (*remoteApplicationDoc, error) {
+func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) *remoteApplicationDoc {
 	doc := &remoteApplicationDoc{
 		Name:            app.Name(),
 		OfferUUID:       app.OfferUUID(),
@@ -1414,7 +1414,7 @@ func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) (
 		spaces[i].Subnets = subnets
 	}
 	doc.Spaces = spaces
-	return nil, doc
+	return doc
 }
 
 func (i *importer) relations() error {

--- a/state/migration_import_unit_test.go
+++ b/state/migration_import_unit_test.go
@@ -72,6 +72,8 @@ func (s *MigrationImportSuite) TestImportRemoteApplications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+// A Remote Application with a missing status field is a valid remote
+// application and should be correctly imported.
 func (s *MigrationImportSuite) TestImportRemoteApplicationsWithMissingStatusField(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -90,7 +92,7 @@ func (s *MigrationImportSuite) TestImportRemoteApplicationsWithMissingStatusFiel
 
 	m := ImportRemoteApplications{}
 	err := m.Execute(model, runner)
-	c.Assert(err, gc.ErrorMatches, "missing status not valid")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *MigrationImportSuite) remoteApplication(ctrl *gomock.Controller, status description.Status) description.RemoteApplication {

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -292,6 +292,7 @@ func (s *MigrationSuite) TestLatestMigrationWithPrevious(c *gc.C) {
 	// having been migrated back to the controller.
 	phases := []migration.Phase{
 		migration.IMPORT,
+		migration.PROCESSRELATIONS,
 		migration.VALIDATION,
 		migration.SUCCESS,
 		migration.LOGTRANSFER,
@@ -331,7 +332,15 @@ func (s *MigrationSuite) TestLatestRemovedModelMigration(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Cycle through the phases and complete the migration
-	phases := []migration.Phase{migration.IMPORT, migration.VALIDATION, migration.SUCCESS, migration.LOGTRANSFER, migration.REAP, migration.DONE}
+	phases := []migration.Phase{
+		migration.IMPORT,
+		migration.PROCESSRELATIONS,
+		migration.VALIDATION,
+		migration.SUCCESS,
+		migration.LOGTRANSFER,
+		migration.REAP,
+		migration.DONE,
+	}
 	for _, phase := range phases {
 		c.Assert(mig1.SetPhase(phase), jc.ErrorIsNil)
 	}
@@ -393,6 +402,7 @@ func (s *MigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
 
 	phases := []migration.Phase{
 		migration.IMPORT,
+		migration.PROCESSRELATIONS,
 		migration.VALIDATION,
 		migration.SUCCESS,
 		migration.LOGTRANSFER,
@@ -462,6 +472,7 @@ func (s *MigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {
 	// Advance the migration to REAPFAILED.
 	phases := []migration.Phase{
 		migration.IMPORT,
+		migration.PROCESSRELATIONS,
 		migration.VALIDATION,
 		migration.SUCCESS,
 		migration.LOGTRANSFER,

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -213,7 +213,7 @@ destroy_controller() {
         echo "====> Destroying model ($(green "${name}"))"
 
         output="${TEST_DIR}/${name}-destroy-model.txt"
-        echo "${name}" | xargs -I % juju destroy-model -y % 2>&1 | add_date >"${output}"
+        echo "${name}" | xargs -I % juju destroy-model --force -y % 2>&1 | add_date >"${output}"
 
         echo "====> Destroyed model ($(green "${name}"))"
         return

--- a/tests/suites/model/bundles/saas_wordpress.yaml
+++ b/tests/suites/model/bundles/saas_wordpress.yaml
@@ -1,7 +1,7 @@
 series: bionic
 saas:
   mysql:
-    url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/model-migration-saas.mysql
+    url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/{{JUJU_MODEL_NAME}}.mysql
 applications:
   wordpress:
     charm: wordpress

--- a/tests/suites/model/model_migration.sh
+++ b/tests/suites/model/model_migration.sh
@@ -46,15 +46,15 @@ run_model_migration_saas_block() {
     juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
     juju deploy mysql
 
-    wait_for "mysql" ".applications | keys[0]"
+    wait_for "mysql" "$(idle_condition "mysql")"
 
     juju offer mysql:db
     juju add-model blog
 
     juju switch blog
 
-    bundle=./tests/suites/model/bundles/saas_wordpress.yaml
-    sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" > "${TEST_DIR}/saas_wordpress.yaml"
+    generate_saas_bundle "${BOOTSTRAPPED_JUJU_CTRL_NAME}" "model-migration-saas"
+
     juju deploy "${TEST_DIR}/saas_wordpress.yaml"
 
     wait_for "wordpress" "$(idle_condition "wordpress")"
@@ -83,46 +83,46 @@ run_model_migration_saas_consumer() {
     echo
 
     # The following ensures that a bootstrap juju exists
-    file="${TEST_DIR}/test-model-migration-saas.txt"
-    ensure "model-migration-saas" "${file}"
+    file="${TEST_DIR}/test-model-migration-consume.txt"
+    ensure "model-migration-consume" "${file}"
 
     # Ensure we have another controller available
-    bootstrap_alt_controller "alt-model-migration-saas"
+    bootstrap_alt_controller "alt-model-migration-consume"
 
     juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
     juju deploy mysql
 
-    wait_for "mysql" ".applications | keys[0]"
+    wait_for "mysql" "$(idle_condition "mysql")"
 
     juju offer mysql:db
     juju add-model blog
 
     juju switch blog
 
-    bundle=./tests/suites/model/bundles/saas_wordpress.yaml
-    sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" > "${TEST_DIR}/saas_wordpress.yaml"
+    generate_saas_bundle "${BOOTSTRAPPED_JUJU_CTRL_NAME}" "model-migration-consume"
+
     juju deploy "${TEST_DIR}/saas_wordpress.yaml"
 
     wait_for "wordpress" "$(idle_condition "wordpress")"
 
-    juju migrate "blog" "alt-model-migration-saas"
-    juju switch "alt-model-migration-saas"
+    juju migrate "blog" "alt-model-migration-consume"
+    juju switch "alt-model-migration-consume"
 
     # Wait for the new model migration to appear in the alt controller.
     wait_for_model "blog"
 
     # Once the model has appeared, switch to it.
-    juju switch "alt-model-migration-saas:blog"
+    juju switch "alt-model-migration-consume:blog"
 
     wait_for "wordpress" "$(idle_condition "wordpress")"
 
     juju expose wordpress
 
     # Clean up!
-    destroy_controller "alt-model-migration-saas"
+    destroy_controller "alt-model-migration-consume"
 
     juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-    destroy_model "model-migration-saas"
+    destroy_model "model-migration-consume"
     destroy_model "blog"
 }
 
@@ -156,4 +156,17 @@ bootstrap_alt_controller() {
 
     END_TIME=$(date +%s)
     echo "====> Bootstrapped destination juju ($((END_TIME-START_TIME))s)"
+}
+
+generate_saas_bundle() {
+    local ctrl_name model_name
+
+    ctrl_name=${1}
+    model_name=${2}
+
+    bundle=./tests/suites/model/bundles/saas_wordpress.yaml
+    cp "${bundle}" "${TEST_DIR}/saas_wordpress.yaml"
+
+    sed -i "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${ctrl_name}/g" "${TEST_DIR}/saas_wordpress.yaml"
+    sed -i "s/{{JUJU_MODEL_NAME}}/${model_name}/g" "${TEST_DIR}/saas_wordpress.yaml"
 }

--- a/worker/migrationmaster/shim.go
+++ b/worker/migrationmaster/shim.go
@@ -12,11 +12,13 @@ import (
 	"github.com/juju/juju/api/watcher"
 )
 
+// NewFacade attempts to create a new facade from the migration master
 func NewFacade(apiCaller base.APICaller) (Facade, error) {
 	facade := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
 	return facade, nil
 }
 
+// NewWorker creates a new Worker from the config supplied.
 func NewWorker(config Config) (worker.Worker, error) {
 	worker, err := New(config)
 	if err != nil {

--- a/worker/migrationmaster/shim.go
+++ b/worker/migrationmaster/shim.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/api/watcher"
 )
 
-// NewFacade attempts to create a new facade from the migration master
+// NewFacade attempts to create a new facade for the migration master
 func NewFacade(apiCaller base.APICaller) (Facade, error) {
 	facade := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
 	return facade, nil

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -255,6 +255,10 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 				s.facade,
 			}},
 			apiCloseCall, // for target controller
+			{"facade.SetPhase", []interface{}{coremigration.PROCESSRELATIONS}},
+
+			// PROCESSRELATIONS
+			{"facade.ProcessRelations", []interface{}{""}},
 			{"facade.SetPhase", []interface{}{coremigration.VALIDATION}},
 
 			// VALIDATION
@@ -1074,9 +1078,10 @@ type stubMasterFacade struct {
 	status         []coremigration.MigrationStatus
 	statusErr      error
 
-	prechecksErr error
-	modelInfoErr error
-	exportErr    error
+	prechecksErr        error
+	modelInfoErr        error
+	exportErr           error
+	processRelationsErr error
 
 	logMessages func(chan<- common.LogMessage)
 	streamErr   error
@@ -1193,6 +1198,14 @@ func (f *stubMasterFacade) Export() (coremigration.SerializedModel, error) {
 	}, nil
 }
 
+func (f *stubMasterFacade) ProcessRelations(controllerAlias string) error {
+	f.stub.AddCall("facade.ProcessRelations", controllerAlias)
+	if f.processRelationsErr != nil {
+		return f.processRelationsErr
+	}
+	return nil
+}
+
 func (f *stubMasterFacade) SetPhase(phase coremigration.Phase) error {
 	f.stub.AddCall("facade.SetPhase", phase)
 	return nil
@@ -1243,10 +1256,11 @@ func (w *mockWatcher) Changes() watcher.NotifyChannel {
 
 type stubConnection struct {
 	api.Connection
-	stub          *jujutesting.Stub
-	prechecksErr  error
-	importErr     error
-	controllerTag names.ControllerTag
+	stub                *jujutesting.Stub
+	prechecksErr        error
+	importErr           error
+	processRelationsErr error
+	controllerTag       names.ControllerTag
 
 	streamErr error
 	logStream *mockStream
@@ -1271,6 +1285,8 @@ func (c *stubConnection) APICall(objType string, version int, id, request string
 			return c.prechecksErr
 		case "Import":
 			return c.importErr
+		case "ProcessRelations":
+			return c.processRelationsErr
 		case "Activate", "AdoptResources":
 			return nil
 		case "LatestLogTime":

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -481,6 +481,20 @@ func (s *Suite) TestQUIESCETargetChecksFail(c *gc.C) {
 	))
 }
 
+func (s *Suite) TestProcessRelationsFailure(c *gc.C) {
+	s.facade.queueStatus(s.makeStatus(coremigration.PROCESSRELATIONS))
+	s.facade.processRelationsErr = errors.New("boom")
+
+	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"facade.ProcessRelations", []interface{}{""}},
+		},
+		abortCalls,
+	))
+}
+
 func (s *Suite) TestExportFailure(c *gc.C) {
 	s.facade.queueStatus(s.makeStatus(coremigration.IMPORT))
 	s.facade.exportErr = errors.New("boom")


### PR DESCRIPTION
## Description of change

The following changes add a integration test for moving a SAAS application
from one controller to another. The previous code would fail because a missing
status would block the migration.

Additional mechanical changes to this also include a new migration phase. This
phase comes after `IMPORT` and before `VALIDATION` phase; the 
`PROCESSRELATIONS` will ensure that we have a unique phase to handle all
the url redirections/firewall rule changes/etc in the future.

The migrationmaster Facade was also bumped to ensure that new clients can
pick up the new method.

Additional work to come to update the offer url next, with the use of the controller
alias. This PR has been broken down into small bitesized chunks to make it easier
to work on CMR migrations.

## QA steps

```sh
make install
cd tests && ./main.sh model
```
