### PR TITLE
Fix Data Racing in the Model Cache

### DIFF
--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -82,14 +82,14 @@ type Controller struct {
 	mu      sync.Mutex
 	metrics *ControllerGauges
 
-	// While a controller is initializing it does not update
-	// any model summaries. The initializing component is handled
-	// with the Mark and Sweep methods. Calling Mark sets the controller
-	// as initializing, and Sweep completes the initialization.
-	// This is a shared variable with the Models. Models only access
-	// the initializer through the interface that allows them to only
-	// read the value.
-	initializing bool
+	// While a controller is initializing it does not update any model
+	// summaries - we want to avoid publishing events related to cache priming.
+	// The initialization status is handled with the Mark and Sweep methods.
+	// Calling Mark sets the controller as initializing, and Sweep completes
+	// the initialization.
+	// This status is shared with the cached models via an indirection that
+	// hides the channel
+	initializing chan struct{}
 }
 
 // NewController creates a new cached controller instance.
@@ -106,14 +106,18 @@ func newController(config ControllerConfig, manager *residentManager) (*Controll
 		return nil, errors.Trace(err)
 	}
 
+	init := make(chan struct{})
+	close(init)
+
 	c := &Controller{
-		manager:  manager,
-		changes:  config.Changes,
-		notify:   config.Notify,
-		idleFunc: IdleFunc,
-		hub:      newPubSubHub(),
-		models:   make(map[string]*Model),
-		metrics:  createControllerGauges(),
+		manager:      manager,
+		changes:      config.Changes,
+		notify:       config.Notify,
+		idleFunc:     IdleFunc,
+		hub:          newPubSubHub(),
+		models:       make(map[string]*Model),
+		metrics:      createControllerGauges(),
+		initializing: init,
 	}
 
 	manager.dying = c.tomb.Dying()
@@ -187,7 +191,7 @@ func (c *Controller) loop() error {
 func (c *Controller) Mark() {
 	c.manager.mark()
 	c.mu.Lock()
-	c.initializing = true
+	c.initializing = make(chan struct{})
 	c.mu.Unlock()
 }
 
@@ -198,10 +202,19 @@ func (c *Controller) Sweep() {
 	case <-c.manager.sweep():
 	case <-c.tomb.Dying():
 	}
+
+	select {
+	case <-c.initializing:
+		// The channel is already closed.
+	default:
+		close(c.initializing)
+	}
+
 	c.mu.Lock()
-	c.initializing = false
 	for _, model := range c.models {
+		model.mu.Lock()
 		model.updateSummary()
+		model.mu.Unlock()
 	}
 	c.mu.Unlock()
 }
@@ -387,7 +400,7 @@ func (c *Controller) ensureModel(modelUUID string) *Model {
 
 	model, found := c.models[modelUUID]
 	if !found {
-		initializer := &initializeState{&c.initializing}
+		initializer := &initializeState{c.initializing}
 		model = newModel(modelConfig{
 			initializer: initializer,
 			metrics:     c.metrics,
@@ -425,9 +438,14 @@ func (c *Controller) WatchAllModels() ModelSummaryWatcher {
 }
 
 type initializeState struct {
-	init *bool
+	init chan struct{}
 }
 
 func (s *initializeState) initializing() bool {
-	return *s.init
+	select {
+	case <-s.init:
+		return false
+	default:
+		return true
+	}
 }

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -387,9 +387,8 @@ func (s *ControllerSuite) TestSweepWithConcurrentUpdates(c *gc.C) {
 
 	done := make(chan struct{})
 
-	// As long as the channel is open, keep running sweep.
-	// No mark has been run, so nothing will be evicted.
-	// But we will keep generating model summaries.
+	// As long as the channel is open, keep running mark/sweep.
+	// This will generate model summaries repeatedly.
 	go func() {
 		for {
 			controller.Sweep()
@@ -402,6 +401,8 @@ func (s *ControllerSuite) TestSweepWithConcurrentUpdates(c *gc.C) {
 	}()
 
 	// Add a bunch of machines while we are sweeping.
+	// Many will be evicted, but we don't care; we are flexing a data race
+	// scenario by causing writes the the model's machines map.
 	for i := 0; i < 50; i++ {
 		m := machineChange
 		m.Id = strconv.Itoa(i)

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -645,12 +645,15 @@ func (w *waitUnitChange) close() {
 	}
 }
 
+// updateSummary generates a summary of the model,
+// then publishes it via the controller's hub.
+// Callers of this method must take responsibility for appropriate locking.
 func (m *Model) updateSummary() {
 	if m.initializer.initializing() {
 		logger.Tracef("skipping update as initializing")
 		return
 	}
-	// This method is only called from within a mutex lock.
+
 	overallStatus := StatusGreen
 	var messages []ModelSummaryMessage
 	var machines, containers int

--- a/core/cache/modelsummarywatcher_test.go
+++ b/core/cache/modelsummarywatcher_test.go
@@ -106,7 +106,7 @@ func (s *modelSummaryWatcherSuite) TestAddPermissionShowsModel(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the initial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.ModelChange{
@@ -219,7 +219,7 @@ func (s *modelSummaryWatcherSuite) TestAddingMachineIsChange(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.MachineChange{
@@ -246,7 +246,7 @@ func (s *modelSummaryWatcherSuite) TestRemovingMachineIsChange(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.RemoveMachine{
@@ -274,7 +274,7 @@ func (s *modelSummaryWatcherSuite) TestAddingApplicationIsChange(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.ApplicationChange{
@@ -301,7 +301,7 @@ func (s *modelSummaryWatcherSuite) TestRemovingApplicationIsChange(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.RemoveApplication{
@@ -330,7 +330,7 @@ func (s *modelSummaryWatcherSuite) TestAddingUnitIsChange(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.UnitChange{
@@ -359,7 +359,7 @@ func (s *modelSummaryWatcherSuite) TestRemovingUnitIsChange(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.RemoveUnit{
@@ -387,7 +387,7 @@ func (s *modelSummaryWatcherSuite) TestChangesToOneModelCoalesced(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	s.ProcessChange(c, cache.RemoveUnit{
@@ -432,7 +432,7 @@ func (s *modelSummaryWatcherSuite) TestUpdatesThatDontChangeSummary(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	modelUpdate := cache.ModelChange{
@@ -491,7 +491,7 @@ func (s *modelSummaryWatcherSuite) TestNoUpdatesDuringInitialization(c *gc.C) {
 	defer workertest.CleanKill(c, watcher)
 
 	changes := watcher.Changes()
-	// discard the intial event
+	// Discard the initial event.
 	_ = s.next(c, changes)
 
 	// Simulate a watcher reset.

--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -587,7 +587,7 @@ func (s *Service) WriteService() error {
 // indicated by the service unit file `ExecStart` property.
 // This is required for non-trivial start-up logic, as bash-isms are not
 // supported.
-//See: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines
+// See: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines
 func (s *Service) execStartFileName() string {
 	return s.Name() + "-exec-start"
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This patch fixes an a concurrency error due to map write+iteration in the model cache. It was introduced with https://github.com/juju/juju/pull/11208.

The model's `updateSummary` method was being called by the controller, unguarded by the model's lock. This means that processing any deltas at the same time as `Sweep` is called could cause a panic.

Testing this fix outed another concurrency bug with passing the `initializing` boolean reference to the models where it escaped the controller's lock and could potentially be read while the controller was setting it.

The boolean is now replaced by a channel to achieve the same result.

## QA steps

New unit test verifies the fix. Passes with the race checker.

## Documentation changes

None.

## Bug reference

N/A
