### PR TITLE
acceptancetests: fix nw-add-creds-aws

### DIFF
--- a/acceptancetests/assess
+++ b/acceptancetests/assess
@@ -132,7 +132,8 @@ def parse_args():
     env_opts = arg_parser.add_argument_group("main testing environment options")
 
     env_opts.add_argument("--juju-home", metavar="HOME_DIR",
-                          help="JUJU_HOME environment variable to be used for test [default: create a new directory in /tmp/juju-ci/* (randomly generated)]")
+                          help="JUJU_HOME environment variable to be used for test "
+                               "[default: create a new directory in /tmp/juju-ci/* (randomly generated)]")
     env_opts.add_argument("--juju-data", metavar="DATA_DIR", required=False,
                           help="JUJU_DATA environment variable to be used for test [default: HOME_DIR/data]")
     env_opts.add_argument("--juju-repository", metavar="REPO_DIR", required=False,
@@ -236,7 +237,8 @@ def parse_args():
     pass_through.add_argument("--maas", action="store_true",
                               help="Run test under MAAS (Relevant only in the network_health test)")
     pass_through.add_argument("--model", help="Model to test against (Relevant only in the network_health test)")
-    # pass_through.add_argument("--stack", choices={"maas", "iaas", "caas"}, help="(Relevant only in the network_health, webscale_deploy tests)") # TODO(tsm) add when relevant
+    # pass_through.add_argument("--stack", choices={"maas", "iaas", "caas"}, help="(Relevant only in the
+    # network_health, webscale_deploy tests)") # TODO(tsm) add when relevant
     pass_through.add_argument("--proxy-scenario", "--proxy-test",
                               choices={'both-proxied', 'client-proxied', 'controller-proxied'}, dest="proxy_scenario",
                               help="Sub-test to run (Only relevant in proxy test)", default="both-proxied")
@@ -254,11 +256,14 @@ def parse_args():
     pass_through.add_argument('--large', '--large-test-enabled', action='store_true', dest="large_test_enabled",
                               help="Use a large file for testing. (Relevant only with resources test)")
     pass_through.add_argument('--agent-timeout', metavar="S", type=int, default=1800,
-                              help='The time to wait for agents to start (Relevant only with resources test) [default: 1800]')
+                              help='The time to wait for agents to start'
+                                   ' (Relevant only with resources test) [default: 1800]')
     pass_through.add_argument('--resource-timeout', metavar="S", type=int, default=1800,
-                              help='The time to wait for agents to start (Relevant only with resources test) [default: 1800]')
+                              help='The time to wait for agents to start (Relevant only with resources test) ['
+                                   'default: 1800]')
     pass_through.add_argument("--clean-environment",
-                              help="Clean up a the environments between runs, rather than creating one from scratch (Only relevant for spaces_subnets test)",
+                              help="Clean up a the environments between runs, rather than creating one from scratch ("
+                                   "Only relevant for spaces_subnets test)",
                               action="store_true")
     pass_through.add_argument('--from-series', default="xenial",
                               help='Series to start machine and units with')
@@ -267,10 +272,12 @@ def parse_args():
 
     caas_opts = arg_parser.add_argument_group("options common to CaaS acceptance tests")
     caas_opts.add_argument("--caas-provider",
-                           help="Provider for CaaS models. (Relevant only for caas_deploy_charms test) [default: microk8s]",
+                           help="Provider for CaaS models. (Relevant only for caas_deploy_charms test) [default: "
+                                "microk8s]",
                            choices=["microk8s", "k8s"])
     caas_opts.add_argument('--caas-image-repo',
-                           help="Docker image repo to use. (Relevant only for caas_deploy_charms test) [default: jujuqabot]",
+                           help="Docker image repo to use. (Relevant only for caas_deploy_charms test) [default: "
+                                "jujuqabot]",
                            default="jujuqabot")
 
     cloud_opts = arg_parser.add_argument_group("options to pass through to the cloud substrate")
@@ -296,11 +303,11 @@ def parse_args():
         args.juju_home = juju_home
 
     if not args.juju_data:
-        juju_data = os.path.join(juju_home, 'data')
+        juju_data = os.path.join(args.juju_home, 'data')
         args.juju_data = juju_data
 
     if not args.log_dir:
