### PR TITLE
Update the schema-gen dependency and rebuild the scheam.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -554,11 +554,11 @@
   revision = "a0ef8b74ebcffeeff9fc374854deb4af388f037e"
 
 [[projects]]
-  digest = "1:bb616b3cb33db532e55c2209ea9b6fe4364953f3ac28010e274e7a37762c7e99"
+  digest = "1:c87397413d99514620284ec0eced142321b3e64e38895aeecb07606c6fe82546"
   name = "github.com/juju/jsonschema-gen"
   packages = ["."]
   pruneopts = ""
-  revision = "8a53421608bbf30e65082e0210d89c2dc34d52c2"
+  revision = "11507d258058ffaeee6efa39e97655e934778c99"
 
 [[projects]]
   digest = "1:e460f07bec03866640127c47aae303167e9c79ee426c5fab03c180001eb4a39f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -505,7 +505,7 @@
   revision = "4d05e43ad98c1edcf2f52291685bd9bbc12fd2cd"
 
 [[constraint]]
-  revision = "8a53421608bbf30e65082e0210d89c2dc34d52c2"
+  revision = "11507d258058ffaeee6efa39e97655e934778c99"
   name = "github.com/juju/jsonschema-gen"
 
 [[constraint]]

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3432,7 +3432,7 @@
                             "type": "string"
                         },
                         "life": {
-                            "$ref": "#/definitions/Value"
+                            "type": "string"
                         },
                         "provider-id": {
                             "type": "string"
@@ -9374,7 +9374,7 @@
                             "type": "integer"
                         },
                         "life": {
-                            "$ref": "#/definitions/Value"
+                            "type": "string"
                         },
                         "meter-statuses": {
                             "type": "object",
@@ -9670,7 +9670,7 @@
                             "type": "string"
                         },
                         "life": {
-                            "$ref": "#/definitions/Value"
+                            "type": "string"
                         },
                         "since": {
                             "type": "string",
@@ -10267,7 +10267,7 @@
                             "type": "boolean"
                         },
                         "life": {
-                            "$ref": "#/definitions/Value"
+                            "type": "string"
                         },
                         "machines": {
                             "type": "array",
@@ -10761,7 +10761,7 @@
                             "$ref": "#/definitions/Error"
                         },
                         "life": {
-                            "$ref": "#/definitions/Value"
+                            "type": "string"
                         },
                         "offer-name": {
                             "type": "string"
@@ -26971,7 +26971,7 @@
                             "$ref": "#/definitions/Error"
                         },
                         "life": {
-                            "$ref": "#/definitions/Value"
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
@@ -27536,7 +27536,7 @@
                             "type": "string"
                         },
                         "life": {
-                            "$ref": "#/definitions/Value"
+                            "type": "string"
                         },
                         "since": {
                             "type": "string",


### PR DESCRIPTION
Bring in the fix to the jsonschema-gen package to have the schema work again.

The introduction of the core/life package to the apiserver/params package brought the problem to light. The schema-gen package would create a constraints.Value type internally, but just call it Value. Then when it came across the life.Value type it incorrectly mapped this to the created constraints type.

The schema is also updated, and you'll see the life values are now strings again (as they are in 2.7).