### PR TITLE
Fix intermittent failure in ActionSuite.TestFindActionTagsByLegacyId

### DIFF
--- a/state/action_test.go
+++ b/state/action_test.go
@@ -601,12 +601,13 @@ func (s *ActionSuite) TestFindActionTagsByLegacyId(c *gc.C) {
 	for {
 		a, err := s.model.EnqueueAction(s.unit.Tag(), "action-1", nil)
 		c.Assert(err, jc.ErrorIsNil)
-		if unicode.IsDigit(rune(a.Id()[0])) {
+		if unicode.IsDigit(rune(a.Id()[0])) && a.Id()[0] != '0' {
 			actionToUse = a
 			uuid = a.Id()
 			break
 		}
 	}
+	c.Logf(uuid)
 
 	// Ensure there's a new action with a numeric id which
 	// matches the starting digit of the uuid above.


### PR DESCRIPTION
## Description of change

It repeatedly enqueues actions until it gets a uuid that starts with a digit, then switches to integer ids and tries to ensure a collision with the first digit of the uuid (to make sure the querying avoids them). But if the first digit of the uuid was a 0 it would fail because the numeric ids start from 1 so no actions were generated.

## QA steps

Running the test under stress-race used to fail in about 10-20 runs, now it runs way more than 50.
```sh
cd ~/juju/state; stress-race -check.f ActionSuite.TestFindActionTagsByLegacyId -check.v
```

## Documentation changes
None

## Bug reference
None