### PR TITLE
Handle detaching a volume attachment with a plan.

### DIFF
--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -309,6 +309,12 @@ func (s *StorageStateSuiteBase) volumeAttachment(c *gc.C, host names.Tag, v name
 	return attachment
 }
 
+func (s *StorageStateSuiteBase) volumeAttachmentPlan(c *gc.C, host names.Tag, v names.VolumeTag) state.VolumeAttachmentPlan {
+	attachmentPlan, err := s.storageBackend.VolumeAttachmentPlan(host, v)
+	c.Assert(err, jc.ErrorIsNil)
+	return attachmentPlan
+}
+
 func (s *StorageStateSuiteBase) storageInstanceVolume(c *gc.C, tag names.StorageTag) state.Volume {
 	volume, err := s.storageBackend.StorageInstanceVolume(tag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/volume.go
+++ b/state/volume.go
@@ -731,6 +731,9 @@ func (sb *storageBackend) DetachVolume(host names.Tag, volume names.VolumeTag) (
 			return nil, errors.Trace(err)
 		} else {
 			if len(plans) > 0 {
+				if plans[0].Life() != Alive {
+					return nil, jujutxn.ErrNoOperations
+				}
 				return detachStorageAttachmentOps(host, volume), nil
 			}
 		}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change? (no)
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR? (no, but has a direct unit test)
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed? (no)
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change
If the VolumeAttachmentPlan is already in Dying, treat DetachVolume as a no-op.

If you *don't* have a plan, and VolumeAttachment is already Dying, DetachVolume was already a no-op. VolumeAttachmentPlan exists to get a sync from the machine agent that it needs to run a local command, and then progress the system by calling RemoveVolumeAttachmentPlan.
If we have already progressed the Plan to Dying, there is nothing else
to do.

This doesn't handle the 'juju destroy-machine --force' case, where the
remote machine will never call RemoveVolumeAttachmentPlan on its own,
but it does prevent us from getting 'state changing too quickly'.

## QA steps

The newly added test would fail with "state changing too quickly", with the patch, it now properly is treated as a no-op.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860542