### PR TITLE
[2.7] fix lp1865229

### DIFF
--- a/api/uniter/settings.go
+++ b/api/uniter/settings.go
@@ -16,6 +16,7 @@ type Settings struct {
 	relationTag string
 	unitTag     string
 	settings    params.Settings
+	dirty       bool
 }
 
 func newSettings(st *State, relationTag, unitTag string, settings params.Settings) *Settings {
@@ -45,6 +46,7 @@ func (s *Settings) Map() params.Settings {
 // Set sets key to value.
 func (s *Settings) Set(key, value string) {
 	s.settings[key] = value
+	s.dirty = true
 }
 
 // Delete removes key.
@@ -52,6 +54,7 @@ func (s *Settings) Delete(key string) {
 	// Keys are only marked as deleted, because we need to report them
 	// back to the server for deletion on Write().
 	s.settings[key] = ""
+	s.dirty = true
 }
 
 // FinalResult returns a params.Settings with the final updates applied.
@@ -63,4 +66,8 @@ func (s *Settings) FinalResult() params.Settings {
 		settingsCopy[k] = v
 	}
 	return settingsCopy
+}
+
+func (s *Settings) IsDirty() bool {
+	return s.dirty
 }

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -34,6 +34,7 @@ TEST_NAMES="static_analysis \
             controller \
             deploy \
             machine \
+            relations \
             smoke"
 
 # Show test suites, can be used to test if a test suite is available or not.

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -1,0 +1,115 @@
+run_relation_data_exchange() {
+    echo
+
+    model_name="test-relation-data-exchange"
+    file="${TEST_DIR}/${model_name}.txt"
+
+    ensure "${model_name}" "${file}"
+
+    # Deploy 2 wordpress instances and one mysql instance
+    juju deploy wordpress -n 2
+    wait_for "wordpress" "$(idle_condition "wordpress" 0 0)"
+    wait_for "wordpress" "$(idle_condition "wordpress" 0 1)"
+    juju deploy mysql
+    wait_for "mysql" "$(idle_condition "mysql")"
+
+    # Establish relation
+    juju relate wordpress mysql
+
+    # Block until the relation is joined; otherwise, the relation-set commands
+    # below will fail
+    attempt=0
+    while true; do
+       got=$(juju run --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress' || echo 'NOT FOUND')
+       if [ "${got}" != "NOT FOUND" ]; then
+         break
+       fi
+       attempt=$((attempt+1))
+       if [ $attempt -eq 30 ]; then
+         # shellcheck disable=SC2046
+         echo $(red "timeout: wordpress has not yet joined db relation after 30sec")
+         exit 1
+       fi
+       sleep 1
+    done
+    attempt=0
+    while true; do
+       got=$(juju run --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql' || echo 'NOT FOUND')
+       if [ "${got}" != "NOT FOUND" ]; then
+         break
+       fi
+       attempt=$((attempt+1))
+       if [ $attempt -eq 30 ]; then
+         # shellcheck disable=SC2046
+         echo $(red "timeout: mysql has not yet joined db relation after 30sec")
+         exit 1
+       fi
+       sleep 1
+    done
+
+    juju run --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
+
+    # As the leader units, set some *application* data for both sides of a
+    # non-peer relation
+    juju run --unit 'wordpress/0' 'relation-set --app -r db:2 origin=wordpress'
+    juju run --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
+
+    # As the leader wordpress unit, also set *application* data for a peer relation
+    juju run --unit 'wordpress/0' 'relation-set --app -r loadbalancer:0 visible=to-peers'
+
+    # Check 1: ensure that leaders can read the application databag for their
+    # own application (LP1854348)
+    got=$(juju run --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress')
+    if [ "${got}" != "wordpress" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected wordpress leader to read its own databag for non-peer relation")
+      exit 1
+    fi
+    got=$(juju run --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql')
+    if [ "${got}" != "mysql" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected mysql leader to read its own databag for non-peer relation")
+      exit 1
+    fi
+
+    # Check 2: ensure that any unit can read its own application databag for
+    # *peer* relations LP1865229)
+    got=$(juju run --unit 'wordpress/0' 'relation-get --app -r loadbalancer:0 visible wordpress')
+    if [ "${got}" != "to-peers" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected wordpress leader to read its own databag for a peer relation")
+      exit 1
+    fi
+    got=$(juju run --unit 'wordpress/1' 'relation-get --app -r loadbalancer:0 visible wordpress')
+    if [ "${got}" != "to-peers" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected wordpress non-leader to read its own databag for a peer relation")
+      exit 1
+    fi
+
+    # Check 3: ensure that non-leader units are not allowed to read their own
+    # application databag for non-peer relations
+    got=$(juju run --unit 'wordpress/1' 'relation-get --app -r db:2 origin wordpress' || echo 'PERMISSION DENIED')
+    if [ "${got}" != "PERMISSION DENIED" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected wordpress non-leader not to be allowed to read the databag for a non-peer relation")
+      exit 1
+    fi
+
+    destroy_model "${model_name}"
+}
+
+test_relation_data_exchange() {
+    if [ "$(skip 'test_relation_data_exchange')" ]; then
+        echo "==> TEST SKIPPED: relation data exchange tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_relation_data_exchange"
+    )
+}

--- a/tests/suites/relations/task.sh
+++ b/tests/suites/relations/task.sh
@@ -1,0 +1,19 @@
+test_relations() {
+    if [ "$(skip 'test_relations')" ]; then
+        echo "==> TEST SKIPPED: relation tests"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju
+
+    file="${TEST_DIR}/test-relations.txt"
+
+    bootstrap "test-relations" "${file}"
+
+    test_relation_data_exchange
+
+    destroy_controller "test-relations"
+}

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -95,7 +95,7 @@ func (ctx *ContextRelation) ApplicationSettings() (jujuc.Settings, error) {
 // WriteSettings persists all changes made to the relation settings (unit and application)
 func (ctx *ContextRelation) WriteSettings() error {
 	var appSettings params.Settings
-	if ctx.applicationSettings != nil {
+	if ctx.applicationSettings != nil && ctx.applicationSettings.IsDirty() {
 		appSettings = ctx.applicationSettings.FinalResult()
 	}
 	var unitSettings params.Settings

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -165,30 +165,6 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 	}
 }
 
-func (s *RelationGetSuite) TestRelationGetAppSettings(c *gc.C) {
-	hctx, rinfo := s.newHookContext(1, "m/0", "mysql")
-	rinfo.rels[1].SetLocalApplicationSettings(jujuctesting.Settings{"local": "true"})
-	rinfo.rels[1].SetRemoteApplicationSettings(jujuctesting.Settings{"remote": "true"})
-
-	// As u/0 (leader) read the application databag for u
-	com, err := jujuc.NewCommand(hctx, cmdString("relation-get"))
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--app", "-", "u"})
-	c.Check(code, gc.Equals, 0)
-	c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-	c.Check(bufferString(ctx.Stdout), gc.Matches, `local: "true"\s*`)
-
-	// As u/0 (leader) read the application databag for mysql
-	com, err = jujuc.NewCommand(hctx, cmdString("relation-get"))
-	c.Assert(err, jc.ErrorIsNil)
-	ctx = cmdtesting.Context(c)
-	code = cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--app", "-", "mysql"})
-	c.Check(code, gc.Equals, 0)
-	c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-	c.Check(bufferString(ctx.Stdout), gc.Matches, `remote: "true"\s*`)
-}
-
 var relationGetFormatTests = []struct {
 	summary string
 	relid   int

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -148,6 +148,12 @@ func (c *RelationSetCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	var settings Settings
 	if c.Application {
+		isLeader, err := c.ctx.IsLeader()
+		if err != nil {
+			return errors.Annotate(err, "cannot determine leadership status")
+		} else if isLeader == false {
+			return errors.Annotate(err, "cannot write relation settings")
+		}
 		settings, err = r.ApplicationSettings()
 	} else {
 		settings, err = r.Settings()


### PR DESCRIPTION
## Description of change

This PR fixes a bug introduced by #11234 which prevents non-leader units from reading their own app databag for **peer-relations**.

To avoid future regressions, this PR also includes an integration test.

## QA steps

```sh
(cd tests ; ./main.sh relations)
```

## Bug reference

Fixes: https://bugs.launchpad.net/juju/+bug/1865229
Related to: https://bugs.launchpad.net/juju/+bug/1854348