### PR TITLE
Fixes lp#1860665: when no controllers are registered on the client, assume client-only operation.

### DIFF
--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -263,7 +263,7 @@ func (s *listCredentialsSuite) TestListAllCredentials(c *gc.C) {
 			{Error: common.ServerError(errors.New("kabbom"))},
 		}, nil
 	}
-	out := s.listCredentials(c, "-c", "mycontroller", "--client")
+	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
 
 Controller Credentials:

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -98,7 +98,7 @@ func (s *regionsSuite) setupControllerData(c *gc.C) cmd.Command {
 
 func (s *regionsSuite) TestListRegions(c *gc.C) {
 	aCommand := s.setupControllerData(c)
-	ctx, err := cmdtesting.RunCommand(c, aCommand, "kloud", "-c", "mycontroller", "--client", "--format", "yaml")
+	ctx, err := cmdtesting.RunCommand(c, aCommand, "kloud", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, jc.DeepEquals, `

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -179,7 +179,7 @@ func (s *showSuite) TestShowControllerAndLocalCloud(c *gc.C) {
 		func() (cloud.ShowCloudAPI, error) {
 			return s.api, nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, command, "aws-china", "-c", "mycontroller", "--client")
+	ctx, err := cmdtesting.RunCommand(c, command, "aws-china")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "Cloud", "Close")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")

--- a/cmd/juju/cloud/showcredential_test.go
+++ b/cmd/juju/cloud/showcredential_test.go
@@ -130,7 +130,7 @@ func (s *ShowCredentialSuite) TestShowCredentialBothClientAndController(c *gc.C)
 		},
 	}
 	cmd := cloud.NewShowCredentialCommandForTest(s.store, s.api)
-	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets", "-c", "controller", "--client")
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--show-secrets")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ``)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -468,6 +468,14 @@ func (c *OptionalControllerCommand) MaybePrompt(ctxt *cmd.Context, action string
 			msg += " but there are other controllers registered: use -c or --controller to specify a controller if needed."
 		}
 		ctxt.Infof(msg)
+
+		// If there are no controllers registered on this client,
+		// assume the operation only needs to run on a client.
+		if len(all) == 0 {
+			c.Client = true
+			return nil
+		}
+
 		pollster := interact.New(ctxt.Stdin, ctxt.Stdout, interact.NewErrWriter(ctxt.Stdout))
 		useClient, err := pollster.YN(fmt.Sprintf("Do you ONLY want to %v this client", action), true)
 		if err != nil {

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -221,26 +221,16 @@ func (s *OptionalControllerCommandSuite) TestPromptManyControllersNoCurrent(c *g
 	})
 }
 
-func (s *OptionalControllerCommandSuite) TestPromptNoControllersAndNoCurrent(c *gc.C) {
+func (s *OptionalControllerCommandSuite) TestPromptNoRegisteredControllers(c *gc.C) {
+	// Since there are no controllers registered on the client, the operation is
+	// assumed to be desired only on the client.
 	s.assertPrompted(c, jujuclient.NewMemStore(), testData{
-		userAnswer:     "y\n",
-		expectedPrompt: "Do you ONLY want to  this client? (Y/n): \n",
+		userAnswer:     "n\n",
+		expectedPrompt: "",
 		expectedInfo: "This operation can be applied to both a copy on this client and to the one on a controller.\n" +
 			"No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.\n",
 		expectedControllerName:  "",
 		expectedClientOperation: true,
-	})
-}
-
-func (s *OptionalControllerCommandSuite) TestPromptDenyClientAndNoCurrent(c *gc.C) {
-	s.assertPrompted(c, jujuclient.NewMemStore(), testData{
-		userAnswer:     "n\n",
-		expectedPrompt: "Do you ONLY want to  this client? (Y/n): \n",
-		expectedInfo: "This operation can be applied to both a copy on this client and to the one on a controller.\n" +
-			"No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.\n" +
-			"Neither client nor controller specified - nothing to do.\n",
-		expectedControllerName:  "",
-		expectedClientOperation: false,
 	})
 }
 


### PR DESCRIPTION
## Description of change

Commands in cmd/juju/cloud package can operate on both client and controller copies of clouds/credentials/regions/etc. When there is an ambiguity where to operate, a command will prompt the operator for confirmation. However, when there are no controllers registered on the client, the operation will only operate using client copy. 

## QA steps

Ensure there are no controllers registered on your client, run any of the commands with *-cloud or *-credential

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860665