### PR TITLE
Don't suppress errors in Start.

### DIFF
--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -515,6 +515,8 @@ func (runner *runner) runCharmHookOnLocal(hookName string, env []string, charmLo
 		runner.context.SetProcess(hookProcess{ps.Process})
 		// Block until execution finishes
 		exitErr = ps.Wait()
+	} else {
+		exitErr = err
 	}
 	// Ensure hook loggers are stopped before reading stdout/stderr
 	// so all the output is captured.

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -91,6 +91,15 @@ var runHookTests = []struct {
 		},
 		err: "exit status 99",
 	}, {
+		summary: "report error with invalid script",
+		relid:   -1,
+		spec: hookSpec{
+			perm:           0700,
+			code:           2,
+			missingShebang: true,
+		},
+		err: "fork/exec.*: exec format error",
+	}, {
 		summary: "output logging",
 		relid:   -1,
 		spec: hookSpec{

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -204,6 +204,8 @@ type hookSpec struct {
 	stderr string
 	// background holds a string to print in the background after 0.2s.
 	background string
+	// missingShebang will omit the '#!/bin/bash' line
+	missingShebang bool
 }
 
 // makeCharm constructs a fake charm dir containing a single named hook
@@ -230,7 +232,7 @@ func makeCharm(c *gc.C, spec hookSpec, charmDir string) {
 		_, err := fmt.Fprintf(hook, f+"\n", a...)
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	if runtime.GOOS != "windows" {
+	if !spec.missingShebang && runtime.GOOS != "windows" {
 		printf("#!/bin/bash")
 	}
 	printf(echoPidScript)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [No] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [N/A] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [N/A ] Do comments answer the question of why design decisions were made?

## Description of change

Don't suppress errors in Start.

When running a charm hook, we would notice if the hook exited nonzero,
but if we failed to Start the hook, that error ended up being
suppressed. This patch just puts the error in the same place as existing
exit error.

## QA steps

You can write a charm that has an invalid 'install' hook. Something like:
```sh
$ cd acceptancetests/repository/charms
$ echo "exit 2" > dummy-sink/hooks/install
$ juju deploy ./dummy-sink
```

Without this patch, it ignores the install hook failure, with this patch you get something like:
```
$ juju status
...
Unit           Workload  Agent  Machine  Public address  Ports  Message
dummy-sink/2*  error     idle   2        10.210.24.221          hook failed: "install"
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1854338