### PR TITLE
Consume New Provisioner API Network Topology

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -83,7 +83,7 @@ var facadeVersions = map[string]int{
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,
 	"Pinger":                       1,
-	"Provisioner":                  9,
+	"Provisioner":                  10,
 	"ProxyUpdater":                 2,
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -45,7 +45,7 @@ type MachineProvisioner interface {
 	Refresh() error
 
 	// ProvisioningInfo returns the information required to provision a machine.
-	ProvisioningInfo() (*params.ProvisioningInfo, error)
+	ProvisioningInfo() (*params.ProvisioningInfoV10, error)
 
 	// SetInstanceStatus sets the status for the provider instance.
 	SetInstanceStatus(status status.Status, message string, data map[string]interface{}) error
@@ -182,8 +182,8 @@ func (m *Machine) Refresh() error {
 }
 
 // ProvisioningInfo implements MachineProvisioner.ProvisioningInfo.
-func (m *Machine) ProvisioningInfo() (*params.ProvisioningInfo, error) {
-	var results params.ProvisioningInfoResults
+func (m *Machine) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
+	var results params.ProvisioningInfoResultsV10
 	args := params.Entities{Entities: []params.Entity{{m.tag.String()}}}
 	err := m.st.facade.FacadeCall("ProvisioningInfo", args, &results)
 	if err != nil {

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -5,16 +5,15 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/life"
+	life "github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	version "github.com/juju/version"
 	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockMachineProvisioner is a mock of MachineProvisioner interface
@@ -42,6 +41,7 @@ func (m *MockMachineProvisioner) EXPECT() *MockMachineProvisionerMockRecorder {
 
 // AvailabilityZone mocks base method
 func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -50,11 +50,13 @@ func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
 
 // AvailabilityZone indicates an expected call of AvailabilityZone
 func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone))
 }
 
 // DistributionGroup mocks base method
 func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DistributionGroup")
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
@@ -63,11 +65,13 @@ func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
 
 // DistributionGroup indicates an expected call of DistributionGroup
 func (mr *MockMachineProvisionerMockRecorder) DistributionGroup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup))
 }
 
 // EnsureDead mocks base method
 func (m *MockMachineProvisioner) EnsureDead() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureDead")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -75,11 +79,13 @@ func (m *MockMachineProvisioner) EnsureDead() error {
 
 // EnsureDead indicates an expected call of EnsureDead
 func (mr *MockMachineProvisionerMockRecorder) EnsureDead() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead))
 }
 
 // Id mocks base method
 func (m *MockMachineProvisioner) Id() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -87,11 +93,13 @@ func (m *MockMachineProvisioner) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockMachineProvisionerMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachineProvisioner)(nil).Id))
 }
 
 // InstanceId mocks base method
 func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
@@ -100,11 +108,13 @@ func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
 
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMachineProvisionerMockRecorder) InstanceId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId))
 }
 
 // InstanceStatus mocks base method
 func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceStatus")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -114,11 +124,13 @@ func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error)
 
 // InstanceStatus indicates an expected call of InstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) InstanceStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus))
 }
 
 // KeepInstance mocks base method
 func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KeepInstance")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -127,11 +139,13 @@ func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
 
 // KeepInstance indicates an expected call of KeepInstance
 func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance))
 }
 
 // Life mocks base method
 func (m *MockMachineProvisioner) Life() life.Value {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
 	ret0, _ := ret[0].(life.Value)
 	return ret0
@@ -139,11 +153,13 @@ func (m *MockMachineProvisioner) Life() life.Value {
 
 // Life indicates an expected call of Life
 func (mr *MockMachineProvisionerMockRecorder) Life() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMachineProvisioner)(nil).Life))
 }
 
 // MachineTag mocks base method
 func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
 	ret0, _ := ret[0].(names_v3.MachineTag)
 	return ret0
@@ -151,11 +167,13 @@ func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
 
 // MachineTag indicates an expected call of MachineTag
 func (mr *MockMachineProvisionerMockRecorder) MachineTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockMachineProvisioner)(nil).MachineTag))
 }
 
 // MarkForRemoval mocks base method
 func (m *MockMachineProvisioner) MarkForRemoval() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarkForRemoval")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -163,11 +181,13 @@ func (m *MockMachineProvisioner) MarkForRemoval() error {
 
 // MarkForRemoval indicates an expected call of MarkForRemoval
 func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval))
 }
 
 // ModelAgentVersion mocks base method
 func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelAgentVersion")
 	ret0, _ := ret[0].(*version.Number)
 	ret1, _ := ret[1].(error)
@@ -176,24 +196,28 @@ func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
 
 // ModelAgentVersion indicates an expected call of ModelAgentVersion
 func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion))
 }
 
 // ProvisioningInfo mocks base method
