### PR TITLE
[dev] introduce remove hook

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1389,7 +1389,7 @@
   revision = "51fa6e26128d74e445c72d3a91af555151cc3654"
 
 [[projects]]
-  digest = "1:60a5ea100a756df3cbfbb3e03109b4efb480d0aaf9b717a40c41f970bd26c6dc"
+  digest = "1:01b347a40b9fd0f0cb6e76b71a332139129edda9025dadc96ff89546c809d100"
   name = "gopkg.in/juju/charm.v6"
   packages = [
     ".",
@@ -1397,7 +1397,7 @@
     "resource",
   ]
   pruneopts = ""
-  revision = "50b290b88b40f6bbe10576723d0b57e22f012628"
+  revision = "5217f4ff9d6d681861601ad653e151ffb2f05b90"
 
 [[projects]]
   digest = "1:f432835a8eb23aa21056c9ac8f38092b4de9d6f06671d588161d6c301dfaee68"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -143,7 +143,7 @@
 
 [[constraint]]
   name = "gopkg.in/juju/charm.v6"
-  revision = "50b290b88b40f6bbe10576723d0b57e22f012628"
+  revision = "5217f4ff9d6d681861601ad653e151ffb2f05b90"
 
 [[constraint]]
   revision = "4a4d9c6d92fd547ab98053fde7874b3c51e4f0f1"

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -121,7 +121,7 @@ var debugHooksTests = []struct {
 }, {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
-	error: `unit "mysql/0" contains neither hook nor action "invalid-hook", valid actions are [anotherfakeaction fakeaction] and valid hooks are [collect-metrics config-changed install juju-info-relation-broken juju-info-relation-changed juju-info-relation-departed juju-info-relation-joined leader-deposed leader-elected leader-settings-changed meter-status-changed metrics-client-relation-broken metrics-client-relation-changed metrics-client-relation-departed metrics-client-relation-joined post-series-upgrade pre-series-upgrade server-admin-relation-broken server-admin-relation-changed server-admin-relation-departed server-admin-relation-joined server-relation-broken server-relation-changed server-relation-departed server-relation-joined start stop update-status upgrade-charm]`,
+	error: `unit "mysql/0" contains neither hook nor action "invalid-hook", valid actions are [anotherfakeaction fakeaction] and valid hooks are [collect-metrics config-changed install juju-info-relation-broken juju-info-relation-changed juju-info-relation-departed juju-info-relation-joined leader-deposed leader-elected leader-settings-changed meter-status-changed metrics-client-relation-broken metrics-client-relation-changed metrics-client-relation-departed metrics-client-relation-joined post-series-upgrade pre-series-upgrade remove server-admin-relation-broken server-admin-relation-changed server-admin-relation-departed server-admin-relation-joined server-relation-broken server-relation-changed server-relation-departed server-relation-joined start stop update-status upgrade-charm]`,
 }, {
 	info:  `no args at all`,
 	args:  nil,

--- a/testcharms/charm-repo/bionic/dummy/hooks/remove
+++ b/testcharms/charm-repo/bionic/dummy/hooks/remove
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Removing service files"

--- a/testcharms/charm-repo/bionic/dummy/hooks/stop
+++ b/testcharms/charm-repo/bionic/dummy/hooks/stop
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Stopping service"

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -63,7 +63,7 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook has a remote unit but no application", hi.Kind)
 		}
 		return nil
-	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken,
+	case hooks.Install, hooks.Remove, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken,
 		hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus, hooks.PreSeriesUpgrade, hooks.PostSeriesUpgrade:
 		return nil
 	case hooks.Action:

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -52,6 +52,7 @@ var validateTests = []struct {
 	{hook.Info{Kind: hooks.Action}, "hooks.Kind Action is deprecated"},
 	{hook.Info{Kind: hooks.UpgradeCharm}, ""},
 	{hook.Info{Kind: hooks.Stop}, ""},
+	{hook.Info{Kind: hooks.Remove}, ""},
 	{hook.Info{Kind: hooks.RelationJoined, RemoteUnit: "x/0", RemoteApplication: "x"}, ""},
 	{hook.Info{Kind: hooks.RelationChanged, RemoteUnit: "x/0", RemoteApplication: "x"}, ""},
 	{hook.Info{Kind: hooks.RelationChanged, RemoteApplication: "x"}, ""},

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -170,6 +170,11 @@ func (rh *runHook) beforeHook(state State) error {
 	case hooks.Stop:
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
 			Status: string(status.Maintenance),
+			Info:   "stopping charm software",
+		})
+	case hooks.Remove:
+		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
+			Status: string(status.Maintenance),
 			Info:   "cleaning up prior to charm deletion",
 		})
 	case hooks.PreSeriesUpgrade:
