### PR TITLE
Migrate Remote Application Macaroons

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -477,11 +477,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:3f6c130d75a67ade8569bf3deff9a35c048062ee5f85a66b6f86f89726374942"
+  digest = "1:02901ae1102fee2f0052af5cb04c1b785b4db6cf0034e8b4be77f60d4a5107dd"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "196af8b0d3222c2d5b3dbd6f340398bb06f56333"
+  revision = "7a7592edce5c83f8c18bb09b9c651ccb27a9d0f0"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "196af8b0d3222c2d5b3dbd6f340398bb06f56333"
+  revision = "7a7592edce5c83f8c18bb09b9c651ccb27a9d0f0"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/state/migration_description_mock_test.go
+++ b/state/migration_description_mock_test.go
@@ -5,12 +5,11 @@
 package state
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
 	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
+	time "time"
 )
 
 // MockApplicationOffer is a mock of ApplicationOffer interface
@@ -499,6 +498,20 @@ func (m *MockRemoteApplication) IsConsumerProxy() bool {
 func (mr *MockRemoteApplicationMockRecorder) IsConsumerProxy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConsumerProxy", reflect.TypeOf((*MockRemoteApplication)(nil).IsConsumerProxy))
+}
+
+// Macaroon mocks base method
+func (m *MockRemoteApplication) Macaroon() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Macaroon")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Macaroon indicates an expected call of Macaroon
+func (mr *MockRemoteApplicationMockRecorder) Macaroon() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Macaroon", reflect.TypeOf((*MockRemoteApplication)(nil).Macaroon))
 }
 
 // Name mocks base method

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -2135,6 +2135,11 @@ func (s remoteApplicationShim) GlobalKey() string {
 	return s.RemoteApplication.globalKey()
 }
 
+// Macaroon returns the encoded macaroon JSON.
+func (s remoteApplicationShim) Macaroon() string {
+	return s.RemoteApplication.doc.Macaroon
+}
+
 func (e *exporter) storage() error {
 	if err := e.volumes(); err != nil {
 		return errors.Trace(err)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1326,6 +1326,7 @@ func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) *
 		SourceModelUUID: app.SourceModelTag().Id(),
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
+		Macaroon:        app.Macaroon(),
 	}
 	descEndpoints := app.Endpoints()
 	eps := make([]remoteEndpointDoc, len(descEndpoints))

--- a/state/migration_import_input_mock_test.go
+++ b/state/migration_import_input_mock_test.go
@@ -5,11 +5,10 @@
 package state
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
 	txn "gopkg.in/mgo.v2/txn"
+	reflect "reflect"
 )
 
 // MockRemoteEntitiesInput is a mock of RemoteEntitiesInput interface

--- a/state/migration_import_mock_test.go
+++ b/state/migration_import_mock_test.go
@@ -5,11 +5,10 @@
 package state
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
 	txn "gopkg.in/mgo.v2/txn"
+	reflect "reflect"
 )
 
 // MockTransactionRunner is a mock of TransactionRunner interface

--- a/state/migrations/description_mock_test.go
+++ b/state/migrations/description_mock_test.go
@@ -5,12 +5,11 @@
 package migrations
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
 	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
+	time "time"
 )
 
 // MockExternalController is a mock of ExternalController interface
@@ -420,6 +419,20 @@ func (m *MockRemoteApplication) IsConsumerProxy() bool {
 func (mr *MockRemoteApplicationMockRecorder) IsConsumerProxy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConsumerProxy", reflect.TypeOf((*MockRemoteApplication)(nil).IsConsumerProxy))
+}
+
+// Macaroon mocks base method
+func (m *MockRemoteApplication) Macaroon() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Macaroon")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Macaroon indicates an expected call of Macaroon
+func (mr *MockRemoteApplicationMockRecorder) Macaroon() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Macaroon", reflect.TypeOf((*MockRemoteApplication)(nil).Macaroon))
 }
 
 // Name mocks base method

--- a/state/migrations/externalcontroller_mock_test.go
+++ b/state/migrations/externalcontroller_mock_test.go
@@ -5,10 +5,9 @@
 package migrations
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
+	reflect "reflect"
 )
 
 // MockMigrationExternalController is a mock of MigrationExternalController interface

--- a/state/migrations/firewallrules_mock_test.go
+++ b/state/migrations/firewallrules_mock_test.go
@@ -5,11 +5,10 @@
 package migrations
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
 	firewall "github.com/juju/juju/core/firewall"
