### PR TITLE
Make non-running status be '503 Service Unavailable'

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -907,6 +907,9 @@ func (srv *Server) healthHandler(w http.ResponseWriter, req *http.Request) {
 	srv.mu.Lock()
 	status := srv.healthStatus
 	srv.mu.Unlock()
+	if status != "running" {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 
 	fmt.Fprintf(w, "%s\n", status)
 }

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -302,22 +302,21 @@ func (s *apiserverSuite) TestRestartMessage(c *gc.C) {
 	c.Assert(err, gc.Equals, dependency.ErrBounce)
 }
 
-func (s *apiserverSuite) getHealth(c *gc.C) string {
+func (s *apiserverSuite) getHealth(c *gc.C) (string, int) {
 	uri := s.server.URL + "/health"
 	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
-
-	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 	body, err := ioutil.ReadAll(resp.Body)
-
 	c.Assert(err, jc.ErrorIsNil)
 	result := string(body)
 	// Ensure that the last value is a carriage return.
 	c.Assert(strings.HasSuffix(result, "\n"), jc.IsTrue)
-	return strings.TrimSuffix(result, "\n")
+	return strings.TrimSuffix(result, "\n"), resp.StatusCode
 }
 
 func (s *apiserverSuite) TestHealthRunning(c *gc.C) {
-	c.Assert(s.getHealth(c), gc.Equals, "running")
+	health, statusCode := s.getHealth(c)
+	c.Assert(health, gc.Equals, "running")
+	c.Assert(statusCode, gc.Equals, http.StatusOK)
 }
 
 func (s *apiserverSuite) TestHealthStopping(c *gc.C) {
@@ -329,9 +328,10 @@ func (s *apiserverSuite) TestHealthStopping(c *gc.C) {
 	// the value, so loop until we see the right health, then exit.
 	timeout := time.After(testing.LongWait)
 	for {
-		health := s.getHealth(c)
+		health, statusCode := s.getHealth(c)
 		if health == "stopping" {
 			// Expected, we're done.
+			c.Assert(statusCode, gc.Equals, http.StatusServiceUnavailable)
 			wg.Done()
 			return
 		}


### PR DESCRIPTION
The health endpoint in the apiserver now returns a '503 Service Unavailable' instead of '200 OK' if the apiserver health isn't 'running'.

## QA steps

```sh
juju bootstrap lxd test
juju ssh -m controller 0
curl --insecure https://localhost:17070/health
```

## Documentation changes

When we add docs around this as outlined in #11096 we'd specify the status code return values.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1797848