### PR TITLE
Feature/podpec validation

### DIFF
--- a/caas/kubernetes/provider/specs/decode.go
+++ b/caas/kubernetes/provider/specs/decode.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package specs
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/errors"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// YAMLOrJSONDecoder attempts to decode a stream of JSON documents or
+// YAML documents by sniffing for a leading { character.
+type YAMLOrJSONDecoder struct {
+	bufferSize int
+	r          io.Reader
+	rawData    []byte
+
+	strict bool
+}
+
+func newStrictYAMLOrJSONDecoder(r io.Reader, bufferSize int) *YAMLOrJSONDecoder {
+	return newYAMLOrJSONDecoder(r, bufferSize, true)
+}
+
+func newYAMLOrJSONDecoder(r io.Reader, bufferSize int, strict bool) *YAMLOrJSONDecoder {
+	return &YAMLOrJSONDecoder{
+		r:          r,
+		bufferSize: bufferSize,
+		strict:     strict,
+	}
+}
+
+func (d *YAMLOrJSONDecoder) jsonify() (err error) {
+	buffer := bufio.NewReaderSize(d.r, d.bufferSize)
+	rawData, _ := buffer.Peek(d.bufferSize)
+	if rawData, err = k8syaml.ToJSON(rawData); err != nil {
+		return errors.Trace(err)
+	}
+	d.r = bytes.NewReader(rawData)
+	d.rawData = rawData
+	return nil
+}
+
+func (d *YAMLOrJSONDecoder) processError(err error, decoder *json.Decoder) error {
+	syntax, ok := err.(*json.SyntaxError)
+	if !ok {
+		return err
+	}
+	data, readErr := ioutil.ReadAll(decoder.Buffered())
+	if readErr != nil {
+		logger.Debugf("reading stream failed: %v", readErr)
+	}
+	jsonData := string(data)
+
+	// if contents from io.Reader are not complete,
+	// use the original raw data to prevent panic
+	if int64(len(jsonData)) <= syntax.Offset {
+		jsonData = string(d.rawData)
+	}
+
+	start := strings.LastIndex(jsonData[:syntax.Offset], "\n") + 1
+	line := strings.Count(jsonData[:start], "\n")
+	return k8syaml.JSONSyntaxError{
+		Line: line,
+		Err:  fmt.Errorf(syntax.Error()),
+	}
+}
+
+// Decode unmarshals the next object from the underlying stream into the
+// provide object, or returns an error.
+func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
+	if err := d.jsonify(); err != nil {
+		return errors.Trace(err)
+	}
+	logger.Debugf("decoding stream as JSON")
+	decoder := json.NewDecoder(d.r)
+	if d.strict {
+		decoder.DisallowUnknownFields()
+	}
+	return d.processError(decoder.Decode(into), decoder)
+}

--- a/caas/kubernetes/provider/specs/decode_test.go
+++ b/caas/kubernetes/provider/specs/decode_test.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package specs_test
+
+import (
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	k8sspces "github.com/juju/juju/caas/kubernetes/provider/specs"
+	"github.com/juju/juju/testing"
+)
+
+type decoderSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&decoderSuite{})
+
+func (s *decoderSuite) TestYAMLOrJSONDecoder(c *gc.C) {
+	type tS struct {
+		Foo string `json:"foo,omitempty" yaml:"foo,omitempty"`
+		Bar string `json:"bar,omitempty" yaml:"bar,omitempty"`
+	}
+
+	var in string
+	var out tS
+
+	in = `
+foo: foo1
+bar: bar1`
+	// decode YAML in strict mode - good.
+	decoder := k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), true)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+	// decode YAML in non-strict mode - good.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), false)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+
+	in = `
+{
+    "foo": "foo1",
+    "bar": "bar1"
+}`
+	// decode JSON in strict mode - good.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), true)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+	// decode JSON in non-strict mode - good.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), false)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+
+	in = `
+foo: foo1
+bar: bar1
+unknownkey: ops`
+	// decode YAML in strict mode - bad.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), true)
+	c.Assert(decoder.Decode(&out), gc.ErrorMatches, `json: unknown field "unknownkey"`)
+	// decode YAML in non-strict mode - unknown field ignored.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), false)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+
+	in = `
+{
+    "foo": "foo1",
+	"bar": "bar1",
+	"unknownkey": "ops"
+}`
+	// decode JSON in strict mode - bad.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), true)
+	c.Assert(decoder.Decode(&out), gc.ErrorMatches, `json: unknown field "unknownkey"`)
+	// decode JSON in non-strict mode - unknown field ignored.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), false)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+}

