### PR TITLE
Fix/caas model teardown

### DIFF
--- a/caas/kubernetes/provider/admissionregistration.go
+++ b/caas/kubernetes/provider/admissionregistration.go
@@ -123,16 +123,20 @@ func (k *kubernetesClient) listMutatingWebhookConfigurations(labels map[string]s
 	return cfgList.Items, nil
 }
 
-func (k *kubernetesClient) deleteMutatingWebhookConfigurations(appName string) error {
+func (k *kubernetesClient) deleteMutatingWebhookConfigurations(labels map[string]string) error {
 	err := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations().DeleteCollection(&metav1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	}, metav1.ListOptions{
-		LabelSelector: labelsToSelector(k.getAdmissionControllerLabels(appName)),
+		LabelSelector: labelsToSelector(labels),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) deleteMutatingWebhookConfigurationsForApp(appName string) error {
+	return errors.Trace(k.deleteMutatingWebhookConfigurations(k.getAdmissionControllerLabels(appName)))
 }
 
 func (k *kubernetesClient) ensureValidatingWebhookConfigurations(
@@ -236,14 +240,18 @@ func (k *kubernetesClient) listValidatingWebhookConfigurations(labels map[string
 	return cfgList.Items, nil
 }
 
-func (k *kubernetesClient) deleteValidatingWebhookConfigurations(appName string) error {
+func (k *kubernetesClient) deleteValidatingWebhookConfigurations(labels map[string]string) error {
 	err := k.client().AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().DeleteCollection(&metav1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	}, metav1.ListOptions{
-		LabelSelector: labelsToSelector(k.getAdmissionControllerLabels(appName)),
+		LabelSelector: labelsToSelector(labels),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 	return errors.Trace(err)
+}
+
+func (k *kubernetesClient) deleteValidatingWebhookConfigurationsForApp(appName string) error {
+	return errors.Trace(k.deleteValidatingWebhookConfigurations(k.getAdmissionControllerLabels(appName)))
 }

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -171,6 +171,7 @@ func (s *BaseSuite) TearDownTest(c *gc.C) {
 	s.clock = nil
 	s.k8sClient = nil
 	s.mockApiextensionsClient = nil
+	s.watchers = nil
 
 	s.BaseSuite.TearDownTest(c)
 }

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -140,7 +140,6 @@ func (k *kubernetesClient) deleteCustomResourcesForApp(appName string) error {
 		if isCRDNameSpaced(crd.Spec.Scope) {
 			labels = k.getCRDLabelsNamespaced(appName)
 		}
-		logger.Criticalf("labels %+v", labels)
 		return labels
 	}
 	return k.deleteCustomResources(labelsGetter)

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -180,7 +180,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreate(c *gc.
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
@@ -290,7 +289,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdate(c *gc.
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
@@ -572,7 +570,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
@@ -701,7 +698,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
@@ -827,7 +823,6 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 	badCRDNoVersion := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
@@ -887,7 +882,6 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
@@ -985,7 +979,6 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 	crd1 := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
@@ -1037,7 +1030,6 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 	crd2 := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "scheduledworkflows.kubeflow.org",
-			Namespace:   "test",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -4,6 +4,9 @@
 package provider
 
 import (
+	"context"
+	"sync"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
@@ -132,6 +135,14 @@ func (k *kubernetesClient) ConfigurePodFiles(
 	cfgMapName configMapNameFunc,
 ) error {
 	return k.configurePodFiles(appName, annotations, workloadSpec, containers, cfgMapName)
+}
+
+func (k *kubernetesClient) DeleteClusterScropeResourcesModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
+	k.deleteClusterScropeResourcesModelTeardown(ctx, wg, errChan)
+}
+
+func (k *kubernetesClient) DeleteNamespaceModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
+	k.deleteNamespaceModelTeardown(ctx, wg, errChan)
 }
 
 func StorageProvider(k8sClient kubernetes.Interface, namespace string) storage.Provider {

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -137,8 +137,8 @@ func (k *kubernetesClient) ConfigurePodFiles(
 	return k.configurePodFiles(appName, annotations, workloadSpec, containers, cfgMapName)
 }
 
-func (k *kubernetesClient) DeleteClusterScropeResourcesModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
-	k.deleteClusterScropeResourcesModelTeardown(ctx, wg, errChan)
+func (k *kubernetesClient) DeleteClusterScopeResourcesModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
+	k.deleteClusterScopeResourcesModelTeardown(ctx, wg, errChan)
 }
 
 func (k *kubernetesClient) DeleteNamespaceModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1498,7 +1498,6 @@ func (k *kubernetesClient) fileSetToVolume(
 				Name: refName,
 			},
 			DefaultMode: fileSet.ConfigMap.DefaultMode,
-			Optional:    fileSet.ConfigMap.Optional,
 			Items:       fileRefsToVolItems(fileSet.ConfigMap.Files),
 		}
 	} else if fileSet.Secret != nil {
@@ -1519,7 +1518,6 @@ func (k *kubernetesClient) fileSetToVolume(
 		vol.Secret = &core.SecretVolumeSource{
 			SecretName:  refName,
 			DefaultMode: fileSet.Secret.DefaultMode,
-			Optional:    fileSet.Secret.Optional,
 			Items:       fileRefsToVolItems(fileSet.Secret.Files),
 		}
 	} else {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -449,7 +449,7 @@ func (k *kubernetesClient) Destroy(callbacks envcontext.ProviderCallContext) (er
 		}
 	}()
 
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	done := make(chan struct{})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -246,7 +246,7 @@ func purifyResource(resource resourcePurifier) {
 	resource.SetResourceVersion("")
 }
 
-func (k *kubernetesClient) extendedCient() apiextensionsclientset.Interface {
+func (k *kubernetesClient) extendedClient() apiextensionsclientset.Interface {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	client := k.apiextensionsClientUnlocked
@@ -457,7 +457,7 @@ func (k *kubernetesClient) Destroy(callbacks envcontext.ProviderCallContext) (er
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go k.deleteClusterScropeResourcesModelTeardown(ctx, &wg, errChan)
+	go k.deleteClusterScopeResourcesModelTeardown(ctx, &wg, errChan)
 	wg.Add(1)
 	go k.deleteNamespaceModelTeardown(ctx, &wg, errChan)
 

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -782,10 +782,10 @@ func (k *kubernetesClient) DeleteService(appName string) (err error) {
 	if err := k.deleteAllServiceAccountResources(appName); err != nil {
 		return errors.Trace(err)
 	}
-	// // Order matters: delete custom resources first then custom resource definitions.
-	// if err := k.deleteCustomResourcesForApp(appName); err != nil {
-	// 	return errors.Trace(err)
-	// }
+	// Order matters: delete custom resources first then custom resource definitions.
+	if err := k.deleteCustomResourcesForApp(appName); err != nil {
+		return errors.Trace(err)
+	}
 	if err := k.deleteCustomResourceDefinitionsForApp(appName); err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -444,8 +444,7 @@ func (*kubernetesClient) Provider() caas.ContainerEnvironProvider {
 func (k *kubernetesClient) Destroy(callbacks envcontext.ProviderCallContext) (err error) {
 	defer func() {
 		if err != nil && k8serrors.ReasonForError(err) == v1.StatusReasonUnknown {
-			// logger.Warningf("k8s cluster is not accessible: %v", err)
-			logger.Criticalf("k8s cluster is not accessible: %v", errors.ErrorStack(err))
+			logger.Warningf("k8s cluster is not accessible: %v", err)
 			err = nil
 		}
 	}()

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1584,7 +1584,9 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 		errCh <- destroyFunc()
 	}()
 
-	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 7)
+	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 6)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -805,7 +805,6 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 					ConfigMap: &specs.ResourceRefVol{
 						Name:        "log-config",
 						DefaultMode: int32Ptr(511),
-						Optional:    boolPtr(true),
 						Files: []specs.FileRef{
 							{
 								Key:  "log_level",
@@ -826,7 +825,6 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 								Name: "log-config",
 							},
 							DefaultMode: int32Ptr(511),
-							Optional:    boolPtr(true),
 							Items: []core.KeyToPath{
 								{
 									Key:  "log_level",
@@ -847,7 +845,6 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 					ConfigMap: &specs.ResourceRefVol{
 						Name:        "non-existing-config-map",
 						DefaultMode: int32Ptr(511),
-						Optional:    boolPtr(true),
 						Files: []specs.FileRef{
 							{
 								Key:  "log_level",
@@ -870,7 +867,6 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 					Secret: &specs.ResourceRefVol{
 						Name:        "mysecret2",
 						DefaultMode: int32Ptr(511),
-						Optional:    boolPtr(true),
 						Files: []specs.FileRef{
 							{
 								Key:  "password",
@@ -889,7 +885,6 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 						Secret: &core.SecretVolumeSource{
 							SecretName:  "mysecret2",
 							DefaultMode: int32Ptr(511),
-							Optional:    boolPtr(true),
 							Items: []core.KeyToPath{
 								{
 									Key:  "password",
@@ -910,7 +905,6 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 					Secret: &specs.ResourceRefVol{
 						Name:        "non-existing-secret",
 						DefaultMode: int32Ptr(511),
-						Optional:    boolPtr(true),
 						Files: []specs.FileRef{
 							{
 								Key:  "password",

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -101,7 +101,6 @@ containers:
         configMap:
           name: log-config
           defaultMode: 511
-          optional: true
           files:
             - key: log_level
               path: log_level
@@ -111,7 +110,6 @@ containers:
         secret:
           name: mysecret2
           defaultMode: 511
-          optional: true
           files:
             - key: password
               path: my-group/my-password
@@ -436,7 +434,6 @@ echo "do some stuff here for gitlab container"
 							ConfigMap: &specs.ResourceRefVol{
 								Name:        "log-config",
 								DefaultMode: int32Ptr(511),
-								Optional:    boolPtr(true),
 								Files: []specs.FileRef{
 									{
 										Key:  "log_level",
@@ -454,7 +451,6 @@ echo "do some stuff here for gitlab container"
 							Secret: &specs.ResourceRefVol{
 								Name:        "mysecret2",
 								DefaultMode: int32Ptr(511),
-								Optional:    boolPtr(true),
 								Files: []specs.FileRef{
 									{
 										Key:  "password",

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -1,0 +1,236 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+	"sync"
+
+	jujuclock "github.com/juju/clock"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/watcher"
+)
+
+func (k *kubernetesClient) deleteClusterScropeResourcesModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
+	defer wg.Done()
+
+	labels := map[string]string{
+		labelModel: k.namespace,
+	}
+	logger.Criticalf("--> deleteClusterScropeResourcesModelTeardown")
+
+	tasks := []teardownResources{
+		// Order matters.
+		k.deleteClusterRoleBindingsModelTeardown,
+		k.deleteClusterRolesModelTeardown,
+		// delete CRDs will delete CRs that were created by this CRD automatically.
+		k.deleteCustomResourceDefinitionsModelTeardown,
+		k.deleteMutatingWebhookConfigurationsModelTeardown,
+		k.deleteValidatingWebhookConfigurationsModelTeardown,
+		k.deleteStorageClassesModelTeardown,
+	}
+	var subwg sync.WaitGroup
+	subwg.Add(len(tasks))
+	defer subwg.Wait()
+
+	for _, f := range tasks {
+		go f(ctx, labels, k.clock, &subwg, errChan)
+	}
+}
+
+type teardownResources func(
+	context.Context,
+	map[string]string,
+	jujuclock.Clock,
+	*sync.WaitGroup,
+	chan<- error,
+)
+
+func (k *kubernetesClient) deleteClusterRoleBindingsModelTeardown(
+	ctx context.Context,
+	labels map[string]string,
+	clk jujuclock.Clock,
+	wg *sync.WaitGroup,
+	errChan chan<- error,
+) {
+	ensureResourcesDeletedfunc(ctx, labels, clk, wg, errChan,
+		k.deleteClusterRoleBindings, func(labels map[string]string) error {
+			_, err := k.listClusterRoleBindings(labels)
+			logger.Criticalf("listClusterRoleBindings err -> %#v", err)
+			return err
+		},
+	)
+}
+
+func (k *kubernetesClient) deleteClusterRolesModelTeardown(
+	ctx context.Context,
+	labels map[string]string,
+	clk jujuclock.Clock,
+	wg *sync.WaitGroup,
+	errChan chan<- error,
+) {
+	ensureResourcesDeletedfunc(ctx, labels, clk, wg, errChan,
+		k.deleteClusterRoles, func(labels map[string]string) error {
+			_, err := k.listClusterRoles(labels)
+			logger.Criticalf("listClusterRoles err -> %#v", err)
+			return err
+		},
+	)
+}
+
+func (k *kubernetesClient) deleteCustomResourceDefinitionsModelTeardown(
+	ctx context.Context,
+	labels map[string]string,
+	clk jujuclock.Clock,
+	wg *sync.WaitGroup,
+	errChan chan<- error,
+) {
+	ensureResourcesDeletedfunc(ctx, labels, clk, wg, errChan,
+		k.deleteCustomResourceDefinitions, func(labels map[string]string) error {
+			_, err := k.listCustomResourceDefinitions(labels)
+			logger.Criticalf("listCustomResourceDefinitions err -> %#v", err)
+			return err
+		},
+	)
+}
+
+func (k *kubernetesClient) deleteMutatingWebhookConfigurationsModelTeardown(
+	ctx context.Context,
+	labels map[string]string,
+	clk jujuclock.Clock,
+	wg *sync.WaitGroup,
+	errChan chan<- error,
+) {
+	ensureResourcesDeletedfunc(ctx, labels, clk, wg, errChan,
+		k.deleteMutatingWebhookConfigurations, func(labels map[string]string) error {
+			_, err := k.listMutatingWebhookConfigurations(labels)
+			logger.Criticalf("listMutatingWebhookConfigurations err -> %#v", err)
+			return err
+		},
+	)
+}
+
+func (k *kubernetesClient) deleteValidatingWebhookConfigurationsModelTeardown(
+	ctx context.Context,
+	labels map[string]string,
+	clk jujuclock.Clock,
+	wg *sync.WaitGroup,
+	errChan chan<- error,
+) {
+	ensureResourcesDeletedfunc(ctx, labels, clk, wg, errChan,
+		k.deleteValidatingWebhookConfigurations, func(labels map[string]string) error {
+			_, err := k.listValidatingWebhookConfigurations(labels)
+			logger.Criticalf("listValidatingWebhookConfigurations err -> %#v", err)
+			return err
+		},
+	)
+}
+func (k *kubernetesClient) deleteStorageClassesModelTeardown(
+	ctx context.Context,
+	labels map[string]string,
+	clk jujuclock.Clock,
+	wg *sync.WaitGroup,
+	errChan chan<- error,
+) {
+	ensureResourcesDeletedfunc(ctx, labels, clk, wg, errChan,
+		k.deleteStorageClasses, func(labels map[string]string) error {
+			_, err := k.listStorageClasses(labels)
+			logger.Criticalf("listStorageClasses err -> %#v", err)
+			return err
+		},
+	)
+}
+
+type deleterChecker func(map[string]string) error
+
+func ensureResourcesDeletedfunc(
+	ctx context.Context,
+	labels map[string]string,
+	clk jujuclock.Clock,
+	wg *sync.WaitGroup,
+	errChan chan<- error,
+	deleter, checker deleterChecker,
+) {
+	defer wg.Done()
+
+	var err error
+	defer func() {
+		if err != nil {
+			select {
+			case errChan <- err:
+			}
+		}
+	}()
+	if err = deleter(labels); err != nil {
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			err = errors.Trace(ctx.Err())
+			return
+		default:
+			err = checker(labels)
+			if errors.IsNotFound(err) {
+				// Deleted already.
+				err = nil
+				return
+			}
+			if err != nil {
+				err = errors.Trace(err)
+				return
+			}
+			// Keep checking.
+		}
+	}
+}
+
+func (k *kubernetesClient) deleteNamespaceModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
+	defer wg.Done()
+
+	var err error
+	defer func() {
+		if err != nil {
+			select {
+			case errChan <- err:
+			}
+		}
+	}()
+
+	logger.Criticalf("--> deleteNamespaceModelTeardown")
+
+	var w watcher.NotifyWatcher
+	if w, err = k.WatchNamespace(); err != nil {
+		err = errors.Annotatef(err, "watching namespace %q", k.namespace)
+		return
+	}
+	defer w.Kill()
+
+	if err = k.deleteNamespace(); err != nil {
+		err = errors.Annotatef(err, "deleting model namespace %q", k.namespace)
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			err = errors.Annotatef(ctx.Err(), "tearing down namespace %q", k.namespace)
+			return
+		case <-w.Changes():
+			// Ensures the namespace to be deleted - notfound error expected.
+			_, err := k.GetNamespace(k.namespace)
+			if errors.IsNotFound(err) {
+				// Namespace has been deleted.
+				err = nil
+				return
+			}
+			if err != nil {
+				err = errors.Trace(err)
+				return
+			}
+			logger.Debugf("namespace %q is still been terminating", k.namespace)
+		}
+	}
+}

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -25,7 +25,7 @@ func (k *kubernetesClient) deleteClusterScropeResourcesModelTeardown(ctx context
 	tasks := []teardownResources{
 		k.deleteClusterRoleBindingsModelTeardown,
 		k.deleteClusterRolesModelTeardown,
-		// delete CRDs will delete CRs that were created by this CRD automatically.
+		k.deleteCustomResourcesModelTeardown,
 		k.deleteCustomResourceDefinitionsModelTeardown,
 		k.deleteMutatingWebhookConfigurationsModelTeardown,
 		k.deleteValidatingWebhookConfigurationsModelTeardown,

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -24,16 +24,15 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardown(c *gc.C) {
+func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardown(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
 	// CRs of this Cluster scope CRD will get deleted.
 	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "tfjobs.kubeflow.org",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:   "tfjobs.kubeflow.org",
+			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -87,9 +86,8 @@ func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardown(c *gc.C) 
 	// CRs of this namespaced scope CRD will be skipped.
 	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "tfjobs.kubeflow.org",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:   "tfjobs.kubeflow.org",
+			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -277,27 +275,28 @@ func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardown(c *gc.C) 
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go s.broker.DeleteClusterScropeResourcesModelTeardown(ctx, &wg, errCh)
+	go s.broker.DeleteClusterScopeResourcesModelTeardown(ctx, &wg, errCh)
 
-	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 7)
+	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 6)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
 	case <-done:
 	case <-time.After(testing.LongWait):
-		c.Fatalf("timed out waiting for DeleteClusterScropeResourcesModelTeardown return")
+		c.Fatalf("timed out waiting for DeleteClusterScopeResourcesModelTeardown return")
 	}
 }
 
-func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardownTimeout(c *gc.C) {
+func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
 	// CRs of this Cluster scope CRD will get deleted.
 	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "tfjobs.kubeflow.org",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:   "tfjobs.kubeflow.org",
+			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -351,9 +350,8 @@ func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardownTimeout(c 
 	// CRs of this namespaced scope CRD will be skipped.
 	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "tfjobs.kubeflow.org",
-			Namespace: "test",
-			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:   "tfjobs.kubeflow.org",
+			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -480,19 +478,19 @@ func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardownTimeout(c 
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
-	go s.broker.DeleteClusterScropeResourcesModelTeardown(ctx, &wg, errCh)
+	go s.broker.DeleteClusterScopeResourcesModelTeardown(ctx, &wg, errCh)
 
-	err := s.clock.WaitAdvance(500*time.Millisecond, testing.ShortWait, 7)
+	err := s.clock.WaitAdvance(500*time.Millisecond, testing.ShortWait, 6)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
 	case <-done:
 		c.Assert(<-errCh, gc.ErrorMatches, `context deadline exceeded`)
 	case <-time.After(testing.LongWait):
-		c.Fatalf("timed out waiting for DeleteClusterScropeResourcesModelTeardown return")
+		c.Fatalf("timed out waiting for DeleteClusterScopeResourcesModelTeardown return")
 	}
 }
 
-func (s *K8sBrokerSuite) TestdeleteNamespaceModelTeardown(c *gc.C) {
+func (s *K8sBrokerSuite) TestDeleteNamespaceModelTeardown(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
@@ -541,7 +539,7 @@ func (s *K8sBrokerSuite) TestdeleteNamespaceModelTeardown(c *gc.C) {
 	}
 }
 
-func (s *K8sBrokerSuite) TestdeleteNamespaceModelTeardownFailed(c *gc.C) {
+func (s *K8sBrokerSuite) TestDeleteNamespaceModelTeardownFailed(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -1,0 +1,593 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/worker.v1/workertest"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/juju/juju/testing"
+)
+
+func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardown(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	// CRs of this Cluster scope CRD will get deleted.
+	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "tfjobs.kubeflow.org",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "kubeflow.org",
+			Version: "v1alpha2",
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true, Storage: true},
+				{Name: "v1alpha2", Served: true, Storage: false},
+			},
+			Scope: apiextensionsv1beta1.ClusterScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"tfReplicaSpecs": {
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"Worker": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"PS": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer", Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"Chief": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+											Maximum: float64Ptr(1),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// CRs of this namespaced scope CRD will be skipped.
+	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "tfjobs.kubeflow.org",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "kubeflow.org",
+			Version: "v1alpha2",
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true, Storage: true},
+				{Name: "v1alpha2", Served: true, Storage: false},
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"tfReplicaSpecs": {
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"Worker": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"PS": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer", Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"Chief": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+											Maximum: float64Ptr(1),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// timer +1.
+	s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-model==test"}).
+		Return(&rbacv1.ClusterRoleBindingList{}, nil).
+		After(
+			s.mockClusterRoleBindings.EXPECT().DeleteCollection(
+				s.deleteOptions(v1.DeletePropagationForeground, ""),
+				v1.ListOptions{LabelSelector: "juju-model==test"},
+			).Return(s.k8sNotFoundError()),
+		)
+
+	// timer +1.
+	s.mockClusterRoles.EXPECT().List(v1.ListOptions{LabelSelector: "juju-model==test"}).
+		Return(&rbacv1.ClusterRoleList{}, nil).
+		After(
+			s.mockClusterRoles.EXPECT().DeleteCollection(
+				s.deleteOptions(v1.DeletePropagationForeground, ""),
+				v1.ListOptions{LabelSelector: "juju-model==test"},
+			).Return(s.k8sNotFoundError()),
+		)
+
+	// timer +1.
+	s.mockNamespaceableResourceClient.EXPECT().List(
+		// list all custom resources for crd "v1alpha2".
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(&unstructured.UnstructuredList{}, nil).After(
+		s.mockDynamicClient.EXPECT().Resource(
+			schema.GroupVersionResource{
+				Group:    crdClusterScope.Spec.Group,
+				Version:  "v1alpha2",
+				Resource: crdClusterScope.Spec.Names.Plural,
+			},
+		).Return(s.mockNamespaceableResourceClient),
+	).After(
+		// list all custom resources for crd "v1".
+		s.mockNamespaceableResourceClient.EXPECT().List(
+			v1.ListOptions{LabelSelector: "juju-model==test"},
+		).Return(&unstructured.UnstructuredList{}, nil),
+	).After(
+		s.mockDynamicClient.EXPECT().Resource(
+			schema.GroupVersionResource{
+				Group:    crdClusterScope.Spec.Group,
+				Version:  "v1",
+				Resource: crdClusterScope.Spec.Names.Plural,
+			},
+		).Return(s.mockNamespaceableResourceClient),
+	).After(
+		// list cluster wide all custom resource definitions for listing custom resources.
+		s.mockCustomResourceDefinition.EXPECT().List(v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+	).After(
+		// delete all custom resources for crd "v1alpha2".
+		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
+			s.deleteOptions(v1.DeletePropagationForeground, ""),
+			v1.ListOptions{LabelSelector: "juju-model==test"},
+		).Return(nil),
+	).After(
+		s.mockDynamicClient.EXPECT().Resource(
+			schema.GroupVersionResource{
+				Group:    crdClusterScope.Spec.Group,
+				Version:  "v1alpha2",
+				Resource: crdClusterScope.Spec.Names.Plural,
+			},
+		).Return(s.mockNamespaceableResourceClient),
+	).After(
+		// delete all custom resources for crd "v1".
+		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
+			s.deleteOptions(v1.DeletePropagationForeground, ""),
+			v1.ListOptions{LabelSelector: "juju-model==test"},
+		).Return(nil),
+	).After(
+		s.mockDynamicClient.EXPECT().Resource(
+			schema.GroupVersionResource{
+				Group:    crdClusterScope.Spec.Group,
+				Version:  "v1",
+				Resource: crdClusterScope.Spec.Names.Plural,
+			},
+		).Return(s.mockNamespaceableResourceClient),
+	).After(
+		// list cluster wide all custom resource definitions for deleting custom resources.
+		s.mockCustomResourceDefinition.EXPECT().List(v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+	)
+
+	// timer +1.
+	s.mockCustomResourceDefinition.EXPECT().List(v1.ListOptions{LabelSelector: "juju-model==test"}).AnyTimes().
+		Return(&apiextensionsv1beta1.CustomResourceDefinitionList{}, nil).
+		After(
+			s.mockCustomResourceDefinition.EXPECT().DeleteCollection(
+				s.deleteOptions(v1.DeletePropagationForeground, ""),
+				v1.ListOptions{LabelSelector: "juju-model==test"},
+			).Return(s.k8sNotFoundError()),
+		)
+
+	// timer +1.
+	s.mockMutatingWebhookConfiguration.EXPECT().List(v1.ListOptions{LabelSelector: "juju-model==test"}).
+		Return(&admissionregistrationv1beta1.MutatingWebhookConfigurationList{}, nil).
+		After(
+			s.mockMutatingWebhookConfiguration.EXPECT().DeleteCollection(
+				s.deleteOptions(v1.DeletePropagationForeground, ""),
+				v1.ListOptions{LabelSelector: "juju-model==test"},
+			).Return(s.k8sNotFoundError()),
+		)
+
+	// timer +1.
+	s.mockValidatingWebhookConfiguration.EXPECT().List(v1.ListOptions{LabelSelector: "juju-model==test"}).
+		Return(&admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}, nil).
+		After(
+			s.mockValidatingWebhookConfiguration.EXPECT().DeleteCollection(
+				s.deleteOptions(v1.DeletePropagationForeground, ""),
+				v1.ListOptions{LabelSelector: "juju-model==test"},
+			).Return(s.k8sNotFoundError()),
+		)
+
+	// timer +1.
+	s.mockStorageClass.EXPECT().List(v1.ListOptions{LabelSelector: "juju-model==test"}).
+		Return(&storagev1.StorageClassList{}, nil).
+		After(
+			s.mockStorageClass.EXPECT().DeleteCollection(
+				s.deleteOptions(v1.DeletePropagationForeground, ""),
+				v1.ListOptions{LabelSelector: "juju-model==test"},
+			).Return(nil),
+		)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error)
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.broker.DeleteClusterScropeResourcesModelTeardown(ctx, &wg, errCh)
+
+	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 7)
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for DeleteClusterScropeResourcesModelTeardown return")
+	}
+}
+
+func (s *K8sBrokerSuite) TestdeleteClusterScropeResourcesModelTeardownTimeout(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	// CRs of this Cluster scope CRD will get deleted.
+	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "tfjobs.kubeflow.org",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "kubeflow.org",
+			Version: "v1alpha2",
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true, Storage: true},
+				{Name: "v1alpha2", Served: true, Storage: false},
+			},
+			Scope: apiextensionsv1beta1.ClusterScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"tfReplicaSpecs": {
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"Worker": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"PS": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer", Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"Chief": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+											Maximum: float64Ptr(1),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// CRs of this namespaced scope CRD will be skipped.
+	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "tfjobs.kubeflow.org",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "kubeflow.org",
+			Version: "v1alpha2",
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true, Storage: true},
+				{Name: "v1alpha2", Served: true, Storage: false},
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"tfReplicaSpecs": {
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"Worker": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"PS": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type: "integer", Minimum: float64Ptr(1),
+										},
+									},
+								},
+								"Chief": {
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"replicas": {
+											Type:    "integer",
+											Minimum: float64Ptr(1),
+											Maximum: float64Ptr(1),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.mockClusterRoleBindings.EXPECT().DeleteCollection(
+		s.deleteOptions(v1.DeletePropagationForeground, ""),
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(s.k8sNotFoundError())
+
+	s.mockClusterRoles.EXPECT().DeleteCollection(
+		s.deleteOptions(v1.DeletePropagationForeground, ""),
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(s.k8sNotFoundError())
+
+	// delete all custom resources for crd "v1alpha2".
+	s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
+		s.deleteOptions(v1.DeletePropagationForeground, ""),
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(nil).After(
+		s.mockDynamicClient.EXPECT().Resource(
+			schema.GroupVersionResource{
+				Group:    crdClusterScope.Spec.Group,
+				Version:  "v1alpha2",
+				Resource: crdClusterScope.Spec.Names.Plural,
+			},
+		).Return(s.mockNamespaceableResourceClient),
+	).After(
+		// delete all custom resources for crd "v1".
+		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
+			s.deleteOptions(v1.DeletePropagationForeground, ""),
+			v1.ListOptions{LabelSelector: "juju-model==test"},
+		).Return(nil),
+	).After(
+		s.mockDynamicClient.EXPECT().Resource(
+			schema.GroupVersionResource{
+				Group:    crdClusterScope.Spec.Group,
+				Version:  "v1",
+				Resource: crdClusterScope.Spec.Names.Plural,
+			},
+		).Return(s.mockNamespaceableResourceClient),
+	).After(
+		// list cluster wide all custom resource definitions for deleting custom resources.
+		s.mockCustomResourceDefinition.EXPECT().List(v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+	)
+
+	s.mockCustomResourceDefinition.EXPECT().DeleteCollection(
+		s.deleteOptions(v1.DeletePropagationForeground, ""),
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(s.k8sNotFoundError())
+
+	s.mockMutatingWebhookConfiguration.EXPECT().DeleteCollection(
+		s.deleteOptions(v1.DeletePropagationForeground, ""),
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(s.k8sNotFoundError())
+
+	s.mockValidatingWebhookConfiguration.EXPECT().DeleteCollection(
+		s.deleteOptions(v1.DeletePropagationForeground, ""),
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(s.k8sNotFoundError())
+
+	s.mockStorageClass.EXPECT().DeleteCollection(
+		s.deleteOptions(v1.DeletePropagationForeground, ""),
+		v1.ListOptions{LabelSelector: "juju-model==test"},
+	).Return(nil)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	go s.broker.DeleteClusterScropeResourcesModelTeardown(ctx, &wg, errCh)
+
+	err := s.clock.WaitAdvance(500*time.Millisecond, testing.ShortWait, 7)
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-done:
+		c.Assert(<-errCh, gc.ErrorMatches, `context deadline exceeded`)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for DeleteClusterScropeResourcesModelTeardown return")
+	}
+}
+
+func (s *K8sBrokerSuite) TestdeleteNamespaceModelTeardown(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	ns := &core.Namespace{}
+	ns.Name = "test"
+	s.ensureJujuNamespaceAnnotations(false, ns)
+	namespaceWatcher, namespaceFirer := newKubernetesTestWatcher()
+	s.k8sWatcherFn = newK8sWatcherFunc(namespaceWatcher)
+
+	s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{}).
+		Return(ns, nil)
+	s.mockNamespaces.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, "")).
+		Return(nil)
+	// still terminating.
+	s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{}).
+		DoAndReturn(func(_, _ interface{}) (*core.Namespace, error) {
+			namespaceFirer()
+			return ns, nil
+		})
+	// terminated, not found returned.
+	s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{}).
+		Return(nil, s.k8sNotFoundError())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.broker.DeleteNamespaceModelTeardown(ctx, &wg, errCh)
+
+	select {
+	case <-done:
+		for _, watcher := range s.watchers {
+			c.Assert(workertest.CheckKilled(c, watcher), jc.ErrorIsNil)
+		}
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for deleteNamespaceModelTeardown return")
+	}
+}
+
+func (s *K8sBrokerSuite) TestdeleteNamespaceModelTeardownFailed(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	ns := &core.Namespace{}
+	ns.Name = "test"
+	s.ensureJujuNamespaceAnnotations(false, ns)
+	namespaceWatcher, namespaceFirer := newKubernetesTestWatcher()
+	s.k8sWatcherFn = newK8sWatcherFunc(namespaceWatcher)
+
+	s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{}).
+		Return(ns, nil)
+	s.mockNamespaces.EXPECT().Delete("test", s.deleteOptions(v1.DeletePropagationForeground, "")).
+		Return(nil)
+	// still terminating.
+	s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{}).
+		DoAndReturn(func(_, _ interface{}) (*core.Namespace, error) {
+			namespaceFirer()
+			return ns, nil
+		})
+	// terminated, not found returned.
+	s.mockNamespaces.EXPECT().Get("test", v1.GetOptions{}).
+		Return(nil, errors.New("error bla"))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.broker.DeleteNamespaceModelTeardown(ctx, &wg, errCh)
+
+	select {
+	case <-done:
+		err := <-errCh
+		c.Assert(err, gc.ErrorMatches, `getting namespace "test": error bla`)
+		for _, watcher := range s.watchers {
+			c.Assert(workertest.CheckKilled(c, watcher), jc.ErrorIsNil)
+		}
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for deleteNamespaceModelTeardown return")
+	}
+}

--- a/caas/specs/filesets.go
+++ b/caas/specs/filesets.go
@@ -191,7 +191,6 @@ type ResourceRefVol struct {
 	Name        string    `json:"name" yaml:"name"`
 	Files       []FileRef `json:"files,omitempty" yaml:"files,omitempty"`
 	DefaultMode *int32    `json:"defaultMode,omitempty" yaml:"defaultMode,omitempty"`
-	Optional    *bool     `json:"optional,omitempty" yaml:"optional,omitempty"`
 }
 
 // Validate validates ResourceRefVol.


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Destroying CAAS model now ensures cluster scope resources get deleted as well;

Driveby fix: 
- remove the `Optional` field from `volumeConfig` items;
- In k8s provider baseSuite, wacher slices wasn't properly cleaned up for each test;

## QA steps

- deploy CAAS app with CRDs, MutatingWebhookConfiguration etc cluster scope resources;
- destroy the model;
- kubectl checks those resources are gone;

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1862426