### PR TITLE
Fixes Errors During Migration Resource POST

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -50,26 +50,26 @@ func (c *Client) Prechecks(model coremigration.ModelInfo) error {
 		AgentVersion:           model.AgentVersion,
 		ControllerAgentVersion: model.ControllerAgentVersion,
 	}
-	return c.caller.FacadeCall("Prechecks", args, nil)
+	return errors.Trace(c.caller.FacadeCall("Prechecks", args, nil))
 }
 
 // Import takes a serialized model and imports it into the target
 // controller.
 func (c *Client) Import(bytes []byte) error {
 	serialized := params.SerializedModel{Bytes: bytes}
-	return c.caller.FacadeCall("Import", serialized, nil)
+	return errors.Trace(c.caller.FacadeCall("Import", serialized, nil))
 }
 
 // Abort removes all data relating to a previously imported model.
 func (c *Client) Abort(modelUUID string) error {
 	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
-	return c.caller.FacadeCall("Abort", args, nil)
+	return errors.Trace(c.caller.FacadeCall("Abort", args, nil))
 }
 
 // Activate marks a migrated model as being ready to use.
 func (c *Client) Activate(modelUUID string) error {
 	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
-	return c.caller.FacadeCall("Activate", args, nil)
+	return errors.Trace(c.caller.FacadeCall("Activate", args, nil))
 }
 
 // UploadCharm sends the content to the API server using an HTTP post in order
@@ -133,9 +133,6 @@ func (c *Client) SetUnitResource(modelUUID, unit string, res resource.Resource) 
 
 func (c *Client) resourcePost(modelUUID string, args url.Values, r io.ReadSeeker) error {
 	uri := "/migrate/resources?" + args.Encode()
-	if r == nil {
-		r = strings.NewReader("")
-	}
 	contentType := "application/octet-stream"
 	err := c.httpPost(modelUUID, r, uri, contentType, nil)
 	return errors.Trace(err)
@@ -174,12 +171,7 @@ func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, con
 		return errors.Trace(err)
 	}
 
-	if err := httpClient.Do(
-		c.caller.RawAPICaller().Context(),
-		req, response); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return errors.Trace(httpClient.Do(c.caller.RawAPICaller().Context(), req, response))
 }
 
 // OpenLogTransferStream connects to the migration logtransfer
@@ -203,7 +195,7 @@ func (c *Client) OpenLogTransferStream(modelUUID string) (base.Stream, error) {
 // restartable.
 func (c *Client) LatestLogTime(modelUUID string) (time.Time, error) {
 	var result time.Time
-	args := params.ModelArgs{names.NewModelTag(modelUUID).String()}
+	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
 	err := c.caller.FacadeCall("LatestLogTime", args, &result)
 	if err != nil {
 		return time.Time{}, errors.Trace(err)
@@ -229,7 +221,7 @@ func (c *Client) CACert() (string, error) {
 	var result params.BytesResult
 	err := c.caller.FacadeCall("CACert", nil, &result)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(err)
 	}
 	return string(result.Result), nil
 }
@@ -238,7 +230,7 @@ func (c *Client) CACert() (string, error) {
 // by the provider and reports any discrepancies.
 func (c *Client) CheckMachines(modelUUID string) ([]error, error) {
 	var result params.ErrorResults
-	args := params.ModelArgs{names.NewModelTag(modelUUID).String()}
+	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
 	err := c.caller.FacadeCall("CheckMachines", args, &result)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -360,6 +360,16 @@ type fakeDoer struct {
 func (d *fakeDoer) Do(req *http.Request) (*http.Response, error) {
 	d.method = req.Method
 	d.url = req.URL.String()
+
+	// If the body is nil, don't do anything about reading the req.Body
+	// The underlying net http go library deals with nil bodies for requests,
+	// so our fake stub should also mirror this.
+	// https://golang.org/src/net/http/client.go?s=17323:17375#L587
+	if req.Body == nil {
+		return d.response, nil
+	}
+
+	// ReadAll the body if it's found.
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch fixes an error that we indirectly materialised by another fix in #11045, namely:
https://github.com/juju/juju/pull/11045/files#diff-4146ed30a9aaf0ffbbe7363177d8877cR164

It was causing failures in migration integration tests like this:
```
message: 'migrating: aborted, removing model from target controller: model data
      transfer failed, failed to migrate binaries: cannot set unit resource: Post
      https://10.5.100.136:17070/migrate/resources?description=File+to+serve.&fingerprint=54e81731b5a4931699167a855d1203ea0169b4c3a69026e079721718032e7ab33ca9f122bfc51a166c6519f1a6ac519c&name=index&origin=upload&path=index.html&revision=0&size=20&timestamp=1576591312486000000&type=file&unit=simple-resource-http%2F0&user=admin:
      request body is not seekable'
```

Uploading resources was passing an empty string reader to the `httpPost` method, which was ignored and substituted with `nil` in the downstream method.

This simply passes the `io.ReadSeeker` as is, preserving a `nil` value.

## QA steps

Migration acceptance tests pass.

## Documentation changes

None.

## Bug reference

N/A
