### PR TITLE
2.7 Fix Controller Integration Test for New Systemd Service File Location

### DIFF
--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -1,6 +1,6 @@
 cat_mongo_service() {
     # shellcheck disable=SC2046
-    echo $(juju run -m controller --machine 0 'cat /lib/systemd/system/juju-db/juju-db.service' | grep "^ExecStart")
+    echo $(juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service' | grep "^ExecStart")
 }
 
 run_mongo_memory_profile() {


### PR DESCRIPTION
## Description of change

Fixes controller integration test to look in the standard Systemd search path for the juju-db service instead of the old /lib/systemd... path.

## QA steps

- `cd tests`
- `./main.sh controller`

## Documentation changes

None.

## Bug reference

N/A
