### PR TITLE
Facade/state work for action abort

### DIFF
--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -148,6 +148,33 @@ func (st *State) getOneAction(tag *names.ActionTag) (params.ActionResult, error)
 	return result, nil
 }
 
+// ActionStatus provides the status of a single action.
+func (st *State) ActionStatus(tag names.ActionTag) (string, error) {
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: tag.String()},
+		},
+	}
+
+	var results params.StringResults
+	err := st.facade.FacadeCall("ActionStatus", args, &results)
+	if err != nil {
+		return "", err
+	}
+
+	if len(results.Results) > 1 {
+		return "", fmt.Errorf("expected only 1 action query result, got %d", len(results.Results))
+	}
+
+	// handle server errors
+	result := results.Results[0]
+	if err := result.Error; err != nil {
+		return "", err
+	}
+
+	return result.Result, nil
+}
+
 // Unit provides access to methods of a state.Unit through the facade.
 func (st *State) Unit(tag names.UnitTag) (*Unit, error) {
 	unit := &Unit{

--- a/apiserver/facades/agent/machineactions/machineactions.go
+++ b/apiserver/facades/agent/machineactions/machineactions.go
@@ -69,7 +69,7 @@ func (f *Facade) FinishActions(args params.ActionExecutionResults) params.ErrorR
 // incoming action calls to a machine.
 func (f *Facade) WatchActionNotifications(args params.Entities) params.StringsWatchResults {
 	tagToActionReceiver := f.backend.TagToActionReceiverFn(f.backend.FindEntity)
-	watchOne := common.WatchOneActionReceiverNotifications(tagToActionReceiver, f.resources.Register)
+	watchOne := common.WatchPendingActionsForReceiver(tagToActionReceiver, f.resources.Register)
 	return common.WatchActionNotifications(args, f.accessMachine, watchOne)
 }
 

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -307,7 +307,7 @@ func (a *ActionAPI) cancel(arg params.Entities, compat bool) (params.ActionResul
 			currentResult.Error = common.ServerError(err)
 			continue
 		}
-		result, err := action.Finish(state.ActionResults{Status: state.ActionCancelled, Message: "action cancelled via the API"})
+		result, err := action.Cancel()
 		if err != nil {
 			currentResult.Error = common.ServerError(err)
 			continue

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -34905,6 +34905,17 @@
                         }
                     }
                 },