-func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfo, error) {
+func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo")
-	ret0, _ := ret[0].(*params.ProvisioningInfo)
+	ret0, _ := ret[0].(*params.ProvisioningInfoV10)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ProvisioningInfo indicates an expected call of ProvisioningInfo
 func (mr *MockMachineProvisionerMockRecorder) ProvisioningInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).ProvisioningInfo))
 }
 
 // Refresh mocks base method
 func (m *MockMachineProvisioner) Refresh() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -201,11 +225,13 @@ func (m *MockMachineProvisioner) Refresh() error {
 
 // Refresh indicates an expected call of Refresh
 func (mr *MockMachineProvisionerMockRecorder) Refresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh))
 }
 
 // Remove mocks base method
 func (m *MockMachineProvisioner) Remove() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -213,11 +239,13 @@ func (m *MockMachineProvisioner) Remove() error {
 
 // Remove indicates an expected call of Remove
 func (mr *MockMachineProvisionerMockRecorder) Remove() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove))
 }
 
 // SetCharmProfiles mocks base method
 func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -225,11 +253,13 @@ func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0)
 }
 
 // SetInstanceInfo mocks base method
 func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 string, arg3 *instance.HardwareCharacteristics, arg4 []params.NetworkConfig, arg5 []params.Volume, arg6 map[string]params.VolumeAttachmentInfo, arg7 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -237,11 +267,13 @@ func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 st
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // SetInstanceStatus mocks base method
 func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -249,11 +281,13 @@ func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 stri
 
 // SetInstanceStatus indicates an expected call of SetInstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2)
 }
 
 // SetModificationStatus mocks base method
 func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -261,11 +295,13 @@ func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 
 
 // SetModificationStatus indicates an expected call of SetModificationStatus
 func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2)
 }
 
 // SetPassword mocks base method
 func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPassword", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -273,11 +309,13 @@ func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
 
 // SetPassword indicates an expected call of SetPassword
 func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0)
 }
 
 // SetStatus mocks base method
 func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -285,11 +323,13 @@ func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2)
 }
 
 // SetSupportedContainers mocks base method
 func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.ContainerType) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -301,11 +341,13 @@ func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.Contain
 
 // SetSupportedContainers indicates an expected call of SetSupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), arg0...)
 }
 
 // Status mocks base method
 func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -315,11 +357,13 @@ func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
 
 // Status indicates an expected call of Status
 func (mr *MockMachineProvisionerMockRecorder) Status() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status))
 }
 
 // String mocks base method
 func (m *MockMachineProvisioner) String() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -327,11 +371,13 @@ func (m *MockMachineProvisioner) String() string {
 
 // String indicates an expected call of String
 func (mr *MockMachineProvisionerMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockMachineProvisioner)(nil).String))
 }
 
 // SupportedContainers mocks base method
 func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType, bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportedContainers")
 	ret0, _ := ret[0].([]instance.ContainerType)
 	ret1, _ := ret[1].(bool)
@@ -341,11 +387,13 @@ func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType
 
 // SupportedContainers indicates an expected call of SupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportedContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers))
 }
 
 // SupportsNoContainers mocks base method
 func (m *MockMachineProvisioner) SupportsNoContainers() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsNoContainers")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -353,11 +401,13 @@ func (m *MockMachineProvisioner) SupportsNoContainers() error {
 
 // SupportsNoContainers indicates an expected call of SupportsNoContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers))
 }
 
 // Tag mocks base method
 func (m *MockMachineProvisioner) Tag() names_v3.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
 	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
@@ -365,11 +415,13 @@ func (m *MockMachineProvisioner) Tag() names_v3.Tag {
 
 // Tag indicates an expected call of Tag
 func (mr *MockMachineProvisionerMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockMachineProvisioner)(nil).Tag))
 }
 
 // WatchAllContainers mocks base method
 func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchAllContainers")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -378,11 +430,13 @@ func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, e
 
 // WatchAllContainers indicates an expected call of WatchAllContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchAllContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAllContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchAllContainers))
 }
 
 // WatchContainers mocks base method
 func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchContainers", arg0)
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -391,5 +445,6 @@ func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (w
 
 // WatchContainers indicates an expected call of WatchContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0)
 }

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -561,9 +561,14 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 	c.Assert(provisioningInfo.Series, gc.Equals, template.Series)
 	c.Assert(provisioningInfo.Placement, gc.Equals, template.Placement)
 	c.Assert(provisioningInfo.Constraints, jc.DeepEquals, template.Constraints)
-	c.Assert(provisioningInfo.SubnetsToZones, jc.DeepEquals, map[string][]string{
-		"subnet-2": {"zone2"},
-		"subnet-3": {"zone3"},
+	c.Assert(provisioningInfo.ProvisioningNetworkTopology, jc.DeepEquals, params.ProvisioningNetworkTopology{
+		SpaceSubnets: map[string][]string{
+			"space2": {"subnet-2", "subnet-3"},
+		},
+		SubnetAZs: map[string][]string{
+			"subnet-2": {"zone2"},
+			"subnet-3": {"zone3"},
+		},
 	})
 }
 

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -561,15 +561,14 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 	c.Assert(provisioningInfo.Series, gc.Equals, template.Series)
 	c.Assert(provisioningInfo.Placement, gc.Equals, template.Placement)
 	c.Assert(provisioningInfo.Constraints, jc.DeepEquals, template.Constraints)
-	c.Assert(provisioningInfo.ProvisioningNetworkTopology, jc.DeepEquals, params.ProvisioningNetworkTopology{
-		SpaceSubnets: map[string][]string{
-			"space2": {"subnet-2", "subnet-3"},
-		},
-		SubnetAZs: map[string][]string{
-			"subnet-2": {"zone2"},
-			"subnet-3": {"zone3"},
-		},
+
+	c.Assert(provisioningInfo.SubnetAZs, jc.DeepEquals, map[string][]string{
+		"subnet-2": {"zone2"},
+		"subnet-3": {"zone3"},
 	})
+
+	c.Assert(provisioningInfo.SpaceSubnets, gc.HasLen, 1)
+	c.Assert(provisioningInfo.SpaceSubnets["space2"], jc.SameContents, []string{"subnet-2", "subnet-3"})
 }
 
 func (s *provisionerSuite) TestProvisioningInfoMachineNotFound(c *gc.C) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -275,11 +275,12 @@ func AllFacades() *facade.Registry {
 	reg("Pinger", 1, NewPinger)
 	reg("Provisioner", 3, provisioner.NewProvisionerAPIV4) // Yes this is weird.
 	reg("Provisioner", 4, provisioner.NewProvisionerAPIV4)
-	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5) // v5 adds DistributionGroupByMachineId()
-	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6) // v6 adds more proxy settings
-	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7) // v7 adds charm profile watcher
-	reg("Provisioner", 8, provisioner.NewProvisionerAPIV8) // v8 adds changes charm profile and modification status
-	reg("Provisioner", 9, provisioner.NewProvisionerAPIV9) // v9 adds supported containers
+	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5)   // v5 adds DistributionGroupByMachineId()
+	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6)   // v6 adds more proxy settings
+	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7)   // v7 adds charm profile watcher
+	reg("Provisioner", 8, provisioner.NewProvisionerAPIV8)   // v8 adds changes charm profile and modification status
+	reg("Provisioner", 9, provisioner.NewProvisionerAPIV9)   // v9 adds supported containers
+	reg("Provisioner", 10, provisioner.NewProvisionerAPIV10) // v10 adds support for multiple space constraints.
 
 	reg("ProxyUpdater", 1, proxyupdater.NewFacadeV1)
 	reg("ProxyUpdater", 2, proxyupdater.NewFacadeV2)

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -193,37 +193,42 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithMultiplePositiveSpaceCo
 
 	result, err := s.provisioner.ProvisioningInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
 
