### PR TITLE
Enable Cluster Scoped CRDs;

### DIFF
--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -417,7 +417,7 @@ customResourceDefinitions:
   tfjobs.kubeflow.org:
     group: kubeflow.org
     version: v1alpha2
-    scope: Cluster
+    scope: invalid-scope
     names:
       plural: "tfjobs"
       singular: "tfjob"
@@ -446,7 +446,7 @@ customResourceDefinitions:
 `[1:]
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, gc.ErrorMatches, `custom resource definition "tfjobs.kubeflow.org" scope "Cluster" is not supported, please use "Namespaced" scope`)
+	c.Assert(err, gc.ErrorMatches, `custom resource definition "tfjobs.kubeflow.org" scope "invalid-scope" is not supported, please use "Namespaced" or "Cluster" scope`)
 }
 
 func (s *legacySpecsSuite) TestUnknownFieldError(c *gc.C) {

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -122,10 +122,10 @@ type KubernetesResources struct {
 }
 
 func validateCustomResourceDefinition(name string, crd apiextensionsv1beta1.CustomResourceDefinitionSpec) error {
-	if crd.Scope != apiextensionsv1beta1.NamespaceScoped {
+	if crd.Scope != apiextensionsv1beta1.NamespaceScoped && crd.Scope != apiextensionsv1beta1.ClusterScoped {
 		return errors.NewNotSupported(nil,
-			fmt.Sprintf("custom resource definition %q scope %q is not supported, please use %q scope",
-				name, crd.Scope, apiextensionsv1beta1.NamespaceScoped),
+			fmt.Sprintf("custom resource definition %q scope %q is not supported, please use %q or %q scope",
+				name, crd.Scope, apiextensionsv1beta1.NamespaceScoped, apiextensionsv1beta1.ClusterScoped),
 		)
 	}
 	return nil

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -173,7 +173,7 @@ kubernetesResources:
   customResourceDefinitions:
     tfjobs.kubeflow.org:
       group: kubeflow.org
-      scope: Namespaced
+      scope: Cluster
       names:
         kind: TFJob
         singular: tfjob
@@ -533,7 +533,7 @@ password: shhhh`[1:],
 							{Name: "v1", Served: true, Storage: true},
 							{Name: "v1beta2", Served: true, Storage: false},
 						},
-						Scope: "Namespaced",
+						Scope: "Cluster",
 						Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 							Kind:     "TFJob",
 							Plural:   "tfjobs",
@@ -734,7 +734,7 @@ kubernetesResources:
     tfjobs.kubeflow.org:
       group: kubeflow.org
       version: v1alpha2
-      scope: Cluster
+      scope: invalid-scope
       names:
         plural: "tfjobs"
         singular: "tfjob"
@@ -763,7 +763,7 @@ kubernetesResources:
 `[1:]
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, gc.ErrorMatches, `custom resource definition "tfjobs.kubeflow.org" scope "Cluster" is not supported, please use "Namespaced" scope`)
+	c.Assert(err, gc.ErrorMatches, `custom resource definition "tfjobs.kubeflow.org" scope "invalid-scope" is not supported, please use "Namespaced" or "Cluster" scope`)
 }
 
 func (s *v2SpecsSuite) TestValidateMutatingWebhookConfigurations(c *gc.C) {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Enables `Cluster` scoped CRDs;

## QA steps

deploy k8s charm with below k8sspec:

```yaml
kubernetesResources:
  customResourceDefinitions:
    tfjobs.kubeflow.org:
      group: kubeflow.org
      scope: Cluster  # cluster scope!
      names:
        kind: TFJob
        singular: tfjob
        plural: tfjobs
      versions:
        - name: v1
          served: true
          storage: true
      subresources:
        status: {}
      validation:
        openAPIV3Schema:
          properties:
            spec:
              properties:
                tfReplicaSpecs:
                  properties:
                    # The validation works when the configuration contains
                    # `Worker`, `PS` or `Chief`. Otherwise it will not be validated.
                    Worker:
                      properties:
                        replicas:
                          type: integer
                          minimum: 1
                    PS:
                      properties:
                        replicas:
                          type: integer
                          minimum: 1
                    Chief:
                      properties:
                        replicas:
                          type: integer
                          minimum: 1
                          maximum: 1
```

```console
$ juju deploy cs:~kelvin.liu/mariadb-k8s-3

$ kubectl get crd tfjobs.kubeflow.org -o jsonpath="{..scope}"
Cluster

$ kubectl get tfjobs
NAME                      AGE
dist-mnist-for-e2e-test   3m28s

# so cr `dist-mnist-for-e2e-test ` is cluster scope;
$ kubectl get tfjobs dist-mnist-for-e2e-test -o jsonpath="{..namespace}"
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860688
