### PR TITLE
2.7 Space ID Upgrade Fix for MAAS

### DIFF
--- a/core/network/space.go
+++ b/core/network/space.go
@@ -3,7 +3,13 @@
 
 package network
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/juju/collections/set"
+)
 
 const (
 	// AlphaSpaceId is the ID of the alpha network space.
@@ -88,4 +94,45 @@ func (s SpaceInfos) GetByName(name string) *SpaceInfo {
 		}
 	}
 	return nil
+}
+
+var (
+	invalidSpaceNameChars = regexp.MustCompile("[^0-9a-z-]")
+	dashPrefix            = regexp.MustCompile("^-*")
+	dashSuffix            = regexp.MustCompile("-*$")
+	multipleDashes        = regexp.MustCompile("--+")
+)
+
+// ConvertSpaceName is used to massage provider-sourced (i.e. MAAS)
+// space names so that they conform to Juju's space name rules.
+func ConvertSpaceName(name string, existing set.Strings) string {
+	// Lower case and replace spaces with dashes.
+	name = strings.Replace(name, " ", "-", -1)
+	name = strings.ToLower(name)
+
+	// Remove any character not in the set "-", "a-z", "0-9".
+	name = invalidSpaceNameChars.ReplaceAllString(name, "")
+
+	// Remove any dashes at the beginning and end.
+	name = dashPrefix.ReplaceAllString(name, "")
+	name = dashSuffix.ReplaceAllString(name, "")
+
+	// Replace multiple dashes with a single dash.
+	name = multipleDashes.ReplaceAllString(name, "-")
+
+	// If the name had only invalid characters, give it a new name.
+	if name == "" {
+		name = "empty"
+	}
+
+	// If this name is in use add a numerical suffix.
+	if existing.Contains(name) {
+		counter := 2
+		for existing.Contains(name + fmt.Sprintf("-%d", counter)) {
+			counter += 1
+		}
+		name = name + fmt.Sprintf("-%d", counter)
+	}
+
+	return name
 }

--- a/network/network.go
+++ b/network/network.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -20,10 +19,6 @@ import (
 )
 
 var logger = loggo.GetLogger("juju.network")
