### PR TITLE
Change to re-install microk8s before running the test to clean env be…

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -112,6 +112,8 @@ class MicroK8s(Base):
     def __ensure_microk8s_installed(self):
         # unfortunately, we need sudo!
         if shutil.which('microk8s.kubectl'):
+            # The microk8s.reset sometimes left ingress namespace in dirty deleting
+            # status which causes the namespace can never be deleted anymore using kubectl.
             self.sh('sudo', 'snap', 'remove', 'microk8s')
 
         # install microk8s.

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -111,13 +111,13 @@ class MicroK8s(Base):
 
     def __ensure_microk8s_installed(self):
         # unfortunately, we need sudo!
-        if shutil.which('microk8s.kubectl') is None:
-            # install microk8s.
-            self.sh('sudo', 'snap', 'install', 'microk8s', '--classic', '--stable')
-            logger.info("microk8s installed successfully")
-        else:
-            # reset mcicrok8s.
-            self.sh('sudo', 'microk8s.reset')
+        if shutil.which('microk8s.kubectl'):
+            self.sh('sudo', 'snap', 'remove', 'microk8s')
+
+        # install microk8s.
+        self.sh('sudo', 'snap', 'install', 'microk8s', '--classic', '--stable')
+        logger.info("microk8s installed successfully")
+
         logger.info(
             "microk8s status \n%s",
             self._microk8s_status(True),
@@ -140,7 +140,7 @@ class MicroK8s(Base):
         data['Corefile'] = data['Corefile'].replace('8.8.8.8 8.8.4.4', get_nameserver())
         coredns_cm['data'] = data
         self.kubectl_apply(json.dumps(coredns_cm))
-        
+
         # restart coredns pod by killing it.
         kubedns_pod_selector = 'k8s-app=kube-dns'
         self.kubectl('delete', 'pod', '-n', 'kube-system', '--selector=%s' % kubedns_pod_selector)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

The `microk8s.reset` sometimes left `ingress` namespace in dirty deleting status which causes the namespace can never be deleted;
So we just `snap remove` it. 

## QA steps

No

## Documentation changes

No

## Bug reference

None
