### PR TITLE
Run deploy openstack bundle

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -18,14 +18,14 @@ wait_for() {
     attempt=0
     # shellcheck disable=SC2046,SC2143
     until [ "$(juju status --format=json 2> /dev/null | jq -S "${query}" | grep "${name}")" ]; do
-        echo "[+] (attempt ${attempt}) polling status"
+        echo "[+] (attempt ${attempt}) polling status for ${name}"
         juju status --relations 2>&1 | sed 's/^/    | /g'
         sleep "${SHORT_TIMEOUT}"
         attempt=$((attempt+1))
     done
 
     if [ "${attempt}" -gt 0 ]; then
-        echo "[+] $(green 'Completed polling status')"
+        echo "[+] $(green 'Completed polling status for') $(green ${name})"
         juju status --relations 2>&1 | sed 's/^/    | /g'
         # Although juju reports as an idle condition, some charms require a
         # breathe period to ensure things have actually settled.

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -43,6 +43,18 @@ idle_condition() {
     echo ".applications | select(.[\"$name\"] | .units | .[\"$name/$unit_index\"] | .[\"juju-status\"] | .current == \"idle\") | keys[$app_index]"
 }
 
+idle_subordinate_condition() {
+    local name parent app_index unit_index parent_index
+
+    name=${1}
+    parent=${2}
+    app_index=${3:-0}
+    unit_index=${4:-0}
+    parent_index=${5:-0}
+
+    echo ".applications | select(.[\"$parent\"] | .units | .[\"$parent/$parent_index\"] | .subordinates | .[\"$name/$unit_index\"] | .[\"juju-status\"] | .current == \"idle\") | keys[$app_index]"
+}
+
 active_condition() {
     local name app_index unit_index
 

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -18,14 +18,14 @@ wait_for() {
     attempt=0
     # shellcheck disable=SC2046,SC2143
     until [ "$(juju status --format=json 2> /dev/null | jq -S "${query}" | grep "${name}")" ]; do
-        echo "[+] (attempt ${attempt}) polling status for ${name}"
+        echo "[+] (attempt ${attempt}) polling status for" "${name}"
         juju status --relations 2>&1 | sed 's/^/    | /g'
         sleep "${SHORT_TIMEOUT}"
         attempt=$((attempt+1))
     done
 
     if [ "${attempt}" -gt 0 ]; then
-        echo "[+] $(green 'Completed polling status for') $(green ${name})"
+        echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
         juju status --relations 2>&1 | sed 's/^/    | /g'
         # Although juju reports as an idle condition, some charms require a
         # breathe period to ensure things have actually settled.

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -82,16 +82,16 @@ run_deploy_lxd_profile_bundle() {
     bundle=cs:~juju-qa/bundle/basic-openstack-lxd-0
     juju deploy "${bundle}"
 
+    wait_for "mysql" "$(idle_condition "mysql" 3)"
+    wait_for "rabbitmq-server" "$(idle_condition "rabbitmq-server" 9)"
     wait_for "glance" "$(idle_condition "glance" 0)"
     wait_for "keystone" "$(idle_condition "keystone" 1)"
-    wait_for "lxd" "$(idle_subordinate_condition "lxd" "nova-compute" 2)"
-    wait_for "mysql" "$(idle_condition "mysql" 3)"
     wait_for "neutron-api" "$(idle_condition "neutron-api" 4)"
     wait_for "neutron-gateway" "$(idle_condition "neutron-gateway" 5)"
+    wait_for "nova-compute" "$(idle_condition "nova-compute" 8)"
+    wait_for "lxd" "$(idle_subordinate_condition "lxd" "nova-compute" 2)"
     wait_for "neutron-openvswitch" "$(idle_subordinate_condition "neutron-openvswitch" "nova-compute" 6)"
     wait_for "nova-cloud-controller" "$(idle_condition "nova-cloud-controller" 7)"
-    wait_for "nova-compute" "$(idle_condition "nova-compute" 8)"
-    wait_for "rabbitmq-server""$(idle_condition "rabbitmq-server" 9)"
 
     lxd_profile_name="juju-${model_name}-neutron-openvswitch"
     machine_6="$(machine_path 6)"


### PR DESCRIPTION
## Description of change

Add run_deploy_lxd_profile_bundle to integration tests, replacing nw-deploy-lxd-profile-bundle-lxd-openstack once stable.  

Add idle_subordinate_condition() as a condition for use in wait_for

## QA steps

```sh
(cd tests ; ./main.sh deploy test_deploy_bundles)
```