### PR TITLE
Introduce rootkey storage from bakeryv2 upstream

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -705,7 +705,6 @@
   revision = "1f8aaeef09898fcee40fe43b8de422533b0cac2b"
 
 [[projects]]
-  branch = "bakeryv2"
   digest = "1:61fdcd5ca2dcd80cd6951a72e7b291e3d40afbb3a38b02cd17d71d2859b2ed98"
   name = "github.com/juju/terms-client"
   packages = [
@@ -713,8 +712,7 @@
     "api/wireformat",
   ]
   pruneopts = ""
-  revision = "9198d01b42a1bf6c0308f9e8de222ad78868468c"
-  source = "github.com/wallyworld/terms-client"
+  revision = "d29f8efe0af6f5ed0e8d5bff8bccbecb16e653d1"
 
 [[projects]]
   digest = "1:0eec58cdcfcc6f4a561e68d779dd136700575148459d4d435c60483a8f721d27"
@@ -1507,6 +1505,7 @@
     "bakery/checkers",
     "bakery/identchecker",
     "bakery/internal/macaroonpb",
+    "bakery/mgorootkeystore",
     "bakerytest",
     "httpbakery",
     "httpbakery/form",
@@ -1516,18 +1515,15 @@
   revision = "6734dc66fe81c761f153bdd3e4ea572a105b6fe0"
 
 [[projects]]
-  branch = "macaroon-v2"
-  digest = "1:6afe17bcd84e8271c07749a62c6857c722d40a079d09927f36714fc2ca29a2f0"
+  digest = "1:01ca591d2010c9aee949a970b82911c6384f4f50a948a36818f75ee677a63962"
   name = "gopkg.in/macaroon-bakery.v2-unstable"
   packages = [
     "bakery",
     "bakery/checkers",
-    "bakery/mgostorage",
-    "bakerytest",
     "httpbakery",
   ]
   pruneopts = ""
-  revision = "e9659ac3cacff3096af6bfd23e9db6b3fa1ae374"
+  revision = "15effef1340d966e9419a176b0a4e0381f345c19"
   source = "github.com/wallyworld/macaroon-bakery"
 
 [[projects]]
@@ -1982,12 +1978,11 @@
     "gopkg.in/juju/worker.v1/workertest",
     "gopkg.in/macaroon-bakery.v2-unstable/bakery",
     "gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers",
-    "gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage",
-    "gopkg.in/macaroon-bakery.v2-unstable/bakerytest",
     "gopkg.in/macaroon-bakery.v2-unstable/httpbakery",
     "gopkg.in/macaroon-bakery.v2/bakery",
     "gopkg.in/macaroon-bakery.v2/bakery/checkers",
     "gopkg.in/macaroon-bakery.v2/bakery/identchecker",
+    "gopkg.in/macaroon-bakery.v2/bakery/mgorootkeystore",
     "gopkg.in/macaroon-bakery.v2/bakerytest",
     "gopkg.in/macaroon-bakery.v2/httpbakery",
     "gopkg.in/macaroon-bakery.v2/httpbakery/form",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,8 +30,8 @@
 
 [[override]]
   name = "gopkg.in/macaroon-bakery.v2-unstable"
-  branch = "macaroon-v2"
   source = "github.com/wallyworld/macaroon-bakery"
+  revision = "15effef1340d966e9419a176b0a4e0381f345c19"
 
 [[constraint]]
   revision = "4e5a4a63d9b78757b4891b8de60be2606d8972ee"
@@ -329,8 +329,7 @@
 
 [[constraint]]
   name = "github.com/juju/terms-client"