-	controllerCfg := s.ControllerConfig
-	expected := params.ProvisioningInfoResultsV10{
-		Results: []params.ProvisioningInfoResultV10{{
-			Result: &params.ProvisioningInfoV10{
-				ProvisioningInfoBase: params.ProvisioningInfoBase{
-					ControllerConfig: controllerCfg,
-					Series:           "quantal",
-					Constraints:      template.Constraints,
-					Placement:        template.Placement,
-					Jobs:             []model.MachineJob{model.JobHostUnits},
-					Tags: map[string]string{
-						tags.JujuController: coretesting.ControllerTag.Id(),
-						tags.JujuModel:      coretesting.ModelTag.Id(),
-						tags.JujuMachine:    "controller-machine-5",
-					},
-				},
-				ProvisioningNetworkTopology: params.ProvisioningNetworkTopology{
-					SubnetAZs: map[string][]string{
-						"subnet-0": {"zone0"},
-						"subnet-1": {"zone1"},
-						"subnet-2": {"zone2"},
-					},
-					SpaceSubnets: map[string][]string{
-						"space1": {"subnet-0"},
-						"space2": {"subnet-1", "subnet-2"},
-					},
-				},
+	expected := params.ProvisioningInfoV10{
+		ProvisioningInfoBase: params.ProvisioningInfoBase{
+			ControllerConfig: s.ControllerConfig,
+			Series:           "quantal",
+			Constraints:      template.Constraints,
+			Placement:        template.Placement,
+			Jobs:             []model.MachineJob{model.JobHostUnits},
+			Tags: map[string]string{
+				tags.JujuController: coretesting.ControllerTag.Id(),
+				tags.JujuModel:      coretesting.ModelTag.Id(),
+				tags.JujuMachine:    "controller-machine-5",
 			},
-		}}}
-	c.Assert(result, jc.DeepEquals, expected)
+		},
+		ProvisioningNetworkTopology: params.ProvisioningNetworkTopology{
+			SubnetAZs: map[string][]string{
+				"subnet-0": {"zone0"},
+				"subnet-1": {"zone1"},
+				"subnet-2": {"zone2"},
+			},
+			SpaceSubnets: map[string][]string{
+				"space1": {"subnet-0"},
+				"space2": {"subnet-1", "subnet-2"},
+			},
+		},
+	}
+
+	res := result.Results[0].Result
+	c.Assert(res.ProvisioningInfoBase, jc.DeepEquals, expected.ProvisioningInfoBase)
+	c.Assert(res.SubnetAZs, jc.DeepEquals, expected.SubnetAZs)
+	c.Assert(res.SpaceSubnets, gc.HasLen, 2)
+	c.Assert(res.SpaceSubnets["space1"], jc.SameContents, expected.SpaceSubnets["space1"])
+	c.Assert(res.SpaceSubnets["space2"], jc.SameContents, expected.SpaceSubnets["space2"])
+
 }
 
 func (s *withoutControllerSuite) addSpacesAndSubnets(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -25632,7 +25632,7 @@
     },
     {
         "Name": "Provisioner",
-        "Version": 9,
+        "Version": 10,
         "Schema": {
             "type": "object",
             "properties": {
@@ -25894,7 +25894,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/ProvisioningInfoResults"
+                            "$ref": "#/definitions/ProvisioningInfoResultsV10"
                         }
                     }
                 },
@@ -27336,106 +27336,6 @@
                         "Build"
                     ]
                 },
-                "ProvisioningInfo": {
-                    "type": "object",
-                    "properties": {
-                        "ProvisioningInfoBase": {
-                            "$ref": "#/definitions/ProvisioningInfoBase"
-                        },
-                        "charm-lxd-profiles": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "cloudinit-userdata": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        },
-                        "constraints": {
-                            "$ref": "#/definitions/Value"
-                        },
-                        "controller-config": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        },
-                        "endpoint-bindings": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "image-metadata": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CloudImageMetadata"
-                            }
-                        },
-                        "jobs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "placement": {
-                            "type": "string"
-                        },
-                        "series": {
-                            "type": "string"
-                        },
-                        "subnets-to-zones": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "tags": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "volume-attachments": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/VolumeAttachmentParams"
-                            }
-                        },
-                        "volumes": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/VolumeParams"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "constraints",
-                        "series",
-                        "placement",
-                        "jobs",
-                        "ProvisioningInfoBase"
-                    ]
-                },
                 "ProvisioningInfoBase": {
                     "type": "object",
                     "properties": {
@@ -27521,14 +27421,14 @@
                         "jobs"
                     ]
                 },
-                "ProvisioningInfoResult": {
+                "ProvisioningInfoResultV10": {
                     "type": "object",
                     "properties": {
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
                         "result": {
-                            "$ref": "#/definitions/ProvisioningInfo"
+                            "$ref": "#/definitions/ProvisioningInfoV10"
                         }
                     },
                     "additionalProperties": false,
@@ -27536,19 +27436,168 @@
                         "result"
                     ]
                 },
