### PR TITLE
Fix intermittent test failure in TestClientWatchAllReadPermission

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -880,6 +880,7 @@ func (s *clientSuite) TestClientWatchAllReadPermission(c *gc.C) {
 	err = m.SetProvisioned("i-0", "", agent.BootstrapNonce, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	user := s.Factory.MakeUser(c, &factory.UserParams{
 		Password: "ro-password",
 	})


### PR DESCRIPTION
Ensure that the internal events for the new machine have flowed through the system before starting the watcher.

The internal multiwatcher store needs to have been updated with the machine before we start the watcher to ensure that the initial event has both the model and the machine.

## QA steps

```sh
cd apiserver/facades/client/client
stress -check.f TestClientWatchAllReadPermission
```

## Documentation changes

Internal test fix only