### PR TITLE
Speed up the loading of the all watcher.

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -879,7 +879,10 @@ func (s *backingStatus) updated(ctx *allWatcherContext) error {
 		if strings.HasSuffix(ctx.id, "#instance") {
 			newInfo.InstanceStatus = s.toStatusInfo()
 		} else {
+			// Preserve the agent version that is set on the agent status.
+			agentVersion := newInfo.AgentStatus.Version
 			newInfo.AgentStatus = s.toStatusInfo()
+			newInfo.AgentStatus.Version = agentVersion
 		}
 		info0 = &newInfo
 	default:
@@ -896,6 +899,8 @@ func (s *backingStatus) updatedUnitStatus(ctx *allWatcherContext, unitStatus mul
 	if strings.HasSuffix(ctx.id, "#charm") || s.Status == status.Error {
 		newInfo.WorkloadStatus = s.toStatusInfo()
 	} else {
+		// Preserve the agent version that is set on the agent status.
+		agentVersion := newInfo.AgentStatus.Version
 		newInfo.AgentStatus = s.toStatusInfo()
 		// If the unit was in error and now it's not, we need to reset its
 		// status back to what was previously recorded.
@@ -905,6 +910,7 @@ func (s *backingStatus) updatedUnitStatus(ctx *allWatcherContext, unitStatus mul
 			newInfo.WorkloadStatus.Data = unitStatus.Data
 			newInfo.WorkloadStatus.Since = unitStatus.Since
 		}
+		newInfo.AgentStatus.Version = agentVersion
 	}
 
 	// Retrieve the unit.
@@ -938,6 +944,8 @@ func (s *backingStatus) updatedUnitStatus(ctx *allWatcherContext, unitStatus mul
 	if applicationInfo == nil {
 		return nil
 	}
+	// TODO: this is very inefficient if there are many units and no application
+	// status set.
 	status, err := application.Status()
 	if err != nil {
 		return errors.Trace(err)

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1505,6 +1505,11 @@ func loadAllWatcherEntities(st *State, collectionByName map[string]allWatcherSta
 	// Use a single new MongoDB connection for all the work here.
 	db, closer := st.newDB()
 	defer closer()
+	start := st.clock().Now()
+	defer func() {
+		elapsed := st.clock().Now().Sub(start)
+		logger.Infof("allwatcher loaded for model %q in %s", st.ModelUUID(), elapsed)
+	}()
 
 	ctx := &allWatcherContext{
 		state:     st,

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/version"
@@ -60,6 +61,7 @@ type allWatcherBaseSuite struct {
 func (s *allWatcherBaseSuite) SetUpTest(c *gc.C) {
 	s.internalStateSuite.SetUpTest(c)
 	s.currentTime = s.state.clock().Now()
+	loggo.GetLogger("juju.state.allwatcher").SetLogLevel(loggo.TRACE)
 }
 
 // setUpScenario adds some entities to the state so that

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -898,18 +898,12 @@ func (s *allWatcherStateSuite) TestApplicationSettings(c *gc.C) {
 	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	err = b.Changed(all, watcher.Change{
-		C:  "settings",
-		Id: s.state.docID("a#dummy-application#local:quantal/quantal-dummy-1"),
+		C:  "applications",
+		Id: s.state.docID("dummy-application"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	entities = all.All()
-	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
-		&multiwatcher.ApplicationInfo{
-			ModelUUID: s.state.ModelUUID(),
-			Name:      "dummy-application",
-			CharmURL:  "local:quantal/quantal-dummy-1",
-		},
-	})
+	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{})
 }
 
 // TestStateWatcher tests the integration of the state watcher

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -43,7 +43,7 @@ func (u *UnitAgent) Status() (status.StatusInfo, error) {
 	// be in error state, but the state model more correctly records the agent
 	// itself as being in error. So we'll do that model translation here.
 	// TODO(fwereade): this should absolutely not be happpening in the model.
-	// TODO: when fixed, also fix code in status.go for UnitAgent.
+	// TODO: when fixed, also fix code in status.go for UnitAgent and backingUnit.
 	if info.Status == status.Error {
 		return status.StatusInfo{
 			Status:  status.Idle,


### PR DESCRIPTION
When the all watcher starts up, it loads all of the entities and sets up the multiwatcher store. There are a bunch of subordinate collections that are read for every individual primary entity. This leads to many small reads. The intent of this branch is introduce a context object that may precache the subordinate values to make it faster to load them.

Unfortunately there are a bunch of things that we can't yet optimize. Primarily the open ports and network address bits. In order to avoid additional database access we need to introduce ordering of collection processing, and even ordering within the collection, so we can process principals before we process subordinates. This way instead of reading the db to find the principal, we could get it out of the multiwatcher store to get the assigned machine.

These additional changes will require another pass through the code to optimize.

## QA steps

```sh
deploy any reasonable sized bundle, as bundle deployments use a multiwatcher
```

## Documentation changes

None, internal change only.