-        log_dir = os.path.join(juju_home, 'log')
+        log_dir = os.path.join(args.juju_home, 'log')
         args.log_dir = log_dir
 
     valid_regions = find_valid_regions(args.substrate)
@@ -337,7 +344,12 @@ def setup(juju_home, juju_data, log_dir, series, substrate, region):
 
     user_home = os.environ.get('HOME') or os.environ["XDG_CONFIG_HOME"]
     user_config = join(user_home, '.local', 'share', 'juju')
-    os.symlink(join(user_config, "credentials.yaml"), join(juju_home, "credentials.yaml"))
+
+    # on err this file already exists, so we don't need to link them.
+    try:
+        os.symlink(join(user_config, "credentials.yaml"), join(juju_home, "credentials.yaml"))
+    except OSError as exc:
+        pass
 
     envs = ENVIRONMENT_TEMPLATE.format(series)
 

--- a/acceptancetests/assess
+++ b/acceptancetests/assess
@@ -13,9 +13,8 @@ import os
 import subprocess
 import sys
 import tempfile
-from time import sleep
-
 import yaml
+from time import sleep
 
 if __name__ != "__main__":
     print(__file__, "must be run as a script", file=sys.stderr)
@@ -229,6 +228,9 @@ def parse_args():
                               help="Path to agent to use when bootstrapping with devel binary (Relevant only for the upgrade test)")
     pass_through.add_argument("--stable-juju-agent",
                               help="Path to agent to use when bootstrapping with stable binary (Relevant only for the upgrade test)")
+    pass_through.add_argument("--cloud-city",
+                              help="Path to cloud-city folder where our test data usually lies. Makes it easy to "
+                                   "replay jenkins test locally.")
     pass_through.add_argument("--reboot", action="store_true",
                               help="Reboot machines and re-run tests (Relevant only in the network_health test)")
     pass_through.add_argument("--maas", action="store_true",
@@ -265,11 +267,11 @@ def parse_args():
 
     caas_opts = arg_parser.add_argument_group("options common to CaaS acceptance tests")
     caas_opts.add_argument("--caas-provider",
-                              help="Provider for CaaS models. (Relevant only for caas_deploy_charms test) [default: microk8s]",
-                              choices=["microk8s", "k8s"])
+                           help="Provider for CaaS models. (Relevant only for caas_deploy_charms test) [default: microk8s]",
+                           choices=["microk8s", "k8s"])
     caas_opts.add_argument('--caas-image-repo',
-                              help="Docker image repo to use. (Relevant only for caas_deploy_charms test) [default: jujuqabot]",
-                              default="jujuqabot")
+                           help="Docker image repo to use. (Relevant only for caas_deploy_charms test) [default: jujuqabot]",
+                           default="jujuqabot")
 
     cloud_opts = arg_parser.add_argument_group("options to pass through to the cloud substrate")
     cloud_opts.add_argument("--cloud-region", metavar="REGION",
@@ -376,6 +378,8 @@ def main():
         "--series", args.series,
         "--logging-config", args.logging_config,
     ]
+    if args.cloud_city:
+        testrun_argv += ["--cloud-city", args.cloud_city]
     if args.debug:
         testrun_argv += ["--debug"]
     if args.verbose:
@@ -390,7 +394,6 @@ def main():
         testrun_argv += ["--agent-url", args.agent_url]
     if args.agent_stream:
         testrun_argv += ["--agent-stream", args.agent_stream]
-
 
     # These are our snowflake tests. They define their own
     # arguments. Usually that's because they've added their
@@ -549,5 +552,6 @@ def main():
         for line in iter(proc.stdout.readline, ''):
             print(line, end='')
     return proc.wait()
+
 
 sys.exit(main())

--- a/acceptancetests/assess_add_credentials.py
+++ b/acceptancetests/assess_add_credentials.py
@@ -49,8 +49,8 @@ def assess_add_credentials(args):
 
     # If no cloud-city path is given, we grab the credentials from env juju_home.
     # Else we override the path where we read the credentials yaml for testing purposes.
