### PR TITLE
--force for update- and remove-credential CLI.

### DIFF
--- a/api/cloud/cloud_test.go
+++ b/api/cloud/cloud_test.go
@@ -455,7 +455,7 @@ func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 			c.Assert(a, jc.DeepEquals, params.RevokeCredentialArgs{
 				Credentials: []params.RevokeCredentialArg{
-					{Tag: "cloudcred-foo_bob_bar"},
+					{Tag: "cloudcred-foo_bob_bar", Force: true},
 				},
 			})
 			*result.(*params.ErrorResults) = params.ErrorResults{
@@ -472,7 +472,7 @@ func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 
 	client := cloudapi.NewClient(apiCaller)
 	tag := names.NewCloudCredentialTag("foo/bob/bar")
-	err := client.RevokeCredential(tag)
+	err := client.RevokeCredential(tag, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.called, jc.IsTrue)
 }
@@ -505,7 +505,7 @@ func (s *cloudSuite) TestRevokeCredentialV2(c *gc.C) {
 
 	client := cloudapi.NewClient(apiCaller)
 	tag := names.NewCloudCredentialTag("foo/bob/bar")
-	err := client.RevokeCredential(tag)
+	err := client.RevokeCredential(tag, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.called, jc.IsTrue)
 }
@@ -1087,6 +1087,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentials(c *gc.C) {
 				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
 				c.Assert(result, gc.FitsTypeOf, &params.UpdateCredentialResults{})
 				c.Assert(a, jc.DeepEquals, params.UpdateCredentialArgs{
+					Force: true,
 					Credentials: []params.TaggedCredential{{
 						Tag: "cloudcred-foo_bob_bar0",
 						Credential: params.CloudCredential{
@@ -1107,7 +1108,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentials(c *gc.C) {
 		BestVersion: 3,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	result, err := client.UpdateCloudsCredentials(createCredentials(1))
+	result, err := client.UpdateCloudsCredentials(createCredentials(1), true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []params.UpdateCredentialResult{{}})
 	c.Assert(s.called, jc.IsTrue)
@@ -1132,7 +1133,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsErrorV2(c *gc.C) {
 		BestVersion: 2,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	errs, err := client.UpdateCloudsCredentials(createCredentials(1))
+	errs, err := client.UpdateCloudsCredentials(createCredentials(1), true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.DeepEquals, []params.UpdateCredentialResult{
 		{CredentialTag: "cloudcred-foo_bob_bar0", Error: &params.Error{Message: "validation failure", Code: ""}},
@@ -1163,7 +1164,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsError(c *gc.C) {
 		BestVersion: 3,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	errs, err := client.UpdateCloudsCredentials(createCredentials(1))
+	errs, err := client.UpdateCloudsCredentials(createCredentials(1), false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.DeepEquals, []params.UpdateCredentialResult{
 		{CredentialTag: "cloudcred-foo_bob_bar0", Error: common.ServerError(errors.New("validation failure"))},
@@ -1187,7 +1188,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsCallErrorV2(c *gc.C) {
 		BestVersion: 2,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	result, err := client.UpdateCloudsCredentials(createCredentials(1))
+	result, err := client.UpdateCloudsCredentials(createCredentials(1), false)
 	c.Assert(err, gc.ErrorMatches, "scary but true")
 	c.Assert(result, gc.IsNil)
 	c.Assert(s.called, jc.IsTrue)
@@ -1209,7 +1210,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsCallError(c *gc.C) {
 		BestVersion: 3,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	result, err := client.UpdateCloudsCredentials(createCredentials(1))
+	result, err := client.UpdateCloudsCredentials(createCredentials(1), false)
 	c.Assert(err, gc.ErrorMatches, "scary but true")
 	c.Assert(result, gc.IsNil)
 	c.Assert(s.called, jc.IsTrue)
@@ -1237,7 +1238,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyResultsV2(c *gc.C) {
 		BestVersion: 2,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	result, err := client.UpdateCloudsCredentials(createCredentials(1))
+	result, err := client.UpdateCloudsCredentials(createCredentials(1), false)
 	c.Assert(err, gc.ErrorMatches, `expected 1 result got 2 when updating credentials`)
 	c.Assert(result, gc.IsNil)
 	c.Assert(s.called, jc.IsTrue)
@@ -1266,7 +1267,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResultsV2(c *gc.C) {
 	}
 	client := cloudapi.NewClient(apiCaller)
 	in := createCredentials(2)
-	result, err := client.UpdateCloudsCredentials(in)
+	result, err := client.UpdateCloudsCredentials(in, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, len(in))
 	for _, one := range result {
@@ -1297,7 +1298,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyResults(c *gc.C) {
 		BestVersion: 3,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	result, err := client.UpdateCloudsCredentials(createCredentials(1))
+	result, err := client.UpdateCloudsCredentials(createCredentials(1), false)
 	c.Assert(err, gc.ErrorMatches, `expected 1 result got 2 when updating credentials`)
 	c.Assert(result, gc.IsNil)
 	c.Assert(s.called, jc.IsTrue)
@@ -1325,7 +1326,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResults(c *gc.C) {
 	}
 	client := cloudapi.NewClient(apiCaller)
 	count := 2
-	result, err := client.UpdateCloudsCredentials(createCredentials(count))
+	result, err := client.UpdateCloudsCredentials(createCredentials(count), false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, count)
 	c.Assert(s.called, jc.IsTrue)
@@ -1363,7 +1364,7 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsModelErrors(c *gc.C) {
 		BestVersion: 3,
 	}
 	client := cloudapi.NewClient(apiCaller)
-	errs, err := client.UpdateCloudsCredentials(createCredentials(1))
+	errs, err := client.UpdateCloudsCredentials(createCredentials(1), false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.DeepEquals, []params.UpdateCredentialResult{
 		{CredentialTag: "cloudcred-foo_bob_bar",
@@ -1378,5 +1379,44 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsModelErrors(c *gc.C) {
 			},
 		},
 	})
+	c.Assert(s.called, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestAddCloudsCredentials(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Check(objType, gc.Equals, "Cloud")
+				c.Check(id, gc.Equals, "")
+				c.Check(request, gc.Equals, "UpdateCredentialsCheckModels")
+				c.Assert(result, gc.FitsTypeOf, &params.UpdateCredentialResults{})
+				c.Assert(a, jc.DeepEquals, params.UpdateCredentialArgs{
+					Credentials: []params.TaggedCredential{{
+						Tag: "cloudcred-foo_bob_bar0",
+						Credential: params.CloudCredential{
+							AuthType: "userpass",
+							Attributes: map[string]string{
+								"username": "admin",
+								"password": "adm1n",
+							},
+						},
+					}}})
+				*result.(*params.UpdateCredentialResults) = params.UpdateCredentialResults{
+					Results: []params.UpdateCredentialResult{{}},
+				}
+				s.called = true
+				return nil
+			},
+		),
+		BestVersion: 3,
+	}
+	client := cloudapi.NewClient(apiCaller)
+	result, err := client.AddCloudsCredentials(createCredentials(1))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, []params.UpdateCredentialResult{{}})
 	c.Assert(s.called, jc.IsTrue)
 }

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -642,7 +642,7 @@ func (c *addCredentialCommand) addRemoteCredentials(ctxt *cmd.Context, all map[s
 		return err
 	}
 	defer client.Close()
-	results, err := client.UpdateCloudsCredentials(verified)
+	results, err := client.AddCloudsCredentials(verified)
 	if err != nil {
 		logger.Errorf("%v", err)
 		ctxt.Warningf("Could not upload credentials to controller %q", c.ControllerName)

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -851,7 +851,7 @@ credentials:
 	sourceFile := s.createTestCredentialFile(c, expectedContents)
 
 	called := false
-	s.api.updateCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
+	s.api.addCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
 		c.Assert(cloudCredentials, gc.HasLen, 1)
 		called = true
 		expectedTag := names.NewCloudCredentialTag(fmt.Sprintf("%v/admin@local/blah", cloudName)).String()

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -491,7 +491,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 			if len(verified) == 0 {
 				return erred
 			}
-			result, err := client.UpdateCloudsCredentials(verified)
+			result, err := client.AddCloudsCredentials(verified)
 			if err != nil {
 				logger.Errorf("%v", err)
 				ctxt.Warningf("Could not upload credentials to controller %q", c.ControllerName)

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -372,7 +372,7 @@ func (s *detectCredentialsSuite) TestRemoteLoad(c *gc.C) {
 	s.setupStore(c)
 	cloudName := "test-cloud"
 	called := false
-	s.api.updateCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
+	s.api.addCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
 		c.Assert(cloudCredentials, gc.HasLen, 1)
 		called = true
 		expectedTag := names.NewCloudCredentialTag(fmt.Sprintf("%v/admin@local/blah", cloudName)).String()
@@ -446,7 +446,7 @@ func (s *detectCredentialsSuite) assertAutoloadCredentials(c *gc.C, expectedStde
 	s.setupStore(c)
 	cloudName := "test-cloud"
 	called := false
-	s.api.updateCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
+	s.api.addCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential) ([]params.UpdateCredentialResult, error) {
 		c.Assert(cloudCredentials, gc.HasLen, 1)
 		called = true
 		expectedTag := names.NewCloudCredentialTag(fmt.Sprintf("%v/admin@local/blah", cloudName)).String()

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -194,6 +194,21 @@ func (s *removeCredentialSuite) TestRemoveRemoteCredentialFail(c *gc.C) {
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Found remote cloud \"somecloud\" from the controller.\nERROR could not remove remote credential: kaboom\n")
+	s.fakeClient.CheckCallNames(c, "Clouds", "RevokeCredential", "Close")
+	s.fakeClient.CheckCall(c, 1, "RevokeCredential", names.NewCloudCredentialTag("somecloud/admin/foo"), false)
+}
+
+func (s *removeCredentialSuite) TestRemoveRemoteCredentialForce(c *gc.C) {
+	store := s.setupStore(c)
+	s.setupClientForRemote(c)
+	s.fakeClient.revokeCredentialF = func(tag names.CloudCredentialTag) error {
+		return nil
+	}
+	command := cloud.NewRemoveCredentialCommandForTest(store, s.cloudByNameFunc, s.clientF)
+	_, err := cmdtesting.RunCommand(c, command, "somecloud", "foo", "-c", "controller", "--force")
+	c.Assert(err, jc.ErrorIsNil)
+	s.fakeClient.CheckCallNames(c, "Clouds", "RevokeCredential", "Close")
+	s.fakeClient.CheckCall(c, 1, "RevokeCredential", names.NewCloudCredentialTag("somecloud/admin/foo"), true)
 }
 
 type fakeRemoveCredentialAPI struct {
@@ -213,8 +228,8 @@ func (f *fakeRemoveCredentialAPI) BestAPIVersion() int {
 	return f.v
 }
 
-func (f *fakeRemoveCredentialAPI) RevokeCredential(c names.CloudCredentialTag) error {
-	f.AddCall("RevokeCredential", c)
+func (f *fakeRemoveCredentialAPI) RevokeCredential(c names.CloudCredentialTag, force bool) error {
+	f.AddCall("RevokeCredential", c, force)
 	return f.revokeCredentialF(c)
 }
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
_No API server change, only api CLI client._
 - [ ]~~ Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~
 - [ ] ~~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Cloud facade has supported the ability to force update and force remove credentials. This PR catches up corresponding CLI.

As a drive-by, I have renamed an internal variable in credential validity to maintain clarity.
  
## QA steps

1. bootstrap with credential A
2. add model with different credential B
3. remove credential B [will fail because a model uses this credential]
4. force remove credential [success]

## Bug reference

Part 2 for https://bugs.launchpad.net/juju/+bug/1852412
