### PR TITLE
back port fix go import stanzas

### DIFF
--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -5,14 +5,14 @@ package instancemutater_test
 
 import (
 	"fmt"
-	jc "github.com/juju/testing/checkers"
-	"gopkg.in/juju/charm.v6"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	coretesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/common"

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -4,12 +4,12 @@
 package simplestreams_test
 
 import (
-	"github.com/juju/utils"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/imagemetadata"


### PR DESCRIPTION
back port of 11252: Fix go import stanzas to satisfy the static analysis tests.