### PR TITLE
Reject k8s charm upgrades that cannot be deployed

### DIFF
--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -123,25 +123,6 @@ func (c *Client) Charm(application string) (_ *charm.URL, forceUpgrade bool, sha
 	return curl, result.ForceUpgrade, result.SHA256, result.CharmModifiedVersion, nil
 }
 
-// SetPodSpec sets the pod spec of the specified application.
-func (c *Client) SetPodSpec(appName string, spec string) error {
-	tag, err := applicationTag(appName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	var result params.ErrorResults
-	args := params.SetPodSpecParams{
-		Specs: []params.EntityString{{
-			Tag:   tag.String(),
-			Value: spec,
-		}},
-	}
-	if err := c.facade.FacadeCall("SetPodSpec", args, &result); err != nil {
-		return errors.Trace(err)
-	}
-	return result.OneError()
-}
-
 func applicationTag(application string) (names.ApplicationTag, error) {
 	if !names.IsValidApplication(application) {
 		return names.ApplicationTag{}, errors.NotValidf("application name %q", application)

--- a/api/caasoperator/client_test.go
+++ b/api/caasoperator/client_test.go
@@ -117,39 +117,6 @@ func (s *operatorSuite) TestCharmInvalidApplicationName(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `application name "" not valid`)
 }
 
-func (s *operatorSuite) TestSetPodSpec(c *gc.C) {
-	tag := names.NewApplicationTag("gitlab")
-	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "CAASOperator")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "SetPodSpec")
-		c.Check(arg, jc.DeepEquals, params.SetPodSpecParams{
-			Specs: []params.EntityString{{
-				Tag:   tag.String(),
-				Value: "spec",
-			}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{Error: &params.Error{Message: "bletch"}}},
-		}
-		return nil
-	})
-
-	client := caasoperator.NewClient(apiCaller)
-	err := client.SetPodSpec(tag.Id(), "spec")
-	c.Assert(err, gc.ErrorMatches, "bletch")
-}
-
-func (s *operatorSuite) TestSetPodSpecInvalidEntityame(c *gc.C) {
-	client := caasoperator.NewClient(basetesting.APICallerFunc(func(_ string, _ int, _, _ string, _, _ interface{}) error {
-		return errors.New("should not be called")
-	}))
-	err := client.SetPodSpec("", "spec")
-	c.Assert(err, gc.ErrorMatches, `application name "" not valid`)
-}
-
 func (s *operatorSuite) TestModel(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "CAASOperator")

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -101,8 +101,8 @@ type mockModel struct {
 	containers []state.CloudContainer
 }
 
-func (m *mockModel) SetPodSpec(tag names.ApplicationTag, spec string) error {
-	m.MethodCall(m, "SetPodSpec", tag, spec)
+func (m *mockModel) SetPodSpec(tag names.ApplicationTag, spec *string) error {
+	m.MethodCall(m, "SetPodSpec", tag, *spec)
 	return m.NextErr()
 }
 

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -184,6 +184,7 @@ func (f *Facade) Charm(args params.Entities) (params.ApplicationCharmResults, er
 }
 
 // SetPodSpec sets the container specs for a set of applications.
+// TODO(juju3) - remove
 func (f *Facade) SetPodSpec(args params.SetPodSpecParams) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Specs)),
