### PR TITLE
More the multiwatcher store into the multiwatcher core package.

### DIFF
--- a/core/multiwatcher/store.go
+++ b/core/multiwatcher/store.go
@@ -1,0 +1,299 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"container/list"
+	"reflect"
+
+	"github.com/kr/pretty"
+)
+
+// Store stores the current entities to use as a basis for the multiwatcher
+// notifications.
+type Store interface {
+	All() []EntityInfo
+	// ChangesSince takes revno. A zero implies that this is the first call for changes.
+	// A slice of changes is returned along with the latest revno that the store has seen.
+	ChangesSince(revno int64) ([]Delta, int64)
+
+	// AddReference and DecReference are used for internal reference counting for the
+	// watchers that have been notified.
+	// TODO: determine if this is actually useful, and whether this is the right place for it.
+	AddReference(revno int64)
+	DecReference(revno int64)
+
+	Get(id EntityID) EntityInfo
+	Update(info EntityInfo)
+	Remove(id EntityID)
+
+	// Size returns the internal size of the store's list.
+	// Used only for tests and metrics.
+	Size() int
+}
+
+// entityEntry holds an entry in the linked list of all entities known
+// to a params.
+type entityEntry struct {
+	// The revno holds the local idea of the latest change to the
+	// given entity.  It is not the same as the transaction revno -
+	// this means we can unconditionally move a newly fetched entity
+	// to the front of the list without worrying if the revno has
+	// changed since the watcher reported it.
+	revno int64
+
+	// creationRevno holds the revision number when the
+	// entity was created.
+	creationRevno int64
+
+	// removed marks whether the entity has been removed.
+	removed bool
+
+	// refCount holds a count of the number of watchers that
+	// have seen this entity. When the entity is marked as removed,
+	// the ref count is decremented whenever a Multiwatcher that
+	// has previously seen the entry now sees that it has been removed;
+	// the entry will be deleted when all such Multiwatchers have
+	// been notified.
+	refCount int
+
+	// info holds the actual information on the entity.
+	info EntityInfo
+}
+
+// store holds a list of all known entities.
+type store struct {
+	latestRevno int64
+	entities    map[interface{}]*list.Element
+	list        *list.List
+	logger      Logger
+}
+
+// Logger describes the logging methods used in this package by the worker.
+type Logger interface {
+	IsTraceEnabled() bool
+	Tracef(string, ...interface{})
+	Errorf(string, ...interface{})
+	Criticalf(string, ...interface{})
+}
+
+// NewStore returns an Store instance holding information about the
+// current state of all entities in the model.
+// It is only exposed here for testing purposes.
+func NewStore(logger Logger) Store {
+	return newStore(logger)
+}
+
+func newStore(logger Logger) *store {
+	return &store{
+		entities: make(map[interface{}]*list.Element),
+		list:     list.New(),
+		logger:   logger,
+	}
+}
+
+// Size returns the length of the internal list.
+func (a *store) Size() int {
+	return a.list.Len()
+}
+
+// All returns all the entities stored in the Store,
+// oldest first.
+func (a *store) All() []EntityInfo {
+	entities := make([]EntityInfo, 0, a.list.Len())
+	for e := a.list.Front(); e != nil; e = e.Next() {
+		entry := e.Value.(*entityEntry)
+		if entry.removed {
+			continue
+		}
+		entities = append(entities, entry.info)
+	}
+	return entities
+}
+
+// add adds a new entity with the given id and associated
+// information to the list.
+func (a *store) add(id interface{}, info EntityInfo) {
+	if _, ok := a.entities[id]; ok {
+		a.logger.Criticalf("programming error: adding new entry with duplicate id %q", id)
+		return
+	}
+	a.latestRevno++
+	entry := &entityEntry{
+		info:          info,
+		revno:         a.latestRevno,
+		creationRevno: a.latestRevno,
+	}
+	a.entities[id] = a.list.PushFront(entry)
+}
+
+// decRef decrements the reference count of an entry within the list,
+// deleting it if it becomes zero and the entry is removed.
+func (a *store) decRef(entry *entityEntry) {
+	if entry.refCount--; entry.refCount > 0 {
+		return
+	}
+	if entry.refCount < 0 {
+		a.logger.Criticalf("programming error: negative reference count\n%s", pretty.Sprint(entry))
+		return
+	}
+	if !entry.removed {
+		return
+	}
+	id := entry.info.EntityID()
+	elem, ok := a.entities[id]
+	if !ok {
+		a.logger.Criticalf("programming error: delete of non-existent entry\n%s", pretty.Sprint(entry))
+		return
+	}
+	delete(a.entities, id)
+	a.list.Remove(elem)
+}
+
+// delete deletes the entry with the given info id.
+func (a *store) delete(id EntityID) {
+	elem, ok := a.entities[id]
+	if !ok {
+		return
+	}
+	delete(a.entities, id)
+	a.list.Remove(elem)
+}
+
+// Remove marks that the entity with the given id has
+// been removed from the backing. If nothing has seen the
+// entity, then we delete it immediately.
+func (a *store) Remove(id EntityID) {
+	if elem := a.entities[id]; elem != nil {
+		entry := elem.Value.(*entityEntry)
+		if entry.removed {
+			return
+		}
+		a.latestRevno++
+		if entry.refCount == 0 {
+			a.delete(id)
+			return
+		}
+		entry.revno = a.latestRevno
+		entry.removed = true
+		a.list.MoveToFront(elem)
+	}
+}
+
+// Update updates the information for the given entity.
+func (a *store) Update(info EntityInfo) {
+	id := info.EntityID()
+	elem, ok := a.entities[id]
+	if !ok {
+		a.add(id, info)
+		return
+	}
+	entry := elem.Value.(*entityEntry)
+	// Nothing has changed, so change nothing.
+	// TODO(rog) do the comparison more efficiently.
+	if reflect.DeepEqual(info, entry.info) {
+		return
+	}
+	// We already know about the entity; update its doc.
+	a.latestRevno++
+	entry.revno = a.latestRevno
+	entry.info = info
+	// The app might have been removed and re-added.
+	entry.removed = false
+	a.list.MoveToFront(elem)
+}
+
+// Get returns the stored entity with the given id, or nil if none was found.
+// The contents of the returned entity MUST not be changed.
+func (a *store) Get(id EntityID) EntityInfo {
+	e, ok := a.entities[id]
+	if !ok {
+		return nil
+	}
+	return e.Value.(*entityEntry).info
+}
+
+// ChangesSince returns any changes that have occurred since
+// the given revno, oldest first.
+func (a *store) ChangesSince(revno int64) ([]Delta, int64) {
+	e := a.list.Front()
+	n := 0
+	for ; e != nil; e = e.Next() {
+		entry := e.Value.(*entityEntry)
+		if entry.revno <= revno {
+			break
+		}
+		n++
+	}
+	if e != nil {
+		// We've found an element that we've already seen.
+		e = e.Prev()
+	} else {
+		// We haven't seen any elements, so we want all of them.
+		e = a.list.Back()
+		n++
+	}
+	changes := make([]Delta, 0, n)
+	for ; e != nil; e = e.Prev() {
+		entry := e.Value.(*entityEntry)
+		if entry.removed && entry.creationRevno > revno {
+			// Don't include entries that have been created
+			// and removed since the revno.
+			continue
+		}
+		changes = append(changes, Delta{
+			Removed: entry.removed,
+			Entity:  entry.info,
+		})
+	}
+	return changes, a.latestRevno
+}
+
+// AddReference states that a Multiwatcher has just been given information about
+// all entities newer than the given revno.  We assume it has already seen all
+// the older entities.
+func (a *store) AddReference(revno int64) {
+	for e := a.list.Front(); e != nil; {
+		next := e.Next()
+		entry := e.Value.(*entityEntry)
+		if entry.revno <= revno {
+			break
+		}
+		if entry.creationRevno > revno {
+			if !entry.removed {
+				// This is a new entity that hasn't been seen yet,
+				// so increment the entry's refCount.
+				entry.refCount++
+			}
+		} else if entry.removed {
+			// This is an entity that we previously saw, but
+			// has now been removed, so decrement its refCount, removing
+			// the entity if nothing else is waiting to be notified that it's
+			// gone.
+			a.decRef(entry)
+		}
+		e = next
+	}
+}
+
+// DecReference is called when a watcher leaves.  It decrements the reference
+// counts of any entities that have been seen by the watcher.
+func (a *store) DecReference(revno int64) {
+	for e := a.list.Front(); e != nil; {
+		next := e.Next()
+		entry := e.Value.(*entityEntry)
+		if entry.creationRevno <= revno {
+			// The watcher has seen this entry.
+			if entry.removed && entry.revno <= revno {
+				// The entity has been removed and the
+				// watcher has already been informed of that,
+				// so its refcount has already been decremented.
+				e = next
+				continue
+			}
+			a.decRef(entry)
+		}
+		e = next
+	}
+}

