### PR TITLE
cmd list space: swap id and name

### DIFF
--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -208,10 +208,10 @@ func printTabularLong(writer io.Writer, value interface{}) error {
 	table.MaxColWidth = 50
 	table.Wrap = true
 
-	table.AddRow("Space", "Name", "Subnets")
+	table.AddRow("Name", "Space ID", "Subnets")
 	for _, s := range list.Spaces {
 		if len(s.Subnets) == 0 {
-			table.AddRow(s.Id, spaceName(s.Name), "")
+			table.AddRow(spaceName(s.Name), s.Id, "")
 			continue
 		}
 
@@ -221,7 +221,7 @@ func printTabularLong(writer io.Writer, value interface{}) error {
 		}
 		sort.Strings(cidrs)
 
-		table.AddRow(s.Id, spaceName(s.Name), cidrs[0])
+		table.AddRow(spaceName(s.Name), s.Id, cidrs[0])
 		for i := 1; i < len(cidrs); i++ {
 			table.AddRow("", "", cidrs[i])
 		}

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -205,13 +205,13 @@ spaces:
 `, "") + "\n"
 
 	expectedTabular := `
-Space  Name    Subnets      
-0      alpha                
-1      space1  2001:db8::/32
-               invalid      
-2      space2  10.1.2.0/24  
-               4.3.2.0/28   
-                            
+Name    Space ID  Subnets      
+alpha   0                      
+space1  1         2001:db8::/32
+                  invalid      
+space2  2         10.1.2.0/24  
+                  4.3.2.0/28   
+                               
 `[1:]
 
 	expectedShortTabular := `

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -175,9 +175,9 @@ func (s *cmdSpaceSuite) TestSpaceListDefaultOnly(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := `
-Space  Name   Subnets
-0      alpha         
-                     
+Name   Space ID  Subnets
+alpha  0                
+                        
 `[1:]
 
 	c.Assert(stdout, gc.Equals, expected)


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

- change the column ordering of tabular output ID and Name

## QA steps

```sh
juju spaces           
Name     Space  Subnets       
aaabbbb  3                    
alpha2   0      172.31.1.0/28 
                172.31.16.0/20
                172.31.2.0/28 
                172.31.3.0/24 
                252.1.0.0/20  
                252.16.0.0/12 
                252.2.0.0/20  
                252.3.0.0/16  
bla      1      172.31.0.0/28 
                252.0.0.0/20  
                              
```

## Documentation changes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1862233