### PR TITLE
All watcher worker - not yet used

### DIFF
--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -96,6 +96,7 @@ func (ms *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
 			"model-cache-initialized-flag",
 			"model-cache-initialized-gate",
 			"model-worker-manager",
+			"multiwatcher",
 			"peer-grouper",
 			"presence",
 			"proxy-config-updater",
@@ -166,6 +167,7 @@ func (ms *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
 			"model-cache-initialized-flag",
 			"model-cache-initialized-gate",
 			"model-worker-manager",
+			"multiwatcher",
 			"peer-grouper",
 			"presence",
 			"proxy-config-updater",
@@ -242,6 +244,7 @@ func (ms *ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"model-cache-initialized-flag",
 		"model-cache-initialized-gate",
 		"model-worker-manager",
+		"multiwatcher",
 		"peer-grouper",
 		"presence",
 		"pubsub-forwarder",
@@ -294,6 +297,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"model-cache",
 		"model-cache-initialized-flag",
 		"model-cache-initialized-gate",
+		"multiwatcher",
 		"lease-manager",
 		"legacy-leases-flag",
 		"raft-transport",
@@ -774,6 +778,15 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-check-gate",
 		"upgrade-steps-flag",
 		"upgrade-steps-gate",
+	},
+
+	"multiwatcher": {
+		"agent",
+		"is-controller-flag",
+		"state",
+		"state-config-watcher",
+		"upgrade-database-flag",
+		"upgrade-database-gate",
 	},
 
 	"peer-grouper": {

--- a/state/workers.go
+++ b/state/workers.go
@@ -193,7 +193,7 @@ func (ws *workers) allModelManager(pool *StatePool) *storeManager {
 		return newDeadStoreManager(errors.Trace(err))
 	}
 	ws.StartWorker(allModelManagerWorker, func() (worker.Worker, error) {
-		return newStoreManager(NewAllModelWatcherStateBacking(ws.state, pool)), nil
+		return newStoreManager(NewAllWatcherBacking(pool)), nil
 	})
 	return ws.allModelManager(pool)
 }

--- a/worker/multiwatcher/doc.go
+++ b/worker/multiwatcher/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package multiwatcher provides watchers that watch the entire model.
+//
+// The package is responsible for creating, feeding, and cleaning up after
+// multiwatchers. The core worker gets an event stream from an
+// AllWatcherBacking, and manages the multiwatcher Store.
+//
+// The behaviour of the multiwatchers is very much tied to the Store implementation.
+// The store provides a mechanism to get changes over time.
+package multiwatcher

--- a/worker/multiwatcher/manifold.go
+++ b/worker/multiwatcher/manifold.go
@@ -1,0 +1,117 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// TODO: go through since this was just copied from the modelcache
+
+package multiwatcher
+
+import (
+	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+
+	"github.com/juju/juju/core/multiwatcher"
+	"github.com/juju/juju/state"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// Logger describes the logging methods used in this package by the worker.
+type Logger interface {
+	IsTraceEnabled() bool
+	Tracef(string, ...interface{})
+	Errorf(string, ...interface{})
+	Criticalf(string, ...interface{})
+}
+
+// ManifoldConfig holds the information necessary to run a model cache worker in
+// a dependency.Engine.
+type ManifoldConfig struct {
+	StateName string
+	Logger    Logger
+
+	// NOTE: what metrics do we want to expose here?
+	// loop restart count for one.
+	PrometheusRegisterer prometheus.Registerer
+
+	NewWorker     func(Config) (worker.Worker, error)
+	NewAllWatcher func(*state.StatePool) state.AllWatcherBacking
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("missing PrometheusRegisterer")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("missing NewWorker func")
+	}
+	if config.NewAllWatcher == nil {
+		return errors.NotValidf("missing NewAllWatcher func")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run a model cache
+// worker. The manifold outputs a *cache.Controller, primarily for
+// the apiserver to depend on and use.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start:  config.start,
+		Output: WorkerFactory,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var stTracker workerstate.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	pool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w, err := config.NewWorker(Config{
+		Logger:               config.Logger,
+		Backing:              config.NewAllWatcher(pool),
+		PrometheusRegisterer: config.PrometheusRegisterer,
+		Cleanup:              func() { _ = stTracker.Done() },
+	})
+	if err != nil {
+		_ = stTracker.Done()
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// WorkerFactory extracts a Factory from a *Worker.
+func WorkerFactory(in worker.Worker, out interface{}) error {
+	inWorker, _ := in.(*Worker)
+	if inWorker == nil {
+		return errors.Errorf("in should be a %T; got %T", inWorker, in)
+	}
+
+	switch outPointer := out.(type) {
+	case *multiwatcher.Factory:
+		// The worker itself is the factory.
+		*outPointer = inWorker
+	default:
+		return errors.Errorf("out should be *multiwatcher.Factory; got %T", out)
+	}
+	return nil
+}

--- a/worker/multiwatcher/manifold.go
+++ b/worker/multiwatcher/manifold.go
@@ -1,7 +1,5 @@
-// Copyright 2018 Canonical Ltd.
+// Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
-
-// TODO: go through since this was just copied from the modelcache
 
 package multiwatcher
 

--- a/worker/multiwatcher/manifold_test.go
+++ b/worker/multiwatcher/manifold_test.go
@@ -1,0 +1,183 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher_test
+
+import (
+	"unsafe"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
+	dt "gopkg.in/juju/worker.v1/dependency/testing"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/multiwatcher"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	config multiwatcher.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = multiwatcher.ManifoldConfig{
+		StateName:            "state",
+		Logger:               loggo.GetLogger("test"),
+		PrometheusRegisterer: noopRegisterer{},
+		NewWorker: func(multiwatcher.Config) (worker.Worker, error) {
+			return nil, errors.New("boom")
+		},
+		NewAllWatcher: func(*state.StatePool) state.AllWatcherBacking {
+			return &fakeAllWatcher{}
+		},
+	}
+}
+
+func (s *ManifoldSuite) manifold() dependency.Manifold {
+	return multiwatcher.Manifold(s.config)
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Check(s.manifold().Inputs, jc.DeepEquals, []string{"state"})
+}
+
+func (s *ManifoldSuite) TestConfigValidation(c *gc.C) {
+	err := s.config.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingStateName(c *gc.C) {
+	s.config.StateName = ""
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "empty StateName not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingPrometheusRegisterer(c *gc.C) {
+	s.config.PrometheusRegisterer = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing PrometheusRegisterer not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Logger not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingNewWorker(c *gc.C) {
+	s.config.NewWorker = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing NewWorker func not valid")
+}
+
+func (s *ManifoldSuite) TestManifoldCallsValidate(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{})
+	s.config.Logger = nil
+	w, err := s.manifold().Start(context)
+	c.Check(w, gc.IsNil)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `missing Logger not valid`)
+}
+
+func (s *ManifoldSuite) TestStateMissing(c *gc.C) {
+	context := dt.StubContext(nil, map[string]interface{}{
+		"state": dependency.ErrMissing,
+	})
+
+	w, err := s.manifold().Start(context)
+	c.Check(w, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestNewWorkerArgs(c *gc.C) {
+	var config multiwatcher.Config
+	s.config.NewWorker = func(c multiwatcher.Config) (worker.Worker, error) {
+		config = c
+		return &fakeWorker{}, nil
+	}
+
+	tracker := &fakeStateTracker{}
+	context := dt.StubContext(nil, map[string]interface{}{
+		"state": tracker,
+	})
+
+	w, err := s.manifold().Start(context)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(w, gc.NotNil)
+
+	c.Check(config.Validate(), jc.ErrorIsNil)
+	c.Check(config.Logger, gc.Equals, s.config.Logger)
+	c.Check(config.PrometheusRegisterer, gc.Equals, s.config.PrometheusRegisterer)
+
+	c.Check(tracker.released, jc.IsFalse)
+	config.Cleanup()
+	c.Check(tracker.released, jc.IsTrue)
+}
+
+func (s *ManifoldSuite) TestNewWorkerErrorReleasesState(c *gc.C) {
+	tracker := &fakeStateTracker{}
+	context := dt.StubContext(nil, map[string]interface{}{
+		"state": tracker,
+	})
+
+	worker, err := s.manifold().Start(context)
+	c.Check(err, gc.ErrorMatches, "boom")
+	c.Check(worker, gc.IsNil)
+	c.Check(tracker.released, jc.IsTrue)
+}
+
+type fakeWorker struct {
+	worker.Worker
+}
+
+type fakeStateTracker struct {
+	workerstate.StateTracker
+	released bool
+}
+
+// Return an invalid but non-zero state pool pointer.
+// Is only ever used for comparison.
+func (f *fakeStateTracker) Use() (*state.StatePool, error) {
+	return f.pool(), nil
+}
+
+// pool returns a non-nil but invalid pointer to a state pool.
+func (f *fakeStateTracker) pool() *state.StatePool {
+	return (*state.StatePool)(unsafe.Pointer(f))
+}
+
+// Done tracks that the used pool is released.
+func (f *fakeStateTracker) Done() error {
+	f.released = true
+	return nil
+}
+
+type noopRegisterer struct {
+	prometheus.Registerer
+}
+
+func (noopRegisterer) Register(prometheus.Collector) error {
+	return nil
+}
+
+func (noopRegisterer) Unregister(prometheus.Collector) bool {
+	return true
+}
+
+type fakeAllWatcher struct {
+	state.AllWatcherBacking
+}

--- a/worker/multiwatcher/manifold_test.go
+++ b/worker/multiwatcher/manifold_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Canonical Ltd.
+// Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package multiwatcher_test

--- a/worker/multiwatcher/metrics.go
+++ b/worker/multiwatcher/metrics.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const metricsNamespace = "juju_multiwatcher"
+
+// Collector is a prometheus.Collector that collects metrics about
+// multiwatcher worker.
+type Collector struct {
+	worker *Worker
+
+	watcherCount prometheus.Gauge
+	restartCount prometheus.Gauge
+	storeSize    prometheus.Gauge
+}
+
+// NewMetricsCollector returns a new Collector.
+func NewMetricsCollector(worker *Worker) *Collector {
+	return &Collector{
+		worker: worker,
+		watcherCount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "watcher_count",
+				Help:      "The number of multiwatcher type watchers there are.",
+			},
+		),
+		restartCount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "restart_count",
+				Help:      "The number of times the all watcher has been restarted.",
+			},
+		),
+		storeSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "store_size",
+				Help:      "The number of entities in the store.",
+			},
+		),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.watcherCount.Describe(ch)
+	c.restartCount.Describe(ch)
+	c.storeSize.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	// The report deals with the synchronization requirements.
+	report := c.worker.Report()
+
+	floatValue := func(key string) float64 {
+		return float64(report[key].(int))
+	}
+
+	c.watcherCount.Set(floatValue(reportWatcherKey))
+	c.restartCount.Set(floatValue(reportRestartKey))
+	c.storeSize.Set(floatValue(reportStoreKey))
+
+	c.watcherCount.Collect(ch)
+	c.restartCount.Collect(ch)
+	c.storeSize.Collect(ch)
+}

--- a/worker/multiwatcher/package_test.go
+++ b/worker/multiwatcher/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/worker/multiwatcher/testbacking/backing.go
+++ b/worker/multiwatcher/testbacking/backing.go
@@ -1,0 +1,170 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testbacking
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/multiwatcher"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/testing"
+)
+
+// Backing is a test state AllWatcherBacking
+type Backing struct {
+	mu       sync.Mutex
+	fetchErr error
+	entities map[multiwatcher.EntityID]multiwatcher.EntityInfo
+	watchc   chan<- watcher.Change
+	txnRevno int64
+}
+
+// New returns a new test backing.
+func New(initial []multiwatcher.EntityInfo) *Backing {
+	b := &Backing{
+		entities: make(map[multiwatcher.EntityID]multiwatcher.EntityInfo),
+	}
+	for _, info := range initial {
+		b.entities[info.EntityID()] = info
+	}
+	return b
+}
+
+// Changed process the change event from the state base watcher.
+func (b *Backing) Changed(store multiwatcher.Store, change watcher.Change) error {
+	modelUUID, changeID, ok := SplitDocID(change.Id.(string))
+	if !ok {
+		return errors.Errorf("unexpected id format: %v", change.Id)
+	}
+	id := multiwatcher.EntityID{
+		Kind:      change.C,
+		ModelUUID: modelUUID,
+		ID:        changeID,
+	}
+	info, err := b.fetch(id)
+	if errors.IsNotFound(err) {
+		store.Remove(id)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	store.Update(info)
+	return nil
+}
+
+func (b *Backing) fetch(id multiwatcher.EntityID) (multiwatcher.EntityInfo, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.fetchErr != nil {
+		return nil, b.fetchErr
+	}
+	if info, ok := b.entities[id]; ok {
+		return info, nil
+	}
+	return nil, errors.NotFoundf("%s.%s", id.Kind, id.ID)
+}
+
+// Watch sets up the channel for the events.
+func (b *Backing) Watch(c chan<- watcher.Change) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.watchc != nil {
+		panic("test backing can only watch once")
+	}
+	b.watchc = c
+}
+
+// Unwatch clears the channel for the events.
+func (b *Backing) Unwatch(c chan<- watcher.Change) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if c != b.watchc {
+		panic("unwatching wrong channel")
+	}
+	b.watchc = nil
+}
+
+// GetAll does the initial population of the store.
+func (b *Backing) GetAll(store multiwatcher.Store) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, info := range b.entities {
+		store.Update(info)
+	}
+	return nil
+}
+
+// UpdateEntity allows the test to push an update.
+func (b *Backing) UpdateEntity(info multiwatcher.EntityInfo) {
+	b.mu.Lock()
+	id := info.EntityID()
+	b.entities[id] = info
+	b.txnRevno++
+	change := watcher.Change{
+		C:     id.Kind,
+		Id:    EnsureModelUUID(id.ModelUUID, id.ID),
+		Revno: b.txnRevno, // This is actually ignored, but fill it in anyway.
+	}
+	listener := b.watchc
+	b.mu.Unlock()
+	if b.watchc != nil {
+		select {
+		case listener <- change:
+		case <-time.After(testing.LongWait):
+			panic("watcher isn't reading off channel")
+
+		}
+	}
+}
+
+// SetFetchError queues up an error to return on the next fetch.
+func (b *Backing) SetFetchError(err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.fetchErr = err
+}
+
+// DeleteEntity allows the test to push a delete through the test.
+func (b *Backing) DeleteEntity(id multiwatcher.EntityID) {
+	b.mu.Lock()
+	delete(b.entities, id)
+	change := watcher.Change{
+		C:     id.Kind,
+		Id:    EnsureModelUUID(id.ModelUUID, id.ID),
+		Revno: -1,
+	}
+	b.txnRevno++
+	listener := b.watchc
+	b.mu.Unlock()
+	if b.watchc != nil {
+		select {
+		case listener <- change:
+		case <-time.After(testing.LongWait):
+			panic("watcher isn't reading off channel")
+		}
+	}
+}
+
+// EnsureModelUUID is exported as it is used in other _test files.
+func EnsureModelUUID(modelUUID, id string) string {
+	prefix := modelUUID + ":"
+	if strings.HasPrefix(id, prefix) {
+		return id
+	}
+	return prefix + id
+}
+
+// SplitDocID is exported as it is used in other _test files.
+func SplitDocID(id string) (string, string, bool) {
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/worker/multiwatcher/watcher.go
+++ b/worker/multiwatcher/watcher.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/multiwatcher"
+)
+
+type control interface {
+	Dying() <-chan struct{}
+	Err() error
+}
+
+// Watcher watches any changes to the state.
+type Watcher struct {
+	request chan *request
+	control control
+	logger  Logger
+	err     chan error
+
+	filter func([]multiwatcher.Delta) []multiwatcher.Delta
+
+	// The following fields are maintained by the Worker goroutine.
+	revno   int64
+	stopped bool
+
+	// used indicates that the watcher was used (i.e. Next() called).
+	used bool
+}
+
+// Stop stops the watcher.
+func (w *Watcher) Stop() error {
+	select {
+	case w.request <- &request{watcher: w}:
+		// We asked to be stopped, and this is processed.
+	case _, stillOpen := <-w.err:
+		// We have been stopped already.
+		if stillOpen {
+			close(w.err)
+		}
+		// Since we are asking to stop, we don't care about the underlying
+		// error from the read.
+	case <-w.control.Dying():
+		// The worker is dying and we will be cleaned up.
+	}
+	// In all of the above cases, we're fine, and don't need to return an
+	// error that would be logged.
+	return nil
+}
+
+// Next retrieves all changes that have happened since the last
+// time it was called, blocking until there are some changes available.
+//
+// The result from the initial call to Next() is different from
+// subsequent calls. The latter will reflect changes that have happened
+// since the last Next() call. In contrast, the initial Next() call will
+// return the deltas that represent the model's complete state at that
+// moment, even when the model is empty. In that empty model case an
+// empty set of deltas is returned.
+func (w *Watcher) Next() ([]multiwatcher.Delta, error) {
+	// In order to be able to apply the filter, yet not signal the caller when
+	// all deltas were filtered out, we need an outer loop.
+	var changes []multiwatcher.Delta
+	for len(changes) == 0 {
+		req := &request{
+			watcher: w,
+			reply:   make(chan bool),
+		}
+		if !w.used {
+			req.noChanges = make(chan struct{})
+			w.used = true
+		}
+
+		select {
+		case err, open := <-w.err:
+			if open {
+				w.logger.Tracef("hit an error: %v", err)
+				close(w.err)
+				return nil, errors.Trace(err)
+			}
+			w.logger.Tracef("err channel closed")
+			return nil, errors.Trace(multiwatcher.NewErrStopped())
+		case <-w.control.Dying():
+			w.logger.Tracef("worker dying")
+			err := w.control.Err()
+			if err == nil {
+				err = multiwatcher.ErrStoppedf("shared state watcher")
+			}
+			return nil, err
+		case w.request <- req:
+		}
+
+		select {
+		case err, open := <-w.err:
+			if open {
+				w.logger.Tracef("hit an error: %v", err)
+				close(w.err)
+				return nil, errors.Trace(err)
+			}
+			w.logger.Tracef("err channel closed")
+			return nil, errors.Trace(multiwatcher.NewErrStopped())
+		case <-w.control.Dying():
+			w.logger.Tracef("worker dying")
+			err := w.control.Err()
+			if err == nil {
+				err = multiwatcher.ErrStoppedf("shared state watcher")
+			}
+			return nil, err
+		case ok := <-req.reply:
+			if !ok {
+				return nil, errors.Trace(multiwatcher.NewErrStopped())
+			}
+		case <-req.noChanges:
+			return []multiwatcher.Delta{}, nil
+		}
+
+		changes = req.changes
+		w.logger.Tracef("received %d changes", len(changes))
+		if w.filter != nil {
+			changes = w.filter(changes)
+			if len(changes) == 0 {
+				w.logger.Tracef("filtered out all changes, looping")
+			}
+		}
+	}
+	w.logger.Tracef("returning %d changes", len(changes))
+	return changes, nil
+}

