### PR TITLE
Fix a small typo (meatadata -> metadata) in the comments of a plugin

### DIFF
--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -202,7 +202,7 @@ func (m metadataInfos) Less(i, j int) bool {
 		// Alphabetical order here is incidentally does what we want:
 		// we want "custom" metadata to precede
 		// "public" metadata.
-		// This may need to b revisited if more meatadata sources will be discovered.
+		// This may need to b revisited if more metadata sources will be discovered.
 		return m[i].Source < m[j].Source
 	}
 	if m[i].Series != m[j].Series {


### PR DESCRIPTION
## Description of change

When reading some of the plugin code, I noticed a typo. So I have fixed the typo

## QA steps

```sh
# check there is nothing incorrectly spelt here
cat cmd/plugins/juju-metadata/listimages.go | pcregrep '\s*//' | spell
```

