### PR TITLE
acceptancetest: add --force option to test series we do not support yet

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -497,6 +497,8 @@ def deploy_job_parse_args(argv=None):
             ' authentication.'))
     parser.add_argument('--use-charmstore', action='store_true',
                         help='Deploy dummy charms from the charmstore.')
+    parser.add_argument('--force', action='store', default=False,
+                        help='forces the controller to be deployed even though the series is not supported.')
     return parser.parse_args(argv)
 
 
@@ -1251,7 +1253,7 @@ def _deploy_job(args, charm_series, series):
         args.temp_env_name, client, client, args.bootstrap_host, args.machine,
         series, args.agent_url, args.agent_stream, args.region, args.logs,
         args.keep_env, controller_strategy=controller_strategy)
-    with bs_manager.booted_context(args.upload_tools):
+    with bs_manager.booted_context(args.upload_tools, force=args.force):
         # Create a no-op context manager, to avoid duplicate calls of
         # deploy_dummy_stack(), as was the case prior to this revision.
         manager = nested()

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -878,7 +878,7 @@ class ModelClient:
             self, upload_tools, config_filename, bootstrap_series=None,
             credential=None, auto_upgrade=False, metadata_source=None,
             no_gui=False, agent_version=None, db_snap_path=None,
-            db_snap_asserts_path=None):
+            db_snap_asserts_path=None, force=False):
         """Return the bootstrap arguments for the substrate."""
         cloud_region = self.get_cloud_region(self.env.get_cloud(),
                                              self.env.get_region())
@@ -894,6 +894,8 @@ class ModelClient:
             '--constraints', self._get_substrate_constraints(),
             '--default-model', self.env.environment
         ]
+        if force:
+            args.extend(['--force'])
         if upload_tools:
             if agent_version is not None:
                 raise ValueError(
@@ -1016,7 +1018,7 @@ class ModelClient:
     def bootstrap(self, upload_tools=False, bootstrap_series=None,
                   credential=None, auto_upgrade=False, metadata_source=None,
                   no_gui=False, agent_version=None, db_snap_path=None,
-                  db_snap_asserts_path=None, mongo_memory_profile=None, caas_image_repo=None):
+                  db_snap_asserts_path=None, mongo_memory_profile=None, caas_image_repo=None, force=False):
         """Bootstrap a controller."""
         self._check_bootstrap()
         with self._bootstrap_config(
@@ -1033,6 +1035,7 @@ class ModelClient:
                 agent_version=agent_version,
                 db_snap_path=db_snap_path,
                 db_snap_asserts_path=db_snap_asserts_path,
+                force=force
             )
             self.update_user_name()
             retvar, ct = self.juju('bootstrap', args, include_e=False)


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change
acceptancetest: add --force option to test series we do not support yet

## QA steps

Running local deploy.py is a small hassle. At least for me.

- Need to make sure to run as a user, who has a `environments.yaml` under `JUJU_HOME`

QA itself:

```
--series focal lxd 
```
should fail with something along the line of: 
```
11:20:22 ERROR juju.cmd.juju.commands bootstrap.go:778 failed to bootstrap model: use --force to override: focal not supported
```

```
deploy.py --series focal lxd --force true
```

Should not fail with the above message. It may fail because of other dependencies though.
