### PR TITLE
[dev] Run start hook on reboots

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,10 +43,11 @@ const (
 
 // These are base values used for the corresponding defaults.
 var (
-	logDir          = paths.MustSucceed(paths.LogDir(series.MustHostSeries()))
-	dataDir         = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
-	confDir         = paths.MustSucceed(paths.ConfDir(series.MustHostSeries()))
-	metricsSpoolDir = paths.MustSucceed(paths.MetricsSpoolDir(series.MustHostSeries()))
+	logDir           = paths.MustSucceed(paths.LogDir(series.MustHostSeries()))
+	dataDir          = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
+	transientDataDir = paths.MustSucceed(paths.TransientDataDir(series.MustHostSeries()))
+	confDir          = paths.MustSucceed(paths.ConfDir(series.MustHostSeries()))
+	metricsSpoolDir  = paths.MustSucceed(paths.MetricsSpoolDir(series.MustHostSeries()))
 )
 
 // Agent exposes the agent's configuration to other components. This
@@ -82,6 +83,9 @@ type Paths struct {
 	// DataDir is the data directory where each agent has a subdirectory
 	// containing the configuration files.
 	DataDir string
+	// TransientDataDir is a directory where each agent can store data that
+	// is not expected to survive a reboot.
+	TransientDataDir string
 	// LogDir is the log directory where all logs from all agents on
 	// the machine are written.
 	LogDir string
@@ -97,6 +101,9 @@ type Paths struct {
 func (p *Paths) Migrate(newPaths Paths) {
 	if newPaths.DataDir != "" {
 		p.DataDir = newPaths.DataDir
+	}
+	if newPaths.TransientDataDir != "" {
+		p.TransientDataDir = newPaths.TransientDataDir
 	}
 	if newPaths.LogDir != "" {
 		p.LogDir = newPaths.LogDir
@@ -115,6 +122,9 @@ func NewPathsWithDefaults(p Paths) Paths {
 	if p.DataDir != "" {
 		paths.DataDir = p.DataDir
 	}
+	if p.TransientDataDir != "" {
+		paths.TransientDataDir = p.TransientDataDir
+	}
 	if p.LogDir != "" {
 		paths.LogDir = p.LogDir
 	}
@@ -130,10 +140,11 @@ func NewPathsWithDefaults(p Paths) Paths {
 var (
 	// DefaultPaths defines the default paths for an agent.
 	DefaultPaths = Paths{
-		DataDir:         dataDir,
-		LogDir:          path.Join(logDir, "juju"),
-		MetricsSpoolDir: metricsSpoolDir,
-		ConfDir:         confDir,
+		DataDir:          dataDir,
+		TransientDataDir: transientDataDir,
+		LogDir:           path.Join(logDir, "juju"),
+		MetricsSpoolDir:  metricsSpoolDir,
+		ConfDir:          confDir,
 	}
 )
 
@@ -188,6 +199,10 @@ type Config interface {
 	// DataDir returns the data directory. Each agent has a subdirectory
 	// containing the configuration files.
 	DataDir() string
+
+	// TransientDataDir returns the directory where this agent should store
+	// any data that is not expected to survive a reboot.
+	TransientDataDir() string
 
 	// LogDir returns the log directory. All logs from all agents on
 	// the machine are written to this directory.
@@ -639,6 +654,10 @@ func (c *configInternal) File(name string) string {
 
 func (c *configInternal) DataDir() string {
 	return c.paths.DataDir
+}
+
+func (c *configInternal) TransientDataDir() string {
+	return c.paths.TransientDataDir
 }
 
 func (c *configInternal) MetricsSpoolDir() string {

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -29,6 +29,7 @@ var _ formatter = formatter_2_0{}
 type format_2_0Serialization struct {
 	Tag               string             `yaml:"tag,omitempty"`
 	DataDir           string             `yaml:"datadir,omitempty"`
+	TransientDataDir  string             `yaml:"transient-datadir,omitempty"`
 	LogDir            string             `yaml:"logdir,omitempty"`
 	MetricsSpoolDir   string             `yaml:"metricsspooldir,omitempty"`
 	Nonce             string             `yaml:"nonce,omitempty"`
@@ -91,9 +92,10 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 	config := &configInternal{
 		tag: tag,
 		paths: NewPathsWithDefaults(Paths{
-			DataDir:         format.DataDir,
-			LogDir:          format.LogDir,
-			MetricsSpoolDir: format.MetricsSpoolDir,
+			DataDir:          format.DataDir,
+			TransientDataDir: format.TransientDataDir,
+			LogDir:           format.LogDir,
+			MetricsSpoolDir:  format.MetricsSpoolDir,
 		}),
 		jobs:              format.Jobs,
 		upgradedToVersion: *format.UpgradedToVersion,
@@ -163,6 +165,7 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 	format := &format_2_0Serialization{
 		Tag:               config.tag.String(),
 		DataDir:           config.paths.DataDir,
+		TransientDataDir:  config.paths.TransientDataDir,
 		LogDir:            config.paths.LogDir,
 		MetricsSpoolDir:   config.paths.MetricsSpoolDir,
 		Jobs:              config.jobs,

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -77,6 +77,10 @@ type InstanceConfig struct {
 	// identical versions and hashes, but may have different URLs.
 	tools coretools.List
 
+	// TransientDataDir holds the directory that juju can use to write
+	// transient files that get purged after a system reboot.
+	TransientDataDir string
+
 	// DataDir holds the directory that juju state will be put in the new
 	// instance.
 	DataDir string
@@ -463,9 +467,10 @@ func (cfg *InstanceConfig) AgentConfig(
 	}
 	configParams := agent.AgentConfigParams{
 		Paths: agent.Paths{
-			DataDir:         cfg.DataDir,
-			LogDir:          cfg.LogDir,
-			MetricsSpoolDir: cfg.MetricsSpoolDir,
+			DataDir:          cfg.DataDir,
+			TransientDataDir: cfg.TransientDataDir,
+			LogDir:           cfg.LogDir,
+			MetricsSpoolDir:  cfg.MetricsSpoolDir,
 		},
 		Jobs:              cfg.Jobs,
 		Tag:               tag,

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -69,6 +69,10 @@ func jujuDataDir(series string) string {
 	return must(paths.DataDir(series))
 }
 
+func jujuTransientDataDir(series string) string {
+	return must(paths.TransientDataDir(series))
+}
+
 func cloudInitOutputLog(logDir string) string {
 	return path.Join(logDir, "cloud-init-output.log")
 }
@@ -215,6 +219,7 @@ func (cfg *testInstanceConfig) setSeries(series string, build int) *testInstance
 	}
 	cfg.Series = series
 	cfg.DataDir = jujuDataDir(series)
+	cfg.TransientDataDir = jujuTransientDataDir(series)
 	cfg.LogDir = jujuLogDir(series)
 	cfg.CloudInitOutputLog = cloudInitOutputLog(series)
 	return cfg

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -83,6 +83,9 @@ rm -rf /var/lib/juju/db/*
 
 echo "removing /var/lib/juju/raft/*"
 rm -rf /var/lib/juju/raft/*
+
+echo "removing /var/run/juju/*"
+rm -rf /var/run/juju/*
 `
 )
 

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -58,6 +58,7 @@ func (w *windowsConfigure) ConfigureBasic() error {
 
 	renderer := w.conf.ShellRenderer()
 	dataDir := renderer.FromSlash(w.icfg.DataDir)
+	transientDataDir := renderer.FromSlash(w.icfg.TransientDataDir)
 	baseDir := renderer.FromSlash(filepath.Dir(tmpDir))
 	binDir := renderer.Join(baseDir, "bin")
 
@@ -74,6 +75,7 @@ func (w *windowsConfigure) ConfigureBasic() error {
 		fmt.Sprintf(`mkdir -Force "%s"`, renderer.FromSlash(baseDir)),
 		fmt.Sprintf(`mkdir %s`, renderer.FromSlash(tmpDir)),
 		fmt.Sprintf(`mkdir "%s"`, binDir),
+		fmt.Sprintf(`mkdir "%s"`, transientDataDir),
 		fmt.Sprintf(`mkdir "%s\locks"`, renderer.FromSlash(dataDir)),
 		`setx /m PATH "$env:PATH;C:\Juju\bin\"`,
 		// This is necessary for setACLs to work

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -694,6 +694,7 @@ $jujuCreds = New-Object System.Management.Automation.PSCredential ($juju_user, $
 mkdir -Force "C:\Juju"
 mkdir C:\Juju\tmp
 mkdir "C:\Juju\bin"
+mkdir "C:\Juju\lib\juju-transient"
 mkdir "C:\Juju\lib\juju\locks"
 setx /m PATH "$env:PATH;C:\Juju\bin\"
 $adminsGroup = (New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")).Translate([System.Security.Principal.NTAccount])
@@ -730,6 +731,7 @@ Set-Content 'C:/Juju/lib/juju/agents/machine-10/agent.conf' @"
 # format 2.0
 tag: machine-10
 datadir: C:/Juju/lib/juju
+transient-datadir: C:/Juju/lib/juju-transient
 logdir: C:/Juju/log/juju
 metricsspooldir: C:/Juju/lib/juju/metricspool
 nonce: FAKE_NONCE

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -147,6 +147,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 	apiInfo := s.APIInfo(c)
 	paths := agent.DefaultPaths
 	paths.DataDir = s.DataDir()
+	paths.TransientDataDir = s.TransientDataDir()
 	paths.LogDir = s.LogDir
 	paths.MetricsSpoolDir = c.MkDir()
 	conf, err := agent.NewAgentConfig(

--- a/core/paths/paths.go
+++ b/core/paths/paths.go
@@ -29,11 +29,16 @@ const (
 	instanceCloudInitDir
 	cloudInitCfgDir
 	curtinInstallConfig
+	transientDataDir
 )
 
 const (
 	// NixDataDir is location for agent binaries on *nix operating systems.
 	NixDataDir = "/var/lib/juju"
+
+	// NixTransientDataDir is location for storing transient data on *nix
+	// operating systems.
+	NixTransientDataDir = "/var/run/juju"
 
 	// NixLogDir is location for Juju logs on *nix operating systems.
 	NixLogDir = "/var/log"
@@ -43,6 +48,7 @@ var nixVals = map[osVarType]string{
 	tmpDir:               "/tmp",
 	logDir:               NixLogDir,
 	dataDir:              NixDataDir,
+	transientDataDir:     NixTransientDataDir,
 	storageDir:           "/var/lib/juju/storage",
 	confDir:              "/etc/juju",
 	jujuRun:              "/usr/bin/juju-run",
@@ -61,6 +67,7 @@ var winVals = map[osVarType]string{
 	tmpDir:           "C:/Juju/tmp",
 	logDir:           "C:/Juju/log",
 	dataDir:          "C:/Juju/lib/juju",
+	transientDataDir: "C:/Juju/lib/juju-transient",
 	storageDir:       "C:/Juju/lib/juju/storage",
 	confDir:          "C:/Juju/etc",
 	jujuRun:          "C:/Juju/bin/juju-run.exe",
@@ -109,6 +116,12 @@ func LogDir(series string) (string, error) {
 // store tools, charms, locks, etc
 func DataDir(series string) (string, error) {
 	return osVal(series, dataDir)
+}
+
+// TransientDataDir returns a filesystem path to the folder used by juju to
+// store transient data that will not survive a reboot.
+func TransientDataDir(series string) (string, error) {
+	return osVal(series, transientDataDir)
 }
 
 // MetricsSpoolDir returns a filesystem path to the folder used by juju

--- a/core/paths/transientfile/create.go
+++ b/core/paths/transientfile/create.go
@@ -1,0 +1,66 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package transientfile provides helpers for creating files that do not
+// survive machine reboots.
+package transientfile
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+)
+
+// Create a transient file with the specified name inside transientDir. The
+// function will attempt to create any missing folders leading up to the
+// place where the transient file is to be created.
+//
+// For *nix targets, the caller is expected to provide a suitable transient
+// directory (e.g. a tmpfs mount) that will be automatically purged after a
+// reboot.
+//
+// For windows targets, any directory can be specified as transientDir but in
+// order to ensure that the file will get removed, the process must be able to
+// access the windows registry.
+func Create(transientDir, name string) (*os.File, error) {
+	if filepath.IsAbs(name) {
+		return nil, errors.New("transient file name contains an absolute path")
+	}
+
+	transientFilePath := filepath.Join(transientDir, name)
+
+	// Create any missing directories. The MkdirAll call below might fail
+	// if the base directory does not exist and multiple agents attempt to
+	// create it concurrently. To work around this potential race, we retry
+	// the attempt a few times before bailing out with an error.
+	//
+	// TODO(achilleasa) this retry block is only needed until we complete
+	// the unification of the machine/unit juju agents.
+	baseDir := filepath.Dir(transientFilePath)
+	for attempt := 0; ; attempt++ {
+		if err := os.MkdirAll(baseDir, os.ModePerm); err != nil {
+			if attempt == 10 {
+				return nil, errors.Annotatef(err, "unable to create directory path for transient file %q", transientFilePath)
+			}
+			continue
+		}
+
+		break
+	}
+
+	f, err := os.Create(transientFilePath)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unable to create transient file %q", transientFilePath)
+	}
+
+	// Invoke platform-specific code to ensure that the file is removed
+	// after a reboot.
+	if err = ensureDeleteAfterReboot(transientFilePath); err != nil {
+		_ = f.Close()
+		_ = os.Remove(transientFilePath)
+		return nil, errors.Annotatef(err, "unable to schedule deletion of transient file %q after reboot", transientFilePath)
+	}
+
+	return f, nil
+}

--- a/core/paths/transientfile/create_test.go
+++ b/core/paths/transientfile/create_test.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//+build !windows
+
+package transientfile
+
+import (
+	"os"
+	"path/filepath"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type transientFileSuite struct{}
+
+var _ = gc.Suite(&transientFileSuite{})
+
+func (s *transientFileSuite) TestCreateTransientFile(c *gc.C) {
+	transientDir := c.MkDir()
+	f, err := Create(transientDir, "foo.test")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.Close(), jc.ErrorIsNil)
+
+	expPath := filepath.Join(transientDir, "foo.test")
+	s.assertFileExists(c, expPath)
+}
+
+func (s *transientFileSuite) TestCreateTransientFileInSubdirectory(c *gc.C) {
+	transientDir := c.MkDir()
+	f, err := Create(transientDir, filepath.Join("1", "2", "foo.test"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.Close(), jc.ErrorIsNil)
+
+	expPath := filepath.Join(transientDir, "1", "2", "foo.test")
+	s.assertFileExists(c, expPath)
+}
+
+func (*transientFileSuite) assertFileExists(c *gc.C, path string) {
+	stat, err := os.Stat(path)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("stat failed for %q", path))
+
+	c.Assert(stat.IsDir(), jc.IsFalse, gc.Commentf("%q seems to be a directory", path))
+}

--- a/core/paths/transientfile/delete.go
+++ b/core/paths/transientfile/delete.go
@@ -1,0 +1,12 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//+build !windows
+
+// Package transientfile provides helpers for creating files that do not
+// survive machine reboots.
+package transientfile
+
+// ensureDeleteAfterReboot is not required for *nix targets as Create expects
+// that the caller provides a true transient folder (e.g. a tmpfs mount).
+func ensureDeleteAfterReboot(string) error { return nil }

--- a/core/paths/transientfile/delete_windows.go
+++ b/core/paths/transientfile/delete_windows.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//+build windows
+
+// Package transientfile provides helpers for creating files that do not
+// survive machine reboots.
+package transientfile
+
+import (
+	"github.com/juju/errors"
+	"golang.org/x/sys/windows"
+)
+
+// ensureDeleteAfterReboot arranges for the specified file to be removed once
+// the machine reboots. It exploits the MoveFileEx API call which allows us to
+// defer the deletion of a file by specifying a nil value as the destination
+// target in conjunction with the MOVEFILE_DELAY_UNTIL_REBOOT flag.
+//
+// The file to be deleted is appended to the windows registry and automatically
+// cleaned up by windows when the system reboots.
+//
+// For more info see: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexa
+func ensureDeleteAfterReboot(file string) error {
+	from, err := windows.UTF16PtrFromString(file)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return windows.MoveFileEx(from, nil, windows.MOVEFILE_DELAY_UNTIL_REBOOT)
+}

--- a/core/paths/transientfile/package_test.go
+++ b/core/paths/transientfile/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package transientfile
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/core/series/validate.go
+++ b/core/series/validate.go
@@ -13,7 +13,7 @@ import (
 // Returns the series it validated against or an error if one is found.
 // Note: the selected series will be returned if there is an error to help use
 // that for a fallback during error scenarios.
-func ValidateSeries(supportedSeries set.Strings, series, fallbackPerferedSeries string) (string, error) {
+func ValidateSeries(supportedSeries set.Strings, series, fallbackPreferredSeries string) (string, error) {
 	// Validate the requested series.
 	// Attempt to do the validation in one place, so it makes it easier to
 	// reason about where the validation happens. This only happens for IAAS
@@ -25,7 +25,7 @@ func ValidateSeries(supportedSeries set.Strings, series, fallbackPerferedSeries 
 		// If no bootstrap series is supplied, go and get that information from
 		// the fallback. We should still validate the fallback value to ensure
 		// that we also work with that series.
-		requestedSeries = fallbackPerferedSeries
+		requestedSeries = fallbackPreferredSeries
 	}
 	if !supportedSeries.Contains(requestedSeries) {
 		return requestedSeries, errors.NotSupportedf("%s", requestedSeries)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -872,6 +872,13 @@ func (s *JujuConnSuite) DataDir() string {
 	return filepath.Join(s.RootDir, "/var/lib/juju")
 }
 
+func (s *JujuConnSuite) TransientDataDir() string {
+	if s.RootDir == "" {
+		panic("TransientDataDir called out of test context")
+	}
+	return filepath.Join(s.RootDir, "/var/run/juju")
+}
+
 func (s *JujuConnSuite) ConfDir() string {
 	if s.RootDir == "" {
 		panic("DataDir called out of test context")

--- a/scripts/removejujuservices.bash
+++ b/scripts/removejujuservices.bash
@@ -17,3 +17,6 @@ rm -rf /var/lib/juju/db/*
 
 echo "removing /var/lib/juju/raft/*"
 rm -rf /var/lib/juju/raft/*
+
+echo "removing /var/run/juju/*"
+rm -rf /var/run/juju/*

--- a/service/agentconf.go
+++ b/service/agentconf.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
@@ -125,40 +124,7 @@ func (s *systemdServiceManager) WriteServiceFiles() error {
 
 // FindAgents finds all the agents available on the machine.
 func (s *systemdServiceManager) FindAgents(dataDir string) (string, []string, []string, error) {
-	var (
-		machineAgent  string
-		unitAgents    []string
-		errAgentNames []string
-	)
-
-	agentDir := filepath.Join(dataDir, "agents")
-	dir, err := os.Open(agentDir)
-	if err != nil {
-		return "", nil, nil, errors.Annotate(err, "opening agents dir")
-	}
-	defer func() { _ = dir.Close() }()
-
-	entries, err := dir.Readdir(-1)
-	if err != nil {
-		return "", nil, nil, errors.Annotate(err, "reading agents dir")
-	}
-	for _, info := range entries {
-		name := info.Name()
-		tag, err := names.ParseTag(name)
-		if err != nil {
-			continue
-		}
-		switch tag.Kind() {
-		case names.MachineTagKind:
-			machineAgent = name
-		case names.UnitTagKind:
-			unitAgents = append(unitAgents, name)
-		default:
-			errAgentNames = append(errAgentNames, name)
-			logger.Infof("%s is not of type Machine nor Unit, ignoring", name)
-		}
-	}
-	return machineAgent, unitAgents, errAgentNames, nil
+	return FindAgents(dataDir)
 }
 
 // WriteSystemdAgents creates systemd files and symlinks for the input machine

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -52,7 +52,8 @@ idle_subordinate_condition() {
     unit_index=${4:-0}
     parent_index=${5:-0}
 
-    echo ".applications | select(.[\"$parent\"] | .units | .[\"$parent/$parent_index\"] | .subordinates | .[\"$name/$unit_index\"] | .[\"juju-status\"] | .current == \"idle\") | keys[$app_index]"
+    # Print the *subordinate* name if it has an idle status in parent application
+    echo ".applications | select(.[\"$parent\"] | .units | .[\"$parent/$parent_index\"] | .subordinates | .[\"$name/$unit_index\"] | .[\"juju-status\"] | .current == \"idle\") | \"$name\""
 }
 
 active_condition() {

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -34,6 +34,7 @@ TEST_NAMES="static_analysis \
             cli \
             controller \
             deploy \
+            hooks \
             hook_tools \
             machine \
             relations \

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -1,0 +1,112 @@
+run_start_hook_fires_after_reboot() {
+    echo
+
+    model_name="test-start-hook-fires-after-reboot"
+    file="${TEST_DIR}/${model_name}.txt"
+
+    ensure "${model_name}" "${file}"
+
+    juju deploy cs:~jameinel/ubuntu-lite-7
+    wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+
+    # Ensure that the implicit start hook after reboot detection does not
+    # fire for the initial charm deployment
+    echo "[+] ensuring that implicit start hook does not fire after initial deployment"
+    logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)
+    echo "$logs" | sed 's/^/    | /g'
+    if [ -n "$logs" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "Uniter incorrectly assumed a reboot occurred after initial charm deployment")
+      exit 1
+    fi
+
+    # Restart the unit agent and ensure that the implicit start hook still
+    # does not fire
+    echo "[+] ensuring that implicit start hook does not fire after restarting the unit agent"
+    juju run --unit ubuntu-lite/0 'sudo service jujud-unit-ubuntu-lite-0 restart'
+    echo
+    sleep 1
+    wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+    logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)
+    echo "$logs" | sed 's/^/    | /g'
+    if [ -n "$logs" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "Uniter incorrectly assumed a reboot occurred after restarting the agent")
+      exit 1
+    fi
+
+    # Trigger a reboot and verify that the implicit start hook fires
+    echo "[+] ensuring that implicit start hook fires after a machine reboot"
+    juju ssh ubuntu-lite/0 'sudo reboot now' || true
+    sleep 1
+    wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+    echo
+    logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)
+    echo "$logs" | sed 's/^/    | /g'
+    if [ -z "$logs" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "Uniter did not fire start hook after the machine rebooted")
+      exit 1
+    fi
+
+    destroy_model "${model_name}"
+}
+
+run_reboot_monitor_state_cleanup() {
+    echo
+
+    model_name="test-reboot-monitor-state-cleanup"
+    file="${TEST_DIR}/${model_name}.txt"
+
+    ensure "${model_name}" "${file}"
+
+    # Deploy mysql/rsyslog-forwarder. The latter is a subordinate
+    juju deploy mysql
+    juju deploy rsyslog-forwarder
+    juju add-relation rsyslog-forwarder mysql
+    wait_for "mysql" "$(idle_condition "mysql")"
+    wait_for "rsyslog-forwarder" "$(idle_subordinate_condition "rsyslog-forwarder" "mysql")"
+
+    # Check that the reboot flag files have been created for both the charm and
+    # the subordinate. Note: juju ssh adds whitespace which we need to trim
+    # with a bit of awk magic to ensure that our comparisons work correctly
+    echo "[+] Verifying that reboot monitor state files are in place"
+    num_files=$(juju ssh mysql/0 'ls -1 /var/run/juju/reboot-monitor/ | wc -l' 2>/dev/null | tr -d "[:space:]")
+    echo "   | number of monitor state files: ${num_files}"
+    if [ "$num_files" != "2" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "Expected 2 reboot monitor state files to be created; got ${num_files}")
+      exit 1
+    fi
+
+    # Remove subordinate and ensure that the state file for its monitor got purged
+    echo "[+] Verifying that reboot monitor state files are removed once a subordinate gets removed"
+    juju remove-relation rsyslog-forwarder mysql
+    wait_for "mysql" "$(idle_condition "mysql")"
+    sleep 5 # there is probably a better way to wait for the subordinate to be removed.
+    num_files=$(juju ssh mysql/0 'ls -1 /var/run/juju/reboot-monitor/ | wc -l' 2>/dev/null | tr -d "[:space:]")
+    echo "   | number of monitor state files: ''${num_files}"
+    if [ "$num_files" != "1" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "Expected one remaining reboot monitor state file after subordinate removal; got ${num_files}")
+      exit 1
+    fi
+
+    destroy_model "${model_name}"
+}
+
+test_start_hook_fires_after_reboot() {
+    if [ "$(skip 'test_start_hook_fires_after_reboot')" ]; then
+        echo "==> TEST SKIPPED: start hook fires after reboot"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_start_hook_fires_after_reboot"
+        run "run_reboot_monitor_state_cleanup"
+    )
+}

--- a/tests/suites/hooks/task.sh
+++ b/tests/suites/hooks/task.sh
@@ -1,0 +1,19 @@
+test_hooks() {
+      if [ "$(skip 'test_hooks')" ]; then
+        echo "==> TEST SKIPPED: hooks"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju
+
+    file="${TEST_DIR}/test-hooks.txt"
+
+    bootstrap "test-hooks" "${file}"
+
+    test_start_hook_fires_after_reboot
+
+    destroy_controller "test-hooks"
+}

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -56,6 +56,7 @@ var upgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.6.3"), stepsFor263()},
 		upgradeToVersion{version.MustParse("2.7.0"), stepsFor27()},
 		upgradeToVersion{version.MustParse("2.7.2"), stepsFor272()},
+		upgradeToVersion{version.MustParse("2.8.0"), stepsFor28()},
 	}
 	return steps
 }

--- a/upgrades/steps_28.go
+++ b/upgrades/steps_28.go
@@ -3,7 +3,14 @@
 
 package upgrades
 
-// stateStepsFor272 returns upgrade steps for Juju 2.8.0.
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/service"
+	"github.com/juju/juju/worker/common/reboot"
+	"gopkg.in/juju/names.v3"
+)
+
+// stateStepsFor28 returns upgrade steps for Juju 2.8.0.
 func stateStepsFor28() []Step {
 	return []Step{
 		&upgradeStep{
@@ -14,4 +21,46 @@ func stateStepsFor28() []Step {
 			},
 		},
 	}
+}
+
+// stepsFor28 returns upgrade steps for Juju 2.8.0.
+func stepsFor28() []Step {
+	return []Step{
+		// This step pre-populates the reboot-handled flag for all
+		// running units so they do not accidentally trigger a start
+		// hook once they get restarted after the upgrade is complete.
+		&upgradeStep{
+			description: "ensure currently running units do not fire start hooks thinking a reboot has occurred",
+			targets:     []Target{HostMachine},
+			run:         prepopulateRebootHandledFlagsForDeployedUnits,
+		},
+	}
+}
+
+func prepopulateRebootHandledFlagsForDeployedUnits(ctx Context) error {
+	// Lookup the names of all unit agents installed on this machine.
+	agentConf := ctx.AgentConfig()
+	_, unitNames, _, err := service.FindAgents(agentConf.DataDir())
+	if err != nil {
+		return errors.Annotate(err, "looking up unit agents")
+	}
+
+	// Pre-populate reboot-handled flag files.
+	monitor := reboot.NewMonitor(agentConf.TransientDataDir())
+	for _, unitName := range unitNames {
+		// This should never fail as it is already validated by the
+		// FindAgents call. However, since this is an upgrade step
+		// it's fine to be a bit extra paranoid.
+		tag, err := names.ParseTag(unitName)
+		if err != nil {
+			return errors.Annotatef(err, "unable to parse unit agent tag %q", unitName)
+		}
+
+		// Querying the reboot monitor will set up the flag for this
+		// unit if it doesn't already exist.
+		if _, err = monitor.Query(tag); err != nil {
+			return errors.Annotatef(err, "querying reboot monitor for %q", unitName)
+		}
+	}
+	return nil
 }

--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -24,3 +24,8 @@ func (s *steps28Suite) TestIncrementTasksSequence(c *gc.C) {
 	step := findStateStep(c, v280, "increment tasks sequence by 1")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps28Suite) TestPopulateRebootHandledFlagsForDeployedUnits(c *gc.C) {
+	step := findStep(c, v280, "ensure currently running units do not fire start hooks thinking a reboot has occurred")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.HostMachine})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -162,6 +162,10 @@ func (mock *mockAgentConfig) DataDir() string {
 	return mock.dataDir
 }
 
+func (mock *mockAgentConfig) TransientDataDir() string {
+	return filepath.Join(mock.dataDir, "transient")
+}
+
 func (mock *mockAgentConfig) LogDir() string {
 	return mock.logDir
 }
@@ -632,7 +636,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"2.0.0", "2.2.0", "2.4.0", "2.4.5", "2.6.3", "2.7.0", "2.7.2",
+		"2.0.0", "2.2.0", "2.4.0", "2.4.5", "2.6.3", "2.7.0", "2.7.2", "2.8.0",
 	})
 }
 

--- a/worker/common/reboot/monitor.go
+++ b/worker/common/reboot/monitor.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package reboot
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/paths/transientfile"
+	"gopkg.in/juju/names.v3"
+)
+
+// Monitor leverages juju's transient file mechanism to deliver one-off
+// machine reboot notifications to interested entities.
+type Monitor struct {
+	transientDir string
+}
+
+// NewMonitor returns a reboot monitor instance that stores its internal state
+// into transientDir.
+func NewMonitor(transientDir string) *Monitor {
+	return &Monitor{
+		transientDir: filepath.Join(transientDir, "reboot-monitor"),
+	}
+}
+
+// Check for a pending reboot notification for the specified tag. Once
+// the notification is consumed, future calls to Check will always
+// return false.
+func (m *Monitor) Query(tag names.Tag) (bool, error) {
+	flagFile := tag.String()
+	flagPath := filepath.Join(m.transientDir, flagFile)
+
+	// If the flag file is present, we have already delivered a reboot
+	// notification.
+	if stat, err := os.Stat(flagPath); err == nil {
+		if stat.IsDir() {
+			return false, errors.Errorf("expected reboot monitor flag %q to be a file", flagPath)
+		}
+
+		return false, nil
+	}
+
+	// Create a transient file to capture the flag and return back a
+	// reboot notification to the caller.
+	f, err := transientfile.Create(m.transientDir, flagFile)
+	if err != nil {
+		return false, errors.Annotatef(err, "creating reboot monitor flag file %q", flagPath)
+	}
+
+	_ = f.Close()
+	return true, nil
+}
+
+// PurgeState deletes any internal state maintained by the monitor for a
+// particular entity.
+func (m *Monitor) PurgeState(tag names.Tag) error {
+	flagPath := filepath.Join(m.transientDir, tag.String())
+	return os.Remove(flagPath)
+}

--- a/worker/common/reboot/monitor_test.go
+++ b/worker/common/reboot/monitor_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//+build !windows
+
+package reboot_test
+
+import (
+	"testing"
+
+	"github.com/juju/juju/worker/common/reboot"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+)
+
+type monitorSuite struct{}
+
+var _ = gc.Suite(&monitorSuite{})
+
+func (s *monitorSuite) TestQueryMonitor(c *gc.C) {
+	transientDir := c.MkDir()
+	mon := reboot.NewMonitor(transientDir)
+
+	unit, err := names.ParseUnitTag("unit-wordpress-0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Since we pointed the monitor to an empty dir, querying it should
+	// return true (reboot detected) and the flag file will be created.
+	rebootDetected, err := mon.Query(unit)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rebootDetected, jc.IsTrue)
+
+	// Querying the monitor a second time should return false as we
+	// already processed the reboot notification
+	rebootDetected, err = mon.Query(unit)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rebootDetected, jc.IsFalse, gc.Commentf("got unexpected reboot notification"))
+
+	// If we purge the monitor's state for this entity we can query it
+	// again and get a reboot detected notification.
+	err = mon.PurgeState(unit)
+	c.Assert(err, jc.ErrorIsNil)
+
+	rebootDetected, err = mon.Query(unit)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rebootDetected, jc.IsTrue)
+}
+
+func (s *monitorSuite) TestQueryMonitorForDifferentEntities(c *gc.C) {
+	transientDir := c.MkDir()
+	mon := reboot.NewMonitor(transientDir)
+
+	unit1, err := names.ParseUnitTag("unit-wordpress-0")
+	c.Assert(err, jc.ErrorIsNil)
+	unit2, err := names.ParseUnitTag("unit-mysql-0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Querying for different entities with no prior monitor state should
+	// yield a reboot notification for each entity.
+	rebootDetected, err := mon.Query(unit1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rebootDetected, jc.IsTrue)
+
+	rebootDetected, err = mon.Query(unit2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rebootDetected, jc.IsTrue)
+
+	// Querying the monitor a second time should return false as we
+	// already processed the reboot notification for both entities
+	rebootDetected, err = mon.Query(unit1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rebootDetected, jc.IsFalse, gc.Commentf("got unexpected reboot notification"))
+	rebootDetected, err = mon.Query(unit2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rebootDetected, jc.IsFalse, gc.Commentf("got unexpected reboot notification"))
+}
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -13,7 +13,7 @@ import (
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -136,10 +136,10 @@ func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names_v3.ControllerTag {
+func (m *MockConfig) Controller() names.ControllerTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
@@ -234,10 +234,10 @@ func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names_v3.ModelTag {
+func (m *MockConfig) Model() names.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
@@ -348,10 +348,10 @@ func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names_v3.Tag {
+func (m *MockConfig) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
@@ -359,6 +359,20 @@ func (m *MockConfig) Tag() names_v3.Tag {
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
+}
+
+// TransientDataDir mocks base method
+func (m *MockConfig) TransientDataDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransientDataDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// TransientDataDir indicates an expected call of TransientDataDir
+func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method

--- a/worker/containerbroker/mocks/base_mock.go
+++ b/worker/containerbroker/mocks/base_mock.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	base "github.com/juju/juju/api/base"
-	httprequest_v1 "gopkg.in/httprequest.v1"
-	names_v3 "gopkg.in/juju/names.v3"
+	httprequest "gopkg.in/httprequest.v1"
+	names "gopkg.in/juju/names.v3"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
@@ -125,10 +125,10 @@ func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
 }
 
 // HTTPClient mocks base method
-func (m *MockAPICaller) HTTPClient() (*httprequest_v1.Client, error) {
+func (m *MockAPICaller) HTTPClient() (*httprequest.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*httprequest_v1.Client)
+	ret0, _ := ret[0].(*httprequest.Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -140,10 +140,10 @@ func (mr *MockAPICallerMockRecorder) HTTPClient() *gomock.Call {
 }
 
 // ModelTag mocks base method
-func (m *MockAPICaller) ModelTag() (names_v3.ModelTag, bool) {
+func (m *MockAPICaller) ModelTag() (names.ModelTag, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/worker/containerbroker/mocks/environs_mock.go
+++ b/worker/containerbroker/mocks/environs_mock.go
@@ -11,7 +11,7 @@ import (
 	environs "github.com/juju/juju/environs"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
-	charm_v6 "gopkg.in/juju/charm.v6"
+	charm "gopkg.in/juju/charm.v6"
 	reflect "reflect"
 )
 
@@ -69,7 +69,7 @@ func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
+func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfile) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/worker/containerbroker/mocks/machine_mock.go
+++ b/worker/containerbroker/mocks/machine_mock.go
@@ -12,7 +12,7 @@ import (
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	version "github.com/juju/version"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -158,10 +158,10 @@ func (mr *MockMachineProvisionerMockRecorder) Life() *gomock.Call {
 }
 
 // MachineTag mocks base method
-func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
+func (m *MockMachineProvisioner) MachineTag() names.MachineTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
-	ret0, _ := ret[0].(names_v3.MachineTag)
+	ret0, _ := ret[0].(names.MachineTag)
 	return ret0
 }
 
@@ -406,10 +406,10 @@ func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *gomock.Cal
 }
 
 // Tag mocks base method
-func (m *MockMachineProvisioner) Tag() names_v3.Tag {
+func (m *MockMachineProvisioner) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 

--- a/worker/containerbroker/mocks/state_mock.go
+++ b/worker/containerbroker/mocks/state_mock.go
@@ -10,7 +10,7 @@ import (
 	params "github.com/juju/juju/apiserver/params"
 	network "github.com/juju/juju/core/network"
 	network0 "github.com/juju/juju/network"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -68,7 +68,7 @@ func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0 interface{}) *gomoc
 }
 
 // GetContainerInterfaceInfo mocks base method
-func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
+func (m *MockState) GetContainerInterfaceInfo(arg0 names.MachineTag) ([]network.InterfaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].([]network.InterfaceInfo)
@@ -83,7 +83,7 @@ func (mr *MockStateMockRecorder) GetContainerInterfaceInfo(arg0 interface{}) *go
 }
 
 // GetContainerProfileInfo mocks base method
-func (m *MockState) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+func (m *MockState) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
@@ -98,7 +98,7 @@ func (mr *MockStateMockRecorder) GetContainerProfileInfo(arg0 interface{}) *gomo
 }
 
 // HostChangesForContainer mocks base method
-func (m *MockState) HostChangesForContainer(arg0 names_v3.MachineTag) ([]network0.DeviceToBridge, int, error) {
+func (m *MockState) HostChangesForContainer(arg0 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
@@ -114,7 +114,7 @@ func (mr *MockStateMockRecorder) HostChangesForContainer(arg0 interface{}) *gomo
 }
 
 // Machines mocks base method
-func (m *MockState) Machines(arg0 ...names_v3.MachineTag) ([]provisioner.MachineResult, error) {
+func (m *MockState) Machines(arg0 ...names.MachineTag) ([]provisioner.MachineResult, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
@@ -133,7 +133,7 @@ func (mr *MockStateMockRecorder) Machines(arg0 ...interface{}) *gomock.Call {
 }
 
 // PrepareContainerInterfaceInfo mocks base method
-func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
+func (m *MockState) PrepareContainerInterfaceInfo(arg0 names.MachineTag) ([]network.InterfaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].([]network.InterfaceInfo)
@@ -148,7 +148,7 @@ func (mr *MockStateMockRecorder) PrepareContainerInterfaceInfo(arg0 interface{})
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockState) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error {
+func (m *MockState) ReleaseContainerAddresses(arg0 names.MachineTag) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
 	ret0, _ := ret[0].(error)
@@ -162,7 +162,7 @@ func (mr *MockStateMockRecorder) ReleaseContainerAddresses(arg0 interface{}) *go
 }
 
 // SetHostMachineNetworkConfig mocks base method
-func (m *MockState) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg1 []params.NetworkConfig) error {
+func (m *MockState) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []params.NetworkConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/worker/deployer/export_test.go
+++ b/worker/deployer/export_test.go
@@ -18,7 +18,7 @@ func (*fakeAPI) ConnectionInfo() (params.DeployerConnectionValues, error) {
 	}, nil
 }
 
-func NewTestSimpleContext(agentConfig agent.Config, logDir string, data *svctesting.FakeServiceData) *SimpleContext {
+func NewTestSimpleContext(agentConfig agent.Config, logDir string, data *svctesting.FakeServiceData, monStatePurger RebootMonitorStatePurger) *SimpleContext {
 	return &SimpleContext{
 		api:         &fakeAPI{},
 		agentConfig: agentConfig,
@@ -30,5 +30,6 @@ func NewTestSimpleContext(agentConfig agent.Config, logDir string, data *svctest
 		listServices: func() ([]string, error) {
 			return data.InstalledNames(), nil
 		},
+		rebootMonitorStatePurger: monStatePurger,
 	}
 }

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
@@ -15,7 +13,8 @@ import (
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface
@@ -137,10 +136,10 @@ func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names_v3.ControllerTag {
+func (m *MockConfig) Controller() names.ControllerTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
@@ -180,6 +179,7 @@ func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -234,10 +234,10 @@ func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names_v3.ModelTag {
+func (m *MockConfig) Model() names.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
@@ -348,10 +348,10 @@ func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names_v3.Tag {
+func (m *MockConfig) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
@@ -359,6 +359,20 @@ func (m *MockConfig) Tag() names_v3.Tag {
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
+}
+
+// TransientDataDir mocks base method
+func (m *MockConfig) TransientDataDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransientDataDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// TransientDataDir indicates an expected call of TransientDataDir
+func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method

--- a/worker/instancemutater/mocks/base_mock.go
+++ b/worker/instancemutater/mocks/base_mock.go
@@ -6,14 +6,13 @@ package mocks
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
+	base "github.com/juju/juju/api/base"
+	httprequest "gopkg.in/httprequest.v1"
+	names "gopkg.in/juju/names.v3"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
-	base "github.com/juju/juju/api/base"
-	httprequest_v1 "gopkg.in/httprequest.v1"
-	names_v3 "gopkg.in/juju/names.v3"
 )
 
 // MockAPICaller is a mock of APICaller interface
@@ -55,6 +54,7 @@ func (mr *MockAPICallerMockRecorder) APICall(arg0, arg1, arg2, arg3, arg4, arg5 
 
 // BakeryClient mocks base method
 func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BakeryClient")
 	ret0, _ := ret[0].(base.MacaroonDischarger)
 	return ret0
@@ -112,6 +112,7 @@ func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 interface{}) *gomo
 
 // Context mocks base method
 func (m *MockAPICaller) Context() context.Context {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
 	return ret0
@@ -119,13 +120,15 @@ func (m *MockAPICaller) Context() context.Context {
 
 // Context indicates an expected call of Context
 func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
 }
 
 // HTTPClient mocks base method
-func (m *MockAPICaller) HTTPClient() (*httprequest_v1.Client, error) {
+func (m *MockAPICaller) HTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*httprequest_v1.Client)
+	ret0, _ := ret[0].(*httprequest.Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -137,10 +140,10 @@ func (mr *MockAPICallerMockRecorder) HTTPClient() *gomock.Call {
 }
 
 // ModelTag mocks base method
-func (m *MockAPICaller) ModelTag() (names_v3.ModelTag, bool) {
+func (m *MockAPICaller) ModelTag() (names.ModelTag, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/worker/instancemutater/mocks/dependency_mock.go
+++ b/worker/instancemutater/mocks/dependency_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockContext is a mock of Context interface

--- a/worker/instancemutater/mocks/environs_mock.go
+++ b/worker/instancemutater/mocks/environs_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
@@ -17,7 +15,8 @@ import (
 	instances "github.com/juju/juju/environs/instances"
 	storage "github.com/juju/juju/storage"
 	version "github.com/juju/version"
-	charm_v6 "gopkg.in/juju/charm.v6"
+	charm "gopkg.in/juju/charm.v6"
+	reflect "reflect"
 )
 
 // MockEnviron is a mock of Environ interface
@@ -406,7 +405,7 @@ func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
+func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfile) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/worker/instancemutater/mocks/instancebroker_mock.go
+++ b/worker/instancemutater/mocks/instancebroker_mock.go
@@ -5,12 +5,11 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
 	watcher "github.com/juju/juju/core/watcher"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockInstanceMutaterAPI is a mock of InstanceMutaterAPI interface
@@ -37,7 +36,7 @@ func (m *MockInstanceMutaterAPI) EXPECT() *MockInstanceMutaterAPIMockRecorder {
 }
 
 // Machine mocks base method
-func (m *MockInstanceMutaterAPI) Machine(arg0 names_v3.MachineTag) (instancemutater.MutaterMachine, error) {
+func (m *MockInstanceMutaterAPI) Machine(arg0 names.MachineTag) (instancemutater.MutaterMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Machine", arg0)
 	ret0, _ := ret[0].(instancemutater.MutaterMachine)

--- a/worker/instancemutater/mocks/logger_mock.go
+++ b/worker/instancemutater/mocks/logger_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLogger is a mock of Logger interface

--- a/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/worker/instancemutater/mocks/machinemutater_mock.go
@@ -5,15 +5,14 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
 	instance "github.com/juju/juju/core/instance"
 	life "github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockMutaterMachine is a mock of MutaterMachine interface
@@ -86,6 +85,7 @@ func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
 
 // Life mocks base method
 func (m *MockMutaterMachine) Life() life.Value {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
 	ret0, _ := ret[0].(life.Value)
 	return ret0
@@ -140,10 +140,10 @@ func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2
 }
 
 // Tag mocks base method
-func (m *MockMutaterMachine) Tag() names_v3.MachineTag {
+func (m *MockMutaterMachine) Tag() names.MachineTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.MachineTag)
+	ret0, _ := ret[0].(names.MachineTag)
 	return ret0
 }
 

--- a/worker/instancemutater/mocks/mutatercontext_mock.go
+++ b/worker/instancemutater/mocks/mutatercontext_mock.go
@@ -5,14 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
 	environs "github.com/juju/juju/environs"
 	instancemutater0 "github.com/juju/juju/worker/instancemutater"
-	names_v3 "gopkg.in/juju/names.v3"
-	worker_v1 "gopkg.in/juju/worker.v1"
+	names "gopkg.in/juju/names.v3"
+	worker "gopkg.in/juju/worker.v1"
+	reflect "reflect"
 )
 
 // MockMutaterContext is a mock of MutaterContext interface
@@ -51,7 +50,7 @@ func (mr *MockMutaterContextMockRecorder) KillWithError(arg0 interface{}) *gomoc
 }
 
 // add mocks base method
-func (m *MockMutaterContext) add(arg0 worker_v1.Worker) error {
+func (m *MockMutaterContext) add(arg0 worker.Worker) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "add", arg0)
 	ret0, _ := ret[0].(error)
@@ -107,7 +106,7 @@ func (mr *MockMutaterContextMockRecorder) getBroker() *gomock.Call {
 }
 
 // getMachine mocks base method
-func (m *MockMutaterContext) getMachine(arg0 names_v3.MachineTag) (instancemutater.MutaterMachine, error) {
+func (m *MockMutaterContext) getMachine(arg0 names.MachineTag) (instancemutater.MutaterMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getMachine", arg0)
 	ret0, _ := ret[0].(instancemutater.MutaterMachine)

--- a/worker/instancemutater/mocks/namestag_mock.go
+++ b/worker/instancemutater/mocks/namestag_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockTag is a mock of Tag interface

--- a/worker/instancemutater/mocks/worker_mock.go
+++ b/worker/instancemutater/mocks/worker_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockWorker is a mock of Worker interface

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/worker/common/reboot"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/resolver"
@@ -105,6 +106,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				NewOperationExecutor: operation.NewExecutor,
 				TranslateResolverErr: config.TranslateResolverErr,
 				Clock:                manifoldConfig.Clock,
+				RebootQuerier:        reboot.NewMonitor(agentConfig.TransientDataDir()),
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -356,6 +356,21 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			},
 			waitHooks{"start"},
 			verifyRunning{},
+		), ut(
+			"start hook after reboot",
+			quickStart{},
+			stopUniter{},
+			startUniter{
+				rebootQuerier: fakeRebootQuerier{
+					rebootDetected: true,
+				},
+			},
+			// Since the unit has already been started before and
+			// a reboot was detected, we expect the uniter to
+			// queue a start hook to notify the charms about the
+			// reboot.
+			waitHooks{"start"},
+			verifyRunning{},
 		),
 	})
 }

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
@@ -16,7 +14,8 @@ import (
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface
@@ -44,6 +43,7 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -51,11 +51,13 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -63,6 +65,7 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -91,6 +94,7 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -99,11 +103,13 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -112,11 +118,13 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -124,23 +132,27 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names_v3.ControllerTag {
+func (m *MockConfig) Controller() names.ControllerTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -148,11 +160,13 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -160,11 +174,13 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -172,11 +188,13 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -184,11 +202,13 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -196,11 +216,13 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -208,23 +230,27 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names_v3.ModelTag {
+func (m *MockConfig) Model() names.ModelTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -233,11 +259,13 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -245,11 +273,13 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -257,11 +287,13 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -269,11 +301,13 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -281,11 +315,13 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
 func (m *MockConfig) StateServingInfo() (params.StateServingInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
 	ret0, _ := ret[0].(params.StateServingInfo)
 	ret1, _ := ret[1].(bool)
@@ -294,11 +330,13 @@ func (m *MockConfig) StateServingInfo() (params.StateServingInfo, bool) {
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -306,23 +344,41 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names_v3.Tag {
+func (m *MockConfig) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
+}
+
+// TransientDataDir mocks base method
+func (m *MockConfig) TransientDataDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransientDataDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// TransientDataDir indicates an expected call of TransientDataDir
+func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -330,11 +386,13 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -342,11 +400,13 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -355,6 +415,7 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }
 
@@ -383,6 +444,7 @@ func (m *MockConfigSetter) EXPECT() *MockConfigSetterMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfigSetter) APIAddresses() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -391,11 +453,13 @@ func (m *MockConfigSetter) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigSetterMockRecorder) APIAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfigSetter)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -404,11 +468,13 @@ func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigSetterMockRecorder) APIInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfigSetter)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfigSetter) CACert() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -416,11 +482,13 @@ func (m *MockConfigSetter) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigSetterMockRecorder) CACert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfigSetter)(nil).CACert))
 }
 
 // Clone mocks base method
 func (m *MockConfigSetter) Clone() agent.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clone")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -428,23 +496,27 @@ func (m *MockConfigSetter) Clone() agent.Config {
 
 // Clone indicates an expected call of Clone
 func (mr *MockConfigSetterMockRecorder) Clone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockConfigSetter)(nil).Clone))
 }
 
 // Controller mocks base method
-func (m *MockConfigSetter) Controller() names_v3.ControllerTag {
+func (m *MockConfigSetter) Controller() names.ControllerTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigSetterMockRecorder) Controller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfigSetter)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfigSetter) DataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -452,11 +524,13 @@ func (m *MockConfigSetter) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigSetterMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfigSetter)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfigSetter) Dir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -464,11 +538,13 @@ func (m *MockConfigSetter) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigSetterMockRecorder) Dir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfigSetter)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfigSetter) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -476,11 +552,13 @@ func (m *MockConfigSetter) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigSetterMockRecorder) Jobs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfigSetter)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfigSetter) LogDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -488,11 +566,13 @@ func (m *MockConfigSetter) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigSetterMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfigSetter)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfigSetter) LoggingConfig() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -500,11 +580,13 @@ func (m *MockConfigSetter) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigSetterMockRecorder) LoggingConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfigSetter) MetricsSpoolDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -512,23 +594,27 @@ func (m *MockConfigSetter) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigSetterMockRecorder) MetricsSpoolDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfigSetter)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfigSetter) Model() names_v3.ModelTag {
+func (m *MockConfigSetter) Model() names.ModelTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigSetterMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfigSetter)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -537,11 +623,13 @@ func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigSetterMockRecorder) MongoInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfigSetter)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -549,11 +637,13 @@ func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigSetterMockRecorder) MongoMemoryProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).MongoMemoryProfile))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfigSetter) MongoVersion() mongo.Version {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -561,11 +651,13 @@ func (m *MockConfigSetter) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigSetterMockRecorder) MongoVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfigSetter) Nonce() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -573,11 +665,13 @@ func (m *MockConfigSetter) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigSetterMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfigSetter)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfigSetter) OldPassword() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -585,121 +679,145 @@ func (m *MockConfigSetter) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigSetterMockRecorder) OldPassword() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfigSetter)(nil).OldPassword))
 }
 
 // SetAPIHostPorts mocks base method
 func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAPIHostPorts", arg0)
 }
 
 // SetAPIHostPorts indicates an expected call of SetAPIHostPorts
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
 }
 
 // SetCACert mocks base method
 func (m *MockConfigSetter) SetCACert(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCACert", arg0)
 }
 
 // SetCACert indicates an expected call of SetCACert
 func (mr *MockConfigSetterMockRecorder) SetCACert(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCACert", reflect.TypeOf((*MockConfigSetter)(nil).SetCACert), arg0)
 }
 
 // SetControllerAPIPort mocks base method
 func (m *MockConfigSetter) SetControllerAPIPort(arg0 int) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetControllerAPIPort", arg0)
 }
 
 // SetControllerAPIPort indicates an expected call of SetControllerAPIPort
 func (mr *MockConfigSetterMockRecorder) SetControllerAPIPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetControllerAPIPort", reflect.TypeOf((*MockConfigSetter)(nil).SetControllerAPIPort), arg0)
 }
 
 // SetLoggingConfig mocks base method
 func (m *MockConfigSetter) SetLoggingConfig(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetLoggingConfig", arg0)
 }
 
 // SetLoggingConfig indicates an expected call of SetLoggingConfig
 func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).SetLoggingConfig), arg0)
 }
 
 // SetMongoMemoryProfile mocks base method
 func (m *MockConfigSetter) SetMongoMemoryProfile(arg0 mongo.MemoryProfile) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoMemoryProfile", arg0)
 }
 
 // SetMongoMemoryProfile indicates an expected call of SetMongoMemoryProfile
 func (mr *MockConfigSetterMockRecorder) SetMongoMemoryProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoMemoryProfile), arg0)
 }
 
 // SetMongoVersion mocks base method
 func (m *MockConfigSetter) SetMongoVersion(arg0 mongo.Version) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoVersion", arg0)
 }
 
 // SetMongoVersion indicates an expected call of SetMongoVersion
 func (mr *MockConfigSetterMockRecorder) SetMongoVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoVersion), arg0)
 }
 
 // SetOldPassword mocks base method
 func (m *MockConfigSetter) SetOldPassword(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetOldPassword", arg0)
 }
 
 // SetOldPassword indicates an expected call of SetOldPassword
 func (mr *MockConfigSetterMockRecorder) SetOldPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOldPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetOldPassword), arg0)
 }
 
 // SetPassword mocks base method
 func (m *MockConfigSetter) SetPassword(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPassword", arg0)
 }
 
 // SetPassword indicates an expected call of SetPassword
 func (mr *MockConfigSetterMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetPassword), arg0)
 }
 
 // SetStateServingInfo mocks base method
 func (m *MockConfigSetter) SetStateServingInfo(arg0 params.StateServingInfo) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetStateServingInfo", arg0)
 }
 
 // SetStateServingInfo indicates an expected call of SetStateServingInfo
 func (mr *MockConfigSetterMockRecorder) SetStateServingInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).SetStateServingInfo), arg0)
 }
 
 // SetUpgradedToVersion mocks base method
 func (m *MockConfigSetter) SetUpgradedToVersion(arg0 version.Number) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetUpgradedToVersion", arg0)
 }
 
 // SetUpgradedToVersion indicates an expected call of SetUpgradedToVersion
 func (mr *MockConfigSetterMockRecorder) SetUpgradedToVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetUpgradedToVersion), arg0)
 }
 
 // SetValue mocks base method
 func (m *MockConfigSetter) SetValue(arg0, arg1 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetValue", arg0, arg1)
 }
 
 // SetValue indicates an expected call of SetValue
 func (mr *MockConfigSetterMockRecorder) SetValue(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValue", reflect.TypeOf((*MockConfigSetter)(nil).SetValue), arg0, arg1)
 }
 
 // StateServingInfo mocks base method
 func (m *MockConfigSetter) StateServingInfo() (params.StateServingInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
 	ret0, _ := ret[0].(params.StateServingInfo)
 	ret1, _ := ret[1].(bool)
@@ -708,11 +826,13 @@ func (m *MockConfigSetter) StateServingInfo() (params.StateServingInfo, bool) {
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigSetterMockRecorder) StateServingInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfigSetter) SystemIdentityPath() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -720,23 +840,41 @@ func (m *MockConfigSetter) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigSetterMockRecorder) SystemIdentityPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfigSetter)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfigSetter) Tag() names_v3.Tag {
+func (m *MockConfigSetter) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigSetterMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfigSetter)(nil).Tag))
+}
+
+// TransientDataDir mocks base method
+func (m *MockConfigSetter) TransientDataDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransientDataDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// TransientDataDir indicates an expected call of TransientDataDir
+func (mr *MockConfigSetterMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfigSetter)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfigSetter) UpgradedToVersion() version.Number {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -744,11 +882,13 @@ func (m *MockConfigSetter) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigSetterMockRecorder) UpgradedToVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfigSetter) Value(arg0 string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -756,11 +896,13 @@ func (m *MockConfigSetter) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigSetterMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfigSetter)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -769,5 +911,6 @@ func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) 
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigSetterMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfigSetter)(nil).WriteCommands), arg0)
 }

--- a/worker/upgradedatabase/mocks/lock.go
+++ b/worker/upgradedatabase/mocks/lock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLock is a mock of Lock interface
@@ -35,6 +34,7 @@ func (m *MockLock) EXPECT() *MockLockMockRecorder {
 
 // IsUnlocked mocks base method
 func (m *MockLock) IsUnlocked() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUnlocked")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -42,21 +42,25 @@ func (m *MockLock) IsUnlocked() bool {
 
 // IsUnlocked indicates an expected call of IsUnlocked
 func (mr *MockLockMockRecorder) IsUnlocked() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnlocked", reflect.TypeOf((*MockLock)(nil).IsUnlocked))
 }
 
 // Unlock mocks base method
 func (m *MockLock) Unlock() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Unlock")
 }
 
 // Unlock indicates an expected call of Unlock
 func (mr *MockLockMockRecorder) Unlock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlock", reflect.TypeOf((*MockLock)(nil).Unlock))
 }
 
 // Unlocked mocks base method
 func (m *MockLock) Unlocked() <-chan struct{} {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unlocked")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -64,5 +68,6 @@ func (m *MockLock) Unlocked() <-chan struct{} {
 
 // Unlocked indicates an expected call of Unlocked
 func (mr *MockLockMockRecorder) Unlocked() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlocked", reflect.TypeOf((*MockLock)(nil).Unlocked))
 }

--- a/worker/upgradedatabase/mocks/package.go
+++ b/worker/upgradedatabase/mocks/package.go
@@ -5,13 +5,12 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
 	upgradedatabase "github.com/juju/juju/worker/upgradedatabase"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockLogger is a mock of Logger interface
@@ -39,6 +38,7 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 
 // Debugf mocks base method
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -48,12 +48,14 @@ func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 
 // Debugf indicates an expected call of Debugf
 func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
 // Errorf mocks base method
 func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -63,12 +65,14 @@ func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
 
 // Errorf indicates an expected call of Errorf
 func (mr *MockLoggerMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLogger)(nil).Errorf), varargs...)
 }
 
 // Infof mocks base method
 func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -78,6 +82,7 @@ func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
 
 // Infof indicates an expected call of Infof
 func (mr *MockLoggerMockRecorder) Infof(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLogger)(nil).Infof), varargs...)
 }
@@ -107,6 +112,7 @@ func (m *MockPool) EXPECT() *MockPoolMockRecorder {
 
 // Close mocks base method
 func (m *MockPool) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -114,11 +120,13 @@ func (m *MockPool) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockPoolMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPool)(nil).Close))
 }
 
 // EnsureUpgradeInfo mocks base method
 func (m *MockPool) EnsureUpgradeInfo(arg0 string, arg1, arg2 version.Number) (upgradedatabase.UpgradeInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureUpgradeInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(upgradedatabase.UpgradeInfo)
 	ret1, _ := ret[1].(error)
@@ -127,11 +135,13 @@ func (m *MockPool) EnsureUpgradeInfo(arg0 string, arg1, arg2 version.Number) (up
 
 // EnsureUpgradeInfo indicates an expected call of EnsureUpgradeInfo
 func (mr *MockPoolMockRecorder) EnsureUpgradeInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureUpgradeInfo", reflect.TypeOf((*MockPool)(nil).EnsureUpgradeInfo), arg0, arg1, arg2)
 }
 
 // IsPrimary mocks base method
 func (m *MockPool) IsPrimary(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPrimary", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -140,11 +150,13 @@ func (m *MockPool) IsPrimary(arg0 string) (bool, error) {
 
 // IsPrimary indicates an expected call of IsPrimary
 func (mr *MockPoolMockRecorder) IsPrimary(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrimary", reflect.TypeOf((*MockPool)(nil).IsPrimary), arg0)
 }
 
 // SetStatus mocks base method
 func (m *MockPool) SetStatus(arg0 string, arg1 status.Status, arg2 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -152,6 +164,7 @@ func (m *MockPool) SetStatus(arg0 string, arg1 status.Status, arg2 string) error
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockPoolMockRecorder) SetStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockPool)(nil).SetStatus), arg0, arg1, arg2)
 }
 
@@ -180,6 +193,7 @@ func (m *MockUpgradeInfo) EXPECT() *MockUpgradeInfoMockRecorder {
 
 // Refresh mocks base method
 func (m *MockUpgradeInfo) Refresh() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -187,11 +201,13 @@ func (m *MockUpgradeInfo) Refresh() error {
 
 // Refresh indicates an expected call of Refresh
 func (mr *MockUpgradeInfoMockRecorder) Refresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockUpgradeInfo)(nil).Refresh))
 }
 
 // SetStatus mocks base method
 func (m *MockUpgradeInfo) SetStatus(arg0 state.UpgradeStatus) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -199,11 +215,13 @@ func (m *MockUpgradeInfo) SetStatus(arg0 state.UpgradeStatus) error {
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockUpgradeInfoMockRecorder) SetStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockUpgradeInfo)(nil).SetStatus), arg0)
 }
 
 // Status mocks base method
 func (m *MockUpgradeInfo) Status() state.UpgradeStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(state.UpgradeStatus)
 	return ret0
@@ -211,11 +229,13 @@ func (m *MockUpgradeInfo) Status() state.UpgradeStatus {
 
 // Status indicates an expected call of Status
 func (mr *MockUpgradeInfoMockRecorder) Status() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockUpgradeInfo)(nil).Status))
 }
 
 // Watch mocks base method
 func (m *MockUpgradeInfo) Watch() state.NotifyWatcher {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch")
 	ret0, _ := ret[0].(state.NotifyWatcher)
 	return ret0
@@ -223,5 +243,6 @@ func (m *MockUpgradeInfo) Watch() state.NotifyWatcher {
 
 // Watch indicates an expected call of Watch
 func (mr *MockUpgradeInfoMockRecorder) Watch() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockUpgradeInfo)(nil).Watch))
 }

--- a/worker/upgradedatabase/mocks/watcher.go
+++ b/worker/upgradedatabase/mocks/watcher.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockNotifyWatcher is a mock of NotifyWatcher interface
@@ -35,6 +34,7 @@ func (m *MockNotifyWatcher) EXPECT() *MockNotifyWatcherMockRecorder {
 
 // Changes mocks base method
 func (m *MockNotifyWatcher) Changes() <-chan struct{} {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Changes")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -42,11 +42,13 @@ func (m *MockNotifyWatcher) Changes() <-chan struct{} {
 
 // Changes indicates an expected call of Changes
 func (mr *MockNotifyWatcherMockRecorder) Changes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Changes", reflect.TypeOf((*MockNotifyWatcher)(nil).Changes))
 }
 
 // Err mocks base method
 func (m *MockNotifyWatcher) Err() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Err")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -54,21 +56,25 @@ func (m *MockNotifyWatcher) Err() error {
 
 // Err indicates an expected call of Err
 func (mr *MockNotifyWatcherMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockNotifyWatcher)(nil).Err))
 }
 
 // Kill mocks base method
 func (m *MockNotifyWatcher) Kill() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
 // Kill indicates an expected call of Kill
 func (mr *MockNotifyWatcherMockRecorder) Kill() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockNotifyWatcher)(nil).Kill))
 }
 
 // Stop mocks base method
 func (m *MockNotifyWatcher) Stop() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -76,11 +82,13 @@ func (m *MockNotifyWatcher) Stop() error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockNotifyWatcherMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockNotifyWatcher)(nil).Stop))
 }
 
 // Wait mocks base method
 func (m *MockNotifyWatcher) Wait() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -88,5 +96,6 @@ func (m *MockNotifyWatcher) Wait() error {
 
 // Wait indicates an expected call of Wait
 func (mr *MockNotifyWatcherMockRecorder) Wait() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockNotifyWatcher)(nil).Wait))
 }


### PR DESCRIPTION
## Description of change
This PR enhances the uniter so that it can detect whether a reboot has occurred and notify
deployed charms by triggering an implicit start hook.

In order to detect reboots, the PR introduces the concept of a transient data
folder, a new agent configuration setting akin to "dataDir". On *nix targets we
get support for transient folders for free. All we need to do is to use a
tmpfs/ramdisk as the location of our transient data. By default (see `core/paths`),
juju will use `/var/run/juju` for storing transient data since that is guaranteed
to be a tmpfs volume (or a symlink to /run which is the equivalent for modern
systems). For windows, we need to use a low-level "syscall" to schedule the
automatic deletion of transient files when the system reboots (see extended
commit log for more details).

The `core/paths/transientfile` package offers a convenient abstraction for
creating transient files within the juju code-base. This functionality is
leveraged by yet another helper package `worker/common/reboot` which provides
per-entity (tag) one-off reboot notifications. The uniter uses this package
to queue start hooks if: a reboot is detected AND the unit has already been
started before (according to the uniter's state). Consequently, if we simply
restart the uniter agent, **no** start hook will be delivered. Similarly, if
we reboot the machine before the charm is installed the installation will
proceed as expected when the agent comes back online.

In addition, the deployer worker has been augmented with extra logic to clean up
any reboot-monitoring state once a unit gets removed. This is important to
avoid polluting manual machines (which may not be rebooted for a long time)
with junk state files.

Finally, to avoid triggering the start hook for existing units when upgrading
to 2.8, the PR includes an upgrade step that introspects the unit agents
running on the machine and pre-populates the reboot-handled state files
before the unit agents get restarted.

## QA steps

Deploy charms, trigger agent restarts and machine reboots and ensure that the
start hook fires when expected.

Or... Try the integration tests from this PR!

```
(cd tests ; ./main.sh hooks)
```

### Windows testing
Unfortunately, we don't have a reliable mechanism for running tests for windows charms. Given that the platform specific code for windows writes to the registry and that our CI machines are rarely restarted, none of the transient file tests are executed on windows. 

The plan (future) is to port the integration tests from this PR to run with windows workloads so we can catch any windows-specific regression.

In the meantime, I have manually verified in a windows VM that the code creates the transient file and that it gets correctly purged after a reboot so you will have to take my word for it :D

## Documentation changes
We need to document and communicate the change in the hook execution contracts.