### PR TITLE
Command add-machine Always Uses machinemanager Facade

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -164,6 +164,13 @@ func (c *Client) AddMachines(machineParams []params.AddMachineParams) ([]params.
 
 // ProvisioningScript returns a shell script that, when run,
 // provisions a machine agent on the machine executing the script.
+//
+// TODO (manadart 2020-01-29): This method, along with its server facade should
+// be moved to the machinemanager client/facade.
+// Then the machinemanager client can be used as an implementation of
+// environs.manual.ProvisioningClientAPI.
+// Then AddMachines above can be removed along with client API facade methods
+// that add machines (AddMachines, AddMachinesV2 and InjectMachines).
 func (c *Client) ProvisioningScript(args params.ProvisioningScriptParams) (script string, err error) {
 	var result params.ProvisioningScriptResult
 	if err = c.facade.FacadeCall("ProvisioningScript", args, &result); err != nil {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch follows the security fixes for `add-machine`. It is a small step towards deprecation of machine commands from the client API facade.

It simply ensures that the `add-machine` command always uses the `machinemanager` facade and never the `client` facade.

I could not remove the command from the client API, because it is used in more places than just the add command. More extensive work is required to clean it up properly, but I have added a comment regarding this.

## QA steps

I ran every variant from the add-machine help (requires MAAS and AWS controllers), except the _winrm_ example:
```
Examples:
   juju add-machine                      (starts a new machine)
   juju add-machine -n 2                 (starts 2 new machines)
   juju add-machine lxd                  (starts a new machine with an lxd container)
   juju add-machine lxd -n 2             (starts 2 new machines with an lxd container)
   juju add-machine lxd:4                (starts a new lxd container on machine 4)
   juju add-machine --constraints mem=8G (starts a machine with at least 8GB RAM)
   juju add-machine ssh:user@10.10.0.3   (manually provisions machine with ssh)
   juju add-machine winrm:user@10.10.0.3 (manually provisions machine with winrm)
   juju add-machine zone=us-east-1a      (start a machine in zone us-east-1a on AWS)
   juju add-machine maas2.name           (acquire machine maas2.name on MAAS)
```

## Documentation changes

None.

## Bug reference

N/A
