### PR TITLE
Enhance run action CLI to deal with new operations

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -66,15 +66,15 @@ func (c *Client) Enqueue(arg params.Actions) (params.ActionResults, error) {
 	return results, err
 }
 
-// EnqueueV2 takes a list of Actions and queues them up to be executed by
-// the designated ActionReceiver, returning the ids of the overall operation
-// and each individual task.
-func (c *Client) EnqueueV2(arg params.Actions) (params.EnqueuedActions, error) {
+// EnqueueOperation takes a list of Actions and queues them up to be executed as
+// an operation, each action running as a task on the the designated ActionReceiver.
+// We return the ID of the overall operation and each individual task.
+func (c *Client) EnqueueOperation(arg params.Actions) (params.EnqueuedActions, error) {
 	results := params.EnqueuedActions{}
 	if v := c.BestAPIVersion(); v < 6 {
-		return results, errors.Errorf("EnqueueV2 not supported by this version (%d) of Juju", v)
+		return results, errors.Errorf("EnqueueOperation not supported by this version (%d) of Juju", v)
 	}
-	err := c.facade.FacadeCall("EnqueueV2", arg, &results)
+	err := c.facade.FacadeCall("EnqueueOperation", arg, &results)
 	return results, err
 }
 

--- a/api/action/client.go
+++ b/api/action/client.go
@@ -66,6 +66,18 @@ func (c *Client) Enqueue(arg params.Actions) (params.ActionResults, error) {
 	return results, err
 }
 
+// EnqueueV2 takes a list of Actions and queues them up to be executed by
+// the designated ActionReceiver, returning the ids of the overall operation
+// and each individual task.
+func (c *Client) EnqueueV2(arg params.Actions) (params.EnqueuedActions, error) {
+	results := params.EnqueuedActions{}
+	if v := c.BestAPIVersion(); v < 6 {
+		return results, errors.Errorf("EnqueueV2 not supported by this version (%d) of Juju", v)
+	}
+	err := c.facade.FacadeCall("EnqueueV2", arg, &results)
+	return results, err
+}
+
 // FindActionsByNames takes a list of action names and returns actions for
 // every name.
 func (c *Client) FindActionsByNames(arg params.FindActionsByNames) (params.ActionsByNames, error) {

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -262,3 +262,63 @@ func (s *actionSuite) TestOperationsNotSupported(c *gc.C) {
 	_, err := client.Operations(params.OperationQueryArgs{})
 	c.Assert(err, gc.ErrorMatches, "Operations not supported by this version \\(4\\) of Juju")
 }
+
+func (s *actionSuite) TestEnqueueV2(c *gc.C) {
+	args := params.Actions{
+		Actions: []params.Action{{
+			Receiver: "unit/0",
+			Name:     "test",
+			Parameters: map[string]interface{}{
+				"foo": "bar",
+			},
+		}},
+	}
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				c.Assert(request, gc.Equals, "EnqueueV2")
+				c.Assert(a, jc.DeepEquals, args)
+				c.Assert(result, gc.FitsTypeOf, &params.EnqueuedActions{})
+				*(result.(*params.EnqueuedActions)) = params.EnqueuedActions{
+					OperationTag: "operation-1",
+					Actions: []params.StringResult{{
+						Error: &params.Error{Message: "FAIL"},
+					}},
+				}
+				return nil
+			},
+		),
+		BestVersion: 6,
+	}
+	client := action.NewClient(apiCaller)
+	result, err := client.EnqueueV2(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.EnqueuedActions{
+		Actions: []params.StringResult{{
+			Error: &params.Error{Message: "FAIL"},
+		}},
+		OperationTag: "operation-1",
+	})
+}
+
+func (s *actionSuite) TestEnqueueV2NotSupported(c *gc.C) {
+	apiCaller := basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string,
+				version int,
+				id, request string,
+				a, result interface{},
+			) error {
+				return nil
+			},
+		),
+		BestVersion: 5,
+	}
+	client := action.NewClient(apiCaller)
+	_, err := client.EnqueueV2(params.Actions{})
+	c.Assert(err, gc.ErrorMatches, "EnqueueV2 not supported by this version \\(5\\) of Juju")
+}

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -263,7 +263,7 @@ func (s *actionSuite) TestOperationsNotSupported(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "Operations not supported by this version \\(4\\) of Juju")
 }
 
