### PR TITLE
2.7 Fix nw-charm-storage

### DIFF
--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -126,7 +126,7 @@ def wait_for_storage_removal(client, storage_id, interval, timeout):
             break
 
 
-def make_expected_ls(client, storage_name, unit_name, kind='filesystem'):
+def make_expected_ls(storage_name, unit_name, kind='filesystem'):
     """Return the expected data from list-storage for filesystem or block."""
     if kind == 'block':
         location = ''
@@ -151,12 +151,12 @@ def make_expected_ls(client, storage_name, unit_name, kind='filesystem'):
     return data
 
 
-def make_expected_disk(client, disk_num, unit_name):
+def make_expected_disk(disk_num, unit_name):
     """Return the expected data from list storage for disks."""
     all_disk = {'storage': {}}
     for num in range(1, disk_num + 1):
         next_disk = make_expected_ls(
-            client, 'disks/{}'.format(num), unit_name, kind='block')
+            'disks/{}'.format(num), unit_name, kind='block')
         all_disk['storage'].update(next_disk['storage'])
     return all_disk
 
@@ -185,7 +185,7 @@ def storage_pool_list(client):
 
 def create_storage_charm(charm_dir, name, summary, storage):
     """Manually create a temporary charm to test with storage."""
-    storage_charm = Charm(name, summary, storage=storage, series=['trusty'])
+    storage_charm = Charm(name, summary, storage=storage, series=['bionic'])
     # Valid charms require at least one hook.
     # Add a dummy install hook.
     install = '#!/bin/sh\necho install'
@@ -297,7 +297,7 @@ def assess_multiple_provider(client, charm_series, amount, charm_name,
 
 def check_storage_list(client, expected):
     storage_list_derived = storage_list(client)
-    assert_dict_is_subset(expected, storage_list_derived)
+    assert_dict_is_subset(expected['storage'], storage_list_derived['storage'])
 
 
 def assess_storage(client, charm_series):
@@ -325,9 +325,9 @@ def assess_storage(client, charm_series):
     log.info('Storage pool PASSED')
 
     log.info('Assessing filesystem rootfs')
-    assess_deploy_storage(client, charm_series,
-                          'dummy-storage-fs', 'filesystem', 'rootfs')
-    expected = make_expected_ls(client, 'data/0', 'dummy-storage-fs/0')
+    assess_deploy_storage(client, charm_series, 'dummy-storage-fs',
+                          'filesystem', 'rootfs')
+    expected = make_expected_ls('data/0', 'dummy-storage-fs/0')
     check_storage_list(client, expected)
     log.info('Filesystem rootfs PASSED')
     client.remove_application('dummy-storage-fs')
@@ -335,13 +335,13 @@ def assess_storage(client, charm_series):
     log.info('Assessing block loop disk 1')
     assess_deploy_storage(client, charm_series,
                           'dummy-storage-lp', 'block', 'loop')
-    expected_block1 = make_expected_disk(client, 1, 'dummy-storage-lp/0')
+    expected_block1 = make_expected_disk(1, 'dummy-storage-lp/0')
     check_storage_list(client, expected_block1)
     log.info('Block loop disk 1 PASSED')
 
     log.info('Assessing add storage block loop disk 2')
     assess_add_storage(client, 'dummy-storage-lp/0', 'disks', "1")
-    expected_block2 = make_expected_disk(client, 2, 'dummy-storage-lp/0')
+    expected_block2 = make_expected_disk(2, 'dummy-storage-lp/0')
     check_storage_list(client, expected_block2)
     log.info('Block loop disk 2 PASSED')
     client.remove_application('dummy-storage-lp')
@@ -349,7 +349,7 @@ def assess_storage(client, charm_series):
     log.info('Assessing filesystem tmpfs')
     assess_deploy_storage(client, charm_series,
                           'dummy-storage-tp', 'filesystem', 'tmpfs')
-    expected = make_expected_ls(client, 'data/3', 'dummy-storage-tp/0')
+    expected = make_expected_ls('data/3', 'dummy-storage-tp/0')
     check_storage_list(client, expected)
     log.info('Filesystem tmpfs PASSED')
     client.remove_application('dummy-storage-tp')
@@ -357,7 +357,7 @@ def assess_storage(client, charm_series):
     log.info('Assessing filesystem')
     assess_deploy_storage(client, charm_series,
                           'dummy-storage-np', 'filesystem')
-    expected = make_expected_ls(client, 'data/4', 'dummy-storage-np/0')
+    expected = make_expected_ls('data/4', 'dummy-storage-np/0')
     check_storage_list(client, expected)
     log.info('Filesystem tmpfs PASSED')
 
@@ -376,7 +376,7 @@ def assess_storage(client, charm_series):
     log.info('Assessing multiple filesystem, block, rootfs, loop')
     assess_multiple_provider(client, charm_series, "1G", 'dummy-storage-mp',
                              'filesystem', 'block', 'rootfs', 'loop')
-    expected = make_expected_ls(client, 'data/5', 'dummy-storage-mp/0')
+    expected = make_expected_ls('data/5', 'dummy-storage-mp/0')
     check_storage_list(client, expected)
     log.info('Multiple filesystem, block, rootfs, loop PASSED')
     client.remove_application('dummy-storage-mp')
@@ -387,7 +387,7 @@ def parse_args(argv):
     """Parse all arguments."""
     parser = argparse.ArgumentParser(description="Test Storage Feature")
     add_basic_testing_arguments(parser)
-    parser.set_defaults(series='trusty')
+    parser.set_defaults(series='bionic')
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The charm storage test was passing for a long time, because it was not actually working properly. 

After #10998, the test began failing because of errors being returned instead of ignored.

The constraints correction was later accommodated by #11038, but the last of the scenarios in the test was failing because it happened to make a comparison for a scenario that did not work.

The comparison of output for the storage command checks that one dictionary is a sub-set of the other, but it doesn't do it recursively - all that is checked is that the items in one are in the other. This of course doesn't work when the dictionaries are structured thusly:
```
    'storage': {
        'data/5': {
            'kind': 'filesystem', 
            'life': 'alive', 
            'attachments': {
            'units': {
                'dummy-storage-mp/0': {
                    'life': 'alive', 
                    'location': '/srv/data'
                }
            }
        }
    }
```
because there is only one key. It is essentially an equivalence check.

The check does work as intended if we pass the sub-dictionary at the `storage` key to the comparison, which is what this change does.

## QA steps

```bash
cd acceptancetests && ./assess storage --juju ~/go/bin/juju --substrate aws
```

## Documentation changes

None.

## Bug reference

N/A
