### PR TITLE
Add Build Number into version

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -40,6 +40,9 @@ jobs:
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')
       run: |
+        # temp fix for github actions bug
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        sudo rm /etc/apt/sources.list.d/dotnetdev.list
         make install-mongo-dependencies
 
     - name: "Install Mongo Dependencies: macOS-latest"

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,17 @@ GIT_TREE_STATE = $(if $(shell test -d .git || echo missing),archive,$(if $(shell
 # Example: BUILD_TAGS="minimal provider_kubernetes"
 BUILD_TAGS ?= 
 
+# Build number passed in must be a monotonic int representing
+# the build.
+JUJU_BUILD_NUMBER ?= 
+
 # Compile with debug flags if requested.
 ifeq ($(DEBUG_JUJU), 1)
     COMPILE_FLAGS = -gcflags "all=-N -l"
-    LINK_FLAGS = -ldflags "-X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE)"
+    LINK_FLAGS = -ldflags "-X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) -X $(PROJECT)/version.build=$(JUJU_BUILD_NUMBER)"
 else
     COMPILE_FLAGS =
-    LINK_FLAGS = -ldflags "-s -w -X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE)"
+    LINK_FLAGS = -ldflags "-s -w -X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) -X $(PROJECT)/version.build=$(JUJU_BUILD_NUMBER)"
 endif
 
 define DEPENDENCIES
@@ -184,29 +188,41 @@ check-deps:
 	@echo "$(GOCHECK_COUNT) instances of gocheck not in test code"
 
 # CAAS related targets
-DOCKER_USERNAME          ?= jujusolutions
-JUJUD_STAGING_DIR        ?= /tmp/jujud-operator
-JUJUD_BIN_DIR            ?= ${GOPATH}/bin
-OPERATOR_IMAGE_BUILD_SRC ?= true
-OPERATOR_IMAGE_TAG       ?= $(shell jujud version | rev | cut -d- -f3- | rev)
-OPERATOR_IMAGE_PATH      = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}
+DOCKER_USERNAME            ?= jujusolutions
+JUJUD_STAGING_DIR          ?= /tmp/jujud-operator
+JUJUD_BIN_DIR              ?= ${GOPATH}/bin
+OPERATOR_IMAGE_BUILD_SRC   ?= true
+# By default the image tag is the full version number, including the build number.
+OPERATOR_IMAGE_TAG         ?= $(shell jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}(\.[[:digit:]]{1,9})?")
+# Legacy tags never have a build number.
+OPERATOR_IMAGE_TAG_LEGACY  ?= $(shell jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}")
+OPERATOR_IMAGE_PATH         = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}
+OPERATOR_IMAGE_PATH_LEGACY  = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG_LEGACY}
 
-operator-image:
-    ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
-		make install
-    else
-		@echo "skipping to build jujud bin, use existing one at ${JUJUD_BIN_DIR}/jujud."
-    endif
+operator-check-build:
+ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
+	make install
+else
+	@echo "skipping to build jujud bin, use existing one at ${JUJUD_BIN_DIR}/jujud."
+endif
+
+operator-image: operator-check-build
 	rm -rf ${JUJUD_STAGING_DIR}
 	mkdir ${JUJUD_STAGING_DIR}
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}
 	docker build -f ${JUJUD_STAGING_DIR}/jujud-operator-dockerfile -t ${OPERATOR_IMAGE_PATH} ${JUJUD_STAGING_DIR}
+ifneq ($(OPERATOR_IMAGE_PATH),$(OPERATOR_IMAGE_PATH_LEGACY))
+	docker tag ${OPERATOR_IMAGE_PATH} ${OPERATOR_IMAGE_PATH_LEGACY}
+endif
 	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
 	docker push ${OPERATOR_IMAGE_PATH}
+ifneq ($(OPERATOR_IMAGE_PATH),$(OPERATOR_IMAGE_PATH_LEGACY))
+	docker push ${OPERATOR_IMAGE_PATH_LEGACY}
+endif
 
 microk8s-operator-update: operator-image
 	docker save ${OPERATOR_IMAGE_PATH} | microk8s.ctr --namespace k8s.io image import -

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,10 @@ else
 	CHECK_ARGS = $(TEST_ARGS)
 endif
 
-GIT_COMMIT = $(shell git -C $(PROJECT_DIR) rev-parse HEAD)
-GIT_TREE_STATE = $(if $(shell git status --porcelain),dirty,clean)
+GIT_COMMIT ?= $(shell git -C $(PROJECT_DIR) rev-parse HEAD)
+# If .git directory is missing, we are building out of an archive, otherwise report
+# if the tree that is checked out is dirty (modified) or clean.
+GIT_TREE_STATE = $(if $(shell test -d .git || echo missing),archive,$(if $(shell git status --porcelain),dirty,clean))
 
 # Build tags passed to go install/build.
 # Example: BUILD_TAGS="minimal provider_kubernetes"
@@ -40,11 +42,9 @@ BUILD_TAGS ?=
 # Compile with debug flags if requested.
 ifeq ($(DEBUG_JUJU), 1)
     COMPILE_FLAGS = -gcflags "all=-N -l"
