### PR TITLE
Change introduction messages to react to --quiet.

### DIFF
--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -64,12 +64,13 @@ var NewUpdatePublicCloudsCommand = func() cmd.Command {
 
 func newUpdatePublicCloudsCommand() cmd.Command {
 	store := jujuclient.NewFileClientStore()
+	access := PublicCloudsAccess()
 	c := &updatePublicCloudsCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
 			Store: store,
 		},
-		publicSigningKey: keys.JujuPublicKey,
-		publicCloudURL:   "https://streams.canonical.com/juju/public-clouds.syaml",
+		publicSigningKey: access.publicSigningKey,
+		publicCloudURL:   access.publicCloudURL,
 	}
 	c.addCloudAPIFunc = c.cloudAPI
 	return modelcmd.WrapBase(c)
@@ -81,6 +82,17 @@ func (c *updatePublicCloudsCommand) Info() *cmd.Info {
 		Purpose: "Updates public cloud information available to Juju.",
 		Doc:     updatePublicCloudsDoc,
 	})
+}
+
+type PublicCloudsAccessDetails struct {
+	publicSigningKey string
+	publicCloudURL   string
+}
+
+// PublicCloudsAccess contains information about
+// where to find published public clouds details.
+func PublicCloudsAccess() PublicCloudsAccessDetails {
+	return PublicCloudsAccessDetails{keys.JujuPublicKey, "https://streams.canonical.com/juju/public-clouds.syaml"}
 }
 
 // Init populates the command with the args from the command line.
