### PR TITLE
Add --strict flag.

### DIFF
--- a/tests/suites/hook_tools/state_tools.sh
+++ b/tests/suites/hook_tools/state_tools.sh
@@ -16,6 +16,8 @@ run_state_delete_get_set() {
     juju run --unit ubuntu-lite/0 'state-get three | grep -q "four"'
     juju run --unit ubuntu-lite/0 'state-delete one'
     juju run --unit ubuntu-lite/0 'state-get | grep -q "three: four"'
+    juju run --unit ubuntu-lite/0 'state-get one --strict | grep -q "ERROR \"one\" not found" || true'
+    juju run --unit ubuntu-lite/0 'state-get one'
 
     destroy_model "${model_name}"
 }

--- a/worker/uniter/runner/jujuc/state-get_test.go
+++ b/worker/uniter/runner/jujuc/state-get_test.go
@@ -38,6 +38,8 @@ Options:
     Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
+--strict  (= false)
+    Return an error if the requested key does not exist
 
 Details:
 state-get prints the value of the server side state specified by key.
@@ -80,12 +82,26 @@ func (s *stateGetSuite) TestStateGet(c *gc.C) {
 			expect:      s.expectStateGetValueOne,
 		},
 		{
-			description: "key not found",
-			args:        []string{"five"},
+			description: "key not found, give me the error",
+			args:        []string{"--strict", "five"},
 			err:         "ERROR \"five\" not found\n",
 			out:         "",
 			expect:      s.expectStateGetValueNotFound,
 			code:        1,
+		},
+		{
+			description: "key not found",
+			args:        []string{"five"},
+			err:         "",
+			out:         "",
+			expect:      s.expectStateGetValueNotFound,
+		},
+		{
+			description: "empty result",
+			args:        []string{"five"},
+			err:         "",
+			out:         "",
+			expect:      s.expectStateGetValueEmpty,
 		},
 	}
 

--- a/worker/uniter/runner/jujuc/state_test.go
+++ b/worker/uniter/runner/jujuc/state_test.go
@@ -53,3 +53,7 @@ func (s *stateSuite) expectStateGetValueOne() {
 func (s *stateSuite) expectStateGetValueNotFound() {
 	s.mockContext.EXPECT().GetSingleCacheValue("five").Return("", errors.NotFoundf("%q", "five"))
 }
+
+func (s *stateSuite) expectStateGetValueEmpty() {
+	s.mockContext.EXPECT().GetSingleCacheValue("five").Return("", nil)
+}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Change behavior of state-get to be like relation-get with no difference between no result and an empty string result.  To get the not found error, add a --strict flag.

## QA steps

```sh
(cd tests ; ./main.sh hook_tools)
```

## Documentation changes

Will be noted as part of 2.8 hook tool additions.


