### PR TITLE
back port PR 11094 Simplestreams ca cert new 2.7

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -760,7 +760,7 @@
   revision = "68a59c96c178fbbad65926e7f93db50a2cd14f33"
 
 [[projects]]
-  digest = "1:ed85b6356e8e1612c96e368bbe082173ebe3993f61adbd9f9fe1456279a18db5"
+  digest = "1:85558d1ebc168aa90832e1d4b6f3068c4b1c7d985d355bea827ce9d2b36be07a"
   name = "github.com/juju/utils"
   packages = [
     ".",
@@ -791,7 +791,7 @@
     "zip",
   ]
   pruneopts = ""
-  revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"
+  revision = "d40c2fe1064788d512a6ed0f3c4fcaf0e42515c6"
 
 [[projects]]
   digest = "1:eab278f98004677adf1d70d6cdaba1c01a446ab10dddb1cf7d83cfd1475c22cc"
@@ -1542,11 +1542,11 @@
   revision = "e057c73bd1beb18e9634151a2410c422bd2057f2"
 
 [[projects]]
-  digest = "1:64cc4822f856fd25eff368bdfc8f532c889fed9724ce184d80020efe20dae158"
+  digest = "1:941d40c0b44b5e362c762047a191ba90c439b4df492ea8a106d964155e1f3f86"
   name = "gopkg.in/juju/names.v3"
   packages = ["."]
   pruneopts = ""
-  revision = "39289f3737654a399166e9cd65c043b5b3bfed01"
+  revision = "139ecaca454cb9101eed8ea76374ddc0be8cc8e8"
 
 [[projects]]
   digest = "1:2041c73bbc755e07a90e03f149933b8ecfce5233a5afbe6b04230386a75f8fda"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -118,7 +118,7 @@
   name = "github.com/juju/testing"
 
 [[constraint]]
-  revision = "bf9cc5bdd62dabc40b7f634b39a5e2dc44d44c45"
+  revision = "d40c2fe1064788d512a6ed0f3c4fcaf0e42515c6"
   name = "github.com/juju/utils"
 
 [[constraint]]
@@ -158,7 +158,7 @@
   name = "gopkg.in/juju/environschema.v1"
 
 [[constraint]]
-  revision = "39289f3737654a399166e9cd65c043b5b3bfed01"
+  revision = "139ecaca454cb9101eed8ea76374ddc0be8cc8e8"
   name = "gopkg.in/juju/names.v3"
 
 [[constraint]]

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -74,6 +74,7 @@ type urlDataSource struct {
 	publicSigningKey     string
 	priority             int
 	requireSigned        bool
+	caCertificates       []string
 }
 
 // Config has values to be used in constructing a datasource.
@@ -98,6 +99,12 @@ type Config struct {
 
 	// RequireSigned indicates whether this datasource requires signed data.
 	RequireSigned bool
+
+	// CACertificates contains an optional list of Certificate
+	// Authority certificates to be used to validate certificates
+	// of cloud infrastructure components
+	// The contents are Base64 encoded x.509 certs.
+	CACertificates []string
 }
 
 // Validate checks that the baseURL is valid and the description is set.
@@ -125,6 +132,7 @@ func NewDataSource(cfg Config) DataSource {
 		publicSigningKey:     cfg.PublicSigningKey,
 		priority:             cfg.Priority,
 		requireSigned:        cfg.RequireSigned,
+		caCertificates:       cfg.CACertificates,
 	}
 }
 
