### PR TITLE
Added simple linting for python.

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -52,6 +52,11 @@ jobs:
         STATIC_ANALYSIS_JOB=test_static_analysis_go make static-analysis
       shell: bash
 
+    - name: "Static Analysis: Python Check"
+      run: |
+        STATIC_ANALYSIS_JOB=test_static_analysis_python make static-analysis
+      shell: bash
+
   schema:
     name: Schema
     runs-on: ubuntu-latest

--- a/acceptancetests/repository/charms/mediawiki/hooks/db-relation-changed
+++ b/acceptancetests/repository/charms/mediawiki/hooks/db-relation-changed
@@ -219,17 +219,17 @@ def setup_mediawiki():
     ofile.close()
     try:
         os.unlink("/var/www/index.php")
-        print "index.php removed"
+        print("index.php removed")
     except OSError:
-        print "index.php not present"
+        print("index.php not present")
     os.rename(ofile.name, "/var/www/index.php")
 
     # This seems to take precedence
     try:
         os.unlink("/var/www/index.html")
-        print "index.html removed"
+        print("index.html removed")
     except OSError:
-        print "index.html not present"
+        print("index.html not present")
 
     # Write the adminsettings
     connection = MySQLdb.connect(user=user, host=private_address, passwd=password, db=database)
@@ -241,7 +241,7 @@ def setup_mediawiki():
       do_install = True
     except Exception as e:
       # If we can't create that table, it has likely already been initialized
-      print 'Could not create mediawiki_juju_setup: ' + str(e)
+      print('Could not create mediawiki_juju_setup: ' + str(e))
       do_install = False
     if do_install:
       # First time setup, we have to POST to the db and capture the LocalSettings.php

--- a/acceptancetests/repository/charms/mysql/hooks/common.py
+++ b/acceptancetests/repository/charms/mysql/hooks/common.py
@@ -47,7 +47,7 @@ elif os.path.exists(database_name_file):
     with open(database_name_file, 'r') as dbname:
         database_name = dbname.readline().strip()
 else:
-    print 'No established database and no REMOTE_UNIT.'
+    print('No established database and no REMOTE_UNIT.')
 # A user per service unit so we can deny access quickly
 user, service_password = get_service_user(database_name)
 connection = None
@@ -90,7 +90,7 @@ def grant_exists(db_name, db_user, remote_ip):
                                                           remote_ip))
         grants = [i[0] for i in cursor.fetchall()]
     except MySQLdb.OperationalError:
-        print "No grants found"
+        print("No grants found")
         return False
     finally:
         cursor.close()

--- a/acceptancetests/repository/charms/peer-xplod/hooks/update.py
+++ b/acceptancetests/repository/charms/peer-xplod/hooks/update.py
@@ -20,7 +20,7 @@ def run_json(cmd):
 
 
 def juju_log(msg):
-    print msg
+    print(msg)
     #subprocess.check_call(["juju-log", msg])
 
 

--- a/acceptancetests/repository/trusty/haproxy/cm.py
+++ b/acceptancetests/repository/trusty/haproxy/cm.py
@@ -54,7 +54,7 @@ def main(config_file, parent_dir, target_dir, verbose):
 
     try:
         os.makedirs(parent_dir)
-    except OSError, e:
+    except OSError as e:
         if e.errno != errno.EEXIST:
             raise
 
@@ -81,7 +81,7 @@ def main(config_file, parent_dir, target_dir, verbose):
         # Remove leftover symlinks/stray files.
         try:
             os.remove(destination_path)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.EISDIR and e.errno != errno.ENOENT:
                 raise
 

--- a/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
+++ b/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
@@ -785,7 +785,7 @@ def write_service_config(services_dict):
                 f.write(content)
 
         if not os.path.exists(default_haproxy_service_config_dir):