-                "ProvisioningInfoResults": {
+                "ProvisioningInfoResultsV10": {
                     "type": "object",
                     "properties": {
                         "results": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ProvisioningInfoResult"
+                                "$ref": "#/definitions/ProvisioningInfoResultV10"
                             }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "ProvisioningInfoV10": {
+                    "type": "object",
+                    "properties": {
+                        "ProvisioningInfoBase": {
+                            "$ref": "#/definitions/ProvisioningInfoBase"
+                        },
+                        "ProvisioningNetworkTopology": {
+                            "$ref": "#/definitions/ProvisioningNetworkTopology"
+                        },
+                        "charm-lxd-profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cloudinit-userdata": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "controller-config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "image-metadata": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadata"
+                            }
+                        },
+                        "jobs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "placement": {
+                            "type": "string"
+                        },
+                        "series": {
+                            "type": "string"
+                        },
+                        "space-subnets": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "subnet-zones": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "volume-attachments": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachmentParams"
+                            }
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints",
+                        "series",
+                        "placement",
+                        "jobs",
+                        "ProvisioningInfoBase",
+                        "subnet-zones",
+                        "space-subnets",
+                        "ProvisioningNetworkTopology"
+                    ]
+                },
+                "ProvisioningNetworkTopology": {
+                    "type": "object",
+                    "properties": {
+                        "space-subnets": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "subnet-zones": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "subnet-zones",
+                        "space-subnets"
                     ]
                 },
                 "SetMachineNetworkConfig": {

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -69,11 +69,12 @@ type StartInstanceParams struct {
 	// necessary to configure on the instance.
 	NetworkInfo []corenetwork.InterfaceInfo
 
-	// SubnetsToZones is an optional map of provider-specific subnet
-	// id to a list of availability zone names the subnet is available
-	// in. It is only populated when valid positive spaces constraints
-	// are present.
-	SubnetsToZones map[corenetwork.Id][]string
+	// SubnetsToZones is an optional collection of maps of provider-specific
+	// subnet IDs to a list of availability zone names each subnet is available
+	// in.
+	// It is only populated when valid positive spaces constraints
+	// are present; one for each such constraint.
+	SubnetsToZones []map[corenetwork.Id][]string
 
 	// EndpointBindings holds the mapping between application endpoint names to
 	// provider-specific space IDs. It is populated when provisioning a machine

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -579,7 +579,16 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		}
 		subnetIDsForZone, subnetErr = getVPCSubnetIDsForAvailabilityZone(e.ec2, ctx, e.ecfg().vpcID(), availabilityZone, allowedSubnetIDs)
 	} else if args.Constraints.HasSpaces() {
-		subnetIDsForZone, subnetErr = corenetwork.FindSubnetIDsForAvailabilityZone(availabilityZone, args.SubnetsToZones)
+
+		// TODO (manadart 2020-02-07): We only take the first subnet/zones
+		// mapping to create a NIC for the instance.
+		// This effectively uses a single positive space constraint if many are
+		// specified; behaviour that dates from the original spaces MVP.
+		// It will not take too much effort to enable multi-NIC support for EC2
+		// if we use them all when constructing the instance creation request.
+		subnetIDsForZone, subnetErr =
+			corenetwork.FindSubnetIDsForAvailabilityZone(availabilityZone, args.SubnetsToZones[0])
+
 		if subnetErr == nil && placementSubnetID != "" {
 			asSet := set.NewStrings(subnetIDsForZone...)
 			if asSet.Contains(placementSubnetID) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -868,11 +868,11 @@ func (t *localServerSuite) testStartInstanceSubnet(c *gc.C, subnet string) (inst
 	params := environs.StartInstanceParams{
 		ControllerUUID: t.ControllerUUID,
 		Placement:      fmt.Sprintf("subnet=%s", subnet),
-		SubnetsToZones: map[corenetwork.Id][]string{
+		SubnetsToZones: []map[corenetwork.Id][]string{{
 			subIDs[0]: {"test-available"},
 			subIDs[1]: {"test-available"},
 			subIDs[2]: {"test-unavailable"},
-		},
+		}},
 	}
 	zonedEnviron := env.(common.ZonedEnviron)
 	zones, err := zonedEnviron.DeriveAvailabilityZones(t.callCtx, params)
@@ -897,11 +897,11 @@ func (t *localServerSuite) TestDeriveAvailabilityZoneSubnetWrongVPC(c *gc.C) {
 	params := environs.StartInstanceParams{
 		ControllerUUID: t.ControllerUUID,
 		Placement:      "subnet=0.1.2.0/24",
-		SubnetsToZones: map[corenetwork.Id][]string{
+		SubnetsToZones: []map[corenetwork.Id][]string{{
 			subIDs[0]: {"test-available"},
 			subIDs[1]: {"test-available"},
 			subIDs[2]: {"test-unavailable"},
-		},
+		}},
 	}
 	zonedEnviron := env.(common.ZonedEnviron)
 	_, err := zonedEnviron.DeriveAvailabilityZones(t.callCtx, params)
@@ -1201,11 +1201,11 @@ func (t *localServerSuite) TestSpaceConstraintsSpaceNotInPlacementZone(c *gc.C) 
 		ControllerUUID: t.ControllerUUID,
 		Placement:      "zone=test-available",
 		Constraints:    constraints.MustParse("spaces=aaaaaaaaaa"),
-		SubnetsToZones: map[corenetwork.Id][]string{
+		SubnetsToZones: []map[corenetwork.Id][]string{{
 			subIDs[0]: {"zone2"},
 			subIDs[1]: {"zone3"},
 			subIDs[2]: {"zone4"},
-		},
+		}},
 		StatusCallback: fakeCallback,
 	}
 	_, err := testing.StartInstanceWithParams(env, t.callCtx, "1", params)
@@ -1222,10 +1222,10 @@ func (t *localServerSuite) TestSpaceConstraintsSpaceInPlacementZone(c *gc.C) {
 		ControllerUUID: t.ControllerUUID,
 		Placement:      "zone=test-available",
 		Constraints:    constraints.MustParse("spaces=aaaaaaaaaa"),
-		SubnetsToZones: map[corenetwork.Id][]string{
+		SubnetsToZones: []map[corenetwork.Id][]string{{
 			subIDs[0]: {"test-available"},
 			subIDs[1]: {"zone3"},
-		},
+		}},
 		StatusCallback: fakeCallback,
 	}
 	_, err := testing.StartInstanceWithParams(env, t.callCtx, "1", params)
@@ -1239,10 +1239,10 @@ func (t *localServerSuite) TestSpaceConstraintsNoPlacement(c *gc.C) {
 	params := environs.StartInstanceParams{
 		ControllerUUID: t.ControllerUUID,
 		Constraints:    constraints.MustParse("spaces=aaaaaaaaaa"),
-		SubnetsToZones: map[corenetwork.Id][]string{
+		SubnetsToZones: []map[corenetwork.Id][]string{{
 			subIDs[0]: {"test-available"},
 			subIDs[1]: {"zone3"},
-		},
+		}},
 		StatusCallback: fakeCallback,
 	}
 	t.assertStartInstanceWithParamsFindAZ(c, env, "1", params)
@@ -1290,9 +1290,9 @@ func (t *localServerSuite) TestSpaceConstraintsNoAvailableSubnets(c *gc.C) {
 	params := environs.StartInstanceParams{
 		ControllerUUID: t.ControllerUUID,
 		Constraints:    constraints.MustParse("spaces=aaaaaaaaaa"),
-		SubnetsToZones: map[corenetwork.Id][]string{
+		SubnetsToZones: []map[corenetwork.Id][]string{{
 			subIDs[0]: {""},
-		},
+		}},
 		StatusCallback: fakeCallback,
 	}
 	//_, err := testing.StartInstanceWithParams(env, "1", params)

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
@@ -16,6 +14,7 @@ import (
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
 	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface
@@ -43,6 +42,7 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -50,11 +50,13 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -62,6 +64,7 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -90,6 +93,7 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -98,11 +102,13 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -111,11 +117,13 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -123,11 +131,13 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
 func (m *MockConfig) Controller() names_v3.ControllerTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
 	ret0, _ := ret[0].(names_v3.ControllerTag)
 	return ret0
@@ -135,11 +145,13 @@ func (m *MockConfig) Controller() names_v3.ControllerTag {
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -147,11 +159,13 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -159,11 +173,13 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -171,11 +187,13 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -183,11 +201,13 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -195,11 +215,13 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -207,11 +229,13 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
 func (m *MockConfig) Model() names_v3.ModelTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
 	ret0, _ := ret[0].(names_v3.ModelTag)
 	return ret0
@@ -219,11 +243,13 @@ func (m *MockConfig) Model() names_v3.ModelTag {
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -232,11 +258,13 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -244,11 +272,13 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -256,11 +286,13 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -268,11 +300,13 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -280,11 +314,13 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
 func (m *MockConfig) StateServingInfo() (params.StateServingInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
 	ret0, _ := ret[0].(params.StateServingInfo)
 	ret1, _ := ret[1].(bool)
@@ -293,11 +329,13 @@ func (m *MockConfig) StateServingInfo() (params.StateServingInfo, bool) {
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -305,11 +343,13 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
 func (m *MockConfig) Tag() names_v3.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
 	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
@@ -317,11 +357,13 @@ func (m *MockConfig) Tag() names_v3.Tag {
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -329,11 +371,13 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -341,11 +385,13 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -354,5 +400,6 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }

--- a/worker/containerbroker/mocks/base_mock.go
+++ b/worker/containerbroker/mocks/base_mock.go
@@ -6,14 +6,13 @@ package mocks
 
 import (
 	context "context"
-	http "net/http"
-	url "net/url"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	base "github.com/juju/juju/api/base"
 	httprequest_v1 "gopkg.in/httprequest.v1"
 	names_v3 "gopkg.in/juju/names.v3"
+	http "net/http"
+	url "net/url"
+	reflect "reflect"
 )
 
 // MockAPICaller is a mock of APICaller interface
@@ -41,6 +40,7 @@ func (m *MockAPICaller) EXPECT() *MockAPICallerMockRecorder {
 
 // APICall mocks base method
 func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, arg5 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APICall", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -48,11 +48,13 @@ func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, 
 
 // APICall indicates an expected call of APICall
 func (mr *MockAPICallerMockRecorder) APICall(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APICall", reflect.TypeOf((*MockAPICaller)(nil).APICall), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // BakeryClient mocks base method
 func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BakeryClient")
 	ret0, _ := ret[0].(base.MacaroonDischarger)
 	return ret0
@@ -60,11 +62,13 @@ func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
 
 // BakeryClient indicates an expected call of BakeryClient
 func (mr *MockAPICallerMockRecorder) BakeryClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BakeryClient", reflect.TypeOf((*MockAPICaller)(nil).BakeryClient))
 }
 
 // BestFacadeVersion mocks base method
 func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BestFacadeVersion", arg0)
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -72,11 +76,13 @@ func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
 
 // BestFacadeVersion indicates an expected call of BestFacadeVersion
 func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestFacadeVersion", reflect.TypeOf((*MockAPICaller)(nil).BestFacadeVersion), arg0)
 }
 
 // ConnectControllerStream mocks base method
 func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -85,11 +91,13 @@ func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, ar
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream
 func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
 }
 
 // ConnectStream mocks base method
 func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -98,11 +106,13 @@ func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream
 
 // ConnectStream indicates an expected call of ConnectStream
 func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
 }
 
 // Context mocks base method
 func (m *MockAPICaller) Context() context.Context {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
 	return ret0
@@ -110,11 +120,13 @@ func (m *MockAPICaller) Context() context.Context {
 
 // Context indicates an expected call of Context
 func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
 }
 
 // HTTPClient mocks base method
 func (m *MockAPICaller) HTTPClient() (*httprequest_v1.Client, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
 	ret0, _ := ret[0].(*httprequest_v1.Client)
 	ret1, _ := ret[1].(error)
@@ -123,11 +135,13 @@ func (m *MockAPICaller) HTTPClient() (*httprequest_v1.Client, error) {
 
 // HTTPClient indicates an expected call of HTTPClient
 func (mr *MockAPICallerMockRecorder) HTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HTTPClient", reflect.TypeOf((*MockAPICaller)(nil).HTTPClient))
 }
 
 // ModelTag mocks base method
 func (m *MockAPICaller) ModelTag() (names_v3.ModelTag, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
 	ret0, _ := ret[0].(names_v3.ModelTag)
 	ret1, _ := ret[1].(bool)
@@ -136,5 +150,6 @@ func (m *MockAPICaller) ModelTag() (names_v3.ModelTag, bool) {
 
 // ModelTag indicates an expected call of ModelTag
 func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }

--- a/worker/containerbroker/mocks/dependency_mock.go
+++ b/worker/containerbroker/mocks/dependency_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockContext is a mock of Context interface
@@ -35,6 +34,7 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 
 // Abort mocks base method
 func (m *MockContext) Abort() <-chan struct{} {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Abort")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -42,11 +42,13 @@ func (m *MockContext) Abort() <-chan struct{} {
 
 // Abort indicates an expected call of Abort
 func (mr *MockContextMockRecorder) Abort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockContext)(nil).Abort))
 }
 
 // Get mocks base method
 func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -54,5 +56,6 @@ func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
 
 // Get indicates an expected call of Get
 func (mr *MockContextMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockContext)(nil).Get), arg0, arg1)
 }

--- a/worker/containerbroker/mocks/environs_mock.go
+++ b/worker/containerbroker/mocks/environs_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
@@ -14,6 +12,7 @@ import (
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	charm_v6 "gopkg.in/juju/charm.v6"
+	reflect "reflect"
 )
 
 // MockLXDProfiler is a mock of LXDProfiler interface
@@ -41,6 +40,7 @@ func (m *MockLXDProfiler) EXPECT() *MockLXDProfilerMockRecorder {
 
 // AssignLXDProfiles mocks base method
 func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignLXDProfiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -49,11 +49,13 @@ func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []l
 
 // AssignLXDProfiles indicates an expected call of AssignLXDProfiles
 func (mr *MockLXDProfilerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignLXDProfiles", reflect.TypeOf((*MockLXDProfiler)(nil).AssignLXDProfiles), arg0, arg1, arg2)
 }
 
 // LXDProfileNames mocks base method
 func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -62,11 +64,13 @@ func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
 
 // LXDProfileNames indicates an expected call of LXDProfileNames
 func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockLXDProfiler)(nil).LXDProfileNames), arg0)
 }
 
 // MaybeWriteLXDProfile mocks base method
 func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -74,6 +78,7 @@ func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDPr
 
 // MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile
 func (mr *MockLXDProfilerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfiler)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
@@ -102,6 +107,7 @@ func (m *MockInstanceBroker) EXPECT() *MockInstanceBrokerMockRecorder {
 
 // AllInstances mocks base method
 func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -110,11 +116,13 @@ func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]i
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllInstances), arg0)
 }
 
 // AllRunningInstances mocks base method
 func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -123,11 +131,13 @@ func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContex
 
 // AllRunningInstances indicates an expected call of AllRunningInstances
 func (mr *MockInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
 // MaintainInstance mocks base method
 func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -135,11 +145,13 @@ func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, 
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockInstanceBrokerMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockInstanceBroker)(nil).MaintainInstance), arg0, arg1)
 }
 
 // StartInstance mocks base method
 func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -148,11 +160,13 @@ func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockInstanceBrokerMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockInstanceBroker)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
 func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -164,6 +178,7 @@ func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockInstanceBrokerMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockInstanceBroker)(nil).StopInstances), varargs...)
 }

