### PR TITLE
Add kubernetes python client to operator image;

### DIFF
--- a/caas/jujud-operator-requirements.txt
+++ b/caas/jujud-operator-requirements.txt
@@ -1,3 +1,4 @@
 pip>=7.0.0,<8.2.0
 charmhelpers>=0.4.0,<1.0.0
 charms.reactive>=0.1.0,<2.0.0
+kubernetes==10.0.*


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] <del>Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?</del>
 - [ ] <del>Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?</del>
 - [ ] <del>Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?</del>
 - [ ] <del>Do comments answer the question of why design decisions were made?</del>

----

## Description of change

Add `kubernetes python client` to operator image;

## QA steps

```console
# bootstrap to k8s;
$ juju bootstrap microk8s k1

# deploy mariadb;
$ juju add-model t1 microk8s && juju deploy cs:~kelvin.liu/mariadb-k8s-3 --debug -m k1:t1

# exec into operator pod;
$ kubectl exec pod/mariadb-k8s-operator-0  -n controller-k1 -it -- bash

# test in python;
$ python
```

```ipython
In [1]: from kubernetes import client, config
In [2]: config.load_incluster_config()
In [3]: v1 = client.CoreV1Api()
In [4]: v1.list_namespace()
Out[4]:
{'api_version': 'v1',
 'items': [{'api_version': None,
            'kind': None,
            'metadata': {'annotations': {'juju.io/controller': '170db7ac-d09e-4f39-88a6-ec62f618bcff',
                                         'juju.io/is-controller': 'true',
                                         'juju.io/model': '388dc4ae-72ce-483a-86e4-a16cac88a9a0'},
                         'cluster_name': None,
                         'creation_timestamp': datetime.datetime(2019, 11, 28, 2, 36, 28, tzinfo=tzlocal()),
                         'deletion_grace_period_seconds': None,
                         'deletion_timestamp': None,
                         'finalizers': None,
                         'generate_name': None,
                         'generation': None,
                         'initializers': None,
                         'labels': None,
                         'managed_fields': None,
                         'name': 'controller-k1',
                         'namespace': None,
                         'owner_references': None,
                         'resource_version': '327462',
                         'self_link': '/api/v1/namespaces/controller-k1',
                         'uid': 'ed3e7f82-1a76-4609-8efa-5a2601a49734'},
            'spec': {'finalizers': ['kubernetes']},
            'status': {'phase': 'Active'}},
           {'api_version': None,
            'kind': None,
            'metadata': {'annotations': None,
                         'cluster_name': None,
                         'creation_timestamp': datetime.datetime(2019, 11, 19, 11, 52, tzinfo=tzlocal()),
                         'deletion_grace_period_seconds': None,
                         'deletion_timestamp': None,
                         'finalizers': None,
                         'generate_name': None,
                         'generation': None,
                         'initializers': None,
                         'labels': None,
                         'managed_fields': None,
                         'name': 'default',
                         'namespace': None,
                         'owner_references': None,
                         'resource_version': '47',
                         'self_link': '/api/v1/namespaces/default',
                         'uid': 'dd7ac1f6-7197-4d7b-934f-d4874e8bb14d'},
            'spec': {'finalizers': ['kubernetes']},
            'status': {'phase': 'Active'}},
           {'api_version': None,
            'kind': None,
            'metadata': {'annotations': {'kubectl.kubernetes.io/last-applied-configuration': '{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"ingress"}}\n'},
                         'cluster_name': None,
                         'creation_timestamp': datetime.datetime(2019, 11, 25, 5, 52, 28, tzinfo=tzlocal()),
                         'deletion_grace_period_seconds': None,
                         'deletion_timestamp': None,
                         'finalizers': None,
                         'generate_name': None,
                         'generation': None,
                         'initializers': None,
                         'labels': None,
                         'managed_fields': None,
                         'name': 'ingress',
                         'namespace': None,
                         'owner_references': None,
                         'resource_version': '186846',
                         'self_link': '/api/v1/namespaces/ingress',
                         'uid': 'af15a587-23e1-45d8-a6ad-bb50505aeed2'},
            'spec': {'finalizers': ['kubernetes']},
            'status': {'phase': 'Active'}},
           {'api_version': None,
            'kind': None,
            'metadata': {'annotations': None,
                         'cluster_name': None,
                         'creation_timestamp': datetime.datetime(2019, 11, 19, 11, 51, 59, tzinfo=tzlocal()),
                         'deletion_grace_period_seconds': None,
                         'deletion_timestamp': None,
                         'finalizers': None,
                         'generate_name': None,
                         'generation': None,
                         'initializers': None,
                         'labels': None,
                         'managed_fields': None,
                         'name': 'kube-node-lease',
                         'namespace': None,
                         'owner_references': None,
                         'resource_version': '6',
                         'self_link': '/api/v1/namespaces/kube-node-lease',
                         'uid': 'b7ebc3dd-3658-45cd-8621-26ffe849f35a'},
            'spec': {'finalizers': ['kubernetes']},
            'status': {'phase': 'Active'}},
           {'api_version': None,
            'kind': None,
            'metadata': {'annotations': None,
                         'cluster_name': None,
                         'creation_timestamp': datetime.datetime(2019, 11, 19, 11, 51, 59, tzinfo=tzlocal()),
                         'deletion_grace_period_seconds': None,
                         'deletion_timestamp': None,
                         'finalizers': None,
                         'generate_name': None,
                         'generation': None,
                         'initializers': None,
                         'labels': None,
                         'managed_fields': None,
                         'name': 'kube-public',
                         'namespace': None,
                         'owner_references': None,
                         'resource_version': '5',
                         'self_link': '/api/v1/namespaces/kube-public',
                         'uid': '3296d2c5-42f6-4398-8583-e2fdc43032f5'},
            'spec': {'finalizers': ['kubernetes']},
            'status': {'phase': 'Active'}},
           {'api_version': None,
            'kind': None,
            'metadata': {'annotations': None,
                         'cluster_name': None,
                         'creation_timestamp': datetime.datetime(2019, 11, 19, 11, 51, 59, tzinfo=tzlocal()),
                         'deletion_grace_period_seconds': None,
                         'deletion_timestamp': None,
                         'finalizers': None,
                         'generate_name': None,
                         'generation': None,
                         'initializers': None,
                         'labels': None,
                         'managed_fields': None,
                         'name': 'kube-system',
                         'namespace': None,
                         'owner_references': None,
                         'resource_version': '4',
                         'self_link': '/api/v1/namespaces/kube-system',
                         'uid': '6b32af7a-7296-4a60-8e96-cd0eacbb77e5'},
            'spec': {'finalizers': ['kubernetes']},
            'status': {'phase': 'Active'}},
           {'api_version': None,
            'kind': None,
            'metadata': {'annotations': {'juju.io/controller': '170db7ac-d09e-4f39-88a6-ec62f618bcff',
                                         'juju.io/model': '835f028c-0e75-4285-88ac-17b2f1aec6cf'},
                         'cluster_name': None,
                         'creation_timestamp': datetime.datetime(2019, 11, 28, 2, 36, 50, tzinfo=tzlocal()),
                         'deletion_grace_period_seconds': None,
                         'deletion_timestamp': None,
                         'finalizers': None,
                         'generate_name': None,
                         'generation': None,
                         'initializers': None,
                         'labels': None,
                         'managed_fields': None,
                         'name': 't1',
                         'namespace': None,
                         'owner_references': None,
                         'resource_version': '327544',
                         'self_link': '/api/v1/namespaces/t1',
                         'uid': 'c22aab77-6d4b-42d0-abb3-ab4827efd4cd'},
            'spec': {'finalizers': ['kubernetes']},
            'status': {'phase': 'Active'}}],
 'kind': 'NamespaceList',
 'metadata': {'_continue': None,
              'resource_version': '328972',
              'self_link': '/api/v1/namespaces'}}
```

## Documentation changes

Yes

## Bug reference

None
