### PR TITLE
featureflag: update generations flag to support branches and generations

### DIFF
--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -1032,7 +1032,7 @@ func (m mockLeadershipReader) Leaders() (map[string]string, error) {
 
 func setGenerationsControllerConfig(c *gc.C, st *state.State) {
 	err := st.UpdateControllerConfig(map[string]interface{}{
-		"features": []interface{}{feature.Generations},
+		"features": []interface{}{feature.Branches},
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -126,7 +126,7 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.configFile, "file", "path to yaml-formatted application config")
 	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided comma delimited keys")
 
-	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		f.StringVar(&c.branchName, "branch", "", "Specifically target config for the supplied branch")
 	}
 }
@@ -190,7 +190,7 @@ func (c *configCommand) validateGeneration() error {
 	// during development. When we remove the flag, there will be tests
 	// (particularly feature tests) that will need to accommodate a value
 	// for branch in the local store.
-	if !featureflag.Enabled(feature.Branches) && !featureflag.Enabled(feature.OldBranchesName) && c.branchName == "" {
+	if !featureflag.Enabled(feature.Branches) && !featureflag.Enabled(feature.Generations) && c.branchName == "" {
 		c.branchName = model.GenerationMaster
 	}
 
@@ -429,7 +429,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 
 	err = c.out.Write(ctx, resultsMap)
 
-	if (featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName)) && err == nil {
+	if (featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations)) && err == nil {
 		var gen string
 		gen, err = c.ActiveBranch()
 		if err == nil {

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -126,7 +126,7 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.configFile, "file", "path to yaml-formatted application config")
 	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided comma delimited keys")
 
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
 		f.StringVar(&c.branchName, "branch", "", "Specifically target config for the supplied branch")
 	}
 }
@@ -190,7 +190,7 @@ func (c *configCommand) validateGeneration() error {
 	// during development. When we remove the flag, there will be tests
 	// (particularly feature tests) that will need to accommodate a value
 	// for branch in the local store.
-	if !featureflag.Enabled(feature.Generations) && c.branchName == "" {
+	if !featureflag.Enabled(feature.Branches) && !featureflag.Enabled(feature.OldBranchesName) && c.branchName == "" {
 		c.branchName = model.GenerationMaster
 	}
 
@@ -429,7 +429,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 
 	err = c.out.Write(ctx, resultsMap)
 
-	if featureflag.Enabled(feature.Generations) && err == nil {
+	if (featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName)) && err == nil {
 		var gen string
 		gen, err = c.ActiveBranch()
 		if err == nil {

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -106,7 +106,7 @@ var getTests = []struct {
 
 func (s *configCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.Generations)
+	s.SetFeatureFlags(feature.Branches)
 
 	s.defaultCharmValues = map[string]interface{}{
 		"title":           "Nearly There",
@@ -164,7 +164,7 @@ func (s *configCommandSuite) TestGetCommandInitWithGeneration(c *gc.C) {
 }
 
 func (s *configCommandSuite) TestGetConfig(c *gc.C) {
-	s.SetFeatureFlags(feature.Generations)
+	s.SetFeatureFlags(feature.Branches)
 	for _, t := range getTests {
 		if !t.useAppConfig {
 			s.fake.appValues = nil

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -106,7 +106,7 @@ var getTests = []struct {
 
 func (s *configCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.Branches)
+	s.SetFeatureFlags(feature.Generations)
 
 	s.defaultCharmValues = map[string]interface{}{
 		"title":           "Nearly There",

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -502,7 +502,7 @@ func (c *bootstrapCommand) initializeHostedModel(
 		ModelType: hostedModelType,
 	}
 
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
 		modelDetails.ActiveBranch = model.GenerationMaster
 	}
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -502,7 +502,7 @@ func (c *bootstrapCommand) initializeHostedModel(
 		ModelType: hostedModelType,
 	}
 
-	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		modelDetails.ActiveBranch = model.GenerationMaster
 	}
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -368,7 +368,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewRevokeCommand())
 	r.Register(model.NewShowCommand())
 	r.Register(model.NewModelCredentialCommand())
-	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		r.Register(model.NewAddBranchCommand())
 		r.Register(model.NewCommitCommand())
 		r.Register(model.NewTrackBranchCommand())

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -368,7 +368,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewRevokeCommand())
 	r.Register(model.NewShowCommand())
 	r.Register(model.NewModelCredentialCommand())
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
 		r.Register(model.NewAddBranchCommand())
 		r.Register(model.NewCommitCommand())
 		r.Register(model.NewTrackBranchCommand())

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -255,7 +255,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		ModelUUID: model.UUID,
 		ModelType: model.Type,
 	}
-	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		// Default target is the master branch.
 		details.ActiveBranch = coremodel.GenerationMaster
 	}

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -255,7 +255,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		ModelUUID: model.UUID,
 		ModelType: model.Type,
 	}
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
 		// Default target is the master branch.
 		details.ActiveBranch = coremodel.GenerationMaster
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -196,7 +196,7 @@ func (s *AddModelSuite) TestInit(c *gc.C) {
 }
 
 func (s *AddModelSuite) TestAddExistingName(c *gc.C) {
-	s.SetFeatureFlags(feature.Generations)
+	s.SetFeatureFlags(feature.Branches)
 	// If there's any model details existing, we just overwrite them. The
 	// controller will error out if the model already exists. Overwriting
 	// means we'll replace any stale details from an previously existing
@@ -600,7 +600,7 @@ func (s *AddModelSuite) TestAddErrorRemoveConfigstoreInfo(c *gc.C) {
 }
 
 func (s *AddModelSuite) TestAddStoresValues(c *gc.C) {
-	s.SetFeatureFlags(feature.Generations)
+	s.SetFeatureFlags(feature.Branches)
 	const controllerName = "test-master"
 
 	_, err := s.run(c, "test")
@@ -621,7 +621,7 @@ func (s *AddModelSuite) TestAddStoresValues(c *gc.C) {
 }
 
 func (s *AddModelSuite) TestNoSwitch(c *gc.C) {
-	s.SetFeatureFlags(feature.Generations)
+	s.SetFeatureFlags(feature.Branches)
 	const controllerName = "test-master"
 	checkNoModelSelected := func() {
 		_, err := s.store.CurrentModel(controllerName)

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -219,6 +219,31 @@ func (s *AddModelSuite) TestAddExistingName(c *gc.C) {
 	})
 }
 
+// We support 2 flags for Generations/Branches. This test ensures that either works.
+func (s *AddModelSuite) TestAddExistingNameAlternativeFlagName(c *gc.C) {
+	s.SetFeatureFlags(feature.Generations)
+	// If there's any model details existing, we just overwrite them. The
+	// controller will error out if the model already exists. Overwriting
+	// means we'll replace any stale details from an previously existing
+	// model with the same name.
+	err := s.store.UpdateModel("test-master", "bob/test", jujuclient.ModelDetails{
+		ModelUUID: "stale-uuid",
+		ModelType: model.IAAS,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.run(c, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	details, err := s.store.ModelByName("test-master", "bob/test")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details, jc.DeepEquals, &jujuclient.ModelDetails{
+		ModelUUID:    "fake-model-uuid",
+		ModelType:    model.IAAS,
+		ActiveBranch: model.GenerationMaster,
+	})
+}
+
 func (s *AddModelSuite) TestAddModelUnauthorizedMentionsJujuGrant(c *gc.C) {
 	s.fakeAddModelAPI.err = &params.Error{
 		Message: "permission denied",

--- a/cmd/juju/model/package_test.go
+++ b/cmd/juju/model/package_test.go
@@ -31,7 +31,7 @@ type generationBaseSuite struct {
 
 func (s *generationBaseSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.SetFeatureFlags(feature.Generations)
+	s.SetFeatureFlags(feature.Branches)
 	s.store = jujuclient.NewMemStore()
 	s.store.CurrentControllerName = "testing"
 	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -165,7 +165,7 @@ func (ctx *context) setAgentPresence(c *gc.C, p presence.Agent) *presence.Pinger
 func (s *StatusSuite) newContext(c *gc.C) *context {
 	st := s.Environ.(testing.GetStater).GetStateInAPIServer()
 	err := st.UpdateControllerConfig(map[string]interface{}{
-		"features": []interface{}{feature.Generations},
+		"features": []interface{}{feature.Branches},
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -225,7 +225,7 @@ func prepare(
 	details.Password = args.AdminSecret
 	details.LastKnownAccess = string(permission.SuperuserAccess)
 	details.ModelUUID = cfg.UUID()
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
 		details.ActiveBranch = model.GenerationMaster
 	}
 	details.ControllerDetails.Cloud = args.Cloud.Name

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -225,7 +225,7 @@ func prepare(
 	details.Password = args.AdminSecret
 	details.LastKnownAccess = string(permission.SuperuserAccess)
 	details.ModelUUID = cfg.UUID()
-	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		details.ActiveBranch = model.GenerationMaster
 	}
 	details.ControllerDetails.Cloud = args.Cloud.Name

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -48,11 +48,11 @@ const OldPresence = "old-presence"
 const LegacyLeases = "legacy-leases"
 
 // Branches will allow for model branches functionality to be used.
-// Historically branches feature was called generations.
 const Branches = "branches"
 
-// OldBranchesName is the old flag name used for generations feature
-const OldBranchesName = "generations"
+// Generations will allow for model generation functionality to be used.
+// This is a deprecated flag name and is synonymous with "branches" above.
+const Generations = "generations"
 
 // MongoDbSnap tells Juju to install MongoDB as a snap, rather than installing
 // it from APT.

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -47,8 +47,12 @@ const OldPresence = "old-presence"
 // Mongo-based lease store, rather than by the Raft FSM.
 const LegacyLeases = "legacy-leases"
 
-// Generations will allow for model generation functionality to be used.
-const Generations = "generations"
+// Branches will allow for model branches functionality to be used.
+// Historically branches feature was called generations.
+const Branches = "branches"
+
+// OldBranchesName is the old flag name used for generations feature
+const OldBranchesName = "generations"
 
 // MongoDbSnap tells Juju to install MongoDB as a snap, rather than installing
 // it from APT.

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -47,7 +47,7 @@ func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
 	if err := addModelType(models); err != nil {
 		return nil, err
 	}
-	if featureflag.Enabled(feature.Generations) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
 		if err := addGeneration(models); err != nil {
 			return nil, err
 		}

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -47,7 +47,7 @@ func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
 	if err := addModelType(models); err != nil {
 		return nil, err
 	}
-	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.OldBranchesName) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		if err := addGeneration(models); err != nil {
 			return nil, err
 		}

--- a/jujuclient/modelsfile_test.go
+++ b/jujuclient/modelsfile_test.go
@@ -111,7 +111,7 @@ func (s *ModelsFileSuite) TestReadEmptyFile(c *gc.C) {
 }
 
 func (s *ModelsFileSuite) TestMigrateLegacyLocal(c *gc.C) {
-	s.SetFeatureFlags(feature.Generations)
+	s.SetFeatureFlags(feature.Branches)
 	err := ioutil.WriteFile(jujuclient.JujuModelsPath(), []byte(testLegacyModelsYAML), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/tests/suites/branches/active_branch.sh
+++ b/tests/suites/branches/active_branch.sh
@@ -6,9 +6,9 @@ run_indicate_active_branch_no_active() {
 
   ensure "indicate-active-branch-no-active" "${file}"
 
-  juju deploy ubuntu
+  juju deploy cs:~jameinel/ubuntu-lite-7
 
-  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+  wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
   check_not_contains "$(juju status)" "Branch"
 
@@ -28,10 +28,10 @@ run_indicate_active_branch_active() {
 
   ensure "indicate-active-branch-active" "${file}"
 
-  juju deploy ubuntu
+  juju deploy cs:~jameinel/ubuntu-lite-7
 
   juju add-branch bla
-  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+  wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
   check_contains "$(juju status)" "bla\*"
 
@@ -41,7 +41,10 @@ run_indicate_active_branch_active() {
   fi
 
   juju add-branch testtest
-  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+  wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+
+  # juju status can be slow, we might need to wait for testtest to appear
+  wait_for "active" ".branches.testtest"
 
   check_contains "$(juju status)" "testtest\*"
   check_not_contains "$(juju status)" "bla\*"


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change`

- we changed the featureflag generations/branches name from 2.7 to develop.
This patch enables to use both for UX.

- acceptancetest test-branches fix ensure that we wait for `add-branch` before asking for it.

## QA steps
any branches/generations cli command (add-branch...)
set the either of the dev_flags and test the commands

```sh
export JUJU_DEV_FEATURE_FLAGS=generations
juju add-branch blub
```

```sh
export JUJU_DEV_FEATURE_FLAGS=branches
juju add-branch bla
```

don't export the respective featureflag
```sh
juju add-branch bla
ERROR juju: "add-branch" is not a juju command. See "juju --help".

Did you mean:
	add-space
```
