### PR TITLE
Add daemonset support in GetService;

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -697,6 +697,8 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			Return(nil, s.k8sNotFoundError()),
 		s.mockDeployments.EXPECT().Get("juju-controller-test", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
+		s.mockDaemonSets.EXPECT().Get("juju-controller-test", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
 
 		// below calls are for GetService - 2nd address is ready.
 		s.mockServices.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==juju-controller-test"}).
@@ -706,6 +708,8 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 		s.mockStatefulSets.EXPECT().Get("juju-controller-test", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockDeployments.EXPECT().Get("juju-controller-test", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockDaemonSets.EXPECT().Get("juju-controller-test", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 
 		// ensure shared-secret secret.

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -751,12 +751,12 @@ func (k *kubernetesClient) GetService(appName string, includeClusterIP bool) (*c
 		}
 		gen := deployment.GetGeneration()
 		result.Generation = &gen
-		message, ssStatus, err := k.getDeploymentStatus(deployment)
+		message, deployStatus, err := k.getDeploymentStatus(deployment)
 		if err != nil {
 			return nil, errors.Annotatef(err, "getting status for %s", ss.Name)
 		}
 		result.Status = status.StatusInfo{
-			Status:  ssStatus,
+			Status:  deployStatus,
 			Message: message,
 		}
 		return &result, nil
@@ -774,12 +774,12 @@ func (k *kubernetesClient) GetService(appName string, includeClusterIP bool) (*c
 
 		gen := ds.GetGeneration()
 		result.Generation = &gen
-		message, ssStatus, err := k.getDaemonSetStatus(ds)
+		message, dsStatus, err := k.getDaemonSetStatus(ds)
 		if err != nil {
 			return nil, errors.Annotatef(err, "getting status for %s", ss.Name)
 		}
 		result.Status = status.StatusInfo{
-			Status:  ssStatus,
+			Status:  dsStatus,
 			Message: message,
 		}
 	}


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Use `DesiredNumberScheduled` for daemonset scale;

## QA steps

```console
# deploy a daemonset charm;
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml --pretty | jq .deployment
{
  "type": "daemon",
  "min-version": "1.10.1",
  "service": "omit"
}
$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb -n1

$ mkubectl get ds -n t1
NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
mariadb-k8s   1         1         1       1            1           <none>          12m

# change k8s spec; then upgrade charm;
$ charm-build ./mariadb/  && juju upgrade-charm mariadb-k8s --path /tmp/charm-builds/mariadb-k8s/ --debug --resource mysql_image=mariadb

# check if terminated unites get removed;
$ juju status
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1864396
