### PR TITLE
show-space: add documentation, add ability to use ID as well

### DIFF
--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -28,6 +28,18 @@ type RemoveCommand struct {
 const removeCommandDoc = `
 Removes an existing Juju network space with the given name. Any subnets
 associated with the space will be transferred to the default space.
+
+Examples:
+
+Remove a space by name:
+	juju remove-space db-space
+
+See also:
+	add-space
+	list-spaces
+	reload-spaces
+	rename-space
+	show-space
 `
 
 // Info is defined on the cmd.Command interface.

--- a/cmd/juju/space/rename.go
+++ b/cmd/juju/space/rename.go
@@ -30,6 +30,18 @@ type RenameCommand struct {
 const renameCommandDoc = `
 Renames an existing space from "old-name" to "new-name". Does not change the
 associated subnets and "new-name" must not match another existing space.
+
+Examples:
+
+rename a space from db to fe:
+	juju rename-space db fe
+
+See also:
+	add-space
+	list-spaces
+	reload-spaces
+	remove-space
+	show-space
 `
 
 func (c *RenameCommand) SetFlags(f *gnuflag.FlagSet) {

--- a/cmd/juju/space/show.go
+++ b/cmd/juju/space/show.go
@@ -34,7 +34,20 @@ type ShowSpaceCommand struct {
 const ShowSpaceCommandDoc = `
 Displays extended information about a given space. 
 Output includes the space subnets, applications with bindings to the space,
-and a count of machines connected to the space.`
+and a count of machines connected to the space.
+
+Examples:
+
+Show a space by name:
+	juju show-space alpha
+
+See also:
+	add-space
+	list-spaces
+	reload-spaces
+	rename-space
+	remove-space
+`
 
 // SetFlags implements part of the cmd.Command interface.
 func (c *ShowSpaceCommand) SetFlags(f *gnuflag.FlagSet) {


### PR DESCRIPTION
## Update

After talking to @achilleasa and @mitechie we don't want to add the ability to search by ID, as this can be error-prone in some providers.

Example:
MAAS

Therefore this patch will only add updated documentation for show-space and rename-space.


### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

- adds the ability to search (show-space) for the ID, besides the name.
- E.g.
```
juju show-space alpha 

juju show-space 0
```


## QA steps

```sh
❯ juju add-space 0

❯ juju spaces                   
Space  Name     Subnets       
4      0                      
3      aaabbbb                
0      alpha    172.31.1.0/28 
                172.31.16.0/20
                172.31.2.0/28 
                172.31.3.0/24 
                252.1.0.0/20  
                252.16.0.0/12 
                252.2.0.0/20  
                252.3.0.0/16  
1      bla      172.31.0.0/28 
                252.0.0.0/20  

❯ juju show-space 0
{}
ERROR cannot retrieve space "0": multiple spaces found with name/ID "0". Spaces found: ["alpha" "0"]. Please use unique name or ID

❯ juju show-space 1
space:
  id: "1"
  name: bla
  subnets:
  - cidr: 172.31.0.0/28
    provider-id: subnet-012ea464634aa2e3d
    provider-network-id: vpc-a12addcb
    vlan-tag: 0
    zones:
    - eu-central-1a
  - cidr: 252.0.0.0/20
    provider-id: subnet-012ea464634aa2e3d-INFAN-172-31-0-0-28
    provider-network-id: vpc-a12addcb
    vlan-tag: 0
    zones:
    - eu-central-1a
applications: []
machine-count: 0


```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1862238