### PR TITLE
Fix for intermittent failure in dummy provider unit tests

### DIFF
--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -61,7 +61,6 @@ func (s *liveSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
 	s.LiveTests.SetUpSuite(c)
-	s.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *liveSuite) TearDownSuite(c *gc.C) {
@@ -95,6 +94,7 @@ type suite struct {
 func (s *suite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
+	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *suite) TearDownSuite(c *gc.C) {
@@ -357,7 +357,7 @@ func assertInterfaces(c *gc.C, e environs.Environ, opc chan dummy.Operation, exp
 		c.Check(netOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(netOp.Info, jc.DeepEquals, expectInfo)
 		return
-	case <-time.After(testing.ShortWait):
+	case <-time.After(testing.LongWait):
 		c.Fatalf("time out wating for operation")
 	}
 }


### PR DESCRIPTION
## Description of change
`provider/dummy:suite.TestNetworkInterfaces` occasionally fails with a timeout in CI. Change the wait to a long wait since it's not expected to happen anyway. 

Also fix a patch which prevented this suite from passing when run by itself:  `keys.JujuPublicKey` was being patched twice in the run of `liveSuite` (once in `LiveTests.SetUpSuite` and then in `liveSuite.SetUpSuite`), which meant that it wasn't being undone right, but the tests in `suite` expected it to be set so they wouldn't pass when just running that suite.

## QA steps

Running the test by itself passes now, and running the test under stress doesn't fail.

## Documentation changes

None

## Bug reference

None