--- a/worker/multiwatcher/watcher_test.go
+++ b/worker/multiwatcher/watcher_test.go
@@ -74,7 +74,7 @@ func (s *watcherSuite) TestRun(c *gc.C) {
 	}, "")
 }
 
-func (s *watcherSuite) TestMultiplemodels(c *gc.C) {
+func (s *watcherSuite) TestMultipleModels(c *gc.C) {
 	b := testbacking.New([]multiwatcher.EntityInfo{
 		&multiwatcher.MachineInfo{ModelUUID: "uuid0", ID: "0"},
 		&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging"},

--- a/worker/multiwatcher/watcher_test.go
+++ b/worker/multiwatcher/watcher_test.go
@@ -1,0 +1,308 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/multiwatcher"
+	"github.com/juju/juju/state"
+	mwWorker "github.com/juju/juju/worker/multiwatcher"
+	"github.com/juju/juju/worker/multiwatcher/testbacking"
+)
+
+type watcherSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&watcherSuite{})
+
+func (s *watcherSuite) startWorker(c *gc.C, backing state.AllWatcherBacking) *mwWorker.Worker {
+	logger := loggo.GetLogger("test")
+	logger.SetLogLevel(loggo.TRACE)
+	config := mwWorker.Config{
+		Logger:               logger,
+		Backing:              backing,
+		PrometheusRegisterer: noopRegisterer{},
+	}
+	w, err := mwWorker.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.CleanKill(c, w)
+	})
+	return w
+}
+
+func (s *watcherSuite) TestEmptyModel(c *gc.C) {
+	b := testbacking.New(nil)
+	f := s.startWorker(c, b)
+	w := f.WatchController()
+	checkNext(c, w, nil, "")
+}
+
+func (s *watcherSuite) TestRun(c *gc.C) {
+	b := testbacking.New([]multiwatcher.EntityInfo{
+		&multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "0"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid", Name: "logging"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid", Name: "wordpress"},
+	})
+	mw := s.startWorker(c, b)
+	w := mw.WatchController()
+
+	checkNext(c, w, []multiwatcher.Delta{
+		{Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "0"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid", Name: "logging"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid", Name: "wordpress"}},
+	}, "")
+
+	b.UpdateEntity(&multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "0", InstanceID: "i-0"})
+	checkNext(c, w, []multiwatcher.Delta{
+		{Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "0", InstanceID: "i-0"}},
+	}, "")
+
+	b.DeleteEntity(multiwatcher.EntityID{"machine", "uuid", "0"})
+	checkNext(c, w, []multiwatcher.Delta{
+		{Removed: true, Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "0"}},
+	}, "")
+}
+
+func (s *watcherSuite) TestMultiplemodels(c *gc.C) {
+	b := testbacking.New([]multiwatcher.EntityInfo{
+		&multiwatcher.MachineInfo{ModelUUID: "uuid0", ID: "0"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "wordpress"},
+		&multiwatcher.MachineInfo{ModelUUID: "uuid1", ID: "0"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid1", Name: "logging"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid1", Name: "wordpress"},
+		&multiwatcher.MachineInfo{ModelUUID: "uuid2", ID: "0"},
+	})
+	mw := s.startWorker(c, b)
+	w := mw.WatchController()
+
+	checkNext(c, w, []multiwatcher.Delta{
+		{Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid0", ID: "0"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "wordpress"}},
+		{Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid1", ID: "0"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid1", Name: "logging"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid1", Name: "wordpress"}},
+		{Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid2", ID: "0"}},
+	}, "")
+
+	b.UpdateEntity(&multiwatcher.MachineInfo{ModelUUID: "uuid1", ID: "0", InstanceID: "i-0"})
+	checkNext(c, w, []multiwatcher.Delta{
+		{Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid1", ID: "0", InstanceID: "i-0"}},
+	}, "")
+
+	b.DeleteEntity(multiwatcher.EntityID{"machine", "uuid2", "0"})
+	checkNext(c, w, []multiwatcher.Delta{
+		{Removed: true, Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid2", ID: "0"}},
+	}, "")
+
+	b.UpdateEntity(&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging", Exposed: true})
+	checkNext(c, w, []multiwatcher.Delta{
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging", Exposed: true}},
+	}, "")
+}
+
+func (s *watcherSuite) TestModelFiltering(c *gc.C) {
+	b := testbacking.New([]multiwatcher.EntityInfo{
+		&multiwatcher.MachineInfo{ModelUUID: "uuid0", ID: "0"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "wordpress"},
+		&multiwatcher.MachineInfo{ModelUUID: "uuid1", ID: "0"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid1", Name: "logging"},
+		&multiwatcher.ApplicationInfo{ModelUUID: "uuid1", Name: "wordpress"},
+		&multiwatcher.MachineInfo{ModelUUID: "uuid2", ID: "0"},
+	})
+	mw := s.startWorker(c, b)
+	w := watchWatcher(c, mw.WatchModel("uuid0"))
+	c.Logf("w.assertNext")
+	w.assertNext([]multiwatcher.Delta{
+		{Entity: &multiwatcher.MachineInfo{ModelUUID: "uuid0", ID: "0"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging"}},
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "wordpress"}},
+	})
+	c.Logf("w.assertNext")
+
+	// Updating uuid1 shouldn't signal a next call
+	b.UpdateEntity(&multiwatcher.MachineInfo{ModelUUID: "uuid1", ID: "0", InstanceID: "i-0"})
+	b.DeleteEntity(multiwatcher.EntityID{"machine", "uuid2", "0"})
+	c.Logf("w.assertNext")
+	w.assertNoChange()
+
+	c.Logf("w.assertNext")
+	b.UpdateEntity(&multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging", Exposed: true})
+	w.assertNext([]multiwatcher.Delta{
+		{Entity: &multiwatcher.ApplicationInfo{ModelUUID: "uuid0", Name: "logging", Exposed: true}},
+	})
+}
+
+func (s *watcherSuite) TestWatcherStop(c *gc.C) {
+	mw := s.startWorker(c, testbacking.New(nil))
+	w := mw.WatchController()
+
+	err := w.Stop()
+	c.Assert(err, jc.ErrorIsNil)
+	checkNext(c, w, nil, multiwatcher.NewErrStopped().Error())
+}
+
+func (s *watcherSuite) TestWatcherStopBecauseBackingError(c *gc.C) {
+	b := testbacking.New([]multiwatcher.EntityInfo{&multiwatcher.MachineInfo{ID: "0"}})
+	mw := s.startWorker(c, b)
+	w := mw.WatchController()
+
+	// Receive one delta to make sure that the storeManager
+	// has seen the initial state.
+	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{ID: "0"}}}, "")
+	c.Logf("setting fetch error")
+	b.SetFetchError(errors.New("some error"))
+
+	c.Logf("updating entity")
+	b.UpdateEntity(&multiwatcher.MachineInfo{ID: "1"})
+	checkNext(c, w, nil, "some error")
+}
+
+func (s *watcherSuite) TestWatcherErrorWhenWorkerStopped(c *gc.C) {
+	b := testbacking.New([]multiwatcher.EntityInfo{&multiwatcher.MachineInfo{ID: "0"}})
+	mw := s.startWorker(c, b)
+	w := mw.WatchController()
+
+	// Receive one delta to make sure that the storeManager
+	// has seen the initial state.
+	checkNext(c, w, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{ID: "0"}}}, "")
+
+	workertest.CleanKill(c, mw)
+
+	b.UpdateEntity(&multiwatcher.MachineInfo{ID: "1"})
+
+	d, err := w.Next()
+	c.Assert(err, gc.ErrorMatches, "shared state watcher was stopped")
+	c.Assert(err, jc.Satisfies, multiwatcher.IsErrStopped)
+	c.Assert(d, gc.HasLen, 0)
+}
+
+func getNext(c *gc.C, w multiwatcher.Watcher, timeout time.Duration) ([]multiwatcher.Delta, error) {
+	var deltas []multiwatcher.Delta
+	var err error
+	ch := make(chan struct{}, 1)
+	go func() {
+		deltas, err = w.Next()
+		ch <- struct{}{}
+	}()
+	select {
+	case <-ch:
+		return deltas, err
+	case <-time.After(timeout):
+	}
+	return nil, errors.New("no change received in sufficient time")
+}
+
+func checkNext(c *gc.C, w multiwatcher.Watcher, deltas []multiwatcher.Delta, expectErr string) {
+	d, err := getNext(c, w, 1*time.Second)
+	if expectErr != "" {
+		c.Check(err, gc.ErrorMatches, expectErr)
+		return
+	}
+	c.Assert(err, jc.ErrorIsNil)
+	checkDeltasEqual(c, d, deltas)
+}
+
+func checkDeltasEqual(c *gc.C, d0, d1 []multiwatcher.Delta) {
+	// Deltas are returned in arbitrary order, so we compare them as maps.
+	c.Check(deltaMap(d0), jc.DeepEquals, deltaMap(d1))
+}
+
+func deltaMap(deltas []multiwatcher.Delta) map[interface{}]multiwatcher.EntityInfo {
+	m := make(map[interface{}]multiwatcher.EntityInfo)
+	for _, d := range deltas {
+		id := d.Entity.EntityID()
+		if d.Removed {
+			m[id] = nil
+		} else {
+			m[id] = d.Entity
+		}
+	}
+	return m
+}
+
+// Need a way to test Next calls that block. This is needed to test filtering.
+
+type watcher struct {
+	c      *gc.C
+	inner  multiwatcher.Watcher
+	next   chan []multiwatcher.Delta
+	err    chan error
+	logger loggo.Logger
+}
+
+func watchWatcher(c *gc.C, w multiwatcher.Watcher) *watcher {
+	result := &watcher{
+		c:     c,
+		inner: w,
+		// We use a buffered channels here so the final next call that returns
+		// an error when the worker stops can be pushed to the channel and allow
+		// the goroutine to stop.
+		next:   make(chan []multiwatcher.Delta, 1),
+		err:    make(chan error, 1),
+		logger: loggo.GetLogger("test"),
+	}
+	go result.loop()
+	return result
+}
+
+func (w *watcher) loop() {
+	for true {
+		deltas, err := w.inner.Next()
+		if err != nil {
+			w.err <- err
+			return
+		}
+		select {
+		case w.next <- deltas:
+			w.logger.Tracef("sent %d deltas down next", len(deltas))
+		case <-time.After(testing.LongWait):
+			w.c.Fatalf("no one listening")
+		}
+	}
+}
+
+func (w *watcher) assertNextErr(expectErr string) {
+	select {
+	case err := <-w.err:
+		w.c.Assert(err, gc.ErrorMatches, expectErr)
+	case next := <-w.next:
+		w.c.Fatalf("unexpected results %#v", next)
+	case <-time.After(testing.LongWait):
+		w.c.Fatalf("no results returned")
+	}
+}
+func (w *watcher) assertNext(deltas []multiwatcher.Delta) {
+	select {
+	case err := <-w.err:
+		w.c.Fatalf("watcher had err: %v", err)
+	case next := <-w.next:
+		checkDeltasEqual(w.c, next, deltas)
+	case <-time.After(testing.LongWait):
+		w.c.Fatalf("no results returned")
+	}
+}
+
+func (w *watcher) assertNoChange() {
+	select {
+	case <-time.After(testing.ShortWait):
+		// all good
+	case err := <-w.err:
+		w.c.Fatalf("watcher had err: %v", err)
+	case next := <-w.next:
+		w.c.Fatalf("unexpected results %#v", next)
+	}
+}

--- a/worker/multiwatcher/worker.go
+++ b/worker/multiwatcher/worker.go
@@ -1,0 +1,338 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/core/multiwatcher"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+)
+
+// Config is an argument struct used to create a Worker.
+type Config struct {
+	Logger               Logger
+	Backing              state.AllWatcherBacking
+	PrometheusRegisterer prometheus.Registerer
+	Cleanup              func()
+}
+
+// Validate validates the worker configuration.
+func (config Config) Validate() error {
+	if config.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	if config.Backing == nil {
+		return errors.NotValidf("missing Backing")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("missing PrometheusRegisterer")
+	}
+	return nil
+}
+
+// Worker runs the primary goroutine for managing the multiwatchers.
+type Worker struct {
+	config Config
+
+	tomb tomb.Tomb
+
+	// store holds information about all known entities.
+	store multiwatcher.Store
+
+	// request receives requests from Multiwatcher clients.
+	request chan *request
+
+	// Each entry in the waiting map holds a linked list of Next requests
+	// outstanding for the associated params.
+	waiting map[*Watcher]*request
+
+	mu           sync.Mutex
+	watchers     []*Watcher
+	restartCount int
+	// remember the last five errors that caused us to restart the internal loop
+	errors []error
+}
+
+// request holds a message from the Multiwatcher to the
+// storeManager for some changes. The request will be
+// replied to when some changes are available.
+type request struct {
+	// w holds the Multiwatcher that has originated the request.
+	watcher *Watcher
+
+	// reply receives a message when deltas are ready.  If reply is
+	// nil, the Multiwatcher will be stopped.  If the reply is true,
+	// the request has been processed; if false, the Multiwatcher
+	// has been stopped,
+	reply chan bool
+
+	// noChanges receives a message when the manager checks for changes
+	// and there are none.
+	noChanges chan struct{}
+
+	// On reply, changes will hold changes that have occurred since
+	// the last replied-to Next request.
+	changes []multiwatcher.Delta
+
+	// next points to the next request in the list of outstanding
+	// requests on a given watcher.  It is used only by the central
+	// storeManager goroutine.
+	next *request
+}
+
+// NewWorkerShim is a method used for hooking up the specific NewWorker
+// to the manifold NewWorker config arg. This allows other tests to use
+// the NewWorker to get something that acts as a multiwatcher.Factory
+// without having to cast the worker.
+func NewWorkerShim(config Config) (worker.Worker, error) {
+	return NewWorker(config)
+}
+
+// NewWorker creates the worker and starts the loop goroutine.
+func NewWorker(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &Worker{
+		config: config,
+		// There always needs to be a valid request channel.
+		request: make(chan *request),
+		waiting: make(map[*Watcher]*request),
+		store:   multiwatcher.NewStore(config.Logger),
+	}
+	w.tomb.Go(w.loop)
+	return w, nil
+}
+
+// Report is shown up in the engine report of the agent.
+func (w *Worker) Report() map[string]interface{} {
+	w.mu.Lock()
+	count := len(w.watchers)
+	restart := w.restartCount
+	var errors []string
+	for _, err := range w.errors {
+		errors = append(errors, err.Error())
+	}
+	w.mu.Unlock()
+
+	report := map[string]interface{}{
+		"num-watchers": count,
+	}
+	if restart > 0 {
+		report["restart-count"] = restart
+	}
+	if len(errors) > 0 {
+		report["errors"] = errors
+	}
+	return report
+}
+
+// WatchController returns entity delta events for all models in the controller.
+func (w *Worker) WatchController() multiwatcher.Watcher {
+	return w.newWatcher(nil)
+}
+
+// WatchModel returns entity delta events just for the specified model.
+func (w *Worker) WatchModel(modelUUID string) multiwatcher.Watcher {
+	return w.newWatcher(
+		func(in []multiwatcher.Delta) []multiwatcher.Delta {
+			// Returns an empty slice if there is nothing to match with the
+			// implementation of the Watcher for noChanges. Both could potentially
+			// be updated to return a nil slice.
+			result := make([]multiwatcher.Delta, 0, len(in))
+			for _, delta := range in {
+				if delta.Entity.EntityID().ModelUUID == modelUUID {
+					result = append(result, delta)
+				}
+			}
+			return result
+		})
+}
+
+func (w *Worker) newWatcher(filter func([]multiwatcher.Delta) []multiwatcher.Delta) *Watcher {
+	watcher := &Watcher{
+		request: w.request,
+		control: &w.tomb,
+		logger:  w.config.Logger,
+		// Buffered err channel as if there is a fetch error on the all watcher backing
+		// the error is passed to the watcher.
+		err:    make(chan error, 1),
+		filter: filter,
+	}
+	w.mu.Lock()
+	w.watchers = append(w.watchers, watcher)
+	w.mu.Unlock()
+	return watcher
+}
+
+func (w *Worker) loop() error {
+	w.config.Logger.Tracef("worker loop started")
+	defer w.config.Logger.Tracef("worker loop completed")
+	defer func() {
+		if w.config.Cleanup != nil {
+			w.config.Cleanup()
+		}
+	}()
+
+	for {
+		err := w.inner()
+		select {
+		case <-w.tomb.Dying():
+			return nil
+		default:
+			w.mu.Lock()
+			w.restartCount++
+			w.errors = append(w.errors, err)
+			if len(w.errors) > 5 {
+				// Since we only ever add one at a time, we know that removing just
+				// the first one will get us back to five.
+				w.errors = w.errors[1:]
+			}
+			w.store = multiwatcher.NewStore(w.config.Logger)
+			w.request = make(chan *request)
+			w.waiting = make(map[*Watcher]*request)
+			// Since the worker itself isn't dying, we need to manually stop all
+			// the watchers.
+			for _, watcher := range w.watchers {
+				watcher.err <- err
+			}
+			w.watchers = nil
+			w.mu.Unlock()
+		}
+	}
+}
+
+// We don't want to restart the worker just because the backing has raised an error.
+// If it does, we record the error, and start again with a new store.
+func (w *Worker) inner() error {
+	w.config.Logger.Tracef("worker inner started")
+	defer w.config.Logger.Tracef("worker inner completed")
+	backing := w.config.Backing
+	in := make(chan watcher.Change)
+	backing.Watch(in)
+	defer backing.Unwatch(in)
+	// We have no idea what changes the watcher might be trying to
+	// send us while getAll proceeds, but we don't mind, because
+	// backing.Changed is idempotent with respect to both updates
+	// and removals.
+	if err := backing.GetAll(w.store); err != nil {
+		return errors.Trace(err)
+	}
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return errors.Trace(tomb.ErrDying)
+		case change := <-in:
+			w.config.Logger.Tracef("handle change: %#v", change)
+			// TODO: retry any errors here to deal with i/o timouts etc.
+			// Although to be honest, by the time we start getting i/o timeouts we
+			// have such a stressed system that nothing is working well.
+			if err := backing.Changed(w.store, change); err != nil {
+				return errors.Trace(err)
+			}
+		case req := <-w.request:
+			w.config.Logger.Tracef("handle request: %#v", req)
+			w.handle(req)
+		}
+		w.respond()
+	}
+}
+
+// Kill implements worker.Worker.Kill.
+func (w *Worker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements worker.Worker.Wait.
+func (w *Worker) Wait() error {
+	return errors.Trace(w.tomb.Wait())
+}
+
+// handle processes a request from a Multiwatcher.
+func (w *Worker) handle(req *request) {
+	w.config.Logger.Tracef("start handle")
+	defer w.config.Logger.Tracef("finish handle")
+	if req.watcher.stopped {
+		w.config.Logger.Tracef("watcher %p is stopped", req.watcher)
+		// The watcher has previously been stopped.
+		if req.reply != nil {
+			select {
+			case req.reply <- false:
+			case <-w.tomb.Dying():
+			}
+		}
+		return
+	}
+	if req.reply == nil {
+		w.config.Logger.Tracef("request to stop watcher %p", req.watcher)
+		// This is a request to stop the watcher.
+		for req := w.waiting[req.watcher]; req != nil; req = req.next {
+			select {
+			case req.reply <- false:
+			case <-w.tomb.Dying():
+			}
+		}
+		delete(w.waiting, req.watcher)
+		req.watcher.stopped = true
+		w.store.DecReference(req.watcher.revno)
+		return
+	}
+	// Add request to head of list.
+	w.config.Logger.Tracef("add watcher %p request to waiting", req.watcher)
+	req.next = w.waiting[req.watcher]
+	w.waiting[req.watcher] = req
+}
+
+// respond responds to all outstanding requests that are satisfiable.
+func (w *Worker) respond() {
+	w.config.Logger.Tracef("start respond")
+	defer w.config.Logger.Tracef("finish respond")
+	for watcher, req := range w.waiting {
+		revno := watcher.revno
+		changes, latestRevno := w.store.ChangesSince(revno)
+		w.config.Logger.Tracef("%d changes since %d for watcher %p", len(changes), revno, watcher)
+		if len(changes) == 0 {
+			if req.noChanges != nil {
+				w.config.Logger.Tracef("sending down noChanges for watcher %p", watcher)
+				select {
+				case req.noChanges <- struct{}{}:
+				case <-w.tomb.Dying():
+					return
+				}
+
+				w.removeWaitingReq(watcher, req)
+			}
+			continue
+		}
+
+		req.changes = changes
+		watcher.revno = latestRevno
+
+		w.config.Logger.Tracef("sending changes down reply channel for watcher %p", watcher)
+		select {
+		case req.reply <- true:
+		case <-w.tomb.Dying():
+			return
+		}
+
+		w.removeWaitingReq(watcher, req)
+		w.store.AddReference(revno)
+	}
+}
+
+func (w *Worker) removeWaitingReq(watcher *Watcher, req *request) {
+	if req := req.next; req == nil {
+		// Last request for this watcher.
+		delete(w.waiting, watcher)
+	} else {
+		w.waiting[watcher] = req
+	}
+}

--- a/worker/multiwatcher/worker_internal_test.go
+++ b/worker/multiwatcher/worker_internal_test.go
@@ -1,0 +1,361 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"fmt"
+
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/multiwatcher"
+	"github.com/juju/juju/worker/multiwatcher/testbacking"
+)
+
+type workerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&workerSuite{})
+
+func (*workerSuite) TestHandle(c *gc.C) {
+	sm := &Worker{
+		config: Config{
+			Logger:  loggo.GetLogger("test.worker"),
+			Backing: testbacking.New(nil),
+		},
+		request: make(chan *request),
+		waiting: make(map[*Watcher]*request),
+		store:   multiwatcher.NewStore(loggo.GetLogger("test.store")),
+	}
+
+	// Add request from first watcher.
+	w0 := sm.newWatcher(nil)
+	req0 := &request{
+		watcher: w0,
+		reply:   make(chan bool, 1),
+	}
+	sm.handle(req0)
+	assertWaitingRequests(c, sm, map[*Watcher][]*request{
+		w0: {req0},
+	})
+
+	// Add second request from first watcher.
+	req1 := &request{
+		watcher: w0,
+		reply:   make(chan bool, 1),
+	}
+	sm.handle(req1)
+	assertWaitingRequests(c, sm, map[*Watcher][]*request{
+		w0: {req1, req0},
+	})
+
+	// Add request from second watcher.
+	w1 := sm.newWatcher(nil)
+	req2 := &request{
+		watcher: w1,
+		reply:   make(chan bool, 1),
+	}
+	sm.handle(req2)
+	assertWaitingRequests(c, sm, map[*Watcher][]*request{
+		w0: {req1, req0},
+		w1: {req2},
+	})
+
+	// Stop first watcher.
+	sm.handle(&request{
+		watcher: w0,
+	})
+	assertWaitingRequests(c, sm, map[*Watcher][]*request{
+		w1: {req2},
+	})
+	assertReplied(c, false, req0)
+	assertReplied(c, false, req1)
+
+	// Stop second watcher.
+	sm.handle(&request{
+		watcher: w1,
+	})
+	assertWaitingRequests(c, sm, nil)
+	assertReplied(c, false, req2)
+}
+
+func (*workerSuite) TestRespondMultiple(c *gc.C) {
+	sm := &Worker{
+		config: Config{
+			Logger:  loggo.GetLogger("test.worker"),
+			Backing: testbacking.New(nil),
+		},
+		request: make(chan *request),
+		waiting: make(map[*Watcher]*request),
+		store:   multiwatcher.NewStore(loggo.GetLogger("test.store")),
+	}
+
+	sm.store.Update(&multiwatcher.MachineInfo{ID: "0"})
+
+	// Add one request and respond.
+	// It should see the above change.
+	w0 := sm.newWatcher(nil)
+	req0 := &request{
+		watcher: w0,
+		reply:   make(chan bool, 1),
+	}
+	sm.handle(req0)
+	sm.respond()
+	assertReplied(c, true, req0)
+	c.Assert(req0.changes, gc.DeepEquals, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{ID: "0"}}})
+	assertWaitingRequests(c, sm, nil)
+
+	// Add another request from the same watcher and respond.
+	// It should have no reply because nothing has changed.
+	req0 = &request{
+		watcher: w0,
+		reply:   make(chan bool, 1),
+	}
+	sm.handle(req0)
+	sm.respond()
+	assertNotReplied(c, req0)
+
+	// Add two requests from another watcher and respond.
+	// The request from the first watcher should still not
+	// be replied to, but the later of the two requests from
+	// the second watcher should get a reply.
+	w1 := sm.newWatcher(nil)
+	req1 := &request{
+		watcher: w1,
+		reply:   make(chan bool, 1),
+	}
+	sm.handle(req1)
+	req2 := &request{
+		watcher: w1,
+		reply:   make(chan bool, 1),
+	}
+	sm.handle(req2)
+	assertWaitingRequests(c, sm, map[*Watcher][]*request{
+		w0: {req0},
+		w1: {req2, req1},
+	})
+	sm.respond()
+	assertNotReplied(c, req0)
+	assertNotReplied(c, req1)
+	assertReplied(c, true, req2)
+	c.Assert(req2.changes, gc.DeepEquals, []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{ID: "0"}}})
+	assertWaitingRequests(c, sm, map[*Watcher][]*request{
+		w0: {req0},
+		w1: {req1},
+	})
+
+	// Check that nothing more gets responded to if we call respond again.
+	sm.respond()
+	assertNotReplied(c, req0)
+	assertNotReplied(c, req1)
+
+	// Now make a change and check that both waiting requests
+	// get serviced.
+	sm.store.Update(&multiwatcher.MachineInfo{ID: "1"})
+	sm.respond()
+	assertReplied(c, true, req0)
+	assertReplied(c, true, req1)
+	assertWaitingRequests(c, sm, nil)
+
+	deltas := []multiwatcher.Delta{{Entity: &multiwatcher.MachineInfo{ID: "1"}}}
+	c.Assert(req0.changes, gc.DeepEquals, deltas)
+	c.Assert(req1.changes, gc.DeepEquals, deltas)
+}
+
+var respondTestChanges = [...]func(store multiwatcher.Store){
+	func(store multiwatcher.Store) {
+		store.Update(&multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "0"})
+	},
+	func(store multiwatcher.Store) {
+		store.Update(&multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "1"})
+	},
+	func(store multiwatcher.Store) {
+		store.Update(&multiwatcher.MachineInfo{ModelUUID: "uuid", ID: "2"})
+	},
+	func(store multiwatcher.Store) {
+		store.Remove(multiwatcher.EntityID{"machine", "uuid", "0"})
+	},
+	func(store multiwatcher.Store) {
+		store.Update(&multiwatcher.MachineInfo{
+			ModelUUID:  "uuid",
+			ID:         "1",
+			InstanceID: "i-1",
+		})
+	},
+	func(store multiwatcher.Store) {
+		store.Remove(multiwatcher.EntityID{"machine", "uuid", "1"})
+	},
+}
+
+func (s *workerSuite) TestRespondResults(c *gc.C) {
+	// We test the response results for a pair of watchers by
+	// interleaving notional Next requests in all possible
+	// combinations after each change in respondTestChanges and
+	// checking that the view of the world as seen by the watchers
+	// matches the actual current state.
+
+	// We decide whether if we make a request for a given
+	// watcher by inspecting a number n - bit i of n determines whether
+	// a request will be responded to after running respondTestChanges[i].
+
+	numCombinations := 1 << uint(len(respondTestChanges))
+	const wcount = 2
+	ns := make([]int, wcount)
+	for ns[0] = 0; ns[0] < numCombinations; ns[0]++ {
+		for ns[1] = 0; ns[1] < numCombinations; ns[1]++ {
+
+			sm := &Worker{
+				config: Config{
+					Logger:  loggo.GetLogger("test.worker"),
+					Backing: testbacking.New(nil),
+				},
+				request: make(chan *request),
+				waiting: make(map[*Watcher]*request),
+				store:   multiwatcher.NewStore(loggo.GetLogger("test.store")),
+			}
+
+			c.Logf("test %0*b", len(respondTestChanges), ns)
+			var (
+				ws      []*Watcher
+				wstates []watcherState
+				reqs    []*request
+			)
+			for i := 0; i < wcount; i++ {
+				ws = append(ws, sm.newWatcher(nil))
+				wstates = append(wstates, make(watcherState))
+				reqs = append(reqs, nil)
+			}
+			// Make each change in turn, and make a request for each
+			// watcher if n and respond
+			for i, change := range respondTestChanges {
+				c.Logf("change %d", i)
+				change(sm.store)
+				needRespond := false
+				for wi, n := range ns {
+					if n&(1<<uint(i)) != 0 {
+						needRespond = true
+						if reqs[wi] == nil {
+							reqs[wi] = &request{
+								watcher: ws[wi],
+								reply:   make(chan bool, 1),
+							}
+							sm.handle(reqs[wi])
+						}
+					}
+				}
+				if !needRespond {
+					continue
+				}
+				// Check that the expected requests are pending.
+				expectWaiting := make(map[*Watcher][]*request)
+				for wi, w := range ws {
+					if reqs[wi] != nil {
+						expectWaiting[w] = []*request{reqs[wi]}
+					}
+				}
+				assertWaitingRequests(c, sm, expectWaiting)
+				// Actually respond; then check that each watcher with
+				// an outstanding request now has an up to date view
+				// of the world.
+				sm.respond()
+				for wi, req := range reqs {
+					if req == nil {
+						continue
+					}
+					select {
+					case ok := <-req.reply:
+						c.Assert(ok, jc.IsTrue)
+						c.Assert(len(req.changes) > 0, jc.IsTrue)
+						wstates[wi].update(req.changes)
+						reqs[wi] = nil
+					default:
+					}
+					c.Logf("check %d", wi)
+					wstates[wi].check(c, sm.store)
+				}
+			}
+			// Stop the watcher and check that all ref counts end up at zero
+			// and removed objects are deleted.
+			for wi, w := range ws {
+				sm.handle(&request{watcher: w})
+				if reqs[wi] != nil {
+					assertReplied(c, false, reqs[wi])
+				}
+			}
+
+			c.Assert(sm.store.All(), jc.DeepEquals, []multiwatcher.EntityInfo{
+				&multiwatcher.MachineInfo{
+					ModelUUID: "uuid",
+					ID:        "2",
+				},
+			})
+			c.Assert(sm.store.Size(), gc.Equals, 1)
+		}
+	}
+}
+
+func assertNotReplied(c *gc.C, req *request) {
+	select {
+	case v := <-req.reply:
+		c.Fatalf("request was unexpectedly replied to (got %v)", v)
+	default:
+	}
+}
+
+func assertReplied(c *gc.C, val bool, req *request) {
+	select {
+	case v := <-req.reply:
+		c.Assert(v, gc.Equals, val)
+	default:
+		c.Fatalf("request was not replied to")
+	}
+}
+
+func assertWaitingRequests(c *gc.C, worker *Worker, waiting map[*Watcher][]*request) {
+	c.Assert(worker.waiting, gc.HasLen, len(waiting))
+	for w, reqs := range waiting {
+		i := 0
+		for req := worker.waiting[w]; ; req = req.next {
+			if i >= len(reqs) {
+				c.Assert(req, gc.IsNil)
+				break
+			}
+			c.Assert(req, gc.Equals, reqs[i])
+			assertNotReplied(c, req)
+			i++
+		}
+	}
+}
+
+// watcherState represents a Multiwatcher client's
+// current view of the state. It holds the last delta that a given
+// state watcher has seen for each entity.
+type watcherState map[interface{}]multiwatcher.Delta
+
+func (s watcherState) update(changes []multiwatcher.Delta) {
+	for _, d := range changes {
+		id := d.Entity.EntityID()
+		if d.Removed {
+			if _, ok := s[id]; !ok {
+				panic(fmt.Errorf("entity id %v removed when it wasn't there", id))
+			}
+			delete(s, id)
+		} else {
+			s[id] = d
+		}
+	}
+}
+
+// check checks that the watcher state matches that
+// held in current.
+func (s watcherState) check(c *gc.C, store multiwatcher.Store) {
+	currentEntities := make(watcherState)
+	for _, info := range store.All() {
+		currentEntities[info.EntityID()] = multiwatcher.Delta{Entity: info}
+	}
+	c.Assert(s, gc.DeepEquals, currentEntities)
+}

