### PR TITLE
backport pr 11083 refactor datasource 2.7

### DIFF
--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"path"
 	"strings"
 	"time"
 
@@ -422,10 +423,10 @@ func (s *UpgradeBaseSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest, upgr
 		}
 
 		// Set up state and environ, and run the command.
-		toolsDir := c.MkDir()
+		testDir := c.MkDir()
 		updateAttrs := map[string]interface{}{
 			"agent-version":      test.agentVersion,
-			"agent-metadata-url": "file://" + toolsDir + "/tools",
+			"agent-metadata-url": path.Join(testDir, "tools"),
 		}
 		err := s.Model.UpdateModelConfig(updateAttrs, nil)
 		c.Assert(err, jc.ErrorIsNil)
@@ -434,7 +435,7 @@ func (s *UpgradeBaseSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest, upgr
 			versions[i] = version.MustParseBinary(v)
 		}
 		if len(versions) > 0 {
-			stor, err := filestorage.NewFileStorageWriter(toolsDir)
+			stor, err := filestorage.NewFileStorageWriter(testDir)
 			c.Assert(err, jc.ErrorIsNil)
 			envtesting.MustUploadFakeToolsVersions(stor, s.Environ.Config().AgentStream(), versions...)
 		}
@@ -725,10 +726,10 @@ func (s *UpgradeBaseSuite) setUpEnvAndTools(c *gc.C, currentVersion string, agen
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
 	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
 
-	toolsDir := c.MkDir()
+	tmpDir := c.MkDir()
 	updateAttrs := map[string]interface{}{
 		"agent-version":      agentVersion,
-		"agent-metadata-url": "file://" + toolsDir + "/tools",
+		"agent-metadata-url": path.Join(tmpDir, "tools"),
 	}
 
 	err := s.Model.UpdateModelConfig(updateAttrs, nil)
@@ -741,7 +742,7 @@ func (s *UpgradeBaseSuite) setUpEnvAndTools(c *gc.C, currentVersion string, agen
 		}
 	}
 	if len(versions) > 0 {
-		stor, err := filestorage.NewFileStorageWriter(toolsDir)
+		stor, err := filestorage.NewFileStorageWriter(tmpDir)
 		c.Assert(err, jc.ErrorIsNil)
 		envtesting.MustUploadFakeToolsVersions(stor, s.Environ.Config().AgentStream(), versions...)
 	}

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -140,13 +140,15 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 func toolsDataSources(urls ...string) []simplestreams.DataSource {
 	dataSources := make([]simplestreams.DataSource, len(urls))
 	for i, url := range urls {
-		dataSources[i] = simplestreams.NewURLSignedDataSource(
-			"local source",
-			url,
-			keys.JujuPublicKey,
-			utils.VerifySSLHostnames,
-			simplestreams.CUSTOM_CLOUD_DATA,
-			false)
+		dataSources[i] = simplestreams.NewDataSource(
+			simplestreams.Config{
+				Description:          "local source",
+				BaseURL:              url,
+				PublicSigningKey:     keys.JujuPublicKey,
+				HostnameVerification: utils.VerifySSLHostnames,
+				Priority:             simplestreams.CUSTOM_CLOUD_DATA,
+			},
+		)
 	}
 	return dataSources
 }

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -241,8 +241,15 @@ var imagesDataSources = func(urls ...string) []simplestreams.DataSource {
 	dataSources := make([]simplestreams.DataSource, len(urls))
 	publicKey, _ := simplestreams.UserPublicSigningKey()
 	for i, url := range urls {
-		dataSources[i] = simplestreams.NewURLSignedDataSource(
-			"local metadata directory", "file://"+url, publicKey, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
+		dataSources[i] = simplestreams.NewDataSource(
+			simplestreams.Config{
+				Description:          "local metadata directory",
+				BaseURL:              "file://" + url,
+				PublicSigningKey:     publicKey,
+				HostnameVerification: utils.VerifySSLHostnames,
+				Priority:             simplestreams.CUSTOM_CLOUD_DATA,
+			},
+		)
 	}
 	return dataSources
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -961,19 +961,35 @@ func setPrivateMetadataSources(metadataDir string) ([]*imagemetadata.ImageMetada
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	publicKey, _ := simplestreams.UserPublicSigningKey()
-	datasource := simplestreams.NewURLSignedDataSource("bootstrap metadata", baseURL, publicKey, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
+	publicKey, err := simplestreams.UserPublicSigningKey()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// TODO: (hml) 2020-01-08
+	// Why ignore the the model-config "ssl-hostname-verification" value in
+	// the config here? Its default value is true.
+	dataSourceConfig := simplestreams.Config{
+		Description:          "bootstrap metadata",
+		BaseURL:              baseURL,
+		PublicSigningKey:     publicKey,
+		HostnameVerification: utils.NoVerifySSLHostnames,
+		Priority:             simplestreams.CUSTOM_CLOUD_DATA,
+	}
+	if err := dataSourceConfig.Validate(); err != nil {
+		return nil, errors.Annotate(err, "simplestreams config validation failed")
+	}
+	dataSource := simplestreams.NewDataSource(dataSourceConfig)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})
-	existingMetadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{datasource}, imageConstraint)
+	existingMetadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, imageConstraint)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Annotate(err, "cannot read image metadata")
 	}
 
 	// Add an image metadata datasource for constraint validation, etc.
 	environs.RegisterUserImageDataSourceFunc("bootstrap metadata", func(environs.Environ) (simplestreams.DataSource, error) {
-		return datasource, nil
+		return dataSource, nil
 	})
 	logger.Infof("custom image metadata added to search path")
 	return existingMetadata, nil

