### PR TITLE
backport pr 10969 JUJU_HOOK_NAME

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -152,6 +152,8 @@ type HookContext struct {
 	// id identifies the context.
 	id string
 
+	hookName string
+
 	// actionData contains the values relevant to the run of an Action:
 	// its tag, its parameters, and its results.
 	actionData *ActionData
@@ -695,6 +697,7 @@ func (context *HookContext) HookVars(paths Paths, remote bool) ([]string, error)
 		"CHARM_DIR="+paths.GetCharmDir(), // legacy, embarrassing
 		"JUJU_CHARM_DIR="+paths.GetCharmDir(),
 		"JUJU_CONTEXT_ID="+context.id,
+		"JUJU_HOOK_NAME="+context.hookName,
 		"JUJU_AGENT_SOCKET_ADDRESS="+paths.GetJujucClientSocket(remote).Address,
 		"JUJU_AGENT_SOCKET_NETWORK="+paths.GetJujucClientSocket(remote).Network,
 		"JUJU_UNIT_NAME="+context.unitName,

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -240,6 +240,7 @@ func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
 		hookName = fmt.Sprintf("%s-%s", storageName, hookName)
 	}
 	ctx.id = f.newId(hookName)
+	ctx.hookName = hookName
 	return ctx, nil
 }
 

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -68,6 +68,7 @@ func (s *EnvSuite) getContext(newProxyOnly bool) (ctx *context.HookContext, expe
 
 	expected := []string{
 		"JUJU_CONTEXT_ID=some-context-id",
+		"JUJU_HOOK_NAME=some-hook-name",
 		"JUJU_MODEL_UUID=model-uuid-deadbeef",
 		"JUJU_PRINCIPAL_UNIT=this-unit/123",
 		"JUJU_MODEL_NAME=some-model-name",
@@ -111,6 +112,7 @@ func (s *EnvSuite) getContext(newProxyOnly bool) (ctx *context.HookContext, expe
 	// what the environment values are.
 	return context.NewModelHookContext(
 		"some-context-id",
+		"some-hook-name",
 		"model-uuid-deadbeef",
 		"some-model-name",
 		"this-unit/123",

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -139,12 +139,13 @@ func StorageAddConstraints(ctx *HookContext) map[string][]params.StorageConstrai
 // NewModelHookContext exists purely to set the fields used in rs.
 // The returned value is not otherwise valid.
 func NewModelHookContext(
-	id, modelUUID, modelName, unitName, meterCode, meterInfo, slaLevel, availZone string,
+	id, hookName, modelUUID, modelName, unitName, meterCode, meterInfo, slaLevel, availZone string,
 	apiAddresses []string, legacyProxySettings proxy.Settings, jujuProxySettings proxy.Settings,
 	machineTag names.MachineTag,
 ) *HookContext {
 	return &HookContext{
 		id:                  id,
+		hookName:            hookName,
 		unitName:            unitName,
 		uuid:                modelUUID,
 		modelName:           modelName,


### PR DESCRIPTION
Backport of #10969 

There are currently indirect mechanisms for a charm to identify the hook
name (argv[0] or JUJU_CONTEXT_ID which does not have a publicly
documented format).

This change adds it to the hook context and environment variables.

JUJU_HOOK_NAME will be set to a function name for functions.

See LP: #1854505