### PR TITLE
Add HostNetwork to k8s spec;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2467,12 +2467,13 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 			spec.ValidatingWebhookConfigurations = k8sResources.ValidatingWebhookConfigurations
 			spec.IngressResources = k8sResources.IngressResources
 			if k8sResources.Pod != nil {
+				spec.Pod.RestartPolicy = k8sResources.Pod.RestartPolicy
 				spec.Pod.ActiveDeadlineSeconds = k8sResources.Pod.ActiveDeadlineSeconds
 				spec.Pod.TerminationGracePeriodSeconds = k8sResources.Pod.TerminationGracePeriodSeconds
-				spec.Pod.DNSPolicy = k8sResources.Pod.DNSPolicy
 				spec.Pod.SecurityContext = k8sResources.Pod.SecurityContext
-				spec.Pod.RestartPolicy = k8sResources.Pod.RestartPolicy
 				spec.Pod.ReadinessGates = k8sResources.Pod.ReadinessGates
+				spec.Pod.DNSPolicy = k8sResources.Pod.DNSPolicy
+				spec.Pod.HostNetwork = k8sResources.Pod.HostNetwork
 			}
 			for _, ksa := range k8sResources.ServiceAccounts {
 				spec.ServiceAccounts = append(spec.ServiceAccounts, &ksa)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -89,7 +89,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 				ReadinessGates: []core.PodReadinessGate{
 					{ConditionType: core.PodInitialized},
 				},
-				DNSPolicy: core.DNSClusterFirst,
+				DNSPolicy:   core.DNSClusterFirst,
+				HostNetwork: true,
 			},
 		},
 	}
@@ -134,6 +135,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 			{ConditionType: core.PodInitialized},
 		},
 		DNSPolicy:                    core.DNSClusterFirst,
+		HostNetwork:                  true,
 		ServiceAccountName:           "app-name",
 		AutomountServiceAccountToken: boolPtr(true),
 		InitContainers:               initContainers(),

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -88,6 +88,7 @@ type PodSpec struct {
 	SecurityContext               *core.PodSecurityContext `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 	ReadinessGates                []core.PodReadinessGate  `json:"readinessGates,omitempty" yaml:"readinessGates,omitempty"`
 	DNSPolicy                     core.DNSPolicy           `json:"dnsPolicy,omitempty" yaml:"dnsPolicy,omitempty"`
+	HostNetwork                   bool                     `json:"hostNetwork,omitempty" yaml:"hostNetwork,omitempty"`
 }
 
 // IsEmpty checks if PodSpec is empty or not.

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -157,6 +157,7 @@ kubernetesResources:
     readinessGates:
       - conditionType: PodScheduled
     dnsPolicy: ClusterFirstWithHostNet
+    hostNetwork: true
   secrets:
     - name: build-robot-secret
       type: Opaque
@@ -557,7 +558,8 @@ echo "do some stuff here for gitlab-init container"
 					ReadinessGates: []core.PodReadinessGate{
 						{ConditionType: core.PodScheduled},
 					},
-					DNSPolicy: "ClusterFirstWithHostNet",
+					DNSPolicy:   "ClusterFirstWithHostNet",
+					HostNetwork: true,
 				},
 				Secrets: []k8sspecs.Secret{
 					{


### PR DESCRIPTION

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Add HostNetwork to k8s spec;

## QA steps

deploy CaaS charm with below k8s spec:

```yaml
kubernetesResources:
  pod:
    hostNetwork: true
```

```sh
$ kubectl get -n t1 pod/mariadb-k8s-64597f57c-msljb -o jsonpath="{.spec.hostNetwork}"
true
```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1861517
