### PR TITLE
Fixes lp#1854232: restrict file permission for bundle export.

### DIFF
--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -23,11 +23,11 @@ import (
 
 // NewExportBundleCommand returns a fully constructed export bundle command.
 func NewExportBundleCommand() cmd.Command {
-	cmd := &exportBundleCommand{}
-	cmd.newAPIFunc = func() (ExportBundleAPI, ConfigAPI, error) {
-		return cmd.getAPIs()
+	command := &exportBundleCommand{}
+	command.newAPIFunc = func() (ExportBundleAPI, ConfigAPI, error) {
+		return command.getAPIs()
 	}
-	return modelcmd.Wrap(cmd)
+	return modelcmd.Wrap(command)
 }
 
 type exportBundleCommand struct {
@@ -122,7 +122,7 @@ func (c *exportBundleCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	filename := c.Filename
-	file, err := os.Create(filename)
+	file, err := os.OpenFile(filename, os.O_CREATE, 0600)
 	if err != nil {
 		return errors.Annotate(err, "while creating local file")
 	}

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -46,7 +46,7 @@ If --filename is not used, the configuration is printed to stdout.
 Examples:
 
     juju export-bundle
-	juju export-bundle --filename mymodel.yaml
+    juju export-bundle --filename mymodel.yaml
 
 `
 
@@ -122,7 +122,7 @@ func (c *exportBundleCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	filename := c.Filename
-	file, err := os.OpenFile(filename, os.O_CREATE, 0600)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
 		return errors.Annotate(err, "while creating local file")
 	}


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ]~~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~~
 - [ ]~~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~
 - [ ]~~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Restrict permissions to generated bundle export file to 0600.

## QA steps
1. bootstrap controller
2. deploy application
3. $ juju export-bundle --filename=mytest
4. check 'mytest' file ls -l
```
-rw-------  1 anastasia anastasia   118 Dec  9 16:53 mytest
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1854232
