### PR TITLE
Fixes expected error message for "juju switch" with no argument.

### DIFF
--- a/acceptancetests/assess_unregister.py
+++ b/acceptancetests/assess_unregister.py
@@ -67,7 +67,7 @@ def assert_switch_raises_error(client):
     try:
         client.get_juju_output('switch', include_e=False)
     except subprocess.CalledProcessError as e:
-        if 'no currently specified model' not in e.stderr:
+        if 'no model name was passed' not in e.stderr:
             raise JujuAssertionError(
                 '"juju switch" command failed for an unexpected reason: '
                 '{}'.format(e.stderr))


### PR DESCRIPTION
## Description of change

The error message returned for running `juju switch` without an argument was changed in https://github.com/juju/juju/pull/10885, but the test `nw-unregister-controller` still makes an assertion based on the old message.

This simply updates the expected message to what the error return is.

## QA steps

Test `nw-unregister-controller` passes.
