### PR TITLE
refactor: branch abort: update msg to reflect situation.

### DIFF
--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -509,7 +509,7 @@ func (g *Generation) Abort(userName string) error {
 		assigned := g.AssignedUnits()
 		for _, units := range assigned {
 			if len(units) > 0 {
-				return nil, errors.New("branch is in progress. Either reset values on tracking units or remove them to abort.")
+				return nil, errors.New("branch is in progress. Either reset values on tracking units and commit the branch or remove them to abort.")
 			}
 		}
 

--- a/state/modelgeneration_test.go
+++ b/state/modelgeneration_test.go
@@ -322,7 +322,7 @@ func (s *generationSuite) TestAbortFailsAssignedUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = gen.Abort(branchCommitter)
-	c.Assert(err, gc.ErrorMatches, "branch is in progress. Either reset values on tracking units or remove them to abort.")
+	c.Assert(err, gc.ErrorMatches, "branch is in progress. Either reset values on tracking units and commit the branch or remove them to abort.")
 }
 
 func (s *generationSuite) TestAbortCommittedBranch(c *gc.C) {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change
The old error message:
```
"branch is in progress. Either reset values on tracking units or remove them to abort."
```

The new proposed error message:
```
"branch is in progress. Either reset values on tracking units and commit the branch or remove them to abort."
```
- The new error message should reflect the situation below:
- Currently, the only way possible over the CLI to "kind of abort" a branch is:
   - reset the values and then `juju commit <branch>`
   - remove the tracking unit 

```
❯ juju remove-unit mediawiki/0
removing unit mediawiki/0                     

~
❯ juju abort test              
Aborting all changes in "test" and closing branch.
Active branch set to "master"
```


## QA steps

```sh
export JUJU_DEV_FEATURE_FLAGS=branches

❯ juju add-branch test
Created branch "test" and set active

~
❯ juju track test mediawiki/0   

~
❯ juju abort test               
ERROR branch is in progress. Either reset values on tracking units and commit the branch or remove them to abort.

```