### PR TITLE
Testing sleep in acceptance test for timing issue

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -117,6 +117,8 @@ def assess_caas_charm_deployment(caas_client, caas_provider):
 
     try:
         endpoint = deploy_test_workloads(caas_client, k8s_model, caas_provider)
+        log.info("sleeping for 30 seconds to let everything start up")
+        sleep(30)
         check_app_healthy(
             endpoint, timeout=300,
             success_hook=success_hook,


### PR DESCRIPTION

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Adds a small wait for microk8s test to wait for media wiki to become active.

## Bug reference

Fixing acceptance tests, specifically the currently failing microk8s test looks to be a timing bug where media wiki hasn't started quick enough for the resulting checks.
