### PR TITLE
Fix FullStatus extra queries on spaces on link layer devices

### DIFF
--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -44,6 +44,7 @@ type Backend interface {
 	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
 	AllRelations() ([]*state.Relation, error)
 	AllSubnets() ([]*state.Subnet, error)
+	AllSpaces() ([]*state.Space, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
 	Application(string) (*state.Application, error)

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -44,7 +44,6 @@ type Backend interface {
 	AllLinkLayerDevices() ([]*state.LinkLayerDevice, error)
 	AllRelations() ([]*state.Relation, error)
 	AllSubnets() ([]*state.Subnet, error)
-	AllSpaces() ([]*state.Space, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
 	Application(string) (*state.Application, error)
@@ -73,6 +72,7 @@ type Backend interface {
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	SetModelAgentVersion(version.Number, bool) error
 	SetModelConstraints(constraints.Value) error
+	SpaceNamesByID() (map[string]string, error)
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error
 	Watch(params state.WatchParams) *state.Multiwatcher

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -580,7 +580,7 @@ func fetchControllerNodes(st Backend) (map[string]state.ControllerNode, error) {
 // so we want all or none.
 func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string]map[string]set.Strings, map[string][]*state.LinkLayerDevice, error) {
 	ipAddresses := make(map[string][]*state.Address)
-	spaces := make(map[string]map[string]set.Strings)
+	spacesPerMachine := make(map[string]map[string]set.Strings)
 	subnets, err := st.AllSubnets()
 	if err != nil {
 		return nil, nil, nil, err
@@ -588,6 +588,14 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 	subnetsByCIDR := make(map[string]*state.Subnet)
 	for _, subnet := range subnets {
 		subnetsByCIDR[subnet.CIDR()] = subnet
+	}
+	spaces, err := st.AllSpaces()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	spaceIDToSpaceName := make(map[string]string)
+	for _, space := range spaces {
+		spaceIDToSpaceName[space.Id()] = space.Name()
 	}
 	// For every machine, track what devices have addresses so we can filter linklayerdevices later
 	devicesWithAddresses := make(map[string]set.Strings)
@@ -602,11 +610,11 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		machineID := ipAddr.MachineID()
 		ipAddresses[machineID] = append(ipAddresses[machineID], ipAddr)
 		if subnet, ok := subnetsByCIDR[ipAddr.SubnetCIDR()]; ok {
-			if spaceName := subnet.SpaceName(); spaceName != "" {
-				devices, ok := spaces[machineID]
+			if spaceName := spaceIDToSpaceName[subnet.SpaceID()]; spaceName != "" {
+				devices, ok := spacesPerMachine[machineID]
 				if !ok {
 					devices = make(map[string]set.Strings)
-					spaces[machineID] = devices
+					spacesPerMachine[machineID] = devices
 				}
 				deviceName := ipAddr.DeviceName()
 				spacesSet, ok := devices[deviceName]
@@ -648,7 +656,7 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		linkLayerDevices[machineID] = append(linkLayerDevices[machineID], llDev)
 	}
 
-	return ipAddresses, spaces, linkLayerDevices, nil
+	return ipAddresses, spacesPerMachine, linkLayerDevices, nil
 }
 
 // fetchAllApplicationsAndUnits returns a map from application name to application,

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -589,13 +589,10 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 	for _, subnet := range subnets {
 		subnetsByCIDR[subnet.CIDR()] = subnet
 	}
-	spaces, err := st.AllSpaces()
+
+	spaceIDToSpaceName, err := st.SpaceNamesByID()
 	if err != nil {
 		return nil, nil, nil, err
-	}
-	spaceIDToSpaceName := make(map[string]string)
-	for _, space := range spaces {
-		spaceIDToSpaceName[space.Id()] = space.Name()
 	}
 	// For every machine, track what devices have addresses so we can filter linklayerdevices later
 	devicesWithAddresses := make(map[string]set.Strings)

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -610,7 +610,11 @@ func fetchNetworkInterfaces(st Backend) (map[string][]*state.Address, map[string
 		machineID := ipAddr.MachineID()
 		ipAddresses[machineID] = append(ipAddresses[machineID], ipAddr)
 		if subnet, ok := subnetsByCIDR[ipAddr.SubnetCIDR()]; ok {
-			if spaceName := spaceIDToSpaceName[subnet.SpaceID()]; spaceName != "" {
+			spaceName, found := spaceIDToSpaceName[subnet.SpaceID()]
+			if !found {
+				spaceName = network.AlphaSpaceName
+			}
+			if spaceName != "" {
 				devices, ok := spacesPerMachine[machineID]
 				if !ok {
 					devices = make(map[string]set.Strings)

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -146,7 +146,9 @@ func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The number of queries should be the same.
-	c.Check(tracker.ReadCount(), gc.Equals, queryCount)
+	c.Check(tracker.ReadCount(), gc.Equals, queryCount,
+		gc.Commentf("if the query count is not the same, there has been a regression "+
+			"in the way the addresses are processed"))
 }
 
 func (s *statusSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, CIDR, providerSubnetID string) {

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -101,6 +101,86 @@ func (s *statusSuite) TestFullStatusUnitLeadership(c *gc.C) {
 	c.Assert(unit.Leader, jc.IsTrue)
 }
 
+func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
+	machine := s.addMachine(c)
+	s.createSpaceAndSubnetWithProviderID(c, "public", "10.0.0.0/24", "prov-0000")
+	s.createSpaceAndSubnetWithProviderID(c, "private", "10.20.0.0/24", "prov-ffff")
+	s.createSpaceAndSubnetWithProviderID(c, "dmz", "10.30.0.0/24", "prov-abcd")
+
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
+	tracker := s.State.TrackQueries()
+
+	client := s.APIState.Client()
+	_, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	queryCount := tracker.ReadCount()
+
+	// Add a bunch of interfaces to the machine.
+	s.createNICWithIP(c, machine, "eth0", "10.0.0.11/24")
+	s.createNICWithIP(c, machine, "eth1", "10.20.0.42/24")
+	s.createNICWithIP(c, machine, "eth2", "10.30.0.99/24")
+
+	err = machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName:        "eth1",
+			ConfigMethod:      state.StaticAddress,
+			ProviderNetworkID: "vpc-abcd",
+			ProviderSubnetID:  "prov-ffff",
+			CIDRAddress:       "10.20.0.42/24",
+		},
+		state.LinkLayerDeviceAddress{
+			DeviceName:        "eth2",
+			ConfigMethod:      state.StaticAddress,
+			ProviderNetworkID: "vpc-abcd",
+			ProviderSubnetID:  "prov-abcd",
+			CIDRAddress:       "10.30.0.99/24",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
+	tracker.Reset()
+
+	_, err = client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The number of queries should be the same.
+	c.Check(tracker.ReadCount(), gc.Equals, queryCount)
+}
+
+func (s *statusSuite) createSpaceAndSubnetWithProviderID(c *gc.C, spaceName, CIDR, providerSubnetID string) {
+	space, err := s.State.AddSpace(spaceName, network.Id(spaceName), nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.AddSubnet(network.SubnetInfo{
+		CIDR:       CIDR,
+		SpaceID:    space.Id(),
+		ProviderId: network.Id(providerSubnetID),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *statusSuite) createNICWithIP(c *gc.C, machine *state.Machine, deviceName, cidrAddress string) {
+	err := machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       deviceName,
+			Type:       network.EthernetDevice,
+			ParentName: "",
+			IsUp:       true,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetDevicesAddresses(
+		state.LinkLayerDeviceAddress{
+			DeviceName:   deviceName,
+			CIDRAddress:  cidrAddress,
+			ConfigMethod: state.StaticAddress,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 var _ = gc.Suite(&statusUnitTestSuite{})
 
 type statusUnitTestSuite struct {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4611,6 +4611,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 
 	// Now execute the command for each format.
 	for _, format := range statusFormats {
+		tracker := ctx.st.TrackQueries()
 		c.Logf("format %q", format.name)
 		// Run command with the required format.
 		args := []string{"--format", format.name}
@@ -4622,6 +4623,8 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 		code, stdout, stderr := runStatus(c, args...)
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(string(stderr), gc.Equals, e.stderr)
+
+		fmt.Fprintf(os.Stderr, "read queries (%s - %s): %d\n", e.what, format.name, tracker.ReadCount())
 
 		// Prepare the output in the same format.
 		buf, err := format.marshal(e.output)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -100,21 +100,6 @@ type stepper interface {
 // context
 //
 
-func newContext(st *state.State, pool *state.StatePool, env environs.Environ, adminUserTag string) *context {
-	// We make changes in the API server's state so that
-	// our changes to presence are immediately noticed
-	// in the status.
-	return &context{
-		st:           st,
-		pool:         pool,
-		env:          env,
-		statusSetter: env.(agentStatusSetter),
-		charms:       make(map[string]*state.Charm),
-		pingers:      make(map[string]*presence.Pinger),
-		adminUserTag: adminUserTag,
-	}
-}
-
 type agentStatusSetter interface {
 	SetAgentStatus(agent string, status corepresence.Status)
 }
@@ -129,6 +114,7 @@ type context struct {
 	adminUserTag  string // A string repr of the tag.
 	expectIsoTime bool
 	skipTest      bool
+	waitForIdle   func()
 }
 
 func (ctx *context) reset(c *gc.C) {
@@ -172,7 +158,22 @@ func (s *StatusSuite) newContext(c *gc.C) *context {
 	// We make changes in the API server's state so that
 	// our changes to presence are immediately noticed
 	// in the status.
-	return newContext(st, s.StatePool, s.Environ, s.AdminUserTag(c).String())
+	wait := func() {
+		s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
+	}
+	// We make changes in the API server's state so that
+	// our changes to presence are immediately noticed
+	// in the status.
+	return &context{
+		st:           st,
+		pool:         s.StatePool,
+		env:          s.Environ,
+		statusSetter: s.Environ.(agentStatusSetter),
+		charms:       make(map[string]*state.Charm),
+		pingers:      make(map[string]*presence.Pinger),
+		adminUserTag: s.AdminUserTag(c).String(),
+		waitForIdle:  wait,
+	}
 }
 
 func (s *StatusSuite) resetContext(c *gc.C, ctx *context) {
@@ -4611,6 +4612,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 
 	// Now execute the command for each format.
 	for _, format := range statusFormats {
+		ctx.waitForIdle()
 		tracker := ctx.st.TrackQueries()
 		c.Logf("format %q", format.name)
 		// Run command with the required format.

--- a/state/collection.go
+++ b/state/collection.go
@@ -18,7 +18,8 @@ import (
 // possible).
 type modelStateCollection struct {
 	mongo.WriteCollection
-	modelUUID string
+	modelUUID    string
+	queryTracker *queryTracker
 }
 
 // Writeable is part of the Collection interface.
@@ -31,6 +32,9 @@ func (c *modelStateCollection) Writeable() mongo.WriteCollection {
 // Count returns the number of documents in the collection that belong
 // to the model that the modelStateCollection is filtering on.
 func (c *modelStateCollection) Count() (int, error) {
+	if c.queryTracker != nil {
+		c.queryTracker.TrackRead(c.Name(), "count")
+	}
 	return c.WriteCollection.Find(bson.D{{"model-uuid", c.modelUUID}}).Count()
 }
 
@@ -47,6 +51,9 @@ func (c *modelStateCollection) Count() (int, error) {
 // these cases it is up to the caller to add model UUID
 // prefixes when necessary.
 func (c *modelStateCollection) Find(query interface{}) mongo.Query {
+	if c.queryTracker != nil {
+		c.queryTracker.TrackRead(c.Name(), query)
+	}
 	return c.WriteCollection.Find(c.mungeQuery(query))
 }
 
@@ -54,6 +61,9 @@ func (c *modelStateCollection) Find(query interface{}) mongo.Query {
 // relevant model UUID prefix will be added to it. Otherwise, the
 // query will be handled as per Find().
 func (c *modelStateCollection) FindId(id interface{}) mongo.Query {
+	if c.queryTracker != nil {
+		c.queryTracker.TrackRead(c.Name(), bson.M{"_id": id})
+	}
 	if sid, ok := id.(string); ok {
 		return c.WriteCollection.FindId(ensureModelUUID(c.modelUUID, sid))
 	}

--- a/state/database.go
+++ b/state/database.go
@@ -259,6 +259,8 @@ type database struct {
 
 	// clock is used to time how long transactions take to run
 	clock clock.Clock
+
+	queryTracker *queryTracker
 }
 
 // RunTransactionObserverFunc is the type of a function to be called
@@ -311,6 +313,7 @@ func (db *database) GetCollection(name string) (collection mongo.Collection, clo
 		collection = &modelStateCollection{
 			WriteCollection: collection.Writeable(),
 			modelUUID:       db.modelUUID,
+			queryTracker:    db.queryTracker,
 		}
 	}
 

--- a/state/querytracker.go
+++ b/state/querytracker.go
@@ -27,7 +27,7 @@ type QueryDetails struct {
 // track the database queries made.
 func (s *State) TrackQueries() QueryTracker {
 	tracker := &queryTracker{}
-	s.database.(*database).queryTracker = tracker
+	s.database.(*database).setTracker(tracker)
 	return tracker
 }
 

--- a/state/querytracker.go
+++ b/state/querytracker.go
@@ -11,7 +11,8 @@ type QueryTracker interface {
 	Reset()
 	ListQueries() []QueryDetails
 	ReadCount() int
-	WriteCount() int
+	// TODO: implement the write tracking.
+	// WriteCount() int
 }
 
 // QueryDetails is a POD type recording the database query

--- a/state/querytracker.go
+++ b/state/querytracker.go
@@ -1,0 +1,82 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "runtime/debug"
+
+// QueryTracker provides a way for tests to determine how many
+// database queries have been made, and who made them.
+type QueryTracker interface {
+	Reset()
+	ListQueries() []QueryDetails
+	ReadCount() int
+	WriteCount() int
+}
+
+// QueryDetails is a POD type recording the database query
+// and who made it.
+type QueryDetails struct {
+	Type           string // read or write
+	CollectionName string
+	Query          interface{}
+	Traceback      string
+}
+
+// TrackQueries allows tests to turn on a mechanism to count and
+// track the database queries made.
+func (s *State) TrackQueries() QueryTracker {
+	tracker := &queryTracker{}
+	s.database.(*database).queryTracker = tracker
+	return tracker
+}
+
+type queryTracker struct {
+	queries []QueryDetails
+}
+
+// Reset clears out all the current reads and writes.
+func (q *queryTracker) Reset() {
+	q.queries = nil
+}
+
+// ListQueries returns the list of all queries that have been
+// done since start or reset.
+func (q *queryTracker) ListQueries() []QueryDetails {
+	return q.queries
+}
+
+// ReadCount returns the number of read queries that have been
+// done since start or reset.
+func (q *queryTracker) ReadCount() int {
+	count := 0
+	for _, query := range q.queries {
+		if query.Type == "read" {
+			count++
+		}
+	}
+	return count
+}
+
+// WriteCount returns the number of write queries that have been
+// done since start or reset.
+func (q *queryTracker) WriteCount() int {
+	count := 0
+	for _, query := range q.queries {
+		if query.Type == "write" {
+			count++
+		}
+	}
+	return count
+}
+
+// TrackRead records the read query against the collection specified
+// and where the call came from.
+func (q *queryTracker) TrackRead(collectionName string, query interface{}) {
+	q.queries = append(q.queries, QueryDetails{
+		Type:           "read",
+		CollectionName: collectionName,
+		Query:          query,
+		Traceback:      string(debug.Stack()),
+	})
+}


### PR DESCRIPTION
During status the code that gets the space name for the link layer device was causing extra queries to the database.

In order to test, John and I introduce a query tracker on the state object to cound the number of database read queries.
