### PR TITLE
Lack controller error refactor

### DIFF
--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/juju/ansiterm"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -84,7 +85,9 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "failed to list controllers")
 	}
 	if len(controllers) == 0 && c.out.Name() == "tabular" {
-		return errors.Trace(modelcmd.ErrNoControllersDefined)
+		w := ansiterm.NewWriter(ctx.Stderr)
+		fmt.Fprintf(w, "%s\n", modelcmd.ErrNoControllersDefined)
+		return cmd.NewRcPassthroughError(1)
 	}
 	if c.refresh && len(controllers) > 0 {
 		var wg sync.WaitGroup

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -32,7 +32,7 @@ func (s *ControllerCommandSuite) TestControllerCommandNoneSpecified(c *gc.C) {
 	command, err := runTestControllerCommand(c, jujuclient.NewMemStore())
 	c.Assert(err, jc.ErrorIsNil)
 	controllerName, err := command.ControllerName()
-	c.Assert(errors.Cause(err), gc.Equals, modelcmd.ErrNoControllersDefined)
+	c.Assert(errors.Cause(err), gc.DeepEquals, cmd.NewRcPassthroughError(1))
 	c.Assert(controllerName, gc.Equals, "")
 }
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

- Changes the thrown error to be not an error but a normal message, which then just returns to finish the context

### Problem
Most information handling is done through errors. If an error is found in the cli it will be returned until the top level and then printed out. 
Below are some possible solutions. 
I have implemented 3.)
### Possible Solutions

#### 1.) Return Error -> top-level check
- handle the information as it would be an error and on the topmost code level, just check for this kind and if that's the case print a non err

<- easier, but kind of weird (saying an error is actually not one) 
`in main.go`
```go
if errors.Cause(noController){
 print (noController.text)
}
```
#### 2.) Return Error and warning/additional information
if not err && warning/additional information -> print warning and stop 

<-- needs changes in all cmd places using methods which directly or indirectly using the controller. Meaning all of them.

from:
`in each <command>.go`
```go
	controllerName, err := c.ControllerName()
```

to 
`in each <command>.go`
```go
	controllerName, err, warning := c.ControllerName()
	if warning != "" {
		_, _ = fmt.Fprintln(ctx.Stdout, warning)
		return nil
	}
```
#### 3.) Return silent Error + Controller prints to os.stderr
- Most functions call two functions before proceeding to do work. Those functions now just print the err as normal text and return a `1` exit code.

## QA steps
run a command which needs a controller
```sh
~/golang/src/github.com/juju/juju lack_controller_error_refactor* ⇣⇡
❯ juju models 
No controllers registered.

Please either create a new controller using "juju bootstrap" or connect to
another controller that you have been given access to using "juju register".

subprocess encountered error code 1
ERROR subprocess encountered error code 1

~/golang/src/github.com/juju/juju lack_controller_error_refactor* ⇣⇡
❯ juju add-user rick
No controllers registered.

Please either create a new controller using "juju bootstrap" or connect to
another controller that you have been given access to using "juju register".

ERROR subprocess encountered error code 1
```

### Launchpad

https://bugs.launchpad.net/juju/+bug/1853529