### PR TITLE
[dev] fetch network interfaces in instance poller

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -54,7 +54,7 @@ var facadeVersions = map[string]int{
 	"ImageMetadata":                3,
 	"ImageMetadataManager":         1,
 	"InstanceMutater":              2,
-	"InstancePoller":               3,
+	"InstancePoller":               4,
 	"KeyManager":                   1,
 	"KeyUpdater":                   1,
 	"LeadershipService":            2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -217,7 +217,7 @@ func AllFacades() *facade.Registry {
 	reg("InstanceMutater", 1, instancemutater.NewFacadeV1)
 	reg("InstanceMutater", 2, instancemutater.NewFacadeV2)
 
-	reg("InstancePoller", 3, instancepoller.NewFacade)
+	reg("InstancePoller", 4, instancepoller.NewFacade)
 	reg("KeyManager", 1, keymanager.NewKeyManagerAPI)
 	reg("KeyUpdater", 1, keyupdater.NewKeyUpdaterAPI)
 

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -53,27 +53,13 @@ func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetw
 		return nil
 	}
 
-	providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
-	if errors.IsNotProvisioned(err) {
-		logger.Infof("not updating machine %q network config: %v", m.Id(), err)
-		return nil
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	mergedConfig := observedConfig
-	if len(providerConfig) != 0 {
-		mergedConfig = MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
-		logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), mergedConfig)
-	}
-
-	mergedConfig, err = api.fixUpFanSubnets(mergedConfig)
+	mergedConfig, err := api.fixUpFanSubnets(observedConfig)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	ifaces := params.InterfaceInfoFromNetworkConfig(mergedConfig)
-	return api.setOneMachineNetworkInterfaces(m, ifaces)
+	return api.setLinkLayerDevicesAndAddresses(m, ifaces)
 }
 
 // fixUpFanSubnets takes network config and updates FAN subnets with proper CIDR, providerId and providerSubnetId.
@@ -140,7 +126,7 @@ func (api *NetworkConfigAPI) SetProviderNetworkConfig(args params.Entities) (par
 		logger.Tracef("provider network config for %q: %+v", m.Id(), providerConfig)
 
 		ifaces := params.InterfaceInfoFromNetworkConfig(providerConfig)
-		if err := api.setOneMachineNetworkInterfaces(m, ifaces); err != nil {
+		if err := api.setLinkLayerDevicesAndAddresses(m, ifaces); err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
@@ -237,7 +223,7 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	return providerConfig, nil
 }
 
-func (api *NetworkConfigAPI) setOneMachineNetworkInterfaces(
+func (api *NetworkConfigAPI) setLinkLayerDevicesAndAddresses(
 	m *state.Machine, ifaces []network.InterfaceInfo,
 ) error {
 	devicesArgs, devicesAddrs := NetworkInterfacesToStateArgs(ifaces)

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -883,8 +883,9 @@ var expectedLinkLayerDeviceAdressesWithFinalNetworkConfig = []state.LinkLayerDev
 	ProviderSubnetID: "11",
 }}
 
-func (s *TypesSuite) TestNetworkConfigsToStateArgs(c *gc.C) {
-	devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(expectedFinalNetworkConfigs)
+func (s *TypesSuite) TestNetworkInterfacesToStateArgs(c *gc.C) {
+	ifaces := params.InterfaceInfoFromNetworkConfig(expectedFinalNetworkConfigs)
+	devicesArgs, devicesAddrs := networkingcommon.NetworkInterfacesToStateArgs(ifaces)
 
 	c.Check(devicesArgs, jc.DeepEquals, expectedLinkLayerDeviceArgsWithFinalNetworkConfig)
 	c.Check(devicesAddrs, jc.DeepEquals, expectedLinkLayerDeviceAdressesWithFinalNetworkConfig)

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -150,7 +150,7 @@ func (api *MachinerAPI) RecordAgentStartTime(args params.Entities) (params.Error
 	return results, nil
 }
 
-// MachinerAPI implements the V1 API used by the machiner worker. Compared to
+// MachinerAPIV1 implements the V1 API used by the machiner worker. Compared to
 // V2, it lacks the RecordAgentStartTime method.
 type MachinerAPIV1 struct {
 	*MachinerAPI

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -804,7 +804,8 @@ func (api *ProvisionerAPI) SetInstanceInfo(args params.InstancesInfo) (params.Er
 			return err
 		}
 
-		devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(arg.NetworkConfig)
+		ifaces := params.InterfaceInfoFromNetworkConfig(arg.NetworkConfig)
+		devicesArgs, devicesAddrs := networkingcommon.NetworkInterfacesToStateArgs(ifaces)
 
 		err = machine.SetInstanceInfo(
 			arg.InstanceId, arg.DisplayName, arg.Nonce, arg.Characteristics,

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -4,10 +4,9 @@
 package instancepoller
 
 import (
-	"fmt"
-
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/common"
@@ -17,6 +16,8 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 )
+
+var logger = loggo.GetLogger("juju.apiserver.instancepoller")
 
 // InstancePollerAPI provides access to the InstancePoller API facade.
 type InstancePollerAPI struct {
@@ -114,21 +115,16 @@ func (a *InstancePollerAPI) getOneMachine(tag string, canAccess common.AuthFunc)
 	if !canAccess(machineTag) {
 		return nil, common.ErrPerm
 	}
-	entity, err := a.st.FindEntity(machineTag)
-	if err != nil {
-		return nil, err
-	}
-	machine, ok := entity.(StateMachine)
-	if !ok {
-		return nil, common.NotSupportedError(
-			machineTag, fmt.Sprintf("expected machine, got %T", entity),
-		)
-	}
-	return machine, nil
+	return a.st.Machine(machineTag.Id())
 }
 
 // SetProviderNetworkConfig updates the provider addresses for one or more
 // machines.
+//
+// What's more, if the client request includes provider-specific IDs (e.g.
+// network, subnet or address IDs), this method will also iterate any present
+// link layer devices (and their addresses) and backfill any missing
+// provider-specific information.
 func (a *InstancePollerAPI) SetProviderNetworkConfig(req params.SetProviderNetworkConfig) (params.SetProviderNetworkConfigResults, error) {
 	result := params.SetProviderNetworkConfigResults{
 		Results: make([]params.SetProviderNetworkConfigResult, len(req.Args)),
@@ -171,6 +167,19 @@ func (a *InstancePollerAPI) SetProviderNetworkConfig(req params.SetProviderNetwo
 
 		result.Results[i].Modified = modified
 		result.Results[i].Addresses = params.FromProviderAddresses(newProviderAddrs...)
+
+		// If we were able to acquire full network device information
+		// from the provider which includes provider-specific IDs that
+		// are not visible to the machiner worker (primary source for
+		// link layer devices/addresses), we can attempt to backfill
+		// the missing provider IDs.
+		if containsProviderIDs(arg.Configs) {
+			// Treat errors as transient; the purpose of this API
+			// method is to simply update the provider addresses.
+			if err := backfillProviderIDs(machine, params.InterfaceInfoFromNetworkConfig(arg.Configs)); err != nil {
+				logger.Errorf("link layer device backfill attempt for machine %v failed due to error: %v; waiting until next instancepoller run to retry", machine.Id(), err)
+			}
+		}
 	}
 	return result, nil
 }
@@ -182,6 +191,84 @@ func maybeUpdateMachineProviderAddresses(m StateMachine, newSpaceAddrs network.S
 	}
 
 	return true, m.SetProviderAddresses(newSpaceAddrs...)
+}
+
+func backfillProviderIDs(m StateMachine, ifaces []network.InterfaceInfo) error {
+	existingDevs, err := m.AllLinkLayerDevices()
+	if err != nil {
+		return err
+	}
+
+	// Since the device name might be different (i.e. providers
+	// like AWS do not report device names) we can only reliably
+	// match on the device address.
+	addrToIfaceMap := make(map[string]network.InterfaceInfo)
+	for _, iface := range ifaces {
+		addrToIfaceMap[iface.PrimaryAddress().Value] = iface
+	}
+
+	var (
+		devUpdates  []state.LinkLayerDeviceArgs
+		addrUpdates []state.LinkLayerDeviceAddress
+	)
+	for _, existingDev := range existingDevs {
+		devAddrs, err := existingDev.Addresses()
+		if err != nil {
+			return err
+		}
+
+		for _, addr := range devAddrs {
+			iface, matched := addrToIfaceMap[addr.Value()]
+			if !matched {
+				continue
+			}
+
+			// Re-use the primary information persisted by the
+			// machiner but populate the provider-related ID fields
+			// with the data obtained by the network provider.
+			devUpdates = append(devUpdates, state.LinkLayerDeviceArgs{
+				Name:        existingDev.Name(),
+				MTU:         existingDev.MTU(),
+				ProviderID:  iface.ProviderId,
+				Type:        existingDev.Type(),
+				MACAddress:  existingDev.MACAddress(),
+				IsAutoStart: existingDev.IsAutoStart(),
+				IsUp:        existingDev.IsUp(),
+				ParentName:  existingDev.ParentName(),
+			})
+
+			addrUpdates = append(addrUpdates, state.LinkLayerDeviceAddress{
+				DeviceName:        existingDev.Name(),
+				ConfigMethod:      addr.ConfigMethod(),
+				ProviderID:        iface.ProviderAddressId,
+				ProviderNetworkID: iface.ProviderNetworkId,
+				ProviderSubnetID:  iface.ProviderSubnetId,
+				CIDRAddress:       addr.SubnetCIDR(),
+				DNSServers:        addr.DNSServers(),
+				DNSSearchDomains:  addr.DNSSearchDomains(),
+				GatewayAddress:    addr.GatewayAddress(),
+				IsDefaultGateway:  addr.IsDefaultGateway(),
+			})
+
+			break
+		}
+	}
+
+	if len(devUpdates) != 0 {
+		logger.Debugf("merging the following link layer devices into device list for machine %v: %+v", m.Id(), devUpdates)
+		if err := m.SetParentLinkLayerDevicesBeforeTheirChildren(devUpdates); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	if len(addrUpdates) != 0 {
+		logger.Debugf("merging the following link layer device addresses into address list for machine %v: %+v", m.Id(), addrUpdates)
+		if err := m.SetDevicesAddressesIdempotently(addrUpdates); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
 }
 
 // mapNetworkConfigsToProviderAddresses iterates the list of incoming network
@@ -239,6 +326,15 @@ func mapNetworkConfigsToProviderAddresses(cfgs []params.NetworkConfig, spaceInfo
 	}
 
 	return addrs, nil
+}
+
+func containsProviderIDs(cfgs []params.NetworkConfig) bool {
+	for _, cfg := range cfgs {
+		if cfg.ProviderId != "" || cfg.ProviderSubnetId != "" || cfg.ProviderAddressId != "" || cfg.ProviderNetworkId != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func spaceInfoForAddress(spaceInfos network.SpaceInfos, CIDR, providerSubnetID, addr string) (*network.SpaceInfo, error) {

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -446,12 +446,12 @@ func (s *InstancePollerSuite) TestProviderAddressesSuccess(c *gc.C) {
 		}},
 	)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 0, "1")
 	s.st.CheckCall(c, 1, "ProviderAddresses")
 	s.st.CheckCall(c, 2, "AllSpaceInfos")
-	s.st.CheckFindEntityCall(c, 3, "2")
+	s.st.CheckMachineCall(c, 3, "2")
 	s.st.CheckCall(c, 4, "ProviderAddresses")
-	s.st.CheckFindEntityCall(c, 5, "42")
+	s.st.CheckMachineCall(c, 5, "42")
 }
 
 func (s *InstancePollerSuite) TestProviderAddressesFailure(c *gc.C) {
@@ -474,10 +474,10 @@ func (s *InstancePollerSuite) TestProviderAddressesFailure(c *gc.C) {
 		}},
 	)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
-	s.st.CheckFindEntityCall(c, 1, "2")
+	s.st.CheckMachineCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 1, "2")
 	s.st.CheckCall(c, 2, "ProviderAddresses")
-	s.st.CheckFindEntityCall(c, 3, "3")
+	s.st.CheckMachineCall(c, 3, "3")
 }
 
 func (s *InstancePollerSuite) TestSetProviderAddressesSuccess(c *gc.C) {
@@ -501,12 +501,12 @@ func (s *InstancePollerSuite) TestSetProviderAddressesSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, s.mixedErrorResults)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 0, "1")
 	s.st.CheckSetProviderAddressesCall(c, 1, []network.SpaceAddress{})
-	s.st.CheckFindEntityCall(c, 2, "2")
+	s.st.CheckMachineCall(c, 2, "2")
 	s.st.CheckCall(c, 3, "AllSpaceInfos")
 	s.st.CheckSetProviderAddressesCall(c, 4, newAddrs)
-	s.st.CheckFindEntityCall(c, 5, "42")
+	s.st.CheckMachineCall(c, 5, "42")
 
 	// Ensure machines were updated.
 	machine, err := s.st.Machine("1")
@@ -540,11 +540,11 @@ func (s *InstancePollerSuite) TestSetProviderAddressesFailure(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, s.machineErrorResults)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
-	s.st.CheckFindEntityCall(c, 1, "2")
+	s.st.CheckMachineCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 1, "2")
 	s.st.CheckCall(c, 2, "AllSpaceInfos")
 	s.st.CheckSetProviderAddressesCall(c, 3, newAddrs)
