### PR TITLE
Replace bash double-bracket syntax with single brackets in space tests

### DIFF
--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -24,14 +24,14 @@ test_spaces_ec2() {
 
 check_prerequisites_for_space_tests() {
   match_count=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24 | jq '.Subnets | length')
-  if [[ "$match_count" != "1" ]]; then
+  if [ "$match_count" != "1" ]; then
       # shellcheck disable=SC2046
       echo $(red "To run these tests you need to create a subnet with name \"isolated\" and CIDR \"172.31.254/24\"")
       exit 1
   fi
 
   if_count=$(aws ec2 describe-network-interfaces --filters Name=tag:nic-type,Values=hotpluggable | jq '.NetworkInterfaces[] | select(.["PrivateIpAddress"] | startswith("172.31.254.")) | .NetworkInterfaceId')
-  if [[ -z "$if_count" ]]; then
+  if [ -z "$if_count" ]; then
       # shellcheck disable=SC2046
       echo $(red "To run these tests you need to create a network interface on the isolated subnet (CIDR \"172.31.254/24\") and tag it with \"nic-type:hotpluggable\"")
       exit 1

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -47,7 +47,7 @@ assert_net_iface_for_endpoint_matches() {
 
     # shellcheck disable=SC2086,SC2016
     got_if=$(juju run -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
-    if [[ "$got_if" != "$exp_if_name" ]]; then
+    if [ "$got_if" != "$exp_if_name" ]; then
         # shellcheck disable=SC2086,SC2016,SC2046
         echo $(red "Expected network interface for ${app_name}:${endpoint_name} to be ${exp_if_name}; got ${got_if}")
         exit 1
@@ -67,7 +67,7 @@ assert_endpoint_binding_matches() {
 
     # shellcheck disable=SC2086,SC2016
     got=$(juju show-application ${app_name} --format json | jq -r ".[\"${app_name}\"] | .[\"endpoint-bindings\"] | .[\"${endpoint_name}\"]")
-    if [[ "$got" != "$exp_space_name" ]]; then
+    if [ "$got" != "$exp_space_name" ]; then
         # shellcheck disable=SC2086,SC2016,SC2046
         echo $(red "Expected endpoint \"${endpoint_name}\" in juju show-application ${app_name} to be ${exp_space_name}; got ${got}")
         exit 1


### PR DESCRIPTION
## Description of change

The test-runner assumes a generic sh binary; this PR replaces double brackets in if blocks with single brackets to avoid errors when running on CI