--- a/worker/containerbroker/mocks/machine_lock_mock.go
+++ b/worker/containerbroker/mocks/machine_lock_mock.go
@@ -5,10 +5,9 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	machinelock "github.com/juju/juju/core/machinelock"
+	reflect "reflect"
 )
 
 // MockLock is a mock of Lock interface
@@ -36,6 +35,7 @@ func (m *MockLock) EXPECT() *MockLockMockRecorder {
 
 // Acquire mocks base method
 func (m *MockLock) Acquire(arg0 machinelock.Spec) (func(), error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Acquire", arg0)
 	ret0, _ := ret[0].(func())
 	ret1, _ := ret[1].(error)
@@ -44,11 +44,13 @@ func (m *MockLock) Acquire(arg0 machinelock.Spec) (func(), error) {
 
 // Acquire indicates an expected call of Acquire
 func (mr *MockLockMockRecorder) Acquire(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Acquire", reflect.TypeOf((*MockLock)(nil).Acquire), arg0)
 }
 
 // Report mocks base method
 func (m *MockLock) Report(arg0 ...machinelock.ReportOption) (string, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -61,5 +63,6 @@ func (m *MockLock) Report(arg0 ...machinelock.ReportOption) (string, error) {
 
 // Report indicates an expected call of Report
 func (mr *MockLockMockRecorder) Report(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockLock)(nil).Report), arg0...)
 }

--- a/worker/containerbroker/mocks/machine_mock.go
+++ b/worker/containerbroker/mocks/machine_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
@@ -15,6 +13,7 @@ import (
 	watcher "github.com/juju/juju/core/watcher"
 	version "github.com/juju/version"
 	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockMachineProvisioner is a mock of MachineProvisioner interface
@@ -42,6 +41,7 @@ func (m *MockMachineProvisioner) EXPECT() *MockMachineProvisionerMockRecorder {
 
 // AvailabilityZone mocks base method
 func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -50,11 +50,13 @@ func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
 
 // AvailabilityZone indicates an expected call of AvailabilityZone
 func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone))
 }
 
 // DistributionGroup mocks base method
 func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DistributionGroup")
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
@@ -63,11 +65,13 @@ func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
 
 // DistributionGroup indicates an expected call of DistributionGroup
 func (mr *MockMachineProvisionerMockRecorder) DistributionGroup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup))
 }
 
 // EnsureDead mocks base method
 func (m *MockMachineProvisioner) EnsureDead() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureDead")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -75,11 +79,13 @@ func (m *MockMachineProvisioner) EnsureDead() error {
 
 // EnsureDead indicates an expected call of EnsureDead
 func (mr *MockMachineProvisionerMockRecorder) EnsureDead() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead))
 }
 
 // Id mocks base method
 func (m *MockMachineProvisioner) Id() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -87,11 +93,13 @@ func (m *MockMachineProvisioner) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockMachineProvisionerMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachineProvisioner)(nil).Id))
 }
 
 // InstanceId mocks base method
 func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
