### PR TITLE
Actions2functions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,8 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:ed6ef6587e8c42c2cdb227c2e1b164bd131e4c84d420cf725b5fcf97c29e9b19"
+  branch = "add-support-functions"
+  digest = "1:4f9201440dc6b732dad20e9bd730b9c8ac418285a069e7dd367834821220aaa9"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1503,8 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
+  revision = "a2b006e9dec7504e36f16334a1ef5be1710d9a4c"
+  source = "github.com/ycliuhw/charm"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,8 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  branch = "add-support-functions"
-  digest = "1:4f9201440dc6b732dad20e9bd730b9c8ac418285a069e7dd367834821220aaa9"
+  digest = "1:79a27343a7bbcf0f95f02624f734d5c1ae62f69309414714c0c287c12b49bceb"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1503,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "a2b006e9dec7504e36f16334a1ef5be1710d9a4c"
+  revision = "e796da0d55361152e5f113fa559c52082731df76"
   source = "github.com/ycliuhw/charm"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:79a27343a7bbcf0f95f02624f734d5c1ae62f69309414714c0c287c12b49bceb"
+  digest = "1:404c0747e3f16e88f08aaeb7b74be7ec08fa94acf3b4dd2e7ae43cea81cdaf44"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,8 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "e796da0d55361152e5f113fa559c52082731df76"
-  source = "github.com/ycliuhw/charm"
+  revision = "a35e524ea871ac01a0522bd37b6267a45e233fb2"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,15 +147,11 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "e796da0d55361152e5f113fa559c52082731df76"
-  # branch = "add-support-functions"
-  source = "github.com/ycliuhw/charm"
+  revision = "a35e524ea871ac01a0522bd37b6267a45e233fb2"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"
   name = "gopkg.in/juju/charmrepo.v3"
-  # branch = "add-support-functions"
-  # source = "github.com/ycliuhw/charmrepo"
 
 [[constraint]]
   revision = "7359fc7857abe2b11b5b3e23811a9c64cb6b01e0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,13 +147,15 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  # revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
-  branch = "add-support-functions"
+  revision = "e796da0d55361152e5f113fa559c52082731df76"
+  # branch = "add-support-functions"
   source = "github.com/ycliuhw/charm"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"
   name = "gopkg.in/juju/charmrepo.v3"
+  # branch = "add-support-functions"
+  # source = "github.com/ycliuhw/charmrepo"
 
 [[constraint]]
   revision = "7359fc7857abe2b11b5b3e23811a9c64cb6b01e0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,9 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
+  # revision = "780719c3e4a68329408cfecf46ed1ee84b530287"
+  branch = "add-support-functions"
+  source = "github.com/ycliuhw/charm"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -714,6 +714,10 @@ func (c *controllerStack) waitForPod(podWatcher watcher.NotifyWatcher, podName s
 		case <-podWatcher.Changes():
 			printPodEvents()
 			pod, err := c.broker.getPod(podName)
+			if errors.IsNotFound(err) {
+				logger.Debugf("pod %q is not provisioned yet", podName)
+				continue
+			}
 			if err != nil {
 				return errors.Annotate(err, "fetching pods' status for controller")
 			}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2112,7 +2112,7 @@ func (k *kubernetesClient) getPod(podName string) (*core.Pod, error) {
 		IncludeUninitialized: true,
 	})
 	if k8serrors.IsNotFound(err) {
-		return nil, errors.NotFoundf("pod not found")
+		return nil, errors.NotFoundf("pod %q", podName)
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -731,6 +731,11 @@ func (context *HookContext) HookVars(paths Paths, remote bool) ([]string, error)
 	}
 	if context.actionData != nil {
 		vars = append(vars,
+			"JUJU_FUNCTION_NAME="+context.actionData.Name,
+			"JUJU_FUNCTION_ID="+context.actionData.Tag.Id(),
+			"JUJU_FUNCTION_TAG="+context.actionData.Tag.String(),
+
+			// TODO(ycliuhw): remove here once action is deprecated.
 			"JUJU_ACTION_NAME="+context.actionData.Name,
 			"JUJU_ACTION_UUID="+context.actionData.Tag.Id(),
 			"JUJU_ACTION_TAG="+context.actionData.Tag.String(),

--- a/worker/uniter/runner/jujuc/action-fail.go
+++ b/worker/uniter/runner/jujuc/action-fail.go
@@ -34,6 +34,7 @@ problem with the action.
 		Args:    "[\"<failure message>\"]",
 		Purpose: "set action fail status with message",
 		Doc:     doc,
+		Aliases: []string{"function-fail"},
 	})
 }
 

--- a/worker/uniter/runner/jujuc/action-fail_test.go
+++ b/worker/uniter/runner/jujuc/action-fail_test.go
@@ -114,6 +114,8 @@ Details:
 action-fail sets the action's fail state with a given error message.  Using
 action-fail without a failure message will set a default message indicating a
 problem with the action.
