### PR TITLE
backport: Make destroy-model test more reliable on slow machines

### DIFF
--- a/acceptancetests/assess_destroy_model.py
+++ b/acceptancetests/assess_destroy_model.py
@@ -7,6 +7,7 @@ import argparse
 import logging
 import sys
 import subprocess
+import time
 
 from deploy_stack import (
     BootstrapManager,
@@ -59,17 +60,28 @@ def destroy_model(client, new_client):
     if not old_model:
         error = 'Juju unset model after it was destroyed'
         raise JujuAssertionError(error)
-    try:
-        client.get_juju_output('status', include_e=False)
-    except subprocess.CalledProcessError as e:
-        not_found_errors = {b'{} not found'.format(old_model),
-                            b'{} has been removed from the controller'.format(old_model)}
-        if not any(not_found in e.stderr for not_found in not_found_errors):
-            error = 'unexpected error calling status\n{}'.format(e.stderr)
+    for attempt in range(10):
+        try:
+            client.get_juju_output('status', include_e=False)
+        except subprocess.CalledProcessError as e:
+            not_found_error = b'{} not found'.format(old_model)
+            if not_found_error in e.stderr:
+                log.info("Model fully removed")
+                break
+            removed_error = b'model "{}" has been removed from the controller'.format(old_model)
+            if removed_error not in e.stderr:
+                error = 'unexpected error calling status\n{}'.format(e.stderr)
+                raise JujuAssertionError(error)
+            log.info("Model reported as removed...")
+        else:
+            error = 'model still valid after it was destroyed'
             raise JujuAssertionError(error)
+        time.sleep(10)
     else:
-        error = 'model still valid after it was destroyed'
-        raise JujuAssertionError(error)
+        # We didn't break out of the loop, so the model-removed message didn't
+        # change to model not found (indicating that the model hasn't been
+        # removed from the state pool).
+        raise JujuAssertionError("didn't get not found error - model still in state pool")
 
 
 def switch_model(client, current_model, current_controller):


### PR DESCRIPTION
## Description of change

Backport of #11108 to 2.7 - this was initially landed against develop while we were waiting for the 2.7.1 release to be approved.

## QA steps

Running test passes.

## Documentation changes
None

## Bug reference
None