### PR TITLE
Add relations to the cache, and extra model details.

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -137,7 +137,7 @@ func (aw *SrvAllWatcher) translate(deltas []multiwatcher.Delta) []params.Delta {
 }
 
 func (aw *SrvAllWatcher) translateModel(info multiwatcher.EntityInfo) params.EntityInfo {
-	orig, ok := info.(*multiwatcher.ModelUpdate)
+	orig, ok := info.(*multiwatcher.ModelInfo)
 	if !ok {
 		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
 		return nil

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/settings"
 	"github.com/juju/juju/core/status"
 )
@@ -18,12 +19,15 @@ import (
 // ModelChange represents either a new model, or a change
 // to an existing model.
 type ModelChange struct {
-	ModelUUID string
-	Name      string
-	Life      life.Value
-	Owner     string // tag maybe?
-	Config    map[string]interface{}
-	Status    status.StatusInfo
+	ModelUUID    string
+	Name         string
+	Life         life.Value
+	Owner        string // tag maybe?
+	IsController bool
+	Config       map[string]interface{}
+	Status       status.StatusInfo
+
+	UserPermissions map[string]permission.Access
 }
 
 // RemoveModel represents the situation when a model is removed

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -19,13 +19,16 @@ import (
 // ModelChange represents either a new model, or a change
 // to an existing model.
 type ModelChange struct {
-	ModelUUID    string
-	Name         string
-	Life         life.Value
-	Owner        string // tag maybe?
-	IsController bool
-	Config       map[string]interface{}
-	Status       status.StatusInfo
+	ModelUUID       string
+	Name            string
+	Life            life.Value
+	Owner           string // tag maybe?
+	IsController    bool
+	Cloud           string
+	CloudRegion     string
+	CloudCredential string
+	Config          map[string]interface{}
+	Status          status.StatusInfo
 
 	UserPermissions map[string]permission.Access
 }

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -178,6 +178,44 @@ type RemoveUnit struct {
 	Name      string
 }
 
+// RelationChange represents either a new relation, or a change
+// to an existing relation in a model.
+type RelationChange struct {
+	ModelUUID string
+	Key       string
+	Endpoints []Endpoint
+}
+
+// Endpoint holds all relevant information about a relation endpoint.
+type Endpoint struct {
+	Application string
+	Name        string
+	Role        string
+	Interface   string
+	Optional    bool
+	Limit       int
+	Scope       string
+}
+
+// copy returns a deep copy of the RelationChange.
+func (c RelationChange) copy() RelationChange {
+	if existing := c.Endpoints; existing != nil {
+		endpoints := make([]Endpoint, len(existing))
+		for i, ep := range existing {
+			endpoints[i] = ep
+		}
+		c.Endpoints = existing
+	}
+	return c
+}
+
+// RemoveRelation represents the situation when a relation
+// is removed from a model in the database.
+type RemoveRelation struct {
+	ModelUUID string
+	Key       string
+}
+
 // MachineChange represents either a new machine, or a change
 // to an existing machine in a model.
 type MachineChange struct {

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -146,6 +146,10 @@ func (c *Controller) loop() error {
 				c.updateUnit(ch)
 			case RemoveUnit:
 				err = c.removeUnit(ch)
+			case RelationChange:
+				c.updateRelation(ch)
+			case RemoveRelation:
+				err = c.removeRelation(ch)
 			case BranchChange:
 				c.updateBranch(ch)
 			case RemoveBranch:
@@ -301,6 +305,16 @@ func (c *Controller) updateUnit(ch UnitChange) {
 // removeUnit removes the unit from the cached model.
 func (c *Controller) removeUnit(ch RemoveUnit) error {
 	return errors.Trace(c.removeResident(ch.ModelUUID, func(m *Model) error { return m.removeUnit(ch) }))
+}
+
+// updateRelation adds or updates the relation in the specified model.
+func (c *Controller) updateRelation(ch RelationChange) {
+	c.ensureModel(ch.ModelUUID).updateRelation(ch, c.manager)
+}
+
+// removeRelation removes the relation from the cached model.
+func (c *Controller) removeRelation(ch RemoveRelation) error {
+	return errors.Trace(c.removeResident(ch.ModelUUID, func(m *Model) error { return m.removeRelation(ch) }))
 }
 
 // updateMachine adds or updates the machine in the specified model.

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
 )
@@ -360,10 +361,11 @@ func (s *ModelSuite) TestWaitForUnitCancelClosesChannel(c *gc.C) {
 }
 
 var modelChange = cache.ModelChange{
-	ModelUUID: "model-uuid",
-	Name:      "test-model",
-	Life:      life.Alive,
-	Owner:     "model-owner",
+	ModelUUID:    "model-uuid",
+	Name:         "test-model",
+	Life:         life.Alive,
+	Owner:        "model-owner",
+	IsController: false,
 	Config: map[string]interface{}{
 		"key":     "value",
 		"another": "foo",
@@ -371,5 +373,9 @@ var modelChange = cache.ModelChange{
 
 	Status: status.StatusInfo{
 		Status: status.Active,
+	},
+	UserPermissions: map[string]permission.Access{
+		"model-owner": permission.AdminAccess,
+		"read-user":   permission.ReadAccess,
 	},
 }

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -35,6 +35,7 @@ func (s *ModelSuite) TestReport(c *gc.C) {
 		"charm-count":       0,
 		"machine-count":     0,
 		"unit-count":        0,
+		"relation-count":    0,
 		"branch-count":      0,
 	})
 }

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -114,6 +114,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/life",
 		"core/lxdprofile",
 		"core/network",
+		"core/permission",
 		"core/settings",
 		"core/status",
 	})

--- a/core/cache/relation.go
+++ b/core/cache/relation.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+// Relation represents a relation in a cached model.
+type Relation struct {
+	// Resident identifies the relation as a type-agnostic cached entity
+	// and tracks resources that it is responsible for cleaning up.
+	*Resident
+
+	model   *Model
+	details RelationChange
+}
+
+func newRelation(model *Model, res *Resident) *Relation {
+	return &Relation{
+		Resident: res,
+		model:    model,
+	}
+}
+
+// Note that these property accessors are not lock-protected.
+// They are intended for calling from external packages that have retrieved a
+// deep copy from the cache.
+
+// Key returns the key of this relation.
+func (r *Relation) Key() string {
+	return r.details.Key
+}
+
+// Endpoints returns the endpoints for this relation.
+func (r *Relation) Endpoints() []Endpoint {
+	return r.details.Endpoints
+}
+
+func (r *Relation) setDetails(details RelationChange) {
+	// If this is the first receipt of details, set the removal message.
+	if r.removalMessage == nil {
+		r.removalMessage = RemoveRelation{
+			ModelUUID: details.ModelUUID,
+			Key:       details.Key,
+		}
+	}
+
+	r.setStale(false)
+}
+
+// copy returns a copy of the unit, ensuring appropriate deep copying.
+func (r *Relation) copy() Relation {
+	cr := *r
+	cr.details = cr.details.copy()
+	return cr
+}

--- a/core/cache/relation_test.go
+++ b/core/cache/relation_test.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	"github.com/juju/juju/core/cache"
+)
+
+// Mostly a placeholder file at this stage.
+
+var relationChange = cache.RelationChange{
+	ModelUUID: "model-uuid",
+	Key:       "provider:ep consumer:ep",
+	Endpoints: []cache.Endpoint{
+		{
+			Application: "provider",
+			Name:        "ep",
+			Role:        "provider",
+			Interface:   "foo",
+		}, {
+			Application: "consumer",
+			Name:        "ep",
+			Role:        "requires",
+			Interface:   "foo",
+		},
+	},
+}

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -169,6 +169,7 @@ func (u *Unit) setDetails(details UnitChange) {
 	u.details = details
 	toPublish := u.copy()
 	if machineChange || u.details.Subordinate {
+		// TODO thumper: check this, it looks like we are publishing too often.
 		u.model.hub.Publish(modelUnitAdd, toPublish)
 	}
 	// Publish change event for those that may be waiting.

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -351,9 +351,9 @@ func (i *BlockInfo) EntityID() EntityID {
 	}
 }
 
-// ModelUpdate holds the information about a model that is
+// ModelInfo holds the information about a model that is
 // tracked by multiwatcherStore.
-type ModelUpdate struct {
+type ModelInfo struct {
 	ModelUUID      string
 	Name           string
 	Life           life.Value
@@ -375,7 +375,7 @@ type ModelSLAInfo struct {
 }
 
 // EntityID returns a unique identifier for a model.
-func (i *ModelUpdate) EntityID() EntityID {
+func (i *ModelInfo) EntityID() EntityID {
 	return EntityID{
 		Kind:      ModelKind,
 		ModelUUID: i.ModelUUID,

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -354,16 +354,19 @@ func (i *BlockInfo) EntityID() EntityID {
 // ModelInfo holds the information about a model that is
 // tracked by multiwatcherStore.
 type ModelInfo struct {
-	ModelUUID      string
-	Name           string
-	Life           life.Value
-	Owner          string
-	ControllerUUID string
-	IsController   bool
-	Config         map[string]interface{}
-	Status         StatusInfo
-	Constraints    constraints.Value
-	SLA            ModelSLAInfo
+	ModelUUID       string
+	Name            string
+	Life            life.Value
+	Owner           string
+	ControllerUUID  string
+	IsController    bool
+	Cloud           string
+	CloudRegion     string
+	CloudCredential string
+	Config          map[string]interface{}
+	Status          StatusInfo
+	Constraints     constraints.Value
+	SLA             ModelSLAInfo
 
 	UserPermissions map[string]permission.Access
 }

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -142,12 +142,15 @@ func (e *backingModel) updated(ctx *allWatcherContext) error {
 	// Update the context with the model type.
 	ctx.modelType_ = e.Type
 	info := &multiwatcher.ModelInfo{
-		ModelUUID:      e.UUID,
-		Name:           e.Name,
-		Life:           life.Value(e.Life.String()),
-		Owner:          e.Owner,
-		ControllerUUID: e.ControllerUUID,
-		IsController:   ctx.state.IsController(),
+		ModelUUID:       e.UUID,
+		Name:            e.Name,
+		Life:            life.Value(e.Life.String()),
+		Owner:           e.Owner,
+		ControllerUUID:  e.ControllerUUID,
+		IsController:    ctx.state.IsController(),
+		Cloud:           e.Cloud,
+		CloudRegion:     e.CloudRegion,
+		CloudCredential: e.CloudCredential,
 		SLA: multiwatcher.ModelSLAInfo{
 			Level: e.SLA.Level.String(),
 			Owner: e.SLA.Owner,

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -141,7 +141,7 @@ func (e *backingModel) updated(ctx *allWatcherContext) error {
 
 	// Update the context with the model type.
 	ctx.modelType_ = e.Type
-	info := &multiwatcher.ModelUpdate{
+	info := &multiwatcher.ModelInfo{
 		ModelUUID:      e.UUID,
 		Name:           e.Name,
 		Life:           life.Value(e.Life.String()),
@@ -200,7 +200,7 @@ func (e *backingModel) updated(ctx *allWatcherContext) error {
 
 		info.UserPermissions = permissions
 	} else {
-		oldInfo := oldInfo.(*multiwatcher.ModelUpdate)
+		oldInfo := oldInfo.(*multiwatcher.ModelInfo)
 		info.Config = oldInfo.Config
 		info.Constraints = oldInfo.Constraints
 		info.Status = oldInfo.Status
@@ -247,7 +247,7 @@ func (e *backingPermission) updated(ctx *allWatcherContext) error {
 		return nil
 	}
 
-	storeKey := &multiwatcher.ModelUpdate{
+	storeKey := &multiwatcher.ModelInfo{
 		ModelUUID: modelUUID,
 	}
 
@@ -256,7 +256,7 @@ func (e *backingPermission) updated(ctx *allWatcherContext) error {
 	case nil:
 		// The parent info doesn't exist. Ignore the permission until it does.
 		return nil
-	case *multiwatcher.ModelUpdate:
+	case *multiwatcher.ModelInfo:
 		// Set the access for the user in the permission map of the model.
 		info.UserPermissions[user] = permission.Access(e.Access)
 	}
@@ -274,7 +274,7 @@ func (e *backingPermission) removed(ctx *allWatcherContext) error {
 		return nil
 	}
 
-	storeKey := &multiwatcher.ModelUpdate{
+	storeKey := &multiwatcher.ModelInfo{
 		ModelUUID: modelUUID,
 	}
 
@@ -283,7 +283,7 @@ func (e *backingPermission) removed(ctx *allWatcherContext) error {
 	case nil:
 		// The parent info doesn't exist. Nothing to remove from.
 		return nil
-	case *multiwatcher.ModelUpdate:
+	case *multiwatcher.ModelInfo:
 		// Remove the user from the permission map.
 		delete(info.UserPermissions, user)
 	}
@@ -1036,7 +1036,7 @@ func (s *backingStatus) updated(ctx *allWatcherContext) error {
 			return err
 		}
 		info0 = &newInfo
-	case *multiwatcher.ModelUpdate:
+	case *multiwatcher.ModelInfo:
 		newInfo := *info
 		newInfo.Status = s.toStatusInfo()
 		info0 = &newInfo
@@ -1164,7 +1164,7 @@ func (c *backingConstraints) updated(ctx *allWatcherContext) error {
 	case *multiwatcher.UnitInfo, *multiwatcher.MachineInfo:
 		// We don't (yet) publish unit or machine constraints.
 		return nil
-	case *multiwatcher.ModelUpdate:
+	case *multiwatcher.ModelInfo:
 		newInfo := *info
 		newInfo.Constraints = constraintsDoc(*c).value()
 		info0 = &newInfo
@@ -1201,7 +1201,7 @@ func (s *backingSettings) updated(ctx *allWatcherContext) error {
 	case nil:
 		// The parent info doesn't exist. Ignore the status until it does.
 		return nil
-	case *multiwatcher.ModelUpdate:
+	case *multiwatcher.ModelInfo:
 		// We need to construct a model config so that coercion
 		// of raw settings values occurs.
 		cfg, err := config.New(config.NoDefaults, s.Settings)
@@ -1996,7 +1996,7 @@ func (ctx *allWatcherContext) getOpenedPorts(unit *Unit) ([]corenetwork.PortRang
 func (ctx *allWatcherContext) entityIDForGlobalKey(key string) (multiwatcher.EntityID, bool) {
 	var result multiwatcher.EntityInfo
 	if key == modelGlobalKey {
-		result = &multiwatcher.ModelUpdate{
+		result = &multiwatcher.ModelInfo{
 			ModelUUID: ctx.modelUUID,
 		}
 		return result.EntityID(), true

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -80,15 +80,18 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	c.Assert(err, jc.ErrorIsNil)
 	modelStatus, err := model.Status()
 	c.Assert(err, jc.ErrorIsNil)
-
+	credential, _ := model.CloudCredential()
 	add(&multiwatcher.ModelInfo{
-		ModelUUID:      model.UUID(),
-		Name:           model.Name(),
-		Life:           life.Alive,
-		Owner:          model.Owner().Id(),
-		ControllerUUID: model.ControllerUUID(),
-		IsController:   model.IsControllerModel(),
-		Config:         modelCfg.AllAttrs(),
+		ModelUUID:       model.UUID(),
+		Name:            model.Name(),
+		Life:            life.Alive,
+		Owner:           model.Owner().Id(),
+		ControllerUUID:  model.ControllerUUID(),
+		IsController:    model.IsControllerModel(),
+		Cloud:           model.Cloud(),
+		CloudRegion:     model.CloudRegion(),
+		CloudCredential: credential.Id(),
+		Config:          modelCfg.AllAttrs(),
 		Status: multiwatcher.StatusInfo{
 			Current: modelStatus.Status,
 			Message: modelStatus.Message,
@@ -1074,6 +1077,8 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 			cons := constraints.MustParse("mem=4G")
 			err = st.SetModelConstraints(cons)
 			c.Assert(err, jc.ErrorIsNil)
+			credential, _ := model.CloudCredential()
+
 			return changeTestCase{
 				about: "model is added if it's in backing but not in Store",
 				change: watcher.Change{
@@ -1082,14 +1087,17 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ModelInfo{
-						ModelUUID:      model.UUID(),
-						Name:           model.Name(),
-						Life:           life.Alive,
-						Owner:          model.Owner().Id(),
-						ControllerUUID: model.ControllerUUID(),
-						IsController:   model.IsControllerModel(),
-						Config:         cfg.AllAttrs(),
-						Constraints:    cons,
+						ModelUUID:       model.UUID(),
+						Name:            model.Name(),
+						Life:            life.Alive,
+						Owner:           model.Owner().Id(),
+						ControllerUUID:  model.ControllerUUID(),
+						IsController:    model.IsControllerModel(),
+						Cloud:           model.Cloud(),
+						CloudRegion:     model.CloudRegion(),
+						CloudCredential: credential.Id(),
+						Config:          cfg.AllAttrs(),
+						Constraints:     cons,
 						Status: multiwatcher.StatusInfo{
 							Current: status.Status,
 							Message: status.Message,
@@ -1112,6 +1120,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			status, err := model.Status()
 			c.Assert(err, jc.ErrorIsNil)
+			credential, _ := model.CloudCredential()
 			return changeTestCase{
 				about: "model is updated if it's in backing and in Store",
 				initialContents: []multiwatcher.EntityInfo{
@@ -1143,13 +1152,16 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ModelInfo{
-						ModelUUID:      model.UUID(),
-						Name:           model.Name(),
-						Life:           life.Alive,
-						Owner:          model.Owner().Id(),
-						ControllerUUID: model.ControllerUUID(),
-						IsController:   model.IsControllerModel(),
-						Config:         cfg.AllAttrs(),
+						ModelUUID:       model.UUID(),
+						Name:            model.Name(),
+						Life:            life.Alive,
+						Owner:           model.Owner().Id(),
+						ControllerUUID:  model.ControllerUUID(),
+						IsController:    model.IsControllerModel(),
+						Cloud:           model.Cloud(),
+						CloudRegion:     model.CloudRegion(),
+						CloudCredential: credential.Id(),
+						Config:          cfg.AllAttrs(),
 						Status: multiwatcher.StatusInfo{
 							Current: status.Status,
 							Message: status.Message,
@@ -1259,6 +1271,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 		func(c *gc.C, st *State) changeTestCase {
 			model, err := st.Model()
 			c.Assert(err, jc.ErrorIsNil)
+			credential, _ := model.CloudCredential()
 
 			return changeTestCase{
 				about: "model update keeps permissions",
@@ -1276,13 +1289,16 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 					Id: st.ModelUUID(),
 				},
 				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
-					ModelUUID:      st.ModelUUID(),
-					Name:           model.Name(),
-					Life:           "alive",
-					Owner:          model.Owner().Id(),
-					ControllerUUID: testing.ControllerTag.Id(),
-					IsController:   model.IsControllerModel(),
-					SLA:            multiwatcher.ModelSLAInfo{Level: "unsupported"},
+					ModelUUID:       st.ModelUUID(),
+					Name:            model.Name(),
+					Life:            "alive",
+					Owner:           model.Owner().Id(),
+					ControllerUUID:  testing.ControllerTag.Id(),
+					IsController:    model.IsControllerModel(),
+					Cloud:           model.Cloud(),
+					CloudRegion:     model.CloudRegion(),
+					CloudCredential: credential.Id(),
+					SLA:             multiwatcher.ModelSLAInfo{Level: "unsupported"},
 					UserPermissions: map[string]permission.Access{
 						"bob":  permission.ReadAccess,
 						"mary": permission.AdminAccess,

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -81,7 +81,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	modelStatus, err := model.Status()
 	c.Assert(err, jc.ErrorIsNil)
 
-	add(&multiwatcher.ModelUpdate{
+	add(&multiwatcher.ModelInfo{
 		ModelUUID:      model.UUID(),
 		Name:           model.Name(),
 		Life:           life.Alive,
@@ -1054,7 +1054,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 		func(c *gc.C, st *State) changeTestCase {
 			return changeTestCase{
 				about: "model is removed if it's not in backing",
-				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: "some-uuid",
 				}},
 				change: watcher.Change{
@@ -1081,7 +1081,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 					Id: st.ModelUUID(),
 				},
 				expectContents: []multiwatcher.EntityInfo{
-					&multiwatcher.ModelUpdate{
+					&multiwatcher.ModelInfo{
 						ModelUUID:      model.UUID(),
 						Name:           model.Name(),
 						Life:           life.Alive,
@@ -1115,7 +1115,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 			return changeTestCase{
 				about: "model is updated if it's in backing and in Store",
 				initialContents: []multiwatcher.EntityInfo{
-					&multiwatcher.ModelUpdate{
+					&multiwatcher.ModelInfo{
 						ModelUUID:      model.UUID(),
 						Name:           "",
 						Life:           life.Alive,
@@ -1142,7 +1142,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 					Id: model.UUID(),
 				},
 				expectContents: []multiwatcher.EntityInfo{
-					&multiwatcher.ModelUpdate{
+					&multiwatcher.ModelInfo{
 						ModelUUID:      model.UUID(),
 						Name:           model.Name(),
 						Life:           life.Alive,
@@ -1232,7 +1232,7 @@ func (s *allModelWatcherStateSuite) TestModelSettings(c *gc.C) {
 	expectedModelSettings["http-proxy"] = "http://invalid"
 	expectedModelSettings["foo"] = "bar"
 
-	all.Update(&multiwatcher.ModelUpdate{
+	all.Update(&multiwatcher.ModelInfo{
 		ModelUUID: s.state.ModelUUID(),
 		Name:      "dummy-model",
 	})
@@ -1243,7 +1243,7 @@ func (s *allModelWatcherStateSuite) TestModelSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	entities := all.All()
 	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
-		&multiwatcher.ModelUpdate{
+		&multiwatcher.ModelInfo{
 			ModelUUID: s.state.ModelUUID(),
 			Name:      "dummy-model",
 			Config:    expectedModelSettings,
@@ -1262,7 +1262,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 
 			return changeTestCase{
 				about: "model update keeps permissions",
-				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: st.ModelUUID(),
 					// Existance doesn't care about the other values, and they are
 					// not entirely relevent to this test.
@@ -1275,7 +1275,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 					C:  "models",
 					Id: st.ModelUUID(),
 				},
-				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID:      st.ModelUUID(),
 					Name:           model.Name(),
 					Life:           "alive",
@@ -1303,7 +1303,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 
 			return changeTestCase{
 				about: "adding a model user updates model",
-				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: st.ModelUUID(),
 					Name:      model.Name(),
 					// Existance doesn't care about the other values, and they are
@@ -1317,7 +1317,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 					C:  permissionsC,
 					Id: permissionID(modelKey(st.ModelUUID()), userGlobalKey("tony@external")),
 				},
-				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: st.ModelUUID(),
 					Name:      model.Name(),
 					// When the permissions are updated, only the user permissions are changed.
@@ -1335,7 +1335,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 
 			return changeTestCase{
 				about: "removing a permission document removes user permission",
-				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: st.ModelUUID(),
 					Name:      model.Name(),
 					// Existance doesn't care about the other values, and they are
@@ -1350,7 +1350,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 					Id:    permissionID(modelKey(st.ModelUUID()), userGlobalKey("bob")),
 					Revno: -1,
 				},
-				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: st.ModelUUID(),
 					Name:      model.Name(),
 					// When the permissions are updated, only the user permissions are changed.
@@ -1382,7 +1382,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 
 			return changeTestCase{
 				about: "updating a permission document updates user permission",
-				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				initialContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: st.ModelUUID(),
 					Name:      model.Name(),
 					// Existance doesn't care about the other values, and they are
@@ -1396,7 +1396,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 					C:  permissionsC,
 					Id: permissionID(modelKey(st.ModelUUID()), userGlobalKey("bob")),
 				},
-				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelUpdate{
+				expectContents: []multiwatcher.EntityInfo{&multiwatcher.ModelInfo{
 					ModelUUID: st.ModelUUID(),
 					Name:      model.Name(),
 					UserPermissions: map[string]permission.Access{

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -340,13 +340,15 @@ func (c *cacheWorker) translateModel(d multiwatcher.Delta) interface{} {
 	}
 
 	return cache.ModelChange{
-		ModelUUID: value.ModelUUID,
-		Name:      value.Name,
-		Life:      life.Value(value.Life),
-		Owner:     value.Owner,
-		Config:    value.Config,
-		Status:    coreStatus(value.Status),
+		ModelUUID:    value.ModelUUID,
+		Name:         value.Name,
+		Life:         life.Value(value.Life),
+		Owner:        value.Owner,
+		IsController: value.IsController,
+		Config:       value.Config,
+		Status:       coreStatus(value.Status),
 		// TODO: constraints, sla
+		UserPermissions: value.UserPermissions,
 	}
 }
 

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -468,7 +468,7 @@ func (c *cacheWorker) translateRelation(d multiwatcher.Delta) interface{} {
 	if d.Removed {
 		return cache.RemoveRelation{
 			ModelUUID: id.ModelUUID,
-			Name:      id.ID,
+			Key:       id.ID,
 		}
 	}
 
@@ -479,22 +479,22 @@ func (c *cacheWorker) translateRelation(d multiwatcher.Delta) interface{} {
 	}
 
 	endpoints := make([]cache.Endpoint, len(value.Endpoints))
-	for i, ep := range value.Endpoints{
-		endpoints[i] := cache.Endpoint{
-			Application: value.ApplicationName,
-			Name: value.Relation.Name,
-			Role: value.Relation.Role,
-			Interface: value.Relation.Interface,
-			Optional: value.Relation.Optional,
-			Limit: value.Relation.Limit,
-			Scope: value.Relation.Scope,
+	for i, ep := range value.Endpoints {
+		endpoints[i] = cache.Endpoint{
+			Application: ep.ApplicationName,
+			Name:        ep.Relation.Name,
+			Role:        ep.Relation.Role,
+			Interface:   ep.Relation.Interface,
+			Optional:    ep.Relation.Optional,
+			Limit:       ep.Relation.Limit,
+			Scope:       ep.Relation.Scope,
 		}
 	}
 
 	return cache.RelationChange{
-		ModelUUID:      value.ModelUUID,
-		Key:           value.Key,
-		Endpoints:    endpoints,
+		ModelUUID: value.ModelUUID,
+		Key:       value.Key,
+		Endpoints: endpoints,
 	}
 }
 

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -340,13 +340,16 @@ func (c *cacheWorker) translateModel(d multiwatcher.Delta) interface{} {
 	}
 
 	return cache.ModelChange{
-		ModelUUID:    value.ModelUUID,
-		Name:         value.Name,
-		Life:         life.Value(value.Life),
-		Owner:        value.Owner,
-		IsController: value.IsController,
-		Config:       value.Config,
-		Status:       coreStatus(value.Status),
+		ModelUUID:       value.ModelUUID,
+		Name:            value.Name,
+		Life:            life.Value(value.Life),
+		Owner:           value.Owner,
+		IsController:    value.IsController,
+		Cloud:           value.Cloud,
+		CloudRegion:     value.CloudRegion,
+		CloudCredential: value.CloudCredential,
+		Config:          value.Config,
+		Status:          coreStatus(value.Status),
 		// TODO: constraints, sla
 		UserPermissions: value.UserPermissions,
 	}

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -333,7 +333,7 @@ func (c *cacheWorker) translateModel(d multiwatcher.Delta) interface{} {
 		}
 	}
 
-	value, ok := e.(*multiwatcher.ModelUpdate)
+	value, ok := e.(*multiwatcher.ModelInfo)
 	if !ok {
 		c.config.Logger.Errorf("unexpected type %T", e)
 		return nil

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -604,7 +604,7 @@ func (s *WorkerSuite) TestWatcherErrorCacheMarkSweep(c *gc.C) {
 						if delta.Entity.EntityID().Kind == "model" && !fakeModelSent {
 							fakeModelSent = true
 							return append(deltas, multiwatcher.Delta{
-								Entity: &multiwatcher.ModelUpdate{
+								Entity: &multiwatcher.ModelInfo{
 									ModelUUID: "fake-ass-model-uuid",
 									Name:      "evict-this-cat",
 								},

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -179,6 +179,11 @@ func (s *WorkerSuite) checkModel(c *gc.C, obtained interface{}, model *state.Mod
 	c.Check(change.Life, gc.Equals, life.Value(model.Life().String()))
 	c.Check(change.Owner, gc.Equals, model.Owner().Name())
 	c.Check(change.IsController, gc.Equals, model.IsControllerModel())
+	c.Check(change.Cloud, gc.Equals, model.Cloud())
+	c.Check(change.CloudRegion, gc.Equals, model.CloudRegion())
+	cred, _ := model.CloudCredential()
+	c.Check(change.CloudCredential, gc.Equals, cred.Id())
+
 	cfg, err := model.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(change.Config, jc.DeepEquals, cfg.AllAttrs())


### PR DESCRIPTION
In order to provide the information to the upcoming model summary watcher (which will be implemented in the cache), we need to get some extra information into the cache.

There is a drive by that renames the ModelUpdate type from the core/multiwatcher package back to ModelInfo. This was renamed previously when the type was moved into the apiserver/params package and we had to deal with a naming collision. Renamed it back for this type for consistency with the rest of the package.

Adds three pieces of information from the state.Model in through the allwatcher: Cloud, Region, and Credential. Each of these is just a string value in the underlying document, so just adding these to the multiwatcher info type is sufficient to pass them along. Also needed to add these to the cache change type, and this makes them available to the internals of the cache.

The cache needed to know about relations, so pass the relation changes from the modelcache worker though to the controller, and add methods to add and remove the relations to the cached model.

## QA steps

Nothing is exposed to the outside world yet, that is coming.

## Documentation changes

Everything is internal, no user facing change.