-func (s *actionSuite) TestEnqueueV2(c *gc.C) {
+func (s *actionSuite) TestEnqueueOperation(c *gc.C) {
 	args := params.Actions{
 		Actions: []params.Action{{
 			Receiver: "unit/0",
@@ -280,7 +280,7 @@ func (s *actionSuite) TestEnqueueV2(c *gc.C) {
 				id, request string,
 				a, result interface{},
 			) error {
-				c.Assert(request, gc.Equals, "EnqueueV2")
+				c.Assert(request, gc.Equals, "EnqueueOperation")
 				c.Assert(a, jc.DeepEquals, args)
 				c.Assert(result, gc.FitsTypeOf, &params.EnqueuedActions{})
 				*(result.(*params.EnqueuedActions)) = params.EnqueuedActions{
@@ -295,7 +295,7 @@ func (s *actionSuite) TestEnqueueV2(c *gc.C) {
 		BestVersion: 6,
 	}
 	client := action.NewClient(apiCaller)
-	result, err := client.EnqueueV2(args)
+	result, err := client.EnqueueOperation(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.EnqueuedActions{
 		Actions: []params.StringResult{{
@@ -305,7 +305,7 @@ func (s *actionSuite) TestEnqueueV2(c *gc.C) {
 	})
 }
 
-func (s *actionSuite) TestEnqueueV2NotSupported(c *gc.C) {
+func (s *actionSuite) TestEnqueueOperationNotSupported(c *gc.C) {
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -319,6 +319,6 @@ func (s *actionSuite) TestEnqueueV2NotSupported(c *gc.C) {
 		BestVersion: 5,
 	}
 	client := action.NewClient(apiCaller)
-	_, err := client.EnqueueV2(params.Actions{})
-	c.Assert(err, gc.ErrorMatches, "EnqueueV2 not supported by this version \\(5\\) of Juju")
+	_, err := client.EnqueueOperation(params.Actions{})
+	c.Assert(err, gc.ErrorMatches, "EnqueueOperation not supported by this version \\(5\\) of Juju")
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -11,7 +11,7 @@ package api
 // New facades should start at 1.
 // Facades that existed before versioning start at 0.
 var facadeVersions = map[string]int{
-	"Action":                       5,
+	"Action":                       6,
 	"ActionPruner":                 1,
 	"Agent":                        2,
 	"AgentTools":                   1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -134,6 +134,7 @@ func AllFacades() *facade.Registry {
 	reg("Action", 3, action.NewActionAPIV3)
 	reg("Action", 4, action.NewActionAPIV4)
 	reg("Action", 5, action.NewActionAPIV5)
+	reg("Action", 6, action.NewActionAPIV6)
 	reg("ActionPruner", 1, actionpruner.NewAPI)
 	reg("Agent", 2, agent.NewAgentAPIV2)
 	reg("AgentTools", 1, agenttools.NewFacade)

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -4,10 +4,6 @@
 package action
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 
@@ -261,30 +257,6 @@ func (a *ActionAPI) FindActionsByNames(arg params.FindActionsByNames) (params.Ac
 	return response, nil
 }
 
-// EnqueueV2 isn't on the V5 API.
-func (*APIv5) EnqueueV2(_, _ struct{}) {}
-
-// EnqueueV2 takes a list of Actions and queues them up to be executed by
-// the designated ActionReceiver, returning the ids of the overall operation
-// and each individual task.
-func (a *ActionAPI) EnqueueV2(arg params.Actions) (params.EnqueuedActions, error) {
-	operationId, actionResults, err := a.enqueue(arg)
-	if err != nil {
-		return params.EnqueuedActions{}, err
-	}
-	results := params.EnqueuedActions{
-		OperationTag: names.NewOperationTag(operationId).String(),
-		Actions:      make([]params.StringResult, len(actionResults.Results)),
-	}
-	for i, action := range actionResults.Results {
-		results.Actions[i].Error = action.Error
-		if action.Action != nil {
-			results.Actions[i].Result = action.Action.Tag
-		}
-	}
-	return results, nil
-}
-
 // Enqueue takes a list of Actions and queues them up to be executed by
 // the designated ActionReceiver, returning the params.Action for each
 // enqueued Action, or an error if there was a problem enqueueing the
@@ -292,76 +264,6 @@ func (a *ActionAPI) EnqueueV2(arg params.Actions) (params.EnqueuedActions, error
 func (a *ActionAPI) Enqueue(arg params.Actions) (params.ActionResults, error) {
 	_, results, err := a.enqueue(arg)
 	return results, err
-}
-
-func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, error) {
-	if err := a.checkCanWrite(); err != nil {
-		return "", params.ActionResults{}, errors.Trace(err)
-	}
-
-	var leaders map[string]string
-	getLeader := func(appName string) (string, error) {
-		if leaders == nil {
-			var err error
-			leaders, err = a.state.ApplicationLeaders()
-			if err != nil {
-				return "", err
-			}
-		}
-		if leader, ok := leaders[appName]; ok {
-			return leader, nil
-		}
-		return "", errors.Errorf("could not determine leader for %q", appName)
-	}
-
-	var operationName string
-	var receivers []string
-	for _, a := range arg.Actions {
-		if a.Receiver != "" {
-			receivers = append(receivers, a.Receiver)
-		}
-		if operationName == "" {
-			operationName = a.Name
-			continue
-		}
-		if operationName != a.Name {
-			operationName = "multiple actions"
-		}
-	}
-	summary := fmt.Sprintf("%v run on %v", operationName, strings.Join(receivers, ","))
-	operationID, err := a.model.EnqueueOperation(summary)
-	if err != nil {
-		return "", params.ActionResults{}, errors.Annotate(err, "creating operation for actions")
-	}
-
-	tagToActionReceiver := common.TagToActionReceiverFn(a.state.FindEntity)
-	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
-	for i, action := range arg.Actions {
-		currentResult := &response.Results[i]
-		actionReceiver := action.Receiver
-		if strings.HasSuffix(actionReceiver, "leader") {
-			app := strings.Split(actionReceiver, "/")[0]
-			receiverName, err := getLeader(app)
-			if err != nil {
-				currentResult.Error = common.ServerError(err)
-				continue
-			}
-			actionReceiver = names.NewUnitTag(receiverName).String()
-		}
-		receiver, err := tagToActionReceiver(actionReceiver)
-		if err != nil {
-			currentResult.Error = common.ServerError(err)
-			continue
-		}
-		enqueued, err := receiver.AddAction(operationID, action.Name, action.Parameters)
-		if err != nil {
-			currentResult.Error = common.ServerError(err)
-			continue
-		}
-
-		response.Results[i] = common.MakeActionResult(receiver.Tag(), enqueued, false)
-	}
-	return operationID, response, nil
 }
 
 // ListAll takes a list of Entities representing ActionReceivers and
@@ -384,92 +286,6 @@ func (a *ActionAPI) listAll(arg params.Entities, compat bool) (params.ActionsByR
 	}
 
 	return a.internalList(arg, combine(pendingActions, runningActions, completedActions), compat)
-}
-
-// Operations fetches the called functions (actions) for specified apps/units.
-func (a *ActionAPI) Operations(arg params.OperationQueryArgs) (params.ActionResults, error) {
-	if err := a.checkCanRead(); err != nil {
-		return params.ActionResults{}, errors.Trace(err)
-	}
-
-	unitTags := set.NewStrings()
-	for _, name := range arg.Units {
-		unitTags.Add(names.NewUnitTag(name).String())
-	}
-	appNames := arg.Applications
-	if len(appNames) == 0 && unitTags.Size() == 0 {
-		apps, err := a.state.AllApplications()
-		if err != nil {
-			return params.ActionResults{}, errors.Trace(err)
-		}
-		for _, a := range apps {
-			appNames = append(appNames, a.Name())
-		}
-	}
-	for _, aName := range appNames {
-		app, err := a.state.Application(aName)
-		if err != nil {
-			return params.ActionResults{}, errors.Trace(err)
-		}
-		units, err := app.AllUnits()
-		if err != nil {
-			return params.ActionResults{}, errors.Trace(err)
-		}
-		for _, u := range units {
-			unitTags.Add(u.Tag().String())
-		}
-	}
-
-	var entities params.Entities
-	for _, unitTag := range unitTags.SortedValues() {
-		entities.Entities = append(entities.Entities, params.Entity{Tag: unitTag})
-	}
-
-	statusSet := set.NewStrings(arg.Status...)
-	if statusSet.Size() == 0 {
-		statusSet = set.NewStrings(params.ActionPending, params.ActionRunning, params.ActionCompleted)
-	}
-	var extractorFuncs []extractorFn
-	for _, status := range statusSet.SortedValues() {
-		switch status {
-		case params.ActionPending:
-			extractorFuncs = append(extractorFuncs, pendingActions)
-		case params.ActionRunning:
-			extractorFuncs = append(extractorFuncs, runningActions)
-		case params.ActionCompleted:
-			extractorFuncs = append(extractorFuncs, completedActions)
-		}
-	}
-
-	byReceivers, err := a.internalList(entities, combine(extractorFuncs...), false)
-	if err != nil {
-		return params.ActionResults{}, errors.Trace(err)
-	}
-
-	nameMatches := func(name string, filter []string) bool {
-		if len(filter) == 0 {
-			return true
-		}
-		for _, f := range filter {
-			if f == name {
-				return true
-			}
-		}
-		return false
-	}
-
-	var result params.ActionResults
-	for _, actions := range byReceivers.Actions {
-		if actions.Error != nil {
-			return params.ActionResults{}, errors.Trace(actions.Error)
-		}
-		for _, ar := range actions.Actions {
-			if nameMatches(ar.Action.Name, arg.FunctionNames) {
-				result.Results = append(result.Results, ar)
-			}
-		}
-	}
-	return result, nil
 }
 
 // ListPending takes a list of Entities representing ActionReceivers

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -7,12 +7,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
 	"testing"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
 
@@ -33,7 +31,7 @@ func TestAll(t *testing.T) {
 	coretesting.MgoTestPackage(t)
 }
 
-type actionSuite struct {
+type baseSuite struct {
 	jujutesting.JujuConnSuite
 	commontesting.BlockHelper
 
@@ -51,9 +49,23 @@ type actionSuite struct {
 	mysqlUnit     *state.Unit
 }
 
+type actionSuite struct {
+	baseSuite
+}
+
 var _ = gc.Suite(&actionSuite{})
 
-func (s *actionSuite) SetUpTest(c *gc.C) {
+func (s *baseSuite) toSupportNewActionID(c *gc.C) {
+	ver, err := s.Model.AgentVersion()
+	c.Assert(err, jc.ErrorIsNil)
+
+	if !state.IsNewActionIDSupported(ver) {
+		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *baseSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
@@ -265,87 +277,6 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 	c.Assert(res.Results[4].Action, gc.NotNil)
 	c.Assert(res.Results[4].Action.Receiver, gc.Equals, s.wordpressUnit.Tag().String())
 	c.Assert(res.Results[4].Action.Tag, gc.Not(gc.Equals), emptyActionTag)
-
-	// Make sure that 2 actions were enqueued for the wordpress Unit.
-	actions, err = s.wordpressUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 2)
-	for _, act := range actions {
-		c.Assert(act.Name(), gc.Equals, expectedName)
-		c.Assert(act.Parameters(), gc.DeepEquals, expectedParameters)
-		c.Assert(act.Receiver(), gc.Equals, s.wordpressUnit.Name())
-	}
-
-	// Make sure an Action was not enqueued for the mysql Unit.
-	actions, err = s.mysqlUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 0)
-
-	operations, err := s.Model.AllOperations()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(operations, gc.HasLen, 1)
-	c.Assert(operations[0].Summary(), gc.Equals, "multiple actions run on unit-wordpress-0,application-wordpress,unit-mysql-0,wordpress/leader")
-}
-
-func (s *actionSuite) TestEnqueueV2(c *gc.C) {
-	// Ensure wordpress unit is the leader.
-	claimer, err := s.LeaseManager.Claimer("application-leadership", s.State.ModelUUID())
-	c.Assert(err, jc.ErrorIsNil)
-	err = claimer.Claim("wordpress", "wordpress/0", time.Minute)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Make sure no Actions already exist on wordpress Unit.
-	actions, err := s.wordpressUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 0)
-
-	// Make sure no Actions already exist on mysql Unit.
-	actions, err = s.mysqlUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 0)
-
-	// Add Actions.
-	expectedName := "fakeaction"
-	expectedParameters := map[string]interface{}{"kan jy nie": "verstaand"}
-	arg := params.Actions{
-		Actions: []params.Action{
-			// No receiver.
-			{Name: "fakeaction"},
-			// Good.
-			{Receiver: s.wordpressUnit.Tag().String(), Name: expectedName, Parameters: expectedParameters},
-			// Application tag instead of Unit tag.
-			{Receiver: s.wordpress.Tag().String(), Name: "fakeaction"},
-			// Missing name.
-			{Receiver: s.mysqlUnit.Tag().String(), Parameters: expectedParameters},
-			// Good (leader syntax).
-			{Receiver: "wordpress/leader", Name: expectedName, Parameters: expectedParameters},
-		},
-	}
-
-	// blocking changes should have no effect
-	s.BlockAllChanges(c, "Enqueue")
-
-	res, err := s.action.EnqueueV2(arg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(res.Actions, gc.HasLen, 5)
-
-	emptyActionTag := names.ActionTag{}
-	c.Assert(res.Actions[0].Error, gc.DeepEquals,
-		&params.Error{Message: fmt.Sprintf("%s not valid", arg.Actions[0].Receiver), Code: ""})
-	c.Assert(res.Actions[0].Result, gc.Equals, "")
-
-	c.Assert(res.Actions[1].Error, gc.IsNil)
-	c.Assert(res.Actions[1].Result, gc.Not(gc.Equals), emptyActionTag)
-
-	errorString := fmt.Sprintf("action receiver interface on entity %s not implemented", arg.Actions[2].Receiver)
-	c.Assert(res.Actions[2].Error, gc.DeepEquals, &params.Error{Message: errorString, Code: "not implemented"})
-	c.Assert(res.Actions[2].Result, gc.Equals, "")
-
-	c.Assert(res.Actions[3].Error, gc.ErrorMatches, "no action name given")
-	c.Assert(res.Actions[3].Result, gc.Equals, "")
-
-	c.Assert(res.Actions[4].Error, gc.IsNil)
-	c.Assert(res.Actions[4].Result, gc.Not(gc.Equals), emptyActionTag)
 
 	// Make sure that 2 actions were enqueued for the wordpress Unit.
 	actions, err = s.wordpressUnit.Actions()
@@ -922,16 +853,6 @@ func stringify(r params.ActionResult) string {
 	return fmt.Sprintf("%s-%s-%#v-%s-%s-%v", a.Tag, a.Name, a.Parameters, r.Status, r.Message, orderedOut)
 }
 
-func (s *actionSuite) toSupportNewActionID(c *gc.C) {
-	ver, err := s.Model.AgentVersion()
-	c.Assert(err, jc.ErrorIsNil)
-
-	if !state.IsNewActionIDSupported(ver) {
-		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
-		c.Assert(err, jc.ErrorIsNil)
-	}
-}
-
 func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
 	s.toSupportNewActionID(c)
 
@@ -979,160 +900,4 @@ func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
 
 	wc.AssertChange(string(expected))
 	wc.AssertNoChange()
-}
-
-func (s *actionSuite) setupOperations(c *gc.C) {
-	s.toSupportNewActionID(c)
-
-	arg := params.Actions{
-		Actions: []params.Action{
-			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
-			{Receiver: s.mysqlUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
-			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
-			{Receiver: s.mysqlUnit.Tag().String(), Name: "anotherfakeaction", Parameters: map[string]interface{}{}},
-		}}
-
-	r, err := s.action.Enqueue(arg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(r.Results, gc.HasLen, len(arg.Actions))
-
-	// There's only one operation created.
-	ops, err := s.Model.AllOperations()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ops, gc.HasLen, 1)
-	operationID, err := strconv.Atoi(ops[0].Id())
-	c.Assert(err, jc.ErrorIsNil)
-
-	a, err := s.Model.Action(strconv.Itoa(operationID + 1))
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = a.Begin()
-	c.Assert(err, jc.ErrorIsNil)
-	a, err = s.Model.Action(strconv.Itoa(operationID + 2))
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = a.Finish(state.ActionResults{})
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *actionSuite) TestOperationsStatusFilter(c *gc.C) {
-	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
-		Status: []string{"running"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 1)
-	result := actions.Results[0]
-	c.Assert(result.Action, gc.NotNil)
-	if result.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	if result.Started.IsZero() {
-		c.Fatal("started time not set")
-	}
-	c.Assert(result.Status, gc.Equals, "running")
-	c.Assert(result.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result.Action.Tag, gc.Equals, "action-2")
-}
-
-func (s *actionSuite) TestOperationsNameFilter(c *gc.C) {
-	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
-		FunctionNames: []string{"anotherfakeaction"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 1)
-	result := actions.Results[0]
-	c.Assert(result.Action, gc.NotNil)
-	if result.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	c.Assert(result.Status, gc.Equals, "pending")
-	c.Assert(result.Action.Name, gc.Equals, "anotherfakeaction")
-	c.Assert(result.Action.Receiver, gc.Equals, "unit-mysql-0")
-	c.Assert(result.Action.Tag, gc.Equals, "action-5")
-}
-
-func (s *actionSuite) TestOperationsAppFilter(c *gc.C) {
-	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
-		Applications: []string{"wordpress"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 2)
-	result0 := actions.Results[0]
-	result1 := actions.Results[1]
-
-	c.Assert(result0.Action, gc.NotNil)
-	if result0.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	c.Assert(result0.Status, gc.Equals, "pending")
-	c.Assert(result0.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result0.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result0.Action.Tag, gc.Equals, "action-4")
-
-	c.Assert(result1.Action, gc.NotNil)
-	if result1.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	if result1.Started.IsZero() {
-		c.Fatal("started time not set")
-	}
-	c.Assert(result1.Status, gc.Equals, "running")
-	c.Assert(result1.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result1.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result1.Action.Tag, gc.Equals, "action-2")
-}
-
-func (s *actionSuite) TestOperationsUnitFilter(c *gc.C) {
-	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
-		Units:  []string{"wordpress/0"},
-		Status: []string{"pending"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 1)
-	result := actions.Results[0]
-
-	c.Assert(result.Action, gc.NotNil)
-	if result.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	c.Assert(result.Status, gc.Equals, "pending")
-	c.Assert(result.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result.Action.Tag, gc.Equals, "action-4")
-}
-
-func (s *actionSuite) TestOperationsAppAndUnitFilter(c *gc.C) {
-	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
-		Applications: []string{"mysql"},
-		Units:        []string{"wordpress/0"},
-		Status:       []string{"pending"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 2)
-	mysqlAction := actions.Results[0]
-	wordpressAction := actions.Results[1]
-	c.Log(pretty.Sprint(actions.Results))
-
-	c.Assert(mysqlAction.Action, gc.NotNil)
-	if mysqlAction.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	c.Assert(mysqlAction.Status, gc.Equals, "pending")
-	c.Assert(mysqlAction.Action.Name, gc.Equals, "anotherfakeaction")
-	c.Assert(mysqlAction.Action.Receiver, gc.Equals, "unit-mysql-0")
-	c.Assert(mysqlAction.Action.Tag, gc.Equals, "action-5")
-
-	c.Assert(wordpressAction.Action, gc.NotNil)
-	if wordpressAction.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	c.Assert(wordpressAction.Status, gc.Equals, "pending")
-	c.Assert(wordpressAction.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(wordpressAction.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(wordpressAction.Action.Tag, gc.Equals, "action-4")
-
 }

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -1,0 +1,196 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// EnqueueOperation isn't on the V5 API.
+func (*APIv5) EnqueueOperation(_, _ struct{}) {}
+
+// EnqueueOperation takes a list of Actions and queues them up to be executed as
+// an operation, each action running as a task on the the designated ActionReceiver.
+// We return the ID of the overall operation and each individual task.
+func (a *ActionAPI) EnqueueOperation(arg params.Actions) (params.EnqueuedActions, error) {
+	operationId, actionResults, err := a.enqueue(arg)
+	if err != nil {
+		return params.EnqueuedActions{}, err
+	}
+	results := params.EnqueuedActions{
+		OperationTag: names.NewOperationTag(operationId).String(),
+		Actions:      make([]params.StringResult, len(actionResults.Results)),
+	}
+	for i, action := range actionResults.Results {
+		results.Actions[i].Error = action.Error
+		if action.Action != nil {
+			results.Actions[i].Result = action.Action.Tag
+		}
+	}
+	return results, nil
+}
+
+func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, error) {
+	if err := a.checkCanWrite(); err != nil {
+		return "", params.ActionResults{}, errors.Trace(err)
+	}
+
+	var leaders map[string]string
+	getLeader := func(appName string) (string, error) {
+		if leaders == nil {
+			var err error
+			leaders, err = a.state.ApplicationLeaders()
+			if err != nil {
+				return "", err
+			}
+		}
+		if leader, ok := leaders[appName]; ok {
+			return leader, nil
+		}
+		return "", errors.Errorf("could not determine leader for %q", appName)
+	}
+
+	var operationName string
+	var receivers []string
+	for _, a := range arg.Actions {
+		if a.Receiver != "" {
+			receivers = append(receivers, a.Receiver)
+		}
+		if operationName == "" {
+			operationName = a.Name
+			continue
+		}
+		if operationName != a.Name {
+			operationName = "multiple actions"
+		}
+	}
+	summary := fmt.Sprintf("%v run on %v", operationName, strings.Join(receivers, ","))
+	operationID, err := a.model.EnqueueOperation(summary)
+	if err != nil {
+		return "", params.ActionResults{}, errors.Annotate(err, "creating operation for actions")
+	}
+
+	tagToActionReceiver := common.TagToActionReceiverFn(a.state.FindEntity)
+	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
+	for i, action := range arg.Actions {
+		currentResult := &response.Results[i]
+		actionReceiver := action.Receiver
+		if strings.HasSuffix(actionReceiver, "leader") {
+			app := strings.Split(actionReceiver, "/")[0]
+			receiverName, err := getLeader(app)
+			if err != nil {
+				currentResult.Error = common.ServerError(err)
+				continue
+			}
+			actionReceiver = names.NewUnitTag(receiverName).String()
+		}
+		receiver, err := tagToActionReceiver(actionReceiver)
+		if err != nil {
+			currentResult.Error = common.ServerError(err)
+			continue
+		}
+		enqueued, err := receiver.AddAction(operationID, action.Name, action.Parameters)
+		if err != nil {
+			currentResult.Error = common.ServerError(err)
+			continue
+		}
+
+		response.Results[i] = common.MakeActionResult(receiver.Tag(), enqueued, false)
+	}
+	return operationID, response, nil
+}
+
+// Operations fetches the called functions (actions) for specified apps/units.
+func (a *ActionAPI) Operations(arg params.OperationQueryArgs) (params.ActionResults, error) {
+	if err := a.checkCanRead(); err != nil {
+		return params.ActionResults{}, errors.Trace(err)
+	}
+
+	unitTags := set.NewStrings()
+	for _, name := range arg.Units {
+		unitTags.Add(names.NewUnitTag(name).String())
+	}
+	appNames := arg.Applications
+	if len(appNames) == 0 && unitTags.Size() == 0 {
+		apps, err := a.state.AllApplications()
+		if err != nil {
+			return params.ActionResults{}, errors.Trace(err)
+		}
+		for _, a := range apps {
+			appNames = append(appNames, a.Name())
+		}
+	}
+	for _, aName := range appNames {
+		app, err := a.state.Application(aName)
+		if err != nil {
+			return params.ActionResults{}, errors.Trace(err)
+		}
+		units, err := app.AllUnits()
+		if err != nil {
+			return params.ActionResults{}, errors.Trace(err)
+		}
+		for _, u := range units {
+			unitTags.Add(u.Tag().String())
+		}
+	}
+
+	var entities params.Entities
+	for _, unitTag := range unitTags.SortedValues() {
+		entities.Entities = append(entities.Entities, params.Entity{Tag: unitTag})
+	}
+
+	statusSet := set.NewStrings(arg.Status...)
+	if statusSet.Size() == 0 {
+		statusSet = set.NewStrings(params.ActionPending, params.ActionRunning, params.ActionCompleted)
+	}
+	var extractorFuncs []extractorFn
+	for _, status := range statusSet.SortedValues() {
+		switch status {
+		case params.ActionPending:
+			extractorFuncs = append(extractorFuncs, pendingActions)
+		case params.ActionRunning:
+			extractorFuncs = append(extractorFuncs, runningActions)
+		case params.ActionCompleted:
+			extractorFuncs = append(extractorFuncs, completedActions)
+		}
+	}
+
+	byReceivers, err := a.internalList(entities, combine(extractorFuncs...), false)
+	if err != nil {
+		return params.ActionResults{}, errors.Trace(err)
+	}
+
+	nameMatches := func(name string, filter []string) bool {
+		if len(filter) == 0 {
+			return true
+		}
+		for _, f := range filter {
+			if f == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	var result params.ActionResults
+	for _, actions := range byReceivers.Actions {
+		if actions.Error != nil {
+			return params.ActionResults{}, errors.Trace(actions.Error)
+		}
+		for _, ar := range actions.Actions {
+			if nameMatches(ar.Action.Name, arg.FunctionNames) {
+				result.Results = append(result.Results, ar)
+			}
+		}
+	}
+	return result, nil
+}

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -1,0 +1,261 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action_test
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/kr/pretty"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+type operationSuite struct {
+	baseSuite
+}
+
+var _ = gc.Suite(&operationSuite{})
+
+func (s *operationSuite) setupOperations(c *gc.C) {
+	s.toSupportNewActionID(c)
+
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+			{Receiver: s.mysqlUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+			{Receiver: s.mysqlUnit.Tag().String(), Name: "anotherfakeaction", Parameters: map[string]interface{}{}},
+		}}
+
+	r, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Results, gc.HasLen, len(arg.Actions))
+
+	// There's only one operation created.
+	ops, err := s.Model.AllOperations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ops, gc.HasLen, 1)
+	operationID, err := strconv.Atoi(ops[0].Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	a, err := s.Model.Action(strconv.Itoa(operationID + 1))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = a.Begin()
+	c.Assert(err, jc.ErrorIsNil)
+	a, err = s.Model.Action(strconv.Itoa(operationID + 2))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = a.Finish(state.ActionResults{})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *operationSuite) TestEnqueueOperation(c *gc.C) {
+	// Ensure wordpress unit is the leader.
+	claimer, err := s.LeaseManager.Claimer("application-leadership", s.State.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	err = claimer.Claim("wordpress", "wordpress/0", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Make sure no Actions already exist on wordpress Unit.
+	actions, err := s.wordpressUnit.Actions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions, gc.HasLen, 0)
+
+	// Make sure no Actions already exist on mysql Unit.
+	actions, err = s.mysqlUnit.Actions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions, gc.HasLen, 0)
+
+	// Add Actions.
+	expectedName := "fakeaction"
+	expectedParameters := map[string]interface{}{"kan jy nie": "verstaand"}
+	arg := params.Actions{
+		Actions: []params.Action{
+			// No receiver.
+			{Name: "fakeaction"},
+			// Good.
+			{Receiver: s.wordpressUnit.Tag().String(), Name: expectedName, Parameters: expectedParameters},
+			// Application tag instead of Unit tag.
+			{Receiver: s.wordpress.Tag().String(), Name: "fakeaction"},
+			// Missing name.
+			{Receiver: s.mysqlUnit.Tag().String(), Parameters: expectedParameters},
+			// Good (leader syntax).
+			{Receiver: "wordpress/leader", Name: expectedName, Parameters: expectedParameters},
+		},
+	}
+
+	// blocking changes should have no effect
+	s.BlockAllChanges(c, "Enqueue")
+
+	res, err := s.action.EnqueueOperation(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res.Actions, gc.HasLen, 5)
+
+	emptyActionTag := names.ActionTag{}
+	c.Assert(res.Actions[0].Error, gc.DeepEquals,
+		&params.Error{Message: fmt.Sprintf("%s not valid", arg.Actions[0].Receiver), Code: ""})
+	c.Assert(res.Actions[0].Result, gc.Equals, "")
+
+	c.Assert(res.Actions[1].Error, gc.IsNil)
+	c.Assert(res.Actions[1].Result, gc.Not(gc.Equals), emptyActionTag)
+
+	errorString := fmt.Sprintf("action receiver interface on entity %s not implemented", arg.Actions[2].Receiver)
+	c.Assert(res.Actions[2].Error, gc.DeepEquals, &params.Error{Message: errorString, Code: "not implemented"})
+	c.Assert(res.Actions[2].Result, gc.Equals, "")
+
+	c.Assert(res.Actions[3].Error, gc.ErrorMatches, "no action name given")
+	c.Assert(res.Actions[3].Result, gc.Equals, "")
+
+	c.Assert(res.Actions[4].Error, gc.IsNil)
+	c.Assert(res.Actions[4].Result, gc.Not(gc.Equals), emptyActionTag)
+
+	// Make sure that 2 actions were enqueued for the wordpress Unit.
+	actions, err = s.wordpressUnit.Actions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions, gc.HasLen, 2)
+	for _, act := range actions {
+		c.Assert(act.Name(), gc.Equals, expectedName)
+		c.Assert(act.Parameters(), gc.DeepEquals, expectedParameters)
+		c.Assert(act.Receiver(), gc.Equals, s.wordpressUnit.Name())
+	}
+
+	// Make sure an Action was not enqueued for the mysql Unit.
+	actions, err = s.mysqlUnit.Actions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions, gc.HasLen, 0)
+
+	operations, err := s.Model.AllOperations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(operations, gc.HasLen, 1)
+	c.Assert(operations[0].Summary(), gc.Equals, "multiple actions run on unit-wordpress-0,application-wordpress,unit-mysql-0,wordpress/leader")
+}
+
+func (s *operationSuite) TestOperationsStatusFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
+		Status: []string{"running"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions.Results, gc.HasLen, 1)
+	result := actions.Results[0]
+	c.Assert(result.Action, gc.NotNil)
+	if result.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	if result.Started.IsZero() {
+		c.Fatal("started time not set")
+	}
+	c.Assert(result.Status, gc.Equals, "running")
+	c.Assert(result.Action.Name, gc.Equals, "fakeaction")
+	c.Assert(result.Action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(result.Action.Tag, gc.Equals, "action-2")
+}
+
+func (s *operationSuite) TestOperationsNameFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
+		FunctionNames: []string{"anotherfakeaction"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions.Results, gc.HasLen, 1)
+	result := actions.Results[0]
+	c.Assert(result.Action, gc.NotNil)
+	if result.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	c.Assert(result.Status, gc.Equals, "pending")
+	c.Assert(result.Action.Name, gc.Equals, "anotherfakeaction")
+	c.Assert(result.Action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(result.Action.Tag, gc.Equals, "action-5")
+}
+
+func (s *operationSuite) TestOperationsAppFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
+		Applications: []string{"wordpress"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions.Results, gc.HasLen, 2)
+	result0 := actions.Results[0]
+	result1 := actions.Results[1]
+
+	c.Assert(result0.Action, gc.NotNil)
+	if result0.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	c.Assert(result0.Status, gc.Equals, "pending")
+	c.Assert(result0.Action.Name, gc.Equals, "fakeaction")
+	c.Assert(result0.Action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(result0.Action.Tag, gc.Equals, "action-4")
+
+	c.Assert(result1.Action, gc.NotNil)
+	if result1.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	if result1.Started.IsZero() {
+		c.Fatal("started time not set")
+	}
+	c.Assert(result1.Status, gc.Equals, "running")
+	c.Assert(result1.Action.Name, gc.Equals, "fakeaction")
+	c.Assert(result1.Action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(result1.Action.Tag, gc.Equals, "action-2")
+}
+
+func (s *operationSuite) TestOperationsUnitFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
+		Units:  []string{"wordpress/0"},
+		Status: []string{"pending"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions.Results, gc.HasLen, 1)
+	result := actions.Results[0]
+
+	c.Assert(result.Action, gc.NotNil)
+	if result.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	c.Assert(result.Status, gc.Equals, "pending")
+	c.Assert(result.Action.Name, gc.Equals, "fakeaction")
+	c.Assert(result.Action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(result.Action.Tag, gc.Equals, "action-4")
+}
+
+func (s *operationSuite) TestOperationsAppAndUnitFilter(c *gc.C) {
+	s.setupOperations(c)
+	actions, err := s.action.Operations(params.OperationQueryArgs{
+		Applications: []string{"mysql"},
+		Units:        []string{"wordpress/0"},
+		Status:       []string{"pending"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actions.Results, gc.HasLen, 2)
+	mysqlAction := actions.Results[0]
+	wordpressAction := actions.Results[1]
+	c.Log(pretty.Sprint(actions.Results))
+
+	c.Assert(mysqlAction.Action, gc.NotNil)
+	if mysqlAction.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	c.Assert(mysqlAction.Status, gc.Equals, "pending")
+	c.Assert(mysqlAction.Action.Name, gc.Equals, "anotherfakeaction")
+	c.Assert(mysqlAction.Action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(mysqlAction.Action.Tag, gc.Equals, "action-5")
+
+	c.Assert(wordpressAction.Action, gc.NotNil)
+	if wordpressAction.Enqueued.IsZero() {
+		c.Fatal("enqueued time not set")
+	}
+	c.Assert(wordpressAction.Status, gc.Equals, "pending")
+	c.Assert(wordpressAction.Action.Name, gc.Equals, "fakeaction")
+	c.Assert(wordpressAction.Action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(wordpressAction.Action.Tag, gc.Equals, "action-4")
+
+}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -49,7 +49,7 @@
                         }
                     }
                 },
-                "EnqueueV2": {
+                "EnqueueOperation": {
                     "type": "object",
                     "properties": {
                         "Params": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1,7 +1,7 @@
 [
     {
         "Name": "Action",
-        "Version": 5,
+        "Version": 6,
         "Schema": {
             "type": "object",
             "properties": {
@@ -46,6 +46,17 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/ActionResults"
+                        }
+                    }
+                },
+                "EnqueueV2": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Actions"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/EnqueuedActions"
                         }
                     }
                 },
@@ -390,6 +401,24 @@
                     },
                     "additionalProperties": false
                 },
+                "EnqueuedActions": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        },
+                        "operation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "operation"
+                    ]
+                },
                 "Entities": {
                     "type": "object",
                     "properties": {
@@ -554,6 +583,21 @@
                     "required": [
                         "commands",
                         "timeout"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
                     ]
                 },
                 "StringsWatchResult": {

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -40,6 +40,12 @@ type Action struct {
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
 }
 
+// EnqueuedActions represents the result of enqueuing actions to run.
+type EnqueuedActions struct {
+	OperationTag string         `json:"operation"`
+	Actions      []StringResult `json:"actions,omitempty"`
+}
+
 // ActionResults is a slice of ActionResult for bulk requests.
 type ActionResults struct {
 	Results []ActionResult `json:"results,omitempty"`

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -29,10 +29,10 @@ type APIClient interface {
 	// TODO(juju3) - remove.
 	Enqueue(params.Actions) (params.ActionResults, error)
 
-	// EnqueueV2 takes a list of Actions and queues them up to be executed by
-	// the designated ActionReceiver, returning the ids of the overall operation
-	// and each individual task.
-	EnqueueV2(params.Actions) (params.EnqueuedActions, error)
+	// EnqueueOperation takes a list of Actions and queues them up to be executed as
+	// an operation, each action running as a task on the the designated ActionReceiver.
+	// We return the ID of the overall operation and each individual task.
+	EnqueueOperation(params.Actions) (params.EnqueuedActions, error)
 
 	// ListAll takes a list of Tags representing ActionReceivers and returns
 	// all of the Actions that have been queued or run by each of those

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -26,7 +26,13 @@ type APIClient interface {
 	// the designated ActionReceiver, returning the params.Action for each
 	// queued Action, or an error if there was a problem queueing up the
 	// Action.
+	// TODO(juju3) - remove.
 	Enqueue(params.Actions) (params.ActionResults, error)
+
+	// EnqueueV2 takes a list of Actions and queues them up to be executed by
+	// the designated ActionReceiver, returning the ids of the overall operation
+	// and each individual task.
+	EnqueueV2(params.Actions) (params.EnqueuedActions, error)
 
 	// ListAll takes a list of Tags representing ActionReceivers and returns
 	// all of the Actions that have been queued or run by each of those

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -173,7 +173,7 @@ func (c *fakeAPIClient) Enqueue(args params.Actions) (params.ActionResults, erro
 	return params.ActionResults{Results: c.actionResults}, c.apiErr
 }
 
-func (c *fakeAPIClient) EnqueueV2(args params.Actions) (params.EnqueuedActions, error) {
+func (c *fakeAPIClient) EnqueueOperation(args params.Actions) (params.EnqueuedActions, error) {
 	c.enqueuedActions = args
 	actions := make([]params.StringResult, len(c.actionResults))
 	for i, a := range c.actionResults {

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -173,6 +173,22 @@ func (c *fakeAPIClient) Enqueue(args params.Actions) (params.ActionResults, erro
 	return params.ActionResults{Results: c.actionResults}, c.apiErr
 }
 
+func (c *fakeAPIClient) EnqueueV2(args params.Actions) (params.EnqueuedActions, error) {
+	c.enqueuedActions = args
+	actions := make([]params.StringResult, len(c.actionResults))
+	for i, a := range c.actionResults {
+		actions[i] = params.StringResult{
+			Error: a.Error,
+		}
+		if a.Action != nil {
+			actions[i].Result = a.Action.Tag
+		}
+	}
+	return params.EnqueuedActions{
+		OperationTag: "operation-1",
+		Actions:      actions}, c.apiErr
+}
+
 func (c *fakeAPIClient) ListAll(args params.Entities) (params.ActionsByReceivers, error) {
 	return params.ActionsByReceivers{
 		Actions: c.actionsByReceivers,

--- a/cmd/juju/action/run_test.go
+++ b/cmd/juju/action/run_test.go
@@ -241,7 +241,7 @@ func (s *CallSuite) TestInit(c *gc.C) {
 	}
 }
 
-func (s *CallSuite) TestCall(c *gc.C) {
+func (s *CallSuite) TestRun(c *gc.C) {
 	tests := []struct {
 		should                 string
 		clientSetup            func(client *fakeAPIClient)
@@ -778,22 +778,8 @@ mysql/1:
 			},
 		}},
 	}, {
-		should:      "fail with not implemented Leaders method",
-		clientSetup: func(api *fakeAPIClient) { api.apiVersion = 2 },
-		withArgs:    []string{"mysql/leader", "some-action", "--background"},
-		withActionResults: []params.ActionResult{{
-			Action: &params.Action{
-				Tag:      validActionTagString,
-				Receiver: names.NewUnitTag(validUnitId).String(),
-			},
-		}},
-		expectedErr: "unable to determine leader for application \"mysql\"" +
-			"\nleader determination is unsupported by this API" +
-			"\neither upgrade your controller, or explicitly specify a unit",
-	}, {
-		should:      "enqueue a basic action on the leader",
-		clientSetup: func(api *fakeAPIClient) { api.apiVersion = 3 },
-		withArgs:    []string{"mysql/leader", "some-action", "--background"},
+		should:   "enqueue a basic action on the leader",
+		withArgs: []string{"mysql/leader", "some-action", "--background"},
 		withActionResults: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      validActionTagString,
@@ -816,7 +802,7 @@ mysql/1:
 				fakeClient := &fakeAPIClient{
 					actionResults:    t.withActionResults,
 					actionTagMatches: t.withTags,
-					apiVersion:       5,
+					apiVersion:       6,
 					logMessageCh:     make(chan []string, len(t.expectedLogs)),
 				}
 				if len(t.expectedLogs) > 0 {
@@ -894,8 +880,9 @@ mysql/1:
 
 						// Make sure the CLI responded with the expected tag
 						c.Assert(outString, gc.Equals, fmt.Sprintf(`
-Scheduled Operation %s
-Check status with 'juju show-operation %s'`[1:],
+Scheduled operation 1 with task %s
+Check operation status with 'juju show-operation 1'
+Check task status with 'juju show-task %s'`[1:],
 							expectedTag.Id(), expectedTag.Id()))
 					} else {
 						outputResult := ctx.Stdout.(*bytes.Buffer).Bytes()

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -108,10 +108,10 @@ func (c *showOutputCommand) Info() *cmd.Info {
 		Doc:     showOutputDoc,
 	})
 	if !c.compat {
-		info.Name = "show-operation"
-		info.Args = "<operation ID>"
-		info.Purpose = "Show results of a operation by ID."
-		info.Doc = strings.Replace(info.Doc, "show-action-output", "show-operation", -1)
+		info.Name = "show-task"
+		info.Args = "<task ID>"
+		info.Purpose = "Show results of a task by ID."
+		info.Doc = strings.Replace(info.Doc, "show-action-output", "show-task", -1)
 		info.Doc = strings.Replace(info.Doc, "run-action", "run", -1)
 	}
 	return info

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -631,7 +631,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"run", "show-operation", "operations", "list-operations",
+	"run", "show-task", "operations", "list-operations",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {


### PR DESCRIPTION
### Checklist

 - [X] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?

libjuju uses the existing Enqueue API - at some point as the need arises it can be updated to work with operations/tasks.

----

## Description of change

Introduce a new EnqueueV2 API for the actions facade which returns the overall operation id for the queued action(s). Enhance the run action CLI to use the operation id. Subsequent work will flesh out the new operations/tasks CLI.

## QA steps

deploy a charm with actions
enable the juju-v3 feature flag
run an action across multiple units, with/without background
run an action across a single unit, with/without background
check the text output of the CLI