### PR TITLE
Add a health endpoint to the apiserver.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -87,6 +88,9 @@ type Server struct {
 
 	// mu guards the fields below it.
 	mu sync.Mutex
+
+	// healthStatus is returned from the health endpoint.
+	healthStatus string
 
 	// publicDNSName_ holds the value that will be returned in
 	// LoginResult.PublicDNSName. Currently this is set once and does
@@ -301,6 +305,8 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 			dbLoggerFlushInterval: cfg.LogSinkConfig.DBLoggerFlushInterval,
 		},
 		metricsCollector: cfg.MetricsCollector,
+
+		healthStatus: "starting",
 	}
 	srv.updateAgentRateLimiter(controllerConfig)
 
@@ -497,8 +503,18 @@ func (srv *Server) loop(ready chan struct{}) error {
 			defer srv.mux.RemoveHandler("HEAD", ep.Pattern)
 		}
 	}
+
 	close(ready)
+	srv.mu.Lock()
+	srv.healthStatus = "running"
+	srv.mu.Unlock()
+
 	<-srv.tomb.Dying()
+
+	srv.mu.Lock()
+	srv.healthStatus = "stopping"
+	srv.mu.Unlock()
+
 	srv.wg.Wait() // wait for any outstanding requests to complete.
 	return tomb.ErrDying
 }
@@ -557,6 +573,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 
 	httpCtxt := httpContext{srv: srv}
 	mainAPIHandler := http.HandlerFunc(srv.apiHandler)
+	healthHandler := http.HandlerFunc(srv.healthHandler)
 	logStreamHandler := newLogStreamEndpointHandler(httpCtxt)
 	debugLogHandler := newDebugLogDBHandler(
 		httpCtxt, srv.authenticator,
@@ -775,6 +792,12 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 		unauthenticated: true,
 		noModelUUID:     true,
 	}, {
+		pattern:         "/health",
+		methods:         []string{"GET"},
+		handler:         healthHandler,
+		unauthenticated: true,
+		noModelUUID:     true,
+	}, {
 		pattern:         "/register",
 		handler:         registerHandler,
 		unauthenticated: true,
@@ -878,6 +901,14 @@ func (srv *Server) trackRequests(handler http.Handler) http.Handler {
 			handler.ServeHTTP(w, r)
 		}
 	})
+}
+
+func (srv *Server) healthHandler(w http.ResponseWriter, req *http.Request) {
+	srv.mu.Lock()
+	status := srv.healthStatus
+	srv.mu.Unlock()
+
+	fmt.Fprintf(w, "%s\n", status)
 }
 
 func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -7,9 +7,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -36,6 +38,7 @@ import (
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/modelcache"
@@ -297,4 +300,46 @@ func (s *apiserverSuite) TestRestartMessage(c *gc.C) {
 
 	err = workertest.CheckKilled(c, s.apiServer)
 	c.Assert(err, gc.Equals, dependency.ErrBounce)
+}
+
+func (s *apiserverSuite) getHealth(c *gc.C) string {
+	uri := s.server.URL + "/health"
+	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
+
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	body, err := ioutil.ReadAll(resp.Body)
+
+	c.Assert(err, jc.ErrorIsNil)
+	result := string(body)
+	// Ensure that the last value is a carriage return.
+	c.Assert(strings.HasSuffix(result, "\n"), jc.IsTrue)
+	return strings.TrimSuffix(result, "\n")
+}
+
+func (s *apiserverSuite) TestHealthRunning(c *gc.C) {
+	c.Assert(s.getHealth(c), gc.Equals, "running")
+}
+
+func (s *apiserverSuite) TestHealthStopping(c *gc.C) {
+	wg := apiserver.ServerWaitGroup(s.apiServer)
+	wg.Add(1)
+
+	s.apiServer.Kill()
+	// There is a race here between the test and the goroutine setting
+	// the value, so loop until we see the right health, then exit.
+	timeout := time.After(testing.LongWait)
+	for {
+		health := s.getHealth(c)
+		if health == "stopping" {
+			// Expected, we're done.
+			wg.Done()
+			return
+		}
+		select {
+		case <-timeout:
+			c.Fatalf("health not set to stopping")
+		case <-time.After(testing.ShortWait):
+			// Look again.
+		}
+	}
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -4,6 +4,8 @@
 package apiserver
 
 import (
+	"sync"
+
 	"github.com/juju/clock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -144,6 +146,12 @@ func PatchGetControllerCACert(p Patcher, caCert string) {
 	p.PatchValue(&getControllerCACert, func(migrationBackend) (string, error) {
 		return caCert, nil
 	})
+}
+
+// ServerWaitGroup exposes the underlying wait group used to track running API calls
+// to allow tests to hold a server open.
+func ServerWaitGroup(server *Server) *sync.WaitGroup {
+	return &server.wg
 }
 
 // Patcher defines an interface that matches the PatchValue method on


### PR DESCRIPTION
This is an unauthenticated endpoint that can be used by external services to detect if
the server is in a state where it will handle user connections.

## QA steps

```sh
juju bootstrap lxd test
juju ssh -m controller 0
curl --insecure https://localhost:17070/health
```

## Documentation changes

The purpose of this endpoint is to be used by the proxy sitting in front of an HA controller set. Perhaps if we had a section on managing named deployments with HA proxy, this is something we'd add to that section.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1797848