### PR TITLE
Fix cross device link in testing.

### DIFF
--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -249,6 +249,10 @@ func (b *buildSuite) setUpFakeBinaries(c *gc.C, versionFile string) string {
 	testBinary := filepath.Join(dir, "tst")
 	os.Args[0] = testBinary
 	err = os.Link(oldArg0, testBinary)
+	if _, ok := err.(*os.LinkError); ok {
+		// Soft link when cross device.
+		err = os.Symlink(oldArg0, testBinary)
+	}
 	c.Assert(err, jc.ErrorIsNil)
 	b.AddCleanup(func(c *gc.C) {
 		os.Args[0] = oldArg0


### PR DESCRIPTION
## Description of change

When precompiling the test package and using a different device for /tmp the test attempts to make a cross device hard link. This tries a soft link when the hard link fails.

## QA steps

N/A

## Documentation changes

N/A

## Bug reference

N/A
