### PR TITLE
[2.7] Extend metadata for disco-supporting test charms to also support focal

### DIFF
--- a/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
+++ b/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
@@ -17,3 +17,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
@@ -16,3 +16,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/dummy-resource/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-resource/metadata.yaml
@@ -11,6 +11,7 @@ series:
   - bionic
   - disco
   - eoan
+  - focal
 resources:
   foo:
     type: file

--- a/acceptancetests/repository/charms/dummy-sink/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-sink/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/dummy-source/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-source/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/dummy-storage/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-storage/metadata.yaml
@@ -13,6 +13,7 @@ series:
   - bionic
   - disco
   - eoan
+  - focal
 storage:
   single-fs:
     type: filesystem

--- a/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
@@ -17,3 +17,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/fill-logs/metadata.yaml
+++ b/acceptancetests/repository/charms/fill-logs/metadata.yaml
@@ -11,3 +11,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
@@ -21,3 +21,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
@@ -18,3 +18,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/mysql/metadata.yaml
+++ b/acceptancetests/repository/charms/mysql/metadata.yaml
@@ -42,3 +42,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/network-health/metadata.yaml
+++ b/acceptancetests/repository/charms/network-health/metadata.yaml
@@ -13,6 +13,7 @@ series:
   - bionic
   - disco
   - eoan
+  - focal
 requires:
   juju-info:
     interface: juju-info

--- a/acceptancetests/repository/charms/peer-xplod/metadata.yaml
+++ b/acceptancetests/repository/charms/peer-xplod/metadata.yaml
@@ -14,6 +14,7 @@ series:
   - bionic
   - disco
   - eoan
+  - focal
 subordinate: false
 peers:
   xplod:

--- a/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
@@ -15,6 +15,7 @@ series:
   - bionic
   - disco
   - eoan
+  - focal
 resources:
   index:
     type: file

--- a/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
@@ -16,3 +16,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/statusstresser/metadata.yaml
+++ b/acceptancetests/repository/charms/statusstresser/metadata.yaml
@@ -12,3 +12,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/ubuntu/metadata.yaml
+++ b/acceptancetests/repository/charms/ubuntu/metadata.yaml
@@ -12,3 +12,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/update-status-tester/metadata.yaml
+++ b/acceptancetests/repository/charms/update-status-tester/metadata.yaml
@@ -12,3 +12,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/charms/wordpress/metadata.yaml
+++ b/acceptancetests/repository/charms/wordpress/metadata.yaml
@@ -25,3 +25,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
@@ -17,3 +17,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
@@ -17,3 +17,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/tests/suites/appdata/charms/appdata-sink/metadata.yaml
+++ b/tests/suites/appdata/charms/appdata-sink/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal

--- a/tests/suites/appdata/charms/appdata-source/metadata.yaml
+++ b/tests/suites/appdata/charms/appdata-source/metadata.yaml
@@ -15,3 +15,4 @@ series:
   - bionic
   - disco
   - eoan
+  - focal


### PR DESCRIPTION
## Description of change
This PR updates the metadata for the charms used by acceptance tests to include support for focal