### PR TITLE
[2.7] Extend metadata for disco-supporting test charms to also support focal

### DIFF
--- a/acceptancetests/repository/charms/appdata-sink/metadata.yaml
+++ b/acceptancetests/repository/charms/appdata-sink/metadata.yaml
@@ -13,5 +13,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/appdata-source/metadata.yaml
+++ b/acceptancetests/repository/charms/appdata-source/metadata.yaml
@@ -13,5 +13,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
+++ b/acceptancetests/repository/charms/chaos-monkey/metadata.yaml
@@ -15,5 +15,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/client-forwardproxy/metadata.yaml
@@ -14,5 +14,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/dummy-resource/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-resource/metadata.yaml
@@ -9,8 +9,9 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+
 resources:
   foo:
     type: file

--- a/acceptancetests/repository/charms/dummy-sink/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-sink/metadata.yaml
@@ -13,5 +13,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/dummy-source/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-source/metadata.yaml
@@ -13,5 +13,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/dummy-storage/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-storage/metadata.yaml
@@ -11,8 +11,9 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+
 storage:
   single-fs:
     type: filesystem

--- a/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-subordinate/metadata.yaml
@@ -15,5 +15,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/fill-logs/metadata.yaml
+++ b/acceptancetests/repository/charms/fill-logs/metadata.yaml
@@ -9,5 +9,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-juju-ci/metadata.yaml
@@ -19,5 +19,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
+++ b/acceptancetests/repository/charms/jenkins-slave/metadata.yaml
@@ -16,5 +16,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/mysql/metadata.yaml
+++ b/acceptancetests/repository/charms/mysql/metadata.yaml
@@ -40,5 +40,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/network-health/metadata.yaml
+++ b/acceptancetests/repository/charms/network-health/metadata.yaml
@@ -11,8 +11,9 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+
 requires:
   juju-info:
     interface: juju-info

--- a/acceptancetests/repository/charms/peer-xplod/metadata.yaml
+++ b/acceptancetests/repository/charms/peer-xplod/metadata.yaml
@@ -12,8 +12,9 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+
 subordinate: false
 peers:
   xplod:

--- a/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
@@ -13,8 +13,9 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+
 resources:
   index:
     type: file

--- a/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
+++ b/acceptancetests/repository/charms/squid-forwardproxy/metadata.yaml
@@ -14,5 +14,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/statusstresser/metadata.yaml
+++ b/acceptancetests/repository/charms/statusstresser/metadata.yaml
@@ -10,5 +10,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/ubuntu/metadata.yaml
+++ b/acceptancetests/repository/charms/ubuntu/metadata.yaml
@@ -10,5 +10,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/update-status-tester/metadata.yaml
+++ b/acceptancetests/repository/charms/update-status-tester/metadata.yaml
@@ -10,5 +10,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/charms/wordpress/metadata.yaml
+++ b/acceptancetests/repository/charms/wordpress/metadata.yaml
@@ -23,5 +23,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/trusty/dummy-subordinate/metadata.yaml
@@ -15,5 +15,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+

--- a/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
+++ b/acceptancetests/repository/xenial/dummy-subordinate/metadata.yaml
@@ -15,5 +15,6 @@ series:
   - xenial
   - artful
   - bionic
-  - disco
   - eoan
+  - focal
+


### PR DESCRIPTION
## Description of change

This PR updates the metadata for the charms used by acceptance tests to include support for eoan