### PR TITLE
acceptancetest: add --force option to test series we do not support yet

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-
 from argparse import ArgumentParser
 from contextlib import contextmanager
+
 try:
     from contextlib import nested
 except ImportError:
@@ -66,7 +66,6 @@ from utility import (
     until_timeout,
     wait_for_port,
 )
-
 
 __metaclass__ = type
 
@@ -421,9 +420,9 @@ def assess_juju_run(client):
     for machine in responses:
         if machine.get('ReturnCode', 0) != 0:
             raise ValueError('juju run on machine %s returned %d: %s' % (
-                             machine.get('MachineId'),
-                             machine.get('ReturnCode'),
-                             machine.get('Stderr')))
+                machine.get('MachineId'),
+                machine.get('ReturnCode'),
+                machine.get('Stderr')))
     logging.info(
         "juju run succeeded on machines: %r",
         [str(machine.get("MachineId")) for machine in responses])
@@ -497,6 +496,8 @@ def deploy_job_parse_args(argv=None):
             ' authentication.'))
     parser.add_argument('--use-charmstore', action='store_true',
                         help='Deploy dummy charms from the charmstore.')
+    parser.add_argument('--force', action='store', default=False,
+                        help='forces the controller to be deployed even though the series is not supported.')
     return parser.parse_args(argv)
 
 
@@ -1251,7 +1252,7 @@ def _deploy_job(args, charm_series, series):
         args.temp_env_name, client, client, args.bootstrap_host, args.machine,
         series, args.agent_url, args.agent_stream, args.region, args.logs,
         args.keep_env, controller_strategy=controller_strategy)
-    with bs_manager.booted_context(args.upload_tools):
+    with bs_manager.booted_context(upload_tools=args.upload_tools, force=args.force):
         # Create a no-op context manager, to avoid duplicate calls of
         # deploy_dummy_stack(), as was the case prior to this revision.
         manager = nested()
@@ -1259,8 +1260,8 @@ def _deploy_job(args, charm_series, series):
             deploy_dummy_stack(client, charm_series, args.use_charmstore)
         assess_juju_relations(client)
         skip_juju_run = (
-            (client.version < "2" and sys.platform in ("win32", "darwin")) or
-            charm_series.startswith(("centos", "win")))
+                (client.version < "2" and sys.platform in ("win32", "darwin")) or
+                charm_series.startswith(("centos", "win")))
         if not skip_juju_run:
             assess_juju_run(client)
         if args.upgrade:

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -878,7 +878,7 @@ class ModelClient:
             self, upload_tools, config_filename, bootstrap_series=None,
             credential=None, auto_upgrade=False, metadata_source=None,
             no_gui=False, agent_version=None, db_snap_path=None,
-            db_snap_asserts_path=None):
+            db_snap_asserts_path=None, force=False):
         """Return the bootstrap arguments for the substrate."""
         cloud_region = self.get_cloud_region(self.env.get_cloud(),
                                              self.env.get_region())
@@ -887,6 +887,8 @@ class ModelClient:
             cloud_region, self.env.environment,
             '--config', config_filename,
         ]
+        if force:
+            args.extend(['--force'])
         if self.env.provider == 'kubernetes':
             return tuple(args)
 
@@ -1016,7 +1018,7 @@ class ModelClient:
     def bootstrap(self, upload_tools=False, bootstrap_series=None,
                   credential=None, auto_upgrade=False, metadata_source=None,
                   no_gui=False, agent_version=None, db_snap_path=None,
-                  db_snap_asserts_path=None, mongo_memory_profile=None, caas_image_repo=None):
+                  db_snap_asserts_path=None, mongo_memory_profile=None, caas_image_repo=None, force=False):
         """Bootstrap a controller."""
         self._check_bootstrap()
         with self._bootstrap_config(
@@ -1033,6 +1035,7 @@ class ModelClient:
                 agent_version=agent_version,
                 db_snap_path=db_snap_path,
                 db_snap_asserts_path=db_snap_asserts_path,
+                force=force
             )
             self.update_user_name()
             retvar, ct = self.juju('bootstrap', args, include_e=False)

--- a/acceptancetests/jujupy/timeout.py
+++ b/acceptancetests/jujupy/timeout.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-#
+# coding=utf-8
+# !/usr/bin/env python
 # This file is part of JujuPy, a library for driving the Juju CLI.
 # Copyright 2015, 2017 Canonical Ltd.
 #
@@ -26,7 +26,6 @@ import time
 
 from utility import until_timeout
 
-
 # Generate a list of all signals that can be used with Popen.send_signal on
 # this platform.
 if sys.platform == 'win32':
@@ -35,7 +34,7 @@ if sys.platform == 'win32':
         # CTRL_C_EVENT is also supposed to work, but experience shows
         # otherwise.
         'CTRL_BREAK': signal.CTRL_BREAK_EVENT,
-        }
+    }
 else:
     # Blech.  No equivalent of errno.errorcode for signals.
     signals = dict(


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Additionally, I needed to add the encoding for the timeout.py file. For some reason, my debugger complained. Doing this should be fine either way.

## QA steps

Running local deploy.py is a small hassle. At least for me.

- Need to make sure to run as a user, who has a `environments.yaml` under `JUJU_HOME`

QA itself:

```
--series focal lxd 
```
should fail with something along the line of: 
```
11:20:22 ERROR juju.cmd.juju.commands bootstrap.go:778 failed to bootstrap model: use --force to override: focal not supported
```

```
deploy.py --series focal lxd --force true
```

Should not fail with the above message. It may fail because of other dependencies though.
