### PR TITLE
Speed up the processing of machines in juju status.

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1759,11 +1759,6 @@ func (ctx *allWatcherContext) loadOpenedPorts() error {
 	return nil
 }
 
-type constraintsWithID struct {
-	DocID  string         `bson:"_id"`
-	Nested constraintsDoc `bson:",inline"`
-}
-
 func (ctx *allWatcherContext) loadConstraints() error {
 	col, closer := ctx.state.db().GetCollection(constraintsC)
 	defer closer()

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -15,6 +15,11 @@ import (
 	"github.com/juju/juju/core/instance"
 )
 
+type constraintsWithID struct {
+	DocID  string         `bson:"_id"`
+	Nested constraintsDoc `bson:",inline"`
+}
+
 // constraintsDoc is the mongodb representation of a constraints.Value.
 type constraintsDoc struct {
 	ModelUUID      string `bson:"model-uuid"`
@@ -114,3 +119,41 @@ func writeConstraints(mb modelBackend, id string, cons constraints.Value) error 
 	}
 	return nil
 }
+
+// AllConstraints retrieves all the constraints in the model
+// and provides a way to query based on machine or application.
+func (m *Model) AllConstraints() (*ModelConstraints, error) {
+	coll, closer := m.st.db().GetCollection(constraintsC)
+	defer closer()
+
+	var docs []constraintsWithID
+	err := coll.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get all constraints for model")
+	}
+	all := &ModelConstraints{
+		data: make(map[string]constraintsDoc),
+	}
+	for _, doc := range docs {
+		all.data[m.localID(doc.DocID)] = doc.Nested
+	}
+	return all, nil
+}
+
+// ModelConstraints represents all the contraints in  a model
+// keyed on global key.
+type ModelConstraints struct {
+	data map[string]constraintsDoc
+}
+
+// Machine returns the constraints for the specified machine.
+func (c *ModelConstraints) Machine(machineID string) constraints.Value {
+	doc, found := c.data[machineGlobalKey(machineID)]
+	if !found {
+		return constraints.Value{}
+	}
+	return doc.value()
+}
+
+// TODO: add methods for Model and Application constraints checks
+// if desired. Not currently used in status calls.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -772,6 +772,12 @@ func (s *MachineSuite) TestMachineSetProvisionedStoresAndInstanceNamesReturnsDis
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(iid), gc.Equals, "umbrella/0")
 	c.Assert(iname, gc.Equals, "snowflake")
+
+	all, err := s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	iid, iname = all.InstanceNames(s.machine.Id())
+	c.Assert(string(iid), gc.Equals, "umbrella/0")
+	c.Assert(iname, gc.Equals, "snowflake")
 }
 
 func (s *MachineSuite) TestMachineInstanceNamesReturnsIsNotProvisionedWhenNotProvisioned(c *gc.C) {
@@ -803,6 +809,30 @@ func (s *MachineSuite) TestMachineSetProvisionedUpdatesCharacteristics(c *gc.C) 
 	md, err = s.machine.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*md, gc.DeepEquals, *expected)
+
+	all, err := s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	md = all.HardwareCharacteristics(s.machine.Id())
+	c.Assert(*md, gc.DeepEquals, *expected)
+}
+
+func (s *MachineSuite) TestMachineCharmProfiles(c *gc.C) {
+	hwc := &instance.HardwareCharacteristics{}
+	err := s.machine.SetProvisioned("umbrella/0", "", "fake_nonce", hwc)
+	c.Assert(err, jc.ErrorIsNil)
+
+	profiles := []string{"secure", "magic"}
+	err = s.machine.SetCharmProfiles(profiles)
+	c.Assert(err, jc.ErrorIsNil)
+
+	saved, err := s.machine.CharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(saved, jc.SameContents, profiles)
+
+	all, err := s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	saved = all.CharmProfiles(s.machine.Id())
+	c.Assert(saved, jc.SameContents, profiles)
 }
 
 func (s *MachineSuite) TestMachineAvailabilityZone(c *gc.C) {
@@ -1586,6 +1616,11 @@ func (s *MachineSuite) TestSetConstraints(c *gc.C) {
 	mcons, err = machine.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mcons, gc.DeepEquals, cons1)
+
+	all, err := s.Model.AllConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	cons := all.Machine(machine.Id())
+	c.Assert(cons, gc.DeepEquals, cons1)
 }
 
 func (s *MachineSuite) TestSetAmbiguousConstraints(c *gc.C) {


### PR DESCRIPTION
This branch addresses the multiple database queries that were being
run for every machine in the generation of the full status results.

The constraints were being read individually, so we read them in bulk
at the start of the function. State tests were augmented to show that
constraints set on a machine can be read from all the constraints.

Additionally the instance data was being queries three times for
every machine. Once to get the instance id and display name,
another time for the hardware characteristics, and a third time
for the charm profiles. The instance data is now read in bulk at
the start of status and used when processing the machines.

Without these changes the test results showed:
```
   c.Check(tracker.ReadCount(), gc.Equals, queryCount,
        gc.Commentf("if the query count is not the same, there has been a regression "+
            "in the processing of machines, please fix it"))
... obtained int = 41
... expected int = 21
```
Which matches expectations, as five machines were added, and the
processing of each added another four queries.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1865172