### PR TITLE
Surface HA primary controller machine to the user.

### DIFF
--- a/api/base/types.go
+++ b/api/base/types.go
@@ -52,6 +52,9 @@ type Machine struct {
 	Status      string
 	Message     string
 	Hardware    *instance.HardwareCharacteristics
+	// HAPrimary indicates whether this machine has a primary mongo instance in replicaset and,
+	// thus, can be considered a primary controller machine in HA setup.
+	HAPrimary *bool
 }
 
 // ModelInfo holds information about a model.

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -49,7 +49,7 @@ func (c *ModelStatusAPI) processModelStatusResults(rs []params.ModelStatus) ([]b
 			results[i].Error = errors.Trace(r.Error)
 			continue
 		}
-		model, err := names.ParseModelTag(r.ModelTag)
+		aModel, err := names.ParseModelTag(r.ModelTag)
 		if err != nil {
 			results[i].Error = errors.Trace(err)
 			continue
@@ -59,7 +59,7 @@ func (c *ModelStatusAPI) processModelStatusResults(rs []params.ModelStatus) ([]b
 			results[i].Error = errors.Trace(err)
 			continue
 		}
-		results[i] = constructModelStatus(model, owner, r)
+		results[i] = constructModelStatus(aModel, owner, r)
 	}
 	return results, nil
 }
@@ -112,6 +112,7 @@ func constructModelStatus(m names.ModelTag, owner names.UserTag, r params.ModelS
 			WantsVote:   mm.WantsVote,
 			Status:      mm.Status,
 			Message:     mm.Message,
+			HAPrimary:   mm.HAPrimary,
 		}
 	}
 	return result

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -147,6 +147,7 @@ func convertParamsModelInfo(modelInfo params.ModelInfo) (base.ModelInfo, error) 
 			HasVote:     m.HasVote,
 			WantsVote:   m.WantsVote,
 			Status:      m.Status,
