### PR TITLE
[2.7] Extend metadata for disco-supporting test charms to also support eoan

### DIFF
--- a/acceptancetests/repository/charms/appdata-sink/metadata.yaml
+++ b/acceptancetests/repository/charms/appdata-sink/metadata.yaml
@@ -14,3 +14,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/appdata-source/metadata.yaml
+++ b/acceptancetests/repository/charms/appdata-source/metadata.yaml
@@ -14,3 +14,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
+++ b/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
@@ -16,3 +16,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/dummy-resource/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-resource/metadata.yaml
@@ -10,6 +10,7 @@ series:
   - artful
   - bionic
   - disco
+  - eoan
 resources:
   foo:
     type: file

--- a/acceptancetests/repository/charms/dummy-sink/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-sink/metadata.yaml
@@ -14,3 +14,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/dummy-source/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-source/metadata.yaml
@@ -14,4 +14,4 @@ series:
   - artful
   - bionic
   - disco
-
+  - eoan

--- a/acceptancetests/repository/charms/dummy-storage/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-storage/metadata.yaml
@@ -12,6 +12,7 @@ series:
   - artful
   - bionic
   - disco
+  - eoan
 storage:
   single-fs:
     type: filesystem

--- a/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
@@ -16,3 +16,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/fill-logs/metadata.yaml
+++ b/acceptancetests/repository/charms/fill-logs/metadata.yaml
@@ -10,3 +10,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
@@ -20,3 +20,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
@@ -17,3 +17,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/mysql/metadata.yaml
+++ b/acceptancetests/repository/charms/mysql/metadata.yaml
@@ -41,3 +41,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/network-health/metadata.yaml
+++ b/acceptancetests/repository/charms/network-health/metadata.yaml
@@ -12,6 +12,7 @@ series:
   - artful
   - bionic
   - disco
+  - eoan
 requires:
   juju-info:
     interface: juju-info

--- a/acceptancetests/repository/charms/peer-xplod/metadata.yaml
+++ b/acceptancetests/repository/charms/peer-xplod/metadata.yaml
@@ -13,6 +13,7 @@ series:
   - artful
   - bionic
   - disco
+  - eoan
 subordinate: false
 peers:
   xplod:

--- a/acceptancetests/repository/charms/simple-resolve/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resolve/metadata.yaml
@@ -11,3 +11,4 @@ series:
   - trusty
   - artful
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
@@ -14,6 +14,7 @@ series:
   - artful
   - bionic
   - disco
+  - eoan
 resources:
   index:
     type: file

--- a/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/statusstresser/metadata.yaml
+++ b/acceptancetests/repository/charms/statusstresser/metadata.yaml
@@ -11,3 +11,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/ubuntu/metadata.yaml
+++ b/acceptancetests/repository/charms/ubuntu/metadata.yaml
@@ -11,3 +11,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/update-status-tester/metadata.yaml
+++ b/acceptancetests/repository/charms/update-status-tester/metadata.yaml
@@ -11,3 +11,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/charms/wordpress/metadata.yaml
+++ b/acceptancetests/repository/charms/wordpress/metadata.yaml
@@ -24,4 +24,4 @@ series:
   - artful
   - bionic
   - disco
-
+  - eoan

--- a/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
@@ -16,3 +16,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan

--- a/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
@@ -16,3 +16,4 @@ series:
   - artful
   - bionic
   - disco
+  - eoan


### PR DESCRIPTION
## Description of change

This PR updates the metadata for the charms used by acceptance tests to include support for eoan