### PR TITLE
[dev] restore channels in bundle feature

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1442,7 +1442,7 @@
   revision = "b0d0ce63cbe0c6e31d38e886a8c7cb20979b509d"
 
 [[projects]]
-  digest = "1:4c36061633490dc60772944614e06b4de202c271bddaef55335af989ea35dfb8"
+  digest = "1:9ba600a74f6c996413ca895535c3ab0174f73c80673781e0dd7f42eeb077cabf"
   name = "gopkg.in/juju/charmrepo.v4"
   packages = [
     ".",
@@ -1451,7 +1451,7 @@
     "testing",
   ]
   pruneopts = ""
-  revision = "cd05de29309bc2c97e7334b8316c916203b0be9d"
+  revision = "b9bdf9c00e26a0340e8050bdaf1e042000222765"
 
 [[projects]]
   digest = "1:7654e769ed719c292d72af4420ca772d9c850299271e15c6f5af4fb89526c3fd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -151,7 +151,7 @@
   revision = "b0d0ce63cbe0c6e31d38e886a8c7cb20979b509d"
 
 [[constraint]]
-  revision = "cd05de29309bc2c97e7334b8316c916203b0be9d"
+  revision = "b9bdf9c00e26a0340e8050bdaf1e042000222765"
   name = "gopkg.in/juju/charmrepo.v4"
 
 [[constraint]]

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -374,7 +374,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		url, _, _, err := resolveCharm(h.bundleResolver.ResolveWithChannel, ch)
+		url, _, _, err := resolveCharm(h.bundleResolver.ResolveWithPreferredChannel, ch, csparams.Channel(spec.Channel))
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve URL %q", spec.Charm)
 		}
