### PR TITLE
Add support for juju list-operations

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -35,10 +35,10 @@ func (c *Client) Actions(arg params.Entities) (params.ActionResults, error) {
 	return results, err
 }
 
-// Operations fetches the called functions (actions) for specified apps/units.
-func (c *Client) Operations(arg params.OperationQueryArgs) (params.ActionResults, error) {
-	results := params.ActionResults{}
-	if v := c.BestAPIVersion(); v < 5 {
+// Operations fetches the called operations for specified apps/units.
+func (c *Client) Operations(arg params.OperationQueryArgs) (params.OperationResults, error) {
+	results := params.OperationResults{}
+	if v := c.BestAPIVersion(); v < 6 {
 		return results, errors.Errorf("Operations not supported by this version (%d) of Juju", v)
 	}
 	err := c.facade.FacadeCall("Operations", arg, &results)

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -224,23 +224,23 @@ func (s *actionSuite) TestOperations(c *gc.C) {
 			) error {
 				c.Assert(request, gc.Equals, "Operations")
 				c.Assert(a, jc.DeepEquals, args)
-				c.Assert(result, gc.FitsTypeOf, &params.ActionResults{})
-				*(result.(*params.ActionResults)) = params.ActionResults{
-					Results: []params.ActionResult{{
-						Error: &params.Error{Message: "FAIL"},
+				c.Assert(result, gc.FitsTypeOf, &params.OperationResults{})
+				*(result.(*params.OperationResults)) = params.OperationResults{
+					Results: []params.OperationResult{{
+						Summary: "hello",
 					}},
 				}
 				return nil
 			},
 		),
-		BestVersion: 5,
+		BestVersion: 6,
 	}
 	client := action.NewClient(apiCaller)
 	result, err := client.Operations(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.ActionResults{
-		Results: []params.ActionResult{{
-			Error: &params.Error{Message: "FAIL"},
+	c.Assert(result, jc.DeepEquals, params.OperationResults{
+		Results: []params.OperationResult{{
+			Summary: "hello",
 		}},
 	})
 }

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -4,14 +4,11 @@
 package action_test
 
 import (
-	"fmt"
 	"strconv"
-	"time"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -51,100 +48,29 @@ func (s *operationSuite) setupOperations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	a, err = s.Model.Action(strconv.Itoa(operationID + 2))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = a.Finish(state.ActionResults{})
+	_, err = a.Finish(state.ActionResults{Status: state.ActionCompleted})
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *operationSuite) TestEnqueueOperation(c *gc.C) {
-	// Ensure wordpress unit is the leader.
-	claimer, err := s.LeaseManager.Claimer("application-leadership", s.State.ModelUUID())
-	c.Assert(err, jc.ErrorIsNil)
-	err = claimer.Claim("wordpress", "wordpress/0", time.Minute)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Make sure no Actions already exist on wordpress Unit.
-	actions, err := s.wordpressUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 0)
-
-	// Make sure no Actions already exist on mysql Unit.
-	actions, err = s.mysqlUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 0)
-
-	// Add Actions.
-	expectedName := "fakeaction"
-	expectedParameters := map[string]interface{}{"kan jy nie": "verstaand"}
-	arg := params.Actions{
-		Actions: []params.Action{
-			// No receiver.
-			{Name: "fakeaction"},
-			// Good.
-			{Receiver: s.wordpressUnit.Tag().String(), Name: expectedName, Parameters: expectedParameters},
-			// Application tag instead of Unit tag.
-			{Receiver: s.wordpress.Tag().String(), Name: "fakeaction"},
-			// Missing name.
-			{Receiver: s.mysqlUnit.Tag().String(), Parameters: expectedParameters},
-			// Good (leader syntax).
-			{Receiver: "wordpress/leader", Name: expectedName, Parameters: expectedParameters},
-		},
-	}
-
-	// blocking changes should have no effect
-	s.BlockAllChanges(c, "Enqueue")
-
-	res, err := s.action.EnqueueOperation(arg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(res.Actions, gc.HasLen, 5)
-
-	emptyActionTag := names.ActionTag{}
-	c.Assert(res.Actions[0].Error, gc.DeepEquals,
-		&params.Error{Message: fmt.Sprintf("%s not valid", arg.Actions[0].Receiver), Code: ""})
-	c.Assert(res.Actions[0].Result, gc.Equals, "")
-
-	c.Assert(res.Actions[1].Error, gc.IsNil)
-	c.Assert(res.Actions[1].Result, gc.Not(gc.Equals), emptyActionTag)
-
-	errorString := fmt.Sprintf("action receiver interface on entity %s not implemented", arg.Actions[2].Receiver)
-	c.Assert(res.Actions[2].Error, gc.DeepEquals, &params.Error{Message: errorString, Code: "not implemented"})
-	c.Assert(res.Actions[2].Result, gc.Equals, "")
-
-	c.Assert(res.Actions[3].Error, gc.ErrorMatches, "no action name given")
-	c.Assert(res.Actions[3].Result, gc.Equals, "")
-
-	c.Assert(res.Actions[4].Error, gc.IsNil)
-	c.Assert(res.Actions[4].Result, gc.Not(gc.Equals), emptyActionTag)
-
-	// Make sure that 2 actions were enqueued for the wordpress Unit.
-	actions, err = s.wordpressUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 2)
-	for _, act := range actions {
-		c.Assert(act.Name(), gc.Equals, expectedName)
-		c.Assert(act.Parameters(), gc.DeepEquals, expectedParameters)
-		c.Assert(act.Receiver(), gc.Equals, s.wordpressUnit.Name())
-	}
-
-	// Make sure an Action was not enqueued for the mysql Unit.
-	actions, err = s.mysqlUnit.Actions()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 0)
-
-	operations, err := s.Model.AllOperations()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(operations, gc.HasLen, 1)
-	c.Assert(operations[0].Summary(), gc.Equals, "multiple actions run on unit-wordpress-0,application-wordpress,unit-mysql-0,wordpress/leader")
 }
 
 func (s *operationSuite) TestOperationsStatusFilter(c *gc.C) {
 	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
+	// Set up a non running operation.
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		}}
+	_, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	operations, err := s.action.Operations(params.OperationQueryArgs{
 		Status: []string{"running"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 1)
-	result := actions.Results[0]
-	c.Assert(result.Action, gc.NotNil)
+	c.Assert(operations.Truncated, jc.IsFalse)
+	c.Assert(operations.Results, gc.HasLen, 1)
+	result := operations.Results[0]
+	c.Assert(result.Actions, gc.HasLen, 4)
+	c.Assert(result.Actions[0].Action, gc.NotNil)
 	if result.Enqueued.IsZero() {
 		c.Fatal("enqueued time not set")
 	}
@@ -152,110 +78,177 @@ func (s *operationSuite) TestOperationsStatusFilter(c *gc.C) {
 		c.Fatal("started time not set")
 	}
 	c.Assert(result.Status, gc.Equals, "running")
-	c.Assert(result.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result.Action.Tag, gc.Equals, "action-2")
+
+	action := result.Actions[0].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(action.Tag, gc.Equals, "action-2")
+	c.Assert(result.Actions[0].Status, gc.Equals, "running")
+	action = result.Actions[1].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(action.Tag, gc.Equals, "action-3")
+	c.Assert(result.Actions[1].Status, gc.Equals, "completed")
+	action = result.Actions[2].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(action.Tag, gc.Equals, "action-4")
+	c.Assert(result.Actions[2].Status, gc.Equals, "pending")
+	action = result.Actions[3].Action
+	c.Assert(action.Name, gc.Equals, "anotherfakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(action.Tag, gc.Equals, "action-5")
+	c.Assert(result.Actions[3].Status, gc.Equals, "pending")
 }
 
 func (s *operationSuite) TestOperationsNameFilter(c *gc.C) {
 	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
-		FunctionNames: []string{"anotherfakeaction"},
+	// Set up a second operation.
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		}}
+	_, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	operations, err := s.action.Operations(params.OperationQueryArgs{
+		ActionNames: []string{"anotherfakeaction"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 1)
-	result := actions.Results[0]
-	c.Assert(result.Action, gc.NotNil)
+	c.Assert(operations.Results, gc.HasLen, 1)
+	result := operations.Results[0]
+	c.Assert(result.Actions, gc.HasLen, 1)
+	c.Assert(result.Actions[0].Action, gc.NotNil)
 	if result.Enqueued.IsZero() {
 		c.Fatal("enqueued time not set")
 	}
-	c.Assert(result.Status, gc.Equals, "pending")
-	c.Assert(result.Action.Name, gc.Equals, "anotherfakeaction")
-	c.Assert(result.Action.Receiver, gc.Equals, "unit-mysql-0")
-	c.Assert(result.Action.Tag, gc.Equals, "action-5")
+	if result.Started.IsZero() {
+		c.Fatal("started time not set")
+	}
+	c.Assert(result.Status, gc.Equals, "running")
+	action := result.Actions[0].Action
+	c.Assert(action.Name, gc.Equals, "anotherfakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(action.Tag, gc.Equals, "action-5")
+	c.Assert(result.Actions[0].Status, gc.Equals, "pending")
 }
 
 func (s *operationSuite) TestOperationsAppFilter(c *gc.C) {
 	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
+	// Set up a second operation for a different app.
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.mysqlUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		}}
+	_, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	operations, err := s.action.Operations(params.OperationQueryArgs{
 		Applications: []string{"wordpress"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 2)
-	result0 := actions.Results[0]
-	result1 := actions.Results[1]
+	c.Assert(operations.Results, gc.HasLen, 1)
+	result := operations.Results[0]
 
-	c.Assert(result0.Action, gc.NotNil)
-	if result0.Enqueued.IsZero() {
+	c.Assert(result.Actions, gc.HasLen, 2)
+	c.Assert(result.Actions[0].Action, gc.NotNil)
+	if result.Enqueued.IsZero() {
 		c.Fatal("enqueued time not set")
 	}
-	c.Assert(result0.Status, gc.Equals, "pending")
-	c.Assert(result0.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result0.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result0.Action.Tag, gc.Equals, "action-4")
-
-	c.Assert(result1.Action, gc.NotNil)
-	if result1.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
-	}
-	if result1.Started.IsZero() {
+	if result.Started.IsZero() {
 		c.Fatal("started time not set")
 	}
-	c.Assert(result1.Status, gc.Equals, "running")
-	c.Assert(result1.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result1.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result1.Action.Tag, gc.Equals, "action-2")
+	c.Assert(result.Status, gc.Equals, "running")
+	action := result.Actions[0].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(action.Tag, gc.Equals, "action-2")
+	c.Assert(result.Actions[0].Status, gc.Equals, "running")
+	action = result.Actions[1].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(action.Tag, gc.Equals, "action-4")
+	c.Assert(result.Actions[1].Status, gc.Equals, "pending")
 }
 
 func (s *operationSuite) TestOperationsUnitFilter(c *gc.C) {
 	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
+	// Set up an operation with a pending action.
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		}}
+	_, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	operations, err := s.action.Operations(params.OperationQueryArgs{
 		Units:  []string{"wordpress/0"},
 		Status: []string{"pending"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 1)
-	result := actions.Results[0]
+	c.Assert(operations.Results, gc.HasLen, 1)
+	result := operations.Results[0]
 
-	c.Assert(result.Action, gc.NotNil)
+	c.Assert(result.Actions, gc.HasLen, 1)
+	c.Assert(result.Actions[0].Action, gc.NotNil)
 	if result.Enqueued.IsZero() {
 		c.Fatal("enqueued time not set")
 	}
 	c.Assert(result.Status, gc.Equals, "pending")
-	c.Assert(result.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(result.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(result.Action.Tag, gc.Equals, "action-4")
+	action := result.Actions[0].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(action.Tag, gc.Equals, "action-7")
+	c.Assert(result.Actions[0].Status, gc.Equals, "pending")
 }
 
 func (s *operationSuite) TestOperationsAppAndUnitFilter(c *gc.C) {
 	s.setupOperations(c)
-	actions, err := s.action.Operations(params.OperationQueryArgs{
+	// Set up an operation with a pending action.
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		}}
+	_, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	operations, err := s.action.Operations(params.OperationQueryArgs{
 		Applications: []string{"mysql"},
 		Units:        []string{"wordpress/0"},
-		Status:       []string{"pending"},
+		Status:       []string{"running"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions.Results, gc.HasLen, 2)
-	mysqlAction := actions.Results[0]
-	wordpressAction := actions.Results[1]
-	c.Log(pretty.Sprint(actions.Results))
+	c.Assert(operations.Results, gc.HasLen, 1)
+	c.Log(pretty.Sprint(operations.Results))
+	result := operations.Results[0]
 
-	c.Assert(mysqlAction.Action, gc.NotNil)
-	if mysqlAction.Enqueued.IsZero() {
+	c.Assert(result.Actions, gc.HasLen, 4)
+	c.Assert(result.Actions[0].Action, gc.NotNil)
+	if result.Enqueued.IsZero() {
 		c.Fatal("enqueued time not set")
 	}
-	c.Assert(mysqlAction.Status, gc.Equals, "pending")
-	c.Assert(mysqlAction.Action.Name, gc.Equals, "anotherfakeaction")
-	c.Assert(mysqlAction.Action.Receiver, gc.Equals, "unit-mysql-0")
-	c.Assert(mysqlAction.Action.Tag, gc.Equals, "action-5")
-
-	c.Assert(wordpressAction.Action, gc.NotNil)
-	if wordpressAction.Enqueued.IsZero() {
-		c.Fatal("enqueued time not set")
+	if result.Started.IsZero() {
+		c.Fatal("started time not set")
 	}
-	c.Assert(wordpressAction.Status, gc.Equals, "pending")
-	c.Assert(wordpressAction.Action.Name, gc.Equals, "fakeaction")
-	c.Assert(wordpressAction.Action.Receiver, gc.Equals, "unit-wordpress-0")
-	c.Assert(wordpressAction.Action.Tag, gc.Equals, "action-4")
 
+	action := result.Actions[0].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(action.Tag, gc.Equals, "action-2")
+	c.Assert(result.Actions[0].Status, gc.Equals, "running")
+	action = result.Actions[1].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(action.Tag, gc.Equals, "action-3")
+	c.Assert(result.Actions[1].Status, gc.Equals, "completed")
+	action = result.Actions[2].Action
+	c.Assert(action.Name, gc.Equals, "fakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-wordpress-0")
+	c.Assert(action.Tag, gc.Equals, "action-4")
+	c.Assert(result.Actions[2].Status, gc.Equals, "pending")
+	action = result.Actions[3].Action
+	c.Assert(action.Name, gc.Equals, "anotherfakeaction")
+	c.Assert(action.Receiver, gc.Equals, "unit-mysql-0")
+	c.Assert(action.Tag, gc.Equals, "action-5")
+	c.Assert(result.Actions[3].Status, gc.Equals, "pending")
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -133,7 +133,7 @@
                             "$ref": "#/definitions/OperationQueryArgs"
                         },
                         "Result": {
-                            "$ref": "#/definitions/ActionResults"
+                            "$ref": "#/definitions/OperationResults"
                         }
                     }
                 },
@@ -521,17 +521,23 @@
                 "OperationQueryArgs": {
                     "type": "object",
                     "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "applications": {
                             "type": "array",
                             "items": {
                                 "type": "string"
                             }
                         },
-                        "functions": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "offset": {
+                            "type": "integer"
                         },
                         "status": {
                             "type": "array",
@@ -544,6 +550,58 @@
                             "items": {
                                 "type": "string"
                             }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "OperationResult": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionResult"
+                            }
+                        },
+                        "completed": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "enqueued": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "operation": {
+                            "type": "string"
+                        },
+                        "started": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "summary": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "operation",
+                        "summary"
+                    ]
+                },
+                "OperationResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OperationResult"
+                            }
+                        },
+                        "truncated": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -116,10 +116,32 @@ type FindActionsByNames struct {
 
 // OperationQueryArgs holds args for listing operations.
 type OperationQueryArgs struct {
-	Applications  []string `json:"applications,omitempty"`
-	Units         []string `json:"units,omitempty"`
-	FunctionNames []string `json:"functions,omitempty"`
-	Status        []string `json:"status,omitempty"`
+	Applications []string `json:"applications,omitempty"`
+	Units        []string `json:"units,omitempty"`
+	ActionNames  []string `json:"actions,omitempty"`
+	Status       []string `json:"status,omitempty"`
+
+	// These attributes are used to support client side
+	// batching of results.
+	Offset *int `json:"offset,omitempty"`
+	Limit  *int `json:"limit,omitempty"`
+}
+
+// OperationResults is a slice of OperationResult for bulk requests.
+type OperationResults struct {
+	Results   []OperationResult `json:"results,omitempty"`
+	Truncated bool              `json:"truncated,omitempty"`
+}
+
+// OperationResult describes an Operation that will be or has been completed.
+type OperationResult struct {
+	OperationTag string         `json:"operation"`
+	Summary      string         `json:"summary"`
+	Enqueued     time.Time      `json:"enqueued,omitempty"`
+	Started      time.Time      `json:"started,omitempty"`
+	Completed    time.Time      `json:"completed,omitempty"`
+	Status       string         `json:"status,omitempty"`
+	Actions      []ActionResult `json:"actions,omitempty"`
 }
 
 // ActionExecutionResults holds a slice of ActionExecutionResult for a

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -45,8 +45,8 @@ type APIClient interface {
 	// the ActionReceiver if necessary.
 	Actions(params.Entities) (params.ActionResults, error)
 
-	// Operations fetches the called functions (actions) for specified apps/units.
-	Operations(params.OperationQueryArgs) (params.ActionResults, error)
+	// Operations fetches the called operations for specified apps/units.
+	Operations(params.OperationQueryArgs) (params.OperationResults, error)
 
 	// FindActionTagsByPrefix takes a list of string prefixes and finds
 	// corresponding ActionTags that match that prefix.

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -140,6 +140,7 @@ type fakeAPIClient struct {
 	delay              *time.Timer
 	timeout            *time.Timer
 	actionResults      []params.ActionResult
+	operationResults   []params.OperationResult
 	operationQueryArgs params.OperationQueryArgs
 	enqueuedActions    params.Actions
 	actionsByReceivers []params.ActionsByReceiver
@@ -265,9 +266,9 @@ func (c *fakeAPIClient) WatchActionProgress(actionId string) (watcher.StringsWat
 	return watchertest.NewMockStringsWatcher(c.logMessageCh), nil
 }
 
-func (c *fakeAPIClient) Operations(args params.OperationQueryArgs) (params.ActionResults, error) {
+func (c *fakeAPIClient) Operations(args params.OperationQueryArgs) (params.OperationResults, error) {
 	c.operationQueryArgs = args
-	return params.ActionResults{
-		Results: c.actionResults,
+	return params.OperationResults{
+		Results: c.operationResults,
 	}, c.apiErr
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -416,7 +416,11 @@ func allCollections() CollectionSchema {
 			}},
 		},
 		actionNotificationsC: {},
-		operationsC:          {},
+		operationsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "_id"},
+			}},
+		},
 
 		// -----
 


### PR DESCRIPTION
### Checklist

 - [X] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?

New API but list-operation sis behind a jujuv3 feature flag.

----

## Description of change

Add support for a revamped list-operations CLI.
We now return operations results, which may each have matching tasks (actions). Previously we were returning a list of tasks (actions) directly. A bunch of old action specific query code in the facade is removed and replaced by a direct state call to fetch the operations.
For future use, add offset/limit params so the CLI can batch possibly large results.

## QA steps

Run some actions.
Run list-operations (with/without --format yaml) to see that the selected operations and any child tasks are returned.