@@ -100,11 +108,13 @@ func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
 
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMachineProvisionerMockRecorder) InstanceId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId))
 }
 
 // InstanceStatus mocks base method
 func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceStatus")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -114,11 +124,13 @@ func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error)
 
 // InstanceStatus indicates an expected call of InstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) InstanceStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus))
 }
 
 // KeepInstance mocks base method
 func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KeepInstance")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -127,11 +139,13 @@ func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
 
 // KeepInstance indicates an expected call of KeepInstance
 func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance))
 }
 
 // Life mocks base method
 func (m *MockMachineProvisioner) Life() life.Value {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
 	ret0, _ := ret[0].(life.Value)
 	return ret0
@@ -139,11 +153,13 @@ func (m *MockMachineProvisioner) Life() life.Value {
 
 // Life indicates an expected call of Life
 func (mr *MockMachineProvisionerMockRecorder) Life() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMachineProvisioner)(nil).Life))
 }
 
 // MachineTag mocks base method
 func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
 	ret0, _ := ret[0].(names_v3.MachineTag)
 	return ret0
@@ -151,11 +167,13 @@ func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
 
 // MachineTag indicates an expected call of MachineTag
 func (mr *MockMachineProvisionerMockRecorder) MachineTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockMachineProvisioner)(nil).MachineTag))
 }
 
 // MarkForRemoval mocks base method
 func (m *MockMachineProvisioner) MarkForRemoval() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarkForRemoval")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -163,11 +181,13 @@ func (m *MockMachineProvisioner) MarkForRemoval() error {
 
 // MarkForRemoval indicates an expected call of MarkForRemoval
 func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval))
 }
 
 // ModelAgentVersion mocks base method
 func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelAgentVersion")
 	ret0, _ := ret[0].(*version.Number)
 	ret1, _ := ret[1].(error)
