### PR TITLE
cli firewall: remove not supported firewallrules in text

### DIFF
--- a/cmd/juju/firewall/setrule.go
+++ b/cmd/juju/firewall/setrule.go
@@ -31,8 +31,6 @@ The currently supported services are:
 
 Examples:
     juju set-firewall-rule ssh --whitelist 192.168.1.0/16
-    juju set-firewall-rule juju-controller --whitelist 192.168.1.0/16
-    juju set-firewall-rule juju-application-offer --whitelist 192.168.1.0/16
 
 See also: 
     list-firewall-rules`
@@ -65,8 +63,6 @@ type setFirewallRuleCommand struct {
 func (c *setFirewallRuleCommand) Info() *cmd.Info {
 	supportedRules := []string{
 		" -" + string(params.SSHRule),
-		" -" + string(params.JujuControllerRule),
-		" -" + string(params.JujuApplicationOfferRule),
 	}
 	return jujucmd.Info(&cmd.Info{
 		Name:    "set-firewall-rule",


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [/] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [/] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x]Do comments answer the question of why design decisions were made?

----

## Description of change

Historically we wanted to support more than ssh. 
Hence we created more possible rules to add.
Ssh is the only supported one, the others can be added but they bear no effect.
Therefore removing them to reduce confusion.

## QA steps

`juju 
```sh
 juju set-firewall-rule --help
>> 
Details:
Firewall rules control ingress to a well known services
within a Juju model. A rule consists of the service name
and a whitelist of allowed ingress subnets.
The currently supported services are:
 -ssh

Examples:
    juju set-firewall-rule ssh --whitelist 192.168.1.0/16
```