### PR TITLE
Main Juju command stderr changes.

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -118,7 +118,7 @@ func (m main) Run(args []string) int {
 	}
 
 	if newInstall {
-		ctx.Infof("\nSince Juju %v is being run for the first time, downloading latest cloud information.\n", jujuversion.Current.Major)
+		ctx.Verbosef("\nSince Juju %v is being run for the first time, downloading latest cloud information.\n", jujuversion.Current.Major)
 		updateCmd := cloud.NewUpdatePublicCloudsCommand()
 		if err := updateCmd.Run(ctx); err != nil {
 			cmd.WriteError(ctx.Stderr, err)
@@ -181,7 +181,7 @@ If you want to use Juju {{.OldJujuVersion}}, run 'juju' commands as '{{.OldJujuC
 		"OldJujuVersion":     ver,
 		"OldJujuCommand":     juju1xCmdName,
 	})
-	ctx.Infof(buf.String())
+	ctx.Verbosef(buf.String())
 	return newInstall
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -105,7 +105,7 @@ func (m main) Run(args []string) int {
 
 	// note that this has to come before we init the juju home directory,
 	// since it relies on detecting the lack of said directory.
-	newInstall := m.maybeWarnJuju1x()
+	newInstall := m.maybeWarnJuju1x(ctx)
 
 	if err = juju.InitJujuXDGDataHome(); err != nil {
 		cmd.WriteError(ctx.Stderr, err)
@@ -118,7 +118,7 @@ func (m main) Run(args []string) int {
 	}
 
 	if newInstall {
-		fmt.Fprintf(ctx.Stderr, "Since Juju %v is being run for the first time, downloading latest cloud information.\n", jujuversion.Current.Major)
+		ctx.Infof("\nSince Juju %v is being run for the first time, downloading latest cloud information.\n", jujuversion.Current.Major)
 		updateCmd := cloud.NewUpdatePublicCloudsCommand()
 		if err := updateCmd.Run(ctx); err != nil {
 			cmd.WriteError(ctx.Stderr, err)
@@ -155,7 +155,7 @@ func installProxy() error {
 	return nil
 }
 
-func (m main) maybeWarnJuju1x() (newInstall bool) {
+func (m main) maybeWarnJuju1x(ctx *cmd.Context) (newInstall bool) {
 	newInstall = !juju2xConfigDataExists()
 	if !shouldWarnJuju1x() {
 		return newInstall
@@ -181,7 +181,7 @@ If you want to use Juju {{.OldJujuVersion}}, run 'juju' commands as '{{.OldJujuC
 		"OldJujuVersion":     ver,
 		"OldJujuCommand":     juju1xCmdName,
 	})
-	fmt.Fprintln(os.Stderr, buf.String())
+	ctx.Infof(buf.String())
 	return newInstall
 }
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -229,7 +229,7 @@ func (s *MainSuite) TestFirstRun2xFrom1xOnUbuntu(c *gc.C) {
 		}.Run([]string{"juju", "version"})
 	}
 
-	stdout, stderr := gitjujutesting.CaptureOutput(c, f)
+	stdout, _ := gitjujutesting.CaptureOutput(c, f)
 
 	select {
 	case args := <-argChan:
@@ -239,14 +239,8 @@ func (s *MainSuite) TestFirstRun2xFrom1xOnUbuntu(c *gc.C) {
 	}
 
 	c.Check(code, gc.Equals, 0)
-	c.Check(string(stderr), gc.Equals, fmt.Sprintf(`
-Welcome to Juju %s. 
-    See https://jujucharms.com/docs/stable/introducing-2 for more details.
-
-If you want to use Juju 1.25.0, run 'juju' commands as 'juju-1'. For example, 'juju-1 bootstrap'.
-   See https://jujucharms.com/docs/stable/juju-coexist for installation details. 
-
-Since Juju 2 is being run for the first time, downloading latest cloud information.`[1:]+"\n", jujuversion.Current))
+	// Since we have not asked for a verbose output the message will be in the log.
+	c.Check(c.GetTestLog(), jc.Contains, fmt.Sprintf("Welcome to Juju %s. \n", jujuversion.Current))
 	checkVersionOutput(c, string(stdout))
 }
 


### PR DESCRIPTION
## Description of change

Information messages should be on stderr and they should react to -v and -q.

This change ensures that main Juju commands output is on the right writer and is responsive to -v and -1 flag by using centrally provided functionality in ctx.Infof(). 

## QA steps

Run 'juju -h' on a new machine.
