### PR TITLE
Remove CMR guard

### DIFF
--- a/feature/flags.go
+++ b/feature/flags.go
@@ -68,9 +68,3 @@ const MultiCloud = "multi-cloud"
 
 // JujuV3 indicates that new CLI commands and behaviour for v3 should be enabled.
 const JujuV3 = "juju-v3"
-
-// CMRMigrations indicates that cross model relations (CMR) can migrate
-// information from one controller to another controller.
-// This feature is disabled during import and export of information, turning
-// this on will allow that to happen.
-const CMRMigrations = "cmr-migrations"

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/description"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/featureflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
@@ -27,7 +26,6 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/storage"
@@ -50,15 +48,6 @@ func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err
 	} else if modelExists {
 		// We have an existing matching model.
 		return nil, nil, errors.AlreadyExistsf("model %s", modelUUID)
-	}
-
-	// Ensure that we only enable CMR migrations if the feature flag is enabled
-	// otherwise just error out as usual.
-	if !featureflag.Enabled(feature.CMRMigrations) && len(model.RemoteApplications()) != 0 {
-		// Cross-model relations are currently limited to models on
-		// the same controller, while migration is for getting the
-		// model to a new controller.
-		return nil, nil, errors.New("can't import models with remote applications")
 	}
 
 	// Unfortunately a version was released that exports v4 models

--- a/tests/suites/model/task.sh
+++ b/tests/suites/model/task.sh
@@ -11,8 +11,6 @@ test_model() {
 
     file="${TEST_DIR}/test-models.txt"
 
-    export JUJU_DEV_FEATURE_FLAGS=cmr-migrations
-
     bootstrap "test-models" "${file}"
 
     # Tests that need to be run are added here.


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Now that CMR for remote applications has landed in develop and we have
integration tests for this, we can finally remove the feature flag.

This means that moving remote applications should be now possible. If
there are any issues then report a bug to https://bugs.launchpad.net/juju/+bugs

## QA steps

It is expected that moving a SAAS block or consumer via CMR should work.

Note: no dev flag is required.

Bootstrap 3 controllers: `source`, `consume`, `dest`.
Deploy `mysql` to source and `expose` to consume.
Deploy `wordpress` to consume, consume `mysql` and relate `wordpress->mysql`.
Migrate `consume` to `dest`.

----

To exercise more code paths, I'm using a bundle here.

```sh
series: bionic
saas:
  mysql:
    url: source:admin/default.mysql
applications:
  wordpress:
    charm: wordpress
    num_units: 1
relations:
- - wordpress:db
  - mysql:db
```

```sh
juju bootstrap lxd source

juju deploy mysql
juju offer mysql:db
```

```sh
juju bootstrap lxd consume

juju deploy bundle.yml
```


```sh
juju bootstrap lxd dest

juju destroy-model -y default --force --no-wait
```

```sh
juju switch source
juju migrate default dest
```

## Documentation changes

Yes, CMR is now available in develop branch in full. 