+			HAPrimary:   m.HAPrimary,
 		}
 		if m.Hardware != nil {
 			machine.Hardware = &instance.HardwareCharacteristics{

--- a/apiserver/common/machine_test.go
+++ b/apiserver/common/machine_test.go
@@ -262,7 +262,7 @@ func (s *machineSuite) TestMachineInstanceInfoWithHAPrimary(c *gc.C) {
 				wantsVote: true,
 			},
 		},
-		haPimaryMachineF: func() (names.MachineTag, error) {
+		haPrimaryMachineF: func() (names.MachineTag, error) {
 			return names.NewMachineTag("1"), nil
 		},
 	}
@@ -284,9 +284,9 @@ func (s *machineSuite) TestMachineInstanceInfoWithHAPrimary(c *gc.C) {
 
 type mockState struct {
 	common.ModelManagerBackend
-	machines         map[string]*mockMachine
-	controllerNodes  map[string]*mockControllerNode
-	haPimaryMachineF func() (names.MachineTag, error)
+	machines          map[string]*mockMachine
+	controllerNodes   map[string]*mockControllerNode
+	haPrimaryMachineF func() (names.MachineTag, error)
 }
 
 func (st *mockState) Machine(id string) (common.Machine, error) {
@@ -318,10 +318,10 @@ func (st *mockState) ControllerNodes() ([]common.ControllerNode, error) {
 }
 
 func (st *mockState) HAPrimaryMachine() (names.MachineTag, error) {
-	if st.haPimaryMachineF == nil {
+	if st.haPrimaryMachineF == nil {
 		return names.MachineTag{}, nil
 	}
-	return st.haPimaryMachineF()
+	return st.haPrimaryMachineF()
 }
 
 type mockControllerNode struct {

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -70,6 +70,7 @@ type ModelManagerBackend interface {
 	LatestMigration() (state.ModelMigration, error)
 	DumpAll() (map[string]interface{}, error)
 	Close() error
+	HAPrimaryMachine() (names.MachineTag, error)
 
 	// Methods required by the metricsender package.
 	MetricsManager() (*state.MetricsManager, error)
@@ -132,8 +133,8 @@ func NewUserAwareModelManagerBackend(m *state.Model, pool *state.StatePool, u na
 
 // NewModel implements ModelManagerBackend.
 func (st modelManagerStateShim) NewModel(args state.ModelArgs) (Model, ModelManagerBackend, error) {
-	controller := state.NewController(st.pool)
-	otherModel, otherState, err := controller.NewModel(args)
+	aController := state.NewController(st.pool)
+	otherModel, otherState, err := aController.NewModel(args)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -56,6 +56,7 @@ type Backend interface {
 	FindEntity(names.Tag) (state.Entity, error)
 	InferEndpoints(...string) ([]state.Endpoint, error)
 	IsController() bool
+	HAPrimaryMachine() (names.MachineTag, error)
 	LatestMigration() (state.ModelMigration, error)
 	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
 	Machine(string) (*state.Machine, error)

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -196,6 +196,7 @@ func (s *modelInfoSuite) TestModelInfoV7(c *gc.C) {
 		{"IsController", nil},
 		{"AllMachines", nil},
 		{"ControllerNodes", nil},
+		{"HAPrimaryMachine", nil},
 		{"LatestMigration", nil},
 	})
 }
@@ -271,6 +272,7 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"IsController", nil},
 		{"AllMachines", nil},
 		{"ControllerNodes", nil},
+		{"HAPrimaryMachine", nil},
 		{"LatestMigration", nil},
 		{"CloudCredential", []interface{}{names.NewCloudCredentialTag("some-cloud/bob/some-credential")}},
 	})
@@ -947,6 +949,11 @@ func (st *mockState) ModelConfig() (*config.Config, error) {
 func (st *mockState) MetricsManager() (*state.MetricsManager, error) {
 	st.MethodCall(st, "MetricsManager")
 	return nil, errors.New("nope")
+}
+
+func (st *mockState) HAPrimaryMachine() (names.MachineTag, error) {
+	st.MethodCall(st, "HAPrimaryMachine")
+	return names.MachineTag{}, nil
 }
 
 type mockBlock struct {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -275,6 +275,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"IsController",
 		"AllMachines",
 		"ControllerNodes",
+		"HAPrimaryMachine",
 		"LatestMigration",
 	)
 
@@ -445,6 +446,7 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 		"IsController",
 		"AllMachines",
 		"ControllerNodes",
+		"HAPrimaryMachine",
 		"LatestMigration",
 	)
 	s.caasBroker.CheckCallNames(c, "Create")

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -10178,6 +10178,9 @@
                                 }
                             }
                         },
+                        "primary-controller-machine": {
+                            "type": "boolean"
+                        },
                         "series": {
                             "type": "string"
                         },
@@ -10324,6 +10327,9 @@
                     "properties": {
                         "display-name": {
                             "type": "string"
+                        },
+                        "ha-primary": {
+                            "type": "boolean"
                         },
                         "hardware": {
                             "$ref": "#/definitions/MachineHardware"
@@ -13066,6 +13072,9 @@
                     "properties": {
                         "display-name": {
                             "type": "string"
+                        },
+                        "ha-primary": {
+                            "type": "boolean"
                         },
                         "hardware": {
                             "$ref": "#/definitions/MachineHardware"
@@ -24273,6 +24282,9 @@
                     "properties": {
                         "display-name": {
                             "type": "string"
+                        },
+                        "ha-primary": {
+                            "type": "boolean"
                         },
                         "hardware": {
                             "$ref": "#/definitions/MachineHardware"

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -304,6 +304,9 @@ type ModelMachineInfo struct {
 	Message     string           `json:"message,omitempty"`
 	HasVote     bool             `json:"has-vote,omitempty"`
 	WantsVote   bool             `json:"wants-vote,omitempty"`
+	// HAPrimary indicates whether this machine has a primary mongo instance in replicaset and,
+	// thus, can be considered a primary controller machine in HA setup.
+	HAPrimary *bool `json:"ha-primary,omitempty"`
 }
 
 // MachineHardware holds information about a machine's hardware characteristics.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -124,6 +124,10 @@ type MachineStatus struct {
 	// LXDProfiles holds all the machines current LXD profiles that have
 	// been applied to the machine
 	LXDProfiles map[string]LXDProfile `json:"lxd-profiles,omitempty"`
+
+	// PrimaryControllerMachine indicates whether this machine has a primary mongo instance in replicaset and,
+	//	// thus, can be considered a primary controller machine in HA setup.
+	PrimaryControllerMachine *bool `json:"primary-controller-machine,omitempty"`
 }
 
 // LXDProfile holds status info about a LXDProfile

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -53,10 +53,10 @@ type showControllerCommand struct {
 
 // NewShowControllerCommand returns a command to show details of the desired controllers.
 func NewShowControllerCommand() cmd.Command {
-	cmd := &showControllerCommand{
+	command := &showControllerCommand{
 		store: jujuclient.NewFileClientStore(),
 	}
-	return modelcmd.WrapBase(cmd)
+	return modelcmd.WrapBase(command)
 }
 
 // Init implements Command.Init.
@@ -350,6 +350,9 @@ type MachineDetails struct {
 
 	// HAStatus holds information informing of the HA status of the machine.
 	HAStatus string `yaml:"ha-status,omitempty" json:"ha-status,omitempty"`
+
+	// HAPrimary is set to true for a primary controller machine in HA.
+	HAPrimary bool `yaml:"ha-primary,omitempty" json:"ha-primary,omitempty"`
 }
 
 // ModelDetails holds details of a model to show.
@@ -533,6 +536,9 @@ func (c *showControllerCommand) convertMachinesForShow(
 		details := MachineDetails{InstanceID: instId}
 		if numControllers > 1 {
 			details.HAStatus = haStatus(m.HasVote, m.WantsVote, m.Status)
+			if m.HAPrimary != nil && *m.HAPrimary {
+				details.HAPrimary = *m.HAPrimary
+			}
 		}
 		nodes[m.Id] = details
 	}

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -615,6 +615,50 @@ func (s *ShowControllerSuite) assertShowController(c *gc.C, args ...string) {
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, s.expectedOutput)
 }
 
+func (s *ShowControllerSuite) TestShowControllerPrimary(c *gc.C) {
+	_ = s.createTestClientStore(c)
+	s.expectedOutput = `
+aws-test:
+  details:
+    uuid: this-is-the-aws-test-uuid
+    controller-uuid: this-is-the-aws-test-uuid
+    api-endpoints: [this-is-aws-test-of-many-api-endpoints]
+    cloud: aws
+    region: us-east-1
+    agent-version: 999.99.99
+    agent-git-commit: badf00d0badf00d0badf00d0badf00d0badf00d0
+    controller-model-version: 999.99.99
+    mongo-version: 3.5.12
+    ca-cert: this-is-aws-test-ca-cert
+  controller-machines:
+    "0":
+      instance-id: id-0
+      ha-status: ha-pending
+    "1":
+      instance-id: id-1
+      ha-status: down, lost connection
+    "2":
+      instance-id: id-2
+      ha-status: ha-enabled
+      ha-primary: true
+  models:
+    controller:
+      uuid: ghi
+      model-uuid: ghi
+      machine-count: 2
+      core-count: 4
+  current-model: admin/controller
+  account:
+    user: admin
+    access: superuser
+`[1:]
+
+	_true := true
+	s.fakeController.machines["ghi"][2].HAPrimary = &_true
+
+	s.assertShowController(c, "aws-test")
+}
+
 type fakeController struct {
 	controllerName    string
 	machines          map[string][]base.Machine

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -77,6 +77,7 @@ type machineStatus struct {
 	Constraints        string                        `json:"constraints,omitempty" yaml:"constraints,omitempty"`
 	Hardware           string                        `json:"hardware,omitempty" yaml:"hardware,omitempty"`
 	HAStatus           string                        `json:"controller-member-status,omitempty" yaml:"controller-member-status,omitempty"`
+	HAPrimary          bool                          `json:"ha-primary,omitempty" yaml:"ha-primary,omitempty"`
 	LXDProfiles        map[string]lxdProfileContents `json:"lxd-profiles,omitempty" yaml:"lxd-profiles,omitempty"`
 }
 

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -210,6 +210,10 @@ func (sf *statusFormatter) formatMachine(machine params.MachineStatus) machineSt
 	for _, job := range machine.Jobs {
 		if job == coremodel.JobManageModel {
 			out.HAStatus = makeHAStatus(machine.HasVote, machine.WantsVote)
+			isPrimary := machine.PrimaryControllerMachine
+			if isPrimary != nil {
+				out.HAPrimary = *isPrimary
+			}
 			break
 		}
 	}

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -281,7 +281,7 @@ func (s *cmdControllerSuite) testAddModel(c *gc.C, args ...string) {
 	)
 	context := s.run(c, args...)
 	c.Check(cmdtesting.Stdout(context), gc.Equals, "")
-	c.Check(cmdtesting.Stderr(context), gc.Equals, `
+	c.Check(cmdtesting.Stderr(context), jc.Contains, `
 Added 'new-model' model on dummy/dummy-region with credential 'cred' for user 'admin'
 `[1:])
 


### PR DESCRIPTION
## Description of change

In HA setups, there is no way to find out which machine is "primary". Primary controller machine is the one has a local mongo that is considered to be primary (or master) in a replicaset.

If the machine is a primary HA. then in HA setup, this will be reflected in the output of:
* 'juju status --format=yaml' - https://pastebin.ubuntu.com/p/XnkmKB4BD9/ 
* 'juju machines --format=yaml' - https://pastebin.ubuntu.com/p/2B4FC3tNWC/
* 'juju show-machine' - https://pastebin.ubuntu.com/p/KFZF72vwvg/
* 'juju show-controller' - https://pastebin.ubuntu.com/p/bvbgdBV5wR/

## QA steps

1. bootstrap
2. enable ha
3. run any of the command above
4. change replicaset master (I've logged in into primary and ```rs.stepDown(90,30)``` until a new primary was selected
5. run any of the modified command to see new primary

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860291
