### PR TITLE
Emit Redirect Errors for Anonymous Logins

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -234,6 +234,19 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 		}
 	}
 
+	// If the login attempt is for a migrated model,
+	// a.root.model will be nil as the model document does not exist on this
+	// controller and a.root.modelUUID cannot be resolved.
+	// In this case use the requested model UUID to check if we need to return
+	// a redirect error.
+	modelUUID := a.root.modelUUID
+	if a.root.model != nil {
+		modelUUID = a.root.model.UUID()
+	}
+	if err := a.maybeEmitRedirectError(modelUUID, result.tag); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	switch result.tag.(type) {
 	case nil:
 		// Macaroon logins are always for users.
@@ -246,41 +259,21 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 		result.userLogin = false
 	}
 
+	// Anonymous logins come from other controllers (in cross-model relations).
+	// We don't need to start pingers because we don't maintain presence
+	// information for them.
+	startPinger := !result.anonymousLogin
+
 	// Only attempt to login with credentials if we are not doing an anonymous login.
-	var (
-		lastConnection *time.Time
-		// Anonymous logins are for other controllers (for cross-model
-		// relations) - we don't need to start pingers because we
-		// don't maintain presence information for them.
-		startPinger = !result.anonymousLogin
-	)
-
 	if !result.anonymousLogin {
-		// If the user attempted to login to a migrated model,
-		// a.root.model will be nil as the model document does not
-		// exist on this controller and a.root.modelUUID cannot be
-		// resolved. In this case use the requested model UUID to check
-		// if we need to redirect the user.
-		modelUUID := a.root.modelUUID
-		if a.root.model != nil {
-			modelUUID = a.root.model.UUID()
-		}
-
-		if err := a.maybeEmitRedirectError(modelUUID, result.tag); err != nil {
-			return nil, err
-		}
-
-		authInfo, err := a.srv.authenticator.AuthenticateLoginRequest(
-			a.root.serverHost,
-			modelUUID,
-			req,
-		)
+		authInfo, err := a.srv.authenticator.AuthenticateLoginRequest(a.root.serverHost, modelUUID, req)
 		if err != nil {
 			return nil, a.handleAuthError(err)
 		}
+
 		result.controllerMachineLogin = authInfo.Controller
-		// controllerConn is used to indicate a connection from the controller
-		// to a non-controller model.
+		// controllerConn is used to indicate a connection from
+		// the controller to a non-controller model.
 		controllerConn := false
 		if authInfo.Controller && !a.root.state.IsController() {
 			// We only need to run a pinger for controller machine
@@ -288,16 +281,13 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 			startPinger = false
 			controllerConn = true
 		}
-		a.root.entity = authInfo.Entity
+
 		// TODO(wallyworld) - we can't yet observe anonymous logins as entity must be non-nil
-		a.apiObserver.Login(
-			authInfo.Entity.Tag(),
-			a.root.model.ModelTag(),
-			controllerConn,
-			req.UserData,
-		)
-	} else if a.root.model == nil { // anonymous login to unknown model
-		// Hide the fact that the model does not exist
+		a.root.entity = authInfo.Entity
+		a.apiObserver.Login(authInfo.Entity.Tag(), a.root.model.ModelTag(), controllerConn, req.UserData)
+	} else if a.root.model == nil {
+		// Anonymous login to unknown model.
+		// Hide the fact that the model does not exist.
 		return nil, errors.Unauthorizedf("invalid entity name or password")
 	}
 	a.loggedIn = true
@@ -315,6 +305,8 @@ func (a *admin) authenticate(req params.LoginRequest) (*authResult, error) {
 			return nil, errors.Trace(err)
 		}
 	}
+
+	var lastConnection *time.Time
 	if err := a.fillLoginDetails(result, lastConnection); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -338,15 +330,18 @@ func (a *admin) maybeEmitRedirectError(modelUUID string, authTag names.Tag) erro
 		return nil
 	}
 
-	// Check if the model was not found because it was migrated to another
-	// controller. If that is the case and the user was able to access it
-	// before the migration return back a RedirectError.
+	// Check if the model was not found due to
+	// being migrated to another controller.
 	mig, err := st.CompletedMigration()
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
 
