### PR TITLE
use mock tests for hook tool unit tests

### DIFF
--- a/worker/uniter/runner/jujuc/jujuc_test.go
+++ b/worker/uniter/runner/jujuc/jujuc_test.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/golang/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc/mocks"
+)
+
+type jujucSuite struct {
+	mockContext *mocks.MockContext
+}
+
+func (s *jujucSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.mockContext = mocks.NewMockContext(ctrl)
+	return ctrl
+}

--- a/worker/uniter/runner/jujuc/jujuctesting/context.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/context.go
@@ -83,8 +83,6 @@ func NewContext(stub *testing.Stub, info *ContextInfo) *Context {
 	ctx.ContextInstance.info = &info.Instance
 	ctx.ContextNetworking.stub = stub
 	ctx.ContextNetworking.info = &info.NetworkInterface
-	ctx.ContextLeader.stub = stub
-	ctx.ContextLeader.info = &info.Leadership
 	ctx.ContextMetrics.stub = stub
 	ctx.ContextMetrics.info = &info.Metrics
 	ctx.ContextStorage.stub = stub
@@ -99,7 +97,5 @@ func NewContext(stub *testing.Stub, info *ContextInfo) *Context {
 	ctx.ContextActionHook.info = &info.ActionHook
 	ctx.ContextVersion.stub = stub
 	ctx.ContextVersion.info = &info.Version
-	ctx.ContextUnitCache.stub = stub
-	ctx.ContextUnitCache.info = &info.UnitCache
 	return &ctx
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/leadership.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/leadership.go
@@ -3,49 +3,26 @@
 
 package jujuctesting
 
-import (
-	"github.com/juju/errors"
-)
-
 // Leadership holds the values for the hook context.
 type Leadership struct {
-	IsLeader       bool
-	LeaderSettings map[string]string
 }
 
 // ContextLeader is a test double for jujuc.ContextLeader.
 type ContextLeader struct {
 	contextBase
-	info *Leadership
 }
 
 // IsLeader implements jujuc.ContextLeader.
 func (c *ContextLeader) IsLeader() (bool, error) {
-	c.stub.AddCall("IsLeader")
-	if err := c.stub.NextErr(); err != nil {
-		return false, errors.Trace(err)
-	}
-
-	return c.info.IsLeader, nil
+	return false, nil
 }
 
 // LeaderSettings implements jujuc.ContextLeader.
 func (c *ContextLeader) LeaderSettings() (map[string]string, error) {
-	c.stub.AddCall("LeaderSettings")
-	if err := c.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return c.info.LeaderSettings, nil
+	return nil, nil
 }
 
 // WriteLeaderSettings implements jujuc.ContextLeader.
 func (c *ContextLeader) WriteLeaderSettings(settings map[string]string) error {
-	c.stub.AddCall("WriteLeaderSettings")
-	if err := c.stub.NextErr(); err != nil {
-		return errors.Trace(err)
-	}
-
-	c.info.LeaderSettings = settings
 	return nil
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/unitcachehook.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/unitcachehook.go
@@ -3,81 +3,33 @@
 
 package jujuctesting
 
-import (
-	"sync"
-)
-
 type UnitCache struct {
-	values map[string]string
-	mu     sync.Mutex
 }
 
 // ContextUnitCache is a test double for jujuc.unitCacheContext.
 type ContextUnitCache struct {
 	contextBase
-	info *UnitCache
 }
 
-func (u *UnitCache) SetCache(newCache map[string]string) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	u.values = newCache
+func (u *UnitCache) SetCache(map[string]string) {
 }
 
 // GetCache implements jujuc.unitCacheContext.
 func (c *ContextUnitCache) GetCache() (map[string]string, error) {
-	c.stub.AddCall("GetCache")
-	_ = c.stub.NextErr()
-	c.info.mu.Lock()
-	defer c.info.mu.Unlock()
-	c.ensureValues()
-	if len(c.info.values) == 0 {
-		return nil, nil
-	}
-
-	retVal := make(map[string]string, len(c.info.values))
-	for k, v := range c.info.values {
-		retVal[k] = v
-	}
-	return retVal, nil
+	return nil, nil
 }
 
 // Implements jujuc.HookContext.unitCacheContext, part of runner.Context.
 func (c *ContextUnitCache) GetSingleCacheValue(key string) (string, error) {
-	c.stub.AddCall("GetSingleCacheValue")
-	c.info.mu.Lock()
-	defer c.info.mu.Unlock()
-
-	c.ensureValues()
-	return c.info.values[key], nil
+	return "", nil
 }
 
 // GetCache implements jujuc.unitCacheContext.
 func (c *ContextUnitCache) DeleteCacheValue(key string) error {
-	c.stub.AddCall("DeleteCacheValue")
-	_ = c.stub.NextErr()
-	c.info.mu.Lock()
-	defer c.info.mu.Unlock()
-	c.ensureValues()
-
-	delete(c.info.values, key)
 	return nil
 }
 
 // GetCache implements jujuc.unitCacheContext.
 func (c *ContextUnitCache) SetCacheValue(key string, value string) error {
-	c.stub.AddCall("SetCacheValue")
-	_ = c.stub.NextErr()
-	c.info.mu.Lock()
-	defer c.info.mu.Unlock()
-	c.ensureValues()
-
-	c.info.values[key] = value
 	return nil
-}
-
-func (c *ContextUnitCache) ensureValues() {
-	if c.info.values == nil {
-		c.info.values = make(map[string]string)
-	}
 }

--- a/worker/uniter/runner/jujuc/state-set_test.go
+++ b/worker/uniter/runner/jujuc/state-set_test.go
@@ -96,7 +96,7 @@ func (s *stateSetSuite) TestStateSet(c *gc.C) {
 			err:         "ERROR yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `one = two` into map[string]string\n",
 		},
 		{
-			description: "single work, not equal sign",
+			description: "single word, not equal sign",
 			args:        []string{"five"},
 			code:        2,
 			err:         "ERROR expected \"key=value\", got \"five\"\n",

--- a/worker/uniter/runner/jujuc/state_test.go
+++ b/worker/uniter/runner/jujuc/state_test.go
@@ -4,21 +4,11 @@
 package jujuc_test
 
 import (
-	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
-	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/worker/uniter/runner/jujuc/mocks"
 )
 
 type stateSuite struct {
-	mockContext *mocks.MockContext
-}
-
-func (s *stateSuite) setupMocks(c *gc.C) *gomock.Controller {
-	ctrl := gomock.NewController(c)
-	s.mockContext = mocks.NewMockContext(ctrl)
-	return ctrl
+	jujucSuite
 }
 
 func (s *stateSuite) expectStateSetOne() {


### PR DESCRIPTION
## Description of change

Start change over of hook tool unit tests to use go mock instead of stubs and the juju IsolationSuite.  Make it easier to grown and change the hook tools.  The goal is remove jujuctesting.


