### PR TITLE
2.6 - Read-Only Users Can Not Add Machines

### DIFF
--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -389,10 +389,6 @@ func (c *Client) SetModelConstraints(args params.SetConstraints) error {
 
 // AddMachines adds new machines with the supplied parameters.
 func (c *Client) AddMachines(args params.AddMachines) (params.AddMachinesResults, error) {
-	if err := c.checkCanWrite(); err != nil {
-		return params.AddMachinesResults{}, err
-	}
-
 	return c.AddMachinesV2(args)
 }
 
@@ -400,6 +396,9 @@ func (c *Client) AddMachines(args params.AddMachines) (params.AddMachinesResults
 func (c *Client) AddMachinesV2(args params.AddMachines) (params.AddMachinesResults, error) {
 	results := params.AddMachinesResults{
 		Machines: make([]params.AddMachinesResult, len(args.MachineParams)),
+	}
+	if err := c.checkCanWrite(); err != nil {
+		return params.AddMachinesResults{}, err
 	}
 	if err := c.check.ChangeAllowed(); err != nil {
 		return results, errors.Trace(err)
@@ -416,10 +415,6 @@ func (c *Client) AddMachinesV2(args params.AddMachines) (params.AddMachinesResul
 
 // InjectMachines injects a machine into state with provisioned status.
 func (c *Client) InjectMachines(args params.AddMachines) (params.AddMachinesResults, error) {
-	if err := c.checkCanWrite(); err != nil {
-		return params.AddMachinesResults{}, err
-	}
-
 	return c.AddMachines(args)
 }
 

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -127,6 +127,20 @@ func (s *serverSuite) TestModelInfo(c *gc.C) {
 	c.Assert(info.IsController, gc.Equals, model.IsControllerModel())
 }
 
+func (s *serverSuite) TestAddMachineVariantsReadOnlyDenied(c *gc.C) {
+	user := s.makeLocalModelUser(c, "read", "Read Only")
+	api := s.authClientForState(c, s.State, testing.FakeAuthorizer{Tag: user.UserTag})
+
+	_, err := api.AddMachines(params.AddMachines{})
+	c.Check(err, gc.ErrorMatches, "permission denied")
+
+	_, err = api.AddMachinesV2(params.AddMachines{})
+	c.Check(err, gc.ErrorMatches, "permission denied")
+
+	_, err = api.InjectMachines(params.AddMachines{})
+	c.Check(err, gc.ErrorMatches, "permission denied")
+}
+
 func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
 	testAdmin := s.AdminUserTag(c)
 	owner, err := s.State.UserAccess(testAdmin, s.Model.ModelTag())
@@ -215,7 +229,7 @@ func (a ByUserName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByUserName) Less(i, j int) bool { return a[i].Result.UserName < a[j].Result.UserName }
 
 func (s *serverSuite) makeLocalModelUser(c *gc.C, username, displayname string) permission.UserAccess {
-	// factory.MakeUser will create an ModelUser for a local user by defalut
+	// factory.MakeUser will create an ModelUser for a local user by default.
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: username, DisplayName: displayname})
 	modelUser, err := s.State.UserAccess(user.UserTag(), s.Model.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Ensures that users must have write access in order to add machines to a model.

This patch makes the minimum hole-plugging change against 2.6. For later branches I will look at whether we can stop using the old `client` facade altogether for machine creation and rely instead on the `machinemanager` facade unconditionally.

## QA steps

Add a user with read access to the model and login as that user. `juju add-machine` should return an error with "permission denied".

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1859644
