### PR TITLE
Fix Expression Used by Python Test Client to Extract Action ID

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1880,12 +1880,10 @@ class ModelClient:
         args = (unit, action) + args
 
         output = self.get_juju_output("run-action", *args)
-        idRegexp = '([0-9]+|((?:[a-f0-9\-]{36})|(?:(?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*)-(?:0|[1-9][0-9]*))))'
-        action_id_pattern = re.compile('Action queued with id: ' + idRegexp)
+        action_id_pattern = re.compile('Action queued with id: "([0-9]+)"')
         match = action_id_pattern.search(output)
         if match is None:
-            raise Exception("Action id not found in output: %s" %
-                            output)
+            raise Exception("Action id not found in output: {}".format(output))
         return match.group(1)
 
     def action_do_fetch(self, unit, action, timeout="1m", *args):


### PR DESCRIPTION
## Description of change

Many tests, including all of the network health tests are failing with errors like this:
```
2019-11-15 23:41:31 ERROR Action id not found in output: Action queued with id: "1"
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests/utility.py", line 423, in logged_exception
    yield
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests/deploy_stack.py", line 1036, in runtime_context
    yield
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests/deploy_stack.py", line 1165, in new_bootstrap
    yield machines
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests/deploy_stack.py", line 1144, in booted_context
    yield machines
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests//assess_network_health.py", line 614, in main
    start_test(bs_manager.client, args, None)
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests//assess_network_health.py", line 580, in start_test
    args.reboot, args.series, maas)
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests//assess_network_health.py", line 72, in assess_network_health
    results_pre = self.testing_iterations(client, series, target_model)
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests//assess_network_health.py", line 97, in testing_iterations
    interface_info = self.get_unit_info(client)
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests//assess_network_health.py", line 224, in get_unit_info
    out = client.action_do(nh_unit, 'unit-info')
  File "/var/lib/jenkins/workspace/nw-network-health-oci/acceptancetests/jujupy/client.py", line 1888, in action_do
    output)
Exception: Action id not found in output: Action queued with id: "1"
```

This appears to have broken when action IDs became numeric.

This patch changes the regular expression used by the Python test client to extract an action ID, anticipating a number instead of a UUID.

## QA steps

Run one of the failing acceptance tests (I used **nw-network-health-oci**). There is a still a failure that needs investigating for this test, but the ID determination error no longer occurs.

## Documentation changes

None

## Bug reference

N/A
