### PR TITLE
Speed up juju status by handling units better.

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -205,8 +205,11 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 			return noStatus, errors.Annotate(err, "could not fetch application offers")
 		}
 	}
-	if context.machines, err = fetchMachines(c.api.stateAccessor, nil); err != nil {
+	if err = context.fetchMachines(c.api.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch machines")
+	}
+	if err = context.fetchOpenPorts(c.api.stateAccessor); err != nil {
+		return noStatus, errors.Annotate(err, "could not fetch open ports")
 	}
 	if context.controllerNodes, err = fetchControllerNodes(c.api.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch controller nodes")
@@ -496,6 +499,9 @@ type statusContext struct {
 	// machines: top-level machine id -> list of machines nested in
 	// this machine.
 	machines map[string][]*state.Machine
+	// allMachines: machine id -> machine
+	// The machine in this map is the same machine in the machines map.
+	allMachines map[string]*state.Machine
 
 	// controllerNodes: node id -> controller node
 	controllerNodes map[string]state.ControllerNode
@@ -512,6 +518,9 @@ type statusContext struct {
 	// remote applications: application name -> application
 	consumerRemoteApplications map[string]*state.RemoteApplication
 
+	// open ports: map machine ID -> Ports
+	openPorts map[string]*state.Ports
+
 	// offers: offer name -> offer
 	offers map[string]offerStatus
 
@@ -521,8 +530,6 @@ type statusContext struct {
 	allAppsUnitsCharmBindings applicationStatusInfo
 	relations                 map[string][]*state.Relation
 	relationsById             map[int]*state.Relation
-	units                     map[string]map[string]*state.Unit
-	latestCharms              map[charm.URL]*state.Charm
 	leaders                   map[string]string
 	branches                  map[string]cache.Branch
 }
@@ -531,32 +538,48 @@ type statusContext struct {
 // machine and machines[1..n] are any containers (including nested ones).
 //
 // If machineIds is non-nil, only machines whose IDs are in the set are returned.
-func fetchMachines(st Backend, machineIds set.Strings) (map[string][]*state.Machine, error) {
-	v := make(map[string][]*state.Machine)
+func (context *statusContext) fetchMachines(st Backend) error {
+	context.machines = make(map[string][]*state.Machine)
+	context.allMachines = make(map[string]*state.Machine)
+
 	machines, err := st.AllMachines()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	// AllMachines gives us machines sorted by id.
 	for _, m := range machines {
-		if machineIds != nil && !machineIds.Contains(m.Id()) {
-			continue
-		}
+		context.allMachines[m.Id()] = m
 		parentId, ok := m.ParentId()
 		if !ok {
 			// Only top level host machines go directly into the machine map.
-			v[m.Id()] = []*state.Machine{m}
+			context.machines[m.Id()] = []*state.Machine{m}
 		} else {
 			topParentId := state.TopParentId(m.Id())
-			machines, ok := v[topParentId]
+			machines, ok := context.machines[topParentId]
 			if !ok {
 				panic(fmt.Errorf("unexpected machine id %q", parentId))
 			}
 			machines = append(machines, m)
-			v[topParentId] = machines
+			context.machines[topParentId] = machines
 		}
 	}
-	return v, nil
+	return nil
+}
+
+func (context *statusContext) fetchOpenPorts(st Backend) error {
+	context.openPorts = make(map[string]*state.Ports)
+	allOpenPorts, err := context.model.AllPorts()
+	if err != nil {
+		return err
+	}
+	// We are only looking for the open ports on the "" subnet.
+	for _, openPorts := range allOpenPorts {
+		if openPorts.SubnetID() != "" {
+			continue
+		}
+		context.openPorts[openPorts.MachineID()] = openPorts
+	}
+	return nil
 }
 
 // fetchControllerNodes returns a map from node id to controller node.
@@ -1322,32 +1345,57 @@ func (context *statusContext) processUnits(units map[string]*state.Unit, applica
 	return unitsMap
 }
 
+func (context *statusContext) unitMachineID(unit *state.Unit) string {
+	// This should never happen, but guarding against segfaults if for
+	// some reason the unit isn't in the context.
+	if unit == nil {
+		return ""
+	}
+	principal, isSubordinate := unit.PrincipalName()
+	if isSubordinate {
+		return context.unitMachineID(context.unitByName(principal))
+	}
+	// machineID will be empty if not currently assigned.
+	machineID, _ := unit.AssignedMachineId()
+	return machineID
+}
+
+func (context *statusContext) unitPublicAddress(unit *state.Unit) string {
+	machine := context.allMachines[context.unitMachineID(unit)]
+	if machine == nil {
+		return ""
+	}
+	// We don't care if the machine doesn't have an address yet.
+	addr, _ := machine.PublicAddress()
+	return addr.Value
+}
+
 func (context *statusContext) processUnit(unit *state.Unit, applicationCharm string, expectWorkload bool) params.UnitStatus {
 	var result params.UnitStatus
-	if unit.ShouldBeAssigned() {
-		addr, err := unit.PublicAddress()
-		if err != nil {
-			// Usually this indicates that no addresses have been set on the
-			// machine yet.
-			addr = network.SpaceAddress{}
-			logger.Debugf("error fetching public address: %v", err)
+	if context.model.Type() == state.ModelTypeIAAS {
+		result.PublicAddress = context.unitPublicAddress(unit)
+
+		if ports := context.openPorts[context.unitMachineID(unit)]; ports != nil {
+			for _, port := range ports.PortsForUnit(unit.Name()) {
+				result.OpenedPorts = append(result.OpenedPorts, port.String())
+			}
 		}
-		result.PublicAddress = addr.Value
 	} else {
 		// For CAAS units we want to provide the container address.
+		// TODO: preload all the container info.
 		container, err := unit.ContainerInfo()
 		if err == nil {
-			addr := container.Address()
-			if addr != nil {
+			if addr := container.Address(); addr != nil {
 				result.Address = addr.Value
 			}
+			result.ProviderId = container.ProviderId()
+			if len(result.OpenedPorts) == 0 {
+				result.OpenedPorts = container.Ports()
+			}
+
 		} else {
-			logger.Debugf("error fetching container address: %v", err)
+			logger.Tracef("container info not yet available for unit: %v", err)
 		}
-	}
-	unitPorts, _ := unit.OpenedPorts()
-	for _, port := range unitPorts {
-		result.OpenedPorts = append(result.OpenedPorts, port.String())
 	}
 	if unit.IsPrincipal() {
 		result.Machine, _ = unit.AssignedMachineId()
@@ -1377,20 +1425,6 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 	}
 	if leader := context.leaders[unit.ApplicationName()]; leader == unit.Name() {
 		result.Leader = true
-	}
-	containerInfo, err := unit.ContainerInfo()
-	if err != nil && !errors.IsNotFound(err) {
-		logger.Debugf("error fetching container info: %v", err)
-	} else if err == nil {
-		result.ProviderId = containerInfo.ProviderId()
-		addr := containerInfo.Address()
-		if addr != nil {
-			result.Address = addr.Value
-		}
-
-		if len(result.OpenedPorts) == 0 {
-			result.OpenedPorts = containerInfo.Ports()
-		}
 	}
 	return result
 }

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -101,6 +101,46 @@ func (s *statusSuite) TestFullStatusUnitLeadership(c *gc.C) {
 	c.Assert(unit.Leader, jc.IsTrue)
 }
 
+func (s *statusSuite) TestFullStatusUnitScaling(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, nil)
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Machine: machine,
+	})
+
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
+	tracker := s.State.TrackQueries()
+
+	client := s.APIState.Client()
+	_, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	queryCount := tracker.ReadCount()
+
+	// Add several more units of the same application to the
+	// same machine. We do this because we want to isolate to
+	// status handling to just additional units, not additional machines
+	// or applications.
+	app, err := unit.Application()
+	c.Assert(err, jc.ErrorIsNil)
+	for i := 0; i < 5; i++ {
+		s.Factory.MakeUnit(c, &factory.UnitParams{
+			Application: app,
+			Machine:     machine,
+		})
+	}
+
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
+	tracker.Reset()
+
+	_, err = client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The number of queries should be the same.
+	c.Check(tracker.ReadCount(), gc.Equals, queryCount,
+		gc.Commentf("if the query count is not the same, there has been a regression "+
+			"in the processing of units, please fix it"))
+}
+
 func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
 	machine := s.addMachine(c)
 	s.createSpaceAndSubnetWithProviderID(c, "public", "10.0.0.0/24", "prov-0000")

--- a/state/ports.go
+++ b/state/ports.go
@@ -181,6 +181,11 @@ func extractPortsIDParts(globalKey string) ([]string, error) {
 	return nil, errors.NotValidf("ports document key %q", globalKey)
 }
 
+// MachineID returns the machine ID associated with this ports document.
+func (p *Ports) MachineID() string {
+	return p.doc.MachineID
+}
+
 // SubnetID returns the subnet ID associated with this ports document.
 func (p *Ports) SubnetID() string {
 	return p.doc.SubnetID
@@ -388,6 +393,24 @@ func (m *Machine) OpenedPorts(subnetID string) (*Ports, error) {
 		return nil, errors.Trace(err)
 	}
 	return ports, nil
+}
+
+// AllPorts returns all opened ports for this machine (on all
+// networks).
+func (m *Model) AllPorts() ([]*Ports, error) {
+	openedPorts, closer := m.st.db().GetCollection(openedPortsC)
+	defer closer()
+
+	docs := []portsDoc{}
+	err := openedPorts.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	results := make([]*Ports, len(docs))
+	for i, doc := range docs {
+		results[i] = &Ports{st: m.st, doc: doc}
+	}
+	return results, nil
 }
 
 // AllPorts returns all opened ports for this machine (on all

--- a/state/ports_test.go
+++ b/state/ports_test.go
@@ -53,6 +53,34 @@ func (s *PortsDocSuite) SetUpTest(c *gc.C) {
 	c.Assert(s.portsWithoutSubnet, gc.NotNil)
 }
 
+func (s *PortsDocSuite) openPorts(c *gc.C, ports *state.Ports, unitname string) {
+	err := ports.OpenPorts(state.PortRange{
+		FromPort: 100,
+		ToPort:   200,
+		UnitName: unitname,
+		Protocol: "TCP",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *PortsDocSuite) TestModelAllPorts(c *gc.C) {
+	s.openPorts(c, s.portsOnSubnet, s.unit1.Name())
+	s.openPorts(c, s.portsWithoutSubnet, s.unit1.Name())
+
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{Series: "quantal"})
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application, Machine: machine})
+	ports, err := state.GetOrCreatePorts(s.State, machine.Id(), s.subnet.ID())
+	c.Assert(err, jc.ErrorIsNil)
+	s.openPorts(c, ports, unit.Name())
+	ports, err = state.GetOrCreatePorts(s.State, machine.Id(), "")
+	c.Assert(err, jc.ErrorIsNil)
+	s.openPorts(c, ports, unit.Name())
+
+	allPorts, err := s.Model.AllPorts()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(allPorts, gc.HasLen, 4)
+}
+
 func (s *PortsDocSuite) TestCreatePortsWithSubnet(c *gc.C) {
 	s.testCreatePortsWithSubnetID(c, s.subnet.ID())
 }
@@ -71,7 +99,8 @@ func (s *PortsDocSuite) testCreatePortsWithSubnetID(c *gc.C, subnetID string) {
 
 	ports, err = state.GetPorts(s.State, s.machine.Id(), subnetID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ports, gc.NotNil)
+	c.Assert(ports.MachineID(), gc.Equals, s.machine.Id())
+	c.Assert(ports.SubnetID(), gc.Equals, subnetID)
 
 	c.Assert(ports.PortsForUnit(s.unit1.Name()), gc.HasLen, 1)
 }


### PR DESCRIPTION
The code in the apiserver for FullStatus tries to read the database objects in bulk, stores them in a context object, and then iterates over those to minimize database access.

Over time regressions and inefficiencies have crept in, or not yet been handled.

This branch addresses the three additional database queries that were done per unit.
