### PR TITLE
Juju version sourced from correct jujud bin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,9 @@ JUJUD_STAGING_DIR          ?= /tmp/jujud-operator
 JUJUD_BIN_DIR              ?= ${GOPATH}/bin
 OPERATOR_IMAGE_BUILD_SRC   ?= true
 # By default the image tag is the full version number, including the build number.
-OPERATOR_IMAGE_TAG         ?= $(shell jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}(\.[[:digit:]]{1,9})?")
+OPERATOR_IMAGE_TAG         ?= $(shell ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}(\.[[:digit:]]{1,9})?")
 # Legacy tags never have a build number.
-OPERATOR_IMAGE_TAG_LEGACY  ?= $(shell jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}")
+OPERATOR_IMAGE_TAG_LEGACY  ?= $(shell ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}")
 OPERATOR_IMAGE_PATH         = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}
 OPERATOR_IMAGE_PATH_LEGACY  = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG_LEGACY}
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Build infra uses a jujud not in PATH, version wasn't being
picked up correctly.

## QA steps

Assuming you only have one jujud in your PATH
```
TMP_DIR=`mktemp -d`
mv ${GOPATH}/bin/jujud ${TMP_DIR}/
make JUJUD_BIN_DIR=${TMP_DIR} operator-image
``` 

## Documentation changes

N/A

## Bug reference

N/A