### PR TITLE
Byebye bakery v2 unstable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1516,18 +1516,6 @@
   revision = "6734dc66fe81c761f153bdd3e4ea572a105b6fe0"
 
 [[projects]]
-  digest = "1:01ca591d2010c9aee949a970b82911c6384f4f50a948a36818f75ee677a63962"
-  name = "gopkg.in/macaroon-bakery.v2-unstable"
-  packages = [
-    "bakery",
-    "bakery/checkers",
-    "httpbakery",
-  ]
-  pruneopts = ""
-  revision = "15effef1340d966e9419a176b0a4e0381f345c19"
-  source = "github.com/wallyworld/macaroon-bakery"
-
-[[projects]]
   digest = "1:7811982c180c7bd1377f5342c1ed8ea385180fa5fb468eabb172244a2edff612"
   name = "gopkg.in/macaroon.v2"
   packages = ["."]
@@ -1943,7 +1931,6 @@
     "gopkg.in/amz.v3/ec2",
     "gopkg.in/amz.v3/ec2/ec2test",
     "gopkg.in/check.v1",
-    "gopkg.in/errgo.v1",
     "gopkg.in/goose.v2/cinder",
     "gopkg.in/goose.v2/client",
     "gopkg.in/goose.v2/errors",
@@ -1977,9 +1964,6 @@
     "gopkg.in/juju/worker.v1/dependency",
     "gopkg.in/juju/worker.v1/dependency/testing",
     "gopkg.in/juju/worker.v1/workertest",
-    "gopkg.in/macaroon-bakery.v2-unstable/bakery",
-    "gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers",
-    "gopkg.in/macaroon-bakery.v2-unstable/httpbakery",
     "gopkg.in/macaroon-bakery.v2/bakery",
     "gopkg.in/macaroon-bakery.v2/bakery/checkers",
     "gopkg.in/macaroon-bakery.v2/bakery/identchecker",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,11 +28,6 @@
   name = "google.golang.org/cloud"
   revision = "f20d6dcccb44ed49de45ae3703312cb46e627db1"
 
-[[override]]
-  name = "gopkg.in/macaroon-bakery.v2-unstable"
-  source = "github.com/wallyworld/macaroon-bakery"
-  revision = "15effef1340d966e9419a176b0a4e0381f345c19"
-
 [[constraint]]
   revision = "4e5a4a63d9b78757b4891b8de60be2606d8972ee"
   name = "github.com/EvilSuperstars/go-cidrman"
@@ -470,10 +465,6 @@
 [[constraint]]
   name = "gopkg.in/check.v1"
   revision = "4f90aeace3a26ad7021961c297b22c42160c7b25"
-
-[[constraint]]
-  name = "gopkg.in/errgo.v1"
-  revision = "442357a80af5c6bf9b6d51ae791a39c3421004f3"
 
 [[constraint]]
   name = "gopkg.in/goose.v2"

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -201,7 +201,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 	if opts.Clock == nil {
 		opts.Clock = clock.WallClock
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	dialCtx := ctx
 	if opts.Timeout > 0 {
 		ctx1, cancel := utils.ContextWithTimeout(dialCtx, opts.Clock, opts.Timeout)

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/utils/parallel"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 	"gopkg.in/macaroon.v2"
 	"gopkg.in/retry.v1"
@@ -502,6 +503,7 @@ func (st *state) addCookiesToHeader(h http.Header) error {
 			req.AddCookie(cookie)
 		}
 	}
+	h.Set(httpbakery.BakeryProtocolHeader, fmt.Sprint(bakery.LatestVersion))
 	return nil
 }
 

--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -205,7 +206,7 @@ func (c *Client) ApplicationOffer(urlStr string) (*crossmodel.ApplicationOfferDe
 
 	found := params.ApplicationOffersResults{}
 
-	err = c.facade.FacadeCall("ApplicationOffers", params.OfferURLs{[]string{urlStr}}, &found)
+	err = c.facade.FacadeCall("ApplicationOffers", params.OfferURLs{[]string{urlStr}, bakery.LatestVersion}, &found)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -265,7 +266,7 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 
 	found := params.ConsumeOfferDetailsResults{}
 
-	err = c.facade.FacadeCall("GetConsumeDetails", params.OfferURLs{[]string{urlStr}}, &found)
+	err = c.facade.FacadeCall("GetConsumeDetails", params.OfferURLs{[]string{urlStr}, bakery.LatestVersion}, &found)
 	if err != nil {
 		return params.ConsumeOfferDetails{}, errors.Trace(err)
 	}

--- a/api/authentication/interactor_test.go
+++ b/api/authentication/interactor_test.go
@@ -5,6 +5,7 @@ package authentication_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -13,7 +14,9 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/httprequest.v1"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"gopkg.in/macaroon-bakery.v2/httpbakery/form"
 
 	"github.com/juju/juju/api/authentication"
 )
@@ -43,7 +46,7 @@ func (s *InteractorSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(c *gc.C) { s.server.Close() })
 }
 
