### PR TITLE
Provisioning Info Space Topology

### DIFF
--- a/apiserver/facades/agent/provisioner/doc.go
+++ b/apiserver/facades/agent/provisioner/doc.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package provisioner supplies the API facade used by the provisioner worker.
+//
+// Versions of the API < 10 have logic dating from the original spaces
+// implementation. If multiple positive space constraints are supplied,
+// only the first in the list is used to determine possible subnet/AZ
+// combinations suitable for machine location.
+//
+// Version 10+ will consider all supplied positive space constraints when
+// making this determination.
+//
+package provisioner

--- a/apiserver/facades/agent/provisioner/imagemetadata_test.go
+++ b/apiserver/facades/agent/provisioner/imagemetadata_test.go
@@ -181,7 +181,9 @@ func (s *ImageMetadataSuite) expectedDataSoureImageMetadata() [][]params.CloudIm
 	return expected
 }
 
-func (s *ImageMetadataSuite) assertImageMetadataResults(c *gc.C, obtained params.ProvisioningInfoResults, expected ...[]params.CloudImageMetadata) {
+func (s *ImageMetadataSuite) assertImageMetadataResults(
+	c *gc.C, obtained params.ProvisioningInfoResultsV10, expected ...[]params.CloudImageMetadata,
+) {
 	c.Assert(obtained.Results, gc.HasLen, len(expected))
 	for i, one := range obtained.Results {
 		// We are only concerned with images here

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -191,6 +191,13 @@ type ProvisionerAPIV8 struct {
 // ProvisionerAPIV9 provides v9 of the provisioner facade.
 // Added SupportedContainers
 type ProvisionerAPIV9 struct {
+	*ProvisionerAPIV10
+}
+
+// ProvisionerAPIV9 provides v9 of the provisioner facade.
+// It returns a new form of ProvisioningInfo that
+// supports multiple space constraints.
+type ProvisionerAPIV10 struct {
 	*ProvisionerAPI
 }
 
@@ -241,11 +248,20 @@ func NewProvisionerAPIV8(st *state.State, resources facade.Resources, authorizer
 
 // NewProvisionerAPIV9 creates a new server-side Provisioner API facade.
 func NewProvisionerAPIV9(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPIV9, error) {
-	provisionerAPI, err := NewProvisionerAPI(st, resources, authorizer)
+	provisionerAPI, err := NewProvisionerAPIV10(st, resources, authorizer)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &ProvisionerAPIV9{provisionerAPI}, nil
+}
+
+// NewProvisionerAPIV10 creates a new server-side Provisioner API facade.
+func NewProvisionerAPIV10(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ProvisionerAPIV10, error) {
+	provisionerAPI, err := NewProvisionerAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ProvisionerAPIV10{provisionerAPI}, nil
 }
 
 func (api *ProvisionerAPI) getMachine(canAccess common.AuthFunc, tag names.MachineTag) (*state.Machine, error) {

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -194,7 +194,7 @@ type ProvisionerAPIV9 struct {
 	*ProvisionerAPIV10
 }
 
-// ProvisionerAPIV9 provides v9 of the provisioner facade.
+// ProvisionerAPIV10 provides v10 of the provisioner facade.
 // It returns a new form of ProvisioningInfo that
 // supports multiple space constraints.
 type ProvisionerAPIV10 struct {

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -52,7 +52,7 @@ type provisionerSuite struct {
 
 	authorizer  apiservertesting.FakeAuthorizer
 	resources   *common.Resources
-	provisioner *provisioner.ProvisionerAPIV9
+	provisioner *provisioner.ProvisionerAPIV10
 }
 
 var _ = gc.Suite(&provisionerSuite{})
@@ -93,7 +93,7 @@ func (s *provisionerSuite) setUpTest(c *gc.C, withController bool) {
 	s.resources = common.NewResources()
 
 	// Create a provisioner API for the machine.
-	provisionerAPI, err := provisioner.NewProvisionerAPIV9(
+	provisionerAPI, err := provisioner.NewProvisionerAPIV10(
 		s.State,
 		s.resources,
 		s.authorizer,

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -30,9 +30,10 @@ import (
 )
 
 // ProvisioningInfo returns the provisioning information for each given machine entity.
-func (api *ProvisionerAPI) ProvisioningInfo(args params.Entities) (params.ProvisioningInfoResults, error) {
-	result := params.ProvisioningInfoResults{
-		Results: make([]params.ProvisioningInfoResult, len(args.Entities)),
+// It supports all positive space constraints.
+func (api *ProvisionerAPI) ProvisioningInfo(args params.Entities) (params.ProvisioningInfoResultsV10, error) {
+	result := params.ProvisioningInfoResultsV10{
+		Results: make([]params.ProvisioningInfoResultV10, len(args.Entities)),
 	}
 	canAccess, err := api.getAuthFunc()
 	if err != nil {
@@ -40,7 +41,7 @@ func (api *ProvisionerAPI) ProvisioningInfo(args params.Entities) (params.Provis
 	}
 	env, err := environs.GetEnviron(api.configGetter, environs.New)
 	if err != nil {
-		return result, errors.Annotate(err, "could not get environ")
+		return result, errors.Annotate(err, "retrieving environ")
 	}
 	for i, entity := range args.Entities {
 		tag, err := names.ParseMachineTag(entity.Tag)
@@ -57,69 +58,115 @@ func (api *ProvisionerAPI) ProvisioningInfo(args params.Entities) (params.Provis
 	return result, nil
 }
 
-func (api *ProvisionerAPI) getProvisioningInfo(m *state.Machine, env environs.Environ) (*params.ProvisioningInfo, error) {
-	cons, err := m.Constraints()
-	if err != nil {
+func (api *ProvisionerAPI) getProvisioningInfo(m *state.Machine, env environs.Environ) (*params.ProvisioningInfoV10, error) {
+	var err error
+	result := params.ProvisioningInfoV10{}
+
+	if result.ProvisioningInfoBase, err = api.getProvisioningInfoBase(m, env); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	volumes, volumeAttachments, err := api.machineVolumeParams(m, env)
+	if result.ProvisioningNetworkTopology, err = api.machineSpaceTopology(m); err != nil {
+		return nil, errors.Annotate(err, "matching subnets to zones")
+	}
+
+	return &result, nil
+}
+
+// ProvisioningInfo returns the provisioning information for each given machine entity.
+// It supports the first of any specified positive space constraints.
+func (api *ProvisionerAPIV9) ProvisioningInfo(args params.Entities) (params.ProvisioningInfoResults, error) {
+	result := params.ProvisioningInfoResults{
+		Results: make([]params.ProvisioningInfoResult, len(args.Entities)),
+	}
+	canAccess, err := api.getAuthFunc()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
-
-	var jobs []model.MachineJob
-	for _, job := range m.Jobs() {
-		jobs = append(jobs, job.ToParams())
+	env, err := environs.GetEnviron(api.configGetter, environs.New)
+	if err != nil {
+		return result, errors.Annotate(err, "retrieving environ")
 	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseMachineTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		machine, err := api.getMachine(canAccess, tag)
+		if err == nil {
+			result.Results[i].Result, err = api.getProvisioningInfo(machine, env)
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
 
-	mTags, err := api.machineTags(m, jobs)
+func (api *ProvisionerAPIV9) getProvisioningInfo(m *state.Machine, env environs.Environ) (*params.ProvisioningInfo, error) {
+	base, err := api.getProvisioningInfoBase(m, env)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	subnetsToZones, err := api.machineSubnetsAndZones(m)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot match subnets to zones")
-	}
-
-	pNames, err := api.machineLXDProfileNames(m, env)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot write lxd profiles")
-	}
-
-	endpointBindings, err := api.machineEndpointBindings(m)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot determine machine endpoint bindings")
-	}
-
-	imageMetadata, err := api.availableImageMetadata(m, env)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get available image metadata")
-	}
-
-	controllerCfg, err := api.st.ControllerConfig()
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get controller configuration")
+		return nil, errors.Annotate(err, "matching subnets to zones")
 	}
 
 	return &params.ProvisioningInfo{
-		ProvisioningInfoBase: params.ProvisioningInfoBase{
-			Constraints:       cons,
-			Series:            m.Series(),
-			Placement:         m.Placement(),
-			Jobs:              jobs,
-			Volumes:           volumes,
-			VolumeAttachments: volumeAttachments,
-			Tags:              mTags,
-			EndpointBindings:  endpointBindings,
-			ImageMetadata:     imageMetadata,
-			ControllerConfig:  controllerCfg,
-			CloudInitUserData: env.Config().CloudInitUserData(),
-			CharmLXDProfiles:  pNames,
-		},
-		SubnetsToZones: subnetsToZones,
+		ProvisioningInfoBase: base,
+		SubnetsToZones:       subnetsToZones,
 	}, nil
+}
+
+// getProvisioningInfoBase returns the component of provisioning
+// info that is common to all versions of the API.
+func (api *ProvisionerAPI) getProvisioningInfoBase(
+	m *state.Machine, env environs.Environ,
+) (params.ProvisioningInfoBase, error) {
+	var err error
+
+	result := params.ProvisioningInfoBase{
+		Series:            m.Series(),
+		Placement:         m.Placement(),
+		CloudInitUserData: env.Config().CloudInitUserData(),
+	}
+
+	if result.Constraints, err = m.Constraints(); err != nil {
+		return result, errors.Trace(err)
+	}
+
+	if result.Volumes, result.VolumeAttachments, err = api.machineVolumeParams(m, env); err != nil {
+		return result, errors.Trace(err)
+	}
+
+	if result.CharmLXDProfiles, err = api.machineLXDProfileNames(m, env); err != nil {
+		return result, errors.Annotate(err, "cannot write lxd profiles")
+	}
+
+	if result.EndpointBindings, err = api.machineEndpointBindings(m); err != nil {
+		return result, errors.Annotate(err, "cannot determine machine endpoint bindings")
+	}
+
+	if result.ImageMetadata, err = api.availableImageMetadata(m, env); err != nil {
+		return result, errors.Annotate(err, "cannot get available image metadata")
+	}
+
+	if result.ControllerConfig, err = api.st.ControllerConfig(); err != nil {
+		return result, errors.Annotate(err, "cannot get controller configuration")
+	}
+
+	var jobs = m.Jobs()
+	result.Jobs = make([]model.MachineJob, len(jobs))
+	for i, job := range jobs {
+		result.Jobs[i] = job.ToParams()
+	}
+
+	if result.Tags, err = api.machineTags(m, result.Jobs); err != nil {
+		return result, errors.Trace(err)
+	}
+
+	return result, nil
 }
 
 // machineVolumeParams retrieves VolumeParams for the volumes that should be
@@ -251,6 +298,43 @@ func (api *ProvisionerAPI) machineTags(m *state.Machine, jobs []model.MachineJob
 	return machineTags, nil
 }
 
+func (api *ProvisionerAPI) machineSpaceTopology(m *state.Machine) (params.ProvisioningNetworkTopology, error) {
+	topology := params.ProvisioningNetworkTopology{}
+
+	cons, err := m.Constraints()
+	if err != nil {
+		return topology, errors.Annotate(err, "retrieving machine constraints")
+	}
+
+	includeSpaces := cons.IncludeSpaces()
+	if len(includeSpaces) < 1 {
+		return topology, nil
+	}
+
+	topology.SubnetAZs = make(map[string][]string)
+	topology.SpaceSubnets = make(map[string][]string)
+
+	for _, spaceName := range includeSpaces {
+		subnetsAndZones, err := api.subnetsAndZonesForSpace(m.Id(), spaceName)
+		if err != nil {
+			return topology, errors.Trace(err)
+		}
+
+		// Record each subnet provider ID as being in the space,
+		// and add the zone mappings to our map
+		subnetIDs := make([]string, 0, len(subnetsAndZones))
+		for sID, zones := range subnetsAndZones {
+			// We do not expect unique provider subnets to be in more than one
+			// space, so no keys will be overwritten by subsequent spaces.
+			topology.SubnetAZs[sID] = zones
+			subnetIDs = append(subnetIDs, sID)
+		}
+		topology.SpaceSubnets[spaceName] = subnetIDs
+	}
+
+	return topology, nil
+}
+
 // machineSubnetsAndZones returns a map of availability zone names
 // keyed by provider subnet ID.
 // The result can be empty if there are no spaces constraints specified
@@ -266,11 +350,8 @@ func (api *ProvisionerAPI) machineSubnetsAndZones(m *state.Machine) (map[string]
 		return nil, nil
 	}
 
-	// TODO(dimitern): For the network model MVP we only use the first
-	// included space and ignore the rest.
-	//
-	// LKK Card: https://canonical.leankit.com/Boards/View/101652562/117352306
-	// LP Bug: http://pad.lv/1498232
+	// Versions 9 and below of the API only support honouring a single positive
+	// space constraint. Take the first if there are any.
 	spaceName := includeSpaces[0]
 	if len(includeSpaces) > 1 {
 		logger.Debugf(
@@ -278,6 +359,12 @@ func (api *ProvisionerAPI) machineSubnetsAndZones(m *state.Machine) (map[string]
 			spaceName, m.Id(), includeSpaces[1:],
 		)
 	}
+
+	subnetsAndZones, err := api.subnetsAndZonesForSpace(m.Id(), spaceName)
+	return subnetsAndZones, errors.Trace(err)
+}
+
+func (api *ProvisionerAPI) subnetsAndZonesForSpace(machineID string, spaceName string) (map[string][]string, error) {
 	space, err := api.st.SpaceByName(spaceName)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -291,9 +378,8 @@ func (api *ProvisionerAPI) machineSubnetsAndZones(m *state.Machine) (map[string]
 	}
 	subnetsToZones := make(map[string][]string, len(subnets))
 	for _, subnet := range subnets {
-		warningPrefix := fmt.Sprintf(
-			"not using subnet %q in space %q for machine %q provisioning: ",
-			subnet.CIDR(), spaceName, m.Id(),
+		warningPrefix := fmt.Sprintf("not using subnet %q in space %q for machine %q provisioning: ",
+			subnet.CIDR(), spaceName, machineID,
 		)
 		providerId := subnet.ProviderId()
 		if providerId == "" {

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -59,55 +59,59 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
-				ControllerConfig: controllerCfg,
-				Series:           "quantal",
-				Jobs:             []model.MachineJob{model.JobHostUnits},
-				Tags: map[string]string{
-					tags.JujuController: coretesting.ControllerTag.Id(),
-					tags.JujuModel:      coretesting.ModelTag.Id(),
-					tags.JujuMachine:    "controller-machine-0",
+				ProvisioningInfoBase: params.ProvisioningInfoBase{
+					ControllerConfig: controllerCfg,
+					Series:           "quantal",
+					Jobs:             []model.MachineJob{model.JobHostUnits},
+					Tags: map[string]string{
+						tags.JujuController: coretesting.ControllerTag.Id(),
+						tags.JujuModel:      coretesting.ModelTag.Id(),
+						tags.JujuMachine:    "controller-machine-0",
+					},
 				},
 			}},
 			{Result: &params.ProvisioningInfo{
-				ControllerConfig: controllerCfg,
-				Series:           "quantal",
-				Constraints:      template.Constraints,
-				Placement:        template.Placement,
-				Jobs:             []model.MachineJob{model.JobHostUnits},
-				Tags: map[string]string{
-					tags.JujuController: coretesting.ControllerTag.Id(),
-					tags.JujuModel:      coretesting.ModelTag.Id(),
-					tags.JujuMachine:    "controller-machine-5",
-				},
-				Volumes: []params.VolumeParams{{
-					VolumeTag:  "volume-0",
-					Size:       1000,
-					Provider:   "static",
-					Attributes: map[string]interface{}{"foo": "bar"},
+				ProvisioningInfoBase: params.ProvisioningInfoBase{
+					ControllerConfig: controllerCfg,
+					Series:           "quantal",
+					Constraints:      template.Constraints,
+					Placement:        template.Placement,
+					Jobs:             []model.MachineJob{model.JobHostUnits},
 					Tags: map[string]string{
 						tags.JujuController: coretesting.ControllerTag.Id(),
 						tags.JujuModel:      coretesting.ModelTag.Id(),
+						tags.JujuMachine:    "controller-machine-5",
 					},
-					Attachment: &params.VolumeAttachmentParams{
-						MachineTag: placementMachine.Tag().String(),
+					Volumes: []params.VolumeParams{{
 						VolumeTag:  "volume-0",
+						Size:       1000,
 						Provider:   "static",
-					},
-				}, {
-					VolumeTag:  "volume-1",
-					Size:       2000,
-					Provider:   "static",
-					Attributes: map[string]interface{}{"foo": "bar"},
-					Tags: map[string]string{
-						tags.JujuController: coretesting.ControllerTag.Id(),
-						tags.JujuModel:      coretesting.ModelTag.Id(),
-					},
-					Attachment: &params.VolumeAttachmentParams{
-						MachineTag: placementMachine.Tag().String(),
+						Attributes: map[string]interface{}{"foo": "bar"},
+						Tags: map[string]string{
+							tags.JujuController: coretesting.ControllerTag.Id(),
+							tags.JujuModel:      coretesting.ModelTag.Id(),
+						},
+						Attachment: &params.VolumeAttachmentParams{
+							MachineTag: placementMachine.Tag().String(),
+							VolumeTag:  "volume-0",
+							Provider:   "static",
+						},
+					}, {
 						VolumeTag:  "volume-1",
+						Size:       2000,
 						Provider:   "static",
-					},
-				}},
+						Attributes: map[string]interface{}{"foo": "bar"},
+						Tags: map[string]string{
+							tags.JujuController: coretesting.ControllerTag.Id(),
+							tags.JujuModel:      coretesting.ModelTag.Id(),
+						},
+						Attachment: &params.VolumeAttachmentParams{
+							MachineTag: placementMachine.Tag().String(),
+							VolumeTag:  "volume-1",
+							Provider:   "static",
+						},
+					}},
+				},
 			}},
 		},
 	}
@@ -144,15 +148,17 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithSingleNegativeAndPositi
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
-				ControllerConfig: controllerCfg,
-				Series:           "quantal",
-				Constraints:      template.Constraints,
-				Placement:        template.Placement,
-				Jobs:             []model.MachineJob{model.JobHostUnits},
-				Tags: map[string]string{
-					tags.JujuController: coretesting.ControllerTag.Id(),
-					tags.JujuModel:      coretesting.ModelTag.Id(),
-					tags.JujuMachine:    "controller-machine-5",
+				ProvisioningInfoBase: params.ProvisioningInfoBase{
+					ControllerConfig: controllerCfg,
+					Series:           "quantal",
+					Constraints:      template.Constraints,
+					Placement:        template.Placement,
+					Jobs:             []model.MachineJob{model.JobHostUnits},
+					Tags: map[string]string{
+						tags.JujuController: coretesting.ControllerTag.Id(),
+						tags.JujuModel:      coretesting.ModelTag.Id(),
+						tags.JujuMachine:    "controller-machine-5",
+					},
 				},
 				SubnetsToZones: map[string][]string{
 					"subnet-1": {"zone1"},
@@ -212,21 +218,23 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
-				ControllerConfig: controllerCfg,
-				Series:           "quantal",
-				Jobs:             []model.MachineJob{model.JobHostUnits},
-				Tags: map[string]string{
-					tags.JujuController:    coretesting.ControllerTag.Id(),
-					tags.JujuModel:         coretesting.ModelTag.Id(),
-					tags.JujuMachine:       "controller-machine-5",
-					tags.JujuUnitsDeployed: wordpressUnit.Name(),
-				},
-				// Ensure space names are translated to provider IDs, where
-				// possible.
-				EndpointBindings: map[string]string{
-					"db":  "space2",         // just name, no provider ID
-					"url": "first space id", // has provider ID
-					// We expect none of the unspecified bindings in the result.
+				ProvisioningInfoBase: params.ProvisioningInfoBase{
+					ControllerConfig: controllerCfg,
+					Series:           "quantal",
+					Jobs:             []model.MachineJob{model.JobHostUnits},
+					Tags: map[string]string{
+						tags.JujuController:    coretesting.ControllerTag.Id(),
+						tags.JujuModel:         coretesting.ModelTag.Id(),
+						tags.JujuMachine:       "controller-machine-5",
+						tags.JujuUnitsDeployed: wordpressUnit.Name(),
+					},
+					// Ensure space names are translated to provider IDs, where
+					// possible.
+					EndpointBindings: map[string]string{
+						"db":  "space2",         // just name, no provider ID
+						"url": "first space id", // has provider ID
+						// We expect none of the unspecified bindings in the result.
+					},
 				},
 			},
 		}}}
@@ -299,17 +307,19 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
 	expected := params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
-				ControllerConfig: controllerCfg,
-				Series:           "quantal",
-				Jobs:             []model.MachineJob{model.JobHostUnits},
-				Tags: map[string]string{
-					tags.JujuController:    coretesting.ControllerTag.Id(),
-					tags.JujuModel:         coretesting.ModelTag.Id(),
-					tags.JujuMachine:       "controller-machine-5",
-					tags.JujuUnitsDeployed: profileUnit.Name(),
+				ProvisioningInfoBase: params.ProvisioningInfoBase{
+					ControllerConfig: controllerCfg,
+					Series:           "quantal",
+					Jobs:             []model.MachineJob{model.JobHostUnits},
+					Tags: map[string]string{
+						tags.JujuController:    coretesting.ControllerTag.Id(),
+						tags.JujuModel:         coretesting.ModelTag.Id(),
+						tags.JujuMachine:       "controller-machine-5",
+						tags.JujuUnitsDeployed: profileUnit.Name(),
+					},
+					EndpointBindings: map[string]string{},
+					CharmLXDProfiles: []string{pName},
 				},
-				EndpointBindings: map[string]string{},
-				CharmLXDProfiles: []string{pName},
 			},
 		}}}
 	c.Assert(result, jc.DeepEquals, expected)
@@ -338,33 +348,35 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
-				ControllerConfig: controllerCfg,
-				Series:           "quantal",
-				Constraints:      template.Constraints,
-				Placement:        template.Placement,
-				Jobs:             []model.MachineJob{model.JobHostUnits},
-				Tags: map[string]string{
-					tags.JujuController: coretesting.ControllerTag.Id(),
-					tags.JujuModel:      coretesting.ModelTag.Id(),
-					tags.JujuMachine:    "controller-machine-5",
-				},
-				// volume-0 should not be included as it is not managed by
-				// the environ provider.
-				Volumes: []params.VolumeParams{{
-					VolumeTag:  "volume-1",
-					Size:       1000,
-					Provider:   "static",
-					Attributes: nil,
+				ProvisioningInfoBase: params.ProvisioningInfoBase{
+					ControllerConfig: controllerCfg,
+					Series:           "quantal",
+					Constraints:      template.Constraints,
+					Placement:        template.Placement,
+					Jobs:             []model.MachineJob{model.JobHostUnits},
 					Tags: map[string]string{
 						tags.JujuController: coretesting.ControllerTag.Id(),
 						tags.JujuModel:      coretesting.ModelTag.Id(),
+						tags.JujuMachine:    "controller-machine-5",
 					},
-					Attachment: &params.VolumeAttachmentParams{
-						MachineTag: placementMachine.Tag().String(),
+					// volume-0 should not be included as it is not managed by
+					// the environ provider.
+					Volumes: []params.VolumeParams{{
 						VolumeTag:  "volume-1",
+						Size:       1000,
 						Provider:   "static",
-					},
-				}},
+						Attributes: nil,
+						Tags: map[string]string{
+							tags.JujuController: coretesting.ControllerTag.Id(),
+							tags.JujuModel:      coretesting.ModelTag.Id(),
+						},
+						Attachment: &params.VolumeAttachmentParams{
+							MachineTag: placementMachine.Tag().String(),
+							VolumeTag:  "volume-1",
+							Provider:   "static",
+						},
+					}},
+				},
 			}},
 		},
 	})
@@ -486,13 +498,15 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{
 			{Result: &params.ProvisioningInfo{
-				ControllerConfig: controllerCfg,
-				Series:           "quantal",
-				Jobs:             []model.MachineJob{model.JobHostUnits},
-				Tags: map[string]string{
-					tags.JujuController: coretesting.ControllerTag.Id(),
-					tags.JujuModel:      coretesting.ModelTag.Id(),
-					tags.JujuMachine:    "controller-machine-0",
+				ProvisioningInfoBase: params.ProvisioningInfoBase{
+					ControllerConfig: controllerCfg,
+					Series:           "quantal",
+					Jobs:             []model.MachineJob{model.JobHostUnits},
+					Tags: map[string]string{
+						tags.JujuController: coretesting.ControllerTag.Id(),
+						tags.JujuModel:      coretesting.ModelTag.Id(),
+						tags.JujuMachine:    "controller-machine-0",
+					},
 				},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 0/lxd/0")},

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -27295,6 +27295,9 @@
                 "ProvisioningInfo": {
                     "type": "object",
                     "properties": {
+                        "ProvisioningInfoBase": {
+                            "$ref": "#/definitions/ProvisioningInfoBase"
+                        },
                         "charm-lxd-profiles": {
                             "type": "array",
                             "items": {
@@ -27358,6 +27361,92 @@
                                     }
                                 }
                             }
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "volume-attachments": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachmentParams"
+                            }
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints",
+                        "series",
+                        "placement",
+                        "jobs",
+                        "ProvisioningInfoBase"
+                    ]
+                },
+                "ProvisioningInfoBase": {
+                    "type": "object",
+                    "properties": {
+                        "charm-lxd-profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cloudinit-userdata": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "controller-config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "image-metadata": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadata"
+                            }
+                        },
+                        "jobs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "placement": {
+                            "type": "string"
+                        },
+                        "series": {
+                            "type": "string"
                         },
                         "tags": {
                             "type": "object",

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -743,8 +743,9 @@ type AgentVersionResult struct {
 	Version version.Number `json:"version"`
 }
 
-// ProvisioningInfo holds machine provisioning info.
-type ProvisioningInfo struct {
+// ProvisioningInfoBase holds machine provisioning info common
+// across different versions of the provisioner API facade.
+type ProvisioningInfoBase struct {
 	Constraints       constraints.Value        `json:"constraints"`
 	Series            string                   `json:"series"`
 	Placement         string                   `json:"placement"`
@@ -752,7 +753,6 @@ type ProvisioningInfo struct {
 	Volumes           []VolumeParams           `json:"volumes,omitempty"`
 	VolumeAttachments []VolumeAttachmentParams `json:"volume-attachments,omitempty"`
 	Tags              map[string]string        `json:"tags,omitempty"`
-	SubnetsToZones    map[string][]string      `json:"subnets-to-zones,omitempty"`
 	ImageMetadata     []CloudImageMetadata     `json:"image-metadata,omitempty"`
 	EndpointBindings  map[string]string        `json:"endpoint-bindings,omitempty"`
 	ControllerConfig  map[string]interface{}   `json:"controller-config,omitempty"`
@@ -760,13 +760,22 @@ type ProvisioningInfo struct {
 	CharmLXDProfiles  []string                 `json:"charm-lxd-profiles,omitempty"`
 }
 
-// ProvisioningInfoResult holds machine provisioning info or an error.
+// ProvisioningInfo holds machine provisioning info returned by
+// versions 9 and lower of the provisioner API facade.
+type ProvisioningInfo struct {
+	ProvisioningInfoBase
+	SubnetsToZones map[string][]string `json:"subnets-to-zones,omitempty"`
+}
+
+// ProvisioningInfoResult holds machine provisioning info or an error
+// for versions 9 and lower of the provisioner API facade.
 type ProvisioningInfoResult struct {
 	Error  *Error            `json:"error,omitempty"`
 	Result *ProvisioningInfo `json:"result"`
 }
 
-// ProvisioningInfoResults holds multiple machine provisioning info results.
+// ProvisioningInfoResults holds multiple machine provisioning info results
+// for versions 9 and lower of the provisioner API facade.
 type ProvisioningInfoResults struct {
 	Results []ProvisioningInfoResult `json:"results"`
 }

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -770,14 +770,51 @@ type ProvisioningInfo struct {
 // ProvisioningInfoResult holds machine provisioning info or an error
 // for versions 9 and lower of the provisioner API facade.
 type ProvisioningInfoResult struct {
-	Error  *Error            `json:"error,omitempty"`
 	Result *ProvisioningInfo `json:"result"`
+	Error  *Error            `json:"error,omitempty"`
 }
 
 // ProvisioningInfoResults holds multiple machine provisioning info results
 // for versions 9 and lower of the provisioner API facade.
 type ProvisioningInfoResults struct {
 	Results []ProvisioningInfoResult `json:"results"`
+}
+
+// ProvisioningNetworkTopology holds a network topology that is based on
+// positive machine space constraints.
+// This is used for creating NICs on instances where the provider is not space
+// aware; I.e. not MAAS.
+// We only care about positive constraints because negative constraints are
+// satisfied implicitly by only creating NICs connected to subnets in inclusive
+// spaces.
+type ProvisioningNetworkTopology struct {
+	// SubnetAZs is a map of availability zone names
+	// indexed by provider subnet ID.
+	SubnetAZs map[string][]string `json:"subnet-zones"`
+
+	// SpaceSubnets is a map of subnet provider IDs from the map above
+	// indexed by the space ID that the subnets reside in.
+	SpaceSubnets map[string][]string `json:"space-subnets"`
+}
+
+// ProvisioningInfo holds machine provisioning info returned by
+// versions 10 and above of the provisioner API facade.
+type ProvisioningInfoV10 struct {
+	ProvisioningInfoBase
+	ProvisioningNetworkTopology
+}
+
+// ProvisioningInfoResultV10 holds machine provisioning info or an error
+// for versions 10 and above of the provisioner API facade.
+type ProvisioningInfoResultV10 struct {
+	Result *ProvisioningInfoV10 `json:"result"`
+	Error  *Error               `json:"error,omitempty"`
+}
+
+// ProvisioningInfoResults holds multiple machine provisioning info results
+// for versions 10 and above of the provisioner API facade.
+type ProvisioningInfoResultsV10 struct {
+	Results []ProvisioningInfoResultV10 `json:"results"`
 }
 
 // Metric holds a single metric.

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -926,8 +926,6 @@ func (env *maasEnviron) DistributeInstances(
 	return common.DistributeInstances(env, ctx, candidates, distributionGroup, limitZones)
 }
 
-var availabilityZoneAllocations = common.AvailabilityZoneAllocations
-
 // MaintainInstance is specified in the InstanceBroker interface.
 func (*maasEnviron) MaintainInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) error {
 	return nil

--- a/state/machine.go
+++ b/state/machine.go
@@ -66,7 +66,7 @@ func (job MachineJob) ToParams() model.MachineJob {
 	return model.MachineJob(fmt.Sprintf("<unknown job %d>", int(job)))
 }
 
-// params.JobsFromJobs converts state jobs to juju jobs.
+// paramsJobsFromJobs converts state jobs to juju jobs.
 func paramsJobsFromJobs(jobs []MachineJob) []model.MachineJob {
 	jujuJobs := make([]model.MachineJob, len(jobs))
 	for i, machineJob := range jobs {

--- a/state/migrations/doc.go
+++ b/state/migrations/doc.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package migrations aims to create an intermidiate state between state and the
+// Package migrations aims to create an intermediate state between state and the
 // description package. One that aims to correctly model the dependencies
 // required for migration.
 //

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -597,7 +597,7 @@ func (m *testMachine) SetInstanceStatus(_ status.Status, message string, _ map[s
 func (m *testMachine) InstanceStatus() (status.Status, string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return status.Status(""), m.instStatusMsg, nil
+	return "", m.instStatusMsg, nil
 }
 
 func (m *testMachine) SetModificationStatus(_ status.Status, message string, _ map[string]interface{}) error {
@@ -610,15 +610,15 @@ func (m *testMachine) SetModificationStatus(_ status.Status, message string, _ m
 func (m *testMachine) ModificationStatus() (status.Status, string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return status.Status(""), m.modStatusMsg, nil
+	return "", m.modStatusMsg, nil
 }
 
-func (m *testMachine) SetStatus(status status.Status, info string, data map[string]interface{}) error {
+func (m *testMachine) SetStatus(_ status.Status, _ string, _ map[string]interface{}) error {
 	return nil
 }
 
 func (m *testMachine) Status() (status.Status, string, error) {
-	return status.Status(""), "", nil
+	return "", "", nil
 }
 
 func (m *testMachine) ModelAgentVersion() (*version.Number, error) {
@@ -626,18 +626,19 @@ func (m *testMachine) ModelAgentVersion() (*version.Number, error) {
 }
 
 func (m *testMachine) SetInstanceInfo(
-	id instance.Id, displayName string, nonce string, characteristics *instance.HardwareCharacteristics,
-	networkConfig []params.NetworkConfig, volumes []params.Volume,
-	volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
+	_ instance.Id, _ string, _ string, _ *instance.HardwareCharacteristics, _ []params.NetworkConfig, _ []params.Volume,
+	_ map[string]params.VolumeAttachmentInfo, _ []string,
 ) error {
 	return nil
 }
 
 func (m *testMachine) ProvisioningInfo() (*params.ProvisioningInfo, error) {
 	return &params.ProvisioningInfo{
-		ControllerConfig: coretesting.FakeControllerConfig(),
-		Series:           series.DefaultSupportedLTS(),
-		Constraints:      constraints.MustParse(m.constraints),
+		ProvisioningInfoBase: params.ProvisioningInfoBase{
+			ControllerConfig: coretesting.FakeControllerConfig(),
+			Series:           series.DefaultSupportedLTS(),
+			Constraints:      constraints.MustParse(m.constraints),
+		},
 	}, nil
 }
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1109,7 +1109,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithUnknownSpaces(c *gc.
 	cons := constraints.MustParse(
 		s.defaultConstraints.String(), "spaces=missing,ignored,^ignored-too",
 	)
-	expectedErrorStatus := `cannot match subnets to zones: space "missing" not found`
+	expectedErrorStatus := `matching subnets to zones: space "missing" not found`
 	s.testProvisioningFailsAndSetsErrorStatusForConstraints(c, cons, expectedErrorStatus)
 }
 
@@ -1119,7 +1119,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithEmptySpaces(c *gc.C)
 	cons := constraints.MustParse(
 		s.defaultConstraints.String(), "spaces=empty",
 	)
-	expectedErrorStatus := `cannot match subnets to zones: ` +
+	expectedErrorStatus := `matching subnets to zones: ` +
 		`cannot use space "empty" as deployment target: no subnets`
 	s.testProvisioningFailsAndSetsErrorStatusForConstraints(c, cons, expectedErrorStatus)
 }


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This change is one of several intended to enable spaces and multi-NIC support on Openstack.

It adds a new version of the provisioner API facade.

This version changes the implementation of `ProvisionerInfo` so that instead of using only a single space to determine possible deployment subnet/AZ combinations, all positive space constraints are represented.

A new parameter type accommodates the extra detail.

## QA steps

These changes will materialise in later patches. For now, unit tests provide validation.

For regression:
- Bootstrap to AWS and add a space
- `juju add-machine --constraints spaces=new-space`

## Documentation changes

None.

## Bug reference

N/A
