### PR TITLE
Deploy tmp directory

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -7,6 +7,7 @@ import (
 	"archive/zip"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -1534,7 +1535,7 @@ func (c *DeployCommand) maybeReadCharmstoreBundleFn(cstore BundleResolver) func(
 			if err != nil {
 				return errors.Trace(err)
 			}
-			bundle, err := cstore.GetBundle(bundleURL, dir)
+			bundle, err := cstore.GetBundle(bundleURL, filepath.Join(dir, bundleURL.Name))
 			if err != nil {
 				return errors.Trace(err)
 			}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The following changes ensure that we create a new unique tmp directory
that we can deploy from. The previous code created this tmp directory
but so did the library function. Assuming we actually want to create a
tmp directory to launch from, I've ensured that we namespace a new
directory inside the tmp directory that the library can create. Although
convoluted, it ensures that we get what we want; ephemeral directory
state and the library gets to create it's own directories that it can
own and manage accordingly.


## QA steps

Bootstrap and deploy a basic bundle.

```sh
juju deploy --debug cs:~juju-qa/bundle/basic-0
```
