### PR TITLE
internal status test: adding check for race condition

### DIFF
--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -6090,7 +6090,7 @@ func (s *StatusSuite) PrepareBranchesOutput(c *gc.C) *context {
 	c.Assert(err, jc.ErrorIsNil)
 	md, err := s.ControllerStore.CurrentModel(ct)
 	c.Assert(err, jc.ErrorIsNil)
-	m, err := s.JujuConnSuite.ControllerStore.ModelByName(ct, md)
+	m, err := s.ControllerStore.ModelByName(ct, md)
 	c.Assert(err, jc.ErrorIsNil)
 	m.ActiveBranch = "bla"
 	err = s.ControllerStore.UpdateModel(ct, md, *m)
@@ -6102,6 +6102,17 @@ func (s *StatusSuite) TestBranchesOutputTabular(c *gc.C) {
 	ctx := s.PrepareBranchesOutput(c)
 	defer s.resetContext(c, ctx)
 
+	// This test seems to have some kind of race condition. Adding this part we can ensure which part is racing. The model/filestore and/or the runStatus.
+	ct, err := s.ControllerStore.CurrentController()
+	c.Assert(err, jc.ErrorIsNil)
+	md, err := s.ControllerStore.CurrentModel(ct)
+	c.Assert(err, jc.ErrorIsNil)
+	m, err := s.ControllerStore.ModelByName(ct, md)
+	c.Assert(err, jc.ErrorIsNil)
+	if m.ActiveBranch != "bla" {
+		c.Fatalf(`Expected "bla" got %q. This test failed because the file store did not save the value in time of access`, m.ActiveBranch)
+	}
+
 	_, stdout, stderr := runStatus(c)
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "bla*"), jc.IsTrue)
@@ -6112,6 +6123,16 @@ func (s *StatusSuite) TestBranchesOutputNonTabular(c *gc.C) {
 	ctx := s.PrepareBranchesOutput(c)
 	defer s.resetContext(c, ctx)
 
+	// This test seems to have some kind of race condition. Adding this part we can ensure which part is racing. The model/filestore and/or the runStatus.
+	ct, err := s.ControllerStore.CurrentController()
+	c.Assert(err, jc.ErrorIsNil)
+	md, err := s.ControllerStore.CurrentModel(ct)
+	c.Assert(err, jc.ErrorIsNil)
+	m, err := s.ControllerStore.ModelByName(ct, md)
+	c.Assert(err, jc.ErrorIsNil)
+	if m.ActiveBranch != "bla" {
+		c.Fatalf(`Expected "bla" got %q. This test failed because the file store did not save the value in time of access`, m.ActiveBranch)
+	}
 	_, stdout, stderr := runStatus(c, "--format=yaml")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "active: true"), jc.IsTrue)


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change
After talking to @SimonRichardson about possible ways to fix this problem we came to the following conclusion: 

- This patch does not actually fix the test
- The `controllerstore` `file` access indicates the race condition, but to be sure adding the below patch should help a future fix by isolating the problem.
   - My gut feeling says that the problem may lie around the `controllerStore` access. As it is a filestore implementation on the `juju con suite` site. A fix may or may not be a change to the Memstore.
But our locks in place should not let that race condition happen.
- Hence, by splitting up the check to `runStatus` and the `file/modelaccess` we can make sure where the test fails.



