### PR TITLE
[2.7] improve errors when resolving bundle includes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:03b796f4e58386334bd38df8f1727b644ebcd282e14334035929b648c2416b7b"
+  digest = "1:f6a4b29206973af84b7e8d277ec5c6fcc3b0503fba83d1a9a8b758ad25790488"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "b0d0ce63cbe0c6e31d38e886a8c7cb20979b509d"
+  revision = "30a23819af30b7d38a6105e90bed6147eb6bb38e"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "b0d0ce63cbe0c6e31d38e886a8c7cb20979b509d"
+  revision = "30a23819af30b7d38a6105e90bed6147eb6bb38e"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"


### PR DESCRIPTION
## Description of change

This PR brings in the changes from https://github.com/juju/charm/pull/301 so the juju CLI can display more informative error messages when failing to locate a relative include from a base bundle or an overlay.

## QA steps

```console
$ mkdir bananas ; cd bananas

#----------------------
# Check error for a base bundle include
#----------------------
$ cat > bundle.yaml <<EOT
applications:
  containerd:
    charm: cs:~containers/containerd-53
    options:
      foo: include-file://../secrets/secret-password.txt
EOT

$ juju deploy ./bundle.yaml --dry-run
ERROR cannot deploy bundle: processing option "foo" for application "containerd": resolving include "../secrets/secret-password.txt": include file "$PWD/secrets/secret-password.txt" not found

#----------------------
# Check error for an overlay include
#----------------------
$ cat > bundle.yaml <<EOT
applications:
  containerd:
    charm: cs:~containers/containerd-53
EOT

$ mkdir bar
$ cat > bar/overlay.yaml <<EOT
applications:
  containerd:
    charm: cs:~containers/containerd-53
    options:
      foo: include-file://../secrets/secret-password.txt
EOT

# Note that the absolute path in the following error has been resolved relative to the *overlay* path
$ juju deploy ./bundle.yaml --overlay bar/overlay.yaml --dry-run
ERROR cannot deploy bundle: processing option "foo" for application "containerd": resolving include "../secrets/secret-password.txt": include file "$PWD/bananas/secrets/secret-password.txt" not found

# Compare the above errors to the ones generated by an older 2.7 CLI (e.g. from snap)
```

## Bug reference

Improves error messages as discussed in https://bugs.launchpad.net/juju/+bug/1851817