### PR TITLE
acceptancetests: Increase the wait time for persistent storage to be detached

### DIFF
--- a/acceptancetests/assess_persistent_storage.py
+++ b/acceptancetests/assess_persistent_storage.py
@@ -335,7 +335,7 @@ def assess_charm_removal_single_block_and_filesystem_storage(client):
     # storage status change after remove-application takes some time.
     # from experiments even 30 seconds is not enough.
     wait_for_storage_status_update(
-        client, storage_id=single_fs_id, interval=15, timeout=90)
+        client, storage_id=single_fs_id, interval=15, timeout=180)
     storage_list = get_storage_list(client)[0]
     assert_storage_count(storage_list=storage_list, expected=1)
     if single_fs_id in storage_list:


### PR DESCRIPTION
## Description of change

I haven't been able to directly reproduce the failure locally, but if I take the wait time right down I can get the test to fail in the same way. Doubling the max wait time will hopefully get it to pass more reliably in CI.

## QA steps

Running the test passes locally.

```sh
./assess --substrate aws --region ca-central-1 --series xenial persistent_storage 
```

## Documentation changes
None

## Bug reference
None