### PR TITLE
[dev] Setup mongo collection for server side charm state

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -288,7 +288,8 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid", "machineid"},
 			}},
 		},
-		minUnitsC: {},
+		unitStatesC: {},
+		minUnitsC:   {},
 
 		// This collection holds documents that indicate units which are queued
 		// to be assigned to machines. It is used exclusively by the
@@ -623,6 +624,7 @@ const (
 	txnLogC                    = "txns.log"
 	txnsC                      = "txns"
 	unitsC                     = "units"
+	unitStatesC                = "unitstates"
 	upgradeInfoC               = "upgradeInfo"
 	userLastLoginC             = "userLastLogin"
 	usermodelnameC             = "usermodelname"

--- a/state/application.go
+++ b/state/application.go
@@ -2116,6 +2116,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 		removeMeterStatusOp(a.st, u.globalMeterStatusKey()),
 		removeStatusOp(a.st, u.globalAgentKey()),
 		removeStatusOp(a.st, u.globalKey()),
+		removeUnitStateOp(a.st, u.globalKey()),
 		removeStatusOp(a.st, u.globalCloudContainerKey()),
 		removeConstraintsOp(u.globalAgentKey()),
 		annotationRemoveOp(a.st, u.globalKey()),

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -219,6 +219,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// sure the leader units' leases are claimed in the target
 		// controller when leases are managed in raft.
 		leaseHoldersC,
+		// TODO(achilleasa) remove this once the required changes to
+		// the description package land.
+		unitStatesC,
 	)
 
 	modelCollections := set.NewStrings()

--- a/state/unit.go
+++ b/state/unit.go
@@ -332,6 +332,16 @@ type unitStateDoc struct {
 	TxnRevno int64 `bson:"txn-revno"`
 }
 
+// removeUnitStateOp returns the operation needed to remove the unit state
+// document associated with the given globalKey.
+func removeUnitStateOp(mb modelBackend, globalKey string) txn.Op {
+	return txn.Op{
+		C:      unitStatesC,
+		Id:     mb.docID(globalKey),
+		Remove: true,
+	}
+}
+
 // SetState persisted the state for a unit.
 func (u *Unit) SetState(unitState map[string]string) error {
 	unitGlobalKey := u.globalKey()

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1687,6 +1687,13 @@ func (s *UnitSuite) TestRemoveUnitDeletesUnitState(c *gc.C) {
 	numDocs, err = coll.Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(numDocs, gc.Equals, 0, gc.Commentf("expected unit state document to be removed when the unit is destroyed"))
+
+	// Any attempts to read/write a unit's state when not Alive should fail
+	_, err = s.unit.State()
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	err = s.unit.SetState(map[string]string{"foo": "bar"})
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *UnitSuite) TestSetClearResolvedWhenNotAlive(c *gc.C) {


### PR DESCRIPTION
## Description of change

This PR is part of the work for supporting server-side stage storage for charms using the new operator framework. 

The per-unit state is stored within a new collection called `unitstates`. Each document in the new collection tracks the state for a particular unit which can be set via the `SetState` method and retrieved via the `State` method on a `Unit` instance. The state itself is stored as a map with string keys and values. Keys are allowed to contain special characters (e.g. dots and dollar signs) and such characters will automatically be escaped/unescaped when saving/loading state data.

Note that the absence of a document is treated as _no state available_ in which case a nil map will be returned by calls to `State`. This behavior also ensures that no migration steps are required from older controller versions.

It is also important to note that the reasoning behind reading/writing maps instead of individual KV pairs is that the uniter will buffer state changes in memory and persist them as a single batch when the uniter's hook context is flushed.

NOTE: 
This PR does not tackle unit state migrations as this requires changes to the juju/description package. This will be handled via a separate PR.