### PR TITLE
add region check

### DIFF
--- a/acceptancetests/assess_add_cloud.py
+++ b/acceptancetests/assess_add_cloud.py
@@ -2,11 +2,11 @@
 
 import logging
 import re
+import sys
 from argparse import ArgumentParser
 from collections import namedtuple
 from copy import deepcopy
 
-import sys
 import yaml
 
 from jujupy import (
@@ -165,7 +165,15 @@ def iter_clouds(clouds, cloud_validation):
         if cloud['type'] == 'vsphere':
             continue
 
-        regions = list(cloud.get('regions', {}).keys())
+        # juju saves for each cloud at least one region, even if the cloud does not support them.
+        # The code below `tests to add invalid regions for each region`
+        # but because juju always at least adds one empty region
+        # it will try to run the code below and test for invalid region endpoints.
+        regions = cloud.get('regions', {})
+        if regions.get("default") == {}:
+            regions = []
+        else:
+            regions = list(cloud.get('regions', {}).keys())
 
         expected_exception = CloudMismatch
         if cloud_validation.has_endpoint(cloud['type']):


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] ~~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~
 - [ ] ~~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

See the code comment on the place for further reference.
One  PR added that we always have at least an empty region in the `clouds.yaml`. The code, in the past, checked for each region invalid endpoints.
Those endpoints do not get called for clouds not "supporting" them.
 
## QA steps
```sh
~/golang/src/juiu/juju/acceptancetests/assess_add_cloud.py ~/cloud-city/example-clouds.yaml ~/golang/bin/juju
```

e.g. output
```
Expected fail (bug #1641970): bogus-auth-canonistack, long-endpoint-canonistack, long-endpoint-canonistack-lcy01, long-endpoint-canonistack-lcy02, long-endpoint-finfolk-vmaas
Expected fail (bug #1641981): numeral-prefix-canonistack, numeral-prefix-finfolk-vmaas, slash-in-name-canonistack, slash-in-name-finfolk-vmaas
Failed: none
```