### PR TITLE
Allow RemoteRelationWatcher facade for CaaS;

### DIFF
--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -63,6 +63,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Uniter",
 	"Upgrader",
 	"VolumeAttachmentsWatcher",
+	"RemoteRelationWatcher",
 )
 
 // caasModelFacadeNames lists facades that are only used with CAAS


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - <del>[ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?</del>
 - <del>[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?</del>
 - <del>[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?</del>
 - <del>[ ] Do comments answer the question of why design decisions were made?</del>

----

## Description of change

Allow facade `RemoteRelationWatcher` for `CaaS` model;

## QA steps

```console
$ juju add-model t1 microk8s
$ juju deploy cs:~kelvin.liu/mariadb-k8s-3 --debug -m k1:t1
$ juju offer t1.mariadb-k8s:server


$ juju add-model t2 microk8s

$ juju deploy cs:~juju/mediawiki-k8s-3
$ juju relate mediawiki-k8s:db t1.mariadb-k8s

$ juju deploy cs:~juju/gitlab-k8s-0  --debug
$ juju relate gitlab-k8s t1.mariadb-k8s

$ juju run --unit mariadb-k8s/0 --timeout=30s "relation-list -r 0 --format=json" --operator=true -m k1:t1
["remote-997ed657b36949228aec0862eaf5f3b0/0"]

$ juju run --unit mediawiki-k8s/0 --timeout=30s "relation-list -r 0 --format=json" --operator=true -m k1:t2
["mariadb-k8s/0"]
$ juju run --unit mediawiki-k8s/0 --timeout=30s "relation-get -r 0 - mariadb-k8s --app=True --format=json" --operator=true -m k1:t2
{}

$ juju run --unit gitlab-k8s/0 --timeout=30s "relation-list -r 1 --format=json" --operator=true -m k1:t2
["mariadb-k8s/0"]
$ juju run --unit gitlab-k8s/0 --timeout=30s "relation-get -r 1 - mariadb-k8s --app=True --format=json" --operator=true -m k1:t2
{}
```

## Documentation changes

None

## Bug reference

None
