### PR TITLE
Add vm-folder option to vsphere provider

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -23,11 +23,11 @@ type Client interface {
 	Close(context.Context) error
 	ComputeResources(context.Context) ([]*mo.ComputeResource, error)
 	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
-	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
+	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams, string) (*mo.VirtualMachine, error)
 	Datastores(context.Context) ([]*mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error
-	EnsureVMFolder(context.Context, string) (*object.Folder, error)
+	EnsureVMFolder(context.Context, string, string) (*object.Folder, error)
 	MoveVMFolderInto(context.Context, string, string) error
 	MoveVMsInto(context.Context, string, ...types.ManagedObjectReference) error
 	RemoveVirtualMachines(context.Context, string) error

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -23,11 +23,11 @@ type Client interface {
 	Close(context.Context) error
 	ComputeResources(context.Context) ([]*mo.ComputeResource, error)
 	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
-	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams, string) (*mo.VirtualMachine, error)
+	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
 	Datastores(context.Context) ([]*mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error
-	EnsureVMFolder(context.Context, string, string) (*object.Folder, error)
+	EnsureVMFolder(context.Context, string) (*object.Folder, error)
 	MoveVMFolderInto(context.Context, string, string) error
 	MoveVMsInto(context.Context, string, ...types.ManagedObjectReference) error
 	RemoveVirtualMachines(context.Context, string) error

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -34,6 +34,7 @@ type Client interface {
 	UpdateVirtualMachineExtraConfig(context.Context, *mo.VirtualMachine, map[string]string) error
 	VirtualMachines(context.Context, string) ([]*mo.VirtualMachine, error)
 	UserHasRootLevelPrivilege(context.Context, string) (bool, error)
+	FindFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error)
 }
 
 func dialClient(

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -27,7 +27,7 @@ type Client interface {
 	Datastores(context.Context) ([]*mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error
-	EnsureVMFolder(context.Context, string) (*object.Folder, error)
+	EnsureVMFolder(context.Context, string, string) (*object.Folder, error)
 	MoveVMFolderInto(context.Context, string, string) error
 	MoveVMsInto(context.Context, string, ...types.ManagedObjectReference) error
 	RemoveVirtualMachines(context.Context, string) error

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -16,7 +16,6 @@ const (
 	cfgExternalNetwork = "external-network"
 	cfgDatastore       = "datastore"
 	cfgEnableDiskUUID  = "enable-disk-uuid"
-	cfgVMFolder        = "vm-folder"
 )
 
 // configFields is the spec for each vmware config value's type.
@@ -25,7 +24,6 @@ var (
 		cfgExternalNetwork: schema.String(),
 		cfgDatastore:       schema.String(),
 		cfgPrimaryNetwork:  schema.String(),
-		cfgVMFolder:        schema.String(),
 		cfgEnableDiskUUID:  schema.Bool(),
 	}
 
@@ -33,7 +31,6 @@ var (
 		cfgExternalNetwork: "",
 		cfgDatastore:       schema.Omit,
 		cfgPrimaryNetwork:  schema.Omit,
-		cfgVMFolder:        schema.Omit,
 		cfgEnableDiskUUID:  true,
 	}
 
@@ -96,11 +93,6 @@ func (c *environConfig) datastore() string {
 func (c *environConfig) primaryNetwork() string {
 	network, _ := c.attrs[cfgPrimaryNetwork].(string)
 	return network
-}
-
-func (c *environConfig) VMFolder() string {
-	folder, _ := c.attrs[cfgVMFolder].(string)
-	return folder
 }
 
 func (c *environConfig) enableDiskUUID() bool {

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -16,6 +16,7 @@ const (
 	cfgExternalNetwork = "external-network"
 	cfgDatastore       = "datastore"
 	cfgEnableDiskUUID  = "enable-disk-uuid"
+	cfgVMFolder        = "vm-folder"
 )
 
 // configFields is the spec for each vmware config value's type.
@@ -24,6 +25,7 @@ var (
 		cfgExternalNetwork: schema.String(),
 		cfgDatastore:       schema.String(),
 		cfgPrimaryNetwork:  schema.String(),
+		cfgVMFolder:        schema.String(),
 		cfgEnableDiskUUID:  schema.Bool(),
 	}
 
@@ -31,6 +33,7 @@ var (
 		cfgExternalNetwork: "",
 		cfgDatastore:       schema.Omit,
 		cfgPrimaryNetwork:  schema.Omit,
+		cfgVMFolder:        schema.Omit, 
 		cfgEnableDiskUUID:  true,
 	}
 
@@ -93,6 +96,11 @@ func (c *environConfig) datastore() string {
 func (c *environConfig) primaryNetwork() string {
 	network, _ := c.attrs[cfgPrimaryNetwork].(string)
 	return network
+}
+
+func (c *environConfig) VMFolder() string {
+	folder, _ := c.attrs[cfgVMFolder].(string)
+	return folder
 }
 
 func (c *environConfig) enableDiskUUID() bool {

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -33,7 +33,7 @@ var (
 		cfgExternalNetwork: "",
 		cfgDatastore:       schema.Omit,
 		cfgPrimaryNetwork:  schema.Omit,
-		cfgVMFolder:        schema.Omit, 
+		cfgVMFolder:        schema.Omit,
 		cfgEnableDiskUUID:  true,
 	}
 

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -13,6 +13,7 @@ import (
 const (
 	credAttrUser     = "user"
 	credAttrPassword = "password"
+	credAttrVMFolder = "vmfolder"
 )
 
 type environProviderCredentials struct{}
@@ -27,6 +28,11 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 				credAttrPassword, cloud.CredentialAttr{
 					Description: "The password to authenticate with.",
 					Hidden:      true,
+				},
+			}, {
+				credAttrVMFolder, cloud.CredentialAttr{
+					Description: "The folder to add VMs from the model.",
+					Optional:    true,
 				},
 			},
 		},

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -152,8 +152,7 @@ func (env *sessionEnviron) Bootstrap(
 }
 
 func (env *sessionEnviron) ensureVMFolder(controllerUUID string, ctx callcontext.ProviderCallContext) error {
-	_, err := env.client.EnsureVMFolder(env.ctx, path.Join(
-		env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
+	_, err := env.client.EnsureVMFolder(env.ctx, env.environ.cloud.Credential.Attributes()[credAttrVMFolder], path.Join(
 		controllerFolderName(controllerUUID),
 		env.modelFolderName(),
 	))
@@ -236,7 +235,9 @@ func (env *sessionEnviron) DestroyController(ctx callcontext.ProviderCallContext
 		HandleCredentialError(err, ctx)
 		return errors.Annotate(err, "removing VMs")
 	}
-	if err := env.client.DestroyVMFolder(env.ctx, controllerFolderName); err != nil {
+	if err := env.client.DestroyVMFolder(env.ctx, path.Join(
+		env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
+		controllerFolderName)); err != nil {
 		HandleCredentialError(err, ctx)
 		return errors.Annotate(err, "destroying VM folder")
 	}

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -153,7 +153,7 @@ func (env *sessionEnviron) Bootstrap(
 
 func (env *sessionEnviron) ensureVMFolder(controllerUUID string, ctx callcontext.ProviderCallContext) error {
 	_, err := env.client.EnsureVMFolder(env.ctx, path.Join(
-		env.ecfg.VMFolder(),
+		env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 		controllerFolderName(controllerUUID),
 		env.modelFolderName(),
 	))
@@ -176,11 +176,11 @@ func (env *environ) AdoptResources(ctx callcontext.ProviderCallContext, controll
 func (env *sessionEnviron) AdoptResources(ctx callcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	err := env.client.MoveVMFolderInto(env.ctx,
 		path.Join(
-			env.ecfg.VMFolder(),
+			env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 			controllerFolderName(controllerUUID),
 		),
 		path.Join(
-			env.ecfg.VMFolder(),
+			env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 			controllerFolderName("*"),
 			env.modelFolderName(),
 		),
@@ -206,7 +206,7 @@ func (env *sessionEnviron) Destroy(ctx callcontext.ProviderCallContext) error {
 		return errors.Trace(err)
 	}
 	err := env.client.DestroyVMFolder(env.ctx, path.Join(
-		env.ecfg.VMFolder(),
+		env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 		controllerFolderName("*"),
 		env.modelFolderName(),
 	))
@@ -228,7 +228,7 @@ func (env *sessionEnviron) DestroyController(ctx callcontext.ProviderCallContext
 	}
 	controllerFolderName := controllerFolderName(controllerUUID)
 	if err := env.client.RemoveVirtualMachines(env.ctx, path.Join(
-		env.ecfg.VMFolder(),
+		env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 		controllerFolderName,
 		modelFolderName("*", "*"),
 		"*",
@@ -249,7 +249,9 @@ func (env *sessionEnviron) DestroyController(ctx callcontext.ProviderCallContext
 		return errors.Annotate(err, "listing datastores")
 	}
 	for _, ds := range datastores {
-		datastorePath := fmt.Sprintf("[%s] %s", ds.Name, vmdkDirectoryName(env.ecfg.VMFolder(), controllerUUID))
+		datastorePath := fmt.Sprintf("[%s] %s", ds.Name, vmdkDirectoryName(
+			env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
+			controllerUUID))
 		logger.Debugf("deleting: %s", datastorePath)
 		if err := env.client.DeleteDatastoreFile(env.ctx, datastorePath); err != nil {
 			HandleCredentialError(err, ctx)

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -155,12 +155,12 @@ func (env *sessionEnviron) ensureVMFolder(controllerUUID string, ctx callcontext
 	_, err := env.client.EnsureVMFolder(env.ctx, path.Join(
 		controllerFolderName(controllerUUID),
 		env.modelFolderName(),
-	))
+	), env.ecfg.VMFolder())
 	HandleCredentialError(err, ctx)
 	return errors.Trace(err)
 }
 
-//this variable is exported, because it has to be rewritten in external unit tests
+// this variable is exported, because it has to be rewritten in external unit tests
 var DestroyEnv = common.Destroy
 
 // AdoptResources is part of the Environ interface.

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -66,7 +66,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([
 	if env.zones == nil {
 		computeResources, err := env.client.ComputeResources(env.ctx)
 		if err != nil {
-			HandleCredentialError(err, ctx)
+			HandleCredentialError(err, env, ctx)
 			return nil, errors.Trace(err)
 		}
 		var zones []common.AvailabilityZone
@@ -77,7 +77,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([
 			}
 			pools, err := env.client.ResourcePools(env.ctx, cr.Name+"/...")
 			if err != nil {
-				HandleCredentialError(err, ctx)
+				HandleCredentialError(err, env, ctx)
 				return nil, errors.Trace(err)
 			}
 			for _, pool := range pools {

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -220,14 +220,14 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs := vsphereclient.CreateVirtualMachineParams{
 		Name: vmName,
 		Folder: path.Join(
-			env.ecfg.VMFolder(),
+			env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 			controllerFolderName(args.ControllerUUID),
 			env.modelFolderName(),
 		),
 		Series:                 series,
 		ReadOVA:                readOVA,
 		OVASHA256:              img.Sha256,
-		VMDKDirectory:          vmdkDirectoryName(env.ecfg.VMFolder(), args.ControllerUUID),
+		VMDKDirectory:          vmdkDirectoryName(env.environ.cloud.Credential.Attributes()[credAttrVMFolder], args.ControllerUUID),
 		UserData:               string(userData),
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,
@@ -283,7 +283,7 @@ func (env *environ) AllInstances(ctx context.ProviderCallContext) (instances []i
 // AllInstances implements environs.InstanceBroker.
 func (env *sessionEnviron) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
 	modelFolderPath := path.Join(
-		env.ecfg.VMFolder(),
+		env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 		controllerFolderName("*"),
 		env.modelFolderName(),
 	)
@@ -324,7 +324,7 @@ func (env *environ) StopInstances(ctx context.ProviderCallContext, ids ...instan
 // StopInstances implements environs.InstanceBroker.
 func (env *sessionEnviron) StopInstances(ctx context.ProviderCallContext, ids ...instance.Id) error {
 	modelFolderPath := path.Join(
-		env.ecfg.VMFolder(),
+		env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 		controllerFolderName("*"),
 		env.modelFolderName(),
 	)

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -227,7 +227,7 @@ func (env *sessionEnviron) newRawInstance(
 		Series:                 series,
 		ReadOVA:                readOVA,
 		OVASHA256:              img.Sha256,
-		VMDKDirectory:          vmdkDirectoryName(env.environ.cloud.Credential.Attributes()[credAttrVMFolder], args.ControllerUUID),
+		VMDKDirectory:          vmdkDirectoryName("", args.ControllerUUID),
 		UserData:               string(userData),
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,
@@ -256,8 +256,9 @@ func (env *sessionEnviron) newRawInstance(
 		err = common.ZoneIndependentError(err)
 	}
 	if err != nil {
-		HandleCredentialError(err, ctx)
+		HandleCredentialError(err, env, ctx)
 		return nil, nil, errors.Trace(err)
+
 	}
 
 	hw := &instance.HardwareCharacteristics{
@@ -289,7 +290,7 @@ func (env *sessionEnviron) AllInstances(ctx context.ProviderCallContext) ([]inst
 	)
 	vms, err := env.client.VirtualMachines(env.ctx, modelFolderPath+"/*")
 	if err != nil {
-		HandleCredentialError(err, ctx)
+		HandleCredentialError(err, env, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -338,7 +339,7 @@ func (env *sessionEnviron) StopInstances(ctx context.ProviderCallContext, ids ..
 				env.ctx,
 				path.Join(modelFolderPath, string(id)),
 			)
-			HandleCredentialError(results[i], ctx)
+			HandleCredentialError(results[i], env, ctx)
 		}(i, id)
 	}
 	wg.Wait()

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -245,7 +245,7 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs.ComputeResource = &availZone.r
 	createVMArgs.ResourcePool = availZone.pool.Reference()
 
-	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
+	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs, env.ecfg.VMFolder())
 	if vsphereclient.IsExtendDiskError(err) {
 		// Ensure we don't try to make the same extension across
 		// different resource groups.

--- a/provider/vsphere/errors.go
+++ b/provider/vsphere/errors.go
@@ -47,6 +47,15 @@ func IsAuthorisationFailure(err error) bool {
 
 // HandleCredentialError marks the current credential as invalid if
 // the passed vsphere error indicates it should be.
-func HandleCredentialError(err error, ctx context.ProviderCallContext) {
-	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+func HandleCredentialError(err error, env *sessionEnviron, ctx context.ProviderCallContext) {
+	// LP #1849194: fell into a situation where we can either have an invalid
+	// credential OR user issued a VM spec that has no rights to, e.g. on a
+	// Resource Pool that it has no permissions on using "zone" on add-machine.
+	// To discover if the credentials are valid, run a command that MUST return
+	// OK: find folder defined on vm-folder credentials
+	_, errfind := env.client.FindFolder(env.ctx, env.environ.cloud.Credential.Attributes()[credAttrVMFolder])
+	if errfind != nil {
+		// This is a credential issue. Now, move to mark credentials as invalid
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	}
 }

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -88,10 +88,10 @@ func (c *Client) lister(ref types.ManagedObjectReference) *list.Lister {
 	}
 }
 
-// findFolder should be able to search for both entire filepaths
+// FindFolder should be able to search for both entire filepaths
 // or relative (.) filepaths. Only ".." not supported as per:
 // https://github.com/vmware/govmomi/blob/master/find/finder.go#L114
-func (c *Client) findFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error) {
+func (c *Client) FindFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error) {
 	finder := find.NewFinder(c.client.Client, true)
 	datacenter, err := finder.Datacenter(ctx, c.datacenter)
 	if err != nil {
@@ -279,10 +279,13 @@ func (c *Client) ResourcePools(ctx context.Context, path string) ([]*object.Reso
 }
 
 // EnsureVMFolder creates the a VM folder with the given path if it doesn't
-// already exists.
-func (c *Client) EnsureVMFolder(ctx context.Context, folderPath string, parentFolderStr string) (*object.Folder, error) {
-
+// already exist.
+func (c *Client) EnsureVMFolder(ctx context.Context, folderPath string) (*object.Folder, error) {
 	finder, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	folders, err := datacenter.Folders(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -298,23 +301,7 @@ func (c *Client) EnsureVMFolder(ctx context.Context, folderPath string, parentFo
 		return folder, err
 	}
 
-	var parentFolder *object.Folder
-
-	// if parentFolderStr was not defined, create models on
-	// root folder, search for parent folder str otherwise
-	if parentFolderStr == "" {
-		folders, err := datacenter.Folders(ctx)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		parentFolder = folders.VmFolder
-	} else {
-		parentFolder, err = c.findFolder(ctx, parentFolderStr)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-
+	parentFolder := folders.VmFolder
 	for _, name := range strings.Split(folderPath, "/") {
 		folder, err := createFolder(parentFolder, name)
 		if err != nil {

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -633,7 +633,7 @@ func (s *clientSuite) TestDestroyVMFolderRace(c *gc.C) {
 
 func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	folder, err := client.EnsureVMFolder(context.Background(), "foo/bar")
+	folder, err := client.EnsureVMFolder(context.Background(), "foo/bar", "juju-folder")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(folder, gc.NotNil)
 

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -633,7 +633,7 @@ func (s *clientSuite) TestDestroyVMFolderRace(c *gc.C) {
 
 func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	folder, err := client.EnsureVMFolder(context.Background(), "foo/bar", "juju-folder")
+	folder, err := client.EnsureVMFolder(context.Background(), "foo/bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(folder, gc.NotNil)
 

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -633,7 +633,7 @@ func (s *clientSuite) TestDestroyVMFolderRace(c *gc.C) {
 
 func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
-	folder, err := client.EnsureVMFolder(context.Background(), "foo/bar")
+	folder, err := client.EnsureVMFolder(context.Background(), "", "foo/bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(folder, gc.NotNil)
 

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -183,7 +183,7 @@ func (c *Client) ensureTemplateVM(
 		return nil, errors.Annotate(err, "creating import spec")
 	}
 
-	vmFolder, err := c.EnsureVMFolder(ctx, vmTemplatePath(args))
+	vmFolder, err := c.EnsureVMFolder(ctx, args.Folder, vmTemplatePath(args))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -165,7 +165,6 @@ func (c *Client) ensureTemplateVM(
 	ctx context.Context,
 	datastore *object.Datastore,
 	args CreateVirtualMachineParams,
-	vmFolderName string,
 ) (vm *object.VirtualMachine, err error) {
 	finder, _, err := c.finder(ctx)
 	if err != nil {
@@ -184,7 +183,7 @@ func (c *Client) ensureTemplateVM(
 		return nil, errors.Annotate(err, "creating import spec")
 	}
 
-	vmFolder, err := c.EnsureVMFolder(ctx, vmTemplatePath(args), vmFolderName)
+	vmFolder, err := c.EnsureVMFolder(ctx, vmTemplatePath(args))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -299,7 +298,6 @@ func (c *Client) ensureTemplateVM(
 func (c *Client) CreateVirtualMachine(
 	ctx context.Context,
 	args CreateVirtualMachineParams,
-	vmFolderName string,
 ) (_ *mo.VirtualMachine, err error) {
 	finder, datacenter, err := c.finder(ctx)
 	if err != nil {
@@ -309,6 +307,7 @@ func (c *Client) CreateVirtualMachine(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	folderPath := path.Join(folders.VmFolder.InventoryPath, args.Folder)
 	vmFolder, err := finder.Folder(ctx, folderPath)
 	if err != nil {
@@ -320,7 +319,7 @@ func (c *Client) CreateVirtualMachine(
 		return nil, errors.Trace(err)
 	}
 
-	templateVM, err := c.ensureTemplateVM(ctx, datastore, args, vmFolderName)
+	templateVM, err := c.ensureTemplateVM(ctx, datastore, args)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating template VM")
 	}

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -165,6 +165,7 @@ func (c *Client) ensureTemplateVM(
 	ctx context.Context,
 	datastore *object.Datastore,
 	args CreateVirtualMachineParams,
+	vmFolderName string,
 ) (vm *object.VirtualMachine, err error) {
 	finder, _, err := c.finder(ctx)
 	if err != nil {
@@ -183,7 +184,7 @@ func (c *Client) ensureTemplateVM(
 		return nil, errors.Annotate(err, "creating import spec")
 	}
 
-	vmFolder, err := c.EnsureVMFolder(ctx, vmTemplatePath(args))
+	vmFolder, err := c.EnsureVMFolder(ctx, vmTemplatePath(args), vmFolderName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -298,6 +299,7 @@ func (c *Client) ensureTemplateVM(
 func (c *Client) CreateVirtualMachine(
 	ctx context.Context,
 	args CreateVirtualMachineParams,
+	vmFolderName string,
 ) (_ *mo.VirtualMachine, err error) {
 	finder, datacenter, err := c.finder(ctx)
 	if err != nil {
@@ -318,7 +320,7 @@ func (c *Client) CreateVirtualMachine(
 		return nil, errors.Trace(err)
 	}
 
-	templateVM, err := c.ensureTemplateVM(ctx, datastore, args)
+	templateVM, err := c.ensureTemplateVM(ctx, datastore, args, vmFolderName)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating template VM")
 	}

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -91,10 +91,10 @@ func (c *mockClient) DestroyVMFolder(ctx context.Context, path string) error {
 	return c.NextErr()
 }
 
-func (c *mockClient) EnsureVMFolder(ctx context.Context, path string) (*object.Folder, error) {
+func (c *mockClient) EnsureVMFolder(ctx context.Context, credAttrFolder string, path string) (*object.Folder, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.MethodCall(c, "EnsureVMFolder", ctx, path)
+	c.MethodCall(c, "EnsureVMFolder", ctx, credAttrFolder, path)
 	return c.vmFolder, c.NextErr()
 }
 

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -91,6 +91,13 @@ func (c *mockClient) DestroyVMFolder(ctx context.Context, path string) error {
 	return c.NextErr()
 }
 
+func (c *mockClient) FindFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.MethodCall(c, "FindFolder", ctx, folderPath)
+	return c.vmFolder, c.NextErr()
+}
+
 func (c *mockClient) EnsureVMFolder(ctx context.Context, credAttrFolder string, path string) (*object.Folder, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -99,10 +99,11 @@ func (step modelFoldersUpgradeStep) Run(ctx context.ProviderCallContext) error {
 	return step.env.withSession(ctx, func(env *sessionEnviron) error {
 		// We must create the folder even if there are no VMs in the model.
 		modelFolderPath := path.Join(
+			env.ecfg.VMFolder(),
 			controllerFolderName(step.controllerUUID),
 			env.modelFolderName(),
 		)
-		if _, err := env.client.EnsureVMFolder(env.ctx, modelFolderPath, env.ecfg.VMFolder()); err != nil {
+		if _, err := env.client.EnsureVMFolder(env.ctx, modelFolderPath); err != nil {
 			HandleCredentialError(err, ctx)
 			return errors.Annotate(err, "creating model folder")
 		}

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -103,7 +103,16 @@ func (step modelFoldersUpgradeStep) Run(ctx context.ProviderCallContext) error {
 			controllerFolderName(step.controllerUUID),
 			env.modelFolderName(),
 		)
-		if _, err := env.client.EnsureVMFolder(env.ctx, modelFolderPath); err != nil {
+
+		// EnsureVMFolder needs credential attributes to be defined separatedly
+		// from the folders it is supposed to create
+		if _, err := env.client.EnsureVMFolder(
+			env.ctx,
+			env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
+			path.Join(
+				controllerFolderName(step.controllerUUID),
+				env.modelFolderName(),
+			)); err != nil {
 			HandleCredentialError(err, ctx)
 			return errors.Annotate(err, "creating model folder")
 		}

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -46,7 +46,7 @@ func (step extraConfigUpgradeStep) Run(ctx context.ProviderCallContext) error {
 	return step.env.withSession(ctx, func(env *sessionEnviron) error {
 		vms, err := env.client.VirtualMachines(env.ctx, env.namespace.Prefix()+"*")
 		if err != nil || len(vms) == 0 {
-			HandleCredentialError(err, ctx)
+			HandleCredentialError(err, env, ctx)
 			return err
 		}
 		for _, vm := range vms {
@@ -74,7 +74,7 @@ func (step extraConfigUpgradeStep) Run(ctx context.ProviderCallContext) error {
 			if err := env.client.UpdateVirtualMachineExtraConfig(
 				env.ctx, vm, metadata,
 			); err != nil {
-				HandleCredentialError(err, ctx)
+				HandleCredentialError(err, env, ctx)
 				return errors.Annotatef(err, "updating VM %s", vm.Name)
 			}
 		}
@@ -113,7 +113,7 @@ func (step modelFoldersUpgradeStep) Run(ctx context.ProviderCallContext) error {
 				controllerFolderName(step.controllerUUID),
 				env.modelFolderName(),
 			)); err != nil {
-			HandleCredentialError(err, ctx)
+			HandleCredentialError(err, env, ctx)
 			return errors.Annotate(err, "creating model folder")
 		}
 
@@ -121,7 +121,7 @@ func (step modelFoldersUpgradeStep) Run(ctx context.ProviderCallContext) error {
 		// and move them into the folder.
 		vms, err := env.client.VirtualMachines(env.ctx, env.namespace.Prefix()+"*")
 		if err != nil || len(vms) == 0 {
-			HandleCredentialError(err, ctx)
+			HandleCredentialError(err, env, ctx)
 			return err
 		}
 		refs := make([]types.ManagedObjectReference, len(vms))
@@ -130,7 +130,7 @@ func (step modelFoldersUpgradeStep) Run(ctx context.ProviderCallContext) error {
 			refs[i] = vm.Reference()
 		}
 		if err := env.client.MoveVMsInto(env.ctx, modelFolderPath, refs...); err != nil {
-			HandleCredentialError(err, ctx)
+			HandleCredentialError(err, env, ctx)
 			return errors.Annotate(err, "moving VMs into model folder")
 		}
 		return nil

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -99,7 +99,7 @@ func (step modelFoldersUpgradeStep) Run(ctx context.ProviderCallContext) error {
 	return step.env.withSession(ctx, func(env *sessionEnviron) error {
 		// We must create the folder even if there are no VMs in the model.
 		modelFolderPath := path.Join(
-			env.ecfg.VMFolder(),
+			env.environ.cloud.Credential.Attributes()[credAttrVMFolder],
 			controllerFolderName(step.controllerUUID),
 			env.modelFolderName(),
 		)

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -102,7 +102,7 @@ func (step modelFoldersUpgradeStep) Run(ctx context.ProviderCallContext) error {
 			controllerFolderName(step.controllerUUID),
 			env.modelFolderName(),
 		)
-		if _, err := env.client.EnsureVMFolder(env.ctx, modelFolderPath); err != nil {
+		if _, err := env.client.EnsureVMFolder(env.ctx, modelFolderPath, env.ecfg.VMFolder()); err != nil {
 			HandleCredentialError(err, ctx)
 			return errors.Annotate(err, "creating model folder")
 		}


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

----

## Description of change

Vsphere provider depends on having access to root VM folder to create its VMs. Since Juju creates folders with customized names for each controller and model, that means in practice the user needs to give write access to vsphere's entire folder structure to Juju user.

To reduce the scope of Juju permissions, first step is to make Juju folder operations predictable. 

This PR proposes adding an option so the user can target an specific folder to be its root folder for entire Juju's controller structure. That will allow the user to set appropriate folder permissions beforehand.

## QA steps

- Create a folder to be vm-folder
- Set write permission to that specific folder
- Read-only role everywhere else
- Bootstrap a controller and create a model with some machines using that option

## Documentation changes

Add vm-folder option via credentials for vsphere provider to CLI and API documentation

## Bug reference

Fixes: https://bugs.launchpad.net/juju/+bug/1849194