### PR TITLE
Adds a core/multiwatcher package.

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -32,6 +32,7 @@ import (
 	apitesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
 	psapiserver "github.com/juju/juju/pubsub/apiserver"
 	"github.com/juju/juju/pubsub/centralhub"
@@ -83,7 +84,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 	modelCache, err := modelcache.NewWorker(modelcache.Config{
 		InitializedGate: initialized,
 		Logger:          loggo.GetLogger("test"),
-		WatcherFactory: func() modelcache.BackingWatcher {
+		WatcherFactory: func() multiwatcher.Watcher {
 			return s.StatePool.SystemState().WatchAllModels(s.StatePool)
 		},
 		PrometheusRegisterer: noopRegisterer{},

--- a/apiserver/params/multiwatcher.go
+++ b/apiserver/params/multiwatcher.go
@@ -105,8 +105,8 @@ func (d *Delta) UnmarshalJSON(data []byte) error {
 		d.Entity = new(ActionInfo)
 	case "charm":
 		d.Entity = new(CharmInfo)
-	case "generation":
-		d.Entity = new(GenerationInfo)
+	case "branch":
+		d.Entity = new(BranchInfo)
 	default:
 		return errors.Errorf("Unexpected entity name %q", entityKind)
 	}
@@ -154,18 +154,6 @@ type StatusInfo struct {
 	Since   *time.Time             `json:"since,omitempty"`
 	Version string                 `json:"version"`
 	Data    map[string]interface{} `json:"data,omitempty"`
-}
-
-// NewStatusInfo return a new multiwatcher StatusInfo from a
-// status StatusInfo.
-func NewStatusInfo(s status.StatusInfo, err error) StatusInfo {
-	return StatusInfo{
-		Err:     err,
-		Current: s.Status,
-		Message: s.Message,
-		Since:   s.Since,
-		Data:    s.Data,
-	}
 }
 
 // ApplicationInfo holds the information about an application that is tracked
@@ -432,9 +420,9 @@ type ItemChange struct {
 	NewValue interface{} `json:"new,omitempty"`
 }
 
-// GenerationInfo holds data about a model generation (branch)
+// BranchInfo holds data about a model generation (branch)
 // that is tracked by multiwatcherStore.
-type GenerationInfo struct {
+type BranchInfo struct {
 	ModelUUID     string                  `json:"model-uuid"`
 	Id            string                  `json:"id"`
 	Name          string                  `json:"name"`
@@ -448,9 +436,9 @@ type GenerationInfo struct {
 }
 
 // EntityId returns a unique identifier for a generation.
-func (i *GenerationInfo) EntityId() EntityId {
+func (i *BranchInfo) EntityId() EntityId {
 	return EntityId{
-		Kind:      "generation",
+		Kind:      "branch",
 		ModelUUID: i.ModelUUID,
 		Id:        i.Id,
 	}

--- a/apiserver/params/multiwatcher_internal_test.go
+++ b/apiserver/params/multiwatcher_internal_test.go
@@ -15,5 +15,5 @@ var (
 	_ EntityInfo = (*BlockInfo)(nil)
 	_ EntityInfo = (*ActionInfo)(nil)
 	_ EntityInfo = (*ModelUpdate)(nil)
-	_ EntityInfo = (*GenerationInfo)(nil)
+	_ EntityInfo = (*BranchInfo)(nil)
 )

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -17,6 +17,7 @@ import (
 
 	corecontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/pubsub/controller"
@@ -43,7 +44,7 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 	modelCache, err := modelcache.NewWorker(modelcache.Config{
 		InitializedGate: initialized,
 		Logger:          loggo.GetLogger("test"),
-		WatcherFactory: func() modelcache.BackingWatcher {
+		WatcherFactory: func() multiwatcher.Watcher {
 			return s.StatePool.SystemState().WatchAllModels(s.StatePool)
 		},
 		PrometheusRegisterer: noopRegisterer{},

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -110,7 +110,7 @@ func (aw *SrvAllWatcher) translate(deltas []multiwatcher.Delta) []params.Delta {
 			converted = aw.translateCharm(delta.Entity)
 		case multiwatcher.RelationKind:
 			converted = aw.translateRelation(delta.Entity)
-		case multiwatcher.BlockKind:
+		case multiwatcher.BranchKind:
 			converted = aw.translateBranch(delta.Entity)
 		case multiwatcher.AnnotationKind: // THIS SEEMS WEIRD
 			// FIXME: annotations should be part of the underlying entity.

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"github.com/juju/errors"
+	"github.com/kr/pretty"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
@@ -15,6 +16,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 )
@@ -40,7 +42,7 @@ func NewAllWatcher(context facade.Context) (facade.Facade, error) {
 		// rights) API calls.
 		return nil, common.ErrPerm
 	}
-	watcher, ok := resources.Get(id).(*state.Multiwatcher)
+	watcher, ok := resources.Get(id).(multiwatcher.Watcher)
 	if !ok {
 		return nil, common.ErrUnknownWatcher
 	}
@@ -76,14 +78,397 @@ func (w *watcherCommon) Stop() error {
 // the AllWatcher and AllModelWatcher facades.
 type SrvAllWatcher struct {
 	watcherCommon
-	watcher *state.Multiwatcher
+	watcher multiwatcher.Watcher
 }
 
+// Next will return the current state of everything on the first call
+// and subsequent calls will
 func (aw *SrvAllWatcher) Next() (params.AllWatcherNextResults, error) {
 	deltas, err := aw.watcher.Next()
 	return params.AllWatcherNextResults{
-		Deltas: deltas,
+		Deltas: aw.translate(deltas),
 	}, err
+}
+
+func (aw *SrvAllWatcher) translate(deltas []multiwatcher.Delta) []params.Delta {
+	response := make([]params.Delta, 0, len(deltas))
+	for _, delta := range deltas {
+		id := delta.Entity.EntityID()
+		var converted params.EntityInfo
+		switch id.Kind {
+		case multiwatcher.ModelKind:
+			converted = aw.translateModel(delta.Entity)
+		case multiwatcher.ApplicationKind:
+			converted = aw.translateApplication(delta.Entity)
+		case multiwatcher.RemoteApplicationKind:
+			converted = aw.translateRemoteApplication(delta.Entity)
+		case multiwatcher.MachineKind:
+			converted = aw.translateMachine(delta.Entity)
+		case multiwatcher.UnitKind:
+			converted = aw.translateUnit(delta.Entity)
+		case multiwatcher.CharmKind:
+			converted = aw.translateCharm(delta.Entity)
+		case multiwatcher.RelationKind:
+			converted = aw.translateRelation(delta.Entity)
+		case multiwatcher.BlockKind:
+			converted = aw.translateBranch(delta.Entity)
+		case multiwatcher.AnnotationKind: // THIS SEEMS WEIRD
+			// FIXME: annotations should be part of the underlying entity.
+			converted = aw.translateAnnotation(delta.Entity)
+		case multiwatcher.BlockKind:
+			converted = aw.translateBlock(delta.Entity)
+		case multiwatcher.ActionKind:
+			converted = aw.translateAction(delta.Entity)
+		case multiwatcher.ApplicationOfferKind:
+			converted = aw.translateApplicationOffer(delta.Entity)
+		default:
+			// converted stays nil
+		}
+		// It is possible that there are some multiwatcher elements that are
+		// internal, and not exposed outside the controller.
+		// Also this is a key place to start versioning the all watchers.
+		if converted != nil {
+			response = append(response, params.Delta{
+				Removed: delta.Removed,
+				Entity:  converted})
+		}
+	}
+	return response
+}
+
+func (aw *SrvAllWatcher) translateModel(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.ModelUpdate)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.ModelUpdate{
+		ModelUUID:      orig.ModelUUID,
+		Name:           orig.Name,
+		Life:           orig.Life,
+		Owner:          orig.Owner,
+		ControllerUUID: orig.ControllerUUID,
+		IsController:   orig.IsController,
+		Config:         orig.Config,
+		Status:         aw.translateStatus(orig.Status),
+		Constraints:    orig.Constraints,
+		SLA: params.ModelSLAInfo{
+			Level: orig.SLA.Level,
+			Owner: orig.SLA.Owner,
+		},
+	}
+}
+
+func (aw *SrvAllWatcher) translateStatus(info multiwatcher.StatusInfo) params.StatusInfo {
+	return params.StatusInfo{
+		Err:     info.Err, // CHECK THIS
+		Current: info.Current,
+		Message: info.Message,
+		Since:   info.Since,
+		Version: info.Version,
+		Data:    info.Data,
+	}
+}
+
+func (aw *SrvAllWatcher) translateApplication(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.ApplicationInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.ApplicationInfo{
+		ModelUUID:       orig.ModelUUID,
+		Name:            orig.Name,
+		Exposed:         orig.Exposed,
+		CharmURL:        orig.CharmURL,
+		OwnerTag:        orig.OwnerTag,
+		Life:            orig.Life,
+		MinUnits:        orig.MinUnits,
+		Constraints:     orig.Constraints,
+		Config:          orig.Config,
+		Subordinate:     orig.Subordinate,
+		Status:          aw.translateStatus(orig.Status),
+		WorkloadVersion: orig.WorkloadVersion,
+	}
+}
+
+func (aw *SrvAllWatcher) translateMachine(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.MachineInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.MachineInfo{
+		ModelUUID:                orig.ModelUUID,
+		Id:                       orig.ID,
+		InstanceId:               orig.InstanceID,
+		AgentStatus:              aw.translateStatus(orig.AgentStatus),
+		InstanceStatus:           aw.translateStatus(orig.InstanceStatus),
+		Life:                     orig.Life,
+		Config:                   orig.Config,
+		Series:                   orig.Series,
+		ContainerType:            orig.ContainerType,
+		SupportedContainers:      orig.SupportedContainers,
+		SupportedContainersKnown: orig.SupportedContainersKnown,
+		HardwareCharacteristics:  orig.HardwareCharacteristics,
+		CharmProfiles:            orig.CharmProfiles,
+		Jobs:                     orig.Jobs,
+		Addresses:                aw.translateAddresses(orig.Addresses),
+		HasVote:                  orig.HasVote,
+		WantsVote:                orig.WantsVote,
+	}
+}
+
+func (aw *SrvAllWatcher) translateAddresses(addresses []network.ProviderAddress) []params.Address {
+	if addresses == nil {
+		return nil
+	}
+	result := make([]params.Address, 0, len(addresses))
+	for _, address := range addresses {
+		result = append(result, params.Address{
+			Value:           address.Value,
+			Type:            string(address.Type),
+			Scope:           string(address.Scope),
+			SpaceName:       string(address.SpaceName),
+			ProviderSpaceID: string(address.ProviderSpaceID),
+		})
+	}
+	return result
+}
+
+func (aw *SrvAllWatcher) translateCharm(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.CharmInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.CharmInfo{
+		ModelUUID:     orig.ModelUUID,
+		CharmURL:      orig.CharmURL,
+		CharmVersion:  orig.CharmVersion,
+		Life:          orig.Life,
+		LXDProfile:    aw.translateProfile(orig.LXDProfile),
+		DefaultConfig: orig.DefaultConfig,
+	}
+}
+
+func (aw *SrvAllWatcher) translateProfile(profile *multiwatcher.Profile) *params.Profile {
+	if profile == nil {
+		return nil
+	}
+	return &params.Profile{
+		Config:      profile.Config,
+		Description: profile.Description,
+		Devices:     profile.Devices,
+	}
+}
+
+func (aw *SrvAllWatcher) translateRemoteApplication(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.RemoteApplicationUpdate)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.RemoteApplicationUpdate{
+		ModelUUID: orig.ModelUUID,
+		Name:      orig.Name,
+		OfferUUID: orig.OfferUUID,
+		OfferURL:  orig.OfferURL,
+		Life:      orig.Life,
+		Status:    aw.translateStatus(orig.Status),
+	}
+}
+
+func (aw *SrvAllWatcher) translateApplicationOffer(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.ApplicationOfferInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.ApplicationOfferInfo{
+		ModelUUID:            orig.ModelUUID,
+		OfferName:            orig.OfferName,
+		OfferUUID:            orig.OfferUUID,
+		ApplicationName:      orig.ApplicationName,
+		CharmName:            orig.CharmName,
+		TotalConnectedCount:  orig.TotalConnectedCount,
+		ActiveConnectedCount: orig.ActiveConnectedCount,
+	}
+}
+
+func (aw *SrvAllWatcher) translateUnit(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.UnitInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.UnitInfo{
+		ModelUUID:      orig.ModelUUID,
+		Name:           orig.Name,
+		Application:    orig.Application,
+		Series:         orig.Series,
+		CharmURL:       orig.CharmURL,
+		Life:           orig.Life,
+		PublicAddress:  orig.PublicAddress,
+		PrivateAddress: orig.PrivateAddress,
+		MachineId:      orig.MachineID,
+		Ports:          aw.translatePorts(orig.Ports),
+		PortRanges:     aw.translatePortRanges(orig.PortRanges),
+		Principal:      orig.Principal,
+		Subordinate:    orig.Subordinate,
+		WorkloadStatus: aw.translateStatus(orig.WorkloadStatus),
+		AgentStatus:    aw.translateStatus(orig.AgentStatus),
+	}
+}
+
+func (aw *SrvAllWatcher) translatePorts(ports []network.Port) []params.Port {
+	if ports == nil {
+		return nil
+	}
+	result := make([]params.Port, 0, len(ports))
+	for _, port := range ports {
+		result = append(result, params.FromNetworkPort(port))
+	}
+	return result
+}
+
+func (aw *SrvAllWatcher) translatePortRanges(ports []network.PortRange) []params.PortRange {
+	if ports == nil {
+		return nil
+	}
+	result := make([]params.PortRange, 0, len(ports))
+	for _, port := range ports {
+		result = append(result, params.FromNetworkPortRange(port))
+	}
+	return result
+}
+
+func (aw *SrvAllWatcher) translateAction(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.ActionInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.ActionInfo{
+		ModelUUID:  orig.ModelUUID,
+		Id:         orig.ID,
+		Receiver:   orig.Receiver,
+		Name:       orig.Name,
+		Parameters: orig.Parameters,
+		Status:     orig.Status,
+		Message:    orig.Message,
+		Results:    orig.Results,
+		Enqueued:   orig.Enqueued,
+		Started:    orig.Started,
+		Completed:  orig.Completed,
+	}
+}
+
+func (aw *SrvAllWatcher) translateRelation(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.RelationInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.RelationInfo{
+		ModelUUID: orig.ModelUUID,
+		Key:       orig.Key,
+		Id:        orig.ID,
+		Endpoints: aw.translateEndpoints(orig.Endpoints),
+	}
+}
+
+func (aw *SrvAllWatcher) translateEndpoints(eps []multiwatcher.Endpoint) []params.Endpoint {
+	if eps == nil {
+		return nil
+	}
+	result := make([]params.Endpoint, 0, len(eps))
+	for _, ep := range eps {
+		result = append(result, params.Endpoint{
+			ApplicationName: ep.ApplicationName,
+			Relation: params.CharmRelation{
+				Name:      ep.Relation.Name,
+				Role:      ep.Relation.Role,
+				Interface: ep.Relation.Interface,
+				Optional:  ep.Relation.Optional,
+				Limit:     ep.Relation.Limit,
+				Scope:     ep.Relation.Scope,
+			},
+		})
+	}
+	return result
+}
+
+func (aw *SrvAllWatcher) translateAnnotation(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.AnnotationInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.AnnotationInfo{
+		ModelUUID:   orig.ModelUUID,
+		Tag:         orig.Tag,
+		Annotations: orig.Annotations,
+	}
+}
+
+func (aw *SrvAllWatcher) translateBlock(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.BlockInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.BlockInfo{
+		ModelUUID: orig.ModelUUID,
+		Id:        orig.ID,
+		Type:      orig.Type,
+		Message:   orig.Message,
+		Tag:       orig.Tag,
+	}
+}
+
+func (aw *SrvAllWatcher) translateBranch(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.BranchInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.BranchInfo{
+		ModelUUID:     orig.ModelUUID,
+		Id:            orig.ID,
+		Name:          orig.Name,
+		AssignedUnits: orig.AssignedUnits,
+		Config:        aw.translateBranchConfig(orig.Config),
+		Created:       orig.Created,
+		CreatedBy:     orig.CreatedBy,
+		Completed:     orig.Completed,
+		CompletedBy:   orig.CompletedBy,
+		GenerationId:  orig.GenerationID,
+	}
+}
+
+func (aw *SrvAllWatcher) translateBranchConfig(config map[string][]multiwatcher.ItemChange) map[string][]params.ItemChange {
+	if config == nil {
+		return nil
+	}
+	result := make(map[string][]params.ItemChange)
+	for key, value := range config {
+		if value == nil {
+			result[key] = nil
+		} else {
+			changes := make([]params.ItemChange, 0, len(value))
+			for _, change := range value {
+				changes = append(changes, params.ItemChange{
+					Type:     change.Type,
+					Key:      change.Key,
+					OldValue: change.OldValue,
+					NewValue: change.NewValue,
+				})
+			}
+			result[key] = changes
+		}
+	}
+	return result
 }
 
 func isAgent(auth facade.Authorizer) bool {

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -242,7 +242,7 @@ type RemoveMachine struct {
 }
 
 // BranchChange represents a change to an active model branch.
-// Note that this corresponds to a multi-watcher GenerationInfo payload,
+// Note that this corresponds to a multi-watcher BranchInfo payload,
 // and that the cache behaviour differs from other entities;
 // when a generation is completed (aborted or committed),
 // it is no longer an active branch and will be removed from the cache.

--- a/core/multiwatcher/package_test.go
+++ b/core/multiwatcher/package_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher_test
+
+import (
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type ImportTest struct{}
+
+var _ = gc.Suite(&ImportTest{})
+
+func (*ImportTest) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/multiwatcher")
+
+	// This package should only depend on other core packages.
+	// If this test fails with a non-core package, please check the dependencies.
+	c.Assert(found, jc.SameContents, []string{
+		"core/constraints",
+		"core/instance",
+		"core/life",
+		"core/model",
+		"core/network",
+		"core/status",
+	})
+}

--- a/core/multiwatcher/stopped.go
+++ b/core/multiwatcher/stopped.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"github.com/juju/errors"
+)
+
+// stopped represents an error when state is supported.
+type stopped struct {
+	errors.Err
+}
+
+// ErrStoppedf returns an error which satisfies IsErrStopped().
+func ErrStoppedf(format string, args ...interface{}) error {
+	newErr := errors.NewErr(format+" was stopped", args...)
+	newErr.SetLocation(2)
+	return &stopped{newErr}
+}
+
+// NewErrStopped returns an error which wraps err and satisfies IsErrStopped().
+func NewErrStopped() error {
+	newErr := errors.NewErr("watcher was stopped")
+	newErr.SetLocation(2)
+	return &stopped{newErr}
+}
+
+// IsErrStopped reports whether the error was created with ErrStoppedf() or NewErrStopped().
+func IsErrStopped(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*stopped)
+	return ok
+}

--- a/core/multiwatcher/stopped_test.go
+++ b/core/multiwatcher/stopped_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/multiwatcher"
+)
+
+var _ = gc.Suite(&stoppedSuite{})
+
+type stoppedSuite struct {
+	testing.IsolationSuite
+}
+
+func (*stoppedSuite) TestIsErrStopped(c *gc.C) {
+	c.Assert(multiwatcher.NewErrStopped(), jc.Satisfies, multiwatcher.IsErrStopped)
+	err := multiwatcher.ErrStoppedf("something")
+	c.Assert(err, jc.Satisfies, multiwatcher.IsErrStopped)
+	c.Assert(err.Error(), gc.Equals, "something was stopped")
+}

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -1,0 +1,413 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"time"
+
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/status"
+)
+
+// The kind constants are there to stop typos when switching on kinds.
+const (
+	ActionKind            = "action"
+	AnnotationKind        = "annotation" // the annotations should really be parts of the other entities
+	ApplicationKind       = "application"
+	ApplicationOfferKind  = "applicationOffer"
+	BlockKind             = "block"
+	BranchKind            = "branch"
+	CharmKind             = "charm"
+	MachineKind           = "machine"
+	ModelKind             = "model"
+	RelationKind          = "relation"
+	RemoteApplicationKind = "remoteApplication"
+	UnitKind              = "unit"
+)
+
+// Factory is used to create multiwatchers.
+type Factory interface {
+	// TODO: WatchUsersModels to filter just the user's models
+	WatchModel(modelUUID string) Watcher
+	WatchController() Watcher
+}
+
+// Watcher is the way a caller can find out what changes have happened
+// on one or more models.
+type Watcher interface {
+	Stop() error
+	Next() ([]Delta, error)
+}
+
+// EntityInfo is implemented by all entity Info types.
+type EntityInfo interface {
+	// EntityID returns an identifier that will uniquely
+	// identify the entity within its kind
+	EntityID() EntityID
+}
+
+// EntityID uniquely identifies an entity being tracked by the
+// multiwatcherStore.
+type EntityID struct {
+	Kind      string
+	ModelUUID string
+	ID        string
+}
+
+// Delta holds details of a change to the model.
+type Delta struct {
+	// If Removed is true, the entity has been removed;
+	// otherwise it has been created or changed.
+	Removed bool
+	// Entity holds data about the entity that has changed.
+	Entity EntityInfo
+}
+
+// MachineInfo holds the information about a machine
+// that is tracked by multiwatcherStore.
+type MachineInfo struct {
+	ModelUUID                string
+	ID                       string
+	InstanceID               string
+	AgentStatus              StatusInfo
+	InstanceStatus           StatusInfo
+	Life                     life.Value
+	Config                   map[string]interface{}
+	Series                   string
+	ContainerType            string
+	SupportedContainers      []instance.ContainerType
+	SupportedContainersKnown bool
+	HardwareCharacteristics  *instance.HardwareCharacteristics
+	CharmProfiles            []string
+	Jobs                     []model.MachineJob
+	Addresses                []network.ProviderAddress
+	HasVote                  bool
+	WantsVote                bool
+}
+
+// EntityID returns a unique identifier for a machine across
+// models.
+func (i *MachineInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      MachineKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.ID,
+	}
+}
+
+// StatusInfo holds the unit and machine status information. It is
+// used by ApplicationInfo and UnitInfo.
+type StatusInfo struct {
+	Err     error
+	Current status.Status
+	Message string
+	Since   *time.Time
+	Version string
+	Data    map[string]interface{}
+}
+
+// NewStatusInfo return a new multiwatcher StatusInfo from a
+// status StatusInfo.
+func NewStatusInfo(s status.StatusInfo, err error) StatusInfo {
+	return StatusInfo{
+		Err:     err,
+		Current: s.Status,
+		Message: s.Message,
+		Since:   s.Since,
+		Data:    s.Data,
+	}
+}
+
+// ApplicationInfo holds the information about an application that is tracked
+// by multiwatcherStore.
+type ApplicationInfo struct {
+	ModelUUID       string
+	Name            string
+	Exposed         bool
+	CharmURL        string
+	OwnerTag        string
+	Life            life.Value
+	MinUnits        int
+	Constraints     constraints.Value
+	Config          map[string]interface{}
+	Subordinate     bool
+	Status          StatusInfo
+	WorkloadVersion string
+}
+
+// EntityID returns a unique identifier for an application across
+// models.
+func (i *ApplicationInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      ApplicationKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.Name,
+	}
+}
+
+// Profile is a representation of charm.v6 LXDProfile
+type Profile struct {
+	Config      map[string]string
+	Description string
+	Devices     map[string]map[string]string
+}
+
+// CharmInfo holds the information about a charm that is tracked by the
+// multiwatcher.
+type CharmInfo struct {
+	ModelUUID    string
+	CharmURL     string
+	CharmVersion string
+	Life         life.Value
+	LXDProfile   *Profile
+	// DefaultConfig is derived from state-stored *charm.Config.
+	DefaultConfig map[string]interface{}
+}
+
+// EntityID returns a unique identifier for an charm across
+// models.
+func (i *CharmInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      CharmKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.CharmURL,
+	}
+}
+
+// RemoteApplicationUpdate holds the information about a remote application that is
+// tracked by multiwatcherStore.
+type RemoteApplicationUpdate struct {
+	ModelUUID string
+	Name      string
+	OfferUUID string
+	OfferURL  string
+	Life      life.Value
+	Status    StatusInfo
+}
+
+// EntityID returns a unique identifier for a remote application across models.
+func (i *RemoteApplicationUpdate) EntityID() EntityID {
+	return EntityID{
+		Kind:      RemoteApplicationKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.Name,
+	}
+}
+
+// ApplicationOfferInfo holds the information about an application offer that is
+// tracked by multiwatcherStore.
+type ApplicationOfferInfo struct {
+	ModelUUID            string
+	OfferName            string
+	OfferUUID            string
+	ApplicationName      string
+	CharmName            string
+	TotalConnectedCount  int
+	ActiveConnectedCount int
+}
+
+// EntityID returns a unique identifier for an application offer across models.
+func (i *ApplicationOfferInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      ApplicationOfferKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.OfferName,
+	}
+}
+
+// UnitInfo holds the information about a unit
+// that is tracked by multiwatcherStore.
+type UnitInfo struct {
+	ModelUUID      string
+	Name           string
+	Application    string
+	Series         string
+	CharmURL       string
+	Life           life.Value
+	PublicAddress  string
+	PrivateAddress string
+	MachineID      string
+	Ports          []network.Port
+	PortRanges     []network.PortRange
+	Principal      string
+	Subordinate    bool
+	// Workload and agent state are modelled separately.
+	WorkloadStatus StatusInfo
+	AgentStatus    StatusInfo
+}
+
+// EntityID returns a unique identifier for a unit across
+// models.
+func (i *UnitInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      UnitKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.Name,
+	}
+}
+
+// ActionInfo holds the information about a action that is tracked by
+// multiwatcherStore.
+type ActionInfo struct {
+	ModelUUID  string
+	ID         string
+	Receiver   string
+	Name       string
+	Parameters map[string]interface{}
+	Status     string
+	Message    string
+	Results    map[string]interface{}
+	Enqueued   time.Time
+	Started    time.Time
+	Completed  time.Time
+}
+
+// EntityID returns a unique identifier for an action across
+// models.
+func (i *ActionInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      ActionKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.ID,
+	}
+}
+
+// RelationInfo holds the information about a relation that is tracked
+// by multiwatcherStore.
+type RelationInfo struct {
+	ModelUUID string
+	Key       string
+	ID        int
+	Endpoints []Endpoint
+}
+
+// Endpoint holds an application-relation pair.
+type Endpoint struct {
+	ApplicationName string
+	Relation        CharmRelation
+}
+
+// CharmRelation mirrors charm.Relation.
+type CharmRelation struct {
+	Name      string
+	Role      string
+	Interface string
+	Optional  bool
+	Limit     int
+	Scope     string
+}
+
+// EntityID returns a unique identifier for a relation across
+// models.
+func (i *RelationInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      RelationKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.Key,
+	}
+}
+
+// AnnotationInfo holds the information about an annotation that is
+// tracked by multiwatcherStore.
+type AnnotationInfo struct {
+	ModelUUID   string
+	Tag         string
+	Annotations map[string]string
+}
+
+// EntityID returns a unique identifier for an annotation across
+// models.
+func (i *AnnotationInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      AnnotationKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.Tag,
+	}
+}
+
+// BlockInfo holds the information about a block that is tracked by
+// multiwatcherStore.
+type BlockInfo struct {
+	ModelUUID string
+	ID        string
+	Type      model.BlockType
+	Message   string
+	Tag       string
+}
+
+// EntityID returns a unique identifier for a block across
+// models.
+func (i *BlockInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      BlockKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.ID,
+	}
+}
+
+// ModelUpdate holds the information about a model that is
+// tracked by multiwatcherStore.
+type ModelUpdate struct {
+	ModelUUID      string
+	Name           string
+	Life           life.Value
+	Owner          string
+	ControllerUUID string
+	IsController   bool
+	Config         map[string]interface{}
+	Status         StatusInfo
+	Constraints    constraints.Value
+	SLA            ModelSLAInfo
+}
+
+// ModelSLAInfo describes the SLA info for a model.
+type ModelSLAInfo struct {
+	Level string
+	Owner string
+}
+
+// EntityID returns a unique identifier for a model.
+func (i *ModelUpdate) EntityID() EntityID {
+	return EntityID{
+		Kind:      ModelKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.ModelUUID,
+	}
+}
+
+// ItemChange is the multiwatcher representation of a core settings ItemChange.
+type ItemChange struct {
+	Type     int
+	Key      string
+	OldValue interface{}
+	NewValue interface{}
+}
+
+// BranchInfo holds data about a model branch
+// that is tracked by multiwatcherStore.
+type BranchInfo struct {
+	ModelUUID     string
+	ID            string
+	Name          string
+	AssignedUnits map[string][]string
+	Config        map[string][]ItemChange
+	Created       int64
+	CreatedBy     string
+	Completed     int64
+	CompletedBy   string
+	GenerationID  int
+}
+
+// EntityID returns a unique identifier for a generation.
+func (i *BranchInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      BranchKind,
+		ModelUUID: i.ModelUUID,
+		ID:        i.ID,
+	}
+}

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -30,13 +30,6 @@ const (
 	UnitKind              = "unit"
 )
 
