### PR TITLE
Handle CMR Redirects

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -171,9 +171,12 @@ type RedirectError struct {
 	// needs to automatically follow the redirect to the new controller.
 	FollowRedirect bool
 
-	// An optional alias for the controller the model got redirected to. It
-	// can be used by the client to present the user with a more meaningful
-	// juju login -c XYZ command
+	// ControllerTag uniquely identifies the controller being redirected to.
+	ControllerTag names.ControllerTag
+
+	// An optional alias for the controller the model got redirected to.
+	// It can be used by the client to present the user with a more
+	// meaningful juju login -c XYZ command
 	ControllerAlias string
 }
 

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -111,24 +111,6 @@ func (c *Client) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) error {
 	return nil
 }
 
-// RelationUnitSettings returns the relation unit settings for the given relation units in the local model.
-func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]params.SettingsResult, error) {
-	args := params.RelationUnits{RelationUnits: relationUnits}
-	var results params.SettingsResults
-	// Force v1 call for now. Fix coming... by babbageclunk.
-	v1Facade := base.NewFacadeCallerForVersion(
-		c.facade.RawAPICaller(),
-		"RemoteRelations", 1)
-	err := v1Facade.FacadeCall("RelationUnitSettings", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results.Results) != len(relationUnits) {
-		return nil, errors.Errorf("expected %d result(s), got %d", len(relationUnits), len(results.Results))
-	}
-	return results.Results, nil
-}
-
 // Relations returns information about the cross-model relations with the specified keys
 // in the local model.
 func (c *Client) Relations(keys []string) ([]params.RemoteRelationResult, error) {

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -5,7 +5,6 @@ package remoterelations
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/crossmodel"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/macaroon.v2"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -316,7 +316,7 @@ func (c *Client) UpdateControllerForModel(controller crossmodel.ControllerInfo, 
 	}}}
 
 	var results params.ErrorResults
