### PR TITLE
state: Change RelationUnitsWatcher to emit core/watcher.RelationUnitsChanges

### DIFF
--- a/api/uniter/application_test.go
+++ b/api/uniter/application_test.go
@@ -41,6 +41,7 @@ func (s *applicationSuite) TestNameTagAndString(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatch(c *gc.C) {
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	c.Assert(s.apiApplication.Life(), gc.Equals, params.Alive)
 
 	w, err := s.apiApplication.Watch()

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v3"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
@@ -163,7 +164,7 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 }
 
 // WatchRelationUnits returns a watcher for changes to the units on the specified relation.
-func WatchRelationUnits(backend Backend, tag names.RelationTag) (state.RelationUnitsWatcher, error) {
+func WatchRelationUnits(backend Backend, tag names.RelationTag) (common.RelationUnitsWatcher, error) {
 	relation, err := backend.KeyRelation(tag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -180,7 +181,11 @@ func WatchRelationUnits(backend Backend, tag names.RelationTag) (state.RelationU
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return w, nil
+		wrapped, err := common.RelationUnitsWatcherFromState(w)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return wrapped, nil
 	}
 	return nil, errors.NotFoundf("local application for %s", names.ReadableString(tag))
 }

--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/network"
 )
 
@@ -242,7 +242,7 @@ func (w *EgressAddressWatcher) unitAddress(unit Unit) (string, bool, error) {
 	return addr.Value, true, nil
 }
 
-func (w *EgressAddressWatcher) processUnitChanges(c params.RelationUnitsChange) (bool, error) {
+func (w *EgressAddressWatcher) processUnitChanges(c watcher.RelationUnitsChange) (bool, error) {
 	changed := false
 	for name := range c.Changed {
 

--- a/apiserver/common/firewall/egressaddresswatcher_test.go
+++ b/apiserver/common/firewall/egressaddresswatcher_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/firewall"
-	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/watcher"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -69,8 +69,8 @@ func (s *addressWatcherSuite) TestInitial(c *gc.C) {
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 	// django/0 is initially in scope
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -85,14 +85,14 @@ func (s *addressWatcherSuite) TestUnitEntersScope(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{}
+	rel.ruw.changes <- watcher.RelationUnitsChange{}
 
 	// Initial event.
 	wc.AssertChange()
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -100,8 +100,8 @@ func (s *addressWatcherSuite) TestUnitEntersScope(c *gc.C) {
 	wc.AssertNoChange()
 
 	// A not found unit doesn't trigger an event.
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"unknown/0": {},
 		},
 	}
@@ -114,7 +114,7 @@ func (s *addressWatcherSuite) TestTwoUnitsEntersScope(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{}
+	rel.ruw.changes <- watcher.RelationUnitsChange{}
 
 	unit := newMockUnit("django/1")
 	unit.publicAddress = network.NewSpaceAddress("54.4.5.6")
@@ -126,8 +126,8 @@ func (s *addressWatcherSuite) TestTwoUnitsEntersScope(c *gc.C) {
 	wc.AssertChange()
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 			"django/1": {},
 		},
@@ -142,14 +142,14 @@ func (s *addressWatcherSuite) TestAnotherUnitsEntersScope(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{}
+	rel.ruw.changes <- watcher.RelationUnitsChange{}
 
 	// Initial event.
 	wc.AssertChange()
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -161,8 +161,8 @@ func (s *addressWatcherSuite) TestAnotherUnitsEntersScope(c *gc.C) {
 	unit.machineId = "1"
 	s.st.units["django/1"] = unit
 	s.st.machines["1"] = newMockMachine("1")
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/1": {},
 		},
 	}
@@ -176,8 +176,8 @@ func (s *addressWatcherSuite) TestUnitEntersScopeNoPublicAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -188,8 +188,8 @@ func (s *addressWatcherSuite) TestUnitEntersScopeNoPublicAddress(c *gc.C) {
 	wc.AssertNoChange()
 
 	// This time no event.
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -204,8 +204,8 @@ func (s *addressWatcherSuite) TestUnitEntersScopeNotAssigned(c *gc.C) {
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -216,8 +216,8 @@ func (s *addressWatcherSuite) TestUnitEntersScopeNotAssigned(c *gc.C) {
 	wc.AssertNoChange()
 
 	// This time no event.
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -231,7 +231,7 @@ func (s *addressWatcherSuite) TestUnitLeavesScopeInitial(c *gc.C) {
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 
-	rel.ruw.changes <- params.RelationUnitsChange{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
 		Departed: []string{"django/0"},
 	}
 
@@ -247,7 +247,7 @@ func (s *addressWatcherSuite) TestUnitLeavesScope(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{}
+	rel.ruw.changes <- watcher.RelationUnitsChange{}
 
 	unit := newMockUnit("django/1")
 	unit.publicAddress = network.NewSpaceAddress("54.4.5.6")
@@ -259,8 +259,8 @@ func (s *addressWatcherSuite) TestUnitLeavesScope(c *gc.C) {
 	wc.AssertChange()
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 			"django/1": {},
 		},
@@ -268,7 +268,7 @@ func (s *addressWatcherSuite) TestUnitLeavesScope(c *gc.C) {
 	wc.AssertChange("54.1.2.3/32", "54.4.5.6/32")
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
 		Departed: []string{"django/0"},
 	}
 
@@ -282,7 +282,7 @@ func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{}
+	rel.ruw.changes <- watcher.RelationUnitsChange{}
 
 	unit := newMockUnit("django/1")
 	unit.publicAddress = network.NewSpaceAddress("54.1.2.3")
@@ -293,8 +293,8 @@ func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
 	wc.AssertChange()
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 			"django/1": {},
 		},
@@ -303,14 +303,14 @@ func (s *addressWatcherSuite) TestTwoUnitsSameAddressOneLeaves(c *gc.C) {
 	wc.AssertNoChange()
 
 	// One leaves, no change.
-	rel.ruw.changes <- params.RelationUnitsChange{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
 		Departed: []string{"django/0"},
 	}
 
 	wc.AssertNoChange()
 
 	// Last one leaves.
-	rel.ruw.changes <- params.RelationUnitsChange{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
 		Departed: []string{"django/1"},
 	}
 
@@ -325,8 +325,8 @@ func (s *addressWatcherSuite) TestSecondUnitJoinsOnSameMachine(c *gc.C) {
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 	// django/0 is initially in scope
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -339,8 +339,8 @@ func (s *addressWatcherSuite) TestSecondUnitJoinsOnSameMachine(c *gc.C) {
 	unit.machineId = "0"
 	s.st.units["django/1"] = unit
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/1": {},
 		},
 	}
@@ -363,8 +363,8 @@ func (s *addressWatcherSuite) TestSeesMachineAddressChanges(c *gc.C) {
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 	// django/0 is initially in scope
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -386,8 +386,8 @@ func (s *addressWatcherSuite) TestHandlesMachineAddressChangesWithNoEffect(c *gc
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
 	// django/0 is initially in scope
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -407,8 +407,8 @@ func (s *addressWatcherSuite) TestHandlesUnitGoneWhenMachineAddressChanges(c *gc
 	unit.publicAddress = network.NewSpaceAddress("2.3.4.5")
 	unit.machineId = "0"
 	s.st.units["django/1"] = unit
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 			"django/1": {},
 		},
@@ -422,7 +422,7 @@ func (s *addressWatcherSuite) TestHandlesUnitGoneWhenMachineAddressChanges(c *gc
 	wc.AssertChange("2.3.4.5/32")
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
 		Departed: []string{"django/1"},
 	}
 	s.st.units["django/0"].updateAddress("6.7.8.9")
@@ -439,14 +439,14 @@ func (s *addressWatcherSuite) TestModelEgressAddressUsed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{}
+	rel.ruw.changes <- watcher.RelationUnitsChange{}
 
 	// Initial event.
 	wc.AssertChange()
 	wc.AssertNoChange()
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -466,8 +466,8 @@ func (s *addressWatcherSuite) TestModelEgressAddressUsed(c *gc.C) {
 	wc.AssertNoChange()
 
 	// A not found unit doesn't trigger an event.
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"unknown/0": {},
 		},
 	}
@@ -482,7 +482,7 @@ func (s *addressWatcherSuite) TestRelationEgressAddressUsed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, nopSyncStarter{}, w)
-	rel.ruw.changes <- params.RelationUnitsChange{}
+	rel.ruw.changes <- watcher.RelationUnitsChange{}
 
 	// Initial event.
 	wc.AssertChange()
@@ -491,8 +491,8 @@ func (s *addressWatcherSuite) TestRelationEgressAddressUsed(c *gc.C) {
 	// New relation ingress cidr.
 	rel.ew.changes <- []string{"192.168.0.0/8"}
 
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 		},
 	}
@@ -509,8 +509,8 @@ func (s *addressWatcherSuite) TestRelationEgressAddressUsed(c *gc.C) {
 	wc.AssertNoChange()
 
 	// A not found unit doesn't trigger an event.
-	rel.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	rel.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"unknown/0": {},
 		},
 	}

--- a/apiserver/common/firewall/firewall_test.go
+++ b/apiserver/common/firewall/firewall_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -62,8 +63,8 @@ func (s *FirewallSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
 	s.st.relations["remote-db2:db django:db"] = db2Relation
 	s.st.remoteEntities[names.NewRelationTag("remote-db2:db django:db")] = "token-db2:db django:db"
 	// django/0 and django/1 are initially in scope
-	db2Relation.ruw.changes <- params.RelationUnitsChange{
-		Changed: map[string]params.UnitSettings{
+	db2Relation.ruw.changes <- watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
 			"django/0": {},
 			"django/1": {},
 		},

--- a/apiserver/common/firewall/mock_test.go
+++ b/apiserver/common/firewall/mock_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/common/firewall"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
 	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -301,7 +301,7 @@ func (r *mockRelation) WatchRelationEgressNetworks() state.StringsWatcher {
 }
 
 func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {
-	w := &mockRelationUnitsWatcher{changes: make(chan params.RelationUnitsChange, 1)}
+	w := &mockRelationUnitsWatcher{changes: make(chan watcher.RelationUnitsChange, 1)}
 	w.Tomb.Go(func() error {
 		<-w.Tomb.Dying()
 		return nil
@@ -311,10 +311,10 @@ func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {
 
 type mockRelationUnitsWatcher struct {
 	mockWatcher
-	changes chan params.RelationUnitsChange
+	changes chan watcher.RelationUnitsChange
 }
 
-func (w *mockRelationUnitsWatcher) Changes() <-chan params.RelationUnitsChange {
+func (w *mockRelationUnitsWatcher) Changes() watcher.RelationUnitsChannel {
 	return w.changes
 }
 

--- a/apiserver/common/relationunitswatcher.go
+++ b/apiserver/common/relationunitswatcher.go
@@ -1,0 +1,113 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/catacomb"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/state"
+)
+
+// RelationUnitsWatcher represents a state.RelationUnitsWatcher at the
+// apiserver level (different type for changes).
+type RelationUnitsWatcher interface {
+	watcher.CoreWatcher
+	Changes() <-chan params.RelationUnitsChange
+
+	// Stop is needed to implement facade.Resource.
+	Stop() error
+
+	// Err implements watcher.Errer.
+	Err() error
+}
+
+// NewRelationUnitsWatcherFromState wraps a state-level
+// RelationUnitsWatcher in an equivalent apiserver-level one, taking
+// responsibility for the source watcher's lifetime.
+func RelationUnitsWatcherFromState(source state.RelationUnitsWatcher) (RelationUnitsWatcher, error) {
+	w := &relationUnitsWatcher{
+		source: source,
+		out:    make(chan params.RelationUnitsChange),
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{source},
+	})
+	return w, errors.Trace(err)
+}
+
+type relationUnitsWatcher struct {
+	source   state.RelationUnitsWatcher
+	out      chan params.RelationUnitsChange
+	catacomb catacomb.Catacomb
+}
+
+func (w *relationUnitsWatcher) loop() error {
+	// We need to close the changes channel because we're inside the
+	// API - see apiserver/watcher.go:srvRelationUnitsWatcher.Next()
+	defer close(w.out)
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case event, ok := <-w.source.Changes():
+			if !ok {
+				return w.catacomb.ErrDying()
+			}
+			select {
+			case <-w.catacomb.Dying():
+				return w.catacomb.ErrDying()
+			case w.out <- w.convert(event):
+			}
+		}
+	}
+}
+
+func (w *relationUnitsWatcher) convert(
+	event watcher.RelationUnitsChange,
+) params.RelationUnitsChange {
+	var changed map[string]params.UnitSettings
+	if event.Changed != nil {
+		changed = make(map[string]params.UnitSettings, len(event.Changed))
+		for key, val := range event.Changed {
+			changed[key] = params.UnitSettings{Version: val.Version}
+		}
+	}
+	return params.RelationUnitsChange{
+		Changed:    changed,
+		AppChanged: event.AppChanged,
+		Departed:   event.Departed,
+	}
+}
+
+// Changes is part of RelationUnitsWatcher.
+func (w *relationUnitsWatcher) Changes() <-chan params.RelationUnitsChange {
+	return w.out
+}
+
+// Kill is part of worker.Worker.
+func (w *relationUnitsWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of worker.Worker.
+func (w *relationUnitsWatcher) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// Stop is part of facade.Resource.
+func (w *relationUnitsWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+// Err is part of state/watcher.Errer.
+func (w *relationUnitsWatcher) Err() error {
+	return w.catacomb.Err()
+}

--- a/apiserver/common/relationunitswatcher_test.go
+++ b/apiserver/common/relationunitswatcher_test.go
@@ -1,0 +1,182 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/testing"
+)
+
+type relationUnitsWatcherSuite struct{}
+
+var _ = gc.Suite(&relationUnitsWatcherSuite{})
+
+func (s *relationUnitsWatcherSuite) TestRelationUnitsWatcherFromState(c *gc.C) {
+
+	source := &mockRUWatcher{
+		changes: make(chan watcher.RelationUnitsChange),
+	}
+	// Ensure the watcher tomb thinks it's still going.
+	source.Tomb.Go(func() error {
+		<-source.Tomb.Dying()
+		return nil
+	})
+	w, err := common.RelationUnitsWatcherFromState(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(source.Err(), gc.Equals, tomb.ErrStillAlive)
+	c.Assert(w.Err(), gc.Equals, tomb.ErrStillAlive)
+
+	event := watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
+			"joni/1": {Version: 23},
+		},
+		AppChanged: map[string]int64{
+			"mitchell": 42,
+		},
+		Departed: []string{"urge", "for", "going"},
+	}
+	select {
+	case source.changes <- event:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting to send event")
+	}
+
+	// The running loop of the watcher is effectively a 1-event
+	// buffer.
+
+	select {
+	case result := <-w.Changes():
+		c.Assert(result, gc.DeepEquals, params.RelationUnitsChange{
+			Changed: map[string]params.UnitSettings{
+				"joni/1": {Version: 23},
+			},
+			AppChanged: map[string]int64{
+				"mitchell": 42,
+			},
+			Departed: []string{"urge", "for", "going"},
+		})
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for output event")
+	}
+
+	c.Assert(w.Stop(), jc.ErrorIsNil)
+	// Ensure that stopping the watcher has stopped the source.
+	c.Assert(source.Err(), jc.ErrorIsNil)
+
+	select {
+	case _, ok := <-w.Changes():
+		c.Assert(ok, gc.Equals, false)
+	default:
+		c.Fatalf("didn't close output channel")
+	}
+}
+
+func (s *relationUnitsWatcherSuite) TestCanStopWithAPendingSend(c *gc.C) {
+	source := &mockRUWatcher{
+		changes: make(chan watcher.RelationUnitsChange),
+	}
+	// Ensure the watcher tomb thinks it's still going.
+	source.Tomb.Go(func() error {
+		<-source.Tomb.Dying()
+		return nil
+	})
+	w, err := common.RelationUnitsWatcherFromState(source)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Kill()
+
+	event := watcher.RelationUnitsChange{
+		Changed: map[string]watcher.UnitSettings{
+			"joni/1": {Version: 23},
+		},
+	}
+	s.send(c, source.changes, event)
+
+	// Stop without accepting the output event.
+	stopped := make(chan error)
+	go func() {
+		err := w.Stop()
+		stopped <- err
+	}()
+
+	select {
+	case err := <-stopped:
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for watcher to stop with pending send")
+	}
+}
+
+func (s *relationUnitsWatcherSuite) TestNilChanged(c *gc.C) {
+	source := &mockRUWatcher{
+		changes: make(chan watcher.RelationUnitsChange),
+	}
+	// Ensure the watcher tomb thinks it's still going.
+	source.Tomb.Go(func() error {
+		<-source.Tomb.Dying()
+		return nil
+	})
+	w, err := common.RelationUnitsWatcherFromState(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	event := watcher.RelationUnitsChange{
+		Departed: []string{"happy", "birthday"},
+	}
+
+	s.send(c, source.changes, event)
+	result := s.receive(c, w)
+	c.Assert(result, gc.DeepEquals, params.RelationUnitsChange{
+		Departed: []string{"happy", "birthday"},
+	})
+}
+
+func (s *relationUnitsWatcherSuite) send(c *gc.C, ch chan watcher.RelationUnitsChange, event watcher.RelationUnitsChange) {
+	select {
+	case ch <- event:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting to send event")
+	}
+}
+
+func (s *relationUnitsWatcherSuite) receive(c *gc.C, w common.RelationUnitsWatcher) params.RelationUnitsChange {
+	select {
+	case result := <-w.Changes():
+		return result
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for output event")
+	}
+	// Can't actually happen, but the go compiler can't tell that
+	// c.Fatalf panics.
+	return params.RelationUnitsChange{}
+}
+
+type mockRUWatcher struct {
+	tomb.Tomb
+	changes chan watcher.RelationUnitsChange
+}
+
+func (w *mockRUWatcher) Changes() watcher.RelationUnitsChannel {
+	return w.changes
+}
+
+func (w *mockRUWatcher) Kill() {
+	w.Tomb.Kill(nil)
+}
+
+func (w *mockRUWatcher) Stop() error {
+	w.Tomb.Kill(nil)
+	return w.Tomb.Wait()
+}
+
+func (w *mockRUWatcher) Err() error {
+	return w.Tomb.Err()
+}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2108,7 +2108,11 @@ func (u *UniterAPIV8) watchOneUnitAddresses(tag names.UnitTag) (string, error) {
 }
 
 func (u *UniterAPI) watchOneRelationUnit(relUnit *state.RelationUnit) (params.RelationUnitsWatchResult, error) {
-	watch := relUnit.Watch()
+	stateWatcher := relUnit.Watch()
+	watch, err := common.RelationUnitsWatcherFromState(stateWatcher)
+	if err != nil {
+		return params.RelationUnitsWatchResult{}, errors.Trace(err)
+	}
 	// Consume the initial event and forward it to the result.
 	if changes, ok := <-watch.Changes(); ok {
 		return params.RelationUnitsWatchResult{

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -15,10 +15,10 @@ import (
 
 	common "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/controller/remoterelations"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -456,12 +456,12 @@ func (w *mockStringsWatcher) Changes() <-chan []string {
 
 type mockRelationUnitsWatcher struct {
 	mockWatcher
-	changes chan params.RelationUnitsChange
+	changes chan watcher.RelationUnitsChange
 }
 
 func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {
 	w := &mockRelationUnitsWatcher{
-		changes: make(chan params.RelationUnitsChange, 1),
+		changes: make(chan watcher.RelationUnitsChange, 1),
 	}
 	w.Tomb.Go(func() error {
 		<-w.Tomb.Dying()
@@ -470,7 +470,7 @@ func newMockRelationUnitsWatcher() *mockRelationUnitsWatcher {
 	return w
 }
 
-func (w *mockRelationUnitsWatcher) Changes() <-chan params.RelationUnitsChange {
+func (w *mockRelationUnitsWatcher) Changes() watcher.RelationUnitsChannel {
 	w.MethodCall(w, "Changes")
 	return w.changes
 }

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -17,6 +17,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -110,8 +111,8 @@ func (s *remoteRelationsSuite) TestWatchRemoteRelations(c *gc.C) {
 
 func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
 	djangoRelationUnitsWatcher := newMockRelationUnitsWatcher()
-	djangoRelationUnitsWatcher.changes <- params.RelationUnitsChange{
-		Changed:    map[string]params.UnitSettings{"django/0": {Version: 1}},
+	djangoRelationUnitsWatcher.changes <- watcher.RelationUnitsChange{
+		Changed:    map[string]watcher.UnitSettings{"django/0": {Version: 1}},
 		AppChanged: map[string]int64{"django": 0},
 	}
 	djangoRelation := newMockRelation(123)

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -199,7 +199,7 @@ func (w *srvStringsWatcher) Next() (params.StringsWatchResult, error) {
 // and changes to the settings of those units known to have entered.
 type srvRelationUnitsWatcher struct {
 	watcherCommon
-	watcher state.RelationUnitsWatcher
+	watcher common.RelationUnitsWatcher
 }
 
 func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
@@ -212,7 +212,7 @@ func newRelationUnitsWatcher(context facade.Context) (facade.Facade, error) {
 	if auth.GetAuthTag() != nil && !isAgent(auth) {
 		return nil, common.ErrPerm
 	}
-	watcher, ok := resources.Get(id).(state.RelationUnitsWatcher)
+	watcher, ok := resources.Get(id).(common.RelationUnitsWatcher)
 	if !ok {
 		return nil, common.ErrUnknownWatcher
 	}

--- a/core/watcher/interface.go
+++ b/core/watcher/interface.go
@@ -27,6 +27,11 @@ import (
 //      sensible clients will still check for closed channels (never trust a
 //      contract...) but can treat that scenario as a simple error.
 //
+//     (This rule only applies to watchers outside the API; watchers inside the
+//     API boundary need to close their changes channel so that the .Next()
+//     method implementations inside the API server (see apiserver/watcher.go)
+//     finish correctly.)
+//
 // To convert a state/watcher.Watcher to a CoreWatcher, ensure that the watcher
 // no longer closes its Changes() channel; and replace Stop() and Err() with the
 // usual worker boilerplate. Namely:

--- a/state/testing/watcher.go
+++ b/state/testing/watcher.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 	tomb "gopkg.in/tomb.v2"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/testing"
 )
 
@@ -277,7 +277,7 @@ func NewRelationUnitsWatcherC(c *gc.C, st SyncStarter, w RelationUnitsWatcher) R
 
 type RelationUnitsWatcher interface {
 	Stop() error
-	Changes() <-chan params.RelationUnitsChange
+	Changes() watcher.RelationUnitsChannel
 }
 
 func (c RelationUnitsWatcherC) AssertNoChange() {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -29,21 +29,9 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	corenetwork "github.com/juju/juju/core/network"
+	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/watcher"
-
-	// TODO(fwereade): 2015-11-18 lp:1517428
-	//
-	// This gets an import block of its own because it's such staggeringly bad
-	// practice. It's here because (1) it always has been, just not quite so
-	// explicitly and (2) even if we had the state watchers implemented as
-	// juju/watcher~s rather than juju/state/watcher~s -- which we don't, so
-	// it's misleading to use those *Chan types etc -- we don't yet have any
-	// ability to transform watcher output in the apiserver layer, so we're
-	// kinda stuck producing what we always have.
-	//
-	// See RelationUnitsWatcher below.
-	"github.com/juju/juju/apiserver/params"
 )
 
 var watchLogger = loggo.GetLogger("juju.state.watch")
@@ -84,12 +72,7 @@ type StringsWatcher interface {
 type RelationUnitsWatcher interface {
 	Watcher
 
-	// Note that it's not very nice exposing a params type directly here. This
-	// is a continuation of existing bad behaviour and not good practice; do
-	// not use this as a model. (FWIW, it used to be in multiwatcher; which is
-	// also api-ey; and the multiwatcher type was used directly in params
-	// anyway.)
-	Changes() <-chan params.RelationUnitsChange
+	Changes() corewatcher.RelationUnitsChannel
 }
 
 // newCommonWatcher exists so that all embedders have a place from which
@@ -1015,7 +998,7 @@ type relationUnitsWatcher struct {
 	updates         chan watcher.Change
 	appSettingsKeys []string
 	appUpdates      chan watcher.Change
-	out             chan params.RelationUnitsChange
+	out             chan corewatcher.RelationUnitsChange
 	logger          loggo.Logger
 }
 
@@ -1059,7 +1042,7 @@ func newRelationUnitsWatcher(backend modelBackend, sw *RelationScopeWatcher, app
 		watching:        make(set.Strings),
 		updates:         make(chan watcher.Change),
 		appUpdates:      make(chan watcher.Change),
-		out:             make(chan params.RelationUnitsChange),
+		out:             make(chan corewatcher.RelationUnitsChange),
 		logger:          logger.Child("relationunits"),
 	}
 	w.tomb.Go(func() error {
@@ -1073,24 +1056,24 @@ func newRelationUnitsWatcher(backend modelBackend, sw *RelationScopeWatcher, app
 // counterpart units in a relation. The first event on the
 // channel holds the initial state of the relation in its
 // Changed field.
-func (w *relationUnitsWatcher) Changes() <-chan params.RelationUnitsChange {
+func (w *relationUnitsWatcher) Changes() corewatcher.RelationUnitsChannel {
 	return w.out
 }
 
-func emptyRelationUnitsChanges(changes *params.RelationUnitsChange) bool {
+func emptyRelationUnitsChanges(changes *corewatcher.RelationUnitsChange) bool {
 	return len(changes.Changed)+len(changes.AppChanged)+len(changes.Departed) == 0
 }
 
-func setRelationUnitChangeVersion(changes *params.RelationUnitsChange, key string, version int64) {
+func setRelationUnitChangeVersion(changes *corewatcher.RelationUnitsChange, key string, version int64) {
 	name := unitNameFromScopeKey(key)
-	settings := params.UnitSettings{Version: version}
+	settings := corewatcher.UnitSettings{Version: version}
 	if changes.Changed == nil {
-		changes.Changed = map[string]params.UnitSettings{}
+		changes.Changed = map[string]corewatcher.UnitSettings{}
 	}
 	changes.Changed[name] = settings
 }
 
-func (w *relationUnitsWatcher) watchRelatedAppSettings(changes *params.RelationUnitsChange) error {
+func (w *relationUnitsWatcher) watchRelatedAppSettings(changes *corewatcher.RelationUnitsChange) error {
 	idsAsInterface := make([]interface{}, len(w.appSettingsKeys))
 	for i, key := range w.appSettingsKeys {
 		idsAsInterface[i] = w.backend.docID(key)
@@ -1112,7 +1095,7 @@ func (w *relationUnitsWatcher) watchRelatedAppSettings(changes *params.RelationU
 // mergeSettings reads the relation settings node for the unit with the
 // supplied key, and sets a value in the Changed field keyed on the unit's
 // name. It returns the mgo/txn revision number of the settings node.
-func (w *relationUnitsWatcher) mergeSettings(changes *params.RelationUnitsChange, key string) error {
+func (w *relationUnitsWatcher) mergeSettings(changes *corewatcher.RelationUnitsChange, key string) error {
 	version, err := readSettingsDocVersion(w.backend.db(), settingsC, key)
 	if err != nil {
 		w.logger.Tracef("relationUnitsWatcher %q merging key %q (not found)", w.sw.prefix, key)
@@ -1123,7 +1106,7 @@ func (w *relationUnitsWatcher) mergeSettings(changes *params.RelationUnitsChange
 	return nil
 }
 
-func (w *relationUnitsWatcher) mergeAppSettings(changes *params.RelationUnitsChange, key string) error {
+func (w *relationUnitsWatcher) mergeAppSettings(changes *corewatcher.RelationUnitsChange, key string) error {
 	version, err := readSettingsDocVersion(w.backend.db(), settingsC, key)
 	if err != nil {
 		w.logger.Tracef("relationUnitsWatcher %q merging app key %q (not found)", w.sw.prefix, key)
@@ -1142,7 +1125,7 @@ func (w *relationUnitsWatcher) mergeAppSettings(changes *params.RelationUnitsCha
 // mergeScope starts and stops settings watches on the units entering and
 // leaving the scope in the supplied RelationScopeChange event, and applies
 // the expressed changes to the supplied RelationUnitsChange event.
-func (w *relationUnitsWatcher) mergeScope(changes *params.RelationUnitsChange, c *RelationScopeChange) error {
+func (w *relationUnitsWatcher) mergeScope(changes *corewatcher.RelationUnitsChange, c *RelationScopeChange) error {
 	docIds := make([]interface{}, len(c.Entered))
 	for i, name := range c.Entered {
 		key := w.sw.prefix + name
@@ -1206,8 +1189,8 @@ func (w *relationUnitsWatcher) loop() (err error) {
 	var (
 		gotInitialScopeWatcher bool
 		sentInitial            bool
-		changes                params.RelationUnitsChange
-		out                    chan<- params.RelationUnitsChange
+		changes                corewatcher.RelationUnitsChange
+		out                    chan<- corewatcher.RelationUnitsChange
 	)
 	// Note that w.ScopeWatcher *does* trigger an initial event, while
 	// WatchMulti from raw document watchers does *not*. (raw database watchers
@@ -1265,7 +1248,7 @@ func (w *relationUnitsWatcher) loop() (err error) {
 		case out <- changes:
 			w.logger.Tracef("relationUnitsWatcher %q sent changes %# v", w.sw.prefix, pretty.Formatter(changes))
 			sentInitial = true
-			changes = params.RelationUnitsChange{}
+			changes = corewatcher.RelationUnitsChange{}
 			out = nil
 		}
 	}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
    _No API change._

 - ~~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~
   _Doesn't change behaviour, just types._

 - ~~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~~

 - [x] Do comments answer the question of why design decisions were made?

## Description of change

state.RelationUnitsWatcher now yields core/watcher.RelationUnitsChanges instead of apiserver/params.RelationUnitsChanges, which caused a nasty dependency from state to apiserver.

This required a wrapper watcher in apiserver to convert the core
events into params ones.

## QA steps

There's no behaviour change, bootstrapping and deploying should be enough - basic smoke test.

## Documentation changes
None

## Bug reference
None