### PR TITLE
cmr saas migration: add initial step for finding the remote model (only works for model migration of same controller)

### DIFF
--- a/api/state_test.go
+++ b/api/state_test.go
@@ -170,16 +170,7 @@ func (s *stateSuite) TestLoginToMigratedModel(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	phases := []migration.Phase{
-		migration.IMPORT,
-		migration.PROCESSRELATIONS,
-		migration.VALIDATION,
-		migration.SUCCESS,
-		migration.LOGTRANSFER,
-		migration.REAP,
-		migration.DONE,
-	}
-	for _, phase := range phases {
+	for _, phase := range migration.SuccessfulMigrationPhases() {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
 	}
 	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -349,7 +349,7 @@ func (a *admin) maybeEmitRedirectError(modelUUID string, authTag names.Tag) erro
 	// Check if the model was not found because it was migrated to another
 	// controller. If that is the case and the user was able to access it
 	// before the migration return back a RedirectError.
-	mig, err := st.LatestRemovedModelMigration()
+	mig, err := st.CompletedMigrationForModel()
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -770,16 +770,7 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	phases := []migration.Phase{
-		migration.IMPORT,
-		migration.PROCESSRELATIONS,
-		migration.VALIDATION,
-		migration.SUCCESS,
-		migration.LOGTRANSFER,
-		migration.REAP,
-		migration.DONE,
-	}
-	for _, phase := range phases {
+	for _, phase := range migration.SuccessfulMigrationPhases() {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
 	}
 	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -169,7 +169,7 @@ func (st modelManagerStateShim) GetBackend(modelUUID string) (ModelManagerBacken
 
 		// Check if this model has been migrated and this user had
 		// access to it before its migration.
-		mig, mErr := otherState.LatestRemovedModelMigration()
+		mig, mErr := otherState.CompletedMigrationForModel()
 		if mErr != nil && !errors.IsNotFound(mErr) {
 			return nil, nil, errors.Trace(mErr)
 		}

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1639,16 +1639,8 @@ func (s *modelManagerStateSuite) TestModelInfoForMigratedModel(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	phases := []migration.Phase{
-		migration.IMPORT,
-		migration.PROCESSRELATIONS,
-		migration.VALIDATION,
-		migration.SUCCESS,
-		migration.LOGTRANSFER,
-		migration.REAP,
-		migration.DONE,
-	}
-	for _, phase := range phases {
+
+	for _, phase := range migration.SuccessfulMigrationPhases() {
 		c.Assert(mig.SetPhase(phase), jc.ErrorIsNil)
 	}
 	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -82,7 +82,7 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		// migrated allow clients to connect and wait for a login
 		// request to decide whether the users should be redirected to
 		// the new controller for this model or not.
-		if _, migErr := st.LatestRemovedModelMigration(); migErr != nil {
+		if _, migErr := st.CompletedMigrationForModel(); migErr != nil {
 			return nil, errors.Trace(err) // return original NotFound error
 		}
 	}

--- a/core/doc.go
+++ b/core/doc.go
@@ -6,7 +6,7 @@ Package core exists to hold concepts and pure logic pertaining to juju's domain.
 We'd call it "model code" if we weren't planning to rename "environ" to "model";
 but that'd be quite needlessly confusing, so "core" it is.
 
-This is a necessarily broad brush; if anything, it's mmost important to be aware
+This is a necessarily broad brush; if anything, it's most important to be aware
 what should *not* go here. In particular:
 
   * if it makes any reference to MongoDB, it should not be in here.
@@ -48,7 +48,7 @@ because:
 
 ...but plenty of other bits will *not* be easy: in particular, all the business
 rules that concern consistency are really tricky, and somewhat dangerous, to
-extract, because (while those rules and relationshipps *are* business logic) we
+extract, because (while those rules and relationships *are* business logic) we
 need to be able to *render* them into a mgo/txn representation to ensure DB
 consistency. If we just depend on implementing the state bits to match, rather
 than *use*, the core logic, we're basically completely screwed.

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -39,6 +39,19 @@ var phaseNames = []string{
 	"ABORTDONE",
 }
 
+// Those phases are only used to get a complete successful round for testing purposes.
+func SuccessfulMigrationPhases() []Phase {
+	return []Phase{
+		IMPORT,
+		PROCESSRELATIONS,
+		VALIDATION,
+		SUCCESS,
+		LOGTRANSFER,
+		REAP,
+		DONE,
+	}
+}
+
 // String returns the name of an model migration phase constant.
 func (p Phase) String() string {
 	i := int(p)

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -331,29 +331,19 @@ func (s *MigrationSuite) TestLatestRemovedModelMigration(c *gc.C) {
 	mig1, err := s.State2.CreateMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Cycle through the phases and complete the migration
-	phases := []migration.Phase{
-		migration.IMPORT,
-		migration.PROCESSRELATIONS,
-		migration.VALIDATION,
-		migration.SUCCESS,
-		migration.LOGTRANSFER,
-		migration.REAP,
-		migration.DONE,
-	}
-	for _, phase := range phases {
+	for _, phase := range migration.SuccessfulMigrationPhases() {
 		c.Assert(mig1.SetPhase(phase), jc.ErrorIsNil)
 	}
 
-	// LatestRemovedModelMigration should fail as the model docs are still there
-	_, err = s.State2.LatestRemovedModelMigration()
+	// CompletedMigrationForModel should fail as the model docs are still there
+	_, err = s.State2.CompletedMigrationForModel()
 	c.Assert(errors.IsNotFound(err), gc.Equals, true)
 
 	// Delete the model and check that we get back the MigrationModel
 	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	c.Assert(s.State2.RemoveDyingModel(), jc.ErrorIsNil)
 
-	mig2, err := s.State2.LatestRemovedModelMigration()
+	mig2, err := s.State2.CompletedMigrationForModel()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mig2, jc.DeepEquals, mig1)
 }
@@ -400,15 +390,7 @@ func (s *MigrationSuite) TestSuccessfulPhaseTransitions(c *gc.C) {
 	mig2, err := st.LatestMigration()
 	c.Assert(err, jc.ErrorIsNil)
 
-	phases := []migration.Phase{
-		migration.IMPORT,
-		migration.PROCESSRELATIONS,
-		migration.VALIDATION,
-		migration.SUCCESS,
-		migration.LOGTRANSFER,
-		migration.REAP,
-		migration.DONE,
-	}
+	phases := migration.SuccessfulMigrationPhases()
 
 	var successTime time.Time
 	for _, phase := range phases[:len(phases)-1] {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

### Edge Cases to work out
- [x] `consumer` and `saas` one same controller a but different models;' saas moved from a to b (same controller, different models)
- [ ]  `consumer` and `saas` one different controller (a, b) and different models; saas moved from b to c  (need to be another pr)
  - because the collection (migrated models) we access only saves the `migration` information from controller a and b as external controller. So we would need to watch b for changed in the migration, which this patch does not check for.


## Description of change

- small refactorings regarding the phases of a model migration for test usages.

- the actual feature: 

cross model relation does not support migration cases.
E.g. QA steps below are not working if we move the offering `SAAS` model from the consuming model.
After the migration, the model is still looking for the original model.
```
controller-0: 15:22:01 ERROR juju.worker.remoterelations error in remote application worker for mysql: external controller with model eaa39728-1adf-451c-85ec-a45686d74c43 not found
```

Luckily we already have a lot of things in place. Especially the collection which keeps track whether something was migrated or not. 
This PR uses them.

## QA steps

*Please replace with how we can verify that the change works?*

```sh
juju bootstrap dst
juju bootstrap src

juju add-model db
juju deploy mysql
juju offer mysql:db

juju add-model blog
juju deploy wikimedia
juju add-relation wikimedia:db mysql:db 
```
another terminal look at the debug-log

```
juju debug-log <- of mediawiki
```
```
juju migrate mysql dst
```

#### from (without this patch):
```
controller-0: 15:21:01 ERROR juju.worker.remoterelations error in remote application worker for mysql: external controller with model eaa39728-1adf-451c-85ec-a45686d74c43 not found
controller-0: 15:22:01 ERROR juju.worker.remoterelations error in remote application worker for mysql: external controller with model eaa39728-1adf-451c-85ec-a45686d74c43 not found
controller-0: 15:23:01 ERROR juju.worker.remoterelations error in remote application worker for mysql: external controller with model eaa39728-1adf-451c-85ec-a45686d74c43 not found
```

####  to the following outcome:
```
controller-0: 17:26:28 DEBUG juju.worker.remoterelations processing remote application changes for: [mysql]
controller-0: 17:26:28 DEBUG juju.worker.remoterelations starting watcher for remote application "mysql"
controller-0: 17:26:28 DEBUG juju.worker.remoterelations remote controller api addresses: [10.75.147.162:17070]
controller-0: 17:26:28 DEBUG juju.worker.remoterelations remote offer for mysql has been removed
```



## Depends on
https://github.com/juju/juju/pull/10960 to fully work
