### PR TITLE
Split vm template path to root folder and relative path because we ne…

### DIFF
--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -239,7 +239,7 @@ func (env *sessionEnviron) DestroyController(ctx callcontext.ProviderCallContext
 		return errors.Annotate(err, "listing datastores")
 	}
 	for _, ds := range datastores {
-		datastorePath := fmt.Sprintf("[%s] %s", ds.Name, templateDirectoryName(env.getVMFolder(), controllerUUID))
+		datastorePath := fmt.Sprintf("[%s] %s", ds.Name, path.Join(env.getVMFolder(), templateDirectoryName(controllerUUID)))
 		logger.Debugf("deleting: %s", datastorePath)
 		if err := env.client.DeleteDatastoreFile(env.ctx, datastorePath); err != nil {
 			HandleCredentialError(err, env, ctx)

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -57,12 +57,8 @@ func modelFolderName(modelUUID, modelName string) string {
 
 // templateDirectoryName returns the name of the datastore directory in which
 // the VM templates are stored for the controller.
-func templateDirectoryName(parentfolder string, controllerFolderName string) string {
-	dName := path.Join(controllerFolderName, "templates")
-	if parentfolder != "" {
-		dName = path.Join(parentfolder, dName)
-	}
-	return dName
+func templateDirectoryName(controllerFolderName string) string {
+	return path.Join(controllerFolderName, "templates")
 }
 
 // MaintainInstance is specified in the InstanceBroker interface.
@@ -224,10 +220,11 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs := vsphereclient.CreateVirtualMachineParams{
 		Name:                   vmName,
 		Folder:                 path.Join(env.getVMFolder(), controllerFolderName(args.ControllerUUID), env.modelFolderName()),
+		RootVMFolder:           env.getVMFolder(),
 		Series:                 series,
 		ReadOVA:                readOVA,
 		OVASHA256:              img.Sha256,
-		VMDKDirectory:          templateDirectoryName(env.getVMFolder(), controllerFolderName(args.ControllerUUID)),
+		VMDKDirectory:          templateDirectoryName(controllerFolderName(args.ControllerUUID)),
 		UserData:               string(userData),
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -228,15 +228,26 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 				{Name: "summary.accessible", Val: true},
 			},
 		}},
-		"FakeVmFolder": {{
-			Obj: types.ManagedObjectReference{
-				Type:  "Folder",
-				Value: "FakeControllerVmFolder",
+		"FakeVmFolder": {
+			{
+				Obj: types.ManagedObjectReference{
+					Type:  "Folder",
+					Value: "FakeControllerVmFolder",
+				},
+				PropSet: []types.DynamicProperty{
+					{Name: "name", Val: "foo"},
+				},
 			},
-			PropSet: []types.DynamicProperty{
-				{Name: "name", Val: "foo"},
+			{
+				Obj: types.ManagedObjectReference{
+					Type:  "Folder",
+					Value: "FakeK8sVMFolder",
+				},
+				PropSet: []types.DynamicProperty{
+					{Name: "name", Val: "k8s"},
+				},
 			},
-		}},
+		},
 		"FakeControllerVmFolder": {{
 			Obj: types.ManagedObjectReference{
 				Type:  "Folder",
@@ -246,6 +257,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 				{Name: "name", Val: "bar"},
 			},
 		}},
+		"FakeK8sVMFolder": {},
 		"FakeModelVmFolder": {{
 			Obj: types.ManagedObjectReference{
 				Type:  "VirtualMachine",

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -58,6 +58,9 @@ type CreateVirtualMachineParams struct {
 	// in which to create the VM.
 	Folder string
 
+	// RootVMFolder is the customized root vm folder.
+	RootVMFolder string
+
 	// VMDKDirectory is the datastore path in which VMDKs are stored for
 	// this controller. Within this directory there will be subdirectories
 	// for each series, and within those the VMDKs will be stored.
@@ -167,7 +170,7 @@ func (c *Client) ensureTemplateVM(
 	args CreateVirtualMachineParams,
 ) (vm *object.VirtualMachine, err error) {
 
-	templateFolder, err := c.FindFolder(ctx, vmTemplatePath(args))
+	templateFolder, err := c.FindFolder(ctx, path.Join(args.RootVMFolder, vmTemplatePath(args)))
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
@@ -192,7 +195,7 @@ func (c *Client) ensureTemplateVM(
 		return nil, errors.Annotate(err, "creating import spec")
 	}
 
-	vmFolder, err := c.EnsureVMFolder(ctx, "", vmTemplatePath(args))
+	vmFolder, err := c.EnsureVMFolder(ctx, args.RootVMFolder, vmTemplatePath(args))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -479,6 +479,19 @@ func (s *clientSuite) TestCreateVirtualMachineRootDiskSize(c *gc.C) {
 	})
 }
 
+func (s *clientSuite) TestCreateVirtualMachineWithCustomizedVMFolder(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	rootDisk := uint64(1024 * 20) // 20 GiB
+	args.Constraints.RootDisk = &rootDisk
+
+	args.RootVMFolder = "k8s"
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.roundTripper.CheckCall(c, 17, "RetrieveProperties", "FakeK8sVMFolder")
+}
+
 func (s *clientSuite) TestVerifyMAC(c *gc.C) {
 	var testData = []struct {
 		Mac    string


### PR DESCRIPTION

## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Avoid reading the `/datacenter/vm` root folder if there is a customized vmfolder specified in credential;

## QA steps

- prepare a credential with vmfolder attributes;
- ensure the vmfolder exists;
- ensure the credential does not have read access to the `/datacenter/vm` path;
- bootstrap to the vsphere;

## Documentation changes

No

## Bug reference

No
