### PR TITLE
Return Space-Less API Server Addresses to Consumers

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -111,11 +111,9 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	if err != nil {
 		return fail, errors.Trace(err)
 	}
-	pServers := make([]network.ProviderHostPorts, len(hostPorts))
+	pServers := make([]network.HostPorts, len(hostPorts))
 	for i, hps := range hostPorts {
-		if pServers[i], err = hps.ToProviderHostPorts(a.root.state); err != nil {
-			return fail, errors.Trace(err)
-		}
+		pServers[i] = hps.HostPorts()
 	}
 
 	// apiRoot is the API root exposed to the client after login.
@@ -164,7 +162,7 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	)
 	a.root.rpcConn.ServeRoot(apiRoot, recorderFactory, serverError)
 	return params.LoginResult{
-		Servers:       params.FromProviderHostsPorts(pServers),
+		Servers:       params.FromHostsPorts(pServers),
 		ControllerTag: a.root.model.ControllerTag().String(),
 		UserInfo:      authResult.userInfo,
 		ServerVersion: jujuversion.Current.String(),

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/network"
@@ -49,18 +47,14 @@ func (a *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
 		return params.APIHostPortsResult{}, err
 	}
 
-	// Convert the SpaceHostPorts to ProviderHostPorts by using state
-	// to look up space IDs.
-	pSvrs := make([]network.ProviderHostPorts, len(sSvrs))
+	// Convert the SpaceHostPorts to the HostPorts indirection.
+	pSvrs := make([]network.HostPorts, len(sSvrs))
 	for i, sHPs := range sSvrs {
-		var err error
-		if pSvrs[i], err = sHPs.ToProviderHostPorts(a.getter); err != nil {
-			return params.APIHostPortsResult{}, errors.Trace(err)
-		}
+		pSvrs[i] = sHPs.HostPorts()
 	}
 
 	return params.APIHostPortsResult{
-		Servers: params.FromProviderHostsPorts(pSvrs),
+		Servers: params.FromHostsPorts(pSvrs),
 	}, nil
 }
 

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -91,6 +91,10 @@ func IsUpgradeInProgressError(err error) bool {
 // the user) has been migrated to a different controller.
 type RedirectError struct {
 	// Servers holds the sets of addresses of the redirected servers.
+	// TODO (manadart 2019-11-08): Change this to be either MachineHostPorts
+	// or the HostPorts indirection. We don't care about space info here.
+	// We can then delete the API params helpers for conversion for this type
+	// as it will no longer be used.
 	Servers []network.ProviderHostPorts `json:"servers"`
 
 	// CACert holds the certificate of the remote server.

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -780,14 +780,12 @@ func (c *Client) APIHostPorts() (result params.APIHostPortsResult, err error) {
 		return result, err
 	}
 
-	pServers := make([]network.ProviderHostPorts, len(servers))
+	pServers := make([]network.HostPorts, len(servers))
 	for i, hps := range servers {
-		if pServers[i], err = hps.ToProviderHostPorts(c.api.stateAccessor); err != nil {
-			return result, err
-		}
+		pServers[i] = hps.HostPorts()
 	}
 
-	result.Servers = params.FromProviderHostsPorts(pServers)
+	result.Servers = params.FromHostsPorts(pServers)
 	return result, nil
 }
 

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -420,7 +420,7 @@ func ToProviderHostPorts(hps []HostPort) network.ProviderHostPorts {
 	return pHps
 }
 
-// FromNetworkHostsPorts is a helper to create a parameter
+// FromProviderHostsPorts is a helper to create a parameter
 // out of the network type, here for a nested slice of HostPort.
 func FromProviderHostsPorts(nhpm []network.ProviderHostPorts) [][]HostPort {
 	hpm := make([][]HostPort, len(nhpm))
@@ -430,7 +430,7 @@ func FromProviderHostsPorts(nhpm []network.ProviderHostPorts) [][]HostPort {
 	return hpm
 }
 
-// FromNetworkHostPorts is a helper to create a parameter
+// FromProviderHostPorts is a helper to create a parameter
 // out of the network type, here for a slice of HostPort.
 func FromProviderHostPorts(nhps network.ProviderHostPorts) []HostPort {
 	hps := make([]HostPort, len(nhps))
@@ -444,6 +444,39 @@ func FromProviderHostPorts(nhps network.ProviderHostPorts) []HostPort {
 // out of the network type, here for ProviderHostPort.
 func FromProviderHostPort(nhp network.ProviderHostPort) HostPort {
 	return HostPort{FromProviderAddress(nhp.ProviderAddress), nhp.Port()}
+}
+
+// FromHostsPorts is a helper to create a parameter
+// out of the network type, here for a nested slice of HostPort.
+func FromHostsPorts(nhpm []network.HostPorts) [][]HostPort {
+	hpm := make([][]HostPort, len(nhpm))
+	for i, nhps := range nhpm {
+		hpm[i] = FromHostPorts(nhps)
+	}
+	return hpm
+}
+
+// FromHostPorts is a helper to create a parameter
+// out of the network type, here for a slice of HostPort.
+func FromHostPorts(nhps network.HostPorts) []HostPort {
+	hps := make([]HostPort, len(nhps))
+	for i, nhp := range nhps {
+		hps[i] = FromHostPort(nhp)
+	}
+	return hps
+}
+
+// FromHostPort is a convenience helper to create a parameter
+// out of the network type, here for HostPort.
+func FromHostPort(nhp network.HostPort) HostPort {
+	return HostPort{
+		Address: Address{
+			Value: nhp.Host(),
+			Type:  string(nhp.AddressType()),
+			Scope: string(nhp.AddressScope()),
+		},
+		Port: nhp.Port(),
+	}
 }
 
 // TODO (wpk) Uniter.NetworkConfig API is obsolete, use NetworkInfo instead

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -371,3 +371,32 @@ func (s *NetworkSuite) TestMachineHostPortConversion(c *gc.C) {
 
 	c.Assert(params.ToMachineHostsPorts(hps), jc.DeepEquals, exp)
 }
+
+func (s *NetworkSuite) TestHostPortConversion(c *gc.C) {
+	mHPs := []network.MachineHostPorts{
+		{
+			{
+				MachineAddress: network.NewScopedMachineAddress("1.2.3.4", network.ScopeCloudLocal),
+				NetPort:        1234,
+			},
+			{
+				MachineAddress: network.NewScopedMachineAddress("2.3.4.5", network.ScopePublic),
+				NetPort:        2345,
+			},
+		},
+		{
+			{
+				MachineAddress: network.NewScopedMachineAddress("3.4.5.6", network.ScopeCloudLocal),
+				NetPort:        3456,
+			},
+		},
+	}
+
+	hps := make([]network.HostPorts, len(mHPs))
+	for i, mHP := range mHPs {
+		hps[i] = mHP.HostPorts()
+	}
+
+	pHPs := params.FromHostsPorts(hps)
+	c.Assert(params.ToMachineHostsPorts(pHPs), jc.DeepEquals, mHPs)
+}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -211,7 +211,7 @@ func (c *CommandBase) NewAPIRoot(
 	if redirErr, ok := errors.Cause(err).(*api.RedirectError); ok {
 		return nil, newModelMigratedError(store, modelName, redirErr)
 	}
-	return conn, err
+	return conn, errors.Trace(err)
 }
 
 // RemoveModelFromClientStore removes given model from client cache, store,

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -401,7 +401,8 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.newAPIRoot(modelName)
+	conn, err := c.newAPIRoot(modelName)
+	return conn, errors.Trace(err)
 }
 
 // NewControllerAPIRoot returns a new connection to the API server for the environment
@@ -419,7 +420,8 @@ func (c *ModelCommandBase) newAPIRoot(modelName string) (api.Connection, error) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.CommandBase.NewAPIRoot(c.store, controllerName, modelName)
+	conn, err := c.CommandBase.NewAPIRoot(c.store, controllerName, modelName)
+	return conn, errors.Trace(err)
 }
 
 // ModelUUIDs returns the model UUIDs for the given model names.

--- a/core/network/hostport.go
+++ b/core/network/hostport.go
@@ -16,9 +16,8 @@ import (
 // HostPort describes methods on an object that
 // represents a network connection endpoint.
 type HostPort interface {
-	Host() string
+	Address
 	Port() int
-	AddressScope() Scope
 }
 
 // HostPorts derives from a slice of HostPort

--- a/juju/api.go
+++ b/juju/api.go
@@ -93,7 +93,7 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 	}
 	defer func() {
 		if err != nil {
-			st.Close()
+			_ = st.Close()
 		}
 	}()
 


### PR DESCRIPTION
## Description of change

This patch fixes an error that can be observed when adding a space-less model (such as k8s) to a space-aware controller (such as MAAS).

MAAS decorates addresses with space IDs, which are returned as API addresses to clients and agents. However the space-less model does not have the space information for these to be resolved, so API connections from clients and agents return not-found errors for the address spaces.

Consumers of the API do not care about the address spaces anyway - they are only used to filter based on HA and management space configurations, so when we pass them out, there is no need to resolve the IDs to space names. Instead we just return space-less host/port parameters.

## QA steps

- Bootstrap a MAAS controller.
- Deploy kubernetes-core.
- Use the `add-k8s` command to add this cluster to the controller.
- Add a k8s model.
- Observe that `status` and `deploy` commands do not return not-found errors for spaces.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1851763
