### PR TITLE
cmd debuglog: remove option from text, which does not exist

### DIFF
--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -70,7 +70,7 @@ append filtered messages:
 Include only unit mysql/0 messages; show a maximum of 50 lines; and then
 exit:
 
-    juju debug-log -T --include unit-mysql-0 --lines 50
+    juju debug-log --include unit-mysql-0 --limit 50
 
 Include only k8s application gitlab-k8s messages:
 
@@ -78,11 +78,11 @@ Include only k8s application gitlab-k8s messages:
 
 Show all messages from unit apache2/3 or machine 1 and then exit:
 
-    juju debug-log -T --replay --include unit-apache2-3 --include machine-1
+    juju debug-log --replay --include unit-apache2-3 --include machine-1 --no-tail
 
 Show all juju.worker.uniter logging module messages that are also unit
 wordpress/0 messages, and then show any new log messages which match the
-filter:
+filter and append:
 
     juju debug-log --replay
         --include-module juju.worker.uniter \


### PR DESCRIPTION
### Checklist

 - [] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?
- [x] double check that all the examples work
----

## Description of change

We suggest using `-T`, we don't have this option defined nor does the text indicate any usage with this option besides confusing people.

I suspect that `-T` was confused with `--no-tail` this patch updates the usage description.

## QA
old:
```
$ juju debug-log --help | grep -B3 -- -T
Include only unit mysql/0 messages; show a maximum of 50 lines; and then
exit:

    juju debug-log -T --include unit-mysql-0 --lines 50
--

Show all messages from unit apache2/3 or machine 1 and then exit:

    juju debug-log -T --replay --include unit-apache2-3 --include machine-1


$ juju debug-log -T
ERROR option provided but not defined: -T
```
new: 
```
 juju debug-log --help | grep -B3 -- -T
>
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1840735