### PR TITLE
Rework the cmd/juju/application tests to avoid using the real charmstore

### DIFF
--- a/apiserver/testing/fakecharmstore.go
+++ b/apiserver/testing/fakecharmstore.go
@@ -95,8 +95,3 @@ func (s *CharmStoreSuite) UploadCharmMultiSeries(c *gc.C, url, name string) (*ch
 	client := &charmstoreClientShim{s.Client}
 	return testcharms.UploadCharmMultiSeries(c, client, url, name)
 }
-
-func (s *CharmStoreSuite) UploadCharmWithSeries(c *gc.C, url, name, series string) (*charm.URL, charm.Charm) {
-	client := &charmstoreClientShim{s.Client}
-	return testcharms.UploadCharmWithSeries(c, client, url, name, series)
-}

--- a/charmstore/fakeclient.go
+++ b/charmstore/fakeclient.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
@@ -433,6 +434,9 @@ func (r Repository) Resolve(ref *charm.URL) (canonRef *charm.URL, supportedSerie
 //
 // Part of the cmd/juju/application.DeployAPI interface
 func (r Repository) ResolveWithPreferredChannel(ref *charm.URL, preferredChannel params.Channel) (*charm.URL, params.Channel, []string, error) {
+	if strings.Contains(ref.String(), "missing") {
+		return nil, "", nil, errors.NotFoundf("cannot resolve URL %q: charm or bundle", ref)
+	}
 	return r.addRevision(ref), preferredChannel, []string{"trusty", "wily", "quantal"}, nil
 }
 

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -102,7 +102,10 @@ type bundleDeploySpec struct {
 	channel           csparams.Channel
 
 	apiRoot              DeployAPI
+	bundleResolver       BundleResolver
+	authorizer           macaroonGetter
 	getConsumeDetailsAPI func(*charm.OfferURL) (ConsumeDetails, error)
+	deployResources      resourceadapters.DeployResourcesFunc
 
 	useExistingMachines bool
 	bundleMachines      map[string]string
@@ -198,7 +201,10 @@ type bundleHandler struct {
 
 	// api is used to interact with the environment.
 	api                  DeployAPI
+	bundleResolver       BundleResolver
+	authorizer           macaroonGetter
 	getConsumeDetailsAPI func(*charm.OfferURL) (ConsumeDetails, error)
+	deployResources      resourceadapters.DeployResourcesFunc
 
 	// bundleStorage contains a mapping of application-specific storage
 	// constraints. For each application, the storage constraints in the
@@ -272,7 +278,10 @@ func makeBundleHandler(bundleData *charm.BundleData, spec bundleDeploySpec) *bun
 		results:              make(map[string]string),
 		channel:              spec.channel,
 		api:                  spec.apiRoot,
+		bundleResolver:       spec.bundleResolver,
+		authorizer:           spec.authorizer,
 		getConsumeDetailsAPI: spec.getConsumeDetailsAPI,
+		deployResources:      spec.deployResources,
 		bundleStorage:        spec.bundleStorage,
 		bundleDevices:        spec.bundleDevices,
 		ctx:                  spec.ctx,
@@ -365,7 +374,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		url, _, _, err := resolveCharm(h.api.ResolveWithPreferredChannel, ch, csparams.Channel(spec.Channel))
+		url, _, _, err := resolveCharm(h.bundleResolver.ResolveWithPreferredChannel, ch, csparams.Channel(spec.Channel))
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve URL %q", spec.Charm)
 		}
@@ -529,7 +538,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 
-	url, channel, _, err := resolveCharm(h.api.ResolveWithPreferredChannel, ch, csparams.Channel(p.Channel))
+	url, channel, _, err := resolveCharm(h.bundleResolver.ResolveWithPreferredChannel, ch, csparams.Channel(p.Channel))
 	if err != nil {
 		return errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
 	}
@@ -537,7 +546,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Errorf("expected charm URL, got bundle URL %q", p.Charm)
 	}
 	var macaroon *macaroon.Macaroon
-	url, macaroon, err = addCharmFromURL(h.api, url, channel, h.force)
+	url, macaroon, err = addCharmFromURL(h.api, h.authorizer, url, channel, h.force)
 	if err != nil {
 		return errors.Annotatef(err, "cannot add charm %q", p.Charm)
 	}
@@ -666,7 +675,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		return errors.Trace(err)
 	}
 
