### PR TITLE
[dev] Mute aws cli output for space tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -87,7 +87,7 @@ bootstrap() {
 
     START_TIME=$(date +%s)
     if [ "${BOOTSTRAP_REUSE}" = "true" ]; then
-        echo "====> Reusing bootstrapped juju ($(green "${version}"))"
+        echo "====> Reusing bootstrapped juju ($(green "${version}:${provider}"))"
 
         OUT=$(juju models -c "${bootstrapped_name}" --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
         if [ -n "${OUT}" ]; then
@@ -100,7 +100,7 @@ bootstrap() {
         add_model "${model}" "${provider}" "${bootstrapped_name}"
         name="${bootstrapped_name}"
     else
-        echo "====> Bootstrapping juju ($(green "${version}"))"
+        echo "====> Bootstrapping juju ($(green "${version}:${provider}"))"
         juju_bootstrap "${provider}" "${name}" "${model}" "${output}"
     fi
     END_TIME=$(date +%s)

--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -23,14 +23,14 @@ test_spaces_ec2() {
 }
 
 check_prerequisites_for_space_tests() {
-  match_count=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24 | jq '.Subnets | length')
+  match_count=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24 2>/dev/null | jq '.Subnets | length')
   if [ "$match_count" != "1" ]; then
       # shellcheck disable=SC2046
       echo $(red "To run these tests you need to create a subnet with name \"isolated\" and CIDR \"172.31.254/24\"")
       exit 1
   fi
 
-  if_count=$(aws ec2 describe-network-interfaces --filters Name=tag:nic-type,Values=hotpluggable | jq '.NetworkInterfaces[] | select(.["PrivateIpAddress"] | startswith("172.31.254.")) | .NetworkInterfaceId')
+  if_count=$(aws ec2 describe-network-interfaces --filters Name=tag:nic-type,Values=hotpluggable 2>/dev/null | jq '.NetworkInterfaces[] | select(.["PrivateIpAddress"] | startswith("172.31.254.")) | .NetworkInterfaceId')
   if [ -z "$if_count" ]; then
       # shellcheck disable=SC2046
       echo $(red "To run these tests you need to create a network interface on the isolated subnet (CIDR \"172.31.254/24\") and tag it with \"nic-type:hotpluggable\"")


### PR DESCRIPTION
## Description of change

The aws-cli tool has the nasty habit of dumping the credential file if it cannot validate this. By suppressing stderr we can at least prevent the AWS keys from being leaked into the CI logs