### PR TITLE
Revise random folder generation

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -64,7 +64,7 @@ bootstrap() {
     output=${1}
     shift
 
-    rnd=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
+    rnd=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8; echo '')
     name="ctrl-${rnd}"
 
     if [ ! -f "${TEST_DIR}/jujus" ]; then


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The follow changes how we generate our random folder names. Instead of
piping all of /dev/urandom to the pipe, use head to get 10 lines and
then work on that.

For some reason the original command would just hang on the head section:

>  `cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1`

I have no idea why this hangs, I can't get it to hang on any other distro release,
so instead of spending hours on this, I'm going to chalk it up as a quirk and do it
another way. That new way asks for the head (first ten lines) of urandom then
works on it.

The new way feels much more efficient, but I've done no tests to prove this! 



## QA steps

```sh
(cd tests && ./main.sh cli)
```
