### PR TITLE
Build less version checking

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -779,11 +779,11 @@
   revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"
 
 [[projects]]
-  digest = "1:eab278f98004677adf1d70d6cdaba1c01a446ab10dddb1cf7d83cfd1475c22cc"
+  digest = "1:ac49627092b42eca5480db7fdae2814f60066dc922907b6c49bfddd30db5824e"
   name = "github.com/juju/version"
   packages = ["."]
   pruneopts = ""
-  revision = "1f41e27e54f21acccf9b2dddae063a782a8a7ceb"
+  revision = "81c1be00b9a67de4490453f6117d13d818c9fb84"
 
 [[projects]]
   digest = "1:151d8c34a506d526d1c5605daa4efef27d7226284bd313b96c320d65b4efb617"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -342,7 +342,7 @@
 
 [[constraint]]
   name = "github.com/juju/version"
-  revision = "1f41e27e54f21acccf9b2dddae063a782a8a7ceb"
+  revision = "81c1be00b9a67de4490453f6117d13d818c9fb84"
 
 [[override]]
   name = "github.com/juju/xml"

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -322,10 +322,8 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	c.Assert(controller.APIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(utils.IsValidUUIDString(controller.ControllerUUID), jc.IsTrue)
 	// We don't care about build numbers here.
-	bootstrapVers := bootstrapVersion.Number
-	bootstrapVers.Build = 0
-	controllerVers := version.MustParse(controller.AgentVersion)
-	controllerVers.Build = 0
+	bootstrapVers := bootstrapVersion.Number.ToPatch()
+	controllerVers := version.MustParse(controller.AgentVersion).ToPatch()
 	c.Assert(controllerVers.String(), gc.Equals, bootstrapVers.String())
 
 	controllerModel, err := s.store.ModelByName(controllerName, "admin/controller")

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -716,10 +716,8 @@ func (context *upgradeContext) uploadTools(client toolsAPI, buildAgent bool, age
 	}
 	// If the Juju client matches the current running agent (excluding build number),
 	// make sure the build number gets incremented.
-	agentVersionCopy := agentVersion
-	agentVersionCopy.Build = 0
-	uploadBaseVersionCopy := uploadBaseVersion
-	uploadBaseVersion.Build = 0
+	agentVersionCopy := agentVersion.ToPatch()
+	uploadBaseVersionCopy := uploadBaseVersion.ToPatch()
 	if agentVersionCopy.Compare(uploadBaseVersionCopy) == 0 {
 		uploadBaseVersion = agentVersion
 	}
@@ -848,7 +846,7 @@ func makeUploadVersion(vers version.Number, existing coretools.Versions) version
 }
 
 func compareNoBuild(a, b version.Number) int {
-	a.Build = 0
-	b.Build = 0
-	return a.Compare(b)
+	x := a.ToPatch()
+	y := b.ToPatch()
+	return x.Compare(y)
 }

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -313,8 +313,7 @@ func (s *ToolsMetadataSuite) TestPatchLevels(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("Skipping on windows, test only set up for Linux tools")
 	}
-	currentVersion := jujuversion.Current
-	currentVersion.Build = 0
+	currentVersion := jujuversion.Current.ToPatch()
 	versionStrings := []string{
 		currentVersion.String() + "-precise-amd64",
 		currentVersion.String() + ".1-precise-amd64",

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -905,9 +905,9 @@ func findCompatibleTools(possibleTools coretools.List, version version.Number) (
 }
 
 func isCompatibleVersion(v1, v2 version.Number) bool {
-	v1.Build = 0
-	v2.Build = 0
-	return v1.Compare(v2) == 0
+	x := v1.ToPatch()
+	y := v2.ToPatch()
+	return x.Compare(y) == 0
 }
 
 // setPrivateMetadataSources verifies the specified metadataDir exists,

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -669,13 +669,12 @@ func (s *bootstrapSuite) TestBootstrapBuildAgent(c *gc.C) {
 				c.Assert(build, jc.IsTrue)
 				c.Assert(ver.String(), gc.Equals, "1.99.0.1")
 				localVer := *ver
-				// If we found an official build we suppress the build number.
-				localVer.Build = 0
 				return &sync.BuiltAgent{
 					Dir:      c.MkDir(),
 					Official: true,
 					Version: version.Binary{
-						Number: localVer,
+						// If we found an official build we suppress the build number.
+						Number: localVer.ToPatch(),
 						Series: "quental",
 						Arch:   "arm64",
 					},

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -66,9 +66,16 @@ func findPackagedTools(
 	// one is configured in the environment.
 	if vers == nil {
 		if agentVersion, ok := env.Config().AgentVersion(); ok {
-			vers = &agentVersion
+			configVersion := agentVersion.ToPatch()
+			vers = &configVersion
 		}
+	} else {
+		// We don't care about the build version here when looking for packaged
+		// tools.
+		buildLessVersion := vers.ToPatch()
+		vers = &buildLessVersion
 	}
+
 	logger.Infof("looking for bootstrap agent binaries: version=%v", vers)
 	toolsList, findToolsErr := findBootstrapTools(env, vers, arch, series)
 	logger.Infof("found %d packaged agent binaries", len(toolsList))

--- a/worker/upgradedatabase/worker.go
+++ b/worker/upgradedatabase/worker.go
@@ -31,11 +31,8 @@ func NewLock(agentConfig agent.Config) gate.Lock {
 	lock := gate.NewLock()
 
 	// Build numbers are irrelevant to upgrade steps.
-	upgradedToVersion := agentConfig.UpgradedToVersion()
-	upgradedToVersion.Build = 0
-
-	currentVersion := jujuversion.Current
-	currentVersion.Build = 0
+	upgradedToVersion := agentConfig.UpgradedToVersion().ToPatch()
+	currentVersion := jujuversion.Current.ToPatch()
 
 	if upgradedToVersion == currentVersion {
 		lock.Unlock()

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -64,10 +64,8 @@ func NewLock(agentConfig agent.Config) gate.Lock {
 	}
 
 	// Build numbers are irrelevant to upgrade steps.
-	upgradedToVersion := agentConfig.UpgradedToVersion()
-	upgradedToVersion.Build = 0
-	currentVersion := jujuversion.Current
-	currentVersion.Build = 0
+	upgradedToVersion := agentConfig.UpgradedToVersion().ToPatch()
+	currentVersion := jujuversion.Current.ToPatch()
 	if upgradedToVersion == currentVersion {
 		logger.Infof(
 			"upgrade steps for %v have already been run.",


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The following brings in build less version checking. When looking for
streams or updates, using the build numbers to signify a change isn't
required. The uniqueness of a build number offers to much variation for
juju to check, instead Major.Minor.Patch.Tag is enough as that's
currently what we store for streams.

These changes should fix the issues around not being able to bootstrap
without the remote source available if you're not on ubuntu.

## QA steps

This is quite involved.

Build the binary for windows, then scp the build to a windows box.
Attempt to bootstrap juju on aws.

```sh
juju.exe bootstrap aws aws --debug --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/ --config agent-stream=build-52959e1
```

Note the build agent config stream doesn't actually matter here, as it will fail before that can be used!
