### PR TITLE
Pad the controller timeout

### DIFF
--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -21,7 +21,8 @@ run_mongo_memory_profile() {
     until $(check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB 2>&1 >/dev/null); do
         echo "[+] (attempt ${attempt}) polling mongo service"
         cat_mongo_service | sed 's/^/    | /g'
-        if [ "${attempt}" -ge 4 ]; then
+        # This will attempt to wait for 2 minutes before failing out.
+        if [ "${attempt}" -ge 24 ]; then
             echo "Failed: expected wiredTigerCacheSizeGB to be set in mongo service."
             exit 1
         fi


### PR DESCRIPTION
### Checklist

 - [ ] ~~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~~
 - [ ] ~~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~

----

## Description of change

The following pads out the controller timeout from 20 seconds to 2
minutes. This should hopefully give enough time when the servers are
underload to be able to respond to a mongo memory profile change.

## QA steps

```sh
cd tests && ./main.sh controller
```