@@ -538,7 +538,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 
-	url, channel, _, err := resolveCharm(h.bundleResolver.ResolveWithChannel, ch)
+	url, channel, _, err := resolveCharm(h.bundleResolver.ResolveWithPreferredChannel, ch, csparams.Channel(p.Channel))
 	if err != nil {
 		return errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
 	}

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -181,7 +181,7 @@ func (c *bundleDiffCommand) bundleDataSource(ctx *cmd.Context) (charm.BundleData
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	bundleURL, _, err := resolveBundleURL(charmStore, c.bundle)
+	bundleURL, _, err := resolveBundleURL(charmStore, c.bundle, c.channel)
 	if err != nil && !errors.IsNotValid(err) {
 		return nil, errors.Trace(err)
 	}
@@ -219,7 +219,7 @@ func (c *bundleDiffCommand) charmStore() (BundleResolver, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cstoreClient := newCharmStoreClient(bakeryClient, csURL, c.channel)
+	cstoreClient := newCharmStoreClient(bakeryClient, csURL).WithChannel(c.channel)
 	return charmrepo.NewCharmStoreFromClient(cstoreClient), nil
 }
 

--- a/cmd/juju/application/bundlediff_test.go
+++ b/cmd/juju/application/bundlediff_test.go
@@ -349,8 +349,8 @@ type mockCharmStore struct {
 	bundle  *mockBundle
 }
 
-func (s *mockCharmStore) ResolveWithChannel(url *charm.URL) (*charm.URL, csparams.Channel, []string, error) {
-	s.stub.AddCall("ResolveWithChannel", url)
+func (s *mockCharmStore) ResolveWithPreferredChannel(url *charm.URL, preferredChannel csparams.Channel) (*charm.URL, csparams.Channel, []string, error) {
+	s.stub.AddCall("ResolveWithPreferredChannel", url, preferredChannel)
 	return s.url, s.channel, s.series, s.stub.NextErr()
 }
 

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -9,7 +9,6 @@ import (
 	gc "gopkg.in/check.v1"
 	charmresource "gopkg.in/juju/charm.v6/resource"
 	"gopkg.in/juju/charmrepo.v4"
-	"gopkg.in/juju/charmrepo.v4/csclient/params"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api"
@@ -41,7 +40,7 @@ func NewDeployCommandForTest(fakeApi *fakeDeployAPI) modelcmd.ModelCommand {
 		) (ids map[string]string, err error) {
 			return nil, nil
 		},
-		NewCharmRepo: func(channel params.Channel) (*charmStoreAdaptor, error) {
+		NewCharmRepo: func() (*charmStoreAdaptor, error) {
 			return fakeApi.charmStoreAdaptor, nil
 		},
 	}
@@ -70,7 +69,7 @@ func NewDeployCommandForTest(fakeApi *fakeDeployAPI) modelcmd.ModelCommand {
 				plansClient:       &plansClient{planURL: mURL},
 			}, nil
 		}
-		deployCmd.NewCharmRepo = func(channel params.Channel) (*charmStoreAdaptor, error) {
+		deployCmd.NewCharmRepo = func() (*charmStoreAdaptor, error) {
 			controllerAPIRoot, err := deployCmd.NewControllerAPIRoot()
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -83,7 +82,7 @@ func NewDeployCommandForTest(fakeApi *fakeDeployAPI) modelcmd.ModelCommand {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			cstoreClient := newCharmStoreClient(bakeryClient, csURL, channel).WithChannel(deployCmd.Channel)
+			cstoreClient := newCharmStoreClient(bakeryClient, csURL).WithChannel(deployCmd.Channel)
 			return &charmStoreAdaptor{
 				macaroonGetter:     cstoreClient,
 				charmrepoForDeploy: charmrepo.NewCharmStoreFromClient(cstoreClient),

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -366,7 +366,7 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 	chID, csMac, err := c.addCharm(addCharmParams{
 		charmAdder:     c.NewCharmAdder(apiRoot),
 		charmRepo:      c.NewCharmStore(bakeryClient, csURL, c.Channel),
-		authorizer:     newCharmStoreClient(bakeryClient, csURL, c.Channel),
+		authorizer:     newCharmStoreClient(bakeryClient, csURL),
 		oldURL:         oldURL,
 		newCharmRef:    newRef,
 		deployedSeries: applicationInfo.Series,
@@ -623,7 +623,7 @@ func getCharmStore(
 	csURL string,
 	channel csclientparams.Channel,
 ) charmrepoForDeploy {
-	csClient := newCharmStoreClient(bakeryClient, csURL, channel)
+	csClient := newCharmStoreClient(bakeryClient, csURL).WithChannel(channel)
 	return charmrepo.NewCharmStoreFromClient(csClient)
 }
 
@@ -679,7 +679,7 @@ func (c *upgradeCharmCommand) addCharm(params addCharmParams) (charmstore.CharmI
 	}
 
 	// Charm has been supplied as a URL so we resolve and deploy using the store.
-	newURL, channel, supportedSeries, err := c.ResolveCharm(params.charmRepo.ResolveWithChannel, refURL)
+	newURL, channel, supportedSeries, err := c.ResolveCharm(params.charmRepo.ResolveWithPreferredChannel, refURL, c.Channel)
 	if err != nil {
 		return id, nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -141,7 +141,7 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 	) (ids map[string]string, err error) {
 		return deployResources(s.State, applicationID, resources)
 	}
-	deploy.NewCharmRepo = func(channel csclientparams.Channel) (*charmStoreAdaptor, error) {
+	deploy.NewCharmRepo = func() (*charmStoreAdaptor, error) {
 		return s.fakeAPI.charmStoreAdaptor, nil
 	}
 

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -96,12 +96,17 @@ func (s *BaseUpgradeCharmSuite) SetUpTest(c *gc.C) {
 
 	s.resolvedChannel = csclientparams.StableChannel
 	s.resolveCharm = func(
-		resolveWithChannel func(*charm.URL) (*charm.URL, csclientparams.Channel, []string, error),
+		resolveWithChannel func(*charm.URL, csclientparams.Channel) (*charm.URL, csclientparams.Channel, []string, error),
 		url *charm.URL,
+		preferredChannel csclientparams.Channel,
 	) (*charm.URL, csclientparams.Channel, []string, error) {
-		s.AddCall("ResolveCharm", url)
+		s.AddCall("ResolveCharm", url, preferredChannel)
 		if err := s.NextErr(); err != nil {
 			return nil, csclientparams.NoChannel, nil, err
+		}
+
+		if s.resolvedChannel != "" {
+			preferredChannel = s.resolvedChannel
 		}
 		return s.resolvedCharmURL, s.resolvedChannel, []string{"quantal"}, nil
 	}


### PR DESCRIPTION
# Description of change

This PR restores the channels-in-bundles code that was accidentally removed by #11045. 

## QA steps

Please follow the QA steps from https://github.com/juju/juju/pull/10480 making sure to check that the following CLI commands work as before when using channels in bundles:

- deploy
- upgradecharm
- diff-bundle