### PR TITLE
Fix some intermittent tests racing with internal events.

### DIFF
--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -68,6 +68,8 @@ func (s *uniterSuite) setUpTest(c *gc.C, addController bool) {
 	s.uniter, err = s.st.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
+
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 }
 
 func (s *uniterSuite) addMachineBoundAppCharmAndUnit(

--- a/api/upgrader/unitupgrader_test.go
+++ b/api/upgrader/unitupgrader_test.go
@@ -56,6 +56,8 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	// Create the upgrader facade.
 	s.st = s.stateAPI.Upgrader()
 	c.Assert(s.st, gc.NotNil)
+
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 }
 
 func (s *unitUpgraderSuite) addMachineApplicationCharmAndUnit(c *gc.C, appName string) (*state.Machine, *state.Application, *state.Charm, *state.Unit) {


### PR DESCRIPTION
With some of the testing infrastructure coming under increasing load, it changes some of the timing for the tests. This is leading to some intermittent test failures where we didn't see them before.

When tests that are full stack tests, like JujuConnSuite, and they create entities, we need to ensure that the internal events have been processed before we continue after creation, or we get spurious test failures like:
```
09:13:48 unitupgrader_test.go:132:
09:13:48     // Initial event
09:13:48     wc.AssertOneChange()
09:13:48 /home/ubuntu/go/src/github.com/juju/juju/core/watcher/watchertest/notify.go:95:
09:13:48     c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
09:13:48 ... Error: watcher sent unexpected change: (_, true)
```
