### PR TITLE
Fixed typo of --egress-subnets

### DIFF
--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -63,7 +63,7 @@ If more than one flag is specified, a map of values is returned.
     --bind-address: the address the local unit should listen on to serve connections, as well
                     as the address that should be advertised to its peers.
     --ingress-address: the address the local unit should advertise as being used for incoming connections.
-    --egress_subnets: subnets (in CIDR notation) from which traffic on this relation will originate.
+    --egress-subnets: subnets (in CIDR notation) from which traffic on this relation will originate.
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "network-get",


### PR DESCRIPTION
It should be --egress-subnets per a few lines above this, not --egress_subnets which fails:

`ubuntu@ip-172-31-5-121:~$ sudo juju-run ubuntu-repository-cache/1 "network-get -r website:4 website --egress_subnets"`
`ERROR option provided but not defined: --egress_subnets`

`ubuntu@ip-172-31-5-121:~$ sudo juju-run ubuntu-repository-cache/1 "network-get -r website:4 website --egress-subnets"`
`172.31.5.121/32`