### PR TITLE
snapcraft fixes to support remote-builds

### DIFF
--- a/snap/.gitignore
+++ b/snap/.gitignore
@@ -1,1 +1,0 @@
-.snapcraft

--- a/snap/local/wrappers/juju
+++ b/snap/local/wrappers/juju
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
-export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
-
-exec $SNAP/bin/juju "$@"
-

--- a/snap/plugins/x-dep.py
+++ b/snap/plugins/x-dep.py
@@ -42,11 +42,12 @@ import shutil
 
 import snapcraft
 from snapcraft import common
-from snapcraft.internal import errors
+from snapcraft import file_utils
 
 logger = logging.getLogger(__name__)
 
 
+# TODO(wallyworld) - remove when we migrate to go mod
 class DepPlugin(snapcraft.BasePlugin):
     @classmethod
     def schema(cls):
@@ -61,7 +62,7 @@ class DepPlugin(snapcraft.BasePlugin):
         }
 
         # The import path must be specified.
-        schema["required"].append("go-importpath")
+        schema["required"] = ["go-importpath"]
 
         return schema
 
@@ -79,7 +80,7 @@ class DepPlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options, project):
         super().__init__(name, options, project)
-        self.build_packages.extend(["golang-go", "git"])
+        self.build_snaps.extend(["go/1.13/stable"])
         self._gopath = os.path.join(self.partdir, "go")
         self._gopath_src = os.path.join(self._gopath, "src")
         self._gopath_bin = os.path.join(self._gopath, "bin")
@@ -96,7 +97,7 @@ class DepPlugin(snapcraft.BasePlugin):
         finally:
             os.makedirs(os.path.dirname(self._path_in_gopath), exist_ok=True)
 
-        shutil.copytree(self.sourcedir, self._path_in_gopath, symlinks=True, ignore_dangling_symlinks=True)
+        file_utils.link_or_copy_tree(self.sourcedir, self._path_in_gopath)
 
         # Fetch and run dep
         logger.info("Fetching dep...")

--- a/snap/plugins/x-dep.yaml
+++ b/snap/plugins/x-dep.yaml
@@ -1,6 +1,0 @@
-options:
-  source:
-    required: true
-  source-type:
-  source-tag:
-  source-branch:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,10 +4,14 @@ summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic
 grade: devel
+base: core
 
 apps:
   juju:
-    command: wrappers/juju
+    environment:
+      # Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
+      PATH: "$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH"
+    command: bin/juju
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
@@ -17,6 +21,10 @@ parts:
     plugin: dump
     source: snap/local
   juju:
+    # TODO(wallyworld) - use go plugin and remove dep when we migrate to go mod.
+    # plugin: go
+    # go-channel: 1.13/stable
+    # go-buildtags: xxx
     plugin: dep
     go-importpath: github.com/juju/juju
     # The source can be your local tree or github
@@ -26,10 +34,8 @@ parts:
     # source: file:///full/file/path
     # By default, reuse existing tree
     source: .
-    source-type: git
-    # this is for building in a docker container
-    build-packages: [gcc, libc6-dev]
-    build-attributes: [no-patchelf]
+    # TODO(wallyworld) - uncomment source-type once LP:1860526 is fixed. 
+    #source-type: git
     # You can grab a specific tag, commit, or branch
     # source-tag: juju-2.0.2
     # source-commit: a83896d913d7e43c960e441c1e41612116d92d46


### PR DESCRIPTION
## Description of change

snapcraft fixes to support the recent snapcrafft remote-build functionality, plus cleanups recommended by the snapcraft guys.

There's also commented out support for migrating to go mod - as soon as we replace go dep with go mod we can delete the snapcraft dep plugin and adjust the snapcraft yaml.

The version of go used is now specified in the snapcraft yaml (1.13) and there's no need for a special ppa containing an old go version to buid the snap.

Next steps are to update the jenkins build jobs to call snapcraft remote-build

## QA steps

Ensure a snap can be built either locally using lxd:

```
snapcraft --use-lxd
```

or remotely on launchpad

```
snapcraft remote-build --launchpad-user juju-qa-bot --launchpad-accept-public-upload --build-on=amd64,arm64,ppc64el,s390x
```
