### PR TITLE
Recreate exec k8s client on failure

### DIFF
--- a/worker/caasunitinit/manifold.go
+++ b/worker/caasunitinit/manifold.go
@@ -112,11 +112,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return unit.ProviderID(), nil
 			}
 
-			execClient, err := config.NewExecClient(os.Getenv(provider.OperatorNamespaceEnvName))
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-
 			cfg := Config{
 				Logger:                config.Logger,
 				Application:           applicationTag.Id(),
@@ -124,8 +119,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				DataDir:               agentConfig.DataDir(),
 				ContainerStartWatcher: client,
 				UnitProviderIDFunc:    unitProviderID,
-				ExecClient:            execClient,
-				InitializeUnit:        InitializeUnit,
+				NewExecClient: func() (exec.Executor, error) {
+					return config.NewExecClient(os.Getenv(provider.OperatorNamespaceEnvName))
+				},
+				InitializeUnit: InitializeUnit,
 			}
 			cfg.Paths = caasoperator.NewPaths(cfg.DataDir, names.NewApplicationTag(cfg.Application))
 

--- a/worker/caasunitinit/manifold_test.go
+++ b/worker/caasunitinit/manifold_test.go
@@ -161,8 +161,8 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.Logger = nil
 	c.Assert(config.ContainerStartWatcher, gc.NotNil)
 	config.ContainerStartWatcher = nil
-	c.Assert(config.ExecClient, gc.NotNil)
-	config.ExecClient = nil
+	c.Assert(config.NewExecClient, gc.NotNil)
+	config.NewExecClient = nil
 	c.Assert(config.InitializeUnit, gc.NotNil)
 	config.InitializeUnit = nil
 	c.Assert(config.Paths.ToolsDir, gc.Not(gc.Equals), "")

--- a/worker/caasunitinit/worker_test.go
+++ b/worker/caasunitinit/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/workertest"
 
+	"github.com/juju/juju/caas/kubernetes/provider/exec"
 	"github.com/juju/juju/core/watcher/watchertest"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/caasoperator/mocks"
@@ -41,8 +42,10 @@ func (s *UnitInitWorkerSuite) TestWorker(c *gc.C) {
 
 	st := &testing.Stub{}
 	cfg := caasunitinit.Config{
-		Logger:     loggo.GetLogger("test"),
-		ExecClient: &mocks.MockExecutor{},
+		Logger: loggo.GetLogger("test"),
+		NewExecClient: func() (exec.Executor, error) {
+			return &mocks.MockExecutor{}, nil
+		},
 		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
 			return "", errors.NotImplementedf("not required")
 		},
@@ -76,8 +79,10 @@ func (s *UnitInitWorkerSuite) TestUnitDeadGraceful(c *gc.C) {
 
 	st := &testing.Stub{}
 	cfg := caasunitinit.Config{
-		Logger:     loggo.GetLogger("test"),
-		ExecClient: &mocks.MockExecutor{},
+		Logger: loggo.GetLogger("test"),
+		NewExecClient: func() (exec.Executor, error) {
+			return &mocks.MockExecutor{}, nil
+		},
 		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
 			return "", errors.NotImplementedf("not required")
 		},
@@ -111,8 +116,10 @@ func (s *UnitInitWorkerSuite) TestInitializeFailed(c *gc.C) {
 
 	st := &testing.Stub{}
 	cfg := caasunitinit.Config{
-		Logger:     loggo.GetLogger("test"),
-		ExecClient: &mocks.MockExecutor{},
+		Logger: loggo.GetLogger("test"),
+		NewExecClient: func() (exec.Executor, error) {
+			return &mocks.MockExecutor{}, nil
+		},
 		UnitProviderIDFunc: func(unit names.UnitTag) (string, error) {
 			return "", errors.NotImplementedf("not required")
 		},


### PR DESCRIPTION
## Recreate exec k8s client on failure

In the case the caas init worker fails, recreate the exec client
on restart. This is due to possible k8s service account being refreshed
and the older credentials still loaded into memory.

## QA steps

deploy kubeflow on microk8s

## Documentation changes

N/A

## Bug reference

N/A