### PR TITLE
Fix/replicasets left over

### DIFF
--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -54,6 +54,7 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs map[s
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},
@@ -276,6 +277,7 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs map
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -54,6 +54,7 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds map[str
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},
@@ -375,6 +376,7 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -48,6 +48,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1090,6 +1090,12 @@ func (k *kubernetesClient) EnsureService(
 		}
 	}
 
+	if params.Deployment.DeploymentType != caas.DeploymentStateful {
+		if workloadSpec.Service != nil && workloadSpec.Service.ScalePolicy != "" {
+			return errors.NewNotValid(nil, fmt.Sprintf("ScalePolicy is only supported for %s application", caas.DeploymentStateful))
+		}
+	}
+
 	hasService := !params.PodSpec.OmitServiceFrontend && !params.Deployment.ServiceType.IsOmit()
 	if hasService {
 		var ports []core.ContainerPort
@@ -1586,7 +1592,7 @@ func (k *kubernetesClient) configureDaemonSet(
 	if err := k.configurePodFiles(appName, annotations, workloadSpec, containers, cfgName); err != nil {
 		return cleanUp, errors.Trace(err)
 	}
-	// We don't want keep any replicaset history.
+	// We don't want to keep any replicaset history.
 	var revisionHistoryLimit int32 = 0
 	daemonSet := &apps.DaemonSet{
 		ObjectMeta: v1.ObjectMeta{
@@ -1628,7 +1634,7 @@ func (k *kubernetesClient) configureDeployment(
 	if err := k.configurePodFiles(appName, annotations, workloadSpec, containers, cfgName); err != nil {
 		return errors.Trace(err)
 	}
-	// We don't want keep any replicaset history.
+	// We don't want to keep any replicaset history.
 	var revisionHistoryLimit int32 = 0
 	deployment := &apps.Deployment{
 		ObjectMeta: v1.ObjectMeta{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1427,6 +1427,7 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},
@@ -1792,7 +1793,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceStatelessWithScalePolicyInvalid(c *gc.
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
 	})
-	c.Assert(err, gc.ErrorMatches, `ScalePolicy is only supported for stateful application`)
+	c.Assert(err, gc.ErrorMatches, `ScalePolicy is only supported for stateful applications`)
 }
 
 func (s *K8sBrokerSuite) TestEnsureServiceWithConfigMapAndSecretsCreate(c *gc.C) {
@@ -2241,6 +2242,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},
@@ -2326,6 +2328,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
 			},
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"juju-app": "app-name"},
@@ -4742,6 +4745,7 @@ func (s *K8sBrokerSuite) TestUpgradeController(c *gc.C) {
 			Labels: map[string]string{"juju-operator": "controller"},
 		},
 		Spec: apps.StatefulSetSpec{
+			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -65,6 +65,7 @@ func (k *kubernetesClient) configureStatefulSet(
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{labelApplication: appName},
 			},
+			RevisionHistoryLimit: getRevisionHistoryLimit(),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels:      k.getStatefulSetLabels(appName),

--- a/caas/specs/types.go
+++ b/caas/specs/types.go
@@ -139,7 +139,7 @@ func (spt ScalePolicyType) Validate() error {
 			return nil
 		}
 	}
-	return errors.NotSupportedf("%v", spt)
+	return errors.NotSupportedf("scale policy %q", spt)
 }
 
 const (
@@ -152,7 +152,7 @@ const (
 	// scale up and strictly decreasing order on scale down, progressing only when
 	// the previous pod is ready or terminated. At most one pod will be changed
 	// at any time.
-	SerialScale = "serial"
+	SerialScale ScalePolicyType = "serial"
 )
 
 var supportedPolicies = []ScalePolicyType{

--- a/caas/specs/types_test.go
+++ b/caas/specs/types_test.go
@@ -68,7 +68,7 @@ func (s *typesSuite) TestValidateServiceSpec(c *gc.C) {
 	spec := specs.ServiceSpec{
 		ScalePolicy: "foo",
 	}
-	c.Assert(spec.Validate(), gc.ErrorMatches, `foo not supported`)
+	c.Assert(spec.Validate(), gc.ErrorMatches, `scale policy "foo" not supported`)
 
 	spec = specs.ServiceSpec{
 		ScalePolicy: "parallel",

--- a/caas/specs/types_test.go
+++ b/caas/specs/types_test.go
@@ -66,9 +66,9 @@ version: 3
 
 func (s *typesSuite) TestValidateServiceSpec(c *gc.C) {
 	spec := specs.ServiceSpec{
-		ScalePolicy: "foo",
+		ScalePolicy: "bar",
 	}
-	c.Assert(spec.Validate(), gc.ErrorMatches, `scale policy "foo" not supported`)
+	c.Assert(spec.Validate(), gc.ErrorMatches, `scale policy "bar" not supported`)
 
 	spec = specs.ServiceSpec{
 		ScalePolicy: "parallel",


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

By default, k8s keeps `10` latest replica sets records.
Juju prefers no history records should be kept, so this PR sets it to `0`.

Drive by fix: validates `ScalePolicy` for non-stateful charms;

## QA steps

deploy a stateless charm then run upgrade-charm after changed k8s specs;

```console
# replicasets should always be one record per application;
$ mkubectl -n gitlab-k8s get rs -n t1
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1864394
