### PR TITLE
Integration tests for state-[delete|get|set] hook tools.

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -33,6 +33,7 @@ TEST_NAMES="static_analysis \
             cli \
             controller \
             deploy \
+            hook_tools \
             machine \
             smoke \
             model"

--- a/tests/suites/hook_tools/state_tools.sh
+++ b/tests/suites/hook_tools/state_tools.sh
@@ -9,13 +9,13 @@ run_state_delete_get_set() {
     juju deploy cs:~jameinel/ubuntu-lite-7
     wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-    juju run --unit ubuntu-lite/0 state-get | grep -q "{}"
-    juju run --unit ubuntu-lite/0 state-set one=two
-    juju run --unit ubuntu-lite/0 state-get | grep -q "one: two"
-    juju run --unit ubuntu-lite/0 state-set three=four
-    juju run --unit ubuntu-lite/0 state-get three | grep -q "four"
-    juju run --unit ubuntu-lite/0 state-delete one
-    juju run --unit ubuntu-lite/0 state-get | grep -q "three: four"
+    juju run --unit ubuntu-lite/0 'state-get | grep -q "{}"'
+    juju run --unit ubuntu-lite/0 'state-set one=two'
+    juju run --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
+    juju run --unit ubuntu-lite/0 'state-set three=four'
+    juju run --unit ubuntu-lite/0 'state-get three | grep -q "four"'
+    juju run --unit ubuntu-lite/0 'state-delete one'
+    juju run --unit ubuntu-lite/0 'state-get | grep -q "three: four"'
 
     destroy_model "${model_name}"
 }

--- a/tests/suites/hook_tools/state_tools.sh
+++ b/tests/suites/hook_tools/state_tools.sh
@@ -1,0 +1,36 @@
+run_state_delete_get_set() {
+    echo
+
+    model_name="test-state-delete-get-set"
+    file="${TEST_DIR}/${model_name}.txt"
+
+    ensure "${model_name}" "${file}"
+
+    juju deploy cs:~jameinel/ubuntu-lite-7
+    wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+
+    juju run --unit ubuntu-lite/0 state-get | grep -q "{}"
+    juju run --unit ubuntu-lite/0 state-set one=two
+    juju run --unit ubuntu-lite/0 state-get | grep -q "one: two"
+    juju run --unit ubuntu-lite/0 state-set three=four
+    juju run --unit ubuntu-lite/0 state-get three | grep -q "four"
+    juju run --unit ubuntu-lite/0 state-delete one
+    juju run --unit ubuntu-lite/0 state-get | grep -q "three: four"
+
+    destroy_model "${model_name}"
+}
+
+test_state_hook_tools() {
+    if [ "$(skip 'test_state_hook_tools')" ]; then
+        echo "==> TEST SKIPPED: state hook tools"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_state_delete_get_set"
+    )
+}

--- a/tests/suites/hook_tools/task.sh
+++ b/tests/suites/hook_tools/task.sh
@@ -1,0 +1,19 @@
+test_hook_tools() {
+      if [ "$(skip 'test_hook_tools')" ]; then
+        echo "==> TEST SKIPPED: hook tools"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju
+
+    file="${TEST_DIR}/test-hook-tools.txt"
+
+    bootstrap "test-hook-tools" "${file}"
+
+    test_state_hook_tools
+
+    destroy_controller "test-hook-tools"
+}


### PR DESCRIPTION
## Description of change

Integration test for work done in PRs:
- #11166 hook tools for state cache get/delete/set 
- #11158 Implement server-side bits for the State/SetState uniter API endpoints
- #11136 Cache unit state
- #11142 Setup mongo collection for server side charm state

## QA steps

```sh
(cd tests ; ./main.sh hook_tools)
```
