### PR TITLE
remove cache usage where we already have a cache

### DIFF
--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -257,8 +257,7 @@ print ("\n".join(
 # List all controllers
 _JUJU_2_list_controllers_noflags() {
     _JUJU_2_cache_cmd ${_JUJU_2_cache_TTL} cat \
-      ${_juju_cmd_JUJU_2?} list-controllers --format json | \
-        _JUJU_2_list_controllers_from_stdin
+      ${_juju_cmd_JUJU_2?} list-controllers --format json | _JUJU_2_list_controllers_from_stdin
 }
 # Print:
 # - list of controllers as: <controller>:<current_model>
@@ -399,10 +398,13 @@ _JUJU_2_cache_cmd() {
     fi
     # if missing => wait
     [ ! -s "${cache_file}" -a -n "${COPROC[0]}" ] && read -u ${COPROC[0]}
-    # if still missing => fail
-    [ ! -s "${cache_file}" ] && echo "" && return 1
-    # use it:
-    "${ret_action}" "${cache_file}"
+    # if still missing => just print the output of the command, the cache will be eventually created
+    if [ ! -s "${cache_file}" ]; then
+        ${cmd}
+    else
+        # use it:
+        "${ret_action}" "${cache_file}"
+    fi
 }
 
 # Main completion function wrap:


### PR DESCRIPTION
## Description of change
sometimes 
`local controllers=$(_JUJU_2_list_controllers_noflags 2>/dev/null)` returns empty list because either:
- python/juju fails
- cache ttl -> dies

which breaks usage because of the error message, tab retrying is the current solution. 

For the controllers and models, we already have a cache implemented in juju.
Hence, we can remove the cache creation and usage from the tab completion for controllers and models. 

This patch does not ensure/add cache reminder, which was missing in the past as well.

`juju switch <tab>` can eventually be too old.
As it is relying on `juju controllers --format=json`, which only refreshes on adding `--refresh` option or calling API commands like`juju status`

## QA steps

`juju switch <tab>`
