### PR TITLE
actions v2 behind feature flag again; fix yaml output with backwards compatibility

### DIFF
--- a/apiserver/facades/agent/machineactions/shim.go
+++ b/apiserver/facades/agent/machineactions/shim.go
@@ -40,5 +40,5 @@ func (shim backendShim) TagToActionReceiverFn(findEntity func(names.Tag) (state.
 }
 
 func (shim backendShim) ConvertActions(ar state.ActionReceiver, fn common.GetActionsFn) ([]params.ActionResult, error) {
-	return common.ConvertActions(ar, fn)
+	return common.ConvertActions(ar, fn, true)
 }

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -137,7 +137,19 @@ func (a *ActionAPI) checkCanAdmin() error {
 
 // Actions takes a list of ActionTags, and returns the full Action for
 // each ID.
+func (a *APIv4) Actions(arg params.Entities) (params.ActionResults, error) {
+	return a.actions(arg, true)
+}
+
+// Actions takes a list of ActionTags, and returns the full Action for
+// each ID.
 func (a *ActionAPI) Actions(arg params.Entities) (params.ActionResults, error) {
+	return a.actions(arg, false)
+}
+
+// Actions takes a list of ActionTags, and returns the full Action for
+// each ID.
+func (a *ActionAPI) actions(arg params.Entities, compat bool) (params.ActionResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}
@@ -169,7 +181,7 @@ func (a *ActionAPI) Actions(arg params.Entities) (params.ActionResults, error) {
 			currentResult.Error = common.ServerError(err)
 			continue
 		}
-		response.Results[i] = common.MakeActionResult(receiverTag, action)
+		response.Results[i] = common.MakeActionResult(receiverTag, action, compat)
 	}
 	return response, nil
 }
@@ -224,7 +236,7 @@ func (a *ActionAPI) FindActionsByNames(arg params.FindActionsByNames) (params.Ac
 				currentResult.Actions = append(currentResult.Actions, params.ActionResult{Error: common.ServerError(err)})
 				continue
 			}
-			currentAction := common.MakeActionResult(recvTag, action)
+			currentAction := common.MakeActionResult(recvTag, action, true)
 			currentResult.Actions = append(currentResult.Actions, currentAction)
 		}
 	}
@@ -280,7 +292,7 @@ func (a *ActionAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 			continue
 		}
 
-		response.Results[i] = common.MakeActionResult(receiver.Tag(), enqueued)
+		response.Results[i] = common.MakeActionResult(receiver.Tag(), enqueued, false)
 	}
 	return response, nil
 }
@@ -288,12 +300,23 @@ func (a *ActionAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 // ListAll takes a list of Entities representing ActionReceivers and
 // returns all of the Actions that have been enqueued or run by each of
 // those Entities.
+func (a *APIv4) ListAll(arg params.Entities) (params.ActionsByReceivers, error) {
+	return a.listAll(arg, true)
+}
+
+// ListAll takes a list of Entities representing ActionReceivers and
+// returns all of the Actions that have been enqueued or run by each of
+// those Entities.
 func (a *ActionAPI) ListAll(arg params.Entities) (params.ActionsByReceivers, error) {
+	return a.listAll(arg, false)
+}
+
+func (a *ActionAPI) listAll(arg params.Entities, compat bool) (params.ActionsByReceivers, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.ActionsByReceivers{}, errors.Trace(err)
 	}
 
-	return a.internalList(arg, combine(pendingActions, runningActions, completedActions))
+	return a.internalList(arg, combine(pendingActions, runningActions, completedActions), compat)
 }
 
 // Tasks fetches the called functions (actions) for specified apps/units.
@@ -351,7 +374,7 @@ func (a *ActionAPI) Tasks(arg params.TaskQueryArgs) (params.ActionResults, error
 		}
 	}
 
-	byReceivers, err := a.internalList(entities, combine(extractorFuncs...))
+	byReceivers, err := a.internalList(entities, combine(extractorFuncs...), false)
 	if err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}
@@ -390,7 +413,7 @@ func (a *ActionAPI) ListPending(arg params.Entities) (params.ActionsByReceivers,
 		return params.ActionsByReceivers{}, errors.Trace(err)
 	}
 
-	return a.internalList(arg, pendingActions)
+	return a.internalList(arg, pendingActions, false)
 }
 
 // ListRunning takes a list of Entities representing ActionReceivers and
@@ -401,22 +424,42 @@ func (a *ActionAPI) ListRunning(arg params.Entities) (params.ActionsByReceivers,
 		return params.ActionsByReceivers{}, errors.Trace(err)
 	}
 
-	return a.internalList(arg, runningActions)
+	return a.internalList(arg, runningActions, false)
+}
+
+// ListCompleted takes a list of Entities representing ActionReceivers
+// and returns all of the Actions that have been run on each of those
+// Entities.
+func (a *APIv4) ListCompleted(arg params.Entities) (params.ActionsByReceivers, error) {
+	return a.listCompleted(arg, true)
 }
 
 // ListCompleted takes a list of Entities representing ActionReceivers
 // and returns all of the Actions that have been run on each of those
 // Entities.
 func (a *ActionAPI) ListCompleted(arg params.Entities) (params.ActionsByReceivers, error) {
+	return a.listCompleted(arg, false)
+}
+
+func (a *ActionAPI) listCompleted(arg params.Entities, compat bool) (params.ActionsByReceivers, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.ActionsByReceivers{}, errors.Trace(err)
 	}
 
