### PR TITLE
2.7 - Show Current Model With Bad Key Errors

### DIFF
--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -318,7 +318,9 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 		if isFileLike(c.keys[0]) {
 			return errors.Errorf("%q seems to be a file but not found", c.keys[0])
 		} else {
-			return errors.Errorf("%q seems to be neither a file nor a key of the currently targeted model: %q", c.keys[0], attrs["name"])
+			mod, _ := c.ModelIdentifier()
+			return errors.Errorf("%q seems to be neither a file nor a key of the currently targeted model: %q",
+				c.keys[0], mod)
 		}
 	}
 	return nil

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -106,7 +106,8 @@ func (s *ConfigCommandSuite) TestSingleValueOutputFile(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestGetUnknownValue(c *gc.C) {
 	context, err := s.run(c, "unknown")
-	c.Assert(err, gc.ErrorMatches, `"unknown" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+	c.Assert(err, gc.ErrorMatches,
+		`"unknown" seems to be neither a file nor a key of the currently targeted model: "king/sword"`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")
@@ -130,7 +131,8 @@ func (s *ConfigCommandSuite) TestGetFileLike(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestNotFileLike(c *gc.C) {
 	context, err := s.run(c, "bundles/k8s-model-config--json")
-	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config--json" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+	c.Assert(err, gc.ErrorMatches,
+		`"bundles/k8s-model-config--json" seems to be neither a file nor a key of the currently targeted model: "king/sword"`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")
@@ -138,7 +140,8 @@ func (s *ConfigCommandSuite) TestNotFileLike(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestNotFileLikeEndsWithDot(c *gc.C) {
 	context, err := s.run(c, "bundles/k8s-model-config.")
-	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config." seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+	c.Assert(err, gc.ErrorMatches,
+		`"bundles/k8s-model-config." seems to be neither a file nor a key of the currently targeted model: "king/sword"`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")
@@ -146,7 +149,8 @@ func (s *ConfigCommandSuite) TestNotFileLikeEndsWithDot(c *gc.C) {
 
 func (s *ConfigCommandSuite) TestNotFileLikeEndsTooLong(c *gc.C) {
 	context, err := s.run(c, "bundles/k8s-model-config.fksdkfsd")
-	c.Assert(err, gc.ErrorMatches, `"bundles/k8s-model-config.fksdkfsd" seems to be neither a file nor a key of the currently targeted model: {<nil> \"\"}`)
+	c.Assert(err, gc.ErrorMatches,
+		`"bundles/k8s-model-config.fksdkfsd" seems to be neither a file nor a key of the currently targeted model: "king/sword"`)
 
 	output := cmdtesting.Stdout(context)
 	c.Assert(output, gc.Equals, "")

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -591,7 +591,7 @@ func newBindingsFromIDs(verificationMap, givenMap map[string]string) (map[string
 // MapWithSpaceNames returns the current bindingMap with space names rather than ids.
 func (b *Bindings) MapWithSpaceNames() (map[string]string, error) {
 	retVal := make(map[string]string, len(b.bindingsMap))
-	namesToIDs, err := b.st.SpaceNamesByID()
+	idsToNames, err := b.st.SpaceNamesByID()
 	if err != nil {
 		return nil, err
 	}
@@ -599,11 +599,11 @@ func (b *Bindings) MapWithSpaceNames() (map[string]string, error) {
 	// Assume that b.bindings is always in space id format due to
 	// Bindings constructor.
 	for k, v := range b.bindingsMap {
-		spaceID, found := namesToIDs[v]
+		spaceName, found := idsToNames[v]
 		if !found {
-			return nil, errors.NotFoundf("space id for space %q", v)
+			return nil, errors.NotFoundf("space with ID %q", v)
 		}
-		retVal[k] = spaceID
+		retVal[k] = spaceName
 	}
 	return retVal, nil
 }


### PR DESCRIPTION
## Description of change

This patch contains a couple of minor fixes stemming from investigation of another bug.
- The current model is displayed with error message output for bad keys as arguments to `model-config`.
- Variables and not-found error output is manipulated for binding space lookups to better indicate the id-to-name transformation.

## QA steps

- `juju model-config banana`.
- Output should be `ERROR "banana" seems to be neither a file nor a key of the currently targeted model: "admin/default"`.
- `juju add-model tester`.
- `juju model-config banana -m tester`.
- Output should be `ERROR "banana" seems to be neither a file nor a key of the currently targeted model: "admin/tester"`.

## Documentation changes

None.

## Bug reference

N/A