-  branch = "bakeryv2"
-  source = "github.com/wallyworld/terms-client"
+  revision = "d29f8efe0af6f5ed0e8d5bff8bccbecb16e653d1"
 
 [[constraint]]
   revision = "5f348e78887d8757a402c7bb81e707c3b244c6da"

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -4,6 +4,7 @@
 package watcher_test
 
 import (
+	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -12,8 +13,8 @@ import (
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/workertest"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api"
@@ -290,24 +291,25 @@ func (s *watcherSuite) assertSetupRelationStatusWatch(
 	// Create a macaroon for authorisation.
 	store, err := s.State.NewBakeryStorage()
 	c.Assert(err, jc.ErrorIsNil)
-	bakery, err := bakery.NewService(bakery.NewServiceParams{
-		Location: "juju model " + s.State.ModelUUID(),
-		Store:    store,
+	b := bakery.New(bakery.BakeryParams{
+		RootKeyStore: store,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	mac, err := bakery.NewMacaroon(
+	mac, err := b.Oven.NewMacaroon(
+		context.Background(),
+		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
 			checkers.DeclaredCaveat("relation-key", rel.String()),
 			checkers.DeclaredCaveat("username", "fred"),
-		})
+		}, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Start watching for a relation change.
 	client := crossmodelrelations.NewClient(s.stateAPI)
 	w, err := client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
 		Token:     token,
-		Macaroons: macaroon.Slice{mac},
+		Macaroons: macaroon.Slice{mac.M()},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	stop := func() {
@@ -424,17 +426,18 @@ func (s *watcherSuite) setupOfferStatusWatch(
 	// Create a macaroon for authorisation.
 	store, err := s.State.NewBakeryStorage()
 	c.Assert(err, jc.ErrorIsNil)
-	bakery, err := bakery.NewService(bakery.NewServiceParams{
-		Location: "juju model " + s.State.ModelUUID(),
-		Store:    store,
+	b := bakery.New(bakery.BakeryParams{
+		RootKeyStore: store,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	mac, err := bakery.NewMacaroon(
+	mac, err := b.Oven.NewMacaroon(
+		context.Background(),
+		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
 			checkers.DeclaredCaveat("offer-uuid", offer.OfferUUID),
 			checkers.DeclaredCaveat("username", "fred"),
-		})
+		}, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
@@ -442,7 +445,7 @@ func (s *watcherSuite) setupOfferStatusWatch(
 	client := crossmodelrelations.NewClient(s.stateAPI)
 	w, err := client.WatchOfferStatus(params.OfferArg{
 		OfferUUID: offer.OfferUUID,
-		Macaroons: macaroon.Slice{mac},
+		Macaroons: macaroon.Slice{mac.M()},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	stop := func() {

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 	checkers2 "gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
-	bakerytest2 "gopkg.in/macaroon-bakery.v2/bakerytest"
+	"gopkg.in/macaroon-bakery.v2/bakerytest"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 	"gopkg.in/macaroon.v2"
 
@@ -300,7 +300,7 @@ func (alwaysIdent) DeclaredIdentity(ctx context.Context, declared map[string]str
 }
 
 func (s *macaroonAuthenticatorSuite) TestMacaroonAuthentication(c *gc.C) {
-	discharger := bakerytest2.NewDischarger(nil)
+	discharger := bakerytest.NewDischarger(nil)
 	defer discharger.Close()
 	for i, test := range authenticateSuccessTests {
 		c.Logf("\ntest %d; %s", i, test.about)

--- a/featuretests/bakerystorage_test.go
+++ b/featuretests/bakerystorage_test.go
@@ -4,13 +4,15 @@
 package featuretests
 
 import (
+	"context"
 	"time"
 
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery/mgorootkeystore"
 	"gopkg.in/macaroon.v2"
 	"gopkg.in/mgo.v2"
 
@@ -24,10 +26,10 @@ type BakeryStorageSuite struct {
 	gitjujutesting.MgoSuite
 	gitjujutesting.LoggingSuite
 
-	store   bakerystorage.ExpirableStorage
-	service *bakery.Service
-	db      *mgo.Database
-	coll    *mgo.Collection
+	store  bakerystorage.ExpirableStorage
+	bakery *bakery.Bakery
+	db     *mgo.Database
+	coll   *mgo.Collection
 }
 
 func (s *BakeryStorageSuite) SetUpTest(c *gc.C) {
@@ -59,8 +61,8 @@ func (s *BakeryStorageSuite) initService(c *gc.C, enableExpiry bool) {
 		GetCollection: func() (mongo.Collection, func()) {
 			return mongo.CollectionFromName(s.db, s.coll.Name)
 		},
-		GetStorage: func(rootKeys *mgostorage.RootKeys, coll mongo.Collection, expireAfter time.Duration) bakery.Storage {
-			return rootKeys.NewStorage(coll.Writeable().Underlying(), mgostorage.Policy{
+		GetStorage: func(rootKeys *mgorootkeystore.RootKeys, coll mongo.Collection, expireAfter time.Duration) bakery.RootKeyStore {
+			return rootKeys.NewStore(coll.Writeable().Underlying(), mgorootkeystore.Policy{
 				ExpiryDuration: expireAfter,
 			})
 		},
@@ -70,13 +72,9 @@ func (s *BakeryStorageSuite) initService(c *gc.C, enableExpiry bool) {
 		store = store.ExpireAfter(10 * time.Second)
 	}
 	s.store = store
-
-	service, err := bakery.NewService(bakery.NewServiceParams{
-		Location: "straya",
-		Store:    s.store,
+	s.bakery = bakery.New(bakery.BakeryParams{
+		RootKeyStore: s.store,
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.service = service
 }
 
 func (s *BakeryStorageSuite) ensureIndexes(c *gc.C) {
@@ -87,16 +85,22 @@ func (s *BakeryStorageSuite) ensureIndexes(c *gc.C) {
 }
 
 func (s *BakeryStorageSuite) TestCheckNewMacaroon(c *gc.C) {
-	mac, err := s.service.NewMacaroon(nil)
+	cav := []checkers.Caveat{{Condition: "something"}}
+	mac, err := s.bakery.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, cav, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.service.CheckAny([]macaroon.Slice{{mac}}, nil, nil)
+	_, _, err = s.bakery.Oven.VerifyMacaroon(context.TODO(), macaroon.Slice{mac.M()})
 	c.Assert(err, gc.ErrorMatches, "verification failed: macaroon not found in storage")
 
 	store := s.store.ExpireAfter(10 * time.Second)
-	mac, err = s.service.WithStore(store).NewMacaroon(nil)
+	b := bakery.New(bakery.BakeryParams{
+		RootKeyStore: store,
+	})
+	mac, err = b.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, cav, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.service.CheckAny([]macaroon.Slice{{mac}}, nil, nil)
+	op, conditions, err := s.bakery.Oven.VerifyMacaroon(context.TODO(), macaroon.Slice{mac.M()})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, jc.DeepEquals, []bakery.Op{bakery.NoOp})
+	c.Assert(conditions, jc.DeepEquals, []string{"something"})
 }
 
 func (s *BakeryStorageSuite) TestExpiryTime(c *gc.C) {
@@ -104,13 +108,13 @@ func (s *BakeryStorageSuite) TestExpiryTime(c *gc.C) {
 	// items immediately.
 	s.initService(c, true)
 
-	mac, err := s.service.NewMacaroon(nil)
+	mac, err := s.bakery.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, nil, bakery.NoOp)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The background thread that removes records runs every 60s.
 	// Give a little bit of leeway for loaded systems.
 	for i := 0; i < 90; i++ {
-		_, err = s.service.CheckAny([]macaroon.Slice{{mac}}, nil, nil)
+		_, _, err = s.bakery.Oven.VerifyMacaroon(context.TODO(), macaroon.Slice{mac.M()})
 		if err == nil {
 			time.Sleep(time.Second)
 			continue

--- a/state/bakerystorage.go
+++ b/state/bakerystorage.go
@@ -6,8 +6,8 @@ package state
 import (
 	"time"
 
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/mgorootkeystore"
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/bakerystorage"
@@ -22,8 +22,8 @@ func (st *State) NewBakeryStorage() (bakerystorage.ExpirableStorage, error) {
 		GetCollection: func() (mongo.Collection, func()) {
 			return st.db().GetCollection(bakeryStorageItemsC)
 		},
-		GetStorage: func(rootKeys *mgostorage.RootKeys, coll mongo.Collection, expireAfter time.Duration) bakery.Storage {
-			return rootKeys.NewStorage(coll.Writeable().Underlying(), mgostorage.Policy{
+		GetStorage: func(rootKeys *mgorootkeystore.RootKeys, coll mongo.Collection, expireAfter time.Duration) bakery.RootKeyStore {
+			return rootKeys.NewStore(coll.Writeable().Underlying(), mgorootkeystore.Policy{
 				ExpiryDuration: expireAfter,
 			})
 		},

--- a/state/bakerystorage/interface.go
+++ b/state/bakerystorage/interface.go
@@ -5,15 +5,15 @@
 // of the bakery Storage interface that uses MongoDB
 // to store items.
 //
-// This is based on gopkg.in/macaroon-bakery.v2/bakery/mgostorage.
+// This is based on gopkg.in/macaroon-bakery.v2/bakery/mgorootkeystore.
 package bakerystorage
 
 import (
 	"time"
 
 	"github.com/juju/errors"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/mgorootkeystore"
 
 	"github.com/juju/juju/mongo"
 )
@@ -26,7 +26,7 @@ type Config struct {
 
 	// GetStorage returns a bakery.Storage and a function that will close
 	// any associated resources.
-	GetStorage func(rootKeys *mgostorage.RootKeys, coll mongo.Collection, expireAfter time.Duration) (storage bakery.Storage)
+	GetStorage func(rootKeys *mgorootkeystore.RootKeys, coll mongo.Collection, expireAfter time.Duration) (storage bakery.RootKeyStore)
 }
 
 // Validate validates the configuration.
@@ -43,7 +43,7 @@ func (c Config) Validate() error {
 // ExpirableStorage extends bakery.Storage with the ExpireAfter method,
 // to expire data added at the specified time.
 type ExpirableStorage interface {
-	bakery.Storage
+	bakery.RootKeyStore
 
 	// ExpireAfter returns a new ExpirableStorage that will expire
 	// added items after the specified duration.
@@ -59,6 +59,6 @@ func New(config Config) (ExpirableStorage, error) {
 	}
 	return &storage{
 		config:   config,
-		rootKeys: mgostorage.NewRootKeys(5),
+		rootKeys: mgorootkeystore.NewRootKeys(5),
 	}, nil
 }


### PR DESCRIPTION
## Description of change

More progress on moving off bakeryv2-unstable.
Some tests are updated to use bakeryv2 and the mongo backed root key storage is also ported across.

## QA steps

bootstrap a controller
clear local cookies
login

