### PR TITLE
Add metrics for monitoring the mongo replicaset.

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -713,12 +713,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{
-			AgentName:          agentName,
-			ClockName:          clockName,
-			ControllerPortName: controllerPortName,
-			StateName:          stateName,
-			Hub:                config.CentralHub,
-			NewWorker:          peergrouper.New,
+			AgentName:            agentName,
+			ClockName:            clockName,
+			ControllerPortName:   controllerPortName,
+			StateName:            stateName,
+			Hub:                  config.CentralHub,
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewWorker:            peergrouper.New,
 		})),
 
 		restoreWatcherName: restorewatcher.Manifold(restorewatcher.ManifoldConfig{

--- a/worker/peergrouper/manifold.go
+++ b/worker/peergrouper/manifold.go
@@ -46,6 +46,9 @@ func (config ManifoldConfig) Validate() error {
 	if config.Hub == nil {
 		return errors.NotValidf("nil Hub")
 	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("nil PrometheusRegisterer")
+	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
 	}

--- a/worker/peergrouper/metrics.go
+++ b/worker/peergrouper/metrics.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/juju/replicaset"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju_peergrouper"
+
+	idLabel      = "id"
+	addressLabel = "address"
+	stateLabel   = "state"
+)
+
+var (
+	replicasetLabelNames = []string{
+		idLabel,
+		addressLabel,
+		stateLabel,
+	}
+)
+
+// Collector is a prometheus.Collector that collects metrics about
+// the Juju global state.
+type Collector struct {
+	replicasetStatus prometheus.Gauge
+
+	mu     sync.Mutex
+	status []replicaset.MemberStatus
+}
+
+// NewMetricsCollector returns a new Collector.
+func NewMetricsCollector() *Collector {
+	return &Collector{
+		replicasetStatus: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: metricsNamespace,
+				Name:      "replicaset_status",
+				Help:      "The details of the mongo replicaset.",
+			},
+		),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.replicasetStatus.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.replicasetStatus.Reset()
+
+	c.mu.Lock()
+	for _, member := range c.status {
+		c.replicasetStatus.With(prometheus.Labels{
+			idLabel:      fmt.Sprint(member.Id),
+			addressLabel: member.Address,
+			stateLabel:   member.State.String(),
+		}).Inc()
+	}
+	c.mu.Unlock()
+
+	c.replicasetStatus.Collect(ch)
+}
+
+func (c *Collector) update(statuses map[string]replicaset.MemberStatus) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.status = make([]replicaset.MemberStatus, 0, len(statuses))
+	for _, status := range statuses {
+		c.status = append(c.status, status)
+	}
+}


### PR DESCRIPTION
Add a new metrics GuageVec to show the mongo replicaset status. Also expose this information in the juju_engine_report.

## QA steps

* bootstrap a controller, and then ssh to the controller machine to check the metrics and engine report. You should see output similar to:

```
ubuntu@juju-6ef4f2-0:~$ juju_metrics | grep peer
Querying @jujud-machine-0 introspection socket: /metrics/
# HELP juju_peergrouper_replicaset_status The details of the mongo replicaset.
# TYPE juju_peergrouper_replicaset_status gauge
juju_peergrouper_replicaset_status{address="10.172.145.121:37017",id="1",state="PRIMARY"} 1

ubuntu@juju-6ef4f2-0:~$ juju_engine_report | grep -A 15 peer-grouper
Querying @jujud-machine-0 introspection socket: /depengine
  peer-grouper:
    inputs:
    - agent
    - clock
    - controller-port
    - state
    - upgrade-steps-flag
    - upgrade-check-flag
    report:
      replicaset:
        "1":                                                                                                                                                                                                              
          address: 10.172.145.121:37017                                                                                                                                                                                   
          state: PRIMARY                                                                                                                                                                                                  
    start-count: 1                                                                                                                                                                                                        
    started: "2019-12-17 04:25:46"                                                                                                                                                                                        
    state: started                                                                                                                                                                                                        
```
Then `juju enable-ha`, wait for things to come up, then test again:

```
$ juju_metrics | grep peer
Querying @jujud-machine-1 introspection socket: /metrics/
# HELP juju_peergrouper_replicaset_status The details of the mongo replicaset.
# TYPE juju_peergrouper_replicaset_status gauge
juju_peergrouper_replicaset_status{address="10.172.145.146:37017",id="1",state="SECONDARY"} 1
juju_peergrouper_replicaset_status{address="10.172.145.177:37017",id="2",state="PRIMARY"} 1
juju_peergrouper_replicaset_status{address="10.172.145.52:37017",id="3",state="SECONDARY"} 1

$ juju_engine_report | grep -A 21 peer-grouper
Querying @jujud-machine-1 introspection socket: /depengine
  peer-grouper:
    inputs:
    - agent
    - clock
    - controller-port
    - state
    - upgrade-steps-flag
    - upgrade-check-flag
    report:
      replicaset:
        "1":
          address: 10.172.145.146:37017
          state: SECONDARY
        "2":
          address: 10.172.145.177:37017
          state: PRIMARY
        "3":
          address: 10.172.145.52:37017
          state: SECONDARY
    start-count: 1
    started: "2019-12-17 04:24:30"
    state: started
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1855974