-	if mig == nil || mig.ModelUserAccess(userTag) == permission.NoAccess {
+	// If a user is trying to access a migrated model to which they are not
+	// granted access, do not return a redirect error.
+	// We need to return redirects if possible for anonymous logins in order
+	// to ensure post-migration operation of CMRs.
+	if mig == nil || userTag.Id() != api.AnonymousUsername && mig.ModelUserAccess(userTag) == permission.NoAccess {
 		return nil
 	}
 
@@ -359,6 +354,7 @@ func (a *admin) maybeEmitRedirectError(modelUUID string, authTag names.Tag) erro
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	return &common.RedirectError{
 		Servers:         []network.ProviderHostPorts{hps},
 		CACert:          target.CACert,

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -341,7 +341,7 @@ func (a *admin) maybeEmitRedirectError(modelUUID string, authTag names.Tag) erro
 	// Check if the model was not found because it was migrated to another
 	// controller. If that is the case and the user was able to access it
 	// before the migration return back a RedirectError.
-	mig, err := st.CompletedMigrationForModel()
+	mig, err := st.CompletedMigration()
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -609,10 +609,11 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 	c.Assert(params.ErrCode(errors.Cause(err)), gc.Equals, params.CodeUnauthorized)
 
 	// Attempt to open an API connection to the migrated model as the
-	// anonymous user; this should also fail with a not-authorized error
+	// anonymous user; this should also be allowed on account of CMRs.
 	info.Tag = names.NewUserTag(api.AnonymousUsername)
 	_, err = api.Open(info, fastDialOpts)
-	c.Assert(params.ErrCode(errors.Cause(err)), gc.Equals, params.CodeUnauthorized)
+	redirErr, ok = errors.Cause(err).(*api.RedirectError)
+	c.Assert(ok, gc.Equals, true)
 }
 
 func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
@@ -621,7 +622,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag: names.NewUserTag("jujuanonymous").String(),
+		AuthTag: names.NewUserTag(api.AnonymousUsername).String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -647,7 +648,7 @@ func (s *loginSuite) TestAnonymousControllerLogin(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag: names.NewUserTag("jujuanonymous").String(),
+		AuthTag: names.NewUserTag(api.AnonymousUsername).String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -218,7 +218,6 @@ func (a *AuthContext) CreateConsumeOfferMacaroon(offer *params.ApplicationOfferD
 			checkers.DeclaredCaveat(offeruuidKey, offer.OfferUUID),
 			checkers.DeclaredCaveat(usernameKey, username),
 		})
-
 }
 
 // CreateRemoteRelationMacaroon creates a macaroon that authorises access to the specified relation.

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -169,7 +169,7 @@ func (st modelManagerStateShim) GetBackend(modelUUID string) (ModelManagerBacken
 
 		// Check if this model has been migrated and this user had
 		// access to it before its migration.
-		mig, mErr := otherState.CompletedMigrationForModel()
+		mig, mErr := otherState.CompletedMigration()
 		if mErr != nil && !errors.IsNotFound(mErr) {
 			return nil, nil, errors.Trace(mErr)
 		}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -82,7 +82,7 @@ func newAPIHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, modelUUID st
 		// migrated allow clients to connect and wait for a login
 		// request to decide whether the users should be redirected to
 		// the new controller for this model or not.
-		if _, migErr := st.CompletedMigrationForModel(); migErr != nil {
+		if _, migErr := st.CompletedMigration(); migErr != nil {
 			return nil, errors.Trace(err) // return original NotFound error
 		}
 	}

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -186,7 +186,7 @@ func (a *Authenticator) checkCreds(
 		// TODO log or return error returned by
 		// UpdateLastLogin? Old code didn't do
 		// anything with it.
-		entity.UpdateLastLogin()
+		_ = entity.UpdateLastLogin()
 	}
 	return authInfo, nil
 }