-            os.mkdir(default_haproxy_service_config_dir, 0600)
+            os.mkdir(default_haproxy_service_config_dir, 0o600)
         with open(os.path.join(default_haproxy_service_config_dir,
                                "%s.service" % service_name), 'w') as config:
             config.write(create_listen_stanza(
@@ -841,7 +841,7 @@ def remove_services(service_name=None):
         if os.path.exists(path):
             try:
                 os.remove(path)
-            except Exception, e:
+            except Exception as e:
                 log(str(e))
                 return False
         return True
@@ -850,7 +850,7 @@ def remove_services(service_name=None):
                                  default_haproxy_service_config_dir):
             try:
                 os.remove(service)
-            except Exception, e:
+            except Exception as e:
                 log(str(e))
                 pass
         return True
@@ -901,7 +901,7 @@ def service_haproxy(action=None, haproxy_config=default_haproxy_config):
 def install_hook():
     # Run both during initial install and during upgrade-charm.
     if not os.path.exists(default_haproxy_service_config_dir):
-        os.mkdir(default_haproxy_service_config_dir, 0600)
+        os.mkdir(default_haproxy_service_config_dir, 0o600)
 
     config_data = config_get()
     source = config_data.get('source')
@@ -1259,7 +1259,7 @@ def gen_selfsigned_cert(cert_file, key_file):
     os.environ['OPENSSL_PRIVATE'] = unit_get("private-address")
     # Set the umask so the child process will inherit it and
     # the generated files will be readable only by root..
-    old_mask = os.umask(077)
+    old_mask = os.umask(0o77)
     subprocess.call(
         ['openssl', 'req', '-new', '-x509', '-nodes', '-config',
          os.path.join(os.environ['CHARM_DIR'], 'data', 'openssl.cnf'),
@@ -1275,7 +1275,7 @@ def write_ssl_pem(path, content):
     # Set the umask so the child process will inherit it and we
     # can make certificate files readable only by the 'haproxy'
     # user (see below).
-    old_mask = os.umask(077)
+    old_mask = os.umask(0o77)
     with open(path, 'w') as f:
         f.write(content)
     os.umask(old_mask)
@@ -1349,7 +1349,7 @@ def main(hook_name):
                        "statistics-relation-changed"):
         statistics_interface()
     else:
-        print "Unknown hook"
+        print("Unknown hook")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/acceptancetests/repository/trusty/haproxy/hooks/tests/test_install.py
+++ b/acceptancetests/repository/trusty/haproxy/hooks/tests/test_install.py
@@ -33,7 +33,7 @@ class InstallTests(TestCase):
         self.path_exists.assert_called_once_with(
             hooks.default_haproxy_service_config_dir)
         mkdir.assert_called_once_with(
-            hooks.default_haproxy_service_config_dir, 0600)
+            hooks.default_haproxy_service_config_dir, 0o600)
 
     @patch('os.mkdir')
     def test_config_dir_already_exists(self, mkdir):

--- a/acceptancetests/repository/trusty/mysql/hooks/common.py
+++ b/acceptancetests/repository/trusty/mysql/hooks/common.py
@@ -47,7 +47,7 @@ elif os.path.exists(database_name_file):
     with open(database_name_file, 'r') as dbname:
         database_name = dbname.readline().strip()
 else:
-    print 'No established database and no REMOTE_UNIT.'
+    print('No established database and no REMOTE_UNIT.')
 # A user per service unit so we can deny access quickly
 user, service_password = get_service_user(database_name)
 connection = None
@@ -90,7 +90,7 @@ def grant_exists(db_name, db_user, remote_ip):
                                                           remote_ip))
         grants = [i[0] for i in cursor.fetchall()]
     except MySQLdb.OperationalError:
-        print "No grants found"
+        print("No grants found")
         return False
     finally:
         cursor.close()

--- a/acceptancetests/repository/xenial/mysql/hooks/common.py
+++ b/acceptancetests/repository/xenial/mysql/hooks/common.py
@@ -45,7 +45,7 @@ elif os.path.exists(database_name_file):
     with open(database_name_file, 'r') as dbname:
         database_name = dbname.readline().strip()
 else:
-    print 'No established database and no REMOTE_UNIT.'
+    print('No established database and no REMOTE_UNIT.')
 # A user per service unit so we can deny access quickly
 user, service_password = get_service_user(database_name)
 connection = None
@@ -88,7 +88,7 @@ def grant_exists(db_name, db_user, remote_ip):
                                                           remote_ip))
         grants = [i[0] for i in cursor.fetchall()]
     except MySQLdb.OperationalError:
-        print "No grants found"
+        print("No grants found")
         return False
     finally:
         cursor.close()

--- a/scripts/find-bad-doc-comments.py
+++ b/scripts/find-bad-doc-comments.py
@@ -60,9 +60,9 @@ def cmdline():
     return parser.parse_args()
 
 def emit(filename, comment):
-    print
-    print '%s: ' % filename
-    print comment
+    print()
+    print('%s: ' % filename)
+    print(comment)
 
 def fix(filename, func_name, comment):
     emit(filename, comment)
@@ -94,8 +94,8 @@ def main():
                 emit(filename, bad_comment)
             count += 1
 
-    print
-    print "Problems found:", count
+    print()
+    print("Problems found:", count)
 
 if __name__ == '__main__':
     main()

--- a/tests/suites/static_analysis/lint_python.sh
+++ b/tests/suites/static_analysis/lint_python.sh
@@ -1,0 +1,36 @@
+run_compileall() {
+  cp -R acceptancetests "${TEST_DIR}/"
+  cp -R scripts "${TEST_DIR}/"
+
+  CURRENT_DIRECTORY=$(pwd)
+  cd "${TEST_DIR}" || exit
+  OUT=$(python3 -m compileall acceptancetests scripts -q 2>&1 || true)
+  cd "${CURRENT_DIRECTORY}" || exit
+
+  if [ -n "${OUT}" ]; then
+    echo ""
+    echo "$(red 'Found some issues:')"
+    echo "${OUT}"
+    exit 1
+  fi
+}
+
+test_static_analysis_python() {
+  if [ "$(skip 'test_static_analysis_python')" ]; then
+      echo "==> TEST SKIPPED: static python analysis"
+      return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    # Shell static analysis
+    if which python3 >/dev/null 2>&1; then
+      run "run_compileall"
+    else
+      echo "python3 not found, python static analysis disabled"
+    fi
+  )
+}

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -9,5 +9,6 @@ test_static_analysis() {
     test_copyright
     test_static_analysis_go
     test_static_analysis_shell
+    test_static_analysis_python
     test_schema
 }


### PR DESCRIPTION
## Added simple linting for python.

Uses the compileall module of python to make sure
python code is valid.

Includes fixes of non-3 python scripts. These changes should
work in the last version of 2.6.

## QA steps

`STATIC_ANALYSIS_JOB=test_static_analysis_python make static-analysis`

## Documentation changes

N/A

## Bug reference

#11210 
