### PR TITLE
Add Cached Model Applications

### DIFF
--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -201,6 +201,19 @@ func (m *Model) Branch(name string) (Branch, error) {
 	return Branch{}, errors.NotFoundf("branch %q", name)
 }
 
+// Applications makes a copy of the model's application collection and returns it.
+func (m *Model) Applications() map[string]Application {
+	m.mu.Lock()
+
+	apps := make(map[string]Application, len(m.applications))
+	for k, v := range m.applications {
+		apps[k] = v.copy()
+	}
+
+	m.mu.Unlock()
+	return apps
+}
+
 // Application returns the application for the input name.
 // If the application is not found, a NotFoundError is returned.
 func (m *Model) Application(appName string) (Application, error) {

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -185,6 +185,17 @@ func (s *ModelSuite) TestApplicationReturnsCopy(c *gc.C) {
 	c.Assert(a2.Config(), gc.DeepEquals, appChange.Config)
 }
 
+func (s *ModelSuite) TestApplications(c *gc.C) {
+	m := s.NewModel(modelChange)
+	m.UpdateApplication(appChange, s.Manager)
+
+	apps := m.Applications()
+	c.Assert(apps, gc.HasLen, 1)
+	app := apps[appChange.Name]
+	c.Check(app.CharmURL(), gc.Equals, appChange.CharmURL)
+	c.Check(app.Config(), gc.DeepEquals, appChange.Config)
+}
+
 func (s *ModelSuite) TestCharmNotFoundError(c *gc.C) {
 	m := s.NewModel(modelChange)
 	_, err := m.Charm("nope")


### PR DESCRIPTION
## Description of change

This patch adds an `Applications` method to the cached `Model` so that all applications can be retrieved at once as a single map. This is congruent with the existing `Machines` and `Units` methods.

## QA steps

No functional recruitment yet. Covered by new unit tests.

## Documentation changes

None.

## Bug reference

N/A
