### PR TITLE
Ensure Relation Scope Entries for Migrated CMRs

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1105,10 +1105,6 @@ func (e *exporter) relations() error {
 		}
 	}
 
-	remoteApps := make(set.Strings)
-	for _, a := range e.model.RemoteApplications() {
-		remoteApps.Add(a.Name())
-	}
 	for _, relation := range rels {
 		exRelation := e.model.AddRelation(description.RelationArgs{
 			Id:  relation.Id(),
@@ -1122,13 +1118,6 @@ func (e *exporter) relations() error {
 			return errors.Annotatef(err, "status for relation %v", relation.Id())
 		}
 
-		isRemote := false
-		for _, ep := range relation.Endpoints() {
-			if remoteApps.Contains(ep.ApplicationName) {
-				isRemote = true
-				break
-			}
-		}
 		for _, ep := range relation.Endpoints() {
 			exEndPoint := exRelation.AddEndpoint(description.EndpointArgs{
 				ApplicationName: ep.ApplicationName,
@@ -1148,12 +1137,10 @@ func (e *exporter) relations() error {
 			delete(e.modelSettings, key)
 			exEndPoint.SetApplicationSettings(appSettingsDoc.Settings)
 
-			// We expect a relationScope and settings for each of the
-			// units of the specified application, unless it is a
-			// remote application.
-			if isRemote {
-				continue
-			}
+			// We expect a relationScope and settings for each of the units of
+			// the specified application unless it is a remote application.
+			// Remote applications will have no units in the local model and
+			// are implicitly ignored.
 			units := e.units[ep.ApplicationName]
 			for _, unit := range units {
 				ru, err := relation.Unit(unit)


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch removes a check in migration export that skips relation unit settings for cross-model relations.

This check was causing the inference of relation scopes to fail on the import side because *no* relation-unit settings were present for such endpoints. In turn, this was causing this error to thrash post-migration:
```
unit-dummy-source-0: 14:26:13 ERROR juju.worker.dependency "uniter" manifold worker returned unexpected error: failed to initialize uniter for "unit-dummy-source-0": cannot create relations: remove /var/lib/juju/agents/unit-dummy-source-0/state/relations/0: directory not empty
```

Now they are present for *local* units participating in the relation.

The check was not required anyway, because there will be no units for remote applications in the local model.

## QA steps

- `export JUJU_DEV_FEATURE_FLAGS=cmr-migrations`.
- Bootstrap 3 controllers: `source`, `consume`, `dest`.
- Ensure all controllers have logging config `<root>=DEBUG`.
- `juju switch source && juju deploy mysql && juju offer mysql:db`.
- `juju switch consume && juju deploy wordpress && juju consume source:admin/default.mysql && juju add-relation wordpress mysql`.
- Wait for quiescence in this model. This includes the wordpress unit processing of the relation-joined hook; it does a bunch of work after getting a DB relation.
- `juju switch dest && juju destroy-model default -y`.
- `juju switch source && juju migrate default dest`.
- `juju switch consume`.
- Watch the logs for the remote relations worker. The relations will be departed, then there will be a redirect, then the relations will resume.
- `juju kill-controller source -y`.
- Check the logs for the migrated model. The uniter should not be showing init errors.

## Documentation changes

None.

## Bug reference

N/A
