### PR TITLE
Fixes lp#1860154: Clearer error message on k8s bootstrap with --build-agent option.

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -233,13 +233,13 @@ func bootstrapCAAS(
 	bootstrapParams environs.BootstrapParams,
 ) error {
 	if args.BuildAgent {
-		return errors.NewNotSupported(nil, "--build-agent when bootstrapping a k8s controller")
+		return errors.NotSupportedf("--build-agent when bootstrapping a k8s controller")
 	}
 	if args.BootstrapImage != "" {
-		return errors.NewNotSupported(nil, "--bootstrap-image when bootstrapping a k8s controller")
+		return errors.NotSupportedf("--bootstrap-image when bootstrapping a k8s controller")
 	}
 	if args.BootstrapSeries != "" {
-		return errors.NewNotSupported(nil, "--bootstrap-series when bootstrapping a k8s controller")
+		return errors.NotSupportedf("--bootstrap-series when bootstrapping a k8s controller")
 	}
 
 	constraintsValidator, err := environ.ConstraintsValidator(callCtx)


### PR DESCRIPTION
## Description of change

Bootstrap message was omitting critical detail when bootstrapping k8s controller with --build-agent option: it was erring out but not saying that the option is not supported. See linked bug.

## QA steps

```
$ juju bootstrap --build-agent microk8s mk8s
Creating Juju controller "mk8s" on microk8s/localhost
ERROR failed to bootstrap model: --build-agent when bootstrapping a k8s controller not supported
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860154
