### PR TITLE
GCE Minor Tweaks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2051,7 +2051,6 @@
     "golang.org/x/crypto/ssh",
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/context",
-    "golang.org/x/oauth2",
     "golang.org/x/oauth2/google",
     "golang.org/x/sys/windows",
     "golang.org/x/sys/windows/svc",

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -4,10 +4,10 @@
 package upgradeseries
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v3"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"

--- a/provider/gce/google/auth.go
+++ b/provider/gce/google/auth.go
@@ -4,23 +4,23 @@
 package google
 
 import (
+	"context"
+
 	"github.com/juju/errors"
-	"golang.org/x/oauth2"
-	goauth2 "golang.org/x/oauth2/google"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 )
 
-var (
-	driverScopes = []string{
-		"https://www.googleapis.com/auth/compute",
-		"https://www.googleapis.com/auth/devstorage.full_control",
-	}
-)
-
-// newConnection opens a new low-level connection to the GCE API using
-// the Auth's data and returns it. This includes building the
-// OAuth-wrapping network transport.
-func newConnection(creds *Credentials) (*compute.Service, error) {
+// newComputeService opens a new low-level connection to the GCE API using
+// the input credentials and returns it.
+// This includes building the OAuth-wrapping network transport.
+// TODO (manadart 2019-11-15) This the bottom layer in a cake of needless
+// abstractions:
+// This is embedded in rawConn, which is embedded in Connection,
+// which is then used by the Environ.
+// This should also be relocated alongside its wrapper,
+// rather than this "auth.go" file.
+func newComputeService(creds *Credentials) (*compute.Service, error) {
 	jsonKey := creds.JSONKey
 	if jsonKey == nil {
 		built, err := creds.buildJSONKey()
@@ -29,11 +29,17 @@ func newConnection(creds *Credentials) (*compute.Service, error) {
 		}
 		jsonKey = built
 	}
-	cfg, err := goauth2.JWTConfigFromJSON(jsonKey, driverScopes...)
+
+	cfg, err := google.JWTConfigFromJSON(
+		jsonKey,
+		"https://www.googleapis.com/auth/compute",
+		"https://www.googleapis.com/auth/devstorage.full_control",
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	client := cfg.Client(oauth2.NoContext)
+
+	client := cfg.Client(context.TODO())
 	service, err := compute.New(client)
 	return service, errors.Trace(err)
 }

--- a/provider/gce/google/auth_test.go
+++ b/provider/gce/google/auth_test.go
@@ -15,6 +15,6 @@ type authSuite struct {
 var _ = gc.Suite(&authSuite{})
 
 func (s *authSuite) TestNewConnection(c *gc.C) {
-	_, err := newConnection(s.Credentials)
+	_, err := newComputeService(s.Credentials)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/gce/google/config.go
+++ b/provider/gce/google/config.go
@@ -18,12 +18,11 @@ import (
 // defined by juju for use with the GCE provider. If Google defines
 // equivalent environment variables they should be used instead.
 const (
-	OSEnvPrivateKey    = "GCE_PRIVATE_KEY"
-	OSEnvClientID      = "GCE_CLIENT_ID"
-	OSEnvClientEmail   = "GCE_CLIENT_EMAIL"
-	OSEnvRegion        = "GCE_REGION"
-	OSEnvProjectID     = "GCE_PROJECT_ID"
-	OSEnvImageEndpoint = "GCE_IMAGE_URL"
+	OSEnvPrivateKey  = "GCE_PRIVATE_KEY"
+	OSEnvClientID    = "GCE_CLIENT_ID"
+	OSEnvClientEmail = "GCE_CLIENT_EMAIL"
+	OSEnvRegion      = "GCE_REGION"
+	OSEnvProjectID   = "GCE_PROJECT_ID"
 )
 
 const (
@@ -157,7 +156,7 @@ func (gc Credentials) Values() map[string]string {
 	}
 }
 
-// Validate checks the credentialss for invalid values. If the values
+// Validate checks the credentials for invalid values. If the values
 // are not valid, it returns errors.NotValid with the message set to
 // the corresponding OS environment variable name.
 //

--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -9,6 +9,17 @@ import (
 )
 
 // service facilitates mocking out the GCE API during tests.
+// TODO (manadart 2019-11-19): This indirection is for *our* wrapper of the
+// underlying compute services. As an indirection, it is one layer too high
+// and sits on an unnecessary type abstraction.
+// We should:
+// - Create interfaces for members of the compute service so our line of
+//   indirection is at the boundary with the dependency.
+// - Use the compute service as the implementer of those interfaces and
+//   embed them directly in an equivalent of Connection (below).
+// - Remove this interface and rawConn altogether.
+// - Remove types that have no purpose other than to mirror those returned by
+//   the compute service such as `MachineType`.
 type service interface {
 	// GetProject sends a request to the GCE API for info about the
 	// specified project. If the project does not exist then an error

--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
-// rawConnectionWrapper facilitates mocking out the GCE API during tests.
-type rawConnectionWrapper interface {
+// service facilitates mocking out the GCE API during tests.
+type service interface {
 	// GetProject sends a request to the GCE API for info about the
 	// specified project. If the project does not exist then an error
 	// will be returned.
@@ -116,8 +116,7 @@ type rawConnectionWrapper interface {
 // called to authenticate and open the raw connection to the GCE API.
 // Otherwise a panic will result.
 type Connection struct {
-	// TODO(ericsnow) name this something else?
-	raw       rawConnectionWrapper
+	service   service
 	region    string
 	projectID string
 }
@@ -128,30 +127,28 @@ type Connection struct {
 // result in an error. All errors that happen while authenticating and
 // connecting are returned by Connect.
 func Connect(connCfg ConnectionConfig, creds *Credentials) (*Connection, error) {
-	raw, err := newRawConnection(creds)
+	raw, err := newService(creds)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	conn := &Connection{
-		raw:       &rawConn{raw},
+		service:   &rawConn{raw},
 		region:    connCfg.Region,
 		projectID: connCfg.ProjectID,
 	}
 	return conn, nil
 }
 
-var newRawConnection = func(creds *Credentials) (*compute.Service, error) {
-	return newConnection(creds)
+var newService = func(creds *Credentials) (*compute.Service, error) {
+	return newComputeService(creds)
 }
-
-// TODO(ericsnow) Verify in each method that Connection.raw is set?
 
 // VerifyCredentials ensures that the authentication credentials used
 // to connect are valid for use in the project and region defined for
 // the Connection. If they are not then an error is returned.
 func (gc Connection) VerifyCredentials() error {
-	if _, err := gc.raw.GetProject(gc.projectID); err != nil {
+	if _, err := gc.service.GetProject(gc.projectID); err != nil {
 		// TODO(ericsnow) Wrap err with something about bad credentials?
 		return errors.Trace(err)
 	}
@@ -162,7 +159,7 @@ func (gc Connection) VerifyCredentials() error {
 // GCE region. If none are found the the list is empty. Any failure in
 // the low-level request is returned as an error.
 func (gc *Connection) AvailabilityZones(region string) ([]AvailabilityZone, error) {
-	rawZones, err := gc.raw.ListAvailabilityZones(gc.projectID, region)
+	rawZones, err := gc.service.ListAvailabilityZones(gc.projectID, region)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/google/conn_disks.go
+++ b/provider/gce/google/conn_disks.go
@@ -28,12 +28,12 @@ func (gce *Connection) CreateDisks(zone string, disks []DiskSpec) ([]*Disk, erro
 }
 
 func (gce *Connection) createDisk(zone string, disk *compute.Disk) error {
-	return gce.raw.CreateDisk(gce.projectID, zone, disk)
+	return gce.service.CreateDisk(gce.projectID, zone, disk)
 }
 
 // Disks implements storage section of gceConnection.
 func (gce *Connection) Disks() ([]*Disk, error) {
-	computeDisks, err := gce.raw.ListDisks(gce.projectID)
+	computeDisks, err := gce.service.ListDisks(gce.projectID)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot list disks")
 	}
@@ -47,12 +47,12 @@ func (gce *Connection) Disks() ([]*Disk, error) {
 // RemoveDisk implements storage section of gceConnection.
 // TODO(perrito666) handle non existing disk, perhaps catch 404.
 func (gce *Connection) RemoveDisk(zone, name string) error {
-	return gce.raw.RemoveDisk(gce.projectID, zone, name)
+	return gce.service.RemoveDisk(gce.projectID, zone, name)
 }
 
 // Disk implements storage section of gceConnection.
 func (gce *Connection) Disk(zone, name string) (*Disk, error) {
-	d, err := gce.raw.GetDisk(gce.projectID, zone, name)
+	d, err := gce.service.GetDisk(gce.projectID, zone, name)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get disk %q in zone %q", name, zone)
 	}
@@ -61,7 +61,7 @@ func (gce *Connection) Disk(zone, name string) (*Disk, error) {
 
 // SetDiskLabels implements storage section of gceConnection.
 func (gce *Connection) SetDiskLabels(zone, name, labelFingerprint string, labels map[string]string) error {
-	err := gce.raw.SetDiskLabels(gce.projectID, zone, name, labelFingerprint, labels)
+	err := gce.service.SetDiskLabels(gce.projectID, zone, name, labelFingerprint, labels)
 	return errors.Annotatef(err, "cannot update labels for disk %q in zone %q", name, zone)
 }
 
@@ -75,7 +75,7 @@ func deviceName(zone string, diskId uint64) string {
 
 // AttachDisk implements storage section of gceConnection.
 func (gce *Connection) AttachDisk(zone, volumeName, instanceId string, mode DiskMode) (*AttachedDisk, error) {
-	disk, err := gce.raw.GetDisk(gce.projectID, zone, volumeName)
+	disk, err := gce.service.GetDisk(gce.projectID, zone, volumeName)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot obtain disk %q to attach it", volumeName)
 	}
@@ -86,7 +86,7 @@ func (gce *Connection) AttachDisk(zone, volumeName, instanceId string, mode Disk
 		Source:     disk.SelfLink,
 		Mode:       string(mode),
 	}
-	err = gce.raw.AttachDisk(gce.projectID, zone, instanceId, attachedDisk)
+	err = gce.service.AttachDisk(gce.projectID, zone, instanceId, attachedDisk)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot attach disk")
 	}
@@ -100,12 +100,12 @@ func (gce *Connection) AttachDisk(zone, volumeName, instanceId string, mode Disk
 // DetachDisk implements storage section of gceConnection.
 // disk existence is checked but not instance nor is attachment.
 func (gce *Connection) DetachDisk(zone, instanceId, volumeName string) error {
-	disk, err := gce.raw.GetDisk(gce.projectID, zone, volumeName)
+	disk, err := gce.service.GetDisk(gce.projectID, zone, volumeName)
 	if err != nil {
 		return errors.Annotatef(err, "cannot obtain disk %q to detach it", volumeName)
 	}
 	dn := deviceName(zone, disk.Id)
-	err = gce.raw.DetachDisk(gce.projectID, zone, instanceId, dn)
+	err = gce.service.DetachDisk(gce.projectID, zone, instanceId, dn)
 	if err != nil {
 		return errors.Annotatef(err, "cannot detach %q from %q", dn, instanceId)
 	}
@@ -134,7 +134,7 @@ func sourceToVolumeName(source string) string {
 
 // InstanceDisks implements storage section of gceConnection.
 func (gce *Connection) InstanceDisks(zone, instanceId string) ([]*AttachedDisk, error) {
-	disks, err := gce.raw.InstanceDisks(gce.projectID, zone, instanceId)
+	disks, err := gce.service.InstanceDisks(gce.projectID, zone, instanceId)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get disks from instance")
 	}

--- a/provider/gce/google/conn_machines.go
+++ b/provider/gce/google/conn_machines.go
@@ -8,7 +8,7 @@ import "github.com/juju/errors"
 // ListMachineTypes returns a list of MachineType available for the
 // given zone.
 func (gce *Connection) ListMachineTypes(zone string) ([]MachineType, error) {
-	machines, err := gce.raw.ListMachineTypes(gce.projectID, zone)
+	machines, err := gce.service.ListMachineTypes(gce.projectID, zone)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/google/conn_network.go
+++ b/provider/gce/google/conn_network.go
@@ -20,7 +20,7 @@ import (
 // no rules match the name the RuleSet will be empty and no error is
 // returned.
 func (gce Connection) firewallRules(fwname string) (ruleSet, error) {
-	firewalls, err := gce.raw.GetFirewalls(gce.projectID, fwname)
+	firewalls, err := gce.service.GetFirewalls(gce.projectID, fwname)
 	if IsNotFound(err) {
 		return make(ruleSet), nil
 	}
@@ -102,7 +102,7 @@ func (gce Connection) OpenPortsWithNamer(target string, namer FirewallNamer, rul
 			}
 			allNames.Add(name)
 			spec := firewallSpec(name, target, inputFirewall.SourceCIDRs, inputFirewall.AllowedPorts)
-			if err := gce.raw.AddFirewall(gce.projectID, spec); err != nil {
+			if err := gce.service.AddFirewall(gce.projectID, spec); err != nil {
 				return errors.Annotatef(err, "opening port(s) %+v", rules)
 			}
 			continue
@@ -121,7 +121,7 @@ func (gce Connection) OpenPortsWithNamer(target string, namer FirewallNamer, rul
 
 		// Copy new firewall details into required firewall spec.
 		spec := firewallSpec(existingFirewall.Name, target, combinedCIDRs, allowedPorts)
-		if err := gce.raw.UpdateFirewall(gce.projectID, existingFirewall.Name, spec); err != nil {
+		if err := gce.service.UpdateFirewall(gce.projectID, existingFirewall.Name, spec); err != nil {
 			return errors.Annotatef(err, "opening port(s) %+v", rules)
 		}
 	}
@@ -179,7 +179,7 @@ func (gce Connection) ClosePorts(target string, rules ...network.IngressRule) er
 			if len(remainingCidrs) == 0 {
 				// Delete a firewall.
 				// TODO(ericsnow) Handle case where firewall does not exist.
-				if err := gce.raw.RemoveFirewall(gce.projectID, existingFirewall.Name); err != nil {
+				if err := gce.service.RemoveFirewall(gce.projectID, existingFirewall.Name); err != nil {
 					return errors.Annotatef(err, "closing port(s) %+v", rules)
 				}
 				continue
@@ -187,7 +187,7 @@ func (gce Connection) ClosePorts(target string, rules ...network.IngressRule) er
 
 			// Update the existing firewall with the remaining CIDRs.
 			spec := firewallSpec(existingFirewall.Name, target, remainingCidrs, existingFirewall.AllowedPorts)
-			if err := gce.raw.UpdateFirewall(gce.projectID, existingFirewall.Name, spec); err != nil {
+			if err := gce.service.UpdateFirewall(gce.projectID, existingFirewall.Name, spec); err != nil {
 				return errors.Annotatef(err, "closing port(s) %+v", rules)
 			}
 			continue
@@ -209,7 +209,7 @@ func (gce Connection) ClosePorts(target string, rules ...network.IngressRule) er
 
 		// Copy new firewall details into required firewall spec.
 		spec := firewallSpec(existingFirewall.Name, target, existingFirewall.SourceCIDRs, remainingPorts)
-		if err := gce.raw.UpdateFirewall(gce.projectID, existingFirewall.Name, spec); err != nil {
+		if err := gce.service.UpdateFirewall(gce.projectID, existingFirewall.Name, spec); err != nil {
 			return errors.Annotatef(err, "closing port(s) %+v", rules)
 		}
 	}
@@ -218,7 +218,7 @@ func (gce Connection) ClosePorts(target string, rules ...network.IngressRule) er
 
 // Subnetworks returns the subnets available in this region.
 func (gce Connection) Subnetworks(region string) ([]*compute.Subnetwork, error) {
-	results, err := gce.raw.ListSubnetworks(gce.projectID, region)
+	results, err := gce.service.ListSubnetworks(gce.projectID, region)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -227,7 +227,7 @@ func (gce Connection) Subnetworks(region string) ([]*compute.Subnetwork, error) 
 
 // Networks returns the networks available.
 func (gce Connection) Networks() ([]*compute.Network, error) {
-	results, err := gce.raw.ListNetworks(gce.projectID)
+	results, err := gce.service.ListNetworks(gce.projectID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/google/conn_test.go
+++ b/provider/gce/google/conn_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&connSuite{})
 func (s *connSuite) TestConnect(c *gc.C) {
 	google.SetRawConn(s.Conn, nil)
 	service := &compute.Service{}
-	s.PatchValue(google.NewRawConnection, func(auth *google.Credentials) (*compute.Service, error) {
+	s.PatchValue(google.NewService, func(auth *google.Credentials) (*compute.Service, error) {
 		return service, nil
 	})
 

--- a/provider/gce/google/export_test.go
+++ b/provider/gce/google/export_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	NewRawConnection = &newRawConnection
+	NewService = &newService
 
 	NewInstanceRaw      = newInstance
 	PackMetadata        = packMetadata
@@ -21,12 +21,12 @@ var (
 	MatchesPrefix       = matchesPrefix
 )
 
-func SetRawConn(conn *Connection, raw rawConnectionWrapper) {
-	conn.raw = raw
+func SetRawConn(conn *Connection, svc service) {
+	conn.service = svc
 }
 
 func ExposeRawService(conn *Connection) *compute.Service {
-	return conn.raw.(*rawConn).Service
+	return conn.service.(*rawConn).Service
 }
 
 func NewAttached(spec DiskSpec) *compute.AttachedDisk {

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -56,7 +56,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	}
 	fake := &fakeConn{}
 	s.Conn = &Connection{
-		raw:       fake,
+		service:   fake,
 		region:    "a",
 		projectID: "spam",
 	}


### PR DESCRIPTION
## Description of change

This is a subset of some refactoring that I began that was to lead up to space-support for GCE. That work has been de-prioritised, but it is worth committing some of the clarification work.

In addition to a couple of spelling and import group fixes:
- `newConnection` is renamed `newComputeService` to better indicate what it creates, and to disambiguate the nesting of ambiguous connection/raw-connection identities.
- Usage of some deprecated items is replaced appropriately.
- Comments indicate how this could be more clearly architected, for when we next have to work in this provider.

## QA steps

A successful bootstrap to GCE should be verification that operation is preserved

## Documentation changes

None

## Bug reference

N/A
