### PR TITLE
Tidy Up Macaroon Omission for Exported Remote Entities

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1196,8 +1196,6 @@ type remoteEntitiesShim struct {
 }
 
 // AllRemoteEntities returns all remote entities in the model.
-// Macaroons are omitted with the assumption that they
-// will be automatically re-minted later.
 func (s remoteEntitiesShim) AllRemoteEntities() ([]migrations.MigrationRemoteEntity, error) {
 	entities, err := s.st.AllRemoteEntities()
 	if err != nil {
@@ -1205,7 +1203,6 @@ func (s remoteEntitiesShim) AllRemoteEntities() ([]migrations.MigrationRemoteEnt
 	}
 	result := make([]migrations.MigrationRemoteEntity, len(entities))
 	for k, v := range entities {
-		v.macaroon = ""
 		result[k] = v
 	}
 	return result, nil
@@ -1921,8 +1918,6 @@ type remoteApplicationsShim struct {
 }
 
 // AllRemoteApplications returns all remote applications in the model.
-// Macaroons are omitted with the assumption that they
-// will be automatically re-minted later.
 func (s remoteApplicationsShim) AllRemoteApplications() ([]migrations.MigrationRemoteApplication, error) {
 	remoteApps, err := s.st.AllRemoteApplications()
 	if err != nil {
@@ -1930,7 +1925,6 @@ func (s remoteApplicationsShim) AllRemoteApplications() ([]migrations.MigrationR
 	}
 	result := make([]migrations.MigrationRemoteApplication, len(remoteApps))
 	for k, v := range remoteApps {
-		v.doc.Macaroon = ""
 		result[k] = remoteApplicationShim{RemoteApplication: v}
 	}
 	return result, nil

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -183,7 +183,10 @@ func (s *MigrationExportSuite) TestModelInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	machineSeq := s.setRandSequenceValue(c, "machine")
 	fooSeq := s.setRandSequenceValue(c, "application-foo")
-	s.State.SwitchBlockOn(state.ChangeBlock, "locked down")
+
+	err = s.State.SwitchBlockOn(state.ChangeBlock, "locked down")
+	c.Assert(err, jc.ErrorIsNil)
+
 	environVersion := 123
 	err = s.Model.SetEnvironVersion(environVersion)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migrations/remoteapplications.go
+++ b/state/migrations/remoteapplications.go
@@ -99,6 +99,9 @@ func (m ExportRemoteApplications) Execute(src RemoteApplicationSource, dst Remot
 
 func (m ExportRemoteApplications) addRemoteApplication(src RemoteApplicationSource, dst RemoteApplicationModel, app MigrationRemoteApplication) error {
 	url, _ := app.URL()
+
+	// Note that remote applications do not include a macaroon member at all.
+	// These are not intended for export.
 	args := description.RemoteApplicationArgs{
 		Tag:             app.Tag().(names.ApplicationTag),
 		OfferUUID:       app.OfferUUID(),

--- a/state/migrations/remoteentities.go
+++ b/state/migrations/remoteentities.go
@@ -42,10 +42,11 @@ func (ExportRemoteEntities) Execute(src RemoteEntitiesSource, dst RemoteEntities
 		return errors.Trace(err)
 	}
 	for _, entity := range entities {
+		// Despite remote entities having a member for macaroon,
+		// they are not exported.
 		dst.AddRemoteEntity(description.RemoteEntityArgs{
-			ID:       entity.ID(),
-			Token:    entity.Token(),
-			Macaroon: entity.Macaroon(),
+			ID:    entity.ID(),
+			Token: entity.Token(),
 		})
 	}
 	return nil

--- a/state/migrations/remoteentities_test.go
+++ b/state/migrations/remoteentities_test.go
@@ -34,9 +34,9 @@ func (s *RemoteEntitiesExportSuite) TestExportRemoteEntities(c *gc.C) {
 		Token: "aaa-bbb",
 	})
 	model.EXPECT().AddRemoteEntity(description.RemoteEntityArgs{
-		ID:       "controller-uuid-4",
-		Token:    "ccc-yyy",
-		Macaroon: "macaroon-5",
+		ID:    "controller-uuid-4",
+		Token: "ccc-yyy",
+		// Note no macaroon.
 	})
 
 	migration := ExportRemoteEntities{}
@@ -58,10 +58,11 @@ func (s *RemoteEntitiesExportSuite) TestExportRemoteEntitiesFailsGettingEntities
 	c.Assert(err, gc.ErrorMatches, "fail")
 }
 
-func (s *RemoteEntitiesExportSuite) remoteEntity(ctrl *gomock.Controller, id, token, macaroon string) *MockMigrationRemoteEntity {
+func (s *RemoteEntitiesExportSuite) remoteEntity(
+	ctrl *gomock.Controller, id, token, macaroon string,
+) *MockMigrationRemoteEntity {
 	entity := NewMockMigrationRemoteEntity(ctrl)
 	entity.EXPECT().ID().Return(names.NewControllerTag(id).String())
 	entity.EXPECT().Token().Return(token)
-	entity.EXPECT().Macaroon().Return(macaroon)
 	return entity
 }


### PR DESCRIPTION
## Description of change

This patch relocates logic added in https://github.com/juju/juju/pull/10941, to the correct place. I.e. the specific handler for the entity rather than where it is queried from state.

## QA steps

Passing unit tests. QA and integration tests will be contrived for the CMR migration scenario to accompany future patches advancing the feature.

## Documentation changes

None.

## Bug reference

NA
