### PR TITLE
CA Certs for Simplestreams

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -736,7 +736,7 @@
   revision = "68a59c96c178fbbad65926e7f93db50a2cd14f33"
 
 [[projects]]
-  digest = "1:ed85b6356e8e1612c96e368bbe082173ebe3993f61adbd9f9fe1456279a18db5"
+  digest = "1:85558d1ebc168aa90832e1d4b6f3068c4b1c7d985d355bea827ce9d2b36be07a"
   name = "github.com/juju/utils"
   packages = [
     ".",
@@ -766,7 +766,7 @@
     "zip",
   ]
   pruneopts = ""
-  revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"
+  revision = "d40c2fe1064788d512a6ed0f3c4fcaf0e42515c6"
 
 [[projects]]
   digest = "1:ac49627092b42eca5480db7fdae2814f60066dc922907b6c49bfddd30db5824e"
@@ -1471,11 +1471,11 @@
   revision = "e057c73bd1beb18e9634151a2410c422bd2057f2"
 
 [[projects]]
-  digest = "1:64cc4822f856fd25eff368bdfc8f532c889fed9724ce184d80020efe20dae158"
+  digest = "1:941d40c0b44b5e362c762047a191ba90c439b4df492ea8a106d964155e1f3f86"
   name = "gopkg.in/juju/names.v3"
   packages = ["."]
   pruneopts = ""
-  revision = "39289f3737654a399166e9cd65c043b5b3bfed01"
+  revision = "139ecaca454cb9101eed8ea76374ddc0be8cc8e8"
 
 [[projects]]
   digest = "1:2041c73bbc755e07a90e03f149933b8ecfce5233a5afbe6b04230386a75f8fda"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@
   name = "github.com/juju/testing"
 
 [[constraint]]
-  revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"
+  revision = "d40c2fe1064788d512a6ed0f3c4fcaf0e42515c6"
   name = "github.com/juju/utils"
 
 [[constraint]]
@@ -154,7 +154,7 @@
   name = "gopkg.in/juju/environschema.v1"
 
 [[constraint]]
-  revision = "39289f3737654a399166e9cd65c043b5b3bfed01"
+  revision = "139ecaca454cb9101eed8ea76374ddc0be8cc8e8"
   name = "gopkg.in/juju/names.v3"
 
 [[constraint]]

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -74,6 +74,7 @@ type urlDataSource struct {
 	publicSigningKey     string
 	priority             int
 	requireSigned        bool
+	caCertificates       []string
 }
 
 // Config has values to be used in constructing a datasource.
@@ -98,6 +99,12 @@ type Config struct {
 
 	// RequireSigned indicates whether this datasource requires signed data.
 	RequireSigned bool
+
+	// CACertificates contains an optional list of Certificate
+	// Authority certificates to be used to validate certificates
+	// of cloud infrastructure components
+	// The contents are Base64 encoded x.509 certs.
+	CACertificates []string
 }
 
 // Validate checks that the baseURL is valid and the description is set.
@@ -125,6 +132,7 @@ func NewDataSource(cfg Config) DataSource {
 		publicSigningKey:     cfg.PublicSigningKey,
 		priority:             cfg.Priority,
 		requireSigned:        cfg.RequireSigned,
+		caCertificates:       cfg.CACertificates,
 	}
 }
 
@@ -151,7 +159,7 @@ func urlJoin(baseURL, relpath string) string {
 // Fetch is defined in simplestreams.DataSource.
 func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 	dataURL := urlJoin(h.baseURL, path)
-	client := utils.GetHTTPClient(h.hostnameVerification)
+	client := utils.GetHTTPClient(h.hostnameVerification, h.caCertificates...)
 	// dataURL can be http:// or file://
 	// MakeFileURL will only modify the URL if it's a file URL
 	dataURL = utils.MakeFileURL(dataURL)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1067,6 +1067,7 @@ func (e *Environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 		BaseURL:              serviceURL,
 		HostnameVerification: verify,
 		Priority:             simplestreams.SPECIFIC_CLOUD_DATA,
+		CACertificates:       e.cloudUnlocked.CACertificates,
 	}
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Annotate(err, "simplestreams config validation failed")
@@ -1103,8 +1104,6 @@ func (e *Environ) DistributeInstances(
 	}
 	return valid, nil
 }
-
-var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
 // MaintainInstance is specified in the InstanceBroker interface.
 func (*Environ) MaintainInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) error {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

If user credentials have CA Certificate(s) for an OpenStack cloud, use them in creating the http client for downloading simple stream data.

## QA steps

Bootstrap a few non OpenStack clouds to ensure their behavior hasn't been broken.
```sh
juju bootstrap aws
juju bootstrap lxd
juju bootstrap openstack.    // without a certificate
```

We'll also need qa from the bug filer, as the config is not normally setup within the juju team.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1856860
