### PR TITLE
help command: fix purpose and doc ordering

### DIFF
--- a/cmd/juju/model/showcommit.go
+++ b/cmd/juju/model/showcommit.go
@@ -75,8 +75,8 @@ func NewShowCommitCommand() cmd.Command {
 func (c *ShowCommitCommand) Info() *cmd.Info {
 	info := &cmd.Info{
 		Name:    "show-commit",
-		Purpose: showCommitDoc,
-		Doc:     showCommitSummary,
+		Purpose: showCommitSummary,
+		Doc:     showCommitDoc,
 	}
 	return jujucmd.Info(info)
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [no] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [no] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change
Old PR added the `show-commit` command and mistakenly confused summary and doc.
That lead to showing the `show-commit` documentation text in the help summary instead.

## QA steps
run `juju` and look whether this shows up (it should not)
```
...
    show-cloud                  - Shows detailed information for a cloud.
    show-commit                 - 
Show-commit shows the committed branches to the model.
Details displayed include:
- user who committed the branch 
- when the branch was committed 
- user who created the branch 
- when the branch was created 
- configuration  made under the branch for each application
- a summary of how many units are tracking the branch

Examples:
    juju show-commit 3
    juju show-commit 3 --utc

See also:
	list-commits
	add-branch
    track
    branch
    abort
    diff

    show-controller             - Shows detailed information of a controller.
    show-credential             - Shows credential information stored either on this client or on a controller.
...
```