@@ -197,9 +197,11 @@ func (a *Authenticator) checkCreds(
 func LoginRequest(req *http.Request) (params.LoginRequest, error) {
 	authHeader := req.Header.Get("Authorization")
 	macaroons := httpbakery.RequestMacaroons(req)
+
 	if authHeader == "" {
 		return params.LoginRequest{Macaroons: macaroons}, nil
 	}
+
 	parts := strings.Fields(authHeader)
 	if len(parts) != 2 || parts[0] != "Basic" {
 		// Invalid header format or no header provided.
@@ -221,10 +223,11 @@ func LoginRequest(req *http.Request) (params.LoginRequest, error) {
 	if _, err := names.ParseTag(tagPass[0]); err != nil {
 		return params.LoginRequest{}, errors.Trace(err)
 	}
+
 	return params.LoginRequest{
 		AuthTag:     tagPass[0],
 		Credentials: tagPass[1],
-		Macaroons:   httpbakery.RequestMacaroons(req),
+		Macaroons:   macaroons,
 		Nonce:       req.Header.Get(params.MachineNonceHeader),
 	}, nil
 }

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -814,7 +814,7 @@ func checkTargetController(st *State, targetControllerTag names.ControllerTag) e
 // LatestMigration returns the most recent ModelMigration (if any) for a model
 // that has not been removed from the state. Callers interested in
 // ModelMigrations for models that have been removed after a successful
-// migration to another controller should use CompletedMigrationForModel
+// migration to another controller should use CompletedMigration
 // instead.
 func (st *State) LatestMigration() (ModelMigration, error) {
 	mig, phase, err := st.latestMigration(st.ModelUUID())
@@ -837,38 +837,26 @@ func (st *State) LatestMigration() (ModelMigration, error) {
 	return mig, nil
 }
 
-// CompletedMigrationForModel returns the most recent ModelMigration (if any)
-// for a model that has been removed from the state after
-// it reached the DONE phase and caused the model to be relocated.
-func (st *State) CompletedMigrationForModel() (ModelMigration, error) {
-	mig, phase, err := st.latestMigration(st.ModelUUID())
-	if err != nil {
-		return nil, err
-	}
-
-	// Return NotFound if the model still exists or the migration is not
-	// flagged as completed.
-	model, _ := st.Model()
-	if phase != migration.DONE || model != nil {
-		return nil, errors.NotFoundf("migration")
-	}
-
-	return mig, nil
+// CompletedMigration returns the most recent migration for this state's
+// model if it reached the DONE phase and caused the model to be relocated.
+func (st *State) CompletedMigration() (ModelMigration, error) {
+	mig, err := st.CompletedMigrationForModel(st.ModelUUID())
+	return mig, errors.Trace(err)
 }
 
-// CompletedMigration returns the most recent ModelMigration (if any)
-// for input model UUID that has been removed from the state after
-// it reached the DONE phase and caused the model to be relocated.
-func (st *State) CompletedMigration(modelUUID string) (ModelMigration, error) {
+// CompletedMigration returns the most recent migration for the
+// input model UUID if it reached the DONE phase and caused the model
+// to be relocated.
+func (st *State) CompletedMigrationForModel(modelUUID string) (ModelMigration, error) {
 	mig, phase, err := st.latestMigration(modelUUID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	// Return NotFound if the model still modelExists or the migration is not
 	// flagged as completed.
 	modelExists, err := st.ModelExists(modelUUID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if phase != migration.DONE || modelExists {
 		return nil, errors.NotFoundf("migration")

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -335,15 +335,15 @@ func (s *MigrationSuite) TestLatestRemovedModelMigration(c *gc.C) {
 		c.Assert(mig1.SetPhase(phase), jc.ErrorIsNil)
 	}
 
-	// CompletedMigrationForModel should fail as the model docs are still there
-	_, err = s.State2.CompletedMigrationForModel()
+	// CompletedMigration should fail as the model docs are still there
+	_, err = s.State2.CompletedMigration()
 	c.Assert(errors.IsNotFound(err), gc.Equals, true)
 
 	// Delete the model and check that we get back the MigrationModel
 	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	c.Assert(s.State2.RemoveDyingModel(), jc.ErrorIsNil)
 
-	mig2, err := s.State2.CompletedMigrationForModel()
+	mig2, err := s.State2.CompletedMigration()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mig2, jc.DeepEquals, mig1)
 }

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -429,11 +429,9 @@ func (fw *Firewaller) startUnit(unit *firewaller.Unit, machineTag names.MachineT
 	if err != nil {
 		return err
 	}
+
 	applicationTag := application.Tag()
 	unitTag := unit.Tag()
-	if err != nil {
-		return err
-	}
 	unitd := &unitData{
 		fw:   fw,
 		unit: unit,


### PR DESCRIPTION
## Description of change

This patch changes API server login behaviour so that redirect errors are emitted for anonymous logins when that login is attempting to access a migrated model.

This is necessary for a following patch that will redirect CMD consumers to the new controller.

## QA steps

- Bootstrap 3 controllers: `source`, `consume`, `dest`.
- `juju switch source && juju deploy mysql && juju offer mysql:db`.
- `juju switch consume && juju deploy wordpress && juju consume source:admin/default.mysql && juju add-relation wordpress mysql`.
- Wait for quiescence in this model.
- `juju switch dest && juju destroy-model default -y`.
- `juju switch source && juju migrate default dest`.
- `juju switch consume`
- Check the logs for the remote relations worker. Errors should indicate redirect instead of permission denied.

## Documentation changes

None

## Bug reference

N/A
