### PR TITLE
featureflag: update generations flag to support branches and generations

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -126,7 +126,7 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.configFile, "file", "path to yaml-formatted application config")
 	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided comma delimited keys")
 
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Generations) || featureflag.Enabled(feature.AltGenerations) {
 		f.StringVar(&c.branchName, "branch", "", "Specifically target config for the supplied branch")
 	}
 }
@@ -190,7 +190,7 @@ func (c *configCommand) validateGeneration() error {
 	// during development. When we remove the flag, there will be tests
 	// (particularly feature tests) that will need to accommodate a value
 	// for branch in the local store.
-	if !featureflag.Enabled(feature.Generations) && c.branchName == "" {
+	if !featureflag.Enabled(feature.Generations) && !featureflag.Enabled(feature.AltGenerations) && c.branchName == "" {
 		c.branchName = model.GenerationMaster
 	}
 
@@ -429,7 +429,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 
 	err = c.out.Write(ctx, resultsMap)
 
-	if featureflag.Enabled(feature.Generations) && err == nil {
+	if (featureflag.Enabled(feature.Generations) || featureflag.Enabled(feature.AltGenerations)) && err == nil {
 		var gen string
 		gen, err = c.ActiveBranch()
 		if err == nil {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -502,7 +502,7 @@ func (c *bootstrapCommand) initializeHostedModel(
 		ModelType: hostedModelType,
 	}
 
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Generations) || featureflag.Enabled(feature.AltGenerations) {
 		modelDetails.ActiveBranch = model.GenerationMaster
 	}
 

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -255,7 +255,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		ModelUUID: model.UUID,
 		ModelType: model.Type,
 	}
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Generations) || featureflag.Enabled(feature.AltGenerations) {
 		// Default target is the master branch.
 		details.ActiveBranch = coremodel.GenerationMaster
 	}

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -225,7 +225,7 @@ func prepare(
 	details.Password = args.AdminSecret
 	details.LastKnownAccess = string(permission.SuperuserAccess)
 	details.ModelUUID = cfg.UUID()
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Generations) || featureflag.Enabled(feature.AltGenerations) {
 		details.ActiveBranch = model.GenerationMaster
 	}
 	details.ControllerDetails.Cloud = args.Cloud.Name

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -48,7 +48,10 @@ const OldPresence = "old-presence"
 const LegacyLeases = "legacy-leases"
 
 // Generations will allow for model generation functionality to be used.
-const Generations = "generations"
+const Generations = "branches"
+
+// AltGenerations is the old flag name used for generations feature
+const AltGenerations = "generations"
 
 // MongoDbSnap tells Juju to install MongoDB as a snap, rather than installing
 // it from APT.

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -47,7 +47,7 @@ func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
 	if err := addModelType(models); err != nil {
 		return nil, err
 	}
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Generations) || featureflag.Enabled(feature.AltGenerations) {
 		if err := addGeneration(models); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change`

we changed the featureflag generations/branches name from 2.7 to develop.
This patch enables to use both for UX.

## QA steps
any branches/generations cli command (add-branch...)
set the either of the dev_flags and test the commands

```sh
export JUJU_DEV_FEATURE_FLAGS=generations
juju add-branch blub
```

```sh
export JUJU_DEV_FEATURE_FLAGS=branches
juju add-branch bla
```

don't export the respective featureflag
```sh
juju add-branch bla
ERROR juju: "add-branch" is not a juju command. See "juju --help".

Did you mean:
	add-space
```
