### PR TITLE
acceptancetest fix:  cloud show

### DIFF
--- a/acceptancetests/assess_add_cloud.py
+++ b/acceptancetests/assess_add_cloud.py
@@ -198,7 +198,7 @@ def assess_all_clouds(client, cloud_specs):
     failed = set()
     client.env.load_yaml()
     for cloud_spec in cloud_specs:
-        sys.stdout.write('Testing {}.\n'.format(cloud_spec.label))
+        sys.stdout.write('\n Testing {}.\n'.format(cloud_spec.label))
         try:
             if cloud_spec.exception is None:
                 assess_cloud(client, cloud_spec.name, cloud_spec.config)

--- a/acceptancetests/assess_cloud_display.py
+++ b/acceptancetests/assess_cloud_display.py
@@ -37,8 +37,9 @@ def remove_display_attributes(cloud):
     # bug #1645783.
     defined = cloud.pop('defined')
     assert_equal(defined, 'local')
-    description = cloud.pop('description', None)
-    # Pop Nones, which are "errors from parsing the yaml"
+    description = cloud.pop('description', "")
+
+    # Delete None values, which are "errors" from parsing the yaml
     # E.g. output can show values which we show to the customers but should actually not parsed and compared
     for key in cloud.keys():
         if cloud[key] is None:


### PR DESCRIPTION

## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?

----

## Description of change
accceptancetest interactive: add newline for better formatting
acceptancetest many: fix show-cloud by using "" instead of None

## QA steps

```sh
/home/nam/golang/src/github.com/juju/juju/acceptancetests/assess_cloud_display.py ~/example-clouds.yaml /home/nam/golang/bin/juju
assess_clouds (no_clouds): PASS
assess_clouds: PASS
assess_show_cloud: PASS
```

