### PR TITLE
Fix worker leak in provisioner

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -122,12 +122,6 @@ func NewProvisionerTask(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// Get existing machine distributions.
-	err = task.populateAvailabilityZoneMachines()
-	// Not all providers implement ZonedEnviron
-	if err != nil && !errors.IsNotImplemented(err) {
-		return nil, errors.Trace(err)
-	}
 	return task, nil
 }
 
@@ -167,6 +161,13 @@ func (task *provisionerTask) Wait() error {
 }
 
 func (task *provisionerTask) loop() error {
+
+	// Get existing machine distributions.
+	err := task.populateAvailabilityZoneMachines()
+	// Not all providers implement ZonedEnviron
+	if err != nil && !errors.IsNotImplemented(err) {
+		return errors.Trace(err)
+	}
 
 	// Don't allow the harvesting mode to change until we have read at
 	// least one set of changes, which will populate the task.machines


### PR DESCRIPTION
During analysis of the goroutine leak on prodstack, we identified that there was a leak of provisioner tasks. Analysing the code, we found that the creation of the availability zone map for the task was done after the task loop was started, but if an error occurred, the task was never killed.

This fix also looks like it will address the error case where a new machine was started but it was not able to log in due to a second active task having reset its password.

## QA steps

Run the tests.

## Documentation changes

Internal change only, nothing to document.