-    LINK_FLAGS =
     LINK_FLAGS = -ldflags "-X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE)"
 else
     COMPILE_FLAGS =
-    LINK_FLAGS = -ldflags "-s -w"
     LINK_FLAGS = -ldflags "-s -w -X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE)"
 endif
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -112,7 +112,6 @@ func (a *API) OperatorProvisioningInfo() (params.OperatorProvisioningInfo, error
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	vers.Build = 0
 
 	imagePath := podcfg.GetJujuOCIImagePath(cfg, vers)
 	storageClassName, _ := modelConfig.AllAttrs()[provider.OperatorStorageKey].(string)

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -276,7 +276,6 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	vers.Build = 0
 	operatorImagePath := podcfg.GetJujuOCIImagePath(controllerCfg, vers)
 
 	filesystemParams, err := f.applicationFilesystemParams(app, controllerCfg, modelConfig)

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -66,7 +66,6 @@ func tagImagePath(path string, ver version.Number) string {
 		verString = splittedPath[1]
 	}
 	if ver != version.Zero {
-		ver.Build = 0
 		verString = ver.String()
 	}
 	if verString != "" {

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -42,6 +42,8 @@ type versionDetail struct {
 	GitTreeState string `json:"git-tree-state,omitempty" yaml:"git-tree-state,omitempty"`
 	// Compiler reported by runtime.Compiler
 	Compiler string `json:"compiler" yaml:"compiler"`
+	// Build is a monotonic integer set by Jenkins.
+	Build int `json:"build,omitempty" yaml:"build,omitempty"`
 }
 
 // NewSuperCommand is like cmd.NewSuperCommand but
@@ -64,6 +66,7 @@ func NewSuperCommand(p cmd.SuperCommandParams) *cmd.SuperCommand {
 		GitCommit:    jujuversion.GitCommit,
 		GitTreeState: jujuversion.GitTreeState,
 		Compiler:     jujuversion.Compiler,
+		Build:        jujuversion.Build,
 	}
 
 	// p.Version should be a version.Binary, but juju/cmd does not

--- a/tests/suites/static_analysis/schema.sh
+++ b/tests/suites/static_analysis/schema.sh
@@ -2,7 +2,8 @@ run_schema() {
     CUR_SHA=$(git show HEAD:apiserver/facades/schema.json | shasum -a 1 | awk '{ print $1 }')
     TMP=$(mktemp /tmp/schema-XXXXX)
     OUT=$(make --no-print-directory SCHEMA_PATH="${TMP}" rebuild-schema 2>&1)
-    if [ "${OUT}" != "Generating facade schema..." ]; then
+    OUT_CODE=$?
+    if [ $OUT_CODE -ne 0 ]; then
         echo ""
         echo "$(red 'Found some issues:')"
         echo "${OUT}"

--- a/version/version.go
+++ b/version/version.go
@@ -22,8 +22,12 @@ import (
 const version = "2.7.1"
 
 const (
+	// TreeStateDirty when the build was made with a dirty checkout.
 	TreeStateDirty = "dirty"
+	// TreeStateClean when the build was made with a clean checkout.
 	TreeStateClean = "clean"
+	// TreeStateArchive when the build was made outside of a git checkout.
+	TreeStateArchive = "archive"
 )
 
 // The version that we switched over from old style numbering to new style.

--- a/version/version.go
+++ b/version/version.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	semversion "github.com/juju/version"
@@ -33,10 +34,17 @@ const (
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = semversion.MustParse("1.19.9")
 
+// build is injected by Jenkins, it must be an integer or empty.
+var build string
+
+// Build is a monotonic number injected by Jenkins. It is added to the Current version only when
+// the version is a development build (see IsDev(1))
+var Build = mustParseBuildInt(build)
+
 // Current gives the current version of the system.  If the file
 // "FORCE-VERSION" is present in the same directory as the running
 // binary, it will override this.
-var Current = semversion.MustParse(version)
+var Current = mustParseVersion(version, build)
 
 // Compiler is the go compiler used to build the binary.
 var Compiler = runtime.Compiler
@@ -75,4 +83,23 @@ func IsDev(v semversion.Number) bool {
 		return isOdd(v.Minor) || v.Build > 0
 	}
 	return v.Tag != "" || v.Build > 0
+}
+
+func mustParseVersion(versionStr string, buildInt string) semversion.Number {
+	ver := semversion.MustParse(versionStr)
+	if IsDev(ver) {
+		ver.Build = mustParseBuildInt(buildInt)
+	}
+	return ver
+}
+
+func mustParseBuildInt(buildInt string) int {
+	if buildInt == "" {
+		return 0
+	}
+	i, err := strconv.Atoi(buildInt)
+	if err != nil {
+		panic(err)
+	}
+	return i
 }


### PR DESCRIPTION
## Description of change

- During make, allow injecting git commit and build number from env.
- Build set on CurrentVersion if the version is a dev build.
- When version tag has a build number, two docker images are tagged and pushed.
- Build number is exposed in version command.

## QA steps

```
make JUJU_BUILD_NUMBER=9001 install
juju version --all
```

## Documentation changes

N/A

## Bug reference

N/A