### PR TITLE
Merge 2.7 into develop

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -40,6 +40,9 @@ jobs:
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')
       run: |
+        # temp fix for github actions bug
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        sudo rm /etc/apt/sources.list.d/dotnetdev.list
         make install-mongo-dependencies
 
     - name: "Install Mongo Dependencies: macOS-latest"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -440,11 +440,11 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:ebbd30a06de5bc3933e34d426cfaa69a0cefa10f575d520e6597acbf37e4d132"
+  digest = "1:ef49e9c114183e3d64d2ed7602dfb175213eb1ba5edcf822376104c4ba9e6e42"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "3ef4201dfd2495d7a56be07a4d095fa624167067"
+  revision = "4ca814a87a328d089e9e610538fc205d7bed3987"
 
 [[projects]]
   digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"
@@ -1443,7 +1443,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:ccd3f6144f4e55a6786e197d119b879d2b68ff26a489476cbfca7a6f83b6c5f3"
+  digest = "1:03b796f4e58386334bd38df8f1727b644ebcd282e14334035929b648c2416b7b"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1451,7 +1451,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "4e6efee6340bbada7f1e0ce873f33c15254ac2b8"
+  revision = "b0d0ce63cbe0c6e31d38e886a8c7cb20979b509d"
 
 [[projects]]
   digest = "1:e4b5e4dc87e06eae6d168f08f9787330aa88164b5f755b92d1a4600960d6c6f9"
@@ -1464,6 +1464,18 @@
   ]
   pruneopts = ""
   revision = "5ca139ef9e6bd138ab2ff3c59aee3c472d12ac89"
+
+[[projects]]
+  digest = "1:4c36061633490dc60772944614e06b4de202c271bddaef55335af989ea35dfb8"
+  name = "gopkg.in/juju/charmrepo.v4"
+  packages = [
+    ".",
+    "csclient",
+    "csclient/params",
+  ]
+  pruneopts = ""
+  revision = "cd05de29309bc2c97e7334b8316c916203b0be9d"
+  version = "v4.1.1"
 
 [[projects]]
   digest = "1:7654e769ed719c292d72af4420ca772d9c850299271e15c6f5af4fb89526c3fd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/hashicorp/raft-boltdb"
 
 [[constraint]]