--- a/core/multiwatcher/store_internal_test.go
+++ b/core/multiwatcher/store_internal_test.go
@@ -1,0 +1,390 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package multiwatcher
+
+import (
+	"container/list"
+	"fmt"
+
+	"github.com/juju/loggo"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&storeSuite{})
+
+type storeSuite struct {
+	testing.BaseSuite
+}
+
+var StoreChangeMethodTests = []struct {
+	about          string
+	change         func(*store)
+	expectRevno    int64
+	expectContents []entityEntry
+}{{
+	about:  "empty at first",
+	change: func(*store) {},
+}, {
+	about: "add single entry",
+	change: func(all *store) {
+		all.Update(&MachineInfo{
+			ID:         "0",
+			InstanceID: "i-0",
+		})
+	},
+	expectRevno: 1,
+	expectContents: []entityEntry{{
+		creationRevno: 1,
+		revno:         1,
+		info: &MachineInfo{
+			ID:         "0",
+			InstanceID: "i-0",
+		},
+	}},
+}, {
+	about: "add two entries",
+	change: func(all *store) {
+		all.Update(&MachineInfo{
+			ID:         "0",
+			InstanceID: "i-0",
+		})
+		all.Update(&ApplicationInfo{
+			Name:    "wordpress",
+			Exposed: true,
+		})
+	},
+	expectRevno: 2,
+	expectContents: []entityEntry{{
+		creationRevno: 1,
+		revno:         1,
+		info: &MachineInfo{
+			ID:         "0",
+			InstanceID: "i-0",
+		},
+	}, {
+		creationRevno: 2,
+		revno:         2,
+		info: &ApplicationInfo{
+			Name:    "wordpress",
+			Exposed: true,
+		},
+	}},
+}, {
+	about: "update an entity that's not currently there",
+	change: func(all *store) {
+		m := &MachineInfo{ID: "1"}
+		all.Update(m)
+	},
+	expectRevno: 1,
+	expectContents: []entityEntry{{
+		creationRevno: 1,
+		revno:         1,
+		info:          &MachineInfo{ID: "1"},
+	}},
+}, {
+	about: "mark application removed then update",
+	change: func(all *store) {
+		all.Update(&ApplicationInfo{ModelUUID: "uuid0", Name: "logging"})
+		all.Update(&ApplicationInfo{ModelUUID: "uuid0", Name: "wordpress"})
+		StoreIncRef(all, EntityID{"application", "uuid0", "logging"})
+		all.Remove(EntityID{"application", "uuid0", "logging"})
+		all.Update(&ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "wordpress",
+			Exposed:   true,
+		})
+		all.Update(&ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "logging",
+			Exposed:   true,
+		})
+	},
+	expectRevno: 5,
+	expectContents: []entityEntry{{
+		revno:         4,
+		creationRevno: 2,
+		removed:       false,
+		refCount:      0,
+		info: &ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "wordpress",
+			Exposed:   true,
+		}}, {
+		revno:         5,
+		creationRevno: 1,
+		removed:       false,
+		refCount:      1,
+		info: &ApplicationInfo{
+			ModelUUID: "uuid0",
+			Name:      "logging",
+			Exposed:   true,
+		},
+	}},
+}, {
+	about: "mark removed on existing entry",
+	change: func(all *store) {
+		all.Update(&MachineInfo{ModelUUID: "uuid", ID: "0"})
+		all.Update(&MachineInfo{ModelUUID: "uuid", ID: "1"})
+		StoreIncRef(all, EntityID{"machine", "uuid", "0"})
+		all.Remove(EntityID{"machine", "uuid", "0"})
+	},
+	expectRevno: 3,
+	expectContents: []entityEntry{{
+		creationRevno: 2,
+		revno:         2,
+		info:          &MachineInfo{ModelUUID: "uuid", ID: "1"},
+	}, {
+		creationRevno: 1,
+		revno:         3,
+		refCount:      1,
+		removed:       true,
+		info:          &MachineInfo{ModelUUID: "uuid", ID: "0"},
+	}},
+}, {
+	about: "mark removed on nonexistent entry",
+	change: func(all *store) {
+		all.Remove(EntityID{"machine", "uuid", "0"})
+	},
+}, {
+	about: "mark removed on already marked entry",
+	change: func(all *store) {
+		all.Update(&MachineInfo{ModelUUID: "uuid", ID: "0"})
+		all.Update(&MachineInfo{ModelUUID: "uuid", ID: "1"})
+		StoreIncRef(all, EntityID{"machine", "uuid", "0"})
+		all.Remove(EntityID{"machine", "uuid", "0"})
+		all.Update(&MachineInfo{
+			ModelUUID:  "uuid",
+			ID:         "1",
+			InstanceID: "i-1",
+		})
+		all.Remove(EntityID{"machine", "uuid", "0"})
+	},
+	expectRevno: 4,
+	expectContents: []entityEntry{{
+		creationRevno: 1,
+		revno:         3,
+		refCount:      1,
+		removed:       true,
+		info:          &MachineInfo{ModelUUID: "uuid", ID: "0"},
+	}, {
+		creationRevno: 2,
+		revno:         4,
+		info: &MachineInfo{
+			ModelUUID:  "uuid",
+			ID:         "1",
+			InstanceID: "i-1",
+		},
+	}},
+}, {
+	about: "mark removed on entry with zero ref count",
+	change: func(all *store) {
+		all.Update(&MachineInfo{ModelUUID: "uuid", ID: "0"})
+		all.Remove(EntityID{"machine", "uuid", "0"})
+	},
+	expectRevno: 2,
+}, {
+	about: "delete entry",
+	change: func(all *store) {
+		all.Update(&MachineInfo{ModelUUID: "uuid", ID: "0"})
+		all.delete(EntityID{"machine", "uuid", "0"})
+	},
+	expectRevno: 1,
+}, {
+	about: "decref of non-removed entity",
+	change: func(all *store) {
+		m := &MachineInfo{ID: "0"}
+		all.Update(m)
+		id := m.EntityID()
+		StoreIncRef(all, id)
+		entry := all.entities[id].Value.(*entityEntry)
+		all.decRef(entry)
+	},
+	expectRevno: 1,
+	expectContents: []entityEntry{{
+		creationRevno: 1,
+		revno:         1,
+		refCount:      0,
+		info:          &MachineInfo{ID: "0"},
+	}},
+}, {
+	about: "decref of removed entity",
+	change: func(all *store) {
+		m := &MachineInfo{ID: "0"}
+		all.Update(m)
+		id := m.EntityID()
+		entry := all.entities[id].Value.(*entityEntry)
+		entry.refCount++
+		all.Remove(id)
+		all.decRef(entry)
+	},
+	expectRevno: 2,
+},
+}
+
+func (s *storeSuite) TestStoreChangeMethods(c *gc.C) {
+	for i, test := range StoreChangeMethodTests {
+		all := newStore(loggo.GetLogger("test"))
+		c.Logf("test %d. %s", i, test.about)
+		test.change(all)
+		assertStoreContents(c, all, test.expectRevno, test.expectContents)
+	}
+}
+
+func (s *storeSuite) TestChangesSince(c *gc.C) {
+	a := newStore(loggo.GetLogger("test"))
+	// Add three entries.
+	var deltas []Delta
+	for i := 0; i < 3; i++ {
+		m := &MachineInfo{
+			ModelUUID: "uuid",
+			ID:        fmt.Sprint(i),
+		}
+		a.Update(m)
+		deltas = append(deltas, Delta{Entity: m})
+	}
+	// Check that the deltas from each revno are as expected.
+	for i := 0; i < 3; i++ {
+		c.Logf("test %d", i)
+		changes, _ := a.ChangesSince(int64(i))
+		c.Assert(changes, gc.DeepEquals, deltas[i:])
+	}
+
+	// Check boundary cases.
+	changes, _ := a.ChangesSince(-1)
+	c.Assert(changes, gc.DeepEquals, deltas)
+	changes, rev := a.ChangesSince(99)
+	c.Assert(changes, gc.HasLen, 0)
+
+	// Update one machine and check we see the changes.
+	m1 := &MachineInfo{
+		ModelUUID:  "uuid",
+		ID:         "1",
+		InstanceID: "foo",
+	}
+	a.Update(m1)
+	changes, latest := a.ChangesSince(rev)
+	c.Assert(changes, gc.DeepEquals, []Delta{{Entity: m1}})
+	c.Assert(latest, gc.Equals, a.latestRevno)
+
+	// Make sure the machine isn't simply removed from
+	// the list when it's marked as removed.
+	StoreIncRef(a, EntityID{"machine", "uuid", "0"})
+
+	// Remove another machine and check we see it's removed.
+	m0 := &MachineInfo{ModelUUID: "uuid", ID: "0"}
+	a.Remove(m0.EntityID())
+
+	// Check that something that never saw m0 does not get
+	// informed of its removal (even those the removed entity
+	// is still in the list.
+	changes, _ = a.ChangesSince(0)
+	c.Assert(changes, gc.DeepEquals, []Delta{{
+		Entity: &MachineInfo{ModelUUID: "uuid", ID: "2"},
+	}, {
+		Entity: m1,
+	}})
+
+	changes, _ = a.ChangesSince(rev)
+	c.Assert(changes, gc.DeepEquals, []Delta{{
+		Entity: m1,
+	}, {
+		Removed: true,
+		Entity:  m0,
+	}})
+
+	changes, _ = a.ChangesSince(rev + 1)
+	c.Assert(changes, gc.DeepEquals, []Delta{{
+		Removed: true,
+		Entity:  m0,
+	}})
+}
+
+func (s *storeSuite) TestGet(c *gc.C) {
+	a := newStore(loggo.GetLogger("test"))
+	m := &MachineInfo{ModelUUID: "uuid", ID: "0"}
+	a.Update(m)
+
+	c.Assert(a.Get(m.EntityID()), gc.Equals, m)
+	c.Assert(a.Get(EntityID{"machine", "uuid", "1"}), gc.IsNil)
+}
+
+func (s *storeSuite) TestDecReferenceWithZero(c *gc.C) {
+	// If a watcher is stopped before it had looked at any items, then we shouldn't
+	// decrement its ref count when it is stopped.
+	store := newStore(loggo.GetLogger("test"))
+	m := &MachineInfo{ModelUUID: "uuid", ID: "0"}
+	store.Update(m)
+
+	StoreIncRef(store, EntityID{"machine", "uuid", "0"})
+	store.DecReference(0)
+
+	assertStoreContents(c, store, 1, []entityEntry{{
+		creationRevno: 1,
+		revno:         1,
+		refCount:      1,
+		info:          m,
+	}})
+}
+
+func (s *storeSuite) TestDecReferenceIfAlreadySeenRemoved(c *gc.C) {
+	// If the Multiwatcher has already seen the item removed, then
+	// we shouldn't decrement its ref count when it is stopped.
+
+	store := newStore(loggo.GetLogger("test"))
+	m := &MachineInfo{ModelUUID: "uuid", ID: "0"}
+	store.Update(m)
+
+	id := EntityID{"machine", "uuid", "0"}
+	StoreIncRef(store, id)
+	store.Remove(id)
+	store.DecReference(0)
+
+	assertStoreContents(c, store, 2, []entityEntry{{
+		creationRevno: 1,
+		revno:         2,
+		refCount:      1,
+		removed:       true,
+		info:          m,
+	}})
+}
+
+func (s *storeSuite) TestHandleStopDecRefIfAlreadySeenAndNotRemoved(c *gc.C) {
+	// If the Multiwatcher has already seen the item removed, then
+	// we should decrement its ref count when it is stopped.
+	store := newStore(loggo.GetLogger("test"))
+	info := &MachineInfo{ModelUUID: "uuid", ID: "0"}
+	store.Update(info)
+
+	StoreIncRef(store, EntityID{"machine", "uuid", "0"})
+	store.DecReference(store.latestRevno)
+
+	assertStoreContents(c, store, 1, []entityEntry{{
+		creationRevno: 1,
+		revno:         1,
+		info:          info,
+	}})
+}
+
+func StoreIncRef(a *store, id interface{}) {
+	entry := a.entities[id].Value.(*entityEntry)
+	entry.refCount++
+}
+
+func assertStoreContents(c *gc.C, a *store, latestRevno int64, entries []entityEntry) {
+	var gotEntries []entityEntry
+	var gotElems []*list.Element
+	c.Check(a.list.Len(), gc.Equals, len(entries))
+	for e := a.list.Back(); e != nil; e = e.Prev() {
+		gotEntries = append(gotEntries, *e.Value.(*entityEntry))
+		gotElems = append(gotElems, e)
+	}
+	c.Assert(gotEntries, gc.DeepEquals, entries)
+	for i, ent := range entries {
+		c.Assert(a.entities[ent.info.EntityID()], gc.Equals, gotElems[i])
+	}
+	c.Assert(a.entities, gc.HasLen, len(entries))
+	c.Assert(a.latestRevno, gc.Equals, latestRevno)
+}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -550,7 +550,7 @@ func (s *allWatcherStateSuite) TestGetAllMultiModelWithOffers(c *gc.C) {
 
 func (s *allWatcherStateSuite) checkGetAll(c *gc.C, expectEntities entityInfoSlice, includeOffers bool) {
 	b := newAllWatcherStateBacking(s.state, WatchParams{IncludeOffers: includeOffers})
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 	err := b.GetAll(all)
 	c.Assert(err, jc.ErrorIsNil)
 	var gotEntities entityInfoSlice = all.All()
@@ -606,7 +606,7 @@ func (s *allWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFuncs [
 
 		c.Logf("test %d. %s", i, test.about)
 		b := newAllWatcherStateBacking(s.state, WatchParams{IncludeOffers: true})
-		all := newStore()
+		all := multiwatcher.NewStore(loggo.GetLogger("test"))
 		for _, info := range test.initialContents {
 			all.Update(info)
 		}
@@ -787,7 +787,7 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// Create all watcher state backing.
 	b := newAllWatcherStateBacking(s.state, WatchParams{IncludeOffers: false})
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 	all.Update(&multiwatcher.MachineInfo{
 		ModelUUID: s.state.ModelUUID(),
 		ID:        "0",
@@ -873,7 +873,7 @@ func (s *allWatcherStateSuite) TestApplicationSettings(c *gc.C) {
 	// Init the test model.
 	app := AddTestingApplication(c, s.state, "dummy-application", AddTestingCharm(c, s.state, "dummy"))
 	b := newAllWatcherStateBacking(s.state, WatchParams{IncludeOffers: false})
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 	// 1st scenario part: set settings and signal change.
 	setApplicationConfigAttr(c, app, "username", "foo")
 	setApplicationConfigAttr(c, app, "outlook", "foo@bar")
@@ -1407,7 +1407,7 @@ func (s *allModelWatcherStateSuite) NewAllModelWatcherStateBacking() Backing {
 func (s *allModelWatcherStateSuite) TestMissingModelNotError(c *gc.C) {
 	b := s.NewAllModelWatcherStateBacking()
 	defer b.Release()
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 
 	dyingModel := "fake-uuid"
 	st, err := s.pool.Get(dyingModel)
@@ -1435,7 +1435,7 @@ func (s *allModelWatcherStateSuite) performChangeTestCases(c *gc.C, changeTestFu
 			c.Logf("test %d. %s", i, test0.about)
 			b := s.NewAllModelWatcherStateBacking()
 			defer b.Release()
-			all := newStore()
+			all := multiwatcher.NewStore(loggo.GetLogger("test"))
 
 			// Do updates and check for first model.
 			for _, info := range test0.initialContents {
@@ -1647,7 +1647,7 @@ func (s *allModelWatcherStateSuite) TestChangeForDeadModel(c *gc.C) {
 
 	b := s.NewAllModelWatcherStateBacking()
 	defer b.Release()
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 
 	// Insert a machine for an model that doesn't actually
 	// exist (mimics model removal).
@@ -1727,7 +1727,7 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 	)
 
 	b := s.NewAllModelWatcherStateBacking()
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 	err = b.GetAll(all)
 	c.Assert(err, jc.ErrorIsNil)
 	var gotEntities entityInfoSlice = all.All()
@@ -1739,7 +1739,7 @@ func (s *allModelWatcherStateSuite) TestGetAll(c *gc.C) {
 func (s *allModelWatcherStateSuite) TestModelSettings(c *gc.C) {
 	// Init the test model.
 	b := s.NewAllModelWatcherStateBacking()
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 	setModelConfigAttr(c, s.state, "http-proxy", "http://invalid")
 	setModelConfigAttr(c, s.state, "foo", "bar")
 
@@ -1774,7 +1774,7 @@ func (s *allModelWatcherStateSuite) TestModelSettings(c *gc.C) {
 func (s *allModelWatcherStateSuite) TestMissingModelSettings(c *gc.C) {
 	// Init the test model.
 	b := s.NewAllModelWatcherStateBacking()
-	all := newStore()
+	all := multiwatcher.NewStore(loggo.GetLogger("test"))
 
 	all.Update(&multiwatcher.ModelUpdate{
 		ModelUUID: s.state.ModelUUID(),

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -4,10 +4,8 @@
 package state
 
 import (
-	"container/list"
-	"reflect"
-
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/tomb.v2"
 
@@ -118,8 +116,8 @@ type storeManager struct {
 	// request receives requests from Multiwatcher clients.
 	request chan *request
 
-	// all holds information on everything the storeManager cares about.
-	all *multiwatcherStore
+	// store holds information on everything the storeManager cares about.
+	store multiwatcher.Store
 
 	// Each entry in the waiting map holds a linked list of Next requests
 	// outstanding for the associated watcher.
@@ -131,20 +129,20 @@ type storeManager struct {
 type Backing interface {
 	// GetAll retrieves information about all information
 	// known to the Backing and stashes it in the Store.
-	GetAll(all *multiwatcherStore) error
+	GetAll(multiwatcher.Store) error
 
 	// Changed informs the backing about a change received
 	// from a watcher channel.  The backing is responsible for
 	// updating the Store to reflect the change.
-	Changed(all *multiwatcherStore, change watcher.Change) error
+	Changed(multiwatcher.Store, watcher.Change) error
 
 	// Watch watches for any changes and sends them
 	// on the given channel.
-	Watch(in chan<- watcher.Change)
+	Watch(chan<- watcher.Change)
 
 	// Unwatch stops watching for changes on the
 	// given channel.
-	Unwatch(in chan<- watcher.Change)
+	Unwatch(chan<- watcher.Change)
 
 	// Release cleans up resources opened by the Backing.
 	Release() error
@@ -183,7 +181,7 @@ func newStoreManagerNoRun(backing Backing) *storeManager {
 	return &storeManager{
 		backing: backing,
 		request: make(chan *request),
-		all:     newStore(),
+		store:   multiwatcher.NewStore(loggo.GetLogger("juju.multiwatcher.store")),
 		waiting: make(map[*Multiwatcher]*request),
 	}
 }
@@ -230,7 +228,7 @@ func (sm *storeManager) loop() error {
 	// and removals.
 	// TODO(rog) Perhaps find a way to avoid blocking all other
 	// watchers while GetAll is running.
-	if err := sm.backing.GetAll(sm.all); err != nil {
+	if err := sm.backing.GetAll(sm.store); err != nil {
 		return err
 	}
 	for {
@@ -238,7 +236,7 @@ func (sm *storeManager) loop() error {
 		case <-sm.tomb.Dying():
 			return errors.Trace(tomb.ErrDying)
 		case change := <-in:
-			if err := sm.backing.Changed(sm.all, change); err != nil {
+			if err := sm.backing.Changed(sm.store, change); err != nil {
 				return errors.Trace(err)
 			}
 		case req := <-sm.request:
@@ -285,7 +283,7 @@ func (sm *storeManager) handle(req *request) {
 		}
 		delete(sm.waiting, req.w)
 		req.w.stopped = true
-		sm.leave(req.w)
+		sm.store.DecReference(req.w.revno)
 		return
 	}
 	// Add request to head of list.
@@ -297,7 +295,7 @@ func (sm *storeManager) handle(req *request) {
 func (sm *storeManager) respond() {
 	for w, req := range sm.waiting {
 		revno := w.revno
-		changes := sm.all.ChangesSince(revno)
+		changes, latestRevno := sm.store.ChangesSince(revno)
 		if len(changes) == 0 {
 			if req.noChanges != nil {
 				select {
@@ -312,7 +310,7 @@ func (sm *storeManager) respond() {
 		}
 
 		req.changes = changes
-		w.revno = sm.all.latestRevno
+		w.revno = latestRevno
 
 		select {
 		case req.reply <- true:
@@ -321,7 +319,7 @@ func (sm *storeManager) respond() {
 		}
 
 		sm.removeWaitingReq(w, req)
-		sm.seen(revno)
+		sm.store.AddReference(revno)
 	}
 }
 
@@ -332,247 +330,4 @@ func (sm *storeManager) removeWaitingReq(w *Multiwatcher, req *request) {
 	} else {
 		sm.waiting[w] = req
 	}
-}
-
-// seen states that a Multiwatcher has just been given information about
-// all entities newer than the given revno.  We assume it has already
-// seen all the older entities.
-func (sm *storeManager) seen(revno int64) {
-	for e := sm.all.list.Front(); e != nil; {
-		next := e.Next()
-		entry := e.Value.(*entityEntry)
-		if entry.revno <= revno {
-			break
-		}
-		if entry.creationRevno > revno {
-			if !entry.removed {
-				// This is a new entity that hasn't been seen yet,
-				// so increment the entry's refCount.
-				entry.refCount++
-			}
-		} else if entry.removed {
-			// This is an entity that we previously saw, but
-			// has now been removed, so decrement its refCount, removing
-			// the entity if nothing else is waiting to be notified that it's
-			// gone.
-			sm.all.decRef(entry)
-		}
-		e = next
-	}
-}
-
-// leave is called when the given watcher leaves.  It decrements the reference
-// counts of any entities that have been seen by the watcher.
-func (sm *storeManager) leave(w *Multiwatcher) {
-	for e := sm.all.list.Front(); e != nil; {
-		next := e.Next()
-		entry := e.Value.(*entityEntry)
-		if entry.creationRevno <= w.revno {
-			// The watcher has seen this entry.
-			if entry.removed && entry.revno <= w.revno {
-				// The entity has been removed and the
-				// watcher has already been informed of that,
-				// so its refcount has already been decremented.
-				e = next
-				continue
-			}
-			sm.all.decRef(entry)
-		}
-		e = next
-	}
-}
-
-// entityEntry holds an entry in the linked list of all entities known
-// to a store.
-type entityEntry struct {
-	// The revno holds the local idea of the latest change to the
-	// given entity.  It is not the same as the transaction revno -
-	// this means we can unconditionally move a newly fetched entity
-	// to the front of the list without worrying if the revno has
-	// changed since the watcher reported it.
-	revno int64
-
-	// creationRevno holds the revision number when the
-	// entity was created.
-	creationRevno int64
-
-	// removed marks whether the entity has been removed.
-	removed bool
-
-	// refCount holds a count of the number of watchers that
-	// have seen this entity. When the entity is marked as removed,
-	// the ref count is decremented whenever a Multiwatcher that
-	// has previously seen the entry now sees that it has been removed;
-	// the entry will be deleted when all such Multiwatchers have
-	// been notified.
-	refCount int
-
-	// info holds the actual information on the entity.
-	info multiwatcher.EntityInfo
-}
-
-// multiwatcherStore holds a list of all entities it knows.
-type multiwatcherStore struct {
-	latestRevno int64
-	entities    map[interface{}]*list.Element
-	list        *list.List
-}
-
-// newStore returns an Store instance holding information about the
-// current state of all entities in the model.
-// It is only exposed here for testing purposes.
-func newStore() *multiwatcherStore {
-	return &multiwatcherStore{
-		entities: make(map[interface{}]*list.Element),
-		list:     list.New(),
-	}
-}
-
-// All returns all the entities stored in the Store,
-// oldest first. It is only exposed for testing purposes.
-func (a *multiwatcherStore) All() []multiwatcher.EntityInfo {
-	entities := make([]multiwatcher.EntityInfo, 0, a.list.Len())
-	for e := a.list.Front(); e != nil; e = e.Next() {
-		entry := e.Value.(*entityEntry)
-		if entry.removed {
-			continue
-		}
-		entities = append(entities, entry.info)
-	}
-	return entities
-}
-
-// add adds a new entity with the given id and associated
-// information to the list.
-func (a *multiwatcherStore) add(id interface{}, info multiwatcher.EntityInfo) {
-	if _, ok := a.entities[id]; ok {
-		panic("adding new entry with duplicate id")
-	}
-	a.latestRevno++
-	entry := &entityEntry{
-		info:          info,
-		revno:         a.latestRevno,
-		creationRevno: a.latestRevno,
-	}
-	a.entities[id] = a.list.PushFront(entry)
-}
-
-// decRef decrements the reference count of an entry within the list,
-// deleting it if it becomes zero and the entry is removed.
-func (a *multiwatcherStore) decRef(entry *entityEntry) {
-	if entry.refCount--; entry.refCount > 0 {
-		return
-	}
-	if entry.refCount < 0 {
-		panic("negative reference count")
-	}
-	if !entry.removed {
-		return
-	}
-	id := entry.info.EntityID()
-	elem, ok := a.entities[id]
-	if !ok {
-		panic("delete of non-existent entry")
-	}
-	delete(a.entities, id)
-	a.list.Remove(elem)
-}
-
-// delete deletes the entry with the given info id.
-func (a *multiwatcherStore) delete(id multiwatcher.EntityID) {
-	elem, ok := a.entities[id]
-	if !ok {
-		return
-	}
-	delete(a.entities, id)
-	a.list.Remove(elem)
-}
-
-// Remove marks that the entity with the given id has
-// been removed from the backing. If nothing has seen the
-// entity, then we delete it immediately.
-func (a *multiwatcherStore) Remove(id multiwatcher.EntityID) {
-	if elem := a.entities[id]; elem != nil {
-		entry := elem.Value.(*entityEntry)
-		if entry.removed {
-			return
-		}
-		a.latestRevno++
-		if entry.refCount == 0 {
-			a.delete(id)
-			return
-		}
-		entry.revno = a.latestRevno
-		entry.removed = true
-		a.list.MoveToFront(elem)
-	}
-}
-
-// Update updates the information for the given entity.
-func (a *multiwatcherStore) Update(info multiwatcher.EntityInfo) {
-	id := info.EntityID()
-	elem, ok := a.entities[id]
-	if !ok {
-		a.add(id, info)
-		return
-	}
-	entry := elem.Value.(*entityEntry)
-	// Nothing has changed, so change nothing.
-	// TODO(rog) do the comparison more efficiently.
-	if reflect.DeepEqual(info, entry.info) {
-		return
-	}
-	// We already know about the entity; update its doc.
-	a.latestRevno++
-	entry.revno = a.latestRevno
-	entry.info = info
-	// The app might have been removed and re-added.
-	entry.removed = false
-	a.list.MoveToFront(elem)
-}
-
-// Get returns the stored entity with the given id, or nil if none was found.
-// The contents of the returned entity MUST not be changed.
-func (a *multiwatcherStore) Get(id multiwatcher.EntityID) multiwatcher.EntityInfo {
-	e, ok := a.entities[id]
-	if !ok {
-		return nil
-	}
-	return e.Value.(*entityEntry).info
-}
-
-// ChangesSince returns any changes that have occurred since
-// the given revno, oldest first.
-func (a *multiwatcherStore) ChangesSince(revno int64) []multiwatcher.Delta {
-	e := a.list.Front()
-	n := 0
-	for ; e != nil; e = e.Next() {
-		entry := e.Value.(*entityEntry)
-		if entry.revno <= revno {
-			break
-		}
-		n++
-	}
-	if e != nil {
-		// We've found an element that we've already seen.
-		e = e.Prev()
-	} else {
-		// We haven't seen any elements, so we want all of them.
-		e = a.list.Back()
-		n++
-	}
-	changes := make([]multiwatcher.Delta, 0, n)
-	for ; e != nil; e = e.Prev() {
-		entry := e.Value.(*entityEntry)
-		if entry.removed && entry.creationRevno > revno {
-			// Don't include entries that have been created
-			// and removed since the revno.
-			continue
-		}
-		changes = append(changes, multiwatcher.Delta{
-			Removed: entry.removed,
-			Entity:  entry.info,
-		})
-	}
-	return changes
 }


### PR DESCRIPTION
The multiwatcherStore type is completely independent of the state package.
It is only concerned with storing entities that the multiwatcher iterates
over and provides a way to reference count the entities. This type is
now moved to the core/multiwatcher package.

This is entirely an internal move of implementation. There are no user facing changes.