+
+Aliases: function-fail
 `)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/action-get.go
+++ b/worker/uniter/runner/jujuc/action-get.go
@@ -38,6 +38,7 @@ map as needed.
 		Name:    "action-get",
 		Args:    "[<key>[.<key>.<key>...]]",
 		Purpose: "get action parameters",
+		Aliases: []string{"function-get"},
 		Doc:     doc,
 	})
 }

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -291,6 +291,8 @@ Details:
 action-get will print the value of the parameter at the given key, serialized
 as YAML.  If multiple keys are passed, action-get will recurse into the param
 map as needed.
+
+Aliases: function-get
 `)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/action-log.go
+++ b/worker/uniter/runner/jujuc/action-log.go
@@ -28,6 +28,7 @@ func (c *ActionLogCommand) Info() *cmd.Info {
 		Name:    "action-log",
 		Args:    "<message>",
 		Purpose: "record a progress message for the current action",
+		Aliases: []string{"function-log"},
 	})
 }
 

--- a/worker/uniter/runner/jujuc/action-log_test.go
+++ b/worker/uniter/runner/jujuc/action-log_test.go
@@ -95,6 +95,8 @@ func (s *ActionLogSuite) TestHelp(c *gc.C) {
 
 Summary:
 record a progress message for the current action
+
+Aliases: function-log
 `)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/action-set.go
+++ b/worker/uniter/runner/jujuc/action-set.go
@@ -42,6 +42,7 @@ Example usage:
  action-set foo.baz.val=3
  action-set foo.bar.zab=4
  action-set foo.baz=1
+ function-set foo.baz=1
 
  will yield:
 
@@ -57,6 +58,7 @@ Example usage:
 		Args:    "<key>=<value> [<key>=<value> ...]",
 		Purpose: "set action results",
 		Doc:     doc,
+		Aliases: []string{"function-set"},
 	})
 }
 

--- a/worker/uniter/runner/jujuc/action-set_test.go
+++ b/worker/uniter/runner/jujuc/action-set_test.go
@@ -161,6 +161,7 @@ Example usage:
  action-set foo.baz.val=3
  action-set foo.bar.zab=4
  action-set foo.baz=1
+ function-set foo.baz=1
 
  will yield:
 
@@ -170,6 +171,8 @@ Example usage:
    bar:
      zab: "4"
    baz: "1"
+
+Aliases: function-set
 `)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -51,10 +51,6 @@ var baseCommands = map[string]creator{
 	"open-port" + cmdSuffix:               NewOpenPortCommand,
 	"opened-ports" + cmdSuffix:            NewOpenedPortsCommand,
 	"relation-get" + cmdSuffix:            NewRelationGetCommand,
-	"action-get" + cmdSuffix:              NewActionGetCommand,
-	"action-set" + cmdSuffix:              NewActionSetCommand,
-	"action-fail" + cmdSuffix:             NewActionFailCommand,
-	"action-log" + cmdSuffix:              NewActionLogCommand,
 	"relation-ids" + cmdSuffix:            NewRelationIdsCommand,
 	"relation-list" + cmdSuffix:           NewRelationListCommand,
 	"relation-set" + cmdSuffix:            NewRelationSetCommand,
@@ -68,6 +64,21 @@ var baseCommands = map[string]creator{
 	"pod-spec-set" + cmdSuffix:            NewPodSpecSetCommand,
 	"goal-state" + cmdSuffix:              NewGoalStateCommand,
 	"credential-get" + cmdSuffix:          NewCredentialGetCommand,
+
+	// Commands have alias.
+	// consider to create a new Command rather than using alias?
+	// It will be cleaner for ensuring symlinks.
+	"action-get" + cmdSuffix:  NewActionGetCommand,
+	"action-set" + cmdSuffix:  NewActionSetCommand,
+	"action-fail" + cmdSuffix: NewActionFailCommand,
+	"action-log" + cmdSuffix:  NewActionLogCommand,
+}
+
+var actionCommandsAlias = []string{
+	"function-get",
+	"function-set",
+	"function-fail",
+	"function-log",
 }
 
 var storageCommands = map[string]creator{
@@ -101,6 +112,7 @@ func CommandNames() (names []string) {
 	for name := range allEnabledCommands() {
 		names = append(names, name)
 	}
+	names = append(names, actionCommandsAlias...)
 	sort.Strings(names)
 	return
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -286,10 +286,19 @@ func (runner *runner) RunAction(actionName string) error {
 	}
 	rMode := runOnLocal
 	if runner.context.ModelType() == model.CAAS {
+		// run actions/functions on remote workload pod if it's caas model.
 		rMode = runOnRemote
 	}
-	// run actions on remote workload pod for caas.
-	return runner.runCharmHookWithLocation(actionName, "actions", rMode)
+	return runner.runCharmHookWithLocation(actionName, runner.getFunctionDir(), rMode)
+}
+
+func (runner *runner) getFunctionDir() string {
+	charmDir := runner.paths.GetCharmDir()
+	dir := filepath.Join(charmDir, "functions")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		return "functions"
+	}
+	return "actions"
 }
 
 // RunHook exists to satisfy the Runner interface.


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?

----

## Description of change

Add functions support (charm.v6 update and hook symlinks);

depends on:

- https://github.com/juju/charm-tools/pull/555
- https://github.com/juju/charm/pull/299

Driveby fix bootstrap to k8s: pod not found  issue:

```
ERROR juju.cmd.juju.commands bootstrap.go:778 failed to bootstrap model: creating controller stack for controller: creating statefulset for controller: fetching pods' status for controller: pod not found not found
```

## QA steps

### CaaS

```console
# deploy charm has `functions.yaml` and `functions/`;

# check operator hooks symlinks;
$ root@mariadb-k8s-0:/var/lib/juju# ll tools/unit-mariadb-k8s-0/action-*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/action-fail -> /var/lib/juju/tools/jujud*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/action-get -> /var/lib/juju/tools/jujud*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/action-log -> /var/lib/juju/tools/jujud*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/action-set -> /var/lib/juju/tools/jujud*
$ root@mariadb-k8s-0:/var/lib/juju# ll tools/unit-mariadb-k8s-0/function-*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/function-fail -> /var/lib/juju/tools/jujud*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/function-get -> /var/lib/juju/tools/jujud*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/function-log -> /var/lib/juju/tools/jujud*
lrwxrwxrwx 1 root root 25 Nov 15 07:41 tools/unit-mariadb-k8s-0/function-set -> /var/lib/juju/tools/jujud*

# list functions;
$ juju functions mariadb-k8s
Function  Description
hello     Hello World.

# show functions;
$ juju show-function mariadb-k8s hello
Hello World.

Arguments
who:
  type: string
  description: The person to say hello to.

# call function
$ juju call mariadb-k8s/0 hello who=kelvin
Running Task 1
Waiting for task 1...
outcome: success
result-map:
  message: |-
    Hello
    kelvin!
  time-completed: Fri Nov 15 08:35:06 UTC 2019

$ juju tasks --apps mariadb-k8s
Time                 Id  Task   Status     Unit
2019-11-15 19:35:07   1  hello  completed  mariadb-k8s/0

$ juju show-task 1
outcome: success
result-map:
  message: |-
    Hello
    kelvin!
  time-completed: Fri Nov 15 08:35:06 UTC 2019
```

### IaaS

```console
# bootstrap to aws;
$ juju bootstrap aws/ap-southeast-2 aws --debug --build-agent

# download postgresql charm and rename `actions` folder to `functions`, `actions.yaml` to `functions.yaml`
# build charm then deploy;
$ charm-build ./ --no-local-layers  && juju deploy /tmp/charm-builds/postgresql/ --debug

$ juju functions postgresql
Function            Description
replication-pause   Pause replication replay on a hot standby unit.
replication-resume  Resume replication replay on a hot standby unit.
switchover          Promote a specific unit to master. Must be run on the leader unit.
test-function       fake echo function.
wal-e-backup        Run a wal-e backup to cloud storage now. Requires WAL shipping to be enabled with wal-e. Action terminates when the backup is complete.
wal-e-list-backups  List backups available for PITR and their metadata.
wal-e-restore       PITR database recovery from configured wal-e store. THIS WILL DESTROY YOUR EXISTING DATA. Most of these options correspond to PostgreSQL recovery target settings, documented at http://www.postgresql.org/docs/current/static/recovery-target-settings.html.

$ juju show-function postgresql test-function
fake echo function.

Arguments
arg:
  type: string
  description: null

$ juju call postgresql/0 test-function arg=hey
Running Task 3
Waiting for task 3...
result: "printed params -> \n{'arg': 'hey'}"

$ juju show-task 3
result: "printed params -> \n{'arg': 'hey'}"

$ juju tasks
Time                 Id  Task           Status     Unit
2019-11-18 15:18:44   1  test-function  completed  postgresql/0
2019-11-18 15:31:15   2  test-function  completed  postgresql/0
2019-11-18 15:31:25   3  test-function  completed  postgresql/0

$ juju run --unit postgresql/0 --timeout=30s env | grep -i "function\|action"
JUJU_ACTION_UUID=7
JUJU_ACTION_NAME=juju-run
JUJU_FUNCTION_TAG=action-7
JUJU_ACTION_TAG=action-7
JUJU_FUNCTION_NAME=juju-run
JUJU_FUNCTION_ID=7
```

## Documentation changes

No

## Bug reference

None
