### PR TITLE
New RemoteRelations Facade for Updating Model's External Controller Info

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -88,7 +88,7 @@ var facadeVersions = map[string]int{
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,
 	"RelationUnitsWatcher":         1,
-	"RemoteRelations":              1,
+	"RemoteRelations":              2,
 	"Resources":                    1,
 	"ResourcesHookContext":         1,
 	"Resumer":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -282,7 +282,8 @@ func AllFacades() *facade.Registry {
 	reg("ProxyUpdater", 1, proxyupdater.NewFacadeV1)
 	reg("ProxyUpdater", 2, proxyupdater.NewFacadeV2)
 	reg("Reboot", 2, reboot.NewRebootAPI)
-	reg("RemoteRelations", 1, remoterelations.NewStateRemoteRelationsAPI)
+	reg("RemoteRelations", 1, remoterelations.NewAPIv1)
+	reg("RemoteRelations", 2, remoterelations.NewAPI) // Adds UpdateControllersForModels.
 
 	reg("Resources", 1, resources.NewPublicFacade)
 	reg("ResourcesHookContext", 1, resourceshookcontext.NewStateFacade)
@@ -304,7 +305,7 @@ func AllFacades() *facade.Registry {
 	reg("Storage", 3, storage.NewStorageAPIV3)
 	reg("Storage", 4, storage.NewStorageAPIV4) // changes Destroy() method signature.
 	reg("Storage", 5, storage.NewStorageAPIV5) // Update and Delete storage pools and CreatePool bulk calls.
-	reg("Storage", 6, storage.NewStorageAPI)   // modify Remove to support force and maxWait; adde DetachStorage to support force and maxWait.
+	reg("Storage", 6, storage.NewStorageAPI)   // modify Remove to support force and maxWait; add DetachStorage to support force and maxWait.
 
 	reg("StorageProvisioner", 3, storageprovisioner.NewFacadeV3)
 	reg("StorageProvisioner", 4, storageprovisioner.NewFacadeV4)

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -208,6 +208,14 @@ func (st *mockState) ApplyOperation(op state.ModelOperation) error {
 	return st.NextErr()
 }
 
+func (st *mockState) UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error {
+	st.MethodCall(st, "UpdateControllerForModel", controller, modelUUID)
+	if err := st.NextErr(); err != nil {
+		return err
+	}
+	return nil
+}
+
 type mockControllerInfo struct {
 	uuid string
 	info crossmodel.ControllerInfo

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -11,41 +11,54 @@ import (
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state/watcher"
 )
 
-// RemoteRelationsAPI provides access to the RemoteRelations API facade.
-type RemoteRelationsAPI struct {
+// API provides access to version 1 of the remote relations API facade.
+type APIv1 struct {
+	*API
+}
+
+// API provides access to the remote relations API facade.
+type API struct {
 	*common.ControllerConfigAPI
 	st         RemoteRelationsState
 	resources  facade.Resources
 	authorizer facade.Authorizer
 }
 
-// NewStateRemoteRelationsAPI creates a new server-side RemoteRelationsAPI facade
-// backed by global state.
-func NewStateRemoteRelationsAPI(ctx facade.Context) (*RemoteRelationsAPI, error) {
+// NewAPI creates a new server-side API facade backed by global state.
+func NewAPIv1(ctx facade.Context) (*APIv1, error) {
+	api, err := NewAPI(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv1{api}, nil
+}
+
+// NewAPI creates a new server-side API facade backed by global state.
+func NewAPI(ctx facade.Context) (*API, error) {
 	return NewRemoteRelationsAPI(
 		stateShim{st: ctx.State(), Backend: commoncrossmodel.GetBackend(ctx.State())},
 		common.NewStateControllerConfig(ctx.State()),
 		ctx.Resources(), ctx.Auth(),
 	)
-
 }
 
-// NewRemoteRelationsAPI returns a new server-side RemoteRelationsAPI facade.
+// NewRemoteRelationsAPI returns a new server-side API facade.
 func NewRemoteRelationsAPI(
 	st RemoteRelationsState,
 	controllerCfgAPI *common.ControllerConfigAPI,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
-) (*RemoteRelationsAPI, error) {
+) (*API, error) {
 	if !authorizer.AuthController() {
 		return nil, common.ErrPerm
 	}
-	return &RemoteRelationsAPI{
+	return &API{
 		st:                  st,
 		ControllerConfigAPI: controllerCfgAPI,
 		resources:           resources,
@@ -54,7 +67,7 @@ func NewRemoteRelationsAPI(
 }
 
 // ImportRemoteEntities adds entities to the remote entities collection with the specified opaque tokens.
-func (api *RemoteRelationsAPI) ImportRemoteEntities(args params.RemoteEntityTokenArgs) (params.ErrorResults, error) {
+func (api *API) ImportRemoteEntities(args params.RemoteEntityTokenArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -65,7 +78,7 @@ func (api *RemoteRelationsAPI) ImportRemoteEntities(args params.RemoteEntityToke
 	return results, nil
 }
 
-func (api *RemoteRelationsAPI) importRemoteEntity(arg params.RemoteEntityTokenArg) error {
+func (api *API) importRemoteEntity(arg params.RemoteEntityTokenArg) error {
 	entityTag, err := names.ParseTag(arg.Tag)
 	if err != nil {
 		return errors.Trace(err)
@@ -74,7 +87,7 @@ func (api *RemoteRelationsAPI) importRemoteEntity(arg params.RemoteEntityTokenAr
 }
 
 // ExportEntities allocates unique, remote entity IDs for the given entities in the local model.
-func (api *RemoteRelationsAPI) ExportEntities(entities params.Entities) (params.TokenResults, error) {
+func (api *API) ExportEntities(entities params.Entities) (params.TokenResults, error) {
 	results := params.TokenResults{
 		Results: make([]params.TokenResult, len(entities.Entities)),
 	}
@@ -97,7 +110,7 @@ func (api *RemoteRelationsAPI) ExportEntities(entities params.Entities) (params.
 }
 
 // GetTokens returns the token associated with the entities with the given tags for the given models.
-func (api *RemoteRelationsAPI) GetTokens(args params.GetTokenArgs) (params.StringResults, error) {
+func (api *API) GetTokens(args params.GetTokenArgs) (params.StringResults, error) {
 	results := params.StringResults{
 		Results: make([]params.StringResult, len(args.Args)),
 	}
@@ -117,7 +130,7 @@ func (api *RemoteRelationsAPI) GetTokens(args params.GetTokenArgs) (params.Strin
 }
 
 // SaveMacaroons saves the macaroons for the given entities.
-func (api *RemoteRelationsAPI) SaveMacaroons(args params.EntityMacaroonArgs) (params.ErrorResults, error) {
+func (api *API) SaveMacaroons(args params.EntityMacaroonArgs) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -134,7 +147,7 @@ func (api *RemoteRelationsAPI) SaveMacaroons(args params.EntityMacaroonArgs) (pa
 }
 
 // RelationUnitSettings returns the relation unit settings for the given relation units in the local model.
-func (api *RemoteRelationsAPI) RelationUnitSettings(relationUnits params.RelationUnits) (params.SettingsResults, error) {
+func (api *API) RelationUnitSettings(relationUnits params.RelationUnits) (params.SettingsResults, error) {
 	results := params.SettingsResults{
 		Results: make([]params.SettingsResult, len(relationUnits.RelationUnits)),
 	}
@@ -163,9 +176,7 @@ func (api *RemoteRelationsAPI) RelationUnitSettings(relationUnits params.Relatio
 		for k, v := range settings {
 			vString, ok := v.(string)
 			if !ok {
-				return nil, errors.Errorf(
-					"invalid relation setting %q: expected string, got %T", k, v,
-				)
+				return nil, errors.Errorf("invalid relation setting %q: expected string, got %T", k, v)
 			}
 			paramsSettings[k] = vString
 		}
@@ -182,7 +193,7 @@ func (api *RemoteRelationsAPI) RelationUnitSettings(relationUnits params.Relatio
 	return results, nil
 }
 
-func (api *RemoteRelationsAPI) remoteRelation(entity params.Entity) (*params.RemoteRelation, error) {
+func (api *API) remoteRelation(entity params.Entity) (*params.RemoteRelation, error) {
 	tag, err := names.ParseRelationTag(entity.Tag)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -227,7 +238,7 @@ func (api *RemoteRelationsAPI) remoteRelation(entity params.Entity) (*params.Rem
 
 // Relations returns information about the cross-model relations with the specified keys
 // in the local model.
-func (api *RemoteRelationsAPI) Relations(entities params.Entities) (params.RemoteRelationResults, error) {
+func (api *API) Relations(entities params.Entities) (params.RemoteRelationResults, error) {
 	results := params.RemoteRelationResults{
 		Results: make([]params.RemoteRelationResult, len(entities.Entities)),
 	}
@@ -244,7 +255,7 @@ func (api *RemoteRelationsAPI) Relations(entities params.Entities) (params.Remot
 
 // RemoteApplications returns the current state of the remote applications with
 // the specified names in the local model.
-func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (params.RemoteApplicationResults, error) {
+func (api *API) RemoteApplications(entities params.Entities) (params.RemoteApplicationResults, error) {
 	results := params.RemoteApplicationResults{
 		Results: make([]params.RemoteApplicationResult, len(entities.Entities)),
 	}
@@ -285,7 +296,7 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 // removal, and lifecycle changes of remote applications in the model; and
 // returns the watcher ID and initial IDs of remote applications, or an error if
 // watching failed.
-func (api *RemoteRelationsAPI) WatchRemoteApplications() (params.StringsWatchResult, error) {
+func (api *API) WatchRemoteApplications() (params.StringsWatchResult, error) {
 	w := api.st.WatchRemoteApplications()
 	// TODO(jam): 2019-10-27 Watching Changes() should be protected with a select with api.ctx.Cancel()
 	if changes, ok := <-w.Changes(); ok {
@@ -301,9 +312,9 @@ func (api *RemoteRelationsAPI) WatchRemoteApplications() (params.StringsWatchRes
 // relation units involved in each specified relation in the local model,
 // and returns the watcher IDs and initial values, or an error if the relation
 // units could not be watched.
-func (api *RemoteRelationsAPI) WatchLocalRelationUnits(args params.Entities) (params.RelationUnitsWatchResults, error) {
+func (api *API) WatchLocalRelationUnits(args params.Entities) (params.RelationUnitsWatchResults, error) {
 	results := params.RelationUnitsWatchResults{
-		make([]params.RelationUnitsWatchResult, len(args.Entities)),
+		Results: make([]params.RelationUnitsWatchResult, len(args.Entities)),
 	}
 	for i, arg := range args.Entities {
 		relationTag, err := names.ParseRelationTag(arg.Tag)
@@ -332,9 +343,9 @@ func (api *RemoteRelationsAPI) WatchLocalRelationUnits(args params.Entities) (pa
 // each specified application in the local model, and returns the watcher IDs
 // and initial values, or an error if the services' relations could not be
 // watched.
-func (api *RemoteRelationsAPI) WatchRemoteApplicationRelations(args params.Entities) (params.StringsWatchResults, error) {
+func (api *API) WatchRemoteApplicationRelations(args params.Entities) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
-		make([]params.StringsWatchResult, len(args.Entities)),
+		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
 	for i, arg := range args.Entities {
 		applicationTag, err := names.ParseApplicationTag(arg.Tag)
@@ -364,7 +375,7 @@ func (api *RemoteRelationsAPI) WatchRemoteApplicationRelations(args params.Entit
 // removal, and lifecycle changes of remote relations in the model; and
 // returns the watcher ID and initial IDs of remote relations, or an error if
 // watching failed.
-func (api *RemoteRelationsAPI) WatchRemoteRelations() (params.StringsWatchResult, error) {
+func (api *API) WatchRemoteRelations() (params.StringsWatchResult, error) {
 	w := api.st.WatchRemoteRelations()
 	// TODO(jam): 2019-10-27 Watching Changes() should be protected with a select with api.ctx.Cancel()
 	if changes, ok := <-w.Changes(); ok {
@@ -378,9 +389,7 @@ func (api *RemoteRelationsAPI) WatchRemoteRelations() (params.StringsWatchResult
 
 // ConsumeRemoteRelationChanges consumes changes to settings originating
 // from the remote/offering side of relations.
-func (api *RemoteRelationsAPI) ConsumeRemoteRelationChanges(
-	changes params.RemoteRelationsChanges,
-) (params.ErrorResults, error) {
+func (api *API) ConsumeRemoteRelationChanges(changes params.RemoteRelationsChanges) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(changes.Changes)),
 	}
@@ -402,7 +411,7 @@ func (api *RemoteRelationsAPI) ConsumeRemoteRelationChanges(
 }
 
 // SetRemoteApplicationsStatus sets the status for the specified remote applications.
-func (f *RemoteRelationsAPI) SetRemoteApplicationsStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (api *API) SetRemoteApplicationsStatus(args params.SetStatus) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	result.Results = make([]params.ErrorResult, len(args.Entities))
 	for i, entity := range args.Entities {
@@ -411,7 +420,7 @@ func (f *RemoteRelationsAPI) SetRemoteApplicationsStatus(args params.SetStatus) 
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		app, err := f.st.RemoteApplication(remoteAppTag.Id())
+		app, err := api.st.RemoteApplication(remoteAppTag.Id())
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -419,7 +428,7 @@ func (f *RemoteRelationsAPI) SetRemoteApplicationsStatus(args params.SetStatus) 
 		statusValue := status.Status(entity.Status)
 		if statusValue == status.Terminated {
 			operation := app.TerminateOperation(entity.Info)
-			err = f.st.ApplyOperation(operation)
+			err = api.st.ApplyOperation(operation)
 		} else {
 			err = app.SetStatus(status.StatusInfo{
 				Status:  statusValue,
@@ -428,5 +437,46 @@ func (f *RemoteRelationsAPI) SetRemoteApplicationsStatus(args params.SetStatus) 
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}
+	return result, nil
+}
+
+// UpdateControllerForModel is not available via the V1 API.
+func (u *APIv1) UpdateControllerForModel(_, _ struct{}) {}
+
+// UpdateControllersForModels changes the external controller records for the
+// associated model entities. This is used when the remote relations worker gets
+// redirected following migration of an offering model.
+func (api *API) UpdateControllersForModels(args params.UpdateControllersForModelsParams) (params.ErrorResults, error) {
+	var result params.ErrorResults
+	result.Results = make([]params.ErrorResult, len(args.Changes))
+
+	for i, change := range args.Changes {
+		cInfo := change.Info
+
+		modelTag, err := names.ParseModelTag(change.ModelTag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+
+		controllerTag, err := names.ParseControllerTag(cInfo.ControllerTag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+
+		controller := crossmodel.ControllerInfo{
+			ControllerTag: controllerTag,
+			Alias:         cInfo.Alias,
+			Addrs:         cInfo.Addrs,
+			CACert:        cInfo.CACert,
+		}
+
+		if err := api.st.UpdateControllerForModel(controller, modelTag.Id()); err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+	}
+
 	return result, nil
 }

--- a/apiserver/facades/controller/remoterelations/state.go
+++ b/apiserver/facades/controller/remoterelations/state.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/macaroon.v2-unstable"
 
 	common "github.com/juju/juju/apiserver/common/crossmodel"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 )
 
@@ -22,7 +23,7 @@ type RemoteRelationsState interface {
 	WatchRemoteApplications() state.StringsWatcher
 
 	// WatchRemoteApplicationRelations returns a StringsWatcher that notifies of
-	// changes to the lifecycles of relations involving the specified remote
+	// changes to the life-cycles of relations involving the specified remote
 	// application.
 	WatchRemoteApplicationRelations(applicationName string) (state.StringsWatcher, error)
 
@@ -35,6 +36,10 @@ type RemoteRelationsState interface {
 
 	// SaveMacaroon saves the given macaroon for the specified entity.
 	SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error
+
+	// UpdateControllerForModel ensures that there is an external controller
+	// record for the input info, associated with the input model ID.
+	UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error
 }
 
 // TODO - CAAS(ericclaudejones): This should contain state alone, model will be
@@ -73,4 +78,12 @@ func (st stateShim) WatchRemoteApplicationRelations(applicationName string) (sta
 		return nil, errors.Trace(err)
 	}
 	return a.WatchRelations(), nil
+}
+
+// UpdateControllerForModel (RemoteRelationsState) ensures that there is an
+// external controller record for the input info,
+// associated with the input model ID.
+func (st stateShim) UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error {
+	_, err := state.NewExternalControllers(st.st).Save(controller, modelUUID)
+	return errors.Trace(err)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -28623,7 +28623,7 @@
     },
     {
         "Name": "RemoteRelations",
-        "Version": 1,
+        "Version": 2,
         "Schema": {
             "type": "object",
             "properties": {
@@ -28739,6 +28739,17 @@
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "UpdateControllersForModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateControllersForModelsParams"
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
@@ -28975,6 +28986,33 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "ExternalControllerInfo": {
+                    "type": "object",
+                    "properties": {
+                        "addrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "controller-alias": {
+                            "type": "string"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "controller-tag",
+                        "controller-alias",
+                        "addrs",
+                        "ca-cert"
                     ]
                 },
                 "GetTokenArg": {
@@ -29516,6 +29554,37 @@
                     "additionalProperties": false,
                     "required": [
                         "version"
+                    ]
+                },
+                "UpdateControllerForModel": {
+                    "type": "object",
+                    "properties": {
+                        "info": {
+                            "$ref": "#/definitions/ExternalControllerInfo"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "info"
+                    ]
+                },
+                "UpdateControllersForModelsParams": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateControllerForModel"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
                     ]
                 }
             }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -609,13 +609,18 @@ type ModifyOfferAccess struct {
 // UpdateControllerForModel contains the parameters for setting
 // a new external controller for the supplied model.
 type UpdateControllerForModel struct {
-	ModelTag string                 `json:"model-tag"`
-	Info     ExternalControllerInfo `json:"info"`
+	// ModelTag identifies the model for which to change the
+	// external controller info
+	ModelTag string `json:"model-tag"`
+
+	// Info is the new controller info for the accompanying model.
+	Info ExternalControllerInfo `json:"info"`
 }
 
 // UpdateControllersForModelsParams contains the parameters for setting
 // new external controllers for the associated models.
 type UpdateControllersForModelsParams struct {
+	// Changes is a collection of model tag and new controller info.
 	Changes []UpdateControllerForModel `json:"changes"`
 }
 

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -606,6 +606,19 @@ type ModifyOfferAccess struct {
 	OfferURL string                `json:"offer-url"`
 }
 
+// UpdateControllerForModel contains the parameters for setting
+// a new external controller for the supplied model.
+type UpdateControllerForModel struct {
+	ModelTag string                 `json:"model-tag"`
+	Info     ExternalControllerInfo `json:"info"`
+}
+
+// UpdateControllersForModelsParams contains the parameters for setting
+// new external controllers for the associated models.
+type UpdateControllersForModelsParams struct {
+	Changes []UpdateControllerForModel `json:"changes"`
+}
+
 // OfferAction is an action that can be performed on an offer.
 type OfferAction string
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch includes a new version of the remote relations API facade with a method intended for updating the external controller associated with a migrated model ID.

## QA steps

The patch to follow this one, which processes the redirect and calls this method will be accompanied by QA steps.

## Documentation changes

None.

## Bug reference

N/A
