### PR TITLE
Optional external controller aliases

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -477,11 +477,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:e97a084297e7148cc963069865645b11ce69b9e8ffd31c812c568e1cf73ed98a"
+  digest = "1:3f6c130d75a67ade8569bf3deff9a35c048062ee5f85a66b6f86f89726374942"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "d109c06282f3fb3b99cfcc3abbfe7cf64e25894b"
+  revision = "196af8b0d3222c2d5b3dbd6f340398bb06f56333"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "d109c06282f3fb3b99cfcc3abbfe7cf64e25894b"
+  revision = "196af8b0d3222c2d5b3dbd6f340398bb06f56333"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -1,5 +1,0 @@
-applications:
-  wordpress:
-    annotations:
-      raw: include-file://example.txt
-      enc: include-base64://example.txt


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The following brings in the latest description package changes which
allow for optional external controller aliases.

## QA steps

Bootstrap 3 controllers: `source`, `consume`, `dest`.
Deploy `mysql` to source and `expose` to consume.
Deploy `wordpress` to consume, consume `mysql` and relate `wordpress->mysql`.
Migrate `consume` to `dest`.

----

To exercise more code paths, I'm using a bundle here.

```sh
series: bionic
saas:
  mysql:
    url: source:admin/default.mysql
applications:
  wordpress:
    charm: wordpress
    num_units: 1
relations:
- - wordpress:db
  - mysql:db
```

```sh
export JUJU_DEV_FEATURE_FLAGS=cmr-migrations
```

```sh
juju bootstrap lxd source

juju deploy mysql
juju offer mysql:db
```

```sh
juju bootstrap lxd consume

juju deploy bundle.yml
```


```sh
juju bootstrap lxd dest

juju destroy-model -y default --force --no-wait
```

```sh
juju switch source
juju migrate default dest
```