### PR TITLE
state: Support appdata for cross-model relations

### DIFF
--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -185,6 +185,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Life(), gc.Equals, params.Alive)
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	w, err := machine.Watch()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -218,7 +218,7 @@ func (s *relationUnitSuite) TestApplicationSettings(c *gc.C) {
 	s.assertInScope(c, wpRelUnit, true)
 	token := s.claimLeadershipFor(c, s.wordpressUnit)
 
-	err = s.stateRelation.UpdateApplicationSettings(s.wordpressApplication, token, map[string]interface{}{
+	err = s.stateRelation.UpdateApplicationSettings("wordpress", token, map[string]interface{}{
 		"foo": "bar",
 		"baz": "1",
 	})
@@ -279,7 +279,7 @@ func (s *relationUnitSuite) TestReadApplicationSettings(c *gc.C) {
 	settings := map[string]interface{}{
 		"app": "settings",
 	}
-	err = s.stateRelation.UpdateApplicationSettings(s.mysqlApplication, token, settings)
+	err = s.stateRelation.UpdateApplicationSettings("mysql", token, settings)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, myRelUnit, true)
 	_, apiRelUnit := s.getRelationUnits(c)

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2008,14 +2008,15 @@ func (u *UniterAPI) getRelationAppSettings(canAccess common.AuthFunc, relTag str
 		return nil, common.ErrPerm
 	}
 
-	app, err := u.st.Application(appTag.Id())
+	appName := appTag.Id()
+	_, err = rel.Endpoint(appName)
 	if errors.IsNotFound(err) {
 		return nil, common.ErrPerm
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	return rel.ApplicationSettings(app)
+	return rel.ApplicationSettings(appName)
 }
 
 func (u *UniterAPI) getRemoteRelationAppSettings(rel *state.Relation, appTag names.ApplicationTag) (map[string]interface{}, error) {
@@ -2048,12 +2049,7 @@ func (u *UniterAPI) getRemoteRelationAppSettings(rel *state.Relation, appTag nam
 		return nil, common.ErrPerm
 	}
 
-	app, err := u.st.Application(appTag.Id())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return rel.ApplicationSettings(app)
+	return rel.ApplicationSettings(appTag.Id())
 }
 
 func (u *UniterAPI) destroySubordinates(principal *state.Unit) error {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1720,15 +1720,11 @@ func (u *UniterAPI) updateApplicationSettings(rel *state.Relation, unit *state.U
 		return nil
 	}
 	token := u.leadershipChecker.LeadershipCheck(unit.ApplicationName(), unit.Name())
-	application, err := unit.Application()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	settingsMap := make(map[string]interface{}, len(settings))
 	for k, v := range settings {
 		settingsMap[k] = v
 	}
-	err = rel.UpdateApplicationSettings(application, token, settingsMap)
+	err := rel.UpdateApplicationSettings(unit.ApplicationName(), token, settingsMap)
 	if leadership.IsNotLeaderError(err) {
 		return common.ErrPerm
 	}
@@ -2008,15 +2004,13 @@ func (u *UniterAPI) getRelationAppSettings(canAccess common.AuthFunc, relTag str
 		return nil, common.ErrPerm
 	}
 
-	appName := appTag.Id()
-	_, err = rel.Endpoint(appName)
+	settings, err := rel.ApplicationSettings(appTag.Id())
 	if errors.IsNotFound(err) {
 		return nil, common.ErrPerm
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	return rel.ApplicationSettings(appName)
+	return settings, nil
 }
 
 func (u *UniterAPI) getRemoteRelationAppSettings(rel *state.Relation, appTag names.ApplicationTag) (map[string]interface{}, error) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2715,7 +2715,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettings(c *gc.C) {
 		Results: []params.ErrorResult{{nil}},
 	})
 
-	readSettings, err := rel.ApplicationSettings(s.wordpress)
+	readSettings, err := rel.ApplicationSettings("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"black midi": "of schlagenheim",
@@ -2758,7 +2758,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettingsOnly(c *gc.C) {
 		Results: []params.ErrorResult{{nil}},
 	})
 
-	readSettings, err := rel.ApplicationSettings(s.wordpress)
+	readSettings, err := rel.ApplicationSettings("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"black midi": "of schlagenheim",

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2226,7 +2226,7 @@ func (s *uniterSuite) TestReadSettings(c *gc.C) {
 
 	token := s.State.LeadershipChecker().LeadershipCheck("wordpress", "wordpress/0")
 
-	err = rel.UpdateApplicationSettings(s.wordpress, token, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("wordpress", token, map[string]interface{}{
 		"wanda": "firebaugh",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2284,7 +2284,7 @@ func (s *uniterSuite) TestReadSettingsForApplicationWhenNotLeader(c *gc.C) {
 
 	token := s.State.LeadershipChecker().LeadershipCheck("wordpress", "wordpress/1")
 
-	err = rel.UpdateApplicationSettings(s.wordpress, token, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("wordpress", token, map[string]interface{}{
 		"wanda": "firebaugh",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2308,7 +2308,7 @@ func (s *uniterSuite) TestReadSettingsForApplicationInPeerRelation(c *gc.C) {
 	rel, err := s.State.EndpointsRelation(ep)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rel.UpdateApplicationSettings(riak, &fakeToken{}, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("riak", &fakeToken{}, map[string]interface{}{
 		"deerhoof": "little hollywood",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2476,7 +2476,7 @@ func (s *uniterSuite) TestReadRemoteSettingsForApplication(c *gc.C) {
 
 	// Set some application settings for mysql and check that we can
 	// see them.
-	err = rel.UpdateApplicationSettings(s.mysql, &fakeToken{}, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("mysql", &fakeToken{}, map[string]interface{}{
 		"problem thinker": "fireproof",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2542,7 +2542,7 @@ func (s *uniterSuite) TestReadRemoteApplicationSettingsForPeerRelation(c *gc.C) 
 	rel, err := s.State.EndpointsRelation(ep)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rel.UpdateApplicationSettings(riak, &fakeToken{}, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("riak", &fakeToken{}, map[string]interface{}{
 		"black midi": "ducter",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2695,7 +2695,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettings(c *gc.C) {
 		"black midi": "ducter",
 		"battles":    "the yabba",
 	}
-	err = rel.UpdateApplicationSettings(s.wordpress, token, appSettings)
+	err = rel.UpdateApplicationSettings("wordpress", token, appSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newAppSettings := params.Settings{
@@ -2739,7 +2739,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettingsOnly(c *gc.C) {
 		"black midi": "ducter",
 		"battles":    "the yabba",
 	}
-	err = rel.UpdateApplicationSettings(s.wordpress, token, appSettings)
+	err = rel.UpdateApplicationSettings("wordpress", token, appSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newAppSettings := params.Settings{

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -913,13 +913,13 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 	wordpressAppSettings := map[string]interface{}{
 		"war": "worlds",
 	}
-	err = rel.UpdateApplicationSettings(wordpress, &fakeToken{}, wordpressAppSettings)
+	err = rel.UpdateApplicationSettings("wordpress", &fakeToken{}, wordpressAppSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	mysqlAppSettings := map[string]interface{}{
 		"million": "one",
 	}
-	err = rel.UpdateApplicationSettings(mysql, &fakeToken{}, mysqlAppSettings)
+	err = rel.UpdateApplicationSettings("mysql", &fakeToken{}, mysqlAppSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2299,14 +2299,11 @@ func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C)
 
 	newRel := rels[0]
 
-	newWpSettings, err := newRel.ApplicationSettings(newWordpress)
+	newWpSettings, err := newRel.ApplicationSettings("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newWpSettings, gc.DeepEquals, wordpressSettings)
 
-	newMysql, err := newSt.Application("mysql")
-	c.Assert(err, jc.ErrorIsNil)
-
-	newMysqlSettings, err := newRel.ApplicationSettings(newMysql)
+	newMysqlSettings, err := newRel.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newMysqlSettings, gc.DeepEquals, mysqlSettings)
 }

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2270,8 +2270,8 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C) {
-	wordpress := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
-	mysql := state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
+	state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
@@ -2280,12 +2280,12 @@ func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C)
 	wordpressSettings := map[string]interface{}{
 		"venusian": "superbug",
 	}
-	err = rel.UpdateApplicationSettings(wordpress, &fakeToken{}, wordpressSettings)
+	err = rel.UpdateApplicationSettings("wordpress", &fakeToken{}, wordpressSettings)
 	c.Assert(err, jc.ErrorIsNil)
 	mysqlSettings := map[string]interface{}{
 		"planet b": "perihelion",
 	}
-	err = rel.UpdateApplicationSettings(mysql, &fakeToken{}, mysqlSettings)
+	err = rel.UpdateApplicationSettings("mysql", &fakeToken{}, mysqlSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, newSt := s.importModel(c, s.State)

--- a/state/relation.go
+++ b/state/relation.go
@@ -807,20 +807,20 @@ func (r *Relation) ApplicationSettings(appName string) (map[string]interface{}, 
 
 // UpdateApplicationSettings updates the given application's settings
 // in this relation. It requires a current leadership token.
-func (r *Relation) UpdateApplicationSettings(app *Application, token leadership.Token, updates map[string]interface{}) error {
+func (r *Relation) UpdateApplicationSettings(appName string, token leadership.Token, updates map[string]interface{}) error {
 	// We can calculate the actual update ahead of time; it's not dependent
 	// upon the current state of the document. (*Writing* it should depend
 	// on document state, but that's handled below.)
-	ep, err := r.Endpoint(app.Name())
+	ep, err := r.Endpoint(appName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	key := relationApplicationSettingsKey(r.Id(), ep.ApplicationName)
 	err = updateLeaderSettings(r.st.db(), token, key, updates)
 	if errors.IsNotFound(err) {
-		return errors.NotFoundf("relation %q application %q", r, app.Name())
+		return errors.NotFoundf("relation %q application %q", r, appName)
 	} else if err != nil {
-		return errors.Annotatef(err, "relation %q application %q", r, app.Name())
+		return errors.Annotatef(err, "relation %q application %q", r, appName)
 	}
 	return nil
 }

--- a/state/relation.go
+++ b/state/relation.go
@@ -792,15 +792,15 @@ func relationApplicationSettingsKey(id int, application string) string {
 
 // ApplicationSettings returns the application-level settings for the
 // specified application in this relation.
-func (r *Relation) ApplicationSettings(app *Application) (map[string]interface{}, error) {
-	ep, err := r.Endpoint(app.Name())
+func (r *Relation) ApplicationSettings(appName string) (map[string]interface{}, error) {
+	ep, err := r.Endpoint(appName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	applicationKey := relationApplicationSettingsKey(r.Id(), ep.ApplicationName)
 	s, err := readSettings(r.st.db(), settingsC, applicationKey)
 	if err != nil {
-		return nil, errors.Annotatef(err, "relation %q application %q", r.String(), app.Name())
+		return nil, errors.Annotatef(err, "relation %q application %q", r.String(), appName)
 	}
 	return s.Map(), nil
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -794,13 +794,13 @@ func (s *RelationSuite) TestResumeRelationNoConsumeAccessRace(c *gc.C) {
 
 func (s *RelationSuite) TestApplicationSettings(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.HasLen, 0)
 
@@ -811,7 +811,7 @@ func (s *RelationSuite) TestApplicationSettings(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err = relation.ApplicationSettings(mysql)
+	settingsMap, err = relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"bailterspace": "blammo",
@@ -832,7 +832,7 @@ func (s *RelationSuite) TestApplicationSettingsPeer(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err := rel.ApplicationSettings(app)
+	settingsMap, err := rel.ApplicationSettings("riak")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"mermaidens": "disappear",
@@ -846,9 +846,9 @@ func (s *RelationSuite) TestApplicationSettingsErrors(c *gc.C) {
 	rel, err := s.State.EndpointsRelation(ep)
 	c.Assert(err, jc.ErrorIsNil)
 
-	unrelated := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
 
-	settings, err := rel.ApplicationSettings(unrelated)
+	settings, err := rel.ApplicationSettings("wordpress")
 	c.Assert(err, gc.ErrorMatches, `application "wordpress" is not a member of "riak:ring"`)
 	c.Assert(settings, gc.HasLen, 0)
 }
@@ -870,7 +870,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"rendezvouse": "rendezvous",
@@ -884,7 +884,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	settingsMap, err = relation.ApplicationSettings(mysql)
+	settingsMap, err = relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"rendezvouse": "rendezvous",
@@ -909,7 +909,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsNotLeader(c *gc.C) {
 	)
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: not the leader`)
 
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.HasLen, 0)
 }
@@ -936,7 +936,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: too late`)
 
 	c.Assert(token.checkedOnce, gc.Equals, true)
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.HasLen, 0)
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -855,7 +855,7 @@ func (s *RelationSuite) TestApplicationSettingsErrors(c *gc.C) {
 
 func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
@@ -863,7 +863,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 
 	// fakeToken always succeeds.
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"rendezvouse": "rendezvous",
 			"olden":       "yolk",
 		},
@@ -879,7 +879,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 
 	// Check that updates only overwrite existing keys.
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"olden": "times",
 		},
 	)
@@ -894,14 +894,14 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 
 func (s *RelationSuite) TestUpdateApplicationSettingsNotLeader(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = relation.UpdateApplicationSettings(
-		mysql,
+		"mysql",
 		&fakeToken{errors.New("not the leader")},
 		map[string]interface{}{
 			"rendezvouse": "rendezvous",
@@ -916,7 +916,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsNotLeader(c *gc.C) {
 
 func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
@@ -927,7 +927,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
 	// second attempt indicating that leadership was lost.
 	var token raceToken
 	err = relation.UpdateApplicationSettings(
-		mysql,
+		"mysql",
 		&token,
 		map[string]interface{}{
 			"rendezvouse": "rendezvous",
@@ -958,7 +958,7 @@ func (s *RelationSuite) TestWatchApplicationSettings(c *gc.C) {
 	wc.AssertOneChange()
 
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"castor": "pollux",
 		},
 	)
@@ -967,7 +967,7 @@ func (s *RelationSuite) TestWatchApplicationSettings(c *gc.C) {
 
 	// No notify for a null change.
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"castor": "pollux",
 		},
 	)
@@ -976,7 +976,7 @@ func (s *RelationSuite) TestWatchApplicationSettings(c *gc.C) {
 }
 
 func (s *RelationSuite) TestWatchApplicationSettingsOtherEnd(c *gc.C) {
-	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
@@ -993,7 +993,7 @@ func (s *RelationSuite) TestWatchApplicationSettingsOtherEnd(c *gc.C) {
 
 	// No notify if the other application's settings are changed.
 	err = relation.UpdateApplicationSettings(
-		wordpress, &fakeToken{}, map[string]interface{}{
+		"wordpress", &fakeToken{}, map[string]interface{}{
 			"grand": "palais",
 		},
 	)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1606,7 +1606,7 @@ func updateAppSettings(c *gc.C, state *state.State, rel *state.Relation, app *st
 	claimer := state.LeadershipClaimer()
 	c.Assert(claimer.ClaimLeadership(app.Name(), unitName, time.Minute), jc.ErrorIsNil)
 	token := state.LeadershipChecker().LeadershipCheck(app.Name(), unitName)
-	c.Assert(rel.UpdateApplicationSettings(app, token, settings), jc.ErrorIsNil)
+	c.Assert(rel.UpdateApplicationSettings(app.Name(), token, settings), jc.ErrorIsNil)
 }
 
 func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {

--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -115,6 +115,7 @@ func (s *RelationerSuite) TestStateDir(c *gc.C) {
 
 func (s *RelationerSuite) TestEnterLeaveScope(c *gc.C) {
 	ru1, _ := s.AddRelationUnit(c, "u/1")
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	r := relation.NewRelationer(s.apiRelUnit, s.dir)
 
 	w := ru1.Watch()


### PR DESCRIPTION
### Checklist

 - [X] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
   No API changes.
 - ~~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~
   This doesn't change behaviour yet.
 - ~~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Relation.ApplicationSettings and Relation.UpdateApplicationSettings expected Applications passed to them, but in the case of cross-model relations there won't be an Application for one of the endpoints in the model. Change them to take the application name, so that future changes can make appdata work for cross-model relations.

## QA steps

* Deploy the appdata-source and appdata-sink applications and ensure that setting the token on the source does propagate to the sink units.

```sh
juju deploy ~/juju/tests/suites/appdata/charms/appdata-source
juju deploy ~/juju/tests/suites/appdata/charms/appdata-sink
juju relate appdata-source appdata-sink
juju config appdata-source token=testvalue
```

## Documentation changes
None

## Bug reference
None