### PR TITLE
Retry the mongo config

### DIFF
--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -16,7 +16,18 @@ run_mongo_memory_profile() {
 
     sleep 5
 
-    check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB
+    attempt=0
+    # shellcheck disable=SC2046,SC2143,SC2091
+    until $(check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB 2>&1 >/dev/null); do
+        echo "[+] (attempt ${attempt}) polling mongo service"
+        cat_mongo_service | sed 's/^/    | /g'
+        if [ "${attempt}" -ge 4 ]; then
+            echo "Failed: expected wiredTigerCacheSizeGB to be set in mongo service."
+            exit 1
+        fi
+        sleep 5
+        attempt=$((attempt+1))
+    done
 
     # Set the value back in case we are reusing a controller
     juju controller-config mongo-memory-profile=default


### PR DESCRIPTION
### Checklist

 - [ ] ~~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?

----

## Description of change

The following attempts to get the mongo memory profile to check that
it has been set in the config. It would seem that sometimes the
mongo service is slow and so it requires that to change, so that it
can then be correctly reflected in the config.

## QA steps

```sh
cd tests && ./main.sh controller
```
