### PR TITLE
Update PR Template by making comments to be comments

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## Please provide the following details to expedite Pull Request review:
+<!--- ## Please provide the following details to expedite Pull Request review: -->
 
 ### Checklist
 
@@ -11,11 +11,11 @@
 
 ## Description of change
 
-*Please replace with a description about why this change is needed, along with a description of what changed?*
+<!--- *Please replace with a description about why this change is needed, along with a description of what changed?* -->
 
 ## QA steps
 
-*Please replace with how we can verify that the change works?*
+<!--- *Please replace with how we can verify that the change works?* -->
 
 ```sh
 QA steps here
@@ -23,8 +23,9 @@ QA steps here
 
 ## Documentation changes
 
-*Please replace with any notes about how it affects current user workflow? CLI? API?*
+<!--- *Please replace with how we can verify that the change works?* 
+ *Please replace with any notes about how it affects current user workflow? CLI? API?* -->
 
 ## Bug reference
 
-*Please add a link to any bugs that this change is related to.*
+<!--*Please add a link to any bugs that this change is related to.* -->


### PR DESCRIPTION
PR FOR DISCUSSION

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

- Usually, if I open a PR I read the comments and try to work on each point. After done I delete the corresponding "comment".
- As the information is meant not be shown in the PR itself IMO we could change them to be comments and only seeable for the person opening/editing the PR