### PR TITLE
Correctly check for git working tree in build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ else
 	CHECK_ARGS = $(TEST_ARGS)
 endif
 
-GIT_COMMIT ?= $(shell git -C $(PROJECT_DIR) rev-parse HEAD)
+GIT_COMMIT ?= $(shell git -C $(PROJECT_DIR) rev-parse HEAD 2>/dev/null)
 # If .git directory is missing, we are building out of an archive, otherwise report
 # if the tree that is checked out is dirty (modified) or clean.
-GIT_TREE_STATE = $(if $(shell test -d .git || echo missing),archive,$(if $(shell git status --porcelain),dirty,clean))
+GIT_TREE_STATE = $(if $(shell git -C $(PROJECT_DIR) rev-parse --is-inside-work-tree 2>/dev/null | grep -e 'true'),$(if $(shell git -C $(PROJECT_DIR) status --porcelain),dirty,clean),archive)
 
 # Build tags passed to go install/build.
 # Example: BUILD_TAGS="minimal provider_kubernetes"


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Use a more reliable method for detecting if the working copy is in a tree for version info.

## QA steps

Check for git commit in make output.
```
$ make install
...
go install -tags ""  -ldflags "-s -w -X github.com/juju/juju/version.GitCommit=0c2906e9e65872bd561218f3de05b77887bde6fe -X github.com/juju/juju/version.GitTreeState=clean -X github.com/juju/juju/version.build=" -v $PROJECT_PACKAGES
```

Check for dirty state
```
$ touch dirty-state
$ make install
...
go install -tags ""  -ldflags "-s -w -X github.com/juju/juju/version.GitCommit=0c2906e9e65872bd561218f3de05b77887bde6fe -X github.com/juju/juju/version.GitTreeState=dirty -X github.com/juju/juju/version.build=" -v $PROJECT_PACKAGES
```

Check for archive
```
$ mv .git .git.bak
$ make install GIT_COMMIT=testcommit
...
go install -tags ""  -ldflags "-s -w -X github.com/juju/juju/version.GitCommit=testcommit -X github.com/juju/juju/version.GitTreeState=archive -X github.com/juju/juju/version.build=" -v $PROJECT_PACKAGES
$ mv .git.bak .git
```

## Documentation changes

N/A

## Bug reference

N/A
