### PR TITLE
Return ErrRestartAgent if k8s watcher lost connection;

### DIFF
--- a/caas/kubernetes/provider/k8swatcher.go
+++ b/caas/kubernetes/provider/k8swatcher.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/juju/juju/core/watcher"
+	jworker "github.com/juju/juju/worker"
 )
 
 // kubernetesNotifyWatcher reports changes to kubernetes
@@ -153,9 +154,10 @@ func (w *kubernetesStringsWatcher) loop() error {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
 		case evt, ok := <-w.k8watcher.ResultChan():
-			// This can happen if the k8s API connection drops.
 			if !ok {
-				return errors.Errorf("k8s event watcher closed, restarting")
+				// This can happen if the k8s API connection drops.
+				logger.Debugf("k8s event watcher closed, restarting")
+				return jworker.ErrRestartAgent
 			}
 			if evt.Type == watch.Error {
 				return errors.Errorf("kubernetes watcher error: %v", k8serrors.FromObject(evt.Object))


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Return `ErrRestartAgent` if k8s watcher lost connection;

## QA steps

None

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1859894