### PR TITLE
2.7 k8s controlling lxd 1866623

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -41,9 +41,6 @@ jobs:
       if: (matrix.os == 'ubuntu-latest')
       working-directory: src/github.com/juju/juju
       run: |
-        # temp fix for github actions bug
-        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-        sudo rm /etc/apt/sources.list.d/dotnetdev.list
         make install-mongo-dependencies
 
     - name: "Install Mongo Dependencies: macOS-latest"

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -28,17 +28,18 @@ jobs:
       # temporary fix
       # see https://github.com/actions/setup-go/issues/14
       run: |
-        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+        echo "##[set-env name=GOPATH;]$GITHUB_WORKSPACE"
+        echo "##[add-path]$GITHUB_WORKSPACE/bin"
       shell: bash
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: src/github.com/juju/juju
 
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')
+      working-directory: src/github.com/juju/juju
       run: |
         # temp fix for github actions bug
         sudo rm /etc/apt/sources.list.d/microsoft-prod.list
@@ -47,6 +48,7 @@ jobs:
 
     - name: "Install Mongo Dependencies: macOS-latest"
       if: (matrix.os == 'macOS-latest')
+      working-directory: src/github.com/juju/juju
       run: |
         curl -o mongodb-3.6.14.tgz https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.14.tgz
         tar xzvf mongodb-3.6.14.tgz
@@ -57,11 +59,13 @@ jobs:
       shell: bash
 
     - name: Install Vendor Dependencies
+      working-directory: src/github.com/juju/juju
       run: |
         make dep
       shell: bash
 
     - name: Test client
+      working-directory: src/github.com/juju/juju
       run: |
         # Jenkins can perform the full jujud testing.
         go test -v ./cmd/juju/... -check.v

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,37 +17,42 @@ jobs:
       # temporary fix
       # see https://github.com/actions/setup-go/issues/14
       run: |
-        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+        echo "##[set-env name=GOPATH;]$GITHUB_WORKSPACE"
+        echo "##[add-path]$GITHUB_WORKSPACE/bin"
       shell: bash
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: src/github.com/juju/juju
 
     - name: Install Vendor dependencies
+      working-directory: src/github.com/juju/juju
       run: |
         make dep
       shell: bash
 
     - name: Install Dependencies
+      working-directory: src/github.com/juju/juju
       run: |
         go get -u github.com/client9/misspell/cmd/misspell
         go get -u github.com/tsenart/deadcode
         go get -u golang.org/x/lint/golint
 
     - name: "Static Analysis: Copyright"
+      working-directory: src/github.com/juju/juju
       run: |
         STATIC_ANALYSIS_JOB=test_copyright make static-analysis
       shell: bash
 
     - name: "Static Analysis: Shell Check"
+      working-directory: src/github.com/juju/juju
       run: |
         STATIC_ANALYSIS_JOB=test_static_analysis_shell make static-analysis
       shell: bash
 
     - name: "Static Analysis: Go Check"
+      working-directory: src/github.com/juju/juju
       run: |
         STATIC_ANALYSIS_JOB=test_static_analysis_go make static-analysis
       shell: bash
@@ -67,21 +72,23 @@ jobs:
       # temporary fix
       # see https://github.com/actions/setup-go/issues/14
       run: |
-        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+        echo "##[set-env name=GOPATH;]$GITHUB_WORKSPACE"
+        echo "##[add-path]$GITHUB_WORKSPACE/bin"
       shell: bash
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: src/github.com/juju/juju
 
     - name: Install Vendor Dependencies
+      working-directory: src/github.com/juju/juju
       run: |
         make dep
       shell: bash
 
     - name: Schema Check
+      working-directory: src/github.com/juju/juju
       run: |
         STATIC_ANALYSIS_JOB=test_schema make static-analysis
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ endif
 
 operator-image: operator-check-build
 	rm -rf ${JUJUD_STAGING_DIR}
-	mkdir ${JUJUD_STAGING_DIR}
+	mkdir -p ${JUJUD_STAGING_DIR}
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}