@@ -176,24 +196,28 @@ func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
 
 // ModelAgentVersion indicates an expected call of ModelAgentVersion
 func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion))
 }
 
 // ProvisioningInfo mocks base method
-func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfo, error) {
+func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo")
-	ret0, _ := ret[0].(*params.ProvisioningInfo)
+	ret0, _ := ret[0].(*params.ProvisioningInfoV10)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ProvisioningInfo indicates an expected call of ProvisioningInfo
 func (mr *MockMachineProvisionerMockRecorder) ProvisioningInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).ProvisioningInfo))
 }
 
 // Refresh mocks base method
 func (m *MockMachineProvisioner) Refresh() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -201,11 +225,13 @@ func (m *MockMachineProvisioner) Refresh() error {
 
 // Refresh indicates an expected call of Refresh
 func (mr *MockMachineProvisionerMockRecorder) Refresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh))
 }
 
 // Remove mocks base method
 func (m *MockMachineProvisioner) Remove() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -213,11 +239,13 @@ func (m *MockMachineProvisioner) Remove() error {
 
 // Remove indicates an expected call of Remove
 func (mr *MockMachineProvisionerMockRecorder) Remove() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove))
 }
 
 // SetCharmProfiles mocks base method
 func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -225,11 +253,13 @@ func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0)
 }
 
 // SetInstanceInfo mocks base method
 func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 string, arg3 *instance.HardwareCharacteristics, arg4 []params.NetworkConfig, arg5 []params.Volume, arg6 map[string]params.VolumeAttachmentInfo, arg7 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -237,11 +267,13 @@ func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 st
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // SetInstanceStatus mocks base method
 func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -249,11 +281,13 @@ func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 stri
 
 // SetInstanceStatus indicates an expected call of SetInstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2)
 }
 
 // SetModificationStatus mocks base method
 func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -261,11 +295,13 @@ func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 
 
 // SetModificationStatus indicates an expected call of SetModificationStatus
 func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2)
 }
 
 // SetPassword mocks base method
 func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPassword", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -273,11 +309,13 @@ func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
 
 // SetPassword indicates an expected call of SetPassword
 func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0)
 }
 
 // SetStatus mocks base method
 func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -285,11 +323,13 @@ func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2)
 }
 
 // SetSupportedContainers mocks base method
 func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.ContainerType) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -301,11 +341,13 @@ func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.Contain
 
 // SetSupportedContainers indicates an expected call of SetSupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), arg0...)
 }
 
 // Status mocks base method
 func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -315,11 +357,13 @@ func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
 
 // Status indicates an expected call of Status
 func (mr *MockMachineProvisionerMockRecorder) Status() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status))
 }
 
 // String mocks base method
 func (m *MockMachineProvisioner) String() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -327,11 +371,13 @@ func (m *MockMachineProvisioner) String() string {
 
 // String indicates an expected call of String
 func (mr *MockMachineProvisionerMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockMachineProvisioner)(nil).String))
 }
 
 // SupportedContainers mocks base method
 func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType, bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportedContainers")
 	ret0, _ := ret[0].([]instance.ContainerType)
 	ret1, _ := ret[1].(bool)
@@ -341,11 +387,13 @@ func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType
 
 // SupportedContainers indicates an expected call of SupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportedContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers))
 }
 
 // SupportsNoContainers mocks base method
 func (m *MockMachineProvisioner) SupportsNoContainers() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsNoContainers")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -353,11 +401,13 @@ func (m *MockMachineProvisioner) SupportsNoContainers() error {
 
 // SupportsNoContainers indicates an expected call of SupportsNoContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers))
 }
 
 // Tag mocks base method
 func (m *MockMachineProvisioner) Tag() names_v3.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
 	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
