### PR TITLE
Support OpenStack block-storage v3 api.

### DIFF
--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -878,7 +878,7 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointVolumeV2(c *gc.C) {
 	c.Assert(url.String(), gc.Equals, "http://cinder.testing/v2")
 }
 
-func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointPreferV2(c *gc.C) {
+func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointV2IfNoV3(c *gc.C) {
 	client := &testEndpointResolver{regionEndpoints: map[string]identity.ServiceURLs{
 		"south": map[string]string{
 			"volume":   "http://cinder.testing/v1",
@@ -888,6 +888,19 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointPreferV2(c *gc.C) {
 	url, err := openstack.GetVolumeEndpointURL(client, "south")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url.String(), gc.Equals, "http://cinder.testing/v2")
+}
+
+func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointPreferV3(c *gc.C) {
+	client := &testEndpointResolver{regionEndpoints: map[string]identity.ServiceURLs{
+		"south": map[string]string{
+			"volume":   "http://cinder.testing/v1",
+			"volumev2": "http://cinder.testing/v2",
+			"volumev3": "http://cinder.testing/v3",
+		},
+	}}
+	url, err := openstack.GetVolumeEndpointURL(client, "south")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(url.String(), gc.Equals, "http://cinder.testing/v3")
 }
 
 func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointMissing(c *gc.C) {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The block storage OpenStack service for v3 is functionally equivalent to
v2.  Therefore we can get the service catalog url for the new version
and use it with the current goose cinder implementation.  No other changes
required.

## QA steps

Serverstack supports volumev3 service type.

```console
$ juju bootstrap serverstack --config logging-config="<root>=WARNING;unit=DEBUG;juju.provider.openstack=DEBUG"
$ juju deploy postgresql --storage pgdata=100G

# once deploy has completed, verify juju storage
$ juju storage
Unit          Storage id  Type        Pool    Size    Status    Message
postgresql/0  pgdata/0    filesystem  cinder  100GiB  attached
$ openstack volume list
+--------------------------------------+------------------------------+--------+------+------------------------------------------------+
| ID                                   | Name                         | Status | Size | Attached to                                    |
+--------------------------------------+------------------------------+--------+------+------------------------------------------------+
| 55256548-490e-4f26-9114-6be01058825e | juju-d69412-default-volume-0 | in-use |  100 | Attached to juju-d69412-default-0 on /dev/vdc  |
+--------------------------------------+------------------------------+--------+------+------------------------------------------------+
```
Check the juju debug-log, messages with 'endpoint "volumev3" not found' should not be seen.
## Documentation changes

Add to the release notes.

## Bug reference

n/a
