### PR TITLE
2.7 Relocate Systemd Files

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -361,7 +361,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 
 	// We add the machine agent's configuration info
 	// before running bootstrap-state so that bootstrap-state
-	// has a chance to rerwrite it to change the password.
+	// has a chance to rewrite it to change the password.
 	// It would be cleaner to change bootstrap-state to
 	// be responsible for starting the machine agent itself,
 	// but this would not be backwardly compatible.

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -227,13 +227,7 @@ func (s *systemdServiceManager) WriteSystemdAgents(
 
 		// Otherwise we need to manually ensure the service unit links.
 		svcFileName := svcName + ".service"
-		if err = os.Symlink(path.Join(systemd.LibSystemdDir, svcName, svcFileName),
-			path.Join(symLinkSystemdDir, svcFileName)); err != nil && !os.IsExist(err) {
-			return nil, nil, nil, errors.Errorf(
-				"failed to link service file (%s) in systemd dir: %s\n", svcFileName, err)
-		}
-
-		if err = os.Symlink(path.Join(systemd.LibSystemdDir, svcName, svcFileName),
+		if err = os.Symlink(path.Join(systemd.EtcSystemdDir, svcFileName),
 			path.Join(symLinkSystemdMultiUserDir, svcFileName)); err != nil && !os.IsExist(err) {
 			return nil, nil, nil, errors.Errorf(
 				"failed to link service file (%s) in multi-user.target.wants dir: %s\n", svcFileName, err)

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	svctesting "github.com/juju/juju/service/common/testing"
-	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/testing"
 	coretest "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -314,7 +313,6 @@ func (s *agentConfSuite) TestWriteSystemdAgentsSystemdNotRunning(c *gc.C) {
 	c.Assert(startedSysServiceNames, gc.DeepEquals, append(s.agentUnitNames(), "jujud-"+s.machineName))
 	c.Assert(errAgents, gc.HasLen, 0)
 	s.assertServicesCalls(c, "WriteService", len(s.services))
-	s.assertServiceSymLinks(c)
 }
 
 func (s *agentConfSuite) TestWriteSystemdAgentsDBusErrManualLink(c *gc.C) {
@@ -369,16 +367,6 @@ func (s *agentConfSuite) assertToolsCopySymlink(c *gc.C, series string) {
 		linkResult, err := os.Readlink(link)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(linkResult, gc.Equals, path.Join(s.dataDir, "tools", ver.String()))
-	}
-}
-
-func (s *agentConfSuite) assertServiceSymLinks(c *gc.C) {
-	for _, name := range append(s.unitNames, s.machineName) {
-		svcName := "jujud-" + name
-		svcFileName := svcName + ".service"
-		result, err := os.Readlink(path.Join(s.systemdDir, svcFileName))
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(result, gc.Equals, path.Join(systemd.LibSystemdDir, svcName, svcFileName))
 	}
 }
 

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -23,13 +23,12 @@ import (
 // DiscoverService returns an interface to a service appropriate
 // for the current system
 func DiscoverService(name string, conf common.Conf) (Service, error) {
-	hostSeries := series.MustHostSeries()
-	initName, err := discoverInitSystem(hostSeries)
+	initName, err := discoverInitSystem(series.MustHostSeries())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	service, err := newService(name, conf, initName, hostSeries)
+	service, err := newService(name, conf, initName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -128,11 +128,11 @@ var NewService = func(name string, conf common.Conf, series string) (Service, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newService(name, conf, initSystem, series)
+	return newService(name, conf, initSystem)
 }
 
 // this needs to be stubbed out in some tests
-func newService(name string, conf common.Conf, initSystem, series string) (Service, error) {
+func newService(name string, conf common.Conf, initSystem string) (Service, error) {
 	var svc Service
 	var err error
 

--- a/service/systemd/dbusapi_mock_test.go
+++ b/service/systemd/dbusapi_mock_test.go
@@ -5,10 +5,9 @@
 package systemd_test
 
 import (
-	reflect "reflect"
-
 	dbus "github.com/coreos/go-systemd/dbus"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockDBusAPI is a mock of DBusAPI interface
@@ -36,16 +35,19 @@ func (m *MockDBusAPI) EXPECT() *MockDBusAPIMockRecorder {
 
 // Close mocks base method
 func (m *MockDBusAPI) Close() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Close")
 }
 
 // Close indicates an expected call of Close
 func (mr *MockDBusAPIMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDBusAPI)(nil).Close))
 }
 
 // DisableUnitFiles mocks base method
 func (m *MockDBusAPI) DisableUnitFiles(arg0 []string, arg1 bool) ([]dbus.DisableUnitFileChange, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableUnitFiles", arg0, arg1)
 	ret0, _ := ret[0].([]dbus.DisableUnitFileChange)
 	ret1, _ := ret[1].(error)
@@ -54,11 +56,13 @@ func (m *MockDBusAPI) DisableUnitFiles(arg0 []string, arg1 bool) ([]dbus.Disable
 
 // DisableUnitFiles indicates an expected call of DisableUnitFiles
 func (mr *MockDBusAPIMockRecorder) DisableUnitFiles(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableUnitFiles", reflect.TypeOf((*MockDBusAPI)(nil).DisableUnitFiles), arg0, arg1)
 }
 
 // EnableUnitFiles mocks base method
 func (m *MockDBusAPI) EnableUnitFiles(arg0 []string, arg1, arg2 bool) (bool, []dbus.EnableUnitFileChange, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableUnitFiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].([]dbus.EnableUnitFileChange)
@@ -68,11 +72,13 @@ func (m *MockDBusAPI) EnableUnitFiles(arg0 []string, arg1, arg2 bool) (bool, []d
 
 // EnableUnitFiles indicates an expected call of EnableUnitFiles
 func (mr *MockDBusAPIMockRecorder) EnableUnitFiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableUnitFiles", reflect.TypeOf((*MockDBusAPI)(nil).EnableUnitFiles), arg0, arg1, arg2)
 }
 
 // GetUnitProperties mocks base method
 func (m *MockDBusAPI) GetUnitProperties(arg0 string) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitProperties", arg0)
 	ret0, _ := ret[0].(map[string]interface{})
 	ret1, _ := ret[1].(error)
@@ -81,11 +87,13 @@ func (m *MockDBusAPI) GetUnitProperties(arg0 string) (map[string]interface{}, er
 
 // GetUnitProperties indicates an expected call of GetUnitProperties
 func (mr *MockDBusAPIMockRecorder) GetUnitProperties(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitProperties", reflect.TypeOf((*MockDBusAPI)(nil).GetUnitProperties), arg0)
 }
 
 // GetUnitTypeProperties mocks base method
 func (m *MockDBusAPI) GetUnitTypeProperties(arg0, arg1 string) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitTypeProperties", arg0, arg1)
 	ret0, _ := ret[0].(map[string]interface{})
 	ret1, _ := ret[1].(error)
@@ -94,11 +102,13 @@ func (m *MockDBusAPI) GetUnitTypeProperties(arg0, arg1 string) (map[string]inter
 
 // GetUnitTypeProperties indicates an expected call of GetUnitTypeProperties
 func (mr *MockDBusAPIMockRecorder) GetUnitTypeProperties(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitTypeProperties", reflect.TypeOf((*MockDBusAPI)(nil).GetUnitTypeProperties), arg0, arg1)
 }
 
 // LinkUnitFiles mocks base method
 func (m *MockDBusAPI) LinkUnitFiles(arg0 []string, arg1, arg2 bool) ([]dbus.LinkUnitFileChange, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LinkUnitFiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]dbus.LinkUnitFileChange)
 	ret1, _ := ret[1].(error)
@@ -107,11 +117,13 @@ func (m *MockDBusAPI) LinkUnitFiles(arg0 []string, arg1, arg2 bool) ([]dbus.Link
 
 // LinkUnitFiles indicates an expected call of LinkUnitFiles
 func (mr *MockDBusAPIMockRecorder) LinkUnitFiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkUnitFiles", reflect.TypeOf((*MockDBusAPI)(nil).LinkUnitFiles), arg0, arg1, arg2)
 }
 
 // ListUnits mocks base method
 func (m *MockDBusAPI) ListUnits() ([]dbus.UnitStatus, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUnits")
 	ret0, _ := ret[0].([]dbus.UnitStatus)
 	ret1, _ := ret[1].(error)
@@ -120,11 +132,13 @@ func (m *MockDBusAPI) ListUnits() ([]dbus.UnitStatus, error) {
 
 // ListUnits indicates an expected call of ListUnits
 func (mr *MockDBusAPIMockRecorder) ListUnits() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUnits", reflect.TypeOf((*MockDBusAPI)(nil).ListUnits))
 }
 
 // Reload mocks base method
 func (m *MockDBusAPI) Reload() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reload")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -132,11 +146,13 @@ func (m *MockDBusAPI) Reload() error {
 
 // Reload indicates an expected call of Reload
 func (mr *MockDBusAPIMockRecorder) Reload() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reload", reflect.TypeOf((*MockDBusAPI)(nil).Reload))
 }
 
 // StartUnit mocks base method
 func (m *MockDBusAPI) StartUnit(arg0, arg1 string, arg2 chan<- string) (int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
@@ -145,11 +161,13 @@ func (m *MockDBusAPI) StartUnit(arg0, arg1 string, arg2 chan<- string) (int, err
 
 // StartUnit indicates an expected call of StartUnit
 func (mr *MockDBusAPIMockRecorder) StartUnit(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartUnit", reflect.TypeOf((*MockDBusAPI)(nil).StartUnit), arg0, arg1, arg2)
 }
 
 // StopUnit mocks base method
 func (m *MockDBusAPI) StopUnit(arg0, arg1 string, arg2 chan<- string) (int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
@@ -158,5 +176,6 @@ func (m *MockDBusAPI) StopUnit(arg0, arg1 string, arg2 chan<- string) (int, erro
 
 // StopUnit indicates an expected call of StopUnit
 func (mr *MockDBusAPIMockRecorder) StopUnit(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopUnit", reflect.TypeOf((*MockDBusAPI)(nil).StopUnit), arg0, arg1, arg2)
 }

--- a/service/systemd/export_test.go
+++ b/service/systemd/export_test.go
@@ -32,8 +32,7 @@ func PatchNewChan(patcher patcher) chan string {
 
 func PatchFileOps(patcher patcher, ctrl *gomock.Controller) *MockShimFileOps {
 	mock := NewMockShimFileOps(ctrl)
-	patcher.PatchValue(&removeAll, mock.RemoveAll)
-	patcher.PatchValue(&mkdirAll, mock.MkdirAll)
+	patcher.PatchValue(&remove, mock.Remove)
 	patcher.PatchValue(&createFile, mock.CreateFile)
 	return mock
 }

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -6,6 +6,7 @@ package systemd_test
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/coreos/go-systemd/dbus"
@@ -108,7 +109,7 @@ func (s *initSystemSuite) newService(c *gc.C) *systemd.Service {
 		fac = func() (systemd.DBusAPI, error) { return s.dBus, nil }
 	}
 
-	svc, err := systemd.NewService(s.name, s.conf, "/lib/systemd/system", fac, renderer.Join(s.dataDir, "init"))
+	svc, err := systemd.NewService(s.name, s.conf, systemd.EtcSystemdDir, fac, renderer.Join(s.dataDir, "init"))
 	c.Assert(err, jc.ErrorIsNil)
 	return svc
 }
@@ -119,7 +120,7 @@ func (s *initSystemSuite) expectConf(c *gc.C, conf common.Conf) *gomock.Call {
 
 	return s.exec.EXPECT().RunCommands(
 		exec.RunParams{
-			Commands: "cat /lib/systemd/system/jujud-machine-0/jujud-machine-0.service",
+			Commands: "cat /etc/systemd/system/jujud-machine-0.service",
 		},
 	).Return(&exec.ExecResponse{Stdout: data}, nil)
 }
@@ -176,7 +177,7 @@ func (s *initSystemSuite) TestNewService(c *gc.C) {
 	c.Check(svc.Service, jc.DeepEquals, common.Service{Name: s.name, Conf: s.conf})
 	c.Check(svc.ConfName, gc.Equals, s.name+".service")
 	c.Check(svc.UnitName, gc.Equals, s.name+".service")
-	c.Check(svc.DirName, gc.Equals, fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name))
+	c.Check(svc.DirName, gc.Equals, systemd.EtcSystemdDir)
 }
 
 func (s *initSystemSuite) TestNewServiceLogfile(c *gc.C) {
@@ -184,7 +185,6 @@ func (s *initSystemSuite) TestNewServiceLogfile(c *gc.C) {
 	svc := s.newService(c)
 
 	user, group := paths.SyslogUserGroup()
-	dirName := fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name)
 	script := `
 #!/usr/bin/env bash
 
@@ -202,14 +202,14 @@ exec 2>&1
 		Name: s.name,
 		Conf: common.Conf{
 			Desc:      s.conf.Desc,
-			ExecStart: dirName + "/exec-start.sh",
+			ExecStart: path.Join(svc.DirName, svc.Name()+"-exec-start.sh"),
 			Logfile:   "/var/log/juju/machine-0.log",
 		},
 	})
 
 	c.Check(svc.ConfName, gc.Equals, s.name+".service")
 	c.Check(svc.UnitName, gc.Equals, s.name+".service")
-	c.Check(svc.DirName, gc.Equals, dirName)
+	c.Check(svc.DirName, gc.Equals, systemd.EtcSystemdDir)
 
 	// This gives us a more readable output if they aren't equal.
 	c.Check(string(svc.Script), gc.Equals, script)
@@ -217,12 +217,13 @@ exec 2>&1
 }
 
 func (s *initSystemSuite) TestNewServiceEmptyConf(c *gc.C) {
-	svc, err := systemd.NewService(s.name, common.Conf{}, "/lib/systemd/system", systemd.NewDBusAPI, renderer.Join(s.dataDir, "init"))
+	svc, err := systemd.NewService(
+		s.name, common.Conf{}, systemd.EtcSystemdDir, systemd.NewDBusAPI, renderer.Join(s.dataDir, "init"))
 	c.Assert(err, gc.IsNil)
 	c.Check(svc.Service, jc.DeepEquals, common.Service{Name: s.name})
 	c.Check(svc.ConfName, gc.Equals, s.name+".service")
 	c.Check(svc.UnitName, gc.Equals, s.name+".service")
-	c.Check(svc.DirName, gc.Equals, fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name))
+	c.Check(svc.DirName, gc.Equals, systemd.EtcSystemdDir)
 }
 
 func (s *initSystemSuite) TestNewServiceBasic(c *gc.C) {
@@ -231,14 +232,13 @@ func (s *initSystemSuite) TestNewServiceBasic(c *gc.C) {
 	c.Check(svc.Service, jc.DeepEquals, common.Service{Name: s.name, Conf: s.conf})
 	c.Check(svc.ConfName, gc.Equals, s.name+".service")
 	c.Check(svc.UnitName, gc.Equals, s.name+".service")
-	c.Check(svc.DirName, gc.Equals, fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name))
+	c.Check(svc.DirName, gc.Equals, systemd.EtcSystemdDir)
 }
 
 func (s *initSystemSuite) TestNewServiceExtraScript(c *gc.C) {
 	s.conf.ExtraScript = "'/path/to/another/command'"
 	svc := s.newService(c)
 
-	dirName := fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name)
 	script := `
 #!/usr/bin/env bash
 
@@ -249,13 +249,13 @@ func (s *initSystemSuite) TestNewServiceExtraScript(c *gc.C) {
 		Name: s.name,
 		Conf: common.Conf{
 			Desc:      s.conf.Desc,
-			ExecStart: dirName + "/exec-start.sh",
+			ExecStart: path.Join(svc.DirName, svc.Name()+"-exec-start.sh"),
 		},
 	})
 
 	c.Check(svc.ConfName, gc.Equals, s.name+".service")
 	c.Check(svc.UnitName, gc.Equals, s.name+".service")
-	c.Check(svc.DirName, gc.Equals, dirName)
+	c.Check(svc.DirName, gc.Equals, systemd.EtcSystemdDir)
 	c.Check(string(svc.Script), gc.Equals, script)
 }
 
@@ -263,7 +263,6 @@ func (s *initSystemSuite) TestNewServiceMultiLine(c *gc.C) {
 	s.conf.ExecStart = "a\nb\nc"
 	svc := s.newService(c)
 
-	dirName := fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name)
 	script := `
 #!/usr/bin/env bash
 
@@ -275,13 +274,13 @@ c`[1:]
 		Name: s.name,
 		Conf: common.Conf{
 			Desc:      s.conf.Desc,
-			ExecStart: dirName + "/exec-start.sh",
+			ExecStart: path.Join(svc.DirName, svc.Name()+"-exec-start.sh"),
 		},
 	})
 
 	c.Check(svc.ConfName, gc.Equals, s.name+".service")
 	c.Check(svc.UnitName, gc.Equals, s.name+".service")
-	c.Check(svc.DirName, gc.Equals, dirName)
+	c.Check(svc.DirName, gc.Equals, systemd.EtcSystemdDir)
 
 	// This gives us a more readable output if they aren't equal.
 	c.Check(string(svc.Script), gc.Equals, script)
@@ -358,7 +357,7 @@ func (s *initSystemSuite) TestExistsError(c *gc.C) {
 
 	s.exec.EXPECT().RunCommands(
 		exec.RunParams{
-			Commands: "cat /lib/systemd/system/jujud-machine-0/jujud-machine-0.service",
+			Commands: "cat /etc/systemd/system/jujud-machine-0.service",
 		},
 	).Return(nil, errFailure)
 
@@ -560,7 +559,8 @@ func (s *initSystemSuite) TestRemove(c *gc.C) {
 		s.exec.EXPECT().RunCommands(listCmdArg).Return(&exec.ExecResponse{Stdout: []byte(svc.Name())}, nil),
 		s.dBus.EXPECT().DisableUnitFiles([]string{svc.UnitName}, false).Return(nil, nil),
 		s.dBus.EXPECT().Reload().Return(nil),
-		s.fops.EXPECT().RemoveAll(svc.DirName).Return(nil),
+		s.fops.EXPECT().Remove(path.Join(svc.DirName, svc.ConfName)).Return(nil),
+		s.fops.EXPECT().Remove(path.Join(svc.DirName, svc.Name()+"-exec-start.sh")).Return(nil),
 		s.dBus.EXPECT().Close(),
 	)
 
@@ -582,12 +582,10 @@ func (s *initSystemSuite) TestInstall(c *gc.C) {
 	ctrl := s.patch(c)
 	defer ctrl.Finish()
 
-	dirName := fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name)
-	fileName := fmt.Sprintf("%s/%s.service", dirName, s.name)
+	fileName := fmt.Sprintf("%s/%s.service", systemd.EtcSystemdDir, s.name)
 
 	gomock.InOrder(
 		s.exec.EXPECT().RunCommands(listCmdArg).Return(&exec.ExecResponse{Stdout: []byte("")}, nil),
-		s.fops.EXPECT().MkdirAll(dirName).Return(nil),
 		s.fops.EXPECT().CreateFile(fileName, []byte(s.newConfStr(s.name)), os.FileMode(0644)).Return(nil),
 		s.dBus.EXPECT().LinkUnitFiles([]string{fileName}, false, true).Return(nil, nil),
 		s.dBus.EXPECT().Reload().Return(nil),
@@ -627,11 +625,16 @@ func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
 	}
 	s.expectConf(c, conf)
 	conf.Env["a"] = "c"
-	svc, err := systemd.NewService(s.name, conf, "/lib/systemd/system", func() (systemd.DBusAPI, error) { return s.dBus, nil }, renderer.Join(s.dataDir, "init"))
+	svc, err := systemd.NewService(
+		s.name,
+		conf,
+		systemd.EtcSystemdDir,
+		func() (systemd.DBusAPI, error) { return s.dBus, nil },
+		renderer.Join(s.dataDir, "init"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	dirName := fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name)
-	fileName := fmt.Sprintf("%s/%s.service", dirName, s.name)
+	fileName := fmt.Sprintf("%s/%s.service", systemd.EtcSystemdDir, s.name)
 
 	s.exec.EXPECT().RunCommands(listCmdArg).Return(&exec.ExecResponse{Stdout: []byte(svc.Name())}, nil).Times(2)
 	s.dBus.EXPECT().Close().Times(3)
@@ -641,8 +644,8 @@ func (s *initSystemSuite) TestInstallZombie(c *gc.C) {
 	}, nil)
 	s.dBus.EXPECT().DisableUnitFiles([]string{svc.UnitName}, false).Return(nil, nil)
 	s.dBus.EXPECT().Reload().Return(nil)
-	s.fops.EXPECT().RemoveAll(svc.DirName).Return(nil)
-	s.fops.EXPECT().MkdirAll(dirName).Return(nil)
+	s.fops.EXPECT().Remove(path.Join(svc.DirName, svc.ConfName)).Return(nil)
+	s.fops.EXPECT().Remove(path.Join(svc.DirName, svc.Name()+"-exec-start.sh")).Return(nil)
 	s.fops.EXPECT().CreateFile(fileName, []byte(s.newConfStrEnv(s.name, `"a=c"`)), os.FileMode(0644)).Return(nil)
 	s.dBus.EXPECT().LinkUnitFiles([]string{fileName}, false, true).Return(nil, nil)
 	s.dBus.EXPECT().Reload().Return(nil)
@@ -656,9 +659,8 @@ func (s *initSystemSuite) TestInstallMultiLine(c *gc.C) {
 	ctrl := s.patch(c)
 	defer ctrl.Finish()
 
-	dirName := fmt.Sprintf("%s/%s", "/lib/systemd/system", s.name)
-	fileName := fmt.Sprintf("%s/%s.service", dirName, s.name)
-	scriptPath := fmt.Sprintf("%s/exec-start.sh", dirName)
+	fileName := fmt.Sprintf("%s/%s.service", systemd.EtcSystemdDir, s.name)
+	scriptPath := fmt.Sprintf("%s/%s-exec-start.sh", systemd.EtcSystemdDir, s.name)
 	cmd := "a\nb\nc"
 
 	svc := s.newService(c)
@@ -667,7 +669,6 @@ func (s *initSystemSuite) TestInstallMultiLine(c *gc.C) {
 
 	gomock.InOrder(
 		s.exec.EXPECT().RunCommands(listCmdArg).Return(&exec.ExecResponse{Stdout: []byte("")}, nil),
-		s.fops.EXPECT().MkdirAll(dirName).Return(nil),
 		s.fops.EXPECT().CreateFile(scriptPath, []byte(cmd), os.FileMode(0755)).Return(nil),
 		s.fops.EXPECT().CreateFile(fileName, []byte(s.newConfStrCmd(s.name, scriptPath)), os.FileMode(0644)).Return(nil),
 		s.dBus.EXPECT().LinkUnitFiles([]string{fileName}, false, true).Return(nil, nil),
@@ -694,7 +695,7 @@ func (s *initSystemSuite) TestInstallCommands(c *gc.C) {
 
 	test := systemdtesting.WriteConfTest{
 		Service:  name,
-		DataDir:  "/lib/systemd/system",
+		DataDir:  systemd.EtcSystemdDir,
 		Expected: s.newConfStr(name),
 	}
 	test.CheckCommands(c, commands)
@@ -710,11 +711,11 @@ func (s *initSystemSuite) TestInstallCommandsLogfile(c *gc.C) {
 	user, group := paths.SyslogUserGroup()
 	test := systemdtesting.WriteConfTest{
 		Service: name,
-		DataDir: "/lib/systemd/system",
+		DataDir: systemd.EtcSystemdDir,
 		Expected: strings.Replace(
 			s.newConfStr(name),
 			"ExecStart=/var/lib/juju/bin/jujud machine-0",
-			"ExecStart=/lib/systemd/system/jujud-machine-0/exec-start.sh",
+			"ExecStart=/etc/systemd/system/jujud-machine-0-exec-start.sh",
 			-1),
 		Script: `
 # Set up logging.
@@ -736,7 +737,8 @@ func (s *initSystemSuite) TestInstallCommandsShutdown(c *gc.C) {
 	conf, err := service.ShutdownAfterConf("cloud-final")
 	c.Assert(err, jc.ErrorIsNil)
 
-	svc, err := systemd.NewService(name, conf, "/lib/systemd/system", systemd.NewDBusAPI, renderer.Join(s.dataDir, "init"))
+	svc, err := systemd.NewService(
+		name, conf, systemd.EtcSystemdDir, systemd.NewDBusAPI, renderer.Join(s.dataDir, "init"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	commands, err := svc.InstallCommands()
@@ -744,7 +746,7 @@ func (s *initSystemSuite) TestInstallCommandsShutdown(c *gc.C) {
 
 	test := systemdtesting.WriteConfTest{
 		Service: name,
-		DataDir: "/lib/systemd/system",
+		DataDir: systemd.EtcSystemdDir,
 		Expected: `
 [Unit]
 Description=juju shutdown job

--- a/service/systemd/shims.go
+++ b/service/systemd/shims.go
@@ -16,7 +16,7 @@ import (
 //go:generate mockgen -package systemd -destination shims_mock_test.go github.com/juju/juju/service/systemd ShimFileOps,ShimExec
 
 type ShimFileOps interface {
-	RemoveAll(name string) error
+	Remove(name string) error
 	MkdirAll(dirname string) error
 	CreateFile(filename string, data []byte, perm os.FileMode) error
 }

--- a/service/systemd/shims_mock_test.go
+++ b/service/systemd/shims_mock_test.go
@@ -5,11 +5,10 @@
 package systemd
 
 import (
-	os "os"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	exec "github.com/juju/utils/exec"
+	os "os"
+	reflect "reflect"
 )
 
 // MockShimFileOps is a mock of ShimFileOps interface
@@ -37,6 +36,7 @@ func (m *MockShimFileOps) EXPECT() *MockShimFileOpsMockRecorder {
 
 // CreateFile mocks base method
 func (m *MockShimFileOps) CreateFile(arg0 string, arg1 []byte, arg2 os.FileMode) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -44,11 +44,13 @@ func (m *MockShimFileOps) CreateFile(arg0 string, arg1 []byte, arg2 os.FileMode)
 
 // CreateFile indicates an expected call of CreateFile
 func (mr *MockShimFileOpsMockRecorder) CreateFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFile", reflect.TypeOf((*MockShimFileOps)(nil).CreateFile), arg0, arg1, arg2)
 }
 
 // MkdirAll mocks base method
 func (m *MockShimFileOps) MkdirAll(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -56,19 +58,22 @@ func (m *MockShimFileOps) MkdirAll(arg0 string) error {
 
 // MkdirAll indicates an expected call of MkdirAll
 func (mr *MockShimFileOpsMockRecorder) MkdirAll(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockShimFileOps)(nil).MkdirAll), arg0)
 }
 
-// RemoveAll mocks base method
-func (m *MockShimFileOps) RemoveAll(arg0 string) error {
-	ret := m.ctrl.Call(m, "RemoveAll", arg0)
+// Remove mocks base method
+func (m *MockShimFileOps) Remove(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Remove", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RemoveAll indicates an expected call of RemoveAll
-func (mr *MockShimFileOpsMockRecorder) RemoveAll(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockShimFileOps)(nil).RemoveAll), arg0)
+// Remove indicates an expected call of Remove
+func (mr *MockShimFileOpsMockRecorder) Remove(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockShimFileOps)(nil).Remove), arg0)
 }
 
 // MockShimExec is a mock of ShimExec interface
@@ -96,6 +101,7 @@ func (m *MockShimExec) EXPECT() *MockShimExecMockRecorder {
 
 // RunCommands mocks base method
 func (m *MockShimExec) RunCommands(arg0 exec.RunParams) (*exec.ExecResponse, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunCommands", arg0)
 	ret0, _ := ret[0].(*exec.ExecResponse)
 	ret1, _ := ret[1].(error)
@@ -104,5 +110,6 @@ func (m *MockShimExec) RunCommands(arg0 exec.RunParams) (*exec.ExecResponse, err
 
 // RunCommands indicates an expected call of RunCommands
 func (mr *MockShimExecMockRecorder) RunCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommands", reflect.TypeOf((*MockShimExec)(nil).RunCommands), arg0)
 }

--- a/service/systemd/testing/writeconf.go
+++ b/service/systemd/testing/writeconf.go
@@ -23,22 +23,16 @@ type WriteConfTest struct {
 	Script   string
 }
 
-func (wct WriteConfTest) dirname() string {
-	return fmt.Sprintf("'%s/%s'", wct.DataDir, wct.Service)
+func (wct WriteConfTest) fileName() string {
+	return fmt.Sprintf("'%s/%s.service'", wct.DataDir, wct.Service)
 }
 
-func (wct WriteConfTest) filename() string {
-	return fmt.Sprintf("'%[1]s/%[2]s/%[2]s.service'", wct.DataDir, wct.Service)
-}
-
-func (wct WriteConfTest) scriptname() string {
-	return fmt.Sprintf("'%s/%s/exec-start.sh'", wct.DataDir, wct.Service)
+func (wct WriteConfTest) scriptName() string {
+	return fmt.Sprintf("'%s/%s-exec-start.sh'", wct.DataDir, wct.Service)
 }
 
 // CheckCommands checks the given commands against the test's expectations.
 func (wct WriteConfTest) CheckCommands(c *gc.C, commands []string) {
-	c.Check(commands[0], gc.Equals, "mkdir -p "+wct.dirname())
-	commands = commands[1:]
 	if wct.Script != "" {
 		wct.checkWriteExecScript(c, commands[:2])
 		commands = commands[2:]
@@ -48,11 +42,11 @@ func (wct WriteConfTest) CheckCommands(c *gc.C, commands []string) {
 
 func (wct WriteConfTest) checkWriteExecScript(c *gc.C, commands []string) {
 	script := "#!/usr/bin/env bash\n\n" + wct.Script
-	testing.CheckWriteFileCommand(c, commands[0], wct.scriptname(), script, nil)
+	testing.CheckWriteFileCommand(c, commands[0], wct.scriptName(), script, nil)
 
 	// Check the remaining commands.
 	c.Check(commands[1:], jc.DeepEquals, []string{
-		"chmod 0755 " + wct.scriptname(),
+		"chmod 0755 " + wct.scriptName(),
 	})
 }
 
@@ -61,13 +55,13 @@ func (wct WriteConfTest) checkWriteConf(c *gc.C, commands []string) {
 	parse := func(lines []string) interface{} {
 		return parseConfSections(lines)
 	}
-	testing.CheckWriteFileCommand(c, commands[0], wct.filename(), wct.Expected, parse)
+	testing.CheckWriteFileCommand(c, commands[0], wct.fileName(), wct.Expected, parse)
 
 	// Check the remaining commands.
 	c.Check(commands[1:], jc.DeepEquals, []string{
-		"/bin/systemctl link " + wct.filename(),
+		"/bin/systemctl link " + wct.fileName(),
 		"/bin/systemctl daemon-reload",
-		"/bin/systemctl enable " + wct.filename(),
+		"/bin/systemctl enable " + wct.fileName(),
 	})
 }
 


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch changes the location of systemd unit files and start-up scripts.

Instead of writing each service definition and it's exec-start script into a service folder in `/lib/systemd/system` and using dbus (systemd) to link them into `/etc/systemd/system`, we write them directly to `/etc/systemd/system`. This means the exec-start script is co-located with its service definition and prefixed with the service name.

This change was required to support Focal Fossa (20.04) which has these two directories on different partitions, causing systemd to fail.

The linking step remains for now, though it effectively does nothing - the service definitions are in the default search path, so reloading the systemd daemon should be sufficient to have them loaded.

Subsequent patches will take care of any required upgrade paths, including upgrading the OS series.

## QA steps

- Bootstrap to Focal: `juju bootstrap lxd systemd-test-focal --bootstrap-series focal --debug --no-gui --force --config image-stream=daily`.
- SSH to the controller machine and observe the shutdown, database and machine services and scripts in `etc/systemd/system`.
- `juju add-machine --series focal`
- `juju deploy cs:ubuntu-13 -n 2 --to 0,0 --series focal --force`
- `juju ssh 0` and observe the service units/scripts are present in `/etc/systemd/system`.
- `juju remove-unit ubuntu/1` and observe that the service and script for the unit disappear.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860432
