### PR TITLE
Check for integration tests

### DIFF
--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -26,10 +26,10 @@ check_not_contains() {
 
     chk=$(echo "${input}" | grep "${value}" || true)
     if [ -n "${chk}" ]; then
-        printf "Unexpected \"${value}\" found\n\n%s\n" "${input}"
+        printf "Unexpected \"${value}\" found\n\n%s\n" "${input}" >&2
         exit 1
     else
-        echo "Success: \"${value}\" not found"
+        echo "Success: \"${value}\" not found" >&2
     fi
 }
 
@@ -44,10 +44,10 @@ check_contains() {
 
     chk=$(echo "${input}" | grep "${value}" || true)
     if [ -z "${chk}" ]; then
-        printf "Expected \"${value}\" not found\n\n%s\n" "${input}"
+        printf "Expected \"${value}\" not found\n\n%s\n" "${input}" >&2
         exit 1
     else
-        echo "Success: \"${value}\" found"
+        echo "Success: \"${value}\" found" >&2
     fi
 }
 
@@ -63,12 +63,12 @@ check() {
 
     OUT=$(echo "${got}" | grep -E "${want}" || true)
     if [ -z "${OUT}" ]; then
-        echo "" 1>&2
+        echo "" >&2
         # shellcheck disable=SC2059
-        printf "$(red \"Expected\"): ${want}\n"  1>&2
+        printf "$(red \"Expected\"): ${want}\n" >&2
         # shellcheck disable=SC2059
-        printf "$(red \"Recieved\"): ${got}\n" 1>&2
-        echo "" 1>&2
+        printf "$(red \"Recieved\"): ${got}\n" >&2
+        echo "" >&2
         exit 1
     fi
 }

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -50,3 +50,25 @@ check_contains() {
         echo "Success: \"${value}\" found"
     fi
 }
