### PR TITLE
[Dev] record agent start time in machine document

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -64,7 +64,7 @@ var facadeVersions = map[string]int{
 	"MachineActions":               1,
 	"MachineManager":               6,
 	"MachineUndertaker":            1,
-	"Machiner":                     1,
+	"Machiner":                     2,
 	"MeterStatus":                  1,
 	"MetricsAdder":                 2,
 	"MetricsDebug":                 2,

--- a/api/instancepoller/instancepoller.go
+++ b/api/instancepoller/instancepoller.go
@@ -47,11 +47,11 @@ func (api *API) Machine(tag names.MachineTag) (*Machine, error) {
 
 var newStringsWatcher = apiwatcher.NewStringsWatcher
 
-// WatchModelMachines return a StringsWatcher reporting waiting for the
-// model configuration to change.
+// WatchModelMachines returns a StringsWatcher reporting changes to the
+// machine life or agent start timestamps.
 func (api *API) WatchModelMachines() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
-	err := api.facade.FacadeCall("WatchModelMachines", nil, &result)
+	err := api.facade.FacadeCall("WatchModelMachineStartTimes", nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/api/instancepoller/instancepoller_test.go
+++ b/api/instancepoller/instancepoller_test.go
@@ -59,7 +59,7 @@ func (s *InstancePollerSuite) TestMachineCallsLife(c *gc.C) {
 	c.Assert(m.Id(), gc.Equals, "42")
 }
 
-func (s *InstancePollerSuite) TestWatchModelMachinesSuccess(c *gc.C) {
+func (s *InstancePollerSuite) TestWatchModelMachineStartTimesSuccess(c *gc.C) {
 	// We're not testing the watcher logic here as it's already tested elsewhere.
 	var numWatcherCalls int
 	expectResult := params.StringsWatchResult{
@@ -74,7 +74,7 @@ func (s *InstancePollerSuite) TestWatchModelMachinesSuccess(c *gc.C) {
 	}
 	s.PatchValue(instancepoller.NewStringsWatcher, watcherFunc)
 
-	apiCaller := successAPICaller(c, "WatchModelMachines", nil, expectResult)
+	apiCaller := successAPICaller(c, "WatchModelMachineStartTimes", nil, expectResult)
 
 	api := instancepoller.NewAPI(apiCaller)
 	w, err := api.WatchModelMachines()
@@ -84,8 +84,8 @@ func (s *InstancePollerSuite) TestWatchModelMachinesSuccess(c *gc.C) {
 	c.Assert(w, gc.IsNil)
 }
 
-func (s *InstancePollerSuite) TestWatchModelMachinesClientError(c *gc.C) {
-	apiCaller := clientErrorAPICaller(c, "WatchModelMachines", nil)
+func (s *InstancePollerSuite) TestWatchModelMachineStartTimesClientError(c *gc.C) {
+	apiCaller := clientErrorAPICaller(c, "WatchModelMachineStartTimes", nil)
 	api := instancepoller.NewAPI(apiCaller)
 	w, err := api.WatchModelMachines()
 	c.Assert(err, gc.ErrorMatches, "client error!")
@@ -93,11 +93,11 @@ func (s *InstancePollerSuite) TestWatchModelMachinesClientError(c *gc.C) {
 	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 }
 
-func (s *InstancePollerSuite) TestWatchModelMachinesServerError(c *gc.C) {
+func (s *InstancePollerSuite) TestWatchModelMachineStartTimesServerError(c *gc.C) {
 	expectedResults := params.StringsWatchResult{
 		Error: apiservertesting.ServerError("server boom!"),
 	}
-	apiCaller := successAPICaller(c, "WatchModelMachines", nil, expectedResults)
+	apiCaller := successAPICaller(c, "WatchModelMachineStartTimes", nil, expectedResults)
 
 	api := instancepoller.NewAPI(apiCaller)
 	w, err := api.WatchModelMachines()

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -138,3 +138,22 @@ func (m *Machine) SetProviderNetworkConfig() error {
 	}
 	return result.OneError()
 }
+
+// RecordAgentStartTime updates the start time for the agent running on the
+// machine.
+func (m *Machine) RecordAgentStartTime() error {
+	// Ignore if connecting to an older, not upgraded controller
+	if m.st.facade.BestAPIVersion() < 2 {
+		return nil
+	}
+
+	var result params.ErrorResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: m.tag.String()}},
+	}
+	err := m.st.facade.FacadeCall("RecordAgentStartTime", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -206,3 +206,21 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }
+
+func (s *machinerSuite) TestRecordAgentStartTime(c *gc.C) {
+	mTag := names.NewMachineTag("1")
+	stMachine, err := s.State.Machine(mTag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	oldStartedAt := stMachine.AgentStartTime()
+
+	machine, err := s.machiner.Machine(mTag)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.RecordAgentStartTime()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = stMachine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(stMachine.AgentStartTime(), gc.Not(gc.Equals), oldStartedAt, gc.Commentf("expected the agent start time to be updated"))
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -235,7 +235,7 @@ func AllFacades() *facade.Registry {
 	reg("MachineManager", 6, machinemanager.NewFacadeV6) // DestroyMachinesWithParams gains maxWait.
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
-	reg("Machiner", 1, machine.NewMachinerAPI)
+	reg("Machiner", 2, machine.NewMachinerAPI)
 
 	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacade)
 	reg("MetricsAdder", 2, metricsadder.NewMetricsAdderAPI)

--- a/apiserver/common/modelmachineswatcher.go
+++ b/apiserver/common/modelmachineswatcher.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
@@ -40,6 +41,27 @@ func (e *ModelMachinesWatcher) WatchModelMachines() (params.StringsWatchResult, 
 		return result, ErrPerm
 	}
 	watch := e.st.WatchModelMachines()
+	// Consume the initial event and forward it to the result.
+	if changes, ok := <-watch.Changes(); ok {
+		result.StringsWatcherId = e.resources.Register(watch)
+		result.Changes = changes
+	} else {
+		err := watcher.EnsureErr(watch)
+		return result, fmt.Errorf("cannot obtain initial model machines: %v", err)
+	}
+	return result, nil
+}
+
+// WatchModelMachineStartTimes watches the non-container machines in the model
+// for changes to the Life or AgentStartTime fields and reports them as a batch
+// after the specified quiesceInterval time has passed without seeing any new
+// change events.
+func (e *ModelMachinesWatcher) WatchModelMachineStartTimes() (params.StringsWatchResult, error) {
+	result := params.StringsWatchResult{}
+	if !e.authorizer.AuthController() {
+		return result, ErrPerm
+	}
+	watch := e.st.WatchModelMachineStartTimes(500 * time.Millisecond)
 	// Consume the initial event and forward it to the result.
 	if changes, ok := <-watch.Changes(); ok {
 		result.StringsWatcherId = e.resources.Register(watch)

--- a/apiserver/facades/controller/instancepoller/mock_test.go
+++ b/apiserver/facades/controller/instancepoller/mock_test.go
@@ -6,6 +6,7 @@ package instancepoller_test
 import (
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -104,6 +105,25 @@ func (m *mockState) WatchModelMachines() state.StringsWatcher {
 	defer m.mu.Unlock()
 
 	m.MethodCall(m, "WatchModelMachines")
+
+	ids := make([]string, 0, len(m.machines))
+	// Initial event - all machine ids, sorted.
+	for id := range m.machines {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	w := NewMockMachinesWatcher(ids, m.NextErr())
+	m.machinesWatchers = append(m.machinesWatchers, w)
+	return w
+}
+
+// WatchModelMachineStartTimes implements StateInterface.
+func (m *mockState) WatchModelMachineStartTimes(_ time.Duration) state.StringsWatcher {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.MethodCall(m, "WatchModelMachineStartTimes")
 
 	ids := make([]string, 0, len(m.machines))
 	// Initial event - all machine ids, sorted.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -16023,6 +16023,14 @@
                         }
                     }
                 },
+                "WatchModelMachineStartTimes": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                },
                 "WatchModelMachines": {
                     "type": "object",
                     "properties": {
@@ -17729,6 +17737,14 @@
                     "properties": {
                         "Result": {
                             "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchModelMachineStartTimes": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
                         }
                     }
                 },
@@ -20452,7 +20468,7 @@
     },
     {
         "Name": "Machiner",
-        "Version": 1,
+        "Version": 2,
         "Schema": {
             "type": "object",
             "properties": {
@@ -20510,6 +20526,17 @@
                     "properties": {
                         "Result": {
                             "$ref": "#/definitions/StringResult"
+                        }
+                    }
+                },
+                "RecordAgentStartTime": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
                         }
                     }
                 },
@@ -25916,6 +25943,14 @@
                     "properties": {
                         "Result": {
                             "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchModelMachineStartTimes": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
                         }
                     }
                 },

--- a/state/interface.go
+++ b/state/interface.go
@@ -113,10 +113,13 @@ type UnitsWatcher interface {
 	WatchUnits() StringsWatcher
 }
 
-// ModelMachinesWatcher defines a single method -
+// ModelMachinesWatcher defines a the methods required for listening to
+// machine lifecycle events or a combination of lifecycle events and changes
+// to the agent start time field.
 // WatchModelMachines.
 type ModelMachinesWatcher interface {
 	WatchModelMachines() StringsWatcher
+	WatchModelMachineStartTimes(quiesceInterval time.Duration) StringsWatcher
 }
 
 // InstanceIdGetter defines a single method - InstanceId.

--- a/state/machine.go
+++ b/state/machine.go
@@ -142,7 +142,7 @@ type machineDoc struct {
 	StopMongoUntilVersion string `bson:",omitempty"`
 
 	// AgentStartedAt records the time when the machine agent started.
-	AgentStartedAt time.Time `bson:"agent-started-at"`
+	AgentStartedAt time.Time `bson:"agent-started-at,omitempty"`
 }
 
 func newMachine(st *State, doc *machineDoc) *Machine {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -126,6 +126,16 @@ func (s *MachineSuite) TestSetUnsetRebootFlag(c *gc.C) {
 	c.Assert(rebootFlag, jc.IsFalse)
 }
 
+func (s *MachineSuite) TestRecordAgentStartTime(c *gc.C) {
+	now := s.Clock.Now().Truncate(time.Millisecond)
+	err := s.machine.RecordAgentStartTime()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine.AgentStartTime(), gc.Equals, now)
+}
+
 func (s *MachineSuite) TestSetKeepInstance(c *gc.C) {
 	err := s.machine.SetProvisioned("1234", "", "nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1581,10 +1581,15 @@ func (s *MachineSuite) TestWatchMachineStartTimes(c *gc.C) {
 	wc.AssertChange("1", "0")
 	wc.AssertNoChange()
 
-	// Kill the machine and check that we get a change event
+	// Kill the machine, remove it from state and check ensure that we
+	// still get back a change event.
 	err = s.machine.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+	err = s.machine.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Remove()
+	c.Assert(err, jc.ErrorIsNil)
 	s.Clock.Advance(quiesceInterval)
 	wc.AssertChange("1")
 	wc.AssertNoChange()

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -320,6 +320,8 @@ func (s *MigrationSuite) TestMachineDocFields(c *gc.C) {
 		// Ignored at this stage, could be an issue if mongo 3.0 isn't
 		// available.
 		"StopMongoUntilVersion",
+		// Ignored; it gets populated on demand when the agent restarts
+		"AgentStartedAt",
 	)
 	migrated := set.NewStrings(
 		"Addresses",

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -581,6 +581,7 @@ func (w *modelMachineStartTimeWatcher) loop() error {
 			// Restart the timer if currently stopped.
 			if !timerArmed {
 				_ = timer.Reset(w.quiesceInterval)
+				timerArmed = true
 			}
 		case <-timer.Chan():
 			timerArmed = false

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -586,7 +586,10 @@ func (w *modelMachineStartTimeWatcher) loop() error {
 				continue
 			}
 			for _, docID := range changes {
-				unprocessedDocs.Add(w.backend.docID(docID))
+				// filter out doc IDs that correspond to containers
+				if !strings.ContainsRune(docID, '/') {
+					unprocessedDocs.Add(w.backend.docID(docID))
+				}
 			}
 
 			// Restart the timer if currently stopped.

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -252,7 +252,7 @@ func (u *updaterWorker) queueMachineForPolling(tag names.MachineTag) error {
 		// status at the next interval.
 		u.moveEntryToPollGroup(shortPollGroup, entry)
 		if groupType == longPollGroup {
-			u.config.Logger.Debugf("moving machine %q (instance ID %q) to long poll group", entry.m, entry.instanceID)
+			u.config.Logger.Debugf("moving machine %q (instance ID %q) to short poll group", entry.m, entry.instanceID)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description of change

When deploying to a provider that uses shadow IPs (eg. AWS), the public IP addresses are not exposed as network interfaces to the instance (so the machiner cannot pick them up) and can only be detected by querying the provider directly inside the instance poller.

The instance poller implementation in 2.6.x and 2.7-rcX (note that 2.7 has a new instancepoller implementation) partitions monitored machines into two groups: a short poll group that gets frequently polled and a long poll group that gets polled approximately every 10-15min. Once a machine is running and has at least one address assigned it gets migrated to the long poll group.

On EC2 (and other providers), there are times when the machine needs to be restarted.
When this happens, the machine will probably (unless it's assigned an elastic IP) get a new public IP. Once the agent reconnects to the API, the machine will show up as working again; however, the controller thinks that the machine still uses the **old public IP**. As a result:

- we cannot `juju ssh` in the machine;
- `juju upgrade-controller` seems to block until the new IP is detected.
 
The problem here is that unless we somehow notify the instancepoller to check the machine, we will need to wait ~10-15min until the next refresh interval!

This PR attempts to resolve this issue by:
- Adding a `AgentStartedAt` (agent-started-at in bson) field in the machine document and arranging for the machine agent to update it when it boots.
- Creating a new watcher that monitors the `[Life, AgentStartedAt]` tuple from the machine documents (ignoring containers) for changes. The instancepoller now uses this instead of the misleadingly-named `WatchModelMachines` which only reports **life-cycle** related changes. 

Notes:
- The new watcher tries to be conservative regarding the number of DB accesses by collecting changes and processing them in bulk after not seeing new changes for some time (configurable; currently set to 500ms). For more details see the extended log commit in https://github.com/juju/juju/pull/10902/commits/6da33b0aae89a0f4bd562e63cf722a3211be246e.
- The changes are split in a way so they can be back-ported to 2.6 **without** the recently introduced 2.7 changes to the instancepoller.
- In the future, we could potentially extend this notification mechanism to also include the link layer devices in the monitored tuple and implement some form of hot-plugging: machiner detects (inotify) a new eth device, link layer devices get updated, instance poller gets triggered and pulls the public (shadow) IP.

## QA steps

I have tested this on AWS but it should work with any provider that uses shadow IPs

```
$ juju bootstrap aws aws --credential aws --no-gui --build-agent
$ juju model-config logging-config='<root>=ERROR;juju.worker.instancepoller=DEBUG'
$ juju deploy cs:~jameinel/ubuntu-lite-7

# Tail the model logs and wait until the new machine enters the long poll group
$ juju debug-log --include-module juju.worker.instancepoller --replay --level DEBUG

# You should see something like this:
controller-0: 13:03:49 INFO juju.worker.instancepoller machine "0" (instance ID "i-05fe715dc5a6e6c6c") instance status changed from {"allocating" "Start instance attempt 1"} to {"running" "running"}
controller-0: 13:03:49 INFO juju.worker.instancepoller machine "0" (instance ID "i-05fe715dc5a6e6c6c") has new addresses: [public:34.228.219.51 local-cloud:172.31.46.138]
controller-0: 13:05:14 DEBUG juju.worker.instancepoller moving machine "0" (instance ID "i-05fe715dc5a6e6c6c") to long poll group

# Then (still tailing the logs) wait until the application shows up as running in `juju status`.
# Log in to the aws console, right click on the "juju-default-machine-0" instance, select
# "instance state" -> "stop".
# 
# Wait for the machine to shutdown and for juju status to show something like
# "agent lost".
#
# Then go back to the aes console and start the machine. After a couple of seconds you 
# should see something like this in the model logs:
controller-0: 13:07:49 DEBUG juju.worker.instancepoller moving machine "0" (instance ID "i-05fe715dc5a6e6c6c") to short poll group
controller-0: 13:07:53 INFO juju.worker.instancepoller machine "0" (instance ID "i-05fe715dc5a6e6c6c") has new addresses: [public:34.207.175.62 local-cloud:172.31.46.138]
controller-0: 13:07:53 DEBUG juju.worker.instancepoller moving machine "0" (instance ID "i-05fe715dc5a6e6c6c") to long poll group

# Double-check that `juju status` now lists the new public IP
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1852164
