### PR TITLE
Reorganise Space Renaming Logic

### DIFF
--- a/apiserver/facades/client/spaces/mocks/package_mock.go
+++ b/apiserver/facades/client/spaces/mocks/package_mock.go
@@ -439,19 +439,19 @@ func (m *MockRenameSpaceState) EXPECT() *MockRenameSpaceStateMockRecorder {
 	return m.recorder
 }
 
-// ConstraintsOpsForSpaceNameChange mocks base method
-func (m *MockRenameSpaceState) ConstraintsOpsForSpaceNameChange(arg0, arg1 string) ([]txn.Op, error) {
+// ConstraintsBySpaceName mocks base method
+func (m *MockRenameSpaceState) ConstraintsBySpaceName(arg0 string) ([]spaces.Constraints, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConstraintsOpsForSpaceNameChange", arg0, arg1)
-	ret0, _ := ret[0].([]txn.Op)
+	ret := m.ctrl.Call(m, "ConstraintsBySpaceName", arg0)
+	ret0, _ := ret[0].([]spaces.Constraints)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ConstraintsOpsForSpaceNameChange indicates an expected call of ConstraintsOpsForSpaceNameChange
-func (mr *MockRenameSpaceStateMockRecorder) ConstraintsOpsForSpaceNameChange(arg0, arg1 interface{}) *gomock.Call {
+// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName
+func (mr *MockRenameSpaceStateMockRecorder) ConstraintsBySpaceName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsOpsForSpaceNameChange", reflect.TypeOf((*MockRenameSpaceState)(nil).ConstraintsOpsForSpaceNameChange), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsBySpaceName", reflect.TypeOf((*MockRenameSpaceState)(nil).ConstraintsBySpaceName), arg0)
 }
 
 // ControllerConfig mocks base method
@@ -669,6 +669,20 @@ func NewMockConstraints(ctrl *gomock.Controller) *MockConstraints {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockConstraints) EXPECT() *MockConstraintsMockRecorder {
 	return m.recorder
+}
+
+// ChangeSpaceNameOps mocks base method
+func (m *MockConstraints) ChangeSpaceNameOps(arg0, arg1 string) []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeSpaceNameOps", arg0, arg1)
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// ChangeSpaceNameOps indicates an expected call of ChangeSpaceNameOps
+func (mr *MockConstraintsMockRecorder) ChangeSpaceNameOps(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeSpaceNameOps", reflect.TypeOf((*MockConstraints)(nil).ChangeSpaceNameOps), arg0, arg1)
 }
 
 // ID mocks base method

--- a/apiserver/facades/client/spaces/opfactory.go
+++ b/apiserver/facades/client/spaces/opfactory.go
@@ -53,5 +53,5 @@ func (f *opFactory) NewRenameSpaceModelOp(fromName, toName string) (state.ModelO
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewRenameSpaceModelOp(f.st.IsController(), controllerSettings, &renameSpaceStateShim{f.st}, space, toName), nil
+	return NewRenameSpaceModelOp(f.st.IsController(), controllerSettings, &renameSpaceState{f.st}, space, toName), nil
 }

--- a/apiserver/facades/client/spaces/remove.go
+++ b/apiserver/facades/client/spaces/remove.go
@@ -214,7 +214,7 @@ func (api *API) entityTagsForSpaceConstraints(spaceName string) ([]names.Tag, er
 
 	tags := make([]names.Tag, len(cons))
 	for i, doc := range cons {
-		tag := state.ParseLocalIDToTags(doc.ID())
+		tag := state.TagFromDocID(doc.ID())
 		if tag == nil {
 			return nil, errors.Errorf("Could not parse id: %q", doc.ID())
 		}

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
+	"gopkg.in/mgo.v2/txn"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.spaces")
@@ -41,6 +42,7 @@ type Machine interface {
 // Constraints defines the methods supported by constraints used in the space context.
 type Constraints interface {
 	ID() string
+	ChangeSpaceNameOps(from, to string) []txn.Op
 }
 
 // ApplicationEndpointBindingsShim is a shim interface for stateless access to ApplicationEndpointBindings
@@ -453,7 +455,7 @@ func (api *API) checkSupportsSpaces() error {
 }
 
 // checkSupportsProviderSpaces checks if the environment implements
-// NetworkingEnviron and also if it support provider spaces.
+// NetworkingEnviron and also if it supports provider spaces.
 func (api *API) checkSupportsProviderSpaces() error {
 	env, err := environs.GetEnviron(api.backing, environs.New)
 	if err != nil {

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -395,7 +395,7 @@ func (api *API) ShowSpace(entities params.Entities) (params.ShowSpaceResults, er
 			result.Space.Subnets[i] = networkingcommon.BackingSubnetToParamsSubnet(subnet)
 		}
 
-		applications, err := api.getApplicationsBindSpace(space.Id())
+		applications, err := api.applicationsBoundToSpace(space.Id())
 		if err != nil {
 			newErr := errors.Annotatef(err, "fetching applications")
 			results[i].Error = common.ServerError(newErr)
@@ -452,8 +452,8 @@ func (api *API) checkSupportsSpaces() error {
 	return nil
 }
 
-// checkSupportsProviderSpaces checks if the environment implements NetworkingEnviron
-// and also if it support provider spaces.
+// checkSupportsProviderSpaces checks if the environment implements
+// NetworkingEnviron and also if it support provider spaces.
 func (api *API) checkSupportsProviderSpaces() error {
 	env, err := environs.GetEnviron(api.backing, environs.New)
 	if err != nil {
@@ -483,16 +483,16 @@ func (api *API) getMachineCountBySpaceID(spaceID string) (int, error) {
 	return count, nil
 }
 
-func (api *API) getApplicationsBindSpace(givenSpaceID string) ([]string, error) {
+func (api *API) applicationsBoundToSpace(spaceID string) ([]string, error) {
 	endpointBindings, err := api.backing.AllEndpointBindings()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// Using a set as we only we want the application names once.
+
 	applications := set.NewStrings()
 	for _, binding := range endpointBindings {
-		for _, spaceID := range binding.Bindings {
-			if spaceID == givenSpaceID {
+		for _, boundSpace := range binding.Bindings {
+			if boundSpace == spaceID {
 				applications.Add(binding.AppName)
 			}
 		}

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -170,7 +170,7 @@ func (s *SpaceTestMockSuite) TestRenameSpaceErrorToAlreadyExist(c *gc.C) {
 
 	res, err := s.api.RenameSpace(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedErr := fmt.Sprintf("space: %q already exists", to)
+	expectedErr := fmt.Sprintf("space %q already exists", to)
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, expectedErr)
 }
 
@@ -187,7 +187,7 @@ func (s *SpaceTestMockSuite) TestRenameSpaceErrorUnexpectedError(c *gc.C) {
 
 	res, err := s.api.RenameSpace(args)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedErr := fmt.Sprintf("retrieving space: %q unexpected error, besides not found: %v", to, bamErr.Error())
+	expectedErr := fmt.Sprintf("retrieving space %q: %v", to, bamErr.Error())
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, expectedErr)
 }
 
@@ -218,7 +218,7 @@ func (s *SpaceTestMockSuite) TestRenameAlphaSpaceError(c *gc.C) {
 
 	res, err := s.api.RenameSpace(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(res.Results[0].Error, gc.ErrorMatches, "the alpha space cannot be renamed")
+	c.Assert(res.Results[0].Error, gc.ErrorMatches, `the "alpha" space cannot be renamed`)
 }
 
 func (s *SpaceTestMockSuite) TestRenameSpaceSuccess(c *gc.C) {

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -102,6 +102,20 @@ func (c *Constraints) ChangeSpaceNameOps(from, to string) []txn.Op {
 	return []txn.Op{setConstraintsOp(c.ID(), val)}
 }
 
+// AllConstraints returns all constraints in the collection.
+func (st *State) AllConstraints() ([]*Constraints, error) {
+	constraintsCollection, closer := st.db().GetCollection(constraintsC)
+	defer closer()
+	var docs []constraintsDoc
+	err := constraintsCollection.Find(nil).All(&docs)
+
+	cons := make([]*Constraints, len(docs))
+	for i, doc := range docs {
+		cons[i] = &Constraints{doc: doc}
+	}
+	return cons, err
+}
+
 // ConstraintsBySpaceName returns all Constraints that include a positive
 // or negative space constraint for the input space name.
 func (st *State) ConstraintsBySpaceName(spaceName string) ([]*Constraints, error) {

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -80,6 +80,12 @@ func (c *Constraints) ID() string {
 	return c.doc.DocID
 }
 
+// Value returns the constraints.Value represented by the Constraints'
+// Mongo document.
+func (c *Constraints) Value() constraints.Value {
+	return c.doc.value()
+}
+
 // ChangeSpaceNameOps returns the transaction operations required to rename
 // a space used in these constraints.
 func (c *Constraints) ChangeSpaceNameOps(from, to string) []txn.Op {

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -4,24 +4,15 @@
 package state_test
 
 import (
+	"regexp"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2/bson"
-	"regexp"
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/state"
 )
-
-type applicationConstraintsSuite struct {
-	ConnSuite
-
-	applicationName string
-	testCharm       *state.Charm
-}
-
-var _ = gc.Suite(&applicationConstraintsSuite{})
 
 type constraintsValidationSuite struct {
 	ConnSuite
@@ -269,6 +260,15 @@ func (s *constraintsValidationSuite) TestApplicationConstraints(c *gc.C) {
 	}
 }
 
+type applicationConstraintsSuite struct {
+	ConnSuite
+
+	applicationName string
+	testCharm       *state.Charm
+}
+
+var _ = gc.Suite(&applicationConstraintsSuite{})
+
 func (s *applicationConstraintsSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
 	s.policy.GetConstraintsValidator = func() (constraints.Validator, error) {
@@ -303,19 +303,18 @@ func (s *applicationConstraintsSuite) TestAddApplicationValidConstraints(c *gc.C
 	c.Assert(application, gc.NotNil)
 }
 
-func (s *applicationConstraintsSuite) TestConstraintsOpsForSpaceNameChange(c *gc.C) {
-	from, to, negatedTo := "db", "newdb", "^newdb"
-	cons := constraints.MustParse("spaces=db,alpha")
+func (s *applicationConstraintsSuite) TestConstraintsRetrieval(c *gc.C) {
+	posCons := constraints.MustParse("spaces=db")
 	application, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:        s.applicationName,
 		Series:      "",
 		Charm:       s.testCharm,
-		Constraints: cons,
+		Constraints: posCons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(application, gc.NotNil)
 
-	negCons := constraints.MustParse("spaces=^db,alpha")
+	negCons := constraints.MustParse("spaces=^db2")
 	negApplication, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:        "unimportant",
 		Series:      "",
@@ -325,19 +324,23 @@ func (s *applicationConstraintsSuite) TestConstraintsOpsForSpaceNameChange(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(negApplication, gc.NotNil)
 
-	ops, err := s.State.ConstraintsOpsForSpaceNameChange(from, to)
+	consBySpace, err := s.State.AllConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ops, gc.HasLen, 2)
 
-	var obtainedConstraintSpaces []string
-	for _, op := range ops {
-		found := op.Update.(bson.D).Map()["$set"].(state.ConstraintsDoc).Spaces
-		obtainedConstraintSpaces = append(obtainedConstraintSpaces, *found...)
-
+	vals := make([]string, len(consBySpace))
+	for i, cons := range consBySpace {
+		c.Log(cons.ID())
+		vals[i] = cons.Value().String()
 	}
-	expectedSpace := []string{to, "alpha"}
-	negExpectedSpace := []string{negatedTo, "alpha"}
-	expectedConstraintSpaces := append(expectedSpace, negExpectedSpace...)
+	// In addition to the application constraints, there is a single empty
+	// constraints document for the model.
+	c.Check(vals, jc.SameContents, []string{posCons.String(), negCons.String(), ""})
 
-	c.Assert(obtainedConstraintSpaces, jc.SameContents, expectedConstraintSpaces)
+	consBySpace, err = s.State.ConstraintsBySpaceName("db")
+	c.Assert(consBySpace, gc.HasLen, 1)
+	c.Check(consBySpace[0].Value(), jc.DeepEquals, posCons)
+
+	consBySpace, err = s.State.ConstraintsBySpaceName("db2")
+	c.Assert(consBySpace, gc.HasLen, 1)
+	c.Check(consBySpace[0].Value(), jc.DeepEquals, negCons)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -2593,9 +2593,11 @@ func (st *State) globalClockReader() (*globalclock.Reader, error) {
 	})
 }
 
-// ParseLocalIDToTags tries to parse a DocID e.g. `c9741ea1-0c2a-444d-82f5-787583a48557:a#mediawiki
-// to a corresponding Tag. In the above case -> applicationTag.
-func ParseLocalIDToTags(docID string) names.Tag {
+// TagFromDocID tries attempts to extract an entity-identifying tag from a
+// Mongo document ID.
+// For example "c9741ea1-0c2a-444d-82f5-787583a48557:a#mediawiki" would yield
+// an application tag for "mediawiki"
+func TagFromDocID(docID string) names.Tag {
 	_, localID, _ := splitDocID(docID)
 	switch {
 	case strings.HasPrefix(localID, "a#"):

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -174,10 +174,10 @@ func (s *StateSuite) TestParseIDToTag(c *gc.C) {
 	machine := "42c4f770-86ed-4fcc-8e39-697063d082bc:m#0"
 	application := "c9741ea1-0c2a-444d-82f5-787583a48557:a#mysql"
 	unit := "c9741ea1-0c2a-444d-82f5-787583a48557:u#mysql/0"
-	moTag := state.ParseLocalIDToTags(model)
-	maTag := state.ParseLocalIDToTags(machine)
-	unTag := state.ParseLocalIDToTags(unit)
-	apTag := state.ParseLocalIDToTags(application)
+	moTag := state.TagFromDocID(model)
+	maTag := state.TagFromDocID(machine)
+	unTag := state.TagFromDocID(unit)
+	apTag := state.TagFromDocID(application)
 
 	tag, err := names.ParseTag(moTag.String())
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch removes `ConstraintsOpsForSpaceNameChange` from the state package, opting instead to implement the method for such ops on the `Constraints` object itself.

This helps minimise the methods that we add the state.State directly.

The API server package for space renaming is updated accordingly, with
tests enhanced for the success cases.

Other enhancement include:
- Method renaming and re-organisation for clarity.
- Method comment enhancements.
- A new `AllConstraints` method that will be used in forthcoming space CLI features.

## QA steps

- `juju bootstrap aws rename-space --no-gui --debug`
- `juju add-space new-space 172.31.16.0/20`
- `juju rename-space new-space renamed-space`

## Documentation changes

None.

## Bug reference

N/A
