### PR TITLE
Fix typo in juju run compat code

### DIFF
--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -416,6 +416,7 @@ func ConvertActionOutput(output map[string]interface{}, compat, alwaysStdout boo
 		codeKey = "ReturnCode"
 	}
 	res, ok = output["Code"].(string)
+	delete(values, "Code")
 	if !ok {
 		var v interface{}
 		if v, ok = output["return-code"]; ok && v != nil {

--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -397,7 +397,7 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 		}
 		stderrKey := "stderr"
 		if c.compat {
-			stdoutKey = "Stderr"
+			stderrKey = "Stderr"
 		}
 		codeKey := "return-code"
 		if c.compat {


### PR DESCRIPTION
## Description of change

Fix a typo in some (temporary) code to enforce backward compatibility of a juju 2.7 client calling juju run on a 2.6 model.
As a driveby, delete an unneeded "Code" value in yaml output.

## QA steps

```text
$ juju run --unit ubuntu-lite/0 pwd
/var/lib/juju/agents/unit-ubuntu-lite-0/charm
```

