### PR TITLE
Relax credential validity check for update.

### DIFF
--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ValidateExistingModelCredential checks if the cloud credential that a given model uses is valid for it.
-func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
+func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext, migrating bool) (params.ErrorResults, error) {
 	model, err := backend.Model()
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -38,11 +38,11 @@ func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.
 		return params.ErrorResults{}, errors.NotValidf("credential %q", storedCredential.Name)
 	}
 	credential := cloud.NewCredential(cloud.AuthType(storedCredential.AuthType), storedCredential.Attributes)
-	return ValidateNewModelCredential(backend, callCtx, credentialTag, &credential)
+	return ValidateNewModelCredential(backend, callCtx, credentialTag, &credential, migrating)
 }
 
 // ValidateNewModelCredential checks if a new cloud credential could be valid for a given model.
-func ValidateNewModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+func ValidateNewModelCredential(backend PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 	openParams, err := buildOpenParams(backend, credentialTag, credential)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -55,7 +55,7 @@ func ValidateNewModelCredential(backend PersistentBackend, callCtx context.Provi
 	case state.ModelTypeCAAS:
 		return checkCAASModelCredential(openParams)
 	case state.ModelTypeIAAS:
-		return checkIAASModelCredential(openParams, backend, callCtx)
+		return checkIAASModelCredential(openParams, backend, callCtx, migrating)
 	default:
 		return params.ErrorResults{}, errors.NotSupportedf("model type %q", model.Type())
 	}
@@ -74,7 +74,7 @@ func checkCAASModelCredential(brokerParams environs.OpenParams) (params.ErrorRes
 	return params.ErrorResults{}, nil
 }
 
-func checkIAASModelCredential(openParams environs.OpenParams, backend PersistentBackend, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
+func checkIAASModelCredential(openParams environs.OpenParams, backend PersistentBackend, callCtx context.ProviderCallContext, migrating bool) (params.ErrorResults, error) {
 	env, err := newEnv(openParams)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
@@ -83,13 +83,13 @@ func checkIAASModelCredential(openParams environs.OpenParams, backend Persistent
 	// In the future, this check may be extended to other cloud resources,
 	// entities and operation-level authorisations such as interfaces,
 	// ability to CRUD storage, etc.
-	return checkMachineInstances(backend, env, callCtx)
+	return checkMachineInstances(backend, env, callCtx, migrating)
 }
 
 // checkMachineInstances compares model machines from state with
 // the ones reported by the provider using supplied credential.
 // This only makes sense for non-k8s providers.
-func checkMachineInstances(backend PersistentBackend, provider CloudProvider, callCtx context.ProviderCallContext) (params.ErrorResults, error) {
+func checkMachineInstances(backend PersistentBackend, provider CloudProvider, callCtx context.ProviderCallContext, migrating bool) (params.ErrorResults, error) {
 	fail := func(original error) (params.ErrorResults, error) {
 		return params.ErrorResults{}, original
 	}
@@ -137,12 +137,22 @@ func checkMachineInstances(backend PersistentBackend, provider CloudProvider, ca
 		return fail(errors.Trace(err))
 	}
 
+	// From here, there 2 ways of checking whether the credential is valid:
+	// 1. Can we reach all cloud instances that machines know about?
+	// 2. Can we cross examine all machines we know about with all the instances we can reach
+	// and ensure that they correspond 1:1.
+	// Second check (2) is more useful for model migration, for example, since we want to know if
+	// we have moved the known universe correctly. However, it is a but redundant if we just care about
+	// credential validity since the first check (1) addresses all our concerns.
+
 	instanceIds := set.NewStrings()
 	for _, instance := range instances {
 		id := string(instance.Id())
 		instanceIds.Add(id)
-		if _, found := machinesByInstance[id]; !found {
-			results = append(results, serverError(errors.Errorf("no machine with instance %q", id)))
+		if migrating {
+			if _, found := machinesByInstance[id]; !found {
+				results = append(results, serverError(errors.Errorf("no machine with instance %q", id)))
+			}
 		}
 	}
 

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -696,6 +696,7 @@ func (api *CloudAPI) validateCredentialForModel(modelUUID string, tag names.Clou
 		callContext,
 		tag,
 		credential,
+		false,
 	)
 	if err != nil {
 		return append(result, params.ErrorResult{common.ServerError(err)})

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -343,7 +343,7 @@ func (s *cloudSuiteV2) TestUpdateCredentialsWithBrokenModels(c *gc.C) {
 			"deadbeef-2f18-4fd2-967d-db9663db7bea": "testModel2",
 		}, nil
 	}
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		if uuid := backend.(*mockModelBackend).uuid; uuid == coretesting.ModelTag.Id() {
 			return params.ErrorResults{[]params.ErrorResult{
 				{&params.Error{Message: "not valid for model"}},

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -665,7 +665,7 @@ func (s *cloudSuite) TestUpdateCredentialsOneModelSuccess(c *gc.C) {
 		}, nil
 	}
 
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		return params.ErrorResults{}, nil
 	})
 
@@ -763,7 +763,7 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidation(c *gc.C) {
 		}, nil
 	}
 
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 
@@ -797,7 +797,7 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidationForce(c *gc.C) {
 		}, nil
 	}
 
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 
@@ -832,7 +832,7 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) {
 		}, nil
 	}
 
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		if backend.(*mockModelBackend).uuid == "deadbeef-0bad-400d-8000-4b1d0d06f00d" {
 			return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 		}
@@ -874,7 +874,7 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidationForce(c *gc.
 		}, nil
 	}
 
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		if backend.(*mockModelBackend).uuid == "deadbeef-0bad-400d-8000-4b1d0d06f00d" {
 			return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 		}
@@ -918,7 +918,7 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidation(c *gc.C) {
 		}, nil
 	}
 
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 
@@ -958,7 +958,7 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidationForce(c *gc.C
 		}, nil
 	}
 
-	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential) (params.ErrorResults, error) {
+	s.PatchValue(cloudfacade.ValidateNewCredentialForModelFunc, func(backend credentialcommon.PersistentBackend, callCtx context.ProviderCallContext, credentialTag names.CloudCredentialTag, credential *cloud.Credential, migrating bool) (params.ErrorResults, error) {
 		return params.ErrorResults{[]params.ErrorResult{{&params.Error{Message: "not valid for model"}}}}, nil
 	})
 

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -266,6 +266,7 @@ func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error
 	return credentialcommon.ValidateExistingModelCredential(
 		credentialcommon.NewPersistentBackend(st.State),
 		state.CallContext(st.State),
+		true,
 	)
 }
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change? 
_No API change._

 - [ ] ~~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~
 - [ ] ~~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Cloud credential check is performed when managing credentials as well as when migrating a model. Juju checks that the cloud instances for the machines are accessible as well as that all cloud instances for a model have associated machines.

For model migration, the second check is a sanity check that verifies that machines are migrated and cloud instances are re-tagged completely and correctly. However, for credential management, this check is not necessary (and can cause problems) since Juju only needs to make sure that machines' cloud instances are accessible.
 
This PR simplifies validity check for credential management by by-passing 2nd check and ensuring that migration checks remain the same.

## QA steps

1. bootstrap
2. deploy application with some units
3. remove a unit such that machine's cloud instance remains (either using harvest mode or db surgery)
4. invalidate cloud credential (first in the cloud console, then try deploying another application or add a unit or a machine)
5. re-validate credential ('juju update-credential...')

(or follow the MAAS locked machine example in linked bug)

## Bug reference

Part 1 for https://bugs.launchpad.net/juju/+bug/1852412
