### PR TITLE
Fix Constraint Merge Error When Deploying with Bindings *and* Space Constraints

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -1823,7 +1823,18 @@ func (st *State) addMachineWithPlacement(unit *Unit, data *placementData) (*Mach
 			spaces.Add(name)
 		}
 	}
+
+	// Merging constraints returns an error if any spaces are already set,
+	// so we "move" any existing constraints over to the bind spaces before
+	// parsing and merging.
+	if unitCons.Spaces != nil {
+		for _, sp := range *unitCons.Spaces {
+			spaces.Add(sp)
+		}
+		unitCons.Spaces = nil
+	}
 	spaceCons := constraints.MustParse("spaces=" + strings.Join(spaces.Values(), ","))
+
 	cons, err := constraints.Merge(*unitCons, spaceCons)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

This patch fixes an error vector introduced with https://github.com/juju/juju/pull/10697.

It turns out `Constraints.Merge` fails if both constraints values have settings for a particular characteristic, in this case, "spaces".

The logic is now tolerant of this situation, brought about when deploying with both bindings and space constraints.

## QA steps

- Bootstrap to aws with `--build-agent`.
- `juju add-space new-space 172.31.0.0/20`.
- `juju deploy keystone --bind "new-space" --to lxd --constraints "spaces=new-space"`.
- `juju show-machine 0` indicates the machine and container got the two bindings as constraints.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1852143