-    if args.cloud_city is not None:
-        cred = get_credentials(env, args.cloud_city)
+    if args.juju_home is not None:
+        cred = get_credentials(env, args.juju_home)
     else:
         cred = get_credentials(env)
 

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -302,8 +302,8 @@ def add_basic_testing_arguments(
     parser.add_argument('--logging-config',
                         help="Override logging configuration for a deployment.",
                         default="<root>=INFO;unit=INFO")
-    parser.add_argument('--cloud-city', help="Directory of cloud city. It is not used during integrationtest runs. "
-                                             "One can override this arg for local runs.", default=None)
+    parser.add_argument('--juju-home', help="Directory of juju home. It is not used during integration test runs. "
+                                            "One can override this arg for local runs.", default=None)
 
     if existing:
         parser.add_argument(

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -1,20 +1,21 @@
-from contextlib import contextmanager
-from datetime import (
-    datetime,
-    timedelta,
-)
 import errno
 import json
 import logging
 import os
 import re
-import subprocess
 import socket
+import subprocess
 import sys
+from contextlib import contextmanager
+from datetime import (
+    datetime,
+    timedelta,
+)
 from time import (
     sleep,
     time,
 )
+
 from jujupy.utility import (
     ensure_deleted,
     ensure_dir,
@@ -44,7 +45,6 @@ __all__ = [
     'temp_dir',
     'temp_yaml_file',
 ]
-
 
 # Equivalent of socket.EAI_NODATA when using windows sockets
 # <https://msdn.microsoft.com/ms740668#WSANO_DATA>
@@ -202,9 +202,9 @@ def generate_default_clean_dir(temp_env_name):
         if e.errno == errno.EEXIST:
             logging.warn('"Directory {} already exists'.format(log_dir))
         else:
-            raise('Failed to create logging directory: {} ' +
-                  log_dir +
-                  '. Please specify empty folder or try again')
+            raise ('Failed to create logging directory: {} ' +
+                   log_dir +
+                   '. Please specify empty folder or try again')
     return log_dir
 
 
@@ -223,7 +223,7 @@ def _to_deadline(timeout):
 def add_arg_juju_bin(parser):
     parser.add_argument('juju_bin', nargs='?',
                         help='Full path to the Juju binary. By default, this'
-                        ' will use $PATH/juju',
+                             ' will use $PATH/juju',
                         default=None)
 
 
@@ -264,13 +264,13 @@ def add_basic_testing_arguments(
     add_arg_juju_bin(parser)
     parser.add_argument('logs', nargs='?', type=_clean_dir,
                         help='A directory in which to store logs. By default,'
-                        ' this will use the current directory',
+                             ' this will use the current directory',
                         default=None)
     parser.add_argument('temp_env_name', nargs='?',
                         help='A temporary test environment name. By default, '
-                        ' this will generate an enviroment name using the '
-                        ' timestamp and testname. '
-                        ' test_name_timestamp_temp_env',
+                             ' this will generate an enviroment name using the '
+                             ' timestamp and testname. '
+                             ' test_name_timestamp_temp_env',
                         default=_generate_default_temp_env_name())
 
     # Optional keyword arguments.
@@ -294,14 +294,17 @@ def add_basic_testing_arguments(
     parser.add_argument('--bootstrap-host',
                         help='The host to use for bootstrap.')
     parser.add_argument('--machine', help='A machine to add or when used with '
-                        'KVM based MaaS, a KVM image to start.',
+                                          'KVM based MaaS, a KVM image to start.',
                         action='append', default=[])
     parser.add_argument('--keep-env', action='store_true',
                         help='Keep the Juju environment after the test'
-                        ' completes.')
+                             ' completes.')
     parser.add_argument('--logging-config',
                         help="Override logging configuration for a deployment.",
                         default="<root>=INFO;unit=INFO")
+    parser.add_argument('--cloud-city', help="Directory of cloud city. It is not used during integrationtest runs. "
+                                             "One can override this arg for local runs.", default=None)
+
     if existing:
         parser.add_argument(
             '--existing',


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [notneeded] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [notneeded] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

add cloud-city arg, add client and region expect, refactoring code to pep style.

## QA steps

```sh
add_credentials --juju-home=/home/nam/xxx --substrate=aws --region=eu-west-2
```

Everything but the last step should be testable on local runs. 
It will fail on `verify_bootstrap` because it expects some special env naming