### PR TITLE
[dev] migrate unit state together with the model 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -469,11 +469,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:02901ae1102fee2f0052af5cb04c1b785b4db6cf0034e8b4be77f60d4a5107dd"
+  digest = "1:4e0797209852d8675c9a6d17d49a543428f7182eef8b6f2ee9c12e4f4648bc4f"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "7a7592edce5c83f8c18bb09b9c651ccb27a9d0f0"
+  revision = "d884fa94b91060a8995d85aca929f96fd100e935"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "7a7592edce5c83f8c18bb09b9c651ccb27a9d0f0"
+  revision = "d884fa94b91060a8995d85aca929f96fd100e935"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -918,6 +918,10 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		if cloudContainer, found := ctx.cloudContainers[unit.globalKey()]; found {
 			args.CloudContainer = e.cloudContainer(cloudContainer)
 		}
+		if args.State, err = unit.State(); err != nil {
+			return errors.Trace(err)
+		}
+
 		exUnit := exApplication.AddUnit(args)
 
 		e.setUnitResources(exUnit, ctx.resources.UnitResources)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -757,6 +757,11 @@ func (s *MigrationExportSuite) assertMigrateUnits(c *gc.C, st *state.State) {
 		err = unit.SetWorkloadVersion(version)
 		c.Assert(err, jc.ErrorIsNil)
 	}
+	err = unit.SetState(map[string]string{
+		"payload": "b4dc0ffee",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
 	dbModel, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -804,6 +809,7 @@ func (s *MigrationExportSuite) assertMigrateUnits(c *gc.C, st *state.State) {
 	c.Assert(exported.MeterStatusInfo(), gc.Equals, "some info")
 	c.Assert(exported.WorkloadVersion(), gc.Equals, "steven")
 	c.Assert(exported.Annotations(), jc.DeepEquals, testAnnotations)
+	c.Assert(exported.State(), jc.DeepEquals, map[string]string{"payload": "b4dc0ffee"})
 	constraints := exported.Constraints()
 	c.Assert(constraints, gc.NotNil)
 	c.Assert(constraints.Architecture(), gc.Equals, "amd64")

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1016,6 +1016,8 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, st *state.State, con
 	c.Assert(err, jc.ErrorIsNil)
 	err = testModel.SetAnnotations(exported, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
+	err = exported.SetState(map[string]string{"payload": "0xb4c0ffee"})
+	c.Assert(err, jc.ErrorIsNil)
 
 	if testModel.Type() == state.ModelTypeCAAS {
 		var updateUnits state.UpdateUnitsOperation
@@ -1087,6 +1089,10 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, st *state.State, con
 	s.checkStatusHistory(c, exported, imported, 5)
 	s.checkStatusHistory(c, exported.Agent(), imported.Agent(), 5)
 	s.checkStatusHistory(c, exported.WorkloadVersionHistory(), imported.WorkloadVersionHistory(), 1)
+
+	unitState, err := imported.State()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unitState, jc.DeepEquals, map[string]string{"payload": "0xb4c0ffee"}, gc.Commentf("persisted charm state not migrated"))
 
 	newCons, err := imported.Constraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -208,6 +208,12 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// Resources are transferred separately
 		"storedResources",
+
+		// Unit state entries will be automatically created when the
+		// operator framework code mutates the state for the charm
+		// running within a unit. This is a new feature that is not
+		// backwards compatible with older controllers.
+		unitStatesC,
 	)
 
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE
@@ -219,9 +225,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// sure the leader units' leases are claimed in the target
 		// controller when leases are managed in raft.
 		leaseHoldersC,
-		// TODO(achilleasa) remove this once the required changes to
-		// the description package land.
-		unitStatesC,
 	)
 
 	modelCollections := set.NewStrings()


### PR DESCRIPTION
## Description of change

This PR is part of the work for implementing server-side storage for charm state. 

The PR brings in the latest version of the juju/description package that introduces additional fields in the unit description to facilitate the serialization of any charm-persisted per-unit state when the unit gets exported.

Furthermore, the code in this PR updates the juju migration code to ensure that persisted unit states are correctly copied over when migrating a model to a new controller.

Note: the uniter worker is wrapped in a `ifNotMigrating` engine housing; when the migration master locks down the relevant fortress, all uniter instances are shut down. Therefore, the unit state can be safely exported without the possibility of a data race occurring.

## QA steps

Unfortunately, the hook tools for manipulating the unit state collection entries have not yet landed. To verify these changes you will first need to apply the following quick & dirty patch which plugs in a value to the unit's state when you `juju add-unit X`:

```diff
diff --git a/apiserver/facades/client/application/deploy.go b/apiserver/facades/client/application/deploy.go
index 340453a0ec..75f6d24f7d 100644
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -120,6 +120,12 @@ func addUnits(
                        return nil, errors.Annotatef(err, "cannot add unit %d/%d to application %q", i+1, n, appName)
                }
                units[i] = unit
+               type stateSetter interface {
+                       SetState(map[string]string) error
+               }
+               if err = unit.(stateSetter).SetState(map[string]string{"hack": "me"}); err != nil {
+                       return nil, errors.Trace(err)
+               }
                if !assignUnits {
                        continue
                }
```

Compile this branch with the above patch applied and then run the following:

```console
$ juju bootstrap lxd dst --no-gui
$ juju bootstrap lxd src --no-gui
$ juju switch src
$ juju add-model foo
$ juju whoami
Controller:  src
Model:       foo
User:        admin

$ juju deploy cs:~jameinel/ubuntu-lite-7
$ juju add-unit ubuntu-lite 
# Wait for the units to settle...

# Connect to src:mongodb
juju:PRIMARY> db.unitstates.find()
{ "_id" : "7f27d6d1-4246-4d28-8fc8-75afa20b0c74:u#ubuntu-lite/1#charm", "state" : { "hack" : "me" }, "txn-revno" : NumberLong(2), "model-uuid" : "7f27d6d1-4246-4d28-8fc8-75afa20b0c74", "txn-queue" : [ "5e302de088793c1e82a89bff_c732481e" ] }

# Migrate the model
$ juju migrate src:foo dst

# Connect to dst:mongodb
juju:PRIMARY> db.unitstates.find()
{ "_id" : "7f27d6d1-4246-4d28-8fc8-75afa20b0c74:u#ubuntu-lite/1#charm", "state" : { "hack" : "me" }, "txn-revno" : NumberLong(2), "model-uuid" : "7f27d6d1-4246-4d28-8fc8-75afa20b0c74", "txn-queue" : [ "5e302de088793c1e82a89bff_c732481e" ] }

# Note: the above output (inc. UUIDs) should be identical to the one from the src controller's mongo
```