### PR TITLE
Get juju output without calling model command

### DIFF
--- a/acceptancetests/assess_unregister.py
+++ b/acceptancetests/assess_unregister.py
@@ -65,7 +65,7 @@ def assess_unregister(client):
 
 def assert_switch_raises_error(client):
     try:
-        client.get_juju_output('switch', include_e=False)
+        client.get_raw_juju_output('switch', include_e=False)
     except subprocess.CalledProcessError as e:
         if 'no model name was passed' not in e.stderr:
             raise JujuAssertionError(

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1142,6 +1142,15 @@ class ModelClient:
         """
         model = self._cmd_model(kwargs.get('include_e', True),
                                 kwargs.get('controller', False))
+        return self.get_raw_juju_output(self, command, model, *args, **kwargs)
+
+    def get_raw_juju_output(self, command, model, *args, **kwargs):
+        """Call a juju command without calling a model for it's values first.
+
+        Sub process will be called as 'juju <command> <args> <kwargs>'. Note
+        that <command> may be a space delimited list of arguments. The -e
+        <environment> flag will be placed after <command> and before args.
+        """
         pass_kwargs = dict(
             (k, kwargs[k]) for k in kwargs if k in ['timeout', 'merge_stderr'])
         return self._backend.get_juju_output(


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

## Description of change

The following prevents an issue where the pylib code requests a model
before asking to switch. This can cause issues where it expects the
model to be there, even though we just unregistered it.

So the code now calls into the "global" juju commands, as we don't have
any other controllers (it checks it prior to calling this code) and so
it's safe to call `juju switch` and see the output correctly.

The code is actually doing what we expect here, rather than calling
`juju models` first.
