### PR TITLE
Terminate instance network ports

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1331,7 +1331,7 @@
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:6edbf680920262839411d84416e427eecf8df7b453f0aeaadae0520fcb763bfe"
+  digest = "1:605d4b873b46c5cdb3460706be5b969445b9f69aea006a0cbe2bb44cf493f3de"
   name = "gopkg.in/goose.v2"
   packages = [
     ".",
@@ -1357,7 +1357,7 @@
     "testservices/swiftservice",
   ]
   pruneopts = ""
-  revision = "871ee3cbcbdb40c7a23ae20d01cbde1ae82b3e8d"
+  revision = "cc624cc0ae77ab888b42b3084ad915c9e5e12bbc"
 
 [[projects]]
   digest = "1:445becf3878aa9bd50dfa972bd65f974ed2468c09350ab9ce28b1e4adce464df"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -472,7 +472,7 @@
 
 [[constraint]]
   name = "gopkg.in/goose.v2"
-  revision = "871ee3cbcbdb40c7a23ae20d01cbde1ae82b3e8d"
+  revision = "cc624cc0ae77ab888b42b3084ad915c9e5e12bbc"
 
 [[override]]
   name = "gopkg.in/httprequest.v1"

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2122,8 +2122,8 @@ func (e *Environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 			logger.Debugf("error attempting to remove ports associated with instance %q: %v", id, err)
 			// Unfortunately there is nothing we can do here, there could be
 			// orphan ports left.
-			// We don't want to block terminating instances so the only option
-			// available to us it to move on to the next instance.
+			// We don't want to block terminating instances, so the only option
+			// available to us, is to move on to the next instance.
 			continue
 		}
 	}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1308,7 +1308,7 @@ func (e *Environ) startInstance(
 		return server, err
 	}
 
-	var opts = nova.RunServerOpts{
+	opts := nova.RunServerOpts{
 		Name:               machineName,
 		FlavorId:           spec.InstanceType.Id,
 		UserData:           userData,
@@ -2115,8 +2115,53 @@ func (e *Environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 				break
 			}
 		}
+
+		// Attempt to destroy the ports that could have been created when using
+		// spaces.
+		if err := e.terminateInstanceNetworkPorts(id); err != nil {
+			logger.Debugf("error attempting to remove ports associated with instance %q: %v", id, err)
+			// Unfortunately there is nothing we can do here, there could be
+			// orphan ports left.
+			// We don't want to block terminating instances so the only option
+			// available to us it to move on to the next instance.
+			continue
+		}
 	}
 	return firstErr
+}
+
+func (e *Environ) terminateInstanceNetworkPorts(id instance.Id) error {
+	filter := neutron.NewFilter()
+	filter.Set("device_id", string(id))
+
+	client := e.neutron()
+	instancePorts, err := client.ListPortsV2(filter)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Unfortunately we're unable to bulk delete these ports, so we have to go
+	// over them, one by one.
+	var errs []error
+	for _, port := range instancePorts {
+		// Ensure we have the ports we want.
+		if port.DeviceId != string(id) {
+			continue
+		}
+
+		// Delete a port. If we encounter an error add it to the list of errors
+		// and continue until we've exhausted all the ports to delete.
+		if err := client.DeletePortV2(port.Id); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Errorf("error terminating network ports: %v", errs)
+	}
+
+	return nil
 }
 
 // MetadataLookupParams returns parameters which are used to query simplestreams metadata.


### PR DESCRIPTION

### Checklist

 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

When creating an openstack instance with spaces, we have to create a
series of ports so that we can land that instance in the right subnet.

To prevent orphan network ports in the operators openstack setup, when
terminating the instance, we go through and ask for all the ports
associated with openstack via the device_id and attempt to delete them
if required.

The code ensures that we don't block when terminating the ports, but
instead, report out to the operator via Debug messages that a failure
occurred.

In an ideal world, we should probably ensure that we report every port id
failure and get them to do it manually, but this could end up being
potentially a lot of information dumped to the operator.


## QA steps

Follow [documentation](https://discourse.jujucharms.com/t/openstack-multi-space-support/2672) for creating a controller in microstack.

```sh
juju bootstrap --bootstrap-series=$OS_SERIES --metadata-source=~/simplestreams \
--model-default network=test --model-default external-network=external \
--model-default use-floating-ip=true microstack test
juju add-space space-1 192.168.222.0/24
juju add-machine --constraints "spaces=space-1"
juju destroy-controller test
```

Check with microstack to ensure ports are removed.

