### PR TITLE
Improve sorting for juju/cmd#68 changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -472,14 +472,14 @@
   revision = "9c5c9712527c7986f012361e7d13756b4d99543d"
 
 [[projects]]
-  digest = "1:d2b54c9eb7d2ae6ad4ab7d2463b0804c3a1aa9c908b8ec3d6f75ddd3ce87bd4c"
+  digest = "1:68bc775aba55be0a3e178439988ba7daf3a86b805942a251146277ea506f935f"
   name = "github.com/juju/cmd"
   packages = [
     ".",
     "cmdtesting",
   ]
   pruneopts = ""
-  revision = "0c5c82a8dfc6992939365fc947d7399e0e2428ae"
+  revision = "74922f23f6436a661dacd8c5fdf9cb15641e7a2e"
 
 [[projects]]
   digest = "1:243ec2217cb77ad028a956bf4d886b0f070d2dbfe861ceadfcf270412c2e7b90"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -288,7 +288,7 @@
 
 [[constraint]]
   name = "github.com/juju/cmd"
-  revision = "0c5c82a8dfc6992939365fc947d7399e0e2428ae"
+  revision = "74922f23f6436a661dacd8c5fdf9cb15641e7a2e"
 
 [[constraint]]
   name = "github.com/juju/collections"


### PR DESCRIPTION
### Checklist

 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The following brings in the changes from juju/cmd#68 PR changes.

------

The following removes the math.MaxInt64, as we have failure to build on
32-bit architectures. Instead the sorting algorithm now performs one
sort over the indexed collections, first by checking the distance
between two strings and then if they're the same distance, falling back
onto the name.

This should improve the performance as you're only looping over once
instead of twice as previous algorithm did, which is a nice bonus!

## QA steps

*Please replace with how we can verify that the change works?*

```sh
➜ juju controll
ERROR juju: "controll" is not a juju command. See "juju --help".

Did you mean:
	controllers
```
