### PR TITLE
2.7 MAAS Addresses With Juju-Compliant Space Names

### DIFF
--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -269,9 +269,13 @@ func maasObjectNetworkInterfaces(
 			nicInfo.ProviderSubnetId = corenetwork.Id(fmt.Sprintf("%v", sub.ID))
 			nicInfo.ProviderVLANId = corenetwork.Id(fmt.Sprintf("%v", sub.VLAN.ID))
 
+			// Provider addresses are created with a space name massaged
+			// to conform to Juju's space name rules.
+			space := corenetwork.ConvertSpaceName(sub.Space, nil)
+
 			// Now we know the subnet and space, we can update the address to
 			// store the space with it.
-			nicInfo.Address = corenetwork.NewProviderAddressInSpace(sub.Space, link.IPAddress)
+			nicInfo.Address = corenetwork.NewProviderAddressInSpace(space, link.IPAddress)
 			spaceId, ok := subnetsMap[sub.CIDR]
 			if !ok {
 				// The space we found is not recognised.
@@ -282,8 +286,8 @@ func maasObjectNetworkInterfaces(
 				nicInfo.ProviderSpaceId = spaceId
 			}
 
-			gwAddr := corenetwork.NewProviderAddressInSpace(sub.Space, sub.GatewayIP)
-			nicInfo.DNSServers = corenetwork.NewProviderAddressesInSpace(sub.Space, sub.DNSServers...)
+			gwAddr := corenetwork.NewProviderAddressInSpace(space, sub.GatewayIP)
+			nicInfo.DNSServers = corenetwork.NewProviderAddressesInSpace(space, sub.DNSServers...)
 			if ok {
 				gwAddr.ProviderSpaceID = spaceId
 				for i := range nicInfo.DNSServers {
@@ -381,9 +385,13 @@ func maas2NetworkInterfaces(
 			nicInfo.ProviderSubnetId = corenetwork.Id(fmt.Sprintf("%v", sub.ID()))
 			nicInfo.ProviderVLANId = corenetwork.Id(fmt.Sprintf("%v", sub.VLAN().ID()))
 
+			// Provider addresses are created with a space name massaged
+			// to conform to Juju's space name rules.
+			space := corenetwork.ConvertSpaceName(sub.Space(), nil)
+
 			// Now we know the subnet and space, we can update the address to
 			// store the space with it.
-			nicInfo.Address = corenetwork.NewProviderAddressInSpace(sub.Space(), link.IPAddress())
+			nicInfo.Address = corenetwork.NewProviderAddressInSpace(space, link.IPAddress())
 			spaceId, ok := subnetsMap[sub.CIDR()]
 			if !ok {
 				// The space we found is not recognised.
@@ -394,8 +402,8 @@ func maas2NetworkInterfaces(
 				nicInfo.ProviderSpaceId = spaceId
 			}
 
-			gwAddr := corenetwork.NewProviderAddressInSpace(sub.Space(), sub.Gateway())
-			nicInfo.DNSServers = corenetwork.NewProviderAddressesInSpace(sub.Space(), sub.DNSServers()...)
+			gwAddr := corenetwork.NewProviderAddressInSpace(space, sub.Gateway())
+			nicInfo.DNSServers = corenetwork.NewProviderAddressesInSpace(space, sub.DNSServers()...)
 			if ok {
 				gwAddr.ProviderSpaceID = spaceId
 				for i := range nicInfo.DNSServers {

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -179,7 +179,7 @@ const exampleInterfaceSetJSON = `
 				"subnet": {
 					"dns_servers": [],
 					"name": "public",
-					"space": "public",
+					"space": "Public",
 					"vlan": {
 						"name": "public",
 						"vid": 100,
@@ -516,11 +516,11 @@ var exampleParsedInterfaceSetJSON = []network.InterfaceInfo{{
 	Disabled:            false,
 	NoAutoStart:         false,
 	ConfigType:          "static",
-	Address:             newAddressOnSpaceWithId("storage", corenetwork.Id("3"), "10.250.19.103"),
+	Address:             newAddressOnSpaceWithId("storage", "3", "10.250.19.103"),
 	DNSServers:          nil,
 	DNSSearchDomains:    nil,
 	MTU:                 1500,
-	GatewayAddress:      newAddressOnSpaceWithId("storage", corenetwork.Id("3"), "10.250.19.2"),
+	GatewayAddress:      newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
 }, {
 	DeviceIndex:         4,
 	MACAddress:          "52:54:00:08:24:2d",
@@ -557,11 +557,11 @@ var exampleParsedInterfaceSetJSON = []network.InterfaceInfo{{
 	Disabled:            false,
 	NoAutoStart:         false,
 	ConfigType:          "dhcp",
-	Address:             newAddressOnSpaceWithId("space-0", corenetwork.Id("4"), "192.168.20.192"),
+	Address:             newAddressOnSpaceWithId("space-0", "4", "192.168.20.192"),
 	DNSServers:          nil,
 	DNSSearchDomains:    nil,
 	MTU:                 1500,
-	GatewayAddress:      newAddressOnSpaceWithId("space-0", corenetwork.Id("4"), "192.168.20.2"),
+	GatewayAddress:      newAddressOnSpaceWithId("space-0", "4", "192.168.20.2"),
 }}
 
 func (s *interfacesSuite) TestParseInterfacesNoJSON(c *gc.C) {
@@ -695,7 +695,7 @@ func (s *interfacesSuite) TestParseInterfacesExampleJSON(c *gc.C) {
 			Subnet: &maasSubnet{
 				ID:          6,
 				Name:        "public",
-				Space:       "public",
+				Space:       "Public",
 				VLAN:        vlan100,
 				GatewayIP:   "10.100.19.2",
 				DNSServers:  []string{},
@@ -786,9 +786,9 @@ func (s *interfacesSuite) TestMAASObjectNetworkInterfaces(c *gc.C) {
     }`, exampleInterfaceSetJSON)
 	obj := s.testMAASObject.TestServer.NewNode(nodeJSON)
 	subnetsMap := make(map[string]corenetwork.Id)
-	subnetsMap["10.250.19.0/24"] = corenetwork.Id("3")
-	subnetsMap["192.168.1.0/24"] = corenetwork.Id("0")
-	subnetsMap["192.168.20.0/24"] = corenetwork.Id("4")
+	subnetsMap["10.250.19.0/24"] = "3"
+	subnetsMap["192.168.1.0/24"] = "0"
+	subnetsMap["192.168.20.0/24"] = "4"
 
 	infos, err := maasObjectNetworkInterfaces(s.callCtx, &obj, subnetsMap)
 	c.Assert(err, jc.ErrorIsNil)
@@ -822,7 +822,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 
 	subnetPXE := fakeSubnet{
 		id:         3,
-		space:      "default",
+		space:      "Default",
 		vlan:       vlan0,
 		gateway:    "10.20.19.2",
 		cidr:       "10.20.19.0/24",
@@ -891,7 +891,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 					id: 519,
 					subnet: &fakeSubnet{
 						id:         6,
-						space:      "public",
+						space:      "Public",
 						vlan:       vlan100,
 						gateway:    "10.100.19.2",
 						cidr:       "10.100.19.0/24",
@@ -932,8 +932,8 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 	}
 
 	subnetsMap := make(map[string]corenetwork.Id)
-	subnetsMap["10.250.19.0/24"] = corenetwork.Id("3")
-	subnetsMap["192.168.1.0/24"] = corenetwork.Id("0")
+	subnetsMap["10.250.19.0/24"] = "3"
+	subnetsMap["192.168.1.0/24"] = "0"
 
 	expected := []network.InterfaceInfo{{
 		DeviceIndex:       0,
@@ -1034,11 +1034,11 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Address:             newAddressOnSpaceWithId("storage", corenetwork.Id("3"), "10.250.19.103"),
+		Address:             newAddressOnSpaceWithId("storage", "3", "10.250.19.103"),
 		DNSServers:          nil,
 		DNSSearchDomains:    nil,
 		MTU:                 1500,
-		GatewayAddress:      newAddressOnSpaceWithId("storage", corenetwork.Id("3"), "10.250.19.2"),
+		GatewayAddress:      newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
 	}}
 	machine := &fakeMachine{interfaceSet: exampleInterfaces}
 	instance := &maas2Instance{machine: machine}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch ensures that provider addresses coming from MAAS have space names that conform to Juju's space name rules.

This prevents errors thrown by the instance poller when it cannot match incoming space names to the Juju space name collection for ID determination

## QA steps

*Please replace with how we can verify that the change works?*

- `juju bootstrap guimaas source-routing --no-gui --debug --to nuc1`
- `juju add-machine --constraints "tags=micro"`. Node micro1 is in a space with an invalid name.
- `juju debug-log -m controller` and observe that the instance poller runs without errors.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1856537