--- a/environs/gui/simplestreams.go
+++ b/environs/gui/simplestreams.go
@@ -37,14 +37,16 @@ func init() {
 // DataSource creates and returns a new simplestreams signed data source for
 // fetching Juju GUI archives, at the given URL.
 func NewDataSource(baseURL string) simplestreams.DataSource {
-	requireSigned := true
-	return simplestreams.NewURLSignedDataSource(
-		sourceDescription,
-		baseURL,
-		keys.JujuPublicKey,
-		utils.VerifySSLHostnames,
-		simplestreams.DEFAULT_CLOUD_DATA,
-		requireSigned)
+	return simplestreams.NewDataSource(
+		simplestreams.Config{
+			Description:          sourceDescription,
+			BaseURL:              baseURL,
+			PublicSigningKey:     keys.JujuPublicKey,
+			HostnameVerification: utils.VerifySSLHostnames,
+			Priority:             simplestreams.DEFAULT_CLOUD_DATA,
+			RequireSigned:        true,
+		},
+	)
 }
 
 // FetchMetadata fetches and returns Juju GUI metadata from simplestreams,

--- a/environs/gui/simplestreams_test.go
+++ b/environs/gui/simplestreams_test.go
@@ -7,12 +7,10 @@ import (
 	"net/http"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/gui"
-	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/juju/keys"
 	coretesting "github.com/juju/juju/testing"
@@ -25,7 +23,7 @@ type simplestreamsSuite struct {
 
 var _ = gc.Suite(&simplestreamsSuite{
 	LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-		Source:          simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false),
+		Source:          sstesting.VerifyDefaultCloudDataSource("test", "test:"),
 		RequireSigned:   false,
 		DataType:        gui.DownloadType,
 		StreamsVersion:  gui.StreamsVersion,
@@ -179,8 +177,7 @@ func (s *simplestreamsSuite) TestFetchMetadata(c *gc.C) {
 		s.PatchValue(&jujuversion.Current, jujuVersion)
 
 		// Add invalid datasource and check later that resolveInfo is correct.
-		invalidSource := simplestreams.NewURLDataSource(
-			"invalid", "file://invalid", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, s.RequireSigned)
+		invalidSource := sstesting.InvalidDataSource(s.RequireSigned)
 
 		// Fetch the Juju GUI archives.
 		allMeta, err := gui.FetchMetadata(test.stream, invalidSource, s.Source)

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -42,13 +42,16 @@ func NewDataSource(baseURL string) simplestreams.DataSource {
 // NewDataSource returns a datasourceFunc from the baseURL provided.
 func newDataSourceFunc(baseURL string) func() simplestreams.DataSource {
 	return func() simplestreams.DataSource {
-		return simplestreams.NewURLSignedDataSource(
-			"ubuntu cloud images",
-			baseURL,
-			imagemetadata.SimplestreamsImagesPublicKey,
-			utils.VerifySSLHostnames,
-			simplestreams.DEFAULT_CLOUD_DATA,
-			true)
+		return simplestreams.NewDataSource(
+			simplestreams.Config{
+				Description:          "ubuntu cloud images",
+				BaseURL:              baseURL,
+				PublicSigningKey:     imagemetadata.SimplestreamsImagesPublicKey,
+				HostnameVerification: utils.VerifySSLHostnames,
+				Priority:             simplestreams.DEFAULT_CLOUD_DATA,
+				RequireSigned:        true,
+			},
+		)
 	}
 }
 

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -84,17 +84,29 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 
 func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	environs.RegisterImageDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false), nil
+		return simplestreams.NewDataSource(simplestreams.Config{
+			Description:          "id0",
+			BaseURL:              "betwixt/releases",
+			HostnameVerification: utils.NoVerifySSLHostnames,
+			Priority:             simplestreams.DEFAULT_CLOUD_DATA}), nil
 	})
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA, false), nil
+		return simplestreams.NewDataSource(simplestreams.Config{
+			Description:          "id1",
+			BaseURL:              "yoink",
+			HostnameVerification: utils.NoVerifySSLHostnames,
+			Priority:             simplestreams.SPECIFIC_CLOUD_DATA}), nil
 	})
 	// overwrite the one previously registered against id1
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
 		return nil, errors.NewNotSupported(nil, "oyvey")
 	})
 	environs.RegisterUserImageDataSourceFunc("id2", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id2", "foobar", utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
+		return simplestreams.NewDataSource(simplestreams.Config{
+			Description:          "id2",
+			BaseURL:              "foobar",
+			HostnameVerification: utils.NoVerifySSLHostnames,
+			Priority:             simplestreams.CUSTOM_CLOUD_DATA}), nil
 	})
 	defer environs.UnregisterImageDataSourceFunc("id0")
 	defer environs.UnregisterImageDataSourceFunc("id1")

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -355,9 +355,13 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 			Arches:    t.arches,
 			Stream:    t.stream,
 		})
