### PR TITLE
Fix 1866658 jujud called in Makefile before built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,9 @@ JUJUD_STAGING_DIR          ?= /tmp/jujud-operator
 JUJUD_BIN_DIR              ?= ${GOPATH}/bin
 OPERATOR_IMAGE_BUILD_SRC   ?= true
 # By default the image tag is the full version number, including the build number.
-OPERATOR_IMAGE_TAG         ?= $(shell ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}(\.[[:digit:]]{1,9})?")
+OPERATOR_IMAGE_TAG         ?= $(shell test -f ${JUJUD_BIN_DIR}/jujud && ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}(\.[[:digit:]]{1,9})?")
 # Legacy tags never have a build number.
-OPERATOR_IMAGE_TAG_LEGACY  ?= $(shell ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}")
+OPERATOR_IMAGE_TAG_LEGACY  ?= $(shell test -f ${JUJUD_BIN_DIR}/jujud && ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}")
 OPERATOR_IMAGE_PATH         = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}
 OPERATOR_IMAGE_PATH_LEGACY  = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG_LEGACY}
 
@@ -207,6 +207,9 @@ else
 endif
 
 operator-image: operator-check-build
+ifeq ($(OPERATOR_IMAGE_TAG),)
+	$(error OPERATOR_IMAGE_TAG not set)
+endif
 	rm -rf ${JUJUD_STAGING_DIR}
 	mkdir ${JUJUD_STAGING_DIR}
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}


### PR DESCRIPTION
## Fix 1866658 jujud called in Makefile before built

Test for existence of jujud before calling it. Due to each make target
evaluating the Makefile we can just ignore the existence of jujud.

## QA steps

Make sure no jujud is in PATH
make operator-image

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1866658