### PR TITLE
[dev] use cidr based ip notation when merging lld addrs

### DIFF
--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -237,13 +237,18 @@ func backfillProviderIDs(m StateMachine, ifaces []network.InterfaceInfo) error {
 				ParentName:  existingDev.ParentName(),
 			})
 
+			addrInCIDRNotation, err := network.IPToCIDRNotation(addr.Value(), addr.SubnetCIDR())
+			if err != nil {
+				return err
+			}
+
 			addrUpdates = append(addrUpdates, state.LinkLayerDeviceAddress{
 				DeviceName:        existingDev.Name(),
 				ConfigMethod:      addr.ConfigMethod(),
 				ProviderID:        iface.ProviderAddressId,
 				ProviderNetworkID: iface.ProviderNetworkId,
 				ProviderSubnetID:  iface.ProviderSubnetId,
-				CIDRAddress:       addr.SubnetCIDR(),
+				CIDRAddress:       addrInCIDRNotation,
 				DNSServers:        addr.DNSServers(),
 				DNSSearchDomains:  addr.DNSSearchDomains(),
 				GatewayAddress:    addr.GatewayAddress(),

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -1002,7 +1002,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigBackfillsProviderIDs(c
 		ProviderID:        "addr-404",    // backfilled
 		ProviderNetworkID: "net-cafe",    // backfilled
 		ProviderSubnetID:  "subnet-f00f", //backfilled
-		CIDRAddress:       "172.31.32.0/24",
+		CIDRAddress:       "172.31.32.33/24",
 		DNSServers:        []string{"1.1.1.1"},
 		DNSSearchDomains:  []string{"cloud"},
 		GatewayAddress:    "172.31.32.1",

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -760,3 +760,15 @@ func MergedAddresses(machineAddresses, providerAddresses []SpaceAddress) []Space
 	}
 	return merged
 }
+
+// IPToCIDRNotation receives as input an IP and a CIDR value and returns back
+// the IP in CIDR notation.
+func IPToCIDRNotation(ip, cidr string) (string, error) {
+	_, netIP, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	netIP.IP = net.ParseIP(ip)
+	return netIP.String(), nil
+}

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -849,3 +849,28 @@ func (s *AddressSuite) TestSpaceAddressesToProviderAddresses(c *gc.C) {
 	_, err = addrs.ToProviderAddresses(stubLookup{})
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
+
+func (s *AddressSuite) TestIPToCIDRNotation(c *gc.C) {
+	type test struct {
+		IP   string
+		CIDR string
+		exp  string
+	}
+
+	tests := []test{{
+		IP:   "172.31.37.53",
+		CIDR: "172.31.32.0/20",
+		exp:  "172.31.37.53/20",
+	}, {
+		IP:   "192.168.0.1",
+		CIDR: "192.168.0.0/31",
+		exp:  "192.168.0.1/31",
+	}}
+
+	for i, t := range tests {
+		c.Logf("test %d: IPToCIDRNotation(%q, %q)", i, t.IP, t.CIDR)
+		got, err := network.IPToCIDRNotation(t.IP, t.CIDR)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(got, gc.Equals, t.exp)
+	}
+}


### PR DESCRIPTION
## Description of change

To create a new link layer device address, we are required to populate an object which among other things includes the IP address in CIDR notation. The code in the state package breaks this down into an IP and CIDR value which is then persisted to the DB.

When we retrieve a link layer device address from disk, we can only access the IP and subnet CIDR values.

The changes introduced by #10979 ([this](https://github.com/juju/juju/pull/10979/commits/2393a6d3d1ce273564080359a62d46090b952ceb) commit in particular) included additional logic to backfill the provider-specific IDs to existing link layer devices and their addresses. The introduced merge code would create a new set of link layer device addresses by re-using the original values (reported by the machiner) plus the provider-specific IDs. 

Unfortunately, that code contained a bug: instead of converting the existing address into CIDR format, it pulled the data from the `SubnetCIDR` method of the link layer device address. By passing that value back into the state, we ended up with invalid IP addresses for the machines (following x.y.z.0 and x.y.0.0 patterns due to the way that the state code works).

This PR contributes a small fix where we basically recombine the existing IP and CIDR into an IP-in-CIDR-format value which we can then pass to the state code and get the correct address values persisted to the DB.

## QA steps

Run `nw-network-health-aws` with this PR (this is how we caught the bug in the first place)