### PR TITLE
'update--public-cloud' can update client and controller copies.

### DIFF
--- a/acceptancetests/public-cloud-check.bash
+++ b/acceptancetests/public-cloud-check.bash
@@ -26,7 +26,7 @@ juju_bin=$1
 test_tmpdir=$(mktemp -d)
 export JUJU_DATA="${test_tmpdir}"
 
-${juju_bin} --show-log update-clouds
+${juju_bin} --show-log update-public-clouds
 
 # The public-clouds.yaml published must match what is built into the Juju binary
 # under test.

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -5,7 +5,7 @@ package cloud
 
 // Generated code - do not edit.
 
-const fallbackPublicCloudInfo = `# DO NOT EDIT, will be overwritten, use "juju update-clouds" to refresh.
+const fallbackPublicCloudInfo = `# DO NOT EDIT, will be overwritten, use "juju update-public-clouds" to refresh.
 clouds:
   aws:
     type: ec2

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -69,8 +69,10 @@ func NewRemoveCloudCommandForTest(store jujuclient.ClientStore, cloudAPI func() 
 	}
 }
 
-func NewUpdatePublicCloudsCommandForTest(publicCloudURL string) *updatePublicCloudsCommand {
+func NewUpdatePublicCloudsCommandForTest(store jujuclient.ClientStore, api updatePublicCloudAPI, publicCloudURL string) *updatePublicCloudsCommand {
 	return &updatePublicCloudsCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
+		addCloudAPIFunc:           func() (updatePublicCloudAPI, error) { return api, nil },
 		// TODO(wallyworld) - move testing key elsewhere
 		publicSigningKey: sstesting.SignedMetadataPublicKey,
 		publicCloudURL:   publicCloudURL,

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -54,8 +54,7 @@ var listCloudsDoc = "" +
 	"machine-readable output.\n" +
 	"\n" +
 	"Cloud metadata sometimes changes, e.g. providers add regions. Use the `update-public-clouds`\n" +
-	"command to update public clouds from a central location or `update-cloud` to" +
-	"update other clouds.\n" +
+	"command to update public clouds or `update-cloud` to update other clouds.\n" +
 	"\n" +
 	"Use the `regions` command to list a cloud's regions.\n" +
 	"\n" +

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -53,8 +53,9 @@ var listCloudsDoc = "" +
 	"This command's default output format is 'tabular'. Use 'json' and 'yaml' for\n" +
 	"machine-readable output.\n" +
 	"\n" +
-	"Cloud metadata sometimes changes, e.g. providers add regions. Use the `update-clouds`\n" +
-	"command to update the current Juju client.\n" +
+	"Cloud metadata sometimes changes, e.g. providers add regions. Use the `update-public-clouds`\n" +
+	"command to update public clouds from a central location or `update-cloud` to" +
+	"update your customised clouds.\n" +
 	"\n" +
 	"Use the `regions` command to list a cloud's regions.\n" +
 	"\n" +
@@ -84,7 +85,8 @@ See also:
     default-credential
     default-region
     show-cloud
-    update-clouds
+    update-cloud
+    update-public-clouds
 `
 
 type ListCloudsAPI interface {
@@ -282,8 +284,16 @@ func (c *cloudList) filter(all bool) bool {
 	return result
 }
 
-func listLocalCloudDetails(store jujuclient.CredentialGetter) (*cloudList, error) {
+func clientPublicClouds() (map[string]jujucloud.Cloud, error) {
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return clouds, nil
+}
+
+func listLocalCloudDetails(store jujuclient.CredentialGetter) (*cloudList, error) {
+	clouds, err := clientPublicClouds()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -55,7 +55,7 @@ var listCloudsDoc = "" +
 	"\n" +
 	"Cloud metadata sometimes changes, e.g. providers add regions. Use the `update-public-clouds`\n" +
 	"command to update public clouds from a central location or `update-cloud` to" +
-	"update your customised clouds.\n" +
+	"update other clouds.\n" +
 	"\n" +
 	"Use the `regions` command to list a cloud's regions.\n" +
 	"\n" +

--- a/cmd/juju/cloud/regions.go
+++ b/cmd/juju/cloud/regions.go
@@ -51,7 +51,8 @@ See also:
     add-cloud
     clouds
     show-cloud
-    update-clouds
+    update-cloud
+    update-public-clouds
 `
 
 type CloudRegionsAPI interface {

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -151,7 +151,7 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 		ctxt.Infof(successMsg)
 	}
 	if c.isPublicCloud(c.Cloud) {
-		ctxt.Infof("To update public clouds from a canonical source, use `juju update-public-clouds`.")
+		ctxt.Infof("To ensure this client's copy or any controller copies of public cloud information is up to date with the latest region information, use `juju update-public-clouds`.")
 	}
 	if c.Client {
 		if c.CloudFile == "" {

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -150,6 +150,9 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 		}
 		ctxt.Infof(successMsg)
 	}
+	if c.isPublicCloud(c.Cloud) {
+		ctxt.Infof("To update public clouds from a canonical source, use `juju update-public-clouds`.")
+	}
 	if c.Client {
 		if c.CloudFile == "" {
 			ctxt.Infof("To update cloud %q on this client, a cloud definition file is required.", c.Cloud)
@@ -169,6 +172,16 @@ func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 		}
 	}
 	return returnErr
+}
+
+func (c *updateCloudCommand) isPublicCloud(cloudName string) bool {
+	all, _ := clientPublicClouds()
+	for oneName := range all {
+		if oneName == cloudName {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *updateCloudCommand) updateLocalCache(ctxt *cmd.Context, newCloud *jujucloud.Cloud) error {

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -150,7 +150,10 @@ func (s *updateCloudSuite) TestUpdateControllerFromLocalCache(c *gc.C) {
 		Endpoint:    "http://garagemaas",
 	})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"garage-maas\" updated on controller \"mycontroller\" using client cloud definition.\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+To update public clouds from a canonical source, use `[1:]+"`juju update-public-clouds`"+`.
+Cloud "garage-maas" updated on controller "mycontroller" using client cloud definition.
+`)
 }
 
 type fakeUpdateCloudAPI struct {

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -151,7 +151,7 @@ func (s *updateCloudSuite) TestUpdateControllerFromLocalCache(c *gc.C) {
 	})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-To update public clouds from a canonical source, use `[1:]+"`juju update-public-clouds`"+`.
+To ensure this client's copy or any controller copies of public cloud information is up to date with the latest region information, use `[1:]+"`juju update-public-clouds`"+`.
 Cloud "garage-maas" updated on controller "mycontroller" using client cloud definition.
 `)
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1031,7 +1031,7 @@ func (c *bootstrapCommand) detectCloud(
 	ctx.Verbosef("cloud %q not found, trying as a provider name", c.Cloud)
 	provider, err := environs.Provider(c.Cloud)
 	if errors.IsNotFound(err) {
-		return fail(errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-clouds")))
+		return fail(errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-public-clouds")))
 	} else if err != nil {
 		return fail(errors.Trace(err))
 	}
@@ -1041,7 +1041,7 @@ func (c *bootstrapCommand) detectCloud(
 			"provider %q does not support detecting regions",
 			c.Cloud,
 		)
-		return fail(errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-clouds")))
+		return fail(errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-public-clouds")))
 	}
 
 	var cloudEndpoint string
@@ -1433,7 +1433,7 @@ func handleChooseCloudRegionError(ctx *cmd.Context, err error) error {
 	}
 	_, _ = fmt.Fprintf(ctx.GetStderr(),
 		"%s\n\nSpecify an alternative region, or try %q.\n",
-		err, "juju update-clouds",
+		err, "juju update-public-clouds",
 	)
 	return cmd.ErrSilent
 }

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -606,7 +606,6 @@ var commandNames = []string{
 	"unexpose",
 	"unregister",
 	"update-cloud",
-	"update-clouds",
 	"update-public-clouds",
 	"update-credential",
 	"update-credentials",
@@ -779,9 +778,9 @@ func (s *MainSuite) TestModelCommands(c *gc.C) {
 	registerCommands(&commands, cmdtesting.Context(c))
 	// There should not be any ModelCommands registered.
 	// ModelCommands must be wrapped using modelcmd.Wrap.
-	for _, cmd := range commands {
-		c.Logf("%v", cmd.Info().Name)
-		c.Check(cmd, gc.Not(gc.FitsTypeOf), modelcmd.ModelCommand(&bootstrapCommand{}))
+	for _, command := range commands {
+		c.Logf("%v", command.Info().Name)
+		c.Check(command, gc.Not(gc.FitsTypeOf), modelcmd.ModelCommand(&bootstrapCommand{}))
 	}
 }
 
@@ -800,8 +799,8 @@ func (s *MainSuite) TestAllCommandsPurpose(c *gc.C) {
 	//   godoc-like by using the command's name in lowercase.
 	var commands commands
 	registerCommands(&commands, cmdtesting.Context(c))
-	for _, cmd := range commands {
-		info := cmd.Info()
+	for _, command := range commands {
+		info := command.Info()
 		purpose := strings.TrimSpace(info.Purpose)
 		doc := strings.TrimSpace(info.Doc)
 		comment := func(message string) interface{} {


### PR DESCRIPTION
## Description of change

Originally, 'update-public-clouds' operated on client only.
This PR allows to update public cloud on the controller reducing the 2-step process described in the bug  down to 1-step.

Remove command alias 'update-clouds' as it is too close to a completely different 'update-cloud' command and is causing confusion.

As a drive-by, renamed some test variables that were conflicting with import names. 

## QA steps

1. bootstrap controller on a public cloud
2. 'juju update-public-clouds -c mycontroller'  says controller clouds are up to date
3. Ensure that there is a difference between your controller public cloud (I had to do db surgery, removing one region, for example)
4.  'juju update-public-clouds -c mycontroller' updates controller cloud definition (by adding that region)

## Documentation changes

as above

## Bug reference

https://bugs.launchpad.net/juju/+bug/1844440 