-	err := c.facade.FacadeCall("ControllerAPIInfoForModels", args, &results)
+	err := c.facade.FacadeCall("UpdateControllersForModels", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -431,6 +431,7 @@ type facadeCallFunc = func(objType string, version int, id, request string, arg,
 func (s *remoteRelationsSuite) TestUpdateControllerForModelResultCount(c *gc.C) {
 	apiCaller := testing.APICallerFunc(
 		func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Assert(request, gc.Equals, "UpdateControllersForModels")
 			*(result.(*params.ErrorResults)) = params.ErrorResults{
 				Results: []params.ErrorResult{
 					{Error: &params.Error{Message: "FAIL"}},
@@ -449,6 +450,7 @@ func (s *remoteRelationsSuite) TestUpdateControllerForModelResultCount(c *gc.C) 
 func (s *remoteRelationsSuite) TestUpdateControllerForModelResultError(c *gc.C) {
 	apiCaller := testing.APICallerFunc(
 		func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Assert(request, gc.Equals, "UpdateControllersForModels")
 			*(result.(*params.ErrorResults)) = params.ErrorResults{
 				Results: []params.ErrorResult{{Error: &params.Error{Message: "FAIL"}}},
 			}
@@ -464,6 +466,7 @@ func (s *remoteRelationsSuite) TestUpdateControllerForModelResultError(c *gc.C) 
 func (s *remoteRelationsSuite) TestUpdateControllerForModelResultSuccess(c *gc.C) {
 	apiCaller := testing.APICallerFunc(
 		func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Assert(request, gc.Equals, "UpdateControllersForModels")
 			*(result.(*params.ErrorResults)) = params.ErrorResults{Results: []params.ErrorResult{{}}}
 			return nil
 		},

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -4,7 +4,6 @@
 package remoterelations_test
 
 import (
-	"github.com/juju/juju/core/crossmodel"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
@@ -13,6 +12,7 @@ import (
 	"github.com/juju/juju/api/remoterelations"
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
 	coretesting "github.com/juju/juju/testing"
 )

--- a/api/state.go
+++ b/api/state.go
@@ -69,9 +69,17 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 			var redirInfo params.RedirectErrorInfo
 			err := rpcErr.UnmarshalInfo(&redirInfo)
 			if err == nil && redirInfo.CACert != "" && len(redirInfo.Servers) != 0 {
+				var controllerTag names.ControllerTag
+				if redirInfo.ControllerTag != "" {
+					if controllerTag, err = names.ParseControllerTag(redirInfo.ControllerTag); err != nil {
+						return errors.Trace(err)
+					}
+				}
+
 				return &RedirectError{
 					Servers:         params.ToMachineHostsPorts(redirInfo.Servers),
 					CACert:          redirInfo.CACert,
+					ControllerTag:   controllerTag,
 					ControllerAlias: redirInfo.ControllerAlias,
 					FollowRedirect:  false, // user-action required
 				}

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -158,11 +158,13 @@ func (s *stateSuite) TestLoginToMigratedModel(c *gc.C) {
 	model, err := modelState.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerTag := names.NewControllerTag(utils.MustNewUUID().String())
+
 	// Migrate the model and delete it from the state
 	mig, err := modelState.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
-			ControllerTag: names.NewControllerTag(utils.MustNewUUID().String()),
+			ControllerTag: controllerTag,
 			Addrs:         []string{"1.2.3.4:5555"},
 			CACert:        coretesting.CACert,
 			AuthTag:       names.NewUserTag("user2"),
@@ -191,6 +193,7 @@ func (s *stateSuite) TestLoginToMigratedModel(c *gc.C) {
 	c.Assert(redirErr.Servers, jc.DeepEquals, []network.MachineHostPorts{nhp})
 	c.Assert(redirErr.CACert, gc.Equals, coretesting.CACert)
 	c.Assert(redirErr.FollowRedirect, gc.Equals, false)
+	c.Assert(redirErr.ControllerTag, gc.Equals, controllerTag)
 }
 
 func (s *stateSuite) TestLoginMacaroonInvalidId(c *gc.C) {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -341,7 +341,7 @@ func (a *admin) maybeEmitRedirectError(modelUUID string, authTag names.Tag) erro
 	// granted access, do not return a redirect error.
 	// We need to return redirects if possible for anonymous logins in order
 	// to ensure post-migration operation of CMRs.
-	if mig == nil || userTag.Id() != api.AnonymousUsername && mig.ModelUserAccess(userTag) == permission.NoAccess {
+	if mig == nil || (userTag.Id() != api.AnonymousUsername && mig.ModelUserAccess(userTag) == permission.NoAccess) {
 		return nil
 	}
 
@@ -358,6 +358,7 @@ func (a *admin) maybeEmitRedirectError(modelUUID string, authTag names.Tag) erro
 	return &common.RedirectError{
 		Servers:         []network.ProviderHostPorts{hps},
 		CACert:          target.CACert,
+		ControllerTag:   target.ControllerTag,
 		ControllerAlias: target.ControllerAlias,
 	}
 }

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -565,11 +565,13 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 	model, err := modelState.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerTag := names.NewControllerTag(utils.MustNewUUID().String())
+
 	// Migrate the model and delete it from the state
 	mig, err := modelState.CreateMigration(state.MigrationSpec{
 		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
-			ControllerTag:   names.NewControllerTag(utils.MustNewUUID().String()),
+			ControllerTag:   controllerTag,
 			ControllerAlias: "target",
 			Addrs:           []string{"1.2.3.4:5555"},
 			CACert:          coretesting.CACert,
@@ -601,6 +603,7 @@ func (s *loginSuite) TestMigratedModelLogin(c *gc.C) {
 	c.Assert(redirErr.Servers, jc.DeepEquals, []network.MachineHostPorts{nhp})
 	c.Assert(redirErr.CACert, gc.Equals, coretesting.CACert)
 	c.Assert(redirErr.FollowRedirect, gc.Equals, false)
+	c.Assert(redirErr.ControllerTag, gc.Equals, controllerTag)
 	c.Assert(redirErr.ControllerAlias, gc.Equals, "target")
 
 	// Attempt to open an API connection to the migrated model as a user

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -101,7 +101,7 @@ type RedirectError struct {
 	CACert string `json:"ca-cert"`
 
 	// ControllerTag uniquely identifies the controller being redirected to.
-	ControllerTag names.ControllerTag
+	ControllerTag names.ControllerTag `json:"controller-tag,omitempty"`
 
 	// An optional alias for the controller where the model got redirected to.
 	ControllerAlias string `json:"controller-alias,omitempty"`

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -100,6 +100,9 @@ type RedirectError struct {
 	// CACert holds the certificate of the remote server.
 	CACert string `json:"ca-cert"`
 
+	// ControllerTag uniquely identifies the controller being redirected to.
+	ControllerTag names.ControllerTag
+
 	// An optional alias for the controller where the model got redirected to.
 	ControllerAlias string `json:"controller-alias,omitempty"`
 }
@@ -291,9 +294,17 @@ func ServerError(err error) *params.Error {
 	case IsRedirectError(err):
 		redirErr := errors.Cause(err).(*RedirectError)
 		code = params.CodeRedirect
+
+		// Check for a zero-value tag. We don't send it over the wire if it is.
+		controllerTag := ""
+		if redirErr.ControllerTag.Id() != "" {
+			controllerTag = redirErr.ControllerTag.String()
+		}
+
 		info = params.RedirectErrorInfo{
 			Servers:         params.FromProviderHostsPorts(redirErr.Servers),
 			CACert:          redirErr.CACert,
+			ControllerTag:   controllerTag,
 			ControllerAlias: redirErr.ControllerAlias,
 		}.AsMap()
 	default:

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -502,8 +502,8 @@ func (api *API) SetRemoteApplicationsStatus(args params.SetStatus) (params.Error
 	return result, nil
 }
 
-// UpdateControllerForModel is not available via the V1 API.
-func (u *APIv1) UpdateControllerForModel(_, _ struct{}) {}
+// UpdateControllersForModels is not available via the V1 API.
+func (u *APIv1) UpdateControllersForModels(_, _ struct{}) {}
 
 // UpdateControllersForModels changes the external controller records for the
 // associated model entities. This is used when the remote relations worker gets

--- a/apiserver/facades/controller/remoterelations/state.go
+++ b/apiserver/facades/controller/remoterelations/state.go
@@ -80,10 +80,11 @@ func (st stateShim) WatchRemoteApplicationRelations(applicationName string) (sta
 	return a.WatchRelations(), nil
 }
 
-// UpdateControllerForModel (RemoteRelationsState) ensures that there is an
-// external controller record for the input info,
-// associated with the input model ID.
+// UpdateControllerForModel (RemoteRelationsState) ensures
+// that there is an external controller record for the input info,
+// associated with the input model UUID.
+// If the model UUID is associated with another external controller record,
+// that record will be modified to remove it.
 func (st stateShim) UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error {
-	_, err := state.NewExternalControllers(st.st).Save(controller, modelUUID)
-	return errors.Trace(err)
+	return errors.Trace(state.NewExternalControllers(st.st).SaveAndMoveModels(controller, modelUUID))
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -103,6 +103,9 @@ type RedirectErrorInfo struct {
 	// CACert holds the certificate of the remote server.
 	CACert string `json:"ca-cert"`
 
+	// ControllerTag uniquely identifies the controller being redirected to.
+	ControllerTag string `json:"controller-tag,omitempty"`
+
 	// An optional alias for the controller the model migrated to.
 	ControllerAlias string `json:"controller-alias,omitempty"`
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -317,7 +317,7 @@ func (conn *Conn) Close() error {
 	conn.mutex.Lock()
 	if conn.root != nil {
 		// It is possible that since we last Killed the root, other resources
-		// may have been added during some of the pending call resoulutions.
+		// may have been added during some of the pending call resolutions.
 		// So to release these resources, double tap the root.
 		conn.root.Kill()
 	}

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -17,6 +17,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -233,6 +234,11 @@ func (m *mockRelationsFacade) ControllerAPIInfoForModel(modelUUID string) (*api.
 
 func (m *mockRelationsFacade) SetRemoteApplicationStatus(applicationName string, status status.Status, message string) error {
 	m.stub.MethodCall(m, "SetRemoteApplicationStatus", applicationName, status.String(), message)
+	return nil
+}
+
+func (m *mockRelationsFacade) UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error {
+	m.stub.MethodCall(m, "UpdateControllerForModel", controller, modelUUID)
 	return nil
 }
 

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -109,6 +110,10 @@ type RemoteRelationsFacade interface {
 
 	// SetRemoteApplicationStatus sets the status for the specified remote application.
 	SetRemoteApplicationStatus(applicationName string, status status.Status, message string) error
+
+	// UpdateControllerForModel ensures that there is an external controller record
+	// for the input info, associated with the input model ID.
+	UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error
 }
 
 type newRemoteRelationsFacadeFunc func(*api.Info) (RemoteModelRelationsFacadeCloser, error)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch adds logic to the remote-relations worker that will process redirects for migrated models.

When such a redirect is received, the worker first ensures that it can establish a connection to the new controller, then updates its own external controllers collection to indicate the new location of the model.

In order to achieve this, the server-side, client-side and transport types for redirect errors have been changed to include the tag for the new controller. This is populated server-side from the migration target info.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=cmr-migrations`.
- Bootstrap 3 controllers: `source`, `consume`, `dest`.
- Ensure all controllers have logging config `<root>=DEBUG`.
- `juju switch source && juju deploy mysql && juju offer mysql:db`.
- `juju switch consume && juju deploy wordpress && juju consume source:admin/default.mysql && juju add-relation wordpress mysql`.
- Wait for quiescence in this model. This includes the wordpress unit processing of the relation-joined hook; it does a bunch of work after getting a DB relation.
- `juju switch dest && juju destroy-model default -y`.
- `juju switch source && juju migrate default dest`.
- `juju switch consume`.
- Watch the logs for the remote relations worker. The relations will be departed, then there will be a redirect, then the relations will resume.
- `juju kill-controller source -y`.
- Do something to restart the `consume` controller, such as an upgrade. Check that the remote application worker comes up using the new controller address, and everything works as desired.

## Documentation changes

None.

## Bug reference

N/A