@@ -199,6 +204,10 @@ func (rh *runHook) afterHook(state State) (_ bool, err error) {
 	hasRunStatusSet := ctx.HasExecutionSetUnitStatus() || state.StatusSet
 	switch rh.info.Kind {
 	case hooks.Stop:
+		err = ctx.SetUnitStatus(jujuc.StatusInfo{
+			Status: string(status.Maintenance),
+		})
+	case hooks.Remove:
 		// Charm is no longer of this world.
 		err = ctx.SetUnitStatus(jujuc.StatusInfo{
 			Status: string(status.Terminated),
@@ -285,6 +294,8 @@ func (rh *runHook) Commit(state State) (*State, error) {
 		newState.Started = true
 	case hooks.Stop:
 		newState.Stopped = true
+	case hooks.Remove:
+		newState.Removed = true
 	}
 
 	return newState, nil

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -407,6 +407,9 @@ func testBeforeHookStatus(c *gc.C, kind hooks.Kind, status *jujuc.StatusInfo) {
 		c.Assert(status.Info, gc.Equals, "installing charm software")
 	case hooks.Stop:
 		c.Assert(status.Status, gc.Equals, "maintenance")
+		c.Assert(status.Info, gc.Equals, "stopping charm software")
+	case hooks.Remove:
+		c.Assert(status.Status, gc.Equals, "maintenance")
 		c.Assert(status.Info, gc.Equals, "cleaning up prior to charm deletion")
 	default:
 		c.Assert(status.Status, gc.Equals, "")
@@ -425,6 +428,8 @@ func testAfterHookStatus(c *gc.C, kind hooks.Kind, status *jujuc.StatusInfo, sta
 			c.Assert(status.Status, gc.Equals, "unknown")
 		}
 	case hooks.Stop:
+		c.Assert(status.Status, gc.Equals, "maintenance")
+	case hooks.Remove:
 		c.Assert(status.Status, gc.Equals, "terminated")
 	default:
 		c.Assert(status.Status, gc.Equals, "")

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -68,6 +68,9 @@ type State struct {
 	// Installed indicates whether the install hook has run.
 	Installed bool `yaml:"installed"`
 
+	// Removed indicates whether the remove hook has run.
+	Removed bool `yaml:"removed"`
+
 	// StatusSet indicates whether the charm being deployed has ever invoked
 	// the status-set hook tool.
 	StatusSet bool `yaml:"status-set"`

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -61,7 +61,7 @@ func (s *uniterResolver) NextOp(
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
 ) (operation.Operation, error) {
-	if remoteState.Life == life.Dead || localState.Stopped {
+	if remoteState.Life == life.Dead || localState.Removed {
 		return nil, resolver.ErrTerminate
 	}
 
@@ -276,8 +276,10 @@ func (s *uniterResolver) nextOp(
 		// TODO(axw) move logic for cascading destruction of
 		//           subordinates, relation units and storage
 		//           attachments into state, via cleanups.
-		if localState.Started {
+		if localState.Started && !localState.Stopped {
 			return opFactory.NewRunHook(hook.Info{Kind: hooks.Stop})
+		} else if localState.Installed && !localState.Removed {
+			return opFactory.NewRunHook(hook.Info{Kind: hooks.Remove})
 		}
 		fallthrough
 	case life.Dead:


### PR DESCRIPTION
## Description of change

This PR introduces a new hook type called `remove` which runs immediately after the `stop` hook.

## QA steps

```console
$ juju bootstrap lxd test
$ juju deploy ./testcharms/charm-repo/bionic/dummy

# In another terminal
$ juju debug-log

# Once the dummy charm is alive run:
$ juju remove-application dummy

# Check the output log for:
unit-dummy-0: 16:35:00 DEBUG unit.dummy/0.remove Removing service files
unit-dummy-0: 16:35:00 INFO juju.worker.uniter.operation ran "remove" hook
```

## Documentation changes

We need to add a reference to the new hook type to our docs.