### PR TITLE
Indicate NotFound Relation as Dead Only if Not Migrating

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -430,18 +430,33 @@ func parseCIDRs(cidrs *[]*net.IPNet, values []string) error {
 }
 
 type relationGetter interface {
+	// KeyRelation returns the relation identified by the input key.
 	KeyRelation(string) (Relation, error)
+	// IsMigrationActive returns true if the current model is
+	// in the process of being migrated to another controller.
+	IsMigrationActive() (bool, error)
 }
 
 // GetRelationLifeSuspendedStatusChange returns a life/suspended status change
 // struct for a specified relation key.
-func GetRelationLifeSuspendedStatusChange(st relationGetter, key string) (*params.RelationLifeSuspendedStatusChange, error) {
+func GetRelationLifeSuspendedStatusChange(
+	st relationGetter, key string,
+) (*params.RelationLifeSuspendedStatusChange, error) {
 	rel, err := st.KeyRelation(key)
 	if errors.IsNotFound(err) {
-		return &params.RelationLifeSuspendedStatusChange{
-			Key:  key,
-			Life: life.Dead,
-		}, nil
+		// If the relation is not found we represent it as dead,
+		// but *only* if we are not currently migrating.
+		// If we are migrating, we do not want to inform remote watchers that
+		// the relation is dead before they have had a chance to be redirected
+		// to the new controller.
+		if migrating, mErr := st.IsMigrationActive(); mErr == nil && !migrating {
+			return &params.RelationLifeSuspendedStatusChange{
+				Key:  key,
+				Life: life.Dead,
+			}, nil
+		} else if mErr != nil {
+			err = mErr
+		}
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -471,17 +486,17 @@ func GetOfferStatusChange(st offerGetter, offerUUID string) (*params.OfferStatus
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	status, err := app.Status()
+	sts, err := app.Status()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &params.OfferStatusChange{
 		OfferName: offer.OfferName,
 		Status: params.EntityStatus{
-			Status: status.Status,
-			Info:   status.Message,
-			Data:   status.Data,
-			Since:  status.Since,
+			Status: sts.Status,
+			Info:   sts.Message,
+			Data:   sts.Data,
+			Since:  sts.Since,
 		},
 	}, nil
 }

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -52,6 +52,7 @@ type mockState struct {
 	remoteEntities        map[names.Tag]string
 	firewallRules         map[corefirewall.WellKnownServiceType]*state.FirewallRule
 	ingressNetworks       map[string][]string
+	migrationActive       bool
 }
 
 func newMockState() *mockState {
@@ -218,6 +219,14 @@ func (st *mockState) KeyRelation(key string) (commoncrossmodel.Relation, error) 
 		return nil, errors.NotFoundf("relation %q", key)
 	}
 	return r, nil
+}
+
+func (st *mockState) IsMigrationActive() (bool, error) {
+	st.MethodCall(st, "IsMigrationActive")
+	if err := st.NextErr(); err != nil {
+		return false, err
+	}
+	return st.migrationActive, nil
 }
 
 func (st *mockState) RemoteApplication(id string) (commoncrossmodel.RemoteApplication, error) {

--- a/apiserver/facades/controller/crossmodelrelations/state.go
+++ b/apiserver/facades/controller/crossmodelrelations/state.go
@@ -4,6 +4,7 @@
 package crossmodelrelations
 
 import (
+	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 
 	common "github.com/juju/juju/apiserver/common/crossmodel"
@@ -25,6 +26,10 @@ type CrossModelRelationsState interface {
 
 	// OfferConnectionForRelation returns the offer connection details for the given relation key.
 	OfferConnectionForRelation(string) (OfferConnection, error)
+
+	// IsMigrationActive returns true if the current model is
+	// in the process of being migrated to another controller.
+	IsMigrationActive() (bool, error)
 }
 
 // TODO - CAAS(ericclaudejones): This should contain state alone, model will be
@@ -45,6 +50,13 @@ func (st stateShim) AddOfferConnection(arg state.AddOfferConnectionParams) (Offe
 
 func (st stateShim) OfferConnectionForRelation(relationKey string) (OfferConnection, error) {
 	return st.st.OfferConnectionForRelation(relationKey)
+}
+
+// IsMigrationActive returns true if the current model is
+// in the process of being migrated to another controller.
+func (st stateShim) IsMigrationActive() (bool, error) {
+	migrating, err := st.st.IsMigrationActive()
+	return migrating, errors.Trace(err)
 }
 
 type Model interface {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch  Modifes `GetRelationLifeSuspendedStatusChange` so that when a relation is not found via its key, we represent the relation as dead *only* if not currently migrating.

This will give remote watchers a chance to redirect *before* marking their relations as dead when collections are deleted at the end of a migration.

## QA steps

This patch is hard to QA test because it depends on the order of collection deletion following migration. This order is random, because we iterate over the model schema, which is a map.

Unit tests verify the behaviour. Integration tests and QA will be included in those for #11025.

## Documentation changes

None

## Bug reference

N/A