-
-// SpaceInvalidChars is a regexp for validating that space names contain no
-// invalid characters.
-var SpaceInvalidChars = regexp.MustCompile("[^0-9a-z-]")
 
 // noAddress represents an error when an address is requested but not available.
 type noAddress struct {
@@ -58,42 +53,6 @@ const DefaultLXDBridge = "lxdbr0"
 // DefaultKVMBridge is the bridge that is set up by installing libvirt-bin
 // Note: we don't import this from 'container' to avoid import loops
 const DefaultKVMBridge = "virbr0"
-
-var dashPrefix = regexp.MustCompile("^-*")
-var dashSuffix = regexp.MustCompile("-*$")
-var multipleDashes = regexp.MustCompile("--+")
-
-// ConvertSpaceName converts names between provider space names and valid juju
-// space names.
-// TODO(mfoord): once MAAS space name rules are in sync with juju space name
-// rules this can go away.
-func ConvertSpaceName(name string, existing set.Strings) string {
-	// First lower case and replace spaces with dashes.
-	name = strings.Replace(name, " ", "-", -1)
-	name = strings.ToLower(name)
-	// Replace any character that isn't in the set "-", "a-z", "0-9".
-	name = SpaceInvalidChars.ReplaceAllString(name, "")
-	// Get rid of any dashes at the start as that isn't valid.
-	name = dashPrefix.ReplaceAllString(name, "")
-	// And any at the end.
-	name = dashSuffix.ReplaceAllString(name, "")
-	// Replace multiple dashes with a single dash.
-	name = multipleDashes.ReplaceAllString(name, "-")
-	// Special case of when the space name was only dashes or invalid
-	// characters!
-	if name == "" {
-		name = "empty"
-	}
-	// If this name is in use add a numerical suffix.
-	if existing.Contains(name) {
-		counter := 2
-		for existing.Contains(name + fmt.Sprintf("-%d", counter)) {
-			counter += 1
-		}
-		name = name + fmt.Sprintf("-%d", counter)
-	}
-	return name
-}
 
 // InterfaceConfigType defines valid network interface configuration
 // types. See interfaces(5) for details

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -177,34 +177,6 @@ type NetworkSuite struct {
 
 var _ = gc.Suite(&NetworkSuite{})
 
-func (s *NetworkSuite) TestConvertSpaceName(c *gc.C) {
-	empty := set.Strings{}
-	nameTests := []struct {
-		name     string
-		existing set.Strings
-		expected string
-	}{
-		{"foo", empty, "foo"},
-		{"foo1", empty, "foo1"},
-		{"Foo Thing", empty, "foo-thing"},
-		{"foo^9*//++!!!!", empty, "foo9"},
-		{"--Foo", empty, "foo"},
-		{"---^^&*()!", empty, "empty"},
-		{" ", empty, "empty"},
-		{"", empty, "empty"},
-		{"foo\u2318", empty, "foo"},
-		{"foo--", empty, "foo"},
-		{"-foo--foo----bar-", empty, "foo-foo-bar"},
-		{"foo-", set.NewStrings("foo", "bar", "baz"), "foo-2"},
-		{"foo", set.NewStrings("foo", "foo-2"), "foo-3"},
-		{"---", set.NewStrings("empty"), "empty-2"},
-	}
-	for _, test := range nameTests {
-		result := network.ConvertSpaceName(test.name, test.existing)
-		c.Check(result, gc.Equals, test.expected)
-	}
-}
-
 func (s *NetworkSuite) TestFilterBridgeAddresses(c *gc.C) {
 	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
 	// We create an LXC bridge named "foobar", and then put 10.0.3.1,

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -750,7 +750,7 @@ func (env *maasEnviron) buildSpaceMap(ctx context.ProviderCallContext) (map[stri
 	spaceMap := make(map[string]corenetwork.SpaceInfo)
 	empty := set.Strings{}
 	for _, space := range spaces {
-		jujuName := network.ConvertSpaceName(string(space.Name), empty)
+		jujuName := corenetwork.ConvertSpaceName(string(space.Name), empty)
 		spaceMap[jujuName] = space
 	}
 	return spaceMap, nil

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -27,13 +27,12 @@ import (
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	envinstance "github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/tags"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	commonProvider "github.com/juju/juju/provider/oracle/common"
 	oraclenet "github.com/juju/juju/provider/oracle/network"
@@ -211,7 +210,7 @@ func (e *OracleEnviron) getCloudInitConfig(series string, networks map[string]oc
 // shamelessly copied from the MAAS provider
 func (e *OracleEnviron) buildSpacesMap(
 	ctx context.ProviderCallContext,
-) (map[string]corenetwork.SpaceInfo, map[string]string, error) {
+) (map[string]network.SpaceInfo, map[string]string, error) {
 	empty := set.Strings{}
 	providerIdMap := map[string]string{}
 	// NOTE (gsamfira): This seems brittle to me, and I would much rather get this
@@ -224,7 +223,7 @@ func (e *OracleEnviron) buildSpacesMap(
 	if err != nil {
 		return nil, providerIdMap, errors.Trace(err)
 	}
-	spaceMap := make(map[string]corenetwork.SpaceInfo)
+	spaceMap := make(map[string]network.SpaceInfo)
 	for _, space := range spaces {
 		jujuName := network.ConvertSpaceName(string(space.Name), empty)
 		spaceMap[jujuName] = space

--- a/state/spacesdiscovery.go
+++ b/state/spacesdiscovery.go
@@ -165,7 +165,7 @@ func (st *State) SaveSpacesFromProvider(providerSpaces []corenetwork.SpaceInfo) 
 		} else {
 			// The space is new, we need to create a valid name for it in state.
 			// Convert the name into a valid name that is not already in use.
-			spaceName := network.ConvertSpaceName(string(spaceInfo.Name), spaceNames)
+			spaceName := corenetwork.ConvertSpaceName(string(spaceInfo.Name), spaceNames)
 
 			logger.Debugf("Adding space %s from provider %s", spaceName, string(spaceInfo.ProviderId))
 			space, err := st.AddSpace(spaceName, spaceInfo.ProviderId, []string{}, false)

--- a/state/upgrade/types.go
+++ b/state/upgrade/types.go
@@ -32,7 +32,7 @@ type OldAddress27 struct {
 	SpaceID     string `bson:"spaceid,omitempty"`
 }
 
-// convert accepts an address and a name-to-ID space lookup and returns a
+// Upgrade accepts an address and a name-to-ID space lookup and returns a
 // new address representation based on whether space name/ID are populated.
 // An error is returned if the address has a non-empty space name that we
 // cannot map to an ID.
@@ -54,7 +54,11 @@ func (a OldAddress27) Upgrade(lookup map[string]string) (OldAddress27, error) {
 			logger.Warningf("not converting address %q with empty space name and ID %q", a.Value, a.SpaceID)
 		}
 	} else {
-		newID, ok := lookup[a.SpaceName]
+		// On old versions of Juju, we did not convert the space names
+		// on addresses that the instance poller received from MAAS.
+		// We need to ensure that these can be matched with the names in the
+		// spaces collected, which *are* converted when reload-spaces is run.
+		newID, ok := lookup[network.ConvertSpaceName(a.SpaceName, nil)]
 		if !ok {
 			return a, errors.NotFoundf("space with name: %q", a.SpaceName)
 		}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3821,7 +3821,9 @@ func (s *upgradesSuite) TestConvertAddressSpaceIDs(c *gc.C) {
 		{
 			Value:     "3.3.3.3",
 			SpaceName: "space3",
-			SpaceID:   "provider3",
+			// This is an invalid form, but should still be
+			// correctly matched to the ID for provider3.
+			SpaceID: "pRoViDeR3",
 		},
 	}
 	m2Private := oldAddress{


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This is the first patch in a series that will address space name disconnects between Juju and MAAS.

When space discovery occurs, Juju ensures that space names from MAAS are valid in Juju, which means changing them to conform to the valid form.

However, provider-source _addresses_ from MAAS do not change the name, which means machine addresses can be decorated with space names that we fail to lookup from in the Juju collection.

This patch changes the upgrade step for replacing machine address space names with IDs, so that only the valid forms of the names are compared in order to lookup space names.

## QA steps

- With Juju 2.6.x: `juju bootstrap guimaas source-routing --no-gui --debug --to nuc1`
- `juju add-machine --constraints "tags=micro"`. Node micro1 is in a space with an invalid name.
- With this patch, `juju upgrade-controller --build-agent`. The upgrade should complete.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1856537
