### PR TITLE
Clean up offers

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -292,7 +292,7 @@ remove_controller_offers() {
             OUT=$(juju offers -m "${name}:${model}" --format=json | jq -r ".[] | .[\"offer-url\"]" || true)
             echo "${OUT}" | while read -r offer; do
                 if [ -n "${offer}" ]; then
-                    juju remove-offer -c "${name}" "${offer}"
+                    juju remove-offer --force -y -c "${name}" "${offer}"
                     echo "${offer}" >> "${TEST_DIR}/${name}-juju_removed_offers.txt"
                 fi
             done

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -286,7 +286,7 @@ remove_controller_offers() {
 
     name=${1}
 
-    OUT=$(juju models -c ${name} --format=json | jq -r ".[\"models\"] | .[] | select(.[\"is-controller\"] == false) | .name" || true)
+    OUT=$(juju models -c "${name}" --format=json | jq -r ".[\"models\"] | .[] | select(.[\"is-controller\"] == false) | .name" || true)
     if [ -n "${OUT}" ]; then
         echo "${OUT}" | while read -r model; do
             OUT=$(juju offers -m "${name}:${model}" --format=json | jq -r ".[] | .[\"offer-url\"]" || true)

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -227,6 +227,18 @@ destroy_controller() {
 
     echo "====> Introspection gathered"
 
+    # Unfortunately having any offers on a model, leads to failure to clean
+    # up a controller.
+    # See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
+    echo "====> Removing offers"
+
+    set +e
+    remove_controller_offers "${name}"
+    set_verbosity
+
+    echo "====> Removed offers"
+
+
     output="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ($(green "${name}"))"
@@ -267,4 +279,23 @@ introspect_controller() {
 
     echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_reports.txt"
     echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"
+}
+
+remove_controller_offers() {
+    local name
+
+    name=${1}
+
+    OUT=$(juju models -c ${name} --format=json | jq -r ".[\"models\"] | .[] | select(.[\"is-controller\"] == false) | .name" || true)
+    if [ -n "${OUT}" ]; then
+        echo "${OUT}" | while read -r model; do
+            OUT=$(juju offers -m "${name}:${model}" --format=json | jq -r ".[] | .[\"offer-url\"]" || true)
+            echo "${OUT}" | while read -r offer; do
+                if [ -n "${offer}" ]; then
+                    juju remove-offer -c "${name}" "${offer}"
+                    echo "${offer}" >> "${TEST_DIR}/${name}-juju_removed_offers.txt"
+                fi
+            done
+        done
+    fi
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

During the cleaning up of integration tests, where the test "framework"
destroys the controllers, if there are any outstanding offers in the
the controller then the destroying of the controller will hang forever!

The fix is quite simple, before the actual destruction of a model, walk
over all the controllers and remove all the offers. It's quite a slow
process esp. with AWS, but it does mean that we don't have any orphaned
controllers.

In fact, this is how a normal operator is supposed to handle controller
destruction.
## QA steps

```sh
cd tests && ./main.sh -A
```
