### PR TITLE
dep update: new charm version update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1494,7 +1494,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:f6a4b29206973af84b7e8d277ec5c6fcc3b0503fba83d1a9a8b758ad25790488"
+  digest = "1:51030a7f5d33377ee5b7a92e45968d37a2a307320053c7b552dfa76d617c529b"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1502,7 +1502,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "30a23819af30b7d38a6105e90bed6147eb6bb38e"
+  revision = "434507794960132879955c3a0cb250f6ac5fbe47"
 
 [[projects]]
   digest = "1:dc05394e66d3dfe6ecc7b966cc0ac4ab40c3d10b0249499af92f4c4ae3ad6e85"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,7 +147,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "30a23819af30b7d38a6105e90bed6147eb6bb38e"
+  revision = "434507794960132879955c3a0cb250f6ac5fbe47"
 
 [[constraint]]
   revision = "2adcece4e962a51e0793b8562560cf9da874026f"


### PR DESCRIPTION
# Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This change: https://github.com/juju/charm/pull/302 makes sure that the logging of the provided path will be absolute and not only relative as in some cases.
This should help in debugging cases.

## QA steps
- get a charm which is not versioned but has "version" file
- deploy it from a relative path

```sh
git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
cd ntp
rm -rf .git
rm version (if exist)
juju deploy . --debug
```

- follow the debug output. It will now show something along the line of:
```
charm is not in version control, but uses a version file charm path: <absolute path>
```

