### PR TITLE
Add show-operation CLI and facade

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -104,6 +104,17 @@
                         }
                     }
                 },
+                "ListOperations": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/OperationQueryArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/OperationResults"
+                        }
+                    }
+                },
                 "ListPending": {
                     "type": "object",
                     "properties": {
@@ -130,7 +141,7 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/OperationQueryArgs"
+                            "$ref": "#/definitions/Entities"
                         },
                         "Result": {
                             "$ref": "#/definitions/OperationResults"
@@ -570,6 +581,9 @@
                         "enqueued": {
                             "type": "string",
                             "format": "date-time"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
                         },
                         "operation": {
                             "type": "string"

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -150,6 +150,7 @@ type OperationResult struct {
 	Completed    time.Time      `json:"completed,omitempty"`
 	Status       string         `json:"status,omitempty"`
 	Actions      []ActionResult `json:"actions,omitempty"`
+	Error        *Error         `json:"error,omitempty"`
 }
 
 // ActionExecutionResults holds a slice of ActionExecutionResult for a

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -45,8 +45,11 @@ type APIClient interface {
 	// the ActionReceiver if necessary.
 	Actions(params.Entities) (params.ActionResults, error)
 
-	// Operations fetches the called operations for specified apps/units.
-	Operations(params.OperationQueryArgs) (params.OperationResults, error)
+	// ListOperations fetches the operation summaries for specified apps/units.
+	ListOperations(params.OperationQueryArgs) (params.OperationResults, error)
+
+	// Operation fetches the operation with the specified id.
+	Operation(id string) (params.OperationResult, error)
 
 	// FindActionTagsByPrefix takes a list of string prefixes and finds
 	// corresponding ActionTags that match that prefix.

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -23,6 +23,10 @@ type ShowOutputCommand struct {
 	*showOutputCommand
 }
 
+type ShowOperationCommand struct {
+	*showOperationCommand
+}
+
 type StatusCommand struct {
 	*statusCommand
 }
@@ -118,6 +122,12 @@ func NewShowOutputCommandForTest(store jujuclient.ClientStore, logMessage func(*
 	}
 	c.SetClientStore(store)
 	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ShowOutputCommand{c}
+}
+
+func NewShowOperationCommandForTest(store jujuclient.ClientStore) (cmd.Command, *ShowOperationCommand) {
+	c := &showOperationCommand{}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c, modelcmd.WrapSkipDefaultModel), &ShowOperationCommand{c}
 }
 
 func NewStatusCommandForTest(store jujuclient.ClientStore) (cmd.Command, *StatusCommand) {

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -333,12 +333,12 @@ func formatOperationResult(operation params.OperationResult, utc bool) operation
 			taskInfo.Host = ut.Id()
 		}
 		if len(task.Log) > 0 {
-			var logs []string
-			for _, msg := range task.Log {
-				logs = append(logs, formatLogMessage(actions.ActionMessage{
+			logs := make([]string, len(task.Log))
+			for i, msg := range task.Log {
+				logs[i] = formatLogMessage(actions.ActionMessage{
 					Timestamp: msg.Timestamp,
 					Message:   msg.Message,
-				}, false, utc, false))
+				}, false, utc, false)
 			}
 			taskInfo.Log = logs
 		}

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -306,7 +306,7 @@ func (c *runCommand) waitForTasks(ctx *cmd.Context, tasks []enqueuedAction, info
 		if err != nil {
 			return errors.Trace(err)
 		}
-		d := FormatActionResult(actionResult, c.utc, false)
+		d := FormatActionResult(tag.Id(), actionResult, c.utc, false)
 		d["id"] = tag.Id() // Action ID is required in case we timed out.
 		info[result.receiver] = d
 	}
@@ -467,7 +467,11 @@ func printPlainOutput(writer io.Writer, value interface{}) error {
 				}
 			}
 		} else {
-			actionOutput[k] = fmt.Sprintf("Operation %v complete\n", resultMetadata["id"])
+			status, ok := resultMetadata["status"].(string)
+			if !ok {
+				status = "has unknown status"
+			}
+			actionOutput[k] = fmt.Sprintf("Task %v %v\n", resultMetadata["id"], status)
 		}
 		actionInfo[k] = map[string]interface{}{
 			"id":     resultMetadata["id"],

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -278,7 +278,7 @@ func (c *runActionCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		d := FormatActionResult(result, false, true)
+		d := FormatActionResult(tag.Id(), result, false, true)
 		d["id"] = tag.Id() // Action ID is required in case we timed out.
 		out[result.Action.Receiver] = d
 	}

--- a/cmd/juju/action/showoperation.go
+++ b/cmd/juju/action/showoperation.go
@@ -1,0 +1,208 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+func NewShowOperationCommand() cmd.Command {
+	return modelcmd.Wrap(&showOperationCommand{})
+}
+
+// showOperationCommand fetches the results of an operation by ID.
+type showOperationCommand struct {
+	ActionCommandBase
+	out         cmd.Output
+	requestedId string
+	wait        string
+	watch       bool
+	utc         bool
+}
+
+const showOperationDoc = `
+Show the results returned by an operation with the given ID.  
+To block until the result is known completed or failed, use
+the --wait option with a duration, as in --wait 5s or --wait 1h.
+If units are left off, seconds are assumed.
+Use --watch to wait indefinitely.  
+
+The default behavior without --wait or --watch is to immediately check and return;
+if the results are "pending" then only the available information will be
+displayed.  This is also the behavior when any negative time is given.
+
+Examples:
+
+    juju show-operation 1
+    juju show-operation 1 --wait=2m
+    juju show-operation 1 --watch
+
+See also:
+    run
+    list-operations
+    show-task
+`
+
+// SetFlags implements Command.
+func (c *showOperationCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ActionCommandBase.SetFlags(f)
+	defaultFormatter := "yaml"
+	c.out.AddFlags(f, defaultFormatter, map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+
+	f.StringVar(&c.wait, "wait", "-1s", "Wait for results")
+	f.BoolVar(&c.watch, "watch", false, "Wait indefinitely for results")
+	f.BoolVar(&c.utc, "utc", false, "Show times in UTC")
+}
+
+// Info implements Command.
+func (c *showOperationCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "show-operation",
+		Args:    "<operation ID>",
+		Purpose: "Show results of an operation by ID.",
+		Doc:     showOperationDoc,
+	})
+}
+
+// Init implements Command.
+func (c *showOperationCommand) Init(args []string) error {
+	if c.watch {
+		if c.wait != "-1s" {
+			return errors.New("specify either --watch or --wait but not both")
+		}
+		// If we are watching the wait is 0 (indefinite).
+		c.wait = "0s"
+	}
+	switch len(args) {
+	case 0:
+		return errors.New("no operation ID specified")
+	case 1:
+		c.requestedId = args[0]
+		return nil
+	default:
+		return cmd.CheckEmpty(args[1:])
+	}
+}
+
+// Run implements Command.
+func (c *showOperationCommand) Run(ctx *cmd.Context) error {
+	// Check whether units were left off our time string.
+	r := regexp.MustCompile("[a-zA-Z]")
+	matches := r.FindStringSubmatch(c.wait[len(c.wait)-1:])
+	// If any match, we have units.  Otherwise, we don't; assume seconds.
+	if len(matches) == 0 {
+		c.wait = c.wait + "s"
+	}
+
+	waitDur, err := time.ParseDuration(c.wait)
+	if err != nil {
+		return err
+	}
+
+	api, err := c.NewActionAPIClient()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	wait := time.NewTimer(0 * time.Second)
+
+	switch {
+	case waitDur.Nanoseconds() < 0:
+		// Negative duration signals immediate return.  All is well.
+	case waitDur.Nanoseconds() == 0:
+		// Zero duration signals indefinite wait.  Discard the tick.
+		wait = time.NewTimer(0 * time.Second)
+		_ = <-wait.C
+	default:
+		// Otherwise, start an ordinary timer.
+		wait = time.NewTimer(waitDur)
+	}
+
+	var result params.OperationResult
+	shouldWatch := waitDur.Nanoseconds() >= 0
+	if shouldWatch {
+		result, err = getOperationResult(api, c.requestedId, wait)
+	} else {
+		result, err = fetchOperationResult(api, c.requestedId)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	formatted := formatOperationResult(result, c.utc)
+	return c.out.Write(ctx, formatted)
+}
+
+// fetchOperationResult queries the given API for the given operation ID.
+func fetchOperationResult(api APIClient, requestedId string) (params.OperationResult, error) {
+	result, err := api.Operation(requestedId)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// getOperationResult tries to repeatedly fetch an operation until it is
+// in a completed state and then it returns it.
+// It waits for a maximum of "wait" before returning with the latest operation status.
+func getOperationResult(api APIClient, requestedId string, wait *time.Timer) (params.OperationResult, error) {
+
+	// tick every two seconds, to delay the loop timer.
+	// TODO(fwereade): 2016-03-17 lp:1558657
+	tick := time.NewTimer(2 * time.Second)
+
+	return operationTimerLoop(api, requestedId, wait, tick)
+}
+
+// operationTimerLoop loops indefinitely to query the given API, until "wait" times
+// out, using the "tick" timer to delay the API queries.  It writes the
+// result to the given output.
+func operationTimerLoop(api APIClient, requestedId string, wait, tick *time.Timer) (params.OperationResult, error) {
+	var (
+		result params.OperationResult
+		err    error
+	)
+
+	// Loop over results until we get "failed", "completed", or "cancelled.  Wait for
+	// timer, and reset it each time.
+	for {
+		result, err = fetchOperationResult(api, requestedId)
+		if err != nil {
+			return result, err
+		}
+
+		// Whether or not we're waiting for a result, if a completed
+		// result arrives, we're done.
+		switch result.Status {
+		case params.ActionRunning, params.ActionPending:
+		default:
+			return result, nil
+		}
+
+		// Block until a tick happens, or the timeout arrives.
+		select {
+		case _ = <-wait.C:
+			switch result.Status {
+			case params.ActionRunning, params.ActionPending:
+				return result, errors.NewTimeout(err, "timeout reached")
+			default:
+				return result, nil
+			}
+		case _ = <-tick.C:
+			tick.Reset(2 * time.Second)
+		}
+	}
+}

--- a/cmd/juju/action/showoperation.go
+++ b/cmd/juju/action/showoperation.go
@@ -4,12 +4,12 @@
 package action
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -23,8 +23,8 @@ func NewShowOperationCommand() cmd.Command {
 type showOperationCommand struct {
 	ActionCommandBase
 	out         cmd.Output
-	requestedId string
-	wait        string
+	requestedID string
+	wait        time.Duration
 	watch       bool
 	utc         bool
 }
@@ -33,7 +33,6 @@ const showOperationDoc = `
 Show the results returned by an operation with the given ID.  
 To block until the result is known completed or failed, use
 the --wait option with a duration, as in --wait 5s or --wait 1h.
-If units are left off, seconds are assumed.
 Use --watch to wait indefinitely.  
 
 The default behavior without --wait or --watch is to immediately check and return;
@@ -52,6 +51,8 @@ See also:
     show-task
 `
 
+const defaultOperationWait = -1 * time.Second
+
 // SetFlags implements Command.
 func (c *showOperationCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ActionCommandBase.SetFlags(f)
@@ -61,7 +62,7 @@ func (c *showOperationCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json": cmd.FormatJson,
 	})
 
-	f.StringVar(&c.wait, "wait", "-1s", "Wait for results")
+	f.DurationVar(&c.wait, "wait", defaultOperationWait, "Wait for results")
 	f.BoolVar(&c.watch, "watch", false, "Wait indefinitely for results")
 	f.BoolVar(&c.utc, "utc", false, "Show times in UTC")
 }
@@ -79,17 +80,17 @@ func (c *showOperationCommand) Info() *cmd.Info {
 // Init implements Command.
 func (c *showOperationCommand) Init(args []string) error {
 	if c.watch {
-		if c.wait != "-1s" {
+		if c.wait != defaultOperationWait {
 			return errors.New("specify either --watch or --wait but not both")
 		}
 		// If we are watching the wait is 0 (indefinite).
-		c.wait = "0s"
+		c.wait = 0 * time.Second
 	}
 	switch len(args) {
 	case 0:
 		return errors.New("no operation ID specified")
 	case 1:
-		c.requestedId = args[0]
+		c.requestedID = args[0]
 		return nil
 	default:
 		return cmd.CheckEmpty(args[1:])
@@ -98,45 +99,24 @@ func (c *showOperationCommand) Init(args []string) error {
 
 // Run implements Command.
 func (c *showOperationCommand) Run(ctx *cmd.Context) error {
-	// Check whether units were left off our time string.
-	r := regexp.MustCompile("[a-zA-Z]")
-	matches := r.FindStringSubmatch(c.wait[len(c.wait)-1:])
-	// If any match, we have units.  Otherwise, we don't; assume seconds.
-	if len(matches) == 0 {
-		c.wait = c.wait + "s"
-	}
-
-	waitDur, err := time.ParseDuration(c.wait)
-	if err != nil {
-		return err
-	}
-
 	api, err := c.NewActionAPIClient()
 	if err != nil {
 		return err
 	}
 	defer api.Close()
 
-	wait := time.NewTimer(0 * time.Second)
-
-	switch {
-	case waitDur.Nanoseconds() < 0:
-		// Negative duration signals immediate return.  All is well.
-	case waitDur.Nanoseconds() == 0:
+	wait := time.NewTimer(c.wait)
+	if c.wait.Nanoseconds() == 0 {
 		// Zero duration signals indefinite wait.  Discard the tick.
-		wait = time.NewTimer(0 * time.Second)
 		_ = <-wait.C
-	default:
-		// Otherwise, start an ordinary timer.
-		wait = time.NewTimer(waitDur)
 	}
 
 	var result params.OperationResult
-	shouldWatch := waitDur.Nanoseconds() >= 0
+	shouldWatch := c.wait.Nanoseconds() >= 0
 	if shouldWatch {
-		result, err = getOperationResult(api, c.requestedId, wait)
+		result, err = getOperationResult(api, c.requestedID, wait)
 	} else {
-		result, err = fetchOperationResult(api, c.requestedId)
+		result, err = fetchOperationResult(api, c.requestedID)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/action/showoperation_test.go
+++ b/cmd/juju/action/showoperation_test.go
@@ -79,7 +79,7 @@ func (s *ShowOperationSuite) TestRun(c *gc.C) {
 	}{{
 		should:         "handle wait-time formatting errors",
 		withClientWait: "not-a-duration-at-all",
-		expectedErr:    "time: invalid duration not-a-duration-at-all",
+		expectedErr:    `invalid value "not-a-duration-at-all" for option --wait.*`,
 	}, {
 		should:            "timeout if result never comes",
 		withClientWait:    "2s",

--- a/cmd/juju/action/showoperation_test.go
+++ b/cmd/juju/action/showoperation_test.go
@@ -1,0 +1,377 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package action_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/juju/cmd/cmdtesting"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/action"
+)
+
+type ShowOperationSuite struct {
+	BaseActionSuite
+}
+
+var _ = gc.Suite(&ShowOperationSuite{})
+
+func (s *ShowOperationSuite) SetUpTest(c *gc.C) {
+	s.BaseActionSuite.SetUpTest(c)
+}
+
+func (s *ShowOperationSuite) TestInit(c *gc.C) {
+	tests := []struct {
+		should      string
+		args        []string
+		expectError string
+	}{{
+		should:      "fail with missing arg",
+		args:        []string{},
+		expectError: "no operation ID specified",
+	}, {
+		should:      "fail with multiple args",
+		args:        []string{"12345", "54321"},
+		expectError: `unrecognized args: \["54321"\]`,
+	}, {
+		should:      "fail with both wait and watch",
+		args:        []string{"--wait", "0s", "--watch"},
+		expectError: `specify either --watch or --wait but not both`,
+	}}
+
+	for i, t := range tests {
+		for _, modelFlag := range s.modelFlags {
+			c.Logf("test %d: it should %s: juju show-operation %s", i,
+				t.should, strings.Join(t.args, " "))
+			cmd, _ := action.NewShowOperationCommandForTest(s.store)
+			args := append([]string{modelFlag, "admin"}, t.args...)
+			err := cmdtesting.InitCommand(cmd, args)
+			if t.expectError != "" {
+				c.Check(err, gc.ErrorMatches, t.expectError)
+			}
+		}
+	}
+}
+
+const operationId = "666"
+
+func (s *ShowOperationSuite) TestRun(c *gc.C) {
+	tests := []struct {
+		should            string
+		withClientWait    string
+		withClientQueryID string
+		withAPIDelay      time.Duration
+		withAPITimeout    time.Duration
+		withAPIResponse   []params.OperationResult
+		withAPIError      string
+		withFormat        string
+		expectedErr       string
+		expectedOutput    string
+		watch             bool
+	}{{
+		should:         "handle wait-time formatting errors",
+		withClientWait: "not-a-duration-at-all",
+		expectedErr:    "time: invalid duration not-a-duration-at-all",
+	}, {
+		should:            "timeout if result never comes",
+		withClientWait:    "2s",
+		withAPIDelay:      3 * time.Second,
+		withAPITimeout:    5 * time.Second,
+		withClientQueryID: operationId,
+		withAPIResponse: []params.OperationResult{{
+			OperationTag: names.NewOperationTag(operationId).String(),
+			Status:       "running",
+		}},
+		expectedErr: "timeout reached",
+		expectedOutput: `
+status: pending
+timing:
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  started: 2015-02-14 08:15:00 +0000 UTC
+`[1:],
+	}, {
+		should:            "pass api error through properly",
+		withClientQueryID: operationId,
+		withAPITimeout:    1 * time.Second,
+		withAPIError:      "api call error",
+		expectedErr:       "api call error",
+	}, {
+		should:            "fail with id not found",
+		withClientQueryID: operationId,
+		withAPITimeout:    1 * time.Second,
+		expectedErr:       `operation "` + operationId + `" not found`,
+	}, {
+		should:            "pass through an error from the API server",
+		withClientQueryID: operationId,
+		withAPITimeout:    1 * time.Second,
+		withAPIResponse: []params.OperationResult{{
+			OperationTag: names.NewOperationTag(operationId).String(),
+			Summary:      "an operation",
+			Status:       "failed",
+			Error:        common.ServerError(errors.New("an apiserver error")),
+		}},
+		expectedOutput: `
+summary: an operation
+status: failed
+error: an apiserver error
+`[1:],
+	}, {
+		should:            "only return once status is no longer running or pending",
+		withAPIDelay:      1 * time.Second,
+		withClientWait:    "10s",
+		withClientQueryID: operationId,
+		withAPITimeout:    3 * time.Second,
+		withAPIResponse: []params.OperationResult{{
+			OperationTag: names.NewOperationTag(operationId).String(),
+			Status:       "running",
+			Actions: []params.ActionResult{{
+				Output: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"bar": "baz",
+					},
+				},
+			}},
+			Enqueued: time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:  time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+		}},
+		expectedErr: "test timed out before wait time",
+	}, {
+		should:            "pretty-print operation output",
+		withClientQueryID: operationId,
+		withAPITimeout:    1 * time.Second,
+		withAPIResponse: []params.OperationResult{{
+			OperationTag: names.NewOperationTag(operationId).String(),
+			Summary:      "an operation",
+			Status:       "complete",
+			Actions: []params.ActionResult{{
+				Action: &params.Action{
+					Tag:        names.NewActionTag("69").String(),
+					Receiver:   "foo/0",
+					Name:       "backup",
+					Parameters: map[string]interface{}{"hello": "world"},
+				},
+				Status:  "completed",
+				Message: "oh dear",
+				Output: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"bar": "baz",
+					},
+				},
+			}},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:   time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
+		}},
+		expectedOutput: `
+summary: an operation
+status: complete
+action:
+  name: backup
+  parameters:
+    hello: world
+timing:
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  started: 2015-02-14 08:15:00 +0000 UTC
+  completed: 2015-02-14 08:15:30 +0000 UTC
+tasks:
+  "69":
+    host: foo/0
+    status: completed
+    message: oh dear
+    results:
+      foo:
+        bar: baz
+`[1:],
+	}, {
+		should:            "pretty-print action output with no completed time",
+		withClientQueryID: operationId,
+		withClientWait:    "1s",
+		withAPITimeout:    2 * time.Second,
+		withAPIResponse: []params.OperationResult{{
+			OperationTag: names.NewOperationTag(operationId).String(),
+			Summary:      "an operation",
+			Status:       "pending",
+			Actions: []params.ActionResult{{
+				Action: &params.Action{
+					Tag:        names.NewActionTag("69").String(),
+					Receiver:   "foo/0",
+					Name:       "backup",
+					Parameters: map[string]interface{}{"hello": "world"},
+				},
+				Status:  "pending",
+				Message: "oh dear",
+				Output: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"bar": "baz",
+					},
+				},
+			}},
+			Enqueued: time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Started:  time.Date(2015, time.February, 14, 8, 15, 0, 0, time.UTC),
+		}},
+		expectedErr: "timeout reached",
+		expectedOutput: `
+summary: an operation
+status: complete
+action:
+  name: backup
+  parameters:
+    hello: world
+timing:
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  started: 2015-02-14 08:15:00 +0000 UTC
+tasks:
+  "69":
+    host: foo/0
+    status: completed
+    message: oh dear
+    results:
+      foo:
+        bar: baz
+`[1:],
+	}, {
+		should:            "set an appropriate timer and wait, get a result",
+		withClientQueryID: operationId,
+		withAPITimeout:    5 * time.Second,
+		withClientWait:    "3s",
+		withAPIDelay:      1 * time.Second,
+		withAPIResponse: []params.OperationResult{{
+			OperationTag: names.NewOperationTag(operationId).String(),
+			Summary:      "an operation",
+			Status:       "completed",
+			Actions: []params.ActionResult{{
+				Action: &params.Action{
+					Tag:      names.NewActionTag("69").String(),
+					Name:     "backup",
+					Receiver: "foo/0",
+				},
+				Status: "completed",
+				Output: map[string]interface{}{
+					"foo": map[string]interface{}{
+						"bar": "baz",
+					},
+				},
+			}},
+			Enqueued:  time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
+		}},
+		expectedOutput: `
+summary: an operation
+status: completed
+action:
+  name: backup
+  parameters: {}
+timing:
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  completed: 2015-02-14 08:15:30 +0000 UTC
+tasks:
+  "69":
+    host: foo/0
+    status: completed
+    results:
+      foo:
+        bar: baz
+`[1:],
+	}, {
+		should:            "watch, wait, get a result",
+		withClientQueryID: operationId,
+		watch:             true,
+		withAPIResponse: []params.OperationResult{{
+			OperationTag: names.NewOperationTag(operationId).String(),
+			Summary:      "an operation",
+			Status:       "completed",
+			Enqueued:     time.Date(2015, time.February, 14, 8, 13, 0, 0, time.UTC),
+			Completed:    time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
+		}},
+		expectedOutput: `
+summary: an operation
+status: completed
+timing:
+  enqueued: 2015-02-14 08:13:00 +0000 UTC
+  completed: 2015-02-14 08:15:30 +0000 UTC
+`[1:],
+	}}
+
+	for i, t := range tests {
+		for _, modelFlag := range s.modelFlags {
+			c.Logf("test %d (model option %v): should %s", i, modelFlag, t.should)
+			fakeClient := makeFakeOperationClient(
+				t.withAPIDelay,
+				t.withAPITimeout,
+				t.withAPIResponse,
+				params.ActionsByNames{},
+				t.withAPIError,
+			)
+			testRunOperationHelper(
+				c, s,
+				fakeClient,
+				t.expectedErr,
+				t.expectedOutput,
+				t.withFormat,
+				t.withClientWait,
+				t.withClientQueryID,
+				modelFlag,
+				t.watch,
+			)
+		}
+	}
+}
+
+func testRunOperationHelper(c *gc.C, s *ShowOperationSuite, client *fakeAPIClient,
+	expectedErr, expectedOutput, format, wait, query, modelFlag string,
+	watch bool,
+) {
+	unpatch := s.BaseActionSuite.patchAPIClient(client)
+	defer unpatch()
+	args := append([]string{modelFlag, "admin"}, query, "--utc")
+	if wait != "" {
+		args = append(args, "--wait", wait)
+	}
+	if format != "" {
+		args = append(args, "--format", format)
+	}
+	if watch {
+		args = append(args, "--watch")
+	}
+
+	cmd, _ := action.NewShowOperationCommandForTest(s.store)
+	ctx, err := cmdtesting.RunCommand(c, cmd, args...)
+
+	if expectedErr != "" {
+		c.Check(err, gc.ErrorMatches, expectedErr)
+	} else {
+		c.Assert(err, gc.IsNil)
+		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expectedOutput)
+	}
+}
+
+func makeFakeOperationClient(
+	delay, timeout time.Duration,
+	response []params.OperationResult,
+	actionsByNames params.ActionsByNames,
+	errStr string,
+) *fakeAPIClient {
+	var delayTimer *time.Timer
+	if delay != 0 {
+		delayTimer = time.NewTimer(delay)
+	}
+	client := &fakeAPIClient{
+		delay:            delayTimer,
+		timeout:          time.NewTimer(timeout),
+		operationResults: response,
+		actionsByNames:   actionsByNames,
+		apiVersion:       5,
+	}
+	if errStr != "" {
+		client.apiErr = errors.New(errStr)
+	}
+	return client
+}

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -46,9 +46,11 @@ type showOutputCommand struct {
 	out         cmd.Output
 	requestedId string
 	fullSchema  bool
-	wait        string
-	watch       bool
-	utc         bool
+	// TODO(juju3) - remove legacyWait
+	legacyWait string
+	wait       time.Duration
+	watch      bool
+	utc        bool
 
 	// compat is true when running as legacy show-action-output
 	compat bool
@@ -60,7 +62,6 @@ const showOutputDoc = `
 Show the results returned by an action with the given ID.  
 To block until the result is known completed or failed, use
 the --wait option with a duration, as in --wait 5s or --wait 1h.
-If units are left off, seconds are assumed.
 Use --watch to wait indefinitely.  
 
 The default behavior without --wait or --watch is to immediately check and return;
@@ -82,6 +83,7 @@ See also:
     list-operations
     show-operation
 `
+const defaultTaskWait = -1 * time.Second
 
 // Set up the output.
 func (c *showOutputCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -96,7 +98,11 @@ func (c *showOutputCommand) SetFlags(f *gnuflag.FlagSet) {
 		"plain": printPlainOutput,
 	})
 
-	f.StringVar(&c.wait, "wait", "-1s", "Wait for results")
+	if c.compat {
+		f.StringVar(&c.legacyWait, "wait", "-1s", "Wait for results")
+	} else {
+		f.DurationVar(&c.wait, "wait", defaultTaskWait, "Wait for results")
+	}
 	f.BoolVar(&c.watch, "watch", false, "Wait indefinitely for results")
 	f.BoolVar(&c.utc, "utc", false, "Show times in UTC")
 }
@@ -121,12 +127,28 @@ func (c *showOutputCommand) Info() *cmd.Info {
 
 // Init validates the action ID and any other options.
 func (c *showOutputCommand) Init(args []string) error {
+	if c.compat {
+		// Check whether units were left off our time string.
+		r := regexp.MustCompile("[a-zA-Z]")
+		matches := r.FindStringSubmatch(c.legacyWait[len(c.legacyWait)-1:])
+		// If any match, we have units.  Otherwise, we don't; assume seconds.
+		if len(matches) == 0 {
+			c.legacyWait = c.legacyWait + "s"
+		}
+
+		waitDur, err := time.ParseDuration(c.legacyWait)
+		if err != nil {
+			return err
+		}
+		c.wait = waitDur
+	}
+
 	if c.watch {
-		if c.wait != "-1s" {
+		if c.wait != defaultTaskWait {
 			return errors.New("specify either --watch or --wait but not both")
 		}
 		// If we are watching the wait is 0 (indefinite).
-		c.wait = "0s"
+		c.wait = 0 * time.Second
 	}
 	switch len(args) {
 	case 0:
@@ -144,44 +166,23 @@ func (c *showOutputCommand) Init(args []string) error {
 
 // Run issues the API call to get Actions by ID.
 func (c *showOutputCommand) Run(ctx *cmd.Context) error {
-	// Check whether units were left off our time string.
-	r := regexp.MustCompile("[a-zA-Z]")
-	matches := r.FindStringSubmatch(c.wait[len(c.wait)-1:])
-	// If any match, we have units.  Otherwise, we don't; assume seconds.
-	if len(matches) == 0 {
-		c.wait = c.wait + "s"
-	}
-
-	waitDur, err := time.ParseDuration(c.wait)
-	if err != nil {
-		return err
-	}
-
 	api, err := c.NewActionAPIClient()
 	if err != nil {
 		return err
 	}
 	defer api.Close()
 
-	wait := time.NewTimer(0 * time.Second)
-
-	switch {
-	case waitDur.Nanoseconds() < 0:
-		// Negative duration signals immediate return.  All is well.
-	case waitDur.Nanoseconds() == 0:
+	wait := time.NewTimer(c.wait)
+	if c.wait.Nanoseconds() == 0 {
 		// Zero duration signals indefinite wait.  Discard the tick.
-		wait = time.NewTimer(0 * time.Second)
 		_ = <-wait.C
-	default:
-		// Otherwise, start an ordinary timer.
-		wait = time.NewTimer(waitDur)
 	}
 
 	actionDone := make(chan struct{})
 	var logsWatcher watcher.StringsWatcher
 	haveLogs := false
 
-	shouldWatch := waitDur.Nanoseconds() >= 0
+	shouldWatch := c.wait.Nanoseconds() >= 0
 	if shouldWatch {
 		result, err := fetchResult(api, c.requestedId, c.compat)
 		if err != nil {

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -103,34 +103,34 @@ timing:
 	}, {
 		should:            "pass api error through properly",
 		withClientQueryID: validActionId,
-		withAPITimeout:    2 * time.Second,
+		withAPITimeout:    1 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIError:      "api call error",
 		expectedErr:       "api call error",
 	}, {
 		should:            "fail with no tag matches",
 		withClientQueryID: validActionId,
-		withAPITimeout:    2 * time.Second,
+		withAPITimeout:    1 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId),
 		expectedErr:       `actions for identifier "` + validActionId + `" not found`,
 	}, {
 		should:            "fail with no results",
 		withClientQueryID: validActionId,
-		withAPITimeout:    2 * time.Second,
+		withAPITimeout:    1 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse:   []params.ActionResult{},
 		expectedErr:       "no results for action " + validActionId,
 	}, {
 		should:            "error correctly with multiple results",
 		withClientQueryID: validActionId,
-		withAPITimeout:    2 * time.Second,
+		withAPITimeout:    1 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse:   []params.ActionResult{{}, {}},
 		expectedErr:       "too many results for action " + validActionId,
 	}, {
 		should:            "pass through an error from the API server",
 		withClientQueryID: validActionId,
-		withAPITimeout:    2 * time.Second,
+		withAPITimeout:    1 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Error: common.ServerError(errors.New("an apiserver error")),
@@ -157,7 +157,7 @@ timing:
 	}, {
 		should:            "pretty-print action output",
 		withClientQueryID: validActionId,
-		withAPITimeout:    2 * time.Second,
+		withAPITimeout:    1 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
 			Status:  "complete",
@@ -172,6 +172,7 @@ timing:
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
 		expectedOutput: `
+id: f47ac10b-58cc-4372-a567-0e02b2c3d479
 message: oh dear
 results:
   foo:
@@ -185,6 +186,7 @@ timing:
 	}, {
 		should:            "pretty-print action output with no completed time",
 		withClientQueryID: validActionId,
+		withClientWait:    "1s",
 		withAPITimeout:    2 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
@@ -210,6 +212,7 @@ timing:
 	}, {
 		should:            "pretty-print action output with no enqueued time",
 		withClientQueryID: validActionId,
+		withClientWait:    "1s",
 		withAPITimeout:    2 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
@@ -224,6 +227,7 @@ timing:
 		}},
 		expectedErr: "timeout reached",
 		expectedOutput: `
+id: f47ac10b-58cc-4372-a567-0e02b2c3d479
 results:
   foo:
     bar: baz
@@ -235,6 +239,7 @@ timing:
 	}, {
 		should:            "pretty-print action output with no started time",
 		withClientQueryID: validActionId,
+		withClientWait:    "1s",
 		withAPITimeout:    2 * time.Second,
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
 		withAPIResponse: []params.ActionResult{{
@@ -249,6 +254,7 @@ timing:
 		}},
 		expectedErr: "timeout reached",
 		expectedOutput: `
+id: f47ac10b-58cc-4372-a567-0e02b2c3d479
 results:
   foo:
     bar: baz
@@ -260,6 +266,7 @@ timing:
 	}, {
 		should:            "plain format action output",
 		withClientQueryID: validActionId,
+		withClientWait:    "1s",
 		withAPITimeout:    2 * time.Second,
 		withFormat:        "plain",
 		withTags:          tagsForIdPrefix(validActionId, validActionTagString),
@@ -301,6 +308,7 @@ hello
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
 		expectedOutput: `
+id: f47ac10b-58cc-4372-a567-0e02b2c3d479
 results:
   foo:
     bar: baz
@@ -320,6 +328,7 @@ timing:
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
 		expectedOutput: `
+id: f47ac10b-58cc-4372-a567-0e02b2c3d479
 status: completed
 timing:
   completed: 2015-02-14 08:15:30 +0000 UTC
@@ -339,6 +348,7 @@ timing:
 			Completed: time.Date(2015, time.February, 14, 8, 15, 30, 0, time.UTC),
 		}},
 		expectedOutput: `
+id: f47ac10b-58cc-4372-a567-0e02b2c3d479
 status: completed
 timing:
   completed: 2015-02-14 08:15:30 +0000 UTC

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -395,6 +395,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 		r.Register(action.NewRunCommand())
 		r.Register(action.NewListOperationsCommand())
 		r.Register(action.NewShowOperationCommand())
+		r.Register(action.NewShowTaskCommand())
 	} else {
 		r.Register(action.NewRunActionCommand())
 		r.Register(action.NewShowActionOutputCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -633,7 +633,7 @@ var devFeatures = []string{
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
-	"run", "show-task", "operations", "list-operations",
+	"run", "show-task", "operations", "list-operations", "show-operation",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?

There's a new API to add when actions work is integrated.

----

## Description of change

Add the show-operation CLI and backend.
The existing Operations() method was renamed to ListOperations().
There was also a driveby fix to timeout handling in show-task. The show-operation implementation is based on what was already done for show-task.

## QA steps

run an action on several units
run juju show-operation <id> before the operation has finished and see partial results
run juju show-operation --watch to see that it blocks until completion
run juju show-operation --wait 1s to see that it times out
run juju show-operation on a completed task to see full results
