### PR TITLE
Make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,11 +234,11 @@ operator-image:
 	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
-## push-operator-image: Push up the build operator image via docker
+## push-operator-image: Push up the new built operator image via docker
 	docker push ${OPERATOR_IMAGE_PATH}
 
 microk8s-operator-update: operator-image
-## microk8s-operator-update: Save and update the operator image for use with microk8s
+## microk8s-operator-update: Push up the new built operator image for use with microk8s
 	docker save ${OPERATOR_IMAGE_PATH} | microk8s.ctr --namespace k8s.io image import -
 
 check-k8s-model:
@@ -247,7 +247,7 @@ check-k8s-model:
 	@juju show-model ${JUJU_K8S_MODEL} > /dev/null
 
 local-operator-update: check-k8s-model operator-image
-## local-operator-update: Update local operator image
+## local-operator-update: Build then update local operator image
 	$(eval kubeworkers != juju status -m ${JUJU_K8S_MODEL} kubernetes-worker --format json | jq -c '.machines | keys' | tr  -c '[:digit:]' ' ' 2>&1)
 	docker save ${OPERATOR_IMAGE_PATH} | gzip > /tmp/jujud-operator-image.tar.gz
 	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/jujud-operator-image.tar.gz $(wm):/tmp/jujud-operator-image.tar.gz ; )
@@ -256,7 +256,7 @@ local-operator-update: check-k8s-model operator-image
 STATIC_ANALYSIS_JOB ?= 
 
 static-analysis:
-## statick-analysis: Check the go code using static-analysis
+## static-analysis: Check the go code using static-analysis
 	@cd tests && ./main.sh static_analysis ${STATIC_ANALYSIS_JOB}
 
 .PHONY: build check install release-install release-build go-build go-install

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ endef
 
 default: build
 
+.PHONY: help
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | sort | column -t -s ':' |  sed -e 's/^/ /'
+
 # Start of GOPATH-dependent targets. Some targets only make sense -
 # and will only work - when this tree is found on the GOPATH.
 ifeq ($(CURDIR),$(PROJECT_DIR))
@@ -71,40 +76,52 @@ $(GOPATH)/bin/dep:
 
 # populate vendor/ from Gopkg.lock without updating it first (lock file is the single source of truth for machine).
 dep: $(GOPATH)/bin/dep
+## dep: Installs go dependencies
 	$(GOPATH)/bin/dep ensure -vendor-only $(verbose)
 endif
 
 build: dep rebuild-schema go-build
+## build: Create Juju binaries
 
 release-build: dep go-build
+## release-build: Construct Juju binaries, without building schema
 
 release-install: dep go-install
+## release-install: Install Juju binaries
 
 pre-check:
+## pre-check: Verify go code via static analysis
 	@echo running pre-test checks
 	@INCLUDE_GOLINTERS=1 $(PROJECT_DIR)/scripts/verify.bash
 
 check: dep pre-check run-tests
+## check: Verify Juju code using static analysis and unit tests
 
 test: dep run-tests
+## test: Verify Juju code using unit tests
 
 # Can't make the length of the TMP dir too long or it hits socket name length issues.
 run-tests:
+## run-tests: Run the unit tests
 	$(eval TMP := $(shell mktemp -d jj-XXX --tmpdir))
 	@echo 'go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$PROJECT_PACKAGES -check.v'
 	@TMPDIR=$(TMP) go test --tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(PROJECT_PACKAGES) -check.v
 	@rm -r $(TMP)
 
 install: dep rebuild-schema go-install
+## install: Install Juju binaries
 
 clean:
+## clean: Clean the cache and test caches
 	go clean -n -r --cache --testcache $(PROJECT_PACKAGES)
 
 go-install:
+## go-install: Install Juju binaries without updating dependencies
 	@echo 'go install -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $$PROJECT_PACKAGES'
 	@go install -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $(PROJECT_PACKAGES)
 
 go-build:
+## go-build: Build Juju binaries without updating dependencies
 	@go build -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(PROJECT_PACKAGES)
 
 else # --------------------------------
@@ -126,17 +143,21 @@ endif
 
 # Reformat source files.
 format:
+## format: Format the go source code
 	gofmt -w -l .
 
 # Reformat and simplify source files.
 simplify:
+## simplify: Format and simplify the go source code
 	gofmt -w -l -s .
 
 # update Gopkg.lock (if needed), but do not update `vendor/`.
 rebuild-dependencies:
+## rebuild-dependencies: Update the dependencies
 	dep ensure -v -no-vendor $(dep-update)
 
 rebuild-schema:
+## rebuild-schema: Rebuild the schema for clients with the latest facades
 	@echo "Generating facade schema..."
 ifdef SCHEMA_PATH
 	@go run ./generate/schemagen/schemagen.go "$(SCHEMA_PATH)"
@@ -148,10 +169,12 @@ endif
 # Install packages required to develop Juju and run tests. The stable
 # PPA includes the required mongodb-server binaries.
 install-snap-dependencies:
+## install-snap-dependencies: Install the supported snap dependencies
 	@echo Installing go-1.12 snap
 	@sudo snap install go --channel=1.12/stable --classic
 
 install-mongo-dependencies:
+## install-mongo-dependencies: Install Mongo and its dependencies
 	@echo Adding juju PPA for mongodb
 	@sudo apt-add-repository --yes ppa:juju/stable
 	@sudo apt-get update
@@ -161,15 +184,18 @@ install-mongo-dependencies:
 	$(shell apt-cache madison mongodb-server-core juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
 
 install-dependencies: install-snap-dependencies install-mongo-dependencies
+## install-dependencies: Install all the dependencies
 	@echo "Installing dependencies"
 
 # Install bash_completion
 install-etc:
+## install-etc: Install auto-completion
 	@echo Installing bash completion
 	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju /usr/share/bash-completion/completions
 	@sudo install -o root -g root -m 644 etc/bash_completion.d/juju-version /usr/share/bash-completion/completions
 
 setup-lxd:
+## setup-lxd: Auto configure LXD
 ifeq ($(shell ifconfig lxdbr0 2>&1 | grep -q "inet addr" && echo true),true)
 	@echo IPv4 networking is already setup for LXD.
 	@echo run "sudo scripts/setup-lxd.sh" to reconfigure IPv4 networking
@@ -181,6 +207,7 @@ endif
 
 GOCHECK_COUNT="$(shell go list -f '{{join .Deps "\n"}}' github.com/juju/juju/... | grep -c "gopkg.in/check.v*")"
 check-deps:
+## check-deps: Check dependencies are correct versions
 	@echo "$(GOCHECK_COUNT) instances of gocheck not in test code"
 
 # CAAS related targets
@@ -192,6 +219,7 @@ OPERATOR_IMAGE_TAG       ?= $(shell jujud version | rev | cut -d- -f3- | rev)
 OPERATOR_IMAGE_PATH      = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}
 
 operator-image:
+## operator-imaage: Build the operator image
     ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
 		make install
     else
@@ -206,16 +234,20 @@ operator-image:
 	rm -rf ${JUJUD_STAGING_DIR}
 
 push-operator-image: operator-image
+## push-operator-image: Push up the build operator image via docker
 	docker push ${OPERATOR_IMAGE_PATH}
 
 microk8s-operator-update: operator-image
+## microk8s-operator-update: Save and update the operator image for use with microk8s
 	docker save ${OPERATOR_IMAGE_PATH} | microk8s.ctr --namespace k8s.io image import -
 
 check-k8s-model:
+## check-k8s-model: Check if k8s model is present in show-model
 	@:$(if $(value JUJU_K8S_MODEL),, $(error Undefined JUJU_K8S_MODEL))
 	@juju show-model ${JUJU_K8S_MODEL} > /dev/null
 
 local-operator-update: check-k8s-model operator-image
+## local-operator-update: Update local operator image
 	$(eval kubeworkers != juju status -m ${JUJU_K8S_MODEL} kubernetes-worker --format json | jq -c '.machines | keys' | tr  -c '[:digit:]' ' ' 2>&1)
 	docker save ${OPERATOR_IMAGE_PATH} | gzip > /tmp/jujud-operator-image.tar.gz
 	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} /tmp/jujud-operator-image.tar.gz $(wm):/tmp/jujud-operator-image.tar.gz ; )
@@ -224,6 +256,7 @@ local-operator-update: check-k8s-model operator-image
 STATIC_ANALYSIS_JOB ?= 
 
 static-analysis:
+## statick-analysis: Check the go code using static-analysis
 	@cd tests && ./main.sh static_analysis ${STATIC_ANALYSIS_JOB}
 
 .PHONY: build check install release-install release-build go-build go-install


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Understanding what is inside make can be somewhat annoying as we have a
LOT of if statements. The following commit aims to solve this, by adding
a very rudimental help command that will print out what's available.

I've already found it quite useful since I added this locally, so I'm
pushing this up so others might also find this beneficial.

It's really easy to add a new item to the help, just start a comment
with double hashes (##) and it will be picked up.

   `## <cmd name>: <description of cmd>`

The output for the make file currently is the following:

```sh
➜ make help
Usage:

  build                        Create Juju binaries
  check-deps                   Check dependencies are correct versions
  check-k8s-model              Check if k8s model is present in show-model
  check                        Verify Juju code using static analysis and unit tests
  clean                        Clean the cache and test caches
  dep                          Installs go dependencies
  format                       Format the go source code
  go-build                     Build Juju binaries without updating dependencies
  go-install                   Install Juju binaries without updating dependencies
  install-dependencies         Install all the dependencies
  install-etc                  Install auto-completion
  install                      Install Juju binaries
  install-mongo-dependencies   Install Mongo and its dependencies
  install-snap-dependencies    Install the supported snap dependencies
  local-operator-update        Update local operator image
  microk8s-operator-update     Save and update the operator image for use with microk8s
  operator-imaage              Build the operator image
  pre-check                    Verify go code via static analysis
  push-operator-image          Push up the build operator image via docker
  rebuild-dependencies         Update the dependencies
  rebuild-schema               Rebuild the schema for clients with the latest facades
  release-build                Construct Juju binaries, without building schema
  release-install              Install Juju binaries
  run-tests                    Run the unit tests
  setup-lxd                    Auto configure LXD
  simplify                     Format and simplify the go source code
  statick-analysis             Check the go code using static-analysis
  test                         Verify Juju code using unit tests
```

## QA steps

```sh
make help
```