-  revision = "3ef4201dfd2495d7a56be07a4d095fa624167067"
+  revision = "4ca814a87a328d089e9e610538fc205d7bed3987"
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "4e6efee6340bbada7f1e0ce873f33c15254ac2b8"
+  revision = "b0d0ce63cbe0c6e31d38e886a8c7cb20979b509d"
 
 [[constraint]]
   revision = "5ca139ef9e6bd138ab2ff3c59aee3c472d12ac89"

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -186,6 +186,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	machine, err := s.machiner.Machine(names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Life(), gc.Equals, life.Alive)
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
 	w, err := machine.Watch()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -218,7 +218,7 @@ func (s *relationUnitSuite) TestApplicationSettings(c *gc.C) {
 	s.assertInScope(c, wpRelUnit, true)
 	token := s.claimLeadershipFor(c, s.wordpressUnit)
 
-	err = s.stateRelation.UpdateApplicationSettings(s.wordpressApplication, token, map[string]interface{}{
+	err = s.stateRelation.UpdateApplicationSettings("wordpress", token, map[string]interface{}{
 		"foo": "bar",
 		"baz": "1",
 	})
@@ -279,7 +279,7 @@ func (s *relationUnitSuite) TestReadApplicationSettings(c *gc.C) {
 	settings := map[string]interface{}{
 		"app": "settings",
 	}
-	err = s.stateRelation.UpdateApplicationSettings(s.mysqlApplication, token, settings)
+	err = s.stateRelation.UpdateApplicationSettings("mysql", token, settings)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, myRelUnit, true)
 	_, apiRelUnit := s.getRelationUnits(c)

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -76,3 +76,42 @@ func MakeCloudSpecWatcherForModel(st *state.State) func(names.ModelTag) (state.N
 		return m.WatchCloudSpecChanges(), nil
 	}
 }
+
+// MakeCloudSpecCredentialWatcherForModel returns a function which returns a
+// NotifyWatcher for changes to a model's credential reference.
+// This watch will detect when model's credential is replaced with another credential.
+// Attempts to request a watcher for any other model other than the
+// one associated with the given state.State results in an error.
+func MakeCloudSpecCredentialWatcherForModel(st *state.State) func(names.ModelTag) (state.NotifyWatcher, error) {
+	return func(tag names.ModelTag) (state.NotifyWatcher, error) {
+		m, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if tag.Id() != st.ModelUUID() {
+			return nil, errors.New("cannot get cloud spec credential for this model")
+		}
+		return m.WatchModelCredential(), nil
+	}
+}
+
+// MakeCloudSpecCredentialContentWatcherForModel returns a function which returns a
+// NotifyWatcher for credential content changes for a single model.
+// Attempts to request a watcher for any other model other than the
+// one associated with the given state.State results in an error.
+func MakeCloudSpecCredentialContentWatcherForModel(st *state.State) func(names.ModelTag) (state.NotifyWatcher, error) {
+	return func(tag names.ModelTag) (state.NotifyWatcher, error) {
+		m, err := st.Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if tag.Id() != st.ModelUUID() {
+			return nil, errors.New("cannot get cloud spec credential content for this model")
+		}
+		credentialTag, exists := m.CloudCredential()
+		if !exists {
+			return nil, nil
+		}
+		return st.WatchCredential(credentialTag), nil
+	}
+}

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -58,6 +58,8 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 			resources,
 			cloudspec.MakeCloudSpecGetterForModel(st),
 			cloudspec.MakeCloudSpecWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
 		st:        st,

--- a/apiserver/facades/agent/caasagent/caasagent.go
+++ b/apiserver/facades/agent/caasagent/caasagent.go
@@ -35,6 +35,8 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 		resources,
 		cloudspec.MakeCloudSpecGetterForModel(ctx.State()),
 		cloudspec.MakeCloudSpecWatcherForModel(ctx.State()),
+		cloudspec.MakeCloudSpecCredentialWatcherForModel(ctx.State()),
+		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(ctx.State()),
 		common.AuthFuncForTag(model.ModelTag()),
 	)
 	return &Facade{

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2226,7 +2226,7 @@ func (s *uniterSuite) TestReadSettings(c *gc.C) {
 
 	token := s.State.LeadershipChecker().LeadershipCheck("wordpress", "wordpress/0")
 
-	err = rel.UpdateApplicationSettings(s.wordpress, token, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("wordpress", token, map[string]interface{}{
 		"wanda": "firebaugh",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2284,7 +2284,7 @@ func (s *uniterSuite) TestReadSettingsForApplicationWhenNotLeader(c *gc.C) {
 
 	token := s.State.LeadershipChecker().LeadershipCheck("wordpress", "wordpress/1")
 
-	err = rel.UpdateApplicationSettings(s.wordpress, token, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("wordpress", token, map[string]interface{}{
 		"wanda": "firebaugh",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2308,7 +2308,7 @@ func (s *uniterSuite) TestReadSettingsForApplicationInPeerRelation(c *gc.C) {
 	rel, err := s.State.EndpointsRelation(ep)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rel.UpdateApplicationSettings(riak, &fakeToken{}, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("riak", &fakeToken{}, map[string]interface{}{
 		"deerhoof": "little hollywood",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2476,7 +2476,7 @@ func (s *uniterSuite) TestReadRemoteSettingsForApplication(c *gc.C) {
 
 	// Set some application settings for mysql and check that we can
 	// see them.
-	err = rel.UpdateApplicationSettings(s.mysql, &fakeToken{}, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("mysql", &fakeToken{}, map[string]interface{}{
 		"problem thinker": "fireproof",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2542,7 +2542,7 @@ func (s *uniterSuite) TestReadRemoteApplicationSettingsForPeerRelation(c *gc.C) 
 	rel, err := s.State.EndpointsRelation(ep)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = rel.UpdateApplicationSettings(riak, &fakeToken{}, map[string]interface{}{
+	err = rel.UpdateApplicationSettings("riak", &fakeToken{}, map[string]interface{}{
 		"black midi": "ducter",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2695,7 +2695,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettings(c *gc.C) {
 		"black midi": "ducter",
 		"battles":    "the yabba",
 	}
-	err = rel.UpdateApplicationSettings(s.wordpress, token, appSettings)
+	err = rel.UpdateApplicationSettings("wordpress", token, appSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newAppSettings := params.Settings{
@@ -2715,7 +2715,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettings(c *gc.C) {
 		Results: []params.ErrorResult{{nil}},
 	})
 
-	readSettings, err := rel.ApplicationSettings(s.wordpress)
+	readSettings, err := rel.ApplicationSettings("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"black midi": "of schlagenheim",
@@ -2739,7 +2739,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettingsOnly(c *gc.C) {
 		"black midi": "ducter",
 		"battles":    "the yabba",
 	}
-	err = rel.UpdateApplicationSettings(s.wordpress, token, appSettings)
+	err = rel.UpdateApplicationSettings("wordpress", token, appSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newAppSettings := params.Settings{
@@ -2758,7 +2758,7 @@ func (s *uniterSuite) TestUpdateSettingsWithAppSettingsOnly(c *gc.C) {
 		Results: []params.ErrorResult{{nil}},
 	})
 
-	readSettings, err := rel.ApplicationSettings(s.wordpress)
+	readSettings, err := rel.ApplicationSettings("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(readSettings, gc.DeepEquals, map[string]interface{}{
 		"black midi": "of schlagenheim",

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -178,6 +178,8 @@ func NewControllerAPI(
 			resources,
 			cloudspec.MakeCloudSpecGetter(pool),
 			cloudspec.MakeCloudSpecWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialWatcherForModel(st),
+			cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 			common.AuthFuncForTag(model.ModelTag()),
 		),
 		state:      st,

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -436,6 +436,7 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 		"ControllerTag",
 		"Cloud",
 		"CloudCredential",
+		"ComposeNewModelConfig",
 		"ControllerConfig",
 		"NewModel",
 		"Close",
@@ -466,10 +467,15 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 	c.Assert(uuid, gc.Not(gc.Equals), s.caasSt.controllerModel.cfg.UUID())
 
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":          "foo",
-		"type":          "kubernetes",
-		"uuid":          uuid,
-		"agent-version": jujuversion.Current.String(),
+		"name":                              "foo",
+		"type":                              "kubernetes",
+		"uuid":                              uuid,
+		"agent-version":                     jujuversion.Current.String(),
+		"storage-default-block-source":      "kubernetes",
+		"storage-default-filesystem-source": "kubernetes",
+		"something":                         "value",
+		"operator-storage":                  "",
+		"workload-storage":                  "",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -65,6 +65,8 @@ func NewStateFirewallerAPIV3(context facade.Context) (*FirewallerAPIV3, error) {
 		context.Resources(),
 		cloudspec.MakeCloudSpecGetterForModel(st),
 		cloudspec.MakeCloudSpecWatcherForModel(st),
+		cloudspec.MakeCloudSpecCredentialWatcherForModel(st),
+		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(st),
 		common.AuthFuncForTag(m.ModelTag()),
 	)
 	return NewFirewallerAPI(stateShim{st: st, State: firewall.StateShim(st, m)}, context.Resources(), context.Auth(), cloudSpecAPI)

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -45,6 +45,8 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 		s.resources,
 		cloudspec.MakeCloudSpecGetterForModel(s.State),
 		cloudspec.MakeCloudSpecWatcherForModel(s.State),
+		cloudspec.MakeCloudSpecCredentialWatcherForModel(s.State),
+		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(s.State),
 		common.AuthFuncForTag(s.Model.ModelTag()),
 	)
 	// Create a firewaller API for the machine.

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -269,7 +269,12 @@ var caasCloudTypes = map[string]bool{
 
 // CloudIsCAAS checks if cloud is a CAAS cloud.
 func CloudIsCAAS(cloud Cloud) bool {
-	return caasCloudTypes[cloud.Type]
+	return CloudTypeIsCAAS(cloud.Type)
+}
+
+// CloudTypeIsCAAS checks if a given cloud type is a CAAS cloud
+func CloudTypeIsCAAS(cloudType string) bool {
+	return caasCloudTypes[cloudType]
 }
 
 // CloudByName returns the cloud with the specified name.

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -126,7 +126,7 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.configFile, "file", "path to yaml-formatted application config")
 	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided comma delimited keys")
 
-	if featureflag.Enabled(feature.Branches) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		f.StringVar(&c.branchName, "branch", "", "Specifically target config for the supplied branch")
 	}
 }
@@ -190,7 +190,7 @@ func (c *configCommand) validateGeneration() error {
 	// during development. When we remove the flag, there will be tests
 	// (particularly feature tests) that will need to accommodate a value
 	// for branch in the local store.
-	if !featureflag.Enabled(feature.Branches) && c.branchName == "" {
+	if !featureflag.Enabled(feature.Branches) && !featureflag.Enabled(feature.Generations) && c.branchName == "" {
 		c.branchName = model.GenerationMaster
 	}
 
@@ -429,7 +429,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 
 	err = c.out.Write(ctx, resultsMap)
 
-	if featureflag.Enabled(feature.Branches) && err == nil {
+	if (featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations)) && err == nil {
 		var gen string
 		gen, err = c.ActiveBranch()
 		if err == nil {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -502,7 +502,7 @@ func (c *bootstrapCommand) initializeHostedModel(
 		ModelType: hostedModelType,
 	}
 
-	if featureflag.Enabled(feature.Branches) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		modelDetails.ActiveBranch = model.GenerationMaster
 	}
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -368,7 +368,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewRevokeCommand())
 	r.Register(model.NewShowCommand())
 	r.Register(model.NewModelCredentialCommand())
-	if featureflag.Enabled(feature.Branches) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		r.Register(model.NewAddBranchCommand())
 		r.Register(model.NewCommitCommand())
 		r.Register(model.NewTrackBranchCommand())

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -255,7 +255,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 		ModelUUID: model.UUID,
 		ModelType: model.Type,
 	}
-	if featureflag.Enabled(feature.Branches) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		// Default target is the master branch.
 		details.ActiveBranch = coremodel.GenerationMaster
 	}

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -225,7 +225,7 @@ func prepare(
 	details.Password = args.AdminSecret
 	details.LastKnownAccess = string(permission.SuperuserAccess)
 	details.ModelUUID = cfg.UUID()
-	if featureflag.Enabled(feature.Branches) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		details.ActiveBranch = model.GenerationMaster
 	}
 	details.ControllerDetails.Cloud = args.Cloud.Name

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -47,9 +47,12 @@ const OldPresence = "old-presence"
 // Mongo-based lease store, rather than by the Raft FSM.
 const LegacyLeases = "legacy-leases"
 
-// Branches will allow for model generation functionality to be used.
-// Historically we called this feature generations. There can be left overs where it is still called that.
+// Branches will allow for model branches functionality to be used.
 const Branches = "branches"
+
+// Generations will allow for model generation functionality to be used.
+// This is a deprecated flag name and is synonymous with "branches" above.
+const Generations = "generations"
 
 // MongoDbSnap tells Juju to install MongoDB as a snap, rather than installing
 // it from APT.

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -47,7 +47,7 @@ func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
 	if err := addModelType(models); err != nil {
 		return nil, err
 	}
-	if featureflag.Enabled(feature.Branches) {
+	if featureflag.Enabled(feature.Branches) || featureflag.Enabled(feature.Generations) {
 		if err := addGeneration(models); err != nil {
 			return nil, err
 		}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1040,13 +1040,13 @@ func (s *MigrationExportSuite) TestRelations(c *gc.C) {
 	wordpressAppSettings := map[string]interface{}{
 		"war": "worlds",
 	}
-	err = rel.UpdateApplicationSettings(wordpress, &fakeToken{}, wordpressAppSettings)
+	err = rel.UpdateApplicationSettings("wordpress", &fakeToken{}, wordpressAppSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	mysqlAppSettings := map[string]interface{}{
 		"million": "one",
 	}
-	err = rel.UpdateApplicationSettings(mysql, &fakeToken{}, mysqlAppSettings)
+	err = rel.UpdateApplicationSettings("mysql", &fakeToken{}, mysqlAppSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2430,8 +2430,8 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C) {
-	wordpress := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
-	mysql := state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
+	state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	rel, err := s.State.AddRelation(eps...)
@@ -2440,12 +2440,12 @@ func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C)
 	wordpressSettings := map[string]interface{}{
 		"venusian": "superbug",
 	}
-	err = rel.UpdateApplicationSettings(wordpress, &fakeToken{}, wordpressSettings)
+	err = rel.UpdateApplicationSettings("wordpress", &fakeToken{}, wordpressSettings)
 	c.Assert(err, jc.ErrorIsNil)
 	mysqlSettings := map[string]interface{}{
 		"planet b": "perihelion",
 	}
-	err = rel.UpdateApplicationSettings(mysql, &fakeToken{}, mysqlSettings)
+	err = rel.UpdateApplicationSettings("mysql", &fakeToken{}, mysqlSettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, newSt := s.importModel(c, s.State)
@@ -2459,14 +2459,11 @@ func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C)
 
 	newRel := rels[0]
 
-	newWpSettings, err := newRel.ApplicationSettings(newWordpress)
+	newWpSettings, err := newRel.ApplicationSettings("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newWpSettings, gc.DeepEquals, wordpressSettings)
 
-	newMysql, err := newSt.Application("mysql")
-	c.Assert(err, jc.ErrorIsNil)
-
-	newMysqlSettings, err := newRel.ApplicationSettings(newMysql)
+	newMysqlSettings, err := newRel.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newMysqlSettings, gc.DeepEquals, mysqlSettings)
 }

--- a/state/relation.go
+++ b/state/relation.go
@@ -792,35 +792,35 @@ func relationApplicationSettingsKey(id int, application string) string {
 
 // ApplicationSettings returns the application-level settings for the
 // specified application in this relation.
-func (r *Relation) ApplicationSettings(app *Application) (map[string]interface{}, error) {
-	ep, err := r.Endpoint(app.Name())
+func (r *Relation) ApplicationSettings(appName string) (map[string]interface{}, error) {
+	ep, err := r.Endpoint(appName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	applicationKey := relationApplicationSettingsKey(r.Id(), ep.ApplicationName)
 	s, err := readSettings(r.st.db(), settingsC, applicationKey)
 	if err != nil {
-		return nil, errors.Annotatef(err, "relation %q application %q", r.String(), app.Name())
+		return nil, errors.Annotatef(err, "relation %q application %q", r.String(), appName)
 	}
 	return s.Map(), nil
 }
 
 // UpdateApplicationSettings updates the given application's settings
 // in this relation. It requires a current leadership token.
-func (r *Relation) UpdateApplicationSettings(app *Application, token leadership.Token, updates map[string]interface{}) error {
+func (r *Relation) UpdateApplicationSettings(appName string, token leadership.Token, updates map[string]interface{}) error {
 	// We can calculate the actual update ahead of time; it's not dependent
 	// upon the current state of the document. (*Writing* it should depend
 	// on document state, but that's handled below.)
-	ep, err := r.Endpoint(app.Name())
+	ep, err := r.Endpoint(appName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	key := relationApplicationSettingsKey(r.Id(), ep.ApplicationName)
 	err = updateLeaderSettings(r.st.db(), token, key, updates)
 	if errors.IsNotFound(err) {
-		return errors.NotFoundf("relation %q application %q", r, app.Name())
+		return errors.NotFoundf("relation %q application %q", r, appName)
 	} else if err != nil {
-		return errors.Annotatef(err, "relation %q application %q", r, app.Name())
+		return errors.Annotatef(err, "relation %q application %q", r, appName)
 	}
 	return nil
 }

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -794,13 +794,13 @@ func (s *RelationSuite) TestResumeRelationNoConsumeAccessRace(c *gc.C) {
 
 func (s *RelationSuite) TestApplicationSettings(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.HasLen, 0)
 
@@ -811,7 +811,7 @@ func (s *RelationSuite) TestApplicationSettings(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err = relation.ApplicationSettings(mysql)
+	settingsMap, err = relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"bailterspace": "blammo",
@@ -832,7 +832,7 @@ func (s *RelationSuite) TestApplicationSettingsPeer(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err := rel.ApplicationSettings(app)
+	settingsMap, err := rel.ApplicationSettings("riak")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"mermaidens": "disappear",
@@ -846,16 +846,16 @@ func (s *RelationSuite) TestApplicationSettingsErrors(c *gc.C) {
 	rel, err := s.State.EndpointsRelation(ep)
 	c.Assert(err, jc.ErrorIsNil)
 
-	unrelated := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
 
-	settings, err := rel.ApplicationSettings(unrelated)
+	settings, err := rel.ApplicationSettings("wordpress")
 	c.Assert(err, gc.ErrorMatches, `application "wordpress" is not a member of "riak:ring"`)
 	c.Assert(settings, gc.HasLen, 0)
 }
 
 func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
@@ -863,14 +863,14 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 
 	// fakeToken always succeeds.
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"rendezvouse": "rendezvous",
 			"olden":       "yolk",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"rendezvouse": "rendezvous",
@@ -879,12 +879,12 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 
 	// Check that updates only overwrite existing keys.
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"olden": "times",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	settingsMap, err = relation.ApplicationSettings(mysql)
+	settingsMap, err = relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.DeepEquals, map[string]interface{}{
 		"rendezvouse": "rendezvous",
@@ -894,14 +894,14 @@ func (s *RelationSuite) TestUpdateApplicationSettingsSuccess(c *gc.C) {
 
 func (s *RelationSuite) TestUpdateApplicationSettingsNotLeader(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = relation.UpdateApplicationSettings(
-		mysql,
+		"mysql",
 		&fakeToken{errors.New("not the leader")},
 		map[string]interface{}{
 			"rendezvouse": "rendezvous",
@@ -909,14 +909,14 @@ func (s *RelationSuite) TestUpdateApplicationSettingsNotLeader(c *gc.C) {
 	)
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: not the leader`)
 
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.HasLen, 0)
 }
 
 func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	relation, err := s.State.AddRelation(eps...)
@@ -927,7 +927,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
 	// second attempt indicating that leadership was lost.
 	var token raceToken
 	err = relation.UpdateApplicationSettings(
-		mysql,
+		"mysql",
 		&token,
 		map[string]interface{}{
 			"rendezvouse": "rendezvous",
@@ -936,7 +936,7 @@ func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: too late`)
 
 	c.Assert(token.checkedOnce, gc.Equals, true)
-	settingsMap, err := relation.ApplicationSettings(mysql)
+	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.HasLen, 0)
 }
@@ -958,7 +958,7 @@ func (s *RelationSuite) TestWatchApplicationSettings(c *gc.C) {
 	wc.AssertOneChange()
 
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"castor": "pollux",
 		},
 	)
@@ -967,7 +967,7 @@ func (s *RelationSuite) TestWatchApplicationSettings(c *gc.C) {
 
 	// No notify for a null change.
 	err = relation.UpdateApplicationSettings(
-		mysql, &fakeToken{}, map[string]interface{}{
+		"mysql", &fakeToken{}, map[string]interface{}{
 			"castor": "pollux",
 		},
 	)
@@ -976,7 +976,7 @@ func (s *RelationSuite) TestWatchApplicationSettings(c *gc.C) {
 }
 
 func (s *RelationSuite) TestWatchApplicationSettingsOtherEnd(c *gc.C) {
-	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
@@ -993,7 +993,7 @@ func (s *RelationSuite) TestWatchApplicationSettingsOtherEnd(c *gc.C) {
 
 	// No notify if the other application's settings are changed.
 	err = relation.UpdateApplicationSettings(
-		wordpress, &fakeToken{}, map[string]interface{}{
+		"wordpress", &fakeToken{}, map[string]interface{}{
 			"grand": "palais",
 		},
 	)

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1606,7 +1606,7 @@ func updateAppSettings(c *gc.C, state *state.State, rel *state.Relation, app *st
 	claimer := state.LeadershipClaimer()
 	c.Assert(claimer.ClaimLeadership(app.Name(), unitName, time.Minute), jc.ErrorIsNil)
 	token := state.LeadershipChecker().LeadershipCheck(app.Name(), unitName)
-	c.Assert(rel.UpdateApplicationSettings(app, token, settings), jc.ErrorIsNil)
+	c.Assert(rel.UpdateApplicationSettings(app.Name(), token, settings), jc.ErrorIsNil)
 }
 
 func (s *WatchUnitsSuite) TestProviderRequirerGlobal(c *gc.C) {

--- a/tests/suites/branches/active_branch.sh
+++ b/tests/suites/branches/active_branch.sh
@@ -6,9 +6,9 @@ run_indicate_active_branch_no_active() {
 
   ensure "indicate-active-branch-no-active" "${file}"
 
-  juju deploy ubuntu
+  juju deploy cs:~jameinel/ubuntu-lite-7
 
-  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+  wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
   check_not_contains "$(juju status)" "Branch"
 
@@ -28,10 +28,10 @@ run_indicate_active_branch_active() {
 
   ensure "indicate-active-branch-active" "${file}"
 
-  juju deploy ubuntu
+  juju deploy cs:~jameinel/ubuntu-lite-7
 
   juju add-branch bla
-  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+  wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
   check_contains "$(juju status)" "bla\*"
 
@@ -41,7 +41,10 @@ run_indicate_active_branch_active() {
   fi
 
   juju add-branch testtest
-  wait_for "ubuntu" "$(idle_condition "ubuntu")"
+  wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+
+  # juju status can be slow, we might need to wait for testtest to appear
+  wait_for "active" ".branches.testtest"
 
   check_contains "$(juju status)" "testtest\*"
   check_not_contains "$(juju status)" "bla\*"

--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -115,6 +115,7 @@ func (s *RelationerSuite) TestStateDir(c *gc.C) {
 
 func (s *RelationerSuite) TestEnterLeaveScope(c *gc.C) {
 	ru1, _ := s.AddRelationUnit(c, "u/1")
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	r := relation.NewRelationer(s.apiRelUnit, s.dir)
 
 	w := ru1.Watch()


### PR DESCRIPTION
Merge 2.7 forward for:
- Mechanical changes for Firewall Rules #11026
- Update juju/bundlechanges dep #11015
- featureflag: update generations flag to support branches and generations #11011
- state: Support appdata for cross-model relations #11004
- Fixes add-model config for CAAS #11005
- Fixes lp#1844976: re-authenticate cloud client when model credential changes. #11018