--- a/worker/multiwatcher/worker_internal_test.go
+++ b/worker/multiwatcher/worker_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package multiwatcher

--- a/worker/multiwatcher/worker_test.go
+++ b/worker/multiwatcher/worker_test.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/worker/multiwatcher"
+)
+
+type WorkerSuite struct {
+	statetesting.StateSuite
+	logger loggo.Logger
+	config multiwatcher.Config
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.logger = loggo.GetLogger("test")
+	s.logger.SetLogLevel(loggo.TRACE)
+
+	s.config = multiwatcher.Config{
+		Logger:               s.logger,
+		Backing:              state.NewAllWatcherBacking(s.StatePool),
+		PrometheusRegisterer: noopRegisterer{},
+	}
+}
+
+func (s *WorkerSuite) TestConfigMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Logger not valid")
+}
+
+func (s *WorkerSuite) TestConfigMissingBacking(c *gc.C) {
+	s.config.Backing = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Backing not valid")
+}
+
+func (s *WorkerSuite) TestConfigMissingRegisterer(c *gc.C) {
+	s.config.PrometheusRegisterer = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing PrometheusRegisterer not valid")
+}
+
+func (s *WorkerSuite) start(c *gc.C) worker.Worker {
+	config := s.config
+	w, err := multiwatcher.NewWorker(config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.CleanKill(c, w)
+	})
+	return w
+}


