### PR TITLE
Remove PrechecksCrossModel from Migration-Master API Server

### DIFF
--- a/apiserver/facades/controller/migrationmaster/backend.go
+++ b/apiserver/facades/controller/migrationmaster/backend.go
@@ -27,8 +27,6 @@ type Backend interface {
 	ModelOwner() (names.UserTag, error)
 	AgentVersion() (version.Number, error)
 	RemoveExportingModelDocs() error
-	AllOfferConnections() ([]OfferConnection, error)
-	ControllerForModel(string) (state.ExternalController, error)
 }
 
 // OfferConnection describes methods offer connection methods

--- a/apiserver/facades/controller/migrationmaster/mocks/backend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/backend.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
-	migrationmaster "github.com/juju/juju/apiserver/facades/controller/migrationmaster"
 	state "github.com/juju/juju/state"
 	version "github.com/juju/version"
 	names_v3 "gopkg.in/juju/names.v3"
@@ -50,36 +49,6 @@ func (m *MockBackend) AgentVersion() (version.Number, error) {
 func (mr *MockBackendMockRecorder) AgentVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentVersion", reflect.TypeOf((*MockBackend)(nil).AgentVersion))
-}
-
-// AllOfferConnections mocks base method
-func (m *MockBackend) AllOfferConnections() ([]migrationmaster.OfferConnection, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllOfferConnections")
-	ret0, _ := ret[0].([]migrationmaster.OfferConnection)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllOfferConnections indicates an expected call of AllOfferConnections
-func (mr *MockBackendMockRecorder) AllOfferConnections() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllOfferConnections", reflect.TypeOf((*MockBackend)(nil).AllOfferConnections))
-}
-
-// ControllerForModel mocks base method
-func (m *MockBackend) ControllerForModel(arg0 string) (state.ExternalController, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControllerForModel", arg0)
-	ret0, _ := ret[0].(state.ExternalController)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ControllerForModel indicates an expected call of ControllerForModel
-func (mr *MockBackendMockRecorder) ControllerForModel(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerForModel", reflect.TypeOf((*MockBackend)(nil).ControllerForModel), arg0)
 }
 
 // Export mocks base method

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21922,14 +21922,6 @@
                 "Prechecks": {
                     "type": "object"
                 },
-                "PrechecksCrossModel": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/MigratingCrossModelResult"
-                        }
-                    }
-                },
                 "ProcessRelations": {
                     "type": "object",
                     "properties": {
@@ -22000,33 +21992,6 @@
                         "code"
                     ]
                 },
-                "ExternalControllerInfo": {
-                    "type": "object",
-                    "properties": {
-                        "addrs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "ca-cert": {
-                            "type": "string"
-                        },
-                        "controller-alias": {
-                            "type": "string"
-                        },
-                        "controller-tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "controller-tag",
-                        "controller-alias",
-                        "addrs",
-                        "ca-cert"
-                    ]
-                },
                 "MasterMigrationStatus": {
                     "type": "object",
                     "properties": {
@@ -22050,57 +22015,6 @@
                         "migration-id",
                         "phase",
                         "phase-changed-time"
-                    ]
-                },
-                "MigratingCrossModelResult": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "external-controllers": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "$ref": "#/definitions/ExternalControllerInfo"
-                                }
-                            }
-                        },
-                        "offer-connections": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/MigratingOfferConnection"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "offer-connections",
-                        "external-controllers"
-                    ]
-                },
-                "MigratingOfferConnection": {
-                    "type": "object",
-                    "properties": {
-                        "offer-uuid": {
-                            "type": "string"
-                        },
-                        "relation-id": {
-                            "type": "integer"
-                        },
-                        "source-model-tag": {
-                            "type": "string"
-                        },
-                        "username": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "offer-uuid",
-                        "source-model-tag",
-                        "relation-id",
-                        "username"
                     ]
                 },
                 "MigrationModelInfo": {

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -218,35 +218,3 @@ type AdoptResourcesArgs struct {
 	// that version.
 	SourceControllerVersion version.Number `json:"source-controller-version"`
 }
-
-// MigratingOfferConnection transports offer connection details for consumed
-// relations that are being migrated to a new model.
-type MigratingOfferConnection struct {
-	// OfferUUID uniquely identifies the offer being consumed.
-	OfferUUID string `json:"offer-uuid"`
-
-	// SourceModelTag identifies the model
-	// from which the relation was consumed.
-	SourceModelTag string `json:"source-model-tag"`
-
-	// RelationID is the ID of the relation to which this connection pertains.
-	RelationID int `json:"relation-id"`
-
-	// UserName is the name of the user who created this connection.
-	UserName string `json:"username"`
-}
-
-// MigratingCrossModelResult holds information for cross-model relations for
-// which consuming models need to be updated as part of a model migration.
-type MigratingCrossModelResult struct {
-	// OfferConnections are all the relations that have been established from
-	// other models to offers made from this model.
-	OfferConnections []MigratingOfferConnection `json:"offer-connections"`
-
-	// External controllers is a map of model tag to controller info for models
-	// consuming relations in the migrating model.
-	ExternalControllers map[string]ExternalControllerInfo `json:"external-controllers"`
-
-	// Error is non-nil if an error occurred processing the request.
-	Error *Error `json:"error,omitempty"`
-}


### PR DESCRIPTION
## Description of change

This patch removes the `PrechecksCrossModel` method from the migration-master API server under https://github.com/juju/juju/pull/10959.

This was added in anticipation of running migration pre-checks on external controllers consuming CMR offers, but the design strategy around migration CMRs has since changed.

This is not simple commit reversion, as sundry fixes were included in that patch that we will retain.

## QA steps

Method was never actually invoked agent-side. Unit tests satisfy QA.

## Documentation changes

None.

## Bug reference

N/A
