### PR TITLE
raft-forwarder: Track metrics for request times

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -779,14 +779,15 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The raft forwarder accepts FSM commands from the hub and
 		// applies them to the raft leader.
 		raftForwarderName: ifRaftLeader(raftforwarder.Manifold(raftforwarder.ManifoldConfig{
-			AgentName:      agentName,
-			RaftName:       raftName,
-			StateName:      stateName,
-			CentralHubName: centralHubName,
-			RequestTopic:   leaseRequestTopic,
-			Logger:         loggo.GetLogger("juju.worker.raft.raftforwarder"),
-			NewWorker:      raftforwarder.NewWorker,
-			NewTarget:      raftforwarder.NewTarget,
+			AgentName:            agentName,
+			RaftName:             raftName,
+			StateName:            stateName,
+			CentralHubName:       centralHubName,
+			RequestTopic:         leaseRequestTopic,
+			Logger:               loggo.GetLogger("juju.worker.raft.raftforwarder"),
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewWorker:            raftforwarder.NewWorker,
+			NewTarget:            raftforwarder.NewTarget,
 		})),
 
 		// The global lease manager tracks lease information in the raft

--- a/worker/raft/raftforwarder/metrics.go
+++ b/worker/raft/raftforwarder/metrics.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftforwarder
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju_raftforwarder"
+)
+
+// metricsCollector is a prometheus.Collector that collects metrics
+// about how long it's taking to forward requests to raft and get
+// responses.
+type metricsCollector struct {
+	requests *prometheus.SummaryVec
+}
+
+func newMetricsCollector() *metricsCollector {
+	return &metricsCollector{
+		requests: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace: metricsNamespace,
+			Name:      "request",
+			Help:      "Request times for raft forwarder operations in ms",
+			Objectives: map[float64]float64{
+				0.5:  0.05,
+				0.9:  0.01,
+				0.99: 0.001,
+			},
+		}, []string{
+			// section can be "apply" (just the time to apply req and
+			// get a response from raft) or "full" (total time from
+			// request received to response sent)
+			"section",
+		}),
+	}
+}
+
+func (m *metricsCollector) record(start time.Time, section string) {
+	elapsedMS := float64(time.Now().Sub(start)) / float64(time.Millisecond)
+	m.requests.With(prometheus.Labels{
+		"section": section,
+	}).Observe(elapsedMS)
+}
+
+// Describe is part of prometheus.Collector.
+func (c *metricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.requests.Describe(ch)
+}
+
+// Collect is part of prometheus.Collector.
+func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
+	c.requests.Collect(ch)
+}

--- a/worker/raft/raftforwarder/worker_test.go
+++ b/worker/raft/raftforwarder/worker_test.go
@@ -46,11 +46,12 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.target = &fakeTarget{}
 	s.hub = centralhub.New(names.NewMachineTag("17"))
 	s.config = raftforwarder.Config{
-		Hub:    s.hub,
-		Raft:   s.raft,
-		Logger: loggo.GetLogger("raftforwarder_test"),
-		Topic:  "raftforwarder_test",
-		Target: s.target,
+		Hub:                  s.hub,
+		Raft:                 s.raft,
+		Logger:               loggo.GetLogger("raftforwarder_test"),
+		PrometheusRegisterer: &noopRegisterer{},
+		Topic:                "raftforwarder_test",
+		Target:               s.target,
 	}
 }
 
@@ -74,6 +75,9 @@ func (s *workerValidationSuite) TestValidateErrors(c *gc.C) {
 	}, {
 		func(cfg *raftforwarder.Config) { cfg.Logger = nil },
 		"nil Logger not valid",
+	}, {
+		func(cfg *raftforwarder.Config) { cfg.PrometheusRegisterer = nil },
+		"nil PrometheusRegisterer not valid",
 	}, {
 		func(cfg *raftforwarder.Config) { cfg.Topic = "" },
 		"empty Topic not valid",


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

We're seeing raft lease operation times longer than we'd expect, particularly given the metrics from the raft internals. Adding metrics to the forwarder should give us more information about where the time is going. The forwarder will report both the full time for each operation from request to response, as well as the time for raft to apply each one and give a response.

## QA steps

Running `juju_metrics` on the raft-leader controller machine includes the new `juju_raftforwarder` metrics, broken down into "full" and "apply" sections.

```
# HELP juju_raftforwarder_request Request times for raft forwarder operations in ms
# TYPE juju_raftforwarder_request summary
juju_raftforwarder_request{section="apply",quantile="0.5"} 3.252875
juju_raftforwarder_request{section="apply",quantile="0.9"} 3.655554
juju_raftforwarder_request{section="apply",quantile="0.99"} 5.74508
juju_raftforwarder_request_sum{section="apply"} 601.1322479999994
juju_raftforwarder_request_count{section="apply"} 190
juju_raftforwarder_request{section="full",quantile="0.5"} 3.487774
juju_raftforwarder_request{section="full",quantile="0.9"} 3.8945
juju_raftforwarder_request{section="full",quantile="0.99"} 5.960011
juju_raftforwarder_request_sum{section="full"} 638.9324020000003
juju_raftforwarder_request_count{section="full"} 190
```

## Documentation changes
None

## Bug reference
None
