### PR TITLE
Action cancel/abort handling on uniter

### DIFF
--- a/caas/kubernetes/provider/exec/copy_test.go
+++ b/caas/kubernetes/provider/exec/copy_test.go
@@ -34,6 +34,8 @@ func (s *execSuite) TestCopyParamsValidate(c *gc.C) {
 	ctrl := s.setupExecClient(c)
 	defer ctrl.Finish()
 
+	s.suiteMocks.EXPECT().RemoteCmdExecutorGetter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(s.mockRemoteCmdExecutor, nil)
+
 	type testcase struct {
 		Params exec.CopyParams
 		Err    string
@@ -118,6 +120,8 @@ func (s *execSuite) TestCopyFromPodNotSupported(c *gc.C) {
 func (s *execSuite) TestCopyToPod(c *gc.C) {
 	ctrl := s.setupExecClient(c)
 	defer ctrl.Finish()
+
+	s.suiteMocks.EXPECT().RemoteCmdExecutorGetter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(s.mockRemoteCmdExecutor, nil)
 
 	srcPath, err := ioutil.TempFile(c.MkDir(), "testfile")
 	c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/provider/exec/export_test.go
+++ b/caas/kubernetes/provider/exec/export_test.go
@@ -11,6 +11,7 @@ var (
 	ProcessEnv                   = processEnv
 	NewForTest                   = newClient
 	HandleContainerNotFoundError = handleContainerNotFoundError
+	RandomString                 = &randomString
 )
 
 func (ep *ExecParams) Validate(podGetter typedcorev1.PodInterface) error {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -448,7 +448,7 @@ var commandNames = []string{
 	"bootstrap",
 	"budget",
 	"cached-images",
-	"cancel-action",
+	"cancel-task",
 	"change-user-password",
 	"charm",
 	"charm-resources",
@@ -653,6 +653,7 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 		cmdSet.Add("show-action")
 		cmdSet.Add("show-action-status")
 		cmdSet.Add("show-action-output")
+		cmdSet.Add("cancel-action")
 	}
 
 	// 1. Default Commands. Disable all features.
@@ -672,7 +673,7 @@ func (s *MainSuite) TestHelpCommands(c *gc.C) {
 	c.Assert(unknown, jc.DeepEquals, set.NewStrings())
 	missing = cmdSet.Difference(registered)
 	c.Assert(missing, jc.DeepEquals, set.NewStrings(
-		"run-action", "show-action-status", "show-action-output"))
+		"cancel-action", "run-action", "show-action-status", "show-action-output"))
 }
 
 func getHelpCommandNames(c *gc.C) set.Strings {
@@ -754,7 +755,7 @@ func (s *MainSuite) TestRegisterCommands(c *gc.C) {
 	copy(expected, commandNames)
 	expected = append(expected, extraNames...)
 	if !featureflag.Enabled(feature.JujuV3) {
-		expected = append(expected, "run-action", "show-action-status", "show-action-output")
+		expected = append(expected, "cancel-action", "run-action", "show-action-status", "show-action-output")
 	}
 	sort.Strings(expected)
 	c.Check(registry.names, jc.DeepEquals, expected)

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -108,6 +108,14 @@ func (opc *operationCallbacks) FailAction(actionId, message string) error {
 	return err
 }
 
+func (opc *operationCallbacks) ActionStatus(actionId string) (string, error) {
+	if !names.IsValidAction(actionId) {
+		return "", errors.NotValidf("invalid action id %q", actionId)
+	}
+	tag := names.NewActionTag(actionId)
+	return opc.u.st.ActionStatus(tag)
+}
+
 // GetArchiveInfo is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) GetArchiveInfo(charmURL *corecharm.URL) (charm.BundleInfo, error) {
 	ch, err := opc.u.st.Charm(charmURL)

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -171,6 +171,10 @@ type Callbacks interface {
 	// RunActions operations.
 	FailAction(actionId, message string) error
 
+	// ActionStatus returns the status of the action required by the action operation for
+	// cancelation.
+	ActionStatus(actionId string) (string, error)
+
 	// GetArchiveInfo is used to find out how to download a charm archive. It's
 	// only used by Deploy operations.
 	GetArchiveInfo(charmURL *corecharm.URL) (charm.BundleInfo, error)

--- a/worker/uniter/runner/context/action.go
+++ b/worker/uniter/runner/context/action.go
@@ -15,16 +15,18 @@ type ActionData struct {
 	Failed         bool
 	ResultsMessage string
 	ResultsMap     map[string]interface{}
+	Cancel         <-chan struct{}
 }
 
 // NewActionData builds a suitable ActionData struct with no nil members.
 // this should only be called in the event that an Action hook is being requested.
-func NewActionData(name string, tag *names.ActionTag, params map[string]interface{}) *ActionData {
+func NewActionData(name string, tag *names.ActionTag, params map[string]interface{}, cancel <-chan struct{}) *ActionData {
 	return &ActionData{
 		Name:       name,
 		Tag:        *tag,
 		Params:     params,
 		ResultsMap: map[string]interface{}{},
+		Cancel:     cancel,
 	}
 }
 

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -97,6 +97,13 @@ func NewMockUnitHookContext(mockUnit *mocks.MockHookUnit) *HookContext {
 	}
 }
 
+func NewMockUnitHookContextWithState(mockUnit *mocks.MockHookUnit, state *uniter.State) *HookContext {
+	return &HookContext{
+		unit:  mockUnit,
+		state: state,
+	}
+}
+
 // SetEnvironmentHookContextRelation exists purely to set the fields used in hookVars.
 // It makes no assumptions about the validity of context.
 func SetEnvironmentHookContextRelation(context *HookContext, relationId int, endpointName, remoteUnitName string, remoteAppName string) {
@@ -124,10 +131,11 @@ func PatchCachedStatus(ctx jujuc.Context, status, info string, data map[string]i
 	}
 }
 
-func WithActionContext(ctx *HookContext, in map[string]interface{}) {
+func WithActionContext(ctx *HookContext, in map[string]interface{}, cancel <-chan struct{}) {
 	ctx.actionData = &ActionData{
 		Tag:        names.NewActionTag("2"),
 		ResultsMap: in,
+		Cancel:     cancel,
 	}
 }
 

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -30,7 +30,7 @@ type Factory interface {
 
 	// NewActionRunner returns an execution context suitable for running the
 	// action identified by the supplied id.
-	NewActionRunner(actionId string) (Runner, error)
+	NewActionRunner(actionId string, cancel <-chan struct{}) (Runner, error)
 }
 
 // NewFactory returns a Factory capable of creating runners for executing
@@ -89,7 +89,7 @@ func (f *factory) NewHookRunner(hookInfo hook.Info) (Runner, error) {
 }
 
 // NewActionRunner exists to satisfy the Factory interface.
-func (f *factory) NewActionRunner(actionId string) (Runner, error) {
+func (f *factory) NewActionRunner(actionId string, cancel <-chan struct{}) (Runner, error) {
 	ch, err := getCharm(f.paths.GetCharmDir())
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -125,7 +125,7 @@ func (f *factory) NewActionRunner(actionId string) (Runner, error) {
 		return nil, charmrunner.NewBadActionError(name, err.Error())
 	}
 
-	actionData := context.NewActionData(name, &tag, params)
+	actionData := context.NewActionData(name, &tag, params, cancel)
 	ctx, err := f.contextFactory.ActionContext(actionData)
 	if err != nil {
 		return nil, charmrunner.NewBadActionError(name, err.Error())


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Action cancel/abort handling on uniter

- Extend k8s exec framework to support signals and cancelation (with
kill).
- Uniter reacts to action change to check for aborting status

## QA steps

Create a charm with an action that sleeps for a few minutes.
Deploy charm.
`juju cancel-action <action-id>`
Action should go to aborting status.
Then should go to aborted status.

## Documentation changes

N/A

## Bug reference

N/A
