### PR TITLE
Fix 1865455 juju show-action-status not listing all

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -429,7 +429,8 @@ func (m *Model) ActionByTag(tag names.ActionTag) (Action, error) {
 
 // FindActionTagsById finds Actions with ids that either
 // share the supplied prefix (for deprecated UUIDs), or match
-// the supplied id (for newer id integers).
+// the supplied id (for newer id integers). If passed an empty string
+// match all Actions.
 // It returns a list of corresponding ActionTags.
 func (m *Model) FindActionTagsById(idValue string) ([]names.ActionTag, error) {
 	actionLogger.Tracef("FindActionTagsById() %q", idValue)
@@ -449,7 +450,11 @@ func (m *Model) FindActionTagsById(idValue string) ([]names.ActionTag, error) {
 	newIdsSupported := IsNewActionIDSupported(agentVersion)
 	maybeOldId := strings.ContainsAny(idValue, "-abcdef")
 	var filter bson.D
-	if !newIdsSupported || maybeOldId {
+	if idValue == "" {
+		// Match all when passed an empty id prefix for
+		// legacy behaviour.
+		filter = nil
+	} else if !newIdsSupported || maybeOldId {
 		filter = bson.D{{
 			"_id", bson.D{{"$regex", "^" + matchValue}},
 		}}

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -589,8 +589,13 @@ func (s *ActionSuite) TestFindActionTagsById(c *gc.C) {
 	tags, err := s.model.FindActionTagsById("1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(len(tags), gc.Equals, 1)
+	c.Assert(tags, gc.HasLen, 1)
 	c.Assert(tags[0].Id(), gc.Equals, "1")
+
+	// Test match all.
+	tags, err = s.model.FindActionTagsById("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tags, gc.HasLen, 4)
 }
 
 func (s *ActionSuite) TestFindActionTagsByLegacyId(c *gc.C) {


### PR DESCRIPTION
## Description of change

When passed an empty prefix/id, juju show-action-status
now has the old behaviour where it would list all actions.

## QA steps

- bootstrap
- deploy charm with actions
- run several actions
- `juju show-action-status`
- should return all actions

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1865455