-	s.st.CheckFindEntityCall(c, 4, "3")
+	s.st.CheckMachineCall(c, 4, "3")
 
 	// Ensure machine 2 wasn't updated.
 	machine, err := s.st.Machine("2")
@@ -584,11 +584,11 @@ func (s *InstancePollerSuite) TestInstanceStatusSuccess(c *gc.C) {
 	},
 	)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 0, "1")
 	s.st.CheckCall(c, 1, "InstanceStatus")
-	s.st.CheckFindEntityCall(c, 2, "2")
+	s.st.CheckMachineCall(c, 2, "2")
 	s.st.CheckCall(c, 3, "InstanceStatus")
-	s.st.CheckFindEntityCall(c, 4, "42")
+	s.st.CheckMachineCall(c, 4, "42")
 }
 
 func (s *InstancePollerSuite) TestInstanceStatusFailure(c *gc.C) {
@@ -611,10 +611,10 @@ func (s *InstancePollerSuite) TestInstanceStatusFailure(c *gc.C) {
 		}},
 	)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
-	s.st.CheckFindEntityCall(c, 1, "2")
+	s.st.CheckMachineCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 1, "2")
 	s.st.CheckCall(c, 2, "InstanceStatus")
-	s.st.CheckFindEntityCall(c, 3, "3")
+	s.st.CheckMachineCall(c, 3, "3")
 }
 
 func (s *InstancePollerSuite) TestSetInstanceStatusSuccess(c *gc.C) {
@@ -637,11 +637,11 @@ func (s *InstancePollerSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, s.mixedErrorResults)
 
 	now := s.clock.Now()
-	s.st.CheckFindEntityCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 0, "1")
 	s.st.CheckCall(c, 1, "SetInstanceStatus", status.StatusInfo{Status: status.Status(""), Since: &now})
-	s.st.CheckFindEntityCall(c, 2, "2")
+	s.st.CheckMachineCall(c, 2, "2")
 	s.st.CheckCall(c, 3, "SetInstanceStatus", status.StatusInfo{Status: status.Status("new status"), Since: &now})
-	s.st.CheckFindEntityCall(c, 4, "42")
+	s.st.CheckMachineCall(c, 4, "42")
 
 	// Ensure machines were updated.
 	machine, err := s.st.Machine("1")
@@ -681,11 +681,11 @@ func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, s.machineErrorResults)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
-	s.st.CheckFindEntityCall(c, 1, "2")
+	s.st.CheckMachineCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 1, "2")
 	now := s.clock.Now()
 	s.st.CheckCall(c, 2, "SetInstanceStatus", status.StatusInfo{Status: "invalid", Since: &now})
-	s.st.CheckFindEntityCall(c, 3, "3")
+	s.st.CheckMachineCall(c, 3, "3")
 }
 
 func (s *InstancePollerSuite) TestAreManuallyProvisionedSuccess(c *gc.C) {
@@ -707,11 +707,11 @@ func (s *InstancePollerSuite) TestAreManuallyProvisionedSuccess(c *gc.C) {
 		}},
 	)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 0, "1")
 	s.st.CheckCall(c, 1, "IsManual")
-	s.st.CheckFindEntityCall(c, 2, "2")
+	s.st.CheckMachineCall(c, 2, "2")
 	s.st.CheckCall(c, 3, "IsManual")
