### PR TITLE
Fix action tag lookup with new ids

### DIFF
--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -200,7 +200,10 @@ func (a *ActionAPI) FindActionTagsByPrefix(arg params.FindTags) (params.FindTags
 		if err != nil {
 			return params.FindTagsResults{}, errors.Trace(err)
 		}
-		found := m.FindActionTagsById(prefix)
+		found, err := m.FindActionTagsById(prefix)
+		if err != nil {
+			return params.FindTagsResults{}, errors.Trace(err)
+		}
 		matches := make([]params.Entity, len(found))
 		for i, tag := range found {
 			matches[i] = params.Entity{Tag: tag.String()}

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -67,6 +67,10 @@ The default behavior without --wait or --watch is to immediately check and retur
 if the results are "pending" then only the available information will be
 displayed.  This is also the behavior when any negative time is given.
 
+Note: if Juju has been upgraded from 2.6 and there are old action UUIDs still in use,
+and you want to specify just the UUID prefix to match on, you will need to include up
+to at least the first "-" to disambiguate from a newer numeric id.
+
 Examples:
 
     juju show-action-output 1

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -390,11 +390,13 @@ func (s *WorkerSuite) TestScaleChangedInCluster(c *gc.C) {
 	}
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		if len(s.containerBroker.Calls()) > 0 {
+		if len(s.containerBroker.Calls()) >= 2 {
 			break
 		}
 	}
-	s.containerBroker.CheckCallNames(c, "Units", "AnnotateUnit")
+	if !s.containerBroker.CheckCallNames(c, "Units", "AnnotateUnit") {
+		return
+	}
 	c.Assert(s.containerBroker.Calls()[0].Args, jc.DeepEquals, []interface{}{"gitlab"})
 	c.Assert(s.containerBroker.Calls()[1].Args, jc.DeepEquals, []interface{}{"gitlab", "u1", names.NewUnitTag("gitlab/0")})
 


### PR DESCRIPTION
## Description of change

If juju is upgraded from 2.6 and there are old action uuids, then running new actions creates new ids such that we have a mix of old and new. Using show-action-output or using --wait would cause the new numeric id to match with an older uuid as a prefix match was done.
This PR changes to logic so that if a new ids are expected, an exact match is done. A legacy prefix match is still possible against any older uuids by including at least up to the "-" in the match string.

## QA steps

bootstrap 2.6 and run some actions until a uuid starting with 1 is used
upgrade to 2.7
run an action --wait and ensure the correct behaviour

## Bug reference

https://bugs.launchpad.net/juju/+bug/1855084
Also driveby fix for
https://bugs.launchpad.net/juju/+bug/1855093
