### PR TITLE
Fix 1864900 ACME v2 autocert support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1227,16 +1227,17 @@
   version = "v0.18.0"
 
 [[projects]]
-  digest = "1:53c4b75f22ea7757dea07eae380ea42de547ae6865a5e3b41866754a8a8219c9"
+  digest = "1:26df9d3abe9f6470c2706b7d2f7660fb3e9ce44e894b1db19be1f094531d6bb4"
   name = "golang.org/x/crypto"
   packages = [
     "acme",
     "acme/autocert",
+    "blake2b",
     "cast5",
+    "chacha20",
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
-    "internal/chacha20",
     "internal/subtle",
     "nacl/box",
     "nacl/secretbox",
@@ -1255,7 +1256,7 @@
     "ssh/terminal",
   ]
   pruneopts = ""
-  revision = "f027049dab0ad238e394a753dba2d14753473a04"
+  revision = "69ecbb4d6d5dab05e49161c6e77ea40a030884e1"
 
 [[projects]]
   digest = "1:40dd5a4f1e82c4d3dc3de550a96152f6a8937bcfcb20c7ee34685f8764e1bda5"
@@ -1301,6 +1302,7 @@
   digest = "1:2e1aadff5bda52e267975408bf6b5e90135fc643829c9e4e964ff82c3826a1dd"
   name = "golang.org/x/sys"
   packages = [
+    "cpu",
     "unix",
     "windows",
     "windows/registry",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -460,7 +460,7 @@
 
 [[constraint]]
   name = "golang.org/x/crypto"
-  revision = "f027049dab0ad238e394a753dba2d14753473a04"
+  revision = "69ecbb4d6d5dab05e49161c6e77ea40a030884e1"
 
 [[constraint]]
   name = "golang.org/x/net"

--- a/worker/httpserver/cert_test.go
+++ b/worker/httpserver/cert_test.go
@@ -94,7 +94,7 @@ func (s *certSuite) TestUpdateCert(c *gc.C) {
 	// Check that we can't connect to the server because of the bad certificate.
 	s.cert = &badTLSCert
 	_, err = s.request(url)
-	c.Assert(err, gc.ErrorMatches, `.*: certificate has expired or is not yet valid`)
+	c.Assert(err, gc.ErrorMatches, `.*: certificate has expired or is not yet valid.*`)
 
 	// Replace the working certificate and check that we can connect again.
 	s.cert = coretesting.ServerTLSCert
@@ -143,7 +143,7 @@ func (s *certSuite) TestAutocertFailure(c *gc.C) {
 	// We will log the failure to get the certificate, thus assuring us that we actually tried.
 	c.Assert(entries, jc.LogMatches, jc.SimpleMessages{{
 		loggo.ERROR,
-		`.*cannot get autocert certificate for "somewhere.example": Get https://0\.1\.2\.3/no-autocert-here: .*`,
+		`.*cannot get autocert certificate for "somewhere.example".*`,
 	}})
 }
 
@@ -180,7 +180,7 @@ func (s *certSuite) TestAutocertNameMismatch(c *gc.C) {
 	// Check that we logged the mismatch.
 	c.Assert(entries, jc.LogMatches, jc.SimpleMessages{{
 		loggo.ERROR,
-		`.*cannot get autocert certificate for "somewhere.else": acme/autocert: host not configured`,
+		`.*cannot get autocert certificate for "somewhere.else": acme/autocert: host "somewhere.else" not configured in HostWhitelist`,
 	}})
 }
 


### PR DESCRIPTION
## Description of change

Updated golang.org/x/crypto package to support
ACME v2 autocert protocol.

## QA steps

NOTE: need access to a domain

- `juju boostrap cloud --config autocert-dns-name=controller.my.domain`
- Update the controller.my.domain RR on the NS for my.domain to point to the controller IP.
- Wait for the apiserver worker to get the letsencypt cert.
- You should be able to browse https://controller.my.domain in your browser with a valid cert.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1864900