### PR TITLE
Increase timeouts of mediawiki endpoint.

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -120,7 +120,7 @@ def assess_caas_charm_deployment(caas_client, caas_provider):
         log.info("sleeping for 30 seconds to let everything start up")
         sleep(30)
         check_app_healthy(
-            endpoint, timeout=300,
+            endpoint, timeout=600,
             success_hook=success_hook,
             fail_hook=fail_hook,
         )


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Failing microk8s tests indicate to small of a timeout for the mediawiki endpoint test. If this change allows the tests to continue working then mediawiki needs to be updated with better readiness probes as the tests is essentially implementing this.