-	s.st.CheckFindEntityCall(c, 4, "42")
+	s.st.CheckMachineCall(c, 4, "42")
 }
 
 func (s *InstancePollerSuite) TestAreManuallyProvisionedFailure(c *gc.C) {
@@ -734,10 +734,10 @@ func (s *InstancePollerSuite) TestAreManuallyProvisionedFailure(c *gc.C) {
 		}},
 	)
 
-	s.st.CheckFindEntityCall(c, 0, "1")
-	s.st.CheckFindEntityCall(c, 1, "2")
+	s.st.CheckMachineCall(c, 0, "1")
+	s.st.CheckMachineCall(c, 1, "2")
 	s.st.CheckCall(c, 2, "IsManual")
-	s.st.CheckFindEntityCall(c, 3, "3")
+	s.st.CheckMachineCall(c, 3, "3")
 }
 
 func (s *InstancePollerSuite) TestSetProviderNetworkConfigSuccess(c *gc.C) {
@@ -905,6 +905,108 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigNoChange(c *gc.C) {
 		Type:      "ipv4",
 		Scope:     "public",
 		SpaceName: "alpha",
+	})
+}
+
+func (s *InstancePollerSuite) TestSetProviderNetworkConfigBackfillsProviderIDs(c *gc.C) {
+	s.st.SetSpaceInfo(network.SpaceInfos{
+		{ID: network.AlphaSpaceId, Name: network.AlphaSpaceName},
+		{ID: "1", Name: "space1", Subnets: []network.SubnetInfo{{CIDR: "10.0.0.0/24"}}},
+		{ID: "2", Name: "my-space-on-maas", Subnets: []network.SubnetInfo{{CIDR: "10.73.37.0/24", ProviderId: "my-space-on-maas"}}},
+	})
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: statusInfo("foo")})
+	s.st.SetMachineLinkLayerDevices(c, "1", []instancepoller.StateLinkLayerDevice{
+		// This device will be matched and its provider IDs backfilled
+		mockLinkLayerDevice{
+			name:        "foo0",
+			mtu:         1234,
+			devType:     network.EthernetDevice,
+			macAddress:  "aa:bb:cc:dd:ee:ff",
+			isAutoStart: true,
+			isUp:        true,
+			parentName:  "bond0",
+			addresses: []instancepoller.StateLinkLayerDeviceAddress{
+				&mockLinkLayerDeviceAddress{
+					configMethod:     state.StaticAddress,
+					subnetCIDR:       "172.31.32.0/24",
+					dnsServers:       []string{"1.1.1.1"},
+					dnsSearchDomains: []string{"cloud"},
+					gatewayAddress:   "172.31.32.1",
+					isDefaultGateway: true,
+					value:            "172.31.32.33",
+				},
+			},
+		},
+		// This device will not be matched
+		mockLinkLayerDevice{
+			name:        "lo",
+			mtu:         1234,
+			devType:     network.EthernetDevice,
+			macAddress:  "aa:bb:cc:dd:ee:00",
+			isAutoStart: true,
+			addresses: []instancepoller.StateLinkLayerDeviceAddress{
+				&mockLinkLayerDeviceAddress{
+					configMethod:     state.LoopbackAddress,
+					subnetCIDR:       "127.0.0.0/24",
+					dnsServers:       []string{"1.1.1.1"},
+					dnsSearchDomains: []string{"cloud"},
+					gatewayAddress:   "172.31.32.1",
+					isDefaultGateway: false,
+					value:            "127.0.0.1",
+				},
+			},
+		},
+	})
+
+	results, err := s.api.SetProviderNetworkConfig(params.SetProviderNetworkConfig{
+		Args: []params.ProviderNetworkConfig{
+			{
+				Tag: "machine-1",
+				Configs: []params.NetworkConfig{
+					{
+						ProviderId:        "eni-1234",
+						ProviderAddressId: "addr-404",
+						ProviderSubnetId:  "subnet-f00f",
+						ProviderNetworkId: "net-cafe",
+						Addresses: []params.Address{
+							{
+								Value: "172.31.32.33",
+								Scope: "local-cloud",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Assert(result.Modified, jc.IsTrue)
+
+	// Verify that the provider IDs were indeed backfilled for the matched
+	// ethernet device.
+	s.st.CheckCall(c, 6, "SetParentLinkLayerDevicesBeforeTheirChildren", state.LinkLayerDeviceArgs{
+		Name:        "foo0",
+		MTU:         1234,
+		ProviderID:  "eni-1234", // backfilled
+		Type:        network.EthernetDevice,
+		MACAddress:  "aa:bb:cc:dd:ee:ff",
+		IsAutoStart: true,
+		IsUp:        true,
+		ParentName:  "bond0",
+	})
+	s.st.CheckCall(c, 8, "SetDevicesAddressesIdempotently", state.LinkLayerDeviceAddress{
+		DeviceName:        "foo0",
+		ConfigMethod:      state.StaticAddress,
+		ProviderID:        "addr-404",    // backfilled
+		ProviderNetworkID: "net-cafe",    // backfilled
+		ProviderSubnetID:  "subnet-f00f", //backfilled
+		CIDRAddress:       "172.31.32.0/24",
+		DNSServers:        []string{"1.1.1.1"},
+		DNSSearchDomains:  []string{"cloud"},
+		GatewayAddress:    "172.31.32.1",
+		IsDefaultGateway:  true,
 	})
 }
 

--- a/apiserver/facades/controller/instancepoller/mock_test.go
+++ b/apiserver/facades/controller/instancepoller/mock_test.go
@@ -33,6 +33,8 @@ type mockState struct {
 
 	config   *config.Config
 	machines map[string]*mockMachine
+
+	spaceInfos network.SpaceInfos
 }
 
 func NewMockState() *mockState {
@@ -224,7 +226,14 @@ func (m *mockState) Machine(id string) (instancepoller.StateMachine, error) {
 // This method never throws an error.
 func (m *mockState) AllSpaceInfos() (network.SpaceInfos, error) {
 	m.MethodCall(m, "AllSpaceInfos")
-	return network.SpaceInfos{}, nil
+	return m.spaceInfos, nil
+}
+
+// SetSpaceInfo updates the mocked space infos returned by AllSpaceInfos()
+func (m *mockState) SetSpaceInfo(infos network.SpaceInfos) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.spaceInfos = infos
 }
 
 // StartSync implements statetesting.SyncStarter, so mockState can be

--- a/apiserver/facades/controller/instancepoller/state.go
+++ b/apiserver/facades/controller/instancepoller/state.go
@@ -10,6 +10,30 @@ import (
 	"github.com/juju/juju/state"
 )
 
+// StateLinkLayerDevice represents a link layer device address from state package.
+type StateLinkLayerDeviceAddress interface {
+	ConfigMethod() state.AddressConfigMethod
+	SubnetCIDR() string
+	DNSServers() []string
+	DNSSearchDomains() []string
+	GatewayAddress() string
+	IsDefaultGateway() bool
+	Value() string
+}
+
+// StateLinkLayerDevice represents a link layer device from state package.
+type StateLinkLayerDevice interface {
+	Name() string
+	MTU() uint
+	Type() network.LinkLayerDeviceType
+	IsLoopbackDevice() bool
+	MACAddress() string
+	IsAutoStart() bool
+	IsUp() bool
+	ParentName() string
+	Addresses() ([]StateLinkLayerDeviceAddress, error)
+}
+
 // StateMachine represents a machine from state package.
 type StateMachine interface {
 	state.Entity
@@ -18,6 +42,9 @@ type StateMachine interface {
 	InstanceId() (instance.Id, error)
 	ProviderAddresses() network.SpaceAddresses
 	SetProviderAddresses(...network.SpaceAddress) error
+	AllLinkLayerDevices() ([]StateLinkLayerDevice, error)
+	SetParentLinkLayerDevicesBeforeTheirChildren([]state.LinkLayerDeviceArgs) error
+	SetDevicesAddressesIdempotently([]state.LinkLayerDeviceAddress) error
 	InstanceStatus() (status.StatusInfo, error)
 	SetInstanceStatus(status.StatusInfo) error
 	SetStatus(status.StatusInfo) error
@@ -37,6 +64,42 @@ type StateInterface interface {
 	Machine(id string) (StateMachine, error)
 }
 
+type linkLayerDeviceShim struct {
+	*state.LinkLayerDevice
+}
+
+func (s linkLayerDeviceShim) Addresses() ([]StateLinkLayerDeviceAddress, error) {
+	addrList, err := s.LinkLayerDevice.Addresses()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]StateLinkLayerDeviceAddress, len(addrList))
+	for i, addr := range addrList {
+		out[i] = addr
+	}
+
+	return out, nil
+}
+
+type machineShim struct {
+	*state.Machine
+}
+
+func (s machineShim) AllLinkLayerDevices() ([]StateLinkLayerDevice, error) {
+	devList, err := s.Machine.AllLinkLayerDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]StateLinkLayerDevice, len(devList))
+	for i, dev := range devList {
+		out[i] = linkLayerDeviceShim{dev}
+	}
+
+	return out, nil
+}
+
 // TODO - CAAS(ericclaudejones): This should contain state alone, model will be
 // removed once all relevant methods are moved from state to model.
 type stateShim struct {
@@ -45,7 +108,12 @@ type stateShim struct {
 }
 
 func (s stateShim) Machine(id string) (StateMachine, error) {
-	return s.State.Machine(id)
+	m, err := s.State.Machine(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return machineShim{m}, nil
 }
 
 var getState = func(st *state.State, m *state.Model) StateInterface {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -17632,7 +17632,7 @@
     },
     {
         "Name": "InstancePoller",
-        "Version": 3,
+        "Version": 4,
         "Schema": {
             "type": "object",
             "properties": {
@@ -17688,17 +17688,6 @@
                         }
                     }
                 },
-                "ProviderAddresses": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/MachineAddressesResults"
-                        }
-                    }
-                },
                 "SetInstanceStatus": {
                     "type": "object",
                     "properties": {
@@ -17710,14 +17699,14 @@
                         }
                     }
                 },
-                "SetProviderAddresses": {
+                "SetProviderNetworkConfig": {
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/SetMachinesAddresses"
+                            "$ref": "#/definitions/SetProviderNetworkConfig"
                         },
                         "Result": {
-                            "$ref": "#/definitions/ErrorResults"
+                            "$ref": "#/definitions/SetProviderNetworkConfigResults"
                         }
                     }
                 },
@@ -17950,58 +17939,6 @@
                         "results"
                     ]
                 },
-                "MachineAddresses": {
-                    "type": "object",
-                    "properties": {
-                        "addresses": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Address"
-                            }
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "tag",
-                        "addresses"
-                    ]
-                },
-                "MachineAddressesResult": {
-                    "type": "object",
-                    "properties": {
-                        "addresses": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Address"
-                            }
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "addresses"
-                    ]
-                },
-                "MachineAddressesResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/MachineAddressesResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
-                    ]
-                },
                 "ModelConfigResult": {
                     "type": "object",
                     "properties": {
@@ -18020,6 +17957,139 @@
                         "config"
                     ]
                 },
