### PR TITLE
Protect against nil profile from the charm.

### DIFF
--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -90,6 +90,9 @@ type charmShim struct {
 
 func (s *charmShim) LXDProfile() lxdprofile.Profile {
 	profile := s.Charm.LXDProfile()
+	if profile == nil {
+		return lxdprofile.Profile{}
+	}
 	return lxdprofile.Profile{
 		Config:      profile.Config,
 		Description: profile.Description,


### PR DESCRIPTION
The 2.7.3 release changed where the instance mutator got its lxd profile from, but did not guard against a nil struct return which old charms will have.