### PR TITLE
Expose the new action CLI by default

### DIFF
--- a/cmd/juju/action/call.go
+++ b/cmd/juju/action/call.go
@@ -267,7 +267,7 @@ func (c *callCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		fmt.Fprintf(ctx.Stderr, "Waiting for task %v...\n", tag.Id())
-		result, err = GetActionResult(c.api, tag.Id(), wait)
+		result, err = GetActionResult(c.api, tag.Id(), wait, false)
 		if i == 0 {
 			waitForWatcher()
 			if haveLogs {
@@ -282,7 +282,7 @@ func (c *callCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		d := FormatActionResult(result, c.utc)
+		d := FormatActionResult(result, c.utc, false)
 		d["id"] = tag.Id() // Action ID is required in case we timed out.
 		info[unitTag.Id()] = d
 	}

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -390,7 +390,7 @@ hello
 world`[1:],
 	}, {
 		should:   "call a basic function with no params with yaml output including stdout, stderr",
-		withArgs: []string{validUnitId, "some-function", "--format", "yaml"},
+		withArgs: []string{validUnitId, "some-function", "--format", "yaml", "--utc"},
 		withTags: tagsForIdPrefix(validActionId, validActionTagString),
 		withFunctionResults: []params.ActionResult{{
 			Action: &params.Action{
@@ -433,9 +433,9 @@ mysql/0:
       message: hello
   status: completed
   timing:
-    completed: 2015-02-14 08:17:00 +0000 UTC
-    enqueued: 2015-02-14 08:13:00 +0000 UTC
-    started: 2015-02-14 08:15:00 +0000 UTC
+    completed: "2015-02-14 08:17:00"
+    enqueued: "2015-02-14 08:13:00"
+    started: "2015-02-14 08:15:00"
   unit: mysql/0`[1:],
 	}, {
 		should:   "call a basic function with progress logs",
@@ -534,13 +534,13 @@ mysql/0:
       message: hello
   status: completed
   timing:
-    completed: 2015-02-14 08:17:00 +0000 UTC
-    enqueued: 2015-02-14 08:13:00 +0000 UTC
-    started: 2015-02-14 08:15:00 +0000 UTC
+    completed: "2015-02-14 08:17:00"
+    enqueued: "2015-02-14 08:13:00"
+    started: "2015-02-14 08:15:00"
   unit: mysql/0`[1:],
 	}, {
 		should:   "call action on multiple units with stdout for each action",
-		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "yaml"},
+		withArgs: []string{validUnitId, validUnitId2, "some-function", "--format", "yaml", "--utc"},
 		withTags: params.FindTagsResults{Matches: map[string][]params.Entity{
 			validActionId:  {{Tag: validActionTagString}},
 			validActionId2: {{Tag: validActionTagString2}},
@@ -596,9 +596,9 @@ mysql/0:
       message: hello
   status: completed
   timing:
-    completed: 2015-02-14 08:17:00 +0000 UTC
-    enqueued: 2015-02-14 08:13:00 +0000 UTC
-    started: 2015-02-14 08:15:00 +0000 UTC
+    completed: "2015-02-14 08:17:00"
+    enqueued: "2015-02-14 08:13:00"
+    started: "2015-02-14 08:15:00"
   unit: mysql/0
 mysql/1:
   id: f47ac10b-58cc-4372-a567-0e02b2c3d478
@@ -608,9 +608,9 @@ mysql/1:
       message: hello2
   status: completed
   timing:
-    completed: 2015-02-14 08:17:00 +0000 UTC
-    enqueued: 2015-02-14 08:13:00 +0000 UTC
-    started: 2015-02-14 08:15:00 +0000 UTC
+    completed: "2015-02-14 08:17:00"
+    enqueued: "2015-02-14 08:13:00"
+    started: "2015-02-14 08:15:00"
   unit: mysql/1`[1:],
 	}, {
 		should:   "call function on multiple units with plain output selected",

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -113,6 +113,7 @@ type ListTasksCommand struct {
 
 func NewShowOutputCommandForTest(store jujuclient.ClientStore, logMessage func(*cmd.Context, string)) (cmd.Command, *ShowOutputCommand) {
 	c := &showOutputCommand{
+		compat:            true,
 		logMessageHandler: logMessage,
 	}
 	c.SetClientStore(store)

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -35,17 +35,17 @@ type listCommand struct {
 }
 
 const listDoc = `
-List the actions available to run on the target application, with a short
-description.  To show the full schema for the actions, use --schema.
+List the functions available to run on the target application, with a short
+description.  To show the full schema for the functions, use --schema.
 
 Examples:
-    juju list-actions postgresql
-    juju list-actions postgresql --format yaml
-    juju list-actions postgresql --schema
+    juju functions postgresql
+    juju functions postgresql --format yaml
+    juju functions postgresql --schema
 
 See also:
-    run-action
-    show-action
+    call
+    show-function
 `
 
 // Set up the output.
@@ -68,23 +68,19 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 		"tabular": c.printTabular,
 		"default": c.dummyDefault,
 	})
-	f.BoolVar(&c.fullSchema, "schema", false, "Display the full action schema")
+	f.BoolVar(&c.fullSchema, "schema", false, "Display the full function schema")
 }
 
 func (c *listCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
-		Name:    "actions",
+		Name:    "functions",
 		Args:    "<application name>",
-		Purpose: "List actions defined for an application.",
+		Purpose: "List functions defined for an application.",
 		Doc:     listDoc,
-		Aliases: []string{"list-actions"},
+		Aliases: []string{"list-functions", "actions", "list-actions"},
 	})
 	if featureflag.Enabled(feature.JujuV3) {
-		info.Name = "functions"
 		info.Aliases = []string{"list-functions"}
-		info.Doc = strings.Replace(info.Doc, "run-action", "call", -1)
-		info.Doc = strings.Replace(info.Doc, "action", "function", -1)
-		info.Purpose = strings.Replace(info.Purpose, "action", "function", -1)
 	}
 	return info
 }
