### PR TITLE
Implement SetCloudSpec() to enable providers to react to its changes.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2225,3 +2225,26 @@ func (e *environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error
 	}
 	return []string{cidr}, nil
 }
+
+// SetCloudSpec is specified in the environs.Environ interface.
+func (e *environ) SetCloudSpec(spec environs.CloudSpec) error {
+	e.ecfgMutex.Lock()
+	defer e.ecfgMutex.Unlock()
+
+	e.cloud = spec
+	// The endpoints in public-clouds.yaml from 2.0-rc2
+	// and before were wrong, so we use whatever is defined
+	// in goamz/aws if available.
+	if isBrokenCloud(e.cloud) {
+		if region, ok := aws.Regions[e.cloud.Region]; ok {
+			e.cloud.Endpoint = region.EC2Endpoint
+		}
+	}
+
+	var err error
+	e.ec2, err = awsClient(e.cloud)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -162,9 +162,6 @@ func (EnvironProvider) Version() int {
 
 func (p EnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Infof("opening model %q", args.Config.Name())
-	if err := validateCloudSpec(args.Cloud); err != nil {
-		return nil, errors.Annotate(err, "validating cloud spec")
-	}
 	uuid := args.Config.UUID()
 	namespace, err := instance.NewNamespace(uuid)
 	if err != nil {
@@ -941,6 +938,9 @@ func (e *Environ) SetCloudSpec(spec environs.CloudSpec) error {
 	e.ecfgMutex.Lock()
 	defer e.ecfgMutex.Unlock()
 
+	if err := validateCloudSpec(spec); err != nil {
+		return errors.Annotate(err, "validating cloud spec")
+	}
 	e.cloudUnlocked = spec
 	client, err := authClient(e.cloudUnlocked, e.ecfgUnlocked)
 	if err != nil {


### PR DESCRIPTION
## Description of change

Cloud credential contents can change throughout the life of the model. EnvironTracker can react to this changes and re-authenticate against a desired cloud as long as the provider implements environs.SetCloudSpec(). Currently, only maas, lxd and openstack implement this method.

This PR adds aws and gce to the mix.
As a drive-by, the validation of cloud spec on openstack provider has been moved from environ construction to SetCloudSpec(), a more appropriate location.

## QA steps

1. bootstrap
2. deploy ubuntu
3. change credential content (not validity!!) to another valid content
4. You should still be able to deploy application to default model, add new models, deploy applications to these models, destroy models and controller