--- a/caas/kubernetes/provider/specs/export_test.go
+++ b/caas/kubernetes/provider/specs/export_test.go
@@ -4,9 +4,10 @@
 package specs
 
 var (
-	ParsePodSpecV2      = parsePodSpecV2
-	ParsePodSpecLegacy  = parsePodSpecLegacy
-	ParsePodSpecForTest = parsePodSpec
+	ParsePodSpecV2       = parsePodSpecV2
+	ParsePodSpecLegacy   = parsePodSpecLegacy
+	ParsePodSpecForTest  = parsePodSpec
+	NewYAMLOrJSONDecoder = newYAMLOrJSONDecoder
 )
 
 type (

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -8,14 +8,13 @@ import (
 
 	"github.com/juju/errors"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/juju/juju/caas/specs"
 )
 
 type k8sContainerLegacy struct {
-	specs.ContainerSpec `json:",inline"`
-	*K8sContainerSpec   `json:",inline"`
+	specs.ContainerSpec `json:",inline" yaml:",inline"`
+	*K8sContainerSpec   `json:",inline" yaml:",inline"`
 }
 
 // Validate validates k8sContainerLegacy.
@@ -109,9 +108,9 @@ func (p podSpecLegacy) ToLatest() *specs.PodSpec {
 // K8sPodSpecLegacy is a subset of v1.PodSpec which defines
 // attributes we expose for charms to set.
 type K8sPodSpecLegacy struct {
-	PodSpec                      `yaml:",inline"`
-	ServiceAccountName           string `json:"serviceAccountName,omitempty"`
-	AutomountServiceAccountToken *bool  `json:"automountServiceAccountToken,omitempty"`
+	PodSpec                      `json:",inline" yaml:",inline"`
+	ServiceAccountName           string `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
+	AutomountServiceAccountToken *bool  `json:"automountServiceAccountToken,omitempty" yaml:"automountServiceAccountToken,omitempty"`
 
 	CustomResourceDefinitions map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec `yaml:"customResourceDefinitions,omitempty"`
 }
@@ -122,8 +121,8 @@ func (*K8sPodSpecLegacy) Validate() error {
 }
 
 type k8sContainersLegacy struct {
-	Containers     []k8sContainerLegacy `json:"containers"`
-	InitContainers []k8sContainerLegacy `json:"initContainers"`
+	Containers     []k8sContainerLegacy `json:"containers" yaml:"containers"`
+	InitContainers []k8sContainerLegacy `json:"initContainers" yaml:"initContainers"`
 }
 
 // Validate is defined on ProviderContainer.
@@ -138,13 +137,13 @@ func parsePodSpecLegacy(in string) (_ PodSpecConverter, err error) {
 	// Do the common fields.
 	var spec podSpecLegacy
 
-	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in))
+	decoder := newStrictYAMLOrJSONDecoder(strings.NewReader(in), len(in))
 	if err = decoder.Decode(&spec.caaSSpec); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// Do the k8s pod attributes.
-	decoder = k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in))
+	decoder = newStrictYAMLOrJSONDecoder(strings.NewReader(in), len(in))
 	if err = decoder.Decode(&spec.k8sSpec); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -421,3 +421,62 @@ containers:
 	_, err := k8sspecs.ParsePodSpec(specStr)
 	c.Assert(err, gc.ErrorMatches, `mount path is missing for file set "configuration"`)
 }
+
+func (s *legacySpecsSuite) TestValidateCustomResourceDefinitions(c *gc.C) {
+	specStr := `
+containers:
+  - name: gitlab-helper
+    image: gitlab-helper/latest
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+customResourceDefinitions:
+  tfjobs.kubeflow.org:
+    group: kubeflow.org
+    version: v1alpha2
+    scope: Cluster
+    names:
+      plural: "tfjobs"
+      singular: "tfjob"
+      kind: TFJob
+    validation:
+      openAPIV3Schema:
+        properties:
+          tfReplicaSpecs:
+            properties:
+              Worker:
+                properties:
+                  replicas:
+                    type: integer
+                    minimum: 1
+              PS:
+                properties:
+                  replicas:
+                    type: integer
+                    minimum: 1
+              Chief:
+                properties:
+                  replicas:
+                    type: integer
+                    minimum: 1
+                    maximum: 1
+`[1:]
+
+	_, err := k8sspecs.ParsePodSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, `custom resource definition "tfjobs.kubeflow.org" scope "Cluster" is not supported, please use "Namespaced" scope`)
+}
+
+func (s *legacySpecsSuite) TestUnknownFieldError(c *gc.C) {
+	specStr := `
+containers:
+  - name: gitlab-helper
+    image: gitlab-helper/latest
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+foo: a-bad-guy
+`[1:]
+
+	_, err := k8sspecs.ParsePodSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, `json: unknown field "foo"`)
+}

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -4,19 +4,13 @@
 package specs
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	core "k8s.io/api/core/v1"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/juju/juju/caas/specs"
 )
@@ -206,76 +200,4 @@ func getParser(specVersion specs.Version) (parserType, error) {
 	default:
 		return nil, errors.NewNotSupported(nil, fmt.Sprintf("latest supported version %d, but got podspec version %d", specs.CurrentVersion, specVersion))
 	}
-}
-
-// YAMLOrJSONDecoder attempts to decode a stream of JSON documents or
-// YAML documents by sniffing for a leading { character.
-type YAMLOrJSONDecoder struct {
-	bufferSize int
-	r          io.Reader
-	rawData    []byte
-
-	strict bool
-}
-
-func newStrictYAMLOrJSONDecoder(r io.Reader, bufferSize int) *YAMLOrJSONDecoder {
-	return newYAMLOrJSONDecoder(r, bufferSize, true)
-}
-
-func newYAMLOrJSONDecoder(r io.Reader, bufferSize int, strict bool) *YAMLOrJSONDecoder {
-	return &YAMLOrJSONDecoder{
-		r:          r,
-		bufferSize: bufferSize,
-		strict:     strict,
-	}
-}
-
-func (d *YAMLOrJSONDecoder) jsonify() (err error) {
-	buffer := bufio.NewReaderSize(d.r, d.bufferSize)
-	rawData, _ := buffer.Peek(d.bufferSize)
-	if rawData, err = k8syaml.ToJSON(rawData); err != nil {
-		return errors.Trace(err)
-	}
-	d.r = bytes.NewReader(rawData)
-	d.rawData = rawData
-	return nil
-}
-
-func (d *YAMLOrJSONDecoder) processError(err error, decoder *json.Decoder) error {
-	syntax, ok := err.(*json.SyntaxError)
-	if !ok {
-		return err
-	}
-	data, readErr := ioutil.ReadAll(decoder.Buffered())
-	if readErr != nil {
-		logger.Debugf("reading stream failed: %v", readErr)
-	}
-	jsonData := string(data)
-
-	// if contents from io.Reader are not complete,
-	// use the original raw data to prevent panic
-	if int64(len(jsonData)) <= syntax.Offset {
-		jsonData = string(d.rawData)
-	}
-
-	start := strings.LastIndex(jsonData[:syntax.Offset], "\n") + 1
-	line := strings.Count(jsonData[:start], "\n")
-	return k8syaml.JSONSyntaxError{
-		Line: line,
-		Err:  fmt.Errorf(syntax.Error()),
-	}
-}
-
-// Decode unmarshals the next object from the underlying stream into the
-// provide object, or returns an error.
-func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
-	if err := d.jsonify(); err != nil {
-		return errors.Trace(err)
-	}
-	logger.Debugf("decoding stream as JSON")
-	decoder := json.NewDecoder(d.r)
-	if d.strict {
-		decoder.DisallowUnknownFields()
-	}
-	return d.processError(decoder.Decode(into), decoder)
 }

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -4,12 +4,16 @@
 package specs
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"gopkg.in/yaml.v2"
 	core "k8s.io/api/core/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
@@ -24,8 +28,8 @@ type (
 )
 
 type k8sContainer struct {
-	specs.ContainerSpec `json:",inline"`
-	Kubernetes          *K8sContainerSpec `json:"kubernetes,omitempty"`
+	specs.ContainerSpec `json:",inline" yaml:",inline"`
+	Kubernetes          *K8sContainerSpec `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 }
 
 // Validate validates k8sContainer.
@@ -70,9 +74,9 @@ func (c *k8sContainer) ToContainerSpec() specs.ContainerSpec {
 // K8sContainerSpec is a subset of v1.Container which defines
 // attributes we expose for charms to set.
 type K8sContainerSpec struct {
-	LivenessProbe   *core.Probe           `json:"livenessProbe,omitempty"`
-	ReadinessProbe  *core.Probe           `json:"readinessProbe,omitempty"`
-	SecurityContext *core.SecurityContext `json:"securityContext,omitempty"`
+	LivenessProbe   *core.Probe           `json:"livenessProbe,omitempty" yaml:"livenessProbe,omitempty"`
+	ReadinessProbe  *core.Probe           `json:"readinessProbe,omitempty" yaml:"readinessProbe,omitempty"`
+	SecurityContext *core.SecurityContext `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 }
 
 // Validate validates K8sContainerSpec.
@@ -83,12 +87,12 @@ func (*K8sContainerSpec) Validate() error {
 // PodSpec is a subset of v1.PodSpec which defines
 // attributes we expose for charms to set.
 type PodSpec struct {
-	RestartPolicy                 core.RestartPolicy       `json:"restartPolicy,omitempty"`
-	ActiveDeadlineSeconds         *int64                   `json:"activeDeadlineSeconds,omitempty"`
-	TerminationGracePeriodSeconds *int64                   `json:"terminationGracePeriodSeconds,omitempty"`
-	SecurityContext               *core.PodSecurityContext `json:"securityContext,omitempty"`
-	ReadinessGates                []core.PodReadinessGate  `json:"readinessGates,omitempty"`
-	DNSPolicy                     core.DNSPolicy           `json:"dnsPolicy,omitempty"`
+	RestartPolicy                 core.RestartPolicy       `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
+	ActiveDeadlineSeconds         *int64                   `json:"activeDeadlineSeconds,omitempty" yaml:"activeDeadlineSeconds,omitempty"`
+	TerminationGracePeriodSeconds *int64                   `json:"terminationGracePeriodSeconds,omitempty" yaml:"terminationGracePeriodSeconds,omitempty"`
+	SecurityContext               *core.PodSecurityContext `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
+	ReadinessGates                []core.PodReadinessGate  `json:"readinessGates,omitempty" yaml:"readinessGates,omitempty"`
+	DNSPolicy                     core.DNSPolicy           `json:"dnsPolicy,omitempty" yaml:"dnsPolicy,omitempty"`
 }
 
 // IsEmpty checks if PodSpec is empty or not.
@@ -122,7 +126,7 @@ func quoteStrings(config map[string]interface{}) {
 }
 
 type k8sContainers struct {
-	Containers []k8sContainer `json:"containers"`
+	Containers []k8sContainer `json:"containers" yaml:"containers"`
 }
 
 // Validate is defined on ProviderContainer.
@@ -138,7 +142,7 @@ type k8sContainersInterface interface {
 }
 
 func parseContainers(in string, containerSpec k8sContainersInterface) error {
-	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in))
+	decoder := newStrictYAMLOrJSONDecoder(strings.NewReader(in), len(in))
 	if err := decoder.Decode(containerSpec); err != nil {
 		return errors.Trace(err)
 	}
@@ -192,4 +196,90 @@ func getParser(specVersion specs.Version) (parserType, error) {
 	default:
 		return nil, errors.NewNotSupported(nil, fmt.Sprintf("latest supported version %d, but got podspec version %d", specs.CurrentVersion, specVersion))
 	}
+}
+
+type decoder interface {
+	Decode(into interface{}) error
+}
+
+// YAMLOrJSONDecoder attempts to decode a stream of JSON documents or
+// YAML documents by sniffing for a leading { character.
+type YAMLOrJSONDecoder struct {
+	r          io.Reader
+	bufferSize int
+
+	decoder decoder
+	rawData []byte
+
+	strict bool
+}
+
+func newStrictYAMLOrJSONDecoder(r io.Reader, bufferSize int) *YAMLOrJSONDecoder {
+	return newYAMLOrJSONDecoder(r, bufferSize, true)
+}
+
+func newYAMLOrJSONDecoder(r io.Reader, bufferSize int, strict bool) *YAMLOrJSONDecoder {
+	return &YAMLOrJSONDecoder{
+		r:          r,
+		bufferSize: bufferSize,
+		strict:     strict,
+	}
+}
+
+func (d *YAMLOrJSONDecoder) getDecoder() decoder {
+	if d.decoder != nil {
+		return d.decoder
+	}
+	buffer, origData, isJSON := k8syaml.GuessJSONStream(d.r, d.bufferSize)
+	if isJSON {
+		logger.Debugf("decoding stream as JSON")
+		jsonDecoder := json.NewDecoder(buffer)
+		if d.strict {
+			jsonDecoder.DisallowUnknownFields()
+		}
+		d.decoder = jsonDecoder
+		d.rawData = origData
+	} else {
+		logger.Debugf("decoding stream as YAML")
+		yamlDecoder := yaml.NewDecoder(buffer)
+		yamlDecoder.SetStrict(d.strict)
+		d.decoder = yamlDecoder
+	}
+	return d.decoder
+}
+
+func (d *YAMLOrJSONDecoder) processError(err error) error {
+	jsonDecoder, ok := d.decoder.(*json.Decoder)
+	if !ok {
+		return err
+	}
+	syntax, ok := err.(*json.SyntaxError)
+	if !ok {
+		return err
+	}
+	data, readErr := ioutil.ReadAll(jsonDecoder.Buffered())
+	if readErr != nil {
+		logger.Debugf("reading stream failed: %v", readErr)
+	}
+	jsonData := string(data)
+
+	// if contents from io.Reader are not complete,
+	// use the original raw data to prevent panic
+	if int64(len(jsonData)) <= syntax.Offset {
+		jsonData = string(d.rawData)
+	}
+
+	start := strings.LastIndex(jsonData[:syntax.Offset], "\n") + 1
+	line := strings.Count(jsonData[:start], "\n")
+	return k8syaml.JSONSyntaxError{
+		Line: line,
+		Err:  fmt.Errorf(syntax.Error()),
+	}
+}
+
+// Decode unmarshals the next object from the underlying stream into the
+// provide object, or returns an error.
+func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
+	decoder := d.getDecoder()
+	return d.processError(decoder.Decode(into))
 }

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -175,14 +175,18 @@ func parsePodSpec(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	spec, err := parser(in)
+	k8sspec, err := parser(in)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err = spec.Validate(); err != nil {
+	if err = k8sspec.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return spec.ToLatest(), nil
+	caaSSpec := k8sspec.ToLatest()
+	if err := caaSSpec.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return caaSSpec, nil
 }
 
 type parserType func(string) (PodSpecConverter, error)

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -134,6 +134,11 @@ func (cs *k8sContainers) Validate() error {
 	if len(cs.Containers) == 0 {
 		return errors.New("require at least one container spec")
 	}
+	for _, c := range cs.Containers {
+		if err := c.Validate(); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	return nil
 }
 

--- a/caas/kubernetes/provider/specs/types_test.go
+++ b/caas/kubernetes/provider/specs/types_test.go
@@ -32,16 +32,26 @@ func (s *typesSuite) TestParsePodSpec(c *gc.C) {
 		}, nil
 	}
 
-	pSpecs := &specs.PodSpec{}
+	minSpecs := &specs.PodSpec{}
+	minSpecs.Version = specs.CurrentVersion
+	minSpecs.Containers = []specs.ContainerSpec{
+		{
+			Name:  "gitlab-helper",
+			Image: "gitlab-helper/latest",
+			Ports: []specs.ContainerPort{
+				{ContainerPort: 8080, Protocol: "TCP"},
+			},
+		},
+	}
 
 	gomock.InOrder(
 		converter.EXPECT().Validate().Return(nil),
-		converter.EXPECT().ToLatest().Return(pSpecs),
+		converter.EXPECT().ToLatest().Return(minSpecs),
 	)
 
 	out, err := k8sspces.ParsePodSpecForTest("", getParser)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pSpecs, jc.DeepEquals, out)
+	c.Assert(minSpecs, jc.DeepEquals, out)
 }
 
 func (s *typesSuite) TestK8sContainersValidate(c *gc.C) {

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/juju/juju/caas/specs"
 )
@@ -48,7 +47,7 @@ func (p podSpecV2) ToLatest() *specs.PodSpec {
 // attributes we expose for charms to set.
 type K8sPodSpecV2 struct {
 	// k8s resources.
-	KubernetesResources *KubernetesResources `json:"kubernetesResources,omitempty"`
+	KubernetesResources *KubernetesResources `json:"kubernetesResources,omitempty" yaml:"kubernetesResources,omitempty"`
 }
 
 // Validate is defined on ProviderPod.
@@ -63,8 +62,8 @@ func (p *K8sPodSpecV2) Validate() error {
 
 // K8sServiceAccountSpec defines spec for referencing or creating a service account.
 type K8sServiceAccountSpec struct {
-	Name           string `yaml:"name" json:"name"`
-	specs.RBACSpec `yaml:",inline"`
+	Name           string `json:"name" yaml:"name"`
+	specs.RBACSpec `json:",inline" yaml:",inline"`
 }
 
 // GetName returns the service accout name.
@@ -87,7 +86,7 @@ func (sa K8sServiceAccountSpec) Validate() error {
 
 // KubernetesResources is the k8s related resources.
 type KubernetesResources struct {
-	Pod *PodSpec `json:"pod,omitempty"`
+	Pod *PodSpec `json:"pod,omitempty" yaml:"pod,omitempty"`
 
 	Secrets                   []Secret                                                     `json:"secrets" yaml:"secrets"`
 	CustomResourceDefinitions map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec `json:"customResourceDefinitions,omitempty" yaml:"customResourceDefinitions,omitempty"`
@@ -125,13 +124,13 @@ func parsePodSpecV2(in string) (_ PodSpecConverter, err error) {
 	// Do the common fields.
 	var spec podSpecV2
 
-	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in))
+	decoder := newStrictYAMLOrJSONDecoder(strings.NewReader(in), len(in))
 	if err = decoder.Decode(&spec.caaSSpec); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// Do the k8s pod attributes.
-	decoder = k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in))
+	decoder = newStrictYAMLOrJSONDecoder(strings.NewReader(in), len(in))
 	if err = decoder.Decode(&spec.k8sSpec); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -655,3 +655,18 @@ kubernetesResources:
 	_, err := k8sspecs.ParsePodSpec(specStr)
 	c.Assert(err, gc.ErrorMatches, `custom resource definition "tfjobs.kubeflow.org" scope "Cluster" is not supported, please use "Namespaced" scope`)
 }
+
+func (s *v2SpecsSuite) TestUnknownFieldError(c *gc.C) {
+	specStr := versionHeader + `
+containers:
+  - name: gitlab-helper
+    image: gitlab-helper/latest
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+bar: a-bad-guy
+`[1:]
+
+	_, err := k8sspecs.ParsePodSpec(specStr)
+	c.Assert(err, gc.ErrorMatches, `json: unknown field "bar"`)
+}

--- a/caas/specs/legacy.go
+++ b/caas/specs/legacy.go
@@ -11,9 +11,6 @@ import (
 // a pod on the CAAS substrate.
 type PodSpecLegacy struct {
 	podSpecBase `yaml:",inline"`
-
-	// legacy version has containers/initContainers two blocks.
-	InitContainers []ContainerSpec `json:"initContainers" yaml:"initContainers"`
 }
 
 // VersionLegacy defines the version number for pod spec version 0 - legacy.
@@ -21,14 +18,5 @@ const VersionLegacy Version = 0
 
 // Validate returns an error if the spec is not valid.
 func (spec *PodSpecLegacy) Validate() error {
-	for i, c := range spec.InitContainers {
-		// set init to true.
-		c.Init = true
-		if err := c.Validate(); err != nil {
-			return errors.Trace(err)
-		}
-		// ensure init set to true for init containers.
-		spec.InitContainers[i] = c
-	}
-	return spec.podSpecBase.Validate(VersionLegacy)
+	return errors.Trace(spec.podSpecBase.Validate(VersionLegacy))
 }

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -207,9 +207,9 @@ func (spec *podSpecBase) Validate(ver Version) error {
 		}
 	}
 
-	// if err := spec.Containers.Validate(); err != nil {
-	// 	return errors.Trace(err)
-	// }
+	if err := spec.caasContainers.Validate(); err != nil {
+		return errors.Trace(err)
+	}
 
 	if spec.ProviderPod != nil {
 		return spec.ProviderPod.Validate()

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -37,16 +37,16 @@ func (fs *FileSet) Validate() error {
 
 // ContainerPort defines a port on a container.
 type ContainerPort struct {
-	Name          string `yaml:"name,omitempty" json:"name,omitempty"`
-	ContainerPort int32  `yaml:"containerPort" json:"containerPort"`
-	Protocol      string `yaml:"protocol" json:"protocol"`
+	Name          string `json:"name,omitempty" yaml:"name,omitempty"`
+	ContainerPort int32  `json:"containerPort" yaml:"containerPort"`
+	Protocol      string `json:"protocol" yaml:"protocol"`
 }
 
 // ImageDetails defines all details required to pull a docker image from any registry
 type ImageDetails struct {
-	ImagePath string `yaml:"imagePath" json:"imagePath"`
-	Username  string `yaml:"username,omitempty" json:"username,omitempty"`
-	Password  string `yaml:"password,omitempty" json:"password,omitempty"`
+	ImagePath string `json:"imagePath" yaml:"imagePath"`
+	Username  string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password  string `json:"password,omitempty" yaml:"password,omitempty"`
 }
 
 // PullPolicy describes a policy for if/when to pull a container image.
@@ -55,24 +55,24 @@ type PullPolicy string
 // ContainerSpec defines the data values used to configure
 // a container on the CAAS substrate.
 type ContainerSpec struct {
-	Name string `yaml:"name"`
-	Init bool   `yaml:"init,omitempty"`
+	Name string `json:"name" yaml:"name"`
+	Init bool   `json:"init,omitempty" yaml:"init,omitempty"`
 	// Image is deprecated in preference to using ImageDetails.
-	Image        string          `yaml:"image,omitempty"`
-	ImageDetails ImageDetails    `yaml:"imageDetails"`
-	Ports        []ContainerPort `yaml:"ports,omitempty"`
+	Image        string          `json:"image,omitempty" yaml:"image,omitempty"`
+	ImageDetails ImageDetails    `json:"imageDetails" yaml:"imageDetails"`
+	Ports        []ContainerPort `json:"ports,omitempty" yaml:"ports,omitempty"`
 
-	Command    []string `yaml:"command,omitempty"`
-	Args       []string `yaml:"args,omitempty"`
-	WorkingDir string   `yaml:"workingDir,omitempty"`
+	Command    []string `json:"command,omitempty" yaml:"command,omitempty"`
+	Args       []string `json:"args,omitempty" yaml:"args,omitempty"`
+	WorkingDir string   `json:"workingDir,omitempty" yaml:"workingDir,omitempty"`
 
-	Config map[string]interface{} `yaml:"config,omitempty"`
-	Files  []FileSet              `yaml:"files,omitempty"`
+	Config map[string]interface{} `json:"config,omitempty" yaml:"config,omitempty"`
+	Files  []FileSet              `json:"files,omitempty" yaml:"files,omitempty"`
 
-	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 
 	// ProviderContainer defines config which is specific to a substrate, eg k8s
-	ProviderContainer `yaml:"-"`
+	ProviderContainer `json:"-" yaml:"-"`
 }
 
 // ProviderContainer defines a provider specific container.
@@ -158,7 +158,7 @@ type ConfigMap map[string]string
 
 // podSpecBase defines the data values used to configure a pod on the CAAS substrate.
 type podSpecBase struct {
-	PodSpecVersion `yaml:",inline"`
+	PodSpecVersion `json:",inline" yaml:",inline"`
 
 	// TODO(caas): remove OmitServiceFrontend later once we deprecate legacy version.
 	// Keep it for now because we have to combine it with the ServerType (from metadata.yaml).

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -19,9 +19,9 @@ type PodSpec = PodSpecV2
 // FileSet defines a set of files to mount
 // into the container.
 type FileSet struct {
-	Name      string            `yaml:"name" json:"name"`
-	MountPath string            `yaml:"mountPath" json:"mountPath"`
-	Files     map[string]string `yaml:"files" json:"files"`
+	Name      string            `json:"name" yaml:"name"`
+	MountPath string            `json:"mountPath" yaml:"mountPath"`
+	Files     map[string]string `json:"files" yaml:"files"`
 }
 
 // Validate validates FileSet.
@@ -150,7 +150,7 @@ type Version int32
 
 // PodSpecVersion indicates the version of the podspec.
 type PodSpecVersion struct {
-	Version Version `json:"version,omitempty"`
+	Version Version `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 // ConfigMap describes the format of configmap resource.

--- a/caas/specs/types_test.go
+++ b/caas/specs/types_test.go
@@ -151,12 +151,21 @@ func (s *typesSuite) TestValidateContainerSpec(c *gc.C) {
 }
 
 func (s *typesSuite) TestValidatePodSpecBase(c *gc.C) {
-	spec := specs.PodSpecBase{}
-	c.Assert(spec.Validate(specs.VersionLegacy), jc.ErrorIsNil)
-	spec.Version = specs.VersionLegacy
-	c.Assert(spec.Validate(specs.VersionLegacy), jc.ErrorIsNil)
+	minSpecs := specs.PodSpecBase{}
+	minSpecs.Containers = []specs.ContainerSpec{
+		{
+			Name:  "gitlab-helper",
+			Image: "gitlab-helper/latest",
+			Ports: []specs.ContainerPort{
+				{ContainerPort: 8080, Protocol: "TCP"},
+			},
+		},
+	}
+	c.Assert(minSpecs.Validate(specs.VersionLegacy), jc.ErrorIsNil)
+	minSpecs.Version = specs.VersionLegacy
+	c.Assert(minSpecs.Validate(specs.VersionLegacy), jc.ErrorIsNil)
 
-	c.Assert(spec.Validate(specs.Version2), gc.ErrorMatches, `expected version 2, but found 0`)
-	spec.Version = specs.Version2
-	c.Assert(spec.Validate(specs.Version2), jc.ErrorIsNil)
+	c.Assert(minSpecs.Validate(specs.Version2), gc.ErrorMatches, `expected version 2, but found 0`)
+	minSpecs.Version = specs.Version2
+	c.Assert(minSpecs.Validate(specs.Version2), jc.ErrorIsNil)
 }

--- a/caas/specs/v2.go
+++ b/caas/specs/v2.go
@@ -10,7 +10,7 @@ import (
 // PodSpecV2 defines the data values used to configure
 // a pod on the CAAS substrate for version 2.
 type PodSpecV2 struct {
-	podSpecBase    `yaml:",inline"`
+	podSpecBase    `json:",inline" yaml:",inline"`
 	ServiceAccount *ServiceAccountSpec `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
 }
 


### PR DESCRIPTION
## Description of change

This PR introduces top-level validation for both legacy and v2 pod spec.

## QA steps

- deploy a CaaS charm with `unknown` fields in pod spec - now Juju will complain about the field;

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1851571