### PR TITLE
Feature/pod value mount

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2537,6 +2537,12 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 		if spec.SecurityContext != nil {
 			pc.SecurityContext = spec.SecurityContext
 		}
+		if spec.Env != nil {
+			pc.Env = spec.Env
+		}
+		if spec.EnvFrom != nil {
+			pc.EnvFrom = spec.EnvFrom
+		}
 	}
 	return nil
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2504,7 +2504,7 @@ func defaultSecurityContext() *core.SecurityContext {
 	}
 }
 
-func populateContainerDetails(deploymentName string, pod *core.PodSpec, podContainers []core.Container, containers []specs.ContainerSpec) error {
+func populateContainerDetails(deploymentName string, pod *core.PodSpec, podContainers []core.Container, containers []specs.ContainerSpec) (err error) {
 	for i, c := range containers {
 		pc := &podContainers[i]
 		if c.Image != "" {
@@ -2518,6 +2518,10 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 		}
 		if c.ImagePullPolicy != "" {
 			pc.ImagePullPolicy = core.PullPolicy(c.ImagePullPolicy)
+		}
+
+		if pc.Env, pc.EnvFrom, err = k8sspecs.ContainerConfigToK8sEnvConfig(c.Config); err != nil {
+			return errors.Trace(err)
 		}
 
 		pc.SecurityContext = defaultSecurityContext()
@@ -2536,12 +2540,6 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 		}
 		if spec.SecurityContext != nil {
 			pc.SecurityContext = spec.SecurityContext
-		}
-		if spec.Env != nil {
-			pc.Env = spec.Env
-		}
-		if spec.EnvFrom != nil {
-			pc.EnvFrom = spec.EnvFrom
 		}
 	}
 	return nil

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -264,6 +264,13 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 						"path": "spec.nodeName",
 					},
 				},