@@ -153,11 +149,7 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		output = shortOutput
 	default:
 		if len(sortedNames) == 0 {
-			functions := "functions"
-			if !featureflag.Enabled(feature.JujuV3) {
-				functions = "actions"
-			}
-			ctx.Infof("No %s defined for %s.", functions, c.applicationTag.Id())
+			ctx.Infof("No functions defined for %s.", c.applicationTag.Id())
 			return nil
 		}
 		var list []listOutput
@@ -188,11 +180,7 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 	}
 
 	tw := output.TabWriter(writer)
-	if featureflag.Enabled(feature.JujuV3) {
-		fmt.Fprintf(tw, "%s\t%s\n", "Function", "Description")
-	} else {
-		fmt.Fprintf(tw, "%s\t%s\n", "Action", "Description")
-	}
+	fmt.Fprintf(tw, "%s\t%s\n", "Function", "Description")
 	for _, value := range list {
 		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.TrimSpace(value.description))
 	}

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -75,7 +75,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d should %s: juju actions defined %s", i,
+			c.Logf("test %d should %s: juju functions defined %s", i,
 				t.should, strings.Join(t.args, " "))
 			s.wrappedCommand, s.command = action.NewListCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)
@@ -93,7 +93,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 
 func (s *ListSuite) TestRun(c *gc.C) {
 	simpleOutput := `
-Action          Description
+Function        Description
 kill            Kill the database.
 no-description  No description
 no-params       An action with no parameters.
@@ -127,7 +127,7 @@ snapshot        Take a snapshot of the database.
 		should:          "work properly when no results found",
 		withArgs:        []string{validApplicationId},
 		expectNoResults: true,
-		expectMessage:   fmt.Sprintf("No actions defined for %s.\n", validApplicationId),
+		expectMessage:   fmt.Sprintf("No functions defined for %s.\n", validApplicationId),
 	}, {
 		should:           "get tabular default output when --schema is NOT specified",
 		withArgs:         []string{"--format=default", validApplicationId},

--- a/cmd/juju/action/listtasks.go
+++ b/cmd/juju/action/listtasks.go
@@ -150,7 +150,7 @@ func (c *listTasksCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		out[tag.Id()] = FormatActionResult(result, c.utc)
+		out[tag.Id()] = FormatActionResult(result, c.utc, false)
 	}
 	if c.out.Name() != "plain" {
 		return c.out.Write(ctx, out)

--- a/cmd/juju/action/listtasks_test.go
+++ b/cmd/juju/action/listtasks_test.go
@@ -184,23 +184,23 @@ func (s *ListTasksSuite) TestRunYaml(c *gc.C) {
 	s.wrappedCommand, _ = action.NewListTasksCommandForTest(s.store)
 	for _, modelFlag := range s.modelFlags {
 		s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
-		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--format", "yaml")
+		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--format", "yaml", "--utc")
 		c.Assert(err, jc.ErrorIsNil)
 		expected := `
 "1":
   status: completed
   timing:
-    started: 2015-02-14 06:06:06 +0000 UTC
+    started: "2015-02-14 06:06:06"
   unit: mysql/0
 "2":
   status: running
   timing:
-    completed: 2014-02-14 06:06:06 +0000 UTC
+    completed: "2014-02-14 06:06:06"
   unit: mysql/1
 "3":
   status: pending
   timing:
-    enqueued: 2013-02-14 06:06:06 +0000 UTC
+    enqueued: "2013-02-14 06:06:06"
   unit: mysql/1
 `[1:]
 		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expected)

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -274,11 +274,11 @@ func (c *runActionCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		result, err = GetActionResult(c.api, tag.Id(), wait)
+		result, err = GetActionResult(c.api, tag.Id(), wait, true)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		d := FormatActionResult(result, false)
+		d := FormatActionResult(result, false, true)
 		d["id"] = tag.Id() // Action ID is required in case we timed out.
 		out[result.Action.Receiver] = d
 	}

--- a/cmd/juju/action/show.go
+++ b/cmd/juju/action/show.go
@@ -5,7 +5,6 @@ package action
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -29,17 +28,17 @@ type showCommand struct {
 }
 
 var showActionDoc = `
-Show detailed information about an action on the target application.
+Show detailed information about a function on the target application.
 
 Examples:
-    juju show-action postgresql backup
+    juju show-function postgresql backup
 
 See also:
-    list-actions
-    run-action
+    call
+    list-functions
 `
 
-// NewShowCommand returns a command to print action information.
+// NewShowCommand returns a command to print function information.
 func NewShowCommand() cmd.Command {
 	return modelcmd.Wrap(&showCommand{})
 }
@@ -49,10 +48,7 @@ func (c *showCommand) Init(args []string) error {
 	case 0:
 		return errors.New("no application name specified")
 	case 1:
-		if featureflag.Enabled(feature.JujuV3) {
-			return errors.New("no function name specified")
-		}
-		return errors.New("no action name specified")
+		return errors.New("no function name specified")
 	case 2:
 		appName := args[0]
 		if !names.IsValidApplication(appName) {
@@ -68,17 +64,14 @@ func (c *showCommand) Init(args []string) error {
 
 func (c *showCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
-		Name:    "show-action",
-		Args:    "<application name> <action name>",
-		Purpose: "Shows detailed information about an action.",
+		Name:    "show-function",
+		Args:    "<application name> <function name>",
+		Purpose: "Shows detailed information about a function.",
 		Doc:     showActionDoc,
+		Aliases: []string{"show-action"},
 	})
 	if featureflag.Enabled(feature.JujuV3) {
-		info.Name = "show-function"
-		info.Doc = strings.Replace(info.Doc, "run-action", "call", -1)
-		info.Doc = strings.Replace(info.Doc, "an action", "a function", -1)
-		info.Doc = strings.Replace(info.Doc, "action", "function", -1)
-		info.Purpose = strings.Replace(info.Purpose, "an action", "a function", -1)
+		info.Aliases = nil
 	}
 	return info
 }
@@ -96,11 +89,7 @@ func (c *showCommand) Run(ctx *cmd.Context) error {
 	}
 	info, ok := actions[c.functionName]
 	if !ok {
-		if featureflag.Enabled(feature.JujuV3) {
-			ctx.Infof("unknown function %q\n", c.functionName)
-		} else {
-			ctx.Infof("unknown action %q\n", c.functionName)
-		}
+		ctx.Infof("unknown function %q\n", c.functionName)
 		return cmd.ErrSilent
 	}
 

--- a/cmd/juju/action/show_test.go
+++ b/cmd/juju/action/show_test.go
@@ -46,7 +46,7 @@ func (s *ShowSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "fail with missing action name",
 		args:        []string{validApplicationId},
-		expectedErr: "no action name specified",
+		expectedErr: "no function name specified",
 	}, {
 		should:      "fail with invalid application name",
 		args:        []string{invalidApplicationId, "doIt"},
@@ -64,7 +64,7 @@ func (s *ShowSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d should %s: juju show-action defined %s", i,
+			c.Logf("test %d should %s: juju show-function defined %s", i,
 				t.should, strings.Join(t.args, " "))
 			s.wrappedCommand, s.command = action.NewShowCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)
@@ -112,12 +112,12 @@ name:
 		withArgs:        []string{validApplicationId, "snapshot"},
 		expectNoResults: true,
 		expectedErr:     "cmd: error out silently",
-		expectMessage:   `unknown action "snapshot"`,
+		expectMessage:   `unknown function "snapshot"`,
 	}, {
-		should:           "error when unknown action specified",
+		should:           "error when unknown function specified",
 		withArgs:         []string{validApplicationId, "something"},
 		withCharmActions: someCharmActions,
-		expectMessage:    `unknown action "something"`,
+		expectMessage:    `unknown function "something"`,
 		expectedErr:      "cmd: error out silently",
 	}, {
 		should:           "get results properly",

--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -113,14 +113,13 @@ NOTE: Juju 2 uses "juju run" which is deprecated in favour of "juju exec".
 
 func (c *execCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
-		Name:    "run",
+		Name:    "exec",
 		Args:    "<commands>",
 		Purpose: "Run the commands on the remote targets specified.",
-		Aliases: []string{"exec"},
+		Aliases: []string{"run"},
 		Doc:     execDoc,
 	})
 	if featureflag.Enabled(feature.JujuV3) {
-		info.Name = "exec"
 		info.Aliases = nil
 	}
 	return info
@@ -462,7 +461,7 @@ var getExecAPIClient = func(c *execCommand) (ExecClient, error) {
 
 // getActionResult abstracts over the action CLI function that we use here to fetch results
 var getActionResult = func(c ExecClient, actionId string, wait *time.Timer) (params.ActionResult, error) {
-	return action.GetActionResult(c, actionId, wait)
+	return action.GetActionResult(c, actionId, wait, false)
 }
 
 // entities is a convenience constructor for params.Entities.

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -383,14 +383,14 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	}
 
 	// Manage and control actions
-	r.Register(action.NewShowOutputCommand())
+	r.Register(action.NewShowTaskCommand())
 	r.Register(action.NewListCommand())
 	r.Register(action.NewShowCommand())
 	r.Register(action.NewCancelCommand())
-	if featureflag.Enabled(feature.JujuV3) {
-		r.Register(action.NewCallCommand())
-		r.Register(action.NewListTasksCommand())
-	} else {
+	r.Register(action.NewCallCommand())
+	r.Register(action.NewListTasksCommand())
+	if !featureflag.Enabled(feature.JujuV3) {
+		r.Register(action.NewShowActionOutputCommand())
 		r.Register(action.NewRunActionCommand())
 		r.Register(action.NewStatusCommand())
 	}

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -447,6 +447,7 @@ var commandNames = []string{
 	"bind",
 	"bootstrap",
 	"budget",
+	"call",
 	"cached-images",
 	"cancel-action",
 	"change-user-password",
@@ -485,6 +486,7 @@ var commandNames = []string{
 	"expose",
 	"find-offers",
 	"firewall-rules",
+	"functions",
 	"get-constraints",
 	"get-model-constraints",
 	"grant",
@@ -507,6 +509,7 @@ var commandNames = []string{
 	"list-credentials",
 	"list-disabled-commands",
 	"list-firewall-rules",
+	"list-functions",
 	"list-machines",
 	"list-models",
 	"list-offers",
@@ -519,6 +522,7 @@ var commandNames = []string{
 	"list-storage",
 	"list-storage-pools",
 	"list-subnets",
+	"list-tasks",
 	"list-users",
 	"list-wallets",
 	"login",
@@ -582,12 +586,14 @@ var commandNames = []string{
 	"show-controller",
 	"show-credential",
 	"show-credentials",
+	"show-function",
 	"show-machine",
 	"show-model",
 	"show-offer",
 	"show-status",
 	"show-status-log",
 	"show-storage",
+	"show-task",
 	"show-user",
 	"show-wallet",
 	"sla",
@@ -602,6 +608,7 @@ var commandNames = []string{
 	"switch",
 	"sync-agent-binaries",
 	"sync-tools",
+	"tasks",
 	"trust",
 	"unexpose",
 	"unregister",
@@ -630,9 +637,7 @@ var devFeatures = []string{
 }
 
 // These are the commands that are behind the `devFeatures`.
-var commandNamesBehindFlags = set.NewStrings(
-	"call", "show-task", "functions", "list-functions", "show-function", "tasks", "list-tasks",
-)
+var commandNamesBehindFlags = set.NewStrings()
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	// Check that we have correctly registered all the commands

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -240,5 +240,5 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 
 // getActionResult abstracts over the action CLI function that we use here to fetch results
 var getActionResult = func(c runClient, actionId string, wait *time.Timer) (params.ActionResult, error) {
-	return action.GetActionResult(c, actionId, wait)
+	return action.GetActionResult(c, actionId, wait, false)
 }

--- a/state/action.go
+++ b/state/action.go
@@ -334,7 +334,7 @@ func newAction(st *State, adoc actionDoc) Action {
 
 // MinVersionSupportNewActionID should be un-exposed after 2.7 released.
 // TODO(action): un-expose MinVersionSupportNewActionID and IsNewActionIDSupported and remove those helper functions using these two vars in tests from 2.7.0.
-var MinVersionSupportNewActionID = version.MustParse("2.7.0")
+var MinVersionSupportNewActionID = version.MustParse("2.6.999")
 
 // IsNewActionIDSupported checks if new action ID is supported for the specified version.
 func IsNewActionIDSupported(ver version.Number) bool {


### PR DESCRIPTION
## Description of change

We want to expose the new actions CLI without the feature flag.
As a sriveby, adjust the version used for the action id check to 2.7rc builds get numeric ids.

## QA steps

bootstrap a k8s model without feature flag
test old and new actions cli