@@ -125,16 +137,19 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	fmt.Fprint(ctxt.Stderr, "Fetching latest public cloud list...\n")
-	publishedClouds, err := PublishedPublicClouds(c.publicCloudURL, c.publicSigningKey)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	var returnedErr error
-	if c.Client {
-		if err := c.updateClientCopy(ctxt, publishedClouds); err != nil {
-			ctxt.Infof("ERROR %v", err)
-			returnedErr = cmd.ErrSilent
+	publishedClouds, msg, err := FetchAndMaybeUpdatePublicClouds(
+		PublicCloudsAccessDetails{c.publicSigningKey, c.publicCloudURL},
+		c.Client)
+	if err != nil {
+		if len(publishedClouds) == 0 {
+			return errors.Trace(err)
 		}
+		ctxt.Infof("ERROR %v", err)
+		returnedErr = cmd.ErrSilent
+	}
+	if msg != "" {
+		ctxt.Infof(msg)
 	}
 	if c.ControllerName != "" {
 		if err := c.updateControllerCopy(ctxt, publishedClouds); err != nil {
@@ -145,26 +160,42 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 	return returnedErr
 }
 
-func (c *updatePublicCloudsCommand) updateClientCopy(ctxt *cmd.Context, publishedClouds map[string]jujucloud.Cloud) error {
+// FetchAndMaybeUpdatePublicClouds gets published public clouds information
+// and updates client copy of public clouds if desired.
+// This call returns discovered public clouds and a user-facing message
+// whether they are different with what was known prior to the call.
+var FetchAndMaybeUpdatePublicClouds = func(access PublicCloudsAccessDetails, updateClient bool) (map[string]jujucloud.Cloud, string, error) {
+	msg := ""
+	publishedClouds, err := PublishedPublicClouds(access.publicCloudURL, access.publicSigningKey)
+	if err != nil {
+		return nil, msg, errors.Trace(err)
+	}
+	if updateClient {
+		if msg, err = updateClientCopy(publishedClouds); err != nil {
+			return publishedClouds, msg, err
+		}
+	}
+	return publishedClouds, msg, nil
+}
+
+func updateClientCopy(publishedClouds map[string]jujucloud.Cloud) (string, error) {
 	currentPublicClouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
-		return errors.Annotate(err, "invalid local public cloud data")
+		return "", errors.Annotate(err, "invalid local public cloud data")
 	}
 	sameCloudInfo, err := jujucloud.IsSameCloudMetadata(publishedClouds, currentPublicClouds)
 	if err != nil {
 		// Should never happen.
-		return err
+		return "", err
 	}
 	if sameCloudInfo {
-		fmt.Fprintln(ctxt.Stderr, "List of public clouds on this client is up to date, see `juju clouds --client`.")
-		return nil
+		return "List of public clouds on this client is up to date, see `juju clouds --client`.\n", nil
 	}
 	if err := jujucloud.WritePublicCloudMetadata(publishedClouds); err != nil {
-		return errors.Annotate(err, "error writing new local public cloud data")
+		return "", errors.Annotate(err, "error writing new local public cloud data")
 	}
 	updateDetails := diffClouds(publishedClouds, currentPublicClouds)
-	fmt.Fprintln(ctxt.Stderr, fmt.Sprintf("Updated list of public clouds on this client, %s", updateDetails))
-	return nil
+	return fmt.Sprintf("Updated list of public clouds on this client, %s\n", updateDetails), nil
 }
 
 func (c *updatePublicCloudsCommand) updateControllerCopy(ctxt *cmd.Context, publishedClouds map[string]jujucloud.Cloud) error {

--- a/cmd/juju/commands/machine_test.go
+++ b/cmd/juju/commands/machine_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&MachineSuite{})
 
 func (s *MachineSuite) RunCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	context := cmdtesting.Context(c)
-	juju := NewJujuCommand(context)
+	juju := NewJujuCommand(context, "")
 	if err := cmdtesting.InitCommand(juju, args); err != nil {
 		return context, err
 	}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -124,7 +124,7 @@ func (m main) Run(args []string) int {
 		if jujuMsg != "" {
 			jujuMsg += "\n"
 		}
-		jujuMsg += fmt.Sprintf("Since Juju %v is being run for the first time, downloaded latest public cloud information.\n", jujuversion.Current.Major)
+		jujuMsg += fmt.Sprintf("Since Juju %v is being run for the first time, downloaded the latest public cloud information.\n", jujuversion.Current.Major)
 	}
 
 	for i := range x {
@@ -158,7 +158,6 @@ func installProxy() error {
 }
 
 func (m main) maybeWarnJuju1x() (newInstall bool, jujuMsg string) {
-	jujuMsg = ""
 	newInstall = !juju2xConfigDataExists()
 	if !shouldWarnJuju1x() {
 		return

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -247,7 +247,7 @@ Welcome to Juju %s.
 If you want to use Juju 1.25.0, run 'juju' commands as 'juju-1'. For example, 'juju-1 bootstrap'.
    See https://jujucharms.com/docs/stable/juju-coexist for installation details. 
 
-Since Juju 2 is being run for the first time, downloaded latest public cloud information.`[1:]+"\n", jujuversion.Current))
+Since Juju 2 is being run for the first time, downloaded the latest public cloud information.`[1:]+"\n", jujuversion.Current))
 	checkVersionOutput(c, string(stdout))
 }
 
@@ -286,7 +286,7 @@ func (s *MainSuite) TestFirstRun2xFrom1xNotUbuntu(c *gc.C) {
 	assertNoArgs(c, argChan)
 
 	c.Check(string(stderr), gc.Equals, `
-Since Juju 2 is being run for the first time, downloaded latest public cloud information.`[1:]+"\n")
+Since Juju 2 is being run for the first time, downloaded the latest public cloud information.`[1:]+"\n")
 	checkVersionOutput(c, string(stdout))
 }
 
@@ -397,7 +397,7 @@ func (s *MainSuite) TestNoWarnWithNo1xOr2xData(c *gc.C) {
 
 	assertNoArgs(c, argChan)
 	c.Check(string(stderr), gc.Equals, `
-Since Juju 2 is being run for the first time, downloaded latest public cloud information.`[1:]+"\n")
+Since Juju 2 is being run for the first time, downloaded the latest public cloud information.`[1:]+"\n")
 	checkVersionOutput(c, string(stdout))
 }
 

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -74,7 +74,15 @@ func NewSuperCommand(p cmd.SuperCommandParams) *cmd.SuperCommand {
 	// tests to assert that this string value is correct.
 	p.Version = detail.Version
 	p.VersionDetail = detail
-	p.NotifyRun = runNotifier
+	if p.NotifyRun != nil {
+		messenger := p.NotifyRun
+		p.NotifyRun = func(str string) {
+			messenger(str)
+			runNotifier(str)
+		}
+	} else {
+		p.NotifyRun = runNotifier
+	}
 	p.FlagKnownAs = "option"
 	return cmd.NewSuperCommand(p)
 }

--- a/featuretests/cmd_juju_cloud_test.go
+++ b/featuretests/cmd_juju_cloud_test.go
@@ -53,7 +53,7 @@ clouds:
 
 func (s *CmdCloudSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	context := cmdtesting.Context(c)
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	err := command.Run(context)
 	loggo.RemoveWriter("warning")

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -40,7 +40,7 @@ type cmdControllerSuite struct {
 
 func (s *cmdControllerSuite) run(c *gc.C, args ...string) *cmd.Context {
 	context := cmdtesting.Context(c)
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	c.Assert(command.Run(context), jc.ErrorIsNil)
 	loggo.RemoveWriter("warning")

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -220,7 +220,7 @@ controller-credentials:
 
 func (s *CmdCredentialSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	context := cmdtesting.Context(c)
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	err := command.Run(context)
 	loggo.RemoveWriter("warning")

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -427,7 +427,7 @@ func (s *crossmodelSuite) runJujuCommndWithStdin(c *gc.C, stdin io.Reader, args 
 	if stdin != nil {
 		context.Stdin = stdin
 	}
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	loggo.RemoveWriter("warning") // remove logger added by main command
 	err := command.Run(context)

--- a/featuretests/cmd_juju_current_controller_test.go
+++ b/featuretests/cmd_juju_current_controller_test.go
@@ -52,7 +52,7 @@ func (s *cmdCurrentControllerSuite) writeStoreFiles(c *gc.C) {
 
 func (s *cmdCurrentControllerSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	context := cmdtesting.Context(c)
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	err := cmdtesting.InitCommand(command, args)
 	if err != nil {
 		return context, err

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -34,7 +34,7 @@ func (s *cmdLoginSuite) run(c *gc.C, stdin io.Reader, args ...string) *cmd.Conte
 	if stdin != nil {
 		context.Stdin = stdin
 	}
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	err := command.Run(context)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("stdout: %q; stderr: %q", context.Stdout, context.Stderr))

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -36,7 +36,7 @@ func (s *cmdModelSuite) SetUpTest(c *gc.C) {
 
 func (s *cmdModelSuite) run(c *gc.C, args ...string) *cmd.Context {
 	context := cmdtesting.Context(c)
-	jujuCmd := commands.NewJujuCommand(context)
+	jujuCmd := commands.NewJujuCommand(context, "")
 	err := cmdtesting.InitCommand(jujuCmd, args)
 	c.Assert(err, jc.ErrorIsNil)
 	err = jujuCmd.Run(context)

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -110,7 +110,7 @@ func run(c *gc.C, stdio io.ReadWriter, args ...string) *cmd.Context {
 	} else {
 		context = cmdtesting.Context(c)
 	}
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	err := command.Run(context)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("stderr: %q", context.Stderr))

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -59,7 +59,7 @@ func (s *StatusSuite) setupMultipleRelationsBetweenApplications(c *gc.C) {
 
 func (s *StatusSuite) run(c *gc.C, args ...string) *cmd.Context {
 	context := cmdtesting.Context(c)
-	command := commands.NewJujuCommand(context)
+	command := commands.NewJujuCommand(context, "")
 	c.Assert(cmdtesting.InitCommand(command, args), jc.ErrorIsNil)
 	c.Assert(command.Run(context), jc.ErrorIsNil)
 	loggo.RemoveWriter("warning")

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -79,7 +79,7 @@ var (
 
 func (s *cmdUpgradeSuite) run(c *gc.C, args ...string) *cmd.Context {
 	context := cmdtesting.Context(c)
-	jujuCmd := commands.NewJujuCommand(context)
+	jujuCmd := commands.NewJujuCommand(context, "")
 	err := cmdtesting.InitCommand(jujuCmd, args)
 	c.Assert(err, jc.ErrorIsNil)
 	err = jujuCmd.Run(context)

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -31,7 +31,7 @@ func (s *UserSuite) RunUserCommand(c *gc.C, stdin string, args ...string) (*cmd.
 	if stdin != "" {
 		context.Stdin = strings.NewReader(stdin)
 	}
-	jujuCmd := commands.NewJujuCommand(context)
+	jujuCmd := commands.NewJujuCommand(context, "")
 	err := cmdtesting.InitCommand(jujuCmd, args)
 	c.Assert(err, jc.ErrorIsNil)
 	err = jujuCmd.Run(context)

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -89,7 +89,7 @@ func runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	// two commands in the same test.
 	loggo.ResetWriters()
 	ctx := cmdtesting.Context(c)
-	command := jujucmd.NewJujuCommand(ctx)
+	command := jujucmd.NewJujuCommand(ctx, "")
 	return cmdtesting.RunCommand(c, command, args...)
 }
 


### PR DESCRIPTION
## Description of change

On a new install of Juju on a machine or a new install of Juju 2 on a machine that has Juju 1, we are helpful printing guidance and hints as well as report updating public clouds.

However, under some circumstances, the operator might want not to see this messages. This PR ensures that with "-q" or "--quiet" option, these messages are not displayed.
 
## QA steps

On a new machine, run 
```
juju version
```
or 
```
juju version -q
```
to see the messages display on or off.

(I've used different directories as juju home to exhibit this behavior) 
