### PR TITLE
Remove the params.Life type and use life.Value from core/life package.

### DIFF
--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -17,6 +17,7 @@ import (
 	apiagent "github.com/juju/juju/api/agent"
 	apiserveragent "github.com/juju/juju/apiserver/facades/agent/agent"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
@@ -135,7 +136,7 @@ func (s *machineSuite) TestMachineEntity(c *gc.C) {
 	m, err = apiSt.Entity(s.machine.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, s.machine.Tag().String())
-	c.Assert(m.Life(), gc.Equals, params.Alive)
+	c.Assert(m.Life(), gc.Equals, life.Alive)
 	c.Assert(m.Jobs(), gc.DeepEquals, []model.MachineJob{model.JobHostUnits})
 
 	err = s.machine.EnsureDead()

--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/common/cloudspec"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 )
 
@@ -101,7 +102,7 @@ func (m *Entity) Tag() string {
 }
 
 // Life returns the current life cycle state of the entity.
-func (m *Entity) Life() params.Life {
+func (m *Entity) Life() life.Value {
 	return m.doc.Life
 }
 

--- a/api/agent/unit_test.go
+++ b/api/agent/unit_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api"
 	apiagent "github.com/juju/juju/api/agent"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 )
@@ -54,7 +55,7 @@ func (s *unitSuite) TestUnitEntity(c *gc.C) {
 	m, err = apiSt.Entity(s.unit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Tag(), gc.Equals, s.unit.Tag().String())
-	c.Assert(m.Life(), gc.Equals, params.Alive)
+	c.Assert(m.Life(), gc.Equals, life.Alive)
 	c.Assert(m.Jobs(), gc.HasLen, 0)
 
 	err = s.unit.EnsureDead()

--- a/api/base/types.go
+++ b/api/base/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/version"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 )
@@ -27,7 +28,7 @@ type UserModel struct {
 // ModelStatus holds information about the status of a juju model.
 type ModelStatus struct {
 	UUID               string
-	Life               string
+	Life               life.Value
 	ModelType          model.ModelType
 	Owner              string
 	TotalMachineCount  int
@@ -66,7 +67,7 @@ type ModelInfo struct {
 	CloudRegion     string
 	CloudCredential string
 	Owner           string
-	Life            string
+	Life            life.Value
 	Status          Status
 	Users           []UserInfo
 	Machines        []Machine
@@ -120,7 +121,7 @@ type UserModelSummary struct {
 	CloudRegion        string
 	CloudCredential    string
 	Owner              string
-	Life               string
+	Life               life.Value
 	Status             Status
 	ModelUserAccess    string
 	UserLastConnection *time.Time

--- a/api/caasfirewaller/client_test.go
+++ b/api/caasfirewaller/client_test.go
@@ -89,7 +89,7 @@ func (s *FirewallerSuite) TestLife(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
 		*(result.(*params.LifeResults)) = params.LifeResults{
 			Results: []params.LifeResult{{
-				Life: params.Alive,
+				Life: life.Alive,
 			}},
 		}
 		return nil

--- a/api/caasoperator/client_test.go
+++ b/api/caasoperator/client_test.go
@@ -257,7 +257,7 @@ func (s *operatorSuite) testLife(c *gc.C, tag names.Tag) {
 		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
 		*(result.(*params.LifeResults)) = params.LifeResults{
 			Results: []params.LifeResult{{
-				Life: params.Alive,
+				Life: life.Alive,
 			}},
 		}
 		return nil

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -104,7 +104,7 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
 		*(result.(*params.LifeResults)) = params.LifeResults{
 			Results: []params.LifeResult{{
-				Life: params.Alive,
+				Life: life.Alive,
 			}},
 		}
 		return nil

--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -157,7 +157,7 @@ func (s *unitprovisionerSuite) testLife(c *gc.C, tag names.Tag) {
 		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
 		*(result.(*params.LifeResults)) = params.LifeResults{
 			Results: []params.LifeResult{{
-				Life: params.Alive,
+				Life: life.Alive,
 			}},
 		}
 		return nil

--- a/api/common/life.go
+++ b/api/common/life.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 // Life requests the life cycle of the given entities from the given
@@ -31,7 +32,7 @@ func Life(caller base.FacadeCaller, tags []names.Tag) ([]params.LifeResult, erro
 
 // OneLife requests the life cycle of the given entity from the given
 // server-side API facade via the given caller.
-func OneLife(caller base.FacadeCaller, tag names.Tag) (params.Life, error) {
+func OneLife(caller base.FacadeCaller, tag names.Tag) (life.Value, error) {
 	result, err := Life(caller, []names.Tag{tag})
 	if err != nil {
 		return "", err

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -89,7 +89,7 @@ func constructModelStatus(m names.ModelTag, owner names.UserTag, r params.ModelS
 
 	result := base.ModelStatus{
 		UUID:               m.Id(),
-		Life:               string(r.Life),
+		Life:               r.Life,
 		Owner:              owner.Id(),
 		ModelType:          model.ModelType(r.Type),
 		HostedMachineCount: r.HostedMachineCount,

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -336,7 +337,7 @@ func (s *Suite) TestModelStatus(c *gc.C) {
 		HostedMachineCount: 2,
 		ApplicationCount:   3,
 		Owner:              "glenda",
-		Life:               string(params.Alive),
+		Life:               life.Alive,
 		Machines:           []base.Machine{{Id: "0", InstanceId: "inst-ance", Status: "pending"}},
 	})
 	c.Assert(results[1].Error, gc.ErrorMatches, "model error")

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/controller"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -191,7 +192,7 @@ func (s *legacySuite) TestWatchAllModels(c *gc.C) {
 		modelInfo.Status.Since = nil
 		c.Assert(modelInfo.ModelUUID, gc.Equals, model.UUID())
 		c.Assert(modelInfo.Name, gc.Equals, model.Name())
-		c.Assert(modelInfo.Life, gc.Equals, params.Life("alive"))
+		c.Assert(modelInfo.Life, gc.Equals, life.Alive)
 		c.Assert(modelInfo.Owner, gc.Equals, model.Owner().Id())
 		c.Assert(modelInfo.ControllerUUID, gc.Equals, model.ControllerUUID())
 		c.Assert(modelInfo.Config, jc.DeepEquals, cfg.AllAttrs())

--- a/api/deployer/deployer.go
+++ b/api/deployer/deployer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 const deployerFacade = "Deployer"
@@ -27,7 +28,7 @@ func NewState(caller base.APICaller) *State {
 }
 
 // unitLife returns the lifecycle state of the given unit.
-func (st *State) unitLife(tag names.UnitTag) (params.Life, error) {
+func (st *State) unitLife(tag names.UnitTag) (life.Value, error) {
 	return common.OneLife(st.facade, tag)
 }
 

--- a/api/deployer/deployer_test.go
+++ b/api/deployer/deployer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/deployer"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -156,7 +157,7 @@ func (s *deployerSuite) TestUnitLifeRefresh(c *gc.C) {
 	unit, err := s.st.Unit(s.subordinate.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(unit.Life(), gc.Equals, params.Alive)
+	c.Assert(unit.Life(), gc.Equals, life.Alive)
 
 	// Now make it dead and check again, then refresh and check.
 	err = s.subordinate.EnsureDead()
@@ -164,10 +165,10 @@ func (s *deployerSuite) TestUnitLifeRefresh(c *gc.C) {
 	err = s.subordinate.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.subordinate.Life(), gc.Equals, state.Dead)
-	c.Assert(unit.Life(), gc.Equals, params.Alive)
+	c.Assert(unit.Life(), gc.Equals, life.Alive)
 	err = unit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unit.Life(), gc.Equals, params.Dead)
+	c.Assert(unit.Life(), gc.Equals, life.Dead)
 }
 
 func (s *deployerSuite) TestUnitRemove(c *gc.C) {

--- a/api/deployer/unit.go
+++ b/api/deployer/unit.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 )
 
 // Unit represents a juju unit as seen by the deployer worker.
 type Unit struct {
 	tag  names.UnitTag
-	life params.Life
+	life life.Value
 	st   *State
 }
 
@@ -29,7 +30,7 @@ func (u *Unit) Name() string {
 }
 
 // Life returns the unit's lifecycle value.
-func (u *Unit) Life() params.Life {
+func (u *Unit) Life() life.Value {
 	return u.life
 }
 

--- a/api/firewaller/application.go
+++ b/api/firewaller/application.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -18,7 +19,7 @@ import (
 type Application struct {
 	st   *Client
 	tag  names.ApplicationTag
-	life params.Life
+	life life.Value
 }
 
 // Name returns the application name.

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/common/cloudspec"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/watcher"
 	"gopkg.in/macaroon.v2-unstable"
@@ -53,7 +54,7 @@ func (c *Client) ModelTag() (names.ModelTag, bool) {
 }
 
 // life requests the life cycle of the given entity from the server.
-func (c *Client) life(tag names.Tag) (params.Life, error) {
+func (c *Client) life(tag names.Tag) (life.Value, error) {
 	return common.OneLife(c.facade, tag)
 }
 

--- a/api/firewaller/machine.go
+++ b/api/firewaller/machine.go
@@ -11,6 +11,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 )
@@ -19,7 +20,7 @@ import (
 type Machine struct {
 	st   *Client
 	tag  names.MachineTag
-	life params.Life
+	life life.Value
 }
 
 // Tag returns the machine tag.
@@ -71,7 +72,7 @@ func (m *Machine) InstanceId() (instance.Id, error) {
 }
 
 // Life returns the machine's life cycle value.
-func (m *Machine) Life() params.Life {
+func (m *Machine) Life() life.Value {
 	return m.life
 }
 

--- a/api/firewaller/relation.go
+++ b/api/firewaller/relation.go
@@ -6,13 +6,13 @@ package firewaller
 import (
 	"gopkg.in/juju/names.v3"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 // Relation represents a juju relation as seen by the firewaller worker.
 type Relation struct {
 	tag  names.RelationTag
-	life params.Life
+	life life.Value
 }
 
 // Tag returns the relation tag.
@@ -21,6 +21,6 @@ func (r *Relation) Tag() names.RelationTag {
 }
 
 // Life returns the relation's life cycle value.
-func (r *Relation) Life() params.Life {
+func (r *Relation) Life() life.Value {
 	return r.life
 }

--- a/api/firewaller/relation_test.go
+++ b/api/firewaller/relation_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 type relationSuite struct {
@@ -47,5 +48,5 @@ func (s *relationSuite) TestTag(c *gc.C) {
 }
 
 func (s *relationSuite) TestLife(c *gc.C) {
-	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiRelation.Life(), gc.Equals, life.Alive)
 }

--- a/api/firewaller/unit.go
+++ b/api/firewaller/unit.go
@@ -8,13 +8,14 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 // Unit represents a juju unit as seen by a firewaller worker.
 type Unit struct {
 	st   *Client
 	tag  names.UnitTag
-	life params.Life
+	life life.Value
 }
 
 // Name returns the name of the unit.
@@ -28,7 +29,7 @@ func (u *Unit) Tag() names.UnitTag {
 }
 
 // Life returns the unit's life cycle value.
-func (u *Unit) Life() params.Life {
+func (u *Unit) Life() life.Value {
 	return u.life
 }
 

--- a/api/firewaller/unit_test.go
+++ b/api/firewaller/unit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 type unitSuite struct {
@@ -46,15 +47,15 @@ func (s *unitSuite) TestUnit(c *gc.C) {
 }
 
 func (s *unitSuite) TestRefresh(c *gc.C) {
-	c.Assert(s.apiUnit.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiUnit.Life(), gc.Equals, life.Alive)
 
 	err := s.units[0].EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiUnit.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiUnit.Life(), gc.Equals, life.Alive)
 
 	err = s.apiUnit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiUnit.Life(), gc.Equals, params.Dead)
+	c.Assert(s.apiUnit.Life(), gc.Equals, life.Dead)
 }
 
 func (s *unitSuite) TestAssignedMachine(c *gc.C) {

--- a/api/instancemutater/export_test.go
+++ b/api/instancemutater/export_test.go
@@ -7,10 +7,10 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
-func NewMachine(facadeCaller base.FacadeCaller, tag names.MachineTag, life params.Life) *Machine {
+func NewMachine(facadeCaller base.FacadeCaller, tag names.MachineTag, life life.Value) *Machine {
 	return &Machine{
 		facade: facadeCaller,
 		tag:    tag,

--- a/api/instancemutater/machine.go
+++ b/api/instancemutater/machine.go
@@ -14,6 +14,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -39,7 +40,7 @@ type MutaterMachine interface {
 	Tag() names.MachineTag
 
 	// Life returns the machine's lifecycle value.
-	Life() params.Life
+	Life() life.Value
 
 	// Refresh updates the cached local copy of the machine's data.
 	Refresh() error
@@ -70,7 +71,7 @@ type Machine struct {
 	facade base.FacadeCaller
 
 	tag  names.MachineTag
-	life params.Life
+	life life.Value
 }
 
 // ContainerType implements MutaterMachine.ContainerType.
@@ -138,7 +139,7 @@ func (m *Machine) Tag() names.MachineTag {
 }
 
 // Life implements MutaterMachine.Life.
-func (m *Machine) Life() params.Life {
+func (m *Machine) Life() life.Value {
 	return m.life
 }
 

--- a/api/instancemutater/machine_test.go
+++ b/api/instancemutater/machine_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/api/instancemutater/mocks"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	jujutesting "github.com/juju/juju/testing"
@@ -234,7 +235,7 @@ func (s *instanceMutaterMachineSuite) setUpSetProfileUpgradeCompleteArgs() param
 }
 
 func (s *instanceMutaterMachineSuite) setupMachine() *instancemutater.Machine {
-	return instancemutater.NewMachine(s.fCaller, s.tag, params.Alive)
+	return instancemutater.NewMachine(s.fCaller, s.tag, life.Alive)
 }
 
 func (s *instanceMutaterMachineSuite) machineForScenario(c *gc.C, behaviours ...func()) *instancemutater.Machine {

--- a/api/instancemutater/mocks/machinemutater_mock.go
+++ b/api/instancemutater/mocks/machinemutater_mock.go
@@ -5,14 +5,15 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
-	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v3 "gopkg.in/juju/names.v3"
-	reflect "reflect"
 )
 
 // MockMutaterMachine is a mock of MutaterMachine interface
@@ -78,9 +79,9 @@ func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
 }
 
 // Life mocks base method
-func (m *MockMutaterMachine) Life() params.Life {
+func (m *MockMutaterMachine) Life() life.Value {
 	ret := m.ctrl.Call(m, "Life")
-	ret0, _ := ret[0].(params.Life)
+	ret0, _ := ret[0].(life.Value)
 	return ret0
 }
 

--- a/api/instancepoller/export_test.go
+++ b/api/instancepoller/export_test.go
@@ -7,10 +7,10 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
-func NewMachine(caller base.APICaller, tag names.MachineTag, life params.Life) *Machine {
+func NewMachine(caller base.APICaller, tag names.MachineTag, life life.Value) *Machine {
 	facade := base.NewFacadeCaller(caller, instancePollerFacade)
 	return &Machine{facade, tag, life}
 }

--- a/api/instancepoller/instancepoller_test.go
+++ b/api/instancepoller/instancepoller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -54,7 +55,7 @@ func (s *InstancePollerSuite) TestMachineCallsLife(c *gc.C) {
 	m, err := api.Machine(names.NewMachineTag("42"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiCaller.CallCount, gc.Equals, 1)
-	c.Assert(m.Life(), gc.Equals, params.Life("working"))
+	c.Assert(m.Life(), gc.Equals, life.Value("working"))
 	c.Assert(m.Id(), gc.Equals, "42")
 }
 

--- a/api/instancepoller/machine.go
+++ b/api/instancepoller/machine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 )
@@ -21,7 +22,7 @@ type Machine struct {
 	facade base.FacadeCaller
 
 	tag  names.MachineTag
-	life params.Life
+	life life.Value
 }
 
 // Id returns the machine's id.
@@ -40,7 +41,7 @@ func (m *Machine) String() string {
 }
 
 // Life returns the machine's lifecycle value.
-func (m *Machine) Life() params.Life {
+func (m *Machine) Life() life.Value {
 	return m.life
 }
 

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -17,7 +18,7 @@ import (
 // Machine represents a juju machine as seen by a machiner worker.
 type Machine struct {
 	tag  names.MachineTag
-	life params.Life
+	life life.Value
 	st   *State
 }
 
@@ -27,7 +28,7 @@ func (m *Machine) Tag() names.Tag {
 }
 
 // Life returns the machine's lifecycle value.
-func (m *Machine) Life() params.Life {
+func (m *Machine) Life() life.Value {
 	return m.life
 }
 

--- a/api/machiner/machiner.go
+++ b/api/machiner/machiner.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 const machinerFacade = "Machiner"
@@ -30,7 +30,7 @@ func NewState(caller base.APICaller) *State {
 }
 
 // machineLife requests the lifecycle of the given machine from the server.
-func (st *State) machineLife(tag names.MachineTag) (params.Life, error) {
+func (st *State) machineLife(tag names.MachineTag) (life.Value, error) {
 	return common.OneLife(st.facade, tag)
 }
 

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/machiner"
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -121,15 +122,15 @@ func (s *machinerSuite) TestEnsureDead(c *gc.C) {
 func (s *machinerSuite) TestRefresh(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Life(), gc.Equals, params.Alive)
+	c.Assert(machine.Life(), gc.Equals, life.Alive)
 
 	err = machine.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Life(), gc.Equals, params.Alive)
+	c.Assert(machine.Life(), gc.Equals, life.Alive)
 
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Life(), gc.Equals, params.Dead)
+	c.Assert(machine.Life(), gc.Equals, life.Dead)
 }
 
 func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
@@ -184,7 +185,7 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 func (s *machinerSuite) TestWatch(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Life(), gc.Equals, params.Alive)
+	c.Assert(machine.Life(), gc.Equals, life.Alive)
 
 	w, err := machine.Watch()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -112,7 +112,7 @@ func convertParamsModelInfo(modelInfo params.ModelInfo) (base.ModelInfo, error) 
 		CloudRegion:     modelInfo.CloudRegion,
 		CloudCredential: credential,
 		Owner:           ownerTag.Id(),
-		Life:            string(modelInfo.Life),
+		Life:            modelInfo.Life,
 		AgentVersion:    modelInfo.AgentVersion,
 	}
 	modelType := modelInfo.Type
@@ -230,7 +230,7 @@ func (c *Client) ListModelSummaries(user string, all bool) ([]base.UserModelSumm
 			ProviderType:       summary.ProviderType,
 			DefaultSeries:      summary.DefaultSeries,
 			CloudRegion:        summary.CloudRegion,
-			Life:               string(summary.Life),
+			Life:               summary.Life,
 			ModelUserAccess:    string(summary.UserAccess),
 			UserLastConnection: summary.UserLastConnection,
 			Counts:             make([]base.EntityCount, len(summary.Counts)),

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
@@ -453,7 +454,7 @@ func (s *modelmanagerSuite) TestModelStatus(c *gc.C) {
 		HostedMachineCount: 2,
 		ApplicationCount:   3,
 		Owner:              "glenda",
-		Life:               string(params.Alive),
+		Life:               life.Alive,
 		Machines:           []base.Machine{{Id: "0", InstanceId: "inst-ance", Status: "pending"}},
 	})
 	c.Assert(results[1].Error, gc.ErrorMatches, "model error")
@@ -498,7 +499,7 @@ func createModelSummary() *params.ModelSummary {
 		CloudRegion:        "us-east-1",
 		CloudCredentialTag: "cloudcred-foo_bob_one",
 		OwnerTag:           "user-admin",
-		Life:               params.Alive,
+		Life:               life.Alive,
 		Status:             params.EntityStatus{Status: status.Status("active")},
 		UserAccess:         params.ModelAdminAccess,
 		Counts:             []params.ModelEntityCount{},

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -13,6 +13,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -38,7 +39,7 @@ type MachineProvisioner interface {
 	String() string
 
 	// Life returns the machine's lifecycle value.
-	Life() params.Life
+	Life() life.Value
 
 	// Refresh updates the cached local copy of the machine's data.
 	Refresh() error
@@ -127,7 +128,7 @@ type MachineProvisioner interface {
 // Machine represents a juju machine as seen by the provisioner worker.
 type Machine struct {
 	tag  names.MachineTag
-	life params.Life
+	life life.Value
 	st   *State
 }
 
@@ -166,7 +167,7 @@ func (m *Machine) String() string {
 }
 
 // Life implements MachineProvisioner..
-func (m *Machine) Life() params.Life {
+func (m *Machine) Life() life.Value {
 	return m.life
 }
 

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -5,14 +5,16 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	version "github.com/juju/version"
 	names_v3 "gopkg.in/juju/names.v3"
-	reflect "reflect"
 )
 
 // MockMachineProvisioner is a mock of MachineProvisioner interface
@@ -129,9 +131,9 @@ func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *gomock.Call {
 }
 
 // Life mocks base method
-func (m *MockMachineProvisioner) Life() params.Life {
+func (m *MockMachineProvisioner) Life() life.Value {
 	ret := m.ctrl.Call(m, "Life")
-	ret0, _ := ret[0].(params.Life)
+	ret0, _ := ret[0].(life.Value)
 	return ret0
 }
 

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/network"
@@ -76,7 +77,7 @@ func NewStateFromFacade(facadeCaller base.FacadeCaller) *State {
 }
 
 // machineLife requests the lifecycle of the given machine from the server.
-func (st *State) machineLife(tag names.MachineTag) (params.Life, error) {
+func (st *State) machineLife(tag names.MachineTag) (life.Value, error) {
 	return common.OneLife(st.facade, tag)
 }
 

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -247,15 +248,15 @@ func (s *provisionerSuite) TestRefreshAndLife(c *gc.C) {
 	c.Assert(otherMachine.Life(), gc.Equals, state.Alive)
 
 	apiMachine := s.assertGetOneMachine(c, otherMachine.MachineTag())
-	c.Assert(apiMachine.Life(), gc.Equals, params.Alive)
+	c.Assert(apiMachine.Life(), gc.Equals, life.Alive)
 
 	err = apiMachine.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apiMachine.Life(), gc.Equals, params.Alive)
+	c.Assert(apiMachine.Life(), gc.Equals, life.Alive)
 
 	err = apiMachine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apiMachine.Life(), gc.Equals, params.Dead)
+	c.Assert(apiMachine.Life(), gc.Equals, life.Dead)
 }
 
 func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {

--- a/api/storageprovisioner/provisioner_test.go
+++ b/api/storageprovisioner/provisioner_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/storageprovisioner"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -1021,7 +1022,7 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "volume-100"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
 		*(result.(*params.LifeResults)) = params.LifeResults{
-			Results: []params.LifeResult{{Life: params.Alive}},
+			Results: []params.LifeResult{{Life: life.Alive}},
 		}
 		callCount++
 		return nil
@@ -1033,7 +1034,7 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 	lifeResults, err := st.Life(volumes)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
-	c.Assert(lifeResults, jc.DeepEquals, []params.LifeResult{{Life: params.Alive}})
+	c.Assert(lifeResults, jc.DeepEquals, []params.LifeResult{{Life: life.Alive}})
 }
 
 func (s *provisionerSuite) testClientError(c *gc.C, apiCall func(*storageprovisioner.State) error) {

--- a/api/uniter/application.go
+++ b/api/uniter/application.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -23,7 +24,7 @@ import (
 type Application struct {
 	st   *State
 	tag  names.ApplicationTag
-	life params.Life
+	life life.Value
 }
 
 // Tag returns the application's tag.
@@ -47,7 +48,7 @@ func (s *Application) Watch() (watcher.NotifyWatcher, error) {
 }
 
 // Life returns the application's current life state.
-func (s *Application) Life() params.Life {
+func (s *Application) Life() life.Value {
 	return s.life
 }
 

--- a/api/uniter/application_test.go
+++ b/api/uniter/application_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/juju/api/leadership"
 	"github.com/juju/juju/api/uniter"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/state"
@@ -41,7 +41,7 @@ func (s *applicationSuite) TestNameTagAndString(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatch(c *gc.C) {
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiApplication.Life(), gc.Equals, life.Alive)
 
 	w, err := s.apiApplication.Watch()
 	c.Assert(err, jc.ErrorIsNil)
@@ -63,15 +63,15 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 }
 
 func (s *applicationSuite) TestRefresh(c *gc.C) {
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiApplication.Life(), gc.Equals, life.Alive)
 
 	err := s.wordpressApplication.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiApplication.Life(), gc.Equals, life.Alive)
 
 	err = s.apiApplication.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiApplication.Life(), gc.Equals, params.Dying)
+	c.Assert(s.apiApplication.Life(), gc.Equals, life.Dying)
 }
 
 func (s *applicationSuite) TestCharmURL(c *gc.C) {

--- a/api/uniter/export_test.go
+++ b/api/uniter/export_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -46,7 +47,7 @@ func CreateUnit(st *State, tag names.UnitTag) *Unit {
 	return &Unit{
 		st:           st,
 		tag:          tag,
-		life:         params.Alive,
+		life:         life.Alive,
 		resolvedMode: params.ResolvedNone,
 	}
 }

--- a/api/uniter/relation.go
+++ b/api/uniter/relation.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 )
 
@@ -22,7 +23,7 @@ type Relation struct {
 	st        *State
 	tag       names.RelationTag
 	id        int
-	life      params.Life
+	life      life.Value
 	suspended bool
 	otherApp  string
 }
@@ -46,7 +47,7 @@ func (r *Relation) Id() int {
 }
 
 // Life returns the relation's current life state.
-func (r *Relation) Life() params.Life {
+func (r *Relation) Life() life.Value {
 	return r.life
 }
 

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/leadership"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/status"
 )
@@ -54,7 +55,7 @@ func (s *relationSuite) TestOtherApplication(c *gc.C) {
 }
 
 func (s *relationSuite) TestRefresh(c *gc.C) {
-	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiRelation.Life(), gc.Equals, life.Alive)
 	c.Assert(s.apiRelation.Suspended(), jc.IsTrue)
 
 	// EnterScope with mysqlUnit, so the relation will be set to dying
@@ -71,19 +72,19 @@ func (s *relationSuite) TestRefresh(c *gc.C) {
 	// Update suspended as well.
 	err = s.stateRelation.SetSuspended(false, "")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiRelation.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiRelation.Life(), gc.Equals, life.Alive)
 	c.Assert(s.apiRelation.Suspended(), jc.IsTrue)
 
 	err = s.apiRelation.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiRelation.Life(), gc.Equals, params.Dying)
+	c.Assert(s.apiRelation.Life(), gc.Equals, life.Dying)
 	c.Assert(s.apiRelation.Suspended(), jc.IsFalse)
 
 	// Leave scope with mysqlUnit, so the relation will be removed.
 	err = myRelUnit.LeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.apiRelation.Life(), gc.Equals, params.Dying)
+	c.Assert(s.apiRelation.Life(), gc.Equals, life.Dying)
 	c.Assert(s.apiRelation.Suspended(), jc.IsFalse)
 	err = s.apiRelation.Refresh()
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -206,7 +207,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
 		*(result.(*params.LifeResults)) = params.LifeResults{
 			Results: []params.LifeResult{{
-				Life: params.Dying,
+				Life: life.Dying,
 			}},
 		}
 		return nil
@@ -218,7 +219,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 		UnitTag:    "unit-mysql-0",
 	}})
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, []params.LifeResult{{Life: params.Dying}})
+	c.Assert(results, jc.DeepEquals, []params.LifeResult{{Life: life.Dying}})
 }
 
 func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -20,7 +21,7 @@ import (
 type Unit struct {
 	st           *State
 	tag          names.UnitTag
-	life         params.Life
+	life         life.Value
 	resolvedMode params.ResolvedMode
 	providerID   string
 }
@@ -46,7 +47,7 @@ func (u *Unit) String() string {
 }
 
 // Life returns the unit's lifecycle value.
-func (u *Unit) Life() params.Life {
+func (u *Unit) Life() life.Value {
 	return u.life
 }
 

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -226,15 +227,15 @@ func (s *unitSuite) TestDestroyAllSubordinates(c *gc.C) {
 }
 
 func (s *unitSuite) TestRefreshLife(c *gc.C) {
-	c.Assert(s.apiUnit.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiUnit.Life(), gc.Equals, life.Alive)
 
 	err := s.apiUnit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiUnit.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiUnit.Life(), gc.Equals, life.Alive)
 
 	err = s.apiUnit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.apiUnit.Life(), gc.Equals, params.Dead)
+	c.Assert(s.apiUnit.Life(), gc.Equals, life.Dead)
 }
 
 func (s *unitSuite) TestRefreshResolve(c *gc.C) {
@@ -281,7 +282,7 @@ func (s *unitSuite) TestRefreshUpdateProviderID(c *gc.C) {
 }
 
 func (s *unitSuite) TestWatch(c *gc.C) {
-	c.Assert(s.apiUnit.Life(), gc.Equals, params.Alive)
+	c.Assert(s.apiUnit.Life(), gc.Equals, life.Alive)
 
 	w, err := s.apiUnit.Watch()
 	c.Assert(err, jc.ErrorIsNil)
@@ -506,7 +507,7 @@ func (s *unitSuite) TestNetworkInfo(c *gc.C) {
 		called++
 		if called == 1 {
 			*(result.(*params.UnitRefreshResults)) = params.UnitRefreshResults{
-				Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}
+				Results: []params.UnitRefreshResult{{Life: life.Alive, Resolved: params.ResolvedNone}}}
 			return nil
 		}
 		c.Check(objType, gc.Equals, "Uniter")

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -15,6 +15,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
@@ -77,7 +78,7 @@ func (st *State) Facade() base.FacadeCaller {
 }
 
 // life requests the lifecycle of the given entity from the server.
-func (st *State) life(tag names.Tag) (params.Life, error) {
+func (st *State) life(tag names.Tag) (life.Value, error) {
 	return common.OneLife(st.facade, tag)
 }
 

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -24,7 +25,7 @@ var logger = loggo.GetLogger("juju.apiserver.common.crossmodel")
 func PublishRelationChange(backend Backend, relationTag names.Tag, change params.RemoteRelationChangeEvent) error {
 	logger.Debugf("publish into model %v change for %v: %+v", backend.ModelUUID(), relationTag, change)
 
-	dyingOrDead := change.Life != "" && change.Life != params.Alive
+	dyingOrDead := change.Life != "" && change.Life != life.Alive
 	// Ensure the relation exists.
 	rel, err := backend.KeyRelation(relationTag.Id())
 	if errors.IsNotFound(err) {
@@ -297,7 +298,7 @@ func GetRelationLifeSuspendedStatusChange(st relationGetter, key string) (*param
 	if errors.IsNotFound(err) {
 		return &params.RelationLifeSuspendedStatusChange{
 			Key:  key,
-			Life: params.Dead,
+			Life: life.Dead,
 		}, nil
 	}
 	if err != nil {
@@ -305,7 +306,7 @@ func GetRelationLifeSuspendedStatusChange(st relationGetter, key string) (*param
 	}
 	return &params.RelationLifeSuspendedStatusChange{
 		Key:             key,
-		Life:            params.Life(rel.Life().String()),
+		Life:            life.Value(rel.Life().String()),
 		Suspended:       rel.Suspended(),
 		SuspendedReason: rel.SuspendedReason(),
 	}, nil

--- a/apiserver/common/life.go
+++ b/apiserver/common/life.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 )
 
@@ -26,7 +27,7 @@ func NewLifeGetter(st state.EntityFinder, getCanRead GetAuthFunc) *LifeGetter {
 	}
 }
 
-func (lg *LifeGetter) oneLife(tag names.Tag) (params.Life, error) {
+func (lg *LifeGetter) oneLife(tag names.Tag) (life.Value, error) {
 	entity0, err := lg.st.FindEntity(tag)
 	if err != nil {
 		return "", err
@@ -35,7 +36,7 @@ func (lg *LifeGetter) oneLife(tag names.Tag) (params.Life, error) {
 	if !ok {
 		return "", NotSupportedError(tag, "life cycles")
 	}
-	return params.Life(entity.Life().String()), nil
+	return life.Value(entity.Life().String()), nil
 }
 
 // Life returns the life status of every supplied entity, where available.

--- a/apiserver/common/life_test.go
+++ b/apiserver/common/life_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 )
 
@@ -55,9 +56,9 @@ func (*lifeSuite) TestLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
-			{Life: params.Alive},
+			{Life: life.Alive},
 			{Error: apiservertesting.ErrUnauthorized},
-			{Life: params.Dead},
+			{Life: life.Dead},
 			{Error: &params.Error{Message: "x3 error"}},
 			{Error: apiservertesting.ErrUnauthorized},
 		},

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 )
 
@@ -100,7 +101,7 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 	result := params.ModelStatus{
 		ModelTag:           tag,
 		OwnerTag:           model.Owner().String(),
-		Life:               params.Life(model.Life().String()),
+		Life:               life.Value(model.Life().String()),
 		Type:               string(model.Type()),
 		HostedMachineCount: len(hostedMachines),
 		ApplicationCount:   len(applications),

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -16,6 +16,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -192,7 +193,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 			HostedMachineCount: 1,
 			ApplicationCount:   1,
 			OwnerTag:           s.Owner.String(),
-			Life:               params.Alive,
+			Life:               life.Alive,
 			Type:               string(state.ModelTypeIAAS),
 			Machines: []params.ModelMachineInfo{
 				{Id: "0", Hardware: &params.MachineHardware{Cores: &eight}, InstanceId: "id-4", DisplayName: "snowflake", Status: "pending", WantsVote: true},
@@ -212,7 +213,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 			HostedMachineCount: 2,
 			ApplicationCount:   1,
 			OwnerTag:           otherModelOwner.UserTag.String(),
-			Life:               params.Alive,
+			Life:               life.Alive,
 			Type:               string(state.ModelTypeIAAS),
 			Machines: []params.ModelMachineInfo{
 				{Id: "0", Hardware: stdHw, InstanceId: "id-8", Status: "pending"},
@@ -258,7 +259,7 @@ func (s *modelStatusSuite) TestModelStatusCAAS(c *gc.C) {
 			HostedMachineCount: 0,
 			ApplicationCount:   0,
 			OwnerTag:           s.Owner.String(),
-			Life:               params.Alive,
+			Life:               life.Alive,
 			Type:               string(state.ModelTypeIAAS),
 		},
 		{
@@ -267,7 +268,7 @@ func (s *modelStatusSuite) TestModelStatusCAAS(c *gc.C) {
 			ApplicationCount:   1,
 			UnitCount:          1,
 			OwnerTag:           otherModelOwner.UserTag.String(),
-			Life:               params.Alive,
+			Life:               life.Alive,
 			Type:               string(state.ModelTypeCAAS),
 		},
 	})
@@ -286,7 +287,7 @@ func (s *modelStatusSuite) TestModelStatusRunsForAllModels(c *gc.C) {
 				Error: common.ServerError(errors.New(`"fail.me" is not a valid tag`))},
 			{
 				ModelTag: s.Model.ModelTag().String(),
-				Life:     params.Life(s.Model.Life().String()),
+				Life:     life.Value(s.Model.Life().String()),
 				OwnerTag: s.Model.Owner().String(),
 				Type:     string(state.ModelTypeIAAS),
 			},

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -80,7 +80,7 @@ type BackingSubnetInfo struct {
 	Status string
 
 	// Live holds the life of the subnet
-	Life params.Life
+	Life life.Value
 }
 
 // BackingSpace defines the methods supported by a Space entity stored
@@ -151,7 +151,7 @@ func BackingSubnetToParamsSubnet(subnet BackingSubnet) params.Subnet {
 		Zones:             zones,
 		Status:            status,
 		SpaceTag:          spaceTag,
-		Life:              params.Life(subnet.Life()),
+		Life:              subnet.Life(),
 	}
 }
 

--- a/apiserver/common/storagecommon/volumes.go
+++ b/apiserver/common/storagecommon/volumes.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -152,7 +153,7 @@ func VolumeAttachmentPlanFromState(v state.VolumeAttachmentPlan) (params.VolumeA
 	return params.VolumeAttachmentPlan{
 		VolumeTag:   v.Volume().String(),
 		MachineTag:  v.Machine().String(),
-		Life:        params.Life(v.Life().String()),
+		Life:        life.Value(v.Life().String()),
 		PlanInfo:    VolumeAttachmentPlanInfoFromState(planInfo),
 		BlockDevice: VolumeAttachmentPlanBlockInfoFromState(blockInfo),
 	}, nil

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
@@ -99,7 +100,7 @@ func (api *AgentAPIV2) getEntity(tag names.Tag) (result params.AgentGetEntitiesR
 		err = common.NotSupportedError(tag, "life cycles")
 		return
 	}
-	result.Life = params.Life(entity.Life().String())
+	result.Life = life.Value(entity.Life().String())
 	if machine, ok := entity.(*state.Machine); ok {
 		result.Jobs = stateJobsToAPIParamsJobs(machine.Jobs())
 		result.ContainerType = machine.ContainerType()

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/caasoperator"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/state"
@@ -166,9 +167,9 @@ func (s *CAASOperatorSuite) TestLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{{
-			Life: params.Dying,
+			Life: life.Dying,
 		}, {
-			Life: params.Alive,
+			Life: life.Alive,
 		}, {
 			Error: &params.Error{
 				Code:    "unauthorized access",

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/instancemutater/mocks"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
@@ -134,7 +135,7 @@ func (s *InstanceMutaterAPILifeSuite) TestLife(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
 			{
-				Life: params.Alive,
+				Life: life.Alive,
 			},
 		},
 	})
@@ -187,7 +188,7 @@ func (s *InstanceMutaterAPILifeSuite) TestLifeWithParentId(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
 			{
-				Life: params.Alive,
+				Life: life.Alive,
 			},
 		},
 	})

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -507,7 +508,7 @@ func (api *ProvisionerAPI) MachinesWithTransientErrors() (params.StatusResults, 
 			continue
 		}
 		result.Id = machine.Id()
-		result.Life = params.Life(machine.Life().String())
+		result.Life = life.Value(machine.Life().String())
 		results.Results = append(results.Results, result)
 	}
 	return results, nil

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
@@ -1491,7 +1492,7 @@ func (s *StorageProvisionerAPIv3) AttachmentLife(args params.MachineStorageIds) 
 	results := params.LifeResults{
 		Results: make([]params.LifeResult, len(args.Ids)),
 	}
-	one := func(arg params.MachineStorageId) (params.Life, error) {
+	one := func(arg params.MachineStorageId) (life.Value, error) {
 		hostTag, err := names.ParseTag(arg.MachineTag)
 		if err != nil {
 			return "", err
@@ -1516,7 +1517,7 @@ func (s *StorageProvisionerAPIv3) AttachmentLife(args params.MachineStorageIds) 
 		if err != nil {
 			return "", errors.Trace(err)
 		}
-		return params.Life(lifer.Life().String()), nil
+		return life.Value(lifer.Life().String()), nil
 	}
 	for i, arg := range args.Ids {
 		life, err := one(arg)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -18,6 +18,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/tags"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -1379,8 +1380,8 @@ func (s *iaasProvisionerSuite) TestLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
-			{Life: params.Alive},
-			{Life: params.Alive},
+			{Life: life.Alive},
+			{Life: life.Alive},
 			{Error: common.ServerError(errors.NotFoundf(`volume "42"`))},
 		},
 	})
@@ -1411,9 +1412,9 @@ func (s *iaasProvisionerSuite) TestAttachmentLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
-			{Life: params.Alive},
-			{Life: params.Alive},
-			{Life: params.Alive},
+			{Life: life.Alive},
+			{Life: life.Alive},
+			{Life: life.Alive},
 			{Error: &params.Error{Message: `volume "42" on "machine 0" not found`, Code: "not found"}},
 		},
 	})
@@ -1746,8 +1747,8 @@ func (s *caasProvisionerSuite) TestFilesystemLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
-			{Life: params.Alive},
-			{Life: params.Alive},
+			{Life: life.Alive},
+			{Life: life.Alive},
 			{Error: apiservertesting.ErrUnauthorized},
 		},
 	})
@@ -1771,8 +1772,8 @@ func (s caasProvisionerSuite) TestFilesystemAttachmentLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
-			{Life: params.Alive},
-			{Life: params.Alive},
+			{Life: life.Alive},
+			{Life: life.Alive},
 			{Error: &params.Error{Message: `filesystem "42" on "unit mariadb/0" not found`, Code: "not found"}},
 		},
 	})

--- a/apiserver/facades/agent/uniter/storage.go
+++ b/apiserver/facades/agent/uniter/storage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
@@ -141,7 +142,7 @@ func (s *StorageAPI) StorageAttachmentLife(args params.StorageAttachmentIds) (pa
 		stateStorageAttachment, err := s.getOneStateStorageAttachment(canAccess, id)
 		if err == nil {
 			life := stateStorageAttachment.Life()
-			result.Results[i].Life = params.Life(life.String())
+			result.Results[i].Life = life.Value()
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}
@@ -204,7 +205,7 @@ func (s *StorageAPI) fromStateStorageAttachment(stateStorageAttachment state.Sto
 		stateStorageAttachment.Unit().String(),
 		params.StorageKind(stateStorageInstance.Kind()),
 		info.Location,
-		params.Life(stateStorageAttachment.Life().String()),
+		life.Value(stateStorageAttachment.Life().String()),
 	}, nil
 }
 

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -25,6 +25,7 @@ import (
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/network"
@@ -1356,7 +1357,7 @@ func (u *UniterAPI) Refresh(args params.Entities) (params.UnitRefreshResults, er
 		if canRead(tag) {
 			var unit *state.Unit
 			if unit, err = u.getUnit(tag); err == nil {
-				result.Results[i].Life = params.Life(unit.Life().String())
+				result.Results[i].Life = life.Value(unit.Life().String())
 				result.Results[i].Resolved = params.ResolvedMode(unit.Resolved())
 
 				var err1 error
@@ -1957,7 +1958,7 @@ func (u *UniterAPI) prepareRelationResult(rel *state.Relation, applicationName s
 	return params.RelationResult{
 		Id:        rel.Id(),
 		Key:       rel.String(),
-		Life:      params.Life(rel.Life().String()),
+		Life:      life.Value(rel.Life().String()),
 		Suspended: rel.Suspended(),
 		Endpoint: params.Endpoint{
 			ApplicationName: ep.ApplicationName,

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -29,6 +29,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas"
 	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -1842,7 +1843,7 @@ func (s *uniterSuite) TestRelation(c *gc.C) {
 			{
 				Id:        rel.Id(),
 				Key:       rel.String(),
-				Life:      params.Life(rel.Life().String()),
+				Life:      life.Value(rel.Life().String()),
 				Suspended: rel.Suspended(),
 				Endpoint: params.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
@@ -1881,7 +1882,7 @@ func (s *uniterSuite) TestRelationById(c *gc.C) {
 			{
 				Id:        rel.Id(),
 				Key:       rel.String(),
-				Life:      params.Life(rel.Life().String()),
+				Life:      life.Value(rel.Life().String()),
 				Suspended: rel.Suspended(),
 				Endpoint: params.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
@@ -3427,7 +3428,7 @@ func (s *uniterSuite) TestV5Relation(c *gc.C) {
 			{
 				Id:   rel.Id(),
 				Key:  rel.String(),
-				Life: params.Life(rel.Life().String()),
+				Life: life.Value(rel.Life().String()),
 				Endpoint: params.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        params.NewCharmRelation(wpEp.Relation),
@@ -3452,7 +3453,7 @@ func (s *uniterSuite) TestV5RelationById(c *gc.C) {
 			{
 				Id:   rel.Id(),
 				Key:  rel.String(),
-				Life: params.Life(rel.Life().String()),
+				Life: life.Value(rel.Life().String()),
 				Endpoint: params.Endpoint{
 					ApplicationName: wpEp.ApplicationName,
 					Relation:        params.NewCharmRelation(wpEp.Relation),
@@ -3474,7 +3475,7 @@ func (s *uniterSuite) TestRefresh(c *gc.C) {
 	}
 	expect := params.UnitRefreshResults{
 		Results: []params.UnitRefreshResult{
-			{Life: params.Alive, Resolved: params.ResolvedNone},
+			{Life: life.Alive, Resolved: params.ResolvedNone},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -576,7 +577,7 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 		Type:           string(model.Type()),
 		UUID:           model.UUID(),
 		OwnerTag:       model.Owner().String(),
-		Life:           params.Life(model.Life().String()),
+		Life:           life.Value(model.Life().String()),
 		ControllerUUID: state.ControllerTag().String(),
 		IsController:   state.IsController(),
 	}

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -126,7 +127,7 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 	c.Assert(info.Type, gc.Equals, string(model.Type()))
 	c.Assert(info.UUID, gc.Equals, model.UUID())
 	c.Assert(info.OwnerTag, gc.Equals, model.Owner().String())
-	c.Assert(info.Life, gc.Equals, params.Alive)
+	c.Assert(info.Life, gc.Equals, life.Alive)
 	expectedAgentVersion, _ := conf.AgentVersion()
 	c.Assert(info.AgentVersion, gc.DeepEquals, &expectedAgentVersion)
 	c.Assert(info.SLA, gc.DeepEquals, &params.ModelSLAInfo{
@@ -834,7 +835,7 @@ func (s *clientSuite) TestClientWatchAllReadPermission(c *gc.C) {
 			InstanceStatus: params.StatusInfo{
 				Current: status.Pending,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "quantal",
 			Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
 			Addresses:               []params.Address{},
@@ -912,7 +913,7 @@ func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
 			InstanceStatus: params.StatusInfo{
 				Current: status.Pending,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "quantal",
 			Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
 			Addresses:               []params.Address{},

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -19,6 +19,7 @@ import (
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -1545,12 +1546,12 @@ func filterStatusData(status map[string]interface{}) map[string]interface{} {
 	return out
 }
 
-func processLife(entity lifer) string {
+func processLife(entity lifer) life.Value {
 	if life := entity.Life(); life != state.Alive {
 		// alive is the usual state so omit it by default.
-		return life.String()
+		return life.Value()
 	}
-	return ""
+	return life.Value("")
 }
 
 type bySinceDescending []status.StatusInfo

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -214,7 +215,7 @@ func (s *modelInfoSuite) expectedModelInfo(c *gc.C, credentialValidity *bool) pa
 		CloudRegion:        "some-region",
 		CloudCredentialTag: "cloudcred-some-cloud_bob_some-credential",
 		DefaultSeries:      series.DefaultSupportedLTS(),
-		Life:               params.Dying,
+		Life:               life.Dying,
 		Status: params.EntityStatus{
 			Status: status.Destroying,
 			Since:  &time.Time{},
@@ -418,7 +419,7 @@ func (s *modelInfoSuite) TestNoMigration(c *gc.C) {
 }
 
 func (s *modelInfoSuite) TestAliveModelGetsAllInfo(c *gc.C) {
-	s.assertSuccess(c, s.st.model.cfg.UUID(), state.Alive, params.Alive)
+	s.assertSuccess(c, s.st.model.cfg.UUID(), state.Alive, life.Alive)
 }
 
 func (s *modelInfoSuite) TestAliveModelWithConfigFailure(c *gc.C) {
@@ -440,14 +441,14 @@ func (s *modelInfoSuite) TestAliveModelWithUsersFailure(c *gc.C) {
 }
 
 func (s *modelInfoSuite) TestDeadModelGetsAllInfo(c *gc.C) {
-	s.assertSuccess(c, s.st.model.cfg.UUID(), state.Dead, params.Dead)
+	s.assertSuccess(c, s.st.model.cfg.UUID(), state.Dead, life.Dead)
 }
 
 func (s *modelInfoSuite) TestDeadModelWithConfigFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelConfigError,
 		desiredLife:  state.Dead,
-		expectedLife: params.Dead,
+		expectedLife: life.Dead,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -456,7 +457,7 @@ func (s *modelInfoSuite) TestDeadModelWithStatusFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelStatusError,
 		desiredLife:  state.Dead,
-		expectedLife: params.Dead,
+		expectedLife: life.Dead,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -465,7 +466,7 @@ func (s *modelInfoSuite) TestDeadModelWithUsersFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelUsersError,
 		desiredLife:  state.Dead,
-		expectedLife: params.Dead,
+		expectedLife: life.Dead,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -474,7 +475,7 @@ func (s *modelInfoSuite) TestDyingModelWithConfigFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelConfigError,
 		desiredLife:  state.Dying,
-		expectedLife: params.Dying,
+		expectedLife: life.Dying,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -483,7 +484,7 @@ func (s *modelInfoSuite) TestDyingModelWithStatusFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelStatusError,
 		desiredLife:  state.Dying,
-		expectedLife: params.Dying,
+		expectedLife: life.Dying,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -492,14 +493,14 @@ func (s *modelInfoSuite) TestDyingModelWithUsersFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelUsersError,
 		desiredLife:  state.Dying,
-		expectedLife: params.Dying,
+		expectedLife: life.Dying,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
 
 func (s *modelInfoSuite) TestImportingModelGetsAllInfo(c *gc.C) {
 	s.st.model.migrationStatus = state.MigrationModeImporting
-	s.assertSuccess(c, s.st.model.cfg.UUID(), state.Alive, params.Alive)
+	s.assertSuccess(c, s.st.model.cfg.UUID(), state.Alive, life.Alive)
 }
 
 func (s *modelInfoSuite) TestImportingModelWithConfigFailure(c *gc.C) {
@@ -507,7 +508,7 @@ func (s *modelInfoSuite) TestImportingModelWithConfigFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelConfigError,
 		desiredLife:  state.Alive,
-		expectedLife: params.Alive,
+		expectedLife: life.Alive,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -517,7 +518,7 @@ func (s *modelInfoSuite) TestImportingModelWithStatusFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelStatusError,
 		desiredLife:  state.Alive,
-		expectedLife: params.Alive,
+		expectedLife: life.Alive,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -527,7 +528,7 @@ func (s *modelInfoSuite) TestImportingModelWithUsersFailure(c *gc.C) {
 	testData := incompleteModelInfoTest{
 		failModel:    s.setModelUsersError,
 		desiredLife:  state.Alive,
-		expectedLife: params.Alive,
+		expectedLife: life.Alive,
 	}
 	s.assertSuccessWithMissingData(c, testData)
 }
@@ -535,7 +536,7 @@ func (s *modelInfoSuite) TestImportingModelWithUsersFailure(c *gc.C) {
 type incompleteModelInfoTest struct {
 	failModel    func()
 	desiredLife  state.Life
-	expectedLife params.Life
+	expectedLife life.Value
 }
 
 func (s *modelInfoSuite) setModelConfigError() {
@@ -563,7 +564,7 @@ func (s *modelInfoSuite) assertSuccessWithMissingData(c *gc.C, test incompleteMo
 	s.assertSuccess(c, s.st.model.cfg.UUID(), test.desiredLife, test.expectedLife)
 }
 
-func (s *modelInfoSuite) assertSuccess(c *gc.C, modelUUID string, desiredLife state.Life, expectedLife params.Life) {
+func (s *modelInfoSuite) assertSuccess(c *gc.C, modelUUID string, desiredLife state.Life, expectedLife life.Value) {
 	s.st.model.life = desiredLife
 	// should get no errors
 	info := s.getModelInfo(c, modelUUID)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/caas"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller/modelmanager"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -888,7 +889,7 @@ func (m *ModelManagerAPI) ListModelSummaries(req params.ModelSummariesRequest) (
 			OwnerTag:       names.NewUserTag(mi.Owner).String(),
 			ControllerUUID: mi.ControllerUUID,
 			IsController:   mi.IsController,
-			Life:           params.Life(mi.Life.String()),
+			Life:           life.Value(mi.Life.String()),
 
 			CloudTag:    mi.CloudTag,
 			CloudRegion: mi.CloudRegion,
@@ -1129,7 +1130,7 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 		ControllerUUID: model.ControllerUUID(),
 		IsController:   st.IsController(),
 		OwnerTag:       model.Owner().String(),
-		Life:           params.Life(model.Life().String()),
+		Life:           life.Value(model.Life().String()),
 		CloudTag:       names.NewCloudTag(model.Cloud()).String(),
 		CloudRegion:    model.CloudRegion(),
 	}

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
@@ -296,7 +297,7 @@ func createStorageDetails(
 				StorageTag: a.StorageInstance().String(),
 				UnitTag:    a.Unit().String(),
 				Location:   location,
-				Life:       params.Life(a.Life().String()),
+				Life:       life.Value(a.Life().String()),
 			}
 			if machineTag.Id() != "" {
 				details.MachineTag = machineTag.String()
@@ -314,7 +315,7 @@ func createStorageDetails(
 		StorageTag:  si.Tag().String(),
 		OwnerTag:    ownerTag,
 		Kind:        params.StorageKind(si.Kind()),
-		Life:        params.Life(si.Life().String()),
+		Life:        life.Value(si.Life().String()),
 		Status:      common.EntityStatusFromState(aStatus),
 		Persistent:  persistent,
 		Attachments: storageAttachmentDetails,
@@ -623,7 +624,7 @@ func createVolumeDetails(
 
 	details := &params.VolumeDetails{
 		VolumeTag: v.VolumeTag().String(),
-		Life:      params.Life(v.Life().String()),
+		Life:      life.Value(v.Life().String()),
 	}
 
 	if info, err := v.Info(); err == nil {
@@ -635,7 +636,7 @@ func createVolumeDetails(
 		details.UnitAttachments = make(map[string]params.VolumeAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
 			attDetails := params.VolumeAttachmentDetails{
-				Life: params.Life(attachment.Life().String()),
+				Life: life.Value(attachment.Life().String()),
 			}
 			if stateInfo, err := attachment.Info(); err == nil {
 				attDetails.VolumeAttachmentInfo = storagecommon.VolumeAttachmentInfoFromState(
@@ -785,7 +786,7 @@ func createFilesystemDetails(
 
 	details := &params.FilesystemDetails{
 		FilesystemTag: f.FilesystemTag().String(),
-		Life:          params.Life(f.Life().String()),
+		Life:          life.Value(f.Life().String()),
 	}
 
 	if volumeTag, err := f.Volume(); err == nil {
@@ -801,7 +802,7 @@ func createFilesystemDetails(
 		details.UnitAttachments = make(map[string]params.FilesystemAttachmentDetails, len(attachments))
 		for _, attachment := range attachments {
 			attDetails := params.FilesystemAttachmentDetails{
-				Life: params.Life(attachment.Life().String()),
+				Life: life.Value(attachment.Life().String()),
 			}
 			if stateInfo, err := attachment.Info(); err == nil {
 				attDetails.FilesystemAttachmentInfo = storagecommon.FilesystemAttachmentInfoFromState(

--- a/apiserver/facades/controller/caasfirewaller/firewaller_test.go
+++ b/apiserver/facades/controller/caasfirewaller/firewaller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasfirewaller"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -133,7 +134,7 @@ func (s *CAASFirewallerSuite) TestLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{{
-			Life: params.Alive,
+			Life: life.Alive,
 		}, {
 			Error: &params.Error{
 				Code:    "unauthorized access",

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasoperatorprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -116,7 +117,7 @@ func (s *CAASProvisionerSuite) TestLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{{
-			Life: params.Alive,
+			Life: life.Alive,
 		}, {
 			Error: &params.Error{
 				Code:    "unauthorized access",

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -21,6 +21,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
@@ -300,9 +301,9 @@ func (s *CAASProvisionerSuite) TestLife(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{{
-			Life: params.Dying,
+			Life: life.Dying,
 		}, {
-			Life: params.Alive,
+			Life: life.Alive,
 		}, {
 			Error: &params.Error{
 				Code:    "unauthorized access",

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
@@ -134,7 +135,7 @@ func (api *CrossModelRelationsAPI) PublishRelationChanges(
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if change.Life != params.Alive {
+		if change.Life != life.Alive {
 			delete(api.relationToOffer, relationTag.Id())
 		}
 	}

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/instancepoller"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
@@ -243,8 +244,8 @@ func (s *InstancePollerSuite) TestLifeSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
-			{Life: params.Alive},
-			{Life: params.Dying},
+			{Life: life.Alive},
+			{Life: life.Dying},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -277,7 +278,7 @@ func (s *InstancePollerSuite) TestLifeFailure(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
 			{Error: apiservertesting.ServerError("pow!")},
-			{Life: params.Dead},
+			{Life: life.Dead},
 			{Error: apiservertesting.NotProvisionedError("42")},
 		}},
 	)

--- a/apiserver/facades/controller/lifeflag/facade_test.go
+++ b/apiserver/facades/controller/lifeflag/facade_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/controller/lifeflag"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 type FacadeSuite struct {
@@ -34,7 +35,7 @@ func (*FacadeSuite) TestLifeBadEntity(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
-	c.Check(result.Life, gc.Equals, params.Life(""))
+	c.Check(result.Life, gc.Equals, life.Value(""))
 
 	// TODO(fwereade): this is DUMB. should just be a parse error.
 	// but I'm not fixing the underlying implementation as well.
@@ -50,7 +51,7 @@ func (*FacadeSuite) TestLifeAuthFailure(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
-	c.Check(result.Life, gc.Equals, params.Life(""))
+	c.Check(result.Life, gc.Equals, life.Value(""))
 	c.Check(result.Error, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
@@ -63,7 +64,7 @@ func (*FacadeSuite) TestLifeNotFound(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
-	c.Check(result.Life, gc.Equals, params.Life(""))
+	c.Check(result.Life, gc.Equals, life.Value(""))
 	c.Check(result.Error, jc.Satisfies, params.IsCodeNotFound)
 }
 
@@ -75,7 +76,7 @@ func (*FacadeSuite) TestLifeSuccess(c *gc.C) {
 	results, err := facade.Life(modelEntity())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(results, jc.DeepEquals, params.LifeResults{
-		Results: []params.LifeResult{{Life: params.Dying}},
+		Results: []params.LifeResult{{Life: life.Dying}},
 	})
 }
 

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -11,6 +11,7 @@ import (
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state/watcher"
 )
@@ -192,7 +193,7 @@ func (api *RemoteRelationsAPI) remoteRelation(entity params.Entity) (*params.Rem
 	}
 	result := &params.RemoteRelation{
 		Id:        rel.Id(),
-		Life:      params.Life(rel.Life().String()),
+		Life:      life.Value(rel.Life().String()),
 		Suspended: rel.Suspended(),
 		Key:       tag.Id(),
 	}
@@ -263,7 +264,7 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		return &params.RemoteApplication{
 			Name:            remoteApp.Name(),
 			OfferUUID:       remoteApp.OfferUUID(),
-			Life:            params.Life(remoteApp.Life().String()),
+			Life:            life.Value(remoteApp.Life().String()),
 			ModelUUID:       remoteApp.SourceModel().Id(),
 			IsConsumerProxy: remoteApp.IsConsumerProxy(),
 			Macaroon:        mac,

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -370,7 +371,7 @@ func (s *remoteRelationsSuite) TestConsumeRemoteRelationChange(c *gc.C) {
 	change := params.RemoteRelationChangeEvent{
 		RelationToken:    "rel-token",
 		ApplicationToken: "app-token",
-		Life:             params.Alive,
+		Life:             life.Alive,
 		ChangedUnits: []params.RemoteRelationUnitChange{{
 			UnitId:   0,
 			Settings: map[string]interface{}{"foo": "bar"},

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
@@ -73,7 +74,7 @@ func (u *UndertakerAPI) ModelInfo() (params.UndertakerModelInfoResult, error) {
 		GlobalName:     model.Owner().String() + "/" + model.Name(),
 		Name:           model.Name(),
 		IsSystem:       u.st.IsController(),
-		Life:           params.Life(model.Life().String()),
+		Life:           life.Value(model.Life().String()),
 		ForceDestroyed: model.ForceDestroyed(),
 	}
 

--- a/apiserver/facades/controller/undertaker/undertaker_test.go
+++ b/apiserver/facades/controller/undertaker/undertaker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/undertaker"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -81,7 +82,7 @@ func (s *undertakerSuite) TestModelInfo(c *gc.C) {
 		c.Assert(info.GlobalName, gc.Equals, "user-admin/"+test.modelName)
 		c.Assert(info.Name, gc.Equals, test.modelName)
 		c.Assert(info.IsSystem, gc.Equals, test.isSystem)
-		c.Assert(info.Life, gc.Equals, params.Dying)
+		c.Assert(info.Life, gc.Equals, life.Dying)
 		c.Assert(info.ForceDestroyed, gc.Equals, true)
 	}
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3432,7 +3432,7 @@
                             "type": "string"
                         },
                         "life": {
-                            "type": "string"
+                            "$ref": "#/definitions/Value"
                         },
                         "provider-id": {
                             "type": "string"
@@ -9371,7 +9371,7 @@
                             "type": "integer"
                         },
                         "life": {
-                            "type": "string"
+                            "$ref": "#/definitions/Value"
                         },
                         "meter-statuses": {
                             "type": "object",
@@ -9667,7 +9667,7 @@
                             "type": "string"
                         },
                         "life": {
-                            "type": "string"
+                            "$ref": "#/definitions/Value"
                         },
                         "since": {
                             "type": "string",
@@ -10261,7 +10261,7 @@
                             "type": "boolean"
                         },
                         "life": {
-                            "type": "string"
+                            "$ref": "#/definitions/Value"
                         },
                         "machines": {
                             "type": "array",
@@ -10752,7 +10752,7 @@
                             "$ref": "#/definitions/Error"
                         },
                         "life": {
-                            "type": "string"
+                            "$ref": "#/definitions/Value"
                         },
                         "offer-name": {
                             "type": "string"
@@ -26718,7 +26718,7 @@
                             "$ref": "#/definitions/Error"
                         },
                         "life": {
-                            "type": "string"
+                            "$ref": "#/definitions/Value"
                         }
                     },
                     "additionalProperties": false,
@@ -27271,7 +27271,7 @@
                             "type": "string"
                         },
                         "life": {
-                            "type": "string"
+                            "$ref": "#/definitions/Value"
                         },
                         "since": {
                             "type": "string",

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -3,6 +3,8 @@
 
 package params
 
+import "github.com/juju/juju/core/life"
+
 // DestroyControllerArgs holds the arguments for destroying a controller.
 type DestroyControllerArgs struct {
 	// DestroyModels specifies whether or not the hosted models
@@ -44,7 +46,7 @@ type RemoveBlocksArgs struct {
 // ModelStatus holds information about the status of a juju model.
 type ModelStatus struct {
 	ModelTag           string                `json:"model-tag"`
-	Life               Life                  `json:"life"`
+	Life               life.Value            `json:"life"`
 	Type               string                `json:"type"`
 	HostedMachineCount int                   `json:"hosted-machine-count"`
 	ApplicationCount   int                   `json:"application-count"`

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -6,6 +6,8 @@ package params
 import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/macaroon.v2-unstable"
+
+	"github.com/juju/juju/core/life"
 )
 
 // ExternalControllerInfoResults contains the results of querying
@@ -203,7 +205,7 @@ type TokenResults struct {
 // RemoteRelation describes the current state of a cross-model relation from
 // the perspective of the local model.
 type RemoteRelation struct {
-	Life                  Life           `json:"life"`
+	Life                  life.Value     `json:"life"`
 	Suspended             bool           `json:"suspended"`
 	Id                    int            `json:"id"`
 	Key                   string         `json:"key"`
@@ -236,7 +238,7 @@ type RemoteApplication struct {
 	OfferUUID string `json:"offer-uuid"`
 
 	// Life is the current lifecycle state of the application.
-	Life Life `json:"life,omitempty"`
+	Life life.Value `json:"life,omitempty"`
 
 	// Status is the current status of the application.
 	Status string `json:"status,omitempty"`
@@ -320,7 +322,7 @@ type RemoteApplicationChange struct {
 	ApplicationTag string `json:"application-tag"`
 
 	// Life is the current lifecycle state of the application.
-	Life Life `json:"life"`
+	Life life.Value `json:"life"`
 
 	// TODO(wallyworld) - status etc
 }
@@ -356,7 +358,7 @@ type RemoteRelationChangeEvent struct {
 	ApplicationToken string `json:"application-token"`
 
 	// Life is the current lifecycle state of the relation.
-	Life Life `json:"life"`
+	Life life.Value `json:"life"`
 
 	// ForceCleanup is true if the offering side should forcibly
 	// ensure that all relation units have left scope.
@@ -385,7 +387,7 @@ type RelationLifeSuspendedStatusChange struct {
 	Key string `json:"key"`
 
 	// Life is the life of the relation.
-	Life Life `json:"life"`
+	Life life.Value `json:"life"`
 
 	// Suspended is the suspended status of the relation.
 	Suspended bool `json:"suspended"`

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/tools"
@@ -332,23 +333,23 @@ type RelationResults struct {
 // RelationResult returns information about a single relation,
 // or an error.
 type RelationResult struct {
-	Error            *Error   `json:"error,omitempty"`
-	Life             Life     `json:"life"`
-	Suspended        bool     `json:"bool,omitempty"`
-	Id               int      `json:"id"`
-	Key              string   `json:"key"`
-	Endpoint         Endpoint `json:"endpoint"`
-	OtherApplication string   `json:"other-application,omitempty"`
+	Error            *Error     `json:"error,omitempty"`
+	Life             life.Value `json:"life"`
+	Suspended        bool       `json:"bool,omitempty"`
+	Id               int        `json:"id"`
+	Key              string     `json:"key"`
+	Endpoint         Endpoint   `json:"endpoint"`
+	OtherApplication string     `json:"other-application,omitempty"`
 }
 
 // RelationResultV5 returns information about a single relation,
 // or an error, but doesn't include the other application name.
 type RelationResultV5 struct {
-	Error    *Error   `json:"error,omitempty"`
-	Life     Life     `json:"life"`
-	Id       int      `json:"id"`
-	Key      string   `json:"key"`
-	Endpoint Endpoint `json:"endpoint"`
+	Error    *Error     `json:"error,omitempty"`
+	Life     life.Value `json:"life"`
+	Id       int        `json:"id"`
+	Key      string     `json:"key"`
+	Endpoint Endpoint   `json:"endpoint"`
 }
 
 // RelationResultsV5 holds the result of an API call that returns
@@ -390,8 +391,8 @@ type BytesResult struct {
 // LifeResult holds the life status of a single entity, or an error
 // indicating why it is not available.
 type LifeResult struct {
-	Life  Life   `json:"life"`
-	Error *Error `json:"error,omitempty"`
+	Life  life.Value `json:"life"`
+	Error *Error     `json:"error,omitempty"`
 }
 
 // LifeResults holds the life or error status of multiple entities.
@@ -472,7 +473,7 @@ type AgentGetEntitiesResults struct {
 // AgentGetEntitiesResult holds the results of a
 // machineagent.API.GetEntities call for a single entity.
 type AgentGetEntitiesResult struct {
-	Life          Life                   `json:"life"`
+	Life          life.Value             `json:"life"`
 	Jobs          []model.MachineJob     `json:"jobs"`
 	ContainerType instance.ContainerType `json:"container-type"`
 	Error         *Error                 `json:"error,omitempty"`
@@ -858,7 +859,7 @@ type ResourceUploadResult struct {
 // UnitRefreshResult is used to return the latest values for attributes
 // on a unit.
 type UnitRefreshResult struct {
-	Life       Life
+	Life       life.Value
 	Resolved   ResolvedMode
 	Error      *Error
 	ProviderID string `json:"provider-id,omitempty"`

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/juju/version"
+
+	"github.com/juju/juju/core/life"
 )
 
 // ConfigValue encapsulates a configuration
@@ -154,7 +156,7 @@ type ModelInfo struct {
 	OwnerTag string `json:"owner-tag"`
 
 	// Life is the current lifecycle state of the model.
-	Life Life `json:"life"`
+	Life life.Value `json:"life"`
 
 	// Status is the current status of the model.
 	Status EntityStatus `json:"status,omitempty"`
@@ -197,7 +199,7 @@ type ModelSummary struct {
 	OwnerTag string `json:"owner-tag"`
 
 	// Life is the current lifecycle state of the model.
-	Life Life `json:"life"`
+	Life life.Value `json:"life"`
 
 	// Status is the current status of the model.
 	Status EntityStatus `json:"status,omitempty"`

--- a/apiserver/params/multiwatcher.go
+++ b/apiserver/params/multiwatcher.go
@@ -14,18 +14,9 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
-)
-
-// Life describes the lifecycle state of an entity ("alive", "dying"
-// or "dead").
-type Life string
-
-const (
-	Alive Life = "alive"
-	Dying Life = "dying"
-	Dead  Life = "dead"
 )
 
 // EntityInfo is implemented by all entity Info types.
@@ -130,7 +121,7 @@ type MachineInfo struct {
 	InstanceId               string                            `json:"instance-id"`
 	AgentStatus              StatusInfo                        `json:"agent-status"`
 	InstanceStatus           StatusInfo                        `json:"instance-status"`
-	Life                     Life                              `json:"life"`
+	Life                     life.Value                        `json:"life"`
 	Config                   map[string]interface{}            `json:"config,omitempty"`
 	Series                   string                            `json:"series"`
 	ContainerType            string                            `json:"container-type"`
@@ -185,7 +176,7 @@ type ApplicationInfo struct {
 	Exposed         bool                   `json:"exposed"`
 	CharmURL        string                 `json:"charm-url"`
 	OwnerTag        string                 `json:"owner-tag"`
-	Life            Life                   `json:"life"`
+	Life            life.Value             `json:"life"`
 	MinUnits        int                    `json:"min-units"`
 	Constraints     constraints.Value      `json:"constraints"`
 	Config          map[string]interface{} `json:"config,omitempty"`
@@ -214,11 +205,11 @@ type Profile struct {
 // CharmInfo holds the information about a charm that is tracked by the
 // multiwatcher.
 type CharmInfo struct {
-	ModelUUID    string   `json:"model-uuid"`
-	CharmURL     string   `json:"charm-url"`
-	CharmVersion string   `json:"charm-version"`
-	Life         Life     `json:"life"`
-	LXDProfile   *Profile `json:"profile"`
+	ModelUUID    string     `json:"model-uuid"`
+	CharmURL     string     `json:"charm-url"`
+	CharmVersion string     `json:"charm-version"`
+	Life         life.Value `json:"life"`
+	LXDProfile   *Profile   `json:"profile"`
 	// DefaultConfig is derived from state-stored *charm.Config.
 	DefaultConfig map[string]interface{} `json:"config,omitempty"`
 }
@@ -240,7 +231,7 @@ type RemoteApplicationUpdate struct {
 	Name      string     `json:"name"`
 	OfferUUID string     `json:"offer-uuid"`
 	OfferURL  string     `json:"offer-url"`
-	Life      Life       `json:"life"`
+	Life      life.Value `json:"life"`
 	Status    StatusInfo `json:"status"`
 }
 
@@ -282,7 +273,7 @@ type UnitInfo struct {
 	Application    string      `json:"application"`
 	Series         string      `json:"series"`
 	CharmURL       string      `json:"charm-url"`
-	Life           Life        `json:"life"`
+	Life           life.Value  `json:"life"`
 	PublicAddress  string      `json:"public-address"`
 	PrivateAddress string      `json:"private-address"`
 	MachineId      string      `json:"machine-id"`
@@ -414,7 +405,7 @@ func (i *BlockInfo) EntityId() EntityId {
 type ModelUpdate struct {
 	ModelUUID      string                 `json:"model-uuid"`
 	Name           string                 `json:"name"`
-	Life           Life                   `json:"life"`
+	Life           life.Value             `json:"life"`
 	Owner          string                 `json:"owner"`
 	ControllerUUID string                 `json:"controller-uuid"`
 	IsController   bool                   `json:"is-controller"`

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -4,6 +4,7 @@
 package params
 
 import (
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 )
 
@@ -37,7 +38,7 @@ type Subnet struct {
 	// Life is the subnet's life cycle value - Alive means the subnet
 	// is in use by one or more machines, Dying or Dead means the
 	// subnet is about to be removed.
-	Life Life `json:"life"`
+	Life life.Value `json:"life"`
 
 	// SpaceTag is the Juju network space this subnet is associated
 	// with.

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
@@ -49,7 +50,7 @@ var marshalTestCases = []struct {
 			InstanceStatus: params.StatusInfo{
 				Current: status.Pending,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "trusty",
 			SupportedContainers:     []instance.ContainerType{instance.LXD},
 			Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
@@ -66,7 +67,7 @@ var marshalTestCases = []struct {
 			Name:        "Benji",
 			Exposed:     true,
 			CharmURL:    "cs:quantal/name",
-			Life:        params.Life("dying"),
+			Life:        life.Dying,
 			OwnerTag:    "test-owner",
 			MinUnits:    42,
 			Constraints: constraints.MustParse("arch=armhf mem=1024M"),
@@ -88,7 +89,7 @@ var marshalTestCases = []struct {
 		Entity: &params.CharmInfo{
 			ModelUUID:    "uuid",
 			CharmURL:     "cs:quantal/name",
-			Life:         params.Life("dying"),
+			Life:         life.Dying,
 			CharmVersion: "3",
 			LXDProfile:   &params.Profile{},
 		},
@@ -103,7 +104,7 @@ var marshalTestCases = []struct {
 			Application: "Shazam",
 			Series:      "precise",
 			CharmURL:    "cs:~user/precise/wordpress-42",
-			Life:        params.Life("alive"),
+			Life:        life.Alive,
 			Ports: []params.Port{{
 				Protocol: "http",
 				Number:   80,

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/relation"
 )
@@ -138,7 +139,7 @@ type ApplicationStatus struct {
 	Charm            string                 `json:"charm"`
 	Series           string                 `json:"series"`
 	Exposed          bool                   `json:"exposed"`
-	Life             string                 `json:"life"`
+	Life             life.Value             `json:"life"`
 	Relations        map[string][]string    `json:"relations"`
 	CanUpgradeTo     string                 `json:"can-upgrade-to"`
 	SubordinateTo    []string               `json:"subordinate-to"`
@@ -162,7 +163,7 @@ type RemoteApplicationStatus struct {
 	OfferURL  string              `json:"offer-url"`
 	OfferName string              `json:"offer-name"`
 	Endpoints []RemoteEndpoint    `json:"endpoints"`
-	Life      string              `json:"life"`
+	Life      life.Value          `json:"life"`
 	Relations map[string][]string `json:"relations"`
 	Status    DetailedStatus      `json:"status"`
 }
@@ -237,7 +238,7 @@ type DetailedStatus struct {
 	Since   *time.Time             `json:"since"`
 	Kind    string                 `json:"kind"`
 	Version string                 `json:"version"`
-	Life    string                 `json:"life"`
+	Life    life.Value             `json:"life"`
 	Err     *Error                 `json:"err,omitempty"`
 }
 
@@ -291,7 +292,7 @@ type StatusHistoryPruneArgs struct {
 type StatusResult struct {
 	Error  *Error                 `json:"error,omitempty"`
 	Id     string                 `json:"id"`
-	Life   Life                   `json:"life"`
+	Life   life.Value             `json:"life"`
 	Status string                 `json:"status"`
 	Info   string                 `json:"info"`
 	Data   map[string]interface{} `json:"data"`

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -6,6 +6,7 @@ package params
 import (
 	"time"
 
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/storage"
 )
 
@@ -97,7 +98,7 @@ type StorageAttachment struct {
 
 	Kind     StorageKind `json:"kind"`
 	Location string      `json:"location"`
-	Life     Life        `json:"life"`
+	Life     life.Value  `json:"life"`
 }
 
 // StorageAttachmentId identifies a storage attachment by the tags of the
@@ -217,7 +218,7 @@ type VolumeAttachment struct {
 type VolumeAttachmentPlan struct {
 	VolumeTag  string                   `json:"volume-tag"`
 	MachineTag string                   `json:"machine-tag"`
-	Life       Life                     `json:"life,omitempty"`
+	Life       life.Value               `json:"life,omitempty"`
 	PlanInfo   VolumeAttachmentPlanInfo `json:"plan-info"`
 	// BlockDevice should only be set by machine agents after
 	// the AttachVolume() function is called. It represents the machines
@@ -524,7 +525,7 @@ type StorageDetails struct {
 	// Life contains the lifecycle state of the storage.
 	// Juju controllers older than 2.2 do not populate this
 	// field, so it may be omitted.
-	Life Life `json:"life,omitempty"`
+	Life life.Value `json:"life,omitempty"`
 
 	// Persistent reports whether or not the underlying volume or
 	// filesystem is persistent; i.e. whether or not it outlives
@@ -588,7 +589,7 @@ type StorageAttachmentDetails struct {
 	// Life contains the lifecycle state of the storage attachment.
 	// Juju controllers older than 2.2 do not populate this
 	// field, so it may be omitted.
-	Life Life `json:"life,omitempty"`
+	Life life.Value `json:"life,omitempty"`
 }
 
 // StoragePool holds data for a pool instance.
@@ -692,7 +693,7 @@ type VolumeDetails struct {
 	// Life contains the lifecycle state of the volume.
 	// Juju controllers older than 2.2 do not populate this
 	// field, so it may be omitted.
-	Life Life `json:"life,omitempty"`
+	Life life.Value `json:"life,omitempty"`
 
 	// Status contains the status of the volume.
 	Status EntityStatus `json:"status"`
@@ -723,7 +724,7 @@ type VolumeAttachmentDetails struct {
 	// Life contains the lifecycle state of the volume attachment.
 	// Juju controllers older than 2.2 do not populate this
 	// field, so it may be omitted.
-	Life Life `json:"life,omitempty"`
+	Life life.Value `json:"life,omitempty"`
 }
 
 // VolumeDetailsResult contains details about a volume, its attachments or
@@ -773,7 +774,7 @@ type FilesystemDetails struct {
 	// Life contains the lifecycle state of the filesystem.
 	// Juju controllers older than 2.2 do not populate this
 	// field, so it may be omitted.
-	Life Life `json:"life,omitempty"`
+	Life life.Value `json:"life,omitempty"`
 
 	// Status contains the status of the filesystem.
 	Status EntityStatus `json:"status"`
@@ -804,7 +805,7 @@ type FilesystemAttachmentDetails struct {
 	// Life contains the lifecycle state of the filesystem attachment.
 	// Juju controllers older than 2.2 do not populate this
 	// field, so it may be omitted.
-	Life Life `json:"life,omitempty"`
+	Life life.Value `json:"life,omitempty"`
 }
 
 // FilesystemDetailsResult contains details about a filesystem, its attachments or

--- a/apiserver/params/undertaker.go
+++ b/apiserver/params/undertaker.go
@@ -3,14 +3,16 @@
 
 package params
 
+import "github.com/juju/juju/core/life"
+
 // UndertakerModelInfo returns information on an model needed by the undertaker worker.
 type UndertakerModelInfo struct {
-	UUID           string `json:"uuid"`
-	Name           string `json:"name"`
-	GlobalName     string `json:"global-name"`
-	IsSystem       bool   `json:"is-system"`
-	Life           Life   `json:"life"`
-	ForceDestroyed bool   `json:"force-destroyed"`
+	UUID           string     `json:"uuid"`
+	Name           string     `json:"name"`
+	GlobalName     string     `json:"global-name"`
+	IsSystem       bool       `json:"is-system"`
+	Life           life.Value `json:"life"`
+	ForceDestroyed bool       `json:"force-destroyed"`
 }
 
 // UndertakerModelInfoResult holds the result of an API call that returns an

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/common/networkingcommon"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
@@ -203,7 +202,7 @@ func (f *FakeSpace) Zones() []string {
 	return []string{""}
 }
 
-func (f *FakeSpace) Life() (life params.Life) {
+func (f *FakeSpace) Life() (life life.Value) {
 	return
 }
 

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -321,7 +322,7 @@ func (c *destroyCommand) checkNoAliveHostedModels(ctx *cmd.Context, models []mod
 	// and there are models still alive.
 	var buf bytes.Buffer
 	for _, model := range models {
-		if model.Life != string(params.Alive) {
+		if model.Life != life.Alive {
 			continue
 		}
 		buf.WriteString(fmtModelStatus(model))

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujucontroller "github.com/juju/juju/controller"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -245,7 +246,7 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 		})
 		s.api.envStatus[model.modelUUID] = base.ModelStatus{
 			UUID:               uuid,
-			Life:               string(params.Dead),
+			Life:               life.Dead,
 			HostedMachineCount: 0,
 			ApplicationCount:   0,
 			Owner:              owner.Id(),
@@ -361,7 +362,7 @@ func (s *DestroySuite) TestDestroyWithDestroyDestroyReleaseStorageFlagsMutuallyE
 func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlagUnspecified(c *gc.C) {
 	var haveFilesystem bool
 	for uuid, status := range s.api.envStatus {
-		status.Life = string(params.Alive)
+		status.Life = life.Alive
 		status.Volumes = append(status.Volumes, base.Volume{Detachable: true})
 		if !haveFilesystem {
 			haveFilesystem = true
@@ -436,7 +437,7 @@ func (s *DestroySuite) TestFailedDestroyController(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyControllerAliveModels(c *gc.C) {
 	for uuid, status := range s.api.envStatus {
-		status.Life = string(params.Alive)
+		status.Life = life.Alive
 		s.api.envStatus[uuid] = status
 	}
 	s.api.SetErrors(&params.Error{Code: params.CodeHasHostedModels})

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/juju/juju/api/base"
 	apicontroller "github.com/juju/juju/api/controller"
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/cmdtest"
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	_ "github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
@@ -115,7 +115,7 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 	s.resetAPIModels(c)
 	s.addModel("model-1", base.ModelStatus{
 		UUID:               test2UUID,
-		Life:               string(params.Dying),
+		Life:               life.Dying,
 		Owner:              "admin",
 		HostedMachineCount: 2,
 		ApplicationCount:   2,
@@ -134,7 +134,7 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 	s.syncClockAlarm(c)
 	s.setModelStatus(base.ModelStatus{
 		UUID:               test2UUID,
-		Life:               string(params.Dying),
+		Life:               life.Dying,
 		Owner:              "admin",
 		HostedMachineCount: 1,
 	})
@@ -163,7 +163,7 @@ func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
 	s.api.envStatus = map[string]base.ModelStatus{}
 	s.addModel("controller", base.ModelStatus{
 		UUID:               test1UUID,
-		Life:               string(params.Alive),
+		Life:               life.Alive,
 		Owner:              "admin",
 		TotalMachineCount:  3,
 		HostedMachineCount: 2,
@@ -184,7 +184,7 @@ func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
 	s.syncClockAlarm(c)
 	s.setModelStatus(base.ModelStatus{
 		UUID:               test1UUID,
-		Life:               string(params.Dying),
+		Life:               life.Dying,
 		Owner:              "admin",
 		HostedMachineCount: 1,
 	})
@@ -193,7 +193,7 @@ func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
 	s.syncClockAlarm(c)
 	s.setModelStatus(base.ModelStatus{
 		UUID:               test1UUID,
-		Life:               string(params.Dying),
+		Life:               life.Dying,
 		Owner:              "admin",
 		HostedMachineCount: 0,
 	})
@@ -217,7 +217,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 	s.resetAPIModels(c)
 	s.addModel("model-1", base.ModelStatus{
 		UUID:               test2UUID,
-		Life:               string(params.Dying),
+		Life:               life.Dying,
 		Owner:              "admin",
 		HostedMachineCount: 2,
 		ApplicationCount:   2,
@@ -239,7 +239,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 	s.syncClockAlarm(c)
 	s.setModelStatus(base.ModelStatus{
 		UUID:               test2UUID,
-		Life:               string(params.Dying),
+		Life:               life.Dying,
 		Owner:              "admin",
 		HostedMachineCount: 1,
 	})
@@ -268,7 +268,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
 	s.resetAPIModels(c)
 	s.addModel("model-1", base.ModelStatus{
 		UUID:               test2UUID,
-		Life:               string(params.Dying),
+		Life:               life.Dying,
 		Owner:              "admin",
 		HostedMachineCount: 2,
 		ApplicationCount:   2,
@@ -317,7 +317,7 @@ func (s *KillSuite) resetAPIModels(c *gc.C) {
 	s.api.envStatus = map[string]base.ModelStatus{}
 	s.addModel("controller", base.ModelStatus{
 		UUID:              test1UUID,
-		Life:              string(params.Alive),
+		Life:              life.Alive,
 		Owner:             "admin",
 		TotalMachineCount: 1,
 	})
@@ -503,7 +503,7 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		s.api.envStatus[env.UUID] = base.ModelStatus{
 			UUID:               env.UUID,
-			Life:               string(params.Dying),
+			Life:               life.Dying,
 			HostedMachineCount: 2,
 			ApplicationCount:   1,
 			Owner:              owner.Id(),
@@ -520,27 +520,27 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 	for i, expected := range []struct {
 		Owner              string
 		Name               string
-		Life               params.Life
+		Life               life.Value
 		HostedMachineCount int
 		ApplicationCount   int
 	}{
 		{
 			Owner:              "bob",
 			Name:               "env1",
-			Life:               params.Dying,
+			Life:               life.Dying,
 			HostedMachineCount: 2,
 			ApplicationCount:   1,
 		}, {
 			Owner:              "jo",
 			Name:               "env2",
-			Life:               params.Dying,
+			Life:               life.Dying,
 			HostedMachineCount: 2,
 			ApplicationCount:   1,
 		},
 	} {
 		c.Assert(envsStatus[i].Owner, gc.Equals, expected.Owner)
 		c.Assert(envsStatus[i].Name, gc.Equals, expected.Name)
-		c.Assert(envsStatus[i].Life, gc.Equals, string(expected.Life))
+		c.Assert(envsStatus[i].Life, gc.Equals, expected.Life)
 		c.Assert(envsStatus[i].HostedMachineCount, gc.Equals, expected.HostedMachineCount)
 		c.Assert(envsStatus[i].ApplicationCount, gc.Equals, expected.ApplicationCount)
 	}
@@ -563,7 +563,7 @@ func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
 		"uuid",
 		"owner",
 		"envname",
-		string(params.Dying),
+		life.Dying,
 		8,
 		1,
 		2,

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 )
 
 type ctrData struct {
@@ -31,7 +31,7 @@ type modelData struct {
 	UUID  string
 	Owner string
 	Name  string
-	Life  string
+	Life  life.Value
 
 	HostedMachineCount        int
 	ApplicationCount          int
@@ -136,7 +136,7 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (ctrData, []m
 		if model.UUID == controllerModelUUID {
 			ctrModelData = modelData
 		} else {
-			if model.Life == string(params.Dead) {
+			if model.Life == life.Dead {
 				// Filter out dead, non-controller models.
 				continue
 			}
@@ -169,7 +169,7 @@ func hasUnreclaimedResources(env environmentStatus) bool {
 
 func hasUnDeadModels(models []modelData) bool {
 	for _, model := range models {
-		if model.Life != string(params.Dead) {
+		if model.Life != life.Dead {
 			return true
 		}
 	}
@@ -178,7 +178,7 @@ func hasUnDeadModels(models []modelData) bool {
 
 func hasAliveModels(models []modelData) bool {
 	for _, model := range models {
-		if model.Life == string(params.Alive) {
+		if model.Life == life.Alive {
 			return true
 		}
 	}

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
 )
@@ -238,7 +239,7 @@ type ModelSummary struct {
 	CloudRegion        string                  `json:"region,omitempty" yaml:"region,omitempty"`
 	CloudCredential    *common.ModelCredential `json:"credential,omitempty" yaml:"credential,omitempty"`
 	ProviderType       string                  `json:"type,omitempty" yaml:"type,omitempty"`
-	Life               string                  `json:"life" yaml:"life"`
+	Life               life.Value              `json:"life" yaml:"life"`
 	Status             *common.ModelStatus     `json:"status,omitempty" yaml:"status,omitempty"`
 	UserAccess         string                  `yaml:"access" json:"access"`
 	UserLastConnection string                  `yaml:"last-connection" json:"last-connection"`

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/jujuclient"
@@ -118,7 +119,7 @@ func (f *fakeModelMgrAPIClient) ListModelSummaries(user string, all bool) ([]bas
 			CloudRegion:     info.Result.CloudRegion,
 			CloudCredential: cred.Id(),
 			Owner:           owner.Id(),
-			Life:            string(info.Result.Life),
+			Life:            info.Result.Life,
 			Status: base.Status{
 				Status: info.Result.Status.Status,
 				Info:   info.Result.Status.Info,
@@ -522,7 +523,7 @@ func createBasicModelInfo() *params.ModelInfo {
 		ControllerUUID: testing.ControllerTag.Id(),
 		IsController:   false,
 		OwnerTag:       names.NewUserTag("owner").String(),
-		Life:           params.Dead,
+		Life:           life.Dead,
 		CloudTag:       names.NewCloudTag("altostratus").String(),
 		CloudRegion:    "mid-level",
 		AgentVersion:   &agentVersion,

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/juju/model"
+	"github.com/juju/juju/core/life"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -66,7 +67,7 @@ func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
 			CloudTag:       "cloud-some-cloud",
 			CloudRegion:    "some-region",
 			ProviderType:   "openstack",
-			Life:           params.Alive,
+			Life:           life.Alive,
 			Status: params.EntityStatus{
 				Status: status.Active,
 				Since:  &statusSince,
@@ -681,7 +682,7 @@ func createBasicModelInfo() *params.ModelInfo {
 		IsController:   false,
 		Type:           "iaas",
 		OwnerTag:       names.NewUserTag("owner").String(),
-		Life:           params.Dead,
+		Life:           life.Dead,
 		CloudTag:       names.NewCloudTag("altostratus").String(),
 		CloudRegion:    "mid-level",
 	}

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -15,10 +15,10 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
-	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/life"
 )
 
 // NewListCommand returns a command used to list spaces.
@@ -139,9 +139,9 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 				// do the same for params.Space, so in case of an
 				// error it can be displayed.
 				switch subnet.Life {
-				case params.Alive:
+				case life.Alive:
 					subResult.Status = statusInUse
-				case params.Dying, params.Dead:
+				case life.Dying, life.Dead:
 					subResult.Status = statusTerminating
 				}
 

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/space"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -165,7 +166,7 @@ func NewStubAPI() *StubAPI {
 		// IPv6 subnet.
 		CIDR:       "2001:db8::/32",
 		ProviderId: "subnet-public",
-		Life:       params.Dying,
+		Life:       life.Dying,
 		SpaceTag:   "space-space1",
 		Zones:      []string{"zone2"},
 	}, {
@@ -178,13 +179,13 @@ func NewStubAPI() *StubAPI {
 		// IPv4 subnet.
 		CIDR:       "10.1.2.0/24",
 		ProviderId: "subnet-private",
-		Life:       params.Alive,
+		Life:       life.Alive,
 		SpaceTag:   "space-space2",
 		Zones:      []string{"zone1", "zone2"},
 	}, {
 		// IPv4 VLAN subnet.
 		CIDR:       "4.3.2.0/28",
-		Life:       params.Dead,
+		Life:       life.Dead,
 		ProviderId: "vlan-42",
 		SpaceTag:   "space-space2",
 		Zones:      []string{"zone1"},

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -267,7 +267,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		CharmVersion:     application.CharmVersion,
 		CharmProfile:     application.CharmProfile,
 		Exposed:          application.Exposed,
-		Life:             application.Life,
+		Life:             string(application.Life),
 		Scale:            application.Scale,
 		ProviderId:       application.ProviderId,
 		Address:          application.PublicAddress,
@@ -297,7 +297,7 @@ func (sf *statusFormatter) formatRemoteApplication(name string, application para
 	out := remoteApplicationStatus{
 		Err:        typedNilCheck(application.Err),
 		OfferURL:   application.OfferURL,
-		Life:       application.Life,
+		Life:       string(application.Life),
 		Relations:  application.Relations,
 		StatusInfo: sf.getRemoteApplicationStatusInfo(application),
 	}
@@ -448,11 +448,12 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 func (sf *statusFormatter) getStatusInfoContents(inst params.DetailedStatus) statusInfoContents {
 	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
-		Err:     typedNilCheck(inst.Err),
+		Err: typedNilCheck(inst.Err),
+		// NOTE: why use a status.Status here, but a string for Life?
 		Current: status.Status(inst.Status),
 		Message: inst.Info,
 		Version: inst.Version,
-		Life:    inst.Life,
+		Life:    string(inst.Life),
 	}
 	if inst.Since != nil {
 		info.Since = common.FormatTime(inst.Since, sf.isoTime)

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -12,10 +12,10 @@ import (
 	"github.com/juju/gnuflag"
 	"gopkg.in/juju/names.v3"
 
-	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/life"
 )
 
 // NewListCommand returns a cammin used to list all subnets
@@ -141,9 +141,9 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 
 			// Display correct status according to the life cycle value.
 			switch sub.Life {
-			case params.Alive:
+			case life.Alive:
 				subResult.Status = statusInUse
-			case params.Dying, params.Dead:
+			case life.Dying, life.Dead:
 				subResult.Status = statusTerminating
 			}
 

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/subnet"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -139,7 +140,7 @@ func NewStubAPI() *StubAPI {
 		// IPv4 subnet.
 		CIDR:       "10.20.0.0/24",
 		ProviderId: "subnet-foo",
-		Life:       params.Alive,
+		Life:       life.Alive,
 		SpaceTag:   "space-public",
 		Zones:      []string{"zone1", "zone2"},
 	}, {
@@ -147,13 +148,13 @@ func NewStubAPI() *StubAPI {
 		CIDR:              "2001:db8::/32",
 		ProviderId:        "subnet-bar",
 		ProviderNetworkId: "network-yay",
-		Life:              params.Dying,
+		Life:              life.Dying,
 		SpaceTag:          "space-dmz",
 		Zones:             []string{"zone2"},
 	}, {
 		// IPv4 VLAN subnet.
 		CIDR:     "10.10.0.0/16",
-		Life:     params.Dead,
+		Life:     life.Dead,
 		SpaceTag: "space-vlan-42",
 		Zones:    []string{"zone1"},
 		VLANTag:  42,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -56,6 +56,7 @@ import (
 	"github.com/juju/juju/container/broker"
 	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/paths"
@@ -778,7 +779,7 @@ func (a *MachineAgent) machine(apiConn api.Connection) (*apimachiner.Machine, er
 
 func (a *MachineAgent) setControllerNetworkConfig(apiConn api.Connection) error {
 	machine, err := a.machine(apiConn)
-	if errors.IsNotFound(err) || err == nil && machine.Life() == params.Dead {
+	if errors.IsNotFound(err) || err == nil && machine.Life() == life.Dead {
 		return jworker.ErrTerminateAgent
 	}
 	if err != nil {
@@ -903,7 +904,7 @@ func (a *MachineAgent) updateSupportedContainers(
 	if len(result) != 1 {
 		return errors.Errorf("expected 1 result, got %d", len(result))
 	}
-	if errors.IsNotFound(result[0].Err) || (result[0].Err == nil && result[0].Machine.Life() == params.Dead) {
+	if errors.IsNotFound(result[0].Err) || (result[0].Err == nil && result[0].Machine.Life() == life.Dead) {
 		return jworker.ErrTerminateAgent
 	}
 	machine := result[0].Machine

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/migration"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -471,7 +472,7 @@ func (s *MachineLegacyLeasesSuite) TestManageModelServesAPI(c *gc.C) {
 		defer st.Close()
 		m, err := apimachiner.NewState(st).Machine(conf.Tag().(names.MachineTag))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(m.Life(), gc.Equals, params.Alive)
+		c.Assert(m.Life(), gc.Equals, life.Alive)
 	})
 }
 

--- a/core/constraints/package_test.go
+++ b/core/constraints/package_test.go
@@ -25,5 +25,5 @@ func (*ImportTest) TestImports(c *gc.C) {
 
 	// This package should only depend on other core packages.
 	// If this test fails with a non-core package, please check the dependencies.
-	c.Assert(found, jc.SameContents, []string{"core/instance", "core/status"})
+	c.Assert(found, jc.SameContents, []string{"core/instance", "core/life", "core/status"})
 }

--- a/core/status/package_test.go
+++ b/core/status/package_test.go
@@ -6,6 +6,7 @@ package status_test
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	coretesting "github.com/juju/juju/testing"
@@ -22,6 +23,5 @@ var _ = gc.Suite(&ImportTest{})
 func (*ImportTest) TestImports(c *gc.C) {
 	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/status")
 
-	// This package brings in nothing else from juju/juju/core
-	c.Assert(found, gc.HasLen, 0)
+	c.Assert(found, jc.SameContents, []string{"core/life"})
 }

--- a/core/status/status_history.go
+++ b/core/status/status_history.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/life"
 )
 
 // StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
@@ -61,7 +62,7 @@ type DetailedStatus struct {
 	Kind   HistoryKind
 	// TODO(perrito666) make sure this is not used and remove.
 	Version string
-	Life    string
+	Life    life.Value
 	Err     error
 }
 

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/undertaker"
 	apiwatcher "github.com/juju/juju/api/watcher"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher/watchertest"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
@@ -62,7 +62,7 @@ func (s *undertakerSuite) TestStateEnvironInfo(c *gc.C) {
 	c.Assert(info.Name, gc.Equals, "controller")
 	c.Assert(info.GlobalName, gc.Equals, "user-admin/controller")
 	c.Assert(info.IsSystem, jc.IsTrue)
-	c.Assert(info.Life, gc.Equals, params.Alive)
+	c.Assert(info.Life, gc.Equals, life.Alive)
 }
 
 func (s *undertakerSuite) TestStateProcessDyingEnviron(c *gc.C) {
@@ -105,7 +105,7 @@ func (s *undertakerSuite) TestHostedEnvironInfo(c *gc.C) {
 	c.Assert(envInfo.Name, gc.Equals, "hosted-env")
 	c.Assert(envInfo.GlobalName, gc.Equals, "user-admin/hosted-env")
 	c.Assert(envInfo.IsSystem, jc.IsFalse)
-	c.Assert(envInfo.Life, gc.Equals, params.Alive)
+	c.Assert(envInfo.Life, gc.Equals, life.Alive)
 }
 
 func (s *undertakerSuite) TestHostedProcessDyingEnviron(c *gc.C) {

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
@@ -146,7 +147,7 @@ func (e *backingModel) updated(st *State, store *multiwatcherStore, id string) e
 	info := &params.ModelUpdate{
 		ModelUUID:      e.UUID,
 		Name:           e.Name,
-		Life:           params.Life(e.Life.String()),
+		Life:           life.Value(e.Life.String()),
 		Owner:          e.Owner,
 		ControllerUUID: e.ControllerUUID,
 		IsController:   st.IsController(),
@@ -245,7 +246,7 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string)
 	info := &params.MachineInfo{
 		ModelUUID:                st.ModelUUID(),
 		Id:                       m.Id,
-		Life:                     params.Life(m.Life.String()),
+		Life:                     life.Value(m.Life.String()),
 		Series:                   m.Series,
 		ContainerType:            m.ContainerType,
 		Jobs:                     paramsJobsFromJobs(m.Jobs),
@@ -444,7 +445,7 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 		Name:        u.Name,
 		Application: u.Application,
 		Series:      u.Series,
-		Life:        params.Life(u.Life.String()),
+		Life:        life.Value(u.Life.String()),
 		MachineId:   u.MachineId,
 		Principal:   u.Principal,
 		Subordinate: u.Principal != "",
@@ -539,7 +540,7 @@ func (app *backingApplication) updated(st *State, store *multiwatcherStore, id s
 		Name:        app.Name,
 		Exposed:     app.Exposed,
 		CharmURL:    app.CharmURL.String(),
-		Life:        params.Life(app.Life.String()),
+		Life:        life.Value(app.Life.String()),
 		MinUnits:    app.MinUnits,
 		Subordinate: app.Subordinate,
 	}
@@ -614,7 +615,7 @@ func (ch *backingCharm) updated(st *State, store *multiwatcherStore, id string) 
 		ModelUUID:    st.ModelUUID(),
 		CharmURL:     ch.URL.String(),
 		CharmVersion: ch.CharmVersion,
-		Life:         params.Life(ch.Life.String()),
+		Life:         life.Value(ch.Life.String()),
 	}
 
 	if ch.LXDProfile != nil && !ch.LXDProfile.Empty() {
@@ -669,7 +670,7 @@ func (app *backingRemoteApplication) updated(st *State, store *multiwatcherStore
 		Name:      app.Name,
 		OfferUUID: app.OfferUUID,
 		OfferURL:  app.URL,
-		Life:      params.Life(app.Life.String()),
+		Life:      life.Value(app.Life.String()),
 	}
 	oldInfo := store.Get(info.EntityId())
 	if oldInfo == nil {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -134,7 +135,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			Data:    map[string]interface{}{},
 			Since:   &now,
 		},
-		Life:                    params.Life("alive"),
+		Life:                    life.Alive,
 		Series:                  "quantal",
 		Jobs:                    jobs,
 		Addresses:               addresses,
@@ -157,7 +158,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 		Name:        "wordpress",
 		Exposed:     true,
 		CharmURL:    applicationCharmURL(wordpress).String(),
-		Life:        params.Life("alive"),
+		Life:        life.Alive,
 		MinUnits:    units,
 		Constraints: constraints.MustParse("mem=100M"),
 		Config:      charm.Settings{"blog-title": "boring"},
@@ -181,7 +182,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	add(&params.CharmInfo{
 		ModelUUID:     modelUUID,
 		CharmURL:      applicationCharmURL(wordpress).String(),
-		Life:          params.Life("alive"),
+		Life:          life.Alive,
 		DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 	})
 
@@ -190,7 +191,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 		ModelUUID:   modelUUID,
 		Name:        "logging",
 		CharmURL:    applicationCharmURL(logging).String(),
-		Life:        params.Life("alive"),
+		Life:        life.Alive,
 		Config:      charm.Settings{},
 		Subordinate: true,
 		Status: params.StatusInfo{
@@ -204,7 +205,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	add(&params.CharmInfo{
 		ModelUUID: modelUUID,
 		CharmURL:  applicationCharmURL(logging).String(),
-		Life:      params.Life("alive"),
+		Life:      life.Alive,
 	})
 
 	eps, err := st.InferEndpoints("logging", "wordpress")
@@ -234,7 +235,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			Name:        fmt.Sprintf("wordpress/%d", i),
 			Application: wordpress.Name(),
 			Series:      m.Series(),
-			Life:        params.Life("alive"),
+			Life:        life.Alive,
 			MachineId:   m.Id(),
 			Ports:       []params.Port{},
 			Subordinate: false,
@@ -287,7 +288,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "quantal",
 			Jobs:                    []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses:               []params.Address{},
@@ -323,7 +324,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 			Name:        fmt.Sprintf("logging/%d", i),
 			Application: "logging",
 			Series:      "quantal",
-			Life:        params.Life("alive"),
+			Life:        life.Alive,
 			Ports:       []params.Port{},
 			Principal:   unitName,
 			Subordinate: true,
@@ -353,7 +354,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 		ModelUUID: modelUUID,
 		Name:      "mysql",
 		CharmURL:  curl.String(),
-		Life:      params.Life("alive"),
+		Life:      life.Alive,
 		Config:    charm.Settings{},
 		Status: params.StatusInfo{
 			Current: "waiting",
@@ -366,7 +367,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int, inclu
 	add(&params.CharmInfo{
 		ModelUUID: modelUUID,
 		CharmURL:  applicationCharmURL(mysql).String(),
-		Life:      params.Life("alive"),
+		Life:      life.Alive,
 	})
 
 	// Set up a remote application related to the offer.
@@ -459,7 +460,7 @@ func addTestingRemoteApplication(
 		Name:      name,
 		OfferUUID: offerUUID,
 		OfferURL:  url,
-		Life:      params.Life(rs.Life().String()),
+		Life:      life.Value(rs.Life().String()),
 		Status:    appStatus,
 	}
 }
@@ -805,7 +806,7 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 			Name:           "wordpress/0",
 			Application:    "wordpress",
 			Series:         "quantal",
-			Life:           params.Life("alive"),
+			Life:           life.Alive,
 			MachineId:      "0",
 			PublicAddress:  "1.2.3.4",
 			PrivateAddress: "4.3.2.1",
@@ -844,7 +845,7 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 			Application:    "wordpress",
 			Series:         "quantal",
 			MachineId:      "0",
-			Life:           params.Life("alive"),
+			Life:           life.Alive,
 			PublicAddress:  "1.2.3.4",
 			PrivateAddress: "4.3.2.1",
 			Ports:          []params.Port{},
@@ -945,7 +946,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("alive"),
+			Life:      life.Alive,
 			Series:    "trusty",
 			Jobs:      []coremodel.MachineJob{JobManageModel.ToParams()},
 			Addresses: []params.Address{},
@@ -966,7 +967,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("alive"),
+			Life:      life.Alive,
 			Series:    "saucy",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -994,7 +995,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("dying"),
+			Life:      life.Dying,
 			Series:    "saucy",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -1021,7 +1022,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("dead"),
+			Life:      life.Dead,
 			Series:    "saucy",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -1097,7 +1098,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "trusty",
 			Jobs:                    []coremodel.MachineJob{JobManageModel.ToParams()},
 			Addresses:               []params.Address{},
@@ -1121,7 +1122,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "trusty",
 			Jobs:                    []coremodel.MachineJob{JobManageModel.ToParams()},
 			Addresses:               []params.Address{},
@@ -1147,7 +1148,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &wpTime,
 			},
-			Life:      params.Life("alive"),
+			Life:      life.Alive,
 			Series:    "quantal",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -1158,7 +1159,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		Entity: &params.CharmInfo{
 			ModelUUID:     s.state.ModelUUID(),
 			CharmURL:      "local:quantal/quantal-wordpress-3",
-			Life:          params.Life("alive"),
+			Life:          life.Alive,
 			DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 		},
 	}, {
@@ -1181,7 +1182,7 @@ func (s *allWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Name:        "wordpress/0",
 			Application: "wordpress",
 			Series:      "quantal",
-			Life:        params.Life("alive"),
+			Life:        life.Alive,
 			MachineId:   "2",
 			WorkloadStatus: params.StatusInfo{
 				Current: "waiting",
@@ -1548,7 +1549,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 					&params.ModelUpdate{
 						ModelUUID:      model.UUID(),
 						Name:           model.Name(),
-						Life:           params.Life("alive"),
+						Life:           life.Alive,
 						Owner:          model.Owner().Id(),
 						ControllerUUID: model.ControllerUUID(),
 						IsController:   model.IsControllerModel(),
@@ -1579,7 +1580,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 					&params.ModelUpdate{
 						ModelUUID:      model.UUID(),
 						Name:           "",
-						Life:           params.Life("alive"),
+						Life:           life.Alive,
 						Owner:          model.Owner().Id(),
 						ControllerUUID: model.ControllerUUID(),
 						IsController:   model.IsControllerModel(),
@@ -1603,7 +1604,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 					&params.ModelUpdate{
 						ModelUUID:      model.UUID(),
 						Name:           model.Name(),
-						Life:           params.Life("alive"),
+						Life:           life.Alive,
 						Owner:          model.Owner().Id(),
 						ControllerUUID: model.ControllerUUID(),
 						IsController:   model.IsControllerModel(),
@@ -1696,7 +1697,7 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 		&params.ModelUpdate{
 			ModelUUID:      model.UUID(),
 			Name:           model.Name(),
-			Life:           params.Life("alive"),
+			Life:           life.Alive,
 			Owner:          model.Owner().Id(),
 			ControllerUUID: model.ControllerUUID(),
 			IsController:   model.IsControllerModel(),
@@ -1714,7 +1715,7 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 		&params.ModelUpdate{
 			ModelUUID:      model1.UUID(),
 			Name:           model1.Name(),
-			Life:           params.Life("alive"),
+			Life:           life.Alive,
 			Owner:          model1.Owner().Id(),
 			ControllerUUID: model1.ControllerUUID(),
 			IsController:   model1.IsControllerModel(),
@@ -1911,7 +1912,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("alive"),
+			Life:      life.Alive,
 			Series:    "trusty",
 			Jobs:      []coremodel.MachineJob{JobManageModel.ToParams()},
 			Addresses: []params.Address{},
@@ -1932,7 +1933,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("alive"),
+			Life:      life.Alive,
 			Series:    "saucy",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -1968,7 +1969,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("dying"),
+			Life:      life.Dying,
 			Series:    "saucy",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -1995,7 +1996,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:      params.Life("dead"),
+			Life:      life.Dead,
 			Series:    "saucy",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -2074,7 +2075,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "trusty",
 			Jobs:                    []coremodel.MachineJob{JobManageModel.ToParams()},
 			Addresses:               []params.Address{},
@@ -2098,7 +2099,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &now,
 			},
-			Life:                    params.Life("alive"),
+			Life:                    life.Alive,
 			Series:                  "trusty",
 			Jobs:                    []coremodel.MachineJob{JobManageModel.ToParams()},
 			Addresses:               []params.Address{},
@@ -2121,7 +2122,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &later,
 			},
-			Life:      params.Life("alive"),
+			Life:      life.Alive,
 			Series:    "quantal",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -2132,7 +2133,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 		Entity: &params.CharmInfo{
 			ModelUUID:     st1.ModelUUID(),
 			CharmURL:      "local:quantal/quantal-wordpress-3",
-			Life:          params.Life("alive"),
+			Life:          life.Alive,
 			DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 		},
 	}, {
@@ -2158,7 +2159,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 			Name:        "wordpress/0",
 			Application: "wordpress",
 			Series:      "quantal",
-			Life:        params.Life("alive"),
+			Life:        life.Alive,
 			MachineId:   "1",
 			WorkloadStatus: params.StatusInfo{
 				Current: "waiting",
@@ -2206,7 +2207,7 @@ func (s *allModelWatcherStateSuite) TestStateWatcher(c *gc.C) {
 				Data:    map[string]interface{}{},
 				Since:   &later,
 			},
-			Life:      params.Life("alive"),
+			Life:      life.Alive,
 			Series:    "trusty",
 			Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 			Addresses: []params.Address{},
@@ -2375,7 +2376,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 							Data:    map[string]interface{}{},
 							Since:   &now,
 						},
-						Life:      params.Life("alive"),
+						Life:      life.Alive,
 						Series:    "quantal",
 						Jobs:      []coremodel.MachineJob{JobHostUnits.ToParams()},
 						Addresses: []params.Address{},
@@ -2434,7 +2435,7 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 							Data:    map[string]interface{}{},
 							Since:   &now,
 						},
-						Life:                     params.Life("alive"),
+						Life:                     life.Alive,
 						Series:                   "trusty",
 						Jobs:                     []coremodel.MachineJob{JobHostUnits.ToParams()},
 						Addresses:                []params.Address{},
@@ -2658,7 +2659,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 						Name:      "wordpress",
 						Exposed:   true,
 						CharmURL:  "local:quantal/quantal-wordpress-3",
-						Life:      params.Life("alive"),
+						Life:      life.Alive,
 						MinUnits:  42,
 						Config:    charm.Settings{},
 						Status: params.StatusInfo{
@@ -2693,7 +2694,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 						ModelUUID:   st.ModelUUID(),
 						Name:        "wordpress",
 						CharmURL:    "local:quantal/quantal-wordpress-3",
-						Life:        params.Life("alive"),
+						Life:        life.Alive,
 						Constraints: constraints.MustParse("mem=99M"),
 						Config:      charm.Settings{"blog-title": "boring"},
 					}}}
@@ -2822,7 +2823,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 						ModelUUID: st.ModelUUID(),
 						Name:      "wordpress",
 						CharmURL:  "local:quantal/quantal-wordpress-3",
-						Life:      params.Life("alive"),
+						Life:      life.Alive,
 						Config:    charm.Settings{"blog-title": "boring"},
 					}}}
 		},
@@ -3011,7 +3012,7 @@ func testChangeCharms(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, [
 					&params.CharmInfo{
 						ModelUUID:     st.ModelUUID(),
 						CharmURL:      ch.URL().String(),
-						Life:          params.Life("alive"),
+						Life:          life.Alive,
 						DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 					}}}
 		},
@@ -3091,7 +3092,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					&params.UnitInfo{
 						ModelUUID: st.ModelUUID(),
 						Name:      "wordpress/1",
-						Life:      params.Life("alive"),
+						Life:      life.Alive,
 					},
 				},
 				change: watcher.Change{
@@ -3134,7 +3135,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Name:        "wordpress/0",
 						Application: "wordpress",
 						Series:      "quantal",
-						Life:        params.Life("alive"),
+						Life:        life.Alive,
 						MachineId:   "0",
 						Ports: []params.Port{
 							{"tcp", 5555},
@@ -3207,7 +3208,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Name:        "wordpress/0",
 						Application: "wordpress",
 						Series:      "quantal",
-						Life:        params.Life("alive"),
+						Life:        life.Alive,
 						MachineId:   "0",
 						Ports:       []params.Port{{"udp", 17070}},
 						PortRanges:  []params.PortRange{{17070, 17070, "udp"}},
@@ -3295,7 +3296,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Name:        "wordpress/0",
 						Application: "wordpress",
 						Series:      "quantal",
-						Life:        params.Life("alive"),
+						Life:        life.Alive,
 						MachineId:   "0",
 						WorkloadStatus: params.StatusInfo{
 							Current: "waiting",
@@ -3352,7 +3353,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Name:           "wordpress/0",
 						Application:    "wordpress",
 						Series:         "quantal",
-						Life:           params.Life("alive"),
+						Life:           life.Alive,
 						PublicAddress:  "public",
 						PrivateAddress: "private",
 						MachineId:      "0",
@@ -3749,7 +3750,7 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 						Name:        "wordpress/0",
 						Application: "wordpress",
 						Series:      "quantal",
-						Life:        params.Life("alive"),
+						Life:        life.Alive,
 						MachineId:   "0",
 						Ports:       []params.Port{},
 						PortRanges:  []params.PortRange{},
@@ -3783,7 +3784,7 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 						Name:           "wordpress/0",
 						Application:    "wordpress",
 						Series:         "quantal",
-						Life:           params.Life("alive"),
+						Life:           life.Alive,
 						MachineId:      "0",
 						PublicAddress:  "1.2.3.4",
 						PrivateAddress: "4.3.2.1",
@@ -3819,7 +3820,7 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 						Name:           "wordpress/0",
 						Application:    "wordpress",
 						Series:         "quantal",
-						Life:           params.Life("alive"),
+						Life:           life.Alive,
 						MachineId:      "0",
 						PublicAddress:  "1.2.3.4",
 						PrivateAddress: "4.3.2.1",
@@ -3855,7 +3856,7 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 						Name:        "wordpress/0",
 						Application: "wordpress",
 						Series:      "quantal",
-						Life:        params.Life("alive"),
+						Life:        life.Alive,
 						Ports:       []params.Port{},
 						PortRanges:  []params.PortRange{},
 						WorkloadStatus: params.StatusInfo{

--- a/state/life.go
+++ b/state/life.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2/bson"
 
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/mongo"
 )
 
@@ -20,6 +21,7 @@ const (
 	Dead
 )
 
+// String is deprecated, use Value.
 func (l Life) String() string {
 	switch l {
 	case Alive:
@@ -30,6 +32,20 @@ func (l Life) String() string {
 		return "dead"
 	default:
 		return "unknown"
+	}
+}
+
+// Value returns the core.life.Value type.
+func (l Life) Value() life.Value {
+	switch l {
+	case Alive:
+		return life.Alive
+	case Dying:
+		return life.Dying
+	case Dead:
+		return life.Dead
+	default:
+		return life.Value("unknown")
 	}
 }
 

--- a/worker/containerbroker/broker.go
+++ b/worker/containerbroker/broker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/broker"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/environs"
 )
@@ -96,7 +97,7 @@ func NewTracker(config Config) (*Tracker, error) {
 	if len(result) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(result))
 	}
-	if errors.IsNotFound(result[0].Err) || (result[0].Err == nil && result[0].Machine.Life() == params.Dead) {
+	if errors.IsNotFound(result[0].Err) || (result[0].Err == nil && result[0].Machine.Life() == life.Dead) {
 		return nil, dependency.ErrUninstall
 	}
 	machine := result[0].Machine

--- a/worker/containerbroker/broker_test.go
+++ b/worker/containerbroker/broker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/broker"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker/containerbroker"
 	"github.com/juju/juju/worker/containerbroker/mocks"
@@ -250,7 +251,7 @@ func (s *trackerSuite) expectMachines() {
 	s.state.EXPECT().Machines(s.machineTag).Return([]provisioner.MachineResult{{
 		Machine: s.machine,
 	}}, nil)
-	s.machine.EXPECT().Life().Return(params.Alive)
+	s.machine.EXPECT().Life().Return(life.Alive)
 }
 
 func (s *trackerSuite) expectNoMachines() {
@@ -261,7 +262,7 @@ func (s *trackerSuite) expectDeadMachines() {
 	s.state.EXPECT().Machines(s.machineTag).Return([]provisioner.MachineResult{{
 		Machine: s.machine,
 	}}, nil)
-	s.machine.EXPECT().Life().Return(params.Dead)
+	s.machine.EXPECT().Life().Return(life.Dead)
 }
 
 func (s *trackerSuite) expectSupportedContainers() {

--- a/worker/containerbroker/mocks/machine_mock.go
+++ b/worker/containerbroker/mocks/machine_mock.go
@@ -5,14 +5,16 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	version "github.com/juju/version"
 	names_v3 "gopkg.in/juju/names.v3"
-	reflect "reflect"
 )
 
 // MockMachineProvisioner is a mock of MachineProvisioner interface
@@ -129,9 +131,9 @@ func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *gomock.Call {
 }
 
 // Life mocks base method
-func (m *MockMachineProvisioner) Life() params.Life {
+func (m *MockMachineProvisioner) Life() life.Value {
 	ret := m.ctrl.Call(m, "Life")
-	ret0, _ := ret[0].(params.Life)
+	ret0, _ := ret[0].(life.Value)
 	return ret0
 }
 

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/api/remoterelations"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/watcher"
@@ -621,13 +622,12 @@ func (fw *Firewaller) unitsChanged(change *unitsChange) error {
 		}
 		if unitd, known := fw.unitds[unitTag]; known {
 			knownMachineTag := fw.unitds[unitTag].machined.tag
-			if unit == nil || unit.Life() == params.Dead || machineTag != knownMachineTag {
+			if unit == nil || unit.Life() == life.Dead || machineTag != knownMachineTag {
 				fw.forgetUnit(unitd)
 				changed = append(changed, unitd)
 				fw.logger.Debugf("stopped watching unit %s", name)
 			}
-			// TODO(dfc) fw.machineds should be map[names.Tag]
-		} else if unit != nil && unit.Life() != params.Dead && fw.machineds[machineTag] != nil {
+		} else if unit != nil && unit.Life() != life.Dead && fw.machineds[machineTag] != nil {
 			err = fw.startUnit(unit, machineTag)
 			if params.IsCodeNotFound(err) {
 				continue
@@ -961,7 +961,7 @@ func (fw *Firewaller) machineLifeChanged(tag names.MachineTag) error {
 	if found && err != nil {
 		return err
 	}
-	dead := !found || m.Life() == params.Dead
+	dead := !found || m.Life() == life.Dead
 	machined, known := fw.machineds[tag]
 	if known && dead {
 		return fw.forgetMachine(machined)
@@ -1254,7 +1254,7 @@ func (fw *Firewaller) relationLifeChanged(tag names.RelationTag) error {
 	}
 	rel := results[0].Result
 
-	gone := notfound || rel.Life == params.Dead || rel.Suspended
+	gone := notfound || rel.Life == life.Dead || rel.Suspended
 	data, known := fw.relationIngress[tag]
 	if known && gone {
 		fw.logger.Debugf("relation %v was known but has died or been suspended", tag.Id())

--- a/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/worker/instancemutater/mocks/machinemutater_mock.go
@@ -5,14 +5,15 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
-	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names_v3 "gopkg.in/juju/names.v3"
-	reflect "reflect"
 )
 
 // MockMutaterMachine is a mock of MutaterMachine interface
@@ -78,9 +79,9 @@ func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
 }
 
 // Life mocks base method
-func (m *MockMutaterMachine) Life() params.Life {
+func (m *MockMutaterMachine) Life() life.Value {
 	ret := m.ctrl.Call(m, "Life")
-	ret0, _ := ret[0].(params.Life)
+	ret0, _ := ret[0].(life.Value)
 	return ret0
 }
 

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/api/instancemutater"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -170,7 +171,7 @@ func (m MutaterMachine) watchProfileChangesLoop(removed <-chan struct{}, profile
 			if err := m.machineApi.Refresh(); err != nil {
 				return errors.Trace(err)
 			}
-			if m.machineApi.Life() == params.Dead {
+			if m.machineApi.Life() == life.Dead {
 				return nil
 			}
 		}
@@ -186,7 +187,7 @@ func (m MutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 	if err := m.machineApi.Refresh(); err != nil {
 		return err
 	}
-	if m.machineApi.Life() == params.Dead {
+	if m.machineApi.Life() == life.Dead {
 		return errors.NotValidf("machine %q", m.id)
 	}
 

--- a/worker/instancemutater/mutater_test.go
+++ b/worker/instancemutater/mutater_test.go
@@ -13,8 +13,8 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	apiinstancemutater "github.com/juju/juju/api/instancemutater"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/worker/instancemutater"
@@ -228,14 +228,14 @@ func (s *mutaterSuite) expectLXDProfileNames(profiles []string, err error) {
 func (s *mutaterSuite) expectRefreshLifeAliveStatusIdle() {
 	mExp := s.machine.EXPECT()
 	mExp.Refresh().Return(nil)
-	mExp.Life().Return(params.Alive)
+	mExp.Life().Return(life.Alive)
 	mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
 }
 
 func (s *mutaterSuite) expectRefreshLifeDead() {
 	mExp := s.machine.EXPECT()
 	mExp.Refresh().Return(nil)
-	mExp.Life().Return(params.Dead)
+	mExp.Life().Return(life.Dead)
 }
 
 func (s *mutaterSuite) expectModificationStatusApplied() {

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -21,6 +21,7 @@ import (
 	apiinstancemutater "github.com/juju/juju/api/instancemutater"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -447,7 +448,7 @@ func (s *workerSuite) expectCharmProfileInfoError(machine int) {
 func (s *workerSuite) expectAliveAndSetModificationStatusIdle(machine int) {
 	mExp := s.machine[machine].EXPECT()
 	mExp.Refresh().Return(nil)
-	mExp.Life().Return(params.Alive)
+	mExp.Life().Return(life.Alive)
 	mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
 }
 
@@ -461,14 +462,14 @@ func (s *workerSuite) expectMachineAliveStatusIdleMachineDead(machine int, group
 	notificationSync := func(_ ...interface{}) { group.Done() }
 
 	mExp.Refresh().Return(nil).Times(2)
-	o1 := mExp.Life().Return(params.Alive).Do(notificationSync)
+	o1 := mExp.Life().Return(life.Alive).Do(notificationSync)
 
 	mExp.SetModificationStatus(status.Idle, "", nil).Return(nil)
 
 	s.machine[0].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil)
 	s.machine[1].EXPECT().SetModificationStatus(status.Applied, "", nil).Return(nil).Do(do)
 
-	mExp.Life().Return(params.Dead).After(o1).Do(do)
+	mExp.Life().Return(life.Dead).After(o1).Do(do)
 }
 
 func (s *workerSuite) expectModificationStatusApplied(machine int) {
@@ -687,7 +688,7 @@ func (s *workerContainerSuite) expectContainerCharmProfilingInfo(rev int) {
 func (s *workerContainerSuite) expectContainerAliveAndSetModificationStatusIdle() {
 	cExp := s.lxdContainer.EXPECT()
 	cExp.Refresh().Return(nil)
-	cExp.Life().Return(params.Alive)
+	cExp.Life().Return(life.Alive)
 	cExp.SetModificationStatus(status.Idle, gomock.Any(), gomock.Any()).Return(nil)
 }
 

--- a/worker/instancepoller/mocks/mocks_instancepoller.go
+++ b/worker/instancepoller/mocks/mocks_instancepoller.go
@@ -5,14 +5,16 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	network "github.com/juju/juju/core/network"
 	status "github.com/juju/juju/core/status"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
-	reflect "reflect"
 )
 
 // MockEnviron is a mock of Environ interface
@@ -126,9 +128,9 @@ func (mr *MockMachineMockRecorder) IsManual() *gomock.Call {
 }
 
 // Life mocks base method
-func (m *MockMachine) Life() params.Life {
+func (m *MockMachine) Life() life.Value {
 	ret := m.ctrl.Call(m, "Life")
-	ret0, _ := ret[0].(params.Life)
+	ret0, _ := ret[0].(life.Value)
 	return ret0
 }
 

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -61,7 +62,7 @@ type Machine interface {
 	String() string
 	Refresh() error
 	Status() (params.StatusResult, error)
-	Life() params.Life
+	Life() life.Value
 	IsManual() (bool, error)
 }
 
@@ -238,7 +239,7 @@ func (u *updaterWorker) queueMachineForPolling(tag names.MachineTag) error {
 		if err := entry.m.Refresh(); err != nil {
 			return errors.Trace(err)
 		}
-		if entry.m.Life() == params.Dead {
+		if entry.m.Life() == life.Dead {
 			u.config.Logger.Debugf("removing dead machine %q (instance ID %q)", entry.m, entry.instanceID)
 			delete(u.pollGroup[groupType], tag)
 			delete(u.instanceIDToGroupEntry, entry.instanceID)
@@ -423,7 +424,7 @@ func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instance
 
 	// We don't care about dead machines; they will be cleaned up when we
 	// process the following machine watcher events.
-	if entry.m.Life() == params.Dead {
+	if entry.m.Life() == life.Dead {
 		return status.Unknown, nil
 	}
 

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -156,7 +157,7 @@ func (s *workerSuite) TestQueueingExistingMachineAlwaysMovesItToShortPollGroup(c
 	machineTag := names.NewMachineTag("0")
 	machine := mocks.NewMockMachine(ctrl)
 	machine.EXPECT().Refresh().Return(nil)
-	machine.EXPECT().Life().Return(params.Alive)
+	machine.EXPECT().Life().Return(life.Alive)
 	updWorker.appendToShortPollGroup(machineTag, machine)
 
 	// Manually move entry to long poll group.
@@ -193,7 +194,7 @@ func (s *workerSuite) TestUpdateOfStatusAndAddressDetails(c *gc.C) {
 	// The machine is alive, has an instance status of "provisioning" and
 	// is aware of its network addresses.
 	machine.EXPECT().Id().Return("0").AnyTimes()
-	machine.EXPECT().Life().Return(params.Alive)
+	machine.EXPECT().Life().Return(life.Alive)
 	machine.EXPECT().InstanceStatus().Return(params.StatusResult{Status: string(status.Provisioning)}, nil)
 	machine.EXPECT().ProviderAddresses().Return(testAddrs, nil)
 
@@ -333,7 +334,7 @@ func (s *workerSuite) TestDeadMachineGetsRemoved(c *gc.C) {
 
 	// On next refresh, the machine reports as dead
 	machine.EXPECT().Refresh().Return(nil)
-	machine.EXPECT().Life().Return(params.Dead)
+	machine.EXPECT().Life().Return(life.Dead)
 
 	// Emit a change for the machine so the queueing code detects the
 	// dead machine and removes it.
@@ -395,7 +396,7 @@ func (s *workerSuite) TestBatchPollingOfGroupMembers(c *gc.C) {
 
 	machineTag1 := names.NewMachineTag("1")
 	machine1 := mocks.NewMockMachine(ctrl)
-	machine1.EXPECT().Life().Return(params.Alive)
+	machine1.EXPECT().Life().Return(life.Alive)
 	machine1.EXPECT().InstanceId().Return(instance.Id("b4dc0ffee"), nil)
 	machine1.EXPECT().InstanceStatus().Return(params.StatusResult{Status: string(status.Running)}, nil)
 	machine1.EXPECT().Status().Return(params.StatusResult{Status: string(status.Started)}, nil)

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	corelife "github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -165,7 +166,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	}
 
 	life := mr.machine.Life()
-	if life == params.Alive {
+	if life == corelife.Alive {
 		observedConfig, err := getObservedNetworkConfig(common.DefaultNetworkConfigSource())
 		if err != nil {
 			return errors.Annotate(err, "cannot discover observed network config")

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/network"
@@ -43,7 +44,7 @@ func (s *MachinerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.accessor = &mockMachineAccessor{}
 	s.accessor.machine.watcher.changes = make(chan struct{})
-	s.accessor.machine.life = params.Alive
+	s.accessor.machine.life = life.Alive
 	s.machineTag = names.NewMachineTag("123")
 	s.addresses = []net.Addr{ // anything will do
 		&net.IPAddr{IP: net.IPv4bcast},
@@ -116,7 +117,7 @@ func (s *MachinerSuite) testMachinerMachineRefreshNotFoundOrUnauthorized(c *gc.C
 }
 
 func (s *MachinerSuite) TestMachinerSetStatusStopped(c *gc.C) {
-	s.accessor.machine.life = params.Dying
+	s.accessor.machine.life = life.Dying
 	s.accessor.machine.SetErrors(
 		nil,                             // SetMachineAddresses
 		nil,                             // SetStatus (started)
@@ -152,7 +153,7 @@ func (s *MachinerSuite) TestMachinerSetStatusStopped(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestMachinerMachineEnsureDeadError(c *gc.C) {
-	s.accessor.machine.life = params.Dying
+	s.accessor.machine.life = life.Dying
 	s.accessor.machine.SetErrors(
 		nil, // SetMachineAddresses
 		nil, // SetStatus
@@ -181,7 +182,7 @@ func (s *MachinerSuite) TestMachinerMachineEnsureDeadError(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestMachinerMachineAssignedUnits(c *gc.C) {
-	s.accessor.machine.life = params.Dying
+	s.accessor.machine.life = life.Dying
 	s.accessor.machine.SetErrors(
 		nil, // SetMachineAddresses
 		nil, // SetStatus
@@ -217,7 +218,7 @@ func (s *MachinerSuite) TestMachinerStorageAttached(c *gc.C) {
 	// Machine is dying. We'll respond to "EnsureDead" by
 	// saying that there are still storage attachments;
 	// this should not cause an error.
-	s.accessor.machine.life = params.Dying
+	s.accessor.machine.life = life.Dying
 	s.accessor.machine.SetErrors(
 		nil, // SetMachineAddresses
 		nil, // SetStatus
@@ -299,7 +300,7 @@ func (s *MachinerSuite) TestStartSetsStatus(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestSetDead(c *gc.C) {
-	s.accessor.machine.life = params.Dying
+	s.accessor.machine.life = life.Dying
 	mr := s.makeMachiner(c, false)
 	s.accessor.machine.watcher.changes <- struct{}{}
 

--- a/worker/machiner/mock_test.go
+++ b/worker/machiner/mock_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -32,7 +33,7 @@ type mockMachine struct {
 	machiner.Machine
 	gitjujutesting.Stub
 	watcher mockWatcher
-	life    params.Life
+	life    life.Value
 }
 
 func (m *mockMachine) Refresh() error {
@@ -40,7 +41,7 @@ func (m *mockMachine) Refresh() error {
 	return m.NextErr()
 }
 
-func (m *mockMachine) Life() params.Life {
+func (m *mockMachine) Life() life.Value {
 	m.MethodCall(m, "Life")
 	return m.life
 }

--- a/worker/machiner/state.go
+++ b/worker/machiner/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -19,7 +20,7 @@ type MachineAccessor interface {
 
 type Machine interface {
 	Refresh() error
-	Life() params.Life
+	Life() life.Value
 	EnsureDead() error
 	SetMachineAddresses(addresses []network.MachineAddress) error
 	SetStatus(machineStatus status.Status, info string, data map[string]interface{}) error

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/container/factory"
 	"github.com/juju/juju/container/testing"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/watcher"
 	coretesting "github.com/juju/juju/testing"
@@ -244,7 +245,7 @@ func (s *containerSetupSuite) stubOutProvisioner(ctrl *gomock.Controller) {
 	uuidSource := params.StringResult{Result: s.modelUUID.String()}
 	fExp.FacadeCall("ModelUUID", nil, gomock.Any()).SetArg(2, uuidSource).Return(nil).AnyTimes()
 
-	lifeSource := params.LifeResults{Results: []params.LifeResult{{Life: params.Alive}}}
+	lifeSource := params.LifeResults{Results: []params.LifeResult{{Life: life.Alive}}}
 	fExp.FacadeCall("Life", gomock.Any(), gomock.Any()).SetArg(2, lifeSource).Return(nil).AnyTimes()
 
 	watchSource := params.StringsWatchResults{Results: []params.StringsWatchResult{{

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/controller/authentication"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -405,7 +406,7 @@ func (task *provisionerTask) pendingOrDeadOrMaintain(ids []string) (pending, dea
 }
 
 type ClassifiableMachine interface {
-	Life() params.Life
+	Life() life.Value
 	InstanceId() (instance.Id, error)
 	EnsureDead() error
 	Status() (status.Status, string, error)
@@ -425,7 +426,7 @@ const (
 func classifyMachine(logger Logger, machine ClassifiableMachine) (
 	MachineClassification, error) {
 	switch machine.Life() {
-	case params.Dying:
+	case life.Dying:
 		if _, err := machine.InstanceId(); err == nil {
 			return None, nil
 		} else if !params.IsCodeNotProvisioned(err) {
@@ -436,7 +437,7 @@ func classifyMachine(logger Logger, machine ClassifiableMachine) (
 			return None, errors.Annotatef(err, "failed to ensure machine dead id:%s, details:%v", machine.Id(), machine)
 		}
 		fallthrough
-	case params.Dead:
+	case life.Dead:
 		return Dead, nil
 	}
 	instId, err := machine.InstanceId()

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/controller/authentication"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -141,12 +142,12 @@ func (s *ProvisionerTaskSuite) TestStopInstancesIgnoresMachinesWithKeep(c *gc.C)
 
 	m0 := &testMachine{
 		id:       "0",
-		life:     params.Dead,
+		life:     life.Dead,
 		instance: i0,
 	}
 	m1 := &testMachine{
 		id:           "1",
-		life:         params.Dead,
+		life:         life.Dead,
 		instance:     i1,
 		keepInstance: true,
 	}
@@ -520,7 +521,7 @@ type testMachine struct {
 
 	*apiprovisioner.Machine
 	id   string
-	life params.Life
+	life life.Value
 
 	instance     *testInstance
 	keepInstance bool
@@ -540,7 +541,7 @@ func (m *testMachine) String() string {
 	return m.Id()
 }
 
-func (m *testMachine) Life() params.Life {
+func (m *testMachine) Life() life.Value {
 	return m.life
 }
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/controller/authentication"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -865,7 +866,7 @@ type MachineClassifySuite struct {
 var _ = gc.Suite(&MachineClassifySuite{})
 
 type MockMachine struct {
-	life          params.Life
+	life          life.Value
 	status        status.Status
 	id            string
 	idErr         error
@@ -873,7 +874,7 @@ type MockMachine struct {
 	statusErr     error
 }
 
-func (m *MockMachine) Life() params.Life {
+func (m *MockMachine) Life() life.Value {
 	return m.life
 }
 
@@ -904,7 +905,7 @@ func (m *MockMachine) Id() string {
 
 type machineClassificationTest struct {
 	description    string
-	life           params.Life
+	life           life.Value
 	status         status.Status
 	idErr          string
 	ensureDeadErr  string
@@ -916,23 +917,23 @@ type machineClassificationTest struct {
 
 var machineClassificationTests = []machineClassificationTest{{
 	description:    "Dead machine is dead",
-	life:           params.Dead,
+	life:           life.Dead,
 	status:         status.Started,
 	classification: provisioner.Dead,
 }, {
 	description:    "Dying machine can carry on dying",
-	life:           params.Dying,
+	life:           life.Dying,
 	status:         status.Started,
 	classification: provisioner.None,
 }, {
 	description:    "Dying unprovisioned machine is ensured dead",
-	life:           params.Dying,
+	life:           life.Dying,
 	status:         status.Started,
 	classification: provisioner.Dead,
 	idErr:          params.CodeNotProvisioned,
 }, {
 	description:    "Can't load provisioned dying machine",
-	life:           params.Dying,
+	life:           life.Dying,
 	status:         status.Started,
 	classification: provisioner.None,
 	idErr:          params.CodeNotFound,
@@ -940,14 +941,14 @@ var machineClassificationTests = []machineClassificationTest{{
 	expectErrFmt:   "failed to load dying machine id:%s.*",
 }, {
 	description:    "Alive machine is not provisioned - pending",
-	life:           params.Alive,
+	life:           life.Alive,
 	status:         status.Pending,
 	classification: provisioner.Pending,
 	idErr:          params.CodeNotProvisioned,
 	expectErrFmt:   "found machine pending provisioning id:%s.*",
 }, {
 	description:    "Alive, pending machine not found",
-	life:           params.Alive,
+	life:           life.Alive,
 	status:         status.Pending,
 	classification: provisioner.None,
 	idErr:          params.CodeNotFound,
@@ -955,13 +956,13 @@ var machineClassificationTests = []machineClassificationTest{{
 	expectErrFmt:   "failed to load machine id:%s.*",
 }, {
 	description:    "Cannot get unprovisioned machine status",
-	life:           params.Alive,
+	life:           life.Alive,
 	classification: provisioner.None,
 	statusErr:      params.CodeNotFound,
 	idErr:          params.CodeNotProvisioned,
 }, {
 	description:    "Dying machine fails to ensure dead",
-	life:           params.Dying,
+	life:           life.Dying,
 	status:         status.Started,
 	classification: provisioner.None,
 	idErr:          params.CodeNotProvisioned,
@@ -972,14 +973,14 @@ var machineClassificationTests = []machineClassificationTest{{
 
 var machineClassificationTestsRequireMaintenance = machineClassificationTest{
 	description:    "Machine needs maintaining",
-	life:           params.Alive,
+	life:           life.Alive,
 	status:         status.Started,
 	classification: provisioner.Maintain,
 }
 
 var machineClassificationTestsNoMaintenance = machineClassificationTest{
 	description:    "Machine doesn't need maintaining",
-	life:           params.Alive,
+	life:           life.Alive,
 	status:         status.Started,
 	classification: provisioner.None,
 }

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -16,6 +16,7 @@ import (
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/worker/remoterelations"
@@ -87,7 +88,7 @@ func (m *mockRelationsFacade) removeRelation(key string) (*mockRelationUnitsWatc
 	return w, ok
 }
 
-func (m *mockRelationsFacade) updateRelationLife(key string, life params.Life) (*mockRelationUnitsWatcher, bool) {
+func (m *mockRelationsFacade) updateRelationLife(key string, life life.Value) (*mockRelationUnitsWatcher, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.relationsUnitsWatchers[key]
@@ -418,7 +419,7 @@ type mockRemoteApplication struct {
 	name       string
 	offeruuid  string
 	url        string
-	life       params.Life
+	life       life.Value
 	modelUUID  string
 	registered bool
 }
@@ -488,7 +489,7 @@ func (w *mockOfferStatusWatcher) Changes() watcher.OfferStatusChannel {
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
 	return &mockRemoteApplication{
-		name: name, url: url, life: params.Alive, offeruuid: "offer-" + name + "-uuid",
+		name: name, url: url, life: life.Alive, offeruuid: "offer-" + name + "-uuid",
 		modelUUID: "remote-model-uuid",
 	}
 }
@@ -503,7 +504,7 @@ func (r *mockRemoteApplication) SourceModel() names.ModelTag {
 	return names.NewModelTag(r.modelUUID)
 }
 
-func (r *mockRemoteApplication) Life() params.Life {
+func (r *mockRemoteApplication) Life() life.Value {
 	r.MethodCall(r, "Life")
 	return r.life
 }
@@ -512,14 +513,14 @@ type mockRelation struct {
 	testing.Stub
 	sync.Mutex
 	id        int
-	life      params.Life
+	life      life.Value
 	suspended bool
 }
 
 func newMockRelation(id int) *mockRelation {
 	return &mockRelation{
 		id:   id,
-		life: params.Alive,
+		life: life.Alive,
 	}
 }
 
@@ -528,7 +529,7 @@ func (r *mockRelation) Id() int {
 	return r.id
 }
 
-func (r *mockRelation) Life() params.Life {
+func (r *mockRelation) Life() life.Value {
 	r.MethodCall(r, "Life")
 	return r.life
 }

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/macaroon.v2-unstable"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -220,7 +221,7 @@ func (w *remoteApplicationWorker) processRelationDying(key string, r *relation, 
 	if !w.isConsumerProxy {
 		change := params.RemoteRelationChangeEvent{
 			RelationToken:    r.relationToken,
-			Life:             params.Dying,
+			Life:             life.Dying,
 			ApplicationToken: r.applicationToken,
 			Macaroons:        macaroon.Slice{r.macaroon},
 		}
@@ -315,7 +316,7 @@ func (w *remoteApplicationWorker) relationChanged(
 		if remoteRelation.Suspended {
 			return w.processRelationSuspended(key, relations)
 		}
-		if !wasSuspended && remoteRelation.Life == params.Alive {
+		if !wasSuspended && remoteRelation.Life == life.Alive {
 			// Nothing to do, we have previously started the watcher.
 			return nil
 		}
@@ -490,7 +491,7 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 	}
 
 	// If the relation is dying, stop the watcher.
-	if remoteRelation.Life != params.Alive {
+	if remoteRelation.Life != life.Alive {
 		return w.processRelationDying(key, r, !relationKnown)
 	}
 

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -398,7 +398,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
 
-	unitsWatcher, _ := s.relationsFacade.updateRelationLife("db2:db django:db", params.Dying)
+	unitsWatcher, _ := s.relationsFacade.updateRelationLife("db2:db django:db", life.Dying)
 	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
 	relWatcher.changes <- []string{"db2:db django:db"}
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
@@ -445,7 +445,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
 		{"PublishRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life:             params.Dying,
+				Life:             life.Dying,
 				ApplicationToken: "token-django",
 				RelationToken:    "token-db2:db django:db",
 				Macaroons:        macaroon.Slice{apiMac},
@@ -599,7 +599,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDyingConsumes(c *gc.C) {
 	expected := []jujutesting.StubCall{
 		{"ConsumeRemoteRelationChange", []interface{}{
 			params.RemoteRelationChangeEvent{
-				Life:             params.Dying,
+				Life:             life.Dying,
 				ApplicationToken: "token-offer-db2-uuid",
 				RelationToken:    "token-db2:db django:db",
 				Suspended:        &suspended,
@@ -693,7 +693,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 	// If a relation is dying and there's been an error, when processing resumes
 	// a cleanup is forced on the remote side.
 	if dying {
-		s.relationsFacade.updateRelationLife("db2:db django:db", params.Dying)
+		s.relationsFacade.updateRelationLife("db2:db django:db", life.Dying)
 		forceCleanup := true
 		expected = append(expected, jujutesting.StubCall{
 			FuncName: "PublishRelationChange",
@@ -701,7 +701,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 				params.RemoteRelationChangeEvent{
 					ApplicationToken: "token-django",
 					RelationToken:    "token-db2:db django:db",
-					Life:             params.Dying,
+					Life:             life.Dying,
 					Macaroons:        macaroon.Slice{apiMac},
 					ForceCleanup:     &forceCleanup,
 				},

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -85,7 +85,7 @@ func (w *remoteRelationsWorker) loop() error {
 			event = params.RemoteRelationChangeEvent{
 				RelationToken:    w.remoteRelationToken,
 				ApplicationToken: w.applicationToken,
-				Life:             params.Life(change.Life),
+				Life:             change.Life,
 				Suspended:        &suspended,
 				SuspendedReason:  change.SuspendedReason,
 			}

--- a/worker/storageprovisioner/caasworker.go
+++ b/worker/storageprovisioner/caasworker.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/worker.v1/catacomb"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -133,7 +134,7 @@ func (p *provisioner) loop() error {
 					}
 					continue
 				}
-				if _, ok := p.getApplicationWorker(appId); ok || appLifeResult.Life == params.Dead {
+				if _, ok := p.getApplicationWorker(appId); ok || appLifeResult.Life == life.Dead {
 					// Already watching the application. or we're
 					// not yet watching it and it's dead.
 					continue

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/storage"
 )
@@ -23,7 +24,7 @@ func storageEntityLife(ctx *context, tags []names.Tag) (alive, dying, dead []nam
 		return nil, nil, nil, errors.Annotate(err, "getting storage entity life")
 	}
 	for i, result := range lifeResults {
-		life := result.Life
+		value := result.Life
 		if result.Error != nil {
 			if !params.IsCodeNotFound(result.Error) {
 				return nil, nil, nil, errors.Annotatef(
@@ -31,14 +32,14 @@ func storageEntityLife(ctx *context, tags []names.Tag) (alive, dying, dead []nam
 					names.ReadableString(tags[i]),
 				)
 			}
-			life = params.Dead
+			value = life.Dead
 		}
-		switch life {
-		case params.Alive:
+		switch value {
+		case life.Alive:
 			alive = append(alive, tags[i])
-		case params.Dying:
+		case life.Dying:
 			dying = append(dying, tags[i])
-		case params.Dead:
+		case life.Dead:
 			dead = append(dead, tags[i])
 		}
 	}
@@ -55,7 +56,7 @@ func attachmentLife(ctx *context, ids []params.MachineStorageId) (
 		return nil, nil, nil, errors.Annotate(err, "getting machine attachment life")
 	}
 	for i, result := range lifeResults {
-		life := result.Life
+		value := result.Life
 		if result.Error != nil {
 			if !params.IsCodeNotFound(result.Error) {
 				return nil, nil, nil, errors.Annotatef(
@@ -63,14 +64,14 @@ func attachmentLife(ctx *context, ids []params.MachineStorageId) (
 					ids[i].AttachmentTag, ids[i].MachineTag,
 				)
 			}
-			life = params.Dead
+			value = life.Dead
 		}
-		switch life {
-		case params.Alive:
+		switch value {
+		case life.Alive:
 			alive = append(alive, ids[i])
-		case params.Dying:
+		case life.Dying:
 			dying = append(dying, ids[i])
-		case params.Dead:
+		case life.Dead:
 			dead = append(dead, ids[i])
 		}
 	}

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/environs/context"
@@ -489,15 +490,15 @@ func (m *mockLifecycleManager) Life(tags []names.Tag) ([]params.LifeResult, erro
 			result = append(result, params.LifeResult{Error: m.err})
 			continue
 		}
-		life := params.Alive
+		value := life.Alive
 		if tag.Kind() == names.ApplicationTagKind {
 			if tag.Id() == "mysql" {
-				life = params.Dying
+				value = life.Dying
 			} else if tag.Id() == "postgresql" {
-				life = params.Dead
+				value = life.Dead
 			}
 		}
-		result = append(result, params.LifeResult{Life: life})
+		result = append(result, params.LifeResult{Life: value})
 	}
 	return result, nil
 }
@@ -511,13 +512,13 @@ func (m *mockLifecycleManager) AttachmentLife(ids []params.MachineStorageId) ([]
 		switch id {
 		case dyingVolumeAttachmentId, dyingUnitVolumeAttachmentId,
 			dyingFilesystemAttachmentId, dyingUnitFilesystemAttachmentId:
-			result = append(result, params.LifeResult{Life: params.Dying})
+			result = append(result, params.LifeResult{Life: life.Dying})
 		case missingVolumeAttachmentId:
 			result = append(result, params.LifeResult{
 				Error: common.ServerError(errors.NotFoundf("attachment %v", id)),
 			})
 		default:
-			result = append(result, params.LifeResult{Life: params.Alive})
+			result = append(result, params.LifeResult{Life: life.Alive})
 		}
 	}
 	return result, nil

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
@@ -540,9 +541,9 @@ func (s *storageProvisionerSuite) TestValidateVolumeParams(c *gc.C) {
 		for i := range results {
 			switch tags[i].String() {
 			case "volume-3":
-				results[i].Life = params.Dead
+				results[i].Life = life.Dead
 			default:
-				results[i].Life = params.Alive
+				results[i].Life = life.Alive
 			}
 		}
 		return results, nil
@@ -634,9 +635,9 @@ func (s *storageProvisionerSuite) TestValidateFilesystemParams(c *gc.C) {
 		for i := range results {
 			switch tags[i].String() {
 			case "filesystem-3":
-				results[i].Life = params.Dead
+				results[i].Life = life.Dead
 			default:
-				results[i].Life = params.Alive
+				results[i].Life = life.Alive
 			}
 		}
 		return results, nil
@@ -1281,11 +1282,11 @@ func (s *storageProvisionerSuite) TestDetachVolumes(c *gc.C) {
 
 	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
 		c.Assert(ids, gc.DeepEquals, expectedAttachmentIds)
-		life := params.Alive
+		value := life.Alive
 		if attached {
-			life = params.Dying
+			value = life.Dying
 		}
-		return []params.LifeResult{{Life: life}}, nil
+		return []params.LifeResult{{Life: value}}, nil
 	}
 
 	detached := make(chan interface{})
@@ -1358,7 +1359,7 @@ func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
 	volumeAccessor.provisionedMachines[machine.String()] = instance.Id("already-provisioned-1")
 
 	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
-		return []params.LifeResult{{Life: params.Dying}}, nil
+		return []params.LifeResult{{Life: life.Dying}}, nil
 	}
 
 	// mockFunc's After will progress the current time by the specified
@@ -1482,11 +1483,11 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 
 	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
 		c.Assert(ids, gc.DeepEquals, expectedAttachmentIds)
-		life := params.Alive
+		value := life.Alive
 		if attached {
-			life = params.Dying
+			value = life.Dying
 		}
-		return []params.LifeResult{{Life: life}}, nil
+		return []params.LifeResult{{Life: value}}, nil
 	}
 
 	detached := make(chan interface{})
@@ -1550,7 +1551,7 @@ func (s *storageProvisionerSuite) TestDestroyVolumes(c *gc.C) {
 	life := func(tags []names.Tag) ([]params.LifeResult, error) {
 		results := make([]params.LifeResult, len(tags))
 		for i := range results {
-			results[i].Life = params.Dead
+			results[i].Life = life.Dead
 		}
 		return results, nil
 	}
@@ -1621,7 +1622,7 @@ func (s *storageProvisionerSuite) TestDestroyVolumesRetry(c *gc.C) {
 	volumeAccessor.provisionVolume(volume)
 
 	life := func(tags []names.Tag) ([]params.LifeResult, error) {
-		return []params.LifeResult{{Life: params.Dead}}, nil
+		return []params.LifeResult{{Life: life.Dead}}, nil
 	}
 
 	// mockFunc's After will progress the current time by the specified
@@ -1704,7 +1705,7 @@ func (s *storageProvisionerSuite) TestDestroyFilesystems(c *gc.C) {
 	life := func(tags []names.Tag) ([]params.LifeResult, error) {
 		results := make([]params.LifeResult, len(tags))
 		for i := range results {
-			results[i].Life = params.Dead
+			results[i].Life = life.Dead
 		}
 		return results, nil
 	}
@@ -1776,7 +1777,7 @@ func (s *storageProvisionerSuite) TestDestroyFilesystemsRetry(c *gc.C) {
 	filesystemAccessor.provisionFilesystem(provisionedDestroyFilesystem)
 
 	life := func(tags []names.Tag) ([]params.LifeResult, error) {
-		return []params.LifeResult{{Life: params.Dead}}, nil
+		return []params.LifeResult{{Life: life.Dead}}, nil
 	}
 
 	// mockFunc's After will progress the current time by the specified
@@ -1900,7 +1901,7 @@ func (s *caasStorageProvisionerSuite) TestDetachVolumes(c *gc.C) {
 	}}
 
 	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
-		return []params.LifeResult{{Life: params.Dying}}, nil
+		return []params.LifeResult{{Life: life.Dying}}, nil
 	}
 
 	detached := make(chan interface{})
@@ -1941,7 +1942,7 @@ func (s *caasStorageProvisionerSuite) TestRemoveVolumes(c *gc.C) {
 	}}
 
 	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
-		return []params.LifeResult{{Life: params.Dying}}, nil
+		return []params.LifeResult{{Life: life.Dying}}, nil
 	}
 
 	removed := make(chan interface{})
@@ -2003,7 +2004,7 @@ func (s *caasStorageProvisionerSuite) TestRemoveFilesystems(c *gc.C) {
 
 	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
 		c.Assert(ids, gc.DeepEquals, expectedAttachmentIds)
-		return []params.LifeResult{{Life: params.Dying}}, nil
+		return []params.LifeResult{{Life: life.Dying}}, nil
 	}
 
 	removed := make(chan interface{})

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/plans"
@@ -64,11 +65,11 @@ func sortVolumeAttachmentPlans(ctx *context, ids []params.MachineStorageId) (
 	ctx.config.Logger.Debugf("Found plans: %v", plans)
 	for _, plan := range plans {
 		switch plan.Result.Life {
-		case params.Alive:
+		case life.Alive:
 			alive = append(alive, plan)
-		case params.Dying:
+		case life.Dying:
 			dying = append(dying, plan)
-		case params.Dead:
+		case life.Dead:
 			dead = append(dead, plan)
 		}
 	}

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	environscontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
@@ -242,7 +243,7 @@ func volumeAttachmentPlanFromAttachment(attachment storage.VolumeAttachment) par
 	return params.VolumeAttachmentPlan{
 		VolumeTag:  attachment.Volume.String(),
 		MachineTag: attachment.Machine.String(),
-		Life:       params.Alive,
+		Life:       life.Alive,
 		PlanInfo:   planInfo,
 	}
 }

--- a/worker/undertaker/undertaker.go
+++ b/worker/undertaker/undertaker.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/worker.v1/catacomb"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
@@ -121,10 +122,10 @@ func (u *Undertaker) run() error {
 	}
 	modelInfo := result.Result
 
-	if modelInfo.Life == params.Alive {
+	if modelInfo.Life == life.Alive {
 		return errors.Errorf("model still alive")
 	}
-	if modelInfo.Life == params.Dying {
+	if modelInfo.Life == life.Dying {
 		// TODO(axw) 2016-04-14 #1570285
 		// We should update status with information
 		// about the remaining resources here, and

--- a/worker/uniter/leadership/resolver.go
+++ b/worker/uniter/leadership/resolver.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6/hooks"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
@@ -41,7 +41,7 @@ func (l *leadershipResolver) NextOp(
 
 	// If we've already accepted leadership, we don't need to do it again.
 	canAcceptLeader := !localState.Leader
-	if remoteState.Life == params.Dying {
+	if remoteState.Life == life.Dying {
 		canAcceptLeader = false
 	} else {
 		// If we're in an unexpected mode (eg pending hook) we shouldn't try either.
@@ -56,7 +56,7 @@ func (l *leadershipResolver) NextOp(
 
 	// If we're the leader but should not be any longer, or
 	// if the unit is dying, we should resign leadership.
-	case localState.Leader && (!remoteState.Leader || remoteState.Life == params.Dying):
+	case localState.Leader && (!remoteState.Leader || remoteState.Life == life.Dying):
 		return opFactory.NewResignLeadership()
 	}
 

--- a/worker/uniter/relation/relations_test.go
+++ b/worker/uniter/relation/relations_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
@@ -137,7 +138,7 @@ func (s *relationsSuite) setupRelations(c *gc.C) relation.Relations {
 	var numCalls int32
 	unitEntity := params.Entities{Entities: []params.Entity{{Tag: "unit-wordpress-0"}}}
 	apiCaller := mockAPICaller(c, &numCalls,
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: life.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 	)
@@ -179,7 +180,7 @@ func (s *relationsSuite) assertNewRelationsWithExistingRelations(c *gc.C, isLead
 			{
 				Id:   1,
 				Key:  "wordpress:db mysql:db",
-				Life: params.Alive,
+				Life: life.Alive,
 				Endpoint: params.Endpoint{
 					ApplicationName: "wordpress",
 					Relation:        params.CharmRelation{Name: "mysql", Role: string(charm.RoleProvider), Interface: "db"},
@@ -193,7 +194,7 @@ func (s *relationsSuite) assertNewRelationsWithExistingRelations(c *gc.C, isLead
 	}}}
 
 	apiCalls := []apiCall{
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: life.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{
 			{RelationResults: []params.RelationUnitStatus{{RelationTag: "relation-wordpress:db mysql:db", InScope: true}}}}}, nil),
@@ -246,7 +247,7 @@ func (s *relationsSuite) TestNextOpNothing(c *gc.C) {
 	var numCalls int32
 	unitEntity := params.Entities{Entities: []params.Entity{{Tag: "unit-wordpress-0"}}}
 	apiCaller := mockAPICaller(c, &numCalls,
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: life.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 	)
@@ -281,7 +282,7 @@ func relationJoinedAPICalls() []apiCall {
 			{
 				Id:   1,
 				Key:  "wordpress:db mysql:db",
-				Life: params.Alive,
+				Life: life.Alive,
 				Endpoint: params.Endpoint{
 					ApplicationName: "wordpress",
 					Relation:        params.CharmRelation{Name: "mysql", Role: string(charm.RoleRequirer), Interface: "db", Scope: "global"},
@@ -297,7 +298,7 @@ func relationJoinedAPICalls() []apiCall {
 		Status:     params.Joined,
 	}}}
 	apiCalls := []apiCall{
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: life.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
@@ -336,7 +337,7 @@ func (s *relationsSuite) assertHookRelationJoined(c *gc.C, numCalls *int32, apiC
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life:      params.Alive,
+				Life:      life.Alive,
 				Suspended: false,
 				Members: map[string]int64{
 					"wordpress/0": 1,
@@ -403,14 +404,14 @@ func (s *relationsSuite) TestHookRelationChanged(c *gc.C) {
 	// members, due to the "changed pending" local persistent
 	// state.
 	s.assertHookRelationChanged(c, r, remotestate.RelationSnapshot{
-		Life:      params.Alive,
+		Life:      life.Alive,
 		Suspended: false,
 	}, &numCalls)
 
 	// wordpress starts at 1, changing to 2 should trigger a
 	// relation-changed hook.
 	s.assertHookRelationChanged(c, r, remotestate.RelationSnapshot{
-		Life:      params.Alive,
+		Life:      life.Alive,
 		Suspended: false,
 		Members: map[string]int64{
 			"wordpress/0": 2,
@@ -424,7 +425,7 @@ func (s *relationsSuite) TestHookRelationChanged(c *gc.C) {
 	// where the relation settings document is removed and
 	// recreated, thus resetting the txn-revno.
 	s.assertHookRelationChanged(c, r, remotestate.RelationSnapshot{
-		Life: params.Alive,
+		Life: life.Alive,
 		Members: map[string]int64{
 			"wordpress/0": 1,
 		},
@@ -440,7 +441,7 @@ func (s *relationsSuite) TestHookRelationChangedApplication(c *gc.C) {
 	// members, due to the "changed pending" local persistent
 	// state.
 	s.assertHookRelationChanged(c, r, remotestate.RelationSnapshot{
-		Life:      params.Alive,
+		Life:      life.Alive,
 		Suspended: false,
 	}, &numCalls)
 
@@ -456,7 +457,7 @@ func (s *relationsSuite) TestHookRelationChangedApplication(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life:      params.Alive,
+				Life:      life.Alive,
 				Suspended: false,
 				Members: map[string]int64{
 					"wordpress/0": 1,
@@ -484,7 +485,7 @@ func (s *relationsSuite) TestHookRelationChangedSuspended(c *gc.C) {
 	// members, due to the "changed pending" local persistent
 	// state.
 	s.assertHookRelationChanged(c, r, remotestate.RelationSnapshot{
-		Life:      params.Alive,
+		Life:      life.Alive,
 		Suspended: true,
 	}, &numCalls)
 	c.Assert(r.GetInfo()[1].RelationUnit.Relation().Suspended(), jc.IsTrue)
@@ -499,7 +500,7 @@ func (s *relationsSuite) TestHookRelationChangedSuspended(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life:      params.Alive,
+				Life:      life.Alive,
 				Suspended: true,
 			},
 		},
@@ -515,7 +516,7 @@ func (s *relationsSuite) TestHookRelationChangedSuspended(c *gc.C) {
 func (s *relationsSuite) assertHookRelationDeparted(c *gc.C, numCalls *int32, apiCalls ...apiCall) relation.Relations {
 	r := s.assertHookRelationJoined(c, numCalls, apiCalls...)
 	s.assertHookRelationChanged(c, r, remotestate.RelationSnapshot{
-		Life:      params.Alive,
+		Life:      life.Alive,
 		Suspended: false,
 	}, numCalls)
 	numCallsBefore := *numCalls
@@ -528,7 +529,7 @@ func (s *relationsSuite) assertHookRelationDeparted(c *gc.C, numCalls *int32, ap
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life: params.Dying,
+				Life: life.Dying,
 				Members: map[string]int64{
 					"wordpress/0": 1,
 				},
@@ -570,7 +571,7 @@ func (s *relationsSuite) TestHookRelationBroken(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life: params.Dying,
+				Life: life.Dying,
 			},
 		},
 	}
@@ -595,7 +596,7 @@ func (s *relationsSuite) TestHookRelationBrokenWhenSuspended(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life:      params.Alive,
+				Life:      life.Alive,
 				Suspended: true,
 			},
 		},
@@ -627,7 +628,7 @@ func (s *relationsSuite) TestHookRelationBrokenOnlyOnce(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life:      params.Alive,
+				Life:      life.Alive,
 				Suspended: true,
 			},
 		},
@@ -690,7 +691,7 @@ func (s *relationsSuite) TestImplicitRelationNoHooks(c *gc.C) {
 			{
 				Id:   1,
 				Key:  "wordpress:juju-info juju-info:juju-info",
-				Life: params.Alive,
+				Life: life.Alive,
 				Endpoint: params.Endpoint{
 					ApplicationName: "wordpress",
 					Relation:        params.CharmRelation{Name: "juju-info", Role: string(charm.RoleProvider), Interface: "juju-info", Scope: "global"},
@@ -706,7 +707,7 @@ func (s *relationsSuite) TestImplicitRelationNoHooks(c *gc.C) {
 		Status:     params.Joined,
 	}}}
 	apiCalls := []apiCall{
-		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
+		uniterAPICall("Refresh", unitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: life.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", unitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "", Ok: false}}}, nil),
 		uniterAPICall("RelationsStatus", unitEntity, params.RelationUnitStatusResults{Results: []params.RelationUnitStatusResult{{RelationResults: []params.RelationUnitStatus{}}}}, nil),
 		uniterAPICall("RelationById", params.RelationIds{RelationIds: []int{1}}, relationResults, nil),
@@ -739,7 +740,7 @@ func (s *relationsSuite) TestImplicitRelationNoHooks(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life: params.Alive,
+				Life: life.Alive,
 				Members: map[string]int64{
 					"wordpress": 1,
 				},
@@ -774,7 +775,7 @@ func subSubRelationAPICalls() []apiCall {
 		Results: []params.RelationResult{{
 			Id:               1,
 			Key:              "wordpress:juju-info nrpe:general-info",
-			Life:             params.Alive,
+			Life:             life.Alive,
 			OtherApplication: "wordpress",
 			Endpoint: params.Endpoint{
 				ApplicationName: "nrpe",
@@ -794,7 +795,7 @@ func subSubRelationAPICalls() []apiCall {
 		Results: []params.RelationResult{{
 			Id:               2,
 			Key:              "ntp:nrpe-external-master nrpe:external-master",
-			Life:             params.Alive,
+			Life:             life.Alive,
 			OtherApplication: "ntp",
 			Endpoint: params.Endpoint{
 				ApplicationName: "nrpe",
@@ -819,7 +820,7 @@ func subSubRelationAPICalls() []apiCall {
 	}}}
 
 	return []apiCall{
-		uniterAPICall("Refresh", nrpeUnitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: params.Alive, Resolved: params.ResolvedNone}}}, nil),
+		uniterAPICall("Refresh", nrpeUnitEntity, params.UnitRefreshResults{Results: []params.UnitRefreshResult{{Life: life.Alive, Resolved: params.ResolvedNone}}}, nil),
 		uniterAPICall("GetPrincipal", nrpeUnitEntity, params.StringBoolResults{Results: []params.StringBoolResult{{Result: "unit-wordpress-0", Ok: true}}}, nil),
 		uniterAPICall("RelationsStatus", nrpeUnitEntity, relationStatusResults, nil),
 		uniterAPICall("Relation", relationUnits1, relationResults1, nil),
@@ -874,13 +875,13 @@ func (s *relationsSuite) TestSubSubPrincipalRelationDyingDestroysUnit(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life: params.Dying,
+				Life: life.Dying,
 				Members: map[string]int64{
 					"wordpress/0": 1,
 				},
 			},
 			2: {
-				Life: params.Alive,
+				Life: life.Alive,
 				Members: map[string]int64{
 					"ntp/0": 1,
 				},
@@ -931,13 +932,13 @@ func (s *relationsSuite) TestSubSubOtherRelationDyingNotDestroyed(c *gc.C) {
 	remoteState := remotestate.Snapshot{
 		Relations: map[int]remotestate.RelationSnapshot{
 			1: {
-				Life: params.Alive,
+				Life: life.Alive,
 				Members: map[string]int64{
 					"wordpress/0": 1,
 				},
 			},
 			2: {
-				Life: params.Dying,
+				Life: life.Dying,
 				Members: map[string]int64{
 					"ntp/0": 1,
 				},

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -7,12 +7,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/core/model"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/worker/uniter/remotestate"
 )
@@ -197,7 +198,7 @@ func (st *mockState) WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, err
 
 type mockUnit struct {
 	tag                              names.UnitTag
-	life                             params.Life
+	life                             life.Value
 	providerID                       string
 	resolved                         params.ResolvedMode
 	application                      mockApplication
@@ -211,7 +212,7 @@ type mockUnit struct {
 	relationsWatcher                 *mockStringsWatcher
 }
 
-func (u *mockUnit) Life() params.Life {
+func (u *mockUnit) Life() life.Value {
 	return u.life
 }
 
@@ -277,7 +278,7 @@ func (u *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) erro
 
 type mockApplication struct {
 	tag                   names.ApplicationTag
-	life                  params.Life
+	life                  life.Value
 	curl                  *charm.URL
 	charmModifiedVersion  int
 	forceUpgrade          bool
@@ -293,7 +294,7 @@ func (s *mockApplication) CharmURL() (*charm.URL, bool, error) {
 	return s.curl, s.forceUpgrade, nil
 }
 
-func (s *mockApplication) Life() params.Life {
+func (s *mockApplication) Life() life.Value {
 	return s.life
 }
 
@@ -316,7 +317,7 @@ func (s *mockApplication) WatchLeadershipSettings() (watcher.NotifyWatcher, erro
 type mockRelation struct {
 	tag       names.RelationTag
 	id        int
-	life      params.Life
+	life      life.Value
 	suspended bool
 }
 
@@ -328,7 +329,7 @@ func (r *mockRelation) Id() int {
 	return r.id
 }
 
-func (r *mockRelation) Life() params.Life {
+func (r *mockRelation) Life() life.Value {
 	return r.life
 }
 

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -8,13 +8,14 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 )
 
 // Snapshot is a snapshot of the remote state of the unit.
 type Snapshot struct {
 	// Life is the lifecycle state of the unit.
-	Life params.Life
+	Life life.Value
 
 	// Relations contains the lifecycle states of
 	// each of the application's relations, keyed by
@@ -93,7 +94,7 @@ type Snapshot struct {
 // RelationSnapshot tracks the state of a relationship from the viewpoint of the local unit.
 type RelationSnapshot struct {
 	// Life indicates whether this relation is active, stopping or dead
-	Life params.Life
+	Life life.Value
 
 	// Suspended is used by cross-model relations to indicate the offer has
 	// disabled the relation, but has not removed it entirely.
@@ -110,7 +111,7 @@ type RelationSnapshot struct {
 // instance belonging to a unit.
 type StorageSnapshot struct {
 	Kind     params.StorageKind
-	Life     params.Life
+	Life     life.Value
 	Attached bool
 	Location string
 }

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 )
@@ -33,7 +34,7 @@ type State interface {
 }
 
 type Unit interface {
-	Life() params.Life
+	Life() life.Value
 	Refresh() error
 	ProviderID() string
 	Resolved() params.ResolvedMode
@@ -59,7 +60,7 @@ type Application interface {
 	// CharmURL returns the url for the charm for this application.
 	CharmURL() (*charm.URL, bool, error)
 	// Life returns whether the application is alive.
-	Life() params.Life
+	Life() life.Value
 	// Refresh syncs this value with the api server.
 	Refresh() error
 	// Tag returns the tag for this application.
@@ -74,7 +75,7 @@ type Application interface {
 type Relation interface {
 	Id() int
 	Tag() names.RelationTag
-	Life() params.Life
+	Life() life.Value
 	Suspended() bool
 	UpdateSuspended(bool)
 }

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	jworker "github.com/juju/juju/worker"
@@ -929,7 +930,7 @@ func (w *RemoteStateWatcher) storageChanged(keys []string) error {
 // the information in the current snapshot.
 func (w *RemoteStateWatcher) watchStorageAttachment(
 	tag names.StorageTag,
-	life params.Life,
+	life life.Value,
 	saw watcher.NotifyWatcher,
 ) error {
 	var storageSnapshot StorageSnapshot

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/charm.v6/hooks"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
@@ -60,7 +61,7 @@ func (s *uniterResolver) NextOp(
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
 ) (operation.Operation, error) {
-	if remoteState.Life == params.Dead || localState.Stopped {
+	if remoteState.Life == life.Dead || localState.Stopped {
 		return nil, resolver.ErrTerminate
 	}
 
@@ -260,8 +261,8 @@ func (s *uniterResolver) nextOp(
 	opFactory operation.Factory,
 ) (operation.Operation, error) {
 	switch remoteState.Life {
-	case params.Alive:
-	case params.Dying:
+	case life.Alive:
+	case life.Dying:
 		// Normally we handle relations last, but if we're dying we
 		// must ensure that all relations are broken first.
 		op, err := s.config.Relations.NextOp(localState, remoteState, opFactory)
@@ -279,7 +280,7 @@ func (s *uniterResolver) nextOp(
 			return opFactory.NewRunHook(hook.Info{Kind: hooks.Stop})
 		}
 		fallthrough
-	case params.Dead:
+	case life.Dead:
 		// The unit is dying/dead and stopped, so tell the uniter
 		// to terminate.
 		return nil, resolver.ErrTerminate

--- a/worker/uniter/storage/attachments_test.go
+++ b/worker/uniter/storage/attachments_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	corestorage "github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
@@ -88,7 +89,7 @@ func (s *attachmentsSuite) TestNewAttachmentsInit(c *gc.C) {
 	attachment := params.StorageAttachment{
 		StorageTag: storageTag.String(),
 		UnitTag:    unitTag.String(),
-		Life:       params.Alive,
+		Life:       life.Alive,
 		Kind:       params.StorageKindBlock,
 		Location:   "/dev/sdb",
 	}
@@ -197,10 +198,10 @@ func (s *attachmentsSuite) TestAttachmentsUpdateShortCircuitDeath(c *gc.C) {
 		Kind: operation.Continue,
 	}}
 	_, err = r.NextOp(localState, remotestate.Snapshot{
-		Life: params.Alive,
+		Life: life.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag0: {
-				Life:     params.Alive,
+				Life:     life.Alive,
 				Kind:     params.StorageKindBlock,
 				Location: "/dev/sdb",
 				Attached: true,
@@ -211,9 +212,9 @@ func (s *attachmentsSuite) TestAttachmentsUpdateShortCircuitDeath(c *gc.C) {
 
 	for _, storageTag := range []names.StorageTag{storageTag0, storageTag1} {
 		_, err = r.NextOp(localState, remotestate.Snapshot{
-			Life: params.Alive,
+			Life: life.Alive,
 			Storage: map[names.StorageTag]remotestate.StorageSnapshot{
-				storageTag: {Life: params.Dying},
+				storageTag: {Life: life.Dying},
 			},
 		}, nil)
 		c.Assert(err, gc.Equals, resolver.ErrNoOperation)
@@ -248,11 +249,11 @@ func (s *attachmentsSuite) TestAttachmentsStorage(c *gc.C) {
 		Kind: operation.Continue,
 	}}
 	op, err := r.NextOp(localState, remotestate.Snapshot{
-		Life: params.Alive,
+		Life: life.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
 				Kind:     params.StorageKindBlock,
-				Life:     params.Alive,
+				Life:     life.Alive,
 				Location: "/dev/sdb",
 				Attached: true,
 			},
@@ -297,11 +298,11 @@ func (s *attachmentsSuite) TestAttachmentsCommitHook(c *gc.C) {
 		Kind: operation.Continue,
 	}}
 	_, err = r.NextOp(localState, remotestate.Snapshot{
-		Life: params.Alive,
+		Life: life.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
 				Kind:     params.StorageKindBlock,
-				Life:     params.Alive,
+				Life:     life.Alive,
 				Location: "/dev/sdb",
 				Attached: true,
 			},
@@ -383,11 +384,11 @@ func (s *attachmentsSuite) TestAttachmentsSetDying(c *gc.C) {
 		Kind: operation.Continue,
 	}}
 	_, err = r.NextOp(localState, remotestate.Snapshot{
-		Life: params.Dying,
+		Life: life.Dying,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
 				Kind:     params.StorageKindBlock,
-				Life:     params.Alive,
+				Life:     life.Alive,
 				Location: "/dev/sdb",
 				Attached: true,
 			},
@@ -421,10 +422,10 @@ func (s *attachmentsSuite) TestAttachmentsWaitPending(c *gc.C) {
 			Kind:      operation.Continue,
 		}}
 		_, err := r.NextOp(localState, remotestate.Snapshot{
-			Life: params.Alive,
+			Life: life.Alive,
 			Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 				storageTag: {
-					Life:     params.Alive,
+					Life:     life.Alive,
 					Attached: false,
 				},
 			},

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
@@ -514,7 +515,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	if err != nil {
 		return err
 	}
-	if u.unit.Life() == params.Dead {
+	if u.unit.Life() == life.Dead {
 		// If we started up already dead, we should not progress further. If we
 		// become Dead immediately after starting up, we may well complete any
 		// operations in progress before detecting it; but that race is fundamental


### PR DESCRIPTION
Some clean up that needed to be done.

We don't need an additional Life type and constants in the apiserver/params package.

Tests pass, and there is no user impact at all.