### PR TITLE
Add run_deploy_lxd_profile_bundle.

### DIFF
--- a/tests/suites/deploy/bundles/lxd-profile-bundle.yaml
+++ b/tests/suites/deploy/bundles/lxd-profile-bundle.yaml
@@ -1,0 +1,27 @@
+series: bionic
+machines:
+  '0': {}
+  '1': {}
+  '2': {}
+  '3': {}
+applications:
+  lxd-profile:
+    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-5
+    num_units: 8
+    to:
+      - lxd:0
+      - lxd:1
+      - lxd:2
+      - lxd:3
+      - lxd:0
+      - lxd:1
+      - lxd:2
+      - lxd:3
+  ubuntu:
+    charm: cs:~jameinel/ubuntu-lite
+    num_units: 4
+    to:
+      - "0"
+      - "1"
+      - "2"
+      - "3"

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -37,7 +37,7 @@ run_test_setup() {
     S=$(grep -owr "${subtest}" tests/suites)
     COUNT=$(echo "${S}" | wc -l)
     TEST_FILE=$(echo "${S}" | cut -f1 -d":")
-    if [ "${COUNT}" -ne 2 ]; then
+    if ${COUNT} % 2 == 0 ; then
       echo ""
       echo "$(red 'Found some issues:')"
       echo "Expected subtest (${subtest}) to be in the same file as test (${TEST_FILE})."


### PR DESCRIPTION
## Description of change

Add run_deploy_lxd_profile_bundle to replace nw-deploy-lxd-profile-bundle-lxd.  The nw test intermittently fails for reasons outside of the scope of the test.  First rename run_deploy_lxd_profile_bundle as run_deploy_lxd_profile_bundle_openstack.

## QA steps
```sh
juju bootstrap localhost
(cd tests ; ./main.sh -r deploy test_deploy_bundles)
```