+	reflect "reflect"
 )
 
 // MockMigrationFirewallRule is a mock of MigrationFirewallRule interface

--- a/state/migrations/offerconntections_mock_test.go
+++ b/state/migrations/offerconntections_mock_test.go
@@ -5,10 +5,9 @@
 package migrations
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
+	reflect "reflect"
 )
 
 // MockMigrationOfferConnection is a mock of MigrationOfferConnection interface

--- a/state/migrations/relationetworks_mock_test.go
+++ b/state/migrations/relationetworks_mock_test.go
@@ -5,10 +5,9 @@
 package migrations
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
+	reflect "reflect"
 )
 
 // MockMigrationRelationNetworks is a mock of MigrationRelationNetworks interface

--- a/state/migrations/remoteapplications_mock_test.go
+++ b/state/migrations/remoteapplications_mock_test.go
@@ -5,11 +5,10 @@
 package migrations
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
 	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockMigrationRemoteApplication is a mock of MigrationRemoteApplication interface
@@ -90,6 +89,20 @@ func (m *MockMigrationRemoteApplication) IsConsumerProxy() bool {
 func (mr *MockMigrationRemoteApplicationMockRecorder) IsConsumerProxy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConsumerProxy", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).IsConsumerProxy))
+}
+
+// Macaroon mocks base method
+func (m *MockMigrationRemoteApplication) Macaroon() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Macaroon")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Macaroon indicates an expected call of Macaroon
+func (mr *MockMigrationRemoteApplicationMockRecorder) Macaroon() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Macaroon", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).Macaroon))
 }
 
 // OfferUUID mocks base method

--- a/state/migrations/remoteapplications_test.go
+++ b/state/migrations/remoteapplications_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
 )
 
@@ -28,6 +27,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 			expect.URL().Return("me/model.foo", true)
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
+			expect.Macaroon().Return("mac")
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -35,7 +35,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 			expect.Endpoints().Return([]MigrationRemoteEndpoint{
 				{
 					Name:      "app-uuid-1-endpoint-1",
-					Role:      charm.RelationRole("role"),
+					Role:      "role",
 					Interface: "db",
 				},
 			}, nil)
@@ -106,6 +106,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 		URL:             "me/model.foo",
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
+		Macaroon:        "mac",
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -130,7 +131,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithSourceFai
 	c.Assert(err, gc.ErrorMatches, "fail")
 }
 
-func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEnpointsFailure(c *gc.C) {
+func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEndpointsFailure(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -141,6 +142,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEnpointsF
 			expect.URL().Return("me/model.foo", true)
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
+			expect.Macaroon().Return("mac")
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -168,6 +170,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEnpointsF
 		URL:             "me/model.foo",
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
+		Macaroon:        "mac",
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -189,6 +192,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 			expect.URL().Return("me/model.foo", true)
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
+			expect.Macaroon().Return("mac")
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -212,6 +216,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 		URL:             "me/model.foo",
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
+		Macaroon:        "mac",
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},

--- a/state/migrations/remoteentities_mock_test.go
+++ b/state/migrations/remoteentities_mock_test.go
@@ -5,10 +5,9 @@
 package migrations
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description"
+	reflect "reflect"
 )
 
 // MockMigrationRemoteEntity is a mock of MigrationRemoteEntity interface


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

Integration tests to follow.

----

## Description of change

Updates the juju/description dependency and ensures that macaroons for remote applications are included in model migrations.

This ensures that migrated CMR consumers still have authorisation required to maintain relations with external offerers.

## QA steps

```
export JUJU_DEV_FEATURE_FLAGS=cmr-migrations

juju bootstrap lxd cmr-source --no-gui
juju model-config logging-config="<root>=DEBUG"
juju deploy ./acceptancetests/repository/charms/dummy-source
juju offer dummy-source:sink

juju bootstrap lxd cmr-consume --no-gui
juju add-model mover
juju model-config logging-config="<root>=DEBUG"
juju deploy ./acceptancetests/repository/charms/dummy-sink
juju consume cmr-source:admin/default.dummy-source
juju relate dummy-sink dummy-source

juju bootstrap lxd cmr-dest --no-gui
```
Then wait for quiescence.
```
juju switch cmr-consume
juju migrate mover cmr-dest
```
Once completed.
```
juju switch cmr-source
juju config dummy-source token=booyah
juju switch cmr-dest:mover
juju status
```
Check that the dummy-sink/0 message indicates the set token.

## Documentation changes

None.

## Bug reference

N/A
