### PR TITLE
'juju status' caches the list of space names.

### DIFF
--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -44,6 +44,7 @@ type Backend interface {
 	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
 	AllRelations() ([]*state.Relation, error)
 	AllSubnets() ([]*state.Subnet, error)
+	AllSpaces() ([]*state.Space, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
 	Application(string) (*state.Application, error)

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -44,7 +44,6 @@ type Backend interface {
 	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
 	AllRelations() ([]*state.Relation, error)
 	AllSubnets() ([]*state.Subnet, error)
-	AllSpaces() ([]*state.Space, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
 	Application(string) (*state.Application, error)
@@ -73,6 +72,7 @@ type Backend interface {
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	SetModelAgentVersion(version.Number, bool) error
 	SetModelConstraints(constraints.Value) error
+	SpaceNamesByID() (map[string]string, error)
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 	Watch(params state.WatchParams) *state.Multiwatcher

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -580,7 +580,7 @@ func fetchControllerNodes(st Backend) (map[string]state.ControllerNode, error) {
 // so we want all or none.
 func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string]map[string]set.Strings, map[string][]*state.LinkLayerDevice, error) {
 	ipAddresses := make(map[string][]*state.Address)
-	spaces := make(map[string]map[string]set.Strings)
+	spacesPerMachine := make(map[string]map[string]set.Strings)
 	subnets, err := st.AllSubnets()
 	if err != nil {
 		return nil, nil, nil, err
@@ -588,6 +588,14 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 	subnetsByCIDR := make(map[string]*state.Subnet)
 	for _, subnet := range subnets {
 		subnetsByCIDR[subnet.CIDR()] = subnet
+	}
+	spaces, err := st.AllSpaces()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	spaceIDToSpaceName := make(map[string]string)
+	for _, space := range spaces {
+		spaceIDToSpaceName[space.Id()] = space.Name()
 	}
 	// For every machine, track what devices have addresses so we can filter linklayerdevices later
 	devicesWithAddresses := make(map[string]set.Strings)
@@ -602,11 +610,11 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		machineID := ipAddr.MachineID()
 		ipAddresses[machineID] = append(ipAddresses[machineID], ipAddr)
 		if subnet, ok := subnetsByCIDR[ipAddr.SubnetCIDR()]; ok {
-			if spaceName := subnet.SpaceName(); spaceName != "" {
-				devices, ok := spaces[machineID]
+			if spaceName := spaceIDToSpaceName[subnet.SpaceID()]; spaceName != "" {
+				devices, ok := spacesPerMachine[machineID]
 				if !ok {
 					devices = make(map[string]set.Strings)
-					spaces[machineID] = devices
+					spacesPerMachine[machineID] = devices
 				}
 				deviceName := ipAddr.DeviceName()
 				spacesSet, ok := devices[deviceName]
@@ -648,7 +656,7 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		linkLayerDevices[machineID] = append(linkLayerDevices[machineID], llDev)
 	}
 
-	return ipAddresses, spaces, linkLayerDevices, nil
+	return ipAddresses, spacesPerMachine, linkLayerDevices, nil
 }
 
 // fetchAllApplicationsAndUnits returns a map from application name to application,

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -610,7 +610,11 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		machineID := ipAddr.MachineID()
 		ipAddresses[machineID] = append(ipAddresses[machineID], ipAddr)
 		if subnet, ok := subnetsByCIDR[ipAddr.SubnetCIDR()]; ok {
-			if spaceName := spaceIDToSpaceName[subnet.SpaceID()]; spaceName != "" {
+			spaceName, found := spaceIDToSpaceName[subnet.SpaceID()]
+			if !found {
+				spaceName = network.AlphaSpaceName
+			}
+			if spaceName != "" {
 				devices, ok := spacesPerMachine[machineID]
 				if !ok {
 					devices = make(map[string]set.Strings)


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Rather than mapping from space-id to space-name for each interface, do
a single query load, and then pull the space names out of the map.

## QA steps

On a controller with many machines (1000 in a model), do 'juju status'. It should return quickly. You can also use 'mongotop' to see that we are making a lot of reads against the spaces collection.

## Documentation changes

None.

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1865172