### PR TITLE
2.7 - Add Detail to Assertion Error for nw-bootstrap-constraints-maas-2-2

### DIFF
--- a/acceptancetests/assess_bootstrap.py
+++ b/acceptancetests/assess_bootstrap.py
@@ -87,7 +87,8 @@ def assess_to(bs_manager, to):
         log.info('To {} bootstrap successful.'.format(to))
         addr = get_controller_hostname(client)
     if addr != to:
-        raise JujuAssertionError('Not bootstrapped to the correct address.')
+        raise JujuAssertionError(
+            'Not bootstrapped to the correct address; expected {}, got {}'.format(to, addr))
 
 
 def assess_bootstrap(args):


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch adds some detail that will allow us to better diagnose the failures that occur intermittently in the acceptance test _nw-bootstrap-constraints-maas-2-2_.

## QA steps

Code review should be sufficient. Doing repeated runs against _finfolk_ by the reviewer hoping for failure output is not feasible. We can observe this in CI and hopefully glean more on the cause for failed runs in the future.

## Documentation changes

None.

## Bug reference

N/A