### PR TITLE
[dev] Implement server-side bits for the State/SetState uniter API endpoints

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -104,7 +104,7 @@ var facadeVersions = map[string]int{
 	"Subnets":                      3,
 	"Undertaker":                   1,
 	"UnitAssigner":                 1,
-	"Uniter":                       14,
+	"Uniter":                       15,
 	"Upgrader":                     1,
 	"UpgradeSeries":                1,
 	"UpgradeSteps":                 1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -326,7 +326,8 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 11, uniter.NewUniterAPIV11)
 	reg("Uniter", 12, uniter.NewUniterAPIV12)
 	reg("Uniter", 13, uniter.NewUniterAPIV13)
-	reg("Uniter", 14, uniter.NewUniterAPI)
+	reg("Uniter", 14, uniter.NewUniterAPIV14)
+	reg("Uniter", 15, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 	reg("UpgradeSeries", 1, upgradeseries.NewAPI)

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -36,8 +36,8 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.uniter")
 
-// UniterAPI implements the latest version (v14) of the Uniter API,
-// which adds GetPodSpec.
+// UniterAPI implements the latest version (v15) of the Uniter API,
+// which adds the State and SetState calls.
 type UniterAPI struct {
 	*common.LifeGetter
 	*StatusAPI
@@ -74,10 +74,16 @@ type UniterAPI struct {
 	cloudSpec       cloudspec.CloudSpecAPI
 }
 
+// UniterAPIV14 implements version (v14) of the Uniter API,
+// which adds GetPodSpec
+type UniterAPIV14 struct {
+	UniterAPI
+}
+
 // UniterAPIV13 implements version (v13) of the Uniter API,
 // which adds UpdateNetworkInfo.
 type UniterAPIV13 struct {
-	UniterAPI
+	UniterAPIV14
 }
 
 // UniterAPIV12 implements version (v12) of the Uniter API,
@@ -228,14 +234,25 @@ func NewUniterAPI(context facade.Context) (*UniterAPI, error) {
 	}, nil
 }
 
-// NewUniterAPIV13 creates an instance of the V13 uniter API.
-func NewUniterAPIV13(context facade.Context) (*UniterAPIV13, error) {
+// NewUniterAPIV14 creates an instance of the V14 uniter API.
+func NewUniterAPIV14(context facade.Context) (*UniterAPIV14, error) {
 	uniterAPI, err := NewUniterAPI(context)
 	if err != nil {
 		return nil, err
 	}
-	return &UniterAPIV13{
+	return &UniterAPIV14{
 		UniterAPI: *uniterAPI,
+	}, nil
+}
+
+// NewUniterAPIV13 creates an instance of the V13 uniter API.
+func NewUniterAPIV13(context facade.Context) (*UniterAPIV13, error) {
+	uniterAPI, err := NewUniterAPIV14(context)
+	if err != nil {
+		return nil, err
+	}
+	return &UniterAPIV13{
+		UniterAPIV14: *uniterAPI,
 	}, nil
 }
 
@@ -3099,7 +3116,7 @@ func (u *UniterAPI) UpdateNetworkInfo(args params.Entities) (params.ErrorResults
 		}
 
 		if !canAccess(unitTag) {
-			res[i].Error = common.ServerError(err)
+			res[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
 
@@ -3163,4 +3180,70 @@ func (u *UniterAPI) updateUnitNetworkInfo(unitTag names.UnitTag) error {
 	}
 
 	return settingsGroup.Write()
+}
+
+func (u *UniterAPI) State(args params.Entities) (params.UnitStateResults, error) {
+	canAccess, err := u.accessUnit()
+	if err != nil {
+		return params.UnitStateResults{}, errors.Trace(err)
+	}
+
+	res := make([]params.UnitStateResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		unitTag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			res[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if !canAccess(unitTag) {
+			res[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+
+		unit, err := u.getUnit(unitTag)
+		if err != nil {
+			res[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if res[i].State, err = unit.State(); err != nil {
+			res[i].Error = common.ServerError(err)
+		}
+	}
+
+	return params.UnitStateResults{Results: res}, nil
+}
+
+func (u *UniterAPI) SetState(args params.SetUnitStateArgs) (params.ErrorResults, error) {
+	canAccess, err := u.accessUnit()
+	if err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
+	}
+
+	res := make([]params.ErrorResult, len(args.Args))
+	for i, arg := range args.Args {
+		unitTag, err := names.ParseUnitTag(arg.Tag)
+		if err != nil {
+			res[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if !canAccess(unitTag) {
+			res[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+
+		unit, err := u.getUnit(unitTag)
+		if err != nil {
+			res[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if err = unit.SetState(arg.State); err != nil {
+			res[i].Error = common.ServerError(err)
+		}
+	}
+
+	return params.ErrorResults{Results: res}, nil
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -3182,6 +3182,10 @@ func (u *UniterAPI) updateUnitNetworkInfo(unitTag names.UnitTag) error {
 	return settingsGroup.Write()
 }
 
+// State isn't on the v14 API.
+func (u *UniterAPIV14) State(_ struct{}) {}
+
+// State returns the state persisted by the charm running in this unit.
 func (u *UniterAPI) State(args params.Entities) (params.UnitStateResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {
@@ -3215,6 +3219,10 @@ func (u *UniterAPI) State(args params.Entities) (params.UnitStateResults, error)
 	return params.UnitStateResults{Results: res}, nil
 }
 
+// SetState isn't on the v14 API.
+func (u *UniterAPIV14) SetState(_ struct{}) {}
+
+// SetState persists the state of the charm running in this unit.
 func (u *UniterAPI) SetState(args params.SetUnitStateArgs) (params.ErrorResults, error) {
 	canAccess, err := u.accessUnit()
 	if err != nil {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -260,6 +260,69 @@ func (s *uniterSuite) TestSetStatus(c *gc.C) {
 	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
+func (s *uniterSuite) TestSetState(c *gc.C) {
+	expState := map[string]string{
+		"foo.bar":  "baz",
+		"payload$": "enc0d3d",
+	}
+	args := params.SetUnitStateArgs{
+		Args: []params.SetUnitStateArg{
+			{Tag: "not-a-unit-tag", State: map[string]string{"not": "important"}},
+			{Tag: "unit-wordpress-0", State: expState},
+			{Tag: "unit-mysql-0", State: map[string]string{"not": "important"}}, // not accessible by current user
+			{Tag: "unit-notfound-0", State: map[string]string{"not": "important"}},
+		},
+	}
+	result, err := s.uniter.SetState(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Message: `"not-a-unit-tag" is not a valid tag`}},
+			{Error: nil},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+
+	// Verify that mysql unit's state was not mutated
+	unitState, err := s.mysqlUnit.State()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unitState, gc.IsNil, gc.Commentf("unexpected state doc mutation"))
+
+	// Verify wordpress state was mutated
+	unitState, err = s.wordpressUnit.State()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unitState, jc.DeepEquals, expState, gc.Commentf("state doc not updated"))
+}
+
+func (s *uniterSuite) TestState(c *gc.C) {
+	expState := map[string]string{
+		"foo.bar":  "baz",
+		"payload$": "enc0d3d",
+	}
+	err := s.wordpressUnit.SetState(expState)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: "not-a-unit-tag"},
+			{Tag: "unit-wordpress-0"},
+			{Tag: "unit-mysql-0"}, // not accessible by current user
+			{Tag: "unit-notfound-0"},
+		},
+	}
+	result, err := s.uniter.State(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.UnitStateResults{
+		Results: []params.UnitStateResult{
+			{Error: &params.Error{Message: `"not-a-unit-tag" is not a valid tag`}},
+			{State: expState},
+			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+}
+
 func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
 	now := time.Now()
 	sInfo := status.StatusInfo{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -34530,7 +34530,7 @@
     },
     {
         "Name": "Uniter",
-        "Version": 14,
+        "Version": 15,
         "Schema": {
             "type": "object",
             "properties": {
@@ -35134,6 +35134,17 @@
                         }
                     }
                 },
+                "SetState": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetUnitStateArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
                 "SetStatus": {
                     "type": "object",
                     "properties": {
@@ -35175,6 +35186,17 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "State": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UnitStateResults"
                         }
                     }
                 },
@@ -37112,6 +37134,42 @@
                         "entities"
                     ]
                 },
+                "SetUnitStateArg": {
+                    "type": "object",
+                    "properties": {
+                        "state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "state"
+                    ]
+                },
+                "SetUnitStateArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SetUnitStateArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
                 "SettingsResult": {
                     "type": "object",
                     "properties": {
@@ -37534,6 +37592,41 @@
                     "additionalProperties": false,
                     "required": [
                         "version"
+                    ]
+                },
+                "UnitStateResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "state"
+                    ]
+                },
+                "UnitStateResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UnitStateResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "UpgradeSeriesStatusParam": {


### PR DESCRIPTION
## Description of change

This PR is part of the work required for supporting server-side storage of charm state. 

It builds on the changes introduced by #11136 and adds the server-side logic for handling the new SetState/State calls for the uniter API

## QA steps

QA steps not available as the client-side bits are not currently wired to call out to this facade.