### PR TITLE
Refactor apiserver ToolsFinder() and ToolsGetter() to take a newEnviron func

### DIFF
--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -108,7 +108,7 @@ func MakeCloudSpecCredentialContentWatcherForModel(st *state.State) func(names.M
 		if tag.Id() != st.ModelUUID() {
 			return nil, errors.New("cannot get cloud spec credential content for this model")
 		}
-		credentialTag, exists := m.CloudCredential()
+		credentialTag, exists := m.CloudCredentialTag()
 		if !exists {
 			return nil, nil
 		}

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -37,7 +37,7 @@ func MakeCloudSpecGetter(pool Pool) func(names.ModelTag) (environs.CloudSpec, er
 		// both state and model but only model.
 		// TODO (manadart 2018-02-15): This potentially frees the state from
 		// the pool. Release is called, but the state reference survives.
-		return stateenvirons.EnvironConfigGetter{State: st.State, Model: m}.CloudSpec()
+		return stateenvirons.EnvironConfigGetter{Model: m}.CloudSpec()
 	}
 }
 
@@ -51,7 +51,7 @@ func MakeCloudSpecGetterForModel(st *state.State) func(names.ModelTag) (environs
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}
-		configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: m}
+		configGetter := stateenvirons.EnvironConfigGetter{Model: m}
 
 		if tag.Id() != st.ModelUUID() {
 			return environs.CloudSpec{}, errors.New("cannot get cloud spec for this model")

--- a/apiserver/common/credentialcommon/backend.go
+++ b/apiserver/common/credentialcommon/backend.go
@@ -36,8 +36,8 @@ type PersistentBackend interface {
 
 // Model defines model methods needed for the check.
 type Model interface {
-	// Cloud returns the name of the cloud to which the model is deployed.
-	Cloud() string
+	// CloudName returns the name of the cloud to which the model is deployed.
+	CloudName() string
 
 	// CloudRegion returns the name of the cloud region to which the model is deployed.
 	CloudRegion() string
@@ -51,9 +51,9 @@ type Model interface {
 	// Type returns the type of the model.
 	Type() state.ModelType
 
-	// CloudCredential returns the tag of the cloud credential used for managing the
+	// CloudCredentialTag returns the tag of the cloud credential used for managing the
 	// model's cloud resources, and a boolean indicating whether a credential is set.
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
 }
 
 // Machine defines machine methods needed for the check.

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -24,7 +24,7 @@ func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
-	credentialTag, isSet := model.CloudCredential()
+	credentialTag, isSet := model.CloudCredentialTag()
 	if !isSet {
 		return params.ErrorResults{}, nil
 	}
@@ -180,7 +180,7 @@ func buildOpenParams(backend PersistentBackend, credentialTag names.CloudCredent
 		return fail(errors.Trace(err))
 	}
 
-	modelCloud, err := backend.Cloud(model.Cloud())
+	modelCloud, err := backend.Cloud(model.CloudName())
 	if err != nil {
 		return fail(errors.Trace(err))
 	}

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -565,7 +565,7 @@ type mockModel struct {
 	cloudCredentialFunc    func() (names.CloudCredentialTag, bool)
 }
 
-func (m *mockModel) Cloud() string {
+func (m *mockModel) CloudName() string {
 	return m.cloudFunc()
 }
 
@@ -581,7 +581,7 @@ func (m *mockModel) Type() state.ModelType {
 	return m.modelType
 }
 
-func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	return m.cloudCredentialFunc()
 }
 

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -91,10 +91,10 @@ type Model interface {
 	ModelTag() names.ModelTag
 	Owner() names.UserTag
 	Status() (status.StatusInfo, error)
-	Cloud() string
-	CloudValue() (cloud.Cloud, error)
-	CloudCredential() (names.CloudCredentialTag, bool)
-	CloudCredentialValue() (state.Credential, bool, error)
+	CloudName() string
+	Cloud() (cloud.Cloud, error)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
+	CloudCredential() (state.Credential, bool, error)
 	CloudRegion() string
 	Users() ([]permission.UserAccess, error)
 	Destroy(state.DestroyModelParams) error

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -91,7 +92,9 @@ type Model interface {
 	Owner() names.UserTag
 	Status() (status.StatusInfo, error)
 	Cloud() string
+	CloudValue() (cloud.Cloud, error)
 	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudCredentialValue() (state.Credential, bool, error)
 	CloudRegion() string
 	Users() ([]permission.UserAccess, error)
 	Destroy(state.DestroyModelParams) error

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -198,7 +198,6 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	}
 	netEnviron, err := NetworkingEnvironFromModelConfig(
 		stateenvirons.EnvironConfigGetter{
-			State: api.st,
 			Model: model,
 		},
 	)

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -57,8 +57,22 @@ type ToolsGetter struct {
 
 // NewToolsGetter returns a new ToolsGetter. The GetAuthFunc will be
 // used on each invocation of Tools to determine current permissions.
-func NewToolsGetter(f state.EntityFinder, c environs.EnvironConfigGetter, s ToolsStorageGetter, t ToolsURLGetter, getCanRead GetAuthFunc, newEnviron NewEnvironFunc) *ToolsGetter {
-	return &ToolsGetter{newEnviron, f, c, s, t, getCanRead}
+func NewToolsGetter(
+	f state.EntityFinder,
+	c environs.EnvironConfigGetter,
+	s ToolsStorageGetter,
+	t ToolsURLGetter,
+	getCanRead GetAuthFunc,
+	newEnviron NewEnvironFunc,
+) *ToolsGetter {
+	return &ToolsGetter{
+		newEnviron:         newEnviron,
+		entityFinder:       f,
+		configGetter:       c,
+		toolsStorageGetter: s,
+		urlGetter:          t,
+		getCanRead:         getCanRead,
+	}
 }
 
 // Tools finds the tools necessary for the given agents.

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -47,6 +47,7 @@ type ToolsStorageGetter interface {
 // ToolsGetter implements a common Tools method for use by various
 // facades.
 type ToolsGetter struct {
+	newEnviron         NewEnvironFunc
 	entityFinder       state.EntityFinder
 	configGetter       environs.EnvironConfigGetter
 	toolsStorageGetter ToolsStorageGetter
@@ -56,8 +57,8 @@ type ToolsGetter struct {
 
 // NewToolsGetter returns a new ToolsGetter. The GetAuthFunc will be
 // used on each invocation of Tools to determine current permissions.
-func NewToolsGetter(f state.EntityFinder, c environs.EnvironConfigGetter, s ToolsStorageGetter, t ToolsURLGetter, getCanRead GetAuthFunc) *ToolsGetter {
-	return &ToolsGetter{f, c, s, t, getCanRead}
+func NewToolsGetter(f state.EntityFinder, c environs.EnvironConfigGetter, s ToolsStorageGetter, t ToolsURLGetter, getCanRead GetAuthFunc, newEnviron NewEnvironFunc) *ToolsGetter {
+	return &ToolsGetter{newEnviron, f, c, s, t, getCanRead}
 }
 
 // Tools finds the tools necessary for the given agents.
@@ -127,7 +128,7 @@ func (t *ToolsGetter) oneAgentTools(canRead AuthFunc, tag names.Tag, agentVersio
 	if err != nil {
 		return nil, err
 	}
-	toolsFinder := NewToolsFinder(t.configGetter, t.toolsStorageGetter, t.urlGetter)
+	toolsFinder := NewToolsFinder(t.configGetter, t.toolsStorageGetter, t.urlGetter, t.newEnviron)
 	list, err := toolsFinder.findTools(params.FindToolsParams{
 		Number:       agentVersion,
 		MajorVersion: -1,
@@ -197,12 +198,16 @@ type ToolsFinder struct {
 	configGetter       environs.EnvironConfigGetter
 	toolsStorageGetter ToolsStorageGetter
 	urlGetter          ToolsURLGetter
+	newEnviron         NewEnvironFunc
 }
 
 // NewToolsFinder returns a new ToolsFinder, returning tools
 // with their URLs pointing at the API server.
-func NewToolsFinder(c environs.EnvironConfigGetter, s ToolsStorageGetter, t ToolsURLGetter) *ToolsFinder {
-	return &ToolsFinder{c, s, t}
+func NewToolsFinder(
+	c environs.EnvironConfigGetter, s ToolsStorageGetter, t ToolsURLGetter,
+	newEnviron NewEnvironFunc,
+) *ToolsFinder {
+	return &ToolsFinder{c, s, t, newEnviron}
 }
 
 // FindTools returns a List containing all tools matching the given parameters.
@@ -256,7 +261,7 @@ func (f *ToolsFinder) findMatchingTools(args params.FindToolsParams) (coretools.
 
 	// Look for tools in simplestreams too, but don't replace
 	// any versions found in storage.
-	env, err := environs.GetEnviron(f.configGetter, environs.New)
+	env, err := f.newEnviron()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -40,7 +40,11 @@ type CAASBrokerInterface interface {
 func NewStateFacade(ctx facade.Context) (*Facade, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
-	caasBroker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	caasBroker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/agent/credentialvalidator/backend.go
+++ b/apiserver/facades/agent/credentialvalidator/backend.go
@@ -45,7 +45,7 @@ func (b *backend) ModelUsesCredential(tag names.CloudCredentialTag) (bool, error
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	modelCredentialTag, exists := m.CloudCredential()
+	modelCredentialTag, exists := m.CloudCredentialTag()
 	return exists && tag == modelCredentialTag, nil
 }
 
@@ -56,12 +56,12 @@ func (b *backend) ModelCredential() (*ModelCredential, error) {
 		return nil, errors.Trace(err)
 	}
 
-	modelCredentialTag, exists := m.CloudCredential()
+	modelCredentialTag, exists := m.CloudCredentialTag()
 	result := &ModelCredential{Model: m.ModelTag(), Exists: exists}
 	if !exists {
 		// A model credential is not set, we must check if the model
 		// is on the cloud that requires a credential.
-		supportsEmptyAuth, err := b.cloudSupportsNoAuth(m.Cloud())
+		supportsEmptyAuth, err := b.cloudSupportsNoAuth(m.CloudName())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -38,7 +38,7 @@ func (s *BackendSuite) TestModelUsesCredential(c *gc.C) {
 	uses, err := s.backend.ModelUsesCredential(s.state.aModel.credentialTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uses, jc.IsTrue)
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag")
 }
 
 func (s *BackendSuite) TestModelUsesCredentialUnset(c *gc.C) {
@@ -46,14 +46,14 @@ func (s *BackendSuite) TestModelUsesCredentialUnset(c *gc.C) {
 	uses, err := s.backend.ModelUsesCredential(s.state.aModel.credentialTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uses, jc.IsFalse)
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag")
 }
 
 func (s *BackendSuite) TestModelUsesCredentialWrongCredential(c *gc.C) {
 	uses, err := s.backend.ModelUsesCredential(names.NewCloudCredentialTag("foo/bob/two"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uses, jc.IsFalse)
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag")
 }
 
 func (s *BackendSuite) TestModelCredentialUnsetNotSupported(c *gc.C) {
@@ -65,7 +65,7 @@ func (s *BackendSuite) TestModelCredentialUnsetNotSupported(c *gc.C) {
 		Credential: names.CloudCredentialTag{},
 		Valid:      false,
 	})
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential", "ModelTag", "Cloud", "Cloud")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag", "ModelTag", "Cloud", "Cloud")
 }
 
 func (s *BackendSuite) TestModelCredentialUnsetSupported(c *gc.C) {
@@ -78,7 +78,7 @@ func (s *BackendSuite) TestModelCredentialUnsetSupported(c *gc.C) {
 		Credential: names.CloudCredentialTag{},
 		Valid:      true,
 	})
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential", "ModelTag", "Cloud", "Cloud")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag", "ModelTag", "Cloud", "Cloud")
 }
 
 func (s *BackendSuite) TestModelCredentialSetButCloudCredentialNotFound(c *gc.C) {
@@ -90,7 +90,7 @@ func (s *BackendSuite) TestModelCredentialSetButCloudCredentialNotFound(c *gc.C)
 			Credential: s.state.aModel.credentialTag,
 			Valid:      expected,
 		})
-		s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential", "ModelTag", "mockState.CloudCredential")
+		s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag", "ModelTag", "mockState.CloudCredentialTag")
 		s.state.ResetCalls()
 	}
 
@@ -145,7 +145,7 @@ func (b *mockState) Model() (credentialvalidator.ModelAccessor, error) {
 }
 
 func (b *mockState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
-	b.AddCall("mockState.CloudCredential", tag)
+	b.AddCall("mockState.CloudCredentialTag", tag)
 	if err := b.NextErr(); err != nil {
 		return state.Credential{}, err
 	}
@@ -181,8 +181,8 @@ type mockModel struct {
 	cloud string
 }
 
-func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
-	m.MethodCall(m, "mockModel.CloudCredential")
+func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
+	m.MethodCall(m, "mockModel.CloudCredentialTag")
 	return m.credentialTag, m.credentialSet
 }
 
@@ -191,7 +191,7 @@ func (m *mockModel) ModelTag() names.ModelTag {
 	return m.modelTag
 }
 
-func (m *mockModel) Cloud() string {
+func (m *mockModel) CloudName() string {
 	m.MethodCall(m, "Cloud")
 	return m.cloud
 }

--- a/apiserver/facades/agent/credentialvalidator/state.go
+++ b/apiserver/facades/agent/credentialvalidator/state.go
@@ -12,9 +12,9 @@ import (
 
 // ModelAccessor exposes Model methods needed by credential validator.
 type ModelAccessor interface {
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
 	ModelTag() names.ModelTag
-	Cloud() string
+	CloudName() string
 	WatchModelCredential() state.NotifyWatcher
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -112,12 +112,12 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 	isCaasModel := model.Type() == state.ModelTypeCAAS
 
 	var env storage.ProviderRegistry
 	if isCaasModel {
-		env, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(st)
+		env, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	} else {
 		env, err = environs.GetEnviron(configGetter, environs.New)
 	}
@@ -155,9 +155,13 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 	if isCaasModel {
 		return api, nil
 	}
+
+	newEnviron := func() (environs.BootstrapEnviron, error) {
+		return environs.GetEnviron(configGetter, environs.New)
+	}
 	api.InstanceIdGetter = common.NewInstanceIdGetter(st, getAuthFunc)
-	api.ToolsFinder = common.NewToolsFinder(configGetter, st, urlGetter)
-	api.ToolsGetter = common.NewToolsGetter(st, configGetter, st, urlGetter, getAuthOwner)
+	api.ToolsFinder = common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	api.ToolsGetter = common.NewToolsGetter(st, configGetter, st, urlGetter, getAuthOwner, newEnviron)
 	return api, nil
 }
 

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -71,7 +71,7 @@ func (s *iaasProvisionerSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
+	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(env)
 	pm := poolmanager.New(state.NewStateSettings(s.State), registry)
@@ -103,7 +103,7 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.State)
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(broker)
 	pm := poolmanager.New(state.NewStateSettings(s.State), registry)

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -3069,7 +3069,7 @@ func (u *UniterAPIV10) CloudAPIVersion(_, _ struct{}) {}
 func (u *UniterAPI) CloudAPIVersion() (params.StringResult, error) {
 	result := params.StringResult{}
 
-	configGetter := stateenvirons.EnvironConfigGetter{State: u.st, Model: u.m, NewContainerBroker: u.containerBrokerFunc}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: u.m, NewContainerBroker: u.containerBrokerFunc}
 	spec, err := configGetter.CloudSpec()
 	if err != nil {
 		return result, common.ServerError(err)

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -83,9 +83,10 @@ func NewUpgraderAPI(
 		return nil, err
 	}
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
+	newEnviron := common.EnvironFuncForModel(model, configGetter)
 	return &UpgraderAPI{
-		ToolsGetter: common.NewToolsGetter(st, configGetter, st, urlGetter, getCanReadWrite),
+		ToolsGetter: common.NewToolsGetter(st, configGetter, st, urlGetter, getCanReadWrite, newEnviron),
 		ToolsSetter: common.NewToolsSetter(st, getCanReadWrite),
 		st:          st,
 		m:           model,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -216,7 +216,7 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		caasBroker         caas.Broker
 	)
 	if facadeModel.Type() == state.ModelTypeCAAS {
-		caasBroker, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+		caasBroker, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(facadeModel)
 		if err != nil {
 			return nil, errors.Annotate(err, "getting caas client")
 		}

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -81,7 +81,7 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		g := stateenvirons.EnvironConfigGetter{State: st.State, Model: model}
+		g := stateenvirons.EnvironConfigGetter{Model: model}
 		env, err := environs.GetEnviron(g, environs.New)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -554,7 +554,7 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 
 	info := params.ModelInfo{
 		DefaultSeries:  config.PreferredSeries(conf),
-		CloudTag:       names.NewCloudTag(model.Cloud()).String(),
+		CloudTag:       names.NewCloudTag(model.CloudName()).String(),
 		CloudRegion:    model.CloudRegion(),
 		ProviderType:   conf.Type(),
 		Name:           conf.Name(),
@@ -568,7 +568,7 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	if agentVersion, exists := conf.AgentVersion(); exists {
 		info.AgentVersion = &agentVersion
 	}
-	if tag, ok := model.CloudCredential(); ok {
+	if tag, ok := model.CloudCredentialTag(); ok {
 		info.CloudCredentialTag = tag.String()
 	}
 	info.SLA = &params.ModelSLAInfo{

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	"github.com/juju/juju/environs/manual/winrmprovisioner"
-
 	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -69,7 +68,7 @@ type Client struct {
 	*modelconfig.ModelConfigAPIV1
 
 	api         *API
-	newEnviron  func() (environs.BootstrapEnviron, error)
+	newEnviron  common.NewEnvironFunc
 	check       *common.BlockChecker
 	callContext context.ProviderCallContext
 }
@@ -151,25 +150,14 @@ func newFacade(ctx facade.Context) (*Client, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
-
-	var newEnviron func() (environs.BootstrapEnviron, error)
-	if model.Type() == state.ModelTypeCAAS {
-		newEnviron = func() (environs.BootstrapEnviron, error) {
-			f := stateenvirons.GetNewCAASBrokerFunc(caas.New)
-			return f(st)
-		}
-	} else {
-		newEnviron = func() (environs.BootstrapEnviron, error) {
-			return environs.GetEnviron(configGetter, environs.New)
-		}
-	}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
+	newEnviron := common.EnvironFuncForModel(model, configGetter)
 
 	modelUUID := model.UUID()
 
 	urlGetter := common.NewToolsURLGetter(modelUUID, st)
 	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
+	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	blockChecker := common.NewBlockChecker(st)
 	backend := modelconfig.NewStateBackend(model)
 	// The modelConfigAPI exposed here is V1.
@@ -215,7 +203,7 @@ func NewClient(
 	presence facade.Presence,
 	statusSetter *common.StatusSetter,
 	toolsFinder *common.ToolsFinder,
-	newEnviron func() (environs.BootstrapEnviron, error),
+	newEnviron common.NewEnvironFunc,
 	blockChecker *common.BlockChecker,
 	callCtx context.ProviderCallContext,
 	leadershipReader leadership.Reader,

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -81,7 +81,7 @@ func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.A
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.newEnviron = func() (environs.BootstrapEnviron, error) {
-		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{State: st, Model: m}, environs.New)
+		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{Model: m}, environs.New)
 	}
 	client.SetNewEnviron(apiserverClient, func() (environs.BootstrapEnviron, error) {
 		return s.newEnviron()

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller/authentication"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
@@ -54,8 +55,11 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 		return nil, errors.New("no agent version set in model configuration")
 	}
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
+	newEnviron := func() (environs.BootstrapEnviron, error) {
+		return environs.GetEnviron(configGetter, environs.New)
+	}
+	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	findToolsResult, err := toolsFinder.FindTools(params.FindToolsParams{
 		Number:       agentVersion,
 		MajorVersion: -1,

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -429,7 +429,7 @@ func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 	}
 	info.Name = m.Name()
 	info.Type = string(m.Type())
-	info.CloudTag = names.NewCloudTag(m.Cloud()).String()
+	info.CloudTag = names.NewCloudTag(m.CloudName()).String()
 	info.CloudRegion = m.CloudRegion()
 
 	cfg, err := m.Config()

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -76,9 +76,9 @@ func (s stateShim) Model() (Model, error) {
 
 type Model interface {
 	UUID() string
-	Cloud() string
-	CloudValue() (cloud.Cloud, error)
-	CloudCredentialValue() (state.Credential, bool, error)
+	CloudName() string
+	Cloud() (cloud.Cloud, error)
+	CloudCredential() (state.Credential, bool, error)
 	CloudRegion() string
 }
 

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -77,7 +77,8 @@ func (s stateShim) Model() (Model, error) {
 type Model interface {
 	UUID() string
 	Cloud() string
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudValue() (cloud.Cloud, error)
+	CloudCredentialValue() (state.Credential, bool, error)
 	CloudRegion() string
 }
 

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -483,7 +483,7 @@ func (api *CloudAPIV4) DefaultCloud() (params.StringResult, error) {
 		return params.StringResult{}, err
 	}
 	return params.StringResult{
-		Result: names.NewCloudTag(controllerModel.Cloud()).String(),
+		Result: names.NewCloudTag(controllerModel.CloudName()).String(),
 	}, nil
 }
 

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -102,12 +102,12 @@ func (s *cloudSuiteV2) SetUpTest(c *gc.C) {
 				cloud:       "dummy",
 				cloudRegion: "nether",
 				cfg:         coretesting.ModelConfig(c),
-			},
-			cloud: cloud.Cloud{
-				Name:      "dummy",
-				Type:      "dummy",
-				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
-				Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+				cloudValue: cloud.Cloud{
+					Name:      "dummy",
+					Type:      "dummy",
+					AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+					Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+				},
 			},
 		}
 	}

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -101,9 +101,9 @@ func newModelBackend(c *gc.C, aCloud cloud.Cloud, uuid string) *mockModelBackend
 			uuid:        coretesting.ModelTag.Id(),
 			cloud:       "dummy",
 			cloudRegion: "nether",
+			cloudValue:  aCloud,
 			cfg:         coretesting.ModelConfig(c),
 		},
-		cloud: aCloud,
 	}
 }
 
@@ -1522,6 +1522,7 @@ type mockModel struct {
 	uuid               string
 	cloud              string
 	cloudRegion        string
+	cloudValue         cloud.Cloud
 	cloudCredentialTag names.CloudCredentialTag
 	cfg                *config.Config
 }
@@ -1536,6 +1537,14 @@ func (m *mockModel) CloudRegion() string {
 
 func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
 	return m.cloudCredentialTag, true
+}
+
+func (m *mockModel) CloudValue() (cloud.Cloud, error) {
+	return m.cloudValue, nil
+}
+
+func (m *mockModel) CloudCredentialValue() (state.Credential, bool, error) {
+	return state.Credential{}, false, nil
 }
 
 func (m *mockModel) ValidateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
@@ -1582,7 +1591,6 @@ func (m *mockPooledModel) Release() bool {
 type mockModelBackend struct {
 	uuid  string
 	model *mockModel
-	cloud cloud.Cloud
 }
 
 func (m *mockModelBackend) Model() (credentialcommon.Model, error) {
@@ -1590,7 +1598,7 @@ func (m *mockModelBackend) Model() (credentialcommon.Model, error) {
 }
 
 func (m *mockModelBackend) Cloud(name string) (cloud.Cloud, error) {
-	return m.cloud, nil
+	return m.model.cloudValue, nil
 }
 
 func (m *mockModelBackend) AllMachines() ([]credentialcommon.Machine, error) {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -1527,7 +1527,7 @@ type mockModel struct {
 	cfg                *config.Config
 }
 
-func (m *mockModel) Cloud() string {
+func (m *mockModel) CloudName() string {
 	return m.cloud
 }
 
@@ -1535,15 +1535,15 @@ func (m *mockModel) CloudRegion() string {
 	return m.cloudRegion
 }
 
-func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	return m.cloudCredentialTag, true
 }
 
-func (m *mockModel) CloudValue() (cloud.Cloud, error) {
+func (m *mockModel) Cloud() (cloud.Cloud, error) {
 	return m.cloudValue, nil
 }
 
-func (m *mockModel) CloudCredentialValue() (state.Credential, bool, error) {
+func (m *mockModel) CloudCredential() (state.Credential, bool, error) {
 	return state.Credential{}, false, nil
 }
 

--- a/apiserver/facades/client/cloud/instance_information.go
+++ b/apiserver/facades/client/cloud/instance_information.go
@@ -28,12 +28,12 @@ func (g cloudEnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}
-	cloud, err := model.CloudValue()
+	cloud, err := model.Cloud()
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}
 	regionName := g.region
-	credentialValue, ok, err := model.CloudCredentialValue()
+	credentialValue, ok, err := model.CloudCredential()
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}
@@ -82,8 +82,8 @@ func instanceTypes(api *CloudAPI,
 			result[i] = params.InstanceTypesResult{Error: common.ServerError(err)}
 			continue
 		}
-		if m.Cloud() != cloudTag.Id() {
-			result[i] = params.InstanceTypesResult{Error: common.ServerError(errors.NotValidf("asking %s cloud information to %s cloud", cloudTag.Id(), m.Cloud()))}
+		if m.CloudName() != cloudTag.Id() {
+			result[i] = params.InstanceTypesResult{Error: common.ServerError(errors.NotValidf("asking %s cloud information to %s cloud", cloudTag.Id(), m.CloudName()))}
 			continue
 		}
 

--- a/apiserver/facades/client/imagemetadatamanager/metadata.go
+++ b/apiserver/facades/client/imagemetadatamanager/metadata.go
@@ -59,8 +59,12 @@ func NewAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	newEnviron := func() (environs.Environ, error) {
-		return stateenvirons.GetNewEnvironFunc(environs.New)(st)
+		return stateenvirons.GetNewEnvironFunc(environs.New)(model)
 	}
 	return createAPI(getState(st), newEnviron, resources, authorizer)
 }

--- a/apiserver/facades/client/machinemanager/instance_information.go
+++ b/apiserver/facades/client/machinemanager/instance_information.go
@@ -32,12 +32,12 @@ func instanceTypes(mm *MachineManagerAPI,
 	}
 
 	cloudSpec := func() (environs.CloudSpec, error) {
-		cloud, err := model.CloudValue()
+		cloud, err := model.Cloud()
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}
 		regionName := model.CloudRegion()
-		credentialValue, ok, err := model.CloudCredentialValue()
+		credentialValue, ok, err := model.CloudCredential()
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -146,7 +146,7 @@ type mockModel struct {
 	machinemanager.Model
 }
 
-func (mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	return names.NewCloudCredentialTag("foo/bob/bar"), true
 }
 
@@ -158,7 +158,7 @@ func (*mockModel) Config() (*config.Config, error) {
 	return config.New(config.UseDefaults, dummy.SampleConfig())
 }
 
-func (*mockModel) Cloud() string {
+func (*mockModel) CloudName() string {
 	return "a-cloud"
 }
 

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cloud"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
@@ -18,7 +19,7 @@ import (
 )
 
 type Backend interface {
-	state.CloudAccessor
+	//state.CloudAccessor
 	network.SpaceLookup
 
 	Machine(string) (Machine, error)
@@ -36,8 +37,8 @@ type Pool interface {
 type Model interface {
 	Name() string
 	UUID() string
-	Cloud() string
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudValue() (cloud.Cloud, error)
+	CloudCredentialValue() (state.Credential, bool, error)
 	CloudRegion() string
 	Config() (*config.Config, error)
 }

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -19,7 +19,6 @@ import (
 )
 
 type Backend interface {
-	//state.CloudAccessor
 	network.SpaceLookup
 
 	Machine(string) (Machine, error)
@@ -37,8 +36,8 @@ type Pool interface {
 type Model interface {
 	Name() string
 	UUID() string
-	CloudValue() (cloud.Cloud, error)
-	CloudCredentialValue() (state.Credential, bool, error)
+	Cloud() (cloud.Cloud, error)
+	CloudCredential() (state.Credential, bool, error)
 	CloudRegion() string
 	Config() (*config.Config, error)
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -293,9 +293,9 @@ func (s *modelInfoSuite) assertModelInfo(c *gc.C, got, expected params.ModelInfo
 		{"UUID", nil},
 		{"Owner", nil},
 		{"Life", nil},
-		{"Cloud", nil},
+		{"CloudName", nil},
 		{"CloudRegion", nil},
-		{"CloudCredential", nil},
+		{"CloudCredentialTag", nil},
 		{"SLALevel", nil},
 		{"SLAOwner", nil},
 		{"Life", nil},
@@ -1079,12 +1079,12 @@ func (m *mockModel) Status() (status.StatusInfo, error) {
 	return m.status, m.NextErr()
 }
 
-func (m *mockModel) Cloud() string {
-	m.MethodCall(m, "Cloud")
+func (m *mockModel) CloudName() string {
+	m.MethodCall(m, "CloudName")
 	return "some-cloud"
 }
 
-func (m *mockModel) CloudValue() (cloud.Cloud, error) {
+func (m *mockModel) Cloud() (cloud.Cloud, error) {
 	m.MethodCall(m, "CloudValue")
 	return m.cloud, nil
 }
@@ -1094,13 +1094,13 @@ func (m *mockModel) CloudRegion() string {
 	return "some-region"
 }
 
-func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
-	m.MethodCall(m, "CloudCredential")
+func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
+	m.MethodCall(m, "CloudCredentialTag")
 	return names.NewCloudCredentialTag("some-cloud/bob/some-credential"), true
 }
 
-func (m *mockModel) CloudCredentialValue() (state.Credential, bool, error) {
-	m.MethodCall(m, "CloudCredentialValue")
+func (m *mockModel) CloudCredential() (state.Credential, bool, error) {
+	m.MethodCall(m, "CloudCredential")
 	return m.cred, true, nil
 }
 
@@ -1173,7 +1173,7 @@ func (m *mockModel) AutoConfigureContainerNetworking(environ environs.BootstrapE
 }
 
 func (m *mockModel) getModelDetails() state.ModelSummary {
-	cred, _ := m.CloudCredential()
+	cred, _ := m.CloudCredentialTag()
 	return state.ModelSummary{
 		Name:               m.Name(),
 		UUID:               m.UUID(),
@@ -1183,7 +1183,7 @@ func (m *mockModel) getModelDetails() state.ModelSummary {
 		ControllerUUID:     m.ControllerUUID(),
 		SLALevel:           m.SLALevel(),
 		SLAOwner:           m.SLAOwner(),
-		CloudTag:           m.Cloud(),
+		CloudTag:           m.CloudName(),
 		CloudRegion:        m.CloudRegion(),
 		CloudCredentialTag: cred.String(),
 	}

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -186,7 +186,7 @@ func NewFacadeV8(ctx facade.Context) (*ModelManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 
 	ctrlModel, err := ctlrSt.Model()
 	if err != nil {
@@ -289,6 +289,13 @@ func NewModelManagerAPI(
 		return nil, errors.Trace(err)
 	}
 	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
+
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	newEnviron := common.EnvironFuncForModel(model, configGetter)
+
 	return &ModelManagerAPI{
 		ModelStatusAPI: common.NewModelStatusAPI(st, authorizer, apiUser),
 		state:          st,
@@ -296,7 +303,7 @@ func NewModelManagerAPI(
 		getBroker:      getBroker,
 		check:          common.NewBlockChecker(st),
 		authorizer:     authorizer,
-		toolsFinder:    common.NewToolsFinder(configGetter, st, urlGetter),
+		toolsFinder:    common.NewToolsFinder(configGetter, st, urlGetter, newEnviron),
 		apiUser:        apiUser,
 		isAdmin:        isAdmin,
 		model:          m,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -425,9 +425,9 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 			return result, errors.Trace(err)
 		}
 	} else {
-		cloudTag = names.NewCloudTag(controllerModel.Cloud())
+		cloudTag = names.NewCloudTag(controllerModel.CloudName())
 	}
-	if cloudRegionName == "" && cloudTag.Id() == controllerModel.Cloud() {
+	if cloudRegionName == "" && cloudTag.Id() == controllerModel.CloudName() {
 		cloudRegionName = controllerModel.CloudRegion()
 	}
 
@@ -487,7 +487,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 		}
 	} else {
 		if ownerTag == controllerModel.Owner() {
-			cloudCredentialTag, _ = controllerModel.CloudCredential()
+			cloudCredentialTag, _ = controllerModel.CloudCredentialTag()
 		} else {
 			// TODO(axw) check if the user has one and only one
 			// cloud credential, and if so, use it? For now, we
@@ -1118,11 +1118,11 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 		IsController:   st.IsController(),
 		OwnerTag:       model.Owner().String(),
 		Life:           params.Life(model.Life().String()),
-		CloudTag:       names.NewCloudTag(model.Cloud()).String(),
+		CloudTag:       names.NewCloudTag(model.CloudName()).String(),
 		CloudRegion:    model.CloudRegion(),
 	}
 
-	if cloudCredentialTag, ok := model.CloudCredential(); ok {
+	if cloudCredentialTag, ok := model.CloudCredentialTag(); ok {
 		info.CloudCredentialTag = cloudCredentialTag.String()
 	}
 
@@ -1411,7 +1411,7 @@ func (m *ModelManagerAPIV5) ModelDefaults() (params.ModelDefaultsResult, error) 
 	if !m.isAdmin {
 		return result, common.ErrPerm
 	}
-	return m.modelDefaults(m.model.Cloud()), nil
+	return m.modelDefaults(m.model.CloudName()), nil
 }
 
 func (m *ModelManagerAPI) modelDefaults(cloud string) params.ModelDefaultsResult {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -262,6 +262,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	s.st.CheckCallNames(c,
 		"ControllerTag",
 		"ModelUUID",
+		"Model",
 		"ControllerTag",
 		"Cloud",
 		"CloudCredential",
@@ -433,6 +434,7 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 	s.caasSt.CheckCallNames(c,
 		"ControllerTag",
 		"ModelUUID",
+		"Model",
 		"ControllerTag",
 		"Cloud",
 		"CloudCredential",
@@ -746,6 +748,7 @@ func (s *modelManagerSuite) TestDumpModelMissingModel(c *gc.C) {
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
 		{"ControllerTag", nil},
 		{"ModelUUID", nil},
+		{"Model", nil},
 		{"GetBackend", []interface{}{tag.Id()}},
 	})
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -804,6 +807,7 @@ func (s *modelManagerSuite) TestDumpModelsDBMissingModel(c *gc.C) {
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
 		{"ControllerTag", nil},
 		{"ModelUUID", nil},
+		{"Model", nil},
 		{"ModelTag", nil},
 		{"GetBackend", []interface{}{tag.Id()}},
 	})
@@ -868,6 +872,7 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 	s.st.CheckCallNames(c,
 		"ControllerTag",
 		"ModelUUID",
+		"Model",
 		"GetBackend",
 		"Model",
 		"GetBlockForType",
@@ -881,6 +886,7 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 	destroyStorage := true
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
 		{"UUID", nil},
+		{"Type", nil},
 		{"Status", nil},
 		{"Destroy", []interface{}{state.DestroyModelParams{
 			DestroyStorage: &destroyStorage,
@@ -920,7 +926,7 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	modelmanager, err := modelmanager.NewModelManagerAPI(
 		common.NewModelManagerBackend(s.Model, s.StatePool),
 		common.NewModelManagerBackend(s.Model, s.StatePool),
-		stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model},
+		stateenvirons.EnvironConfigGetter{Model: s.Model},
 		nil,
 		s.authoriser,
 		s.Model,
@@ -1871,7 +1877,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialGetModelFail(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, `getting model`)
-	s.st.CheckCallNames(c, "ControllerTag", "ModelUUID", "ModelTag", "GetBlockForType", "ControllerTag", "GetModel")
+	s.st.CheckCallNames(c, "ControllerTag", "ModelUUID", "Model", "ModelTag", "GetBlockForType", "ControllerTag", "GetModel")
 }
 
 func (s *modelManagerSuite) TestChangeModelCredentialNotUpdated(c *gc.C) {

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -19,7 +19,7 @@ func NewStateShim(st *state.State) (*stateShim, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &stateShim{EnvironConfigGetter: stateenvirons.EnvironConfigGetter{State: st, Model: m},
+	return &stateShim{EnvironConfigGetter: stateenvirons.EnvironConfigGetter{Model: m},
 		State: st, modelTag: m.ModelTag()}, nil
 }
 

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -36,7 +36,7 @@ func NewFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return internalFacade(&backend{stateenvirons.EnvironConfigGetter{State: st, Model: m}}, ctx.Auth(), state.CallContext(st))
+	return internalFacade(&backend{st, stateenvirons.EnvironConfigGetter{Model: m}}, ctx.Auth(), state.CallContext(st))
 }
 
 func internalFacade(backend Backend, auth facade.Authorizer, callCtx context.ProviderCallContext) (*Facade, error) {

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -34,6 +34,7 @@ type SSHMachine interface {
 }
 
 type backend struct {
+	*state.State
 	stateenvirons.EnvironConfigGetter
 }
 

--- a/apiserver/facades/client/subnets/shims.go
+++ b/apiserver/facades/client/subnets/shims.go
@@ -19,7 +19,7 @@ func NewStateShim(st *state.State) (*stateShim, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &stateShim{EnvironConfigGetter: stateenvirons.EnvironConfigGetter{State: st, Model: m},
+	return &stateShim{EnvironConfigGetter: stateenvirons.EnvironConfigGetter{Model: m},
 		State: st, modelTag: m.ModelTag()}, nil
 }
 

--- a/apiserver/facades/controller/agenttools/agenttools.go
+++ b/apiserver/facades/controller/agenttools/agenttools.go
@@ -36,9 +36,13 @@ type AgentToolsAPI struct {
 
 // NewFacade is used to register the facade.
 func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*AgentToolsAPI, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	newEnviron := func() (environs.Environ, error) {
 		newEnviron := stateenvirons.GetNewEnvironFunc(environs.New)
-		return newEnviron(st)
+		return newEnviron(model)
 	}
 	return NewAgentToolsAPI(st, newEnviron, findTools, envVersionUpdate, authorizer)
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -43,7 +43,11 @@ func NewStateCAASOperatorProvisionerAPI(ctx facade.Context) (*API, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
 
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -27,7 +27,11 @@ type API struct {
 // NewStateCAASOperatorUpgraderAPI provides the signature required for facade registration.
 func NewStateCAASOperatorUpgraderAPI(ctx facade.Context) (*API, error) {
 	authorizer := ctx.Auth()
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -60,7 +60,11 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 		return nil, errors.Trace(err)
 	}
 
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -154,11 +154,11 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		"model_uuid":         model.UUID(),
 		"controller_uuid":    st.ControllerUUID(),
 		"controller_version": version.Current.String(),
-		"cloud":              model.Cloud(),
+		"cloud":              model.CloudName(),
 		"cloud_region":       model.CloudRegion(),
 		"is_controller":      strconv.FormatBool(model.IsControllerModel()),
 	}
-	cloud, err := st.Cloud(model.Cloud())
+	cloud, err := st.Cloud(model.CloudName())
 	if err != nil {
 		metadata["provider"] = "unknown"
 	} else {

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -183,11 +183,11 @@ func (s *charmVersionSuite) TestJujuMetadataHeaderIsSent(c *gc.C) {
 
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	cloud, err := s.State.Cloud(model.Cloud())
+	cloud, err := s.State.Cloud(model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedHeader := []string{
 		"arch=amd64", // This is the architecture of the deployed applications.
-		"cloud=" + model.Cloud(),
+		"cloud=" + model.CloudName(),
 		"cloud_region=" + model.CloudRegion(),
 		"controller_uuid=" + s.State.ControllerUUID(),
 		"controller_version=" + version.Current.String(),

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -239,9 +239,9 @@ func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
 
 	var ra environs.ResourceAdopter
 	if m.Type() == state.ModelTypeCAAS {
-		ra, err = api.getCAASBroker(st.State)
+		ra, err = api.getCAASBroker(m)
 	} else {
-		ra, err = api.getEnviron(st.State)
+		ra, err = api.getEnviron(m)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -288,10 +288,10 @@ func (s *Suite) TestAdoptIAASResources(c *gc.C) {
 	defer st.Close()
 
 	env := mockEnv{Stub: &testing.Stub{}}
-	api, err := s.newAPI(func(modelSt *state.State) (environs.Environ, error) {
-		c.Assert(modelSt.ModelUUID(), gc.Equals, st.ModelUUID())
+	api, err := s.newAPI(func(model stateenvirons.Model) (environs.Environ, error) {
+		c.Assert(model.ModelTag().Id(), gc.Equals, st.ModelUUID())
 		return &env, nil
-	}, func(modelSt *state.State) (caas.Broker, error) {
+	}, func(model stateenvirons.Model) (caas.Broker, error) {
 		return nil, errors.New("should not be called")
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -317,10 +317,10 @@ func (s *Suite) TestAdoptCAASResources(c *gc.C) {
 	defer st.Close()
 
 	broker := mockBroker{Stub: &testing.Stub{}}
-	api, err := s.newAPI(func(modelSt *state.State) (environs.Environ, error) {
+	api, err := s.newAPI(func(model stateenvirons.Model) (environs.Environ, error) {
 		return nil, errors.New("should not be called")
-	}, func(modelSt *state.State) (caas.Broker, error) {
-		c.Assert(modelSt.ModelUUID(), gc.Equals, st.ModelUUID())
+	}, func(model stateenvirons.Model) (caas.Broker, error) {
+		c.Assert(model.ModelTag().Id(), gc.Equals, st.ModelUUID())
 		return &broker, nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -431,9 +431,9 @@ func (s *Suite) mustNewAPI(c *gc.C) *migrationtarget.API {
 }
 
 func (s *Suite) mustNewAPIWithModel(c *gc.C, env environs.Environ, broker caas.Broker) *migrationtarget.API {
-	api, err := s.newAPI(func(*state.State) (environs.Environ, error) {
+	api, err := s.newAPI(func(stateenvirons.Model) (environs.Environ, error) {
 		return env, nil
-	}, func(*state.State) (caas.Broker, error) {
+	}, func(stateenvirons.Model) (caas.Broker, error) {
 		return broker, nil
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/modelupgrader/backend.go
+++ b/apiserver/facades/controller/modelupgrader/backend.go
@@ -18,7 +18,7 @@ type Pool interface {
 }
 
 type Model interface {
-	Cloud() string
+	CloudName() string
 	EnvironVersion() int
 	SetEnvironVersion(int) error
 }

--- a/apiserver/facades/controller/modelupgrader/modelupgrader.go
+++ b/apiserver/facades/controller/modelupgrader/modelupgrader.go
@@ -137,7 +137,7 @@ func (f *Facade) modelTargetEnvironVersion(arg params.Entity) (int, error) {
 		return -1, errors.Trace(err)
 	}
 	defer release()
-	cloud, err := f.backend.Cloud(model.Cloud())
+	cloud, err := f.backend.Cloud(model.CloudName())
 	if err != nil {
 		return -1, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/modelupgrader/modelupgrader_test.go
+++ b/apiserver/facades/controller/modelupgrader/modelupgrader_test.go
@@ -131,8 +131,8 @@ func (s *ModelUpgraderSuite) TestModelTargetEnvironVersion(c *gc.C) {
 		{"GetModel", []interface{}{modelTag1.Id()}},
 		{"GetModel", []interface{}{modelTag2.Id()}},
 	})
-	s.pool.models[modelTag1.Id()].CheckCallNames(c, "Cloud")
-	s.pool.models[modelTag2.Id()].CheckCallNames(c, "Cloud")
+	s.pool.models[modelTag1.Id()].CheckCallNames(c, "CloudName")
+	s.pool.models[modelTag2.Id()].CheckCallNames(c, "CloudName")
 	s.providers.CheckCalls(c, []testing.StubCall{
 		{"Provider", []interface{}{"foo-provider"}},
 		{"Provider", []interface{}{"bar-provider"}},
@@ -219,8 +219,8 @@ type mockModel struct {
 	v     int
 }
 
-func (m *mockModel) Cloud() string {
-	m.MethodCall(m, "Cloud")
+func (m *mockModel) CloudName() string {
+	m.MethodCall(m, "CloudName")
 	m.PopNoErr()
 	return m.cloud
 }

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -173,8 +173,12 @@ func (h *toolsDownloadHandler) fetchAndCacheTools(
 ) (binarystorage.Metadata, io.ReadCloser, error) {
 	md := binarystorage.Metadata{Version: v.String()}
 
+	model, err := st.Model()
+	if err != nil {
+		return md, nil, err
+	}
 	newEnviron := stateenvirons.GetNewEnvironFunc(environs.New)
-	env, err := newEnviron(st)
+	env, err := newEnviron(model)
 	if err != nil {
 		return md, nil, err
 	}

--- a/environs/environ_test.go
+++ b/environs/environ_test.go
@@ -19,7 +19,7 @@ type environSuite struct {
 var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) TestGetEnvironment(c *gc.C) {
-	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
+	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/api_credentialmanager_test.go
+++ b/featuretests/api_credentialmanager_test.go
@@ -36,7 +36,7 @@ func (s *CredentialManagerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
-	tag, set := s.Model.CloudCredential()
+	tag, set := s.Model.CloudCredentialTag()
 	c.Assert(set, jc.IsTrue)
 	credential, err := s.State.CloudCredential(tag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -149,7 +149,7 @@ clouds:
 	c.Assert(result[0].Error.Error(), gc.DeepEquals, "credential \"newcred\" not found")
 
 	// Check model references original credential.
-	originalCredentialTag, set := s.Model.CloudCredential()
+	originalCredentialTag, set := s.Model.CloudCredentialTag()
 	c.Assert(set, jc.IsTrue)
 	c.Assert(originalCredentialTag.String(), jc.DeepEquals, "cloudcred-dummy_admin_cred")
 
@@ -178,7 +178,7 @@ Changed cloud credential on model "controller" to "newcred".
 	// Check model reference was updated to a new credential.
 	err = s.Model.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	updatedCredentialTag, set := s.Model.CloudCredential()
+	updatedCredentialTag, set := s.Model.CloudCredentialTag()
 	c.Assert(set, jc.IsTrue)
 	c.Assert(updatedCredentialTag.String(), jc.DeepEquals, "cloudcred-dummy_admin_newcred")
 

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -168,7 +168,7 @@ special         -        -
 
 func (s *cmdModelSuite) TestModelDefaultsSet(c *gc.C) {
 	s.run(c, "model-defaults", "special=known")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	value, found := defaults["special"]
 	c.Assert(found, jc.IsTrue)
@@ -177,7 +177,7 @@ func (s *cmdModelSuite) TestModelDefaultsSet(c *gc.C) {
 
 func (s *cmdModelSuite) TestModelDefaultsSetCloud(c *gc.C) {
 	s.run(c, "model-defaults", "dummy", "special=known")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	value, found := defaults["special"]
 	c.Assert(found, jc.IsTrue)
@@ -187,7 +187,7 @@ func (s *cmdModelSuite) TestModelDefaultsSetCloud(c *gc.C) {
 
 func (s *cmdModelSuite) TestModelDefaultsSetRegion(c *gc.C) {
 	s.run(c, "model-defaults", "dummy/dummy-region", "special=known")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	value, found := defaults["special"]
 	c.Assert(found, jc.IsTrue)
@@ -200,7 +200,7 @@ func (s *cmdModelSuite) TestModelDefaultsReset(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "--reset", "special")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]
 	c.Assert(found, jc.IsFalse)
@@ -211,7 +211,7 @@ func (s *cmdModelSuite) TestModelDefaultsResetCloud(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "dummy", "--reset", "special")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]
 	c.Assert(found, jc.IsFalse)
@@ -222,7 +222,7 @@ func (s *cmdModelSuite) TestModelDefaultsResetRegion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "dummy-region", "--reset", "special")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]
 	c.Assert(found, jc.IsFalse)

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -52,7 +52,7 @@ type PrecheckModel interface {
 	Owner() names.UserTag
 	Life() state.Life
 	MigrationMode() state.MigrationMode
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
 }
 
 // PrecheckMachine describes the state interface for a machine needed
@@ -172,7 +172,7 @@ func (ctx *precheckContext) checkModel() error {
 	if model.MigrationMode() == state.MigrationModeImporting {
 		return errors.New("model is being imported as part of another migration")
 	}
-	if credTag, found := model.CloudCredential(); found {
+	if credTag, found := model.CloudCredentialTag(); found {
 		creds, err := ctx.backend.CloudCredential(credTag)
 		if err != nil {
 			return errors.Trace(err)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -893,7 +893,7 @@ func (m *fakeModel) MigrationMode() state.MigrationMode {
 	return m.migrationMode
 }
 
-func (m *fakeModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *fakeModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	if names.IsValidCloudCredential(m.credential) {
 		return names.NewCloudCredentialTag(m.credential), true
 	}

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -122,7 +122,7 @@ func (s *CAASModelSuite) TestDestroyModel(c *gc.C) {
 
 func (s *CAASModelSuite) TestDestroyModelDestroyStorage(c *gc.C) {
 	model, st := s.newCAASModel(c)
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(st)
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(broker)
 	s.policy = testing.MockPolicy{

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -869,7 +869,9 @@ func (s *CleanupSuite) assertCleanupCAASEntityWithStorage(c *gc.C, deleteOp func
 	defer st.Close()
 	sb, err := state.NewStorageBackend(st)
 	c.Assert(err, jc.ErrorIsNil)
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(st)
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(broker)
 	s.policy = testing.MockPolicy{

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -237,9 +237,9 @@ func (s *CloudCredentialsSuite) TestRemoveModelsCredential(c *gc.C) {
 	aModel, helper, err := s.StatePool.GetModel(modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	defer helper.Release()
-	_, isSet := aModel.CloudCredential()
+	_, isSet := aModel.CloudCredentialTag()
 	c.Assert(isSet, jc.IsFalse)
-	_, isSet, err = aModel.CloudCredentialValue()
+	_, isSet, err = aModel.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isSet, jc.IsFalse)
 }
@@ -267,11 +267,11 @@ func (s *CloudCredentialsSuite) TestRemoveModelsCredentialConcurrentModelDelete(
 	aModel, helper, err := s.StatePool.GetModel(modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	defer helper.Release()
-	_, isSet := aModel.CloudCredential()
+	_, isSet := aModel.CloudCredentialTag()
 	// Since the model was marked 'dead' in the middle of 1st transaction attempt,
 	// and 2nd attempt would not have picked it up, the model credential would not actually be cleared.
 	c.Assert(isSet, jc.IsTrue)
-	_, isSet, err = aModel.CloudCredentialValue()
+	_, isSet, err = aModel.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isSet, jc.IsTrue)
 	c.Assert(c.GetTestLog(), jc.Contains, "creating operations to remove models credential, attempt 1")

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -239,6 +239,9 @@ func (s *CloudCredentialsSuite) TestRemoveModelsCredential(c *gc.C) {
 	defer helper.Release()
 	_, isSet := aModel.CloudCredential()
 	c.Assert(isSet, jc.IsFalse)
+	_, isSet, err = aModel.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(isSet, jc.IsFalse)
 }
 
 func (s *CloudCredentialsSuite) TestRemoveModelsCredentialConcurrentModelDelete(c *gc.C) {
@@ -267,6 +270,9 @@ func (s *CloudCredentialsSuite) TestRemoveModelsCredentialConcurrentModelDelete(
 	_, isSet := aModel.CloudCredential()
 	// Since the model was marked 'dead' in the middle of 1st transaction attempt,
 	// and 2nd attempt would not have picked it up, the model credential would not actually be cleared.
+	c.Assert(isSet, jc.IsTrue)
+	_, isSet, err = aModel.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isSet, jc.IsTrue)
 	c.Assert(c.GetTestLog(), jc.Contains, "creating operations to remove models credential, attempt 1")
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -199,11 +199,11 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 
 	// Check that the model's cloud and credential names are as
 	// expected, and the owner's cloud credentials are initialised.
-	c.Assert(model.Cloud(), gc.Equals, "dummy")
-	credentialTag, ok := model.CloudCredential()
+	c.Assert(model.CloudName(), gc.Equals, "dummy")
+	credentialTag, ok := model.CloudCredentialTag()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(credentialTag, gc.Equals, userPassCredentialTag)
-	cred, credentialSet, err := model.CloudCredentialValue()
+	cred, credentialSet, err := model.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsTrue)
 	stateCred, err := s.State.CloudCredential(credentialTag)

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -203,6 +203,12 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	credentialTag, ok := model.CloudCredential()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(credentialTag, gc.Equals, userPassCredentialTag)
+	cred, credentialSet, err := model.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentialSet, jc.IsTrue)
+	stateCred, err := s.State.CloudCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, stateCred)
 	cloudCredentials, err := s.State.CloudCredentials(model.Owner(), "dummy")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudCredentials, jc.DeepEquals, map[string]state.Credential{

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -123,7 +123,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 
 	args := description.ModelArgs{
 		Type:               string(dbModel.Type()),
-		Cloud:              dbModel.Cloud(),
+		Cloud:              dbModel.CloudName(),
 		CloudRegion:        dbModel.CloudRegion(),
 		Owner:              dbModel.Owner(),
 		Config:             modelConfig.Settings,
@@ -132,7 +132,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 		Blocks:             blocks,
 	}
 	export.model = description.NewModel(args)
-	if credsTag, credsSet := dbModel.CloudCredential(); credsSet && !cfg.SkipCredentials {
+	if credsTag, credsSet := dbModel.CloudCredentialTag(); credsSet && !cfg.SkipCredentials {
 		creds, err := st.CloudCredential(credsTag)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/state/model.go
+++ b/state/model.go
@@ -584,14 +584,14 @@ func (m *Model) Type() ModelType {
 	return m.doc.Type
 }
 
-// Cloud returns the name of the cloud to which the model is deployed.
-func (m *Model) Cloud() string {
+// CloudName returns the name of the cloud to which the model is deployed.
+func (m *Model) CloudName() string {
 	return m.doc.Cloud
 }
 
-// CloudValue returns the cloud to which the model is deployed.
-func (m *Model) CloudValue() (jujucloud.Cloud, error) {
-	return m.st.Cloud(m.Cloud())
+// Cloud returns the cloud to which the model is deployed.
+func (m *Model) Cloud() (jujucloud.Cloud, error) {
+	return m.st.Cloud(m.CloudName())
 }
 
 // CloudRegion returns the name of the cloud region to which the model is deployed.
@@ -599,19 +599,19 @@ func (m *Model) CloudRegion() string {
 	return m.doc.CloudRegion
 }
 
-// CloudCredential returns the tag of the cloud credential used for managing the
+// CloudCredentialTag returns the tag of the cloud credential used for managing the
 // model's cloud resources, and a boolean indicating whether a credential is set.
-func (m *Model) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *Model) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	if names.IsValidCloudCredential(m.doc.CloudCredential) {
 		return names.NewCloudCredentialTag(m.doc.CloudCredential), true
 	}
 	return names.CloudCredentialTag{}, false
 }
 
-// CloudCredentialValue returns the cloud credential used for managing the
+// CloudCredential returns the cloud credential used for managing the
 // model's cloud resources, and a boolean indicating whether a credential is set.
-func (m *Model) CloudCredentialValue() (Credential, bool, error) {
-	tag, ok := m.CloudCredential()
+func (m *Model) CloudCredential() (Credential, bool, error) {
+	tag, ok := m.CloudCredentialTag()
 	if !ok {
 		return Credential{}, false, nil
 	}
@@ -662,7 +662,7 @@ func modelStatusInvalidCredential() status.StatusInfo {
 // Status returns the status of the model.
 func (m *Model) Status() (status.StatusInfo, error) {
 	// If model credential is invalid, model is suspended.
-	if credentialTag, hasCredential := m.CloudCredential(); hasCredential {
+	if credentialTag, hasCredential := m.CloudCredentialTag(); hasCredential {
 		credential, err := m.st.CloudCredential(credentialTag)
 		if err != nil {
 			return status.StatusInfo{}, errors.Annotatef(err, "could not get model credential %v", credentialTag.Id())

--- a/state/model.go
+++ b/state/model.go
@@ -589,6 +589,11 @@ func (m *Model) Cloud() string {
 	return m.doc.Cloud
 }
 
+// CloudValue returns the cloud to which the model is deployed.
+func (m *Model) CloudValue() (jujucloud.Cloud, error) {
+	return m.st.Cloud(m.Cloud())
+}
+
 // CloudRegion returns the name of the cloud region to which the model is deployed.
 func (m *Model) CloudRegion() string {
 	return m.doc.CloudRegion
@@ -601,6 +606,17 @@ func (m *Model) CloudCredential() (names.CloudCredentialTag, bool) {
 		return names.NewCloudCredentialTag(m.doc.CloudCredential), true
 	}
 	return names.CloudCredentialTag{}, false
+}
+
+// CloudCredentialValue returns the cloud credential used for managing the
+// model's cloud resources, and a boolean indicating whether a credential is set.
+func (m *Model) CloudCredentialValue() (Credential, bool, error) {
+	tag, ok := m.CloudCredential()
+	if !ok {
+		return Credential{}, false, nil
+	}
+	cred, err := m.st.CloudCredential(tag)
+	return cred, true, err
 }
 
 // MigrationMode returns whether the model is active or being migrated.

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1678,8 +1678,8 @@ func (s *ModelCloudValidationSuite) TestNewModelDifferentCloud(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer newSt.Close()
-	c.Assert(m.Cloud(), gc.Equals, "another")
-	cloudValue, err := m.CloudValue()
+	c.Assert(m.CloudName(), gc.Equals, "another")
+	cloudValue, err := m.Cloud()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudValue, jc.DeepEquals, aCloud)
 }

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1659,11 +1659,12 @@ func (s *ModelCloudValidationSuite) TestNewModelDifferentCloud(c *gc.C) {
 	controller, owner := s.initializeState(c, []cloud.Region{{Name: "some-region"}}, []cloud.AuthType{cloud.EmptyAuthType}, nil)
 	defer controller.Close()
 	st := controller.SystemState()
-	err := st.AddCloud(cloud.Cloud{
+	aCloud := cloud.Cloud{
 		Name:      "another",
 		Type:      "dummy",
 		AuthTypes: cloud.AuthTypes{"empty", "userpass"},
-	}, owner.Name())
+	}
+	err := st.AddCloud(aCloud, owner.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	cfg, err = cfg.Apply(map[string]interface{}{"name": "whatever"})
@@ -1678,6 +1679,9 @@ func (s *ModelCloudValidationSuite) TestNewModelDifferentCloud(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer newSt.Close()
 	c.Assert(m.Cloud(), gc.Equals, "another")
+	cloudValue, err := m.CloudValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudValue, jc.DeepEquals, aCloud)
 }
 
 func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudRegion(c *gc.C) {

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -167,7 +167,7 @@ func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, re
 		if err != nil {
 			return errors.Trace(err)
 		}
-		key = cloudGlobalKey(model.Cloud())
+		key = cloudGlobalKey(model.CloudName())
 	}
 	settings, err := readSettings(st.db(), globalSettingsC, key)
 	if err != nil {
@@ -463,7 +463,7 @@ func (st *State) regionSpec() (*environs.CloudRegionSpec, error) {
 		return nil, errors.Trace(err)
 	}
 	rspec := &environs.CloudRegionSpec{
-		Cloud:  model.Cloud(),
+		Cloud:  model.CloudName(),
 		Region: model.CloudRegion(),
 	}
 	return rspec, nil

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -442,7 +442,7 @@ func (s *ModelConfigSourceSuite) TestModelConfigDefaults(c *gc.C) {
 		Value: "dummy-proxy"}}
 	expectedValues["no-proxy"] = ds
 
-	sources, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	sources, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sources, jc.DeepEquals, expectedValues)
 }
@@ -462,7 +462,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedValues := make(config.ModelDefaultAttributes)
 	for attr, val := range config.ConfigDefaults() {
@@ -503,7 +503,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	err = s.State.UpdateModelConfigDefaultValues(attrs, nil, rspec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedValues := make(config.ModelDefaultAttributes)
 	for attr, val := range config.ConfigDefaults() {
@@ -535,7 +535,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// and check again
-	cfg, err = s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err = s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedValues = make(config.ModelDefaultAttributes)
 	for attr, val := range config.ConfigDefaults() {
@@ -572,7 +572,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultValuesUnknownRegion
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Then check config.
-	cfg, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg["no-proxy"], jc.DeepEquals, config.AttributeDefaultValues{
 		Default:    "127.0.0.1,localhost,::1",

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -22,7 +22,7 @@ func (st *State) InvalidateModelCredential(reason string) error {
 		return errors.Trace(err)
 	}
 
-	tag, exists := m.CloudCredential()
+	tag, exists := m.CloudCredentialTag()
 	if !exists {
 		// Model is on the cloud that does not require auth - nothing to do.
 		return nil
@@ -66,9 +66,9 @@ func (st *State) suspendCredentialModels(tag names.CloudCredentialTag) error {
 
 // ValidateCloudCredential validates new cloud credential for this model.
 func (m *Model) ValidateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
-	aCloud, err := m.st.Cloud(m.Cloud())
+	aCloud, err := m.st.Cloud(m.CloudName())
 	if err != nil {
-		return errors.Annotatef(err, "getting cloud %q", m.Cloud())
+		return errors.Annotatef(err, "getting cloud %q", m.CloudName())
 	}
 
 	err = validateCredentialForCloud(aCloud, tag, convertCloudCredentialToState(tag, credential))
@@ -88,9 +88,9 @@ func (m *Model) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
 		return false, errors.Annotatef(err, "getting model status %q", m.UUID())
 	}
 	revert := modelStatus.Status == status.Suspended
-	aCloud, err := m.st.Cloud(m.Cloud())
+	aCloud, err := m.st.Cloud(m.CloudName())
 	if err != nil {
-		return false, errors.Annotatef(err, "getting cloud %q", m.Cloud())
+		return false, errors.Annotatef(err, "getting cloud %q", m.CloudName())
 	}
 	updating := true
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -40,6 +40,9 @@ func (s *ModelCredentialSuite) TestInvalidateModelCredentialNone(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, exists := m.CloudCredential()
 	c.Assert(exists, jc.IsFalse)
+	_, exists, err = m.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(exists, jc.IsFalse)
 
 	reason := "special invalidation"
 	err = s.State.InvalidateModelCredential(reason)
@@ -113,6 +116,12 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialNoUpdate(c *gc.C) {
 	credentialTag, credentialSet := m.CloudCredential()
 	c.Assert(credentialTag, gc.DeepEquals, tag)
 	c.Assert(credentialSet, jc.IsTrue)
+	cred, credentialSet, err := m.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentialSet, jc.IsTrue)
+	stateCred, err := s.State.CloudCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, stateCred)
 }
 
 func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialContent(c *gc.C) {
@@ -132,6 +141,9 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialContent(c 
 	credentialTag, credentialSet := m.CloudCredential()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+	_, credentialSet, err = m.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 }
 
@@ -155,6 +167,9 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialForModel(c
 	credentialTag, credentialSet := m.CloudCredential()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+	_, credentialSet, err = m.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 }
 
@@ -204,6 +219,9 @@ func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.Cloud
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
 	c.Assert(credentialSet, jc.IsFalse)
+	_, credentialSet, err = m.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentialSet, jc.IsFalse)
 
 	err = s.State.UpdateCloudCredential(tag, credential)
 	c.Assert(err, jc.ErrorIsNil)
@@ -216,6 +234,12 @@ func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.Cloud
 	credentialTag, credentialSet = m.CloudCredential()
 	c.Assert(credentialTag, gc.DeepEquals, tag)
 	c.Assert(credentialSet, jc.IsTrue)
+	cred, credentialSet, err := m.CloudCredentialValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentialSet, jc.IsTrue)
+	stateCred, err := s.State.CloudCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, stateCred)
 	return m
 }
 

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -38,9 +38,9 @@ func (s *ModelCredentialSuite) TestInvalidateModelCredentialNone(c *gc.C) {
 	// The model created in ConnSuite does not have a credential.
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	_, exists := m.CloudCredential()
+	_, exists := m.CloudCredentialTag()
 	c.Assert(exists, jc.IsFalse)
-	_, exists, err = m.CloudCredentialValue()
+	_, exists, err = m.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsFalse)
 
@@ -113,10 +113,10 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialNoUpdate(c *gc.C) {
 	c.Assert(set, jc.IsFalse)
 
 	// Check credential is still set.
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	c.Assert(credentialTag, gc.DeepEquals, tag)
 	c.Assert(credentialSet, jc.IsTrue)
-	cred, credentialSet, err := m.CloudCredentialValue()
+	cred, credentialSet, err := m.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsTrue)
 	stateCred, err := s.State.CloudCredential(credentialTag)
@@ -138,11 +138,11 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialContent(c 
 	c.Assert(err, gc.ErrorMatches, `credential "dummy/bob/foobar" not valid`)
 	c.Assert(set, jc.IsFalse)
 
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
 	c.Assert(credentialSet, jc.IsFalse)
-	_, credentialSet, err = m.CloudCredentialValue()
+	_, credentialSet, err = m.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 }
@@ -164,11 +164,11 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialForModel(c
 	c.Assert(err, gc.ErrorMatches, `cloud "stratus" not valid`)
 	c.Assert(set, jc.IsFalse)
 
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
 	c.Assert(credentialSet, jc.IsFalse)
-	_, credentialSet, err = m.CloudCredentialValue()
+	_, credentialSet, err = m.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 }
@@ -215,11 +215,11 @@ func (s *ModelCredentialSuite) TestWatchModelCredential(c *gc.C) {
 func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.CloudCredentialTag, credential cloud.Credential) *state.Model {
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
 	c.Assert(credentialSet, jc.IsFalse)
-	_, credentialSet, err = m.CloudCredentialValue()
+	_, credentialSet, err = m.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 
@@ -231,10 +231,10 @@ func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.Cloud
 	c.Assert(set, jc.IsTrue)
 
 	// Check credential is set.
-	credentialTag, credentialSet = m.CloudCredential()
+	credentialTag, credentialSet = m.CloudCredentialTag()
 	c.Assert(credentialTag, gc.DeepEquals, tag)
 	c.Assert(credentialSet, jc.IsTrue)
-	cred, credentialSet, err := m.CloudCredentialValue()
+	cred, credentialSet, err := m.CloudCredential()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsTrue)
 	stateCred, err := s.State.CloudCredential(credentialTag)

--- a/state/state.go
+++ b/state/state.go
@@ -364,7 +364,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	}}
 
 	// Decrement the model count for the cloud to which this model belongs.
-	decCloudRefOp, err := decCloudModelRefOp(st, model.Cloud())
+	decCloudRefOp, err := decCloudModelRefOp(st, model.CloudName())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2808,7 +2808,7 @@ func (s *StateSuite) TestRemoveModel(c *gc.C) {
 	err = model.SetDead()
 	c.Assert(err, jc.ErrorIsNil)
 
-	cloud, err := s.State.Cloud(model.Cloud())
+	cloud, err := s.State.Cloud(model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	refCount, err := state.CloudModelRefCount(st, cloud.Name)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2817,7 +2817,7 @@ func (s *StateSuite) TestRemoveModel(c *gc.C) {
 	err = st.RemoveDyingModel()
 	c.Assert(err, jc.ErrorIsNil)
 
-	cloud, err = s.State.Cloud(model.Cloud())
+	cloud, err = s.State.Cloud(model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = state.CloudModelRefCount(st, cloud.Name)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -3143,7 +3143,7 @@ func (s *StateSuite) TestWatchCloudSpecChanges(c *gc.C) {
 	// Initially we get one change notification
 	wc.AssertOneChange()
 
-	cloud, err := s.State.Cloud(s.Model.Cloud())
+	cloud, err := s.State.Cloud(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Multiple changes will only result in a single change notification

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -19,9 +19,9 @@ type Model interface {
 	ModelTag() names.ModelTag
 	ControllerUUID() string
 	Type() state.ModelType
-	CloudValue() (cloud.Cloud, error)
+	Cloud() (cloud.Cloud, error)
 	CloudRegion() string
-	CloudCredentialValue() (state.Credential, bool, error)
+	CloudCredential() (state.Credential, bool, error)
 	Config() (*config.Config, error)
 }
 
@@ -67,12 +67,12 @@ func (g EnvironConfigGetter) ModelConfig() (*config.Config, error) {
 
 // CloudSpec implements environs.EnvironConfigGetter.
 func (g EnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
-	cloud, err := g.Model.CloudValue()
+	cloud, err := g.Model.Cloud()
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}
 	regionName := g.Model.CloudRegion()
-	credentialValue, ok, err := g.Model.CloudCredentialValue()
+	credentialValue, ok, err := g.Model.CloudCredential()
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -30,7 +30,7 @@ func (s *environSuite) TestGetNewEnvironFunc(c *gc.C) {
 		callArgs = args
 		return nil, nil
 	}
-	_, err := stateenvirons.GetNewEnvironFunc(newEnviron)(s.State)
+	_, err := stateenvirons.GetNewEnvironFunc(newEnviron)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(calls, gc.Equals, 1)
@@ -59,7 +59,7 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	emptyCredential.Label = "empty-credential"
-	cloudSpec, err := stateenvirons.EnvironConfigGetter{State: st, Model: m}.CloudSpec()
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{Model: m}.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
 		Type:             "dummy",
@@ -80,7 +80,7 @@ func (s *environSuite) TestGetNewCAASBrokerFunc(c *gc.C) {
 		callArgs = args
 		return nil, nil
 	}
-	_, err := stateenvirons.GetNewCAASBrokerFunc(newBroker)(s.State)
+	_, err := stateenvirons.GetNewCAASBrokerFunc(newBroker)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(calls, gc.Equals, 1)
 
@@ -116,7 +116,7 @@ func (s *environSuite) TestCloudAPIVersion(c *gc.C) {
 		return &fakeBroker{}, nil
 	}
 
-	envConfigGetter := stateenvirons.EnvironConfigGetter{State: st, Model: m, NewContainerBroker: newBrokerFunc}
+	envConfigGetter := stateenvirons.EnvironConfigGetter{Model: m, NewContainerBroker: newBrokerFunc}
 	cloudSpec, err := envConfigGetter.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	apiVersion, err := envConfigGetter.CloudAPIVersion(cloudSpec)

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -51,7 +51,7 @@ func (p environStatePolicy) ConfigValidator() (config.Validator, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cloud, err := p.st.Cloud(model.Cloud())
+	cloud, err := p.st.Cloud(model.CloudName())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting cloud")
 	}

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -40,9 +40,9 @@ func (p environStatePolicy) Prechecker() (environs.InstancePrechecker, error) {
 		return nil, errors.Trace(err)
 	}
 	if model.Type() == state.ModelTypeIAAS {
-		return p.getEnviron(p.st)
+		return p.getEnviron(model)
 	}
-	return p.getBroker(p.st)
+	return p.getBroker(model)
 }
 
 // ConfigValidator implements state.Policy.
@@ -82,13 +82,13 @@ func (p environStatePolicy) ConstraintsValidator(ctx context.ProviderCallContext
 	}
 
 	if model.Type() == state.ModelTypeIAAS {
-		env, err := p.getEnviron(p.st)
+		env, err := p.getEnviron(model)
 		if err != nil {
 			return nil, err
 		}
 		return env.ConstraintsValidator(ctx)
 	}
-	broker, err := p.getBroker(p.st)
+	broker, err := p.getBroker(model)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -105,7 +105,7 @@ func (p environStatePolicy) InstanceDistributor() (context.Distributor, error) {
 		// Only IAAS models support machines, hence distribution.
 		return nil, errors.NotImplementedf("InstanceDistributor")
 	}
-	env, err := p.getEnviron(p.st)
+	env, err := p.getEnviron(model)
 	if err != nil {
 		return nil, err
 	}
@@ -133,11 +133,11 @@ func NewStorageProviderRegistryForModel(
 ) (_ storage.ProviderRegistry, err error) {
 	var reg storage.ProviderRegistry
 	if model.Type() == state.ModelTypeIAAS {
-		if reg, err = newEnv(model.State()); err != nil {
+		if reg, err = newEnv(model); err != nil {
 			return nil, errors.Trace(err)
 		}
 	} else {
-		if reg, err = newBroker(model.State()); err != nil {
+		if reg, err = newBroker(model); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -43,7 +43,10 @@ func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 	if s.series == "kubernetes" {
 		s.st = s.Factory.MakeCAASModel(c, nil)
 		s.AddCleanup(func(_ *gc.C) { s.st.Close() })
-		broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.st)
+		var err error
+		s.Model, err = s.st.Model()
+		c.Assert(err, jc.ErrorIsNil)
+		broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.Model)
 		c.Assert(err, jc.ErrorIsNil)
 		registry = stateenvirons.NewStorageProviderRegistry(broker)
 	} else {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1859,7 +1859,7 @@ func UpdateInheritedControllerConfig(pool *StatePool) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	key := cloudGlobalKey(model.Cloud())
+	key := cloudGlobalKey(model.CloudName())
 
 	var ops []txn.Op
 	coll, closer := st.db().GetRawCollection(globalSettingsC)
@@ -1939,7 +1939,7 @@ func updateKubernetesStorageConfig(st *State) error {
 		// longer have settings to update.
 		return nil
 	}
-	cred, ok := model.CloudCredential()
+	cred, ok := model.CloudCredentialTag()
 	if !ok {
 		return nil
 	}
@@ -1948,13 +1948,13 @@ func updateKubernetesStorageConfig(st *State) error {
 		return errors.Trace(err)
 	}
 
-	defaults, err := st.controllerInheritedConfig(model.Cloud())()
+	defaults, err := st.controllerInheritedConfig(model.CloudName())()
 	if err != nil {
 		return errors.Annotate(err, "getting cloud config")
 	}
 	operatorStorage, haveDefaultOperatorStorage := defaults[k8s.OperatorStorageKey]
 	if !haveDefaultOperatorStorage {
-		cloudSpec, err := cloudSpec(st, model.Cloud(), model.CloudRegion(), cred)
+		cloudSpec, err := cloudSpec(st, model.CloudName(), model.CloudRegion(), cred)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1970,7 +1970,7 @@ func updateKubernetesStorageConfig(st *State) error {
 			return nil
 		}
 		operatorStorage = metadata.NominatedStorageClass.Name
-		err = st.updateConfigDefaults(model.Cloud(), cloud.Attrs{
+		err = st.updateConfigDefaults(model.CloudName(), cloud.Attrs{
 			k8s.OperatorStorageKey: operatorStorage,
 			k8s.WorkloadStorageKey: operatorStorage, // use same storage for both
 		}, nil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1774,7 +1774,7 @@ func (model *Model) WatchForModelConfigChanges() NotifyWatcher {
 // WatchCloudSpecChanges returns a NotifyWatcher waiting for the cloud
 // to change for the model.
 func (model *Model) WatchCloudSpecChanges() NotifyWatcher {
-	return newEntityWatcher(model.st, cloudsC, model.Cloud())
+	return newEntityWatcher(model.st, cloudsC, model.CloudName())
 }
 
 // WatchModelEntityReferences returns a NotifyWatcher waiting for the Model


### PR DESCRIPTION
## Description of change

The apiserver ToolsGetter and ToolsFnder helpers were constructing an IAAS Environ directly. This change refactors them to take a newEnviron func so that the relevant instance for the model can be constructed. The change allows a k8s model to ask for agent binary metadata even though the agent binaries are not used directly.

Part of the change involved fixing the situation where EnvironConfigGetter had both a State and a Model. Only a model is used now (and an interface at that). As more methods are moved/copied to Model from State, we can eventually avoid using State other than to wrap mgo connections.

## QA steps

bootstrap an aws controller with --agent-version=2.7.2
deploy postgresql with an ebs volume
(ensures storage registry in state works)
run upgrade-controller --dry-run
(check that 2.7.3 is suggested)
upgrade controller
run upgrade-model --dry-run
(check that 2.7.3 is suggested)
upgrade model