+                "NetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "device-index": {
+                            "type": "integer"
+                        },
+                        "disabled": {
+                            "type": "boolean"
+                        },
+                        "dns-search-domains": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "dns-servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "gateway-address": {
+                            "type": "string"
+                        },
+                        "interface-name": {
+                            "type": "string"
+                        },
+                        "interface-type": {
+                            "type": "string"
+                        },
+                        "is-default-gateway": {
+                            "type": "boolean"
+                        },
+                        "mac-address": {
+                            "type": "string"
+                        },
+                        "mtu": {
+                            "type": "integer"
+                        },
+                        "no-auto-start": {
+                            "type": "boolean"
+                        },
+                        "parent-interface-name": {
+                            "type": "string"
+                        },
+                        "provider-address-id": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "provider-network-id": {
+                            "type": "string"
+                        },
+                        "provider-space-id": {
+                            "type": "string"
+                        },
+                        "provider-subnet-id": {
+                            "type": "string"
+                        },
+                        "provider-vlan-id": {
+                            "type": "string"
+                        },
+                        "routes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkRoute"
+                            }
+                        },
+                        "shadow-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "vlan-tag": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "device-index",
+                        "mac-address",
+                        "cidr",
+                        "mtu",
+                        "provider-id",
+                        "provider-network-id",
+                        "provider-subnet-id",
+                        "provider-space-id",
+                        "provider-address-id",
+                        "provider-vlan-id",
+                        "vlan-tag",
+                        "interface-name",
+                        "parent-interface-name",
+                        "interface-type",
+                        "disabled"
+                    ]
+                },
+                "NetworkRoute": {
+                    "type": "object",
+                    "properties": {
+                        "destination-cidr": {
+                            "type": "string"
+                        },
+                        "gateway-ip": {
+                            "type": "string"
+                        },
+                        "metric": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "destination-cidr",
+                        "gateway-ip",
+                        "metric"
+                    ]
+                },
                 "NotifyWatchResult": {
                     "type": "object",
                     "properties": {
@@ -18035,19 +18105,75 @@
                         "NotifyWatcherId"
                     ]
                 },
-                "SetMachinesAddresses": {
+                "ProviderNetworkConfig": {
                     "type": "object",
                     "properties": {
-                        "machine-addresses": {
+                        "config": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/MachineAddresses"
+                                "$ref": "#/definitions/NetworkConfig"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "config"
+                    ]
+                },
+                "SetProviderNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ProviderNetworkConfig"
                             }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "machine-addresses"
+                        "args"
+                    ]
+                },
+                "SetProviderNetworkConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "modified": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses",
+                        "modified"
+                    ]
+                },
+                "SetProviderNetworkConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SetProviderNetworkConfigResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "SetStatus": {
@@ -20559,17 +20685,6 @@
                         }
                     }
                 },
-                "SetProviderNetworkConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ErrorResults"
-                        }
-                    }
-                },
                 "SetStatus": {
                     "type": "object",
                     "properties": {
@@ -20885,6 +21000,12 @@
                         "address": {
                             "type": "string"
                         },
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
                         "cidr": {
                             "type": "string"
                         },
@@ -20955,6 +21076,12 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/NetworkRoute"
+                            }
+                        },
+                        "shadow-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
                             }
                         },
                         "vlan-tag": {
@@ -25901,17 +26028,6 @@
                         }
                     }
                 },
-                "SetProviderNetworkConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ErrorResults"
-                        }
-                    }
-                },
                 "SetStatus": {
                     "type": "object",
                     "properties": {
@@ -27065,6 +27181,12 @@
                         "address": {
                             "type": "string"
                         },
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
                         "cidr": {
                             "type": "string"
                         },
@@ -27135,6 +27257,12 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/NetworkRoute"
+                            }
+                        },
+                        "shadow-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
                             }
                         },
                         "vlan-tag": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -17688,11 +17688,33 @@
                         }
                     }
                 },
+                "ProviderAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MachineAddressesResults"
+                        }
+                    }
+                },
                 "SetInstanceStatus": {
                     "type": "object",
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetProviderAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetMachinesAddresses"
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
@@ -17939,6 +17961,58 @@
                         "results"
                     ]
                 },
+                "MachineAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "addresses"
+                    ]
+                },
+                "MachineAddressesResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses"
+                    ]
+                },
+                "MachineAddressesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineAddressesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
                 "ModelConfigResult": {
                     "type": "object",
                     "properties": {
@@ -18122,6 +18196,21 @@
                     "required": [
                         "tag",
                         "config"
+                    ]
+                },
+                "SetMachinesAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "machine-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineAddresses"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-addresses"
                     ]
                 },
                 "SetProviderNetworkConfig": {
@@ -20682,6 +20771,17 @@
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/SetMachineNetworkConfig"
+                        }
+                    }
+                },
+                "SetProviderNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
                         }
                     }
                 },
@@ -26022,6 +26122,17 @@
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/EntityPasswords"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetProviderNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -561,6 +561,36 @@ type UnitNetworkConfig struct {
 	BindingName string `json:"binding-name"`
 }
 
+// SetProviderNetworkConfigs holds a machine tag and a list of network interface
+// info obtained by querying the provider.
+type SetProviderNetworkConfig struct {
+	Args []ProviderNetworkConfig `json:"args"`
+}
+
+// ProviderNetworkConfig holds a machine tag and a list of network interface
+// info obtained by querying the provider.
+type ProviderNetworkConfig struct {
+	Tag     string          `json:"tag"`
+	Configs []NetworkConfig `json:"config"`
+}
+
+// SetProviderNetworkConfigResults holds a list of SetProviderNetwork config
+// results.
+type SetProviderNetworkConfigResults struct {
+	Results []SetProviderNetworkConfigResult `json:"results"`
+}
+
+// SetProviderNetworkConfigResult holds a list of provider addresses or an
+// error.
+type SetProviderNetworkConfigResult struct {
+	Error     *Error    `json:"error,omitempty"`
+	Addresses []Address `json:"addresses"`
+
+	// Modified will be set to true if the provider address list has been
+	// updated.
+	Modified bool `json:"modified"`
+}
+
 // MachineAddresses holds an machine tag and addresses.
 type MachineAddresses struct {
 	Tag       string    `json:"tag"`

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -548,6 +548,23 @@ func (sas SpaceAddresses) AllMatchingScope(getMatcher ScopeMatchFunc) SpaceAddre
 	return out
 }
 
