### PR TITLE
Improve MachineLXDProfileWatcher to reduce unnecessary notification.

### DIFF
--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -233,7 +233,7 @@ func (w *MachineLXDProfileWatcher) addUnit(_ string, value interface{}) {
 			return
 		}
 		if w.machineId != principal.MachineId() {
-			logger.Tracef("watching unit changes on machine-%s not machine-%s", w.machineId, unitMachineId)
+			logger.Tracef("watching subordinate unit changes on machine-%s not machine-%s", w.machineId, principal.MachineId())
 			return
 		}
 	case w.machineId != unitMachineId:
@@ -278,6 +278,9 @@ func (w *MachineLXDProfileWatcher) add(unit Unit) bool {
 		}
 		w.applications[appName] = info
 	} else {
+		if w.applications[appName].units.Contains(unitName) {
+			return false
+		}
 		w.applications[appName].units.Add(unitName)
 	}
 	if !w.applications[appName].charmProfile.Empty() {

--- a/core/cache/lxdprofilewatcher_test.go
+++ b/core/cache/lxdprofilewatcher_test.go
@@ -141,6 +141,27 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateWithProf
 	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 1)
 }
 
+func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateWithProfileUpdateUnit(c *gc.C) {
+	defer workertest.CleanKill(c, s.assertStartOneMachineWatcher(c))
+	// Add a new subordinate unit with a profile of a new application.
+	s.newUnitForMachineLXDProfileWatcherSubProfile(c, s.machine0.Id(), unitChange.Name)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertOneChange, 0, 1, 1)
+
+	unitChange := cache.UnitChange{
+		ModelUUID:   "model-uuid",
+		Name:        "name-me/0",
+		Application: "name-me",
+		Series:      "bionic",
+		MachineId:   s.machine0.Id(),
+		Principal:   unitChange.Name,
+		Subordinate: true,
+	}
+
+	// New subordinate unit.
+	s.model.UpdateUnit(unitChange, s.Manager)
+	s.assertChangeValidateMetrics(c, s.wc0.AssertNoChange, 0, 1, 2)
+}
+
 func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateNoProfile(c *gc.C) {
 	defer workertest.CleanKill(c, s.assertStartOneMachineWatcher(c))
 	// Add a new subordinate unit with no profile of a new application.

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -169,6 +169,17 @@ func (u *Unit) setDetails(details UnitChange) {
 	u.details = details
 	toPublish := u.copy()
 	if machineChange || u.details.Subordinate {
+		// TODO thumper: check this, it looks like we are publishing too often.
+		//
+		// We do publish too often with subordinates.  However the
+		// watcher in this case, MachineLXDProfileWatcher, can do
+		// a more detailed check so it doesn't notify too often.
+		//
+		// Without checking for a subordinate here, we will
+		// not apply an lxd profile to existing containers if
+		// needed. We need a clean way to Publish when a
+		// subordinate unit is created.  For pricipal units,
+		// ensure the machineID is set.
 		u.model.hub.Publish(modelUnitAdd, toPublish)
 	}
 	// Publish change event for those that may be waiting.


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

If an application had been see, we added the unit as known, without checking that we'd see it before.  Notifying even when seen previously caused unnecessary notifications to the instance-mutater.

Added comments regarding publishing changes for subordinate unit changes.  Improvement can be done there as well.  This changes should help address the high number of calls to CharmProfileInfo from the instance-mutater seen in prod stack recently.

## QA steps

```sh
juju bootstrap localhost --config logging-config="<root>=DEBUG;unit=DEBUG;juju.worker.instancemutater=TRACE"
juju deploy nova-compute
juju deploy neutron-openvswitch
juju add-relation nova-compute neutron-openvswitch 
juju debug-log  --include machine-0 --include-module juju.worker.instancemutater
```
Check the logs, excessive output of "no changes necessary to machine-0" should not longer happen after the neutron-openvswitch unit is added.