+				"my-resource-limit": map[string]interface{}{
+					"resource": map[string]interface{}{
+						"container-name": "container1",
+						"resource":       "requests.cpu",
+						"divisor":        "1m",
+					},
+				},
 				"attr": "foo=bar; name[\"fred\"]=\"blogs\";",
 				"configmap1": map[string]interface{}{
 					"config-map": map[string]interface{}{
@@ -357,6 +364,16 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 					{Name: "float", Value: "111.11111111"},
 					{Name: "foo", Value: "bar"},
 					{Name: "int", Value: "111"},
+					{
+						Name: "my-resource-limit",
+						ValueFrom: &core.EnvVarSource{
+							ResourceFieldRef: &core.ResourceFieldSelector{
+								ContainerName: "container1",
+								Resource:      "requests.cpu",
+								Divisor:       resource.MustParse("1m"),
+							},
+						},
+					},
 					{Name: "restricted", Value: "yes"},
 					{Name: "special", Value: "p@ssword's"},
 					{Name: "switch", Value: "true"},

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -246,35 +246,39 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 			ImagePullPolicy: specs.PullPolicy("Always"),
 			Config: map[string]interface{}{
 				"restricted": "yes",
-				"secretRef": []interface{}{
-					map[string]interface{}{
+				"secret1": map[string]interface{}{
+					"secret": map[string]interface{}{
 						"optional": bool(true),
 						"name":     "secret1",
 					},
-					map[string]interface{}{
+				},
+				"secret2": map[string]interface{}{
+					"secret": map[string]interface{}{
 						"name": "secret2",
 					},
 				},
 				"special": "p@ssword's",
 				"switch":  bool(true),
 				"MY_NODE_NAME": map[string]interface{}{
-					"fieldRef": map[string]interface{}{
-						"fieldPath": "spec.nodeName",
+					"field": map[string]interface{}{
+						"path": "spec.nodeName",
 					},
 				},
 				"attr": "foo=bar; name[\"fred\"]=\"blogs\";",
-				"configMapRef": []interface{}{
-					map[string]interface{}{
+				"configmap1": map[string]interface{}{
+					"config-map": map[string]interface{}{
 						"name":     "configmap1",
 						"optional": bool(true),
 					},
-					map[string]interface{}{
+				},
+				"configmap2": map[string]interface{}{
+					"config-map": map[string]interface{}{
 						"name": "configmap2",
 					},
 				},
 				"float": float64(111.11111111),
 				"thing1": map[string]interface{}{
-					"configMapKeyRef": map[string]interface{}{
+					"config-map": map[string]interface{}{
 						"key":  "bar",
 						"name": "foo",
 					},
@@ -283,7 +287,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 				"foo":      "bar",
 				"int":      float64(111),
 				"thing": map[string]interface{}{
-					"secretKeyRef": map[string]interface{}{
+					"secret": map[string]interface{}{
 						"key":  "bar",
 						"name": "foo",
 					},

--- a/caas/kubernetes/provider/specs/container_env.go
+++ b/caas/kubernetes/provider/specs/container_env.go
@@ -1,0 +1,235 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package specs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	"github.com/kr/pretty"
+	core "k8s.io/api/core/v1"
+
+	"github.com/juju/juju/caas/specs"
+)
+
+var boolValues = set.NewStrings(
+	strings.Split("y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF", "|")...)
+
+var specialValues = ":{}[],&*#?|-<>=!%@`"
+
+func quoteStrings(config map[string]interface{}) {
+	// Any string config values that could be interpreted as bools
+	// or which contain special YAML chars need to be quoted.
+	for k, v := range config {
+		strValue, ok := v.(string)
+		if !ok {
+			continue
+		}
+		config[k] = quoteString(strValue)
+	}
+}
+
+func quoteString(i string) string {
+	if boolValues.Contains(i) || strings.IndexAny(i, specialValues) >= 0 {
+		i = strings.Replace(i, "'", "''", -1)
+		i = fmt.Sprintf("'%s'", i)
+	}
+	return i
+}
+
+type fieldRef struct {
+	FieldRef *core.ObjectFieldSelector `json:"fieldRef" yaml:"fieldRef"`
+}
+
+func (fr fieldRef) to(name string) (out []core.EnvVar) {
+	if fr.FieldRef != nil {
+		out = append(out, core.EnvVar{Name: name, ValueFrom: &core.EnvVarSource{FieldRef: fr.FieldRef}})
+	}
+	return out
+}
+
+type resourceRef struct {
+	ResourceRef *core.ResourceFieldSelector `json:"resourceRef" yaml:"resourceRef"`
+}
+
+func (rr resourceRef) to(name string) (out []core.EnvVar) {
+	if rr.ResourceRef != nil {
+		out = append(out, core.EnvVar{Name: name, ValueFrom: &core.EnvVarSource{ResourceFieldRef: rr.ResourceRef}})
+	}
+	return out
+}
+
+const (
+	secretRefName    = "secretRef"
+	configMapRefName = "configMapRef"
+)
+
+type secretRefValue []core.SecretEnvSource
+type configMapRefValue []core.ConfigMapEnvSource
+
+func (sr secretRefValue) to() (out []core.EnvFromSource) {
+	for _, v := range sr {
+		sRef := v
+		out = append(out, core.EnvFromSource{SecretRef: &sRef})
+	}
+	return out
+}
+
+func (cmr configMapRefValue) to() (out []core.EnvFromSource) {
+	for _, v := range cmr {
+		cRef := v
+		out = append(out, core.EnvFromSource{ConfigMapRef: &cRef})
+	}
+	return out
+}
+
+type secretKeyRef struct {
+	SecretKeyRef *core.SecretKeySelector `json:"secretKeyRef" yaml:"secretKeyRef"`
+}
+
+func (skr secretKeyRef) to(name string) (out []core.EnvVar) {
+	if skr.SecretKeyRef != nil {
+		out = append(out, core.EnvVar{Name: name, ValueFrom: &core.EnvVarSource{SecretKeyRef: skr.SecretKeyRef}})
+	}
+	return out
+}
+
+type configMapKeyRef struct {
+	ConfigMapKeyRef *core.ConfigMapKeySelector `json:"configMapKeyRef" yaml:"configMapKeyRef"`
+}
+
+func (cmkr configMapKeyRef) to(name string) (out []core.EnvVar) {
+	if cmkr.ConfigMapKeyRef != nil {
+		out = append(out, core.EnvVar{Name: name, ValueFrom: &core.EnvVarSource{ConfigMapKeyRef: cmkr.ConfigMapKeyRef}})
+	}
+	return out
+}
+
+type configValue struct {
+	fieldRef    `json:",inline" yaml:",inline"`
+	resourceRef `json:",inline" yaml:",inline"`
+
+	secretKeyRef    `json:",inline" yaml:",inline"`
+	configMapKeyRef `json:",inline" yaml:",inline"`
+}
+
+func (cv configValue) to(name string) (out []core.EnvVar, err error) {
+	out = append(out, cv.fieldRef.to(name)...)
+	out = append(out, cv.resourceRef.to(name)...)
+	out = append(out, cv.secretKeyRef.to(name)...)
+	out = append(out, cv.configMapKeyRef.to(name)...)
+
+	if len(out) == 0 {
+		return nil, errors.NotSupportedf("config format of %q", name)
+	}
+	if len(out) > 1 {
+		return nil, errors.NotValidf("duplicated values found for config %q", name)
+	}
+	return out, nil
+}
+
+// JSON Unmarshal types: https://golang.org/pkg/encoding/json/#Unmarshal
+func stringify(i interface{}) (string, error) {
+	switch v := i.(type) {
+	case string:
+		// return v, nil
+		return quoteString(v), nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	case float64:
+		// All the numbers are float64 - https://golang.org/pkg/encoding/json/#Number
+		return fmt.Sprintf("%g", v), nil
+	default:
+		return "", errors.NotSupportedf("%v with type %T", i, i)
+	}
+}
+
+func processMapInterfaceValue(k string, v interface{}) (envVars []core.EnvVar, envFromSources []core.EnvFromSource, err error) {
+	logger.Criticalf("processMapInterfaceValue %q, %+v", k, v)
+
+	parse := func(into interface{}) error {
+		jsonbody, err := json.Marshal(v)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		decoder := newStrictYAMLOrJSONDecoder(bytes.NewReader(jsonbody), len(jsonbody))
+		return decoder.Decode(&into)
+	}
+	switch k {
+	case secretRefName:
+		var val secretRefValue
+		defer func() {
+			envFromSources = append(envFromSources, val.to()...)
+			logger.Criticalf("processMapInterfaceValue %q result -> %s, xxxx -> %s", k, pretty.Sprint(val), pretty.Sprint(val.to()))
+		}()
+		return envVars, envFromSources, errors.Trace(parse(&val))
+	case configMapRefName:
+		var val configMapRefValue
+		defer func() {
+			envFromSources = append(envFromSources, val.to()...)
+			logger.Criticalf("processMapInterfaceValue %q result -> %s", k, pretty.Sprint(val))
+		}()
+		return envVars, envFromSources, errors.Trace(parse(&val))
+	default:
+		var val configValue
+		if err := parse(&val); err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		logger.Criticalf("processMapInterfaceValue %q result -> %s", k, pretty.Sprint(val))
+		items, err := val.to(k)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		envVars = append(envVars, items...)
+		return envVars, envFromSources, nil
+	}
+}
+
+// ContainerConfigToK8sEnvConfig converts ContainerConfig to k8s format for container value mount.
+func ContainerConfigToK8sEnvConfig(cc specs.ContainerConfig) (envVars []core.EnvVar, envFromSources []core.EnvFromSource, err error) {
+	valNames := set.NewStrings()
+	for k, v := range cc {
+		if valNames.Contains(k) {
+			return nil, nil, errors.NotValidf("duplicated config %q", k)
+		}
+		valNames.Add(k)
+
+		logger.Criticalf("%T\t%q-> %#v", v, k, v)
+
+		if k != secretRefName && k != configMapRefName {
+			// Normal key value pairs.
+			if strV, err := stringify(v); err == nil {
+				envVars = append(envVars, core.EnvVar{Name: k, Value: strV})
+				continue
+			} else {
+				logger.Criticalf("stringify %q:%#v, err -> %+v", k, v, err)
+			}
+		}
+
+		switch envVal := v.(type) {
+		case map[string]interface{}, []interface{}:
+
+			vars, envFroms, err := processMapInterfaceValue(k, envVal)
+			if err != nil {
+				logger.Criticalf("processMapInterfaceValue err -> %v", errors.ErrorStack(err))
+				return nil, nil, errors.Trace(err)
+			}
+			envVars = append(envVars, vars...)
+			envFromSources = append(envFromSources, envFroms...)
+		default:
+			// envVars = append(envVars, core.EnvVar{Name: k, Value: fmt.Sprintf("%s", envVal)})
+			return nil, nil, errors.NotSupportedf("config %q with type %T", k, v)
+		}
+	}
+
+	logger.Criticalf("envVars -> %s", pretty.Sprint(envVars))
+	logger.Criticalf("envFromSources -> %s", pretty.Sprint(envFromSources))
+	// return envVars, envFromSources, errors.NotFoundf("xxx")
+	return envVars, envFromSources, nil
+}

--- a/caas/kubernetes/provider/specs/container_env_test.go
+++ b/caas/kubernetes/provider/specs/container_env_test.go
@@ -1,0 +1,125 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package specs_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
+
+	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
+	"github.com/juju/juju/testing"
+)
+
+type containerEnvSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&containerEnvSuite{})
+
+func (s *v2SpecsSuite) TestContainerConfigToK8sEnvConfig(c *gc.C) {
+
+	specStr := versionHeader + `
+containers:
+  - name: gitlab
+    image: gitlab/latest
+    config:
+      attr: foo=bar; name["fred"]="blogs";
+      foo: bar
+      brackets: '["hello", "world"]'
+      restricted: 'yes'
+      switch: on
+      bar: true
+      special: p@ssword's
+      foo: bar
+      float: 111.11111111
+      int: 111
+      MY_NODE_NAME:
+        fieldRef:
+          fieldPath: spec.nodeName
+      thing:
+         secretKeyRef:
+           name: foo
+           key: bar
+      thing1:
+         configMapKeyRef:
+           name: foo
+           key: bar
+      secretRef:
+        - name: secret1
+          optional: true
+        - name: secret2
+      configMapRef:
+        - name: configmap1
+          optional: true
+        - name: configmap2
+`[1:]
+
+	envVarThing := core.EnvVar{
+		Name: "thing",
+		ValueFrom: &core.EnvVarSource{
+			SecretKeyRef: &core.SecretKeySelector{Key: "bar"},
+		},
+	}
+	envVarThing.ValueFrom.SecretKeyRef.Name = "foo"
+
+	envVarThing1 := core.EnvVar{
+		Name: "thing1",
+		ValueFrom: &core.EnvVarSource{
+			ConfigMapKeyRef: &core.ConfigMapKeySelector{Key: "bar"},
+		},
+	}
+	envVarThing1.ValueFrom.ConfigMapKeyRef.Name = "foo"
+
+	envFromSourceSecret1 := core.EnvFromSource{
+		SecretRef: &core.SecretEnvSource{Optional: boolPtr(true)},
+	}
+	envFromSourceSecret1.SecretRef.Name = "secret1"
+
+	envFromSourceSecret2 := core.EnvFromSource{
+		SecretRef: &core.SecretEnvSource{},
+	}
+	envFromSourceSecret2.SecretRef.Name = "secret2"
+
+	envFromSourceConfigmap1 := core.EnvFromSource{
+		ConfigMapRef: &core.ConfigMapEnvSource{Optional: boolPtr(true)},
+	}
+	envFromSourceConfigmap1.ConfigMapRef.Name = "configmap1"
+
+	envFromSourceConfigmap2 := core.EnvFromSource{
+		ConfigMapRef: &core.ConfigMapEnvSource{},
+	}
+	envFromSourceConfigmap2.ConfigMapRef.Name = "configmap2"
+
+	specs, err := k8sspecs.ParsePodSpec(specStr)
+	c.Assert(err, jc.ErrorIsNil)
+	envVars, envFromSource, err := k8sspecs.ContainerConfigToK8sEnvConfig(specs.Containers[0].Config)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedEnvVar := []core.EnvVar{
+		{Name: "MY_NODE_NAME", ValueFrom: &core.EnvVarSource{FieldRef: &core.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "attr", Value: `foo=bar; name["fred"]="blogs";`},
+		{Name: "bar", Value: "true"},
+		{Name: "brackets", Value: `["hello", "world"]`},
+		{Name: "float", Value: "111.11111111"},
+		{Name: "foo", Value: "bar"},
+		{Name: "int", Value: "111"},
+		{Name: "restricted", Value: "yes"},
+		{Name: "special", Value: "p@ssword's"},
+		{Name: "switch", Value: "true"},
+		envVarThing,
+		envVarThing1,
+	}
+	expectedEnvFromSource := []core.EnvFromSource{
+		envFromSourceConfigmap1,
+		envFromSourceConfigmap2,
+		envFromSourceSecret1,
+		envFromSourceSecret2,
+	}
+	for i := range envVars {
+		c.Check(envVars[i], jc.DeepEquals, expectedEnvVar[i])
+	}
+	for i := range envFromSource {
+		c.Check(envFromSource[i], jc.DeepEquals, expectedEnvFromSource[i])
+	}
+}

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -31,7 +31,7 @@ func (c *k8sContainerLegacy) Validate() error {
 }
 
 func (c *k8sContainerLegacy) ToContainerSpec() specs.ContainerSpec {
-	// quoteStrings(c.Config)
+	quoteStrings(c.Config)
 	result := specs.ContainerSpec{
 		ImageDetails:    c.ImageDetails,
 		Name:            c.Name,

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -31,7 +31,6 @@ func (c *k8sContainerLegacy) Validate() error {
 }
 
 func (c *k8sContainerLegacy) ToContainerSpec() specs.ContainerSpec {
-	quoteStrings(c.Config)
 	result := specs.ContainerSpec{
 		ImageDetails:    c.ImageDetails,
 		Name:            c.Name,

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -31,7 +31,7 @@ func (c *k8sContainerLegacy) Validate() error {
 }
 
 func (c *k8sContainerLegacy) ToContainerSpec() specs.ContainerSpec {
-	quoteStrings(c.Config)
+	// quoteStrings(c.Config)
 	result := specs.ContainerSpec{
 		ImageDetails:    c.ImageDetails,
 		Name:            c.Name,

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -180,12 +180,12 @@ echo "do some stuff here for gitlab container"
 					{ContainerPort: 443, Name: "mary"},
 				},
 				Config: map[string]interface{}{
-					"attr":       `'foo=bar; name["fred"]="blogs";'`,
+					"attr":       `foo=bar; name["fred"]="blogs";`,
 					"foo":        "bar",
-					"restricted": "'yes'",
+					"restricted": "yes",
 					"switch":     true,
-					"brackets":   `'["hello", "world"]'`,
-					"special":    "'p@ssword''s'",
+					"brackets":   `["hello", "world"]`,
+					"special":    "p@ssword's",
 				},
 				Files: []specs.FileSet{
 					{
@@ -256,10 +256,10 @@ echo "do some stuff here for gitlab-init container"
 				},
 				Config: map[string]interface{}{
 					"foo":        "bar",
-					"restricted": "'yes'",
+					"restricted": "yes",
 					"switch":     true,
-					"brackets":   `'["hello", "world"]'`,
-					"special":    "'p@ssword''s'",
+					"brackets":   `["hello", "world"]`,
+					"special":    "p@ssword's",
 				},
 			},
 		}

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -45,7 +45,6 @@ type k8sContainerInterface interface {
 }
 
 func (c *k8sContainer) ToContainerSpec() specs.ContainerSpec {
-	// quoteStrings(c.Config)
 	result := specs.ContainerSpec{
 		ImageDetails:    c.ImageDetails,
 		Name:            c.Name,

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -71,9 +71,6 @@ type K8sContainerSpec struct {
 	LivenessProbe   *core.Probe           `json:"livenessProbe,omitempty" yaml:"livenessProbe,omitempty"`
 	ReadinessProbe  *core.Probe           `json:"readinessProbe,omitempty" yaml:"readinessProbe,omitempty"`
 	SecurityContext *core.SecurityContext `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
-
-	EnvFrom []core.EnvFromSource `json:"envFrom,omitempty" yaml:"envFrom,omitempty"`
-	Env     []core.EnvVar        `json:"env,omitempty" yaml:"env,omitempty"`
 }
 
 // Validate validates K8sContainerSpec.

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	core "k8s.io/api/core/v1"
@@ -46,7 +45,7 @@ type k8sContainerInterface interface {
 }
 
 func (c *k8sContainer) ToContainerSpec() specs.ContainerSpec {
-	quoteStrings(c.Config)
+	// quoteStrings(c.Config)
 	result := specs.ContainerSpec{
 		ImageDetails:    c.ImageDetails,
 		Name:            c.Name,
@@ -101,26 +100,6 @@ func (ps PodSpec) IsEmpty() bool {
 		ps.SecurityContext == nil &&
 		len(ps.ReadinessGates) == 0 &&
 		ps.DNSPolicy == ""
-}
-
-var boolValues = set.NewStrings(
-	strings.Split("y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF", "|")...)
-
-var specialValues = ":{}[],&*#?|-<>=!%@`"
-
-func quoteStrings(config map[string]interface{}) {
-	// Any string config values that could be interpreted as bools
-	// or which contain special YAML chars need to be quoted.
-	for k, v := range config {
-		strValue, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if boolValues.Contains(strValue) || strings.IndexAny(strValue, specialValues) >= 0 {
-			strValue = strings.Replace(strValue, "'", "''", -1)
-			config[k] = fmt.Sprintf("'%s'", strValue)
-		}
-	}
 }
 
 type k8sContainers struct {

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -72,6 +72,9 @@ type K8sContainerSpec struct {
 	LivenessProbe   *core.Probe           `json:"livenessProbe,omitempty" yaml:"livenessProbe,omitempty"`
 	ReadinessProbe  *core.Probe           `json:"readinessProbe,omitempty" yaml:"readinessProbe,omitempty"`
 	SecurityContext *core.SecurityContext `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
+
+	EnvFrom []core.EnvFromSource `json:"envFrom,omitempty" yaml:"envFrom,omitempty"`
+	Env     []core.EnvVar        `json:"env,omitempty" yaml:"env,omitempty"`
 }
 
 // Validate validates K8sContainerSpec.

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -5,10 +5,10 @@ package specs_test
 
 import (
 	"encoding/base64"
-	"sort"
+	// "sort"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/kr/pretty"
+	// "github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	core "k8s.io/api/core/v1"
@@ -68,33 +68,6 @@ containers:
         httpGet:
           path: /pingReady
           port: www
-      env:
-        - name: DEMO_GREETING
-          value: "Hello from the environment"
-        - name: MY_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: BACKEND_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: backend-user
-              key: backend-username
-        - name: SPECIAL_LEVEL_KEY
-          valueFrom:
-            configMapKeyRef:
-              name: special-config
-              key: special.how
-        - name: MY_MEM_LIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: test-container
-              resource: limits.memory
-      envFrom:
-      - configMapRef:
-          name: special-config
-      - secretRef:
-          name: test-secret
     config:
       attr: foo=bar; name["fred"]="blogs";
       foo: bar
@@ -332,33 +305,33 @@ foo: bar
 		// always parse to latest version.
 		pSpecs.Version = specs.CurrentVersion
 
-		envVar1 := core.EnvVar{
-			Name: "BACKEND_USERNAME", ValueFrom: &core.EnvVarSource{
-				SecretKeyRef: &core.SecretKeySelector{
-					Key: "backend-username",
-				},
-			},
-		}
-		envVar1.ValueFrom.SecretKeyRef.Name = "backend-user"
+		// envVar1 := core.EnvVar{
+		// 	Name: "BACKEND_USERNAME", ValueFrom: &core.EnvVarSource{
+		// 		SecretKeyRef: &core.SecretKeySelector{
+		// 			Key: "backend-username",
+		// 		},
+		// 	},
+		// }
+		// envVar1.ValueFrom.SecretKeyRef.Name = "backend-user"
 
-		envVar2 := core.EnvVar{
-			Name: "SPECIAL_LEVEL_KEY", ValueFrom: &core.EnvVarSource{
-				ConfigMapKeyRef: &core.ConfigMapKeySelector{
-					Key: "special.how",
-				},
-			},
-		}
-		envVar2.ValueFrom.ConfigMapKeyRef.Name = "special-config"
+		// envVar2 := core.EnvVar{
+		// 	Name: "SPECIAL_LEVEL_KEY", ValueFrom: &core.EnvVarSource{
+		// 		ConfigMapKeyRef: &core.ConfigMapKeySelector{
+		// 			Key: "special.how",
+		// 		},
+		// 	},
+		// }
+		// envVar2.ValueFrom.ConfigMapKeyRef.Name = "special-config"
 
-		envFrom1 := core.EnvFromSource{
-			ConfigMapRef: &core.ConfigMapEnvSource{},
-		}
-		envFrom1.ConfigMapRef.Name = "special-config"
+		// envFrom1 := core.EnvFromSource{
+		// 	ConfigMapRef: &core.ConfigMapEnvSource{},
+		// }
+		// envFrom1.ConfigMapRef.Name = "special-config"
 
-		envFrom2 := core.EnvFromSource{
-			SecretRef: &core.SecretEnvSource{},
-		}
-		envFrom2.SecretRef.Name = "test-secret"
+		// envFrom2 := core.EnvFromSource{
+		// 	SecretRef: &core.SecretEnvSource{},
+		// }
+		// envFrom2.SecretRef.Name = "test-secret"
 
 		pSpecs.Containers = []specs.ContainerSpec{
 			{
@@ -376,12 +349,12 @@ echo "do some stuff here for gitlab container"
 					{ContainerPort: 443, Name: "mary"},
 				},
 				Config: map[string]interface{}{
-					"attr":       `'foo=bar; name["fred"]="blogs";'`,
+					"attr":       `foo=bar; name["fred"]="blogs";`,
 					"foo":        "bar",
-					"restricted": "'yes'",
+					"restricted": "yes",
 					"switch":     true,
-					"brackets":   `'["hello", "world"]'`,
-					"special":    "'p@ssword''s'",
+					"brackets":   `["hello", "world"]`,
+					"special":    "p@ssword's",
 				},
 				Files: []specs.FileSet{
 					{
@@ -415,30 +388,30 @@ echo "do some stuff here for gitlab container"
 							},
 						},
 					},
-					Env: []core.EnvVar{
-						{
-							Name: "DEMO_GREETING", Value: "Hello from the environment",
-						},
-						{
-							Name: "MY_NODE_NAME", ValueFrom: &core.EnvVarSource{
-								FieldRef: &core.ObjectFieldSelector{
-									FieldPath: "spec.nodeName",
-								},
-							},
-						},
-						envVar1, envVar2,
-						{
-							Name: "MY_MEM_LIMIT", ValueFrom: &core.EnvVarSource{
-								ResourceFieldRef: &core.ResourceFieldSelector{
-									ContainerName: "test-container", Resource: "limits.memory",
-								},
-							},
-						},
-					},
-					EnvFrom: []core.EnvFromSource{
-						envFrom1,
-						envFrom2,
-					},
+					// Env: []core.EnvVar{
+					// 	{
+					// 		Name: "DEMO_GREETING", Value: "Hello from the environment",
+					// 	},
+					// 	{
+					// 		Name: "MY_NODE_NAME", ValueFrom: &core.EnvVarSource{
+					// 			FieldRef: &core.ObjectFieldSelector{
+					// 				FieldPath: "spec.nodeName",
+					// 			},
+					// 		},
+					// 	},
+					// 	envVar1, envVar2,
+					// 	{
+					// 		Name: "MY_MEM_LIMIT", ValueFrom: &core.EnvVarSource{
+					// 			ResourceFieldRef: &core.ResourceFieldSelector{
+					// 				ContainerName: "test-container", Resource: "limits.memory",
+					// 			},
+					// 		},
+					// 	},
+					// },
+					// EnvFrom: []core.EnvFromSource{
+					// 	envFrom1,
+					// 	envFrom2,
+					// },
 				},
 			}, {
 				Name:  "gitlab-helper",
@@ -476,10 +449,10 @@ echo "do some stuff here for gitlab-init container"
 				},
 				Config: map[string]interface{}{
 					"foo":        "bar",
-					"restricted": "'yes'",
+					"restricted": "yes",
 					"switch":     true,
-					"brackets":   `'["hello", "world"]'`,
-					"special":    "'p@ssword''s'",
+					"brackets":   `["hello", "world"]`,
+					"special":    "p@ssword's",
 				},
 			},
 		}
@@ -767,124 +740,6 @@ containers:
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
 	c.Assert(err, gc.ErrorMatches, `file set name is missing`)
-}
-
-func (s *v2SpecsSuite) TestContainerConfigToK8sEnvConfig(c *gc.C) {
-
-	specStr := versionHeader + `
-containers:
-  - name: gitlab
-    image: gitlab/latest
-    config:
-      attr: foo=bar; name["fred"]="blogs";
-      foo: bar
-      brackets: '["hello", "world"]'
-      restricted: 'yes'
-      switch: on
-      special: p@ssword's
-      foo: bar
-      aFloatConfig: 111.11111111
-      anIntConfig: 111
-      current-k8s-node-name:
-        fieldRef:
-          fieldPath: spec.nodeName
-      thing:
-         secretKeyRef:
-           name: foo
-           key: bar
-      thing1:
-         configMapKeyRef:
-           name: foo
-           key: bar
-      secretRef:
-        - name: secret1
-          optional: true
-        - name: secret2
-      configMapRef:
-        - name: configmap1
-          optional: true
-        - name: configmap2
-`[1:]
-
-	envVarThing := core.EnvVar{
-		Name: "thing",
-		ValueFrom: &core.EnvVarSource{
-			SecretKeyRef: &core.SecretKeySelector{Key: "bar"},
-		},
-	}
-	envVarThing.ValueFrom.SecretKeyRef.Name = "foo"
-
-	envVarThing1 := core.EnvVar{
-		Name: "thing1",
-		ValueFrom: &core.EnvVarSource{
-			ConfigMapKeyRef: &core.ConfigMapKeySelector{Key: "bar"},
-		},
-	}
-	envVarThing1.ValueFrom.ConfigMapKeyRef.Name = "foo"
-
-	envFromSourceSecret1 := core.EnvFromSource{
-		SecretRef: &core.SecretEnvSource{Optional: boolPtr(true)},
-	}
-	envFromSourceSecret1.SecretRef.Name = "secret1"
-
-	envFromSourceSecret2 := core.EnvFromSource{
-		SecretRef: &core.SecretEnvSource{},
-	}
-	envFromSourceSecret2.SecretRef.Name = "secret2"
-
-	envFromSourceConfigmap1 := core.EnvFromSource{
-		ConfigMapRef: &core.ConfigMapEnvSource{Optional: boolPtr(true)},
-	}
-	envFromSourceConfigmap1.ConfigMapRef.Name = "configmap1"
-
-	envFromSourceConfigmap2 := core.EnvFromSource{
-		ConfigMapRef: &core.ConfigMapEnvSource{},
-	}
-	envFromSourceConfigmap2.ConfigMapRef.Name = "configmap2"
-
-	specs, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, jc.ErrorIsNil)
-	envVars, envFromSource, err := k8sspecs.ContainerConfigToK8sEnvConfig(specs.Containers[0].Config)
-	c.Assert(err, jc.ErrorIsNil)
-	expectedEnvVar := []core.EnvVar{
-		{Name: "attr", Value: `'foo=bar; name["fred"]="blogs";'`},
-		{Name: "foo", Value: "bar"},
-		{Name: "brackets", Value: `'["hello", "world"]'`},
-		{Name: "restricted", Value: "'yes'"},
-		{Name: "switch", Value: "true"},
-		{Name: "special", Value: "'p@ssword''s'"},
-		{Name: "aFloatConfig", Value: "111.11111111"},
-		{Name: "anIntConfig", Value: "111"},
-		{Name: "current-k8s-node-name", ValueFrom: &core.EnvVarSource{FieldRef: &core.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
-		envVarThing,
-		envVarThing1,
-	}
-	expectedEnvFromSource := []core.EnvFromSource{
-		envFromSourceSecret1,
-		envFromSourceSecret2,
-		envFromSourceConfigmap1,
-		envFromSourceConfigmap2,
-	}
-	sort.SliceStable(expectedEnvVar, func(i, j int) bool {
-		return len(expectedEnvVar[i].Name) < len(expectedEnvVar[j].Name)
-	})
-	sort.SliceStable(envVars, func(i, j int) bool {
-		return len(envVars[i].Name) < len(envVars[j].Name)
-	})
-	// sort.SliceStable(expectedEnvFromSource, func(i, j int) bool {
-	// 	return len(expectedEnvFromSource[i].Name) < len(expectedEnvFromSource[j].Name)
-	// })
-	// sort.SliceStable(envFromSource, func(i, j int) bool {
-	// 	return len(envFromSource[i].Name) < len(envFromSource[j].Name)
-	// })
-
-	c.Logf("envVars -> %s", pretty.Sprint(envVars))
-	c.Logf("expectedEnvVar -> %s", pretty.Sprint(expectedEnvVar))
-	c.Logf("envFromSource -> %s", pretty.Sprint(envFromSource))
-	c.Logf("expectedEnvFromSource -> %s", pretty.Sprint(expectedEnvFromSource))
-	c.Assert(envVars, jc.SameContents, expectedEnvVar)
-	c.Assert(envFromSource, jc.SameContents, expectedEnvFromSource)
-
 }
 
 func (s *v2SpecsSuite) TestValidateMissingMountPath(c *gc.C) {

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -5,8 +5,10 @@ package specs_test
 
 import (
 	"encoding/base64"
+	"sort"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	core "k8s.io/api/core/v1"
@@ -765,6 +767,124 @@ containers:
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
 	c.Assert(err, gc.ErrorMatches, `file set name is missing`)
+}
+
+func (s *v2SpecsSuite) TestContainerConfigToK8sEnvConfig(c *gc.C) {
+
+	specStr := versionHeader + `
+containers:
+  - name: gitlab
+    image: gitlab/latest
+    config:
+      attr: foo=bar; name["fred"]="blogs";
+      foo: bar
+      brackets: '["hello", "world"]'
+      restricted: 'yes'
+      switch: on
+      special: p@ssword's
+      foo: bar
+      aFloatConfig: 111.11111111
+      anIntConfig: 111
+      current-k8s-node-name:
+        fieldRef:
+          fieldPath: spec.nodeName
+      thing:
+         secretKeyRef:
+           name: foo
+           key: bar
+      thing1:
+         configMapKeyRef:
+           name: foo
+           key: bar
+      secretRef:
+        - name: secret1
+          optional: true
+        - name: secret2
+      configMapRef:
+        - name: configmap1
+          optional: true
+        - name: configmap2
+`[1:]
+
+	envVarThing := core.EnvVar{
+		Name: "thing",
+		ValueFrom: &core.EnvVarSource{
+			SecretKeyRef: &core.SecretKeySelector{Key: "bar"},
+		},
+	}
+	envVarThing.ValueFrom.SecretKeyRef.Name = "foo"
+
+	envVarThing1 := core.EnvVar{
+		Name: "thing1",
+		ValueFrom: &core.EnvVarSource{
+			ConfigMapKeyRef: &core.ConfigMapKeySelector{Key: "bar"},
+		},
+	}
+	envVarThing1.ValueFrom.ConfigMapKeyRef.Name = "foo"
+
+	envFromSourceSecret1 := core.EnvFromSource{
+		SecretRef: &core.SecretEnvSource{Optional: boolPtr(true)},
+	}
+	envFromSourceSecret1.SecretRef.Name = "secret1"
+
+	envFromSourceSecret2 := core.EnvFromSource{
+		SecretRef: &core.SecretEnvSource{},
+	}
+	envFromSourceSecret2.SecretRef.Name = "secret2"
+
+	envFromSourceConfigmap1 := core.EnvFromSource{
+		ConfigMapRef: &core.ConfigMapEnvSource{Optional: boolPtr(true)},
+	}
+	envFromSourceConfigmap1.ConfigMapRef.Name = "configmap1"
+
+	envFromSourceConfigmap2 := core.EnvFromSource{
+		ConfigMapRef: &core.ConfigMapEnvSource{},
+	}
+	envFromSourceConfigmap2.ConfigMapRef.Name = "configmap2"
+
+	specs, err := k8sspecs.ParsePodSpec(specStr)
+	c.Assert(err, jc.ErrorIsNil)
+	envVars, envFromSource, err := k8sspecs.ContainerConfigToK8sEnvConfig(specs.Containers[0].Config)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedEnvVar := []core.EnvVar{
+		{Name: "attr", Value: `'foo=bar; name["fred"]="blogs";'`},
+		{Name: "foo", Value: "bar"},
+		{Name: "brackets", Value: `'["hello", "world"]'`},
+		{Name: "restricted", Value: "'yes'"},
+		{Name: "switch", Value: "true"},
+		{Name: "special", Value: "'p@ssword''s'"},
+		{Name: "aFloatConfig", Value: "111.11111111"},
+		{Name: "anIntConfig", Value: "111"},
+		{Name: "current-k8s-node-name", ValueFrom: &core.EnvVarSource{FieldRef: &core.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		envVarThing,
+		envVarThing1,
+	}
+	expectedEnvFromSource := []core.EnvFromSource{
+		envFromSourceSecret1,
+		envFromSourceSecret2,
+		envFromSourceConfigmap1,
+		envFromSourceConfigmap2,
+	}
+	sort.SliceStable(expectedEnvVar, func(i, j int) bool {
+		return len(expectedEnvVar[i].Name) < len(expectedEnvVar[j].Name)
+	})
+	sort.SliceStable(envVars, func(i, j int) bool {
+		return len(envVars[i].Name) < len(envVars[j].Name)
+	})
+	// sort.SliceStable(expectedEnvFromSource, func(i, j int) bool {
+	// 	return len(expectedEnvFromSource[i].Name) < len(expectedEnvFromSource[j].Name)
+	// })
+	// sort.SliceStable(envFromSource, func(i, j int) bool {
+	// 	return len(envFromSource[i].Name) < len(envFromSource[j].Name)
+	// })
+
+	c.Logf("envVars -> %s", pretty.Sprint(envVars))
+	c.Logf("expectedEnvVar -> %s", pretty.Sprint(expectedEnvVar))
+	c.Logf("envFromSource -> %s", pretty.Sprint(envFromSource))
+	c.Logf("expectedEnvFromSource -> %s", pretty.Sprint(expectedEnvFromSource))
+	c.Assert(envVars, jc.SameContents, expectedEnvVar)
+	c.Assert(envFromSource, jc.SameContents, expectedEnvFromSource)
+
 }
 
 func (s *v2SpecsSuite) TestValidateMissingMountPath(c *gc.C) {

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -5,10 +5,8 @@ package specs_test
 
 import (
 	"encoding/base64"
-	// "sort"
 
 	jc "github.com/juju/testing/checkers"
-	// "github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	core "k8s.io/api/core/v1"
@@ -75,6 +73,11 @@ containers:
       restricted: 'yes'
       switch: on
       special: p@ssword's
+      my-resource-limit:
+        resource:
+          container-name: container1
+          resource: requests.cpu
+          divisor: 1m
     files:
       - name: configuration
         mountPath: /var/lib/foo
@@ -305,34 +308,6 @@ foo: bar
 		// always parse to latest version.
 		pSpecs.Version = specs.CurrentVersion
 
-		// envVar1 := core.EnvVar{
-		// 	Name: "BACKEND_USERNAME", ValueFrom: &core.EnvVarSource{
-		// 		SecretKeyRef: &core.SecretKeySelector{
-		// 			Key: "backend-username",
-		// 		},
-		// 	},
-		// }
-		// envVar1.ValueFrom.SecretKeyRef.Name = "backend-user"
-
-		// envVar2 := core.EnvVar{
-		// 	Name: "SPECIAL_LEVEL_KEY", ValueFrom: &core.EnvVarSource{
-		// 		ConfigMapKeyRef: &core.ConfigMapKeySelector{
-		// 			Key: "special.how",
-		// 		},
-		// 	},
-		// }
-		// envVar2.ValueFrom.ConfigMapKeyRef.Name = "special-config"
-
-		// envFrom1 := core.EnvFromSource{
-		// 	ConfigMapRef: &core.ConfigMapEnvSource{},
-		// }
-		// envFrom1.ConfigMapRef.Name = "special-config"
-
-		// envFrom2 := core.EnvFromSource{
-		// 	SecretRef: &core.SecretEnvSource{},
-		// }
-		// envFrom2.SecretRef.Name = "test-secret"
-
 		pSpecs.Containers = []specs.ContainerSpec{
 			{
 				Name:            "gitlab",
@@ -355,6 +330,13 @@ echo "do some stuff here for gitlab container"
 					"switch":     true,
 					"brackets":   `["hello", "world"]`,
 					"special":    "p@ssword's",
+					"my-resource-limit": map[string]interface{}{
+						"resource": map[string]interface{}{
+							"container-name": "container1",
+							"resource":       "requests.cpu",
+							"divisor":        "1m",
+						},
+					},
 				},
 				Files: []specs.FileSet{
 					{
@@ -388,30 +370,6 @@ echo "do some stuff here for gitlab container"
 							},
 						},
 					},
-					// Env: []core.EnvVar{
-					// 	{
-					// 		Name: "DEMO_GREETING", Value: "Hello from the environment",
-					// 	},
-					// 	{
-					// 		Name: "MY_NODE_NAME", ValueFrom: &core.EnvVarSource{
-					// 			FieldRef: &core.ObjectFieldSelector{
-					// 				FieldPath: "spec.nodeName",
-					// 			},
-					// 		},
-					// 	},
-					// 	envVar1, envVar2,
-					// 	{
-					// 		Name: "MY_MEM_LIMIT", ValueFrom: &core.EnvVarSource{
-					// 			ResourceFieldRef: &core.ResourceFieldSelector{
-					// 				ContainerName: "test-container", Resource: "limits.memory",
-					// 			},
-					// 		},
-					// 	},
-					// },
-					// EnvFrom: []core.EnvFromSource{
-					// 	envFrom1,
-					// 	envFrom2,
-					// },
 				},
 			}, {
 				Name:  "gitlab-helper",

--- a/caas/kubernetes/provider/template.go
+++ b/caas/kubernetes/provider/template.go
@@ -32,13 +32,6 @@ var containerTemplate = `
   {{end}}
   {{if .WorkingDir}}
   workingDir: {{.WorkingDir}}
-  {{end}}
-  {{if .Config}}
-  env:
-  {{- range $k, $v := .Config }}
-    - name: {{$k}}
-      value: {{$v}}
-  {{- end}}
   {{end}}`[1:]
 
 var defaultPodTemplateStr = fmt.Sprintf(`

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -52,7 +52,7 @@ type ImageDetails struct {
 // PullPolicy describes a policy for if/when to pull a container image.
 type PullPolicy string
 
-// ContainerConfig describes a config map for a container.
+// ContainerConfig describes the config used for setting up a pod container's environment variables.
 type ContainerConfig map[string]interface{}
 
 // ContainerSpec defines the data values used to configure

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -52,6 +52,9 @@ type ImageDetails struct {
 // PullPolicy describes a policy for if/when to pull a container image.
 type PullPolicy string
 
+// ContainerConfig describes a config map for a container.
+type ContainerConfig map[string]interface{}
+
 // ContainerSpec defines the data values used to configure
 // a container on the CAAS substrate.
 type ContainerSpec struct {
@@ -66,8 +69,8 @@ type ContainerSpec struct {
 	Args       []string `json:"args,omitempty" yaml:"args,omitempty"`
 	WorkingDir string   `json:"workingDir,omitempty" yaml:"workingDir,omitempty"`
 
-	Config map[string]interface{} `json:"config,omitempty" yaml:"config,omitempty"`
-	Files  []FileSet              `json:"files,omitempty" yaml:"files,omitempty"`
+	Config ContainerConfig `json:"config,omitempty" yaml:"config,omitempty"`
+	Files  []FileSet       `json:"files,omitempty" yaml:"files,omitempty"`
 
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -87,7 +87,7 @@ func getParsedSpec() *specs.PodSpec {
 				{ContainerPort: 443},
 			},
 			Config: map[string]interface{}{
-				"attr": "'foo=bar; fred=blogs'",
+				"attr": "foo=bar; fred=blogs",
 				"foo":  "bar",
 			},
 		},


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Introduce `config` options in k8sspec for environment value mount using `Env` and `EnvFrom`.

## QA steps

deploy a CaaS application with below k8s spec format;

```yaml
containers:
  - name: gitlab
    image: gitlab/latest
    config:
      attr: foo=bar; name["fred"]="blogs";
      foo: bar
      brackets: '["hello", "world"]'
      restricted: 'yes'
      switch: on
      bar: true
      special: p@ssword's
      foo: bar
      float: 111.11111111
      int: 111
      MY_NODE_NAME:
        field:
          path: spec.nodeName
          api-version: v1
      my-resource-limit:
        resource:
          container-name: container1
          resource: requests.cpu
          divisor: 1m
      thing:
        secret:
          name: foo
          key: bar
      a-secret:
        secret:
          name: secret1
          optional: true
      another-secret:
        secret:
          name: secret2
      thing1:
        config-map:
          name: foo
          key: bar
      a-configmap:
        config-map:
          name: configmap1
          optional: true
      another-configmap:
        config-map:
          name: configmap2
```

```console
$ cat reactive/spec_template.yaml
version: 2
omitServiceFrontend: true
containers:
  - name: %(name)s
    imageDetails:
      imagePath: %(docker_image_path)s
      username: %(docker_image_username)s
      password: %(docker_image_password)s
    ports:
      - containerPort: %(port)s
        protocol: TCP
    config:
      MYSQL_ROOT_PASSWORD: %(root_password)s
      MYSQL_USER: %(user)s
      MYSQL_PASSWORD: %(password)s
      MYSQL_DATABASE: %(database)s
      MY_NODE_NAME:
        field:
          path: spec.nodeName
          api-version: v1
      build-robot-secret:
        secret:
          name: build-robot-secret
      ...

$ mkubectl get pod/mariadb-k8s-0 -n t1 -o jsonpath="{..env}"
[map[name:MYSQL_DATABASE value:database] map[name:MYSQL_PASSWORD value:password] map[name:MYSQL_ROOT_PASSWORD value:root] map[name:MYSQL_USER value:admin] map[name:MY_NODE_NAME valueFrom:map[fieldRef:map[apiVersion:v1 fieldPath:spec.nodeName]]] map[name:build-robot-secret valueFrom:map[secretKeyRef:map[key:config.yaml name:build-robot-secret]]]]

$ juju run --unit mariadb-k8s/2 --timeout=30s "env" --operator=false -m k1:t1
MYSQL_ROOT_PASSWORD=root
MYSQL_USER=admin
MYSQL_PASSWORD=password
MYSQL_DATABASE=database
MY_NODE_NAME=ubuntu
username=admin  # from `secret/build-robot-secret`
password=1f2d1e2e67df  # from `secret/build-robot-secret`
...

```

## Documentation changes

Yes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1858515
