### PR TITLE
Update manual provisioned machine check

### DIFF
--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -181,7 +181,7 @@ func checkProvisioned(host string) (bool, error) {
 	}
 
 	output := strings.TrimSpace(stdout.String())
-	provisioned := strings.Contains(output, "juju")
+	provisioned := strings.Contains(output, "jujud")
 	return provisioned, nil
 }
 


### PR DESCRIPTION
If it not enough to check for a "juju" process to find out if the machine is provisioned.
Example - the machine can run juju command (when provisioning itself).
All juju machine-related services run as "jujud"

## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?

----

## Description of change

*Please replace with a description about why this change is needed, along with a description of what changed?*

## QA steps

*Please replace with how we can verify that the change works?*

```sh
QA steps here
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?*

## Bug reference

*Please add a link to any bugs that this change is related to.*