+
+check() {
+    local want got
+
+    want=${1}
+
+    got=
+    while read -r d; do
+        got="${got}\n${d}"
+    done
+
+    OUT=$(echo "${got}" | grep -E "${want}" || true)
+    if [ -z "${OUT}" ]; then
+        echo "" 1>&2
+        # shellcheck disable=SC2059
+        printf "Expected: ${want}\n" 1>&2
+        # shellcheck disable=SC2059
+        printf "Recieved: ${got}\n" 1>&2
+        echo "" 1>&2
+        exit 1
+    fi
+}

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -65,9 +65,9 @@ check() {
     if [ -z "${OUT}" ]; then
         echo "" 1>&2
         # shellcheck disable=SC2059
-        printf "Expected: ${want}\n" 1>&2
+        printf "$(red \"Expected\"): ${want}\n"  1>&2
         # shellcheck disable=SC2059
-        printf "Recieved: ${got}\n" 1>&2
+        printf "$(red \"Recieved\"): ${got}\n" 1>&2
         echo "" 1>&2
         exit 1
     fi

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -180,7 +180,7 @@ destroy_model() {
     output="${TEST_DIR}/${name}-destroy.txt"
 
     echo "====> Destroying juju model ${name}"
-    echo "${name}" | xargs -I % juju destroy-model --force -y % 2>&1 | add_date >"${output}"
+    echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
     CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
@@ -214,37 +214,30 @@ destroy_controller() {
         echo "====> Destroying model ($(green "${name}"))"
 
         output="${TEST_DIR}/${name}-destroy-model.txt"
-        echo "${name}" | xargs -I % juju destroy-model --force -y % 2>&1 | add_date >"${output}"
+        echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
 
         echo "====> Destroyed model ($(green "${name}"))"
         return
     fi
 
-    echo "====> Introspection gathering"
-
     set +e
-    introspect_controller "${name}" || true
-    set_verbosity
 
+    echo "====> Introspection gathering"
+    introspect_controller "${name}" || true
     echo "====> Introspection gathered"
 
     # Unfortunately having any offers on a model, leads to failure to clean
     # up a controller.
     # See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
     echo "====> Removing offers"
-
-    set +e
     remove_controller_offers "${name}"
-    set_verbosity
-
     echo "====> Removed offers"
-
 
     output="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ($(green "${name}"))"
-    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % 2>&1 | add_date >"${output}"
-    CHK=$(cat "${output}" | grep -i "ERROR" || true)
+    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+    CHK=$(cat "${OUT}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
         cat "${output}"
@@ -252,6 +245,8 @@ destroy_controller() {
     fi
     sed -i "/^${name}$/d" "${TEST_DIR}/jujus"
     echo "====> Destroyed juju ($(green "${name}"))"
+
+    set_verbosity
 }
 
 # cleanup_jujus is used to destroy all the known controllers the test suite
@@ -266,6 +261,7 @@ cleanup_jujus() {
         done < "${TEST_DIR}/jujus"
         rm -f "${TEST_DIR}/jujus"
     fi
+    echo "====> Completed cleaning up jujus"
 }
 
 introspect_controller() {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -233,20 +233,24 @@ destroy_controller() {
     remove_controller_offers "${name}"
     echo "====> Removed offers"
 
+    set_verbosity
+
     output="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ($(green "${name}"))"
     echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+
+    set +e
     CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
         cat "${output}"
         exit 1
     fi
+    set_verbosity
+
     sed -i "/^${name}$/d" "${TEST_DIR}/jujus"
     echo "====> Destroyed juju ($(green "${name}"))"
-
-    set_verbosity
 }
 
 # cleanup_jujus is used to destroy all the known controllers the test suite
@@ -259,7 +263,7 @@ cleanup_jujus() {
         while read -r juju_name; do
             destroy_controller "${juju_name}"
         done < "${TEST_DIR}/jujus"
-        rm -f "${TEST_DIR}/jujus"
+        rm -f "${TEST_DIR}/jujus" || true
     fi
     echo "====> Completed cleaning up jujus"
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -237,7 +237,7 @@ destroy_controller() {
 
     echo "====> Destroying juju ($(green "${name}"))"
     echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
-    CHK=$(cat "${OUT}" | grep -i "ERROR" || true)
+    CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
         cat "${output}"

--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -6,21 +6,21 @@ run_branch() {
     file="${TEST_DIR}/test-branches.txt"
     ensure "branches" "${file}"
 
-    juju branch | grep -q 'Active branch is "master"'
+    juju branch | check 'Active branch is "master"'
 
     juju deploy redis
 
     wait_for "redis" "$(idle_condition "redis")"
 
     juju add-branch test-branch
-    juju branch | grep -q 'Active branch is "test-branch"'
+    juju branch | check 'Active branch is "test-branch"'
 
     juju config redis password=pass --branch test-branch
-    juju config redis password --branch test-branch | grep -q "pass"
-    juju config redis password --branch master | wc -c | grep -q "0"
+    juju config redis password --branch test-branch | check "pass"
+    juju config redis password --branch master | wc -c | check "0"
 
-    juju commit test-branch | grep -q 'Active branch set to "master"'
-    juju config redis password | grep -q "pass"
+    juju commit test-branch | check 'Active branch set to "master"'
+    juju config redis password | check "pass"
 
     # Clean up!
     destroy_model "branches"

--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -18,7 +18,7 @@ run_mongo_memory_profile() {
 
     attempt=0
     # shellcheck disable=SC2046,SC2143,SC2091
-    until $(check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB 2>&1 >/dev/null); do
+    until $(check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB >/dev/null 2>&1); do
         echo "[+] (attempt ${attempt}) polling mongo service"
         cat_mongo_service | sed 's/^/    | /g'
         # This will attempt to wait for 2 minutes before failing out.

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -62,7 +62,7 @@ run_deploy_trusted_bundle() {
 
     bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
     OUT=$(juju deploy ${bundle} 2>&1 || true)
-    echo "${OUT}" | grep "repeat the deploy command with the --trust argument"
+    echo "${OUT}" | check "repeat the deploy command with the --trust argument"
 
     juju deploy --trust ${bundle}
 
@@ -98,7 +98,7 @@ run_deploy_lxd_profile_bundle_openstack() {
 
     lxd_profile_name="juju-${model_name}-neutron-openvswitch"
     machine_6="$(machine_path 6)"
-    juju status --format=json | jq "${machine_6}" | grep -q "${lxd_profile_name}"
+    juju status --format=json | jq "${machine_6}" | check "${lxd_profile_name}"
 
     destroy_model "${model_name}"
 }
@@ -133,9 +133,9 @@ run_deploy_lxd_profile_bundle() {
     for i in 0 1 2 3
     do
         machine_n_lxd0="$(machine_container_path "${i}" "${i}"/lxd/0)"
-        juju status --format=json | jq "${machine_n_lxd0}" | grep -q "${lxd_profile_name}"
+        juju status --format=json | jq "${machine_n_lxd0}" | check "${lxd_profile_name}"
         machine_n_lxd1="$(machine_container_path "${i}" "${i}"/lxd/1)"
-        juju status --format=json | jq "${machine_n_lxd1}" | grep -q "${lxd_profile_name}"
+        juju status --format=json | jq "${machine_n_lxd1}" | check "${lxd_profile_name}"
     done
 
     destroy_model "${model_name}"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -62,7 +62,7 @@ run_deploy_trusted_bundle() {
 
     bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
     OUT=$(juju deploy ${bundle} 2>&1 || true)
-    echo "${OUT}" | check "FAIL!!: repeat the deploy command with the --trust argument"
+    echo "${OUT}" | check "repeat the deploy command with the --trust argument"
 
     juju deploy --trust ${bundle}
 

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -62,7 +62,7 @@ run_deploy_trusted_bundle() {
 
     bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
     OUT=$(juju deploy ${bundle} 2>&1 || true)
-    echo "${OUT}" | check "repeat the deploy command with the --trust argument"
+    echo "${OUT}" | check "FAIL!!: repeat the deploy command with the --trust argument"
 
     juju deploy --trust ${bundle}
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -1,14 +1,14 @@
 run_deploy_charm() {
     echo
 
-    file="${TEST_DIR}/test-deploy.txt"
+    file="${TEST_DIR}/test-deploy-charm.txt"
 
-    ensure "test-deploy" "${file}"
+    ensure "test-deploy-charm" "${file}"
 
     juju deploy cs:~jameinel/ubuntu-lite-7
     wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-    destroy_model "test-deploy"
+    destroy_model "test-deploy-charm"
 }
 
 run_deploy_lxd_profile_charm() {

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -21,7 +21,7 @@ run_deploy_lxd_profile_charm() {
     juju deploy cs:~juju-qa/bionic/lxd-profile-without-devices-5
     wait_for "lxd-profile" "$(idle_condition "lxd-profile")"
 
-    juju status --format=json | jq ".machines | .[\"0\"] | .[\"lxd-profiles\"] | keys[0]" | grep -q "juju-test-deploy-lxd-profile-lxd-profile"
+    juju status --format=json | jq ".machines | .[\"0\"] | .[\"lxd-profiles\"] | keys[0]" | check "juju-test-deploy-lxd-profile-lxd-profile"
 
     destroy_model "test-deploy-lxd-profile"
 }
@@ -47,24 +47,24 @@ run_deploy_local_lxd_profile_charm() {
     machine_0="$(machine_path 0)"
     wait_for "${lxd_profile_sub_name}" "${machine_0}"
 
-    juju status --format=json | jq "${machine_0}" | grep -q "${lxd_profile_name}"
-    juju status --format=json | jq "${machine_0}" | grep -q "${lxd_profile_sub_name}"
+    juju status --format=json | jq "${machine_0}" | check "${lxd_profile_name}"
+    juju status --format=json | jq "${machine_0}" | check "${lxd_profile_sub_name}"
 
     juju add-unit "lxd-profile"
 
     machine_1="$(machine_path 1)"
     wait_for "${lxd_profile_sub_name}" "${machine_1}"
 
-    juju status --format=json | jq "${machine_1}" | grep -q "${lxd_profile_name}"
-    juju status --format=json | jq "${machine_1}" | grep -q "${lxd_profile_sub_name}"
+    juju status --format=json | jq "${machine_1}" | check "${lxd_profile_name}"
+    juju status --format=json | jq "${machine_1}" | check "${lxd_profile_sub_name}"
 
     juju add-unit "lxd-profile" --to lxd
 
     machine_2="$(machine_container_path 2 2/lxd/0)"
     wait_for "${lxd_profile_sub_name}" "${machine_2}"
 
-    juju status --format=json | jq "${machine_2}" | grep -q "${lxd_profile_name}"
-    juju status --format=json | jq "${machine_2}" | grep -q "${lxd_profile_sub_name}"
+    juju status --format=json | jq "${machine_2}" | check "${lxd_profile_name}"
+    juju status --format=json | jq "${machine_2}" | check "${lxd_profile_sub_name}"
 
     destroy_model "test-deploy-local-lxd-profile"
 }

--- a/tests/suites/deploy/export_overlay.sh
+++ b/tests/suites/deploy/export_overlay.sh
@@ -31,8 +31,8 @@ EOT
 
     # did the annotations and overlay get exported?
     echo "${OUT}" | grep -- "--- # overlay.yaml"
-    echo "${OUT}" | grep "enc: bXktaW5jbHVkZQ=="
-    echo "${OUT}" | grep "raw: my-include"
+    echo "${OUT}" | check "enc: bXktaW5jbHVkZQ=="
+    echo "${OUT}" | check "raw: my-include"
 
     destroy_model "cmr-bundles-test-export-overlay"
     destroy_model "test1"

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -9,13 +9,13 @@ test_deploy() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-cmr-bundles.txt"
+    file="${TEST_DIR}/test-deploy-ctl.txt"
 
-    bootstrap "test-cmr-bundles" "${file}"
+    bootstrap "test-deploy-ctl" "${file}"
 
     test_deploy_charms
     test_deploy_bundles
     test_cmr_bundles_export_overlay
 
-    destroy_controller "test-cmr-bundles"
+    destroy_controller "test-deploy-ctl"
 }

--- a/tests/suites/examples/example.sh
+++ b/tests/suites/examples/example.sh
@@ -7,7 +7,7 @@ run_example1() {
     ensure "example1" "${file}"
 
     # Run your checks here
-    echo "Hello example 1!"
+    echo "Hello example 1!" | check "Hello example 1!"
 
     # Clean up!
     destroy_model "example1"
@@ -16,9 +16,10 @@ run_example1() {
 run_example2() {
     echo
 
+    file="${TEST_DIR}/test-example2.txt"
     ensure "example2" "${file}"
 
-    echo "Hello example 2!"
+    echo "Hello example 2!" | check "Hello example 2!"
 
     destroy_model "example2"
 }

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -20,7 +20,7 @@ run_whitespace() {
 }
 
 run_trailing_whitespace() {
-  OUT=$(grep -r " $" tests/ | grep '\.sh:' || true)
+  OUT=$(grep -nr " $" tests/ | grep '\.sh:' || true)
   if [ -n "${OUT}" ]; then
     echo ""
     echo "$(red 'Found some issues:')"


### PR DESCRIPTION
## Description of change

Add check that acts as a better equality checker for integration charms.
This works *only* as a pipe action, so anything else should use grep.

By reading all the content until it's exhausted we can then do a grep
check for the assertion.

Using ./main.sh -t or ./main.sh -v should then permit better debugging
when things go wrong. At the very least -t should be used in CI runs
of the integration test runner.

## QA steps

#### Presteps

```sh
diff --git a/tests/suites/deploy/deploy_bundles.sh b/tests/suites/deploy/deploy_bundles.sh
index cc8b9be2ea..21e6c8bebe 100644
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -62,7 +62,7 @@ run_deploy_trusted_bundle() {
 
     bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
     OUT=$(juju deploy ${bundle} 2>&1 || true)
-    echo "${OUT}" | check "repeat the deploy command with the --trust argument"
+    echo "${OUT}" | check "FAIL! repeat the deploy command with the --trust argument"
 
     juju deploy --trust ${bundle}
 
@@ -152,11 +152,11 @@ test_deploy_bundles() {
 
         cd .. || exit
 
-        run "run_deploy_bundle"
-        run "run_deploy_cmr_bundle"
-        run "run_deploy_exported_bundle"
+        #run "run_deploy_bundle"
+        #run "run_deploy_cmr_bundle"
+        #run "run_deploy_exported_bundle"
         run "run_deploy_trusted_bundle"
-        run "run_deploy_lxd_profile_bundle_openstack"
-        run "run_deploy_lxd_profile_bundle"
+        #run "run_deploy_lxd_profile_bundle_openstack"
+        #run "run_deploy_lxd_profile_bundle"
     )
 }
```

#### Run

```sh
cd tests && ./main.sh deploy
```

#### Output

```sh
➜ ./main.sh deploy

==> Checking for dependencies
==> TEST BEGIN: test_deploy
==> Checking for dependencies
====> Unable to reuse bootstrapped juju
====> Bootstrapping juju (2.8:lxd)
====> Bootstrapped juju (272s)
===> [   ] Running: deploy trusted bundle==> Cleaning up
====> Cleaning up jujus
====> Introspection gathering
Querying @jujud-machine-0 introspection socket: /depengine
Querying @jujud-machine-0 introspection socket: /debug/pprof/goroutine?debug=1
====> Introspection gathered
====> Removing offers
====> Removed offers
====> Destroying juju (ctrl-18cvw9ji)
====> Destroyed juju (ctrl-18cvw9ji)
====> Completed cleaning up jujus

==> TESTS DONE: test_deploy
==> RUN OUTPUT: test_deploy
    | 
    | ====> Reusing bootstrapped juju (2.8:lxd)
    | Added 'test-trusted-bundles-deploy' model on localhost/localhost with credential 'localhost' for user 'admin'
    | ====> Bootstrapped juju (51s)
    | 
    | Expected: FAIL! repeat the deploy command with the --trust argument
    | Recieved: ERROR Bundle cannot be deployed without trusting applications with your cloud credentials.
    | Please repeat the deploy command with the --trust argument if you consent to trust the following application(s):$
==> Test result: failure
==> TEST COMPLETE
```

