### PR TITLE
2.7 Update Bootstrap Success Message

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -91,7 +91,7 @@ func WaitForAgentInitialisation(
 	for attempt := attempts.Start(); attempt.Next(); apiAttempts++ {
 		err = tryAPI(c)
 		if err == nil {
-			msg := fmt.Sprintf("\nBootstrap complete, controller %q now is available", controllerName)
+			msg := fmt.Sprintf("\nBootstrap complete, controller %q is now available", controllerName)
 			if isCAASController {
 				msg += fmt.Sprintf(" in namespace %q", caasprovider.DecideControllerNamespace(controllerName))
 			} else {


### PR DESCRIPTION
## Description of change

This is a trivial change to update the bootstrap completion log line.

> controller x is now available 

rolls off the (internal) tongue better than 

> controller x now is available

I checked unit and functional tests, plus pylibjuju. This output does not appear to be relied upon for any application logic or tests.

## QA steps

Bootstrap and check that the output reflects the change.

## Documentation changes

None.

## Bug reference

N/A