@@ -204,7 +205,7 @@ func (f *Facade) SetPodSpec(args params.SetPodSpecParams) (params.ErrorResults, 
 			continue
 		}
 		results.Results[i].Error = common.ServerError(
-			f.model.SetPodSpec(tag, arg.Value),
+			f.model.SetPodSpec(tag, &arg.Value),
 		)
 	}
 	return results, nil

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -28,7 +28,7 @@ type CAASOperatorState interface {
 // Model provides the subset of CAAS model state required
 // by the CAAS operator facade.
 type Model interface {
-	SetPodSpec(names.ApplicationTag, string) error
+	SetPodSpec(names.ApplicationTag, *string) error
 	Name() string
 	UUID() string
 	Type() state.ModelType

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3632,9 +3632,22 @@ containers:
 func (s *uniterSuite) TestSetPodSpec(c *gc.C) {
 	u, cm, app, _ := s.setupCAASModel(c)
 
-	err := u.SetPodSpec(app.Name(), podSpec)
+	err := u.SetPodSpec(app.Name(), &podSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	spec, err := cm.PodSpec(app.ApplicationTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spec, gc.Equals, podSpec)
+}
+
+func (s *uniterSuite) TestSetPodSpecNil(c *gc.C) {
+	u, cm, app, _ := s.setupCAASModel(c)
+
+	err := cm.SetPodSpec(app.ApplicationTag(), &podSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	err = cm.SetPodSpec(app.ApplicationTag(), nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// Spec doesn't change when setting with nil.
+	spec, err := u.GetPodSpec(app.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spec, gc.Equals, podSpec)
 }
@@ -3642,7 +3655,7 @@ func (s *uniterSuite) TestSetPodSpec(c *gc.C) {
 func (s *uniterSuite) TestGetPodSpec(c *gc.C) {
 	u, cm, app, _ := s.setupCAASModel(c)
 
-	err := cm.SetPodSpec(app.ApplicationTag(), podSpec)
+	err := cm.SetPodSpec(app.ApplicationTag(), &podSpec)
 	c.Assert(err, jc.ErrorIsNil)
 	spec, err := u.GetPodSpec(app.Name())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -313,6 +313,23 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	})
 }
 
+func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
+	s.model.modelType = state.ModelTypeCAAS
+	s.setAPIUser(c, names.NewUserTag("admin"))
+	s.backend.charm = &mockCharm{
+		meta: &charm.Meta{
+			Deployment: &charm.Deployment{},
+		},
+	}
+	err := s.api.SetCharm(params.ApplicationSetCharm{
+		ApplicationName: "postgresql",
+		CharmURL:        "cs:postgresql",
+	})
+	c.Assert(err, gc.NotNil)
+	msg := strings.Replace(err.Error(), "\n", "", -1)
+	c.Assert(msg, gc.Matches, "Juju on k8s does not support updating deployment info.*")
+}
+
 func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -753,7 +753,7 @@ containers:
   - name: gitlab
     image: gitlab/latest
 `[1:]
-	err = cm.SetPodSpec(s.app.ApplicationTag(), spec)
+	err = cm.SetPodSpec(s.app.ApplicationTag(), &spec)
 	c.Assert(err, jc.ErrorIsNil)
 
 	status, err := client.Status(nil)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -35690,7 +35690,7 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/SetPodSpecParams"
+                            "$ref": "#/definitions/SetPodSpecParamsV2"
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
@@ -37334,6 +37334,21 @@
                         "results"
                     ]
                 },
+                "PodSpec": {
+                    "type": "object",
+                    "properties": {
+                        "spec": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
                 "PortRange": {
                     "type": "object",
                     "properties": {
@@ -37719,13 +37734,13 @@
                         "results"
                     ]
                 },
-                "SetPodSpecParams": {
+                "SetPodSpecParamsV2": {
                     "type": "object",
                     "properties": {
                         "specs": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/EntityString"
+                                "$ref": "#/definitions/PodSpec"
                             }
                         }
                     },

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -966,8 +966,21 @@ type EntityString struct {
 
 // SetPodSpecParams holds the arguments for setting the pod
 // spec for a set of applications.
+// TODO(juju3) - remove
 type SetPodSpecParams struct {
 	Specs []EntityString `json:"specs"`
+}
+
+// PodSpec holds an entity tag and optional podspec value.
+type PodSpec struct {
+	Tag  string  `json:"tag"`
+	Spec *string `json:"spec,omitempty"`
+}
+
+// SetPodSpecParamsV2 holds the arguments for setting the pod
+// spec for a set of applications.
+type SetPodSpecParamsV2 struct {
+	Specs []PodSpec `json:"specs"`
 }
 
 // GoalStateResults holds the results of GoalStates API call

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -482,7 +482,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 
 		caasModel, err := dbModel.CAASModel()
 		c.Assert(err, jc.ErrorIsNil)
-		err = caasModel.SetPodSpec(application.ApplicationTag(), "pod spec")
+		err = caasModel.SetPodSpec(application.ApplicationTag(), strPtr("pod spec"))
 		c.Assert(err, jc.ErrorIsNil)
 		addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal)
 		err = application.UpdateCloudService("provider-id", []network.SpaceAddress{addr})

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -870,7 +870,8 @@ func (i *importer) application(a description.Application) error {
 		if err != nil {
 			return errors.NewNotSupported(err, "adding pod spec to IAAS model")
 		}
-		if err := cm.SetPodSpec(a.Tag(), a.PodSpec()); err != nil {
+		spec := a.PodSpec()
+		if err := cm.SetPodSpec(a.Tag(), &spec); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -673,7 +673,7 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	caasModel, err := model.CAASModel()
 	c.Assert(err, jc.ErrorIsNil)
-	err = caasModel.SetPodSpec(application.ApplicationTag(), "pod spec")
+	err = caasModel.SetPodSpec(application.ApplicationTag(), strPtr("pod spec"))
 	c.Assert(err, jc.ErrorIsNil)
 	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal)
 	addr.SpaceID = "0"
@@ -747,7 +747,7 @@ func (s *MigrationImportSuite) TestCAASApplicationStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	caasModel, err := testModel.CAASModel()
 	c.Assert(err, jc.ErrorIsNil)
-	err = caasModel.SetPodSpec(application.ApplicationTag(), "pod spec")
+	err = caasModel.SetPodSpec(application.ApplicationTag(), strPtr("pod spec"))
 	c.Assert(err, jc.ErrorIsNil)
 	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal)
 	err = application.UpdateCloudService("provider-id", []network.SpaceAddress{addr})

--- a/state/podspec.go
+++ b/state/podspec.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"github.com/juju/errors"
-	jujutxn "github.com/juju/txn"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -19,11 +18,13 @@ type containerSpecDoc struct {
 	Id string `bson:"_id"`
 
 	Spec string `bson:"spec"`
+
+	UpgradeCounter int `bson:"upgrade-counter"`
 }
 
 // SetPodSpec sets the pod spec for the given application tag.
 // An error will be returned if the specified application is not alive.
-func (m *CAASModel) SetPodSpec(appTag names.ApplicationTag, spec string) error {
+func (m *CAASModel) SetPodSpec(appTag names.ApplicationTag, spec *string) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		var prereqOps []txn.Op
 		app, err := m.State().Application(appTag.Id())
@@ -43,16 +44,21 @@ func (m *CAASModel) SetPodSpec(appTag names.ApplicationTag, spec string) error {
 			C:  podSpecsC,
 			Id: applicationGlobalKey(appTag.Id()),
 		}
-		existing, err := m.PodSpec(appTag)
+		existing, err := m.podInfo(appTag)
 		if err == nil {
-			if existing == spec {
-				return nil, jujutxn.ErrNoOperations
+			updates := bson.D{{"$inc", bson.D{{"upgrade-counter", 1}}}}
+			if spec != nil {
+				updates = append(updates, bson.DocElem{"$set", bson.D{{"spec", *spec}}})
 			}
-			op.Assert = txn.DocExists
-			op.Update = bson.D{{"$set", bson.D{{"spec", spec}}}}
+			op.Assert = bson.D{{"upgrade-counter", existing.UpgradeCounter}}
+			op.Update = updates
 		} else if errors.IsNotFound(err) {
 			op.Assert = txn.DocMissing
-			op.Insert = containerSpecDoc{Spec: spec}
+			var specStr string
+			if spec != nil {
+				specStr = *spec
+			}
+			op.Insert = containerSpecDoc{Spec: specStr}
 		} else {
 			return nil, err
 		}
@@ -63,19 +69,27 @@ func (m *CAASModel) SetPodSpec(appTag names.ApplicationTag, spec string) error {
 
 // PodSpec returns the pod spec for the given application tag.
 func (m *CAASModel) PodSpec(appTag names.ApplicationTag) (string, error) {
+	info, err := m.podInfo(appTag)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return info.Spec, nil
+}
+
+func (m *CAASModel) podInfo(appTag names.ApplicationTag) (*containerSpecDoc, error) {
 	coll, cleanup := m.mb.db().GetCollection(podSpecsC)
 	defer cleanup()
 	var doc containerSpecDoc
 	if err := coll.FindId(applicationGlobalKey(appTag.Id())).One(&doc); err != nil {
 		if err == mgo.ErrNotFound {
-			return "", errors.NotFoundf(
+			return nil, errors.NotFoundf(
 				"pod spec for %s",
 				names.ReadableString(appTag),
 			)
 		}
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	return doc.Spec, nil
+	return &doc, nil
 }
 
 func removePodSpecOp(appTag names.ApplicationTag) txn.Op {

--- a/state/podspec_test.go
+++ b/state/podspec_test.go
@@ -50,7 +50,7 @@ func (s *PodSpecSuite) assertPodSpecNotFound(c *gc.C, tag names.ApplicationTag) 
 }
 
 func (s *PodSpecSuite) TestSetPodSpecApplication(c *gc.C) {
-	err := s.Model.SetPodSpec(s.application.ApplicationTag(), "foo")
+	err := s.Model.SetPodSpec(s.application.ApplicationTag(), strPtr("foo"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPodSpec(c, s.application.ApplicationTag(), "foo")
 }
@@ -61,21 +61,21 @@ func (s *PodSpecSuite) TestSetPodSpecApplicationDying(c *gc.C) {
 	err := s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.Model.SetPodSpec(s.application.ApplicationTag(), "foo")
+	err = s.Model.SetPodSpec(s.application.ApplicationTag(), strPtr("foo"))
 	c.Assert(err, gc.ErrorMatches, "application gitlab not alive")
 	s.assertPodSpecNotFound(c, s.application.ApplicationTag())
 }
 
 func (s *PodSpecSuite) TestSetPodSpecUpdates(c *gc.C) {
 	for _, spec := range []string{"spec0", "spec1"} {
-		err := s.Model.SetPodSpec(s.application.ApplicationTag(), spec)
+		err := s.Model.SetPodSpec(s.application.ApplicationTag(), &spec)
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertPodSpec(c, s.application.ApplicationTag(), spec)
 	}
 }
 
 func (s *PodSpecSuite) TestRemoveApplicationRemovesPodSpec(c *gc.C) {
-	err := s.Model.SetPodSpec(s.application.ApplicationTag(), "spec")
+	err := s.Model.SetPodSpec(s.application.ApplicationTag(), strPtr("spec"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.application.Destroy()
@@ -90,19 +90,27 @@ func (s *PodSpecSuite) TestWatchPodSpec(c *gc.C) {
 	wc.AssertOneChange()
 
 	// No spec -> spec set.
-	err = s.Model.SetPodSpec(s.application.ApplicationTag(), "spec0")
+	err = s.Model.SetPodSpec(s.application.ApplicationTag(), strPtr("spec0"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
-	// No change.
-	err = s.Model.SetPodSpec(s.application.ApplicationTag(), "spec0")
+	// No change to spec but still a change because of incremented counter.
+	err = s.Model.SetPodSpec(s.application.ApplicationTag(), strPtr("spec0"))
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertNoChange()
+	wc.AssertOneChange()
+
+	// Nil spec also triggers a change because of incremented counter.
+	err = s.Model.SetPodSpec(s.application.ApplicationTag(), nil)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
 
 	// Multiple changes coalesced.
-	err = s.Model.SetPodSpec(s.application.ApplicationTag(), "spec1")
+	err = s.Model.SetPodSpec(s.application.ApplicationTag(), strPtr("spec1"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.Model.SetPodSpec(s.application.ApplicationTag(), "spec2")
+	err = s.Model.SetPodSpec(s.application.ApplicationTag(), strPtr("spec2"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
+
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
 }

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -87,10 +87,6 @@ type Config struct {
 	// for time-related operations.
 	Clock clock.Clock
 
-	// PodSpecSetter provides an interface for
-	// setting the pod spec for the application.
-	PodSpecSetter PodSpecSetter
-
 	// DataDir holds the path to the Juju "data directory",
 	// i.e. "/var/lib/juju" (by default). The CAAS operator
 	// expects to find the jujud binary at <data-dir>/tools/jujud.
@@ -175,9 +171,6 @@ func (config Config) Validate() error {
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("missing Clock")
-	}
-	if config.PodSpecSetter == nil {
-		return errors.NotValidf("missing PodSpecSetter")
 	}
 	if config.DataDir == "" {
 		return errors.NotValidf("missing DataDir")

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -117,7 +117,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		Application:           "gitlab",
 		CharmGetter:           &s.client,
 		Clock:                 s.clock,
-		PodSpecSetter:         &s.client,
 		DataDir:               c.MkDir(),
 		ProfileDir:            c.MkDir(),
 		Downloader:            &s.charmDownloader,
@@ -185,10 +184,6 @@ func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
 	s.testValidateConfig(c, func(config *caasoperator.Config) {
 		config.Clock = nil
 	}, `missing Clock not valid`)
-
-	s.testValidateConfig(c, func(config *caasoperator.Config) {
-		config.PodSpecSetter = nil
-	}, `missing PodSpecSetter not valid`)
 
 	s.testValidateConfig(c, func(config *caasoperator.Config) {
 		config.DataDir = ""

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -22,7 +22,6 @@ type Client interface {
 	UnitRemover
 	ApplicationWatcher
 	ContainerStartWatcher
-	PodSpecSetter
 	StatusSetter
 	VersionSetter
 	Model() (*model.Model, error)
@@ -60,12 +59,6 @@ type ApplicationWatcher interface {
 // for unit starts.
 type ContainerStartWatcher interface {
 	WatchContainerStart(string, string) (watcher.StringsWatcher, error)
-}
-
-// PodSpecSetter provides an interface for
-// setting the pod spec for the application.
-type PodSpecSetter interface {
-	SetPodSpec(appName, spec string) error
 }
 
 // StatusSetter provides an interface for setting

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -181,7 +181,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Application:           applicationTag.Id(),
 				CharmGetter:           client,
 				Clock:                 clock,
-				PodSpecSetter:         client,
 				DataDir:               agentConfig.DataDir(),
 				ProfileDir:            config.ProfileDir,
 				Downloader:            downloader,

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -198,7 +198,6 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		DataDir:               s.dataDir,
 		CharmGetter:           &s.client,
 		Clock:                 s.clock,
-		PodSpecSetter:         &s.client,
 		Downloader:            &s.charmDownloader,
 		StatusSetter:          &s.client,
 		UnitGetter:            &s.client,

--- a/worker/caasoperator/mock_test.go
+++ b/worker/caasoperator/mock_test.go
@@ -88,11 +88,6 @@ func (c *fakeClient) Charm(application string) (*charm.URL, bool, string, int, e
 	return gitlabCharmURL, true, fakeCharmSHA256, fakeModifiedVersion, nil
 }
 
-func (c *fakeClient) SetPodSpec(entityName, spec string) error {
-	c.MethodCall(c, "SetPodSpec", entityName, spec)
-	return c.NextErr()
-}
-
 func (c *fakeClient) CharmConfig(application string) (charm.Settings, error) {
 	c.MethodCall(c, "CharmConfig", application)
 	if err := c.NextErr(); err != nil {

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -163,7 +163,9 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		deleted:        s.serviceDeleted,
 		serviceWatcher: watchertest.NewMockNotifyWatcher(s.caasServiceChanges),
 	}
-	s.statusSetter = mockProvisioningStatusSetter{}
+	s.statusSetter = mockProvisioningStatusSetter{
+		statusSet: make(chan struct{}, 1),
+	}
 
 	s.config = caasunitprovisioner.Config{
 		ApplicationGetter:        &s.applicationGetter,
@@ -461,8 +463,17 @@ containers:
 	}}
 
 	s.podSpecGetter.setProvisioningInfo(apicaasunitprovisioner.ProvisioningInfo{
-		PodSpec: anotherSpec,
-		Tags:    map[string]string{"foo": "bar"},
+		PodSpec:     anotherSpec,
+		Tags:        map[string]string{"foo": "bar"},
+		Constraints: constraints.MustParse("mem=4G"),
+		DeploymentInfo: apicaasunitprovisioner.DeploymentInfo{
+			DeploymentType: "stateful",
+			ServiceType:    "loadbalancer",
+		},
+		Filesystems: []storage.KubernetesFilesystemParams{{
+			StorageName: "database",
+			Size:        100,
+		}},
 	})
 	s.sendContainerSpecChange(c)
 	s.podSpecGetter.assertSpecRetrieved(c)
@@ -476,10 +487,75 @@ containers:
 	expectedParams := &caas.ServiceParams{
 		PodSpec:      anotherParsedSpec,
 		ResourceTags: map[string]string{"foo": "bar"},
+		Constraints:  constraints.MustParse("mem=4G"),
+		Deployment: caas.DeploymentParams{
+			DeploymentType: "stateful",
+			ServiceType:    "loadbalancer",
+		},
+		Filesystems: []storage.KubernetesFilesystemParams{{
+			StorageName: "database",
+			Size:        100,
+		}},
 	}
 	s.serviceBroker.CheckCallNames(c, "EnsureService")
 	s.serviceBroker.CheckCall(c, 0, "EnsureService",
 		"gitlab", expectedParams, 1, application.ConfigAttributes{"juju-external-hostname": "exthost"})
+}
+
+func (s *WorkerSuite) TestInvalidDeploymentChange(c *gc.C) {
+	w := s.setupNewUnitScenario(c)
+	defer workertest.CleanKill(c, w)
+
+	s.serviceBroker.ResetCalls()
+
+	// Same spec, nothing happens.
+	s.sendContainerSpecChange(c)
+	s.podSpecGetter.assertSpecRetrieved(c)
+	select {
+	case <-s.serviceEnsured:
+		c.Fatal("service/unit ensured unexpectedly")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	var (
+		anotherSpec = `
+containers:
+  - name: gitlab
+    image: gitlab/latest
+`[1:]
+	)
+	anotherParsedSpec := &specs.PodSpec{}
+	anotherParsedSpec.Version = specs.CurrentVersion
+	anotherParsedSpec.Containers = []specs.ContainerSpec{{
+		Name:  "gitlab",
+		Image: "gitlab/latest",
+	}}
+
+	s.podSpecGetter.setProvisioningInfo(apicaasunitprovisioner.ProvisioningInfo{
+		PodSpec:     anotherSpec,
+		Tags:        map[string]string{"foo": "bar"},
+		Constraints: constraints.MustParse("mem=4G"),
+		DeploymentInfo: apicaasunitprovisioner.DeploymentInfo{
+			DeploymentType: "stateful",
+			ServiceType:    "loadbalancer",
+		},
+		Filesystems: []storage.KubernetesFilesystemParams{{
+			StorageName: "database",
+			Size:        100,
+		}, {
+			StorageName: "logs",
+			Size:        100,
+		}},
+	})
+	s.sendContainerSpecChange(c)
+	s.podSpecGetter.assertSpecRetrieved(c)
+	s.statusSetter.assertStatusSet(c)
+
+	c.Assert(s.serviceBroker.Calls(), gc.HasLen, 0)
+	// First call is for "waiting"
+	s.statusSetter.CheckCallNames(c, "SetOperatorStatus", "SetOperatorStatus")
+	s.statusSetter.CheckCall(c, 1, "SetOperatorStatus",
+		"gitlab", status.Error, "k8s does not support updating storage", map[string]interface{}(nil))
 }
 
 func (s *WorkerSuite) TestScaleZero(c *gc.C) {


### PR DESCRIPTION
### Checklist

 - [X] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?

Will need updating when we fully support k8s charms.

----

## Description of change

Current k8s limitations mean that we cannot upgrade a charm to alter the storage requirements because we cannot patch statefulset volume claim templates. The same restriction applies to devices and deployment type info. So we add checks in the api facades to prevent an incompatible charm from being upgraded, otherwise thinsg break in a non obvious way.

To allow for future support of such upgrades (when k8s is fixed), we trigger the k8s deployment worker whenever a charm upgrade hook is flushed, regardless of whether a new pod spec has been sent in. This allows for charm metadata changes to trigger upgrade processing. This is achieved by adding an UpgradeCounter field to the mongo doc holding the podspec. This is always updated even if the podspec has not changed, triggering a notification.

A now unused SetPodSpec() client API was removed from the caas operator facade.

## QA steps

Deploy a k8s charm.
Edit the metadata.yaml to add new storage.
Attempt to upgrade the charm.
See an error saying changing storage is not supported.
