### PR TITLE
Reduce the number of space id/name helpers needed by enhancing SpaceInfos

### DIFF
--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -433,11 +433,7 @@ func (m *mockBackend) Machine(id string) (application.Machine, error) {
 	return nil, errors.NotFoundf("machine %q", id)
 }
 
-func (m *mockBackend) SpaceIDsByName() (map[string]string, error) {
-	return nil, nil
-}
-
-func (m *mockBackend) SpaceNamesByID() (map[string]string, error) {
+func (m *mockBackend) AllSpaceInfos() (network.SpaceInfos, error) {
 	return nil, nil
 }
 

--- a/apiserver/facades/client/bundle/mock_test.go
+++ b/apiserver/facades/client/bundle/mock_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/testing"
 
 	"github.com/juju/juju/apiserver/facades/client/bundle"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 )
 
@@ -39,16 +40,14 @@ func (m *mockState) GetExportConfig() state.ExportConfig {
 	}
 }
 
-func (m *mockState) SpaceNamesByID() (map[string]string, error) {
-	return m.Spaces, nil
-}
-
-func (m *mockState) SpaceIDsByName() (map[string]string, error) {
-	idsByName := make(map[string]string, len(m.Spaces))
-	for k, v := range m.Spaces {
-		idsByName[v] = k
+func (m *mockState) AllSpaceInfos() (network.SpaceInfos, error) {
+	result := make(network.SpaceInfos, len(m.Spaces))
+	i := 0
+	for id, name := range m.Spaces {
+		result[i] = network.SpaceInfo{ID: id, Name: network.SpaceName(name)}
+		i += 1
 	}
-	return idsByName, nil
+	return result, nil
 }
 
 func (m *mockState) Space(_ string) (*state.Space, error) {

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -248,20 +248,20 @@ func validatePlacementForSpaces(st *state.State, spaceNames *[]string, placement
 			return errors.Annotate(err, "retrieving machine")
 		}
 
-		spaceLookup, err := st.SpaceIDsByName()
+		spaceInfos, err := st.AllSpaceInfos()
 		if err != nil {
 			return errors.Trace(err)
 		}
 
 		for _, name := range *spaceNames {
-			spaceID, ok := spaceLookup[name]
-			if !ok {
+			spaceInfo := spaceInfos.GetByName(name)
+			if spaceInfo == nil {
 				return errors.NotFoundf("space with name %q", name)
 			}
 
 			inSpace := false
 			for _, addr := range m.Addresses() {
-				if addr.SpaceID == spaceID {
+				if addr.SpaceID == spaceInfo.ID {
 					inSpace = true
 					break
 				}

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -85,14 +85,9 @@ func (st *mockState) ResolveConstraints(cons constraints.Value) (constraints.Val
 	return cons, nil
 }
 
-func (st *mockState) SpaceIDsByName() (map[string]string, error) {
-	st.MethodCall(st, "SpaceIDsByName")
-	return map[string]string{}, nil
-}
-
-func (st *mockState) SpaceInfosByID() (map[string]network.SpaceInfo, error) {
-	st.MethodCall(st, "SpaceInfosByID")
-	return map[string]network.SpaceInfo{}, nil
+func (m *mockState) AllSpaceInfos() (network.SpaceInfos, error) {
+	m.MethodCall(m, "AllSpaceInfos")
+	return network.SpaceInfos{}, nil
 }
 
 type mockModel struct {

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -431,7 +431,7 @@ func (s *InstancePollerSuite) TestProviderAddressesSuccess(c *gc.C) {
 
 	s.st.CheckFindEntityCall(c, 0, "1")
 	s.st.CheckCall(c, 1, "ProviderAddresses")
-	s.st.CheckCall(c, 2, "SpaceInfosByName")
+	s.st.CheckCall(c, 2, "AllSpaceInfos")
 	s.st.CheckFindEntityCall(c, 3, "2")
 	s.st.CheckCall(c, 4, "ProviderAddresses")
 	s.st.CheckFindEntityCall(c, 5, "42")
@@ -487,7 +487,7 @@ func (s *InstancePollerSuite) TestSetProviderAddressesSuccess(c *gc.C) {
 	s.st.CheckFindEntityCall(c, 0, "1")
 	s.st.CheckSetProviderAddressesCall(c, 1, []network.SpaceAddress{})
 	s.st.CheckFindEntityCall(c, 2, "2")
-	s.st.CheckCall(c, 3, "SpaceIDsByName")
+	s.st.CheckCall(c, 3, "AllSpaceInfos")
 	s.st.CheckSetProviderAddressesCall(c, 4, newAddrs)
 	s.st.CheckFindEntityCall(c, 5, "42")
 
@@ -525,7 +525,7 @@ func (s *InstancePollerSuite) TestSetProviderAddressesFailure(c *gc.C) {
 
 	s.st.CheckFindEntityCall(c, 0, "1")
 	s.st.CheckFindEntityCall(c, 1, "2")
-	s.st.CheckCall(c, 2, "SpaceIDsByName")
+	s.st.CheckCall(c, 2, "AllSpaceInfos")
 	s.st.CheckSetProviderAddressesCall(c, 3, newAddrs)
 	s.st.CheckFindEntityCall(c, 4, "3")
 

--- a/apiserver/facades/controller/instancepoller/mock_test.go
+++ b/apiserver/facades/controller/instancepoller/mock_test.go
@@ -200,18 +200,11 @@ func (m *mockState) Machine(id string) (instancepoller.StateMachine, error) {
 	return machine, nil
 }
 
-// SpaceIDsByName implements network.SpaceLookup.
+// AllSpaceInfos implements network.AllSpaceInfos.
 // This method never throws an error.
-func (m *mockState) SpaceIDsByName() (map[string]string, error) {
-	m.MethodCall(m, "SpaceIDsByName")
-	return map[string]string{}, nil
-}
-
-// SpaceInfosByID implements network.SpaceLookup.
-// This method never throws an error.
-func (m *mockState) SpaceInfosByID() (map[string]network.SpaceInfo, error) {
-	m.MethodCall(m, "SpaceInfosByName")
-	return map[string]network.SpaceInfo{}, nil
+func (m *mockState) AllSpaceInfos() (network.SpaceInfos, error) {
+	m.MethodCall(m, "AllSpaceInfos")
+	return network.SpaceInfos{}, nil
 }
 
 // StartSync implements statetesting.SyncStarter, so mockState can be

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -477,10 +477,10 @@ func (sas SpaceAddresses) ToProviderAddresses(lookup SpaceLookup) (ProviderAddre
 		return nil, nil
 	}
 
-	var infoFor SpaceInfos
+	var spaces SpaceInfos
 	if len(sas) > 0 {
 		var err error
-		if infoFor, err = lookup.AllSpaceInfos(); err != nil {
+		if spaces, err = lookup.AllSpaceInfos(); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -489,7 +489,7 @@ func (sas SpaceAddresses) ToProviderAddresses(lookup SpaceLookup) (ProviderAddre
 	for i, sa := range sas {
 		pas[i] = ProviderAddress{MachineAddress: sa.MachineAddress}
 		if sa.SpaceID != "" {
-			info := infoFor.GetByID(sa.SpaceID)
+			info := spaces.GetByID(sa.SpaceID)
 			if info == nil {
 				return nil, errors.NotFoundf("space with ID %q", sa.SpaceID)
 			}

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -374,10 +374,10 @@ func (pas ProviderAddresses) ToSpaceAddresses(lookup SpaceLookup) (SpaceAddresse
 		return nil, nil
 	}
 
-	var idFor map[string]string
+	var spaceInfos SpaceInfos
 	if len(pas) > 0 {
 		var err error
-		if idFor, err = lookup.SpaceIDsByName(); err != nil {
+		if spaceInfos, err = lookup.AllSpaceInfos(); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -386,11 +386,11 @@ func (pas ProviderAddresses) ToSpaceAddresses(lookup SpaceLookup) (SpaceAddresse
 	for i, pa := range pas {
 		sas[i] = SpaceAddress{MachineAddress: pa.MachineAddress}
 		if pa.SpaceName != "" {
-			id, ok := idFor[string(pa.SpaceName)]
-			if !ok {
+			info := spaceInfos.GetByName(string(pa.SpaceName))
+			if info == nil {
 				return nil, errors.NotFoundf("space with name %q", pa.SpaceName)
 			}
-			sas[i].SpaceID = id
+			sas[i].SpaceID = info.ID
 		}
 	}
 	return sas, nil
@@ -477,10 +477,10 @@ func (sas SpaceAddresses) ToProviderAddresses(lookup SpaceLookup) (ProviderAddre
 		return nil, nil
 	}
 
-	var infoFor map[string]SpaceInfo
+	var infoFor SpaceInfos
 	if len(sas) > 0 {
 		var err error
-		if infoFor, err = lookup.SpaceInfosByID(); err != nil {
+		if infoFor, err = lookup.AllSpaceInfos(); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -489,8 +489,8 @@ func (sas SpaceAddresses) ToProviderAddresses(lookup SpaceLookup) (ProviderAddre
 	for i, sa := range sas {
 		pas[i] = ProviderAddress{MachineAddress: sa.MachineAddress}
 		if sa.SpaceID != "" {
-			info, ok := infoFor[sa.SpaceID]
-			if !ok {
+			info := infoFor.GetByID(sa.SpaceID)
+			if info == nil {
 				return nil, errors.NotFoundf("space with ID %q", sa.SpaceID)
 			}
 			pas[i].SpaceName = info.Name

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -796,17 +796,10 @@ type stubLookup struct{}
 
 var _ network.SpaceLookup = stubLookup{}
 
-func (s stubLookup) SpaceIDsByName() (map[string]string, error) {
-	return map[string]string{
-		"space-one": "1",
-		"space-two": "2",
-	}, nil
-}
-
-func (s stubLookup) SpaceInfosByID() (map[string]network.SpaceInfo, error) {
-	return map[string]network.SpaceInfo{
-		"1": {ID: "1", Name: "space-one", ProviderId: "p1"},
-		"2": {ID: "2", Name: "space-two"},
+func (s stubLookup) AllSpaceInfos() (network.SpaceInfos, error) {
+	return network.SpaceInfos{
+		{ID: "1", Name: "space-one", ProviderId: "p1"},
+		{ID: "2", Name: "space-two"},
 	}, nil
 }
 

--- a/core/network/hostport.go
+++ b/core/network/hostport.go
@@ -325,10 +325,10 @@ func (hps SpaceHostPorts) ToProviderHostPorts(lookup SpaceLookup) (ProviderHostP
 		return nil, nil
 	}
 
-	var infoFor map[string]SpaceInfo
+	var infoFor SpaceInfos
 	if len(hps) > 0 {
 		var err error
-		if infoFor, err = lookup.SpaceInfosByID(); err != nil {
+		if infoFor, err = lookup.AllSpaceInfos(); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -341,8 +341,8 @@ func (hps SpaceHostPorts) ToProviderHostPorts(lookup SpaceLookup) (ProviderHostP
 		}
 
 		if hp.SpaceID != "" {
-			info, ok := infoFor[hp.SpaceID]
-			if !ok {
+			info := infoFor.GetByID(hp.SpaceID)
+			if info == nil {
 				return nil, errors.NotFoundf("space with ID %q", hp.SpaceID)
 			}
 			pHPs[i].SpaceName = info.Name

--- a/core/network/hostport.go
+++ b/core/network/hostport.go
@@ -325,10 +325,10 @@ func (hps SpaceHostPorts) ToProviderHostPorts(lookup SpaceLookup) (ProviderHostP
 		return nil, nil
 	}
 
-	var infoFor SpaceInfos
+	var spaces SpaceInfos
 	if len(hps) > 0 {
 		var err error
-		if infoFor, err = lookup.AllSpaceInfos(); err != nil {
+		if spaces, err = lookup.AllSpaceInfos(); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -341,7 +341,7 @@ func (hps SpaceHostPorts) ToProviderHostPorts(lookup SpaceLookup) (ProviderHostP
 		}
 
 		if hp.SpaceID != "" {
-			info := infoFor.GetByID(hp.SpaceID)
+			info := spaces.GetByID(hp.SpaceID)
 			if info == nil {
 				return nil, errors.NotFoundf("space with ID %q", hp.SpaceID)
 			}

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -112,10 +112,10 @@ func (s SpaceInfos) ContainsName(name string) bool {
 	return s.GetByName(name) != nil
 }
 
-// Difference returns a new SpaceInfos representing all the
+// Minus returns a new SpaceInfos representing all the
 // values in the target that are not in the parameter. Value
 // matching is done by ID.
-func (s SpaceInfos) Difference(other SpaceInfos) SpaceInfos {
+func (s SpaceInfos) Minus(other SpaceInfos) SpaceInfos {
 	result := make(SpaceInfos, 0)
 	for _, value := range s {
 		if !other.ContainsID(value.ID) {

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -3,7 +3,10 @@
 
 package network
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	// AlphaSpaceId is the ID of the alpha network space.
@@ -15,11 +18,10 @@ const (
 	AlphaSpaceName = "alpha"
 )
 
-// SpaceLookup describes methods for acquiring lookups that
-// will translate space IDs to space names and vice versa.
+// SpaceLookup describes methods for acquiring SpaceInfos
+// to translate space IDs to space names and vice versa.
 type SpaceLookup interface {
-	SpaceIDsByName() (map[string]string, error)
-	SpaceInfosByID() (map[string]SpaceInfo, error)
+	AllSpaceInfos() (SpaceInfos, error)
 }
 
 // SpaceName is the name of a network space.
@@ -45,9 +47,17 @@ type SpaceInfo struct {
 // SpaceInfos is a collection of spaces.
 type SpaceInfos []SpaceInfo
 
-// String returns the comma-delimited names of the spaces in the collection.
+// String returns returns a quoted, comma-delimited names of the spaces in the
+// collection, or <none> if the collection is empty.
 func (s SpaceInfos) String() string {
-	return strings.Join(s.Names(), ", ")
+	if len(s) == 0 {
+		return "<none>"
+	}
+	names := make([]string, len(s))
+	for i, v := range s {
+		names[i] = fmt.Sprintf("%q", string(v.Name))
+	}
+	return strings.Join(names, ", ")
 }
 
 // Names returns a string slice with each of the space names in the collection.
@@ -88,4 +98,29 @@ func (s SpaceInfos) GetByName(name string) *SpaceInfo {
 		}
 	}
 	return nil
+}
+
+// ContainsID returns true if the collection contains a
+// space with the given ID.
+func (s SpaceInfos) ContainsID(id string) bool {
+	return s.GetByID(id) != nil
+}
+
+// ContainsName returns true if the collection contains a
+// space with the given name.
+func (s SpaceInfos) ContainsName(name string) bool {
+	return s.GetByName(name) != nil
+}
+
+// Difference returns a new SpaceInfos representing all the
+// values in the target that are not in the parameter. Value
+// matching is done by ID.
+func (s SpaceInfos) Difference(other SpaceInfos) SpaceInfos {
+	result := make(SpaceInfos, 0)
+	for _, value := range s {
+		if !other.ContainsID(value.ID) {
+			result = append(result, value)
+		}
+	}
+	return result
 }

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -5,6 +5,7 @@ package network_test
 
 import (
 	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
@@ -12,38 +13,55 @@ import (
 
 type spaceSuite struct {
 	testing.IsolationSuite
+
+	spaces network.SpaceInfos
 }
 
 var _ = gc.Suite(&spaceSuite{})
 
-func (*spaceSuite) TestString(c *gc.C) {
-	result := network.SpaceInfos{
-		{Name: "space1"},
-		{Name: "space2"},
-		{Name: "space3"},
-	}.String()
-
-	c.Assert(result, gc.Equals, "space1, space2, space3")
+func (s *spaceSuite) SetUpTest(c *gc.C) {
+	s.spaces = network.SpaceInfos{
+		{ID: "1", Name: "space1"},
+		{ID: "2", Name: "space2"},
+		{ID: "3", Name: "space3"},
+	}
 }
 
-func (*spaceSuite) TestGetByName(c *gc.C) {
-	spaces := network.SpaceInfos{
-		{Name: "space1"},
-		{Name: "space2"},
-		{Name: "space3"},
-	}
-
-	c.Assert(spaces.GetByName("space1"), gc.NotNil)
-	c.Assert(spaces.GetByName("space666"), gc.IsNil)
+func (s *spaceSuite) TestString(c *gc.C) {
+	result := s.spaces.String()
+	c.Assert(result, gc.Equals, `"space1", "space2", "space3"`)
 }
 
-func (*spaceSuite) TestGetByID(c *gc.C) {
-	spaces := network.SpaceInfos{
-		{ID: "space1"},
-		{ID: "space2"},
-		{ID: "space3"},
-	}
+func (s *spaceSuite) TestGetByName(c *gc.C) {
+	c.Assert(s.spaces.GetByName("space1"), gc.NotNil)
+	c.Assert(s.spaces.GetByName("space666"), gc.IsNil)
+}
 
-	c.Assert(spaces.GetByID("space1"), gc.NotNil)
-	c.Assert(spaces.GetByID("space666"), gc.IsNil)
+func (s *spaceSuite) TestGetByID(c *gc.C) {
+	c.Assert(s.spaces.GetByID("1"), gc.NotNil)
+	c.Assert(s.spaces.GetByID("999"), gc.IsNil)
+}
+
+func (s *spaceSuite) TestContainsName(c *gc.C) {
+	c.Assert(s.spaces.ContainsName("space3"), jc.IsTrue)
+	c.Assert(s.spaces.ContainsName("space666"), jc.IsFalse)
+}
+
+func (s *spaceSuite) TestDifference(c *gc.C) {
+	infos := network.SpaceInfos{
+		{ID: "2", Name: "space2"},
+		{ID: "3", Name: "space3"},
+	}
+	result := s.spaces.Difference(infos)
+	c.Assert(result, gc.DeepEquals, network.SpaceInfos{{ID: "1", Name: "space1"}})
+}
+
+func (s *spaceSuite) TestDifferenceNoDiff(c *gc.C) {
+	infos := network.SpaceInfos{
+		{ID: "1", Name: "space1"},
+		{ID: "2", Name: "space2"},
+		{ID: "3", Name: "space3"},
+	}
+	result := s.spaces.Difference(infos)
+	c.Assert(result, gc.DeepEquals, network.SpaceInfos{})
 }

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -47,21 +47,21 @@ func (s *spaceSuite) TestContainsName(c *gc.C) {
 	c.Assert(s.spaces.ContainsName("space666"), jc.IsFalse)
 }
 
-func (s *spaceSuite) TestDifference(c *gc.C) {
+func (s *spaceSuite) TestMinus(c *gc.C) {
 	infos := network.SpaceInfos{
 		{ID: "2", Name: "space2"},
 		{ID: "3", Name: "space3"},
 	}
-	result := s.spaces.Difference(infos)
+	result := s.spaces.Minus(infos)
 	c.Assert(result, gc.DeepEquals, network.SpaceInfos{{ID: "1", Name: "space1"}})
 }
 
-func (s *spaceSuite) TestDifferenceNoDiff(c *gc.C) {
+func (s *spaceSuite) TestMinuxNoDiff(c *gc.C) {
 	infos := network.SpaceInfos{
 		{ID: "1", Name: "space1"},
 		{ID: "2", Name: "space2"},
 		{ID: "3", Name: "space3"},
 	}
-	result := s.spaces.Difference(infos)
+	result := s.spaces.Minus(infos)
 	c.Assert(result, gc.DeepEquals, network.SpaceInfos{})
 }

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -161,7 +161,7 @@ func (p *BridgePolicy) FindMissingBridgesForContainer(
 		}
 	}
 	notFound = notFound.Difference(spacesFound)
-	if len(notFound) == 0 {
+	if len(notFound) != 0 {
 		hostSpaces, err := host.AllSpaces()
 		if err != nil {
 			// log it, but we're returning another error right now

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -99,8 +99,8 @@ func (p *BridgePolicy) FindMissingBridgesForContainer(
 		}
 	}
 
-	notFound := guestSpaceInfos.Difference(spacesFound)
-	fanNotFound := guestSpaceInfos.Difference(fanSpacesFound)
+	notFound := guestSpaceInfos.Minus(spacesFound)
+	fanNotFound := guestSpaceInfos.Minus(fanSpacesFound)
 
 	if p.containerNetworkingMethod == "fan" {
 		if len(fanNotFound) == 0 {
@@ -160,7 +160,7 @@ func (p *BridgePolicy) FindMissingBridgesForContainer(
 			}
 		}
 	}
-	notFound = notFound.Difference(spacesFound)
+	notFound = notFound.Minus(spacesFound)
 	if len(notFound) != 0 {
 		hostSpaces, err := host.AllSpaces()
 		if err != nil {
@@ -505,7 +505,7 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(host Machine, guest Con
 		}
 	}
 
-	missingSpaces := guestSpaces.Difference(spacesFound)
+	missingSpaces := guestSpaces.Minus(spacesFound)
 
 	// Check if we are missing the default space and can fill it in with a local bridge
 	if len(missingSpaces) == 1 &&
@@ -516,7 +516,7 @@ func (p *BridgePolicy) PopulateContainerLinkLayerDevices(host Machine, guest Con
 			name := hostDevice.Name()
 			if hostDevice.Type() == corenetwork.BridgeDevice && name == localBridgeName {
 				alphaInfo := p.spaces.GetByID(corenetwork.AlphaSpaceId)
-				missingSpaces = missingSpaces.Difference(corenetwork.SpaceInfos{*alphaInfo})
+				missingSpaces = missingSpaces.Minus(corenetwork.SpaceInfos{*alphaInfo})
 				devicesByName[name] = hostDevice
 				bridgeDeviceNames = append(bridgeDeviceNames, name)
 				spacesFound = append(spacesFound, *alphaInfo)

--- a/network/containerizer/bridgepolicy_integration_test.go
+++ b/network/containerizer/bridgepolicy_integration_test.go
@@ -409,6 +409,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesMismatchCo
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
+	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for space(s) "dmz" for container "0/lxd/0"`)
 
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
@@ -430,6 +431,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesMissingBri
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
+	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for space(s) "dmz" for container "0/lxd/0"`)
 
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
@@ -572,6 +574,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesNoLocal(c 
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = bridgePolicy.PopulateContainerLinkLayerDevices(s.machine, s.containerMachine)
+	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `unable to find host bridge for space(s) "alpha" for container "0/lxd/0"`)
 	s.assertNoDevicesOnMachine(c, s.containerMachine)
 }
@@ -653,6 +656,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerNoHostDevices
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, reconfigureDelay, err := bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
+	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `host machine "0" has no available device in space(s) "dmz", "third"`)
 	c.Check(reconfigureDelay, gc.Equals, 0)
 }
@@ -670,6 +674,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerTwoSpacesOneM
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, _, err = bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
+	c.Assert(err, gc.NotNil)
 	// both somespace and dmz are needed, but somespace is missing
 	c.Assert(err.Error(), gc.Equals, `host machine "0" has no available device in space(s) "somespace"`)
 }
@@ -799,6 +804,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerUnknownWithCo
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, _, err = bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
+	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals,
 		`host machine "0" has no available device in space(s) "somespace"`)
 }

--- a/network/containerizer/linklayerdevicesforspaces_test.go
+++ b/network/containerizer/linklayerdevicesforspaces_test.go
@@ -41,7 +41,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpaces(c *gc.C) {
 	s.expectNICAndBridgeWithIP(ctrl, "eth0", "br-eth0", "1")
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{"1"})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: "1"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 1)
 
@@ -59,7 +59,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesNoSuchSpace(c 
 	s.expectNICAndBridgeWithIP(ctrl, "eth0", "br-eth0", "1")
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{"2"})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: "2"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 0)
 }
@@ -76,7 +76,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesNoBridge(c *gc
 	s.expectNICWithIP(ctrl, "eth0", "1")
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{"1"})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: "1"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 1)
 
@@ -97,7 +97,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesMultipleSpaces
 	s.expectNICWithIP(ctrl, "eth1", "2")
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{"1", "2"})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: "1"}, {ID: "2"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 2)
 
@@ -124,7 +124,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesWithExtraAddre
 	s.expectNICWithIP(ctrl, "ens5", network.AlphaSpaceId)
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{"1"})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: "1"}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
 
@@ -142,7 +142,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesInDefaultSpace
 	s.expectNICWithIP(ctrl, "ens5", network.AlphaSpaceId)
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{network.AlphaSpaceId})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: network.AlphaSpaceId}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 1)
 
@@ -164,7 +164,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesWithUnknown(c 
 	s.expectLoopbackNIC(ctrl)
 	s.expectMachineAddressesDevices()
 
-	spaces := []string{network.AlphaSpaceId, "1"}
+	spaces := network.SpaceInfos{{ID: network.AlphaSpaceId}, {ID: "1"}}
 	res, err := linkLayerDevicesForSpaces(s.machine, spaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 2)
@@ -193,7 +193,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesWithNoAddress(
 	s.expectNICWithIP(ctrl, "ens5", network.AlphaSpaceId)
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{network.AlphaSpaceId})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: network.AlphaSpaceId}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 1)
 
@@ -222,7 +222,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesUnknownIgnores
 	s.expectBridgeDevice(ctrl, "virbr0")
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{network.AlphaSpaceId})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: network.AlphaSpaceId}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.HasLen, 1)
 	devices, ok := res[network.AlphaSpaceId]
@@ -242,7 +242,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesSortOrder(c *g
 	s.setupForNaturalSort(ctrl)
 	s.expectMachineAddressesDevices()
 
-	res, err := linkLayerDevicesForSpaces(s.machine, []string{network.AlphaSpaceId})
+	res, err := linkLayerDevicesForSpaces(s.machine, network.SpaceInfos{{ID: network.AlphaSpaceId}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
 	defaultDevices, ok := res[network.AlphaSpaceId]

--- a/network/containerizer/shim.go
+++ b/network/containerizer/shim.go
@@ -17,8 +17,7 @@ import (
 
 // SpaceBacking describes the retrieval of all spaces from the DB.
 type SpaceBacking interface {
-	SpaceIDsByName() (map[string]string, error)
-	SpaceNamesByID() (map[string]string, error)
+	AllSpaceInfos() (network.SpaceInfos, error)
 }
 
 // LinkLayerDevice is an indirection for state.LinkLayerDevice.

--- a/state/endpoint_bindings_test.go
+++ b/state/endpoint_bindings_test.go
@@ -342,8 +342,7 @@ type bindingsMockSuite struct {
 
 func (s *bindingsMockSuite) TestNewBindingsNilMap(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.expectIDsByName()
-	s.expectNamesByID()
+	s.expectAllSpaceInfos()
 
 	binding, err := state.NewBindings(s.endpointBinding, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -353,8 +352,7 @@ func (s *bindingsMockSuite) TestNewBindingsNilMap(c *gc.C) {
 
 func (s *bindingsMockSuite) TestNewBindingsByID(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.expectIDsByName()
-	s.expectNamesByID()
+	s.expectAllSpaceInfos()
 	initial := map[string]string{
 		"db":      "2",
 		"testing": "5",
@@ -370,8 +368,7 @@ func (s *bindingsMockSuite) TestNewBindingsByID(c *gc.C) {
 
 func (s *bindingsMockSuite) TestNewBindingsByName(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.expectIDsByName()
-	s.expectNamesByID()
+	s.expectAllSpaceInfos()
 	initial := map[string]string{
 		"db":      "two",
 		"testing": "42",
@@ -393,8 +390,7 @@ func (s *bindingsMockSuite) TestNewBindingsByName(c *gc.C) {
 
 func (s *bindingsMockSuite) TestNewBindingsNotFound(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.expectIDsByName()
-	s.expectNamesByID()
+	s.expectAllSpaceInfos()
 	initial := map[string]string{
 		"db":      "2",
 		"testing": "three",
@@ -408,8 +404,7 @@ func (s *bindingsMockSuite) TestNewBindingsNotFound(c *gc.C) {
 
 func (s *bindingsMockSuite) TestMapWithSpaceNames(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.expectIDsByName()
-	s.expectNamesByID()
+	s.expectAllSpaceInfos()
 	initial := map[string]string{
 		"db":      "2",
 		"testing": "3",
@@ -430,30 +425,17 @@ func (s *bindingsMockSuite) TestMapWithSpaceNames(c *gc.C) {
 	c.Assert(withSpaceNames, jc.DeepEquals, expected)
 }
 
-func (s *bindingsMockSuite) expectNamesByID() {
-	n2i := map[string]string{
-		network.AlphaSpaceId: network.AlphaSpaceName,
-		"1":                  "one",
-		"2":                  "two",
-		"3":                  "three",
-		"4":                  "four",
-		"5":                  "42",
+func (s *bindingsMockSuite) expectAllSpaceInfos() {
+	infos := network.SpaceInfos{
+		{ID: network.AlphaSpaceId, Name: network.AlphaSpaceName},
+		{ID: "1", Name: "one"},
+		{ID: "2", Name: "two"},
+		{ID: "3", Name: "three"},
+		{ID: "4", Name: "four"},
+		{ID: "5", Name: "42"},
 	}
-	s.endpointBinding.EXPECT().SpaceNamesByID().Return(n2i, nil).AnyTimes()
+	s.endpointBinding.EXPECT().AllSpaceInfos().Return(infos, nil).AnyTimes()
 }
-
-func (s *bindingsMockSuite) expectIDsByName() {
-	i2n := map[string]string{
-		network.AlphaSpaceName: network.AlphaSpaceId,
-		"one":                  "1",
-		"two":                  "2",
-		"three":                "3",
-		"four":                 "4",
-		"42":                   "5",
-	}
-	s.endpointBinding.EXPECT().SpaceIDsByName().Return(i2n, nil).AnyTimes()
-}
-
 func (s *bindingsMockSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.endpointBinding = mocks.NewMockEndpointBinding(ctrl)

--- a/state/mocks/endpointbinding_mock.go
+++ b/state/mocks/endpointbinding_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
 	reflect "reflect"
 )
@@ -33,6 +34,19 @@ func (m *MockEndpointBinding) EXPECT() *MockEndpointBindingMockRecorder {
 	return m.recorder
 }
 
+// AllSpaceInfos mocks base method
+func (m *MockEndpointBinding) AllSpaceInfos() (network.SpaceInfos, error) {
+	ret := m.ctrl.Call(m, "AllSpaceInfos")
+	ret0, _ := ret[0].(network.SpaceInfos)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllSpaceInfos indicates an expected call of AllSpaceInfos
+func (mr *MockEndpointBindingMockRecorder) AllSpaceInfos() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaceInfos", reflect.TypeOf((*MockEndpointBinding)(nil).AllSpaceInfos))
+}
+
 // DefaultEndpointBindingSpace mocks base method
 func (m *MockEndpointBinding) DefaultEndpointBindingSpace() (string, error) {
 	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
@@ -57,30 +71,4 @@ func (m *MockEndpointBinding) Space(arg0 string) (*state.Space, error) {
 // Space indicates an expected call of Space
 func (mr *MockEndpointBindingMockRecorder) Space(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Space", reflect.TypeOf((*MockEndpointBinding)(nil).Space), arg0)
-}
-
-// SpaceIDsByName mocks base method
-func (m *MockEndpointBinding) SpaceIDsByName() (map[string]string, error) {
-	ret := m.ctrl.Call(m, "SpaceIDsByName")
-	ret0, _ := ret[0].(map[string]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SpaceIDsByName indicates an expected call of SpaceIDsByName
-func (mr *MockEndpointBindingMockRecorder) SpaceIDsByName() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceIDsByName", reflect.TypeOf((*MockEndpointBinding)(nil).SpaceIDsByName))
-}
-
-// SpaceNamesByID mocks base method
-func (m *MockEndpointBinding) SpaceNamesByID() (map[string]string, error) {
-	ret := m.ctrl.Call(m, "SpaceNamesByID")
-	ret0, _ := ret[0].(map[string]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SpaceNamesByID indicates an expected call of SpaceNamesByID
-func (mr *MockEndpointBindingMockRecorder) SpaceNamesByID() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceNamesByID", reflect.TypeOf((*MockEndpointBinding)(nil).SpaceNamesByID))
 }

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -243,46 +243,17 @@ func (st *State) SpaceByName(name string) (*Space, error) {
 	return &Space{st, doc}, nil
 }
 
-// SpaceIDsByName (core/network.SpaceLookup)
-// returns a map of space names to space IDs.
-func (st *State) SpaceIDsByName() (map[string]string, error) {
+// AllSpaceInfos return SpaceInfos for all spaces in the model.
+func (st *State) AllSpaceInfos() (network.SpaceInfos, error) {
 	spaces, err := st.AllSpaces()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	lookup := make(map[string]string, len(spaces))
-	for _, space := range spaces {
-		lookup[space.Name()] = space.Id()
+	result := make(network.SpaceInfos, len(spaces))
+	for i, space := range spaces {
+		result[i] = space.NetworkSpace()
 	}
-	return lookup, nil
-}
-
-// SpaceNamesByID (core/network.SpaceLookup)
-// returns a map of space IDs to space names.
-func (st *State) SpaceNamesByID() (map[string]string, error) {
-	spaces, err := st.AllSpaces()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	lookup := make(map[string]string, len(spaces))
-	for _, space := range spaces {
-		lookup[space.Id()] = space.Name()
-	}
-	return lookup, nil
-}
-
-// SpaceNamesByID (core/network.SpaceLookup)
-// returns a map of space IDs to SpaceInfos.
-func (st *State) SpaceInfosByID() (map[string]network.SpaceInfo, error) {
-	spaces, err := st.AllSpaces()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	lookup := make(map[string]network.SpaceInfo, len(spaces))
-	for _, space := range spaces {
-		lookup[space.Id()] = space.NetworkSpace()
-	}
-	return lookup, nil
+	return result, nil
 }
 
 // AllSpaces returns all spaces for the model.

--- a/state/upgrade/types.go
+++ b/state/upgrade/types.go
@@ -36,7 +36,7 @@ type OldAddress27 struct {
 // new address representation based on whether space name/ID are populated.
 // An error is returned if the address has a non-empty space name that we
 // cannot map to an ID.
-func (a OldAddress27) Upgrade(lookup map[string]string) (OldAddress27, error) {
+func (a OldAddress27) Upgrade(lookup network.SpaceInfos) (OldAddress27, error) {
 	// Ignore zero-type addresses.
 	if a.Value == "" {
 		return a, nil
@@ -54,11 +54,11 @@ func (a OldAddress27) Upgrade(lookup map[string]string) (OldAddress27, error) {
 			logger.Warningf("not converting address %q with empty space name and ID %q", a.Value, a.SpaceID)
 		}
 	} else {
-		newID, ok := lookup[a.SpaceName]
-		if !ok {
+		spaceInfo := lookup.GetByName(a.SpaceName)
+		if spaceInfo == nil {
 			return a, errors.NotFoundf("space with name: %q", a.SpaceName)
 		}
-		a.SpaceID = newID
+		a.SpaceID = spaceInfo.ID
 		a.SpaceName = ""
 	}
 	return a, nil

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2596,7 +2596,7 @@ func EnsureRelationApplicationSettings(pool *StatePool) error {
 // The space is retrieved and these fields are removed in favour of space's ID.
 func ConvertAddressSpaceIDs(pool *StatePool) error {
 	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
-		lookup, err := st.SpaceIDsByName()
+		lookup, err := st.AllSpaceInfos()
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -2626,7 +2626,7 @@ func ConvertAddressSpaceIDs(pool *StatePool) error {
 	}))
 }
 
-func convertMachineAddressSpaceIDs(db Database, lookup map[string]string) ([]txn.Op, error) {
+func convertMachineAddressSpaceIDs(db Database, lookup network.SpaceInfos) ([]txn.Op, error) {
 	// machine is a subset of machine document fields that we care about
 	// for updating the address fields.
 	type machine struct {


### PR DESCRIPTION
## Description of change

Replace SpaceInfosByID(), SpaceNamesByID() and SpaceIDsByName() with AllSpaceInfos().  Reduces the number of  Add methods attached to SpaceInfo{} to facilitate use in replacing the mentioned functions: ContainsName(), ContainsID(), and Difference().

## QA steps

1. deploy a charm with bindings
2. upgrade juju 