-// Factory is used to create multiwatchers.
-type Factory interface {
-	// TODO: WatchUsersModels to filter just the user's models
-	WatchModel(modelUUID string) Watcher
-	WatchController() Watcher
-}
-
 // Watcher is the way a caller can find out what changes have happened
 // on one or more models.
 type Watcher interface {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -65,6 +65,7 @@ import (
 	corelease "github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/multiwatcher"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
@@ -931,7 +932,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			modelCache, err := modelcache.NewWorker(modelcache.Config{
 				InitializedGate: initialized,
 				Logger:          loggo.GetLogger("dummy"),
-				WatcherFactory: func() modelcache.BackingWatcher {
+				WatcherFactory: func() multiwatcher.Watcher {
 					return statePool.SystemState().WatchAllModels(statePool)
 				},
 				PrometheusRegisterer: noopRegisterer{},

--- a/state/relation.go
+++ b/state/relation.go
@@ -38,7 +38,7 @@ func relationKey(endpoints []Endpoint) string {
 }
 
 // relationDoc is the internal representation of a Relation in MongoDB.
-// Note the correspondence with RelationInfo in apiserver/params.
+// Note the correspondence with RelationInfo in core/multiwatcher.
 type relationDoc struct {
 	DocID           string     `bson:"_id"`
 	Key             string     `bson:"key"`

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -30,12 +30,12 @@ import (
 	mgotxn "gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
@@ -246,16 +246,16 @@ func (s *StateSuite) TestWatch(c *gc.C) {
 	select {
 	case deltas := <-deltasC:
 		c.Assert(deltas, gc.HasLen, 1)
-		info := deltas[0].Entity.(*params.MachineInfo)
+		info := deltas[0].Entity.(*multiwatcher.MachineInfo)
 		c.Assert(info.ModelUUID, gc.Equals, s.State.ModelUUID())
-		c.Assert(info.Id, gc.Equals, m.Id())
+		c.Assert(info.ID, gc.Equals, m.Id())
 	case <-time.After(testing.LongWait):
 		c.Fatal("timed out")
 	}
 }
 
-func makeMultiwatcherOutput(w *state.Multiwatcher) chan []params.Delta {
-	deltasC := make(chan []params.Delta)
+func makeMultiwatcherOutput(w *state.Multiwatcher) chan []multiwatcher.Delta {
+	deltasC := make(chan []multiwatcher.Delta)
 	go func() {
 		for {
 			deltas, err := w.Next()
@@ -286,12 +286,12 @@ func (s *StateSuite) TestWatchAllModels(c *gc.C) {
 		case deltas := <-deltasC:
 			for _, delta := range deltas {
 				switch e := delta.Entity.(type) {
-				case *params.ModelUpdate:
+				case *multiwatcher.ModelUpdate:
 					c.Assert(e.ModelUUID, gc.Equals, s.State.ModelUUID())
 					modelSeen = true
-				case *params.MachineInfo:
+				case *multiwatcher.MachineInfo:
 					c.Assert(e.ModelUUID, gc.Equals, s.State.ModelUUID())
-					c.Assert(e.Id, gc.Equals, m.Id())
+					c.Assert(e.ID, gc.Equals, m.Id())
 					machineSeen = true
 				}
 			}

--- a/state/unit.go
+++ b/state/unit.go
@@ -79,7 +79,7 @@ type port struct {
 }
 
 // unitDoc represents the internal state of a unit in MongoDB.
-// Note the correspondence with UnitInfo in apiserver/params.
+// Note the correspondence with UnitInfo in core/multiwatcher.
 type unitDoc struct {
 	DocID                  string `bson:"_id"`
 	Name                   string `bson:"name"`

--- a/worker/modelcache/manifold.go
+++ b/worker/modelcache/manifold.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/worker.v1/dependency"
 
 	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/worker/gate"
 	workerstate "github.com/juju/juju/worker/state"
 )
@@ -89,7 +90,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	w, err := config.NewWorker(Config{
 		InitializedGate:      unlocker,
 		Logger:               config.Logger,
-		WatcherFactory:       func() BackingWatcher { return pool.SystemState().WatchAllModels(pool) },
+		WatcherFactory:       func() multiwatcher.Watcher { return pool.SystemState().WatchAllModels(pool) },
 		PrometheusRegisterer: config.PrometheusRegisterer,
 		Cleanup:              func() { _ = stTracker.Done() },
 	}.WithDefaultRestartStrategy())

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -305,17 +305,17 @@ func (c *cacheWorker) handleWatcherErr(err error) {
 func (c *cacheWorker) translate(d multiwatcher.Delta) interface{} {
 	id := d.Entity.EntityID()
 	switch id.Kind {
-	case "model":
+	case multiwatcher.ModelKind:
 		return c.translateModel(d)
-	case "application":
+	case multiwatcher.ApplicationKind:
 		return c.translateApplication(d)
-	case "machine":
+	case multiwatcher.MachineKind:
 		return c.translateMachine(d)
-	case "unit":
+	case multiwatcher.UnitKind:
 		return c.translateUnit(d)
-	case "charm":
+	case multiwatcher.CharmKind:
 		return c.translateCharm(d)
-	case "generation":
+	case multiwatcher.BranchKind:
 		// Generation deltas are processed as cache branch changes,
 		// as only "in-flight" branches should ever be in the cache.
 		return c.translateBranch(d)

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -14,22 +14,13 @@ import (
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
-	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/settings"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/state"
 )
-
-// BackingWatcher describes watcher methods that supply deltas from state to
-// this worker. In-theatre it is satisfied by a state.Multiwatcher.
-type BackingWatcher interface {
-	Next() ([]params.Delta, error)
-	Stop() error
-}
 
 // Unlocker is used to indicate that the model cache is ready to be used.
 type Unlocker interface {
@@ -59,7 +50,7 @@ type Config struct {
 	// We use a factory because we do not allow the worker loop to be crashed
 	// by a watcher that stops in an error state.
 	// Watcher acquisition my occur multiple times during a worker life-cycle.
-	WatcherFactory func() BackingWatcher
+	WatcherFactory func() multiwatcher.Watcher
 
 	// WatcherRestartDelayMin is the minimum duration of the worker pause
 	// before instantiating a new all-watcher when the previous one returns an
@@ -120,7 +111,7 @@ type cacheWorker struct {
 	catacomb            catacomb.Catacomb
 	controller          *cache.Controller
 	changes             chan interface{}
-	watcher             BackingWatcher
+	watcher             multiwatcher.Watcher
 	watcherRestartDelay time.Duration
 	mu                  sync.Mutex
 }
@@ -175,7 +166,7 @@ func (c *cacheWorker) loop() error {
 	defer c.config.PrometheusRegisterer.Unregister(allWatcherStarts)
 	defer c.config.PrometheusRegisterer.Unregister(collector)
 
-	watcherChanges := make(chan []params.Delta)
+	watcherChanges := make(chan []multiwatcher.Delta)
 	// This worker needs to be robust with respect to the multiwatcher errors.
 	// If we get an unexpected error we should get a new allWatcher.
 	// We don't want a weird error in the multiwatcher taking down the apiserver,
@@ -263,7 +254,7 @@ func (c *cacheWorker) loop() error {
 	}
 }
 
-func (c *cacheWorker) processWatcher(watcherChanges chan<- []params.Delta) error {
+func (c *cacheWorker) processWatcher(watcherChanges chan<- []multiwatcher.Delta) error {
 	for {
 		deltas, err := c.watcher.Next()
 		if err != nil {
@@ -284,7 +275,7 @@ func (c *cacheWorker) handleWatcherErr(err error) {
 	// been told to die, then we exit cleanly. Otherwise die with an
 	// error and let the dependency engine handle starting us up
 	// again.
-	if state.IsErrStopped(err) {
+	if multiwatcher.IsErrStopped(err) {
 		select {
 		case <-c.catacomb.Dying():
 			return
@@ -311,8 +302,8 @@ func (c *cacheWorker) handleWatcherErr(err error) {
 	}
 }
 
-func (c *cacheWorker) translate(d params.Delta) interface{} {
-	id := d.Entity.EntityId()
+func (c *cacheWorker) translate(d multiwatcher.Delta) interface{} {
+	id := d.Entity.EntityID()
 	switch id.Kind {
 	case "model":
 		return c.translateModel(d)
@@ -333,16 +324,16 @@ func (c *cacheWorker) translate(d params.Delta) interface{} {
 	}
 }
 
-func (c *cacheWorker) translateModel(d params.Delta) interface{} {
+func (c *cacheWorker) translateModel(d multiwatcher.Delta) interface{} {
 	e := d.Entity
 
 	if d.Removed {
 		return cache.RemoveModel{
-			ModelUUID: e.EntityId().ModelUUID,
+			ModelUUID: e.EntityID().ModelUUID,
 		}
 	}
 
-	value, ok := e.(*params.ModelUpdate)
+	value, ok := e.(*multiwatcher.ModelUpdate)
 	if !ok {
 		c.config.Logger.Errorf("unexpected type %T", e)
 		return nil
@@ -359,18 +350,18 @@ func (c *cacheWorker) translateModel(d params.Delta) interface{} {
 	}
 }
 
-func (c *cacheWorker) translateApplication(d params.Delta) interface{} {
+func (c *cacheWorker) translateApplication(d multiwatcher.Delta) interface{} {
 	e := d.Entity
-	id := e.EntityId()
+	id := e.EntityID()
 
 	if d.Removed {
 		return cache.RemoveApplication{
 			ModelUUID: id.ModelUUID,
-			Name:      id.Id,
+			Name:      id.ID,
 		}
 	}
 
-	value, ok := e.(*params.ApplicationInfo)
+	value, ok := e.(*multiwatcher.ApplicationInfo)
 	if !ok {
 		c.config.Logger.Errorf("unexpected type %T", e)
 		return nil
@@ -391,18 +382,18 @@ func (c *cacheWorker) translateApplication(d params.Delta) interface{} {
 	}
 }
 
-func (c *cacheWorker) translateMachine(d params.Delta) interface{} {
+func (c *cacheWorker) translateMachine(d multiwatcher.Delta) interface{} {
 	e := d.Entity
-	id := e.EntityId()
+	id := e.EntityID()
 
 	if d.Removed {
 		return cache.RemoveMachine{
 			ModelUUID: id.ModelUUID,
-			Id:        id.Id,
+			Id:        id.ID,
 		}
 	}
 
-	value, ok := e.(*params.MachineInfo)
+	value, ok := e.(*multiwatcher.MachineInfo)
 	if !ok {
 		c.config.Logger.Errorf("unexpected type %T", e)
 		return nil
@@ -410,8 +401,8 @@ func (c *cacheWorker) translateMachine(d params.Delta) interface{} {
 
 	return cache.MachineChange{
 		ModelUUID:                value.ModelUUID,
-		Id:                       value.Id,
-		InstanceId:               value.InstanceId,
+		Id:                       value.ID,
+		InstanceId:               value.InstanceID,
 		AgentStatus:              coreStatus(value.AgentStatus),
 		Life:                     life.Value(value.Life),
 		Config:                   value.Config,
@@ -421,24 +412,24 @@ func (c *cacheWorker) translateMachine(d params.Delta) interface{} {
 		SupportedContainersKnown: value.SupportedContainersKnown,
 		HardwareCharacteristics:  value.HardwareCharacteristics,
 		CharmProfiles:            value.CharmProfiles,
-		Addresses:                providerAddresses(value.Addresses),
+		Addresses:                value.Addresses,
 		HasVote:                  value.HasVote,
 		WantsVote:                value.WantsVote,
 	}
 }
 
-func (c *cacheWorker) translateUnit(d params.Delta) interface{} {
+func (c *cacheWorker) translateUnit(d multiwatcher.Delta) interface{} {
 	e := d.Entity
-	id := e.EntityId()
+	id := e.EntityID()
 
 	if d.Removed {
 		return cache.RemoveUnit{
 			ModelUUID: id.ModelUUID,
-			Name:      id.Id,
+			Name:      id.ID,
 		}
 	}
 
-	value, ok := e.(*params.UnitInfo)
+	value, ok := e.(*multiwatcher.UnitInfo)
 	if !ok {
 		c.config.Logger.Errorf("unexpected type %T", e)
 		return nil
@@ -453,9 +444,9 @@ func (c *cacheWorker) translateUnit(d params.Delta) interface{} {
 		Life:           life.Value(value.Life),
 		PublicAddress:  value.PublicAddress,
 		PrivateAddress: value.PrivateAddress,
-		MachineId:      value.MachineId,
-		Ports:          networkPorts(value.Ports),
-		PortRanges:     networkPortRanges(value.PortRanges),
+		MachineId:      value.MachineID,
+		Ports:          value.Ports,
+		PortRanges:     value.PortRanges,
 		Principal:      value.Principal,
 		Subordinate:    value.Subordinate,
 		WorkloadStatus: coreStatus(value.WorkloadStatus),
@@ -463,18 +454,18 @@ func (c *cacheWorker) translateUnit(d params.Delta) interface{} {
 	}
 }
 
-func (c *cacheWorker) translateCharm(d params.Delta) interface{} {
+func (c *cacheWorker) translateCharm(d multiwatcher.Delta) interface{} {
 	e := d.Entity
-	id := e.EntityId()
+	id := e.EntityID()
 
 	if d.Removed {
 		return cache.RemoveCharm{
 			ModelUUID: id.ModelUUID,
-			CharmURL:  id.Id,
+			CharmURL:  id.ID,
 		}
 	}
 
-	value, ok := e.(*params.CharmInfo)
+	value, ok := e.(*multiwatcher.CharmInfo)
 	if !ok {
 		c.config.Logger.Errorf("unexpected type %T", e)
 		return nil
@@ -488,18 +479,18 @@ func (c *cacheWorker) translateCharm(d params.Delta) interface{} {
 	}
 }
 
-func (c *cacheWorker) translateBranch(d params.Delta) interface{} {
+func (c *cacheWorker) translateBranch(d multiwatcher.Delta) interface{} {
 	e := d.Entity
-	id := e.EntityId()
+	id := e.EntityID()
 
 	if d.Removed {
 		return cache.RemoveBranch{
 			ModelUUID: id.ModelUUID,
-			Id:        id.Id,
+			Id:        id.ID,
 		}
 	}
 
-	value, ok := e.(*params.GenerationInfo)
+	value, ok := e.(*multiwatcher.BranchInfo)
 	if !ok {
 		c.config.Logger.Errorf("unexpected type %T", e)
 		return nil
@@ -512,21 +503,21 @@ func (c *cacheWorker) translateBranch(d params.Delta) interface{} {
 	if value.Completed > 0 {
 		return cache.RemoveBranch{
 			ModelUUID: id.ModelUUID,
-			Id:        id.Id,
+			Id:        id.ID,
 		}
 	}
 
 	return cache.BranchChange{
 		ModelUUID:     value.ModelUUID,
 		Name:          value.Name,
-		Id:            value.Id,
+		Id:            value.ID,
 		AssignedUnits: value.AssignedUnits,
 		Config:        coreItemChanges(value.Config),
 		Created:       value.Created,
 		CreatedBy:     value.CreatedBy,
 		Completed:     value.Completed,
 		CompletedBy:   value.CompletedBy,
-		GenerationId:  value.GenerationId,
+		GenerationId:  value.GenerationID,
 	}
 }
 
@@ -540,7 +531,7 @@ func (c *cacheWorker) Wait() error {
 	return c.catacomb.Wait()
 }
 
-func coreStatus(info params.StatusInfo) status.StatusInfo {
+func coreStatus(info multiwatcher.StatusInfo) status.StatusInfo {
 	return status.StatusInfo{
 		Status:  info.Current,
 		Message: info.Message,
@@ -549,46 +540,7 @@ func coreStatus(info params.StatusInfo) status.StatusInfo {
 	}
 }
 
-func networkPorts(delta []params.Port) []network.Port {
-	ports := make([]network.Port, len(delta))
-	for i, d := range delta {
-		ports[i] = network.Port{
-			Protocol: d.Protocol,
-			Number:   d.Number,
-		}
-	}
-	return ports
-}
-
-func networkPortRanges(delta []params.PortRange) []network.PortRange {
-	ports := make([]network.PortRange, len(delta))
-	for i, d := range delta {
-		ports[i] = network.PortRange{
-			Protocol: d.Protocol,
-			FromPort: d.FromPort,
-			ToPort:   d.ToPort,
-		}
-	}
-	return ports
-}
-
-func providerAddresses(delta []params.Address) network.ProviderAddresses {
-	addresses := make(network.ProviderAddresses, len(delta))
-	for i, d := range delta {
-		addresses[i] = network.ProviderAddress{
-			MachineAddress: network.MachineAddress{
-				Value: d.Value,
-				Type:  network.AddressType(d.Type),
-				Scope: network.Scope(d.Scope),
-			},
-			SpaceName:       network.SpaceName(d.SpaceName),
-			ProviderSpaceID: network.Id(d.ProviderSpaceID),
-		}
-	}
-	return addresses
-}
-
-func coreLXDProfile(delta *params.Profile) lxdprofile.Profile {
+func coreLXDProfile(delta *multiwatcher.Profile) lxdprofile.Profile {
 	if delta == nil {
 		return lxdprofile.Profile{}
 	}
@@ -599,7 +551,7 @@ func coreLXDProfile(delta *params.Profile) lxdprofile.Profile {
 	}
 }
 
-func coreItemChanges(delta map[string][]params.ItemChange) map[string]settings.ItemChanges {
+func coreItemChanges(delta map[string][]multiwatcher.ItemChange) map[string]settings.ItemChanges {
 	if delta == nil {
 		return nil
 	}


### PR DESCRIPTION
This is step one of the multiwatcher refactoring.

Introduce a new core package for multiwatcher types. Have the state multiwatchers use this core type. This necessitates changes in the modelcache worker and in the apiserver.

The apiserver now does the translation between the core/multiwatcher types and the types returned over the API using apiserver/params types. This should almost be the last of the apiserver/params dependencies in the state package.

## QA steps

Unit tests keep passing. Any bundle deployment uses the multiwatchers.
Bootstrap a new controller, deploy stuff into some models and look at the controller engine report to see that the model cache is being populated properly.

## Documentation changes

Everything is internal, no user facing changes.