-	return a.internalList(arg, completedActions)
+	return a.internalList(arg, completedActions, compat)
+}
+
+// Cancel attempts to cancel enqueued Actions from running.
+func (a *APIv4) Cancel(arg params.Entities) (params.ActionResults, error) {
+	return a.cancel(arg, true)
 }
 
 // Cancel attempts to cancel enqueued Actions from running.
 func (a *ActionAPI) Cancel(arg params.Entities) (params.ActionResults, error) {
+	return a.cancel(arg, false)
+}
+
+func (a *ActionAPI) cancel(arg params.Entities, compat bool) (params.ActionResults, error) {
 	if err := a.checkCanWrite(); err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}
@@ -458,7 +501,7 @@ func (a *ActionAPI) Cancel(arg params.Entities) (params.ActionResults, error) {
 			continue
 		}
 
-		response.Results[i] = common.MakeActionResult(receiverTag, result)
+		response.Results[i] = common.MakeActionResult(receiverTag, result, compat)
 	}
 	return response, nil
 }
@@ -506,7 +549,7 @@ func (a *ActionAPI) ApplicationsCharmsActions(args params.Entities) (params.Appl
 // internalList takes a list of Entities representing ActionReceivers
 // and returns all of the Actions the extractorFn can get out of the
 // ActionReceiver.
-func (a *ActionAPI) internalList(arg params.Entities, fn extractorFn) (params.ActionsByReceivers, error) {
+func (a *ActionAPI) internalList(arg params.Entities, fn extractorFn, compat bool) (params.ActionsByReceivers, error) {
 	tagToActionReceiver := common.TagToActionReceiverFn(a.state.FindEntity)
 	response := params.ActionsByReceivers{Actions: make([]params.ActionsByReceiver, len(arg.Entities))}
 	for i, entity := range arg.Entities {
@@ -518,7 +561,7 @@ func (a *ActionAPI) internalList(arg params.Entities, fn extractorFn) (params.Ac
 		}
 		currentResult.Receiver = receiver.Tag().String()
 
-		results, err := fn(receiver)
+		results, err := fn(receiver, compat)
 		if err != nil {
 			currentResult.Error = common.ServerError(err)
 			continue
@@ -531,15 +574,15 @@ func (a *ActionAPI) internalList(arg params.Entities, fn extractorFn) (params.Ac
 // extractorFn is the generic signature for functions that extract
 // state.Actions from an ActionReceiver, and return them as a slice of
 // params.ActionResult.
-type extractorFn func(state.ActionReceiver) ([]params.ActionResult, error)
+type extractorFn func(state.ActionReceiver, bool) ([]params.ActionResult, error)
 
 // combine takes multiple extractorFn's and combines them into one
 // function.
 func combine(funcs ...extractorFn) extractorFn {
-	return func(ar state.ActionReceiver) ([]params.ActionResult, error) {
+	return func(ar state.ActionReceiver, compat bool) ([]params.ActionResult, error) {
 		result := []params.ActionResult{}
 		for _, fn := range funcs {
-			items, err := fn(ar)
+			items, err := fn(ar, compat)
 			if err != nil {
 				return result, errors.Trace(err)
 			}
@@ -551,21 +594,21 @@ func combine(funcs ...extractorFn) extractorFn {
 
 // pendingActions iterates through the Actions() enqueued for an
 // ActionReceiver, and converts them to a slice of params.ActionResult.
-func pendingActions(ar state.ActionReceiver) ([]params.ActionResult, error) {
-	return common.ConvertActions(ar, ar.PendingActions)
+func pendingActions(ar state.ActionReceiver, compat bool) ([]params.ActionResult, error) {
+	return common.ConvertActions(ar, ar.PendingActions, compat)
 }
 
 // runningActions iterates through the Actions() running on an
 // ActionReceiver, and converts them to a slice of params.ActionResult.
-func runningActions(ar state.ActionReceiver) ([]params.ActionResult, error) {
-	return common.ConvertActions(ar, ar.RunningActions)
+func runningActions(ar state.ActionReceiver, compat bool) ([]params.ActionResult, error) {
+	return common.ConvertActions(ar, ar.RunningActions, compat)
 }
 
 // completedActions iterates through the Actions() that have run to
 // completion for an ActionReceiver, and converts them to a slice of
 // params.ActionResult.
-func completedActions(ar state.ActionReceiver) ([]params.ActionResult, error) {
-	return common.ConvertActions(ar, ar.CompletedActions)
+func completedActions(ar state.ActionReceiver, compat bool) ([]params.ActionResult, error) {
+	return common.ConvertActions(ar, ar.CompletedActions, compat)
 }
 
 // WatchActionsProgress creates a watcher that reports on action log messages.

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -361,7 +361,14 @@ func (s *actionSuite) TestListAll(c *gc.C) {
 					err = added.Log("hello")
 					c.Assert(err, jc.ErrorIsNil)
 					status := state.ActionCompleted
-					output := map[string]interface{}{"output": "blah, blah, blah"}
+					output := map[string]interface{}{
+						"output":         "blah, blah, blah",
+						"Stdout":         "out",
+						"StdoutEncoding": "utf-8",
+						"Stderr":         "err",
+						"StderrEncoding": "utf-8",
+						"Code":           "1",
+					}
 					message := "success"
 
 					fa, err := added.Finish(state.ActionResults{Status: status, Results: output, Message: message})
@@ -370,7 +377,14 @@ func (s *actionSuite) TestListAll(c *gc.C) {
 
 					exp.Status = string(status)
 					exp.Message = message
-					exp.Output = output
+					exp.Output = map[string]interface{}{
+						"output":          "blah, blah, blah",
+						"stdout":          "out",
+						"stdout-encoding": "utf-8",
+						"stderr":          "err",
+						"stderr-encoding": "utf-8",
+						"return-code":     1,
+					}
 					exp.Log = []params.ActionMessage{{Message: "hello"}}
 				}
 			}
@@ -539,7 +553,14 @@ func (s *actionSuite) TestListCompleted(c *gc.C) {
 
 				if act.Execute {
 					status := state.ActionCompleted
-					output := map[string]interface{}{"output": "blah, blah, blah"}
+					output := map[string]interface{}{
+						"output":         "blah, blah, blah",
+						"Stdout":         "out",
+						"StdoutEncoding": "utf-8",
+						"Stderr":         "err",
+						"StderrEncoding": "utf-8",
+						"Code":           "1",
+					}
 					message := "success"
 
 					_, err = added.Finish(state.ActionResults{Status: status, Results: output, Message: message})
@@ -554,7 +575,14 @@ func (s *actionSuite) TestListCompleted(c *gc.C) {
 						},
 						Status:  string(status),
 						Message: message,
-						Output:  output,
+						Output: map[string]interface{}{
+							"output":          "blah, blah, blah",
+							"stdout":          "out",
+							"stdout-encoding": "utf-8",
+							"stderr":          "err",
+							"stderr-encoding": "utf-8",
+							"return-code":     1,
+						},
 					}
 					cur.Actions = append(cur.Actions, exp)
 				}

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -362,12 +362,12 @@ result-map:
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
-				"Code":           "0",
-				"Stdout":         "hello",
-				"Stderr":         "world",
-				"StdoutEncoding": "utf-8",
-				"StderrEncoding": "utf-8",
-				"outcome":        "success",
+				"return-code":     "0",
+				"stdout":          "hello",
+				"stderr":          "world",
+				"stdout-encoding": "utf-8",
+				"stderr-encoding": "utf-8",
+				"outcome":         "success",
 				"result-map": map[string]interface{}{
 					"message": "hello",
 				},
@@ -400,12 +400,12 @@ world`[1:],
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
-				"Code":           "0",
-				"Stdout":         "hello",
-				"Stderr":         "world",
-				"StdoutEncoding": "utf-8",
-				"StderrEncoding": "utf-8",
-				"outcome":        "success",
+				"return-code":     "0",
+				"stdout":          "hello",
+				"stderr":          "world",
+				"stdout-encoding": "utf-8",
+				"stderr-encoding": "utf-8",
+				"outcome":         "success",
 				"result-map": map[string]interface{}{
 					"message": "hello",
 				},
@@ -423,19 +423,19 @@ world`[1:],
 mysql/0:
   id: f47ac10b-58cc-4372-a567-0e02b2c3d479
   results:
-    Code: "0"
-    Stderr: world
-    StderrEncoding: utf-8
-    Stdout: hello
-    StdoutEncoding: utf-8
     outcome: success
     result-map:
       message: hello
+    return-code: "0"
+    stderr: world
+    stderr-encoding: utf-8
+    stdout: hello
+    stdout-encoding: utf-8
   status: completed
   timing:
-    completed: "2015-02-14 08:17:00"
-    enqueued: "2015-02-14 08:13:00"
-    started: "2015-02-14 08:15:00"
+    completed: 2015-02-14 08:17:00 +0000 UTC
+    enqueued: 2015-02-14 08:13:00 +0000 UTC
+    started: 2015-02-14 08:15:00 +0000 UTC
   unit: mysql/0`[1:],
 	}, {
 		should:   "call a basic function with progress logs",
@@ -450,12 +450,12 @@ mysql/0:
 			},
 			Status: "completed",
 			Output: map[string]interface{}{
-				"Code":           "0",
-				"Stdout":         "hello",
-				"Stderr":         "world",
-				"StdoutEncoding": "utf-8",
-				"StderrEncoding": "utf-8",
-				"outcome":        "success",
+				"return-code":     "0",
+				"stdout":          "hello",
+				"stderr":          "world",
+				"stdout-encoding": "utf-8",
+				"stderr-encoding": "utf-8",
+				"outcome":         "success",
 				"result-map": map[string]interface{}{
 					"message": "hello",
 				},
@@ -497,12 +497,12 @@ world`[1:],
 			}},
 			Status: "completed",
 			Output: map[string]interface{}{
-				"Code":           "0",
-				"Stdout":         "hello",
-				"Stderr":         "world",
-				"StdoutEncoding": "utf-8",
-				"StderrEncoding": "utf-8",
-				"outcome":        "success",
+				"return-code":     "0",
+				"stdout":          "hello",
+				"stderr":          "world",
+				"stdout-encoding": "utf-8",
+				"stderr-encoding": "utf-8",
+				"outcome":         "success",
 				"result-map": map[string]interface{}{
 					"message": "hello",
 				},
@@ -521,22 +521,22 @@ world`[1:],
 mysql/0:
   id: f47ac10b-58cc-4372-a567-0e02b2c3d479
   log:
-  - 2015-02-14 06:06:06 log line 1
-  - 2015-02-14 06:06:06 log line 2
+  - 2015-02-14 06:06:06 +0000 UTC log line 1
+  - 2015-02-14 06:06:06 +0000 UTC log line 2
   results:
-    Code: "0"
-    Stderr: world
-    StderrEncoding: utf-8
-    Stdout: hello
-    StdoutEncoding: utf-8
     outcome: success
     result-map:
       message: hello
+    return-code: "0"
+    stderr: world
+    stderr-encoding: utf-8
+    stdout: hello
+    stdout-encoding: utf-8
   status: completed
   timing:
-    completed: "2015-02-14 08:17:00"
-    enqueued: "2015-02-14 08:13:00"
-    started: "2015-02-14 08:15:00"
+    completed: 2015-02-14 08:17:00 +0000 UTC
+    enqueued: 2015-02-14 08:13:00 +0000 UTC
+    started: 2015-02-14 08:15:00 +0000 UTC
   unit: mysql/0`[1:],
 	}, {
 		should:   "call action on multiple units with stdout for each action",
@@ -596,9 +596,9 @@ mysql/0:
       message: hello
   status: completed
   timing:
-    completed: "2015-02-14 08:17:00"
-    enqueued: "2015-02-14 08:13:00"
-    started: "2015-02-14 08:15:00"
+    completed: 2015-02-14 08:17:00 +0000 UTC
+    enqueued: 2015-02-14 08:13:00 +0000 UTC
+    started: 2015-02-14 08:15:00 +0000 UTC
   unit: mysql/0
 mysql/1:
   id: f47ac10b-58cc-4372-a567-0e02b2c3d478
@@ -608,9 +608,9 @@ mysql/1:
       message: hello2
   status: completed
   timing:
-    completed: "2015-02-14 08:17:00"
-    enqueued: "2015-02-14 08:13:00"
-    started: "2015-02-14 08:15:00"
+    completed: 2015-02-14 08:17:00 +0000 UTC
+    enqueued: 2015-02-14 08:13:00 +0000 UTC
+    started: 2015-02-14 08:15:00 +0000 UTC
   unit: mysql/1`[1:],
 	}, {
 		should:   "call function on multiple units with plain output selected",

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -118,7 +118,7 @@ func addValueToMap(keys []string, value interface{}, target map[string]interface
 
 const (
 	watchTimestampFormat  = "15:04:05"
-	resultTimestampFormat = "2006-01-02 15:04:05"
+	resultTimestampFormat = "2006-01-02T15:04:05"
 )
 
 func decodeLogMessage(encodedMessage string, utc bool) (string, error) {
@@ -127,14 +127,20 @@ func decodeLogMessage(encodedMessage string, utc bool) (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return formatLogMessage(actionMessage, true, utc), nil
+	return formatLogMessage(actionMessage, true, utc, true), nil
 }
 
-func formatTimestamp(timestamp time.Time, progressFormat, utc bool) string {
+func formatTimestamp(timestamp time.Time, progressFormat, utc, plain bool) string {
+	if timestamp.IsZero() {
+		return ""
+	}
 	if utc {
 		timestamp = timestamp.UTC()
 	} else {
 		timestamp = timestamp.Local()
+	}
+	if !progressFormat && !plain {
+		return timestamp.String()
 	}
 	timestampFormat := resultTimestampFormat
 	if progressFormat {
@@ -143,8 +149,8 @@ func formatTimestamp(timestamp time.Time, progressFormat, utc bool) string {
 	return timestamp.Format(timestampFormat)
 }
 
-func formatLogMessage(actionMessage coreactions.ActionMessage, progressFormat, utc bool) string {
-	return fmt.Sprintf("%v %v", formatTimestamp(actionMessage.Timestamp, progressFormat, utc), actionMessage.Message)
+func formatLogMessage(actionMessage coreactions.ActionMessage, progressFormat, utc, plain bool) string {
+	return fmt.Sprintf("%v %v", formatTimestamp(actionMessage.Timestamp, progressFormat, utc, plain), actionMessage.Message)
 }
 
 // processLogMessages starts a go routine to decode and handle any incoming

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -35,17 +35,17 @@ type listCommand struct {
 }
 
 const listDoc = `
-List the functions available to run on the target application, with a short
-description.  To show the full schema for the functions, use --schema.
+List the actions available to run on the target application, with a short
+description.  To show the full schema for the actions, use --schema.
 
 Examples:
-    juju functions postgresql
-    juju functions postgresql --format yaml
-    juju functions postgresql --schema
+    juju list-actions postgresql
+    juju list-actions postgresql --format yaml
+    juju list-actions postgresql --schema
 
 See also:
-    call
-    show-function
+    run-action
+    show-action
 `
 
 // Set up the output.
@@ -68,19 +68,23 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 		"tabular": c.printTabular,
 		"default": c.dummyDefault,
 	})
-	f.BoolVar(&c.fullSchema, "schema", false, "Display the full function schema")
+	f.BoolVar(&c.fullSchema, "schema", false, "Display the full action schema")
 }
 
 func (c *listCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
-		Name:    "functions",
+		Name:    "actions",
 		Args:    "<application name>",
-		Purpose: "List functions defined for an application.",
+		Purpose: "List actions defined for an application.",
 		Doc:     listDoc,
-		Aliases: []string{"list-functions", "actions", "list-actions"},
+		Aliases: []string{"list-actions"},
 	})
 	if featureflag.Enabled(feature.JujuV3) {
+		info.Name = "functions"
 		info.Aliases = []string{"list-functions"}
+		info.Doc = strings.Replace(info.Doc, "run-action", "call", -1)
+		info.Doc = strings.Replace(info.Doc, "action", "function", -1)
+		info.Purpose = strings.Replace(info.Purpose, "action", "function", -1)
 	}
 	return info
 }
@@ -149,7 +153,11 @@ func (c *listCommand) Run(ctx *cmd.Context) error {
 		output = shortOutput
 	default:
 		if len(sortedNames) == 0 {
-			ctx.Infof("No functions defined for %s.", c.applicationTag.Id())
+			functions := "functions"
+			if !featureflag.Enabled(feature.JujuV3) {
+				functions = "actions"
+			}
+			ctx.Infof("No %s defined for %s.", functions, c.applicationTag.Id())
 			return nil
 		}
 		var list []listOutput
@@ -180,7 +188,11 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 	}
 
 	tw := output.TabWriter(writer)
-	fmt.Fprintf(tw, "%s\t%s\n", "Function", "Description")
+	if featureflag.Enabled(feature.JujuV3) {
+		fmt.Fprintf(tw, "%s\t%s\n", "Function", "Description")
+	} else {
+		fmt.Fprintf(tw, "%s\t%s\n", "Action", "Description")
+	}
 	for _, value := range list {
 		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.TrimSpace(value.description))
 	}

--- a/cmd/juju/action/list_test.go
+++ b/cmd/juju/action/list_test.go
@@ -75,7 +75,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d should %s: juju functions defined %s", i,
+			c.Logf("test %d should %s: juju actions defined %s", i,
 				t.should, strings.Join(t.args, " "))
 			s.wrappedCommand, s.command = action.NewListCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)
@@ -93,7 +93,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 
 func (s *ListSuite) TestRun(c *gc.C) {
 	simpleOutput := `
-Function        Description
+Action          Description
 kill            Kill the database.
 no-description  No description
 no-params       An action with no parameters.
@@ -127,7 +127,7 @@ snapshot        Take a snapshot of the database.
 		should:          "work properly when no results found",
 		withArgs:        []string{validApplicationId},
 		expectNoResults: true,
-		expectMessage:   fmt.Sprintf("No functions defined for %s.\n", validApplicationId),
+		expectMessage:   fmt.Sprintf("No actions defined for %s.\n", validApplicationId),
 	}, {
 		should:           "get tabular default output when --schema is NOT specified",
 		withArgs:         []string{"--format=default", validApplicationId},

--- a/cmd/juju/action/listtasks.go
+++ b/cmd/juju/action/listtasks.go
@@ -173,15 +173,15 @@ func (c *listTasksCommand) formatTabular(writer io.Writer, value interface{}) er
 	}
 	tw := output.TabWriter(writer)
 	w := output.Wrapper{tw}
-	w.SetColumnAlignRight(1)
+	w.SetColumnAlignRight(0)
 
 	printTasks := func(tasks []taskLine, utc bool) {
 		for _, line := range tasks {
-			w.Print(formatTimestamp(line.timestamp, false, c.utc))
-			w.Println(line.id, line.task, line.status, line.unit)
+			w.Print(line.id, line.task, line.status, line.unit)
+			w.Println(formatTimestamp(line.timestamp, false, c.utc, true))
 		}
 	}
-	w.Println("Time", "Id", "Task", "Status", "Unit")
+	w.Println("Id", "Task", "Status", "Unit", "Time")
 	printTasks(actionTaskLinesFromResults(results), c.utc)
 	return tw.Flush()
 }

--- a/cmd/juju/action/listtasks_test.go
+++ b/cmd/juju/action/listtasks_test.go
@@ -87,7 +87,7 @@ func (s *ListTasksSuite) TestRunQueryArgs(c *gc.C) {
 	}
 	for _, modelFlag := range s.modelFlags {
 		s.wrappedCommand, s.command = action.NewListTasksCommandForTest(s.store)
-		args = append([]string{modelFlag, "admin"}, args...)
+		args = append([]string{modelFlag, "admin", "--utc"}, args...)
 
 		_, err := cmdtesting.RunCommand(c, s.wrappedCommand, args...)
 		c.Assert(err, jc.ErrorIsNil)
@@ -164,10 +164,10 @@ func (s *ListTasksSuite) TestRunPlain(c *gc.C) {
 		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--utc")
 		c.Assert(err, jc.ErrorIsNil)
 		expected := `
-Time                 Id  Task     Status     Unit
-2013-02-14 06:06:06   3  vacuum   pending    mysql/1
-2014-02-14 06:06:06   2  restore  running    mysql/1
-2015-02-14 06:06:06   1  backup   completed  mysql/0
+Id  Task     Status     Unit     Time
+ 3  vacuum   pending    mysql/1  2013-02-14T06:06:06
+ 2  restore  running    mysql/1  2014-02-14T06:06:06
+ 1  backup   completed  mysql/0  2015-02-14T06:06:06
 
 `[1:]
 		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expected)
@@ -190,17 +190,17 @@ func (s *ListTasksSuite) TestRunYaml(c *gc.C) {
 "1":
   status: completed
   timing:
-    started: "2015-02-14 06:06:06"
+    started: 2015-02-14 06:06:06 +0000 UTC
   unit: mysql/0
 "2":
   status: running
   timing:
-    completed: "2014-02-14 06:06:06"
+    completed: 2014-02-14 06:06:06 +0000 UTC
   unit: mysql/1
 "3":
   status: pending
   timing:
-    enqueued: "2013-02-14 06:06:06"
+    enqueued: 2013-02-14 06:06:06 +0000 UTC
   unit: mysql/1
 `[1:]
 		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expected)

--- a/cmd/juju/action/show_test.go
+++ b/cmd/juju/action/show_test.go
@@ -46,7 +46,7 @@ func (s *ShowSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "fail with missing action name",
 		args:        []string{validApplicationId},
-		expectedErr: "no function name specified",
+		expectedErr: "no action name specified",
 	}, {
 		should:      "fail with invalid application name",
 		args:        []string{invalidApplicationId, "doIt"},
@@ -64,7 +64,7 @@ func (s *ShowSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d should %s: juju show-function defined %s", i,
+			c.Logf("test %d should %s: juju show-action defined %s", i,
 				t.should, strings.Join(t.args, " "))
 			s.wrappedCommand, s.command = action.NewShowCommandForTest(s.store)
 			args := append([]string{modelFlag, "admin"}, t.args...)
@@ -112,12 +112,12 @@ name:
 		withArgs:        []string{validApplicationId, "snapshot"},
 		expectNoResults: true,
 		expectedErr:     "cmd: error out silently",
-		expectMessage:   `unknown function "snapshot"`,
+		expectMessage:   `unknown action "snapshot"`,
 	}, {
-		should:           "error when unknown function specified",
+		should:           "error when unknown action specified",
 		withArgs:         []string{validApplicationId, "something"},
 		withCharmActions: someCharmActions,
-		expectMessage:    `unknown function "something"`,
+		expectMessage:    `unknown action "something"`,
 		expectedErr:      "cmd: error out silently",
 	}, {
 		should:           "get results properly",

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -270,7 +270,7 @@ timing:
 				"foo": map[string]interface{}{
 					"bar": "baz",
 				},
-				"Stdout": "hello",
+				"stdout": "hello",
 			},
 			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
 			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),

--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils"
-	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/names.v3"
 
 	actionapi "github.com/juju/juju/api/action"
@@ -25,7 +23,6 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -36,12 +33,17 @@ const leaderSnippet = "(" + names.ApplicationSnippet + ")/leader"
 var validLeader = regexp.MustCompile("^" + leaderSnippet + "$")
 
 func newDefaultRunCommand(store jujuclient.ClientStore) cmd.Command {
-	return newExecCommand(store, time.After)
+	return newExecCommand(store, time.After, true)
 }
 
-func newExecCommand(store jujuclient.ClientStore, timeAfter func(time.Duration) <-chan time.Time) cmd.Command {
+func newDefaultExecCommand(store jujuclient.ClientStore) cmd.Command {
+	return newExecCommand(store, time.After, false)
+}
+
+func newExecCommand(store jujuclient.ClientStore, timeAfter func(time.Duration) <-chan time.Time, compat bool) cmd.Command {
 	cmd := modelcmd.Wrap(&execCommand{
 		timeAfter: timeAfter,
+		compat:    compat,
 	})
 	cmd.SetClientStore(store)
 	return cmd
@@ -51,6 +53,7 @@ func newExecCommand(store jujuclient.ClientStore, timeAfter func(time.Duration) 
 type execCommand struct {
 	modelcmd.ModelCommandBase
 	out          cmd.Output
+	compat       bool
 	all          bool
 	operator     bool
 	timeout      time.Duration
@@ -108,7 +111,6 @@ those arguments. For example:
 
     juju exec --all -- hostname -f
 
-NOTE: Juju 2 uses "juju run" which is deprecated in favour of "juju exec".
 `
 
 func (c *execCommand) Info() *cmd.Info {
@@ -116,11 +118,11 @@ func (c *execCommand) Info() *cmd.Info {
 		Name:    "exec",
 		Args:    "<commands>",
 		Purpose: "Run the commands on the remote targets specified.",
-		Aliases: []string{"run"},
 		Doc:     execDoc,
 	})
-	if featureflag.Enabled(feature.JujuV3) {
-		info.Aliases = nil
+	if c.compat {
+		info.Name = "run"
+		info.Doc = strings.Replace(info.Doc, "juju exec", "juju run", -1)
 	}
 	return info
 }
@@ -205,7 +207,7 @@ func (c *execCommand) Init(args []string) error {
 
 // ConvertActionResults takes the results from the api and creates a map
 // suitable for format conversion to YAML or JSON.
-func ConvertActionResults(result params.ActionResult, query actionQuery) map[string]interface{} {
+func ConvertActionResults(result params.ActionResult, query actionQuery, compat bool) map[string]interface{} {
 	values := make(map[string]interface{})
 	values[query.receiver.receiverType] = query.receiver.tag.Id()
 	if result.Error != nil {
@@ -224,29 +226,23 @@ func ConvertActionResults(result params.ActionResult, query actionQuery) map[str
 		return values
 	}
 	if result.Message != "" {
-		values["Message"] = result.Message
-	}
-	// We always want to have a string for stdout, but only show stderr,
-	// code and error if they are there.
-	if res, ok := result.Output["Stdout"].(string); ok {
-		values["Stdout"] = strings.Replace(res, "\r\n", "\n", -1)
-		if res, ok := result.Output["StdoutEncoding"].(string); ok && res != "" {
-			values["Stdout.encoding"] = res
+		messageKey := "message"
+		if compat {
+			messageKey = "Message"
 		}
-	} else {
-		values["Stdout"] = ""
+		values[messageKey] = result.Message
 	}
-	if res, ok := result.Output["Stderr"].(string); ok && res != "" {
-		values["Stderr"] = strings.Replace(res, "\r\n", "\n", -1)
-		if res, ok := result.Output["StderrEncoding"].(string); ok && res != "" {
-			values["Stderr.encoding"] = res
-		}
+	val := action.ConvertActionOutput(result.Output, compat, true)
+	for k, v := range val {
+		values[k] = v
 	}
-	if res, ok := result.Output["Code"].(string); ok {
-		code, err := strconv.Atoi(res)
-		if err == nil && code != 0 {
-			values["ReturnCode"] = code
-		}
+	if unit, ok := values["UnitId"]; ok && !compat {
+		delete(values, "UnitId")
+		values["unit"] = unit
+	}
+	if unit, ok := values["unit"]; ok && compat {
+		delete(values, "unit")
+		values["UnitId"] = unit
 	}
 	return values
 }
@@ -364,7 +360,7 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 				}
 			}
 
-			values = append(values, ConvertActionResults(result, actionsToQuery[i]))
+			values = append(values, ConvertActionResults(result, actionsToQuery[i], c.compat))
 		}
 		actionsToQuery = newActionsToQuery
 
@@ -395,13 +391,29 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 		if res, ok := result["Error"].(string); ok {
 			return errors.New(res)
 		}
-		ctx.Stdout.Write(formatOutput(result, "Stdout"))
-		ctx.Stderr.Write(formatOutput(result, "Stderr"))
-		if code, ok := result["ReturnCode"].(int); ok && code != 0 {
+		stdoutKey := "stdout"
+		if c.compat {
+			stdoutKey = "Stdout"
+		}
+		stderrKey := "stderr"
+		if c.compat {
+			stdoutKey = "Stderr"
+		}
+		codeKey := "return-code"
+		if c.compat {
+			codeKey = "ReturnCode"
+		}
+		ctx.Stdout.Write(formatOutput(result, stdoutKey, c.compat))
+		ctx.Stderr.Write(formatOutput(result, stderrKey, c.compat))
+		if code, ok := result[codeKey].(int); ok && code != 0 {
 			return cmd.NewRcPassthroughError(code)
 		}
 		// Message should always contain only errors.
-		if res, ok := result["Message"].(string); ok && res != "" {
+		messageKey := "message"
+		if c.compat {
+			messageKey = "Message"
+		}
+		if res, ok := result[messageKey].(string); ok && res != "" {
 			ctx.Stderr.Write([]byte(res))
 		}
 
@@ -475,12 +487,16 @@ func entities(actions []actionQuery) params.Entities {
 	return entities
 }
 
-func formatOutput(results map[string]interface{}, key string) []byte {
+func formatOutput(results map[string]interface{}, key string, compat bool) []byte {
 	res, ok := results[key].(string)
 	if !ok {
 		return []byte("")
 	}
-	if enc, ok := results[key+".encoding"].(string); ok && enc != "" {
+	encodingKey := "-encoding"
+	if compat {
+		encodingKey = ".encoding"
+	}
+	if enc, ok := results[key+encodingKey].(string); ok && enc != "" {
 		switch enc {
 		case "base64":
 			decoded, err := base64.StdEncoding.DecodeString(res)

--- a/cmd/juju/commands/exec_test.go
+++ b/cmd/juju/commands/exec_test.go
@@ -39,7 +39,7 @@ func (s *ExecSuite) SetUpTest(c *gc.C) {
 }
 
 func newTestExecCommand(clock clock.Clock, modelType model.ModelType) cmd.Command {
-	return newExecCommand(minimalStore(modelType), clock.After)
+	return newExecCommand(minimalStore(modelType), clock.After, false)
 }
 
 func minimalStore(modelType model.ModelType) *jujuclient.MemStore {
@@ -285,7 +285,6 @@ func (s *ExecSuite) TestConvertRunResults(c *gc.C) {
 		query:   makeActionQuery(validUUID, "MachineId", names.NewMachineTag("1")),
 		expected: map[string]interface{}{
 			"MachineId": "1",
-			"Stdout":    "",
 		},
 	}, {
 		message: "other fields are copied if there",
@@ -298,15 +297,15 @@ func (s *ExecSuite) TestConvertRunResults(c *gc.C) {
 		}, "action-"+validUUID),
 		query: makeActionQuery(validUUID, "UnitId", names.NewUnitTag("unit/0")),
 		expected: map[string]interface{}{
-			"UnitId":     "unit/0",
-			"Stdout":     "stdout",
-			"Stderr":     "stderr",
-			"Message":    "msg",
-			"ReturnCode": 42,
+			"unit":        "unit/0",
+			"stdout":      "stdout",
+			"stderr":      "stderr",
+			"message":     "msg",
+			"return-code": 42,
 		},
 	}} {
 		c.Log(fmt.Sprintf("%v: %s", i, test.message))
-		result := ConvertActionResults(test.results, test.query)
+		result := ConvertActionResults(test.results, test.query, false)
 		c.Check(result, jc.DeepEquals, test.expected)
 	}
 }
@@ -334,8 +333,8 @@ func (s *ExecSuite) TestExecForMachineAndUnit(c *gc.C) {
 	machineQuery := makeActionQuery(mock.receiverIdMap["0"], "MachineId", names.NewMachineTag("0"))
 	unitQuery := makeActionQuery(mock.receiverIdMap["unit/0"], "UnitId", names.NewUnitTag("unit/0"))
 	unformatted := []interface{}{
-		ConvertActionResults(machineResult, machineQuery),
-		ConvertActionResults(unitResult, unitQuery),
+		ConvertActionResults(machineResult, machineQuery, false),
+		ConvertActionResults(unitResult, unitQuery, false),
 	}
 
 	buff := &bytes.Buffer{}
@@ -389,8 +388,8 @@ func (s *ExecSuite) TestAllMachines(c *gc.C) {
 	machine0Query := makeActionQuery(mock.receiverIdMap["0"], "MachineId", names.NewMachineTag("0"))
 	machine1Query := makeActionQuery(mock.receiverIdMap["1"], "MachineId", names.NewMachineTag("1"))
 	unformatted := []interface{}{
-		ConvertActionResults(machine0Result, machine0Query),
-		ConvertActionResults(machine1Result, machine1Query),
+		ConvertActionResults(machine0Result, machine0Query, false),
+		ConvertActionResults(machine1Result, machine1Query, false),
 		map[string]interface{}{
 			"Action":    mock.receiverIdMap["2"],
 			"MachineId": "2",
@@ -441,7 +440,7 @@ func (s *ExecSuite) TestTimeout(c *gc.C) {
 
 	var buf bytes.Buffer
 	err := cmd.FormatJson(&buf, []interface{}{
-		ConvertActionResults(machine0Result, machine0Query),
+		ConvertActionResults(machine0Result, machine0Query, false),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -537,7 +536,7 @@ func (s *ExecSuite) TestCAASExecOnOperator(c *gc.C) {
 
 	unitQuery := makeActionQuery(mock.receiverIdMap["unit/0"], "UnitId", names.NewUnitTag("unit/0"))
 	unformatted := []interface{}{
-		ConvertActionResults(unitResult, unitQuery),
+		ConvertActionResults(unitResult, unitQuery, false),
 	}
 
 	buff := &bytes.Buffer{}
@@ -574,7 +573,7 @@ func (s *ExecSuite) TestCAASExecOnWorkload(c *gc.C) {
 
 	unitQuery := makeActionQuery(mock.receiverIdMap["unit/0"], "UnitId", names.NewUnitTag("unit/0"))
 	unformatted := []interface{}{
-		ConvertActionResults(unitResult, unitQuery),
+		ConvertActionResults(unitResult, unitQuery, false),
 	}
 
 	buff := &bytes.Buffer{}
@@ -654,7 +653,7 @@ func (s *ExecSuite) TestSingleResponse(c *gc.C) {
 
 	query := makeActionQuery(mock.receiverIdMap["0"], "MachineId", names.NewMachineTag("0"))
 	unformatted := []interface{}{
-		ConvertActionResults(machineResult, query),
+		ConvertActionResults(machineResult, query, false),
 	}
 
 	jsonFormatted := &bytes.Buffer{}
@@ -780,9 +779,9 @@ func makeActionResult(mock mockResponse, actionTag string) params.ActionResult {
 		Status:  mock.status,
 		Error:   mock.error,
 		Output: map[string]interface{}{
-			"Stdout": mock.stdout,
-			"Stderr": mock.stderr,
-			"Code":   mock.code,
+			"stdout":      mock.stdout,
+			"stderr":      mock.stderr,
+			"return-code": mock.code,
 		},
 	}
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -295,7 +295,10 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(status.NewStatusHistoryCommand())
 
 	// Error resolution and debugging commands.
-	r.Register(newDefaultRunCommand(nil))
+	if !featureflag.Enabled(feature.JujuV3) {
+		r.Register(newDefaultRunCommand(nil))
+	}
+	r.Register(newDefaultExecCommand(nil))
 	r.Register(newSCPCommand(nil))
 	r.Register(newSSHCommand(nil, nil))
 	r.Register(application.NewResolvedCommand())
@@ -383,15 +386,16 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	}
 
 	// Manage and control actions
-	r.Register(action.NewShowTaskCommand())
 	r.Register(action.NewListCommand())
 	r.Register(action.NewShowCommand())
 	r.Register(action.NewCancelCommand())
-	r.Register(action.NewCallCommand())
-	r.Register(action.NewListTasksCommand())
-	if !featureflag.Enabled(feature.JujuV3) {
-		r.Register(action.NewShowActionOutputCommand())
+	if featureflag.Enabled(feature.JujuV3) {
+		r.Register(action.NewCallCommand())
+		r.Register(action.NewListTasksCommand())
+		r.Register(action.NewShowTaskCommand())
+	} else {
 		r.Register(action.NewRunActionCommand())
+		r.Register(action.NewShowActionOutputCommand())
 		r.Register(action.NewStatusCommand())
 	}
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -447,7 +447,6 @@ var commandNames = []string{
 	"bind",
 	"bootstrap",
 	"budget",
-	"call",
 	"cached-images",
 	"cancel-action",
 	"change-user-password",
@@ -486,7 +485,6 @@ var commandNames = []string{
 	"expose",
 	"find-offers",
 	"firewall-rules",
-	"functions",
 	"get-constraints",
 	"get-model-constraints",
 	"grant",
@@ -509,7 +507,6 @@ var commandNames = []string{
 	"list-credentials",
 	"list-disabled-commands",
 	"list-firewall-rules",
-	"list-functions",
 	"list-machines",
 	"list-models",
 	"list-offers",
@@ -522,7 +519,6 @@ var commandNames = []string{
 	"list-storage",
 	"list-storage-pools",
 	"list-subnets",
-	"list-tasks",
 	"list-users",
 	"list-wallets",
 	"login",
@@ -586,14 +582,12 @@ var commandNames = []string{
 	"show-controller",
 	"show-credential",
 	"show-credentials",
-	"show-function",
 	"show-machine",
 	"show-model",
 	"show-offer",
 	"show-status",
 	"show-status-log",
 	"show-storage",
-	"show-task",
 	"show-user",
 	"show-wallet",
 	"sla",
@@ -608,7 +602,6 @@ var commandNames = []string{
 	"switch",
 	"sync-agent-binaries",
 	"sync-tools",
-	"tasks",
 	"trust",
 	"unexpose",
 	"unregister",
@@ -637,7 +630,9 @@ var devFeatures = []string{
 }
 
 // These are the commands that are behind the `devFeatures`.
-var commandNamesBehindFlags = set.NewStrings()
+var commandNamesBehindFlags = set.NewStrings(
+	"call", "show-task", "functions", "list-functions", "show-function", "tasks", "list-tasks",
+)
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	// Check that we have correctly registered all the commands

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -246,6 +246,7 @@ func encodeBytes(input []byte) (value string, encoding string) {
 }
 
 func (runner *runner) updateActionResults(results *utilexec.ExecResponse) error {
+	// TODO(juju3) - use lower case here
 	if err := runner.context.UpdateActionResults([]string{"Code"}, fmt.Sprintf("%d", results.Code)); err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

New action/function commands back behind feature flag.

When serving the action result data map, the new v5 facade will now use lower case yaml attributes. The v4 and earlier facade continues to use the CamelCase versions. To make this change, several pieces were needed:
- server side conversion of data map from state to new format
- on client side, when older action commands are being used, convert back to old format

Fix the rendering of timestamps in task yaml and list tasks. For list tasks, move time column to end. In yaml, ensure the timezone offset is always included.

## QA steps

start a 2.6 controller
add a model
run an action and use juju run
ensure show-action-output works with 2.6 and 2.7 client
upgrade the controller to 2.7
use list tasks to see the ids from the previous runs
use 2.6.9 client to run show-action-output
use 2.7 client to run show task and show-action-output for all task ids