### PR TITLE
2.7 - Fix Destroy Model Acceptance Test

### DIFF
--- a/acceptancetests/assess_destroy_model.py
+++ b/acceptancetests/assess_destroy_model.py
@@ -62,7 +62,9 @@ def destroy_model(client, new_client):
     try:
         client.get_juju_output('status', include_e=False)
     except subprocess.CalledProcessError as e:
-        if b'{} not found'.format(old_model) not in e.stderr:
+        not_found_errors = {b'{} not found'.format(old_model),
+                            b'{} has been removed from the controller'.format(old_model)}
+        if not any(not_found in e.stderr for not_found in not_found_errors):
             error = 'unexpected error calling status\n{}'.format(e.stderr)
             raise JujuAssertionError(error)
     else:


### PR DESCRIPTION
## Description of change

Fixes the acceptance test logic for _assess_destroy_model_, by checking for both error sub-strings that might result when a model is not found on the current controller.

## QA steps

`./assess destroy_model --juju ~/go/bin/juju`

## Documentation changes

None.

## Bug reference

N/A