@@ -365,11 +415,13 @@ func (m *MockMachineProvisioner) Tag() names_v3.Tag {
 
 // Tag indicates an expected call of Tag
 func (mr *MockMachineProvisionerMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockMachineProvisioner)(nil).Tag))
 }
 
 // WatchAllContainers mocks base method
 func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchAllContainers")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -378,11 +430,13 @@ func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, e
 
 // WatchAllContainers indicates an expected call of WatchAllContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchAllContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAllContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchAllContainers))
 }
 
 // WatchContainers mocks base method
 func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchContainers", arg0)
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -391,5 +445,6 @@ func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (w
 
 // WatchContainers indicates an expected call of WatchContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0)
 }

--- a/worker/containerbroker/mocks/state_mock.go
+++ b/worker/containerbroker/mocks/state_mock.go
@@ -5,14 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	provisioner "github.com/juju/juju/api/provisioner"
 	params "github.com/juju/juju/apiserver/params"
 	network "github.com/juju/juju/core/network"
 	network0 "github.com/juju/juju/network"
 	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockState is a mock of State interface
@@ -40,6 +39,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 
 // ContainerConfig mocks base method
 func (m *MockState) ContainerConfig() (params.ContainerConfig, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerConfig")
 	ret0, _ := ret[0].(params.ContainerConfig)
 	ret1, _ := ret[1].(error)
@@ -48,11 +48,13 @@ func (m *MockState) ContainerConfig() (params.ContainerConfig, error) {
 
 // ContainerConfig indicates an expected call of ContainerConfig
 func (mr *MockStateMockRecorder) ContainerConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockState)(nil).ContainerConfig))
 }
 
 // ContainerManagerConfig mocks base method
 func (m *MockState) ContainerManagerConfig(arg0 params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerManagerConfig", arg0)
 	ret0, _ := ret[0].(params.ContainerManagerConfig)
 	ret1, _ := ret[1].(error)
@@ -61,11 +63,13 @@ func (m *MockState) ContainerManagerConfig(arg0 params.ContainerManagerConfigPar
 
 // ContainerManagerConfig indicates an expected call of ContainerManagerConfig
 func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockState)(nil).ContainerManagerConfig), arg0)
 }
 
 // GetContainerInterfaceInfo mocks base method
 func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].([]network.InterfaceInfo)
 	ret1, _ := ret[1].(error)
@@ -74,11 +78,13 @@ func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]netwo
 
 // GetContainerInterfaceInfo indicates an expected call of GetContainerInterfaceInfo
 func (mr *MockStateMockRecorder) GetContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).GetContainerInterfaceInfo), arg0)
 }
 
 // GetContainerProfileInfo mocks base method
 func (m *MockState) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
@@ -87,11 +93,13 @@ func (m *MockState) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*provis
 
 // GetContainerProfileInfo indicates an expected call of GetContainerProfileInfo
 func (mr *MockStateMockRecorder) GetContainerProfileInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockState)(nil).GetContainerProfileInfo), arg0)
 }
 
 // HostChangesForContainer mocks base method
 func (m *MockState) HostChangesForContainer(arg0 names_v3.MachineTag) ([]network0.DeviceToBridge, int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
@@ -101,11 +109,13 @@ func (m *MockState) HostChangesForContainer(arg0 names_v3.MachineTag) ([]network
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer
 func (mr *MockStateMockRecorder) HostChangesForContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockState)(nil).HostChangesForContainer), arg0)
 }
 
 // Machines mocks base method
 func (m *MockState) Machines(arg0 ...names_v3.MachineTag) ([]provisioner.MachineResult, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -118,11 +128,13 @@ func (m *MockState) Machines(arg0 ...names_v3.MachineTag) ([]provisioner.Machine
 
 // Machines indicates an expected call of Machines
 func (mr *MockStateMockRecorder) Machines(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockState)(nil).Machines), arg0...)
 }
 
 // PrepareContainerInterfaceInfo mocks base method
 func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].([]network.InterfaceInfo)
 	ret1, _ := ret[1].(error)
@@ -131,11 +143,13 @@ func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]n
 
 // PrepareContainerInterfaceInfo indicates an expected call of PrepareContainerInterfaceInfo
 func (mr *MockStateMockRecorder) PrepareContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).PrepareContainerInterfaceInfo), arg0)
 }
 
 // ReleaseContainerAddresses mocks base method
 func (m *MockState) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -143,11 +157,13 @@ func (m *MockState) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error {
 
 // ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses
 func (mr *MockStateMockRecorder) ReleaseContainerAddresses(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockState)(nil).ReleaseContainerAddresses), arg0)
 }
 
 // SetHostMachineNetworkConfig mocks base method
 func (m *MockState) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg1 []params.NetworkConfig) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -155,5 +171,6 @@ func (m *MockState) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg1 [
 
 // SetHostMachineNetworkConfig indicates an expected call of SetHostMachineNetworkConfig
 func (mr *MockStateMockRecorder) SetHostMachineNetworkConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockState)(nil).SetHostMachineNetworkConfig), arg0, arg1)
 }

--- a/worker/containerbroker/mocks/worker_mock.go
+++ b/worker/containerbroker/mocks/worker_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockWorker is a mock of Worker interface
@@ -35,16 +34,19 @@ func (m *MockWorker) EXPECT() *MockWorkerMockRecorder {
 
 // Kill mocks base method
 func (m *MockWorker) Kill() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
 // Kill indicates an expected call of Kill
 func (mr *MockWorkerMockRecorder) Kill() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockWorker)(nil).Kill))
 }
 
 // Wait mocks base method
 func (m *MockWorker) Wait() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -52,5 +54,6 @@ func (m *MockWorker) Wait() error {
 
 // Wait indicates an expected call of Wait
 func (mr *MockWorkerMockRecorder) Wait() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockWorker)(nil).Wait))
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch consumes the changes in #11185 and sends them through `StartInstanceParams` for use by the providers.

The EC2 provider uses only the first of any of the subnet-AZs mappings, preserving its old behaviour.

## QA steps

Test that everything still works:
```sh
juju bootstrap aws provisioning-info --no-gui --debug
juju add-space new-space 172.31.16.0/20
juju add-machine --constraints "spaces=new-space"
```

## Documentation changes

None.

## Bug reference

N/A
