### PR TITLE
Add SaveAndMoveModels to ExternalControllers

### DIFF
--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -51,6 +51,17 @@ type externalControllerDoc struct {
 	Models []string `bson:"models"`
 }
 
+// newExternalControllerDoc returns a new external controller document
+// reference representing the input controller info.
+func newExternalControllerDoc(controller crossmodel.ControllerInfo) *externalControllerDoc {
+	return &externalControllerDoc{
+		Id:     controller.ControllerTag.Id(),
+		Alias:  controller.Alias,
+		Addrs:  controller.Addrs,
+		CACert: controller.CACert,
+	}
+}
+
 // Id implements ExternalController.
 func (rc *externalController) Id() string {
 	return rc.doc.Id
@@ -69,6 +80,7 @@ func (rc *externalController) ControllerInfo() crossmodel.ControllerInfo {
 // ExternalControllers instances provide access to external controllers in state.
 type ExternalControllers interface {
 	Save(_ crossmodel.ControllerInfo, modelUUIDs ...string) (ExternalController, error)
+	SaveAndMoveModels(_ crossmodel.ControllerInfo, modelUUIDs ...string) error
 	Controller(controllerUUID string) (ExternalController, error)
 	ControllerForModel(modelUUID string) (ExternalController, error)
 	Remove(controllerUUID string) error
@@ -85,43 +97,100 @@ func NewExternalControllers(st *State) *externalControllers {
 	return &externalControllers{st: st}
 }
 
-// Add creates or updates an external controller record.
-func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelUUIDs ...string) (ExternalController, error) {
+// Save creates or updates an external controller record.
+func (ec *externalControllers) Save(
+	controller crossmodel.ControllerInfo, modelUUIDs ...string,
+) (ExternalController, error) {
 	if err := controller.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	doc := externalControllerDoc{
-		Id:     controller.ControllerTag.Id(),
-		Alias:  controller.Alias,
-		Addrs:  controller.Addrs,
-		CACert: controller.CACert,
-	}
+	doc := newExternalControllerDoc(controller)
 	buildTxn := func(int) ([]txn.Op, error) {
-		model, err := ec.st.Model()
-		if err != nil {
-			return nil, errors.Annotate(err, "failed to load model")
-		}
-		if err := checkModelActive(ec.st); err != nil {
-			return nil, errors.Trace(err)
-		}
-		existing, err := ec.controller(controller.ControllerTag.Id())
-		if err != nil && !errors.IsNotFound(err) {
-			return nil, errors.Trace(err)
-		}
-		createOp := upsertExternalControllerOp(&doc, existing, modelUUIDs)
-		ops := []txn.Op{
-			createOp,
-			model.assertActiveOp(),
-		}
-		return ops, nil
+		ops, err := ec.upsertExternalControllerOps(doc, modelUUIDs)
+		return ops, errors.Trace(err)
 	}
 	if err := ec.st.db().Run(buildTxn); err != nil {
-		return nil, errors.Annotate(err, "failed to create external controllers")
+		return nil, errors.Annotate(err, "failed to save external controller")
 	}
 
 	return &externalController{
-		doc: doc,
+		doc: *doc,
 	}, nil
+}
+
+// SaveAndMoveModels is the same as `Save`, but if any of the input model UUIDs
+// are in other external external controllers, those records will be updated
+// to disassociate them.
+func (ec *externalControllers) SaveAndMoveModels(controller crossmodel.ControllerInfo, modelUUIDs ...string) error {
+	if err := controller.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	doc := newExternalControllerDoc(controller)
+	buildTxn := func(int) ([]txn.Op, error) {
+		// Find any controllers that already have one of
+		// the input model UUIDs associated with it.
+		controllers, err := ec.st.externalControllerDocsForModels(modelUUIDs...)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		var ops []txn.Op
+		changingModels := set.NewStrings(modelUUIDs...)
+		for _, controller := range controllers {
+			// If the controller to be saved already has one
+			// of the input model UUIDs, do not change it.
+			if controller.Id == doc.Id {
+				continue
+			}
+
+			// If the models for the controller need changing,
+			// generate a transaction operation.
+			currentModels := set.NewStrings(controller.Models...)
+			modelDiff := currentModels.Difference(changingModels)
+			if modelDiff.Size() != currentModels.Size() {
+				// TODO (manadart 2019-12-13): There is a case for deleting
+				// records with no more associated model UUIDs.
+				// We are being conservative here and keeping them.
+				ops = append(ops, txn.Op{
+					C:      externalControllersC,
+					Id:     controller.Id,
+					Assert: txn.DocExists,
+					Update: bson.D{{"$set", bson.D{{"models", modelDiff.SortedValues()}}}},
+				})
+			}
+		}
+
+		newControllerOps, err := ec.upsertExternalControllerOps(doc, modelUUIDs)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return append(ops, newControllerOps...), nil
+	}
+	return errors.Annotate(ec.st.db().Run(buildTxn), "saving location of external models")
+}
+
+// upsertExternalControllerOps returns the transaction operations for saving
+// the input controller document as the location of the input models.
+func (ec *externalControllers) upsertExternalControllerOps(
+	doc *externalControllerDoc, modelUUIDs []string,
+) ([]txn.Op, error) {
+	model, err := ec.st.Model()
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to load model")
+	}
+	if err := checkModelActive(ec.st); err != nil {
+		return nil, errors.Trace(err)
+	}
+	existing, err := ec.controller(doc.Id)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	upsertOp := upsertExternalControllerOp(doc, existing, modelUUIDs)
+	ops := []txn.Op{
+		upsertOp,
+		model.assertActiveOp(),
+	}
+	return ops, nil
 }
 
 // Remove removes an external controller record with the given controller UUID.
@@ -182,24 +251,27 @@ func (ec *externalControllers) WatchController(controllerUUID string) NotifyWatc
 // This is very similar to externalControllers.ControllerForModel, except the
 // return type is a lot less strict, one that we can access the ModelUUIDs from
 // the controller.
-func (s *State) ExternalControllerForModel(modelUUID string) (*externalController, error) {
-	coll, closer := s.db().GetCollection(externalControllersC)
-	defer closer()
-
-	var doc []externalControllerDoc
-	err := coll.Find(bson.M{"models": bson.M{"$in": []string{modelUUID}}}).All(&doc)
+func (st *State) ExternalControllerForModel(modelUUID string) (*externalController, error) {
+	docs, err := st.externalControllerDocsForModels(modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	switch len(doc) {
+	switch len(docs) {
 	case 0:
 		return nil, errors.NotFoundf("external controller with model %v", modelUUID)
 	case 1:
-		return &externalController{
-			doc: doc[0],
-		}, nil
+		return &externalController{doc: docs[0]}, nil
 	}
-	return nil, errors.Errorf("expected 1 controller with model %v, got %d", modelUUID, len(doc))
+	return nil, errors.Errorf("expected 1 controller with model %v, got %d", modelUUID, len(docs))
+}
+
+func (st *State) externalControllerDocsForModels(modelUUIDs ...string) ([]externalControllerDoc, error) {
+	coll, closer := st.db().GetCollection(externalControllersC)
+	defer closer()
+
+	var docs []externalControllerDoc
+	err := coll.Find(bson.M{"models": bson.M{"$in": modelUUIDs}}).All(&docs)
+	return docs, errors.Trace(err)
 }
 
 func upsertExternalControllerOp(doc *externalControllerDoc, existing *externalControllerDoc, modelUUIDs []string) txn.Op {
@@ -212,10 +284,12 @@ func upsertExternalControllerOp(doc *externalControllerDoc, existing *externalCo
 			Assert: txn.DocExists,
 			Update: bson.D{
 				{"$set",
-					bson.D{{"addresses", doc.Addrs},
+					bson.D{
+						{"addresses", doc.Addrs},
 						{"alias", doc.Alias},
 						{"cacert", doc.CACert},
-						{"models", models.Values()}},
+						{"models", models.SortedValues()},
+					},
 				},
 			},
 		}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch adds a new method, `SaveAndMoveModels` to the `state.ExternalControllers` type.

The method works just like Save, but it any of the input model UUIDs are associated with other external controllers, those records are modified to remove them.

## QA steps

Method not yet called, but verified by unit tests. QA steps will be in the patch immediately following.

## Documentation changes

None.

## Bug reference

N/A
