### PR TITLE
[dev] allow leader unit to read the databag for its application

### DIFF
--- a/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -24,14 +24,17 @@ type Relation struct {
 	Units map[string]Settings
 	// UnitName is data for jujuc.ContextRelation.
 	UnitName string
-	// ApplicationSettings is data for jujuc.ContextRelation
-	ApplicationSettings Settings
+	// RemoteApplicationSettings is data for jujuc.ContextRelation
+	RemoteApplicationSettings Settings
+	// LocalApplicationSettings is data for jujuc.ContextRelation
+	LocalApplicationSettings Settings
 }
 
 // Reset clears the Relation's settings.
 func (r *Relation) Reset() {
 	r.Units = nil
-	r.ApplicationSettings = nil
+	r.RemoteApplicationSettings = nil
+	r.LocalApplicationSettings = nil
 }
 
 // SetRelated adds the relation settings for the unit.
@@ -42,8 +45,14 @@ func (r *Relation) SetRelated(name string, settings Settings) {
 	r.Units[name] = settings
 }
 
-func (r *Relation) SetRelatedApplicationSettings(settings Settings) {
-	r.ApplicationSettings = settings
+// SetRemoteApplicationSettings sets the settings for the remote application.
+func (r *Relation) SetRemoteApplicationSettings(settings Settings) {
+	r.RemoteApplicationSettings = settings
+}
+
+// SetLocalApplicationSettings sets the settings for the local application.
+func (r *Relation) SetLocalApplicationSettings(settings Settings) {
+	r.LocalApplicationSettings = settings
 }
 
 // ContextRelation is a test double for jujuc.ContextRelation.
@@ -97,7 +106,7 @@ func (r *ContextRelation) ApplicationSettings() (jujuc.Settings, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return r.info.ApplicationSettings, nil
+	return r.info.LocalApplicationSettings, nil
 }
 
 // UnitNames implements jujuc.ContextRelation.
@@ -134,7 +143,7 @@ func (r *ContextRelation) ReadApplicationSettings(name string) (params.Settings,
 		return nil, errors.Trace(err)
 	}
 
-	return r.info.ApplicationSettings.Map(), nil
+	return r.info.RemoteApplicationSettings.Map(), nil
 }
 
 // Suspended implements jujuc.ContextRelation.

--- a/worker/uniter/runner/jujuc/relation-get.go
+++ b/worker/uniter/runner/jujuc/relation-get.go
@@ -179,7 +179,23 @@ func (c *RelationGetCommand) Run(ctx *cmd.Context) error {
 	} else {
 		var err error
 		if c.Application {
-			settings, err = r.ReadApplicationSettings(c.UnitOrAppName)
+			// Check if the unit tries to access the remote app's
+			// databag or it tries to access the databag for its
+			// own application.
+			localAppName, pErr := names.UnitApplication(c.ctx.UnitName())
+			if pErr != nil {
+				return pErr
+			}
+
+			if c.UnitOrAppName == localAppName {
+				appSettings, readErr := r.ApplicationSettings()
+				if readErr != nil {
+					return readErr
+				}
+				settings = appSettings.Map()
+			} else {
+				settings, err = r.ReadApplicationSettings(c.UnitOrAppName)
+			}
 		} else {
 			settings, err = r.ReadSettings(c.UnitOrAppName)
 		}

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -165,6 +165,30 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 	}
 }
 
+func (s *RelationGetSuite) TestRelationGetAppSettings(c *gc.C) {
+	hctx, rinfo := s.newHookContext(1, "m/0", "mysql")
+	rinfo.rels[1].SetLocalApplicationSettings(jujuctesting.Settings{"local": "true"})
+	rinfo.rels[1].SetRemoteApplicationSettings(jujuctesting.Settings{"remote": "true"})
+
+	// As u/0 (leader) read the application databag for u
+	com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--app", "-", "u"})
+	c.Check(code, gc.Equals, 0)
+	c.Check(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Check(bufferString(ctx.Stdout), gc.Matches, `local: "true"\s*`)
+
+	// As u/0 (leader) read the application databag for mysql
+	com, err = jujuc.NewCommand(hctx, cmdString("relation-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx = cmdtesting.Context(c)
+	code = cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--app", "-", "mysql"})
+	c.Check(code, gc.Equals, 0)
+	c.Check(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Check(bufferString(ctx.Stdout), gc.Matches, `remote: "true"\s*`)
+}
+
 var relationGetFormatTests = []struct {
 	summary string
 	relid   int


### PR DESCRIPTION
## Description of change

This PR adds a bit of extra logic to the `relation-get` tool implementation so that leader units can introspect the contents of their application databag.

## QA steps

```sh
$ juju bootstrap lxd --no-gui
$ juju deploy wordpress
$ juju deploy mysql

# In a second terminal  run this command
$ juju debug-hooks mysql/0 db-relation-joined

# Go back to another terminal and run:
$ juju relate wordpress mysql

# Wait for the debug-hook to trigger and in the tmux session run the following commands:
#-----------------------
$ ./hooks/db-relation-joined
$ is-leader
True
$ relation-set --app answer-to-the-ultimate-question=42
$ relation-get --app - mysql        # <- this command would fail before this fix
answer-to-the-ultimate-question: "42"
$ relation-get --app - wordpress
{}
$ env | grep JUJU_RELATION_ID
JUJU_RELATION_ID=db:2          # <- note the relation ID for the next step
$ exit
$ exit  # second exit exits 'juju debug-hooks'
#-----------------------

# Verify that the mutated application data was persisted correctly
# NOTE: replace "db:2" with the relation ID from the above step!
$ juju run --unit mysql/0 'relation-get --app -r db:2 - mysql'
answer-to-the-ultimate-question: "42"
$ juju run --unit mysql/0 'relation-get --app -r db:2 - wordpress'
{}
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1854348