### PR TITLE
Extend RBAC under kubernetesResources to support multi roles/clusterr…

### DIFF
--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -1023,7 +1023,7 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 	// side and so any previously attached filesystems become orphaned and need to
 	// be cleaned up.
 	appName := app.Name()
-	if err := a.cleaupOrphanedFilesystems(processedFilesystemIds); err != nil {
+	if err := a.cleanupOrphanedFilesystems(processedFilesystemIds); err != nil {
 		return errors.Annotatef(err, "deleting orphaned filesystems for %v", appName)
 	}
 
@@ -1036,7 +1036,7 @@ func (a *Facade) updateStateUnits(app Application, unitInfo *updateStateUnitPara
 	return errors.Annotatef(err, "updating filesystem information for %v", appName)
 }
 
-func (a *Facade) cleaupOrphanedFilesystems(processedFilesystemIds set.Strings) error {
+func (a *Facade) cleanupOrphanedFilesystems(processedFilesystemIds set.Strings) error {
 	// TODO(caas) - record unit id on the filesystem so we can query by unit
 	allFilesystems, err := a.storage.AllFilesystems()
 	if err != nil {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -105,14 +105,18 @@ func (s *K8sSuite) TestPushUniqVolume(c *gc.C) {
 
 func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 
-	sa := &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	sa := &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -223,14 +227,18 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 
 func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 
-	sa := &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	sa := &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -2744,14 +2752,18 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 	defer ctrl.Finish()
 
 	podSpec := getBasicPodspec()
-	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -2912,14 +2924,18 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 	defer ctrl.Finish()
 
 	podSpec := getBasicPodspec()
-	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -3102,15 +3118,19 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 	defer ctrl.Finish()
 
 	podSpec := getBasicPodspec()
-	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Global:                       true,
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Global: true,
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -3271,15 +3291,19 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	defer ctrl.Finish()
 
 	podSpec := getBasicPodspec()
-	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
-			Global:                       true,
+	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Global: true,
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -3462,14 +3486,18 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 	defer ctrl.Finish()
 
 	podSpec := getBasicPodspec()
-	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -3480,19 +3508,21 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			K8sRBACResources: k8sspecs.K8sRBACResources{
 				ServiceAccounts: []k8sspecs.K8sServiceAccountSpec{
 					{
-						Name:                         "sa2",
-						AutomountServiceAccountToken: boolPtr(true),
-						Roles:                        []string{"role2"},
-					},
-				},
-				ServiceAccountRoles: []k8sspecs.RoleSpec{
-					{
-						Name: "role2",
-						Rules: []specs.PolicyRule{
-							{
-								APIGroups: []string{""},
-								Resources: []string{"pods"},
-								Verbs:     []string{"get", "watch", "list"},
+						Name: "sa2",
+						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+
+							AutomountServiceAccountToken: boolPtr(true),
+							Roles: []specs.Role{
+								{
+									Name: "role2",
+									Rules: []specs.PolicyRule{
+										{
+											APIGroups: []string{""},
+											Resources: []string{"pods"},
+											Verbs:     []string{"get", "watch", "list"},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -3717,14 +3747,18 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 	defer ctrl.Finish()
 
 	podSpec := getBasicPodspec()
-	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -3735,30 +3769,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			K8sRBACResources: k8sspecs.K8sRBACResources{
 				ServiceAccounts: []k8sspecs.K8sServiceAccountSpec{
 					{
-						Name:                         "sa2",
-						Roles:                        []string{"cluster-role2"},
-						AutomountServiceAccountToken: boolPtr(true),
-					},
-				},
-				ServiceAccountRoles: []k8sspecs.RoleSpec{
-					{
-						Name:   "cluster-role2",
-						Global: true,
-						Rules: []specs.PolicyRule{
-							{
-								APIGroups: []string{""},
-								Resources: []string{"pods"},
-								Verbs:     []string{"get", "watch", "list"},
-							},
-							{
-								NonResourceURLs: []string{"/healthz", "/healthz/*"},
-								Verbs:           []string{"get", "post"},
-							},
-							{
-								APIGroups:     []string{"rbac.authorization.k8s.io"},
-								Resources:     []string{"clusterroles"},
-								Verbs:         []string{"bind"},
-								ResourceNames: []string{"admin", "edit", "view"},
+						Name: "sa2",
+						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+							AutomountServiceAccountToken: boolPtr(true),
+							Roles: []specs.Role{
+								{
+									Name:   "cluster-role2",
+									Global: true,
+									Rules: []specs.PolicyRule{
+										{
+											APIGroups: []string{""},
+											Resources: []string{"pods"},
+											Verbs:     []string{"get", "watch", "list"},
+										},
+										{
+											NonResourceURLs: []string{"/healthz", "/healthz/*"},
+											Verbs:           []string{"get", "post"},
+										},
+										{
+											APIGroups:     []string{"rbac.authorization.k8s.io"},
+											Resources:     []string{"clusterroles"},
+											Verbs:         []string{"bind"},
+											ResourceNames: []string{"admin", "edit", "view"},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -3952,6 +3987,340 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		s.mockRoleBindings.EXPECT().Create(rb1).Return(rb1, nil),
 
 		s.mockServiceAccounts.EXPECT().Create(svcAccount2).Return(svcAccount2, nil),
+		s.mockClusterRoles.EXPECT().Create(clusterrole2).Return(clusterrole2, nil),
+		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test"}).
+			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{}}, nil),
+		s.mockClusterRoleBindings.EXPECT().Create(crb2).Return(crb2, nil),
+
+		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
+		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Get("app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Update(serviceArg).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Create(serviceArg).
+			Return(nil, nil),
+		s.mockDeployments.EXPECT().Update(deploymentArg).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockDeployments.EXPECT().Create(deploymentArg).
+			Return(nil, nil),
+	)
+
+	params := &caas.ServiceParams{
+		PodSpec: podSpec,
+		ResourceTags: map[string]string{
+			"juju-controller-uuid": testing.ControllerTag.Id(),
+			"fred":                 "mary",
+		},
+		OperatorImagePath: "operator/image-path",
+	}
+	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
+		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
+		"kubernetes-service-externalname":    "ext-name",
+		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccountWithoutRoleNames(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	podSpec := getBasicPodspec()
+	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+			AutomountServiceAccountToken: boolPtr(true),
+			Roles: []specs.Role{
+				{
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	podSpec.ProviderPod = &k8sspecs.K8sPodSpec{
+		KubernetesResources: &k8sspecs.KubernetesResources{
+			K8sRBACResources: k8sspecs.K8sRBACResources{
+				ServiceAccounts: []k8sspecs.K8sServiceAccountSpec{
+					{
+						Name: "sa-foo",
+						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+							AutomountServiceAccountToken: boolPtr(true),
+							Roles: []specs.Role{
+								{
+									Global: true,
+									Rules: []specs.PolicyRule{
+										{
+											APIGroups: []string{""},
+											Resources: []string{"pods"},
+											Verbs:     []string{"get", "watch", "list"},
+										},
+										{
+											NonResourceURLs: []string{"/healthz", "/healthz/*"},
+											Verbs:           []string{"get", "post"},
+										},
+										{
+											APIGroups:     []string{"rbac.authorization.k8s.io"},
+											Resources:     []string{"clusterroles"},
+											Verbs:         []string{"bind"},
+											ResourceNames: []string{"admin", "edit", "view"},
+										},
+									},
+								},
+								{
+									Rules: []specs.PolicyRule{
+										{
+											APIGroups: []string{""},
+											Resources: []string{"pods"},
+											Verbs:     []string{"get", "watch", "list"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	numUnits := int32(2)
+	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	c.Assert(err, jc.ErrorIsNil)
+
+	deploymentArg := &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "app-name",
+			Labels: map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"juju.io/controller": testing.ControllerTag.Id(),
+				"fred":               "mary",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &numUnits,
+			Selector: &v1.LabelSelector{
+				MatchLabels: map[string]string{"juju-app": "app-name"},
+			},
+			RevisionHistoryLimit: int32Ptr(0),
+			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					GenerateName: "app-name-",
+					Labels: map[string]string{
+						"juju-app": "app-name",
+					},
+					Annotations: map[string]string{
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"fred":                                     "mary",
+					},
+				},
+				Spec: provider.PodSpec(workloadSpec),
+			},
+		},
+	}
+	serviceArg := &core.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "app-name",
+			Labels: map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"a":                  "b",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			}},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"juju-app": "app-name"},
+			Type:     "nodeIP",
+			Ports: []core.ServicePort{
+				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
+				{Port: 8080, Protocol: "TCP", Name: "fred"},
+			},
+			LoadBalancerIP: "10.0.0.1",
+			ExternalName:   "ext-name",
+		},
+	}
+
+	svcAccount1 := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "app-name",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		AutomountServiceAccountToken: boolPtr(true),
+	}
+	role1 := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "app-name",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
+		},
+	}
+	rb1 := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "app-name-app-name",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "app-name",
+			Kind: "Role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "app-name",
+				Namespace: "test",
+			},
+		},
+	}
+
+	svcAccount2 := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "sa-foo",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		AutomountServiceAccountToken: boolPtr(true),
+	}
+	clusterrole2 := &rbacv1.ClusterRole{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-app-name-sa-foo",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
+			{
+				NonResourceURLs: []string{"/healthz", "/healthz/*"},
+				Verbs:           []string{"get", "post"},
+			},
+			{
+				APIGroups:     []string{"rbac.authorization.k8s.io"},
+				Resources:     []string{"clusterroles"},
+				Verbs:         []string{"bind"},
+				ResourceNames: []string{"admin", "edit", "view"},
+			},
+		},
+	}
+	role2 := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "app-name-sa-foo1",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
+		},
+	}
+	crb2 := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "sa-foo-test-app-name-sa-foo",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "test-app-name-sa-foo",
+			Kind: "ClusterRole",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "sa-foo",
+				Namespace: "test",
+			},
+		},
+	}
+	rb2 := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "sa-foo-app-name-sa-foo1",
+			Namespace: "test",
+			Labels:    map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"fred":               "mary",
+				"juju.io/controller": testing.ControllerTag.Id(),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "app-name-sa-foo1",
+			Kind: "Role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "sa-foo",
+				Namespace: "test",
+			},
+		},
+	}
+
+	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
+	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+
+		s.mockServiceAccounts.EXPECT().Create(svcAccount1).Return(svcAccount1, nil),
+		s.mockRoles.EXPECT().Create(role1).Return(role1, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name"}).
+			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
+		s.mockRoleBindings.EXPECT().Create(rb1).Return(rb1, nil),
+
+		s.mockServiceAccounts.EXPECT().Create(svcAccount2).Return(svcAccount2, nil),
+		s.mockRoles.EXPECT().Create(role2).Return(role2, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name"}).
+			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
+		s.mockRoleBindings.EXPECT().Create(rb2).Return(rb2, nil),
 		s.mockClusterRoles.EXPECT().Create(clusterrole2).Return(clusterrole2, nil),
 		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test"}).
 			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{}}, nil),

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -3186,7 +3186,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 	}
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name",
+			Name:      "test-app-name",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{
@@ -3204,7 +3204,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 	}
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name-app-name",
+			Name:      "app-name-test-app-name",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{
@@ -3213,7 +3213,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: "app-name",
+			Name: "test-app-name",
 			Kind: "ClusterRole",
 		},
 		Subjects: []rbacv1.Subject{
@@ -3355,7 +3355,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	}
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name",
+			Name:      "test-app-name",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{
@@ -3373,7 +3373,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	}
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "app-name-app-name",
+			Name:      "app-name-test-app-name",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{
@@ -3382,7 +3382,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: "app-name",
+			Name: "test-app-name",
 			Kind: "ClusterRole",
 		},
 		Subjects: []rbacv1.Subject{
@@ -3409,9 +3409,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 		s.mockClusterRoles.EXPECT().Update(cr).Return(cr, nil),
 		s.mockClusterRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app==app-name,juju-model==test"}).
 			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*crb}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Delete("app-name-app-name", s.deleteOptions(v1.DeletePropagationForeground, crbUID)).Return(nil),
-		s.mockClusterRoleBindings.EXPECT().Get("app-name-app-name", v1.GetOptions{}).Return(crb, nil),
-		s.mockClusterRoleBindings.EXPECT().Get("app-name-app-name", v1.GetOptions{}).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Delete("app-name-test-app-name", s.deleteOptions(v1.DeletePropagationForeground, crbUID)).Return(nil),
+		s.mockClusterRoleBindings.EXPECT().Get("app-name-test-app-name", v1.GetOptions{}).Return(crb, nil),
+		s.mockClusterRoleBindings.EXPECT().Get("app-name-test-app-name", v1.GetOptions{}).Return(nil, s.k8sNotFoundError()),
 		s.mockClusterRoleBindings.EXPECT().Create(crb).Return(crb, nil),
 		s.mockSecrets.EXPECT().Create(secretArg).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
@@ -3891,7 +3891,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 	}
 	clusterrole2 := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "cluster-role2",
+			Name:      "test-cluster-role2",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{
@@ -3919,7 +3919,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 	}
 	crb2 := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "sa2-cluster-role2",
+			Name:      "sa2-test-cluster-role2",
 			Namespace: "test",
 			Labels:    map[string]string{"juju-app": "app-name", "juju-model": "test"},
 			Annotations: map[string]string{
@@ -3928,7 +3928,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
-			Name: "cluster-role2",
+			Name: "test-cluster-role2",
 			Kind: "ClusterRole",
 		},
 		Subjects: []rbacv1.Subject{

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -61,28 +61,28 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 			Annotations: annotations,
 		}
 	}
-	getRoleClusterRoleName := func(name string, index int) string {
-		if name != "" {
-			return name
+	getRoleClusterRoleName := func(roleName, serviceAccountName string, index int) string {
+		if roleName != "" {
+			return roleName
 		}
-		name = appName
+		roleName = fmt.Sprintf("%s-%s", appName, serviceAccountName)
 		if index == 0 {
-			return name
+			return roleName
 		}
-		return fmt.Sprintf("%s%d", name, index)
+		return fmt.Sprintf("%s%d", roleName, index)
 	}
-	getRoleMeta := func(name string, index int) v1.ObjectMeta {
+	getRoleMeta := func(roleName, serviceAccountName string, index int) v1.ObjectMeta {
 		return v1.ObjectMeta{
-			Name:        getRoleClusterRoleName(name, index),
+			Name:        getRoleClusterRoleName(roleName, serviceAccountName, index),
 			Namespace:   k.namespace,
 			Labels:      k.getRBACLabels(appName, false),
 			Annotations: annotations,
 		}
 	}
-	getClusterRoleMeta := func(name string, index int) v1.ObjectMeta {
-		name = getRoleClusterRoleName(name, index)
+	getClusterRoleMeta := func(roleName, serviceAccountName string, index int) v1.ObjectMeta {
+		roleName = getRoleClusterRoleName(roleName, serviceAccountName, index)
 		return v1.ObjectMeta{
-			Name:        prefixNameSpace(name),
+			Name:        prefixNameSpace(roleName),
 			Namespace:   k.namespace,
 			Labels:      k.getRBACLabels(appName, true),
 			Annotations: annotations,

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -43,17 +43,16 @@ func toK8sRules(rules []specs.PolicyRule) (out []rbacv1.PolicyRule) {
 	return out
 }
 
-func getBindingName(sa, cR k8sspecs.NameGetter) string {
-	return fmt.Sprintf("%s-%s", sa.GetName(), cR.GetName())
-}
-
 func (k *kubernetesClient) ensureServiceAccountForApp(
 	appName string, annotations map[string]string, rbacDefinition k8sspecs.K8sRBACSpecConverter,
 ) (cleanups []func(), err error) {
 
-	// prefixNameSpace := func(name string) string {
-	// 	return fmt.Sprintf("%s-%s", k.namespace, name)
-	// }
+	prefixNameSpace := func(name string) string {
+		return fmt.Sprintf("%s-%s", k.namespace, name)
+	}
+	getBindingName := func(sa, cR k8sspecs.NameGetter) string {
+		return fmt.Sprintf("%s-%s", sa.GetName(), cR.GetName())
+	}
 
 	getSAMeta := func(name string) v1.ObjectMeta {
 		return v1.ObjectMeta{
@@ -73,9 +72,7 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 	}
 	getClusterRoleMeta := func(name string) v1.ObjectMeta {
 		return v1.ObjectMeta{
-			// TODO: can't prefix namespace anymore because SA reference the Cluster Roles by name.!!!!!!!!
-			// Name:        prefixNameSpace(name),
-			Name:        name,
+			Name:        prefixNameSpace(name),
 			Namespace:   k.namespace,
 			Labels:      k.getRBACLabels(appName, true),
 			Annotations: annotations,

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -53,7 +53,6 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 	getBindingName := func(sa, cR k8sspecs.NameGetter) string {
 		return fmt.Sprintf("%s-%s", sa.GetName(), cR.GetName())
 	}
-
 	getSAMeta := func(name string) v1.ObjectMeta {
 		return v1.ObjectMeta{
 			Name:        name,
@@ -62,15 +61,26 @@ func (k *kubernetesClient) ensureServiceAccountForApp(
 			Annotations: annotations,
 		}
 	}
-	getRoleMeta := func(name string) v1.ObjectMeta {
+	getRoleClusterRoleName := func(name string, index int) string {
+		if name != "" {
+			return name
+		}
+		name = appName
+		if index == 0 {
+			return name
+		}
+		return fmt.Sprintf("%s%d", name, index)
+	}
+	getRoleMeta := func(name string, index int) v1.ObjectMeta {
 		return v1.ObjectMeta{
-			Name:        name,
+			Name:        getRoleClusterRoleName(name, index),
 			Namespace:   k.namespace,
 			Labels:      k.getRBACLabels(appName, false),
 			Annotations: annotations,
 		}
 	}
-	getClusterRoleMeta := func(name string) v1.ObjectMeta {
+	getClusterRoleMeta := func(name string, index int) v1.ObjectMeta {
+		name = getRoleClusterRoleName(name, index)
 		return v1.ObjectMeta{
 			Name:        prefixNameSpace(name),
 			Namespace:   k.namespace,

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -167,16 +167,6 @@ func (ksa K8sServiceAccountSpecV2) toLatest() K8sRBACResources {
 	}
 }
 
-// // GetName returns the service accout name.
-// func (sa K8sServiceAccountSpecV2) GetName() string {
-// 	return sa.Name
-// }
-
-// // GetSpec returns the RBAC spec.
-// func (sa K8sServiceAccountSpecV2) GetSpec() specs.RBACSpec {
-// 	return sa.RBACSpecV2
-// }
-
 // Validate returns an error if the spec is not valid.
 func (ksa K8sServiceAccountSpecV2) Validate() error {
 	if ksa.Name == "" {

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -118,8 +118,11 @@ func (p podSpecV2) ToLatest() *specs.PodSpec {
 	pSpec.Service = p.caaSSpecV2.Service
 	pSpec.ConfigMaps = p.caaSSpecV2.ConfigMaps
 	pSpec.ServiceAccount = p.caaSSpecV2.ServiceAccount
-	pSpec.ProviderPod = &K8sPodSpec{
-		KubernetesResources: p.K8sPodSpecV2.KubernetesResources,
+
+	if p.K8sPodSpecV2.KubernetesResources != nil {
+		pSpec.ProviderPod = &K8sPodSpec{
+			KubernetesResources: p.K8sPodSpecV2.KubernetesResources.toLatest(),
+		}
 	}
 	return pSpec
 }
@@ -128,7 +131,7 @@ func (p podSpecV2) ToLatest() *specs.PodSpec {
 // attributes we expose for charms to set.
 type K8sPodSpecV2 struct {
 	// k8s resources.
-	KubernetesResources *KubernetesResources `json:"kubernetesResources,omitempty" yaml:"kubernetesResources,omitempty"`
+	KubernetesResources *KubernetesResourcesV2 `json:"kubernetesResources,omitempty" yaml:"kubernetesResources,omitempty"`
 }
 
 // Validate is defined on ProviderPod.
@@ -141,28 +144,45 @@ func (p *K8sPodSpecV2) Validate() error {
 	return nil
 }
 
-// K8sServiceAccountSpec defines spec for referencing or creating a service account.
-type K8sServiceAccountSpec struct {
-	Name           string `json:"name" yaml:"name"`
-	specs.RBACSpec `json:",inline" yaml:",inline"`
+// K8sServiceAccountSpecV2 defines spec for referencing or creating a service account for version 2.
+type K8sServiceAccountSpecV2 struct {
+	Name             string `json:"name" yaml:"name"`
+	specs.RBACSpecV2 `json:",inline" yaml:",inline"`
 }
 
-// GetName returns the service accout name.
-func (sa K8sServiceAccountSpec) GetName() string {
-	return sa.Name
+func (ksa K8sServiceAccountSpecV2) toLatest() K8sRBACResources {
+	role := RoleSpec{
+		Name:   ksa.Name,
+		Global: ksa.Global,
+		Rules:  ksa.Rules,
+	}
+	sa := K8sServiceAccountSpec{
+		Name:                         ksa.Name,
+		AutomountServiceAccountToken: ksa.AutomountServiceAccountToken,
+		Roles:                        []string{role.Name},
+	}
+	return K8sRBACResources{
+		ServiceAccounts:     []K8sServiceAccountSpec{sa},
+		ServiceAccountRoles: []RoleSpec{role},
+	}
 }
 
-// GetSpec returns the RBAC spec.
-func (sa K8sServiceAccountSpec) GetSpec() specs.RBACSpec {
-	return sa.RBACSpec
-}
+// // GetName returns the service accout name.
+// func (sa K8sServiceAccountSpecV2) GetName() string {
+// 	return sa.Name
+// }
+
+// // GetSpec returns the RBAC spec.
+// func (sa K8sServiceAccountSpecV2) GetSpec() specs.RBACSpec {
+// 	return sa.RBACSpecV2
+// }
 
 // Validate returns an error if the spec is not valid.
-func (sa K8sServiceAccountSpec) Validate() error {
-	if sa.Name == "" {
+func (ksa K8sServiceAccountSpecV2) Validate() error {
+	if ksa.Name == "" {
 		return errors.New("service account name is missing")
 	}
-	return errors.Trace(sa.RBACSpec.Validate())
+	return errors.Trace(ksa.RBACSpecV2.Validate())
 }
 
 // K8sIngressSpec defines spec for creating or updating an ingress resource.
@@ -181,8 +201,8 @@ func (ing K8sIngressSpec) Validate() error {
 	return nil
 }
 
-// KubernetesResources is the k8s related resources.
-type KubernetesResources struct {
+// KubernetesResourcesV2 is the k8s related resources for version 2.
+type KubernetesResourcesV2 struct {
 	Pod *PodSpec `json:"pod,omitempty" yaml:"pod,omitempty"`
 
 	Secrets                   []Secret                                                     `json:"secrets" yaml:"secrets"`
@@ -192,11 +212,11 @@ type KubernetesResources struct {
 	MutatingWebhookConfigurations   map[string][]admissionregistration.MutatingWebhook   `json:"mutatingWebhookConfigurations,omitempty" yaml:"mutatingWebhookConfigurations,omitempty"`
 	ValidatingWebhookConfigurations map[string][]admissionregistration.ValidatingWebhook `json:"validatingWebhookConfigurations,omitempty" yaml:"validatingWebhookConfigurations,omitempty"`
 
-	ServiceAccounts  []K8sServiceAccountSpec `json:"serviceAccounts,omitempty" yaml:"serviceAccounts,omitempty"`
-	IngressResources []K8sIngressSpec        `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
+	ServiceAccounts  []K8sServiceAccountSpecV2 `json:"serviceAccounts,omitempty" yaml:"serviceAccounts,omitempty"`
+	IngressResources []K8sIngressSpec          `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
 }
 
-func validateCustomResourceDefinition(name string, crd apiextensionsv1beta1.CustomResourceDefinitionSpec) error {
+func validateCustomResourceDefinitionV2(name string, crd apiextensionsv1beta1.CustomResourceDefinitionSpec) error {
 	if crd.Scope != apiextensionsv1beta1.NamespaceScoped && crd.Scope != apiextensionsv1beta1.ClusterScoped {
 		return errors.NewNotSupported(nil,
 			fmt.Sprintf("custom resource definition %q scope %q is not supported, please use %q or %q scope",
@@ -206,8 +226,26 @@ func validateCustomResourceDefinition(name string, crd apiextensionsv1beta1.Cust
 	return nil
 }
 
+func (krs *KubernetesResourcesV2) toLatest() *KubernetesResources {
+	out := &KubernetesResources{
+		Pod:                             krs.Pod,
+		Secrets:                         krs.Secrets,
+		CustomResourceDefinitions:       krs.CustomResourceDefinitions,
+		CustomResources:                 krs.CustomResources,
+		MutatingWebhookConfigurations:   krs.MutatingWebhookConfigurations,
+		ValidatingWebhookConfigurations: krs.ValidatingWebhookConfigurations,
+		IngressResources:                krs.IngressResources,
+	}
+	for _, sa := range krs.ServiceAccounts {
+		rbacSources := sa.toLatest()
+		out.ServiceAccounts = append(out.ServiceAccounts, rbacSources.ServiceAccounts...)
+		out.ServiceAccountRoles = append(out.ServiceAccountRoles, rbacSources.ServiceAccountRoles...)
+	}
+	return out
+}
+
 // Validate is defined on ProviderPod.
-func (krs *KubernetesResources) Validate() error {
+func (krs *KubernetesResourcesV2) Validate() error {
 	for k, crd := range krs.CustomResourceDefinitions {
 		if err := validateCustomResourceDefinition(k, crd); err != nil {
 			return errors.Trace(err)

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -309,15 +309,19 @@ kubernetesResources:
 foo: bar
 `[1:]
 
-	sa1 := &specs.PrimeServiceAccountSpec{
-		PrimeRBACSpec: specs.PrimeRBACSpec{
+	sa1 := &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 			AutomountServiceAccountToken: boolPtr(true),
-			Global:                       true,
-			Rules: []specs.PolicyRule{
+			Roles: []specs.Role{
 				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "watch", "list"},
+					Global: true,
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
 				},
 			},
 		},
@@ -450,30 +454,31 @@ echo "do some stuff here for gitlab-init container"
 		rbacResources := k8sspecs.K8sRBACResources{
 			ServiceAccounts: []k8sspecs.K8sServiceAccountSpec{
 				{
-					Name:                         "k8sServiceAccount1",
-					AutomountServiceAccountToken: boolPtr(true),
-					Roles:                        []string{"k8sServiceAccount1"},
-				},
-			},
-			ServiceAccountRoles: []k8sspecs.RoleSpec{
-				{
-					Name:   "k8sServiceAccount1",
-					Global: true,
-					Rules: []specs.PolicyRule{
-						{
-							APIGroups: []string{""},
-							Resources: []string{"pods"},
-							Verbs:     []string{"get", "watch", "list"},
-						},
-						{
-							NonResourceURLs: []string{"/healthz", "/healthz/*"},
-							Verbs:           []string{"get", "post"},
-						},
-						{
-							APIGroups:     []string{"rbac.authorization.k8s.io"},
-							Resources:     []string{"clusterroles"},
-							Verbs:         []string{"bind"},
-							ResourceNames: []string{"admin", "edit", "view"},
+					Name: "k8sServiceAccount1",
+					ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+						AutomountServiceAccountToken: boolPtr(true),
+						Roles: []specs.Role{
+							{
+								Name:   "k8sServiceAccount1",
+								Global: true,
+								Rules: []specs.PolicyRule{
+									{
+										APIGroups: []string{""},
+										Resources: []string{"pods"},
+										Verbs:     []string{"get", "watch", "list"},
+									},
+									{
+										NonResourceURLs: []string{"/healthz", "/healthz/*"},
+										Verbs:           []string{"get", "post"},
+									},
+									{
+										APIGroups:     []string{"rbac.authorization.k8s.io"},
+										Resources:     []string{"clusterroles"},
+										Verbs:         []string{"bind"},
+										ResourceNames: []string{"admin", "edit", "view"},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/caas/kubernetes/provider/specs/v3.go
+++ b/caas/kubernetes/provider/specs/v3.go
@@ -112,7 +112,7 @@ func (ks K8sRBACResources) Validate() error {
 			// All good.
 			continue
 		}
-		return errors.NewNotValid(nil, fmt.Sprintf("either all or none of the roles of the service account %q should be set a name", sa.Name))
+		return errors.NewNotValid(nil, fmt.Sprintf("either all or none of the roles of the service account %q should have a name set", sa.Name))
 	}
 	return nil
 }

--- a/caas/kubernetes/provider/specs/v3.go
+++ b/caas/kubernetes/provider/specs/v3.go
@@ -4,9 +4,16 @@
 package specs
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
+	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/juju/juju/caas/specs"
 )
@@ -41,6 +48,146 @@ func (p podSpecV3) ToLatest() *specs.PodSpec {
 	pSpec.ServiceAccount = p.caaSSpecV3.ServiceAccount
 	pSpec.ProviderPod = &p.K8sPodSpecV3
 	return pSpec
+}
+
+// RoleSpec defines a spec for creating a role or cluster role.
+type RoleSpec struct {
+	Name   string             `json:"name" yaml:"name"`
+	Global bool               `json:"global" yaml:"global"`
+	Rules  []specs.PolicyRule `json:"rules" yaml:"rules"`
+}
+
+// Validate returns an error if the spec is not valid.
+func (rs RoleSpec) Validate() error {
+	if rs.Name == "" {
+		return errors.New("spec name is missing")
+	}
+	if len(rs.Rules) == 0 {
+		return errors.NewNotValid(nil, "rules is required")
+	}
+	return nil
+}
+
+// K8sServiceAccountSpec defines spec for referencing or creating additional RBAC resources.
+type K8sServiceAccountSpec struct {
+	Name string `json:"name" yaml:"name"`
+	// RBACSpec `yaml:",inline"`
+	AutomountServiceAccountToken *bool    `yaml:"automountServiceAccountToken,omitempty"`
+	Roles                        []string `json:"roles" yaml:"roles"`
+}
+
+// Validate returns an error if the spec is not valid.
+func (sa K8sServiceAccountSpec) Validate() error {
+	if sa.Name == "" {
+		return errors.New("name is missing")
+	}
+	return nil
+	// return errors.Trace(sa.RBACSpec.Validate())
+}
+
+// K8sRBACResources defines a spec for creating RBAC resources.
+type K8sRBACResources struct {
+	K8sSpecConverter
+	ServiceAccounts     []K8sServiceAccountSpec `json:"serviceAccounts,omitempty" yaml:"serviceAccounts,omitempty"`
+	ServiceAccountRoles []RoleSpec              `json:"serviceAccountRoles,omitempty" yaml:"serviceAccountRoles,omitempty"`
+}
+
+// K8sSpecConverter has a method to convert modelled spec to k8s spec.
+type K8sSpecConverter interface {
+	ToK8s()
+}
+
+// Validate is defined on ProviderPod.
+func (ks K8sRBACResources) Validate() error {
+	roleNames := set.NewStrings()
+	for _, r := range ks.ServiceAccountRoles {
+		if err := r.Validate(); err != nil {
+			return errors.Trace(err)
+		}
+		if roleNames.Contains(r.Name) {
+			return errors.NotValidf("duplicated role name %q", r.Name)
+		}
+		roleNames.Add(r.Name)
+	}
+	for _, sa := range ks.ServiceAccounts {
+		if err := sa.Validate(); err != nil {
+			return errors.Trace(err)
+		}
+		for _, rName := range sa.Roles {
+			if !roleNames.Contains(rName) {
+				return errors.NewNotValid(nil, fmt.Sprintf("service account %q references an unknown role %q", sa.Name, rName))
+			}
+		}
+	}
+	return nil
+}
+
+// ToK8s converts modelled spec to k8s spec.
+func (ks K8sRBACResources) ToK8s() ([]core.ServiceAccount, []rbacv1.Role, []rbacv1.ClusterRole) {
+	// TODO:!!
+	return nil, nil, nil
+}
+
+// KubernetesResources is the k8s related resources.
+type KubernetesResources struct {
+	Pod *PodSpec `json:"pod,omitempty" yaml:"pod,omitempty"`
+
+	Secrets                   []Secret                                                     `json:"secrets" yaml:"secrets"`
+	CustomResourceDefinitions map[string]apiextensionsv1beta1.CustomResourceDefinitionSpec `json:"customResourceDefinitions,omitempty" yaml:"customResourceDefinitions,omitempty"`
+	CustomResources           map[string][]unstructured.Unstructured                       `json:"customResources,omitempty" yaml:"customResources,omitempty"`
+
+	MutatingWebhookConfigurations   map[string][]admissionregistration.MutatingWebhook   `json:"mutatingWebhookConfigurations,omitempty" yaml:"mutatingWebhookConfigurations,omitempty"`
+	ValidatingWebhookConfigurations map[string][]admissionregistration.ValidatingWebhook `json:"validatingWebhookConfigurations,omitempty" yaml:"validatingWebhookConfigurations,omitempty"`
+
+	K8sRBACResources `json:",inline" yaml:",inline"`
+
+	IngressResources []K8sIngressSpec `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
+}
+
+func validateCustomResourceDefinition(name string, crd apiextensionsv1beta1.CustomResourceDefinitionSpec) error {
+	if crd.Scope != apiextensionsv1beta1.NamespaceScoped && crd.Scope != apiextensionsv1beta1.ClusterScoped {
+		return errors.NewNotSupported(nil,
+			fmt.Sprintf("custom resource definition %q scope %q is not supported, please use %q or %q scope",
+				name, crd.Scope, apiextensionsv1beta1.NamespaceScoped, apiextensionsv1beta1.ClusterScoped),
+		)
+	}
+	return nil
+}
+
+// Validate is defined on ProviderPod.
+func (krs *KubernetesResources) Validate() error {
+	for k, crd := range krs.CustomResourceDefinitions {
+		if err := validateCustomResourceDefinition(k, crd); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	for k, crs := range krs.CustomResources {
+		if len(crs) == 0 {
+			return errors.NotValidf("empty custom resources %q", k)
+		}
+	}
+
+	for k, webhooks := range krs.MutatingWebhookConfigurations {
+		if len(webhooks) == 0 {
+			return errors.NotValidf("empty webhooks %q", k)
+		}
+	}
+	for k, webhooks := range krs.ValidatingWebhookConfigurations {
+		if len(webhooks) == 0 {
+			return errors.NotValidf("empty webhooks %q", k)
+		}
+	}
+
+	if err := krs.K8sRBACResources.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, ing := range krs.IngressResources {
+		if err := ing.Validate(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
 }
 
 // K8sPodSpecV3 is a subset of v1.PodSpec which defines

--- a/caas/kubernetes/provider/specs/v3.go
+++ b/caas/kubernetes/provider/specs/v3.go
@@ -5,14 +5,17 @@ package specs
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/kr/pretty"
 	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/juju/juju/caas/specs"
@@ -70,8 +73,7 @@ func (rs RoleSpec) Validate() error {
 
 // K8sServiceAccountSpec defines spec for referencing or creating additional RBAC resources.
 type K8sServiceAccountSpec struct {
-	Name string `json:"name" yaml:"name"`
-	// RBACSpec `yaml:",inline"`
+	Name                         string   `json:"name" yaml:"name"`
 	AutomountServiceAccountToken *bool    `yaml:"automountServiceAccountToken,omitempty"`
 	Roles                        []string `json:"roles" yaml:"roles"`
 }
@@ -82,19 +84,30 @@ func (sa K8sServiceAccountSpec) Validate() error {
 		return errors.New("name is missing")
 	}
 	return nil
-	// return errors.Trace(sa.RBACSpec.Validate())
 }
 
 // K8sRBACResources defines a spec for creating RBAC resources.
 type K8sRBACResources struct {
-	K8sSpecConverter
+	K8sRBACSpecConverter
 	ServiceAccounts     []K8sServiceAccountSpec `json:"serviceAccounts,omitempty" yaml:"serviceAccounts,omitempty"`
 	ServiceAccountRoles []RoleSpec              `json:"serviceAccountRoles,omitempty" yaml:"serviceAccountRoles,omitempty"`
 }
 
-// K8sSpecConverter has a method to convert modelled spec to k8s spec.
-type K8sSpecConverter interface {
-	ToK8s()
+// K8sRBACSpecConverter has a method to convert modelled RBAC spec to k8s spec.
+type K8sRBACSpecConverter interface {
+	ToK8s(
+		getSaMeta,
+		getRoleMeta,
+		getClusterRoleMeta MetaGetter,
+		getBindingMeta,
+		getClusterBindingMeta BindingMetaGetter,
+	) (
+		[]core.ServiceAccount,
+		[]rbacv1.Role,
+		[]rbacv1.ClusterRole,
+		[]rbacv1.RoleBinding,
+		[]rbacv1.ClusterRoleBinding,
+	)
 }
 
 // Validate is defined on ProviderPod.
@@ -109,10 +122,15 @@ func (ks K8sRBACResources) Validate() error {
 		}
 		roleNames.Add(r.Name)
 	}
+	saNames := set.NewStrings()
 	for _, sa := range ks.ServiceAccounts {
 		if err := sa.Validate(); err != nil {
 			return errors.Trace(err)
 		}
+		if saNames.Contains(sa.Name) {
+			return errors.NotValidf("duplicated service account name %q", sa.Name)
+		}
+		saNames.Add(sa.Name)
 		for _, rName := range sa.Roles {
 			if !roleNames.Contains(rName) {
 				return errors.NewNotValid(nil, fmt.Sprintf("service account %q references an unknown role %q", sa.Name, rName))
@@ -122,10 +140,142 @@ func (ks K8sRBACResources) Validate() error {
 	return nil
 }
 
-// ToK8s converts modelled spec to k8s spec.
-func (ks K8sRBACResources) ToK8s() ([]core.ServiceAccount, []rbacv1.Role, []rbacv1.ClusterRole) {
-	// TODO:!!
-	return nil, nil, nil
+// NameGetter defines method to get name from the resource.
+type NameGetter interface {
+	GetName() string
+}
+
+// MetaGetter generates ObjectMeta for service accounts, roles, cluster roles.
+type MetaGetter func(rawName string) v1.ObjectMeta
+
+// BindingMetaGetter generates ObjectMeta for role bindings, cluster role bindings.
+type BindingMetaGetter func(sa, roleOrClusterRole NameGetter) v1.ObjectMeta
+
+func toK8sRules(rules []specs.PolicyRule) (out []rbacv1.PolicyRule) {
+	for _, r := range rules {
+		out = append(out, rbacv1.PolicyRule{
+			Verbs:           r.Verbs,
+			APIGroups:       r.APIGroups,
+			Resources:       r.Resources,
+			ResourceNames:   r.ResourceNames,
+			NonResourceURLs: r.NonResourceURLs,
+		})
+	}
+	return out
+}
+
+// ToK8s converts modelled RBAC specs to k8s specs.
+func (ks K8sRBACResources) ToK8s(
+	getSaMeta,
+	getRoleMeta,
+	getClusterRoleMeta MetaGetter,
+	getBindingMeta,
+	getClusterBindingMeta BindingMetaGetter,
+) (
+	serviceAccounts []core.ServiceAccount,
+	roles []rbacv1.Role,
+	clusterroles []rbacv1.ClusterRole,
+	roleBindings []rbacv1.RoleBinding,
+	clusterRoleBindings []rbacv1.ClusterRoleBinding,
+) {
+	bindingInfo := map[string][]core.ServiceAccount{}
+	appendSA := func(roleName string, sa core.ServiceAccount) {
+		if _, ok := bindingInfo[roleName]; !ok {
+			bindingInfo[roleName] = []core.ServiceAccount{sa}
+			return
+		}
+		for _, v := range bindingInfo[roleName] {
+			if reflect.DeepEqual(v, sa) {
+				return
+			}
+		}
+		bindingInfo[roleName] = append(bindingInfo[roleName], sa)
+	}
+	for _, spec := range ks.ServiceAccounts {
+		sa := core.ServiceAccount{
+			ObjectMeta:                   getSaMeta(spec.Name),
+			AutomountServiceAccountToken: spec.AutomountServiceAccountToken,
+		}
+		serviceAccounts = append(serviceAccounts, sa)
+		for _, r := range spec.Roles {
+			appendSA(r, sa)
+		}
+	}
+	for _, spec := range ks.ServiceAccountRoles {
+		if spec.Global {
+			cR := rbacv1.ClusterRole{
+				ObjectMeta: getClusterRoleMeta(spec.Name),
+				Rules:      toK8sRules(spec.Rules),
+			}
+			clusterroles = append(clusterroles, cR)
+			for _, sa := range bindingInfo[cR.GetName()] {
+				clusterRoleBindings = append(clusterRoleBindings, rbacv1.ClusterRoleBinding{
+					ObjectMeta: getClusterBindingMeta(&sa, &cR),
+					RoleRef: rbacv1.RoleRef{
+						Name: cR.GetName(),
+						Kind: "ClusterRole",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind:      rbacv1.ServiceAccountKind,
+							Name:      sa.GetName(),
+							Namespace: sa.GetNamespace(),
+						},
+					},
+				})
+			}
+		} else {
+			r := rbacv1.Role{
+				ObjectMeta: getRoleMeta(spec.Name),
+				Rules:      toK8sRules(spec.Rules),
+			}
+			roles = append(roles, r)
+			for _, sa := range bindingInfo[r.GetName()] {
+				roleBindings = append(roleBindings, rbacv1.RoleBinding{
+					ObjectMeta: getBindingMeta(&sa, &r),
+					RoleRef: rbacv1.RoleRef{
+						Name: r.GetName(),
+						Kind: "Role",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind:      rbacv1.ServiceAccountKind,
+							Name:      sa.GetName(),
+							Namespace: sa.GetNamespace(),
+						},
+					},
+				})
+			}
+		}
+	}
+	logger.Criticalf("serviceAccounts -> %s", pretty.Sprint(serviceAccounts))
+	logger.Criticalf("roles -> %s", pretty.Sprint(roles))
+	logger.Criticalf("roleBindings -> %s", pretty.Sprint(roleBindings))
+	logger.Criticalf("clusterRoles -> %s", pretty.Sprint(clusterroles))
+	logger.Criticalf("clusterRoleBindings -> %s", pretty.Sprint(clusterRoleBindings))
+	return
+}
+
+// PrimeServiceAccountToK8sRBACResources converts PrimeServiceAccount to K8sRBACResources.
+func PrimeServiceAccountToK8sRBACResources(spec specs.PrimeServiceAccountSpec) (*K8sRBACResources, error) {
+	role := RoleSpec{
+		Name:   spec.GetName(),
+		Global: spec.Global,
+		Rules:  spec.Rules,
+	}
+	sa := K8sServiceAccountSpec{
+		Name:                         spec.GetName(),
+		AutomountServiceAccountToken: spec.AutomountServiceAccountToken,
+		Roles:                        []string{role.Name},
+	}
+	out := &K8sRBACResources{
+		ServiceAccounts:     []K8sServiceAccountSpec{sa},
+		ServiceAccountRoles: []RoleSpec{role},
+	}
+	if err := out.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return out, nil
 }
 
 // KubernetesResources is the k8s related resources.

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -1219,7 +1219,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesValidate(c *gc.C) {
 					},
 				},
 			},
-			ErrStr: `either all or none of the roles of the service account "sa2" should be set a name`,
+			ErrStr: `either all or none of the roles of the service account "sa2" should have a name set`,
 		},
 	} {
 		c.Logf("checking K8sRBACResources Validate %d", i)

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -555,7 +555,8 @@ echo "do some stuff here for gitlab-init container"
 			},
 			ServiceAccountRoles: []k8sspecs.RoleSpec{
 				{
-					Name: "k8sRole",
+					Name:   "k8sRole",
+					Global: false,
 					Rules: []specs.PolicyRule{
 						{
 							APIGroups: []string{""},

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -1248,28 +1248,28 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 			Annotations: annotations,
 		}
 	}
-	getRoleClusterRoleName := func(name string, index int) string {
-		if name != "" {
-			return name
+	getRoleClusterRoleName := func(roleName, serviceAccountName string, index int) string {
+		if roleName != "" {
+			return roleName
 		}
-		name = appName
+		roleName = fmt.Sprintf("%s-%s", appName, serviceAccountName)
 		if index == 0 {
-			return name
+			return roleName
 		}
-		return fmt.Sprintf("%s%d", name, index)
+		return fmt.Sprintf("%s%d", roleName, index)
 	}
-	getRoleMeta := func(name string, index int) metav1.ObjectMeta {
+	getRoleMeta := func(roleName, serviceAccountName string, index int) metav1.ObjectMeta {
 		return metav1.ObjectMeta{
-			Name:        getRoleClusterRoleName(name, index),
+			Name:        getRoleClusterRoleName(roleName, serviceAccountName, index),
 			Namespace:   namespace,
 			Labels:      map[string]string{"juju-app": appName},
 			Annotations: annotations,
 		}
 	}
-	getClusterRoleMeta := func(name string, index int) metav1.ObjectMeta {
-		name = getRoleClusterRoleName(name, index)
+	getClusterRoleMeta := func(roleName, serviceAccountName string, index int) metav1.ObjectMeta {
+		roleName = getRoleClusterRoleName(roleName, serviceAccountName, index)
 		return metav1.ObjectMeta{
-			Name:        prefixNameSpace(name),
+			Name:        prefixNameSpace(roleName),
 			Namespace:   namespace,
 			Labels:      map[string]string{"juju-app": appName, "juju-model": namespace},
 			Annotations: annotations,
@@ -1335,7 +1335,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 				},
 			},
 			{
-				Name: "sa2",
+				Name: "sa-foo",
 				ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 					Roles: []specs.Role{
 						{
@@ -1401,7 +1401,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "sa2",
+				Name:        "sa-foo",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name"},
 				Annotations: annotations,
@@ -1426,7 +1426,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "app-name",
+				Name:        "app-name-sa-foo",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name"},
 				Annotations: annotations,
@@ -1441,7 +1441,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "app-name1",
+				Name:        "app-name-sa-foo1",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name"},
 				Annotations: annotations,
@@ -1488,7 +1488,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "test-app-name2",
+				Name:        "test-app-name-sa-foo2",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 				Annotations: annotations,
@@ -1502,7 +1502,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "test-app-name3",
+				Name:        "test-app-name-sa-foo3",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 				Annotations: annotations,
@@ -1539,38 +1539,38 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "sa2-app-name",
+				Name:        "sa-foo-app-name-sa-foo",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name"},
 				Annotations: annotations,
 			},
 			RoleRef: rbacv1.RoleRef{
-				Name: "app-name",
+				Name: "app-name-sa-foo",
 				Kind: "Role",
 			},
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      rbacv1.ServiceAccountKind,
-					Name:      "sa2",
+					Name:      "sa-foo",
 					Namespace: "test",
 				},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "sa2-app-name1",
+				Name:        "sa-foo-app-name-sa-foo1",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name"},
 				Annotations: annotations,
 			},
 			RoleRef: rbacv1.RoleRef{
-				Name: "app-name1",
+				Name: "app-name-sa-foo1",
 				Kind: "Role",
 			},
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      rbacv1.ServiceAccountKind,
-					Name:      "sa2",
+					Name:      "sa-foo",
 					Namespace: "test",
 				},
 			},
@@ -1617,38 +1617,38 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "sa2-test-app-name2",
+				Name:        "sa-foo-test-app-name-sa-foo2",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 				Annotations: annotations,
 			},
 			RoleRef: rbacv1.RoleRef{
-				Name: "test-app-name2",
+				Name: "test-app-name-sa-foo2",
 				Kind: "ClusterRole",
 			},
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      rbacv1.ServiceAccountKind,
-					Name:      "sa2",
+					Name:      "sa-foo",
 					Namespace: "test",
 				},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "sa2-test-app-name3",
+				Name:        "sa-foo-test-app-name-sa-foo3",
 				Namespace:   "test",
 				Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
 				Annotations: annotations,
 			},
 			RoleRef: rbacv1.RoleRef{
-				Name: "test-app-name3",
+				Name: "test-app-name-sa-foo3",
 				Kind: "ClusterRole",
 			},
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      rbacv1.ServiceAccountKind,
-					Name:      "sa2",
+					Name:      "sa-foo",
 					Namespace: "test",
 				},
 			},

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -54,8 +54,8 @@ type Role struct {
 }
 
 // Validate returns an error if the spec is not valid.
-func (rs Role) Validate() error {
-	if len(rs.Rules) == 0 {
+func (r Role) Validate() error {
+	if len(r.Rules) == 0 {
 		return errors.NewNotValid(nil, "rules is required")
 	}
 	return nil
@@ -103,5 +103,11 @@ func (psa *PrimeServiceAccountSpecV3) SetName(name string) {
 
 // Validate returns an error if the spec is not valid.
 func (psa PrimeServiceAccountSpecV3) Validate() error {
-	return errors.Trace(psa.ServiceAccountSpecV3.Validate())
+	if err := psa.ServiceAccountSpecV3.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	if len(psa.Roles) > 1 {
+		return errors.NewNotValid(nil, "the prime service can only have one role or cluster role")
+	}
+	return nil
 }

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -16,38 +16,92 @@ type PolicyRule struct {
 	NonResourceURLs []string `json:"nonResourceURLs,omitempty" yaml:"nonResourceURLs,omitempty"`
 }
 
-// PrimeRBACSpec defines RBAC related spec.
-type PrimeRBACSpec struct {
-	AutomountServiceAccountToken *bool        `yaml:"automountServiceAccountToken,omitempty"`
-	Global                       bool         `yaml:"global,omitempty"`
-	Rules                        []PolicyRule `yaml:"rules,omitempty"`
+// ServiceAccountSpecV2 defines spec for referencing or creating RBAC resource for the application for version 2.
+type ServiceAccountSpecV2 struct {
+	AutomountServiceAccountToken *bool        `json:"automountServiceAccountToken,omitempty" yaml:"automountServiceAccountToken,omitempty"`
+	Global                       bool         `json:"global,omitempty" yaml:"global,omitempty"`
+	Rules                        []PolicyRule `json:"rules,omitempty" yaml:"rules,omitempty"`
 }
 
 // Validate returns an error if the spec is not valid.
-func (rs PrimeRBACSpec) Validate() error {
+func (sa ServiceAccountSpecV2) Validate() error {
+	if len(sa.Rules) == 0 {
+		return errors.NewNotValid(nil, "rules is required")
+	}
+	return nil
+}
+
+// ToLatest converts ServiceAccountSpecV2 to the latest version.
+func (sa ServiceAccountSpecV2) ToLatest() *PrimeServiceAccountSpecV3 {
+	return &PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: ServiceAccountSpecV3{
+			AutomountServiceAccountToken: sa.AutomountServiceAccountToken,
+			Roles: []Role{
+				{
+					Global: sa.Global,
+					Rules:  sa.Rules,
+				},
+			},
+		},
+	}
+}
+
+// Role defines role spec for version 3.
+type Role struct {
+	Name   string       `json:"name" yaml:"name"`
+	Global bool         `json:"global,omitempty" yaml:"global,omitempty"`
+	Rules  []PolicyRule `json:"rules,omitempty" yaml:"rules,omitempty"`
+}
+
+// Validate returns an error if the spec is not valid.
+func (rs Role) Validate() error {
 	if len(rs.Rules) == 0 {
 		return errors.NewNotValid(nil, "rules is required")
 	}
 	return nil
 }
 
-// PrimeServiceAccountSpec defines spec for referencing or creating RBAC resource for the application.
-type PrimeServiceAccountSpec struct {
-	name          string
-	PrimeRBACSpec `yaml:",inline"`
-}
+// ServiceAccountSpecV3 defines spec for creating RBAC resource for the application for version 3.
+type ServiceAccountSpecV3 struct {
+	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty" yaml:"automountServiceAccountToken,omitempty"`
 
-// GetName returns the service accout name.
-func (sa PrimeServiceAccountSpec) GetName() string {
-	return sa.name
-}
-
-// SetName sets the service accout name.
-func (sa *PrimeServiceAccountSpec) SetName(name string) {
-	sa.name = name
+	Roles []Role `json:"roles" yaml:"roles"`
 }
 
 // Validate returns an error if the spec is not valid.
-func (sa PrimeServiceAccountSpec) Validate() error {
-	return errors.Trace(sa.PrimeRBACSpec.Validate())
+func (sa ServiceAccountSpecV3) Validate() error {
+	if len(sa.Roles) == 0 {
+		return errors.NewNotValid(nil, "roles is required")
+	}
+	for _, r := range sa.Roles {
+		if err := r.Validate(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// PrimeServiceAccountSpecV3 defines spec for creating the prime RBAC resources for version 3.
+type PrimeServiceAccountSpecV3 struct {
+	name                 string
+	ServiceAccountSpecV3 `json:",inline" yaml:",inline"`
+}
+
+// GetName returns the service accout name.
+func (psa PrimeServiceAccountSpecV3) GetName() string {
+	return psa.name
+}
+
+// SetName sets the service accout name.
+func (psa *PrimeServiceAccountSpecV3) SetName(name string) {
+	psa.name = name
+	for i, r := range psa.Roles {
+		r.Name = name
+		psa.Roles[i] = r
+	}
+}
+
+// Validate returns an error if the spec is not valid.
+func (psa PrimeServiceAccountSpecV3) Validate() error {
+	return errors.Trace(psa.ServiceAccountSpecV3.Validate())
 }

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -7,52 +7,52 @@ import (
 	"github.com/juju/errors"
 )
 
-// PolicyRule defines rule spec for creating a role or cluster role.
+// PolicyRule defines a rule policy for a role or cluster role.
 type PolicyRule struct {
-	Verbs           []string `yaml:"verbs"`
-	APIGroups       []string `yaml:"apiGroups,omitempty"`
-	Resources       []string `yaml:"resources,omitempty"`
-	ResourceNames   []string `yaml:"resourceNames,omitempty"`
-	NonResourceURLs []string `yaml:"nonResourceURLs,omitempty"`
+	Verbs           []string `json:"verbs" yaml:"verbs"`
+	APIGroups       []string `json:"apiGroups,omitempty" yaml:"apiGroups,omitempty"`
+	Resources       []string `json:"resources,omitempty" yaml:"resources,omitempty"`
+	ResourceNames   []string `json:"resourceNames,omitempty" yaml:"resourceNames,omitempty"`
+	NonResourceURLs []string `json:"nonResourceURLs,omitempty" yaml:"nonResourceURLs,omitempty"`
 }
 
-// RBACSpec defines RBAC related spec.
-type RBACSpec struct {
+// PrimeRBACSpec defines RBAC related spec.
+type PrimeRBACSpec struct {
 	AutomountServiceAccountToken *bool        `yaml:"automountServiceAccountToken,omitempty"`
 	Global                       bool         `yaml:"global,omitempty"`
 	Rules                        []PolicyRule `yaml:"rules,omitempty"`
 }
 
 // Validate returns an error if the spec is not valid.
-func (rs RBACSpec) Validate() error {
+func (rs PrimeRBACSpec) Validate() error {
 	if len(rs.Rules) == 0 {
 		return errors.NewNotValid(nil, "rules is required")
 	}
 	return nil
 }
 
-// ServiceAccountSpec defines spec for referencing or creating a service account.
-type ServiceAccountSpec struct {
-	name     string
-	RBACSpec `yaml:",inline"`
+// PrimeServiceAccountSpec defines spec for referencing or creating RBAC resource for the application.
+type PrimeServiceAccountSpec struct {
+	name          string
+	PrimeRBACSpec `yaml:",inline"`
 }
 
 // GetName returns the service accout name.
-func (sa ServiceAccountSpec) GetName() string {
+func (sa PrimeServiceAccountSpec) GetName() string {
 	return sa.name
 }
 
 // GetSpec returns the RBAC spec.
-func (sa ServiceAccountSpec) GetSpec() RBACSpec {
-	return sa.RBACSpec
+func (sa PrimeServiceAccountSpec) GetSpec() PrimeRBACSpec {
+	return sa.PrimeRBACSpec
 }
 
 // SetName sets the service accout name.
-func (sa *ServiceAccountSpec) SetName(name string) {
+func (sa *PrimeServiceAccountSpec) SetName(name string) {
 	sa.name = name
 }
 
 // Validate returns an error if the spec is not valid.
-func (sa ServiceAccountSpec) Validate() error {
-	return errors.Trace(sa.RBACSpec.Validate())
+func (sa PrimeServiceAccountSpec) Validate() error {
+	return errors.Trace(sa.PrimeRBACSpec.Validate())
 }

--- a/caas/specs/rbac.go
+++ b/caas/specs/rbac.go
@@ -42,11 +42,6 @@ func (sa PrimeServiceAccountSpec) GetName() string {
 	return sa.name
 }
 
-// GetSpec returns the RBAC spec.
-func (sa PrimeServiceAccountSpec) GetSpec() PrimeRBACSpec {
-	return sa.PrimeRBACSpec
-}
-
 // SetName sets the service accout name.
 func (sa *PrimeServiceAccountSpec) SetName(name string) {
 	sa.name = name

--- a/caas/specs/rbac_test.go
+++ b/caas/specs/rbac_test.go
@@ -1,0 +1,113 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package specs_test
+
+import (
+	// jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/caas/specs"
+	// "github.com/juju/juju/testing"
+)
+
+func (s *typesSuite) TestServiceAccountSpecV2Validate(c *gc.C) {
+	spec := specs.ServiceAccountSpecV2{}
+	c.Assert(spec.Validate(), gc.ErrorMatches, `rules is required`)
+
+	spec = specs.ServiceAccountSpecV2{
+		Global: true,
+		Rules: []specs.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
+		},
+	}
+	c.Assert(spec.ToLatest(), gc.DeepEquals, &specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+			Roles: []specs.Role{
+				{
+					Global: true,
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *typesSuite) TestServiceAccountSpecV3Validate(c *gc.C) {
+	spec := specs.ServiceAccountSpecV3{}
+	c.Assert(spec.Validate(), gc.ErrorMatches, `roles is required`)
+
+	spec = specs.ServiceAccountSpecV3{
+		Roles: []specs.Role{
+			{
+				Name: "role1",
+			},
+		},
+	}
+	c.Assert(spec.Validate(), gc.ErrorMatches, `rules is required`)
+}
+
+func (s *typesSuite) TestPrimeServiceAccountSpecV3Validate(c *gc.C) {
+	spec := specs.PrimeServiceAccountSpecV3{}
+	c.Assert(spec.Validate(), gc.ErrorMatches, `roles is required`)
+
+	spec = specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+			Roles: []specs.Role{
+				{
+					Global: true,
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
+				},
+				{
+					Global: true,
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Assert(spec.Validate(), gc.ErrorMatches, `the prime service can only have one role or cluster role`)
+}
+
+func (s *typesSuite) TestPrimeServiceAccountSpecV3SetName(c *gc.C) {
+	spec := specs.PrimeServiceAccountSpecV3{
+		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
+			Roles: []specs.Role{
+				{
+					Global: true,
+					Rules: []specs.PolicyRule{
+						{
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+							Verbs:     []string{"get", "watch", "list"},
+						},
+					},
+				},
+			},
+		},
+	}
+	spec.SetName("mariadb-k8s")
+	c.Assert(spec.GetName(), gc.DeepEquals, "mariadb-k8s")
+	c.Assert(spec.Roles[0].Name, gc.DeepEquals, "mariadb-k8s")
+}

--- a/caas/specs/v2.go
+++ b/caas/specs/v2.go
@@ -7,11 +7,18 @@ import (
 	"github.com/juju/errors"
 )
 
+type (
+	// ServiceAccountSpecV2 defines spec for referencing or creating a service account for version 2.
+	ServiceAccountSpecV2 = PrimeServiceAccountSpec
+	// RBACSpecV2 defines RBAC related spec for version 2.
+	RBACSpecV2 = PrimeRBACSpec
+)
+
 // PodSpecV2 defines the data values used to configure
 // a pod on the CAAS substrate for version 2.
 type PodSpecV2 struct {
 	podSpecBaseV2  `json:",inline" yaml:",inline"`
-	ServiceAccount *ServiceAccountSpec `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
+	ServiceAccount *PrimeServiceAccountSpec `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
 }
 
 // Version2 defines the version number for pod spec version 2.

--- a/caas/specs/v2.go
+++ b/caas/specs/v2.go
@@ -7,18 +7,11 @@ import (
 	"github.com/juju/errors"
 )
 
-type (
-	// ServiceAccountSpecV2 defines spec for referencing or creating a service account for version 2.
-	ServiceAccountSpecV2 = PrimeServiceAccountSpec
-	// RBACSpecV2 defines RBAC related spec for version 2.
-	RBACSpecV2 = PrimeRBACSpec
-)
-
 // PodSpecV2 defines the data values used to configure
 // a pod on the CAAS substrate for version 2.
 type PodSpecV2 struct {
 	podSpecBaseV2  `json:",inline" yaml:",inline"`
-	ServiceAccount *PrimeServiceAccountSpec `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
+	ServiceAccount *ServiceAccountSpecV2 `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
 }
 
 // Version2 defines the version number for pod spec version 2.

--- a/caas/specs/v3.go
+++ b/caas/specs/v3.go
@@ -11,7 +11,7 @@ import (
 // a pod on the CAAS substrate for version 3.
 type PodSpecV3 struct {
 	podSpecBase    `json:",inline" yaml:",inline"`
-	ServiceAccount *PrimeServiceAccountSpec `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
+	ServiceAccount *PrimeServiceAccountSpecV3 `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
 }
 
 // Version3 defines the version number for pod spec version 3.
@@ -23,6 +23,7 @@ func (spec *PodSpecV3) Validate() error {
 		return errors.Trace(err)
 	}
 	if spec.ServiceAccount != nil {
+		// TODO: do we want to restrict the prime sa can only have 1 role/clusterrole???????
 		return errors.Trace(spec.ServiceAccount.Validate())
 	}
 	return nil

--- a/caas/specs/v3.go
+++ b/caas/specs/v3.go
@@ -11,7 +11,7 @@ import (
 // a pod on the CAAS substrate for version 3.
 type PodSpecV3 struct {
 	podSpecBase    `json:",inline" yaml:",inline"`
-	ServiceAccount *ServiceAccountSpec `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
+	ServiceAccount *PrimeServiceAccountSpec `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
 }
 
 // Version3 defines the version number for pod spec version 3.


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Change the additional k8s RBAC resources under `kubernetesResources` to support multiple service accounts and multiple roles/clusterroles for each service account;


## QA steps

deploy k8s charm with below k8s specs;

```yaml
# spec_template.yaml
version: 3
serviceAccount:
  automountServiceAccountToken: true
  roles:
    - global: true
      rules:
        - apiGroups: [""]
          resources: ["pods"]
          verbs: ["get", "watch", "list"]
        - nonResourceURLs: ["*"]
          verbs: ["*"]

# k8s_resources.yaml
kubernetesResources:
  serviceAccounts:
    - name: rbac-foo
      automountServiceAccountToken: true
      roles:
        - name: pod-role
          rules:
            - apiGroups: [""]
              resources: ["pods"]
              verbs: ["get", "watch", "list"]
        - name: pod-cluster-role
          global: true
          rules:
            - apiGroups: [""]
              resources: ["pods"]
              verbs: ["get", "watch", "list"]
    - name: rbac-bar
      automountServiceAccountToken: true
      roles:  # roles does not have a name.
        - rules:
            - apiGroups: [""]
              resources: ["pods"]
              verbs: ["get", "watch", "list"]
        - global: true
          rules:
            - apiGroups: [""]
              resources: ["pods"]
              verbs: ["get", "watch", "list"]
```


```console
$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb

$ mkubectl get sa,role,rolebindings,clusterrole,clusterrolebinding -n t1
NAME                                  SECRETS   AGE
serviceaccount/mariadb-k8s            1         27s
serviceaccount/rbac-bar               1         27s
serviceaccount/rbac-foo               1         27s

NAME                                                  AGE
role.rbac.authorization.k8s.io/pod-role               27s
role.rbac.authorization.k8s.io/rbac-bar               27s

NAME                                                         AGE
rolebinding.rbac.authorization.k8s.io/rbac-bar               27s
rolebinding.rbac.authorization.k8s.io/rbac-foo-pod-role      27s

NAME                                                             AGE
clusterrole.rbac.authorization.k8s.io/t1-mariadb-k8s             27s
clusterrole.rbac.authorization.k8s.io/t1-pod-cluster-role        27s
clusterrole.rbac.authorization.k8s.io/t1-rbac-bar1               27s

NAME                                                                        AGE
clusterrolebinding.rbac.authorization.k8s.io/mariadb-k8s-t1-mariadb-k8s     27s
clusterrolebinding.rbac.authorization.k8s.io/rbac-bar-t1-rbac-bar1          26s
clusterrolebinding.rbac.authorization.k8s.io/rbac-foo-t1-pod-cluster-role   27s

```

## Documentation changes

Yes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1861246
