### PR TITLE
Dispatch k8s actions

### DIFF
--- a/worker/uniter/operation/runaction.go
+++ b/worker/uniter/operation/runaction.go
@@ -103,13 +103,14 @@ func (ra *runAction) Execute(state State) (*State, error) {
 		}
 	}()
 
-	err := ra.runner.RunAction(ra.name)
+	handlerType, err := ra.runner.RunAction(ra.name)
 	close(done)
 	<-wait
+
 	if err != nil {
 		// This indicates an actual error -- an action merely failing should
 		// be handled inside the Runner, and returned as nil.
-		return nil, errors.Annotatef(err, "running action %q", ra.name)
+		return nil, errors.Annotatef(err, "action %q (via %s) failed", ra.name, handlerType)
 	}
 	return stateChange{
 		Kind:     RunAction,

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -418,8 +418,8 @@ func (r *MockRunner) Context() runner.Context {
 	return r.context
 }
 
-func (r *MockRunner) RunAction(actionName string) error {
-	return r.MockRunAction.Call(actionName)
+func (r *MockRunner) RunAction(actionName string) (runner.HookHandlerType, error) {
+	return runner.ExplicitHookHandler, r.MockRunAction.Call(actionName)
 }
 
 func (r *MockRunner) RunCommands(commands string) (*utilexec.ExecResponse, error) {
@@ -444,9 +444,9 @@ func (r *MockActionWaitRunner) Context() runner.Context {
 	return r.context
 }
 
-func (r *MockActionWaitRunner) RunAction(actionName string) error {
+func (r *MockActionWaitRunner) RunAction(actionName string) (runner.HookHandlerType, error) {
 	r.actionName = actionName
-	return <-r.actionChan
+	return runner.ExplicitHookHandler, <-r.actionChan
 }
 
 func NewDeployCallbacks() *DeployCallbacks {

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -325,17 +325,8 @@ func (runner *runner) RunAction(actionName string) error {
 		rMode = runOnRemote
 	}
 
-	_, err := runner.runCharmHookWithLocation(actionName, runner.getFunctionDir(), rMode)
+	_, err := runner.runCharmHookWithLocation(actionName, "actions", rMode)
 	return err
-}
-
-func (runner *runner) getFunctionDir() string {
-	charmDir := runner.paths.GetCharmDir()
-	dir := filepath.Join(charmDir, "functions")
-	if _, err := os.Stat(dir); !os.IsNotExist(err) {
-		return "functions"
-	}
-	return "actions"
 }
 
 // RunHook exists to satisfy the Runner interface.


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Follow up to  #11257, by adding support for k8s actions via the dispatching script.  Including a little clean up that is now possible with this change.  Since the operator pod and the unit pods both have the same contents, it's possible to verify that dispatch exists via the local methods, instead of attempting with the remote methods.

## QA steps
Run the same qa steps as #11257 

For the k8s section also do:
```console
$ juju run-action ubuntu-plus-k8s/0 hello filename=testfile
Action queued with id: "2"
$ juju show-action-output 2
...
  outcome: success
  result-map:
    message: Hello !
    time-completed: Thu Mar 12 21:04:23 UTC 2020
status: completed
...
$ juju debug-log --replay  | grep Call
application-ubuntu-plus-k8s: 21:04:07 INFO unit.ubuntu-plus-k8s/0.juju-log Calling hooks/install, from dispatch
application-ubuntu-plus-k8s: 21:04:10 INFO unit.ubuntu-plus-k8s/0.juju-log Calling hooks/leader-elected, from dispatch
application-ubuntu-plus-k8s: 21:04:10 INFO unit.ubuntu-plus-k8s/0.juju-log Calling hooks/config-changed, from dispatch
application-ubuntu-plus-k8s: 21:04:11 INFO unit.ubuntu-plus-k8s/0.juju-log Calling hooks/start, from dispatch
application-ubuntu-plus-k8s: 21:04:23 INFO unit.ubuntu-plus-k8s/0.juju-log Calling actions/hello, from dispatch
```

## Documentation changes

part of juju 2.8 docs
