### PR TITLE
Introduce a new watcher to the cache to feed the new JAAS dashboard.

### DIFF
--- a/core/cache/charmconfigwatcher.go
+++ b/core/cache/charmconfigwatcher.go
@@ -241,7 +241,7 @@ func (w *CharmConfigWatcher) setConfigHash() (bool, error) {
 		}
 	}
 
-	newHash, err := hash(cfg, w.charmURL)
+	newHash, err := hashSettings(cfg, w.charmURL)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/core/cache/charmconfigwatcher_test.go
+++ b/core/cache/charmconfigwatcher_test.go
@@ -187,7 +187,7 @@ func (s *charmConfigWatcherSuite) newStubModel() *stubCharmConfigModel {
 func (s *charmConfigWatcherSuite) assertOneChange(
 	c *gc.C, wc StringsWatcherC, cfg map[string]interface{}, extra ...string,
 ) {
-	h, err := hash(cfg, extra...)
+	h, err := hashSettings(cfg, extra...)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange([]string{h})
 }

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -186,7 +186,9 @@ func (c *Controller) loop() error {
 // Mark updates all cached entities to indicate they are stale.
 func (c *Controller) Mark() {
 	c.manager.mark()
+	c.mu.Lock()
 	c.initializing = true
+	c.mu.Unlock()
 }
 
 // Sweep evicts any stale entities from the cache,
@@ -196,8 +198,8 @@ func (c *Controller) Sweep() {
 	case <-c.manager.sweep():
 	case <-c.tomb.Dying():
 	}
-	c.initializing = false
 	c.mu.Lock()
+	c.initializing = false
 	for _, model := range c.models {
 		model.updateSummary()
 	}

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -45,8 +45,8 @@ func (s *ControllerSuite) TestController(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestAddModel(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, modelChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, modelChange, events)
 
 	c.Check(controller.ModelUUIDs(), jc.SameContents, []string{modelChange.ModelUUID})
 	c.Check(controller.Report(), gc.DeepEquals, map[string]interface{}{
@@ -68,14 +68,14 @@ func (s *ControllerSuite) TestAddModel(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestRemoveModel(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, modelChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, modelChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	remove := cache.RemoveModel{ModelUUID: modelChange.ModelUUID}
-	s.processChange(c, remove, events)
+	s.ProcessChange(c, remove, events)
 
 	c.Check(controller.ModelUUIDs(), gc.HasLen, 0)
 	c.Check(controller.Report(), gc.HasLen, 0)
@@ -83,12 +83,12 @@ func (s *ControllerSuite) TestRemoveModel(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestWaitForModelExists(c *gc.C) {
-	controller, events := s.new(c)
+	controller, events := s.New(c)
 	clock := testclock.NewClock(time.Now())
 	done := make(chan struct{})
 	// Process the change event before waiting on the model. This
 	// way we know the model exists in the cache before we ask.
-	s.processChange(c, modelChange, events)
+	s.ProcessChange(c, modelChange, events)
 
 	go func() {
 		defer close(done)
@@ -106,7 +106,7 @@ func (s *ControllerSuite) TestWaitForModelExists(c *gc.C) {
 
 func (s *ControllerSuite) TestWaitForModelArrives(c *gc.C) {
 	//loggo.GetLogger("juju.core.cache").SetLogLevel(loggo.TRACE)
-	controller, events := s.new(c)
+	controller, events := s.New(c)
 	clock := testclock.NewClock(time.Now())
 	done := make(chan struct{})
 	go func() {
@@ -119,7 +119,7 @@ func (s *ControllerSuite) TestWaitForModelArrives(c *gc.C) {
 	// Don't process the change until we know the model is selecting
 	// on the clock.
 	c.Assert(clock.WaitAdvance(time.Second, testing.LongWait, 1), jc.ErrorIsNil)
-	s.processChange(c, modelChange, events)
+	s.ProcessChange(c, modelChange, events)
 	select {
 	case <-done:
 	case <-time.After(testing.LongWait):
@@ -128,7 +128,7 @@ func (s *ControllerSuite) TestWaitForModelArrives(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestWaitForModelTimeout(c *gc.C) {
-	controller, events := s.new(c)
+	controller, events := s.New(c)
 	clock := testclock.NewClock(time.Now())
 	done := make(chan struct{})
 	go func() {
@@ -140,7 +140,7 @@ func (s *ControllerSuite) TestWaitForModelTimeout(c *gc.C) {
 
 	c.Assert(clock.WaitAdvance(10*time.Second, testing.LongWait, 1), jc.ErrorIsNil)
 
-	s.processChange(c, modelChange, events)
+	s.ProcessChange(c, modelChange, events)
 	select {
 	case <-done:
 	case <-time.After(testing.LongWait):
@@ -149,8 +149,8 @@ func (s *ControllerSuite) TestWaitForModelTimeout(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestAddApplication(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, appChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, appChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -164,8 +164,8 @@ func (s *ControllerSuite) TestAddApplication(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestRemoveApplication(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, appChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, appChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -176,7 +176,7 @@ func (s *ControllerSuite) TestRemoveApplication(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Name:      appChange.Name,
 	}
-	s.processChange(c, remove, events)
+	s.ProcessChange(c, remove, events)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mod.Report()["application-count"], gc.Equals, 0)
@@ -184,8 +184,8 @@ func (s *ControllerSuite) TestRemoveApplication(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestAddCharm(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, charmChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, charmChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -198,8 +198,8 @@ func (s *ControllerSuite) TestAddCharm(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestRemoveCharm(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, charmChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, charmChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -210,15 +210,15 @@ func (s *ControllerSuite) TestRemoveCharm(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		CharmURL:  charmChange.CharmURL,
 	}
-	s.processChange(c, remove, events)
+	s.ProcessChange(c, remove, events)
 
 	c.Check(mod.Report()["charm-count"], gc.Equals, 0)
 	s.AssertResident(c, ch.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddMachine(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, machineChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, machineChange, events)
 
 	mod, err := controller.Model(machineChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -231,8 +231,8 @@ func (s *ControllerSuite) TestAddMachine(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestRemoveMachine(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, machineChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, machineChange, events)
 
 	mod, err := controller.Model(machineChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -243,15 +243,15 @@ func (s *ControllerSuite) TestRemoveMachine(c *gc.C) {
 		ModelUUID: machineChange.ModelUUID,
 		Id:        machineChange.Id,
 	}
-	s.processChange(c, remove, events)
+	s.ProcessChange(c, remove, events)
 
 	c.Check(mod.Report()["machine-count"], gc.Equals, 0)
 	s.AssertResident(c, machine.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddUnit(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, unitChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, unitChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -263,8 +263,8 @@ func (s *ControllerSuite) TestAddUnit(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestRemoveUnit(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, unitChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, unitChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -275,15 +275,15 @@ func (s *ControllerSuite) TestRemoveUnit(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Name:      unitChange.Name,
 	}
-	s.processChange(c, remove, events)
+	s.ProcessChange(c, remove, events)
 
 	c.Check(mod.Report()["unit-count"], gc.Equals, 0)
 	s.AssertResident(c, unit.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddRelation(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, relationChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, relationChange, events)
 
 	mod, err := controller.Model(relationChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -295,8 +295,8 @@ func (s *ControllerSuite) TestAddRelation(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestRemoveRelation(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, relationChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, relationChange, events)
 
 	mod, err := controller.Model(relationChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -307,15 +307,15 @@ func (s *ControllerSuite) TestRemoveRelation(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Key:       relationChange.Key,
 	}
-	s.processChange(c, remove, events)
+	s.ProcessChange(c, remove, events)
 
 	c.Check(mod.Report()["relation-count"], gc.Equals, 0)
 	s.AssertResident(c, relation.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestAddBranch(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, branchChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, branchChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -327,8 +327,8 @@ func (s *ControllerSuite) TestAddBranch(c *gc.C) {
 }
 
 func (s *ControllerSuite) TestRemoveBranch(c *gc.C) {
-	controller, events := s.new(c)
-	s.processChange(c, branchChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, branchChange, events)
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -339,21 +339,21 @@ func (s *ControllerSuite) TestRemoveBranch(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Id:        branchChange.Id,
 	}
-	s.processChange(c, remove, events)
+	s.ProcessChange(c, remove, events)
 
 	c.Check(mod.Report()["unit-count"], gc.Equals, 0)
 	s.AssertResident(c, branch.CacheId(), false)
 }
 
 func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
-	controller, events := s.new(c)
+	controller, events := s.New(c)
 
 	// Note that the model change is processed last.
-	s.processChange(c, charmChange, events)
-	s.processChange(c, appChange, events)
-	s.processChange(c, machineChange, events)
-	s.processChange(c, unitChange, events)
-	s.processChange(c, modelChange, events)
+	s.ProcessChange(c, charmChange, events)
+	s.ProcessChange(c, appChange, events)
+	s.ProcessChange(c, machineChange, events)
+	s.ProcessChange(c, unitChange, events)
+	s.ProcessChange(c, modelChange, events)
 
 	controller.Mark()
 
@@ -362,11 +362,11 @@ func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 		// Removals are congruent with LIFO.
 		// Model is last because models are added if they do not exist,
 		// when we first get a delta for one of their entities.
-		c.Check(s.nextChange(c, events), gc.FitsTypeOf, cache.RemoveUnit{})
-		c.Check(s.nextChange(c, events), gc.FitsTypeOf, cache.RemoveMachine{})
-		c.Check(s.nextChange(c, events), gc.FitsTypeOf, cache.RemoveApplication{})
-		c.Check(s.nextChange(c, events), gc.FitsTypeOf, cache.RemoveCharm{})
-		c.Check(s.nextChange(c, events), gc.FitsTypeOf, cache.RemoveModel{})
+		c.Check(s.NextChange(c, events), gc.FitsTypeOf, cache.RemoveUnit{})
+		c.Check(s.NextChange(c, events), gc.FitsTypeOf, cache.RemoveMachine{})
+		c.Check(s.NextChange(c, events), gc.FitsTypeOf, cache.RemoveApplication{})
+		c.Check(s.NextChange(c, events), gc.FitsTypeOf, cache.RemoveCharm{})
+		c.Check(s.NextChange(c, events), gc.FitsTypeOf, cache.RemoveModel{})
 		close(done)
 	}()
 
@@ -378,86 +378,6 @@ func (s *ControllerSuite) TestMarkAndSweep(c *gc.C) {
 	}
 
 	s.AssertNoResidents(c)
-}
-
-func (s *ControllerSuite) new(c *gc.C) (*cache.Controller, <-chan interface{}) {
-	events := s.captureEvents(c)
-	controller, err := s.NewController()
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
-	return controller, events
-}
-
-func (s *ControllerSuite) captureEvents(c *gc.C) <-chan interface{} {
-	events := make(chan interface{})
-	s.Config.Notify = func(change interface{}) {
-		send := false
-		switch change.(type) {
-		case cache.ModelChange:
-			send = true
-		case cache.RemoveModel:
-			send = true
-		case cache.ApplicationChange:
-			send = true
-		case cache.RemoveApplication:
-			send = true
-		case cache.CharmChange:
-			send = true
-		case cache.RemoveCharm:
-			send = true
-		case cache.MachineChange:
-			send = true
-		case cache.RemoveMachine:
-			send = true
-		case cache.UnitChange:
-			send = true
-		case cache.RemoveUnit:
-			send = true
-		case cache.RelationChange:
-			send = true
-		case cache.RemoveRelation:
-			send = true
-		case cache.BranchChange:
-			send = true
-		case cache.RemoveBranch:
-			send = true
-		default:
-			// no-op
-		}
-		if send {
-			c.Logf("sending %#v", change)
-			select {
-			case events <- change:
-			case <-time.After(testing.LongWait):
-				c.Fatalf("change not processed by test")
-			}
-		}
-	}
-	return events
-}
-
-func (s *ControllerSuite) processChange(c *gc.C, change interface{}, notify <-chan interface{}) {
-	select {
-	case s.Changes <- change:
-	case <-time.After(testing.LongWait):
-		c.Fatalf("controller did not read change")
-	}
-	select {
-	case obtained := <-notify:
-		c.Check(obtained, jc.DeepEquals, change)
-	case <-time.After(testing.LongWait):
-		c.Fatalf("controller did not handle change")
-	}
-}
-
-func (s *ControllerSuite) nextChange(c *gc.C, changes <-chan interface{}) interface{} {
-	var obtained interface{}
-	select {
-	case obtained = <-changes:
-	case <-time.After(testing.LongWait):
-		c.Fatalf("no change")
-	}
-	return obtained
 }
 
 func (s *ControllerSuite) TestWatchMachineStops(c *gc.C) {
@@ -480,7 +400,6 @@ func (s *ControllerSuite) TestWatchMachineStops(c *gc.C) {
 
 func (s *ControllerSuite) TestWatchMachineAddMachine(c *gc.C) {
 	w, events := s.setupWithWatchMachine(c)
-	defer workertest.CleanKill(c, w)
 	wc := cache.NewStringsWatcherC(c, w)
 	// Sends initial event.
 	wc.AssertOneChange([]string{machineChange.Id})
@@ -489,13 +408,12 @@ func (s *ControllerSuite) TestWatchMachineAddMachine(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Id:        "2",
 	}
-	s.processChange(c, change, events)
+	s.ProcessChange(c, change, events)
 	wc.AssertOneChange([]string{change.Id})
 }
 
 func (s *ControllerSuite) TestWatchMachineAddContainerNoChange(c *gc.C) {
 	w, events := s.setupWithWatchMachine(c)
-	defer workertest.CleanKill(c, w)
 	wc := cache.NewStringsWatcherC(c, w)
 	// Sends initial event.
 	wc.AssertOneChange([]string{machineChange.Id})
@@ -504,10 +422,10 @@ func (s *ControllerSuite) TestWatchMachineAddContainerNoChange(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Id:        "2/lxd/0",
 	}
-	s.processChange(c, change, events)
+	s.ProcessChange(c, change, events)
 	change2 := change
 	change2.Id = "3"
-	s.processChange(c, change2, events)
+	s.ProcessChange(c, change2, events)
 	wc.AssertOneChange([]string{change2.Id})
 }
 
@@ -522,7 +440,7 @@ func (s *ControllerSuite) TestWatchMachineRemoveMachine(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Id:        machineChange.Id,
 	}
-	s.processChange(c, change, events)
+	s.ProcessChange(c, change, events)
 	wc.AssertOneChange([]string{change.Id})
 }
 
@@ -537,7 +455,7 @@ func (s *ControllerSuite) TestWatchMachineChangeMachine(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Id:        "0",
 	}
-	s.processChange(c, change, events)
+	s.ProcessChange(c, change, events)
 	wc.AssertNoChange()
 }
 
@@ -552,20 +470,17 @@ func (s *ControllerSuite) TestWatchMachineGatherMachines(c *gc.C) {
 		ModelUUID: modelChange.ModelUUID,
 		Id:        "2",
 	}
-	s.processChange(c, change, events)
+	s.ProcessChange(c, change, events)
 	change2 := change
 	change2.Id = "3"
-	s.processChange(c, change2, events)
+	s.ProcessChange(c, change2, events)
 	wc.AssertMaybeCombinedChanges([]string{change.Id, change2.Id})
 }
 
 func (s *ControllerSuite) newWithMachine(c *gc.C) (*cache.Controller, <-chan interface{}) {
-	events := s.captureEvents(c)
-	controller, err := s.NewController()
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
-	s.processChange(c, modelChange, events)
-	s.processChange(c, machineChange, events)
+	controller, events := s.New(c)
+	s.ProcessChange(c, modelChange, events)
+	s.ProcessChange(c, machineChange, events)
 	return controller, events
 }
 
@@ -578,7 +493,7 @@ func (s *ControllerSuite) setupWithWatchMachine(c *gc.C) (*cache.PredicateString
 		ModelUUID: modelChange.ModelUUID,
 		Id:        "2/lxd/0",
 	}
-	s.processChange(c, containerChange, events)
+	s.ProcessChange(c, containerChange, events)
 
 	w, err := m.WatchMachines()
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -3,6 +3,14 @@
 
 package cache
 
+import (
+	"time"
+
+	"github.com/juju/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
 // Expose SetDetails for testing.
 
 func (a *Application) SetDetails(details ApplicationChange) {
@@ -51,4 +59,17 @@ func (m *Model) UpdateCharm(details CharmChange, manager *residentManager) {
 
 func (m *Model) UpdateBranch(details BranchChange, manager *residentManager) {
 	m.updateBranch(details, manager)
+}
+
+// WaitForModelSummaryHandled is used in the tests to ensure that the
+// most recent summary publish events of a model have been handled.
+func WaitForModelSummaryHandled(c *gc.C, ctrl *Controller, uuid string) {
+	model, err := ctrl.Model(uuid)
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-time.After(testing.LongWait):
+		c.Fatal("summary event not handled")
+	case <-model.lastSummaryPublish:
+		// Event handled, all good.
+	}
 }

--- a/core/cache/export_test.go
+++ b/core/cache/export_test.go
@@ -6,9 +6,10 @@ package cache
 import (
 	"time"
 
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
 )
 
 // Expose SetDetails for testing.

--- a/core/cache/hash.go
+++ b/core/cache/hash.go
@@ -95,21 +95,23 @@ func (c *hashCache) incMisses() {
 // hash returns a hash of the yaml serialized settings.
 // If the settings are not able to be serialized an error is returned.
 func hash(settings map[string]interface{}, extra ...string) (string, error) {
-	encoded, err := yaml.Marshal(settings)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
 	hash := sha256.New()
 	for _, s := range extra {
-		_, err = hash.Write([]byte(s))
+		_, err := hash.Write([]byte(s))
 		if err != nil {
 			return "", errors.Trace(err)
 		}
 	}
-	_, err = hash.Write(encoded)
-	if err != nil {
-		return "", errors.Trace(err)
+	if settings != nil {
+		encoded, err := yaml.Marshal(settings)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+
+		_, err = hash.Write(encoded)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -172,7 +172,7 @@ func (m *Machine) setDetails(details MachineChange) {
 		m.model.hub.Publish(m.topic(machineProvisioned), nil)
 	}
 
-	configHash, err := hash(details.Config)
+	configHash, err := hashSettings(details.Config)
 	if err != nil {
 		logger.Errorf("invariant error - machine config should be yaml serializable and hashable, %v", err)
 		configHash = ""

--- a/core/cache/metrics_test.go
+++ b/core/cache/metrics_test.go
@@ -19,14 +19,14 @@ import (
 
 func (s *ControllerSuite) TestCollect(c *gc.C) {
 	loggo.GetLogger("juju.core.cache").SetLogLevel(loggo.TRACE)
-	controller, events := s.new(c)
+	controller, events := s.New(c)
 
 	// Note that the model change is processed last.
-	s.processChange(c, charmChange, events)
-	s.processChange(c, appChange, events)
-	s.processChange(c, machineChange, events)
-	s.processChange(c, unitChange, events)
-	s.processChange(c, modelChange, events)
+	s.ProcessChange(c, charmChange, events)
+	s.ProcessChange(c, appChange, events)
+	s.ProcessChange(c, machineChange, events)
+	s.ProcessChange(c, unitChange, events)
+	s.ProcessChange(c, modelChange, events)
 
 	collector := cache.NewMetricsCollector(controller)
 

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -9,12 +9,12 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/juju/juju/core/permission"
-	"github.com/juju/juju/core/status"
-
 	"github.com/juju/errors"
 	"github.com/juju/pubsub"
 	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/status"
 )
 
 const (
@@ -128,23 +128,19 @@ func (m *Model) Summary() (ModelSummary, string) {
 func (m *Model) summaryCopy() ModelSummary {
 	result := m.summary
 	// Make a copy of the admins slice.
-	admins := make([]string, len(result.Admins))
-	copy(admins, result.Admins)
-	result.Admins = admins
+	result.Admins = append([]string(nil), result.Admins...)
 	// Make a copy of the messages slice.
-	messages := make([]ModelSummaryMessage, len(result.Messages))
-	copy(messages, result.Messages)
-	result.Messages = messages
+	result.Messages = append([]ModelSummaryMessage(nil), result.Messages...)
 	return result
 }
 
 func (m *Model) visibleTo(user string) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if user == "" {
 		return true
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	// Any permission is sufficient for the user to see the model.
 	// Read, Write, or Admin are all good for us. If the user doesn't

--- a/core/cache/modelsummarywatcher.go
+++ b/core/cache/modelsummarywatcher.go
@@ -20,8 +20,8 @@ const (
 	StatusGreen  = "green"
 )
 
-// ModelSummary represents a high level view of a model. Primary use case is to drive
-// the JAAS dashboard.
+// ModelSummary represents a high level view of a model. Primary use case is to
+// drive a dashboard with model level overview.
 type ModelSummary struct {
 	UUID string
 	// Removed indicates that the user can no longer see this model, because it has

--- a/core/cache/modelsummarywatcher.go
+++ b/core/cache/modelsummarywatcher.go
@@ -4,7 +4,7 @@
 package cache
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -264,11 +264,15 @@ func (s *ModelSummary) hash() (string, error) {
 		messages = m.Agent + m.Message
 	}
 	admins := strings.Join(s.Admins, ", ")
-	asString := fmt.Sprintf(
-		"%s %v %s %s %s %s %s %s %s %s %s, %d %d %d %d %d",
-		s.UUID, s.Removed, s.Namespace, s.Name, admins, s.Status, messages,
-		s.Cloud, s.Region, s.Credential, s.LastModified,
-		s.MachineCount, s.ContainerCount, s.ApplicationCount,
-		s.UnitCount, s.RelationCount)
-	return hash(asString)
+	return hash(
+		s.UUID, strconv.FormatBool(s.Removed),
+		s.Namespace, s.Name, admins, s.Status, messages,
+		s.Cloud, s.Region, s.Credential,
+		s.LastModified.String(),
+		strconv.Itoa(s.MachineCount),
+		strconv.Itoa(s.ContainerCount),
+		strconv.Itoa(s.ApplicationCount),
+		strconv.Itoa(s.UnitCount),
+		strconv.Itoa(s.RelationCount),
+	)
 }

--- a/core/cache/modelsummarywatcher.go
+++ b/core/cache/modelsummarywatcher.go
@@ -270,5 +270,5 @@ func (s *ModelSummary) hash() (string, error) {
 		s.Cloud, s.Region, s.Credential, s.LastModified,
 		s.MachineCount, s.ContainerCount, s.ApplicationCount,
 		s.UnitCount, s.RelationCount)
-	return hash(nil, asString)
+	return hash(asString)
 }

--- a/core/cache/modelsummarywatcher.go
+++ b/core/cache/modelsummarywatcher.go
@@ -1,0 +1,274 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/collections/set"
+	"gopkg.in/tomb.v2"
+)
+
+// Status values show a high level indicator of model health.
+const (
+	StatusRed    = "red"
+	StatusYellow = "yellow" // amber?
+	StatusGreen  = "green"
+)
+
+// ModelSummary represents a high level view of a model. Primary use case is to drive
+// the JAAS dashboard.
+type ModelSummary struct {
+	UUID string
+	// Removed indicates that the user can no longer see this model, because it has
+	// either been removed, or there access revoked.
+	Removed bool
+
+	Namespace string
+	Name      string
+	Admins    []string
+	Status    string
+
+	// Messages contain status message for any unit status in error.
+	Messages []ModelSummaryMessage
+
+	Cloud        string
+	Region       string
+	Credential   string
+	LastModified time.Time // Currently missing in cache and underlying db model.
+
+	// MachineCount is just top level machines.
+	MachineCount     int
+	ContainerCount   int
+	ApplicationCount int
+	UnitCount        int
+	RelationCount    int
+}
+
+// ModelSummaryMessage holds information about an error message from an
+// agent, and when that message was set.
+type ModelSummaryMessage struct {
+	Agent   string
+	Message string
+}
+
+// ModelSummaryWatcher will return a slice for all existing models
+type ModelSummaryWatcher interface {
+	Watcher
+	Changes() <-chan []ModelSummary
+}
+
+type modelSummaryPayload struct {
+	summary   ModelSummary
+	visibleTo func(user string) bool
+	hash      string
+}
+
+func newModelSummaryWatcher(controller *Controller, user string) *modelSummaryWatcher {
+	w := &modelSummaryWatcher{
+		controller: controller,
+		// Force the user name to lowercase as all permissions use lower case user keys.
+		user:          strings.ToLower(user),
+		hashes:        make(map[string]string),
+		visibleModels: set.NewStrings(),
+		changes:       make(chan []ModelSummary),
+		summaryChange: make(chan ModelSummary),
+	}
+	w.tomb.Go(w.loop)
+	return w
+}
+
+type modelSummaryWatcher struct {
+	tomb       tomb.Tomb
+	controller *Controller
+	changes    chan []ModelSummary
+
+	// If user is set, the models returned will be limited to the models
+	// that the user can see. If user is the empty string, all models are returned.
+	user string
+
+	summaryChange chan ModelSummary
+	pending       []ModelSummary
+
+	// The mutex protects the attributes below it. Used primarily to keep track of
+	// which models we are seeing.
+	mu            sync.Mutex
+	hashes        map[string]string
+	visibleModels set.Strings
+}
+
+func (w *modelSummaryWatcher) init() {
+	w.controller.mu.Lock()
+	defer w.controller.mu.Unlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, model := range w.controller.models {
+		if !model.visibleTo(w.user) {
+			continue
+		}
+		summary, hash := model.Summary()
+		w.pending = append(w.pending, summary)
+		uuid := model.UUID()
+		w.hashes[uuid] = hash
+		w.visibleModels.Add(uuid)
+	}
+}
+
+func (w *modelSummaryWatcher) loop() error {
+	defer close(w.changes)
+	// Use a hub multiplexer to avoid all the extra goroutines for subscribers.
+	multiplexer := w.controller.hub.NewMultiplexer()
+	defer multiplexer.Unsubscribe()
+	multiplexer.Add(modelSummaryUpdatedTopic, w.onSummaryUpdate)
+	multiplexer.Add(modelRemovedTopic, w.onModelRemove)
+
+	w.init()
+	// We want the first call to Next to get an empty list if that is all the user
+	// can see.
+	first := true
+	for {
+		var changes chan []ModelSummary
+		// If the pending slice is empty, we don't want to send down the changes
+		// channel, so we evaluate that each time through the loop, and determine
+		// whether the changes channel should be the member variable, or nil.
+		// Sending down a nil channel blocks forever (https://dave.cheney.net/2014/03/19/channel-axioms).
+		if first || len(w.pending) > 0 {
+			changes = w.changes
+		}
+
+		select {
+		case <-w.tomb.Dying():
+			return nil
+		case changes <- w.pending:
+			// Changes received, clear pending.
+			w.pending = nil
+			first = false
+		case summary := <-w.summaryChange:
+			// If there is an existing summary for this model, replace it with the
+			// new summary, otherwise add it to the end.
+			replaced := false
+			for i, value := range w.pending {
+				if value.UUID == summary.UUID {
+					logger.Tracef("replacing pending summary for %q", summary.UUID)
+					w.pending[i] = summary
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				logger.Tracef("adding new summary for %q", summary.UUID)
+				w.pending = append(w.pending, summary)
+			}
+		}
+	}
+
+}
+
+func (w *modelSummaryWatcher) onSummaryUpdate(topic string, data interface{}) {
+	// Cast to expected type.
+	payload, ok := data.(modelSummaryPayload)
+	if !ok {
+		logger.Criticalf("programming error: topic data expected modelSummaryPayload, got %T", data)
+		return
+	}
+
+	uuid := payload.summary.UUID
+	logger.Tracef("onSummaryChange: %s", uuid)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var summary ModelSummary
+	if payload.visibleTo(w.user) {
+		// Add is idempotent, and we don't care if we weren't previously tracking.
+		if lastHash := w.hashes[uuid]; lastHash == payload.hash {
+			// If we have already notified for this hash, then don't send
+			// again. If this is a newly watched model, the hash in the map
+			// will be the empty string.
+			return
+		}
+		w.hashes[uuid] = payload.hash
+		w.visibleModels.Add(uuid)
+		summary = payload.summary
+	} else {
+		if !w.visibleModels.Contains(uuid) {
+			// We aren't tracking, and shouldn't be, so nothing to do.
+			return
+		}
+		// If we were tracking this model, stop tracking this model.
+		w.visibleModels.Remove(uuid)
+		delete(w.hashes, uuid)
+		summary = ModelSummary{
+			UUID:    uuid,
+			Removed: true,
+		}
+	}
+
+	select {
+	case <-w.tomb.Dying():
+	case w.summaryChange <- summary:
+	}
+}
+
+func (w *modelSummaryWatcher) onModelRemove(topic string, data interface{}) {
+	uuid, ok := data.(string)
+	if !ok {
+		logger.Criticalf("programming error: topic data expected string, got %T", data)
+		return
+	}
+	logger.Tracef("onModelRemove: %s", uuid)
+	w.mu.Lock()
+	if !w.visibleModels.Contains(uuid) {
+		// We are not tracking it, so nothing to do.
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Unlock()
+	summary := ModelSummary{
+		UUID:    uuid,
+		Removed: true,
+	}
+	select {
+	case <-w.tomb.Dying():
+	case w.summaryChange <- summary:
+	}
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *modelSummaryWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *modelSummaryWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Stop is currently required by the Resources wrapper in the apiserver.
+func (w *modelSummaryWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+// Changes returns the channel that notifies of summary updates.
+func (w *modelSummaryWatcher) Changes() <-chan []ModelSummary {
+	return w.changes
+}
+
+func (s *ModelSummary) hash() (string, error) {
+	// Make a string representation of the summary, and hash that string.
+	var messages string
+	for _, m := range s.Messages {
+		messages = m.Agent + m.Message
+	}
+	admins := strings.Join(s.Admins, ", ")
+	asString := fmt.Sprintf(
+		"%s %v %s %s %s %s %s %s %s %s %s, %d %d %d %d %d",
+		s.UUID, s.Removed, s.Namespace, s.Name, admins, s.Status, messages,
+		s.Cloud, s.Region, s.Credential, s.LastModified,
+		s.MachineCount, s.ContainerCount, s.ApplicationCount,
+		s.UnitCount, s.RelationCount)
+	return hash(nil, asString)
+}

--- a/core/cache/modelsummarywatcher_test.go
+++ b/core/cache/modelsummarywatcher_test.go
@@ -1,0 +1,578 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache_test
+
+import (
+	"sort"
+	"time"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+
+	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/testing"
+)
+
+type modelSummaryWatcherSuite struct {
+	cache.BaseSuite
+	controller *cache.Controller
+	events     <-chan interface{}
+}
+
+var _ = gc.Suite(&modelSummaryWatcherSuite{})
+
+func (s *modelSummaryWatcherSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.controller, s.events = s.New(c)
+	s.baseScenario(c)
+	loggo.GetLogger("").SetLogLevel(loggo.TRACE)
+}
+
+func (s *modelSummaryWatcherSuite) TestInitialModelsAll(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	initial := s.next(c, changes)
+	c.Assert(initial, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:         "controller-uuid",
+			Namespace:    "test-admin",
+			Name:         "controller",
+			Admins:       []string{"test-admin"},
+			Status:       cache.StatusGreen,
+			MachineCount: 1,
+		}, {
+			UUID:             "model-1-uuid",
+			Namespace:        "test-admin",
+			Name:             "model-1",
+			Admins:           []string{"test-admin"},
+			Status:           cache.StatusGreen,
+			MachineCount:     1,
+			ApplicationCount: 1,
+			UnitCount:        1,
+		}, {
+			UUID:      "model-2-uuid",
+			Namespace: "bob",
+			Admins:    []string{"bob"},
+			Name:      "model-2",
+			Status:    cache.StatusGreen,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestInitialModelsBob(c *gc.C) {
+	watcher := s.controller.WatchModelsAsUser("bob")
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	initial := s.next(c, changes)
+	c.Assert(initial, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:             "model-1-uuid",
+			Namespace:        "test-admin",
+			Name:             "model-1",
+			Admins:           []string{"test-admin"},
+			Status:           cache.StatusGreen,
+			MachineCount:     1,
+			ApplicationCount: 1,
+			UnitCount:        1,
+		}, {
+			UUID:      "model-2-uuid",
+			Namespace: "bob",
+			Name:      "model-2",
+			Admins:    []string{"bob"},
+			Status:    cache.StatusGreen,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestInitialModelsCharlie(c *gc.C) {
+	watcher := s.controller.WatchModelsAsUser("charlie")
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	initial := s.next(c, changes)
+	c.Assert(initial, gc.HasLen, 0)
+}
+
+func (s *modelSummaryWatcherSuite) TestAddPermissionShowsModel(c *gc.C) {
+	watcher := s.controller.WatchModelsAsUser("charlie")
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the initial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.ModelChange{
+		ModelUUID: "model-2-uuid",
+		Name:      "model-2",
+		Life:      life.Alive,
+		Owner:     "bob",
+		UserPermissions: map[string]permission.Access{
+			"albert":  permission.AdminAccess,
+			"bob":     permission.AdminAccess,
+			"mary":    permission.ReadAccess,
+			"charlie": permission.ReadAccess,
+		},
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:      "model-2-uuid",
+			Namespace: "bob",
+			Name:      "model-2",
+			Admins:    []string{"albert", "bob"},
+			Status:    cache.StatusGreen,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestRemovingPermissionRemovesModel(c *gc.C) {
+	watcher := s.controller.WatchModelsAsUser("bob")
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the initial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.ModelChange{
+		ModelUUID: "model-2-uuid",
+		Name:      "model-2",
+		Life:      life.Alive,
+		Owner:     "bob",
+		UserPermissions: map[string]permission.Access{
+			"mary":    permission.ReadAccess,
+			"charlie": permission.ReadAccess,
+		},
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:    "model-2-uuid",
+			Removed: true,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestAddModelShowsModel(c *gc.C) {
+	watcher := s.controller.WatchModelsAsUser("bob")
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the initial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.ModelChange{
+		ModelUUID: "model-3-uuid",
+		Name:      "model-3",
+		Life:      life.Alive,
+		Owner:     "mary",
+		UserPermissions: map[string]permission.Access{
+			"bob":  permission.ReadAccess,
+			"mary": permission.AdminAccess,
+		},
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:      "model-3-uuid",
+			Namespace: "mary",
+			Name:      "model-3",
+			Admins:    []string{"mary"},
+			Status:    cache.StatusGreen,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestRemoveModelRemovesModel(c *gc.C) {
+	watcher := s.controller.WatchModelsAsUser("bob")
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the initial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.RemoveModel{
+		ModelUUID: "model-2-uuid",
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:    "model-2-uuid",
+			Removed: true,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestAddingMachineIsChange(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.MachineChange{
+		ModelUUID: "model-2-uuid",
+		Id:        "0",
+		Life:      life.Alive,
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:         "model-2-uuid",
+			Namespace:    "bob",
+			Name:         "model-2",
+			Admins:       []string{"bob"},
+			Status:       cache.StatusGreen,
+			MachineCount: 1,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestRemovingMachineIsChange(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.RemoveMachine{
+		ModelUUID: "model-1-uuid",
+		Id:        "0",
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:      "model-1-uuid",
+			Namespace: "test-admin",
+			Name:      "model-1",
+			Admins:    []string{"test-admin"},
+			Status:    cache.StatusGreen,
+			// We didn't actually remove the application, or unit yet.
+			ApplicationCount: 1,
+			UnitCount:        1,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestAddingApplicationIsChange(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.ApplicationChange{
+		ModelUUID: "model-2-uuid",
+		Name:      "foo",
+		Life:      life.Alive,
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:             "model-2-uuid",
+			Namespace:        "bob",
+			Name:             "model-2",
+			Admins:           []string{"bob"},
+			Status:           cache.StatusGreen,
+			ApplicationCount: 1,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestRemovingApplicationIsChange(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.RemoveApplication{
+		ModelUUID: "model-1-uuid",
+		Name:      "magic",
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:      "model-1-uuid",
+			Namespace: "test-admin",
+			Name:      "model-1",
+			Admins:    []string{"test-admin"},
+			Status:    cache.StatusGreen,
+			// We didn't actually remove the machine, or unit yet.
+			// Yes I know in theory this can't happen, but hey, this is a test.
+			MachineCount: 1,
+			UnitCount:    1,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestAddingUnitIsChange(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.UnitChange{
+		ModelUUID: "model-1-uuid",
+		Name:      "magic/1",
+		Life:      life.Alive,
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:             "model-1-uuid",
+			Namespace:        "test-admin",
+			Name:             "model-1",
+			Admins:           []string{"test-admin"},
+			Status:           cache.StatusGreen,
+			MachineCount:     1,
+			ApplicationCount: 1,
+			UnitCount:        2,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestRemovingUnitIsChange(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.RemoveUnit{
+		ModelUUID: "model-1-uuid",
+		Name:      "magic/0",
+	}, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:      "model-1-uuid",
+			Namespace: "test-admin",
+			Name:      "model-1",
+			Admins:    []string{"test-admin"},
+			Status:    cache.StatusGreen,
+			// We didn't actually remove the machine, or application yet.
+			MachineCount:     1,
+			ApplicationCount: 1,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestChangesToOneModelCoalesced(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	s.ProcessChange(c, cache.RemoveUnit{
+		ModelUUID: "model-1-uuid",
+		Name:      "magic/0",
+	}, s.events)
+	s.ProcessChange(c, cache.RemoveApplication{
+		ModelUUID: "model-1-uuid",
+		Name:      "magic",
+	}, s.events)
+	s.ProcessChange(c, cache.RemoveMachine{
+		ModelUUID: "model-1-uuid",
+		Id:        "0",
+	}, s.events)
+	s.ProcessChange(c, cache.ApplicationChange{
+		ModelUUID: "model-2-uuid",
+		Name:      "foo",
+		Life:      life.Alive,
+	}, s.events)
+
+	// Make sure all the published summary events have been handled.
+	// We know that the events are consumed in the order that they are
+	// published, and that any publishing will take place during the
+	// above ProcessChange calls above, so we only need to wait on the
+	// last publish event from model 2.
+	cache.WaitForModelSummaryHandled(c, s.controller, "model-2-uuid")
+
+	update := s.next(c, changes, "model-2-uuid")
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:      "model-1-uuid",
+			Namespace: "test-admin",
+			Name:      "model-1",
+			Admins:    []string{"test-admin"},
+			Status:    cache.StatusGreen,
+		}, {
+			UUID:             "model-2-uuid",
+			Namespace:        "bob",
+			Name:             "model-2",
+			Admins:           []string{"bob"},
+			Status:           cache.StatusGreen,
+			ApplicationCount: 1,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) TestUpdatesThatDontChangeSummary(c *gc.C) {
+	watcher := s.controller.WatchAllModels()
+	defer workertest.CleanKill(c, watcher)
+
+	changes := watcher.Changes()
+	// discard the intial event
+	_ = s.next(c, changes)
+
+	modelUpdate := cache.ModelChange{
+		ModelUUID: "new-model-uuid",
+		Name:      "new-model",
+		Life:      life.Alive,
+		Owner:     "mary",
+		UserPermissions: map[string]permission.Access{
+			"bob":  permission.ReadAccess,
+			"mary": permission.AdminAccess,
+		},
+	}
+	s.ProcessChange(c, modelUpdate, s.events)
+
+	update := s.next(c, changes)
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:      "new-model-uuid",
+			Namespace: "mary",
+			Name:      "new-model",
+			Admins:    []string{"mary"},
+			Status:    cache.StatusGreen,
+		},
+	})
+
+	// Now we send the same model update, the hash shouldn't change
+	// so it shouldn't generate a new event.
+	s.ProcessChange(c, modelUpdate, s.events)
+	// We send another event after it so we aren't waiting for something
+	// to not happen, which makes tests slower. Here we add an application
+	// to an existing model to force an update.
+	s.ProcessChange(c, cache.ApplicationChange{
+		ModelUUID: "model-2-uuid",
+		Name:      "foo",
+		Life:      life.Alive,
+	}, s.events)
+
+	update = s.next(c, changes, "model-2-uuid")
+
+	// No update for the new model, but we do see the second model
+	// application change.
+	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
+		{
+			UUID:             "model-2-uuid",
+			Namespace:        "bob",
+			Name:             "model-2",
+			Admins:           []string{"bob"},
+			Status:           cache.StatusGreen,
+			ApplicationCount: 1,
+		},
+	})
+}
+
+func (s *modelSummaryWatcherSuite) next(c *gc.C, changes <-chan []cache.ModelSummary, uuids ...string) []cache.ModelSummary {
+	// If we are passed the optional uuid in, there should only be one.
+	if len(uuids) > 0 {
+		if len(uuids) > 1 {
+			c.Fatalf("only one uuid should be passed into next, got %d", len(uuids))
+		}
+		// Make sure all the published summary events have been handled.
+		// We know that the events are consumed in the order that they are
+		// published. The model uuid for the last model change is what should
+		// be passed in here if there are multiple events.
+		cache.WaitForModelSummaryHandled(c, s.controller, uuids[0])
+	}
+
+	select {
+	case <-time.After(testing.LongWait):
+		c.Fatal("no changes sent")
+	case summaries := <-changes:
+		sort.SliceStable(summaries, func(i, j int) bool { return summaries[i].UUID < summaries[j].UUID })
+		return summaries
+	}
+	// Unreachable due to fatal.
+	return nil
+}
+
+func (s *modelSummaryWatcherSuite) baseScenario(c *gc.C) {
+	// The values here a minimal, and only set values that are really necessary.
+	s.ProcessChange(c, cache.ModelChange{
+		ModelUUID: "controller-uuid",
+		Name:      "controller",
+		Life:      life.Alive,
+		Owner:     "test-admin",
+		UserPermissions: map[string]permission.Access{
+			"test-admin": permission.AdminAccess,
+		},
+	}, s.events)
+	s.ProcessChange(c, cache.MachineChange{
+		ModelUUID: "controller-uuid",
+		Id:        "0",
+		Life:      life.Alive,
+	}, s.events)
+	s.ProcessChange(c, cache.ModelChange{
+		ModelUUID: "model-1-uuid",
+		Name:      "model-1",
+		Life:      life.Alive,
+		Owner:     "test-admin",
+		UserPermissions: map[string]permission.Access{
+			"test-admin": permission.AdminAccess,
+			"bob":        permission.ReadAccess,
+		},
+	}, s.events)
+	s.ProcessChange(c, cache.MachineChange{
+		ModelUUID: "model-1-uuid",
+		Id:        "0",
+		Life:      life.Alive,
+	}, s.events)
+	s.ProcessChange(c, cache.CharmChange{
+		ModelUUID: "model-1-uuid",
+		CharmURL:  "magic-42",
+	}, s.events)
+	s.ProcessChange(c, cache.ApplicationChange{
+		ModelUUID: "model-1-uuid",
+		Name:      "magic",
+		Life:      life.Alive,
+		CharmURL:  "magic-42",
+	}, s.events)
+	s.ProcessChange(c, cache.UnitChange{
+		ModelUUID:   "model-1-uuid",
+		Name:        "magic/0",
+		Application: "magic",
+		CharmURL:    "magic-42",
+		Life:        life.Alive,
+	}, s.events)
+	s.ProcessChange(c, cache.ModelChange{
+		ModelUUID: "model-2-uuid",
+		Name:      "model-2",
+		Life:      life.Alive,
+		Owner:     "bob",
+		UserPermissions: map[string]permission.Access{
+			"bob":  permission.AdminAccess,
+			"mary": permission.ReadAccess,
+		},
+	}, s.events)
+}

--- a/core/cache/modelsummarywatcher_test.go
+++ b/core/cache/modelsummarywatcher_test.go
@@ -408,13 +408,6 @@ func (s *modelSummaryWatcherSuite) TestChangesToOneModelCoalesced(c *gc.C) {
 		Life:      life.Alive,
 	}, s.events)
 
-	// Make sure all the published summary events have been handled.
-	// We know that the events are consumed in the order that they are
-	// published, and that any publishing will take place during the
-	// above ProcessChange calls above, so we only need to wait on the
-	// last publish event from model 2.
-	cache.WaitForModelSummaryHandled(c, s.controller, "model-2-uuid")
-
 	update := s.next(c, changes, "model-2-uuid")
 	c.Assert(update, jc.DeepEquals, []cache.ModelSummary{
 		{

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -80,33 +80,13 @@ func (s *BaseSuite) CaptureEvents(c *gc.C) <-chan interface{} {
 	s.Config.Notify = func(change interface{}) {
 		send := false
 		switch change.(type) {
-		case ModelChange:
-			send = true
-		case RemoveModel:
-			send = true
-		case ApplicationChange:
-			send = true
-		case RemoveApplication:
-			send = true
-		case CharmChange:
-			send = true
-		case RemoveCharm:
-			send = true
-		case MachineChange:
-			send = true
-		case RemoveMachine:
-			send = true
-		case UnitChange:
-			send = true
-		case RemoveUnit:
-			send = true
-		case RelationChange:
-			send = true
-		case RemoveRelation:
-			send = true
-		case BranchChange:
-			send = true
-		case RemoveBranch:
+		case ModelChange, RemoveModel,
+			ApplicationChange, RemoveApplication,
+			CharmChange, RemoveCharm,
+			MachineChange, RemoveMachine,
+			UnitChange, RemoveUnit,
+			RelationChange, RemoveRelation,
+			BranchChange, RemoveBranch:
 			send = true
 		default:
 			// no-op

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -13,6 +13,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
 
 	coretesting "github.com/juju/juju/testing"
 )
@@ -66,6 +67,86 @@ func (s *BaseSuite) NewHub() *pubsub.SimpleHub {
 	return pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{Logger: logger})
 }
 
+func (s *BaseSuite) New(c *gc.C) (*Controller, <-chan interface{}) {
+	events := s.CaptureEvents(c)
+	controller, err := s.NewController()
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
+	return controller, events
+}
+
+func (s *BaseSuite) CaptureEvents(c *gc.C) <-chan interface{} {
+	events := make(chan interface{})
+	s.Config.Notify = func(change interface{}) {
+		send := false
+		switch change.(type) {
+		case ModelChange:
+			send = true
+		case RemoveModel:
+			send = true
+		case ApplicationChange:
+			send = true
+		case RemoveApplication:
+			send = true
+		case CharmChange:
+			send = true
+		case RemoveCharm:
+			send = true
+		case MachineChange:
+			send = true
+		case RemoveMachine:
+			send = true
+		case UnitChange:
+			send = true
+		case RemoveUnit:
+			send = true
+		case RelationChange:
+			send = true
+		case RemoveRelation:
+			send = true
+		case BranchChange:
+			send = true
+		case RemoveBranch:
+			send = true
+		default:
+			// no-op
+		}
+		if send {
+			c.Logf("sending %#v", change)
+			select {
+			case events <- change:
+			case <-time.After(coretesting.LongWait):
+				c.Fatalf("change not processed by test")
+			}
+		}
+	}
+	return events
+}
+
+func (s *BaseSuite) ProcessChange(c *gc.C, change interface{}, notify <-chan interface{}) {
+	select {
+	case s.Changes <- change:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("controller did not read change")
+	}
+	select {
+	case obtained := <-notify:
+		c.Check(obtained, jc.DeepEquals, change)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("controller did not handle change")
+	}
+}
+
+func (s *BaseSuite) NextChange(c *gc.C, changes <-chan interface{}) interface{} {
+	var obtained interface{}
+	select {
+	case obtained = <-changes:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("no change")
+	}
+	return obtained
+}
+
 // entitySuite is the base suite for testing cached entities
 // (models, applications, machines).
 type EntitySuite struct {
@@ -83,7 +164,7 @@ func (s *EntitySuite) SetUpTest(c *gc.C) {
 }
 
 func (s *EntitySuite) NewModel(details ModelChange) *Model {
-	m := newModel(s.Gauges, s.Hub, s.Manager.new())
+	m := newModel(s.Gauges, s.Hub, s.NewHub(), s.Manager.new())
 	m.setDetails(details)
 	return m
 }

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -144,7 +144,13 @@ func (s *EntitySuite) SetUpTest(c *gc.C) {
 }
 
 func (s *EntitySuite) NewModel(details ModelChange) *Model {
-	m := newModel(s.Gauges, s.Hub, s.NewHub(), s.Manager.new())
+	m := newModel(modelConfig{
+		initializer: noopInitializer{},
+		metrics:     s.Gauges,
+		hub:         s.Hub,
+		chub:        s.NewHub(),
+		res:         s.Manager.new(),
+	})
 	m.setDetails(details)
 	return m
 }
@@ -345,4 +351,10 @@ func (c StringsWatcherC) AssertStops() {
 	default:
 		c.Fatalf("channel not closed")
 	}
+}
+
+type noopInitializer struct{}
+
+func (noopInitializer) initializing() bool {
+	return false
 }


### PR DESCRIPTION
In order to test the new watcher, the BaseSuite was moved into the
package_test file. The controller tests were internal, so the methods
needed to be renamed to export them to make them available to the
test package.

The hash function is updated to make the settings map optional.

## QA steps

```sh
cd core/cache
go test -check.v
```

## Documentation changes

Everything is internal for now.