--- a/controller/authentication/authentication.go
+++ b/controller/authentication/authentication.go
@@ -45,10 +45,9 @@ func NewAPIAuthenticator(st *apiprovisioner.State) (AuthenticationProvider, erro
 	}
 	var stateInfo *mongo.MongoInfo
 	stateAddresses, err := st.StateAddresses()
-	if err != nil {
-		// no state addresses to be found, this can happen if we are on a K8s model.
-		return nil, errors.Annotate(err, "could not read state addresses")
-	} else {
+	// We may not have stateAddresses (we don't on K8s), but the common case is that we don't need them
+	//  (we only need them for controller machines).
+	if err == nil {
 		stateInfo = &mongo.MongoInfo{
 			Info: mongo.Info{
 				Addrs:  stateAddresses,

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.7.3"
+const version = "2.7.4"
 
 const (
 	// TreeStateDirty when the build was made with a dirty checkout.

--- a/worker/instancemutater/manifold.go
+++ b/worker/instancemutater/manifold.go
@@ -79,7 +79,7 @@ func (config ModelManifoldConfig) newWorker(environ environs.Environ, apiCaller 
 
 	w, err := config.NewWorker(cfg)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot start machine instancemutater worker")
+		return nil, errors.Annotate(err, "cannot start model instance-mutater worker")
 	}
 	return w, nil
 }

--- a/worker/instancemutater/manifold_test.go
+++ b/worker/instancemutater/manifold_test.go
@@ -324,7 +324,7 @@ func (s *modelManifoldSuite) TestNewWorkerReturnsError(c *gc.C) {
 	}
 	manifold := instancemutater.ModelManifold(config)
 	_, err := manifold.Start(s.context)
-	c.Assert(err, gc.ErrorMatches, "cannot start machine instancemutater worker: errored")
+	c.Assert(err, gc.ErrorMatches, "cannot start model instance-mutater worker: errored")
 }
 
 func (s *modelManifoldSuite) TestConfigValidatesForMissingWorker(c *gc.C) {

--- a/worker/instancemutater/manifold_test.go
+++ b/worker/instancemutater/manifold_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
 	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
@@ -279,6 +280,30 @@ func (s *modelManifoldSuite) TestNewWorkerIsCalled(c *gc.C) {
 	c.Assert(result, gc.Equals, s.worker)
 }
 
+func (s *modelManifoldSuite) TestNewWorkerFromK8sController(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.behaviourContext()
+	s.behaviorK8sController()
+
+	config := instancemutater.ModelManifoldConfig{
+		EnvironName:   "foobar",
+		APICallerName: "baz",
+		AgentName:     "moon",
+		Logger:        s.logger,
+		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+			return s.worker, nil
+		},
+		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
+			return s.api
+		},
+	}
+	manifold := instancemutater.ModelManifold(config)
+	result, err := manifold.Start(s.context)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, s.worker)
+}
+
 func (s *modelManifoldSuite) TestNewWorkerReturnsError(c *gc.C) {
 	defer s.setup(c).Finish()
 
@@ -350,6 +375,14 @@ func (s *modelManifoldSuite) behaviourAgent() {
 
 	cExp := s.agentConfig.EXPECT()
 	cExp.Tag().Return(names.MachineTag{})
+}
+
+func (s *modelManifoldSuite) behaviorK8sController() {
+	aExp := s.agent.EXPECT()
+	aExp.CurrentConfig().Return(s.agentConfig)
+
+	cExp := s.agentConfig.EXPECT()
+	cExp.Tag().Return(names.ControllerAgentTag{})
 }
 
 type environShim struct {
@@ -618,6 +651,30 @@ func (s *machineManifoldSuite) TestNewWorkerIsCalled(c *gc.C) {
 	c.Assert(result, gc.Equals, s.worker)
 }
 
+func (s *machineManifoldSuite) TestNewWorkerIsRejectedForK8sController(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.behaviourContext()
+	s.behaviorK8sController()
+
+	config := instancemutater.MachineManifoldConfig{
+		BrokerName:    "foobar",
+		APICallerName: "baz",
+		AgentName:     "moon",
+		Logger:        s.logger,
+		NewWorker: func(cfg instancemutater.Config) (worker.Worker, error) {
+			return s.worker, nil
+		},
+		NewClient: func(base.APICaller) instancemutater.InstanceMutaterAPI {
+			return s.api
+		},
+	}
+	manifold := instancemutater.MachineManifold(config)
+	result, err := manifold.Start(s.context)
+	c.Assert(err, gc.Equals, dependency.ErrUninstall)
+	c.Assert(result, gc.IsNil)
+}
+
 func (s *machineManifoldSuite) TestNewWorkerReturnsError(c *gc.C) {
 	defer s.setup(c).Finish()
 
@@ -689,6 +746,17 @@ func (s *machineManifoldSuite) behaviourAgent() {
 
 	cExp := s.agentConfig.EXPECT()
 	cExp.Tag().Return(names.MachineTag{})
+}
+
+func (s *machineManifoldSuite) behaviorK8sController() {
+	aExp := s.agent.EXPECT()
+	aExp.CurrentConfig().Return(s.agentConfig)
+
+	cExp := s.agentConfig.EXPECT()
+	cExp.Tag().Return(names.ControllerAgentTag{})
+
+	lExp := s.logger.EXPECT()
+	lExp.Warningf(gomock.Any(), "controller")
 }
 
 type brokerShim struct {

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -130,8 +130,6 @@ func NewEnvironWorker(config Config) (worker.Worker, error) {
 // polls their instance for addition or removal changes.
 func NewContainerWorker(config Config) (worker.Worker, error) {
 	if _, ok := config.Tag.(names.MachineTag); !ok {
-		// Should we be returning a no-op worker of some sort?
-		return nil, errors.NotValidf("Tag of kind %q", config.Tag.Kind())
 		config.Logger.Infof("cannot start a ContainerWorker on a %q, not restarting", config.Tag.Kind())
 		return nil, dependency.ErrUninstall
 	}
@@ -159,7 +157,6 @@ func newWorker(config Config) (*mutaterWorker, error) {
 		logger:                     config.Logger,
 		facade:                     config.Facade,
 		broker:                     config.Broker,
-		machineTag:                 config.Tag.(names.MachineTag),
 		machineWatcher:             watcher,
 		getRequiredLXDProfilesFunc: config.GetRequiredLXDProfiles,
 		getRequiredContextFunc:     config.GetRequiredContext,
@@ -182,7 +179,6 @@ type mutaterWorker struct {
 
 	logger                     Logger
 	broker                     environs.LXDProfiler
-	machineTag                 names.MachineTag
 	facade                     InstanceMutaterAPI
 	machineWatcher             watcher.StringsWatcher
 	getRequiredLXDProfilesFunc RequiredLXDProfilesFunc

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -131,6 +131,7 @@ func NewEnvironWorker(config Config) (worker.Worker, error) {
 func NewContainerWorker(config Config) (worker.Worker, error) {
 	if _, ok := config.Tag.(names.MachineTag); !ok {
 		// Should we be returning a no-op worker of some sort?
+		return nil, errors.NotValidf("Tag of kind %q", config.Tag.Kind())
 		config.Logger.Infof("cannot start a ContainerWorker on a %q, not restarting", config.Tag.Kind())
 		return nil, dependency.ErrUninstall
 	}

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -97,7 +97,7 @@ func (config Config) Validate() error {
 			// machine anyway. This is a hack for bug #1866623
 			return errors.NotValidf("Tag of kind %v", config.Tag.Kind())
 		}
-		config.Logger.Warningf("asked to start an instance mutator with Tag of kind %q", config.Tag.Kind())
+		config.Logger.Debugf("asked to start an instance mutator with Tag of kind %q", config.Tag.Kind())
 	}
 	if config.GetMachineWatcher == nil {
 		return errors.NotValidf("nil GetMachineWatcher")
@@ -130,7 +130,7 @@ func NewEnvironWorker(config Config) (worker.Worker, error) {
 // polls their instance for addition or removal changes.
 func NewContainerWorker(config Config) (worker.Worker, error) {
 	if _, ok := config.Tag.(names.MachineTag); !ok {
-		config.Logger.Infof("cannot start a ContainerWorker on a %q, not restarting", config.Tag.Kind())
+		config.Logger.Warningf("cannot start a ContainerWorker on a %q, not restarting", config.Tag.Kind())
 		return nil, dependency.ErrUninstall
 	}
 	m, err := config.Facade.Machine(config.Tag.(names.MachineTag))

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/catacomb"
+	"gopkg.in/juju/worker.v1/dependency"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/instancemutater"
@@ -90,7 +91,13 @@ func (config Config) Validate() error {
 		return errors.NotValidf("nil Tag")
 	}
 	if _, ok := config.Tag.(names.MachineTag); !ok {
-		return errors.NotValidf("Tag")
+		if config.Tag.Kind() != names.ControllerAgentTagKind {
+			// On K8s controllers, the controller agent has a ControllerAgentTagKind not a MachineKind
+			// However, we shouldn't be running the InstanceMutater worker to track the state on the Controller
+			// machine anyway. This is a hack for bug #1866623
+			return errors.NotValidf("Tag of kind %v", config.Tag.Kind())
+		}
+		config.Logger.Warningf("asked to start an instance mutator with Tag of kind %q", config.Tag.Kind())
 	}
 	if config.GetMachineWatcher == nil {
 		return errors.NotValidf("nil GetMachineWatcher")
@@ -122,6 +129,11 @@ func NewEnvironWorker(config Config) (worker.Worker, error) {
 // the containers in the state for this machine agent and
 // polls their instance for addition or removal changes.
 func NewContainerWorker(config Config) (worker.Worker, error) {
+	if _, ok := config.Tag.(names.MachineTag); !ok {
+		// Should we be returning a no-op worker of some sort?
+		config.Logger.Infof("cannot start a ContainerWorker on a %q, not restarting", config.Tag.Kind())
+		return nil, dependency.ErrUninstall
+	}
 	m, err := config.Facade.Machine(config.Tag.(names.MachineTag))
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -591,6 +591,10 @@ func (task *provisionerTask) constructInstanceConfig(
 		if err != nil {
 			return nil, err
 		}
+		if stateInfo == nil {
+			return nil, errors.Errorf("Job needs state, but stateInfo is nil: jobs %v for %v",
+				instanceConfig.Jobs, machine.Tag().String())
+		}
 		instanceConfig.Controller = &instancecfg.ControllerConfig{
 			PublicImageSigningKey: publicKey,
 			MongoInfo:             stateInfo,


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

If we want to drive a non-kubernetes cloud from a kubernetes controller there are a couple of places where we were making assumptions about running from an agent that had a MachineTag. However, the Kubernetes controller runs as a ControllerAgent (or possibly a Controller, as they have identical Kind() fields).

Provisioner was always grabbing the StateAddresses because it might want them to configure Mongo in cloud-init, but it actually throws away those credentials. (It might be that we still have a code path where Provisioner can set up a controller agent in cloud-init, but I think we do all the controller agent setup after the agent comes up, and if we haven't yet, we should.)

## QA steps

```sh
sudo snap install microk8s --classic
sudo snap install lxd
sudo apt remove lxd lxd-client
lxd init --auto --network :: --storage zfs
lxc network set lxdbr0 ipv6.address none
juju add-cloud --client lxd # go through the manual prompts
juju add-credential --client lxd # go through the manual prompts
juju bootstrap microk8s micro
juju add-cloud --controller micro lxd
juju add-model test lxd
juju deploy cs:~jameinel/ubuntu-lite
```

Without this patch, `juju debug-log -m controller` will show that the instance-mutator and the compute-provisioner workers are bouncing because they have incorrect configurations.
```
controller-0: 11:57:08 ERROR juju.worker.dependency "instance-mutater" manifold worker returned unexpected error: cannot start machine instancemutater worker: Tag not valid
controller-0: 11:57:30 ERROR juju.worker.dependency "compute-provisioner" manifold worker returned unexpected error: no controller machines found
```

Note there is a side bug that firewaller also bounces if we have a machine in the model that isn't provisioned:
```
controller-0: 11:57:19 ERROR juju.worker.dependency "firewaller" manifold worker returned unexpected error: machine 0 not provisioned
```
That is not addressed by this patch.

## Documentation changes

None at this time. (We may want to add documentation explicitly about using a K8s controller with non-K8s models.)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1866623