### PR TITLE
Fix fixture panic on eoan.

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -310,7 +310,7 @@ func (s *BootstrapSuite) initBootstrapCommand(c *gc.C, jobs []model.MachineJob, 
 		Nonce:             agent.BootstrapNonce,
 		Controller:        testing.ControllerTag,
 		Model:             testing.ModelTag,
-		APIAddresses:      []string{"0.1.2.3:1234"},
+		APIAddresses:      []string{"127.0.0.2:1234"},
 		CACert:            testing.CACert,
 		Values: map[string]string{
 			agent.Namespace:      "foobar",


### PR DESCRIPTION
## Description of change

Fixes a panic inside the BootstrapSuite tear down due to mgo cluster stuck trying to connect to `0.1.2.3`. Removing the timeout check in testing.MgoSuite tear down would also fix this, but waits a long time until the connect times out. Using a locally reachable address so the connection can be refused.

## QA steps

On eoan:
`go test github.com/juju/juju/cmd/jujud/agent -check.f="BootstrapSuite"`

## Documentation changes

N/A

## Bug reference

N/A
