### PR TITLE
Rename tasks to operations

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -35,13 +35,13 @@ func (c *Client) Actions(arg params.Entities) (params.ActionResults, error) {
 	return results, err
 }
 
-// Tasks fetches the called functions (actions) for specified apps/units.
-func (c *Client) Tasks(arg params.TaskQueryArgs) (params.ActionResults, error) {
+// Operations fetches the called functions (actions) for specified apps/units.
+func (c *Client) Operations(arg params.OperationQueryArgs) (params.ActionResults, error) {
 	results := params.ActionResults{}
 	if v := c.BestAPIVersion(); v < 5 {
-		return results, errors.Errorf("Tasks not supported by this version (%d) of Juju", v)
+		return results, errors.Errorf("Operations not supported by this version (%d) of Juju", v)
 	}
-	err := c.facade.FacadeCall("Tasks", arg, &results)
+	err := c.facade.FacadeCall("Operations", arg, &results)
 	if params.ErrCode(err) == params.CodeNotFound {
 		err = nil
 	}

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -213,8 +213,8 @@ func (s *actionSuite) TestWatchActionProgressNotSupported(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "WatchActionProgress not supported by this version \\(4\\) of Juju")
 }
 
-func (s *actionSuite) TestTasks(c *gc.C) {
-	var args params.TaskQueryArgs
+func (s *actionSuite) TestOperations(c *gc.C) {
+	var args params.OperationQueryArgs
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -222,7 +222,7 @@ func (s *actionSuite) TestTasks(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				c.Assert(request, gc.Equals, "Tasks")
+				c.Assert(request, gc.Equals, "Operations")
 				c.Assert(a, jc.DeepEquals, args)
 				c.Assert(result, gc.FitsTypeOf, &params.ActionResults{})
 				*(result.(*params.ActionResults)) = params.ActionResults{
@@ -236,7 +236,7 @@ func (s *actionSuite) TestTasks(c *gc.C) {
 		BestVersion: 5,
 	}
 	client := action.NewClient(apiCaller)
-	result, err := client.Tasks(args)
+	result, err := client.Operations(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ActionResults{
 		Results: []params.ActionResult{{
@@ -245,7 +245,7 @@ func (s *actionSuite) TestTasks(c *gc.C) {
 	})
 }
 
-func (s *actionSuite) TestTasksNotSupported(c *gc.C) {
+func (s *actionSuite) TestOperationsNotSupported(c *gc.C) {
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -259,6 +259,6 @@ func (s *actionSuite) TestTasksNotSupported(c *gc.C) {
 		BestVersion: 4,
 	}
 	client := action.NewClient(apiCaller)
-	_, err := client.Tasks(params.TaskQueryArgs{})
-	c.Assert(err, gc.ErrorMatches, "Tasks not supported by this version \\(4\\) of Juju")
+	_, err := client.Operations(params.OperationQueryArgs{})
+	c.Assert(err, gc.ErrorMatches, "Operations not supported by this version \\(4\\) of Juju")
 }

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -319,8 +319,8 @@ func (a *ActionAPI) listAll(arg params.Entities, compat bool) (params.ActionsByR
 	return a.internalList(arg, combine(pendingActions, runningActions, completedActions), compat)
 }
 
-// Tasks fetches the called functions (actions) for specified apps/units.
-func (a *ActionAPI) Tasks(arg params.TaskQueryArgs) (params.ActionResults, error) {
+// Operations fetches the called functions (actions) for specified apps/units.
+func (a *ActionAPI) Operations(arg params.OperationQueryArgs) (params.ActionResults, error) {
 	if err := a.checkCanRead(); err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -868,7 +868,7 @@ func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
 	wc.AssertNoChange()
 }
 
-func (s *actionSuite) setupTasks(c *gc.C) {
+func (s *actionSuite) setupOperations(c *gc.C) {
 	s.toSupportNewActionID(c)
 
 	arg := params.Actions{
@@ -892,9 +892,9 @@ func (s *actionSuite) setupTasks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *actionSuite) TestTasksStatusFilter(c *gc.C) {
-	s.setupTasks(c)
-	actions, err := s.action.Tasks(params.TaskQueryArgs{
+func (s *actionSuite) TestOperationsStatusFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
 		Status: []string{"running"},
 	})
 	c.Assert(err, gc.Equals, nil)
@@ -913,9 +913,9 @@ func (s *actionSuite) TestTasksStatusFilter(c *gc.C) {
 	c.Assert(result.Action.Tag, gc.Equals, "action-1")
 }
 
-func (s *actionSuite) TestTasksNameFilter(c *gc.C) {
-	s.setupTasks(c)
-	actions, err := s.action.Tasks(params.TaskQueryArgs{
+func (s *actionSuite) TestOperationsNameFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
 		FunctionNames: []string{"anotherfakeaction"},
 	})
 	c.Assert(err, gc.Equals, nil)
@@ -931,9 +931,9 @@ func (s *actionSuite) TestTasksNameFilter(c *gc.C) {
 	c.Assert(result.Action.Tag, gc.Equals, "action-4")
 }
 
-func (s *actionSuite) TestTasksAppFilter(c *gc.C) {
-	s.setupTasks(c)
-	actions, err := s.action.Tasks(params.TaskQueryArgs{
+func (s *actionSuite) TestOperationsAppFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
 		Applications: []string{"wordpress"},
 	})
 	c.Assert(err, gc.Equals, nil)
@@ -963,9 +963,9 @@ func (s *actionSuite) TestTasksAppFilter(c *gc.C) {
 	c.Assert(result1.Action.Tag, gc.Equals, "action-1")
 }
 
-func (s *actionSuite) TestTasksUnitFilter(c *gc.C) {
-	s.setupTasks(c)
-	actions, err := s.action.Tasks(params.TaskQueryArgs{
+func (s *actionSuite) TestOperationsUnitFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
 		Units:  []string{"wordpress/0"},
 		Status: []string{"pending"},
 	})
@@ -983,9 +983,9 @@ func (s *actionSuite) TestTasksUnitFilter(c *gc.C) {
 	c.Assert(result.Action.Tag, gc.Equals, "action-3")
 }
 
-func (s *actionSuite) TestTasksAppAndUnitFilter(c *gc.C) {
-	s.setupTasks(c)
-	actions, err := s.action.Tasks(params.TaskQueryArgs{
+func (s *actionSuite) TestOperationsAppAndUnitFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
 		Applications: []string{"mysql"},
 		Units:        []string{"wordpress/0"},
 		Status:       []string{"pending"},

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -115,6 +115,17 @@
                         }
                     }
                 },
+                "Operations": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/OperationQueryArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ActionResults"
+                        }
+                    }
+                },
                 "Run": {
                     "type": "object",
                     "properties": {
@@ -131,17 +142,6 @@
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/RunParams"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ActionResults"
-                        }
-                    }
-                },
-                "Tasks": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/TaskQueryArgs"
                         },
                         "Result": {
                             "$ref": "#/definitions/ActionResults"
@@ -489,6 +489,36 @@
                         "matches"
                     ]
                 },
+                "OperationQueryArgs": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "status": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "RunParams": {
                     "type": "object",
                     "properties": {
@@ -561,36 +591,6 @@
                     "required": [
                         "results"
                     ]
-                },
-                "TaskQueryArgs": {
-                    "type": "object",
-                    "properties": {
-                        "applications": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "functions": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "status": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "units": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "additionalProperties": false
                 }
             }
         }

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -108,8 +108,8 @@ type FindActionsByNames struct {
 	ActionNames []string `json:"names,omitempty"`
 }
 
-// TaskQueryArgs holds args for listing tasks.
-type TaskQueryArgs struct {
+// OperationQueryArgs holds args for listing operations.
+type OperationQueryArgs struct {
 	Applications  []string `json:"applications,omitempty"`
 	Units         []string `json:"units,omitempty"`
 	FunctionNames []string `json:"functions,omitempty"`

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -54,8 +54,8 @@ type APIClient interface {
 	// the ActionReceiver if necessary.
 	Actions(params.Entities) (params.ActionResults, error)
 
-	// Tasks fetches the called functions (actions) for specified apps/units.
-	Tasks(params.TaskQueryArgs) (params.ActionResults, error)
+	// Operations fetches the called functions (actions) for specified apps/units.
+	Operations(params.OperationQueryArgs) (params.ActionResults, error)
 
 	// FindActionTagsByPrefix takes a list of string prefixes and finds
 	// corresponding ActionTags that match that prefix.

--- a/cmd/juju/action/call.go
+++ b/cmd/juju/action/call.go
@@ -62,7 +62,7 @@ type callCommand struct {
 
 const callDoc = `
 Run a charm function for execution on a given unit, with a given set of params.
-An ID is returned for use with 'juju show-task <ID>'.
+An ID is returned for use with 'juju show-operation <ID>'.
 
 To queue a function to be run in the background without waiting for it to finish,
 use the --background option.
@@ -100,7 +100,7 @@ Examples:
     juju call mysql/3 backup --utc
     juju call mysql/3 backup
     juju call mysql/leader backup
-    juju show-task <ID>
+    juju show-operation <ID>
     juju call mysql/3 backup --params parameters.yml
     juju call mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
     juju call mysql/3 backup --params p.yml file.kind=xz file.quality=high
@@ -108,8 +108,8 @@ Examples:
     juju call sleeper/0 pause --string-args time=1000
 
 See also:
-    list-tasks
-    show-task
+    list-operations
+    show-operation
 `
 
 // SetFlags offers an option for YAML output.
@@ -201,14 +201,14 @@ func (c *callCommand) Run(ctx *cmd.Context) error {
 			return result.Error
 		}
 		if result.Action == nil {
-			return errors.Errorf("task failed to enqueue on %q", result.Action.Receiver)
+			return errors.Errorf("operation failed to enqueue on %q", result.Action.Receiver)
 		}
 		if actionTag, err = names.ParseActionTag(result.Action.Tag); err != nil {
 			return err
 		}
 
 		if !c.background {
-			ctx.Infof("Running Task %s", actionTag.Id())
+			ctx.Infof("Running Operation %s", actionTag.Id())
 		}
 		unitTag, err := names.ParseUnitTag(result.Action.Receiver)
 		if err != nil {
@@ -220,12 +220,12 @@ func (c *callCommand) Run(ctx *cmd.Context) error {
 	}
 	if c.background {
 		if len(results.Results) == 1 {
-			ctx.Infof("Scheduled Task %s", actionTag.Id())
-			ctx.Infof("Check status with 'juju show-task %s'", actionTag.Id())
+			ctx.Infof("Scheduled Operation %s", actionTag.Id())
+			ctx.Infof("Check status with 'juju show-operation %s'", actionTag.Id())
 		} else {
-			ctx.Infof("Scheduled Tasks:")
+			ctx.Infof("Scheduled Operations:")
 			cmd.FormatYaml(ctx.Stderr, info)
-			ctx.Infof("Check status with 'juju show-task <id>'")
+			ctx.Infof("Check status with 'juju show-operation <id>'")
 		}
 		return nil
 	}
@@ -266,7 +266,7 @@ func (c *callCommand) Run(ctx *cmd.Context) error {
 			waitForWatcher()
 			return errors.Trace(err)
 		}
-		fmt.Fprintf(ctx.Stderr, "Waiting for task %v...\n", tag.Id())
+		fmt.Fprintf(ctx.Stderr, "Waiting for operation %v...\n", tag.Id())
 		result, err = GetActionResult(c.api, tag.Id(), wait, false)
 		if i == 0 {
 			waitForWatcher()
@@ -423,7 +423,7 @@ func printPlainOutput(writer io.Writer, value interface{}) error {
 				}
 			}
 		} else {
-			actionOutput[k] = fmt.Sprintf("Task %v complete\n", resultMetadata["id"])
+			actionOutput[k] = fmt.Sprintf("Operation %v complete\n", resultMetadata["id"])
 		}
 		actionInfo[k] = map[string]interface{}{
 			"id":     resultMetadata["id"],

--- a/cmd/juju/action/call_test.go
+++ b/cmd/juju/action/call_test.go
@@ -894,8 +894,8 @@ mysql/1:
 
 						// Make sure the CLI responded with the expected tag
 						c.Assert(outString, gc.Equals, fmt.Sprintf(`
-Scheduled Task %s
-Check status with 'juju show-task %s'`[1:],
+Scheduled Operation %s
+Check status with 'juju show-operation %s'`[1:],
 							expectedTag.Id(), expectedTag.Id()))
 					} else {
 						outputResult := ctx.Stdout.(*bytes.Buffer).Bytes()

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -107,8 +107,8 @@ func (c *ShowCommand) ActionName() string {
 	return c.functionName
 }
 
-type ListTasksCommand struct {
-	*listTasksCommand
+type ListOperationsCommand struct {
+	*listOperationsCommand
 }
 
 func NewShowOutputCommandForTest(store jujuclient.ClientStore, logMessage func(*cmd.Context, string)) (cmd.Command, *ShowOutputCommand) {
@@ -162,8 +162,8 @@ func ActionResultsToMap(results []params.ActionResult) map[string]interface{} {
 	return resultsToMap(results)
 }
 
-func NewListTasksCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ListTasksCommand) {
-	c := &listTasksCommand{}
+func NewListOperationsCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ListOperationsCommand) {
+	c := &listOperationsCommand{}
 	c.SetClientStore(store)
-	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ListTasksCommand{c}
+	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ListOperationsCommand{c}
 }

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -21,12 +21,12 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
-func NewListTasksCommand() cmd.Command {
-	return modelcmd.Wrap(&listTasksCommand{})
+func NewListOperationsCommand() cmd.Command {
+	return modelcmd.Wrap(&listOperationsCommand{})
 }
 
-// listTasksCommand fetches the results of an action by ID.
-type listTasksCommand struct {
+// listOperationsCommand fetches the results of an action by ID.
+type listOperationsCommand struct {
 	ActionCommandBase
 	out              cmd.Output
 	utc              bool
@@ -36,29 +36,29 @@ type listTasksCommand struct {
 	statusValues     []string
 }
 
-const listTasksDoc = `
-List the tasks with the specified query criteria.
-With no query arguments, any completed tasks will be listed.
-A completed task is one that has run successfully, been cancelled, or failed.
+const listOperationsDoc = `
+List the operations with the specified query criteria.
+With no query arguments, any completed operations will be listed.
+A completed operation is one that has run successfully, been cancelled, or failed.
 
 When an application is specified, all units from that application are relevant.
 
 Examples:
-    juju tasks
-    juju tasks --format yaml
-    juju tasks --functions backup,restore
-    juju tasks --apps mysql,mediawiki
-    juju tasks --units mysql/0,mediawiki/1
-    juju tasks --status pending,completed
-    juju tasks --apps mysql --units mediawiki/0 --status running --functions backup
+    juju operations
+    juju operations --format yaml
+    juju operations --functions backup,restore
+    juju operations --apps mysql,mediawiki
+    juju operations --units mysql/0,mediawiki/1
+    juju operations --status pending,completed
+    juju operations --apps mysql --units mediawiki/0 --status running --functions backup
 
 See also:
     call
-    show-task
+    show-operation
 `
 
 // Set up the output.
-func (c *listTasksCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *listOperationsCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ActionCommandBase.SetFlags(f)
 	defaultFormatter := "plain"
 	c.out.AddFlags(f, defaultFormatter, map[string]cmd.Formatter{
@@ -72,20 +72,20 @@ func (c *listTasksCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(cmd.NewStringsValue(nil, &c.applicationNames), "apps", "Comma separated list of applications to filter on")
 	f.Var(cmd.NewStringsValue(nil, &c.unitNames), "units", "Comma separated list of units to filter on")
 	f.Var(cmd.NewStringsValue(nil, &c.functionNames), "functions", "Comma separated list of function names to filter on")
-	f.Var(cmd.NewStringsValue([]string{params.ActionCompleted}, &c.statusValues), "status", "Comma separated list of task status values to filter on")
+	f.Var(cmd.NewStringsValue([]string{params.ActionCompleted}, &c.statusValues), "status", "Comma separated list of operation status values to filter on")
 }
 
-func (c *listTasksCommand) Info() *cmd.Info {
+func (c *listOperationsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "tasks",
-		Purpose: "Lists pending, running, or completed tasks for specified application, units, or all.",
-		Doc:     listTasksDoc,
-		Aliases: []string{"list-tasks"},
+		Name:    "operations",
+		Purpose: "Lists pending, running, or completed operations for specified application, units, or all.",
+		Doc:     listOperationsDoc,
+		Aliases: []string{"list-operations"},
 	})
 }
 
 // Init implements Command.
-func (c *listTasksCommand) Init(args []string) error {
+func (c *listOperationsCommand) Init(args []string) error {
 	var nameErrors []string
 	for _, application := range c.applicationNames {
 		if !names.IsValidApplication(application) {
@@ -116,20 +116,20 @@ func (c *listTasksCommand) Init(args []string) error {
 }
 
 // Run implements Command.
-func (c *listTasksCommand) Run(ctx *cmd.Context) error {
+func (c *listOperationsCommand) Run(ctx *cmd.Context) error {
 	api, err := c.NewActionAPIClient()
 	if err != nil {
 		return err
 	}
 	defer api.Close()
 
-	args := params.TaskQueryArgs{
+	args := params.OperationQueryArgs{
 		Applications:  c.applicationNames,
 		Units:         c.unitNames,
 		FunctionNames: c.functionNames,
 		Status:        c.statusValues,
 	}
-	results, err := api.Tasks(args)
+	results, err := api.Operations(args)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -137,7 +137,7 @@ func (c *listTasksCommand) Run(ctx *cmd.Context) error {
 	out := make(map[string]interface{})
 	var actionResults byId = results.Results
 	if len(actionResults) == 0 {
-		fmt.Fprintln(ctx.Stderr, "no matching tasks")
+		fmt.Fprintln(ctx.Stderr, "no matching operations")
 		return nil
 	}
 
@@ -158,15 +158,15 @@ func (c *listTasksCommand) Run(ctx *cmd.Context) error {
 	return c.out.Write(ctx, actionResults)
 }
 
-type taskLine struct {
+type operationLine struct {
 	timestamp time.Time
 	id        string
-	task      string
+	operation string
 	status    string
 	unit      string
 }
 
-func (c *listTasksCommand) formatTabular(writer io.Writer, value interface{}) error {
+func (c *listOperationsCommand) formatTabular(writer io.Writer, value interface{}) error {
 	results, ok := value.(byId)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", results, value)
@@ -175,18 +175,18 @@ func (c *listTasksCommand) formatTabular(writer io.Writer, value interface{}) er
 	w := output.Wrapper{tw}
 	w.SetColumnAlignRight(0)
 
-	printTasks := func(tasks []taskLine, utc bool) {
-		for _, line := range tasks {
-			w.Print(line.id, line.task, line.status, line.unit)
+	printOperations := func(operations []operationLine, utc bool) {
+		for _, line := range operations {
+			w.Print(line.id, line.operation, line.status, line.unit)
 			w.Println(formatTimestamp(line.timestamp, false, c.utc, true))
 		}
 	}
-	w.Println("Id", "Task", "Status", "Unit", "Time")
-	printTasks(actionTaskLinesFromResults(results), c.utc)
+	w.Println("Id", "Operation", "Status", "Unit", "Time")
+	printOperations(actionOperationLinesFromResults(results), c.utc)
 	return tw.Flush()
 }
 
-func taskDisplayTime(r params.ActionResult) time.Time {
+func operationDisplayTime(r params.ActionResult) time.Time {
 	timestamp := r.Completed
 	if timestamp.IsZero() {
 		timestamp = r.Started
@@ -197,18 +197,18 @@ func taskDisplayTime(r params.ActionResult) time.Time {
 	return timestamp
 }
 
-func actionTaskLinesFromResults(results []params.ActionResult) []taskLine {
+func actionOperationLinesFromResults(results []params.ActionResult) []operationLine {
 	sort.Sort(byTimestamp(results))
 
-	var taskLines []taskLine
+	var operationLines []operationLine
 	for _, r := range results {
 		if r.Action == nil {
 			continue
 		}
-		line := taskLine{
-			timestamp: taskDisplayTime(r),
+		line := operationLine{
+			timestamp: operationDisplayTime(r),
 			status:    r.Status,
-			task:      r.Action.Name,
+			operation: r.Action.Name,
 		}
 		if at, err := names.ParseActionTag(r.Action.Tag); err == nil {
 			line.id = at.Id()
@@ -216,9 +216,9 @@ func actionTaskLinesFromResults(results []params.ActionResult) []taskLine {
 		if ut, err := names.ParseUnitTag(r.Action.Receiver); err == nil {
 			line.unit = ut.Id()
 		}
-		taskLines = append(taskLines, line)
+		operationLines = append(operationLines, line)
 	}
-	return taskLines
+	return operationLines
 }
 
 type byTimestamp []params.ActionResult
@@ -232,7 +232,7 @@ func (s byTimestamp) Swap(i, j int) {
 }
 
 func (s byTimestamp) Less(i, j int) bool {
-	return taskDisplayTime(s[i]).UnixNano() < taskDisplayTime(s[j]).UnixNano()
+	return operationDisplayTime(s[i]).UnixNano() < operationDisplayTime(s[j]).UnixNano()
 }
 
 type byId []params.ActionResult

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -140,7 +140,7 @@ type fakeAPIClient struct {
 	delay              *time.Timer
 	timeout            *time.Timer
 	actionResults      []params.ActionResult
-	taskQueryArgs      params.TaskQueryArgs
+	operationQueryArgs params.OperationQueryArgs
 	enqueuedActions    params.Actions
 	actionsByReceivers []params.ActionsByReceiver
 	actionTagMatches   params.FindTagsResults
@@ -267,8 +267,8 @@ func (c *fakeAPIClient) WatchActionProgress(actionId string) (watcher.StringsWat
 	return watchertest.NewMockStringsWatcher(c.logMessageCh), nil
 }
 
-func (c *fakeAPIClient) Tasks(args params.TaskQueryArgs) (params.ActionResults, error) {
-	c.taskQueryArgs = args
+func (c *fakeAPIClient) Operations(args params.OperationQueryArgs) (params.ActionResults, error) {
+	c.operationQueryArgs = args
 	return params.ActionResults{
 		Results: c.actionResults,
 	}, c.apiErr

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -31,7 +31,7 @@ func NewShowActionOutputCommand() cmd.Command {
 	})
 }
 
-func NewShowTaskCommand() cmd.Command {
+func NewShowOperationCommand() cmd.Command {
 	return modelcmd.Wrap(&showOutputCommand{
 		compat: false,
 		logMessageHandler: func(ctx *cmd.Context, msg string) {
@@ -75,7 +75,7 @@ Examples:
 
 See also:
     run-action
-    list-tasks
+    list-operations
 `
 
 // Set up the output.
@@ -104,11 +104,11 @@ func (c *showOutputCommand) Info() *cmd.Info {
 		Doc:     showOutputDoc,
 	})
 	if !c.compat {
-		info.Name = "show-task"
-		info.Args = "<task ID>"
-		info.Purpose = "Show results of a task by ID."
+		info.Name = "show-operation"
+		info.Args = "<operation ID>"
+		info.Purpose = "Show results of a operation by ID."
 		info.Doc = strings.Replace(info.Doc, "an action", "a function call", -1)
-		info.Doc = strings.Replace(info.Doc, "show-action-output", "show-task", -1)
+		info.Doc = strings.Replace(info.Doc, "show-action-output", "show-operation", -1)
 		info.Doc = strings.Replace(info.Doc, "run-action", "call", -1)
 	}
 	return info
@@ -128,7 +128,7 @@ func (c *showOutputCommand) Init(args []string) error {
 		if c.compat {
 			return errors.New("no action ID specified")
 		}
-		return errors.New("no task ID specified")
+		return errors.New("no operation ID specified")
 	case 1:
 		c.requestedId = args[0]
 		return nil
@@ -289,15 +289,15 @@ func fetchResult(api APIClient, requestedId string, compat bool) (params.ActionR
 	}
 	actionResults := actions.Results
 	numActionResults := len(actionResults)
-	task := "task"
+	operation := "operation"
 	if compat {
-		task = "action"
+		operation = "action"
 	}
 	if numActionResults == 0 {
-		return none, errors.Errorf("no results for %s %s", task, requestedId)
+		return none, errors.Errorf("no results for %s %s", operation, requestedId)
 	}
 	if numActionResults != 1 {
-		return none, errors.Errorf("too many results for %s %s", task, requestedId)
+		return none, errors.Errorf("too many results for %s %s", operation, requestedId)
 	}
 
 	result := actionResults[0]

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -54,7 +54,7 @@ func (s *ShowOutputSuite) TestInit(c *gc.C) {
 
 	for i, t := range tests {
 		for _, modelFlag := range s.modelFlags {
-			c.Logf("test %d: it should %s: juju show-task %s", i,
+			c.Logf("test %d: it should %s: juju show-operation %s", i,
 				t.should, strings.Join(t.args, " "))
 			cmd, _ := action.NewShowOutputCommandForTest(s.store, nil)
 			args := append([]string{modelFlag, "admin"}, t.args...)

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -391,8 +391,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(action.NewCancelCommand())
 	if featureflag.Enabled(feature.JujuV3) {
 		r.Register(action.NewCallCommand())
-		r.Register(action.NewListTasksCommand())
-		r.Register(action.NewShowTaskCommand())
+		r.Register(action.NewListOperationsCommand())
+		r.Register(action.NewShowOperationCommand())
 	} else {
 		r.Register(action.NewRunActionCommand())
 		r.Register(action.NewShowActionOutputCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -631,7 +631,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"call", "show-task", "functions", "list-functions", "show-function", "tasks", "list-tasks",
+	"call", "show-operation", "functions", "list-functions", "show-function", "operations", "list-operations",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {


### PR DESCRIPTION
## Description of change

The result of running a function is now an operation rather than a task. 

## QA steps

juju call somefunction
juju list-tasks
juju show-task