+                "ActionStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
                 "Actions": {
                     "type": "object",
                     "properties": {

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -25,6 +25,14 @@ const (
 	// ActionRunning is the status of an Action that has been started but
 	// not completed yet.
 	ActionRunning string = "running"
+
+	// ActionAborting is the status of an Action that is running but is to be
+	// terminated. Identical to ActionRunning.
+	ActionAborting string = "aborting"
+
+	// ActionAborted is the status of an Action that was aborted.
+	// Identical to ActionFailed and can have an error.
+	ActionAborted string = "aborted"
 )
 
 // Actions is a slice of Action for bulk requests.

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -101,12 +101,21 @@ func (c *listOperationsCommand) Init(args []string) error {
 		case params.ActionPending,
 			params.ActionRunning,
 			params.ActionCompleted,
-			params.ActionFailed:
+			params.ActionFailed,
+			params.ActionCancelled,
+			params.ActionAborting,
+			params.ActionAborted:
 		default:
 			nameErrors = append(nameErrors,
-				fmt.Sprintf("%q is not a valid function status, want one of %v",
+				fmt.Sprintf("%q is not a valid task status, want one of %v",
 					status,
-					[]string{params.ActionPending, params.ActionRunning, params.ActionCompleted, params.ActionFailed}))
+					[]string{params.ActionPending,
+						params.ActionRunning,
+						params.ActionCompleted,
+						params.ActionFailed,
+						params.ActionCancelled,
+						params.ActionAborting,
+						params.ActionAborted}))
 		}
 	}
 	if len(nameErrors) > 0 {

--- a/cmd/juju/action/listoperations_test.go
+++ b/cmd/juju/action/listoperations_test.go
@@ -46,7 +46,7 @@ func (s *ListOperationsSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "fail with invalid status value",
 		args:        []string{"--status", "pending," + "error"},
-		expectedErr: `"error" is not a valid function status, want one of \[pending running completed failed\]`,
+		expectedErr: `"error" is not a valid task status, want one of \[pending running completed failed cancelled aborting aborted\]`,
 	}, {
 		should:      "fail with multiple errors",
 		args:        []string{"--units", "valid/0," + invalidUnitId, "--apps", "valid," + invalidApplicationId},

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -1036,7 +1036,7 @@ func (st *State) cleanupRemovedUnit(unitId string, cleanupArgs []bson.Raw) error
 	}
 	for _, action := range actions {
 		switch action.Status() {
-		case ActionCompleted, ActionCancelled, ActionFailed:
+		case ActionCompleted, ActionCancelled, ActionFailed, ActionAborted:
 			// nothing to do here
 		default:
 			if _, err = action.Finish(cancelled); err != nil {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -69,6 +69,7 @@ var (
 	DBCollectionSizeToInt         = dbCollectionSizeToInt
 	NewEntityWatcher              = newEntityWatcher
 	ApplicationHasConnectedOffers = applicationHasConnectedOffers
+	NewActionNotificationWatcher  = newActionNotificationWatcher
 )
 
 type (

--- a/state/interface.go
+++ b/state/interface.go
@@ -132,6 +132,7 @@ type InstanceIdGetter interface {
 type ActionsWatcher interface {
 	Entity
 	WatchActionNotifications() StringsWatcher
+	WatchPendingActionNotifications() StringsWatcher
 }
 
 // ActionReceiver describes Entities that can have Actions queued for
@@ -153,6 +154,10 @@ type ActionReceiver interface {
 	// WatchActionNotifications returns a StringsWatcher that will notify
 	// on changes to the queued actions for this ActionReceiver.
 	WatchActionNotifications() StringsWatcher
+
+	// WatchPendingActionNotifications returns a StringsWatcher that will notify
+	// on pending queued actions for this ActionReceiver.
+	WatchPendingActionNotifications() StringsWatcher
 
 	// Actions returns the list of Actions queued and completed for this
 	// ActionReceiver.
@@ -230,6 +235,12 @@ type Action interface {
 
 	// Messages returns the action's progress messages.
 	Messages() []ActionMessage
+
+	// Cancel or Abort the action.
+	Cancel() (Action, error)
+
+	// Refresh the contents of the action.
+	Refresh() error
 }
 
 // ApplicationEntity represents a local or remote application.

--- a/state/machine.go
+++ b/state/machine.go
@@ -2041,6 +2041,11 @@ func (m *Machine) CancelAction(action Action) (Action, error) {
 
 // WatchActionNotifications is part of the ActionReceiver interface.
 func (m *Machine) WatchActionNotifications() StringsWatcher {
+	return m.st.watchActionNotificationsFilteredBy(m)
+}
+
+// WatchPendingActionNotifications is part of the ActionReceiver interface.
+func (m *Machine) WatchPendingActionNotifications() StringsWatcher {
 	return m.st.watchEnqueuedActionsFilteredBy(m)
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -591,7 +591,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 
 				unit, err := application.AddUnit(state.AddUnitParams{})
 				c.Assert(err, jc.ErrorIsNil)
-				return unit.WatchActionNotifications()
+				return unit.WatchPendingActionNotifications()
 			},
 			triggerEvent: func(st *state.State) {
 				unit, err := st.Unit("dummy/0")

--- a/state/unit.go
+++ b/state/unit.go
@@ -3101,6 +3101,11 @@ func (u *Unit) CancelAction(action Action) (Action, error) {
 // WatchActionNotifications starts and returns a StringsWatcher that
 // notifies when actions with Id prefixes matching this Unit are added
 func (u *Unit) WatchActionNotifications() StringsWatcher {
+	return u.st.watchActionNotificationsFilteredBy(u)
+}
+
+// WatchPendingActionNotifications is part of the ActionReceiver interface.
+func (u *Unit) WatchPendingActionNotifications() StringsWatcher {
 	return u.st.watchEnqueuedActionsFilteredBy(u)
 }
 

--- a/worker/uniter/actions/resolver.go
+++ b/worker/uniter/actions/resolver.go
@@ -50,7 +50,7 @@ func (r *actionsResolver) NextOp(
 	// error signaling such here, we must first check to see if an action is
 	// already running (that has been interrupted) before we declare that
 	// there is nothing to do.
-	nextAction, err := nextAction(remoteState.Actions, localState.CompletedActions)
+	nextAction, err := nextAction(remoteState.ActionsPending, localState.CompletedActions)
 	if err != nil && err != resolver.ErrNoOperation {
 		return nil, err
 	}
@@ -65,29 +65,28 @@ func (r *actionsResolver) NextOp(
 			logger.Infof("found incomplete action %v; ignoring", localState.ActionId)
 			logger.Infof("recommitting prior %q hook", localState.Hook.Kind)
 			return opFactory.NewSkipHook(*localState.Hook)
-		} else {
-			logger.Infof("%q hook is nil", operation.RunAction)
-
-			// If the next action is the same as what the uniter is
-			// currently running then this means that the uniter was
-			// some how interrupted (killed) when running the action
-			// and before updating the remote state to indicate that
-			// the action was completed. The only safe thing to do
-			// is fail the action, since rerunning an arbitrary
-			// command can potentially be hazardous.
-			if nextAction == *localState.ActionId {
-				return opFactory.NewFailAction(*localState.ActionId)
-			}
-
-			// If the next action is different then what the uniter
-			// is currently running, then the uniter may have been
-			// interrupted while running the action but the remote
-			// state was updated. Thus, the semantics of
-			// (re)preparing the running operation should move the
-			// uniter's state along safely. Thus, we return the
-			// running action.
-			return opFactory.NewAction(*localState.ActionId)
 		}
+
+		logger.Infof("%q hook is nil", operation.RunAction)
+		// If the next action is the same as what the uniter is
+		// currently running then this means that the uniter was
+		// some how interrupted (killed) when running the action
+		// and before updating the remote state to indicate that
+		// the action was completed. The only safe thing to do
+		// is fail the action, since rerunning an arbitrary
+		// command can potentially be hazardous.
+		if nextAction == *localState.ActionId {
+			return opFactory.NewFailAction(*localState.ActionId)
+		}
+
+		// If the next action is different then what the uniter
+		// is currently running, then the uniter may have been
+		// interrupted while running the action but the remote
+		// state was updated. Thus, the semantics of
+		// (re)preparing the running operation should move the
+		// uniter's state along safely. Thus, we return the
+		// running action.
+		return opFactory.NewAction(*localState.ActionId)
 	case operation.Continue:
 		if err != resolver.ErrNoOperation {
 			return opFactory.NewAction(nextAction)

--- a/worker/uniter/actions/resolver_test.go
+++ b/worker/uniter/actions/resolver_test.go
@@ -33,7 +33,7 @@ func (s *actionsSuite) TestActionStateKindContinue(c *gc.C) {
 		},
 	}
 	remoteState := remotestate.Snapshot{
-		Actions: []string{"actionA", "actionB"},
+		ActionsPending: []string{"actionA", "actionB"},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -49,7 +49,7 @@ func (s *actionsSuite) TestActionRunHook(c *gc.C) {
 		},
 	}
 	remoteState := remotestate.Snapshot{
-		Actions: []string{"actionA", "actionB"},
+		ActionsPending: []string{"actionA", "actionB"},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,7 +65,7 @@ func (s *actionsSuite) TestNextAction(c *gc.C) {
 		CompletedActions: map[string]struct{}{"actionA": {}},
 	}
 	remoteState := remotestate.Snapshot{
-		Actions: []string{"actionA", "actionB"},
+		ActionsPending: []string{"actionA", "actionB"},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -81,7 +81,7 @@ func (s *actionsSuite) TestNextActionBlocked(c *gc.C) {
 		CompletedActions: map[string]struct{}{"actionA": {}},
 	}
 	remoteState := remotestate.Snapshot{
-		Actions:        []string{"actionA", "actionB"},
+		ActionsPending: []string{"actionA", "actionB"},
 		ActionsBlocked: true,
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
@@ -101,7 +101,7 @@ func (s *actionsSuite) TestActionStateKindRunAction(c *gc.C) {
 		CompletedActions: map[string]struct{}{},
 	}
 	remoteState := remotestate.Snapshot{
-		Actions: []string{},
+		ActionsPending: []string{},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -120,7 +120,7 @@ func (s *actionsSuite) TestActionStateKindRunActionPendingRemote(c *gc.C) {
 		CompletedActions: map[string]struct{}{},
 	}
 	remoteState := remotestate.Snapshot{
-		Actions: []string{"actionA", "actionB"},
+		ActionsPending: []string{"actionA", "actionB"},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/operation/deploy.go
+++ b/worker/uniter/operation/deploy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/worker/uniter/charm"
 	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 // deploy implements charm install and charm upgrade operations.
@@ -97,6 +98,11 @@ func (d *deploy) Commit(state State) (*State, error) {
 		change.Step = Queued
 	}
 	return change.apply(state), nil
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (d *deploy) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }
 
 func (d *deploy) checkAlreadyDone(state State) error {

--- a/worker/uniter/operation/failaction.go
+++ b/worker/uniter/operation/failaction.go
@@ -5,6 +5,8 @@ package operation
 
 import (
 	"fmt"
+
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 type failAction struct {
@@ -51,4 +53,9 @@ func (fa *failAction) Commit(state State) (*State, error) {
 		Step: Pending,
 		Hook: state.Hook,
 	}.apply(state), nil
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (fa *failAction) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/uniter/charm"
 	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/runner"
 )
 
@@ -45,6 +46,10 @@ type Operation interface {
 	// Commit ensures that the operation's completion is recorded. If it returns
 	// a non-nil state, that state will be validated and recorded.
 	Commit(state State) (*State, error)
+
+	// RemoteStateChanged is called when the remote state changed during execution
+	// of the operation.
+	RemoteStateChanged(snapshot remotestate.Snapshot)
 }
 
 // Executor records and exposes uniter state, and applies suitable changes as
@@ -57,7 +62,9 @@ type Executor interface {
 	// Run will Prepare, Execute, and Commit the supplied operation, writing
 	// indicated state changes between steps. If any step returns an unknown
 	// error, the run will be aborted and an error will be returned.
-	Run(Operation) error
+	// On remote state change, the executor will fire the operation's
+	// RemoteStateChanged method.
+	Run(Operation, <-chan remotestate.Snapshot) error
 
 	// Skip will Commit the supplied operation, and write any state change
 	// indicated. If Commit returns an error, so will Skip.

--- a/worker/uniter/operation/leader.go
+++ b/worker/uniter/operation/leader.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/juju/charm.v6/hooks"
 
 	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 type acceptLeadership struct {
@@ -50,6 +51,11 @@ func (al *acceptLeadership) Commit(state State) (*State, error) {
 	}.apply(state)
 	newState.Leader = true
 	return newState, nil
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (al *acceptLeadership) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }
 
 func (al *acceptLeadership) checkState(state State) error {
@@ -121,4 +127,9 @@ func (rl *resignLeadership) Execute(state State) (*State, error) {
 func (rl *resignLeadership) Commit(state State) (*State, error) {
 	state.Leader = false
 	return &state, nil
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (rl *resignLeadership) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }

--- a/worker/uniter/operation/mocks/interface_mock.go
+++ b/worker/uniter/operation/mocks/interface_mock.go
@@ -5,12 +5,12 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	hook "github.com/juju/juju/worker/uniter/hook"
 	operation "github.com/juju/juju/worker/uniter/operation"
+	remotestate "github.com/juju/juju/worker/uniter/remotestate"
 	charm_v6 "gopkg.in/juju/charm.v6"
+	reflect "reflect"
 )
 
 // MockOperation is a mock of Operation interface
@@ -38,6 +38,7 @@ func (m *MockOperation) EXPECT() *MockOperationMockRecorder {
 
 // Commit mocks base method
 func (m *MockOperation) Commit(arg0 operation.State) (*operation.State, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(*operation.State)
 	ret1, _ := ret[1].(error)
@@ -46,11 +47,13 @@ func (m *MockOperation) Commit(arg0 operation.State) (*operation.State, error) {
 
 // Commit indicates an expected call of Commit
 func (mr *MockOperationMockRecorder) Commit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockOperation)(nil).Commit), arg0)
 }
 
 // Execute mocks base method
 func (m *MockOperation) Execute(arg0 operation.State) (*operation.State, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", arg0)
 	ret0, _ := ret[0].(*operation.State)
 	ret1, _ := ret[1].(error)
@@ -59,11 +62,13 @@ func (m *MockOperation) Execute(arg0 operation.State) (*operation.State, error) 
 
 // Execute indicates an expected call of Execute
 func (mr *MockOperationMockRecorder) Execute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockOperation)(nil).Execute), arg0)
 }
 
 // NeedsGlobalMachineLock mocks base method
 func (m *MockOperation) NeedsGlobalMachineLock() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NeedsGlobalMachineLock")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -71,11 +76,13 @@ func (m *MockOperation) NeedsGlobalMachineLock() bool {
 
 // NeedsGlobalMachineLock indicates an expected call of NeedsGlobalMachineLock
 func (mr *MockOperationMockRecorder) NeedsGlobalMachineLock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedsGlobalMachineLock", reflect.TypeOf((*MockOperation)(nil).NeedsGlobalMachineLock))
 }
 
 // Prepare mocks base method
 func (m *MockOperation) Prepare(arg0 operation.State) (*operation.State, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prepare", arg0)
 	ret0, _ := ret[0].(*operation.State)
 	ret1, _ := ret[1].(error)
@@ -84,11 +91,25 @@ func (m *MockOperation) Prepare(arg0 operation.State) (*operation.State, error) 
 
 // Prepare indicates an expected call of Prepare
 func (mr *MockOperationMockRecorder) Prepare(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockOperation)(nil).Prepare), arg0)
+}
+
+// RemoteStateChanged mocks base method
+func (m *MockOperation) RemoteStateChanged(arg0 remotestate.Snapshot) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoteStateChanged", arg0)
+}
+
+// RemoteStateChanged indicates an expected call of RemoteStateChanged
+func (mr *MockOperationMockRecorder) RemoteStateChanged(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteStateChanged", reflect.TypeOf((*MockOperation)(nil).RemoteStateChanged), arg0)
 }
 
 // String mocks base method
 func (m *MockOperation) String() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -96,6 +117,7 @@ func (m *MockOperation) String() string {
 
 // String indicates an expected call of String
 func (mr *MockOperationMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockOperation)(nil).String))
 }
 
@@ -124,6 +146,7 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 
 // NewAcceptLeadership mocks base method
 func (m *MockFactory) NewAcceptLeadership() (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewAcceptLeadership")
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -132,11 +155,13 @@ func (m *MockFactory) NewAcceptLeadership() (operation.Operation, error) {
 
 // NewAcceptLeadership indicates an expected call of NewAcceptLeadership
 func (mr *MockFactoryMockRecorder) NewAcceptLeadership() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAcceptLeadership", reflect.TypeOf((*MockFactory)(nil).NewAcceptLeadership))
 }
 
 // NewAction mocks base method
 func (m *MockFactory) NewAction(arg0 string) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewAction", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -145,11 +170,13 @@ func (m *MockFactory) NewAction(arg0 string) (operation.Operation, error) {
 
 // NewAction indicates an expected call of NewAction
 func (mr *MockFactoryMockRecorder) NewAction(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAction", reflect.TypeOf((*MockFactory)(nil).NewAction), arg0)
 }
 
 // NewCommands mocks base method
 func (m *MockFactory) NewCommands(arg0 operation.CommandArgs, arg1 operation.CommandResponseFunc) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewCommands", arg0, arg1)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -158,11 +185,13 @@ func (m *MockFactory) NewCommands(arg0 operation.CommandArgs, arg1 operation.Com
 
 // NewCommands indicates an expected call of NewCommands
 func (mr *MockFactoryMockRecorder) NewCommands(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCommands", reflect.TypeOf((*MockFactory)(nil).NewCommands), arg0, arg1)
 }
 
 // NewFailAction mocks base method
 func (m *MockFactory) NewFailAction(arg0 string) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewFailAction", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -171,11 +200,13 @@ func (m *MockFactory) NewFailAction(arg0 string) (operation.Operation, error) {
 
 // NewFailAction indicates an expected call of NewFailAction
 func (mr *MockFactoryMockRecorder) NewFailAction(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewFailAction", reflect.TypeOf((*MockFactory)(nil).NewFailAction), arg0)
 }
 
 // NewInstall mocks base method
 func (m *MockFactory) NewInstall(arg0 *charm_v6.URL) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewInstall", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -184,11 +215,13 @@ func (m *MockFactory) NewInstall(arg0 *charm_v6.URL) (operation.Operation, error
 
 // NewInstall indicates an expected call of NewInstall
 func (mr *MockFactoryMockRecorder) NewInstall(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewInstall", reflect.TypeOf((*MockFactory)(nil).NewInstall), arg0)
 }
 
 // NewNoOpFinishUpgradeSeries mocks base method
 func (m *MockFactory) NewNoOpFinishUpgradeSeries() (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewNoOpFinishUpgradeSeries")
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -197,11 +230,13 @@ func (m *MockFactory) NewNoOpFinishUpgradeSeries() (operation.Operation, error) 
 
 // NewNoOpFinishUpgradeSeries indicates an expected call of NewNoOpFinishUpgradeSeries
 func (mr *MockFactoryMockRecorder) NewNoOpFinishUpgradeSeries() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewNoOpFinishUpgradeSeries", reflect.TypeOf((*MockFactory)(nil).NewNoOpFinishUpgradeSeries))
 }
 
 // NewNoOpUpgrade mocks base method
 func (m *MockFactory) NewNoOpUpgrade(arg0 *charm_v6.URL) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewNoOpUpgrade", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -210,11 +245,13 @@ func (m *MockFactory) NewNoOpUpgrade(arg0 *charm_v6.URL) (operation.Operation, e
 
 // NewNoOpUpgrade indicates an expected call of NewNoOpUpgrade
 func (mr *MockFactoryMockRecorder) NewNoOpUpgrade(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewNoOpUpgrade", reflect.TypeOf((*MockFactory)(nil).NewNoOpUpgrade), arg0)
 }
 
 // NewResignLeadership mocks base method
 func (m *MockFactory) NewResignLeadership() (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewResignLeadership")
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -223,11 +260,13 @@ func (m *MockFactory) NewResignLeadership() (operation.Operation, error) {
 
 // NewResignLeadership indicates an expected call of NewResignLeadership
 func (mr *MockFactoryMockRecorder) NewResignLeadership() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewResignLeadership", reflect.TypeOf((*MockFactory)(nil).NewResignLeadership))
 }
 
 // NewResolvedUpgrade mocks base method
 func (m *MockFactory) NewResolvedUpgrade(arg0 *charm_v6.URL) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewResolvedUpgrade", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -236,11 +275,13 @@ func (m *MockFactory) NewResolvedUpgrade(arg0 *charm_v6.URL) (operation.Operatio
 
 // NewResolvedUpgrade indicates an expected call of NewResolvedUpgrade
 func (mr *MockFactoryMockRecorder) NewResolvedUpgrade(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewResolvedUpgrade", reflect.TypeOf((*MockFactory)(nil).NewResolvedUpgrade), arg0)
 }
 
 // NewRevertUpgrade mocks base method
 func (m *MockFactory) NewRevertUpgrade(arg0 *charm_v6.URL) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRevertUpgrade", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -249,11 +290,13 @@ func (m *MockFactory) NewRevertUpgrade(arg0 *charm_v6.URL) (operation.Operation,
 
 // NewRevertUpgrade indicates an expected call of NewRevertUpgrade
 func (mr *MockFactoryMockRecorder) NewRevertUpgrade(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRevertUpgrade", reflect.TypeOf((*MockFactory)(nil).NewRevertUpgrade), arg0)
 }
 
 // NewRunHook mocks base method
 func (m *MockFactory) NewRunHook(arg0 hook.Info) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRunHook", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -262,11 +305,13 @@ func (m *MockFactory) NewRunHook(arg0 hook.Info) (operation.Operation, error) {
 
 // NewRunHook indicates an expected call of NewRunHook
 func (mr *MockFactoryMockRecorder) NewRunHook(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRunHook", reflect.TypeOf((*MockFactory)(nil).NewRunHook), arg0)
 }
 
 // NewSkipHook mocks base method
 func (m *MockFactory) NewSkipHook(arg0 hook.Info) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewSkipHook", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -275,11 +320,13 @@ func (m *MockFactory) NewSkipHook(arg0 hook.Info) (operation.Operation, error) {
 
 // NewSkipHook indicates an expected call of NewSkipHook
 func (mr *MockFactoryMockRecorder) NewSkipHook(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSkipHook", reflect.TypeOf((*MockFactory)(nil).NewSkipHook), arg0)
 }
 
 // NewUpgrade mocks base method
 func (m *MockFactory) NewUpgrade(arg0 *charm_v6.URL) (operation.Operation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewUpgrade", arg0)
 	ret0, _ := ret[0].(operation.Operation)
 	ret1, _ := ret[1].(error)
@@ -288,5 +335,6 @@ func (m *MockFactory) NewUpgrade(arg0 *charm_v6.URL) (operation.Operation, error
 
 // NewUpgrade indicates an expected call of NewUpgrade
 func (mr *MockFactoryMockRecorder) NewUpgrade(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewUpgrade", reflect.TypeOf((*MockFactory)(nil).NewUpgrade), arg0)
 }

--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/worker/common/charmrunner"
+	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/runner"
 )
 
@@ -94,6 +95,11 @@ func (ra *runAction) Commit(state State) (*State, error) {
 		Step: Pending,
 		Hook: state.Hook,
 	}.apply(state), nil
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (ra *runAction) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }
 
 // continuationKind determines what State Kind the operation

--- a/worker/uniter/operation/runcommands.go
+++ b/worker/uniter/operation/runcommands.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
@@ -85,4 +86,9 @@ func (rc *runCommands) Execute(state State) (*State, error) {
 // Commit is part of the Operation interface.
 func (rc *runCommands) Commit(state State) (*State, error) {
 	return nil, nil
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (rc *runCommands) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/worker/common/charmrunner"
 	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
@@ -287,4 +288,9 @@ func (rh *runHook) Commit(state State) (*State, error) {
 	}
 
 	return newState, nil
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (rh *runHook) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }

--- a/worker/uniter/operation/skip.go
+++ b/worker/uniter/operation/skip.go
@@ -5,6 +5,8 @@ package operation
 
 import (
 	"fmt"
+
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 type skipOperation struct {
@@ -29,4 +31,9 @@ func (op *skipOperation) Prepare(state State) (*State, error) {
 // Execute is part of the Operation interface.
 func (op *skipOperation) Execute(state State) (*State, error) {
 	return nil, ErrSkipExecute
+}
+
+// RemoteStateChanged is called when the remote state changed during execution
+// of the operation.
+func (op *skipOperation) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }

--- a/worker/uniter/relation/mock_test.go
+++ b/worker/uniter/relation/mock_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 type mockOperations struct {
@@ -52,4 +53,7 @@ func (m *mockOperation) Execute(state operation.State) (*operation.State, error)
 
 func (m *mockOperation) Commit(state operation.State) (*operation.State, error) {
 	return &state, nil
+}
+
+func (m *mockOperation) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -74,9 +74,13 @@ type Snapshot struct {
 	// update-status hook is supposed to run.
 	UpdateStatusVersion int
 
-	// Actions is the list of pending actions to
+	// ActionsPending is the list of pending actions to
 	// be performed by this unit.
-	Actions []string
+	ActionsPending []string
+
+	// ActionChanged contains a monotonically incrementing
+	// integer to signify changes in the Action's remote state.
+	ActionChanged map[string]int
 
 	// ActionsBlocked is true on CAAS when actions cannot be run due to
 	// pod initialization.

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -176,7 +176,80 @@ func (s *LoopSuite) TestLoop(c *gc.C) {
 	c.Assert(err, gc.Equals, resolver.ErrLoopAborted)
 	c.Assert(resolverCalls, gc.Equals, 3)
 	s.executor.CheckCallNames(c, "State", "State", "Run", "State", "State")
-	c.Assert(s.executor.Calls()[2].Args, jc.SameContents, []interface{}{theOp})
+
+	runArgs := s.executor.Calls()[2].Args
+	c.Assert(runArgs, gc.HasLen, 2)
+	c.Assert(runArgs[0], gc.DeepEquals, theOp)
+	c.Assert(runArgs[1], gc.NotNil)
+}
+
+func (s *LoopSuite) TestLoopWithChange(c *gc.C) {
+	var resolverCalls int
+	theOp := &mockOp{}
+	s.resolver = resolver.ResolverFunc(func(
+		_ resolver.LocalState,
+		_ remotestate.Snapshot,
+		_ operation.Factory,
+	) (operation.Operation, error) {
+		resolverCalls++
+		switch resolverCalls {
+		// On the first call, return an operation.
+		case 1:
+			return theOp, nil
+		// On the second call, simulate having
+		// no operations to perform, at which
+		// point we'll wait for a remote state
+		// change.
+		case 2:
+			s.watcher.changes <- struct{}{}
+			break
+		case 3:
+			break
+		// On the fourth call, kill the loop.
+		case 4:
+			close(s.abort)
+			break
+		}
+		return nil, resolver.ErrNoOperation
+	})
+
+	var remoteStateSnapshotChan <-chan remotestate.Snapshot
+	remoteStateSnapshotCount := 0
+	s.executor.run = func(op operation.Operation, rs <-chan remotestate.Snapshot) error {
+		remoteStateSnapshotChan = rs
+		for i := 0; i < 5; i++ {
+			// queue up a change to trigger snapshot channel.
+			s.watcher.changes <- struct{}{}
+			// wait for changes to propagate
+			select {
+			case _, ok := <-rs:
+				c.Assert(ok, jc.IsTrue)
+				remoteStateSnapshotCount++
+			case <-time.After(testing.ShortWait):
+				c.Fatalf("timed out waiting for remote state snapshot")
+				panic("unreachable")
+			}
+		}
+		return nil
+	}
+
+	_, err := s.loop()
+	c.Assert(err, gc.Equals, resolver.ErrLoopAborted)
+	c.Assert(resolverCalls, gc.Equals, 4)
+	s.executor.CheckCallNames(c, "State", "State", "Run", "State", "State", "State")
+
+	c.Assert(remoteStateSnapshotCount, gc.Equals, 5)
+	select {
+	case _, ok := <-remoteStateSnapshotChan:
+		c.Assert(ok, jc.IsTrue)
+		c.Fatalf("remote state snapshot channel fired more than once")
+	default:
+	}
+
+	runArgs := s.executor.Calls()[2].Args
+	c.Assert(runArgs, gc.HasLen, 2)
+	c.Assert(runArgs[0], gc.DeepEquals, theOp)
+	c.Assert(runArgs[1], gc.NotNil)
 }
 
 func (s *LoopSuite) TestRunFails(c *gc.C) {

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -71,7 +71,8 @@ func (f *mockOpFactory) NewAction(id string) (operation.Operation, error) {
 type mockOpExecutor struct {
 	operation.Executor
 	testing.Stub
-	st operation.State
+	st  operation.State
+	run func(operation.Operation, <-chan remotestate.Snapshot) error
 }
 
 func (e *mockOpExecutor) State() operation.State {
@@ -79,8 +80,11 @@ func (e *mockOpExecutor) State() operation.State {
 	return e.st
 }
 
-func (e *mockOpExecutor) Run(op operation.Operation) error {
-	e.MethodCall(e, "Run", op)
+func (e *mockOpExecutor) Run(op operation.Operation, rs <-chan remotestate.Snapshot) error {
+	e.MethodCall(e, "Run", op, rs)
+	if e.run != nil {
+		return e.run(op, rs)
+	}
 	return e.NextErr()
 }
 

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -103,7 +103,7 @@ func (s *resolverOpFactory) NewAction(id string) (operation.Operation, error) {
 			s.LocalState.CompletedActions = make(map[string]struct{})
 		}
 		s.LocalState.CompletedActions[id] = struct{}{}
-		s.LocalState.CompletedActions = trimCompletedActions(s.RemoteState.Actions, s.LocalState.CompletedActions)
+		s.LocalState.CompletedActions = trimCompletedActions(s.RemoteState.ActionsPending, s.LocalState.CompletedActions)
 	}
 	op = onCommitWrapper{op, f}
 	return op, nil

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -213,7 +213,7 @@ func (s *ResolverOpFactorySuite) TestCommitError(c *gc.C) {
 
 func (s *ResolverOpFactorySuite) TestActionsCommit(c *gc.C) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
-	f.RemoteState.Actions = []string{"action 1", "action 2", "action 3"}
+	f.RemoteState.ActionsPending = []string{"action 1", "action 2", "action 3"}
 	f.LocalState.CompletedActions = map[string]struct{}{}
 	op, err := f.NewAction("action 1")
 	c.Assert(err, jc.ErrorIsNil)
@@ -226,7 +226,7 @@ func (s *ResolverOpFactorySuite) TestActionsCommit(c *gc.C) {
 
 func (s *ResolverOpFactorySuite) TestActionsTrimming(c *gc.C) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
-	f.RemoteState.Actions = []string{"c", "d"}
+	f.RemoteState.ActionsPending = []string{"c", "d"}
 	f.LocalState.CompletedActions = map[string]struct{}{
 		"a": {},
 		"b": {},

--- a/worker/uniter/storage/mock_test.go
+++ b/worker/uniter/storage/mock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 type mockStorageAccessor struct {
@@ -70,4 +71,7 @@ func (m *mockOperation) Execute(state operation.State) (*operation.State, error)
 
 func (m *mockOperation) Commit(state operation.State) (*operation.State, error) {
 	return &state, nil
+}
+
+func (m *mockOperation) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -258,7 +258,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if err := u.operationExecutor.Run(op); err != nil {
+		if err := u.operationExecutor.Run(op, nil); err != nil {
 			return errors.Trace(err)
 		}
 		charmURL = opState.CharmURL

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 type UniterSuite struct {
@@ -1926,10 +1927,10 @@ type mockExecutor struct {
 	operation.Executor
 }
 
-func (m *mockExecutor) Run(op operation.Operation) error {
+func (m *mockExecutor) Run(op operation.Operation, rs <-chan remotestate.Snapshot) error {
 	// want to allow charm unpacking to occur
 	if strings.HasPrefix(op.String(), "install") {
-		return m.Executor.Run(op)
+		return m.Executor.Run(op, rs)
 	}
 	// but hooks should error
 	return mockExecutorErr


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Facade/state work for action abort

This PR encapsulates state and facade changes to deal with `juju cancel-action` aborting running actions.

Actions can enter an Aborting state when `juju cancel-action`, this will refire the action notifications watcher, allowing the uniter to handle the abort. The uniter will need to fetch the current action status hence the introduction of the ActionStatus facade call.

Second PR will follow to handle aborting action status.
Third PR will follow to handle aborting machine actions.

## QA steps

Create an action that sleeps for a few minutes.

juju run-action myapp/0 mysleepyaction
juju show-action-status action-1

Action should be running.

juju cancel-action action-1

Action should enter the aborting state, but not do anything.
Action should complete successfully after sleep has elapsed.

## Documentation changes

N/A

## Bug reference

N/A
