### PR TITLE
cli charm test: make sure that no version file exist

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:f6a4b29206973af84b7e8d277ec5c6fcc3b0503fba83d1a9a8b758ad25790488"
+  digest = "1:51030a7f5d33377ee5b7a92e45968d37a2a307320053c7b552dfa76d617c529b"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "30a23819af30b7d38a6105e90bed6147eb6bb38e"
+  revision = "434507794960132879955c3a0cb250f6ac5fbe47"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "30a23819af30b7d38a6105e90bed6147eb6bb38e"
+  revision = "434507794960132879955c3a0cb250f6ac5fbe47"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"

--- a/tests/suites/cli/use_local_charm.sh
+++ b/tests/suites/cli/use_local_charm.sh
@@ -18,7 +18,7 @@ run_deploy_local_charm_revision() {
   wait_for "ntp" ".applications | keys[0]"
   CURRENT_CHARM_SHA=$(juju status --format=json | jq '.applications.ntp."charm-version"')
 
-  # If a error happens it means it could not use the git sha of the CWD
+  # If a error happens it means it could not use the git sha of the CWD.
   check_not_contains "${OUTPUT}" "exit status 128"
 
   if [ "${SHA_OF_NTP}" != "${CURRENT_CHARM_SHA}" ]; then
@@ -29,7 +29,7 @@ run_deploy_local_charm_revision() {
   destroy_model "local-charm-deploy"
 }
 
-# Checks the cwd has no vcs
+# Checks the cwd has no vcs of any kind.
 run_deploy_local_charm_revision_no_vcs() {
   echo
 
@@ -43,13 +43,15 @@ run_deploy_local_charm_revision_no_vcs() {
   git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
   cd "${TMP}/ntp" || exit 1
   rm -rf .git
+  # make sure that no version file exists.
+  rm version
 
   OUTPUT=$(juju deploy --debug . 2>&1)
 
   check_contains "${OUTPUT}" "charm is not versioned"
 }
 
-# Checks the cwd has no vcs but a version file
+# Checks the cwd has no vcs but a version file.
 run_deploy_local_charm_revision_no_vcs_but_version_file() {
   echo
 
@@ -67,7 +69,10 @@ run_deploy_local_charm_revision_no_vcs_but_version_file() {
   echo 123 >version
   VERSION_OUTPUT=\""$(cat version)"\"
 
-  juju deploy --debug .
+  CURRENT_DIRECTORY=$(pwd)
+
+  # this is done relative because we expect that the output will be absolute in the end.
+  OUTPUT=$(juju deploy --debug . 2>&1)
 
   wait_for "ntp" ".applications | keys[0]"
   CURRENT_CHARM_SHA=$(juju status --format=json | jq '.applications.ntp."charm-version"')
@@ -76,6 +81,9 @@ run_deploy_local_charm_revision_no_vcs_but_version_file() {
     echo "The expected sha does not equal the ntp SHA. Current sha: ${CURRENT_CHARM_SHA} expected sha: ${VERSION_OUTPUT}"
     exit 1
   fi
+
+  # we expect the debug output to be absolute and not relative.
+  check_contains "${OUTPUT}" "${CURRENT_DIRECTORY}"
 }
 
 # Checks whether the cwd is used for the juju local deploy.
@@ -118,7 +126,7 @@ run_deploy_local_charm_revision_relative_path() {
   destroy_model "relative-path"
 }
 
-# CWD with git, deploy charm with git, but -> check that git describe is correct
+# CWD with git, deploy charm with git, but -> check that git describe is correct.
 run_deploy_local_charm_revision_invalid_git() {
   echo
 
@@ -142,7 +150,7 @@ run_deploy_local_charm_revision_invalid_git() {
   juju deploy "${TMP_CHARM_GIT}"/ntp ntp
 
   wait_for "ntp" ".applications | keys[0]"
-  # We still expect the SHA to be the one from the place we deploy and not the CWD, which in this case has no SHA
+  # We still expect the SHA to be the one from the place we deploy and not the CWD, which in this case has no SHA.
   CURRENT_CHARM_SHA=$(juju status --format=json | jq '.applications.ntp."charm-version"')
   if [ "${WANTED_CHARM_SHA}" != "${CURRENT_CHARM_SHA}" ]; then
     echo "The expected sha does not equal the ntp SHA. Current sha: ${CURRENT_CHARM_SHA} expected sha: ${WANTED_CHARM_SHA}"


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

- main test repo added a version file (ntp).
    - deleting it should make sure that no version file is parsed in any case.
- adding a test to ensure that the logging output contains an absolute path, not relative.
- updating charmv6 dep.

## QA steps

```sh
 BOOTSTRAP_REUSE_LOCAL=<a controller> ./main.sh cli test_local_charms
```