### PR TITLE
Migrate external auth backend to use bakery.v2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1985,6 +1985,8 @@
     "gopkg.in/macaroon-bakery.v2-unstable/httpbakery",
     "gopkg.in/macaroon-bakery.v2/bakery",
     "gopkg.in/macaroon-bakery.v2/bakery/checkers",
+    "gopkg.in/macaroon-bakery.v2/bakery/identchecker",
+    "gopkg.in/macaroon-bakery.v2/bakerytest",
     "gopkg.in/macaroon-bakery.v2/httpbakery",
     "gopkg.in/macaroon-bakery.v2/httpbakery/form",
     "gopkg.in/macaroon.v2",

--- a/api/http.go
+++ b/api/http.go
@@ -208,9 +208,11 @@ func bakeryError(err error) error {
 			MacaroonPath: info.MacaroonPath,
 		},
 	}
-	if info.Macaroon != nil {
-		dcMac, err := bakery.NewLegacyMacaroon(info.Macaroon)
-		if err != nil {
+	if info.Macaroon != nil || info.BakeryMacaroon != nil {
+		// Prefer the newer bakery.v2 macaroon.
+		dcMac := info.BakeryMacaroon
+		if dcMac == nil {
+			dcMac, err = bakery.NewLegacyMacaroon(info.Macaroon)
 			return errors.Annotate(err, "unable to create legacy macaroon details from discharge-required response error")
 		}
 		bakeryErr.Info.Macaroon = dcMac

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -90,7 +90,8 @@ func (a *admin) login(req params.LoginRequest, loginVersion int) (params.LoginRe
 	authResult, err := a.authenticate(req)
 	if err, ok := errors.Cause(err).(*common.DischargeRequiredError); ok {
 		loginResult := params.LoginResult{
-			DischargeRequired:       err.Macaroon,
+			DischargeRequired:       err.LegacyMacaroon,
+			BakeryDischargeRequired: err.Macaroon,
 			DischargeRequiredReason: err.Error(),
 		}
 		logger.Infof("login failed with discharge-required error: %v", err)

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1246,8 +1246,12 @@ func (s *macaroonLoginSuite) login(c *gc.C, info *api.Info) (params.LoginResult,
 
 	bakeryClient := httpbakery.NewClient()
 
-	mac, err := bakery.NewLegacyMacaroon(result.DischargeRequired)
-	c.Assert(err, jc.ErrorIsNil)
+	mac := result.BakeryDischargeRequired
+	if mac == nil {
+		var err error
+		mac, err = bakery.NewLegacyMacaroon(result.DischargeRequired)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 	err = bakeryClient.HandleError(context.Background(), cookieURL, &httpbakery.Error{
 		Message: result.DischargeRequiredReason,
 		Code:    httpbakery.ErrDischargeRequired,

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -333,8 +333,8 @@ func (a *authenticator) checkMacaroons(mac macaroon.Slice, requiredValues map[st
 		return nil, errors.Annotate(err, "cannot create macaroon")
 	}
 	return nil, &common.DischargeRequiredError{
-		Cause:    cause,
-		Macaroon: m,
+		Cause:          cause,
+		LegacyMacaroon: m,
 	}
 }
 

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -333,7 +333,7 @@ func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
 	)
 	dischargeErr, ok := err.(*common.DischargeRequiredError)
 	c.Assert(ok, jc.IsTrue)
-	cav := dischargeErr.Macaroon.Caveats()
+	cav := dischargeErr.LegacyMacaroon.Caveats()
 	c.Assert(cav, gc.HasLen, 2)
 	c.Assert(cav[0].Location, gc.Equals, "http://thirdparty")
 }
@@ -432,7 +432,7 @@ func (s *authSuite) TestCheckRelationMacaroonsDischargeRequired(c *gc.C) {
 	)
 	dischargeErr, ok := err.(*common.DischargeRequiredError)
 	c.Assert(ok, jc.IsTrue)
-	cav := dischargeErr.Macaroon.Caveats()
+	cav := dischargeErr.LegacyMacaroon.Caveats()
 	c.Assert(cav, gc.HasLen, 2)
 	c.Assert(cav[0].Location, gc.Equals, "http://thirdparty")
 }

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/txn"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/params"
@@ -62,8 +63,9 @@ func isUnknownModelError(err error) bool {
 // DischargeRequiredError is the error returned when a macaroon requires discharging
 // to complete authentication.
 type DischargeRequiredError struct {
-	Cause    error
-	Macaroon *macaroon.Macaroon
+	Cause          error
+	LegacyMacaroon *macaroon.Macaroon
+	Macaroon       *bakery.Macaroon
 }
 
 // Error implements the error interface.
@@ -284,7 +286,8 @@ func ServerError(err error) *params.Error {
 		dischErr := errors.Cause(err).(*DischargeRequiredError)
 		code = params.CodeDischargeRequired
 		info = params.DischargeRequiredErrorInfo{
-			Macaroon: dischErr.Macaroon,
+			Macaroon:       dischErr.LegacyMacaroon,
+			BakeryMacaroon: dischErr.Macaroon,
 			// One macaroon fits all.
 			MacaroonPath: "/",
 		}.AsMap()

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -172,8 +172,8 @@ var errorTransformTests = []struct {
 	code:   "",
 }, {
 	err: &common.DischargeRequiredError{
-		Cause:    errors.New("something"),
-		Macaroon: sampleMacaroon,
+		Cause:          errors.New("something"),
+		LegacyMacaroon: sampleMacaroon,
 	},
 	status: http.StatusUnauthorized,
 	code:   params.CodeDischargeRequired,

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 )
 
@@ -81,6 +82,13 @@ type DischargeRequiredErrorInfo struct {
 	// This field is associated with the ErrDischargeRequired
 	// error code.
 	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
+
+	// BakeryMacaroon may hold a macaroon that, when
+	// discharged, may allow access to the juju API.
+	// This field is associated with the ErrDischargeRequired
+	// error code.
+	// This is the macaroon emitted by newer Juju controllers using bakery.v2.
+	BakeryMacaroon *bakery.Macaroon `json:"bakery-macaroon,omitempty"`
 
 	// MacaroonPath holds the URL path to be associated
 	// with the macaroon. The macaroon is potentially

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/proxy"
 	"github.com/juju/utils/ssh"
 	"github.com/juju/version"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/core/constraints"
@@ -771,6 +772,17 @@ type LoginResult struct {
 	// however because of the above it is suitable to use the Macaroon type
 	// here.
 	DischargeRequired *macaroon.Macaroon `json:"discharge-required,omitempty"`
+
+	// BakeryDischargeRequired implies that the login request has failed, and none of
+	// the other fields are populated. It contains a macaroon which, when
+	// discharged, will grant access on a subsequent call to Login.
+	// Note: It is OK to use the Macaroon type here as it is explicitly
+	// designed to provide stable serialisation of macaroons.  It's good
+	// practice to only use primitives in types that will be serialised,
+	// however because of the above it is suitable to use the Macaroon type
+	// here.
+	// This is the macaroon emitted by newer Juju controllers using bakery.v2.
+	BakeryDischargeRequired *bakery.Macaroon `json:"bakery-discharge-required,omitempty"`
 
 	// DischargeRequiredReason holds the reason that the above discharge was
 	// required.

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -4,6 +4,7 @@
 package stateauthenticator
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"strings"
@@ -43,7 +44,7 @@ type Authenticator struct {
 
 // NewAuthenticator returns a new Authenticator using the given StatePool.
 func NewAuthenticator(statePool *state.StatePool, clock clock.Clock) (*Authenticator, error) {
-	authContext, err := newAuthContext(statePool.SystemState(), clock)
+	authContext, err := newAuthContext(statePool.SystemState(), clock, context.Background())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/stateauthenticator/export_test.go
+++ b/apiserver/stateauthenticator/export_test.go
@@ -5,7 +5,7 @@ package stateauthenticator
 
 import (
 	"gopkg.in/juju/names.v3"
-	"gopkg.in/macaroon.v2"
+	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
 
 	"github.com/juju/juju/apiserver/authentication"
 )
@@ -16,18 +16,10 @@ func EntityAuthenticator(authenticator *Authenticator, tag names.Tag) (authentic
 	return authenticator.authContext.authenticator("testing.invalid:1234").authenticatorForTag(tag)
 }
 
-func ServerMacaroon(a *Authenticator) (*macaroon.Macaroon, error) {
-	auth, err := a.authContext.externalMacaroonAuth()
+func ServerBakery(a *Authenticator, identClient identchecker.IdentityClient) (*identchecker.Bakery, error) {
+	auth, err := a.authContext.externalMacaroonAuth(identClient)
 	if err != nil {
 		return nil, err
 	}
-	return auth.(*authentication.ExternalMacaroonAuthenticator).Macaroon, nil
-}
-
-func ServerBakeryService(a *Authenticator) (authentication.BakeryService, error) {
-	auth, err := a.authContext.externalMacaroonAuth()
-	if err != nil {
-		return nil, err
-	}
-	return auth.(*authentication.ExternalMacaroonAuthenticator).Service, nil
+	return auth.(*authentication.ExternalMacaroonAuthenticator).Bakery, nil
 }


### PR DESCRIPTION
## Description of change

Migrate the external authentication backend to use bakery.v2 
We need to support passing back to the caller a newer bakery macaroon. This is added
to the relevant params structs and the caller code has been updated to look for the newer macaroon first and fallback to the older one for old controllers.

## QA steps

juju bootstrap lxd --config identity-url=https://api.jujucharms.com/identity --config identity-public-key=hmHaPgCC1UfuhYHUSX5+aihSAZesqpVdjRv0mgfIwjo=
juju grant fred@external superuser
juju change_user_password
juju logout
juju login -u fred@external