### PR DESCRIPTION
Create a real worker for managing the multiwatchers. Future branches will remove the workers that are running in the state objects.

The all watcher code that the multiwatcher worker uses is based on the one that watches all the models. Watching an individual model is now a simple filter on the event stream for the entire controller.

The multiwatcher worker is added to the machine manifolds, but neither the apiserver nor the modelcache worker are yet updated to use it. It has been added to confirm that it is running and the metrics are being exported.
 
## QA steps

```sh
juju bootstrap lxd multiwatcher
juju ssh -m controller 0

juju_engine_report | grep -A 8 multiwatcher
Querying @jujud-machine-0 introspection socket: /depengine
  multiwatcher:
    inputs:
    - state
    - is-controller-flag
    - upgrade-database-flag
    report:
      num-watchers: 0
      restart-count: 0
      store-size: 3

juju_metrics | grep multiwatcher
Querying @jujud-machine-0 introspection socket: /metrics/
# HELP juju_multiwatcher_restart_count The number of times the all watcher has been restarted.
# TYPE juju_multiwatcher_restart_count gauge
juju_multiwatcher_restart_count 0
# HELP juju_multiwatcher_store_size The number of entities in the store.
# TYPE juju_multiwatcher_store_size gauge
juju_multiwatcher_store_size 3
# HELP juju_multiwatcher_watcher_count The number of multiwatcher type watchers there are.
# TYPE juju_multiwatcher_watcher_count gauge
juju_multiwatcher_watcher_count 0
```

## Documentation changes

This is an internal only change.