-		imageMeta, err := imagemetadata.GetLatestImageIdMetadata(
-			[]byte(jsonImagesContent),
-			simplestreams.NewURLDataSource("test", "some-url", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false), cons)
+		dataSource := simplestreams.NewDataSource(simplestreams.Config{
+			Description:          "test",
+			BaseURL:              "some-url",
+			HostnameVerification: utils.VerifySSLHostnames,
+			Priority:             simplestreams.DEFAULT_CLOUD_DATA,
+		})
+		imageMeta, err := imagemetadata.GetLatestImageIdMetadata([]byte(jsonImagesContent), dataSource, cons)
 		c.Assert(err, jc.ErrorIsNil)
 		var images []Image
 		for _, imageMetadata := range imageMeta {

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/juju/errors"
@@ -34,9 +35,11 @@ type DataSource interface {
 	// SetAllowRetry sets the flag which determines if the datasource will retry fetching the metadata
 	// if it is not immediately available.
 	SetAllowRetry(allow bool)
+
 	// Priority is an importance factor for Data Source. Higher number means higher priority.
 	// This is will allow to sort data sources in order of importance.
 	Priority() int
+
 	// RequireSigned indicates whether this data source requires signed data.
 	RequireSigned() bool
 }
@@ -50,7 +53,7 @@ const (
 	EXISTING_CLOUD_DATA = 0
 
 	// DEFAULT_CLOUD_DATA is used for common cloud data that
-	// is shared an is publically available.
+	// is shared an is publicly available.
 	DEFAULT_CLOUD_DATA = 10
 
 	// SPECIFIC_CLOUD_DATA is used to rank cloud specific data
@@ -73,26 +76,55 @@ type urlDataSource struct {
 	requireSigned        bool
 }
 
-// NewURLDataSource returns a new datasource reading from the specified baseURL.
-func NewURLDataSource(description, baseURL string, hostnameVerification utils.SSLHostnameVerification, priority int, requireSigned bool) DataSource {
-	return &urlDataSource{
-		description:          description,
-		baseURL:              baseURL,
-		hostnameVerification: hostnameVerification,
-		priority:             priority,
-		requireSigned:        requireSigned,
-	}
+// Config has values to be used in constructing a datasource.
+type Config struct {
+	// Description of the datasource
+	Description string
+
+	// BaseURL is the URL for this datasource.
+	BaseURL string
+
+	// HostnameVerification indicates whether to use self-signed credentials
+	// and not try to verify the hostname on the TLS/SSL certificates.
+	HostnameVerification utils.SSLHostnameVerification
+
+	// PublicSigningKey is the public key used to validate signed metadata.
+	PublicSigningKey string
+
+	// Priority is an importance factor for the datasource. Higher number means
+	// higher priority. This is will facilitate sorting data sources in order of
+	// importance.
+	Priority int
+
+	// RequireSigned indicates whether this datasource requires signed data.
+	RequireSigned bool
 }
 
-// NewURLSignedDataSource returns a new datasource for signed metadata reading from the specified baseURL.
-func NewURLSignedDataSource(description, baseURL, publicKey string, hostnameVerification utils.SSLHostnameVerification, priority int, requireSigned bool) DataSource {
+// Validate() checks that the baseURL is valid and the description is set.
+func (c *Config) Validate() error {
+	if c.Description == "" {
+		return errors.New("no description specified")
+	}
+	if _, err := url.Parse(c.BaseURL); err != nil {
+		return errors.Annotate(err, "base URL is not valid")
+	}
+	// TODO (hml) 2020-01-08
+	// Add validation for PublicSigningKey
+	return nil
+}
+
+// NewDataSource returns a new DataSource as defined
+// by the given config.
+func NewDataSource(cfg Config) DataSource {
+	// TODO (hml) 2020-01-08
+	// Move call to cfg.Validate() here and add return of error.
 	return &urlDataSource{
-		description:          description,
-		baseURL:              baseURL,
-		publicSigningKey:     publicKey,
-		hostnameVerification: hostnameVerification,
-		priority:             priority,
-		requireSigned:        requireSigned,
+		description:          cfg.Description,
+		baseURL:              cfg.BaseURL,
+		hostnameVerification: cfg.HostnameVerification,
+		publicSigningKey:     cfg.PublicSigningKey,
+		priority:             cfg.Priority,
+		requireSigned:        cfg.RequireSigned,
 	}
 }
 
@@ -129,7 +161,7 @@ func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 		return nil, dataURL, errors.NotFoundf("invalid URL %q", dataURL)
 	}
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		switch resp.StatusCode {
 		case http.StatusNotFound:
 			return nil, dataURL, errors.NotFoundf("cannot find URL %q", dataURL)

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -100,7 +100,7 @@ type Config struct {
 	RequireSigned bool
 }
 
-// Validate() checks that the baseURL is valid and the description is set.
+// Validate checks that the baseURL is valid and the description is set.
 func (c *Config) Validate() error {
 	if c.Description == "" {
 		return errors.New("no description specified")

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -4,12 +4,12 @@
 package simplestreams_test
 
 import (
+	"github.com/juju/utils"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/imagemetadata"
@@ -25,10 +25,10 @@ type datasourceSuite struct {
 }
 
 func (s *datasourceSuite) TestFetch(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
+	ds := testing.VerifyDefaultCloudDataSource("test", "test:")
 	rc, url, err := ds.Fetch("streams/v1/tools_metadata.json")
 	c.Assert(err, jc.ErrorIsNil)
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	c.Assert(url, gc.Equals, "test:/streams/v1/tools_metadata.json")
 	data, err := ioutil.ReadAll(rc)
 	c.Assert(err, jc.ErrorIsNil)
@@ -38,7 +38,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 }
 
 func (s *datasourceSuite) TestURL(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "foo", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
+	ds := testing.VerifyDefaultCloudDataSource("test", "foo")
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.Equals, "foo/bar")
@@ -51,9 +51,9 @@ type datasourceHTTPSSuite struct {
 func (s *datasourceHTTPSSuite) SetUpTest(c *gc.C) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(resp http.ResponseWriter, req *http.Request) {
-		req.Body.Close()
+		_ = req.Body.Close()
 		resp.WriteHeader(200)
-		resp.Write([]byte("Greetings!\n"))
+		_, _ = resp.Write([]byte("Greetings!\n"))
 	})
 	s.Server = httptest.NewTLSServer(mux)
 }
@@ -66,7 +66,7 @@ func (s *datasourceHTTPSSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
+	ds := testing.VerifyDefaultCloudDataSource("test", s.Server.URL)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")
@@ -78,7 +78,12 @@ func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNonVerifyingClientSucceeds(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
+	ds := simplestreams.NewDataSource(simplestreams.Config{
+		Description:          "test",
+		BaseURL:              s.Server.URL,
+		HostnameVerification: utils.NoVerifySSLHostnames,
+		Priority:             simplestreams.DEFAULT_CLOUD_DATA,
+	})
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")
@@ -86,7 +91,7 @@ func (s *datasourceHTTPSSuite) TestNonVerifyingClientSucceeds(c *gc.C) {
 	// The underlying failure is a x509: certificate signed by unknown authority
 	// However, the urlDataSource abstraction hides that as a simple NotFound
 	c.Assert(err, jc.ErrorIsNil)
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	byteContent, err := ioutil.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(byteContent), gc.Equals, "Greetings!\n")

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -542,7 +542,16 @@ func GetIndexWithFormat(source DataSource, indexPath, indexFormat, mirrorsPath s
 			source, mirrors, params.DataType, params.MirrorContentId, cloudSpec, requireSigned)
 		if err == nil {
 			logger.Debugf("using mirrored products path: %s", path.Join(mirrorInfo.MirrorURL, mirrorInfo.Path))
-			indexRef.Source = NewURLSignedDataSource("mirror", mirrorInfo.MirrorURL, source.PublicSigningKey(), utils.VerifySSLHostnames, source.Priority(), requireSigned)
+			indexRef.Source = NewDataSource(
+				Config{
+					Description:          "mirror",
+					BaseURL:              mirrorInfo.MirrorURL,
+					PublicSigningKey:     source.PublicSigningKey(),
+					HostnameVerification: utils.VerifySSLHostnames,
+					Priority:             source.Priority(),
+					RequireSigned:        requireSigned,
+				},
+			)
 			indexRef.MirroredProductsPath = mirrorInfo.Path
 		} else {
 			logger.Tracef("no mirror information available for %s: %v", cloudSpec, err)

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/simplestreams"
@@ -24,7 +23,7 @@ func Test(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false),
+			Source:         sstesting.VerifyDefaultCloudDataSource("test", "test:"),
 			RequireSigned:  false,
 			DataType:       "image-ids",
 			StreamsVersion: "v1",
@@ -327,13 +326,7 @@ func (s *countingSource) URL(path string) (string, error) {
 
 func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 	source := &countingSource{
-		DataSource: simplestreams.NewURLDataSource(
-			"test",
-			"test:/daily",
-			utils.VerifySSLHostnames,
-			simplestreams.DEFAULT_CLOUD_DATA,
-			false,
-		),
+		DataSource: sstesting.VerifyDefaultCloudDataSource("test", "test:/daily"),
 	}
 	sources := []simplestreams.DataSource{source, source, source}
 	constraint := sstesting.NewTestConstraint(simplestreams.LookupParams{

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/simplestreams"
@@ -815,4 +816,21 @@ func (s *LocalLiveSimplestreamsSuite) AssertGetItemCollections(c *gc.C, version 
 	metadataCatalog := metadata.Products["com.ubuntu.cloud:server:12.04:amd64"]
 	ic := metadataCatalog.Items[version]
 	return ic
+}
+
+func InvalidDataSource(requireSigned bool) simplestreams.DataSource {
+	return simplestreams.NewDataSource(simplestreams.Config{
+		Description:          "invalid",
+		BaseURL:              "file://invalid",
+		HostnameVerification: utils.VerifySSLHostnames,
+		Priority:             simplestreams.DEFAULT_CLOUD_DATA,
+		RequireSigned:        requireSigned})
+}
+
+func VerifyDefaultCloudDataSource(description, baseURL string) simplestreams.DataSource {
+	return simplestreams.NewDataSource(simplestreams.Config{
+		Description:          description,
+		BaseURL:              baseURL,
+		HostnameVerification: utils.VerifySSLHostnames,
+		Priority:             simplestreams.DEFAULT_CLOUD_DATA})
 }

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -158,7 +158,17 @@ func selectSourceDatasource(syncContext *SyncContext) (simplestreams.DataSource,
 		return nil, err
 	}
 	logger.Infof("source for sync of agent binaries: %v", sourceURL)
-	return simplestreams.NewURLSignedDataSource("sync agent binaries source", sourceURL, keys.JujuPublicKey, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
+	config := simplestreams.Config{
+		Description:          "sync agent binaries source",
+		BaseURL:              sourceURL,
+		PublicSigningKey:     keys.JujuPublicKey,
+		HostnameVerification: utils.VerifySSLHostnames,
+		Priority:             simplestreams.CUSTOM_CLOUD_DATA,
+	}
+	if err := config.Validate(); err != nil {
+		return nil, errors.Annotate(err, "simplestreams config validation failed")
+	}
+	return simplestreams.NewDataSource(config), nil
 }
 
 // copyTools copies a set of tools from the source to the target.

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -77,10 +77,18 @@ func (s *URLsSuite) TestToolsSources(c *gc.C) {
 
 func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	tools.RegisterToolsDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false), nil
+		return simplestreams.NewDataSource(simplestreams.Config{
+			Description:          "id0",
+			BaseURL:              "betwixt/releases",
+			HostnameVerification: utils.NoVerifySSLHostnames,
+			Priority:             simplestreams.DEFAULT_CLOUD_DATA}), nil
 	})
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA, false), nil
+		return simplestreams.NewDataSource(simplestreams.Config{
+			Description:          "id1",
+			BaseURL:              "yoink",
+			HostnameVerification: utils.NoVerifySSLHostnames,
+			Priority:             simplestreams.SPECIFIC_CLOUD_DATA}), nil
 	})
 	// overwrite the one previously registered against id1
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -31,13 +31,16 @@ func getImageSource(env environs.Environ) (simplestreams.DataSource, error) {
 	if !ok {
 		return nil, errors.NotSupportedf("non-cloudsigma model")
 	}
-	return simplestreams.NewURLDataSource(
-		"cloud images",
-		fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.cloud.Region),
-		utils.VerifySSLHostnames,
-		simplestreams.SPECIFIC_CLOUD_DATA,
-		false,
-	), nil
+	dataSourceConfig := simplestreams.Config{
+		Description:          "cloud images",
+		BaseURL:              fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.cloud.Region),
+		HostnameVerification: utils.VerifySSLHostnames,
+		Priority:             simplestreams.SPECIFIC_CLOUD_DATA,
+	}
+	if err := dataSourceConfig.Validate(); err != nil {
+		return nil, errors.Annotate(err, "simplestreams config validation failed")
+	}
+	return simplestreams.NewDataSource(dataSourceConfig), nil
 }
 
 type environProvider struct {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1650,7 +1650,11 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 
 func (s *localServerSuite) TestImageMetadataSourceOrder(c *gc.C) {
 	src := func(env environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("my datasource", "bar", false, simplestreams.CUSTOM_CLOUD_DATA, false), nil
+		return simplestreams.NewDataSource(simplestreams.Config{
+			Description:          "my datasource",
+			BaseURL:              "bar",
+			HostnameVerification: false,
+			Priority:             simplestreams.CUSTOM_CLOUD_DATA}), nil
 	}
 	environs.RegisterUserImageDataSourceFunc("my func", src)
 	env := s.Open(c, s.env.Config())

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1039,7 +1039,8 @@ func (e *Environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 		Description:          "keystone catalog",
 		BaseURL:              serviceURL,
 		HostnameVerification: verify,
-		Priority:             simplestreams.SPECIFIC_CLOUD_DATA}
+		Priority:             simplestreams.SPECIFIC_CLOUD_DATA,
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Annotate(err, "simplestreams config validation failed")
 	}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1020,14 +1020,14 @@ func (e *Environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 		return *datasource, nil
 	}
 
-	client := e.client()
-	if !client.IsAuthenticated() {
-		if err := authenticateClient(client); err != nil {
+	cl := e.client()
+	if !cl.IsAuthenticated() {
+		if err := authenticateClient(cl); err != nil {
 			return nil, err
 		}
 	}
 
-	url, err := makeServiceURL(client, keystoneName, "", nil)
+	serviceURL, err := makeServiceURL(cl, keystoneName, "", nil)
 	if err != nil {
 		return nil, errors.NewNotSupported(err, fmt.Sprintf("cannot make service URL: %v", err))
 	}
@@ -1035,7 +1035,15 @@ func (e *Environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 	if !e.Config().SSLHostnameVerification() {
 		verify = utils.NoVerifySSLHostnames
 	}
-	*datasource = simplestreams.NewURLDataSource("keystone catalog", url, verify, simplestreams.SPECIFIC_CLOUD_DATA, false)
+	cfg := simplestreams.Config{
+		Description:          "keystone catalog",
+		BaseURL:              serviceURL,
+		HostnameVerification: verify,
+		Priority:             simplestreams.SPECIFIC_CLOUD_DATA}
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Annotate(err, "simplestreams config validation failed")
+	}
+	*datasource = simplestreams.NewDataSource(cfg)
 	return *datasource, nil
 }
 


### PR DESCRIPTION
## Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Backport of #11083 

Combine the DataSource constructors into one using a config to create the different types. A precursor to passing CA Certs to the clients used for Fetch() to fix but 1856860.

Add Validate() for this new simplestreams.Config.  Ideally this would be part of the constructor, however doing so would result in significant rewrite of related tests at this time.  Added a TODO for future work.

Add InvalidDataSource() and VerifyDefaultCloudDataSource() helpers for test purposes.

Some clean up of compiler warnings has been added around checking returned errors and variable names overlapping with package names.

## QA steps

```sh
juju bootstrap <openstack>
juju bootstrap localhost
juju bootstrap aws
juju generate-image
juju generate-agents
juju validate-image
juju validate-agents
```
