### PR TITLE
Make args formatting uniform for action commands

### DIFF
--- a/cmd/juju/action/cancel.go
+++ b/cmd/juju/action/cancel.go
@@ -44,14 +44,14 @@ func (c *cancelCommand) Info() *cmd.Info {
 	if featureflag.Enabled(feature.JujuV3) {
 		info = &cmd.Info{
 			Name:    "cancel-task",
-			Args:    "<<task ID | task ID prefix>...>",
+			Args:    "(<task-id>|<task-id-prefix>) [...]",
 			Purpose: "Cancel pending or running tasks.",
 			Doc:     cancelDoc,
 		}
 	} else {
 		info = &cmd.Info{
 			Name:    "cancel-action",
-			Args:    "<<action ID | action ID prefix>...>",
+			Args:    "(<action-id>|<action-id-prefix>) [...]",
 			Purpose: "Cancel pending or running actions.",
 			Doc:     strings.Replace(cancelDoc, "task", "action", -1),
 			Aliases: []string{"cancel-task"},

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -74,7 +74,7 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *listCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
 		Name:    "actions",
-		Args:    "<application name>",
+		Args:    "<application>",
 		Purpose: "List actions defined for an application.",
 		Doc:     listDoc,
 		Aliases: []string{"list-actions"},

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -139,7 +139,7 @@ func (c *runCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *runCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "run",
-		Args:    "<unit> [<unit> ...] <action name> [key.key.key...=value]",
+		Args:    "<unit> [<unit> ...] <action-name> [<key>=<value> [<key>[.<key> ...]=<value>]]",
 		Purpose: "Run a action on a specified unit.",
 		Doc:     runDoc,
 	})

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -88,7 +88,7 @@ func (c *runActionCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *runActionCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "run-action",
-		Args:    "<unit> [<unit> ...] <action name> [key.key.key...=value]",
+		Args:    "<unit> [<unit> ...] <action> [<key>=<value> [<key>[.<key> ...]=<value>]]",
 		Purpose: "Queue an action for execution.",
 		Doc:     runActionDoc,
 	})

--- a/cmd/juju/action/show.go
+++ b/cmd/juju/action/show.go
@@ -47,9 +47,9 @@ func NewShowCommand() cmd.Command {
 func (c *showCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
-		return errors.New("no application name specified")
+		return errors.New("no application specified")
 	case 1:
-		return errors.New("no action name specified")
+		return errors.New("no action specified")
 	case 2:
 		appName := args[0]
 		if !names.IsValidApplication(appName) {
@@ -66,7 +66,7 @@ func (c *showCommand) Init(args []string) error {
 func (c *showCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
 		Name:    "show-action",
-		Args:    "<application name> <action name>",
+		Args:    "<application> <action>",
 		Purpose: "Shows detailed information about an action.",
 		Doc:     showActionDoc,
 	})

--- a/cmd/juju/action/show_test.go
+++ b/cmd/juju/action/show_test.go
@@ -42,11 +42,11 @@ func (s *ShowSuite) TestInit(c *gc.C) {
 	}{{
 		should:      "fail with missing application name",
 		args:        []string{},
-		expectedErr: "no application name specified",
+		expectedErr: "no application specified",
 	}, {
 		should:      "fail with missing action name",
 		args:        []string{validApplicationId},
-		expectedErr: "no action name specified",
+		expectedErr: "no action specified",
 	}, {
 		should:      "fail with invalid application name",
 		args:        []string{invalidApplicationId, "doIt"},

--- a/cmd/juju/action/showoperation.go
+++ b/cmd/juju/action/showoperation.go
@@ -71,8 +71,8 @@ func (c *showOperationCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *showOperationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "show-operation",
-		Args:    "<operation ID>",
-		Purpose: "Show results of an operation by ID.",
+		Args:    "<operation-id>",
+		Purpose: "Show results of an operation.",
 		Doc:     showOperationDoc,
 	})
 }

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -110,8 +110,8 @@ func (c *showOutputCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *showOutputCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
 		Name:    "show-action-output",
-		Args:    "<action ID>",
-		Purpose: "Show results of an action by ID.",
+		Args:    "<action>",
+		Purpose: "Show results of an action.",
 		Doc:     showOutputDoc,
 	})
 	if !c.compat {

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -44,7 +44,7 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *statusCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "show-action-status",
-		Args:    "[<action ID>|<action ID prefix>]",
+		Args:    "[<action>|<action-id-prefix>]",
 		Purpose: "Show results of all actions filtered by optional ID prefix.",
 		Doc:     statusDoc,
 	})


### PR DESCRIPTION
## Description of change

This change re-formats the usage arguments for each of the action commands to make them consistent.

## QA steps

N/A

## Documentation changes

N/A

## Bug reference

N/A