### PR TITLE
Fix test failure due to RSA PSS signatures.

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -95,7 +95,7 @@ func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	s.MgoSuite.SetUpSuite(c)
 	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	s.PatchValue(&cert.NewCA, coretesting.NewCA)
-	s.PatchValue(&cert.NewLeafKeyBits, 512)
+	s.PatchValue(&cert.NewLeafKeyBits, 1024)
 }
 
 func (s *BootstrapSuite) SetUpTest(c *gc.C) {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -152,7 +152,7 @@ func (s *JujuConnSuite) SetUpSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
 	s.PatchValue(&utils.OutgoingAccessAllowed, false)
 	s.PatchValue(&cert.NewCA, testing.NewCA)
-	s.PatchValue(&cert.NewLeafKeyBits, 512)
+	s.PatchValue(&cert.NewLeafKeyBits, 1024)
 	s.PatchValue(&paths.Chown, func(name string, uid, gid int) error { return nil })
 }
 

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -36,7 +36,7 @@ var _ = gc.Suite(&CertUpdaterSuite{})
 
 func (s *CertUpdaterSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.PatchValue(&jujucert.NewLeafKeyBits, 512)
+	s.PatchValue(&jujucert.NewLeafKeyBits, 1024)
 
 	s.stateServingInfo = params.StateServingInfo{
 		Cert:         coretesting.ServerCert,


### PR DESCRIPTION
## Description of change

Testing RSA private keys are too small to encode a PSS signature.
Only affects test runs on newer versions of Go.

## QA steps

Run tests.

## Documentation changes

N/A

## Bug reference

N/A