@@ -151,7 +159,7 @@ func urlJoin(baseURL, relpath string) string {
 // Fetch is defined in simplestreams.DataSource.
 func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 	dataURL := urlJoin(h.baseURL, path)
-	client := utils.GetHTTPClient(h.hostnameVerification)
+	client := utils.GetHTTPClient(h.hostnameVerification, h.caCertificates...)
 	// dataURL can be http:// or file://
 	// MakeFileURL will only modify the URL if it's a file URL
 	dataURL = utils.MakeFileURL(dataURL)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -170,6 +170,27 @@ func (s *localServer) openstackCertificate(c *gc.C) ([]string, error) {
 	return []string{string(buf)}, nil
 }
 
+func (s *localHTTPSServerSuite) envUsingCertificate(c *gc.C) environs.Environ {
+	newattrs := make(map[string]interface{}, len(s.attrs))
+	for k, v := range s.attrs {
+		newattrs[k] = v
+	}
+	newattrs["ssl-hostname-verification"] = true
+	cfg, err := config.New(config.NoDefaults, newattrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cloudSpec := makeCloudSpec(s.cred)
+	cloudSpec.CACertificates, err = s.srv.openstackCertificate(c)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := environs.New(environs.OpenParams{
+		Cloud:  cloudSpec,
+		Config: cfg,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return env
+}
+
 // localLiveSuite runs tests from LiveTests using an Openstack service double.
 type localLiveSuite struct {
 	coretesting.BaseSuite
@@ -1883,24 +1904,8 @@ func (s *localHTTPSServerSuite) TestSSLVerify(c *gc.C) {
 	// If you don't have ssl-hostname-verification set to false, and do have
 	// a CA Certificate, then we can connect to the environment. Copy the attrs
 	// used by SetUp and force hostname verification.
-	newattrs := make(map[string]interface{}, len(s.attrs))
-	for k, v := range s.attrs {
-		newattrs[k] = v
-	}
-	newattrs["ssl-hostname-verification"] = true
-	cfg, err := config.New(config.NoDefaults, newattrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	cloudSpec := makeCloudSpec(s.cred)
-	cloudSpec.CACertificates, err = s.srv.openstackCertificate(c)
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := environs.New(environs.OpenParams{
-		Cloud:  cloudSpec,
-		Config: cfg,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = env.AllRunningInstances(s.callCtx)
+	env := s.envUsingCertificate(c)
+	_, err := env.AllRunningInstances(s.callCtx)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -1982,27 +1987,77 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	}
 
 	// Read from the Config entry's image-metadata-url
-	contentReader, url, err := mappedSources["image-metadata-url"].Fetch(custom)
+	contentReader, imageURL, err := mappedSources["image-metadata-url"].Fetch(custom)
 	c.Assert(err, jc.ErrorIsNil)
-	defer contentReader.Close()
+	defer func() { _ = contentReader.Close() }()
 	content, err := ioutil.ReadAll(contentReader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, custom)
-	c.Check(url[:8], gc.Equals, "https://")
+	c.Check(imageURL[:8], gc.Equals, "https://")
 
 	// Check the entry we got from keystone
-	contentReader, url, err = mappedSources["keystone catalog"].Fetch(metadata)
+	contentReader, imageURL, err = mappedSources["keystone catalog"].Fetch(metadata)
 	c.Assert(err, jc.ErrorIsNil)
-	defer contentReader.Close()
+	defer func() { _ = contentReader.Close() }()
 	content, err = ioutil.ReadAll(contentReader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, metadata)
-	c.Check(url[:8], gc.Equals, "https://")
+	c.Check(imageURL[:8], gc.Equals, "https://")
 	// Verify that we are pointing at exactly where metadataStorage thinks we are
 	metaURL, err := metadataStorage.URL(metadata)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(url, gc.Equals, metaURL)
+	c.Check(imageURL, gc.Equals, metaURL)
+}
 
+func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSourcesWithCertificate(c *gc.C) {
+	env := s.envUsingCertificate(c)
+
+	// Setup a custom URL for image metadata
+	customStorage := openstack.CreateCustomStorage(env, "custom-metadata")
+	customURL, err := customStorage.URL("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(customURL[:8], gc.Equals, "https://")
+
+	envConfig, err := env.Config().Apply(
+		map[string]interface{}{"image-metadata-url": customURL},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.SetConfig(envConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	sources, err := environs.ImageMetadataSources(env)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sources, gc.HasLen, 4)
+
+	// Make sure there is something to download from each location
+	metadata := "metadata-content"
+	metadataStorage := openstack.ImageMetadataStorage(env)
+	err = metadataStorage.Put(metadata, bytes.NewBufferString(metadata), int64(len(metadata)))
+	c.Assert(err, jc.ErrorIsNil)
+
+	custom := "custom-content"
+	err = customStorage.Put(custom, bytes.NewBufferString(custom), int64(len(custom)))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Produce map of data sources keyed on description
+	mappedSources := make(map[string]simplestreams.DataSource, len(sources))
+	for i, s := range sources {
+		c.Logf("datasource %d: %+v", i, s)
+		mappedSources[s.Description()] = s
+	}
+
+	// Check the entry we got from keystone
+	contentReader, imageURL, err := mappedSources["keystone catalog"].Fetch(metadata)
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() { _ = contentReader.Close() }()
+	content, err := ioutil.ReadAll(contentReader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(content), gc.Equals, metadata)
+	c.Check(imageURL[:8], gc.Equals, "https://")
+
+	// Verify that we are pointing at exactly where metadataStorage thinks we are
+	metaURL, err := metadataStorage.URL(metadata)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(imageURL, gc.Equals, metaURL)
 }
 
 func (s *localHTTPSServerSuite) TestFetchFromToolsMetadataSources(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1040,6 +1040,7 @@ func (e *Environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 		BaseURL:              serviceURL,
 		HostnameVerification: verify,
 		Priority:             simplestreams.SPECIFIC_CLOUD_DATA,
+		CACertificates:       e.cloudUnlocked.CACertificates,
 	}
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Annotate(err, "simplestreams config validation failed")
@@ -1076,8 +1077,6 @@ func (e *Environ) DistributeInstances(
 	}
 	return valid, nil
 }
-
-var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
 // MaintainInstance is specified in the InstanceBroker interface.
 func (*Environ) MaintainInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) error {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Backport #11094 

If user credentials have CA Certificate(s) for an OpenStack cloud, use them in creating the http client for downloading simple stream data.

## QA steps

Bootstrap a few non OpenStack clouds to ensure their behavior hasn't been broken.
```sh
juju bootstrap aws
juju bootstrap lxd
juju bootstrap openstack.    // without a certificate
```

We'll also need qa from the bug filer, as the config is not normally setup within the juju team.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1856860
