### PR TITLE
Fixes lp#1844976: re-authenticate cloud client when model credential changes.

### DIFF
--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -76,3 +76,42 @@ func MakeCloudSpecWatcherForModel(st *state.State) func(names.ModelTag) (state.N
 		return m.WatchCloudSpecChanges(), nil
 	}
 }
+
+// MakeCloudSpecCredentialWatcherForModel returns a function which returns a
+// NotifyWatcher for changes to a model's credential reference.
+// This watch will detect when model's credential is replaced with another credential.
+// Attempts to request a watcher for any other model other than the
+// one associated with the given state.State results in an error.
+func MakeCloudSpecCredentialWatcherForModel(st *state.State) func(names.ModelTag) (state.NotifyWatcher, error) {
+	return func(tag names.ModelTag) (state.NotifyWatcher, error) {
+		m, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if tag.Id() != st.ModelUUID() {
+			return nil, errors.New("cannot get cloud spec credential for this model")
+		}
+		return m.WatchModelCredential(), nil
+	}
+}
+
+// MakeCloudSpecCredentialContentWatcherForModel returns a function which returns a
+// NotifyWatcher for credential content changes for a single model.
+// Attempts to request a watcher for any other model other than the
+// one associated with the given state.State results in an error.
+func MakeCloudSpecCredentialContentWatcherForModel(st *state.State) func(names.ModelTag) (state.NotifyWatcher, error) {
+	return func(tag names.ModelTag) (state.NotifyWatcher, error) {
+		m, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if tag.Id() != st.ModelUUID() {
+			return nil, errors.New("cannot get cloud spec credential content for this model")
+		}
+		credentialTag, exists := m.CloudCredential()
+		if !exists {
+			return nil, nil
+		}
+		return st.WatchCredential(credentialTag), nil
+	}
+}

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -57,6 +57,8 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 			resources,
 			cloudspec.MakeCloudSpecGetterForModel(st),
 			cloudspec.MakeCloudSpecWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
 		st:        st,

--- a/apiserver/facades/agent/caasagent/caasagent.go
+++ b/apiserver/facades/agent/caasagent/caasagent.go
@@ -35,6 +35,8 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 		resources,
 		cloudspec.MakeCloudSpecGetterForModel(ctx.State()),
 		cloudspec.MakeCloudSpecWatcherForModel(ctx.State()),
+		cloudspec.MakeCloudSpecCredentialWatcherForModel(ctx.State()),
+		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(ctx.State()),
 		common.AuthFuncForTag(model.ModelTag()),
 	)
 	return &Facade{

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -151,7 +151,7 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 		return nil, common.ErrPerm
 	}
 	st := context.State()
-	clock := context.StatePool().Clock()
+	aClock := context.StatePool().Clock()
 	resources := context.Resources()
 	leadershipChecker, err := context.LeadershipChecker()
 	if err != nil {
@@ -184,10 +184,11 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 	}
 	accessUnitOrApplication := common.AuthAny(accessUnit, accessApplication)
 
-	cloudSpec := cloudspec.NewCloudSpec(
-		resources,
+	cloudSpec := cloudspec.NewCloudSpec(resources,
 		cloudspec.MakeCloudSpecGetterForModel(st),
 		cloudspec.MakeCloudSpecWatcherForModel(st),
+		cloudspec.MakeCloudSpecCredentialWatcherForModel(st),
+		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 		common.AuthFuncForTag(m.ModelTag()),
 	)
 
@@ -212,7 +213,7 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 
 		m:                 m,
 		st:                st,
-		clock:             clock,
+		clock:             aClock,
 		cancel:            context.Cancel(),
 		cacheModel:        cacheModel,
 		auth:              authorizer,

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -178,6 +178,8 @@ func NewControllerAPI(
 			resources,
 			cloudspec.MakeCloudSpecGetter(pool),
 			cloudspec.MakeCloudSpecWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
 		state:      st,

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -64,6 +64,8 @@ func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 		context.Resources(),
 		cloudspec.MakeCloudSpecGetterForModel(st),
 		cloudspec.MakeCloudSpecWatcherForModel(st),
+		cloudspec.MakeCloudSpecCredentialWatcherForModel(st),
+		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 		common.AuthFuncForTag(m.ModelTag()),
 	)
 	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st, m)}, context.Resources(), context.Auth(), cloudSpecAPI)

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -45,6 +45,8 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 		s.resources,
 		cloudspec.MakeCloudSpecGetterForModel(s.State),
 		cloudspec.MakeCloudSpecWatcherForModel(s.State),
+		cloudspec.MakeCloudSpecCredentialWatcherForModel(s.State),
+		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(s.State),
 		common.AuthFuncForTag(s.Model.ModelTag()),
 	)
 	// Create a firewaller API for the machine.


### PR DESCRIPTION
### Checklist

 - [ ] ~~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~~
 - [ ] ~~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~~
 - [ ] ~~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~~
 - [x] Do comments answer the question of why design decisions were made?

## Description of change

Each Juju model has a cloud client that allows communication with the cloud provider. When cloud information is updated on the model, CloudSpec watcher fires and causes EnvironTracker to re-authenticate this client. CloudSpec watcher was meant to have catered for the credential changes but didn't.

This PR ensures that, in addition to cloud changes  like regions, etc, CloudSpec watcher also reacts to changes to model credential reference (for example, when model credential is replaced), as well as to the changes to cloud credential content/attributes (for example, a password change). 

## QA steps

1. bootstrap
2. add model with a credential that will be manipulated, say password update 
3. deploy an application and wait for all units to stabilize
4. manipulate password both on the cloud and on Juju side
5. deploy another unit/application [units will stabilize]

## Bug reference

https://bugs.launchpad.net/juju/+bug/1844976
