### PR TITLE
Change the text used to match the model-removed error

### DIFF
--- a/acceptancetests/assess_destroy_model.py
+++ b/acceptancetests/assess_destroy_model.py
@@ -68,7 +68,7 @@ def destroy_model(client, new_client):
             if not_found_error in e.stderr:
                 log.info("Model fully removed")
                 break
-            removed_error = b'model "{}" has been removed from the controller'.format(old_model)
+            removed_error = b'model "admin/{}" has been removed from the controller'.format(old_model)
             if removed_error not in e.stderr:
                 error = 'unexpected error calling status\n{}'.format(e.stderr)
                 raise JujuAssertionError(error)


### PR DESCRIPTION
## Description of change

The old_model we have only contains the model name, not the user-qualified one. To ensure it matches the error that comes back with the user name, include the username in the template (it's always "admin" in the test).

Example of the error: https://jenkins.juju.canonical.com/job/nw-destroy-model-lxd/2210/console

We haven't been able to reproduce this error locally in a reliable way unfortunately, which is why there's a bit of churn in this test.

## QA steps

Run the destroy-model test, it passes.

## Documentation changes

None

## Bug reference

None
