### PR TITLE
Add replicaset check for controller upgrade.

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
 )
 
 type clientSuite struct {
@@ -684,31 +683,6 @@ func (s *clientSuite) TestOpenUsesModelUUIDPaths(c *gc.C) {
 	})
 	c.Check(err, jc.Satisfies, params.IsCodeModelNotFound)
 	c.Assert(apistate, gc.IsNil)
-}
-
-func (s *clientSuite) TestSetModelAgentVersionDuringUpgrade(c *gc.C) {
-	// This is an integration test which ensure that a test with the
-	// correct error code is seen by the client from the
-	// SetModelAgentVersion call when an upgrade is in progress.
-	modelConfig, err := s.Model.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	agentVersion, ok := modelConfig.AgentVersion()
-	c.Assert(ok, jc.IsTrue)
-	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
-		Jobs: []state.MachineJob{state.JobManageModel},
-	})
-	err = machine.SetAgentVersion(version.MustParseBinary(agentVersion.String() + "-quantal-amd64"))
-	c.Assert(err, jc.ErrorIsNil)
-	nextVersion := version.MustParse("9.8.7")
-	_, err = s.State.EnsureUpgradeInfo(machine.Id(), agentVersion, nextVersion)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.APIState.Client().SetModelAgentVersion(nextVersion, false)
-
-	// Expect an error with a error code that indicates this specific
-	// situation. The client needs to be able to reliably identify
-	// this error and handle it differently to other errors.
-	c.Assert(params.IsCodeUpgradeInProgress(err), jc.IsTrue)
 }
 
 func (s *clientSuite) TestAbortCurrentUpgrade(c *gc.C) {

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -108,7 +108,8 @@ type Unit interface {
 // removed once all relevant methods are moved from state to model.
 type stateShim struct {
 	*state.State
-	model *state.Model
+	model   *state.Model
+	session MongoSession
 }
 
 func (s stateShim) UpdateModelConfig(u map[string]interface{}, r []string, a ...state.ValidateConfigFunc) error {
@@ -186,6 +187,9 @@ func (s stateShim) ControllerNodes() ([]state.ControllerNode, error) {
 }
 
 func (s stateShim) MongoSession() MongoSession {
+	if s.session != nil {
+		return s.session
+	}
 	return MongoSessionShim{s.State.MongoSession()}
 }
 

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -7,9 +7,11 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/replicaset"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
@@ -63,6 +65,7 @@ type Backend interface {
 	ModelConstraints() (constraints.Value, error)
 	ModelTag() names.ModelTag
 	ModelUUID() string
+	MongoSession() MongoSession
 	RemoteApplication(string) (*state.RemoteApplication, error)
 	RemoteConnectionStatus(string) (*state.RemoteConnectionStatus, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
@@ -72,6 +75,11 @@ type Backend interface {
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 	Watch(params state.WatchParams) *state.Multiwatcher
+}
+
+// MongoSession provides a way to get the status for the mongo replicaset.
+type MongoSession interface {
+	CurrentStatus() (*replicaset.Status, error)
 }
 
 // Model contains the state.Model methods used in this package.
@@ -175,4 +183,19 @@ func (s stateShim) ControllerNodes() ([]state.ControllerNode, error) {
 		result[i] = n
 	}
 	return result, nil
+}
+
+func (s stateShim) MongoSession() MongoSession {
+	return MongoSessionShim{s.State.MongoSession()}
+}
+
+// MongoSessionShim wraps a *mgo.Session to conform to the
+// MongoSession interface.
+type MongoSessionShim struct {
+	*mgo.Session
+}
+
+// CurrentStatus returns the current status of the replicaset.
+func (s MongoSessionShim) CurrentStatus() (*replicaset.Status, error) {
+	return replicaset.CurrentStatus(s.Session)
 }

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -86,6 +86,20 @@ func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.A
 	client.SetNewEnviron(apiserverClient, func() (environs.BootstrapEnviron, error) {
 		return s.newEnviron()
 	})
+	// Wrap in a happy replicaset.
+	session := &fakeSession{
+		status: &replicaset.Status{
+			Name: "test",
+			Members: []replicaset.MemberStatus{
+				{
+					Id:      1,
+					State:   replicaset.PrimaryState,
+					Address: "192.168.42.1",
+				},
+			},
+		},
+	}
+	client.OverrideClientBackendMongoSession(apiserverClient, session)
 	return apiserverClient
 }
 

--- a/apiserver/facades/client/client/export_test.go
+++ b/apiserver/facades/client/client/export_test.go
@@ -16,3 +16,19 @@ var (
 func SetNewEnviron(c *Client, newEnviron func() (environs.BootstrapEnviron, error)) {
 	c.newEnviron = newEnviron
 }
+
+// OverrideClientBackendMongoSession is necessary to provide the tests a way to
+// return a mongo session that will pretend to have a happy replicaset.
+// This is necessary right now as the tests don't run with a replicaset for
+// speed.
+func OverrideClientBackendMongoSession(c *Client, session MongoSession) {
+	c.api.stateAccessor.(*stateShim).session = session
+}
+
+func SkipReplicaCheck(patcher Patcher) {
+	patcher.PatchValue(&skipReplicaCheck, true)
+}
+
+type Patcher interface {
+	PatchValue(dest, value interface{})
+}

--- a/apiserver/facades/client/client/export_test.go
+++ b/apiserver/facades/client/client/export_test.go
@@ -24,11 +24,3 @@ func SetNewEnviron(c *Client, newEnviron func() (environs.BootstrapEnviron, erro
 func OverrideClientBackendMongoSession(c *Client, session MongoSession) {
 	c.api.stateAccessor.(*stateShim).session = session
 }
-
-func SkipReplicaCheck(patcher Patcher) {
-	patcher.PatchValue(&skipReplicaCheck, true)
-}
-
-type Patcher interface {
-	PatchValue(dest, value interface{})
-}

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api/annotations"
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/apiserver/facades/client/client"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/core/constraints"
@@ -59,6 +60,11 @@ loop:
 		p[e0] = true
 	}
 	return p
+}
+
+func (s *permSuite) SetUpTest(c *gc.C) {
+	s.baseSuite.SetUpTest(c)
+	client.SkipReplicaCheck(s)
 }
 
 func (s *permSuite) TestOperationPerm(c *gc.C) {

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -24,6 +24,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/client/client"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/model"
@@ -51,6 +52,11 @@ type UpgradeBaseSuite struct {
 
 	toolsDir string
 	coretesting.CmdBlockHelper
+}
+
+func (s *UpgradeBaseSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	client.SkipReplicaCheck(s)
 }
 
 type UpgradeJujuSuite struct {


### PR DESCRIPTION
When we come to upgrade a controller, if the mongo replicaset is not in a good state, nothing good can happen. This branch introduces a check of the replicaset status when asking to upgrade a controller.

## QA steps

```sh
juju boostrap lxd test
juju enable-ha
# Wait for them to be up.
juju ssh -m controller 2
sudo service juju-db stop
^D
juju upgrade-controller --build-agent
```
You should get an error like:

ERROR unable to upgrade, database node 3 (10.172.145.52:37017) has state DOWN

## Documentation changes

Perhaps we'll want to upgrade the docs around upgrade controller to mention that it requires a healthy replicaset.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1855956