### PR TITLE
Address issues found with scale testing.

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1473,8 +1473,7 @@ func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, 
 			// ingress-address is the preferred settings attribute name as it more accurately
 			// reflects the purpose of the attribute value. We'll deprecate private-address.
 			settings["ingress-address"] = ingressAddress
-		} else {
-			// Is this worth logging if there is no error?
+		} else if err != nil {
 			logger.Warningf("cannot set ingress/egress addresses for unit %v in relation %v: %v",
 				unitTag.Id(), relTag, err)
 		}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1474,6 +1474,7 @@ func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, 
 			// reflects the purpose of the attribute value. We'll deprecate private-address.
 			settings["ingress-address"] = ingressAddress
 		} else {
+			// Is this worth logging if there is no error?
 			logger.Warningf("cannot set ingress/egress addresses for unit %v in relation %v: %v",
 				unitTag.Id(), relTag, err)
 		}

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -257,7 +257,8 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 
 	select {
 	case <-s.config.Clock.After(s.config.ForwardTimeout):
-		// scaletest hit this a *lot*
+		// TODO (thumper) 2019-12-20, bug 1857072
+		// Scale testing hit this a *lot*,
 		// perhaps we need to consider batching messages to run on the leader?
 		logger.Infof("timeout")
 		s.record(command.Operation, "timeout", start)

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -257,6 +257,8 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 
 	select {
 	case <-s.config.Clock.After(s.config.ForwardTimeout):
+		// scaletest hit this a *lot*
+		// perhaps we need to consider batching messages to run on the leader?
 		logger.Infof("timeout")
 		s.record(command.Operation, "timeout", start)
 		return lease.ErrTimeout

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -36,8 +36,7 @@ func (environProvider) Version() int {
 
 // Open is specified in the EnvironProvider interface.
 func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
-	// This really shouldn't be INFO, it happens a lot.
-	logger.Infof("opening model %q", args.Config.Name())
+	logger.Debugf("opening model %q", args.Config.Name())
 
 	e := new(environ)
 	e.name = args.Config.Name()

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -36,6 +36,7 @@ func (environProvider) Version() int {
 
 // Open is specified in the EnvironProvider interface.
 func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+	// This really shouldn't be INFO, it happens a lot.
 	logger.Infof("opening model %q", args.Config.Name())
 
 	e := new(environ)

--- a/state/application.go
+++ b/state/application.go
@@ -2649,6 +2649,7 @@ func (a *Application) Status() (status.StatusInfo, error) {
 		// This in turn implies the application status document is likely to be
 		// inaccurate, so we return aggregated unit statuses instead.
 		//
+		// TODO(thumper) 2019-12-20: bug 1857075
 		// TODO(fwereade): this is completely wrong and will produce bad results
 		// in not-very-challenging scenarios. The leader unit remains responsible
 		// for setting the application status in a timely way, *whether or not the
@@ -2664,6 +2665,10 @@ func (a *Application) Status() (status.StatusInfo, error) {
 		for _, unit := range units {
 			unitStatus, err := unit.Status()
 			if err != nil {
+				// Sometimes as units are being removed, we may hit a not found error here.
+				if errors.IsNotFound(err) {
+					continue
+				}
 				return status.StatusInfo{}, errors.Annotatef(err, "deriving application status from %q", unit.Name())
 			}
 			unitStatuses = append(unitStatuses, unitStatus)


### PR DESCRIPTION
During unit teardown, the all watcher code tries to update the application
status as it is updating the unit. This can cause a timing issue where
the unit is removed in the middle of the attempt to derive an application
status. A bug has been filed to remove the deriviation of the status.
    
Also the ec2 provider mentioned *a lot* that it was opening the model.
This has been reduced from INFO to DEBUG.
