### PR TITLE
Merge 2.7 to develop

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -40,9 +40,6 @@ jobs:
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')
       run: |
-        # temp fix for github actions bug
-        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-        sudo rm /etc/apt/sources.list.d/dotnetdev.list
         make install-mongo-dependencies
 
     - name: "Install Mongo Dependencies: macOS-latest"

--- a/core/cache/metrics.go
+++ b/core/cache/metrics.go
@@ -4,6 +4,8 @@
 package cache
 
 import (
+	"sync"
+
 	"github.com/juju/loggo"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -204,6 +206,10 @@ type Collector struct {
 	applications *prometheus.GaugeVec
 	units        *prometheus.GaugeVec
 	users        *prometheus.GaugeVec
+
+	// Since the collector resets the GuageVecs and iterates the model cache,
+	// we need to ensure that we don't have overlapping collect calls.
+	mu sync.Mutex
 }
 
 // NewMetricsCollector returns a new Collector.
@@ -284,6 +290,9 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect is part of the prometheus.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(c.scrapeDuration.Set))
 	defer c.scrapeDuration.Collect(ch)
 	defer timer.ObserveDuration()

--- a/core/cache/metrics_test.go
+++ b/core/cache/metrics_test.go
@@ -62,7 +62,7 @@ juju_cache_units{agent_status="active",life="alive",workload_status="active"} 1
 }
 
 func (s *ControllerSuite) TestCollectIsolation(c *gc.C) {
-	controller, events := s.new(c)
+	controller, events := s.New(c)
 
 	// Populate the cache with 10 models so the collect takes
 	// more time.
@@ -70,7 +70,7 @@ func (s *ControllerSuite) TestCollectIsolation(c *gc.C) {
 		change := modelChange
 		change.ModelUUID = utils.MustNewUUID().String()
 		change.Name = fmt.Sprintf("test-model-%d", i)
-		s.processChange(c, change, events)
+		s.ProcessChange(c, change, events)
 	}
 
 	collector := cache.NewMetricsCollector(controller)

--- a/snap/.gitignore
+++ b/snap/.gitignore
@@ -1,1 +1,0 @@
-.snapcraft

--- a/snap/local/wrappers/juju
+++ b/snap/local/wrappers/juju
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
-export PATH=$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH
-
-exec $SNAP/bin/juju "$@"
-

--- a/snap/plugins/x-dep.yaml
+++ b/snap/plugins/x-dep.yaml
@@ -1,6 +1,0 @@
-options:
-  source:
-    required: true
-  source-type:
-  source-tag:
-  source-branch:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,10 +4,14 @@ summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic
 grade: devel
+base: core18
 
 apps:
   juju:
-    command: wrappers/juju
+    environment:
+      # Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
+      PATH: "$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH"
+    command: bin/juju
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
@@ -17,7 +21,11 @@ parts:
     plugin: dump
     source: snap/local
   juju:
+    # TODO(wallyworld) - use go plugin and remove dep when we migrate to go mod.
+    # plugin: go
+    # go-buildtags: xxx
     plugin: dep
+    go-channel: 1.14/stable
     go-importpath: github.com/juju/juju
     # The source can be your local tree or github
     # source: https://github.com/juju/juju.git
@@ -26,10 +34,8 @@ parts:
     # source: file:///full/file/path
     # By default, reuse existing tree
     source: .
-    source-type: git
-    # this is for building in a docker container
-    build-packages: [gcc, libc6-dev]
-    build-attributes: [no-patchelf]
+    # TODO(wallyworld) - uncomment source-type once LP:1860526 is fixed. 
+    #source-type: git
     # You can grab a specific tag, commit, or branch
     # source-tag: juju-2.0.2
     # source-commit: a83896d913d7e43c960e441c1e41612116d92d46
@@ -41,6 +47,10 @@ parts:
       # Instead, you should use the released agent
       - github.com/juju/juju/cmd/jujud
       - github.com/juju/juju/cmd/plugins/juju-metadata
+    go-external-strings:
+      github.com/juju/juju/version.GitCommit: ""
+      github.com/juju/juju/version.GitTreeState: ""
+      github.com/juju/juju/version.build: ""
     override-build: |
       snapcraftctl build
 
@@ -60,9 +70,9 @@ parts:
       cp -a jujud-versions.yaml $SNAPCRAFT_PART_INSTALL/bin
 
 hooks:
-  install: {}
   connect-plug-peers: {}
   disconnect-plug-peers: {}
+  post-refresh: {}
 
 plugs:
   peers:


### PR DESCRIPTION
# Forward port
- Synchronise while collecting cache metrics. #11273
- Enable multipass and LXD-based builds #10589
- Snapcraft fixes to support remote-builds #11277
- Remove github actions workarounds. #11278

# New changes
core/cache/metrics_test.go needed to be manually fixed in a second commit.