### PR TITLE
cmr: Handle applications being offered with a different name

### DIFF
--- a/acceptancetests/assess_cross_model_relations.py
+++ b/acceptancetests/assess_cross_model_relations.py
@@ -240,7 +240,7 @@ def deploy_and_offer_db_app(client):
     client.deploy('cs:mysql')
     client.wait_for_started()
     client.wait_for_workloads()
-    return offer_endpoint(client, 'mysql', 'db')
+    return offer_endpoint(client, 'mysql', 'db', offer_name='offered-mysql')
 
 
 def offer_endpoint(client, app_name, relation_name, offer_name=None):

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -54,6 +54,10 @@ type Backend interface {
 	// with the supplied name (which must be unique across all applications, local and remote).
 	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
 
+	// OfferNameForRelation gets the name of the offer for the
+	// specified cross-model relation key.
+	OfferNameForRelation(string) (string, error)
+
 	// GetRemoteEntity returns the tag of the entity associated with the given token.
 	GetRemoteEntity(string) (names.Tag, error)
 

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -135,6 +135,19 @@ func (st stateShim) AddRemoteApplication(args state.AddRemoteApplicationParams) 
 	return remoteApplicationShim{a}, nil
 }
 
+func (st stateShim) OfferNameForRelation(key string) (string, error) {
+	oc, err := st.State.OfferConnectionForRelation(key)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	appOffers := state.NewApplicationOffers(st.State)
+	offer, err := appOffers.ApplicationOfferForUUID(oc.OfferUUID())
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return offer.OfferName, nil
+}
+
 func (st stateShim) GetRemoteEntity(token string) (names.Tag, error) {
 	r := st.State.RemoteEntities()
 	return r.GetRemoteEntity(token)

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -378,7 +378,7 @@ func (api *CrossModelRelationsAPI) WatchRelationChanges(remoteRelationArgs param
 		if !ok {
 			return nil, empty, common.ErrPerm
 		}
-		relationToken, appToken, err := commoncrossmodel.GetRelationTokens(api.st, relationTag)
+		relationToken, appToken, err := commoncrossmodel.GetOfferingRelationTokens(api.st, relationTag)
 		if err != nil {
 			return nil, empty, errors.Trace(err)
 		}
@@ -406,6 +406,7 @@ func (api *CrossModelRelationsAPI) WatchRelationChanges(remoteRelationArgs param
 	for i, arg := range remoteRelationArgs.Args {
 		w, changes, err := watchOne(arg)
 		if err != nil {
+			logger.Tracef("not found watching relation %s: %s", arg.Token, errors.ErrorStack(err))
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -606,7 +606,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 	s.st.remoteApplications["db2"] = &mockRemoteApplication{}
 	s.st.remoteEntities[names.NewApplicationTag("db2")] = "token-db2"
 	s.st.applications["django"] = &mockApplication{}
-	s.st.remoteEntities[names.NewApplicationTag("django")] = "token-django"
+	s.st.remoteEntities[names.NewApplicationTag("offer-django")] = "token-offer-django"
 	rel := newMockRelation(1)
 	ru1 := newMockRelationUnit()
 	ru2 := newMockRelationUnit()
@@ -648,6 +648,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 		relationKey:     "db2:db django:db",
 		relationId:      1,
 	}
+	s.st.offerNames["db2:db django:db"] = "offer-django"
 	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
 	mac, err := s.bakery.NewMacaroon(
 		[]checkers.Caveat{
@@ -670,7 +671,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 			RemoteRelationWatcherId: "1",
 			Changes: params.RemoteRelationChangeEvent{
 				RelationToken:    "token-db2:db django:db",
-				ApplicationToken: "token-django",
+				ApplicationToken: "token-offer-django",
 				Macaroons:        nil,
 				ApplicationSettings: map[string]interface{}{
 					"majoribanks": "mt victoria",
@@ -693,7 +694,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 	outw, ok := resource.(*commoncrossmodel.WrappedUnitsWatcher)
 	c.Assert(ok, gc.Equals, true)
 	c.Assert(outw.RelationToken, gc.Equals, "token-db2:db django:db")
-	c.Assert(outw.ApplicationToken, gc.Equals, "token-django")
+	c.Assert(outw.ApplicationToken, gc.Equals, "token-offer-django")
 
 	// TODO(babbageclunk): add locking around updating mock
 	// relation/relunit settings.

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -46,6 +46,7 @@ type mockState struct {
 	remoteApplications    map[string]*mockRemoteApplication
 	applications          map[string]*mockApplication
 	offers                map[string]*crossmodel.ApplicationOffer
+	offerNames            map[string]string
 	offerConnections      map[int]*mockOfferConnection
 	offerConnectionsByKey map[string]*mockOfferConnection
 	remoteEntities        map[names.Tag]string
@@ -60,6 +61,7 @@ func newMockState() *mockState {
 		applications:          make(map[string]*mockApplication),
 		remoteEntities:        make(map[names.Tag]string),
 		offers:                make(map[string]*crossmodel.ApplicationOffer),
+		offerNames:            make(map[string]string),
 		offerConnections:      make(map[int]*mockOfferConnection),
 		offerConnectionsByKey: make(map[string]*mockOfferConnection),
 		firewallRules:         make(map[state.WellKnownServiceType]*state.FirewallRule),
@@ -154,6 +156,14 @@ func (st *mockState) AddRemoteApplication(params state.AddRemoteApplicationParam
 		consumerproxy:   params.IsConsumerProxy}
 	st.remoteApplications[params.Name] = app
 	return app, nil
+}
+
+func (st *mockState) OfferNameForRelation(key string) (string, error) {
+	st.MethodCall(st, "OfferNameForRelation", key)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	return st.offerNames[key], nil
 }
 
 func (st *mockState) ImportRemoteEntity(entity names.Tag, token string) error {

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -358,7 +358,7 @@ func (api *RemoteRelationsAPI) WatchLocalRelationChanges(args params.Entities) (
 		if err != nil {
 			return nil, empty, errors.Trace(err)
 		}
-		relationToken, appToken, err := commoncrossmodel.GetRelationTokens(api.st, relationTag)
+		relationToken, appToken, err := commoncrossmodel.GetConsumingRelationTokens(api.st, relationTag)
 		if err != nil {
 			return nil, empty, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -244,7 +244,8 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 		{"Application", []interface{}{"django"}},
 		{"GetRemoteEntity", []interface{}{"token-relation-django.db#db2.db"}},
 		{"KeyRelation", []interface{}{"django:db db2:db"}},
-		{"GetRemoteEntity", []interface{}{"token-application-django"}},
+		{"Application", []interface{}{"db2"}},
+		{"Application", []interface{}{"django"}},
 		{"KeyRelation", []interface{}{"hadoop:db db2:db"}},
 	})
 
@@ -252,6 +253,7 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 		{"Endpoints", []interface{}{}},
 		{"Endpoints", []interface{}{}},
 		{"WatchUnits", []interface{}{"django"}},
+		{"Endpoints", []interface{}{}},
 		{"ApplicationSettings", []interface{}{"django"}},
 		{"Unit", []interface{}{"django/0"}},
 	})

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -17,6 +17,7 @@ import (
 
 // Logger represents the methods used by the worker to log details.
 type Logger interface {
+	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
 	Infof(string, ...interface{})
 	Warningf(string, ...interface{})

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -182,6 +182,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 				key := change[i]
 				if err := w.relationChanged(key, result, relations); err != nil {
 					if params.IsCodeNotFound(err) {
+						w.logger.Tracef("not found from relationChanged for %#v: %s", result, errors.ErrorStack(err))
 						return w.remoteOfferRemoved()
 					}
 					return errors.Annotatef(err, "handling change for relation %q", key)


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change
The appdata changes to the crossmodelrelations and remoterelations facades incorrectly assumed that the application token always translates to the application tag, when in fact in offering models it contains the offer name (as an application tag). This meant that if an application was offered under a different name the crossmodel code would return a NotFound error when the worker in the consuming model tried to watch the new relation, so the worker would mark the SAAS terminated in its model and give up.

Split GetRelationTokens into a consuming version (which gets the application name from the relation) and an offering one that gets it from the offer.

## QA steps

```sh
juju deploy -m offering-model percona-cluster
juju offer offering-model.percona-cluster.db offered-db

juju deploy -m consuming-model mediawiki
juju relate -m consuming-model mediawiki:db offering-model.offered-db

# mediawiki should become unblocked because it has a db.
# The offered-db saas in consuming-model shouldn't be in "terminated" state.
```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860992