-func (s *InteractorSuite) TestInteract(c *gc.C) {
+func (s *InteractorSuite) TestLegacyInteract(c *gc.C) {
 	v := authentication.NewInteractor("bob", func(username string) (string, error) {
 		c.Assert(username, gc.Equals, "bob")
 		return "hunter2", nil
@@ -56,7 +59,7 @@ func (s *InteractorSuite) TestInteract(c *gc.C) {
 		formUser = r.Form.Get("user")
 		formPassword = r.Form.Get("password")
 	})
-	err := lv.LegacyInteract(context.Background(), s.client, "", mustParseURL(s.server.URL))
+	err := lv.LegacyInteract(context.TODO(), s.client, "", mustParseURL(s.server.URL))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(formUser, gc.Equals, "bob")
 	c.Assert(formPassword, gc.Equals, "hunter2")
@@ -67,7 +70,7 @@ func (s *InteractorSuite) TestKind(c *gc.C) {
 	c.Assert(v.Kind(), gc.Equals, "juju_userpass")
 }
 
-func (s *InteractorSuite) TestInteractErrorResult(c *gc.C) {
+func (s *InteractorSuite) TestLegacyInteractErrorResult(c *gc.C) {
 	v := authentication.NewInteractor("bob", func(username string) (string, error) {
 		return "hunter2", nil
 	})
@@ -76,8 +79,77 @@ func (s *InteractorSuite) TestInteractErrorResult(c *gc.C) {
 	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"Message":"bleh"}`, http.StatusInternalServerError)
 	})
-	err := lv.LegacyInteract(context.Background(), s.client, "", mustParseURL(s.server.URL))
+	err := lv.LegacyInteract(context.TODO(), s.client, "", mustParseURL(s.server.URL))
 	c.Assert(err, gc.ErrorMatches, "bleh")
+}
+
+func (s *InteractorSuite) TestInteract(c *gc.C) {
+	v := authentication.NewInteractor("bob", func(username string) (string, error) {
+		c.Assert(username, gc.Equals, "bob")
+		return "hunter2", nil
+	})
+	var formUser, formPassword string
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqParams := httprequest.Params{
+			Response: w,
+			Request:  r,
+			Context:  context.TODO(),
+		}
+		loginRequest := form.LoginRequest{}
+		err := httprequest.Unmarshal(reqParams, &loginRequest)
+		c.Assert(err, jc.ErrorIsNil)
+		formUser = loginRequest.Body.Form["user"].(string)
+		formPassword = loginRequest.Body.Form["password"].(string)
+		loginResponse := form.LoginResponse{
+			Token: &httpbakery.DischargeToken{
+				Kind:  "juju_userpass",
+				Value: []byte("token"),
+			},
+		}
+		httprequest.WriteJSON(w, http.StatusOK, loginResponse)
+	})
+	info := form.InteractionInfo{
+		URL: s.server.URL,
+	}
+	infoData, err := json.Marshal(info)
+	msgData := json.RawMessage(infoData)
+	c.Assert(err, jc.ErrorIsNil)
+	token, err := v.Interact(context.TODO(), s.client, "", &httpbakery.Error{
+		Code: httpbakery.ErrInteractionRequired,
+		Info: &httpbakery.ErrorInfo{
+			InteractionMethods: map[string]*json.RawMessage{
+				"juju_userpass": &msgData,
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(formUser, gc.Equals, "bob")
+	c.Assert(formPassword, gc.Equals, "hunter2")
+	c.Assert(token.Kind, gc.Equals, "juju_userpass")
+	c.Assert(string(token.Value), gc.Equals, "token")
+}
+
+func (s *InteractorSuite) TestInteractErrorResult(c *gc.C) {
+	v := authentication.NewInteractor("bob", func(username string) (string, error) {
+		return "hunter2", nil
+	})
+	s.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"Message":"bleh"}`, http.StatusInternalServerError)
+	})
+	info := form.InteractionInfo{
+		URL: s.server.URL,
+	}
+	infoData, err := json.Marshal(info)
+	msgData := json.RawMessage(infoData)
+	_, err = v.Interact(context.TODO(), s.client, "", &httpbakery.Error{
+		Code: httpbakery.ErrInteractionRequired,
+		Info: &httpbakery.ErrorInfo{
+			InteractionMethods: map[string]*json.RawMessage{
+				"juju_userpass": &msgData,
+			},
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, ".*bleh.*")
 }
 
 func mustParseURL(s string) *url.URL {

--- a/api/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/crossmodelrelations/crossmodelrelations_test.go
@@ -90,7 +90,9 @@ func (s *CrossModelRelationsSuite) TestPublishRelationChange(c *gc.C) {
 		c.Check(arg, gc.DeepEquals, params.RemoteRelationsChanges{
 			Changes: []params.RemoteRelationChangeEvent{{
 				RelationToken: "token",
-				DepartedUnits: []int{1}, Macaroons: macaroon.Slice{mac}}},
+				DepartedUnits: []int{1}, Macaroons: macaroon.Slice{mac},
+				BakeryVersion: bakery.LatestVersion,
+			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
@@ -106,6 +108,7 @@ func (s *CrossModelRelationsSuite) TestPublishRelationChange(c *gc.C) {
 		RelationToken: "token",
 		DepartedUnits: []int{1},
 		Macaroons:     macaroon.Slice{mac},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	// Call again with a different macaroon but the first one will be
@@ -117,6 +120,7 @@ func (s *CrossModelRelationsSuite) TestPublishRelationChange(c *gc.C) {
 		RelationToken: "token",
 		DepartedUnits: []int{1},
 		Macaroons:     macaroon.Slice{different},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 2)
@@ -177,7 +181,9 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 			Relations: []params.RegisterRemoteRelationArg{{
 				RelationToken: "token",
 				OfferUUID:     "offer-uuid",
-				Macaroons:     macaroon.Slice{mac}}}})
+				Macaroons:     macaroon.Slice{mac},
+				BakeryVersion: bakery.LatestVersion,
+			}}})
 		c.Assert(result, gc.FitsTypeOf, &params.RegisterRemoteRelationResults{})
 		*(result.(*params.RegisterRemoteRelationResults)) = params.RegisterRemoteRelationResults{
 			Results: []params.RegisterRemoteRelationResult{{
@@ -192,6 +198,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 		RelationToken: "token",
 		OfferUUID:     "offer-uuid",
 		Macaroons:     macaroon.Slice{mac},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
@@ -205,6 +212,7 @@ func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
 		RelationToken: "token",
 		OfferUUID:     "offer-uuid",
 		Macaroons:     macaroon.Slice{different},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
@@ -281,7 +289,9 @@ func (s *CrossModelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 			c.Check(version, gc.Equals, 2)
 			c.Check(id, gc.Equals, "")
 			c.Check(arg, jc.DeepEquals, params.RemoteEntityArgs{Args: []params.RemoteEntityArg{{
-				Token: remoteRelationToken, Macaroons: macaroon.Slice{mac}}}})
+				Token: remoteRelationToken, Macaroons: macaroon.Slice{mac},
+				BakeryVersion: bakery.LatestVersion,
+			}}})
 			c.Check(request, gc.Equals, "WatchRelationChanges")
 			c.Assert(result, gc.FitsTypeOf, &params.RemoteRelationWatchResults{})
 			*(result.(*params.RemoteRelationWatchResults)) = params.RemoteRelationWatchResults{
@@ -377,7 +387,9 @@ func (s *CrossModelRelationsSuite) TestWatchRelationChangesV1Fallback(c *gc.C) {
 			case "CrossModelRelations.WatchRelationUnits":
 				c.Check(id, gc.Equals, "")
 				c.Check(arg, jc.DeepEquals, params.RemoteEntityArgs{Args: []params.RemoteEntityArg{{
-					Token: remoteRelationToken, Macaroons: macaroon.Slice{mac}}}})
+					Token: remoteRelationToken, Macaroons: macaroon.Slice{mac},
+					BakeryVersion: bakery.LatestVersion,
+				}}})
 				c.Assert(result, gc.FitsTypeOf, &params.RelationUnitsWatchResults{})
 				*(result.(*params.RelationUnitsWatchResults)) = params.RelationUnitsWatchResults{
 					Results: []params.RelationUnitsWatchResult{{
@@ -396,6 +408,7 @@ func (s *CrossModelRelationsSuite) TestWatchRelationChangesV1Fallback(c *gc.C) {
 					RelationUnits: []params.RemoteRelationUnit{{
 						RelationToken: remoteRelationToken,
 						Macaroons:     macaroon.Slice{mac},
+						BakeryVersion: bakery.LatestVersion,
 						Unit:          "unit-app-1",
 					}}})
 				c.Assert(result, gc.FitsTypeOf, &params.SettingsResults{})
@@ -493,7 +506,9 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(arg, jc.DeepEquals, params.RemoteEntityArgs{Args: []params.RemoteEntityArg{{
-			Token: remoteRelationToken, Macaroons: macaroon.Slice{mac}}}})
+			Token: remoteRelationToken, Macaroons: macaroon.Slice{mac},
+			BakeryVersion: bakery.LatestVersion,
+		}}})
 		c.Check(request, gc.Equals, "WatchRelationsSuspendedStatus")
 		c.Assert(result, gc.FitsTypeOf, &params.RelationStatusWatchResults{})
 		*(result.(*params.RelationStatusWatchResults)) = params.RelationStatusWatchResults{
@@ -506,8 +521,9 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
 	_, err = client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
-		Token:     remoteRelationToken,
-		Macaroons: macaroon.Slice{mac},
+		Token:         remoteRelationToken,
+		Macaroons:     macaroon.Slice{mac},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	// Call again with a different macaroon but the first one will be
@@ -516,8 +532,9 @@ func (s *CrossModelRelationsSuite) TestWatchRelationStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("token", macaroon.Slice{mac})
 	_, err = client.WatchRelationSuspendedStatus(params.RemoteEntityArg{
-		Token:     remoteRelationToken,
-		Macaroons: macaroon.Slice{different},
+		Token:         remoteRelationToken,
+		Macaroons:     macaroon.Slice{different},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 2)
@@ -578,7 +595,9 @@ func (s *CrossModelRelationsSuite) TestPublishIngressNetworkChange(c *gc.C) {
 		c.Check(arg, gc.DeepEquals, params.IngressNetworksChanges{
 			Changes: []params.IngressNetworksChangeEvent{{
 				RelationToken: "token",
-				Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{mac}}},
+				Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{mac},
+				BakeryVersion: bakery.LatestVersion,
+			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
@@ -592,7 +611,9 @@ func (s *CrossModelRelationsSuite) TestPublishIngressNetworkChange(c *gc.C) {
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
 	err = client.PublishIngressNetworkChange(params.IngressNetworksChangeEvent{
 		RelationToken: "token",
-		Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{mac}})
+		Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{mac},
+		BakeryVersion: bakery.LatestVersion,
+	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	// Call again with a different macaroon but the first one will be
 	// cached and override the passed in macaroon.
@@ -601,7 +622,9 @@ func (s *CrossModelRelationsSuite) TestPublishIngressNetworkChange(c *gc.C) {
 	s.cache.Upsert("token", macaroon.Slice{mac})
 	err = client.PublishIngressNetworkChange(params.IngressNetworksChangeEvent{
 		RelationToken: "token",
-		Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{different}})
+		Networks:      []string{"1.2.3.4/32"}, Macaroons: macaroon.Slice{different},
+		BakeryVersion: bakery.LatestVersion,
+	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 2)
 }
@@ -652,7 +675,9 @@ func (s *CrossModelRelationsSuite) TestWatchEgressAddressesForRelation(c *gc.C) 
 	remoteRelationToken := "token"
 	mac, err := apitesting.NewMacaroon("id")
 	relation := params.RemoteEntityArg{
-		Token: remoteRelationToken, Macaroons: macaroon.Slice{mac}}
+		Token: remoteRelationToken, Macaroons: macaroon.Slice{mac},
+		BakeryVersion: bakery.LatestVersion,
+	}
 	c.Check(err, jc.ErrorIsNil)
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CrossModelRelations")
@@ -680,6 +705,7 @@ func (s *CrossModelRelationsSuite) TestWatchEgressAddressesForRelation(c *gc.C) 
 	s.cache.Upsert("token", macaroon.Slice{mac})
 	rel2 := relation
 	rel2.Macaroons = macaroon.Slice{different}
+	rel2.BakeryVersion = bakery.LatestVersion
 	_, err = client.WatchEgressAddressesForRelation(rel2)
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 2)
@@ -739,7 +765,9 @@ func (s *CrossModelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(arg, jc.DeepEquals, params.OfferArgs{Args: []params.OfferArg{{
-			OfferUUID: offerUUID, Macaroons: macaroon.Slice{mac}}}})
+			OfferUUID: offerUUID, Macaroons: macaroon.Slice{mac},
+			BakeryVersion: bakery.LatestVersion,
+		}}})
 		c.Check(request, gc.Equals, "WatchOfferStatus")
 		c.Assert(result, gc.FitsTypeOf, &params.OfferStatusWatchResults{})
 		*(result.(*params.OfferStatusWatchResults)) = params.OfferStatusWatchResults{
@@ -752,8 +780,9 @@ func (s *CrossModelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	})
 	client := crossmodelrelations.NewClientWithCache(apiCaller, s.cache)
 	_, err = client.WatchOfferStatus(params.OfferArg{
-		OfferUUID: offerUUID,
-		Macaroons: macaroon.Slice{mac},
+		OfferUUID:     offerUUID,
+		Macaroons:     macaroon.Slice{mac},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	// Call again with a different macaroon but the first one will be
@@ -762,8 +791,9 @@ func (s *CrossModelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.cache.Upsert("offer-uuid", macaroon.Slice{mac})
 	_, err = client.WatchOfferStatus(params.OfferArg{
-		OfferUUID: offerUUID,
-		Macaroons: macaroon.Slice{different},
+		OfferUUID:     offerUUID,
+		Macaroons:     macaroon.Slice{different},
+		BakeryVersion: bakery.LatestVersion,
 	})
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 2)

--- a/api/http.go
+++ b/api/http.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -105,6 +106,7 @@ func authHTTPRequest(req *http.Request, tag, password, nonce string, macaroons [
 	if nonce != "" {
 		req.Header.Set(params.MachineNonceHeader, nonce)
 	}
+	req.Header.Set(httpbakery.BakeryProtocolHeader, fmt.Sprint(bakery.LatestVersion))
 	for _, ms := range macaroons {
 		encoded, err := encodeMacaroonSlice(ms)
 		if err != nil {

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -230,13 +230,15 @@ func (s *httpSuite) TestAuthHTTPRequest(c *gc.C) {
 	req := s.authHTTPRequest(c, apiInfo)
 	_, _, ok := req.BasicAuth()
 	c.Assert(ok, jc.IsFalse)
-	c.Assert(req.Header, gc.HasLen, 0)
+	c.Assert(req.Header, gc.HasLen, 1)
+	c.Assert(req.Header.Get(httpbakery.BakeryProtocolHeader), gc.Equals, "3")
 
 	apiInfo.Nonce = "foo"
 	req = s.authHTTPRequest(c, apiInfo)
 	_, _, ok = req.BasicAuth()
 	c.Assert(ok, jc.IsFalse)
 	c.Assert(req.Header.Get(params.MachineNonceHeader), gc.Equals, "foo")
+	c.Assert(req.Header.Get(httpbakery.BakeryProtocolHeader), gc.Equals, "3")
 
 	apiInfo.Tag = names.NewMachineTag("123")
 	apiInfo.Password = "password"
@@ -246,12 +248,14 @@ func (s *httpSuite) TestAuthHTTPRequest(c *gc.C) {
 	c.Assert(user, gc.Equals, "machine-123")
 	c.Assert(pass, gc.Equals, "password")
 	c.Assert(req.Header.Get(params.MachineNonceHeader), gc.Equals, "foo")
+	c.Assert(req.Header.Get(httpbakery.BakeryProtocolHeader), gc.Equals, "3")
 
 	mac, err := apitesting.NewMacaroon("id")
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo.Macaroons = []macaroon.Slice{{mac}}
 	req = s.authHTTPRequest(c, apiInfo)
 	c.Assert(req.Header.Get(params.MachineNonceHeader), gc.Equals, "foo")
+	c.Assert(req.Header.Get(httpbakery.BakeryProtocolHeader), gc.Equals, "3")
 	macaroons := httpbakery.RequestMacaroons(req)
 	apitesting.MacaroonsEqual(c, macaroons, apiInfo.Macaroons)
 }

--- a/api/state.go
+++ b/api/state.go
@@ -39,11 +39,12 @@ import (
 func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaroon.Slice) error {
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     tagToString(tag),
-		Credentials: password,
-		Nonce:       nonce,
-		Macaroons:   macaroons,
-		CLIArgs:     utils.CommandString(os.Args...),
+		AuthTag:       tagToString(tag),
+		Credentials:   password,
+		Nonce:         nonce,
+		Macaroons:     macaroons,
+		BakeryVersion: bakery.LatestVersion,
+		CLIArgs:       utils.CommandString(os.Args...),
 	}
 	// If we are in developer mode, add the stack location as user data to the
 	// login request. This will allow the apiserver to connect connection ids

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -183,6 +183,7 @@ func (s *macaroonLoginSuite) TestConnectStreamWithDischargedMacaroons(c *gc.C) {
 	defer conn.Close()
 
 	headers := catcher.headers
+	c.Assert(headers.Get(httpbakery.BakeryProtocolHeader), gc.Equals, "3")
 	c.Assert(headers.Get("Cookie"), jc.HasPrefix, "macaroon-")
 	assertHeaderMatchesMacaroon(c, headers, dischargedMacaroons[0])
 }

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -4,6 +4,8 @@
 package authentication
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 
@@ -24,7 +26,7 @@ type taggedAuthenticator interface {
 
 // Authenticate authenticates the provided entity.
 // It takes an entityfinder and the tag used to find the entity that requires authentication.
-func (*AgentAuthenticator) Authenticate(entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
+func (*AgentAuthenticator) Authenticate(ctx context.Context, entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
 	entity, err := entityFinder.FindEntity(tag)
 	if errors.IsNotFound(err) {
 		return nil, errors.Trace(common.ErrBadCreds)

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -4,6 +4,8 @@
 package authentication_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -102,7 +104,7 @@ func (s *agentAuthenticatorSuite) TestValidLogins(c *gc.C) {
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
 		var authenticator authentication.AgentAuthenticator
-		entity, err := authenticator.Authenticate(s.State, t.entity.Tag(), params.LoginRequest{
+		entity, err := authenticator.Authenticate(context.TODO(), s.State, t.entity.Tag(), params.LoginRequest{
 			Credentials: t.credentials,
 			Nonce:       t.nonce,
 		})
@@ -138,7 +140,7 @@ func (s *agentAuthenticatorSuite) TestInvalidLogins(c *gc.C) {
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
 		var authenticator authentication.AgentAuthenticator
-		entity, err := authenticator.Authenticate(s.State, t.entity.Tag(), params.LoginRequest{
+		entity, err := authenticator.Authenticate(context.TODO(), s.State, t.entity.Tag(), params.LoginRequest{
 			Credentials: t.credentials,
 			Nonce:       t.nonce,
 		})

--- a/apiserver/authentication/interfaces.go
+++ b/apiserver/authentication/interfaces.go
@@ -4,6 +4,8 @@
 package authentication
 
 import (
+	"context"
+
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
@@ -14,7 +16,7 @@ import (
 // to authenticate juju entities.
 type EntityAuthenticator interface {
 	// Authenticate authenticates the given entity
-	Authenticate(entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error)
+	Authenticate(ctx context.Context, entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error)
 }
 
 // EntityFinder finds the entity described by the tag.

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -51,7 +51,7 @@ func (s *userAuthenticatorSuite) TestMachineLoginFails(c *gc.C) {
 
 	// attempt machine login
 	authenticator := &authentication.UserAuthenticator{}
-	_, err = authenticator.Authenticate(nil, machine.Tag(), params.LoginRequest{
+	_, err = authenticator.Authenticate(context.TODO(), nil, machine.Tag(), params.LoginRequest{
 		Credentials: machinePassword,
 		Nonce:       nonce,
 	})
@@ -71,7 +71,7 @@ func (s *userAuthenticatorSuite) TestUnitLoginFails(c *gc.C) {
 
 	// Attempt unit login
 	authenticator := &authentication.UserAuthenticator{}
-	_, err = authenticator.Authenticate(nil, unit.Tag(), params.LoginRequest{
+	_, err = authenticator.Authenticate(context.TODO(), nil, unit.Tag(), params.LoginRequest{
 		Credentials: unitPassword,
 		Nonce:       "",
 	})
@@ -87,7 +87,7 @@ func (s *userAuthenticatorSuite) TestValidUserLogin(c *gc.C) {
 
 	// User login
 	authenticator := &authentication.UserAuthenticator{}
-	_, err := authenticator.Authenticate(s.State, user.Tag(), params.LoginRequest{
+	_, err := authenticator.Authenticate(context.TODO(), s.State, user.Tag(), params.LoginRequest{
 		Credentials: "password",
 		Nonce:       "",
 	})
@@ -103,7 +103,7 @@ func (s *userAuthenticatorSuite) TestUserLoginWrongPassword(c *gc.C) {
 
 	// User login
 	authenticator := &authentication.UserAuthenticator{}
-	_, err := authenticator.Authenticate(s.State, user.Tag(), params.LoginRequest{
+	_, err := authenticator.Authenticate(context.TODO(), s.State, user.Tag(), params.LoginRequest{
 		Credentials: "wrongpassword",
 		Nonce:       "",
 	})
@@ -125,7 +125,7 @@ func (s *userAuthenticatorSuite) TestInvalidRelationLogin(c *gc.C) {
 
 	// Attempt relation login
 	authenticator := &authentication.UserAuthenticator{}
-	_, err = authenticator.Authenticate(nil, relation.Tag(), params.LoginRequest{
+	_, err = authenticator.Authenticate(context.TODO(), nil, relation.Tag(), params.LoginRequest{
 		Credentials: "dummy-secret",
 		Nonce:       "",
 	})
@@ -145,7 +145,7 @@ func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 
 	// User login
 	authenticator := &authentication.UserAuthenticator{Bakery: &service, Clock: testclock.NewClock(time.Time{})}
-	_, err = authenticator.Authenticate(s.State, user.Tag(), params.LoginRequest{
+	_, err = authenticator.Authenticate(context.TODO(), s.State, user.Tag(), params.LoginRequest{
 		Credentials: "",
 		Nonce:       "",
 		Macaroons:   macaroons,
@@ -162,6 +162,7 @@ func (s *userAuthenticatorSuite) TestCreateLocalLoginMacaroon(c *gc.C) {
 	service := mockBakeryService{}
 	clock := testclock.NewClock(time.Time{})
 	_, err := authentication.CreateLocalLoginMacaroon(
+		context.TODO(),
 		names.NewUserTag("bobbrown"), &service, clock, bakery.LatestVersion,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -183,6 +184,7 @@ func (s *userAuthenticatorSuite) TestAuthenticateLocalLoginMacaroon(c *gc.C) {
 
 	service.SetErrors(nil, &bakery.VerificationError{})
 	_, err := authenticator.Authenticate(
+		context.TODO(),
 		authentication.EntityFinder(nil),
 		names.NewUserTag("bobbrown"),
 		params.LoginRequest{},
@@ -332,12 +334,11 @@ func (s *macaroonAuthenticatorSuite) TestMacaroonAuthentication(c *gc.C) {
 		authenticator := &authentication.ExternalMacaroonAuthenticator{
 			Bakery:           bakery,
 			IdentityLocation: discharger.Location(),
-			Context:          context.Background(),
 			Clock:            testclock.NewClock(time.Time{}),
 		}
 
 		// Authenticate once to obtain the macaroon to be discharged.
-		_, err := authenticator.Authenticate(test.finder, nil, params.LoginRequest{
+		_, err := authenticator.Authenticate(context.TODO(), test.finder, nil, params.LoginRequest{
 			Credentials: "",
 			Nonce:       "",
 			Macaroons:   nil,
@@ -350,7 +351,7 @@ func (s *macaroonAuthenticatorSuite) TestMacaroonAuthentication(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Authenticate again with the discharged macaroon.
-		entity, err := authenticator.Authenticate(test.finder, nil, params.LoginRequest{
+		entity, err := authenticator.Authenticate(context.TODO(), test.finder, nil, params.LoginRequest{
 			Credentials: "",
 			Nonce:       "",
 			Macaroons:   []macaroon.Slice{ms},

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -14,9 +14,8 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
-	checkers2 "gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
 	"gopkg.in/macaroon-bakery.v2/bakerytest"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
@@ -135,15 +134,17 @@ func (s *userAuthenticatorSuite) TestInvalidRelationLogin(c *gc.C) {
 
 func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{
-		Name: "bobbrown",
+		Name: "bob",
 	})
 	mac, err := macaroon.New(nil, nil, "", macaroon.LatestVersion)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mac.AddFirstPartyCaveat([]byte("declared username bob"))
 	c.Assert(err, jc.ErrorIsNil)
 	macaroons := []macaroon.Slice{{mac}}
 	service := mockBakeryService{}
 
 	// User login
-	authenticator := &authentication.UserAuthenticator{Service: &service}
+	authenticator := &authentication.UserAuthenticator{Bakery: &service, Clock: testclock.NewClock(time.Time{})}
 	_, err = authenticator.Authenticate(s.State, user.Tag(), params.LoginRequest{
 		Credentials: "",
 		Nonce:       "",
@@ -151,25 +152,23 @@ func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	service.CheckCallNames(c, "CheckAny")
+	service.CheckCallNames(c, "Auth")
 	call := service.Calls()[0]
-	c.Assert(call.Args, gc.HasLen, 3)
+	c.Assert(call.Args, gc.HasLen, 1)
 	c.Assert(call.Args[0], jc.DeepEquals, macaroons)
-	c.Assert(call.Args[1], jc.DeepEquals, map[string]string{"username": "bobbrown"})
-	// no check for checker function, can't compare functions
 }
 
 func (s *userAuthenticatorSuite) TestCreateLocalLoginMacaroon(c *gc.C) {
 	service := mockBakeryService{}
 	clock := testclock.NewClock(time.Time{})
 	_, err := authentication.CreateLocalLoginMacaroon(
-		names.NewUserTag("bobbrown"), &service, clock,
+		names.NewUserTag("bobbrown"), &service, clock, bakery.LatestVersion,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	service.CheckCallNames(c, "NewMacaroon")
 	service.CheckCall(c, 0, "NewMacaroon", []checkers.Caveat{
 		{Condition: "is-authenticated-user bobbrown"},
-		{Condition: "time-before 0001-01-01T00:02:00Z"},
+		{Condition: "time-before 0001-01-01T00:02:00Z", Namespace: "std"},
 	})
 }
 
@@ -177,12 +176,12 @@ func (s *userAuthenticatorSuite) TestAuthenticateLocalLoginMacaroon(c *gc.C) {
 	service := mockBakeryService{}
 	clock := testclock.NewClock(time.Time{})
 	authenticator := &authentication.UserAuthenticator{
-		Service:                   &service,
+		Bakery:                    &service,
 		Clock:                     clock,
 		LocalUserIdentityLocation: "https://testing.invalid:1234/auth",
 	}
 
-	service.SetErrors(&bakery.VerificationError{})
+	service.SetErrors(nil, &bakery.VerificationError{})
 	_, err := authenticator.Authenticate(
 		authentication.EntityFinder(nil),
 		names.NewUserTag("bobbrown"),
@@ -190,19 +189,20 @@ func (s *userAuthenticatorSuite) TestAuthenticateLocalLoginMacaroon(c *gc.C) {
 	)
 	c.Assert(err, gc.FitsTypeOf, &common.DischargeRequiredError{})
 
-	service.CheckCallNames(c, "CheckAny", "ExpireStorageAfter", "NewMacaroon")
+	service.CheckCallNames(c, "Auth", "ExpireStorageAfter", "NewMacaroon")
 	calls := service.Calls()
 	c.Assert(calls[1].Args, jc.DeepEquals, []interface{}{24 * time.Hour})
 	c.Assert(calls[2].Args, jc.DeepEquals, []interface{}{
 		[]checkers.Caveat{
+			{Condition: "time-before 0001-01-02T00:00:00Z", Namespace: "std"},
 			checkers.NeedDeclaredCaveat(
 				checkers.Caveat{
 					Location:  "https://testing.invalid:1234/auth",
 					Condition: "is-authenticated-user bobbrown",
+					Namespace: "std",
 				},
 				"username",
 			),
-			{Condition: "time-before 0001-01-02T00:00:00Z"},
 		},
 	})
 }
@@ -211,24 +211,43 @@ type mockBakeryService struct {
 	testing.Stub
 }
 
-func (s *mockBakeryService) AddCaveat(m *macaroon.Macaroon, caveat checkers.Caveat) error {
-	s.MethodCall(s, "AddCaveat", m, caveat)
-	return s.NextErr()
+func (s *mockBakeryService) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
+	s.MethodCall(s, "Auth", mss)
+	checker := bakery.NewChecker(bakery.CheckerParams{
+		OpsAuthorizer:    mockAuthorizer{},
+		MacaroonVerifier: mockVerifier{},
+	})
+	return checker.Auth(mss...)
 }
 
-func (s *mockBakeryService) CheckAny(ms []macaroon.Slice, assert map[string]string, checker checkers.Checker) (map[string]string, error) {
-	s.MethodCall(s, "CheckAny", ms, assert, checker)
-	return nil, s.NextErr()
-}
-
-func (s *mockBakeryService) NewMacaroon(caveats []checkers.Caveat) (*macaroon.Macaroon, error) {
+func (s *mockBakeryService) NewMacaroon(ctx context.Context, version bakery.Version, caveats []checkers.Caveat, ops ...bakery.Op) (*bakery.Macaroon, error) {
 	s.MethodCall(s, "NewMacaroon", caveats)
-	return macaroon.New(nil, nil, "", macaroon.LatestVersion)
+	mac, err := macaroon.New(nil, nil, "", macaroon.LatestVersion)
+	if err != nil {
+		return nil, err
+	}
+	return bakery.NewLegacyMacaroon(mac)
 }
 
-func (s *mockBakeryService) ExpireStorageAfter(t time.Duration) (authentication.ExpirableStorageBakeryService, error) {
+func (s *mockBakeryService) ExpireStorageAfter(t time.Duration) (authentication.ExpirableStorageBakery, error) {
 	s.MethodCall(s, "ExpireStorageAfter", t)
 	return s, s.NextErr()
+}
+
+type mockAuthorizer struct{}
+
+func (mockAuthorizer) AuthorizeOps(ctx context.Context, authorizedOp bakery.Op, queryOps []bakery.Op) ([]bool, []checkers.Caveat, error) {
+	allowed := make([]bool, len(queryOps))
+	for i := range allowed {
+		allowed[i] = queryOps[i] == identchecker.LoginOp
+	}
+	return allowed, nil, nil
+}
+
+type mockVerifier struct{}
+
+func (mockVerifier) VerifyMacaroon(ctx context.Context, ms macaroon.Slice) ([]bakery.Op, []string, error) {
+	return []bakery.Op{identchecker.LoginOp}, []string{"declared username bob"}, nil
 }
 
 type macaroonAuthenticatorSuite struct {
@@ -290,8 +309,8 @@ type alwaysIdent struct {
 }
 
 // IdentityFromContext implements IdentityClient.IdentityFromContext.
-func (m *alwaysIdent) IdentityFromContext(ctx context.Context) (identchecker.Identity, []checkers2.Caveat, error) {
-	return nil, []checkers2.Caveat{checkers2.DeclaredCaveat("username", m.username)}, nil
+func (m *alwaysIdent) IdentityFromContext(ctx context.Context) (identchecker.Identity, []checkers.Caveat, error) {
+	return nil, []checkers.Caveat{checkers.DeclaredCaveat("username", m.username)}, nil
 }
 
 func (alwaysIdent) DeclaredIdentity(ctx context.Context, declared map[string]string) (identchecker.Identity, error) {

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -210,7 +210,7 @@ func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferUUID:      "mysql-uuid",
 	}
-	mac, err := s.authContext.CreateConsumeOfferMacaroon(offer, "mary", bakery.LatestVersion)
+	mac, err := s.authContext.CreateConsumeOfferMacaroon(context.TODO(), offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 	cav := mac.M().Caveats()
 	c.Assert(cav, gc.HasLen, 4)
@@ -222,6 +222,7 @@ func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
 
 func (s *authSuite) TestCreateRemoteRelationMacaroon(c *gc.C) {
 	mac, err := s.authContext.CreateRemoteRelationMacaroon(
+		context.TODO(),
 		coretesting.ModelTag.Id(), "mysql-uuid", "mary", names.NewRelationTag("mediawiki:db mysql:server"), bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 	cav := mac.M().Caveats()
@@ -246,6 +247,7 @@ func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	attr, err := s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+		context.TODO(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -272,6 +274,7 @@ func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+		context.TODO(),
 		"prod.another",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -294,6 +297,7 @@ func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+		context.TODO(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -309,11 +313,12 @@ func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferUUID:      "mysql-uuid",
 	}
-	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary", bakery.LatestVersion)
+	mac, err := authContext.CreateConsumeOfferMacaroon(context.TODO(), offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
+		context.TODO(),
 		"mysql-uuid",
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -339,6 +344,7 @@ func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+		context.TODO(),
 		relationTag,
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -360,6 +366,7 @@ func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+		context.TODO(),
 		names.NewRelationTag("app:db offer:db"),
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -383,6 +390,7 @@ func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+		context.TODO(),
 		relationTag,
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,
@@ -396,11 +404,13 @@ func (s *authSuite) TestCheckRelationMacaroonsDischargeRequired(c *gc.C) {
 	authContext = authContext.WithDischargeURL("http://thirdparty")
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := authContext.CreateRemoteRelationMacaroon(
+		context.TODO(),
 		coretesting.ModelTag.Id(), "mysql-uuid", "mary", relationTag, bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+		context.TODO(),
 		relationTag,
 		macaroon.Slice{mac.M()},
 		bakery.LatestVersion,

--- a/apiserver/common/crossmodel/auth_test.go
+++ b/apiserver/common/crossmodel/auth_test.go
@@ -5,17 +5,19 @@ package crossmodel_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/authentication"
@@ -31,8 +33,24 @@ var _ = gc.Suite(&authSuite{})
 type authSuite struct {
 	coretesting.BaseSuite
 
-	bakery        authentication.ExpirableStorageBakeryService
+	authContext   *crossmodel.AuthContext
+	bakery        authentication.ExpirableStorageBakery
+	bakeryKey     *bakery.KeyPair
 	mockStatePool *mockStatePool
+}
+
+type testLocator struct {
+	PublicKey bakery.PublicKey
+}
+
+func (b testLocator) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+	if loc != "http://thirdparty" {
+		return bakery.ThirdPartyInfo{}, errors.NotFoundf("location %v", loc)
+	}
+	return bakery.ThirdPartyInfo{
+		PublicKey: b.PublicKey,
+		Version:   bakery.LatestVersion,
+	}, nil
 }
 
 func (s *authSuite) SetUpTest(c *gc.C) {
@@ -40,19 +58,19 @@ func (s *authSuite) SetUpTest(c *gc.C) {
 
 	key, err := bakery.GenerateKey()
 	c.Assert(err, jc.ErrorIsNil)
-	bakery, err := bakery.NewService(bakery.NewServiceParams{
-		Locator: bakery.PublicKeyLocatorMap{
-			"http://thirdparty": &key.Public,
-		},
+	locator := testLocator{key.Public}
+	bakery := bakery.New(bakery.BakeryParams{
+		Locator:       locator,
+		Key:           bakery.MustGenerateKey(),
+		OpsAuthorizer: crossmodel.CrossModelAuthorizer{},
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.bakery = &mockBakeryService{bakery}
+	s.bakery = &mockBakery{bakery}
 	s.mockStatePool = &mockStatePool{st: make(map[string]crossmodel.Backend)}
+	s.authContext, err = crossmodel.NewAuthContext(s.mockStatePool, s.bakeryKey, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *authSuite) TestCheckValidCaveat(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	uuid := utils.MustNewUUID()
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
@@ -61,7 +79,7 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	opc, err := s.authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(opc.SourceModelUUID, gc.Equals, uuid.String())
 	c.Assert(opc.User, gc.Equals, "mary")
@@ -71,8 +89,6 @@ permission: consume
 }
 
 func (s *authSuite) TestCheckInvalidCaveatId(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	uuid := utils.MustNewUUID()
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
@@ -81,13 +97,11 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	_, err = authContext.CheckOfferAccessCaveat("different-caveat " + permCheckDetails)
+	_, err := s.authContext.CheckOfferAccessCaveat("different-caveat " + permCheckDetails)
 	c.Assert(err, gc.ErrorMatches, ".*caveat not recognized.*")
 }
 
 func (s *authSuite) TestCheckInvalidCaveatContents(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := `
 source-model-uuid: invalid
 username: mary
@@ -95,7 +109,7 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:]
-	_, err = authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	_, err := s.authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, gc.ErrorMatches, `source-model-uuid "invalid" not valid`)
 }
 
@@ -108,8 +122,6 @@ func (s *authSuite) TestCheckLocalAccessRequest(c *gc.C) {
 		},
 	}
 	s.mockStatePool.st[uuid.String()] = st
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
 username: mary
@@ -117,9 +129,9 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	opc, err := s.authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, jc.ErrorIsNil)
-	cav, err := authContext.CheckLocalAccessRequest(opc)
+	cav, err := s.authContext.CheckLocalAccessRequest(opc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cav, gc.HasLen, 5)
 	c.Assert(cav[0].Condition, gc.Equals, "declared source-model-uuid "+uuid.String())
@@ -138,8 +150,6 @@ func (s *authSuite) TestCheckLocalAccessRequestControllerAdmin(c *gc.C) {
 		},
 	}
 	s.mockStatePool.st[uuid.String()] = st
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
 username: mary
@@ -147,9 +157,9 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	opc, err := s.authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = authContext.CheckLocalAccessRequest(opc)
+	_, err = s.authContext.CheckLocalAccessRequest(opc)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -162,8 +172,6 @@ func (s *authSuite) TestCheckLocalAccessRequestModelAdmin(c *gc.C) {
 		},
 	}
 	s.mockStatePool.st[uuid.String()] = st
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
 username: mary
@@ -171,9 +179,9 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	opc, err := s.authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = authContext.CheckLocalAccessRequest(opc)
+	_, err = s.authContext.CheckLocalAccessRequest(opc)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -184,8 +192,6 @@ func (s *authSuite) TestCheckLocalAccessRequestNoPermission(c *gc.C) {
 		permissions: make(map[string]permission.Access),
 	}
 	s.mockStatePool.st[uuid.String()] = st
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	permCheckDetails := fmt.Sprintf(`
 source-model-uuid: %v
 username: mary
@@ -193,22 +199,20 @@ offer-uuid: mysql-uuid
 relation-key: mediawiki:db mysql:server
 permission: consume
 `[1:], uuid)
-	opc, err := authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
+	opc, err := s.authContext.CheckOfferAccessCaveat("has-offer-permission " + permCheckDetails)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = authContext.CheckLocalAccessRequest(opc)
+	_, err = s.authContext.CheckLocalAccessRequest(opc)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
 func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	offer := &params.ApplicationOfferDetails{
 		SourceModelTag: coretesting.ModelTag.String(),
 		OfferUUID:      "mysql-uuid",
 	}
-	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary")
+	mac, err := s.authContext.CreateConsumeOfferMacaroon(offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
-	cav := mac.Caveats()
+	cav := mac.M().Caveats()
 	c.Assert(cav, gc.HasLen, 4)
 	c.Assert(bytes.HasPrefix(cav[0].Id, []byte("time-before")), jc.IsTrue)
 	c.Assert(cav[1].Id, jc.DeepEquals, []byte("declared source-model-uuid "+coretesting.ModelTag.Id()))
@@ -217,12 +221,10 @@ func (s *authSuite) TestCreateConsumeOfferMacaroon(c *gc.C) {
 }
 
 func (s *authSuite) TestCreateRemoteRelationMacaroon(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
+	mac, err := s.authContext.CreateRemoteRelationMacaroon(
+		coretesting.ModelTag.Id(), "mysql-uuid", "mary", names.NewRelationTag("mediawiki:db mysql:server"), bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
-	mac, err := authContext.CreateRemoteRelationMacaroon(
-		coretesting.ModelTag.Id(), "mysql-uuid", "mary", names.NewRelationTag("mediawiki:db mysql:server"))
-	c.Assert(err, jc.ErrorIsNil)
-	cav := mac.Caveats()
+	cav := mac.M().Caveats()
 	c.Assert(cav, gc.HasLen, 5)
 	c.Assert(bytes.HasPrefix(cav[0].Id, []byte("time-before")), jc.IsTrue)
 	c.Assert(cav[1].Id, jc.DeepEquals, []byte("declared source-model-uuid "+coretesting.ModelTag.Id()))
@@ -232,19 +234,21 @@ func (s *authSuite) TestCreateRemoteRelationMacaroon(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := s.bakery.NewMacaroon([]checkers.Caveat{
-		checkers.DeclaredCaveat("username", "mary"),
-		checkers.DeclaredCaveat("offer-uuid", "mysql-uuid"),
-		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
-	})
+	mac, err := s.bakery.NewMacaroon(
+		context.TODO(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("username", "mary"),
+			checkers.DeclaredCaveat("offer-uuid", "mysql-uuid"),
+			checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+		}, bakery.Op{"consume", "mysql-uuid"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	attr, err := authContext.Authenticator(
+	attr, err := s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
 		"mysql-uuid",
-		macaroon.Slice{mac},
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attr, gc.HasLen, 3)
@@ -256,80 +260,63 @@ func (s *authSuite) TestCheckOfferMacaroons(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckOfferMacaroonsWrongOffer(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := s.bakery.NewMacaroon([]checkers.Caveat{
-		checkers.DeclaredCaveat("username", "mary"),
-		checkers.DeclaredCaveat("offer-uuid", "mysql-uuid"),
-		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
-	})
+	mac, err := s.bakery.NewMacaroon(
+		context.TODO(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("username", "mary"),
+			checkers.DeclaredCaveat("offer-uuid", "mysql-uuid"),
+			checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+		}, bakery.Op{"consume", "mysql-uuid"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = authContext.Authenticator(
+	_, err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
 		"prod.another",
-		macaroon.Slice{mac},
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	c.Assert(
 		err,
 		gc.ErrorMatches,
-		`.*caveat "declared offer-uuid mysql-uuid" not satisfied: got offer-uuid="prod.another", expected "mysql-uuid"`)
+		"permission denied")
 }
 
 func (s *authSuite) TestCheckOfferMacaroonsNoUser(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := s.bakery.NewMacaroon([]checkers.Caveat{
-		checkers.DeclaredCaveat("offer-uuid", "mysql-uuid"),
-		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
-	})
+	mac, err := s.bakery.NewMacaroon(
+		context.TODO(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("offer-uuid", "mysql-uuid"),
+			checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+		}, bakery.Op{"consume", "mysql-uuid"})
 
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = authContext.Authenticator(
+	_, err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
 		"mysql-uuid",
-		macaroon.Slice{mac},
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
-func (s *authSuite) TestCheckOfferMacaroonsExpired(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
-	clock := testclock.NewClock(time.Now().Add(-10 * time.Minute))
-	authContext = authContext.WithClock(clock)
-	offer := &params.ApplicationOfferDetails{
-		SourceModelTag: coretesting.ModelTag.String(),
-		OfferURL:       "mysql-uuid",
-	}
-	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary")
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
-		"mysql-uuid",
-		macaroon.Slice{mac},
-	)
-	c.Assert(err, gc.ErrorMatches, ".*macaroon has expired")
-}
-
 func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	clock := testclock.NewClock(time.Now().Add(-10 * time.Minute))
-	authContext = authContext.WithClock(clock)
+	authContext := s.authContext.WithClock(clock)
 	authContext = authContext.WithDischargeURL("http://thirdparty")
 	offer := &params.ApplicationOfferDetails{
 		SourceModelTag: coretesting.ModelTag.String(),
-		OfferURL:       "mysql-uuid",
+		OfferUUID:      "mysql-uuid",
 	}
-	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary")
+	mac, err := authContext.CreateConsumeOfferMacaroon(offer, "mary", bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
 		"mysql-uuid",
-		macaroon.Slice{mac},
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	dischargeErr, ok := err.(*common.DischargeRequiredError)
 	c.Assert(ok, jc.IsTrue)
@@ -339,96 +326,84 @@ func (s *authSuite) TestCheckOfferMacaroonsDischargeRequired(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckRelationMacaroons(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
-	mac, err := s.bakery.NewMacaroon([]checkers.Caveat{
-		checkers.DeclaredCaveat("username", "mary"),
-		checkers.DeclaredCaveat("relation-key", relationTag.Id()),
-		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
-	})
+	mac, err := s.bakery.NewMacaroon(
+		context.TODO(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("username", "mary"),
+			checkers.DeclaredCaveat("relation-key", relationTag.Id()),
+			checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+		}, bakery.Op{"relate", relationTag.Id()})
 
 	c.Assert(err, jc.ErrorIsNil)
-	err = authContext.Authenticator(
+	err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
 		relationTag,
-		macaroon.Slice{mac},
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *authSuite) TestCheckRelationMacaroonsWrongRelation(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := s.bakery.NewMacaroon([]checkers.Caveat{
-		checkers.DeclaredCaveat("username", "mary"),
-		checkers.DeclaredCaveat("relation-key", names.NewRelationTag("mediawiki:db mysql:server").Id()),
-		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
-	})
+	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
+	mac, err := s.bakery.NewMacaroon(
+		context.TODO(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("username", "mary"),
+			checkers.DeclaredCaveat("relation-key", relationTag.Id()),
+			checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+		}, bakery.Op{"relate", relationTag.Id()})
 
 	c.Assert(err, jc.ErrorIsNil)
-	err = authContext.Authenticator(
+	err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
 		names.NewRelationTag("app:db offer:db"),
-		macaroon.Slice{mac},
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	c.Assert(
 		err,
 		gc.ErrorMatches,
-		`.*caveat "declared relation-key mediawiki:db mysql:server" not satisfied: got relation-key="app:db offer:db", expected "mediawiki:db mysql:server"`)
+		"permission denied")
 }
 
 func (s *authSuite) TestCheckRelationMacaroonsNoUser(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
-	mac, err := s.bakery.NewMacaroon([]checkers.Caveat{
-		checkers.DeclaredCaveat("relation-key", relationTag.Id()),
-		checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
-	})
+	mac, err := s.bakery.NewMacaroon(
+		context.TODO(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("relation-key", relationTag.Id()),
+			checkers.DeclaredCaveat("source-model-uuid", coretesting.ModelTag.Id()),
+		}, bakery.Op{"relate", relationTag.Id()})
 
 	c.Assert(err, jc.ErrorIsNil)
-	err = authContext.Authenticator(
+	err = s.authContext.Authenticator(
 		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
 		relationTag,
-		macaroon.Slice{mac},
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
-func (s *authSuite) TestCheckRelationMacaroonsExpired(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
-	clock := testclock.NewClock(time.Now().Add(-10 * time.Minute))
-	authContext = authContext.WithClock(clock)
-	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
-	mac, err := authContext.CreateRemoteRelationMacaroon(
-		coretesting.ModelTag.Id(), "prod.offer", "mary", relationTag)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
-		"mysql-uuid",
-		macaroon.Slice{mac},
-	)
-	c.Assert(err, gc.ErrorMatches, ".*macaroon has expired")
-}
-
 func (s *authSuite) TestCheckRelationMacaroonsDischargeRequired(c *gc.C) {
-	authContext, err := crossmodel.NewAuthContext(s.mockStatePool, s.bakery, s.bakery)
-	c.Assert(err, jc.ErrorIsNil)
 	clock := testclock.NewClock(time.Now().Add(-10 * time.Minute))
-	authContext = authContext.WithClock(clock)
+	authContext := s.authContext.WithClock(clock)
 	authContext = authContext.WithDischargeURL("http://thirdparty")
 	relationTag := names.NewRelationTag("mediawiki:db mysql:server")
 	mac, err := authContext.CreateRemoteRelationMacaroon(
-		coretesting.ModelTag.Id(), "mysql-uuid", "mary", relationTag)
+		coretesting.ModelTag.Id(), "mysql-uuid", "mary", relationTag, bakery.LatestVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = authContext.Authenticator(
-		coretesting.ModelTag.Id(), "mysql-uuid").CheckOfferMacaroons(
-		"mysql-uuid",
-		macaroon.Slice{mac},
+	err = authContext.Authenticator(
+		coretesting.ModelTag.Id(), "mysql-uuid").CheckRelationMacaroons(
+		relationTag,
+		macaroon.Slice{mac.M()},
+		bakery.LatestVersion,
 	)
 	dischargeErr, ok := err.(*common.DischargeRequiredError)
 	c.Assert(ok, jc.IsTrue)

--- a/apiserver/common/crossmodel/mock_test.go
+++ b/apiserver/common/crossmodel/mock_test.go
@@ -4,11 +4,14 @@
 package crossmodel_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common/crossmodel"
@@ -17,12 +20,20 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-type mockBakeryService struct {
-	*bakery.Service
+type mockBakery struct {
+	*bakery.Bakery
 }
 
-func (m *mockBakeryService) ExpireStorageAfter(time.Duration) (authentication.ExpirableStorageBakeryService, error) {
+func (m *mockBakery) ExpireStorageAfter(time.Duration) (authentication.ExpirableStorageBakery, error) {
 	return m, nil
+}
+
+func (m *mockBakery) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
+	return m.Bakery.Checker.Auth(mss...)
+}
+
+func (m *mockBakery) NewMacaroon(ctx context.Context, version bakery.Version, caveats []checkers.Caveat, ops ...bakery.Op) (*bakery.Macaroon, error) {
+	return m.Bakery.Oven.NewMacaroon(ctx, version, caveats, ops...)
 }
 
 type mockStatePool struct {

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
@@ -37,7 +38,8 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
 	var err error
-	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
+	thirdPartyKey := bakery.MustGenerateKey()
+	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, nil, getFakeControllerInfo,

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -467,12 +467,12 @@ func (api *OffersAPI) GetConsumeDetails(args params.OfferURLs) (params.ConsumeOf
 		offerDetails := &offer.ApplicationOfferDetails
 		results[i].Offer = offerDetails
 		results[i].ControllerInfo = controllerInfo
-		offerMacaroon, err := api.authContext.CreateConsumeOfferMacaroon(offerDetails, api.Authorizer.GetAuthTag().Id())
+		offerMacaroon, err := api.authContext.CreateConsumeOfferMacaroon(offerDetails, api.Authorizer.GetAuthTag().Id(), args.BakeryVersion)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
 		}
-		results[i].Macaroon = offerMacaroon
+		results[i].Macaroon = offerMacaroon.M()
 	}
 	consumeResults.Results = results
 	return consumeResults, nil

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -4,6 +4,7 @@
 package applicationoffers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -58,6 +59,7 @@ func createOffersAPI(
 		dataDir:     dataDir.String(),
 		authContext: authContext,
 		BaseAPI: BaseAPI{
+			ctx:                  context.Background(),
 			Authorizer:           authorizer,
 			GetApplicationOffers: getApplicationOffers,
 			ControllerModel:      backend,
@@ -467,7 +469,7 @@ func (api *OffersAPI) GetConsumeDetails(args params.OfferURLs) (params.ConsumeOf
 		offerDetails := &offer.ApplicationOfferDetails
 		results[i].Offer = offerDetails
 		results[i].ControllerInfo = controllerInfo
-		offerMacaroon, err := api.authContext.CreateConsumeOfferMacaroon(offerDetails, api.Authorizer.GetAuthTag().Id(), args.BakeryVersion)
+		offerMacaroon, err := api.authContext.CreateConsumeOfferMacaroon(api.ctx, offerDetails, api.Authorizer.GetAuthTag().Id(), args.BakeryVersion)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -12,7 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
@@ -48,7 +49,8 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	s.bakery = &mockBakeryService{caveats: make(map[string][]checkers.Caveat)}
-	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
+	thirdPartyKey := bakery.MustGenerateKey()
+	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
@@ -358,7 +360,7 @@ func (s *applicationOffersSuite) assertShow(c *gc.C, url string, expected []para
 	s.mockState.CreateOfferAccess(
 		names.NewApplicationOfferTag("hosted-db2"),
 		names.NewUserTag("mary"), permission.ConsumeAccess)
-	filter := params.OfferURLs{[]string{url}}
+	filter := params.OfferURLs{[]string{url}, bakery.LatestVersion}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
@@ -469,7 +471,7 @@ func (s *applicationOffersSuite) TestShowPermission(c *gc.C) {
 
 func (s *applicationOffersSuite) TestShowError(c *gc.C) {
 	url := "fred/prod.hosted-db2"
-	filter := params.OfferURLs{[]string{url}}
+	filter := params.OfferURLs{[]string{url}, bakery.LatestVersion}
 	msg := "fail"
 
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
@@ -484,7 +486,7 @@ func (s *applicationOffersSuite) TestShowError(c *gc.C) {
 
 func (s *applicationOffersSuite) TestShowNotFound(c *gc.C) {
 	urls := []string{"fred/prod.hosted-db2"}
-	filter := params.OfferURLs{urls}
+	filter := params.OfferURLs{urls, bakery.LatestVersion}
 
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, nil
@@ -500,7 +502,7 @@ func (s *applicationOffersSuite) TestShowNotFound(c *gc.C) {
 
 func (s *applicationOffersSuite) TestShowRejectsEndpoints(c *gc.C) {
 	urls := []string{"fred/prod.hosted-db2:db"}
-	filter := params.OfferURLs{urls}
+	filter := params.OfferURLs{urls, bakery.LatestVersion}
 	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
 
 	found, err := s.api.ApplicationOffers(filter)
@@ -511,7 +513,7 @@ func (s *applicationOffersSuite) TestShowRejectsEndpoints(c *gc.C) {
 
 func (s *applicationOffersSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
 	urls := []string{"fred/prod.hosted-mysql", "fred/test.hosted-db2"}
-	filter := params.OfferURLs{urls}
+	filter := params.OfferURLs{urls, bakery.LatestVersion}
 
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, nil
@@ -553,7 +555,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 		Endpoints:              map[string]charm.Relation{"db2": {Name: "db2"}},
 	}
 
-	filter := params.OfferURLs{[]string{url, url2}}
+	filter := params.OfferURLs{[]string{url, url2}, bakery.LatestVersion}
 
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		c.Assert(filters, gc.HasLen, 1)
@@ -1070,7 +1072,8 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 		return s.env, nil
 	}
 	var err error
-	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
+	thirdPartyKey := bakery.MustGenerateKey()
+	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	apiV1, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
@@ -1338,7 +1341,7 @@ func (s *consumeSuite) assertDestroyOffersNoForce(c *gc.C, api destroyOffers) {
 	})
 
 	urls := []string{"fred/prod.hosted-db2"}
-	filter := params.OfferURLs{urls}
+	filter := params.OfferURLs{urls, bakery.LatestVersion}
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
@@ -1379,7 +1382,7 @@ func (s *consumeSuite) TestDestroyOffersForce(c *gc.C) {
 	})
 
 	urls := []string{"fred/prod.hosted-db2"}
-	filter := params.OfferURLs{urls}
+	filter := params.OfferURLs{urls, bakery.LatestVersion}
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -4,6 +4,7 @@
 package applicationoffers
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -30,6 +31,7 @@ type BaseAPI struct {
 	StatePool            StatePool
 	getEnviron           environFromModelFunc
 	getControllerInfo    func() (apiAddrs []string, caCert string, _ error)
+	ctx                  context.Context
 }
 
 // checkPermission ensures that the logged in user holds the given permission on an entity.

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -4,6 +4,7 @@
 package applicationoffers_test
 
 import (
+	stdcontet "context"
 	"fmt"
 	"time"
 
@@ -11,7 +12,8 @@ import (
 	jtesting "github.com/juju/testing"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/authentication"
@@ -494,18 +496,27 @@ func (st *mockCommonStatePool) Get(modelUUID string) (crossmodel.Backend, func()
 }
 
 type mockBakeryService struct {
-	authentication.ExpirableStorageBakeryService
+	authentication.ExpirableStorageBakery
 	jtesting.Stub
 	caveats map[string][]checkers.Caveat
 }
 
-func (s *mockBakeryService) NewMacaroon(caveats []checkers.Caveat) (*macaroon.Macaroon, error) {
+func (s *mockBakeryService) NewMacaroon(ctx stdcontet.Context, version bakery.Version, caveats []checkers.Caveat, ops ...bakery.Op) (*bakery.Macaroon, error) {
 	s.MethodCall(s, "NewMacaroon", caveats)
+	mac, err := macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
+	if err != nil {
+		return nil, err
+	}
+	for _, cav := range caveats {
+		if err := mac.AddFirstPartyCaveat([]byte(cav.Condition)); err != nil {
+			return nil, err
+		}
+	}
 	s.caveats["id"] = caveats
-	return macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
+	return bakery.NewLegacyMacaroon(mac)
 }
 
-func (s *mockBakeryService) ExpireStorageAfter(when time.Duration) (authentication.ExpirableStorageBakeryService, error) {
+func (s *mockBakeryService) ExpireStorageAfter(when time.Duration) (authentication.ExpirableStorageBakery, error) {
 	s.MethodCall(s, "ExpireStorageAfter", when)
 	return s, nil
 }

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -107,7 +108,7 @@ func NewCrossModelRelationsAPI(
 	}, nil
 }
 
-func (api *CrossModelRelationsAPI) checkMacaroonsForRelation(relationTag names.Tag, mac macaroon.Slice) error {
+func (api *CrossModelRelationsAPI) checkMacaroonsForRelation(relationTag names.Tag, mac macaroon.Slice, version bakery.Version) error {
 	api.mu.Lock()
 	defer api.mu.Unlock()
 
@@ -120,7 +121,7 @@ func (api *CrossModelRelationsAPI) checkMacaroonsForRelation(relationTag names.T
 		offerUUID = oc.OfferUUID()
 	}
 	auth := api.authCtxt.Authenticator(api.st.ModelUUID(), offerUUID)
-	return auth.CheckRelationMacaroons(relationTag, mac)
+	return auth.CheckRelationMacaroons(relationTag, mac, version)
 }
 
 // PublishRelationChanges publishes relation changes to the
@@ -142,7 +143,7 @@ func (api *CrossModelRelationsAPI) PublishRelationChanges(
 			continue
 		}
 		logger.Debugf("relation tag for token %+v is %v", change.RelationToken, relationTag)
-		if err := api.checkMacaroonsForRelation(relationTag, change.Macaroons); err != nil {
+		if err := api.checkMacaroonsForRelation(relationTag, change.Macaroons, change.BakeryVersion); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
@@ -186,7 +187,7 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 
 	// Check that the supplied macaroon allows access.
 	auth := api.authCtxt.Authenticator(api.st.ModelUUID(), appOffer.OfferUUID)
-	attr, err := auth.CheckOfferMacaroons(appOffer.OfferUUID, relation.Macaroons)
+	attr, err := auth.CheckOfferMacaroons(appOffer.OfferUUID, relation.Macaroons, relation.BakeryVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -313,13 +314,13 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 
 	// Mint a new macaroon attenuated to the actual relation.
 	relationMacaroon, err := api.authCtxt.CreateRemoteRelationMacaroon(
-		api.st.ModelUUID(), relation.OfferUUID, username, localRel.Tag())
+		api.st.ModelUUID(), relation.OfferUUID, username, localRel.Tag(), relation.BakeryVersion)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating relation macaroon")
 	}
 	return &params.RemoteRelationDetails{
 		Token:    token,
-		Macaroon: relationMacaroon,
+		Macaroon: relationMacaroon.M(),
 	}, nil
 }
 
@@ -338,7 +339,7 @@ func (api *CrossModelRelationsAPIV1) WatchRelationUnits(remoteRelationArgs param
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons); err != nil {
+		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons, arg.BakeryVersion); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
@@ -374,7 +375,7 @@ func (api *CrossModelRelationsAPI) WatchRelationChanges(remoteRelationArgs param
 		if err != nil {
 			return nil, empty, errors.Trace(err)
 		}
-		if err := api.checkMacaroonsForRelation(tag, arg.Macaroons); err != nil {
+		if err := api.checkMacaroonsForRelation(tag, arg.Macaroons, arg.BakeryVersion); err != nil {
 			return nil, empty, errors.Trace(err)
 		}
 		relationTag, ok := tag.(names.RelationTag)
@@ -439,7 +440,7 @@ func (api *CrossModelRelationsAPIV1) RelationUnitSettings(relationUnits params.R
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons); err != nil {
+		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons, arg.BakeryVersion); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
@@ -481,7 +482,7 @@ func (api *CrossModelRelationsAPI) WatchRelationsSuspendedStatus(
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons); err != nil {
+		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons, arg.BakeryVersion); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
@@ -547,7 +548,7 @@ func (api *CrossModelRelationsAPI) WatchOfferStatus(
 	for i, arg := range offerArgs.Args {
 		// Ensure the supplied macaroon allows access.
 		auth := api.authCtxt.Authenticator(api.st.ModelUUID(), arg.OfferUUID)
-		_, err := auth.CheckOfferMacaroons(arg.OfferUUID, arg.Macaroons)
+		_, err := auth.CheckOfferMacaroons(arg.OfferUUID, arg.Macaroons, arg.BakeryVersion)
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
@@ -591,7 +592,7 @@ func (api *CrossModelRelationsAPI) PublishIngressNetworkChanges(
 		}
 		logger.Debugf("relation tag for token %+v is %v", change.RelationToken, relationTag)
 
-		if err := api.checkMacaroonsForRelation(relationTag, change.Macaroons); err != nil {
+		if err := api.checkMacaroonsForRelation(relationTag, change.Macaroons, change.BakeryVersion); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
@@ -617,7 +618,7 @@ func (api *CrossModelRelationsAPI) WatchEgressAddressesForRelations(remoteRelati
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons); err != nil {
+		if err := api.checkMacaroonsForRelation(relationTag, arg.Macaroons, arg.BakeryVersion); err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4210,6 +4210,9 @@
                 "OfferURLs": {
                     "type": "object",
                     "properties": {
+                        "bakery-version": {
+                            "type": "integer"
+                        },
                         "offer-urls": {
                             "type": "array",
                             "items": {
@@ -13853,6 +13856,9 @@
                         "application-token": {
                             "type": "string"
                         },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
                         "ingress-required": {
                             "type": "boolean"
                         },
@@ -13898,6 +13904,9 @@
                 "OfferArg": {
                     "type": "object",
                     "properties": {
+                        "bakery-version": {
+                            "type": "integer"
+                        },
                         "macaroons": {
                             "type": "array",
                             "items": {
@@ -13986,6 +13995,9 @@
                     "properties": {
                         "application-token": {
                             "type": "string"
+                        },
+                        "bakery-version": {
+                            "type": "integer"
                         },
                         "local-endpoint-name": {
                             "type": "string"
@@ -14150,6 +14162,9 @@
                 "RemoteEntityArg": {
                     "type": "object",
                     "properties": {
+                        "bakery-version": {
+                            "type": "integer"
+                        },
                         "macaroons": {
                             "type": "array",
                             "items": {
@@ -14195,6 +14210,9 @@
                         "application-token": {
                             "type": "string"
                         },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
                         "changed-units": {
                             "type": "array",
                             "items": {
@@ -14239,6 +14257,9 @@
                 "RemoteRelationDetails": {
                     "type": "object",
                     "properties": {
+                        "bakery-version": {
+                            "type": "integer"
+                        },
                         "macaroon": {
                             "$ref": "#/definitions/Macaroon"
                         },
@@ -28567,6 +28588,9 @@
                         "application-token": {
                             "type": "string"
                         },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
                         "changed-units": {
                             "type": "array",
                             "items": {
@@ -29234,6 +29258,9 @@
                         },
                         "application-token": {
                             "type": "string"
+                        },
+                        "bakery-version": {
+                            "type": "integer"
                         },
                         "changed-units": {
                             "type": "array",

--- a/apiserver/httpcontext/auth.go
+++ b/apiserver/httpcontext/auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -33,7 +34,7 @@ type LocalMacaroonAuthenticator interface {
 	// used to obtain a discharge macaroon so that the user can
 	// log in without presenting their password for a set amount
 	// of time.
-	CreateLocalLoginMacaroon(names.UserTag) (*macaroon.Macaroon, error)
+	CreateLocalLoginMacaroon(names.UserTag, bakery.Version) (*macaroon.Macaroon, error)
 }
 
 // Authenticator provides an interface for authenticating a request.

--- a/apiserver/httpcontext/auth.go
+++ b/apiserver/httpcontext/auth.go
@@ -34,7 +34,7 @@ type LocalMacaroonAuthenticator interface {
 	// used to obtain a discharge macaroon so that the user can
 	// log in without presenting their password for a set amount
 	// of time.
-	CreateLocalLoginMacaroon(names.UserTag, bakery.Version) (*macaroon.Macaroon, error)
+	CreateLocalLoginMacaroon(context.Context, names.UserTag, bakery.Version) (*macaroon.Macaroon, error)
 }
 
 // Authenticator provides an interface for authenticating a request.
@@ -54,6 +54,7 @@ type Authenticator interface {
 	//
 	// TODO(axw) we shouldn't be using params types here.
 	AuthenticateLoginRequest(
+		ctx context.Context,
 		serverHost string,
 		modelUUID string,
 		req params.LoginRequest,

--- a/apiserver/httpcontext/auth_test.go
+++ b/apiserver/httpcontext/auth_test.go
@@ -4,6 +4,7 @@
 package httpcontext_test
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -60,7 +61,7 @@ func (s *BasicAuthHandlerSuite) Authenticate(req *http.Request) (httpcontext.Aut
 }
 
 func (s *BasicAuthHandlerSuite) AuthenticateLoginRequest(
-	serverHost, modelUUID string, req params.LoginRequest,
+	ctx context.Context, serverHost, modelUUID string, req params.LoginRequest,
 ) (httpcontext.AuthInfo, error) {
 	panic("should not be called")
 }

--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -4,14 +4,18 @@
 package apiserver
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/juju/errors"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
+	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/bakeryutil"
 	"github.com/juju/juju/apiserver/common/crossmodel"
+	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/state"
 )
 
@@ -23,15 +27,28 @@ type localOfferAuthHandler struct {
 	authCtx *crossmodel.AuthContext
 }
 
+func addOfferAuthHandlers(offerAuthCtxt *crossmodel.AuthContext, mux *apiserverhttp.Mux) {
+	appOfferHandler := &localOfferAuthHandler{authCtx: offerAuthCtxt}
+	appOfferDischargeMux := http.NewServeMux()
+
+	discharger := httpbakery.NewDischarger(
+		httpbakery.DischargerParams{
+			Key:     offerAuthCtxt.OfferThirdPartyKey(),
+			Checker: httpbakery.ThirdPartyCaveatCheckerFunc(appOfferHandler.checkThirdPartyCaveat),
+		})
+	discharger.AddMuxHandlers(appOfferDischargeMux, localOfferAccessLocationPath)
+
+	mux.AddHandler("POST", localOfferAccessLocationPath+"/discharge", appOfferDischargeMux)
+	mux.AddHandler("GET", localOfferAccessLocationPath+"/publickey", appOfferDischargeMux)
+}
+
 func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error) {
 	// Create a bakery service for discharging third-party caveats for
 	// local offer access authentication. This service does not persist keys;
 	// its macaroons should be very short-lived.
 	st := pool.SystemState()
-	localOfferThirdPartyBakeryService, _, err := bakeryutil.NewBakeryService(st, nil, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	location := "juju model " + st.ModelUUID()
+	checker := checkers.New(charmstore.MacaroonNamespace)
 
 	// Create a bakery service for local offer access authentication. This service
 	// persists keys into MongoDB in a TTL collection.
@@ -39,42 +56,41 @@ func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	locator := bakeryutil.BakeryServicePublicKeyLocator{localOfferThirdPartyBakeryService}
-	localUserBakeryService, localUserBakeryServiceKey, err := bakeryutil.NewBakeryService(
-		st, store, locator,
-	)
+	key, err := bakery.GenerateKey()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	localOfferBakeryService := &bakeryutil.ExpirableStorageBakeryService{
-		localUserBakeryService, localUserBakeryServiceKey, store, locator,
+	locator := bakeryutil.BakeryThirdPartyLocator{PublicKey: key.Public}
+	localOfferBakery := bakery.New(
+		bakery.BakeryParams{
+			Checker:       checker,
+			RootKeyStore:  store,
+			Locator:       locator,
+			Key:           key,
+			OpsAuthorizer: crossmodel.CrossModelAuthorizer{},
+			Location:      location,
+		},
+	)
+	localOfferBakeryKey := key
+	offerBakery := &bakeryutil.ExpirableStorageBakery{
+		localOfferBakery, location, localOfferBakeryKey, store, locator,
 	}
-	authCtx, err := crossmodel.NewAuthContext(crossmodel.GetStatePool(pool), localOfferThirdPartyBakeryService, localOfferBakeryService)
+	authCtx, err := crossmodel.NewAuthContext(
+		crossmodel.GetStatePool(pool), key, offerBakery)
 	if err != nil {
 		return nil, err
 	}
 	return authCtx, nil
 }
 
-func (h *localOfferAuthHandler) checkThirdPartyCaveat(req *http.Request, cavInfo *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-	ctx := &macaroonOfferAuthContext{h.authCtx, req}
-	return ctx.CheckThirdPartyCaveat(cavInfo)
-}
-
-type macaroonOfferAuthContext struct {
-	*crossmodel.AuthContext
-	req *http.Request
-}
-
-// CheckThirdPartyCaveat is part of the bakery.ThirdPartyChecker interface.
-func (ctx *macaroonOfferAuthContext) CheckThirdPartyCaveat(cavInfo *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
-	logger.Debugf("check third party caveat %#v", cavInfo)
-	details, err := ctx.CheckOfferAccessCaveat(cavInfo.Condition)
+func (h *localOfferAuthHandler) checkThirdPartyCaveat(stdctx context.Context, req *http.Request, cavInfo *bakery.ThirdPartyCaveatInfo, _ *httpbakery.DischargeToken) ([]checkers.Caveat, error) {
+	logger.Debugf("check offer third party caveat %q", cavInfo.Condition)
+	details, err := h.authCtx.CheckOfferAccessCaveat(string(cavInfo.Condition))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	firstPartyCaveats, err := ctx.CheckLocalAccessRequest(details)
+	firstPartyCaveats, err := h.authCtx.CheckLocalAccessRequest(details)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -5,6 +5,7 @@ package params
 
 import (
 	"gopkg.in/juju/charm.v6"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/core/life"
@@ -168,6 +169,9 @@ type ApplicationOffersResults struct {
 type OfferURLs struct {
 	// OfferURLs contains collection of urls for applications that are to be shown.
 	OfferURLs []string `json:"offer-urls,omitempty"`
+
+	// BakeryVersion is the version of the bakery used to mint macaroons.
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
 // ConsumeApplicationArg holds the arguments for consuming a remote application.
@@ -382,6 +386,9 @@ type RemoteRelationChangeEvent struct {
 
 	// Macaroons are used for authentication.
 	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+
+	// BakeryVersion is the version of the bakery used to mint macaroons.
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
 // RemoteRelationWatchResult holds a RemoteRelationWatcher id, initial
@@ -472,6 +479,9 @@ type IngressNetworksChangeEvent struct {
 
 	// Macaroons are used for authentication.
 	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+
+	// BakeryVersion is the version of the bakery used to mint macaroons.
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
 // RegisterRemoteRelationArg holds attributes used to register a remote relation.
@@ -500,6 +510,9 @@ type RegisterRemoteRelationArg struct {
 
 	// Macaroons are used for authentication.
 	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+
+	// BakeryVersion is the version of the bakery used to mint macaroons.
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
 // RegisterRemoteRelationArgs holds args used to add remote relations.
@@ -520,8 +533,9 @@ type RegisterRemoteRelationResults struct {
 
 // RemoteRelationDetails holds a remote relation token and corresponding macaroon.
 type RemoteRelationDetails struct {
-	Token    string             `json:"relation-token"`
-	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
+	Token         string             `json:"relation-token"`
+	Macaroon      *macaroon.Macaroon `json:"macaroon,omitempty"`
+	BakeryVersion bakery.Version     `json:"bakery-version,omitempty"`
 }
 
 // RemoteEntityArgs holds arguments to an API call dealing with remote relations.
@@ -531,8 +545,9 @@ type RemoteEntityArgs struct {
 
 // RemoteEntityArg holds a remote relation token corresponding macaroons.
 type RemoteEntityArg struct {
-	Token     string         `json:"relation-token"`
-	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+	Token         string         `json:"relation-token"`
+	Macaroons     macaroon.Slice `json:"macaroons,omitempty"`
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
 // OfferArgs holds arguments to an API call dealing with offers.
@@ -542,8 +557,9 @@ type OfferArgs struct {
 
 // OfferArg holds an offer uuid and corresponding macaroons.
 type OfferArg struct {
-	OfferUUID string         `json:"offer-uuid"`
-	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+	OfferUUID     string         `json:"offer-uuid"`
+	Macaroons     macaroon.Slice `json:"macaroons,omitempty"`
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
 // RemoteApplicationInfo has attributes for a remote application.
@@ -604,6 +620,7 @@ type RemoteRelationUnit struct {
 	RelationToken string         `json:"relation-token"`
 	Unit          string         `json:"unit"`
 	Macaroons     macaroon.Slice `json:"macaroons,omitempty"`
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
 // RemoteRelationUnits identifies multiple remote relation units.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -507,12 +507,13 @@ type Creds struct {
 // the LoginResult will contain a macaroon that when
 // discharged, may allow access.
 type LoginRequest struct {
-	AuthTag     string           `json:"auth-tag"`
-	Credentials string           `json:"credentials"`
-	Nonce       string           `json:"nonce"`
-	Macaroons   []macaroon.Slice `json:"macaroons"`
-	CLIArgs     string           `json:"cli-args,omitempty"`
-	UserData    string           `json:"user-data"`
+	AuthTag       string           `json:"auth-tag"`
+	Credentials   string           `json:"credentials"`
+	Nonce         string           `json:"nonce"`
+	Macaroons     []macaroon.Slice `json:"macaroons"`
+	BakeryVersion bakery.Version   `json:"bakery-version,omitempty"`
+	CLIArgs       string           `json:"cli-args,omitempty"`
+	UserData      string           `json:"user-data"`
 }
 
 // LoginRequestCompat holds credentials for identifying an entity to the Login v1

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -59,7 +59,7 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 
 	// Set a short-lived macaroon as a cookie on the response,
 	// which the client can use to obtain a discharge macaroon.
-	m, err := h.ctxt.srv.authenticator.CreateLocalLoginMacaroon(userTag)
+	m, err := h.ctxt.srv.authenticator.CreateLocalLoginMacaroon(userTag, httpbakery.RequestVersion(req))
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -59,7 +59,7 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 
 	// Set a short-lived macaroon as a cookie on the response,
 	// which the client can use to obtain a discharge macaroon.
-	m, err := h.ctxt.srv.authenticator.CreateLocalLoginMacaroon(userTag, httpbakery.RequestVersion(req))
+	m, err := h.ctxt.srv.authenticator.CreateLocalLoginMacaroon(req.Context(), userTag, httpbakery.RequestVersion(req))
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -4,6 +4,7 @@
 package apiserver_test
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -418,6 +419,7 @@ func (a *mockAuthenticator) Authenticate(req *http.Request) (httpcontext.AuthInf
 }
 
 func (a *mockAuthenticator) AuthenticateLoginRequest(
+	ctx context.Context,
 	serverHost string,
 	modelUUID string,
 	req params.LoginRequest,
@@ -431,7 +433,7 @@ func (a *mockAuthenticator) AuthenticateLoginRequest(
 	}, nil
 }
 
-func (a *mockAuthenticator) CreateLocalLoginMacaroon(tag names.UserTag, version bakery.Version) (*macaroon.Macaroon, error) {
+func (a *mockAuthenticator) CreateLocalLoginMacaroon(ctx context.Context, tag names.UserTag, version bakery.Version) (*macaroon.Macaroon, error) {
 	return nil, nil
 }
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api"
@@ -430,7 +431,7 @@ func (a *mockAuthenticator) AuthenticateLoginRequest(
 	}, nil
 }
 
-func (a *mockAuthenticator) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
+func (a *mockAuthenticator) CreateLocalLoginMacaroon(tag names.UserTag, version bakery.Version) (*macaroon.Macaroon, error) {
 	return nil, nil
 }
 

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -4,6 +4,8 @@
 package stateauthenticator_test
 
 import (
+	"context"
+
 	"github.com/juju/clock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,7 +43,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	c.Assert(authenticator, gc.NotNil)
 	userFinder := userFinder{user}
 
-	entity, err := authenticator.Authenticate(userFinder, user.Tag(), params.LoginRequest{
+	entity, err := authenticator.Authenticate(context.TODO(), userFinder, user.Tag(), params.LoginRequest{
 		Credentials: "password",
 		Nonce:       "nonce",
 	})

--- a/apiserver/stateauthenticator/legacy.go
+++ b/apiserver/stateauthenticator/legacy.go
@@ -77,7 +77,7 @@ func (h *localLoginHandlers) serveLoginPost(response http.ResponseWriter, req *h
 	}
 
 	authenticator := h.authCtxt.authenticator(req.Host)
-	if _, err := authenticator.Authenticate(h.finder, userTag, params.LoginRequest{
+	if _, err := authenticator.Authenticate(req.Context(), h.finder, userTag, params.LoginRequest{
 		Credentials: password,
 	}); err != nil {
 		// Mark the interaction as done (but failed),
@@ -96,7 +96,7 @@ func (h *localLoginHandlers) serveLoginPost(response http.ResponseWriter, req *h
 	// Provide the client with a macaroon that they can use to
 	// prove that they have logged in, and obtain a discharge
 	// macaroon.
-	m, err := h.authCtxt.CreateLocalLoginMacaroon(userTag, httpbakery.RequestVersion(req))
+	m, err := h.authCtxt.CreateLocalLoginMacaroon(req.Context(), userTag, httpbakery.RequestVersion(req))
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (ctx *macaroonAuthContext) legacyCheckThirdPartyCaveat(stdCtx context.Conte
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := ctx.CheckLocalLoginRequest(ctx.req, tag); err != nil {
+	if err := ctx.CheckLocalLoginRequest(stdCtx, ctx.req); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return ctx.DischargeCaveats(tag), nil

--- a/apiserver/stateauthenticator/legacy.go
+++ b/apiserver/stateauthenticator/legacy.go
@@ -1,0 +1,185 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stateauthenticator
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/juju/errors"
+	"gopkg.in/httprequest.v1"
+	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"gopkg.in/macaroon.v2"
+
+	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/charmstore"
+)
+
+// TODO(juju3) - legacy login handlers are not needed once we stop supporting Juju 2 clients.
+
+// AddHandlers adds the local login handlers to the given mux.
+func (h *localLoginHandlers) AddLegacyHandlers(mux *apiserverhttp.Mux, dischargeMux *http.ServeMux) {
+	makeHandler := func(h func(http.ResponseWriter, *http.Request) (interface{}, error)) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			val, err := h(w, req)
+			if err != nil {
+				httpbakery.WriteError(context.TODO(), w, err)
+				return
+			}
+			httprequest.WriteJSON(w, http.StatusOK, val)
+		})
+	}
+	dischargeMux.Handle(
+		localUserIdentityLocationPath+"/login",
+		makeHandler(h.serveLogin),
+	)
+	dischargeMux.Handle(
+		localUserIdentityLocationPath+"/wait",
+		makeHandler(h.serveWait),
+	)
+	mux.AddHandler("GET", localUserIdentityLocationPath+"/wait", dischargeMux)
+	mux.AddHandler("GET", localUserIdentityLocationPath+"/login", dischargeMux)
+	mux.AddHandler("POST", localUserIdentityLocationPath+"/login", dischargeMux)
+}
+
+func (h *localLoginHandlers) serveLogin(response http.ResponseWriter, req *http.Request) (interface{}, error) {
+	switch req.Method {
+	case "POST":
+		return h.serveLoginPost(response, req)
+	case "GET":
+		return h.serveLoginGet(req)
+	default:
+		return nil, errors.Errorf("unsupported method %q", req.Method)
+	}
+}
+
+func (h *localLoginHandlers) serveLoginPost(response http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if err := req.ParseForm(); err != nil {
+		return nil, err
+	}
+	waitId := req.Form.Get("waitid")
+	if waitId == "" {
+		return nil, errors.NotValidf("missing waitid")
+	}
+	username := req.Form.Get("user")
+	password := req.Form.Get("password")
+	if !names.IsValidUser(username) {
+		return nil, errors.NotValidf("username %q", username)
+	}
+	userTag := names.NewUserTag(username)
+	if !userTag.IsLocal() {
+		return nil, errors.NotValidf("non-local username %q", username)
+	}
+
+	authenticator := h.authCtxt.authenticator(req.Host)
+	if _, err := authenticator.Authenticate(h.finder, userTag, params.LoginRequest{
+		Credentials: password,
+	}); err != nil {
+		// Mark the interaction as done (but failed),
+		// unblocking a pending "/auth/wait" request.
+		if err := h.authCtxt.localUserInteractions.Done(waitId, userTag, err); err != nil {
+			if !errors.IsNotFound(err) {
+				logger.Warningf(
+					"failed to record completion of interaction %q for %q",
+					waitId, userTag.Id(),
+				)
+			}
+		}
+		return nil, errors.Trace(err)
+	}
+
+	// Provide the client with a macaroon that they can use to
+	// prove that they have logged in, and obtain a discharge
+	// macaroon.
+	m, err := h.authCtxt.CreateLocalLoginMacaroon(userTag, httpbakery.RequestVersion(req))
+	if err != nil {
+		return nil, err
+	}
+	cookie, err := httpbakery.NewCookie(charmstore.MacaroonNamespace, macaroon.Slice{m.M()})
+	if err != nil {
+		return nil, err
+	}
+	http.SetCookie(response, cookie)
+
+	// Mark the interaction as done, unblocking a pending
+	// "/auth/wait" request.
+	if err := h.authCtxt.localUserInteractions.Done(
+		waitId, userTag, nil,
+	); err != nil {
+		if errors.IsNotFound(err) {
+			err = errors.New("login timed out")
+		}
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (h *localLoginHandlers) serveLoginGet(req *http.Request) (interface{}, error) {
+	if req.Header.Get("Accept") == "application/json" {
+		// The application/json content-type is used to
+		// inform the client of the supported auth methods.
+		return map[string]string{
+			"juju_userpass": req.URL.String(),
+		}, nil
+	}
+	// TODO(axw) return an HTML form. If waitid is supplied,
+	// it should be passed through so we can unblock a request
+	// on the /auth/wait endpoint. We should also support logging
+	// in when not specifically directed to the login page.
+	return nil, errors.NotImplementedf("GET")
+}
+
+func (h *localLoginHandlers) serveWait(_ http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if err := req.ParseForm(); err != nil {
+		return nil, err
+	}
+	if req.Method != "GET" {
+		return nil, errors.Errorf("unsupported method %q", req.Method)
+	}
+	waitId := req.Form.Get("waitid")
+	if waitId == "" {
+		return nil, errors.NotValidf("missing waitid")
+	}
+	interaction, err := h.authCtxt.localUserInteractions.Wait(waitId, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if interaction.LoginError != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ctx := macaroonAuthContext{
+		authContext: h.authCtxt,
+		req:         req,
+	}
+	mac, err := bakery.Discharge(context.TODO(), bakery.DischargeParams{
+		Id:      interaction.CaveatId,
+		Key:     h.authCtxt.localUserThirdPartyBakeryKey,
+		Checker: bakery.ThirdPartyCaveatCheckerFunc(ctx.legacyCheckThirdPartyCaveat),
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "discharging macaroon")
+	}
+	return httpbakery.WaitResponse{mac}, nil
+}
+
+type macaroonAuthContext struct {
+	*authContext
+	req *http.Request
+}
+
+func (ctx *macaroonAuthContext) legacyCheckThirdPartyCaveat(stdCtx context.Context, cavInfo *bakery.ThirdPartyCaveatInfo) ([]checkers.Caveat, error) {
+	tag, err := ctx.CheckLocalLoginCaveat(string(cavInfo.Condition))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := ctx.CheckLocalLoginRequest(ctx.req, tag); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return ctx.DischargeCaveats(tag), nil
+}

--- a/apiserver/stateauthenticator/locallogin.go
+++ b/apiserver/stateauthenticator/locallogin.go
@@ -65,10 +65,11 @@ func (h *localLoginHandlers) bakeryError(w http.ResponseWriter, err error) {
 func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "POST":
+		ctx := req.Context()
 		reqParams := httprequest.Params{
 			Response: w,
 			Request:  req,
-			Context:  context.TODO(),
+			Context:  ctx,
 		}
 		loginRequest := form.LoginRequest{}
 		if err := httprequest.Unmarshal(reqParams, &loginRequest); err != nil {
@@ -85,7 +86,7 @@ func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Reques
 		}
 
 		authenticator := h.authCtxt.authenticator(req.Host)
-		if _, err := authenticator.Authenticate(h.finder, userTag, params.LoginRequest{
+		if _, err := authenticator.Authenticate(ctx, h.finder, userTag, params.LoginRequest{
 			Credentials: password,
 		}); err != nil {
 			h.bakeryError(w, err)
@@ -125,7 +126,7 @@ func (h *localLoginHandlers) checkThirdPartyCaveat(stdCtx context.Context, req *
 		return nil, errors.Trace(err)
 	}
 	if token == nil {
-		if err := h.authCtxt.CheckLocalLoginRequest(req, tag); err == nil {
+		if err := h.authCtxt.CheckLocalLoginRequest(stdCtx, req); err == nil {
 			return h.authCtxt.DischargeCaveats(tag), nil
 		}
 		err2 := httpbakery.NewInteractionRequiredError(nil, req)

--- a/charmstore/jar.go
+++ b/charmstore/jar.go
@@ -15,8 +15,11 @@ import (
 	"gopkg.in/macaroon.v2"
 )
 
+// MacaroonURI is use when register new Juju checkers with the bakery.
+const MacaroonURI = "github.com/juju/juju"
+
 // MacaroonNamespace is the namespace Juju uses for managing macaroons.
-var MacaroonNamespace *checkers.Namespace
+var MacaroonNamespace = checkers.NewNamespace(map[string]string{MacaroonURI: ""})
 
 // newMacaroonJar returns a new macaroonJar wrapping the given cache and
 // expecting to be used against the given URL.  Both the cache and url must

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -1518,14 +1518,7 @@ func (c *DeployCommand) maybeReadCharmstoreBundleFn(cstore BundleResolver) func(
 		}
 
 		return func(ctx *cmd.Context, apiRoot DeployAPI, deployResources resourceadapters.DeployResourcesFunc, cstore *charmStoreAdaptor) error {
-			// Ideally, we would like to expose a GetBundleDataSource
-			// method for the charmstore. As we want to avoid further
-			// diverging charmrepo.v4 from charmrepo.v4, the best
-			// solution would be to converge to a charmrepo.v5.
-			// Unfortunately, the macaroon-related changes from v4
-			// wreak havoc with our bakery.v2/v2-unstable includes
-			// and therefore require quite a bit of effort to fix.
-			//
+			// TODO(bundles) - Ideally, we would like to expose a GetBundleDataSource method for the charmstore.
 			// As a short-term solution and given that we don't
 			// want to support (for now at least) multi-doc bundles
 			// from the charmstore we simply use the existing

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -24,6 +24,8 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -508,6 +510,7 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 		return nil, errors.Trace(err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(httpbakery.BakeryProtocolHeader, fmt.Sprint(bakery.LatestVersion))
 	httpClient := utils.GetNonValidatingHTTPClient()
 	httpClient.Jar = cookieJar
 	httpResp, err := httpClient.Do(httpReq)

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -617,6 +618,10 @@ func (s *RegisterSuite) encodeRegistrationData(c *gc.C, info jujuclient.Registra
 }
 
 func (srv *mockServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get(httpbakery.BakeryProtocolHeader) != "3" {
+		http.Error(w, "unexpected bakery version", http.StatusInternalServerError)
+		return
+	}
 	srv.requests = append(srv.requests, r)
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -453,8 +453,15 @@ Run "juju logout" first before attempting to log in as a different user.`,
 		User: username,
 	}
 	conn, err := dial(accountDetails)
+	if err != nil {
+		if strings.Contains(err.Error(), badCred) {
+			err = errors.New(badCred)
+		}
+	}
 	return conn, accountDetails, errors.Trace(err)
 }
+
+const badCred = "invalid entity name or password"
 
 const noModelsMessage = `
 There are no models available. You can add models with

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api"
@@ -1509,6 +1510,7 @@ func (rd *remoteRelationData) updateProviderModel(cidrs []string) error {
 		Networks:         change.networks.Values(),
 		IngressRequired:  change.ingressRequired,
 		Macaroons:        macaroon.Slice{mac},
+		BakeryVersion:    bakery.LatestVersion,
 	}
 	err = remoteModelAPI.PublishIngressNetworkChange(event)
 	if errors.IsNotFound(err) {

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"github.com/juju/juju/api"
 	basetesting "github.com/juju/juju/api/base/testing"
@@ -813,6 +814,7 @@ func (s *InstanceModeSuite) setupRemoteRelationRequirerRoleConsumingSide(
 
 		changes.Changes[0].Networks = nil
 		expected.Changes[0].IngressRequired = argIngressRequired
+		expected.Changes[0].BakeryVersion = bakery.LatestVersion
 		c.Check(arg, gc.DeepEquals, expected)
 
 		if !*ingressRequired {

--- a/worker/raft/rafttransport/worker_test.go
+++ b/worker/raft/rafttransport/worker_test.go
@@ -4,6 +4,7 @@
 package rafttransport_test
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -354,6 +355,7 @@ func (a *mockAuthenticator) Authenticate(req *http.Request) (httpcontext.AuthInf
 }
 
 func (a *mockAuthenticator) AuthenticateLoginRequest(
+	ctx context.Context,
 	serverHost string,
 	modelUUID string,
 	req params.LoginRequest,

--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api/watcher"
@@ -84,6 +85,7 @@ func (w *relationUnitsWorker) loop() error {
 			// TODO(babbageclunk): move this so it happens just before
 			// the event is published to the remote facade.
 			change.Macaroons = macaroon.Slice{w.macaroon}
+			change.BakeryVersion = bakery.LatestVersion
 
 			// Send in lockstep so we don't drop events (otherwise
 			// we'd need to merge them - not too hard in this

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/workertest"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api"
@@ -313,6 +314,7 @@ func (s *remoteRelationsSuite) TestRemoteNotFoundTerminatesOnChange(c *gc.C) {
 			OfferUUID:         "offer-db2-uuid",
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
+			BakeryVersion:     bakery.LatestVersion,
 		}}}},
 		{"SetRemoteApplicationStatus", []interface{}{"db2", "terminated", "offer has been removed"}},
 		{"Close", nil},
@@ -359,6 +361,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsWorkers(c *gc.C) worker.Work
 			OfferUUID:         "offer-db2-uuid",
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
+			BakeryVersion:     bakery.LatestVersion,
 		}}}},
 		{"SaveMacaroon", []interface{}{relTag, apiMac}},
 		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
@@ -445,6 +448,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsRevoked(c *gc.C) {
 			OfferUUID:         "offer-db2-uuid",
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
+			BakeryVersion:     bakery.LatestVersion,
 		}}}},
 		{"SetRemoteApplicationStatus", []interface{}{"db2", "error", "message"}},
 		{"Close", nil},
@@ -501,6 +505,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 			OfferUUID:         "offer-db2-uuid",
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
+			BakeryVersion:     bakery.LatestVersion,
 		}}}},
 		{"SaveMacaroon", []interface{}{relTag, apiMac}},
 		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
@@ -510,6 +515,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 				ApplicationToken: "token-django",
 				RelationToken:    "token-db2:db django:db",
 				Macaroons:        macaroon.Slice{apiMac},
+				BakeryVersion:    bakery.LatestVersion,
 			},
 		}},
 	}
@@ -568,6 +574,7 @@ func (s *remoteRelationsSuite) TestLocalRelationsChangedNotifies(c *gc.C) {
 				}},
 				DepartedUnits: []int{2},
 				Macaroons:     macaroon.Slice{mac},
+				BakeryVersion: bakery.LatestVersion,
 			},
 		}},
 	}
@@ -605,6 +612,7 @@ func (s *remoteRelationsSuite) TestRemoteNotFoundTerminatesOnPublish(c *gc.C) {
 				}},
 				DepartedUnits: []int{2},
 				Macaroons:     macaroon.Slice{mac},
+				BakeryVersion: bakery.LatestVersion,
 			},
 		}},
 		{"SetRemoteApplicationStatus", []interface{}{"db2", "terminated", "offer has been removed"}},
@@ -642,6 +650,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationsChangedConsumes(c *gc.C) {
 				}},
 				DepartedUnits: []int{2},
 				Macaroons:     macaroon.Slice{mac},
+				BakeryVersion: bakery.LatestVersion,
 			},
 		}},
 	}
@@ -703,6 +712,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 				RelationToken:    "token-db2:db django:db",
 				DepartedUnits:    []int{1},
 				Macaroons:        macaroon.Slice{apiMac},
+				BakeryVersion:    bakery.LatestVersion,
 			},
 		}},
 		{"Close", nil},
@@ -747,6 +757,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 			OfferUUID:         "offer-db2-uuid",
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
+			BakeryVersion:     bakery.LatestVersion,
 		}}}},
 		{"SaveMacaroon", []interface{}{relTag, apiMac}},
 		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},
@@ -768,6 +779,7 @@ func (s *remoteRelationsSuite) assertRemoteRelationsChangedError(c *gc.C, dying 
 					RelationToken:    "token-db2:db django:db",
 					Life:             life.Dying,
 					Macaroons:        macaroon.Slice{apiMac},
+					BakeryVersion:    bakery.LatestVersion,
 					ForceCleanup:     &forceCleanup,
 				},
 			}},
@@ -864,6 +876,7 @@ func (s *remoteRelationsSuite) TestRemoteRelationSuspended(c *gc.C) {
 			OfferUUID:         "offer-db2-uuid",
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
+			BakeryVersion:     bakery.LatestVersion,
 		}}}},
 		{"SaveMacaroon", []interface{}{relTag, apiMac}},
 		{"ImportRemoteEntity", []interface{}{names.NewApplicationTag("db2"), "token-offer-db2-uuid"}},


### PR DESCRIPTION
## Description of change

Update the controller backend to use bakery.v2 instead of bakery.v2-unstable.

There's 3 commits - the first is largely boilerplate.
1. Add the bakery version to client requests which pass in macaroons, including
- login requests
- user registration
- cross model relation calls
(just adding a new attribute to params structs)

2. Update the cross model relations auth backend to user bakery.v2. This includes moving some code from apiserver to live with the rest of the cmr auth code.

3. Update the user auth backend to use bakery.v2

## QA steps

Perform the following tests with both 2.7 and 2.8 clients...

bootstrap a controller
add a user
from a different client, register as that new user
logout and login and ensure juju status works
change user password and check again
login with incorrect password -> error
edit accounts.yaml to alter user name and juju status -> error
delete local cookies and check login

add a new model and create an offer
consume the offer and wait 3 minutes for macaroon to expire
add a cross model relation and check status

bootstrap a 2.7 controller, upgrade, and re-check