-	resNames2IDs, err := resourceadapters.DeployResources(
+	resNames2IDs, err := h.deployResources(
 		p.Application,
 		chID,
 		macaroon,
@@ -965,7 +974,7 @@ func (h *bundleHandler) upgradeCharm(change *bundlechanges.UpgradeCharmChange) e
 	}
 	var resNames2IDs map[string]string
 	if len(filtered) != 0 {
-		resNames2IDs, err = resourceadapters.DeployResources(
+		resNames2IDs, err = h.deployResources(
 			p.Application,
 			chID,
 			macaroon,

--- a/cmd/juju/application/cmd_test.go
+++ b/cmd/juju/application/cmd_test.go
@@ -76,7 +76,7 @@ var deployTests = []struct {
 func (s *CmdSuite) TestDeployCommandInit(c *gc.C) {
 	for i, t := range deployTests {
 		c.Logf("\ntest %d: %s", i, t.about)
-		wrappedDeployCmd := NewDeployCommandForTest(nil, nil)
+		wrappedDeployCmd := NewDeployCommandForTest(nil)
 		wrappedDeployCmd.SetClientStore(jujuclienttesting.MinimalStore())
 		err := cmdtesting.InitCommand(wrappedDeployCmd, t.args)
 		if t.expectError != "" {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -56,7 +56,6 @@ type CharmAdder interface {
 	AddLocalCharm(*charm.URL, charm.Charm, bool) (*charm.URL, error)
 	AddCharm(*charm.URL, params.Channel, bool) error
 	AddCharmWithAuthorization(*charm.URL, params.Channel, *macaroon.Macaroon, bool) error
-	AuthorizeCharmstoreEntity(*charm.URL) (*macaroon.Macaroon, error)
 }
 
 type ApplicationAPI interface {
@@ -143,10 +142,6 @@ type DeployAPI interface {
 	Deploy(application.DeployArgs) error
 	Status(patterns []string) (*apiparams.FullStatus, error)
 
-	ResolveWithPreferredChannel(*charm.URL, params.Channel) (*charm.URL, params.Channel, []string, error)
-
-	GetBundle(*charm.URL) (charm.Bundle, error)
-
 	WatchAll() (*api.AllWatcher, error)
 
 	// PlanURL returns the configured URL prefix for the metering plan API.
@@ -185,10 +180,6 @@ type charmrepoForDeploy interface {
 	ResolveWithPreferredChannel(*charm.URL, params.Channel) (*charm.URL, params.Channel, []string, error)
 }
 
-type charmRepoClient struct {
-	charmrepoForDeploy
-}
-
 // charmstoreForDeploy is a subset of the methods implemented
 // by gopkg.in/juju/charmrepo.v3/csclient.Client. It is
 // used by tests that embed a DeploySuiteBase.
@@ -197,20 +188,12 @@ type charmstoreForDeploy interface {
 	WithChannel(csparams.Channel) charmstoreForDeploy
 }
 
-type charmstoreClient struct {
-	charmstoreForDeploy
-}
-
 type annotationsClient struct {
 	*annotations.Client
 }
 
 type plansClient struct {
 	planURL string
-}
-
-func (a *charmstoreClient) AuthorizeCharmstoreEntity(url *charm.URL) (*macaroon.Macaroon, error) {
-	return authorizeCharmStoreEntity(a, url)
 }
 
 func (c *plansClient) PlanURL() string {
@@ -231,12 +214,15 @@ type deployAPIAdapter struct {
 	*charmsClient
 	*applicationClient
 	*modelConfigClient
-	*charmRepoClient
-	*charmstoreClient
 	*annotationsClient
 	*plansClient
 	*offerClient
 	*spacesClient
+}
+
+type charmStoreAdaptor struct {
+	charmrepoForDeploy
+	charmstoreForDeploy
 }
 
 func (a *deployAPIAdapter) Client() *api.Client {
@@ -258,17 +244,17 @@ func (a *deployAPIAdapter) Deploy(args application.DeployArgs) error {
 	return errors.Trace(a.applicationClient.Deploy(args))
 }
 
-func (a *deployAPIAdapter) Resolve(cfg *config.Config, url *charm.URL, preferredChannel params.Channel) (
+func (a *charmStoreAdaptor) Resolve(cfg *config.Config, url *charm.URL, preferredChannel params.Channel) (
 	*charm.URL,
 	params.Channel,
 	[]string,
 	error,
 ) {
-	return resolveCharm(a.charmRepoClient.ResolveWithPreferredChannel, url, preferredChannel)
+	return resolveCharm(a.charmrepoForDeploy.ResolveWithPreferredChannel, url, preferredChannel)
 }
 
-func (a *deployAPIAdapter) Get(url *charm.URL) (charm.Charm, error) {
-	return a.charmRepoClient.Get(url)
+func (a *charmStoreAdaptor) Get(url *charm.URL) (charm.Charm, error) {
+	return a.charmrepoForDeploy.Get(url)
 }
 
 func (a *deployAPIAdapter) SetAnnotation(annotations map[string]map[string]string) ([]apiparams.ErrorResult, error) {
@@ -281,6 +267,10 @@ func (a *deployAPIAdapter) GetAnnotations(tags []string) ([]apiparams.Annotation
 
 // NewDeployCommand returns a command to deploy applications.
 func NewDeployCommand() modelcmd.ModelCommand {
+	return modelcmd.Wrap(newDeployCommand())
+}
+
+func newDeployCommand() *DeployCommand {
 	steps := []DeployStep{
 		&RegisterMeteredCharm{
 			PlanURL:      romulus.DefaultAPIRoot,
@@ -290,14 +280,10 @@ func NewDeployCommand() modelcmd.ModelCommand {
 		&ValidateLXDProfileCharm{},
 	}
 	deployCmd := &DeployCommand{
-		Steps: steps,
+		Steps:           steps,
+		DeployResources: resourceadapters.DeployResources,
 	}
-	deployCmd.NewAPIRoot = func() (DeployAPI, error) {
-		apiRoot, err := deployCmd.ModelCommandBase.NewAPIRoot()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
+	deployCmd.NewCharmRepo = func() (*charmStoreAdaptor, error) {
 		controllerAPIRoot, err := deployCmd.NewControllerAPIRoot()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -306,25 +292,36 @@ func NewDeployCommand() modelcmd.ModelCommand {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		mURL, err := deployCmd.getMeteringAPIURL(controllerAPIRoot)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		bakeryClient, err := deployCmd.BakeryClient()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		cstoreClient := newCharmStoreClient(bakeryClient, csURL)
-
+		return &charmStoreAdaptor{
+			charmrepoForDeploy:  charmrepo.NewCharmStoreFromClient(cstoreClient),
+			charmstoreForDeploy: &charmstoreClientShim{cstoreClient},
+		}, nil
+	}
+	deployCmd.NewAPIRoot = func() (DeployAPI, error) {
+		apiRoot, err := deployCmd.ModelCommandBase.NewAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		controllerAPIRoot, err := deployCmd.NewControllerAPIRoot()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		mURL, err := deployCmd.getMeteringAPIURL(controllerAPIRoot)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		return &deployAPIAdapter{
 			Connection:        apiRoot,
 			apiClient:         &apiClient{Client: apiRoot.Client()},
 			charmsClient:      &charmsClient{Client: apicharms.NewClient(apiRoot)},
 			applicationClient: &applicationClient{Client: application.NewClient(apiRoot)},
 			modelConfigClient: &modelConfigClient{Client: modelconfig.NewClient(apiRoot)},
-			charmstoreClient:  &charmstoreClient{&charmstoreClientShim{cstoreClient}},
 			annotationsClient: &annotationsClient{Client: annotations.NewClient(apiRoot)},
-			charmRepoClient:   &charmRepoClient{charmrepo.NewCharmStoreFromClient(cstoreClient)},
 			plansClient:       &plansClient{planURL: mURL},
 			offerClient:       &offerClient{Client: applicationoffers.NewClient(controllerAPIRoot)},
 			spacesClient:      &spacesClient{API: spaces.NewAPI(apiRoot)},
@@ -338,7 +335,7 @@ func NewDeployCommand() modelcmd.ModelCommand {
 		return applicationoffers.NewClient(root), nil
 	}
 
-	return modelcmd.Wrap(deployCmd)
+	return deployCmd
 }
 
 type DeployCommand struct {
@@ -408,9 +405,15 @@ type DeployCommand struct {
 	// NewAPIRoot stores a function which returns a new API root.
 	NewAPIRoot func() (DeployAPI, error)
 
+	// NewCharmRepo stores a function which returns a charm store client.
+	NewCharmRepo func() (*charmStoreAdaptor, error)
+
 	// NewConsumeDetailsAPI stores a function which will return a new API
 	// for consume details API using the url as the source.
 	NewConsumeDetailsAPI func(url *charm.OfferURL) (ConsumeDetails, error)
+
+	// DeployResources stores a function which deploys charm resources.
+	DeployResources resourceadapters.DeployResourcesFunc
 
 	// When deploying a charm, Trust signifies that the charm should be
 	// deployed with access to trusted credentials. That is, hooks run by
@@ -425,8 +428,6 @@ type DeployCommand struct {
 
 	unknownModel bool
 }
-
-const kubernetesSeriesName = "kubernetes"
 
 const deployDoc = `
 A charm can be referred to by its simple name and a series can optionally be
@@ -1115,7 +1116,7 @@ func (c *DeployCommand) deployCharm(
 			strings.Join(charmInfo.Meta.Terms, " "))
 	}
 
-	ids, err := resourceadapters.DeployResources(
+	ids, err := c.DeployResources(
 		applicationName,
 		id,
 		csMac,
@@ -1163,6 +1164,10 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
+	cstoreAPI, err := c.NewCharmRepo()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	apiRoot, err := c.NewAPIRoot()
 	if err != nil {
 		return errors.Trace(err)
@@ -1181,14 +1186,14 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		func() (deployFn, error) { return c.maybeReadLocalBundle(ctx) },
 		func() (deployFn, error) { return c.maybeReadLocalCharm(apiRoot) },
 		c.maybePredeployedLocalCharm,
-		c.maybeReadCharmstoreBundleFn(apiRoot),
+		c.maybeReadCharmstoreBundleFn(apiRoot, cstoreAPI),
 		c.charmStoreCharm, // This always returns a deployer
 	)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	return block.ProcessBlockedError(deploy(ctx, apiRoot), block.BlockChange)
+	return block.ProcessBlockedError(deploy(ctx, apiRoot, c.DeployResources, cstoreAPI), block.BlockChange)
 }
 
 func (c *DeployCommand) parseBindFlag(apiRoot DeployAPI) error {
@@ -1228,7 +1233,7 @@ func findDeployerFIFO(maybeDeployers ...func() (deployFn, error)) (deployFn, err
 	return nil, errors.NotFoundf("suitable deployer")
 }
 
-type deployFn func(*cmd.Context, DeployAPI) error
+type deployFn func(*cmd.Context, DeployAPI, resourceadapters.DeployResourcesFunc, *charmStoreAdaptor) error
 
 func (c *DeployCommand) validateBundleFlags() error {
 	if flags := getFlags(c.flagSet, charmOnlyFlags()); len(flags) > 0 {
@@ -1304,7 +1309,7 @@ func (c *DeployCommand) maybePredeployedLocalCharm() (deployFn, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return func(ctx *cmd.Context, api DeployAPI) error {
+	return func(ctx *cmd.Context, api DeployAPI, deployResources resourceadapters.DeployResourcesFunc, cstore *charmStoreAdaptor) error {
 		if err := c.validateCharmFlags(); err != nil {
 			return errors.Trace(err)
 		}
@@ -1353,7 +1358,7 @@ func (c *DeployCommand) maybeReadLocalBundle(ctx *cmd.Context) (deployFn, error)
 		return nil, errors.Trace(err)
 	}
 
-	return func(ctx *cmd.Context, apiRoot DeployAPI) error {
+	return func(ctx *cmd.Context, apiRoot DeployAPI, deployResources resourceadapters.DeployResourcesFunc, cstore *charmStoreAdaptor) error {
 		return errors.Trace(c.deployBundle(bundleDeploySpec{
 			ctx:                 ctx,
 			dryRun:              c.DryRun,
@@ -1363,6 +1368,9 @@ func (c *DeployCommand) maybeReadLocalBundle(ctx *cmd.Context) (deployFn, error)
 			bundleOverlayFile:   c.BundleOverlayFile,
 			channel:             c.Channel,
 			apiRoot:             apiRoot,
+			bundleResolver:      cstore,
+			deployResources:     deployResources,
+			authorizer:          cstore.charmstoreForDeploy,
 			useExistingMachines: c.UseExisting,
 			bundleMachines:      c.BundleMachines,
 			bundleStorage:       c.BundleStorage,
@@ -1443,7 +1451,7 @@ func (c *DeployCommand) maybeReadLocalCharm(apiRoot DeployAPI) (deployFn, error)
 		return nil, errors.Trace(err)
 	}
 
-	return func(ctx *cmd.Context, apiRoot DeployAPI) error {
+	return func(ctx *cmd.Context, apiRoot DeployAPI, deployResources resourceadapters.DeployResourcesFunc, cstore *charmStoreAdaptor) error {
 		if err := c.validateCharmFlags(); err != nil {
 			return errors.Trace(err)
 		}
@@ -1478,7 +1486,7 @@ type URLResolver interface {
 // bundle. If it turns out to be a bundle, the resolved URL and
 // channel are returned. If it isn't but there wasn't a problem
 // checking it, it returns a nil charm URL.
-func resolveBundleURL(store URLResolver, maybeBundle string, preferredChannel params.Channel) (*charm.URL, params.Channel, error) {
+func resolveBundleURL(cstore URLResolver, maybeBundle string, preferredChannel params.Channel) (*charm.URL, params.Channel, error) {
 	userRequestedURL, err := charm.ParseURL(maybeBundle)
 	if err != nil {
 		return nil, "", errors.Trace(err)
@@ -1486,7 +1494,7 @@ func resolveBundleURL(store URLResolver, maybeBundle string, preferredChannel pa
 
 	// Charm or bundle has been supplied as a URL so we resolve and
 	// deploy using the store.
-	storeCharmOrBundleURL, channel, _, err := resolveCharm(store.ResolveWithPreferredChannel, userRequestedURL, preferredChannel)
+	storeCharmOrBundleURL, channel, _, err := resolveCharm(cstore.ResolveWithPreferredChannel, userRequestedURL, preferredChannel)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
@@ -1500,9 +1508,9 @@ func resolveBundleURL(store URLResolver, maybeBundle string, preferredChannel pa
 	return storeCharmOrBundleURL, channel, nil
 }
 
-func (c *DeployCommand) maybeReadCharmstoreBundleFn(apiRoot DeployAPI) func() (deployFn, error) {
+func (c *DeployCommand) maybeReadCharmstoreBundleFn(apiRoot DeployAPI, cstore BundleResolver) func() (deployFn, error) {
 	return func() (deployFn, error) {
-		bundleURL, channel, err := resolveBundleURL(apiRoot, c.CharmOrBundle, c.Channel)
+		bundleURL, channel, err := resolveBundleURL(cstore, c.CharmOrBundle, c.Channel)
 		if charm.IsUnsupportedSeriesError(errors.Cause(err)) {
 			return nil, errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 		}
@@ -1517,7 +1525,7 @@ func (c *DeployCommand) maybeReadCharmstoreBundleFn(apiRoot DeployAPI) func() (d
 			return nil, errors.Trace(err)
 		}
 
-		return func(ctx *cmd.Context, apiRoot DeployAPI) error {
+		return func(ctx *cmd.Context, apiRoot DeployAPI, deployResources resourceadapters.DeployResourcesFunc, cstore *charmStoreAdaptor) error {
 			// Ideally, we would like to expose a GetBundleDataSource
 			// method for the charmstore. As we want to avoid further
 			// diverging charmrepo.v3 from charmrepo.v4, the best
@@ -1531,7 +1539,7 @@ func (c *DeployCommand) maybeReadCharmstoreBundleFn(apiRoot DeployAPI) func() (d
 			// from the charmstore we simply use the existing
 			// charmrepo.v3 API to read the base bundle and
 			// wrap it in a BundleDataSource for use by deployBundle.
-			bundle, err := apiRoot.GetBundle(bundleURL)
+			bundle, err := cstore.GetBundle(bundleURL)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -1547,6 +1555,9 @@ func (c *DeployCommand) maybeReadCharmstoreBundleFn(apiRoot DeployAPI) func() (d
 				bundleOverlayFile:   c.BundleOverlayFile,
 				channel:             channel,
 				apiRoot:             apiRoot,
+				bundleResolver:      cstore,
+				deployResources:     deployResources,
+				authorizer:          cstore.charmstoreForDeploy,
 				useExistingMachines: c.UseExisting,
 				bundleMachines:      c.BundleMachines,
 				bundleStorage:       c.BundleStorage,
@@ -1571,7 +1582,7 @@ func (c *DeployCommand) charmStoreCharm() (deployFn, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return func(ctx *cmd.Context, apiRoot DeployAPI) error {
+	return func(ctx *cmd.Context, apiRoot DeployAPI, deployResources resourceadapters.DeployResourcesFunc, cstore *charmStoreAdaptor) error {
 		// resolver.resolve potentially updates the series of anything
 		// passed in. Store this for use in seriesSelector.
 		userRequestedSeries := userRequestedURL.Series
@@ -1585,7 +1596,7 @@ func (c *DeployCommand) charmStoreCharm() (deployFn, error) {
 		// deploy using the store but pass in the channel command line
 		// argument so users can target a specific channel.
 		storeCharmOrBundleURL, channel, supportedSeries, err := resolveCharm(
-			apiRoot.ResolveWithPreferredChannel, userRequestedURL, c.Channel,
+			cstore.ResolveWithPreferredChannel, userRequestedURL, c.Channel,
 		)
 		if charm.IsUnsupportedSeriesError(err) {
 			return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
@@ -1632,7 +1643,7 @@ func (c *DeployCommand) charmStoreCharm() (deployFn, error) {
 		}
 
 		// Store the charm in the controller
-		curl, csMac, err := addCharmFromURL(apiRoot, storeCharmOrBundleURL, channel, c.Force)
+		curl, csMac, err := addCharmFromURL(apiRoot, cstore.charmstoreForDeploy, storeCharmOrBundleURL, channel, c.Force)
 		if err != nil {
 			if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 				return errors.Trace(termErr.UserErr())

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -8,16 +8,9 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charmrepo.v3"
 
-	"github.com/juju/juju/api/annotations"
-	"github.com/juju/juju/api/application"
-	"github.com/juju/juju/api/charms"
-	"github.com/juju/juju/api/modelconfig"
-	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -144,47 +137,4 @@ func (s *RemoveApplicationSuite) TestInvalidArgs(c *gc.C) {
 func (s *RemoveApplicationSuite) TestNoWaitWithoutForce(c *gc.C) {
 	_, err := runRemoveApplication(c, "gargleblaster", "--no-wait")
 	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
-}
-
-//TODO(tsm) remove unused RemoveCharmStoreCharmsSuite
-type RemoveCharmStoreCharmsSuite struct {
-	legacyCharmStoreSuite
-	ctx *cmd.Context
-}
-
-var _ = gc.Suite(&RemoveCharmStoreCharmsSuite{})
-
-func (s *RemoveCharmStoreCharmsSuite) SetUpTest(c *gc.C) {
-	s.legacyCharmStoreSuite.SetUpTest(c)
-
-	s.ctx = cmdtesting.Context(c)
-
-	testcharms.UploadCharmWithSeries(c, s.client, "cs:quantal/metered-1", "metered", "bionic")
-	deployCmd := &DeployCommand{}
-	cmd := modelcmd.Wrap(deployCmd)
-	deployCmd.NewAPIRoot = func() (DeployAPI, error) {
-		apiRoot, err := deployCmd.ModelCommandBase.NewAPIRoot()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		bakeryClient, err := deployCmd.BakeryClient()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		cstoreClient := newCharmStoreClient(bakeryClient, s.srv.URL).WithChannel(deployCmd.Channel)
-		return &deployAPIAdapter{
-			Connection:        apiRoot,
-			apiClient:         &apiClient{Client: apiRoot.Client()},
-			charmsClient:      &charmsClient{Client: charms.NewClient(apiRoot)},
-			applicationClient: &applicationClient{Client: application.NewClient(apiRoot)},
-			modelConfigClient: &modelConfigClient{Client: modelconfig.NewClient(apiRoot)},
-			charmstoreClient:  &charmstoreClient{&charmstoreClientShim{cstoreClient}},
-			annotationsClient: &annotationsClient{Client: annotations.NewClient(apiRoot)},
-			charmRepoClient:   &charmRepoClient{charmrepo.NewCharmStoreFromClient(cstoreClient)},
-		}, nil
-	}
-
-	_, err := cmdtesting.RunCommand(c, cmd, "cs:quantal/metered-1")
-	c.Assert(err, jc.ErrorIsNil)
-
 }

--- a/cmd/juju/application/store.go
+++ b/cmd/juju/application/store.go
@@ -61,13 +61,13 @@ func resolveCharm(
 // given charm URL to state. For non-public charm URLs, this function also
 // handles the macaroon authorization process using the given csClient.
 // The resulting charm URL of the added charm is displayed on stdout.
-func addCharmFromURL(client CharmAdder, curl *charm.URL, channel csparams.Channel, force bool) (*charm.URL, *macaroon.Macaroon, error) {
+func addCharmFromURL(client CharmAdder, cs macaroonGetter, curl *charm.URL, channel csparams.Channel, force bool) (*charm.URL, *macaroon.Macaroon, error) {
 	var csMac *macaroon.Macaroon
 	if err := client.AddCharm(curl, channel, force); err != nil {
 		if !params.IsCodeUnauthorized(err) {
 			return nil, nil, errors.Trace(err)
 		}
-		m, err := client.AuthorizeCharmstoreEntity(curl)
+		m, err := authorizeCharmStoreEntity(cs, curl)
 		if err != nil {
 			return nil, nil, common.MaybeTermsAgreementError(err)
 		}
@@ -88,11 +88,15 @@ var newCharmStoreClient = func(client *httpbakery.Client, csURL string) *csclien
 	})
 }
 
+type macaroonGetter interface {
+	Get(endpoint string, extra interface{}) error
+}
+
 // authorizeCharmStoreEntity acquires and return the charm store delegatable macaroon to be
 // used to add the charm corresponding to the given URL.
 // The macaroon is properly attenuated so that it can only be used to deploy
 // the given charm URL.
-func authorizeCharmStoreEntity(csClient charmstoreForDeploy, curl *charm.URL) (*macaroon.Macaroon, error) {
+func authorizeCharmStoreEntity(csClient macaroonGetter, curl *charm.URL) (*macaroon.Macaroon, error) {
 	endpoint := "/delegatable-macaroon?id=" + url.QueryEscape(curl.String())
 	var m *macaroon.Macaroon
 	if err := csClient.Get(endpoint, &m); err != nil {

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -1,55 +1,46 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package application_test
+package application
 
 import (
 	"bytes"
 	"io/ioutil"
-	"net/http/httptest"
 	"path"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/juju/cmd/cmdtesting"
-	gitjujutesting "github.com/juju/testing"
+	"github.com/juju/juju/api/charms"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	charmresource "gopkg.in/juju/charm.v6/resource"
-	"gopkg.in/juju/charmrepo.v3"
-	"gopkg.in/juju/charmrepo.v3/csclient"
-	"gopkg.in/juju/charmrepo.v3/csclient/params"
-	"gopkg.in/juju/charmstore.v5"
+	csclientparams "gopkg.in/juju/charmrepo.v3/csclient/params"
 	"gopkg.in/juju/names.v3"
-	"gopkg.in/mgo.v2"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon.v2-unstable"
 
-	"github.com/juju/juju/cmd/juju/application"
-	"github.com/juju/juju/component/all"
-	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	jjcharmstore "github.com/juju/juju/charmstore"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/resource"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 )
 
 type UpgradeCharmResourceSuite struct {
-	application.RepoSuiteBaseSuite
+	RepoSuiteBaseSuite
 }
 
 var _ = gc.Suite(&UpgradeCharmResourceSuite{})
 
-func (s *UpgradeCharmResourceSuite) SetUpSuite(c *gc.C) {
-	s.RepoSuite.SetUpSuite(c)
-	all.RegisterForServer()
-}
-
 func (s *UpgradeCharmResourceSuite) SetUpTest(c *gc.C) {
 	s.RepoSuiteBaseSuite.SetUpTest(c)
 	chPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(s.CharmsPath, "riak")
-	_, err := runDeploy(c, chPath, "riak", "--series", "quantal", "--force")
+	err := runDeploy(c, chPath, "riak", "--series", "quantal", "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := charm.MustParseURL("local:quantal/riak-7")
 	riak, _ := s.RepoSuite.AssertApplication(c, "riak", curl, 1, 1)
@@ -91,7 +82,7 @@ resources:
 	err = ioutil.WriteFile(resourceFile, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = cmdtesting.RunCommand(c, application.NewUpgradeCharmCommand(),
+	_, err = cmdtesting.RunCommand(c, NewUpgradeCharmCommand(),
 		"riak", "--path="+myriakPath.Path, "--resource", "data="+resourceFile)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -125,85 +116,14 @@ resources:
 	})
 }
 
-type charmstoreClientToTestcharmsClientShim struct {
-	*csclient.Client
-}
-
-func (c charmstoreClientToTestcharmsClientShim) WithChannel(channel params.Channel) testcharms.CharmstoreClient {
-	client := c.Client.WithChannel(channel)
-	return charmstoreClientToTestcharmsClientShim{client}
-}
-
-// charmStoreSuite is a suite fixture that puts the machinery in
-// place to allow testing code that calls addCharmViaAPI.
-type charmStoreSuite struct {
-	application.JujuConnBaseSuite
-	handler    charmstore.HTTPCloseHandler
-	srv        *httptest.Server
-	srvSession *mgo.Session
-	client     charmstoreClientToTestcharmsClientShim
-}
-
-func (s *charmStoreSuite) SetUpTest(c *gc.C) {
-	srvSession, err := gitjujutesting.MgoServer.Dial()
-	c.Assert(err, gc.IsNil)
-	s.srvSession = srvSession
-
-	// Set up the charm store testing server.
-	db := s.srvSession.DB("juju-testing")
-	params := charmstore.ServerParams{
-		AuthUsername: "test-user",
-		AuthPassword: "test-password",
-	}
-	handler, err := charmstore.NewServer(db, nil, "", params, charmstore.V5)
-	c.Assert(err, jc.ErrorIsNil)
-	s.handler = handler
-	s.srv = httptest.NewServer(handler)
-	client := csclient.New(csclient.Params{
-		URL:      s.srv.URL,
-		User:     params.AuthUsername,
-		Password: params.AuthPassword,
-	})
-	s.client = charmstoreClientToTestcharmsClientShim{client}
-
-	// Set charmstore URL config so the config is set during bootstrap
-	if s.ControllerConfigAttrs == nil {
-		s.ControllerConfigAttrs = make(map[string]interface{})
-	}
-	s.JujuConnSuite.ControllerConfigAttrs[controller.CharmStoreURL] = s.srv.URL
-
-	s.JujuConnBaseSuite.SetUpTest(c)
-
-	// Initialize the charm cache dir.
-	s.PatchValue(&charmrepo.CacheDir, c.MkDir())
-}
-
-func (s *charmStoreSuite) TearDownTest(c *gc.C) {
-	s.handler.Close()
-	s.srv.Close()
-	s.srvSession.Close()
-	s.JujuConnSuite.TearDownTest(c)
-}
-
 type UpgradeCharmStoreResourceSuite struct {
-	charmStoreSuite
+	FakeStoreStateSuite
 }
 
 var _ = gc.Suite(&UpgradeCharmStoreResourceSuite{})
 
-func (s *UpgradeCharmStoreResourceSuite) SetUpSuite(c *gc.C) {
-	s.charmStoreSuite.SetUpSuite(c)
-	err := all.RegisterForServer()
-	c.Assert(err, jc.ErrorIsNil)
-	err = all.RegisterForClient()
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-// TODO(ericsnow) Adapt this test to check passing revisions once the
-// charmstore endpoints are implemented.
-
 func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
-	testcharms.UploadCharmWithSeries(c, s.client, "trusty/starsay-1", "starsay", "bionic")
+	ch := s.setupCharm(c, "bionic/starsay-1", "starsay", "bionic")
 
 	// let's make a fake resource file to upload
 	resourceContent := "some-data"
@@ -212,15 +132,29 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 	err := ioutil.WriteFile(resourceFile, []byte(resourceContent), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
-	output, err := runDeploy(c, "trusty/starsay", "--resource", "upload-resource="+resourceFile)
+	deploy := newDeployCommand()
+	deploy.DeployResources = func(applicationID string,
+		chID jjcharmstore.CharmID,
+		csMac *macaroon.Macaroon,
+		filesAndRevisions map[string]string,
+		resources map[string]charmresource.Meta,
+		conn base.APICallCloser,
+	) (ids map[string]string, err error) {
+		return deployResources(s.State, applicationID, resources)
+	}
+	deploy.NewCharmRepo = func() (*charmStoreAdaptor, error) {
+		return s.fakeAPI.charmStoreAdaptor, nil
+	}
+
+	_, output, err := runDeployWithOutput(c, modelcmd.Wrap(deploy), "bionic/starsay", "--resource", "upload-resource="+resourceFile)
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedOutput := `Located charm "cs:trusty/starsay-1".
-Deploying charm "cs:trusty/starsay-1".`
+	expectedOutput := `Located charm "cs:bionic/starsay-1".
+Deploying charm "cs:bionic/starsay-1".`
 	c.Assert(output, gc.Equals, expectedOutput)
-	s.assertCharmsUploaded(c, "cs:trusty/starsay-1")
+	s.assertCharmsUploaded(c, "cs:bionic/starsay-1")
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"starsay": {charm: "cs:trusty/starsay-1"},
+		"starsay": {charm: "cs:bionic/starsay-1", config: ch.Config().DefaultSettings()},
 	})
 
 	unit, err := s.State.Unit("starsay/0")
@@ -232,14 +166,14 @@ Deploying charm "cs:trusty/starsay-1".`
 
 	res, err := s.State.Resources()
 	c.Assert(err, jc.ErrorIsNil)
-	svcres, err := res.ListResources("starsay")
+	appResources, err := res.ListResources("starsay")
 	c.Assert(err, jc.ErrorIsNil)
 
-	sort.Sort(byname(svcres.Resources))
+	sort.Sort(byname(appResources.Resources))
 
-	c.Assert(svcres.Resources, gc.HasLen, 3)
-	c.Check(svcres.Resources[2].Timestamp, gc.Not(gc.Equals), time.Time{})
-	svcres.Resources[2].Timestamp = time.Time{}
+	c.Assert(appResources.Resources, gc.HasLen, 3)
+	c.Check(appResources.Resources[2].Timestamp, gc.Not(gc.Equals), time.Time{})
+	appResources.Resources[2].Timestamp = time.Time{}
 
 	// Note that all charm resources were uploaded by testcharms.UploadCharm
 	// so that the charm could be published.
@@ -292,38 +226,75 @@ Deploying charm "cs:trusty/starsay-1".`
 		// Timestamp is checked above
 	}}
 
-	c.Check(svcres.Resources, jc.DeepEquals, expectedResources)
+	c.Check(appResources.Resources, jc.DeepEquals, expectedResources)
 
-	oldCharmStoreResources := make([]charmresource.Resource, len(svcres.CharmStoreResources))
-	copy(oldCharmStoreResources, svcres.CharmStoreResources)
+	oldCharmStoreResources := make([]charmresource.Resource, len(appResources.CharmStoreResources))
+	copy(oldCharmStoreResources, appResources.CharmStoreResources)
 
 	sort.Sort(csbyname(oldCharmStoreResources))
 
-	testcharms.UploadCharmWithSeries(c, s.client, "trusty/starsay-2", "starsay", "bionic")
+	s.setupCharm(c, "bionic/starsay-2", "starsay", "bionic")
+	repo := jjcharmstore.NewRepository()
+	charmClient := &mockCharmClient{
+		charmInfo: &charms.CharmInfo{
+			URL:  "bionic/starsay-2",
+			Meta: &charm.Meta{},
+		},
+	}
+	charmAdder := &mockCharmAdder{}
+	upgrade := NewUpgradeCharmCommandForStateTest(
+		func(
+			bakeryClient *httpbakery.Client,
+			csURL string,
+			channel csclientparams.Channel,
+			modelConfig *config.Config,
+		) charmrepoForDeploy {
+			return repo
+		},
+		func(conn api.Connection) CharmAdder {
+			return charmAdder
+		},
+		func(conn base.APICallCloser) CharmClient {
+			return charmClient
+		},
+		func(applicationID string,
+			chID jjcharmstore.CharmID,
+			csMac *macaroon.Macaroon,
+			filesAndRevisions map[string]string,
+			resources map[string]charmresource.Meta,
+			conn base.APICallCloser,
+		) (ids map[string]string, err error) {
+			return deployResources(s.State, applicationID, resources)
+		},
+		func(conn base.APICallCloser) CharmAPIClient {
+			return &mockCharmAPIClient{
+				charmURL: charm.MustParseURL("bionic/starsay-2"),
+			}
+		},
+	)
 
-	_, err = cmdtesting.RunCommand(c, application.NewUpgradeCharmCommand(), "starsay")
+	_, err = cmdtesting.RunCommand(c, upgrade, "starsay")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"starsay": {charm: "cs:trusty/starsay-2"},
-	})
+	charmAdder.CheckCall(c, 0,
+		"AddCharm", charm.MustParseURL("cs:bionic/starsay-0"), csclientparams.NoChannel, false)
 
 	res, err = s.State.Resources()
 	c.Assert(err, jc.ErrorIsNil)
-	svcres, err = res.ListResources("starsay")
+	appResources, err = res.ListResources("starsay")
 	c.Assert(err, jc.ErrorIsNil)
 
-	sort.Sort(byname(svcres.Resources))
+	sort.Sort(byname(appResources.Resources))
 
-	c.Assert(svcres.Resources, gc.HasLen, 3)
-	c.Check(svcres.Resources[2].Timestamp, gc.Not(gc.Equals), time.Time{})
-	svcres.Resources[2].Timestamp = time.Time{}
+	c.Assert(appResources.Resources, gc.HasLen, 3)
+	c.Check(appResources.Resources[2].Timestamp, gc.Not(gc.Equals), time.Time{})
+	appResources.Resources[2].Timestamp = time.Time{}
 
 	// ensure that we haven't overridden the previously uploaded resource.
-	c.Check(svcres.Resources, jc.DeepEquals, expectedResources)
+	c.Check(appResources.Resources, jc.DeepEquals, expectedResources)
 
-	sort.Sort(csbyname(svcres.CharmStoreResources))
-	c.Check(oldCharmStoreResources, gc.DeepEquals, svcres.CharmStoreResources)
+	sort.Sort(csbyname(appResources.CharmStoreResources))
+	c.Check(oldCharmStoreResources, gc.DeepEquals, appResources.CharmStoreResources)
 }
 
 func resourceHash(content string) charmresource.Fingerprint {
@@ -345,62 +316,3 @@ type csbyname []charmresource.Resource
 func (b csbyname) Len() int           { return len(b) }
 func (b csbyname) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b csbyname) Less(i, j int) bool { return b[i].Name < b[j].Name }
-
-// assertCharmsUploaded checks that the given charm ids have been uploaded.
-func (s *charmStoreSuite) assertCharmsUploaded(c *gc.C, ids ...string) {
-	charms, err := s.State.AllCharms()
-	c.Assert(err, jc.ErrorIsNil)
-	uploaded := make([]string, len(charms))
-	for i, charm := range charms {
-		uploaded[i] = charm.URL().String()
-	}
-	c.Assert(uploaded, jc.SameContents, ids)
-}
-
-// assertApplicationsDeployed checks that the given applications have been deployed.
-func (s *charmStoreSuite) assertApplicationsDeployed(c *gc.C, info map[string]applicationInfo) {
-	applications, err := s.State.AllApplications()
-	c.Assert(err, jc.ErrorIsNil)
-	deployed := make(map[string]applicationInfo, len(applications))
-	for _, app := range applications {
-		ch, _ := app.CharmURL()
-		config, err := app.CharmConfig(model.GenerationMaster)
-		c.Assert(err, jc.ErrorIsNil)
-		if len(config) == 0 {
-			config = nil
-		}
-		cons, err := app.Constraints()
-		c.Assert(err, jc.ErrorIsNil)
-		storage, err := app.StorageConstraints()
-		c.Assert(err, jc.ErrorIsNil)
-		if len(storage) == 0 {
-			storage = nil
-		}
-		deployed[app.Name()] = applicationInfo{
-			charm:       ch.String(),
-			config:      config,
-			constraints: cons,
-			exposed:     app.IsExposed(),
-			storage:     storage,
-		}
-	}
-	c.Assert(deployed, jc.DeepEquals, info)
-}
-
-// applicationInfo holds information about a deployed application.
-type applicationInfo struct {
-	charm            string
-	config           charm.Settings
-	constraints      constraints.Value
-	exposed          bool
-	storage          map[string]state.StorageConstraints
-	endpointBindings map[string]string
-}
-
-// runDeploy executes the deploy command in order to deploy the given
-// charm or bundle. The deployment stderr output and error are returned.
-// TODO(rog) delete this when tests are universally internal or external.
-func runDeploy(c *gc.C, args ...string) (string, error) {
-	ctx, err := cmdtesting.RunCommand(c, application.NewDeployCommand(), args...)
-	return strings.Trim(cmdtesting.Stderr(ctx), "\n"), err
-}


### PR DESCRIPTION
## Description of change

The tests in the cmd/juju/application package no longer use the real charmstore. The various test suites in use were already a mix of old and style go mocks, some used a real database, there were several variations of making a test command etc.

This PR doesn't change the world - it does what's needed to remove the need to import charmstore.v5. There's not a large code change - it's vast majority of changes are in the tests. The main aspects include:
- breaking up larger interfaces to make stubbing easier (eg deployAPI)
- with the above, introduce a smaller charm store interface
- inject the charm store implementation into the commands (use stubs for tests)
- place code to upload charms etc to the real store with functions to set up the stubs with expected api calls to mimic the desired store behaviour
- remove some tests which only tested real store behaviour (eg auth errors, registration of terms)

## QA steps

bootstrap a controller
deploy various local/store charms (with resources) and bundles
redeploy the bundle
upgrade the charms