+// EqualTo returns true if this set of SpaceAddresses is equal to other.
+func (sas SpaceAddresses) EqualTo(other SpaceAddresses) bool {
+	if len(sas) != len(other) {
+		return false
+	}
+
+	SortAddresses(sas)
+	SortAddresses(other)
+	for i := 0; i < len(sas); i++ {
+		if sas[i].String() != other[i].String() {
+			return false
+		}
+	}
+
+	return true
+}
+
 // DeriveAddressType attempts to detect the type of address given.
 func DeriveAddressType(value string) AddressType {
 	ip := net.ParseIP(value)

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -333,12 +333,20 @@ func NewScopedProviderAddress(value string, scope Scope) ProviderAddress {
 	return ProviderAddress{MachineAddress: NewScopedMachineAddress(value, scope)}
 }
 
-// NewProviderAddressInSpace creates a new ProviderAddress,
-// deriving its type and scope from the value,
-// and associating it with the given space name.
+// NewProviderAddressInSpace creates a new ProviderAddress, deriving its type
+// and scope from the value, and associating it with the given space name.
 func NewProviderAddressInSpace(spaceName string, value string) ProviderAddress {
 	return ProviderAddress{
 		MachineAddress: NewMachineAddress(value),
+		SpaceName:      SpaceName(spaceName),
+	}
+}
+
+// NewScopedProviderAddressInSpace creates a new ProviderAddress, deriving its
+// type from the value, and associating it with the given scope and space name.
+func NewScopedProviderAddressInSpace(spaceName string, value string, scope Scope) ProviderAddress {
+	return ProviderAddress{
+		MachineAddress: NewScopedMachineAddress(value, scope),
 		SpaceName:      SpaceName(spaceName),
 	}
 }

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -375,6 +375,20 @@ func NewProviderAddressesInSpace(spaceName string, inAddresses ...string) (outAd
 	return outAddresses
 }
 
+// ToIPAddresses transforms the ProviderAddresses to a string slice containing
+// their raw IP values.
+func (pas ProviderAddresses) ToIPAddresses() []string {
+	if pas == nil {
+		return nil
+	}
+
+	ips := make([]string, len(pas))
+	for i, addr := range pas {
+		ips[i] = addr.Value
+	}
+	return ips
+}
+
 // ToSpaceAddresses transforms the ProviderAddresses to SpaceAddresses by using
 // the input lookup for conversion of space name to space ID.
 func (pas ProviderAddresses) ToSpaceAddresses(lookup SpaceLookup) (SpaceAddresses, error) {

--- a/state/address.go
+++ b/state/address.go
@@ -197,7 +197,10 @@ func (st *State) filterHostPortsForManagementSpace(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		spaceInfo := sp.NetworkSpace()
+		spaceInfo, err := sp.NetworkSpace()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 
 		hostPortsForAgents = make([]network.SpaceHostPorts, len(apiHostPorts))
 		for i := range apiHostPorts {

--- a/state/controller.go
+++ b/state/controller.go
@@ -173,7 +173,12 @@ func (st *State) checkSpaceIsAvailableToAllControllers(spaceName string) error {
 		if err != nil {
 			return errors.Annotate(err, "cannot get machine")
 		}
-		if _, ok := m.Addresses().InSpaces(space.NetworkSpace()); !ok {
+		netSpace, err := space.NetworkSpace()
+		if err != nil {
+			return errors.Annotate(err, "cannot get network space")
+		}
+
+		if _, ok := m.Addresses().InSpaces(netSpace); !ok {
 			missing = append(missing, id)
 		}
 	}

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -281,7 +281,8 @@ func updateIPAddressDocOp(existingDoc, newDoc *ipAddressDoc) (txn.Op, bool) {
 		// Only allow changing the ProviderID if it was empty.
 		changes["providerid"] = newDoc.ProviderID
 	}
-	if existingDoc.ProviderSubnetID != newDoc.ProviderSubnetID {
+	if existingDoc.ProviderSubnetID == "" && newDoc.ProviderSubnetID != "" {
+		// Only allow changing the ProviderSubnetID if it was empty.
 		changes["provider-subnet-id"] = newDoc.ProviderSubnetID
 	}
 	if existingDoc.ConfigMethod != newDoc.ConfigMethod {

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -644,7 +644,9 @@ func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CI
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, CIDR, providerSubnetID string) {
 	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
-	s.spaces[spaceName] = space.NetworkSpace()
+	spaceInfo, err := space.NetworkSpace()
+	c.Assert(err, gc.IsNil)
+	s.spaces[spaceName] = spaceInfo
 
 	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
 		CIDR:       CIDR,

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -90,14 +90,27 @@ func (s *Space) Subnets() ([]*Subnet, error) {
 	return results, nil
 }
 
-func (s *Space) NetworkSpace() network.SpaceInfo {
+// NetworkSpace maps the space fields into a network.SpaceInfo.
+func (s *Space) NetworkSpace() (network.SpaceInfo, error) {
+	subnets, err := s.Subnets()
+	if err != nil {
+		return network.SpaceInfo{}, errors.Trace(err)
+	}
+
+	mappedSubnets := make([]network.SubnetInfo, len(subnets))
+	for i, subnet := range subnets {
+		mappedSubnet := subnet.networkSubnet()
+		mappedSubnet.SpaceID = s.Id()
+		mappedSubnet.SpaceName = s.Name()
+		mappedSubnets[i] = mappedSubnet
+	}
+
 	return network.SpaceInfo{
 		ID:         s.Id(),
 		Name:       network.SpaceName(s.Name()),
 		ProviderId: s.ProviderId(),
-		// TODO (manadart 2019-08-13): Populate these after subnet refactor.
-		Subnets: nil,
-	}
+		Subnets:    mappedSubnets,
+	}, nil
 }
 
 // AddSpace creates and returns a new space.
@@ -251,7 +264,9 @@ func (st *State) AllSpaceInfos() (network.SpaceInfos, error) {
 	}
 	result := make(network.SpaceInfos, len(spaces))
 	for i, space := range spaces {
-		result[i] = space.NetworkSpace()
+		if result[i], err = space.NetworkSpace(); err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -648,14 +648,14 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 		ID:         space.Id(),
 		ProviderId: args.ProviderId,
 		Subnets: []network.SubnetInfo{
-			network.SubnetInfo{
+			{
 				SpaceID:           space.Id(),
 				SpaceName:         "space1",
 				CIDR:              "1.1.1.0/24",
 				VLANTag:           79,
 				AvailabilityZones: []string{"AvailabilityZone"},
 			},
-			network.SubnetInfo{
+			{
 				SpaceID:           space.Id(),
 				SpaceName:         "space1",
 				CIDR:              "253.1.0.0/16",
@@ -666,7 +666,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 					FanOverlay:       "253.0.0.0/8",
 				},
 			},
-			network.SubnetInfo{
+			{
 				SpaceID:           space.Id(),
 				SpaceName:         "space1",
 				CIDR:              "2001:cbd0::/32",

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"fmt"
 	"net"
+	"sort"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -616,4 +617,68 @@ func (s *SpacesSuite) TestFanSubnetInheritsSpace(c *gc.C) {
 	}
 	c.Assert(foundSubnet, gc.NotNil)
 	c.Assert(foundSubnet.SpaceID(), gc.Equals, space.Id())
+}
+
+func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "space1",
+		ProviderId:  network.Id("some id 2"),
+		SubnetCIDRs: []string{"1.1.1.0/24", "2001:cbd0::/32"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+	info := network.SubnetInfo{
+		CIDR:              "253.1.0.0/16",
+		VLANTag:           79,
+		AvailabilityZones: []string{"AvailabilityZone"},
+	}
+	info.SetFan("1.1.1.0/24", "253.0.0.0/8")
+	_, err = s.State.AddSubnet(info)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = space.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+
+	spaceInfo, err := space.NetworkSpace()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expSpaceInfo := network.SpaceInfo{
+		Name:       "space1",
+		ID:         space.Id(),
+		ProviderId: args.ProviderId,
+		Subnets: []network.SubnetInfo{
+			network.SubnetInfo{
+				SpaceID:           space.Id(),
+				SpaceName:         "space1",
+				CIDR:              "1.1.1.0/24",
+				VLANTag:           79,
+				AvailabilityZones: []string{"AvailabilityZone"},
+			},
+			network.SubnetInfo{
+				SpaceID:           space.Id(),
+				SpaceName:         "space1",
+				CIDR:              "253.1.0.0/16",
+				VLANTag:           79,
+				AvailabilityZones: []string{"AvailabilityZone"},
+				FanInfo: &network.FanCIDRs{
+					FanLocalUnderlay: "1.1.1.0/24",
+					FanOverlay:       "253.0.0.0/8",
+				},
+			},
+			network.SubnetInfo{
+				SpaceID:           space.Id(),
+				SpaceName:         "space1",
+				CIDR:              "2001:cbd0::/32",
+				VLANTag:           79,
+				AvailabilityZones: []string{"AvailabilityZone"},
+			},
+		},
+	}
+
+	// Sort subnets by CIDR to avoid flaky tests
+	sort.Slice(spaceInfo.Subnets, func(l, r int) bool { return spaceInfo.Subnets[l].CIDR < spaceInfo.Subnets[r].CIDR })
+	sort.Slice(expSpaceInfo.Subnets, func(l, r int) bool { return expSpaceInfo.Subnets[l].CIDR < expSpaceInfo.Subnets[r].CIDR })
+
+	c.Assert(spaceInfo, gc.DeepEquals, expSpaceInfo)
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -301,6 +301,28 @@ func (s *Subnet) updateSpaceName(spaceName string) (bool, error) {
 	return spaceNameChange && spaceName != "" && s.doc.FanLocalUnderlay == "", nil
 }
 
+// networkSubnet maps the subnet fields into a network.SubnetInfo.
+func (s *Subnet) networkSubnet() network.SubnetInfo {
+	var fanInfo *network.FanCIDRs
+	if s.doc.FanLocalUnderlay != "" || s.doc.FanOverlay != "" {
+		fanInfo = &network.FanCIDRs{
+			FanLocalUnderlay: s.doc.FanLocalUnderlay,
+			FanOverlay:       s.doc.FanOverlay,
+		}
+	}
+
+	return network.SubnetInfo{
+		CIDR:              s.doc.CIDR,
+		ProviderId:        network.Id(s.doc.ProviderId),
+		ProviderNetworkId: network.Id(s.doc.ProviderNetworkId),
+		VLANTag:           s.doc.VLANTag,
+		AvailabilityZones: s.doc.AvailabilityZones,
+		// SpaceName and ID will be populated by space.NetworkSpace
+		FanInfo:  fanInfo,
+		IsPublic: s.doc.IsPublic,
+	}
+}
+
 // SubnetUpdate adds new info to the subnet based on provided info.
 func (st *State) SubnetUpdate(args network.SubnetInfo) error {
 	s, err := st.SubnetByCIDR(args.CIDR)

--- a/worker/instancepoller/mocks/mocks_instancepoller.go
+++ b/worker/instancepoller/mocks/mocks_instancepoller.go
@@ -5,16 +5,15 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/life"
+	life "github.com/juju/juju/core/life"
 	network "github.com/juju/juju/core/network"
 	status "github.com/juju/juju/core/status"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
+	reflect "reflect"
 )
 
 // MockEnviron is a mock of Environ interface
@@ -51,6 +50,19 @@ func (m *MockEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instanc
 // Instances indicates an expected call of Instances
 func (mr *MockEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Instances", reflect.TypeOf((*MockEnviron)(nil).Instances), arg0, arg1)
+}
+
+// NetworkInterfaces mocks base method
+func (m *MockEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([][]network.InterfaceInfo, error) {
+	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
+	ret0, _ := ret[0].([][]network.InterfaceInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NetworkInterfaces indicates an expected call of NetworkInterfaces
+func (mr *MockEnvironMockRecorder) NetworkInterfaces(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInterfaces", reflect.TypeOf((*MockEnviron)(nil).NetworkInterfaces), arg0, arg1)
 }
 
 // MockMachine is a mock of Machine interface
@@ -139,19 +151,6 @@ func (mr *MockMachineMockRecorder) Life() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMachine)(nil).Life))
 }
 
-// ProviderAddresses mocks base method
-func (m *MockMachine) ProviderAddresses() (network.ProviderAddresses, error) {
-	ret := m.ctrl.Call(m, "ProviderAddresses")
-	ret0, _ := ret[0].(network.ProviderAddresses)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ProviderAddresses indicates an expected call of ProviderAddresses
-func (mr *MockMachineMockRecorder) ProviderAddresses() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderAddresses", reflect.TypeOf((*MockMachine)(nil).ProviderAddresses))
-}
-
 // Refresh mocks base method
 func (m *MockMachine) Refresh() error {
 	ret := m.ctrl.Call(m, "Refresh")
@@ -176,20 +175,18 @@ func (mr *MockMachineMockRecorder) SetInstanceStatus(arg0, arg1, arg2 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachine)(nil).SetInstanceStatus), arg0, arg1, arg2)
 }
 
-// SetProviderAddresses mocks base method
-func (m *MockMachine) SetProviderAddresses(arg0 ...network.ProviderAddress) error {
-	varargs := []interface{}{}
-	for _, a := range arg0 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "SetProviderAddresses", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+// SetProviderNetworkConfig mocks base method
+func (m *MockMachine) SetProviderNetworkConfig(arg0 []network.InterfaceInfo) (network.ProviderAddresses, bool, error) {
+	ret := m.ctrl.Call(m, "SetProviderNetworkConfig", arg0)
+	ret0, _ := ret[0].(network.ProviderAddresses)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// SetProviderAddresses indicates an expected call of SetProviderAddresses
-func (mr *MockMachineMockRecorder) SetProviderAddresses(arg0 ...interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProviderAddresses", reflect.TypeOf((*MockMachine)(nil).SetProviderAddresses), arg0...)
+// SetProviderNetworkConfig indicates an expected call of SetProviderNetworkConfig
+func (mr *MockMachineMockRecorder) SetProviderNetworkConfig(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProviderNetworkConfig", reflect.TypeOf((*MockMachine)(nil).SetProviderNetworkConfig), arg0)
 }
 
 // Status mocks base method

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
+	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/worker/common"
 )
 
@@ -48,6 +49,7 @@ var (
 // poller.
 type Environ interface {
 	Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error)
+	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]jujunetwork.InterfaceInfo, error)
 }
 
 // Machine specifies an interface for machine instances processed by the

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -36,28 +36,37 @@ var (
 	_ = gc.Suite(&workerSuite{})
 
 	testAddrs = network.ProviderAddresses{
-		network.NewProviderAddress("127.0.0.1"),
-		{
-			MachineAddress: network.MachineAddress{
-				Value: "10.6.6.6",
-				Type:  network.IPv4Address,
-				Scope: network.ScopeCloudLocal,
+		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),
+	}
+
+	testNetIfs = []network.InterfaceInfo{
+		network.InterfaceInfo{
+			DeviceIndex:   0,
+			InterfaceName: "eth0",
+			MACAddress:    "de:ad:be:ef:00:00",
+			CIDR:          "10.0.0.0/24",
+			Addresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
 			},
-			SpaceName:       "test-space",
-			ProviderSpaceID: "1",
+			ShadowAddresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),
+			},
 		},
 	}
 
-	testAddrs2 = network.ProviderAddresses{
-		network.NewProviderAddress("127.0.0.1"),
-		{
-			MachineAddress: network.MachineAddress{
-				Value: "10.9.9.9",
-				Type:  network.IPv4Address,
-				Scope: network.ScopeCloudLocal,
+	testCoercedNetIfs = []network.InterfaceInfo{
+		network.InterfaceInfo{
+			DeviceIndex: 0,
+			Addresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
 			},
-			SpaceName:       "test-space",
-			ProviderSpaceID: "1",
+		},
+		network.InterfaceInfo{
+			DeviceIndex: 1,
+			ShadowAddresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),
+			},
 		},
 	}
 )
@@ -196,23 +205,22 @@ func (s *workerSuite) TestUpdateOfStatusAndAddressDetails(c *gc.C) {
 	machine.EXPECT().Id().Return("0").AnyTimes()
 	machine.EXPECT().Life().Return(life.Alive)
 	machine.EXPECT().InstanceStatus().Return(params.StatusResult{Status: string(status.Provisioning)}, nil)
-	machine.EXPECT().ProviderAddresses().Return(testAddrs, nil)
 
 	// The provider reports the instance status as running and also indicates
 	// that network addresses have been *changed*.
 	instInfo := mocks.NewMockInstance(ctrl)
 	instInfo.EXPECT().Status(gomock.Any()).Return(instance.Status{Status: status.Running, Message: "Running wild"})
-	instInfo.EXPECT().Addresses(gomock.Any()).Return(testAddrs2, nil)
 
 	// When we process the instance info we expect the machine instance
 	// status and list of network addresses to be updated so they match
 	// the values reported by the provider.
 	machine.EXPECT().SetInstanceStatus(status.Running, "Running wild", nil).Return(nil)
-	machine.EXPECT().SetProviderAddresses(testAddrs2[0], testAddrs2[1]).Return(nil)
+	machine.EXPECT().SetProviderNetworkConfig(testNetIfs).Return(testAddrs, true, nil)
 
-	providerStatus, err := updWorker.processProviderInfo(entry, instInfo)
+	providerStatus, addrCount, err := updWorker.processProviderInfo(entry, instInfo, testNetIfs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(providerStatus, gc.Equals, status.Running)
+	c.Assert(addrCount, gc.Equals, len(testAddrs))
 }
 
 func (s *workerSuite) TestStartedMachineWithNetAddressesMovesToLongPollGroup(c *gc.C) {
@@ -229,13 +237,10 @@ func (s *workerSuite) TestStartedMachineWithNetAddressesMovesToLongPollGroup(c *
 	updWorker.appendToShortPollGroup(machineTag, machine)
 	c.Assert(updWorker.pollGroup[shortPollGroup], gc.HasLen, 1)
 
-	// The machine is assigned a network address.
-	machine.EXPECT().ProviderAddresses().Return(testAddrs, nil)
-
 	// The provider reports an instance status of "running"; the machine
 	// reports it's machine status as "started".
 	entry, _ := updWorker.lookupPolledMachine(machineTag)
-	updWorker.maybeSwitchPollGroup(shortPollGroup, entry, status.Running, status.Started)
+	updWorker.maybeSwitchPollGroup(shortPollGroup, entry, status.Running, status.Started, 1)
 
 	c.Assert(updWorker.pollGroup[shortPollGroup], gc.HasLen, 0)
 	c.Assert(updWorker.pollGroup[longPollGroup], gc.HasLen, 1)
@@ -258,7 +263,7 @@ func (s *workerSuite) TestNonStartedMachinesGetBumpedPollInterval(c *gc.C) {
 		updWorker.appendToShortPollGroup(machineTag, machine)
 		entry, _ := updWorker.lookupPolledMachine(machineTag)
 
-		updWorker.maybeSwitchPollGroup(shortPollGroup, entry, spec, status.Pending)
+		updWorker.maybeSwitchPollGroup(shortPollGroup, entry, spec, status.Pending, 0)
 		c.Assert(entry.shortPollInterval, gc.Equals, time.Duration(float64(ShortPoll)*ShortPollBackoff))
 	}
 }
@@ -274,18 +279,17 @@ func (s *workerSuite) TestMoveMachineWithUnknownStatusBackToShortPollGroup(c *gc
 	// The machine is assigned a network address.
 	machineTag := names.NewMachineTag("0")
 	machine := mocks.NewMockMachine(ctrl)
-	machine.EXPECT().ProviderAddresses().Return(testAddrs, nil).AnyTimes()
 
 	// Move the machine to the long poll group.
 	updWorker.appendToShortPollGroup(machineTag, machine)
 	entry, _ := updWorker.lookupPolledMachine(machineTag)
-	updWorker.maybeSwitchPollGroup(shortPollGroup, entry, status.Running, status.Started)
+	updWorker.maybeSwitchPollGroup(shortPollGroup, entry, status.Running, status.Started, 1)
 	c.Assert(updWorker.pollGroup[shortPollGroup], gc.HasLen, 0)
 	c.Assert(updWorker.pollGroup[longPollGroup], gc.HasLen, 1)
 
 	// If we get unknown status from the provider we expect the machine to
 	// be moved back to the short poll group.
-	updWorker.maybeSwitchPollGroup(longPollGroup, entry, status.Unknown, status.Started)
+	updWorker.maybeSwitchPollGroup(longPollGroup, entry, status.Unknown, status.Started, 1)
 	c.Assert(updWorker.pollGroup[shortPollGroup], gc.HasLen, 1)
 	c.Assert(updWorker.pollGroup[longPollGroup], gc.HasLen, 0)
 	c.Assert(entry.shortPollInterval, gc.Equals, ShortPoll)
@@ -429,13 +433,59 @@ func (s *workerSuite) TestBatchPollingOfGroupMembers(c *gc.C) {
 	machine1.EXPECT().InstanceId().Return(instance.Id("b4dc0ffee"), nil)
 	machine1.EXPECT().InstanceStatus().Return(params.StatusResult{Status: string(status.Running)}, nil)
 	machine1.EXPECT().Status().Return(params.StatusResult{Status: string(status.Started)}, nil)
-	machine1.EXPECT().ProviderAddresses().Return(nil, nil).AnyTimes() // no addresses assigned yet
+	machine1.EXPECT().SetProviderNetworkConfig(testNetIfs).Return(testAddrs, false, nil)
 	updWorker.appendToShortPollGroup(machineTag1, machine1)
 
 	machine1Info := mocks.NewMockInstance(ctrl)
-	machine1Info.EXPECT().Addresses(gomock.Any()).Return(nil, nil) // no addresses reported by provider
 	machine1Info.EXPECT().Status(gomock.Any()).Return(instance.Status{Status: status.Running})
 	mocked.environ.EXPECT().Instances(gomock.Any(), []instance.Id{"b4dc0ffee"}).Return([]instances.Instance{machine1Info}, nil)
+	mocked.environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{"b4dc0ffee"}).Return(
+		[][]network.InterfaceInfo{testNetIfs},
+		nil,
+	)
+
+	// Trigger a poll of the short poll group and wait for the worker loop
+	// to complete.
+	s.assertWorkerCompletesLoop(c, updWorker, func() {
+		mocked.clock.Advance(ShortPoll)
+	})
+}
+
+func (s *workerSuite) TestBatchPollingOfGroupMembersWithProviderNotSupportingNetworkInfo(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	// Add two machines, one that is not yet provisioned and one that is
+	// has a "created" machine status and a "running" instance status.
+	machineTag0 := names.NewMachineTag("0")
+	machine0 := mocks.NewMockMachine(ctrl)
+	machine0.EXPECT().InstanceId().Return(instance.Id(""), common.ServerError(errors.NotProvisionedf("not there")))
+	updWorker.appendToShortPollGroup(machineTag0, machine0)
+
+	machineTag1 := names.NewMachineTag("1")
+	machine1 := mocks.NewMockMachine(ctrl)
+	machine1.EXPECT().Life().Return(life.Alive)
+	machine1.EXPECT().InstanceId().Return(instance.Id("b4dc0ffee"), nil)
+	machine1.EXPECT().InstanceStatus().Return(params.StatusResult{Status: string(status.Running)}, nil)
+	machine1.EXPECT().Status().Return(params.StatusResult{Status: string(status.Started)}, nil)
+	machine1.EXPECT().SetProviderNetworkConfig(testCoercedNetIfs).Return(testAddrs, false, nil)
+	updWorker.appendToShortPollGroup(machineTag1, machine1)
+
+	machine1Info := mocks.NewMockInstance(ctrl)
+	machine1Info.EXPECT().Status(gomock.Any()).Return(instance.Status{Status: status.Running})
+	// Since the provider does not support environ.Networking, the worker
+	// will fall-back to fetching the instance addresses and coercing them
+	// into an interface list.
+	machine1Info.EXPECT().Addresses(gomock.Any()).Return(testAddrs, nil)
+
+	mocked.environ.EXPECT().Instances(gomock.Any(), []instance.Id{"b4dc0ffee"}).Return([]instances.Instance{machine1Info}, nil)
+	mocked.environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{"b4dc0ffee"}).Return(
+		nil, errors.NotSupportedf("network interfaces"),
+	)
 
 	// Trigger a poll of the short poll group and wait for the worker loop
 	// to complete.
@@ -467,6 +517,9 @@ func (s *workerSuite) TestLongPollMachineNotKnownByProvider(c *gc.C) {
 	machine.EXPECT().InstanceId().Return(instID, nil)
 	mocked.environ.EXPECT().Instances(gomock.Any(), []instance.Id{instID}).Return(
 		[]instances.Instance{}, environs.ErrPartialInstances,
+	)
+	mocked.environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{instID}).Return(
+		nil, errors.NotSupportedf("network interfaces"),
 	)
 
 	// Advance the clock to trigger processing of both the short AND long
@@ -500,6 +553,9 @@ func (s *workerSuite) TestLongPollNoMachineInGroupKnownByProvider(c *gc.C) {
 	machine.EXPECT().InstanceId().Return(instID, nil)
 	mocked.environ.EXPECT().Instances(gomock.Any(), []instance.Id{instID}).Return(
 		nil, environs.ErrNoInstances,
+	)
+	mocked.environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{instID}).Return(
+		nil, errors.NotSupportedf("network interfaces"),
 	)
 
 	// Advance the clock to trigger processing of both the short AND long

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -41,7 +41,7 @@ var (
 	}
 
 	testNetIfs = []network.InterfaceInfo{
-		network.InterfaceInfo{
+		{
 			DeviceIndex:   0,
 			InterfaceName: "eth0",
 			MACAddress:    "de:ad:be:ef:00:00",
@@ -56,13 +56,13 @@ var (
 	}
 
 	testCoercedNetIfs = []network.InterfaceInfo{
-		network.InterfaceInfo{
+		{
 			DeviceIndex: 0,
 			Addresses: network.ProviderAddresses{
 				network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
 			},
 		},
-		network.InterfaceInfo{
+		{
 			DeviceIndex: 1,
 			ShadowAddresses: network.ProviderAddresses{
 				network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -467,8 +467,8 @@ type fakeSpace struct {
 	network.SpaceInfo
 }
 
-func (s *fakeSpace) NetworkSpace() network.SpaceInfo {
-	return s.SpaceInfo
+func (s *fakeSpace) NetworkSpace() (network.SpaceInfo, error) {
+	return s.SpaceInfo, nil
 }
 
 type fakeMongoSession struct {

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -61,7 +61,7 @@ type ControllerHost interface {
 }
 
 type Space interface {
-	NetworkSpace() network.SpaceInfo
+	NetworkSpace() (network.SpaceInfo, error)
 }
 
 type MongoSession interface {
@@ -757,7 +757,7 @@ func (w *pgWorker) getHASpaceFromConfig() (network.SpaceInfo, error) {
 	if err != nil {
 		return network.SpaceInfo{}, errors.Trace(err)
 	}
-	return space.NetworkSpace(), nil
+	return space.NetworkSpace()
 }
 
 // setHasVote sets the HasVote status of all the given nodes to hasVote.


### PR DESCRIPTION
## Description of change

This PR concludes the refactoring work for the instance poller.

### The old approach

Prior to this PR, the machiner worker would periodically wake up, collect the device information that was visible to it and sent it to the controller via the `SetObservedNetworkConfig` API call. The implementation for this API method (lives in the `networkingcommon` package) would then query the network provider for additional interface info and merge that to the data sent in by the machiner.

The final piece of fused data would then be broken down into two slices:
- a `[]state.LinkLayerDeviceArgs`
- a `[]state.LinkLayerDeviceAddresses`

A state-based setter method would then be invoked for each one of those slices to update the link layer devices collection and the machine addresses collection. However, the original approach had some caveats:

- We would need to query the provider for network info each time that the machiner worker wakes up; if we have deployed a large number of machines we would be making an API call to the provider for each machine in the model even though the provider-based information doesn't really change that often.
- As far as detecting, populating (and keeping in sync) the **provider** addresses for the machine we were currently relying on the fact that the machiner worker is running and always able to connect to the API server.

### The new approach

In the new world, the machiner worker is the primary source for collecting and updating the link layer device (and LLD address) collection. The code that queried the underlying provider for extra info has now been removed from the `SetObservedNetworkConfig` code path.

Instead, the instancepoller (a more dependable worker since it runs on the controller) will now also collect (if the provider supports it) the interface information using a single batch call at the same time when it queries the instance information (yet another batch call). If the provider does not support querying for network interfaces (e.g. MAAS, LXD etc.), the instancepoller will create a fake list of minimal network interface information using the address info obtained via the instance status query.

This information is then sent to the controller via a new instancepoller API method called `SetProviderNetworkConfig`. The controller-side implementation:

- attempts to infer the space ID for each provided interface address (private and/or shadow) using one of the following mechanisms (depending on what bits of information is provided by the instance poller):
  - match address to a subnet CIDR (multiple matches are considered ambiguous and will cause an error)
  - match CIDR **and** providerID to a subnet (this one is un-ambiguous)
 
In the case where we cannot match an address to any subnet (e.g. public shadow address), we automatically assign it to the **alpha** space. The operator can (will be able to) later use the juju CLI and re-assign the address so using a sane default should not cause any issues.

Finally, since the interface information pushed by the instance poller may contain provider specific IDs (network, address, subnet IDs) that are not visible to the machiner worker, the introduced `SetProviderNetworkConfig` also makes a _best-effort_ attempt to match (by address) each instancepoller-reported interface to an existing linklayer device/address combination and backfill the provider specific bits.

## Caveats and potential issues

Since the instancepoller will detect the machine before it actually starts (hence, before the machiner worker runs) it would be a good opportunity to pre-populate the link layer device/address collections from the instancepoller-sourced data. 

Unfortunately, some providers (I am looking at you ec2!) do not report the names for network interfaces  **and** our linklayer device document IDs include the interface name. Therefore, pre-populating and then merging the machiner worker information is not really an option as we will end up with different documents.

The chosen approach does not have this problem as we only backfill the provider ID bits to devices that have been already added by the machiner. The caveat here is that this backfill process will take a while to complete; once a machine enters the long poll group, it won't be refreshed for about 15 minutes which is more or less the latency we expect to see.

Furthermore, I would like to point out that while testing this code, I have noticed that in the case of EC2, the link layer device collection and its sibling IP address collection **DOES** in fact include duplicate entries for the same link layer device. This also happens in the 2.6 branch which does not include any of the instancepoller refactoring work and might allude to a potential bug.

The following examples (link layer device and ip.address collection bits) were obtained by bootstrapping a 2.6 controller on AWS

```json
{
        "_id" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0:m#0#d#unsupported0",
        "name" : "unsupported0",
        "model-uuid" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0",
        "mtu" : 0,
        "providerid" : "eni-067314af609749f26",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "0e:89:85:5c:80:47",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5de64e7d90f35328503a5868_33348be2",
                "5de64e7d90f35328503a5869_d8534326"
        ]
}
...
{
        "_id" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0:m#0#d#ens5",
        "name" : "ens5",
        "model-uuid" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0",
        "mtu" : 9001,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "0e:89:85:5c:80:47",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5de64e7d90f35328503a586d_0056020f",
                "5de64e7d90f35328503a586f_b036dc72"
        ]
}
```

```json
{
        "_id" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0:m#0#d#unsupported0#ip#172.31.36.2",
        "model-uuid" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0",
        "device-name" : "unsupported0",
        "machine-id" : "0",
        "subnet-cidr" : "172.31.32.0/20",
        "config-method" : "dynamic",
        "value" : "172.31.36.2",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5de64e7d90f35328503a5869_d8534326"
        ]
}
...
{
        "_id" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0:m#0#d#ens5#ip#172.31.36.2",
        "model-uuid" : "181280d3-d776-4790-82bc-fd7f7b7bd8a0",
        "device-name" : "ens5",
        "machine-id" : "0",
        "subnet-cidr" : "172.31.32.0/20",
        "config-method" : "static",
        "value" : "172.31.36.2",
        "gateway-address" : "172.31.32.1",
        "is-default-gateway" : true,
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5de64e7d90f35328503a586f_b036dc72"
        ]
}
```

## QA steps

Bootstrap on ec2, gce, maas and lxd with 
```--logging-config='<root>=ERROR;juju.worker.instancepoller=DEBUG;juju.apiserver.instancepoller=DEBUG'```

If the provider supports spaces, create a new space from a subnet and spin up a machine on both the alpha (or the default equivalent on MAAS) and the new space. Tailing the debug logs should report that the instancepoller has detected new provider addresses which should include a space ID as their suffix.

```console
$ juju debug-log -m {controller/default} --include-module juju.worker.instancepoller --include-module juju.apiserver.instancepoller --replay --level DEBUG
```