### PR TITLE
Show Output of Failed MAAS CLI Commands in Tests

### DIFF
--- a/acceptancetests/substrate.py
+++ b/acceptancetests/substrate.py
@@ -677,10 +677,14 @@ class MAASAccount:
 
     def _maas(self, *args):
         """Call maas api with given arguments and parse json result."""
-        output = subprocess.check_output(('maas',) + args)
-        if not output:
-            return None
-        return json.loads(output)
+        try:
+            command = ('maas',) + args
+            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+            if not output:
+                return None
+            return json.loads(output)
+        except subprocess.CalledProcessError as e:
+            raise Exception('%s failed:\n %s' % (command, e.output))
 
     def login(self):
         """Login with the maas cli."""


### PR DESCRIPTION
We have failures in MAAS tests that look like this:
```
...
  File "/var/lib/jenkins/workspace/nw-deploy-xenial-amd64-maas-2-2/acceptancetests/substrate.py", line 680, in _maas
    output = subprocess.check_output(('maas',) + args)
  File "/usr/lib/python2.7/subprocess.py", line 223, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
```

This change captures the actual error output so we can see specifics for the failure.