### PR TITLE
Merge 2.7 into develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,9 +220,9 @@ JUJUD_STAGING_DIR          ?= /tmp/jujud-operator
 JUJUD_BIN_DIR              ?= ${GOPATH}/bin
 OPERATOR_IMAGE_BUILD_SRC   ?= true
 # By default the image tag is the full version number, including the build number.
-OPERATOR_IMAGE_TAG         ?= $(shell ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}(\.[[:digit:]]{1,9})?")
+OPERATOR_IMAGE_TAG         ?= $(shell test -f ${JUJUD_BIN_DIR}/jujud && ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}(\.[[:digit:]]{1,9})?")
 # Legacy tags never have a build number.
-OPERATOR_IMAGE_TAG_LEGACY  ?= $(shell ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}")
+OPERATOR_IMAGE_TAG_LEGACY  ?= $(shell test -f ${JUJUD_BIN_DIR}/jujud && ${JUJUD_BIN_DIR}/jujud version | grep -E -o "^[[:digit:]]{1,9}\.[[:digit:]]{1,9}(\.|-[[:alpha:]]+)[[:digit:]]{1,9}")
 ifneq ($(JUJU_BUILD_NUMBER),)
 	OPERATOR_IMAGE_PATH = ${DOCKER_USERNAME}/jujud-operator:${OPERATOR_IMAGE_TAG}.${JUJU_BUILD_NUMBER}
 else
@@ -238,8 +238,11 @@ else
 endif
 
 operator-image: operator-check-build
+ifeq ($(OPERATOR_IMAGE_TAG),)
+	$(error OPERATOR_IMAGE_TAG not set)
+endif
 	rm -rf ${JUJUD_STAGING_DIR}
-	mkdir ${JUJUD_STAGING_DIR}
+	mkdir -p ${JUJUD_STAGING_DIR}
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}

--- a/apiserver/common/cloudspec/statehelpers.go
+++ b/apiserver/common/cloudspec/statehelpers.go
@@ -37,7 +37,7 @@ func MakeCloudSpecGetter(pool Pool) func(names.ModelTag) (environs.CloudSpec, er
 		// both state and model but only model.
 		// TODO (manadart 2018-02-15): This potentially frees the state from
 		// the pool. Release is called, but the state reference survives.
-		return stateenvirons.EnvironConfigGetter{State: st.State, Model: m}.CloudSpec()
+		return stateenvirons.EnvironConfigGetter{Model: m}.CloudSpec()
 	}
 }
 
@@ -51,7 +51,7 @@ func MakeCloudSpecGetterForModel(st *state.State) func(names.ModelTag) (environs
 		if err != nil {
 			return environs.CloudSpec{}, errors.Trace(err)
 		}
-		configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: m}
+		configGetter := stateenvirons.EnvironConfigGetter{Model: m}
 
 		if tag.Id() != st.ModelUUID() {
 			return environs.CloudSpec{}, errors.New("cannot get cloud spec for this model")
@@ -108,7 +108,7 @@ func MakeCloudSpecCredentialContentWatcherForModel(st *state.State) func(names.M
 		if tag.Id() != st.ModelUUID() {
 			return nil, errors.New("cannot get cloud spec credential content for this model")
 		}
-		credentialTag, exists := m.CloudCredential()
+		credentialTag, exists := m.CloudCredentialTag()
 		if !exists {
 			return nil, nil
 		}

--- a/apiserver/common/credentialcommon/backend.go
+++ b/apiserver/common/credentialcommon/backend.go
@@ -36,8 +36,8 @@ type PersistentBackend interface {
 
 // Model defines model methods needed for the check.
 type Model interface {
-	// Cloud returns the name of the cloud to which the model is deployed.
-	Cloud() string
+	// CloudName returns the name of the cloud to which the model is deployed.
+	CloudName() string
 
 	// CloudRegion returns the name of the cloud region to which the model is deployed.
 	CloudRegion() string
@@ -51,9 +51,9 @@ type Model interface {
 	// Type returns the type of the model.
 	Type() state.ModelType
 
-	// CloudCredential returns the tag of the cloud credential used for managing the
+	// CloudCredentialTag returns the tag of the cloud credential used for managing the
 	// model's cloud resources, and a boolean indicating whether a credential is set.
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
 }
 
 // Machine defines machine methods needed for the check.

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -24,7 +24,7 @@ func ValidateExistingModelCredential(backend PersistentBackend, callCtx context.
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
-	credentialTag, isSet := model.CloudCredential()
+	credentialTag, isSet := model.CloudCredentialTag()
 	if !isSet {
 		return params.ErrorResults{}, nil
 	}
@@ -180,7 +180,7 @@ func buildOpenParams(backend PersistentBackend, credentialTag names.CloudCredent
 		return fail(errors.Trace(err))
 	}
 
-	modelCloud, err := backend.Cloud(model.Cloud())
+	modelCloud, err := backend.Cloud(model.CloudName())
 	if err != nil {
 		return fail(errors.Trace(err))
 	}

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -565,7 +565,7 @@ type mockModel struct {
 	cloudCredentialFunc    func() (names.CloudCredentialTag, bool)
 }
 
-func (m *mockModel) Cloud() string {
+func (m *mockModel) CloudName() string {
 	return m.cloudFunc()
 }
 
@@ -581,7 +581,7 @@ func (m *mockModel) Type() state.ModelType {
 	return m.modelType
 }
 
-func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	return m.cloudCredentialFunc()
 }
 

--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
@@ -91,8 +92,10 @@ type Model interface {
 	ModelTag() names.ModelTag
 	Owner() names.UserTag
 	Status() (status.StatusInfo, error)
-	Cloud() string
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudName() string
+	Cloud() (cloud.Cloud, error)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
+	CloudCredential() (state.Credential, bool, error)
 	CloudRegion() string
 	Users() ([]permission.UserAccess, error)
 	Destroy(state.DestroyModelParams) error

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -187,7 +187,6 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 	}
 	netEnviron, err := NetworkingEnvironFromModelConfig(
 		stateenvirons.EnvironConfigGetter{
-			State: api.st,
 			Model: model,
 		},
 	)

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -40,7 +40,11 @@ type CAASBrokerInterface interface {
 func NewStateFacade(ctx facade.Context) (*Facade, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
-	caasBroker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	caasBroker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/agent/credentialvalidator/backend.go
+++ b/apiserver/facades/agent/credentialvalidator/backend.go
@@ -45,7 +45,7 @@ func (b *backend) ModelUsesCredential(tag names.CloudCredentialTag) (bool, error
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	modelCredentialTag, exists := m.CloudCredential()
+	modelCredentialTag, exists := m.CloudCredentialTag()
 	return exists && tag == modelCredentialTag, nil
 }
 
@@ -56,12 +56,12 @@ func (b *backend) ModelCredential() (*ModelCredential, error) {
 		return nil, errors.Trace(err)
 	}
 
-	modelCredentialTag, exists := m.CloudCredential()
+	modelCredentialTag, exists := m.CloudCredentialTag()
 	result := &ModelCredential{Model: m.ModelTag(), Exists: exists}
 	if !exists {
 		// A model credential is not set, we must check if the model
 		// is on the cloud that requires a credential.
-		supportsEmptyAuth, err := b.cloudSupportsNoAuth(m.Cloud())
+		supportsEmptyAuth, err := b.cloudSupportsNoAuth(m.CloudName())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/agent/credentialvalidator/backend_test.go
+++ b/apiserver/facades/agent/credentialvalidator/backend_test.go
@@ -38,7 +38,7 @@ func (s *BackendSuite) TestModelUsesCredential(c *gc.C) {
 	uses, err := s.backend.ModelUsesCredential(s.state.aModel.credentialTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uses, jc.IsTrue)
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag")
 }
 
 func (s *BackendSuite) TestModelUsesCredentialUnset(c *gc.C) {
@@ -46,14 +46,14 @@ func (s *BackendSuite) TestModelUsesCredentialUnset(c *gc.C) {
 	uses, err := s.backend.ModelUsesCredential(s.state.aModel.credentialTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uses, jc.IsFalse)
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag")
 }
 
 func (s *BackendSuite) TestModelUsesCredentialWrongCredential(c *gc.C) {
 	uses, err := s.backend.ModelUsesCredential(names.NewCloudCredentialTag("foo/bob/two"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uses, jc.IsFalse)
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag")
 }
 
 func (s *BackendSuite) TestModelCredentialUnsetNotSupported(c *gc.C) {
@@ -65,7 +65,7 @@ func (s *BackendSuite) TestModelCredentialUnsetNotSupported(c *gc.C) {
 		Credential: names.CloudCredentialTag{},
 		Valid:      false,
 	})
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential", "ModelTag", "Cloud", "Cloud")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag", "ModelTag", "Cloud", "Cloud")
 }
 
 func (s *BackendSuite) TestModelCredentialUnsetSupported(c *gc.C) {
@@ -78,7 +78,7 @@ func (s *BackendSuite) TestModelCredentialUnsetSupported(c *gc.C) {
 		Credential: names.CloudCredentialTag{},
 		Valid:      true,
 	})
-	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential", "ModelTag", "Cloud", "Cloud")
+	s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag", "ModelTag", "Cloud", "Cloud")
 }
 
 func (s *BackendSuite) TestModelCredentialSetButCloudCredentialNotFound(c *gc.C) {
@@ -90,7 +90,7 @@ func (s *BackendSuite) TestModelCredentialSetButCloudCredentialNotFound(c *gc.C)
 			Credential: s.state.aModel.credentialTag,
 			Valid:      expected,
 		})
-		s.state.CheckCallNames(c, "Model", "mockModel.CloudCredential", "ModelTag", "mockState.CloudCredential")
+		s.state.CheckCallNames(c, "Model", "mockModel.CloudCredentialTag", "ModelTag", "mockState.CloudCredentialTag")
 		s.state.ResetCalls()
 	}
 
@@ -145,7 +145,7 @@ func (b *mockState) Model() (credentialvalidator.ModelAccessor, error) {
 }
 
 func (b *mockState) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
-	b.AddCall("mockState.CloudCredential", tag)
+	b.AddCall("mockState.CloudCredentialTag", tag)
 	if err := b.NextErr(); err != nil {
 		return state.Credential{}, err
 	}
@@ -181,8 +181,8 @@ type mockModel struct {
 	cloud string
 }
 
-func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
-	m.MethodCall(m, "mockModel.CloudCredential")
+func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
+	m.MethodCall(m, "mockModel.CloudCredentialTag")
 	return m.credentialTag, m.credentialSet
 }
 
@@ -191,7 +191,7 @@ func (m *mockModel) ModelTag() names.ModelTag {
 	return m.modelTag
 }
 
-func (m *mockModel) Cloud() string {
+func (m *mockModel) CloudName() string {
 	m.MethodCall(m, "Cloud")
 	return m.cloud
 }

--- a/apiserver/facades/agent/credentialvalidator/state.go
+++ b/apiserver/facades/agent/credentialvalidator/state.go
@@ -12,9 +12,9 @@ import (
 
 // ModelAccessor exposes Model methods needed by credential validator.
 type ModelAccessor interface {
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
 	ModelTag() names.ModelTag
-	Cloud() string
+	CloudName() string
 	WatchModelCredential() state.NotifyWatcher
 }
 

--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -90,6 +90,9 @@ type charmShim struct {
 
 func (s *charmShim) LXDProfile() lxdprofile.Profile {
 	profile := s.Charm.LXDProfile()
+	if profile == nil {
+		return lxdprofile.Profile{}
+	}
 	return lxdprofile.Profile{
 		Config:      profile.Config,
 		Description: profile.Description,

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -72,7 +72,7 @@ func (s *iaasProvisionerSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
+	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(env)
 	pm := poolmanager.New(state.NewStateSettings(s.State), registry)
@@ -104,7 +104,7 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.State)
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(broker)
 	pm := poolmanager.New(state.NewStateSettings(s.State), registry)

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -3190,7 +3190,7 @@ func (u *UniterAPIV10) CloudAPIVersion(_, _ struct{}) {}
 func (u *UniterAPI) CloudAPIVersion() (params.StringResult, error) {
 	result := params.StringResult{}
 
-	configGetter := stateenvirons.EnvironConfigGetter{State: u.st, Model: u.m, NewContainerBroker: u.containerBrokerFunc}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: u.m, NewContainerBroker: u.containerBrokerFunc}
 	spec, err := configGetter.CloudSpec()
 	if err != nil {
 		return result, common.ServerError(err)

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -83,9 +83,10 @@ func NewUpgraderAPI(
 		return nil, err
 	}
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
+	newEnviron := common.EnvironFuncForModel(model, configGetter)
 	return &UpgraderAPI{
-		ToolsGetter: common.NewToolsGetter(st, configGetter, st, urlGetter, getCanReadWrite),
+		ToolsGetter: common.NewToolsGetter(st, configGetter, st, urlGetter, getCanReadWrite, newEnviron),
 		ToolsSetter: common.NewToolsSetter(st, getCanReadWrite),
 		st:          st,
 		m:           model,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -217,7 +217,7 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		caasBroker         caas.Broker
 	)
 	if facadeModel.Type() == state.ModelTypeCAAS {
-		caasBroker, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+		caasBroker, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(facadeModel)
 		if err != nil {
 			return nil, errors.Annotate(err, "getting caas client")
 		}

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -83,7 +83,7 @@ func NewOffersAPI(ctx facade.Context) (*OffersAPI, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		g := stateenvirons.EnvironConfigGetter{State: st.State, Model: model}
+		g := stateenvirons.EnvironConfigGetter{Model: model}
 		env, err := environs.GetEnviron(g, environs.New)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -72,7 +72,7 @@ type Client struct {
 	*modelconfig.ModelConfigAPIV1
 
 	api         *API
-	newEnviron  func() (environs.BootstrapEnviron, error)
+	newEnviron  common.NewEnvironFunc
 	check       *common.BlockChecker
 	callContext context.ProviderCallContext
 	openCSRepo  application.OpenCSRepoFunc
@@ -156,25 +156,14 @@ func newFacade(ctx facade.Context) (*Client, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
-
-	var newEnviron func() (environs.BootstrapEnviron, error)
-	if model.Type() == state.ModelTypeCAAS {
-		newEnviron = func() (environs.BootstrapEnviron, error) {
-			f := stateenvirons.GetNewCAASBrokerFunc(caas.New)
-			return f(st)
-		}
-	} else {
-		newEnviron = func() (environs.BootstrapEnviron, error) {
-			return environs.GetEnviron(configGetter, environs.New)
-		}
-	}
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
+	newEnviron := common.EnvironFuncForModel(model, configGetter)
 
 	modelUUID := model.UUID()
 
 	urlGetter := common.NewToolsURLGetter(modelUUID, st)
 	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
+	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	blockChecker := common.NewBlockChecker(st)
 	backend := modelconfig.NewStateBackend(model)
 	// The modelConfigAPI exposed here is V1.
@@ -222,7 +211,7 @@ func NewClient(
 	presence facade.Presence,
 	statusSetter *common.StatusSetter,
 	toolsFinder *common.ToolsFinder,
-	newEnviron func() (environs.BootstrapEnviron, error),
+	newEnviron common.NewEnvironFunc,
 	blockChecker *common.BlockChecker,
 	callCtx context.ProviderCallContext,
 	leadershipReader leadership.Reader,
@@ -605,7 +594,7 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 
 	info := params.ModelInfo{
 		DefaultSeries:  config.PreferredSeries(conf),
-		CloudTag:       names.NewCloudTag(model.Cloud()).String(),
+		CloudTag:       names.NewCloudTag(model.CloudName()).String(),
 		CloudRegion:    model.CloudRegion(),
 		ProviderType:   conf.Type(),
 		Name:           conf.Name(),
@@ -619,7 +608,7 @@ func (c *Client) ModelInfo() (params.ModelInfo, error) {
 	if agentVersion, exists := conf.AgentVersion(); exists {
 		info.AgentVersion = &agentVersion
 	}
-	if tag, ok := model.CloudCredential(); ok {
+	if tag, ok := model.CloudCredentialTag(); ok {
 		info.CloudCredentialTag = tag.String()
 	}
 	info.SLA = &params.ModelSLAInfo{

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -86,7 +86,7 @@ func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.A
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.newEnviron = func() (environs.BootstrapEnviron, error) {
-		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{State: st, Model: m}, environs.New)
+		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{Model: m}, environs.New)
 	}
 	client.SetNewEnviron(apiserverClient, func() (environs.BootstrapEnviron, error) {
 		return s.newEnviron()

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller/authentication"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
@@ -54,8 +55,11 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 		return nil, errors.New("no agent version set in model configuration")
 	}
 	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
-	configGetter := stateenvirons.EnvironConfigGetter{State: st, Model: model}
-	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter)
+	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
+	newEnviron := func() (environs.BootstrapEnviron, error) {
+		return environs.GetEnviron(configGetter, environs.New)
+	}
+	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	findToolsResult, err := toolsFinder.FindTools(params.FindToolsParams{
 		Number:       agentVersion,
 		MajorVersion: -1,

--- a/apiserver/facades/client/cloud/backend.go
+++ b/apiserver/facades/client/cloud/backend.go
@@ -76,8 +76,9 @@ func (s stateShim) Model() (Model, error) {
 
 type Model interface {
 	UUID() string
-	Cloud() string
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudName() string
+	Cloud() (cloud.Cloud, error)
+	CloudCredential() (state.Credential, bool, error)
 	CloudRegion() string
 }
 

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -483,7 +483,7 @@ func (api *CloudAPIV4) DefaultCloud() (params.StringResult, error) {
 		return params.StringResult{}, err
 	}
 	return params.StringResult{
-		Result: names.NewCloudTag(controllerModel.Cloud()).String(),
+		Result: names.NewCloudTag(controllerModel.CloudName()).String(),
 	}, nil
 }
 

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -102,12 +102,12 @@ func (s *cloudSuiteV2) SetUpTest(c *gc.C) {
 				cloud:       "dummy",
 				cloudRegion: "nether",
 				cfg:         coretesting.ModelConfig(c),
-			},
-			cloud: cloud.Cloud{
-				Name:      "dummy",
-				Type:      "dummy",
-				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
-				Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+				cloudValue: cloud.Cloud{
+					Name:      "dummy",
+					Type:      "dummy",
+					AuthTypes: []cloud.AuthType{cloud.EmptyAuthType, cloud.UserPassAuthType},
+					Regions:   []cloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+				},
 			},
 		}
 	}

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -101,9 +101,9 @@ func newModelBackend(c *gc.C, aCloud cloud.Cloud, uuid string) *mockModelBackend
 			uuid:        coretesting.ModelTag.Id(),
 			cloud:       "dummy",
 			cloudRegion: "nether",
+			cloudValue:  aCloud,
 			cfg:         coretesting.ModelConfig(c),
 		},
-		cloud: aCloud,
 	}
 }
 
@@ -1522,11 +1522,12 @@ type mockModel struct {
 	uuid               string
 	cloud              string
 	cloudRegion        string
+	cloudValue         cloud.Cloud
 	cloudCredentialTag names.CloudCredentialTag
 	cfg                *config.Config
 }
 
-func (m *mockModel) Cloud() string {
+func (m *mockModel) CloudName() string {
 	return m.cloud
 }
 
@@ -1534,8 +1535,16 @@ func (m *mockModel) CloudRegion() string {
 	return m.cloudRegion
 }
 
-func (m *mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	return m.cloudCredentialTag, true
+}
+
+func (m *mockModel) Cloud() (cloud.Cloud, error) {
+	return m.cloudValue, nil
+}
+
+func (m *mockModel) CloudCredential() (state.Credential, bool, error) {
+	return state.Credential{}, false, nil
 }
 
 func (m *mockModel) ValidateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
@@ -1582,7 +1591,6 @@ func (m *mockPooledModel) Release() bool {
 type mockModelBackend struct {
 	uuid  string
 	model *mockModel
-	cloud cloud.Cloud
 }
 
 func (m *mockModelBackend) Model() (credentialcommon.Model, error) {
@@ -1590,7 +1598,7 @@ func (m *mockModelBackend) Model() (credentialcommon.Model, error) {
 }
 
 func (m *mockModelBackend) Cloud(name string) (cloud.Cloud, error) {
-	return m.cloud, nil
+	return m.model.cloudValue, nil
 }
 
 func (m *mockModelBackend) AllMachines() ([]credentialcommon.Machine, error) {

--- a/apiserver/facades/client/cloud/instance_information.go
+++ b/apiserver/facades/client/cloud/instance_information.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -27,10 +28,20 @@ func (g cloudEnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
 	if err != nil {
 		return environs.CloudSpec{}, errors.Trace(err)
 	}
-	cloudName := model.Cloud()
+	cloud, err := model.Cloud()
+	if err != nil {
+		return environs.CloudSpec{}, errors.Trace(err)
+	}
 	regionName := g.region
-	credentialTag, _ := model.CloudCredential()
-	return stateenvirons.CloudSpec(g.Backend, cloudName, regionName, credentialTag)
+	credentialValue, ok, err := model.CloudCredential()
+	if err != nil {
+		return environs.CloudSpec{}, errors.Trace(err)
+	}
+	var credential *state.Credential
+	if ok {
+		credential = &credentialValue
+	}
+	return stateenvirons.CloudSpec(cloud, regionName, credential)
 }
 
 // InstanceTypes returns instance type information for the cloud and region
@@ -71,8 +82,8 @@ func instanceTypes(api *CloudAPI,
 			result[i] = params.InstanceTypesResult{Error: common.ServerError(err)}
 			continue
 		}
-		if m.Cloud() != cloudTag.Id() {
-			result[i] = params.InstanceTypesResult{Error: common.ServerError(errors.NotValidf("asking %s cloud information to %s cloud", cloudTag.Id(), m.Cloud()))}
+		if m.CloudName() != cloudTag.Id() {
+			result[i] = params.InstanceTypesResult{Error: common.ServerError(errors.NotValidf("asking %s cloud information to %s cloud", cloudTag.Id(), m.CloudName()))}
 			continue
 		}
 

--- a/apiserver/facades/client/imagemetadatamanager/metadata.go
+++ b/apiserver/facades/client/imagemetadatamanager/metadata.go
@@ -59,8 +59,12 @@ func NewAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	newEnviron := func() (environs.Environ, error) {
-		return stateenvirons.GetNewEnvironFunc(environs.New)(st)
+		return stateenvirons.GetNewEnvironFunc(environs.New)(model)
 	}
 	return createAPI(getState(st), newEnviron, resources, authorizer)
 }

--- a/apiserver/facades/client/machinemanager/instance_information.go
+++ b/apiserver/facades/client/machinemanager/instance_information.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -31,10 +32,20 @@ func instanceTypes(mm *MachineManagerAPI,
 	}
 
 	cloudSpec := func() (environs.CloudSpec, error) {
-		cloudName := model.Cloud()
+		cloud, err := model.Cloud()
+		if err != nil {
+			return environs.CloudSpec{}, errors.Trace(err)
+		}
 		regionName := model.CloudRegion()
-		credentialTag, _ := model.CloudCredential()
-		return stateenvirons.CloudSpec(mm.st, cloudName, regionName, credentialTag)
+		credentialValue, ok, err := model.CloudCredential()
+		if err != nil {
+			return environs.CloudSpec{}, errors.Trace(err)
+		}
+		var credential *state.Credential
+		if ok {
+			credential = &credentialValue
+		}
+		return stateenvirons.CloudSpec(cloud, regionName, credential)
 	}
 	backend := common.EnvironConfigGetterFuncs{
 		CloudSpecFunc:   cloudSpec,

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -146,7 +146,7 @@ type mockModel struct {
 	machinemanager.Model
 }
 
-func (mockModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (mockModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	return names.NewCloudCredentialTag("foo/bob/bar"), true
 }
 
@@ -158,7 +158,7 @@ func (*mockModel) Config() (*config.Config, error) {
 	return config.New(config.UseDefaults, dummy.SampleConfig())
 }
 
-func (*mockModel) Cloud() string {
+func (*mockModel) CloudName() string {
 	return "a-cloud"
 }
 

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/cloud"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
@@ -18,7 +19,6 @@ import (
 )
 
 type Backend interface {
-	state.CloudAccessor
 	network.SpaceLookup
 
 	Machine(string) (Machine, error)
@@ -36,8 +36,8 @@ type Pool interface {
 type Model interface {
 	Name() string
 	UUID() string
-	Cloud() string
-	CloudCredential() (names.CloudCredentialTag, bool)
+	Cloud() (cloud.Cloud, error)
+	CloudCredential() (state.Credential, bool, error)
 	CloudRegion() string
 	Config() (*config.Config, error)
 }

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -262,6 +262,7 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 	s.st.CheckCallNames(c,
 		"ControllerTag",
 		"ModelUUID",
+		"Model",
 		"ControllerTag",
 		"Cloud",
 		"CloudCredential",
@@ -434,6 +435,7 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 	s.caasSt.CheckCallNames(c,
 		"ControllerTag",
 		"ModelUUID",
+		"Model",
 		"ControllerTag",
 		"Cloud",
 		"CloudCredential",
@@ -748,6 +750,7 @@ func (s *modelManagerSuite) TestDumpModelMissingModel(c *gc.C) {
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
 		{"ControllerTag", nil},
 		{"ModelUUID", nil},
+		{"Model", nil},
 		{"GetBackend", []interface{}{tag.Id()}},
 	})
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -806,6 +809,7 @@ func (s *modelManagerSuite) TestDumpModelsDBMissingModel(c *gc.C) {
 	s.st.CheckCalls(c, []gitjujutesting.StubCall{
 		{"ControllerTag", nil},
 		{"ModelUUID", nil},
+		{"Model", nil},
 		{"ModelTag", nil},
 		{"GetBackend", []interface{}{tag.Id()}},
 	})
@@ -870,6 +874,7 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 	s.st.CheckCallNames(c,
 		"ControllerTag",
 		"ModelUUID",
+		"Model",
 		"GetBackend",
 		"Model",
 		"GetBlockForType",
@@ -883,6 +888,7 @@ func (s *modelManagerSuite) TestDestroyModelsV3(c *gc.C) {
 	destroyStorage := true
 	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
 		{"UUID", nil},
+		{"Type", nil},
 		{"Status", nil},
 		{"Destroy", []interface{}{state.DestroyModelParams{
 			DestroyStorage: &destroyStorage,
@@ -922,7 +928,7 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	modelmanager, err := modelmanager.NewModelManagerAPI(
 		common.NewModelManagerBackend(s.Model, s.StatePool),
 		common.NewModelManagerBackend(s.Model, s.StatePool),
-		stateenvirons.EnvironConfigGetter{State: s.State, Model: s.Model},
+		stateenvirons.EnvironConfigGetter{Model: s.Model},
 		nil,
 		s.authoriser,
 		s.Model,
@@ -1873,7 +1879,7 @@ func (s *modelManagerSuite) TestChangeModelCredentialGetModelFail(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, `getting model`)
-	s.st.CheckCallNames(c, "ControllerTag", "ModelUUID", "ModelTag", "GetBlockForType", "ControllerTag", "GetModel")
+	s.st.CheckCallNames(c, "ControllerTag", "ModelUUID", "Model", "ModelTag", "GetBlockForType", "ControllerTag", "GetModel")
 }
 
 func (s *modelManagerSuite) TestChangeModelCredentialNotUpdated(c *gc.C) {

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -20,7 +20,7 @@ func NewStateShim(st *state.State) (*stateShim, error) {
 		return nil, errors.Trace(err)
 	}
 	return &stateShim{
-		EnvironConfigGetter: stateenvirons.EnvironConfigGetter{State: st, Model: m},
+		EnvironConfigGetter: stateenvirons.EnvironConfigGetter{Model: m},
 		State:               st,
 		model:               m,
 	}, nil

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -36,7 +36,7 @@ func NewFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return internalFacade(&backend{stateenvirons.EnvironConfigGetter{State: st, Model: m}}, ctx.Auth(), state.CallContext(st))
+	return internalFacade(&backend{st, stateenvirons.EnvironConfigGetter{Model: m}}, ctx.Auth(), state.CallContext(st))
 }
 
 func internalFacade(backend Backend, auth facade.Authorizer, callCtx context.ProviderCallContext) (*Facade, error) {

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -34,6 +34,7 @@ type SSHMachine interface {
 }
 
 type backend struct {
+	*state.State
 	stateenvirons.EnvironConfigGetter
 }
 

--- a/apiserver/facades/client/subnets/shims.go
+++ b/apiserver/facades/client/subnets/shims.go
@@ -19,7 +19,7 @@ func NewStateShim(st *state.State) (*stateShim, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &stateShim{EnvironConfigGetter: stateenvirons.EnvironConfigGetter{State: st, Model: m},
+	return &stateShim{EnvironConfigGetter: stateenvirons.EnvironConfigGetter{Model: m},
 		State: st, modelTag: m.ModelTag()}, nil
 }
 

--- a/apiserver/facades/controller/agenttools/agenttools.go
+++ b/apiserver/facades/controller/agenttools/agenttools.go
@@ -36,9 +36,13 @@ type AgentToolsAPI struct {
 
 // NewFacade is used to register the facade.
 func NewFacade(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*AgentToolsAPI, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	newEnviron := func() (environs.Environ, error) {
 		newEnviron := stateenvirons.GetNewEnvironFunc(environs.New)
-		return newEnviron(st)
+		return newEnviron(model)
 	}
 	return NewAgentToolsAPI(st, newEnviron, findTools, envVersionUpdate, authorizer)
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -44,7 +44,11 @@ func NewStateCAASOperatorProvisionerAPI(ctx facade.Context) (*API, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
 
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -27,7 +27,11 @@ type API struct {
 // NewStateCAASOperatorUpgraderAPI provides the signature required for facade registration.
 func NewStateCAASOperatorUpgraderAPI(ctx facade.Context) (*API, error) {
 	authorizer := ctx.Auth()
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -61,7 +61,11 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 		return nil, errors.Trace(err)
 	}
 
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(ctx.State())
+	model, err := ctx.State().Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
+++ b/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
@@ -98,11 +98,11 @@ func (s *CharmSuite) SetUpTest(c *gc.C) {
 	}
 	model, err := s.jcSuite.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	cloud, err := s.jcSuite.State.Cloud(model.Cloud())
+	cloud, err := s.jcSuite.State.Cloud(model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	headers := []string{
 		"arch=amd64", // This is the architecture of the deployed applications.
-		"cloud=" + model.Cloud(),
+		"cloud=" + model.CloudName(),
 		"cloud_region=" + model.CloudRegion(),
 		"controller_uuid=" + s.jcSuite.State.ControllerUUID(),
 		"controller_version=" + version.Current.String(),

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -154,11 +154,11 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		"model_uuid":         model.UUID(),
 		"controller_uuid":    st.ControllerUUID(),
 		"controller_version": version.Current.String(),
-		"cloud":              model.Cloud(),
+		"cloud":              model.CloudName(),
 		"cloud_region":       model.CloudRegion(),
 		"is_controller":      strconv.FormatBool(model.IsControllerModel()),
 	}
-	cloud, err := st.Cloud(model.Cloud())
+	cloud, err := st.Cloud(model.CloudName())
 	if err != nil {
 		metadata["provider"] = "unknown"
 	} else {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -239,9 +239,9 @@ func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
 
 	var ra environs.ResourceAdopter
 	if m.Type() == state.ModelTypeCAAS {
-		ra, err = api.getCAASBroker(st.State)
+		ra, err = api.getCAASBroker(m)
 	} else {
-		ra, err = api.getEnviron(st.State)
+		ra, err = api.getEnviron(m)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -288,10 +288,10 @@ func (s *Suite) TestAdoptIAASResources(c *gc.C) {
 	defer st.Close()
 
 	env := mockEnv{Stub: &testing.Stub{}}
-	api, err := s.newAPI(func(modelSt *state.State) (environs.Environ, error) {
-		c.Assert(modelSt.ModelUUID(), gc.Equals, st.ModelUUID())
+	api, err := s.newAPI(func(model stateenvirons.Model) (environs.Environ, error) {
+		c.Assert(model.ModelTag().Id(), gc.Equals, st.ModelUUID())
 		return &env, nil
-	}, func(modelSt *state.State) (caas.Broker, error) {
+	}, func(model stateenvirons.Model) (caas.Broker, error) {
 		return nil, errors.New("should not be called")
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -317,10 +317,10 @@ func (s *Suite) TestAdoptCAASResources(c *gc.C) {
 	defer st.Close()
 
 	broker := mockBroker{Stub: &testing.Stub{}}
-	api, err := s.newAPI(func(modelSt *state.State) (environs.Environ, error) {
+	api, err := s.newAPI(func(model stateenvirons.Model) (environs.Environ, error) {
 		return nil, errors.New("should not be called")
-	}, func(modelSt *state.State) (caas.Broker, error) {
-		c.Assert(modelSt.ModelUUID(), gc.Equals, st.ModelUUID())
+	}, func(model stateenvirons.Model) (caas.Broker, error) {
+		c.Assert(model.ModelTag().Id(), gc.Equals, st.ModelUUID())
 		return &broker, nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -431,9 +431,9 @@ func (s *Suite) mustNewAPI(c *gc.C) *migrationtarget.API {
 }
 
 func (s *Suite) mustNewAPIWithModel(c *gc.C, env environs.Environ, broker caas.Broker) *migrationtarget.API {
-	api, err := s.newAPI(func(*state.State) (environs.Environ, error) {
+	api, err := s.newAPI(func(stateenvirons.Model) (environs.Environ, error) {
 		return env, nil
-	}, func(*state.State) (caas.Broker, error) {
+	}, func(stateenvirons.Model) (caas.Broker, error) {
 		return broker, nil
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/modelupgrader/backend.go
+++ b/apiserver/facades/controller/modelupgrader/backend.go
@@ -18,7 +18,7 @@ type Pool interface {
 }
 
 type Model interface {
-	Cloud() string
+	CloudName() string
 	EnvironVersion() int
 	SetEnvironVersion(int) error
 }

--- a/apiserver/facades/controller/modelupgrader/modelupgrader.go
+++ b/apiserver/facades/controller/modelupgrader/modelupgrader.go
@@ -137,7 +137,7 @@ func (f *Facade) modelTargetEnvironVersion(arg params.Entity) (int, error) {
 		return -1, errors.Trace(err)
 	}
 	defer release()
-	cloud, err := f.backend.Cloud(model.Cloud())
+	cloud, err := f.backend.Cloud(model.CloudName())
 	if err != nil {
 		return -1, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/modelupgrader/modelupgrader_test.go
+++ b/apiserver/facades/controller/modelupgrader/modelupgrader_test.go
@@ -131,8 +131,8 @@ func (s *ModelUpgraderSuite) TestModelTargetEnvironVersion(c *gc.C) {
 		{"GetModel", []interface{}{modelTag1.Id()}},
 		{"GetModel", []interface{}{modelTag2.Id()}},
 	})
-	s.pool.models[modelTag1.Id()].CheckCallNames(c, "Cloud")
-	s.pool.models[modelTag2.Id()].CheckCallNames(c, "Cloud")
+	s.pool.models[modelTag1.Id()].CheckCallNames(c, "CloudName")
+	s.pool.models[modelTag2.Id()].CheckCallNames(c, "CloudName")
 	s.providers.CheckCalls(c, []testing.StubCall{
 		{"Provider", []interface{}{"foo-provider"}},
 		{"Provider", []interface{}{"bar-provider"}},
@@ -219,8 +219,8 @@ type mockModel struct {
 	v     int
 }
 
-func (m *mockModel) Cloud() string {
-	m.MethodCall(m, "Cloud")
+func (m *mockModel) CloudName() string {
+	m.MethodCall(m, "CloudName")
 	m.PopNoErr()
 	return m.cloud
 }

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -173,8 +173,12 @@ func (h *toolsDownloadHandler) fetchAndCacheTools(
 ) (binarystorage.Metadata, io.ReadCloser, error) {
 	md := binarystorage.Metadata{Version: v.String()}
 
+	model, err := st.Model()
+	if err != nil {
+		return md, nil, err
+	}
 	newEnviron := stateenvirons.GetNewEnvironFunc(environs.New)
-	env, err := newEnviron(st)
+	env, err := newEnviron(model)
 	if err != nil {
 		return md, nil, err
 	}

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -5,14 +5,18 @@ package commands
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/version"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -23,6 +27,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
+	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -64,7 +69,7 @@ type upgradeControllerCommand struct {
 	modelcmd.ControllerCommandBase
 	baseUpgradeCommand
 
-	upgradeJujuAPI upgradeJujuAPI
+	upgradeJujuAPI jujuClientAPI
 	rawArgs        []string
 }
 
@@ -81,7 +86,7 @@ func (c *upgradeControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.baseUpgradeCommand.SetFlags(f)
 }
 
-func (c *upgradeControllerCommand) getUpgradeJujuAPI() (upgradeJujuAPI, error) {
+func (c *upgradeControllerCommand) getUpgradeJujuAPI() (jujuClientAPI, error) {
 	if c.upgradeJujuAPI != nil {
 		return c.upgradeJujuAPI, nil
 	}
@@ -144,6 +149,46 @@ func (c *upgradeControllerCommand) Run(ctx *cmd.Context) (err error) {
 	return c.upgradeIAASController(ctx, fullControllerModelName)
 }
 
+// fetchStreamsVersions returns simplestreams agent metadata
+// for the specified stream. timeout ensures we don't block forever.
+func fetchStreamsVersions(
+	client toolsAPI, majorVersion int, stream string, timeout time.Duration,
+) (tools.List, error) {
+	// Use a go routine so we can timeout.
+	result := make(chan tools.List, 1)
+	errChan := make(chan error, 1)
+	go func() {
+		findResult, err := client.FindTools(majorVersion, -1, "", "", stream)
+		if err == nil {
+			if findResult.Error != nil {
+				err = findResult.Error
+				// We need to deal with older controllers.
+				if strings.HasSuffix(findResult.Error.Message, "not valid") {
+					err = errors.NotValidf("finding stream data for this model")
+				}
+			}
+		}
+		if err != nil {
+			errChan <- err
+		} else {
+			result <- findResult.List
+		}
+	}()
+
+	for {
+		select {
+		case <-time.After(timeout):
+			return nil, nil
+		case err := <-errChan:
+			return nil, err
+		case resultList := <-result:
+			return resultList, nil
+		}
+	}
+}
+
+const caasStreamsTimeout = 20 * time.Second
+
 func (c *upgradeControllerCommand) upgradeCAASController(ctx *cmd.Context) error {
 	if c.BuildAgent {
 		return errors.NotSupportedf("--build-agent for k8s controller upgrades")
@@ -197,10 +242,9 @@ func (c *upgradeControllerCommand) upgradeCAASController(ctx *cmd.Context) error
 		return err
 	}
 
-	c.upgradeMessage = "upgrade to this version by running\n    juju upgrade-controller"
-	context, err := initCAASVersions(controllerCfg, c.Version, currentAgentVersion, warnCompat)
-	if err != nil {
-		return err
+	context, versionsErr := c.initVersions(client, controllerCfg, cfg, currentAgentVersion, warnCompat, caasStreamsTimeout, c.initCAASVersions)
+	if versionsErr != nil && !params.IsCodeNotFound(versionsErr) {
+		return versionsErr
 	}
 
 	if err := context.maybeChoosePackagedAgent(); err != nil {
@@ -217,6 +261,7 @@ func (c *upgradeControllerCommand) upgradeCAASController(ctx *cmd.Context) error
 		fmt.Fprintf(ctx.Stderr, "version %s incompatible with this client (%s)\n", context.chosen, jujuversion.Current)
 	}
 	if c.DryRun {
+		c.upgradeMessage = "upgrade to this version by running\n    juju upgrade-controller"
 		fmt.Fprintf(ctx.Stderr, "%s\n", c.upgradeMessage)
 		return nil
 	}
@@ -227,50 +272,43 @@ func (c *upgradeControllerCommand) upgradeCAASController(ctx *cmd.Context) error
 // agent and client versions, and the list of currently available operator images, will
 // always be accurate; the chosen version, and the flag indicating development
 // mode, may remain blank until uploadTools or validate is called.
-func initCAASVersions(
-	controllerCfg controller.Config, desiredVersion, agentVersion version.Number, filterOnPrior bool,
-) (*upgradeContext, error) {
-	if desiredVersion == agentVersion {
-		return nil, errUpToDate
-	}
-
-	filterVersion := jujuversion.Current
-	if desiredVersion != version.Zero {
-		filterVersion = desiredVersion
-	} else if filterOnPrior {
-		filterVersion.Major--
-	}
-	logger.Debugf("searching for agent images with major: %d", filterVersion.Major)
+func (c *baseUpgradeCommand) initCAASVersions(
+	controllerCfg controller.Config, majorVersion int, streamsAgents tools.List,
+) (tools.Versions, error) {
+	logger.Debugf("searching for agent images with major: %d", majorVersion)
 	imagePath := podcfg.GetJujuOCIImagePath(controllerCfg, version.Zero, 0)
 	availableTags, err := docker.ListOperatorImages(imagePath)
 	if err != nil {
 		return nil, err
 	}
+	streamsVersions := set.NewStrings()
+	for _, a := range streamsAgents {
+		streamsVersions.Add(a.Version.Number.String())
+	}
 	logger.Debugf("found available tags: %v", availableTags)
 	var matchingTags tools.Versions
 	for _, t := range availableTags {
 		vers := t.AgentVersion()
-		if filterVersion.Major != -1 && vers.Major != filterVersion.Major {
+		if majorVersion != -1 && vers.Major != majorVersion {
 			continue
+		}
+		// Only include a docker image if we've published simple streams
+		// metadata for that version.
+		vers.Build = 0
+		if streamsVersions.Size() > 0 {
+			if !streamsVersions.Contains(vers.String()) {
+				continue
+			}
+		} else {
+			// Fallback for when we can't query the streams versions.
+			// Ignore tagged (non-release) versions if agent stream is released.
+			if (c.AgentStream == "" || c.AgentStream == envtools.ReleasedStream) && vers.Tag != "" {
+				continue
+			}
 		}
 		matchingTags = append(matchingTags, t)
 	}
-
-	logger.Debugf("found matching tags: %v", matchingTags)
-	if len(matchingTags) == 0 {
-		// No images found, so if we are not asking for a major upgrade,
-		// pretend there is no more recent version available.
-		if desiredVersion == version.Zero && agentVersion.Major == filterVersion.Major {
-			return nil, errUpToDate
-		}
-		return nil, err
-	}
-	return &upgradeContext{
-		agent:          agentVersion,
-		client:         jujuversion.Current,
-		chosen:         desiredVersion,
-		packagedAgents: matchingTags,
-	}, nil
+	return matchingTags, nil
 }
 
 func (c *upgradeControllerCommand) upgradeIAASController(ctx *cmd.Context, controllerModel string) error {

--- a/environs/environ_test.go
+++ b/environs/environ_test.go
@@ -19,7 +19,7 @@ type environSuite struct {
 var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) TestGetEnvironment(c *gc.C) {
-	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.State)
+	env, err := stateenvirons.GetNewEnvironFunc(environs.New)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	config, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/api_credentialmanager_test.go
+++ b/featuretests/api_credentialmanager_test.go
@@ -36,7 +36,7 @@ func (s *CredentialManagerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *CredentialManagerSuite) TestInvalidateModelCredential(c *gc.C) {
-	tag, set := s.Model.CloudCredential()
+	tag, set := s.Model.CloudCredentialTag()
 	c.Assert(set, jc.IsTrue)
 	credential, err := s.State.CloudCredential(tag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_credential_test.go
+++ b/featuretests/cmd_juju_credential_test.go
@@ -149,7 +149,7 @@ clouds:
 	c.Assert(result[0].Error.Error(), gc.DeepEquals, "credential \"newcred\" not found")
 
 	// Check model references original credential.
-	originalCredentialTag, set := s.Model.CloudCredential()
+	originalCredentialTag, set := s.Model.CloudCredentialTag()
 	c.Assert(set, jc.IsTrue)
 	c.Assert(originalCredentialTag.String(), jc.DeepEquals, "cloudcred-dummy_admin_cred")
 
@@ -178,7 +178,7 @@ Changed cloud credential on model "controller" to "newcred".
 	// Check model reference was updated to a new credential.
 	err = s.Model.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	updatedCredentialTag, set := s.Model.CloudCredential()
+	updatedCredentialTag, set := s.Model.CloudCredentialTag()
 	c.Assert(set, jc.IsTrue)
 	c.Assert(updatedCredentialTag.String(), jc.DeepEquals, "cloudcred-dummy_admin_newcred")
 

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -168,7 +168,7 @@ special         -        -
 
 func (s *cmdModelSuite) TestModelDefaultsSet(c *gc.C) {
 	s.run(c, "model-defaults", "special=known")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	value, found := defaults["special"]
 	c.Assert(found, jc.IsTrue)
@@ -177,7 +177,7 @@ func (s *cmdModelSuite) TestModelDefaultsSet(c *gc.C) {
 
 func (s *cmdModelSuite) TestModelDefaultsSetCloud(c *gc.C) {
 	s.run(c, "model-defaults", "dummy", "special=known")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	value, found := defaults["special"]
 	c.Assert(found, jc.IsTrue)
@@ -187,7 +187,7 @@ func (s *cmdModelSuite) TestModelDefaultsSetCloud(c *gc.C) {
 
 func (s *cmdModelSuite) TestModelDefaultsSetRegion(c *gc.C) {
 	s.run(c, "model-defaults", "dummy/dummy-region", "special=known")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	value, found := defaults["special"]
 	c.Assert(found, jc.IsTrue)
@@ -200,7 +200,7 @@ func (s *cmdModelSuite) TestModelDefaultsReset(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "--reset", "special")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]
 	c.Assert(found, jc.IsFalse)
@@ -211,7 +211,7 @@ func (s *cmdModelSuite) TestModelDefaultsResetCloud(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "dummy", "--reset", "special")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]
 	c.Assert(found, jc.IsFalse)
@@ -222,7 +222,7 @@ func (s *cmdModelSuite) TestModelDefaultsResetRegion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "model-defaults", "dummy-region", "--reset", "special")
-	defaults, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	defaults, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	_, found := defaults["special"]
 	c.Assert(found, jc.IsFalse)

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -52,7 +52,7 @@ type PrecheckModel interface {
 	Owner() names.UserTag
 	Life() state.Life
 	MigrationMode() state.MigrationMode
-	CloudCredential() (names.CloudCredentialTag, bool)
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
 }
 
 // PrecheckMachine describes the state interface for a machine needed
@@ -172,7 +172,7 @@ func (ctx *precheckContext) checkModel() error {
 	if model.MigrationMode() == state.MigrationModeImporting {
 		return errors.New("model is being imported as part of another migration")
 	}
-	if credTag, found := model.CloudCredential(); found {
+	if credTag, found := model.CloudCredentialTag(); found {
 		creds, err := ctx.backend.CloudCredential(credTag)
 		if err != nil {
 			return errors.Trace(err)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -893,7 +893,7 @@ func (m *fakeModel) MigrationMode() state.MigrationMode {
 	return m.migrationMode
 }
 
-func (m *fakeModel) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *fakeModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	if names.IsValidCloudCredential(m.credential) {
 		return names.NewCloudCredentialTag(m.credential), true
 	}

--- a/state/action.go
+++ b/state/action.go
@@ -626,7 +626,8 @@ func (m *Model) ActionByTag(tag names.ActionTag) (Action, error) {
 
 // FindActionTagsById finds Actions with ids that either
 // share the supplied prefix (for deprecated UUIDs), or match
-// the supplied id (for newer id integers).
+// the supplied id (for newer id integers). If passed an empty string
+// match all Actions.
 // It returns a list of corresponding ActionTags.
 func (m *Model) FindActionTagsById(idValue string) ([]names.ActionTag, error) {
 	actionLogger.Tracef("FindActionTagsById() %q", idValue)
@@ -646,7 +647,11 @@ func (m *Model) FindActionTagsById(idValue string) ([]names.ActionTag, error) {
 	newIdsSupported := IsNewActionIDSupported(agentVersion)
 	maybeOldId := strings.ContainsAny(idValue, "-abcdef")
 	var filter bson.D
-	if !newIdsSupported || maybeOldId {
+	if idValue == "" {
+		// Match all when passed an empty id prefix for
+		// legacy behaviour.
+		filter = nil
+	} else if !newIdsSupported || maybeOldId {
 		filter = bson.D{{
 			"_id", bson.D{{"$regex", "^" + matchValue}},
 		}}

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -768,8 +768,13 @@ func (s *ActionSuite) TestFindActionTagsById(c *gc.C) {
 	tags, err := s.model.FindActionTagsById("2")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(len(tags), gc.Equals, 1)
+	c.Assert(tags, gc.HasLen, 1)
 	c.Assert(tags[0].Id(), gc.Equals, "2")
+
+	// Test match all.
+	tags, err = s.model.FindActionTagsById("")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tags, gc.HasLen, 4)
 }
 
 func (s *ActionSuite) TestFindActionTagsByLegacyId(c *gc.C) {

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -62,6 +62,7 @@ func (s *ControllerAddressesSuite) SetUpTest(c *gc.C) {
 		},
 	})
 	c.Logf("machine addresses: %#v", machine.Addresses())
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 }
 
 func (s *ControllerAddressesSuite) TestControllerModel(c *gc.C) {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -85,7 +85,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	c.Assert(err, jc.ErrorIsNil)
 	modelStatus, err := model.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	credential, _ := model.CloudCredential()
+	credential, _ := model.CloudCredentialTag()
 	add(&multiwatcher.ModelInfo{
 		ModelUUID:       model.UUID(),
 		Name:            model.Name(),
@@ -93,7 +93,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		Owner:           model.Owner().Id(),
 		ControllerUUID:  model.ControllerUUID(),
 		IsController:    model.IsControllerModel(),
-		Cloud:           model.Cloud(),
+		Cloud:           model.CloudName(),
 		CloudRegion:     model.CloudRegion(),
 		CloudCredential: credential.Id(),
 		Config:          modelCfg.AllAttrs(),
@@ -1084,7 +1084,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 			cons := constraints.MustParse("mem=4G")
 			err = st.SetModelConstraints(cons)
 			c.Assert(err, jc.ErrorIsNil)
-			credential, _ := model.CloudCredential()
+			credential, _ := model.CloudCredentialTag()
 
 			return changeTestCase{
 				about: "model is added if it's in backing but not in Store",
@@ -1100,7 +1100,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 						Owner:           model.Owner().Id(),
 						ControllerUUID:  model.ControllerUUID(),
 						IsController:    model.IsControllerModel(),
-						Cloud:           model.Cloud(),
+						Cloud:           model.CloudName(),
 						CloudRegion:     model.CloudRegion(),
 						CloudCredential: credential.Id(),
 						Config:          cfg.AllAttrs(),
@@ -1127,7 +1127,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			status, err := model.Status()
 			c.Assert(err, jc.ErrorIsNil)
-			credential, _ := model.CloudCredential()
+			credential, _ := model.CloudCredentialTag()
 			return changeTestCase{
 				about: "model is updated if it's in backing and in Store",
 				initialContents: []multiwatcher.EntityInfo{
@@ -1165,7 +1165,7 @@ func (s *allModelWatcherStateSuite) TestChangeModels(c *gc.C) {
 						Owner:           model.Owner().Id(),
 						ControllerUUID:  model.ControllerUUID(),
 						IsController:    model.IsControllerModel(),
-						Cloud:           model.Cloud(),
+						Cloud:           model.CloudName(),
 						CloudRegion:     model.CloudRegion(),
 						CloudCredential: credential.Id(),
 						Config:          cfg.AllAttrs(),
@@ -1278,7 +1278,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 		func(c *gc.C, st *State) changeTestCase {
 			model, err := st.Model()
 			c.Assert(err, jc.ErrorIsNil)
-			credential, _ := model.CloudCredential()
+			credential, _ := model.CloudCredentialTag()
 
 			return changeTestCase{
 				about: "model update keeps permissions",
@@ -1302,7 +1302,7 @@ func testChangePermissions(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)
 					Owner:           model.Owner().Id(),
 					ControllerUUID:  testing.ControllerTag.Id(),
 					IsController:    model.IsControllerModel(),
-					Cloud:           model.Cloud(),
+					Cloud:           model.CloudName(),
 					CloudRegion:     model.CloudRegion(),
 					CloudCredential: credential.Id(),
 					SLA:             multiwatcher.ModelSLAInfo{Level: "unsupported"},

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -122,7 +122,7 @@ func (s *CAASModelSuite) TestDestroyModel(c *gc.C) {
 
 func (s *CAASModelSuite) TestDestroyModelDestroyStorage(c *gc.C) {
 	model, st := s.newCAASModel(c)
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(st)
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(broker)
 	s.policy = testing.MockPolicy{

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -880,7 +880,9 @@ func (s *CleanupSuite) assertCleanupCAASEntityWithStorage(c *gc.C, deleteOp func
 	defer st.Close()
 	sb, err := state.NewStorageBackend(st)
 	c.Assert(err, jc.ErrorIsNil)
-	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(st)
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
 	c.Assert(err, jc.ErrorIsNil)
 	registry := stateenvirons.NewStorageProviderRegistry(broker)
 	s.policy = testing.MockPolicy{

--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -237,7 +237,10 @@ func (s *CloudCredentialsSuite) TestRemoveModelsCredential(c *gc.C) {
 	aModel, helper, err := s.StatePool.GetModel(modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	defer helper.Release()
-	_, isSet := aModel.CloudCredential()
+	_, isSet := aModel.CloudCredentialTag()
+	c.Assert(isSet, jc.IsFalse)
+	_, isSet, err = aModel.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isSet, jc.IsFalse)
 }
 
@@ -264,9 +267,12 @@ func (s *CloudCredentialsSuite) TestRemoveModelsCredentialConcurrentModelDelete(
 	aModel, helper, err := s.StatePool.GetModel(modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	defer helper.Release()
-	_, isSet := aModel.CloudCredential()
+	_, isSet := aModel.CloudCredentialTag()
 	// Since the model was marked 'dead' in the middle of 1st transaction attempt,
 	// and 2nd attempt would not have picked it up, the model credential would not actually be cleared.
+	c.Assert(isSet, jc.IsTrue)
+	_, isSet, err = aModel.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isSet, jc.IsTrue)
 	c.Assert(c.GetTestLog(), jc.Contains, "creating operations to remove models credential, attempt 1")
 }

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -199,10 +199,16 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 
 	// Check that the model's cloud and credential names are as
 	// expected, and the owner's cloud credentials are initialised.
-	c.Assert(model.Cloud(), gc.Equals, "dummy")
-	credentialTag, ok := model.CloudCredential()
+	c.Assert(model.CloudName(), gc.Equals, "dummy")
+	credentialTag, ok := model.CloudCredentialTag()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(credentialTag, gc.Equals, userPassCredentialTag)
+	cred, credentialSet, err := model.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentialSet, jc.IsTrue)
+	stateCred, err := s.State.CloudCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, stateCred)
 	cloudCredentials, err := s.State.CloudCredentials(model.Owner(), "dummy")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudCredentials, jc.DeepEquals, map[string]state.Credential{

--- a/state/machine.go
+++ b/state/machine.go
@@ -276,6 +276,63 @@ func getInstanceData(st *State, id string) (instanceData, error) {
 	return instData, nil
 }
 
+// AllInstanceData retrieves all instance data in the model
+// and provides a way to query hardware characteristics and
+// charm profiles by machine.
+func (m *Model) AllInstanceData() (*ModelInstanceData, error) {
+	coll, closer := m.st.db().GetCollection(instanceDataC)
+	defer closer()
+
+	var docs []instanceData
+	err := coll.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get all instance data for model")
+	}
+	all := &ModelInstanceData{
+		data: make(map[string]instanceData),
+	}
+	for _, doc := range docs {
+		all.data[doc.MachineId] = doc
+	}
+	return all, nil
+}
+
+// ModelInstanceData represents all the instance data for a model
+// keyed on machine ID.
+type ModelInstanceData struct {
+	data map[string]instanceData
+}
+
+// HardwareCharacteristics returns the hardware characteristics of the
+// machine. If it isn't found in the map, a nil is returned.
+func (d *ModelInstanceData) HardwareCharacteristics(machineID string) *instance.HardwareCharacteristics {
+	instData, found := d.data[machineID]
+	if !found {
+		return nil
+	}
+	return hardwareCharacteristics(instData)
+}
+
+// CharmProfiles returns the names of the profiles that are defined for
+// the machine. If the machine isn't found in the map, a nil is returned.
+func (d *ModelInstanceData) CharmProfiles(machineID string) []string {
+	instData, found := d.data[machineID]
+	if !found {
+		return nil
+	}
+	return instData.CharmProfiles
+}
+
+// InstanceNames returns both the provider instance id and the user
+// friendly name. If the machine isn't found, empty strings are returned.
+func (d *ModelInstanceData) InstanceNames(machineID string) (instance.Id, string) {
+	instData, found := d.data[machineID]
+	if !found {
+		return "", ""
+	}
+	return instData.InstanceId, instData.DisplayName
+}
+
 // Tag returns a tag identifying the machine. The String method provides a
 // string representation that is safe to use as a file name. The returned name
 // will be different from other Tag values returned by any other entities

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -783,6 +783,12 @@ func (s *MachineSuite) TestMachineSetProvisionedStoresAndInstanceNamesReturnsDis
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(iid), gc.Equals, "umbrella/0")
 	c.Assert(iname, gc.Equals, "snowflake")
+
+	all, err := s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	iid, iname = all.InstanceNames(s.machine.Id())
+	c.Assert(string(iid), gc.Equals, "umbrella/0")
+	c.Assert(iname, gc.Equals, "snowflake")
 }
 
 func (s *MachineSuite) TestMachineInstanceNamesReturnsIsNotProvisionedWhenNotProvisioned(c *gc.C) {
@@ -814,6 +820,30 @@ func (s *MachineSuite) TestMachineSetProvisionedUpdatesCharacteristics(c *gc.C) 
 	md, err = s.machine.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*md, gc.DeepEquals, *expected)
+
+	all, err := s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	md = all.HardwareCharacteristics(s.machine.Id())
+	c.Assert(*md, gc.DeepEquals, *expected)
+}
+
+func (s *MachineSuite) TestMachineCharmProfiles(c *gc.C) {
+	hwc := &instance.HardwareCharacteristics{}
+	err := s.machine.SetProvisioned("umbrella/0", "", "fake_nonce", hwc)
+	c.Assert(err, jc.ErrorIsNil)
+
+	profiles := []string{"secure", "magic"}
+	err = s.machine.SetCharmProfiles(profiles)
+	c.Assert(err, jc.ErrorIsNil)
+
+	saved, err := s.machine.CharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(saved, jc.SameContents, profiles)
+
+	all, err := s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	saved = all.CharmProfiles(s.machine.Id())
+	c.Assert(saved, jc.SameContents, profiles)
 }
 
 func (s *MachineSuite) TestMachineAvailabilityZone(c *gc.C) {
@@ -1647,6 +1677,11 @@ func (s *MachineSuite) TestSetConstraints(c *gc.C) {
 	mcons, err = machine.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mcons, gc.DeepEquals, cons1)
+
+	all, err := s.Model.AllConstraints()
+	c.Assert(err, jc.ErrorIsNil)
+	cons := all.Machine(machine.Id())
+	c.Assert(cons, gc.DeepEquals, cons1)
 }
 
 func (s *MachineSuite) TestSetAmbiguousConstraints(c *gc.C) {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -125,7 +125,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 
 	args := description.ModelArgs{
 		Type:               string(dbModel.Type()),
-		Cloud:              dbModel.Cloud(),
+		Cloud:              dbModel.CloudName(),
 		CloudRegion:        dbModel.CloudRegion(),
 		Owner:              dbModel.Owner(),
 		Config:             modelConfig.Settings,
@@ -134,7 +134,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 		Blocks:             blocks,
 	}
 	export.model = description.NewModel(args)
-	if credsTag, credsSet := dbModel.CloudCredential(); credsSet && !cfg.SkipCredentials {
+	if credsTag, credsSet := dbModel.CloudCredentialTag(); credsSet && !cfg.SkipCredentials {
 		creds, err := st.CloudCredential(credsTag)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/state/model.go
+++ b/state/model.go
@@ -584,9 +584,14 @@ func (m *Model) Type() ModelType {
 	return m.doc.Type
 }
 
-// Cloud returns the name of the cloud to which the model is deployed.
-func (m *Model) Cloud() string {
+// CloudName returns the name of the cloud to which the model is deployed.
+func (m *Model) CloudName() string {
 	return m.doc.Cloud
+}
+
+// Cloud returns the cloud to which the model is deployed.
+func (m *Model) Cloud() (jujucloud.Cloud, error) {
+	return m.st.Cloud(m.CloudName())
 }
 
 // CloudRegion returns the name of the cloud region to which the model is deployed.
@@ -594,13 +599,24 @@ func (m *Model) CloudRegion() string {
 	return m.doc.CloudRegion
 }
 
-// CloudCredential returns the tag of the cloud credential used for managing the
+// CloudCredentialTag returns the tag of the cloud credential used for managing the
 // model's cloud resources, and a boolean indicating whether a credential is set.
-func (m *Model) CloudCredential() (names.CloudCredentialTag, bool) {
+func (m *Model) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 	if names.IsValidCloudCredential(m.doc.CloudCredential) {
 		return names.NewCloudCredentialTag(m.doc.CloudCredential), true
 	}
 	return names.CloudCredentialTag{}, false
+}
+
+// CloudCredential returns the cloud credential used for managing the
+// model's cloud resources, and a boolean indicating whether a credential is set.
+func (m *Model) CloudCredential() (Credential, bool, error) {
+	tag, ok := m.CloudCredentialTag()
+	if !ok {
+		return Credential{}, false, nil
+	}
+	cred, err := m.st.CloudCredential(tag)
+	return cred, true, err
 }
 
 // MigrationMode returns whether the model is active or being migrated.
@@ -646,7 +662,7 @@ func modelStatusInvalidCredential() status.StatusInfo {
 // Status returns the status of the model.
 func (m *Model) Status() (status.StatusInfo, error) {
 	// If model credential is invalid, model is suspended.
-	if credentialTag, hasCredential := m.CloudCredential(); hasCredential {
+	if credentialTag, hasCredential := m.CloudCredentialTag(); hasCredential {
 		credential, err := m.st.CloudCredential(credentialTag)
 		if err != nil {
 			return status.StatusInfo{}, errors.Annotatef(err, "could not get model credential %v", credentialTag.Id())

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -1659,11 +1659,12 @@ func (s *ModelCloudValidationSuite) TestNewModelDifferentCloud(c *gc.C) {
 	controller, owner := s.initializeState(c, []cloud.Region{{Name: "some-region"}}, []cloud.AuthType{cloud.EmptyAuthType}, nil)
 	defer controller.Close()
 	st := controller.SystemState()
-	err := st.AddCloud(cloud.Cloud{
+	aCloud := cloud.Cloud{
 		Name:      "another",
 		Type:      "dummy",
 		AuthTypes: cloud.AuthTypes{"empty", "userpass"},
-	}, owner.Name())
+	}
+	err := st.AddCloud(aCloud, owner.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, _ := createTestModelConfig(c, st.ModelUUID())
 	cfg, err = cfg.Apply(map[string]interface{}{"name": "whatever"})
@@ -1677,7 +1678,10 @@ func (s *ModelCloudValidationSuite) TestNewModelDifferentCloud(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer newSt.Close()
-	c.Assert(m.Cloud(), gc.Equals, "another")
+	c.Assert(m.CloudName(), gc.Equals, "another")
+	cloudValue, err := m.Cloud()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudValue, jc.DeepEquals, aCloud)
 }
 
 func (s *ModelCloudValidationSuite) TestNewModelUnknownCloudRegion(c *gc.C) {

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -167,7 +167,7 @@ func (st *State) UpdateModelConfigDefaultValues(attrs map[string]interface{}, re
 		if err != nil {
 			return errors.Trace(err)
 		}
-		key = cloudGlobalKey(model.Cloud())
+		key = cloudGlobalKey(model.CloudName())
 	}
 	settings, err := readSettings(st.db(), globalSettingsC, key)
 	if err != nil {
@@ -463,7 +463,7 @@ func (st *State) regionSpec() (*environs.CloudRegionSpec, error) {
 		return nil, errors.Trace(err)
 	}
 	rspec := &environs.CloudRegionSpec{
-		Cloud:  model.Cloud(),
+		Cloud:  model.CloudName(),
 		Region: model.CloudRegion(),
 	}
 	return rspec, nil

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -442,7 +442,7 @@ func (s *ModelConfigSourceSuite) TestModelConfigDefaults(c *gc.C) {
 		Value: "dummy-proxy"}}
 	expectedValues["no-proxy"] = ds
 
-	sources, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	sources, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sources, jc.DeepEquals, expectedValues)
 }
@@ -462,7 +462,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedValues := make(config.ModelDefaultAttributes)
 	for attr, val := range config.ConfigDefaults() {
@@ -503,7 +503,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	err = s.State.UpdateModelConfigDefaultValues(attrs, nil, rspec)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedValues := make(config.ModelDefaultAttributes)
 	for attr, val := range config.ConfigDefaults() {
@@ -535,7 +535,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// and check again
-	cfg, err = s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err = s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	expectedValues = make(config.ModelDefaultAttributes)
 	for attr, val := range config.ConfigDefaults() {
@@ -572,7 +572,7 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultValuesUnknownRegion
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Then check config.
-	cfg, err := s.State.ModelConfigDefaultValues(s.Model.Cloud())
+	cfg, err := s.State.ModelConfigDefaultValues(s.Model.CloudName())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg["no-proxy"], jc.DeepEquals, config.AttributeDefaultValues{
 		Default:    "127.0.0.1,localhost,::1",

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -22,7 +22,7 @@ func (st *State) InvalidateModelCredential(reason string) error {
 		return errors.Trace(err)
 	}
 
-	tag, exists := m.CloudCredential()
+	tag, exists := m.CloudCredentialTag()
 	if !exists {
 		// Model is on the cloud that does not require auth - nothing to do.
 		return nil
@@ -66,9 +66,9 @@ func (st *State) suspendCredentialModels(tag names.CloudCredentialTag) error {
 
 // ValidateCloudCredential validates new cloud credential for this model.
 func (m *Model) ValidateCloudCredential(tag names.CloudCredentialTag, credential cloud.Credential) error {
-	aCloud, err := m.st.Cloud(m.Cloud())
+	aCloud, err := m.st.Cloud(m.CloudName())
 	if err != nil {
-		return errors.Annotatef(err, "getting cloud %q", m.Cloud())
+		return errors.Annotatef(err, "getting cloud %q", m.CloudName())
 	}
 
 	err = validateCredentialForCloud(aCloud, tag, convertCloudCredentialToState(tag, credential))
@@ -88,9 +88,9 @@ func (m *Model) SetCloudCredential(tag names.CloudCredentialTag) (bool, error) {
 		return false, errors.Annotatef(err, "getting model status %q", m.UUID())
 	}
 	revert := modelStatus.Status == status.Suspended
-	aCloud, err := m.st.Cloud(m.Cloud())
+	aCloud, err := m.st.Cloud(m.CloudName())
 	if err != nil {
-		return false, errors.Annotatef(err, "getting cloud %q", m.Cloud())
+		return false, errors.Annotatef(err, "getting cloud %q", m.CloudName())
 	}
 	updating := true
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -38,7 +38,10 @@ func (s *ModelCredentialSuite) TestInvalidateModelCredentialNone(c *gc.C) {
 	// The model created in ConnSuite does not have a credential.
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	_, exists := m.CloudCredential()
+	_, exists := m.CloudCredentialTag()
+	c.Assert(exists, jc.IsFalse)
+	_, exists, err = m.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(exists, jc.IsFalse)
 
 	reason := "special invalidation"
@@ -110,9 +113,15 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialNoUpdate(c *gc.C) {
 	c.Assert(set, jc.IsFalse)
 
 	// Check credential is still set.
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	c.Assert(credentialTag, gc.DeepEquals, tag)
 	c.Assert(credentialSet, jc.IsTrue)
+	cred, credentialSet, err := m.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentialSet, jc.IsTrue)
+	stateCred, err := s.State.CloudCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, stateCred)
 }
 
 func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialContent(c *gc.C) {
@@ -129,9 +138,12 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialContent(c 
 	c.Assert(err, gc.ErrorMatches, `credential "dummy/bob/foobar" not valid`)
 	c.Assert(set, jc.IsFalse)
 
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+	_, credentialSet, err = m.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 }
 
@@ -152,9 +164,12 @@ func (s *ModelCredentialSuite) TestSetCloudCredentialInvalidCredentialForModel(c
 	c.Assert(err, gc.ErrorMatches, `cloud "stratus" not valid`)
 	c.Assert(set, jc.IsFalse)
 
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+	_, credentialSet, err = m.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 }
 
@@ -200,9 +215,12 @@ func (s *ModelCredentialSuite) TestWatchModelCredential(c *gc.C) {
 func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.CloudCredentialTag, credential cloud.Credential) *state.Model {
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	credentialTag, credentialSet := m.CloudCredential()
+	credentialTag, credentialSet := m.CloudCredentialTag()
 	// Make sure no credential is set.
 	c.Assert(credentialTag, gc.DeepEquals, names.CloudCredentialTag{})
+	c.Assert(credentialSet, jc.IsFalse)
+	_, credentialSet, err = m.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentialSet, jc.IsFalse)
 
 	err = s.State.UpdateCloudCredential(tag, credential)
@@ -213,9 +231,15 @@ func (s *ModelCredentialSuite) assertSetCloudCredential(c *gc.C, tag names.Cloud
 	c.Assert(set, jc.IsTrue)
 
 	// Check credential is set.
-	credentialTag, credentialSet = m.CloudCredential()
+	credentialTag, credentialSet = m.CloudCredentialTag()
 	c.Assert(credentialTag, gc.DeepEquals, tag)
 	c.Assert(credentialSet, jc.IsTrue)
+	cred, credentialSet, err := m.CloudCredential()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentialSet, jc.IsTrue)
+	stateCred, err := s.State.CloudCredential(credentialTag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cred, jc.DeepEquals, stateCred)
 	return m
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -364,7 +364,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	}}
 
 	// Decrement the model count for the cloud to which this model belongs.
-	decCloudRefOp, err := decCloudModelRefOp(st, model.Cloud())
+	decCloudRefOp, err := decCloudModelRefOp(st, model.CloudName())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -10,17 +10,25 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
 
+// Model exposes the methods needed for an EnvironConfigGetter.
+type Model interface {
+	ModelTag() names.ModelTag
+	ControllerUUID() string
+	Type() state.ModelType
+	Cloud() (cloud.Cloud, error)
+	CloudRegion() string
+	CloudCredential() (state.Credential, bool, error)
+	Config() (*config.Config, error)
+}
+
 // EnvironConfigGetter implements environs.EnvironConfigGetter
-// in terms of a *state.State.
-// TODO - CAAS(externalreality): Once cloud methods are migrated
-// to model EnvironConfigGetter will no longer need to contain
-// both state and model but only model.
+// in terms of a Model.
 type EnvironConfigGetter struct {
-	*state.State
-	*state.Model
+	Model
 
 	// NewContainerBroker is a func that returns a caas container broker
 	// for the relevant model.
@@ -33,11 +41,7 @@ func (g EnvironConfigGetter) CloudAPIVersion(spec environs.CloudSpec) (string, e
 	if g.Model.Type() == state.ModelTypeIAAS {
 		return "", nil
 	}
-	cfg, err := g.ModelConfig()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	ctrlCfg, err := g.ControllerConfig()
+	cfg, err := g.Config()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -46,7 +50,7 @@ func (g EnvironConfigGetter) CloudAPIVersion(spec environs.CloudSpec) (string, e
 		newBroker = caas.New
 	}
 	broker, err := newBroker(environs.OpenParams{
-		ControllerUUID: ctrlCfg.ControllerUUID(),
+		ControllerUUID: g.Model.ControllerUUID(),
 		Cloud:          spec,
 		Config:         cfg,
 	})
@@ -56,87 +60,81 @@ func (g EnvironConfigGetter) CloudAPIVersion(spec environs.CloudSpec) (string, e
 	return broker.APIVersion()
 }
 
+// ModelConfig implements environs.EnvironConfigGetter.
+func (g EnvironConfigGetter) ModelConfig() (*config.Config, error) {
+	return g.Config()
+}
+
 // CloudSpec implements environs.EnvironConfigGetter.
 func (g EnvironConfigGetter) CloudSpec() (environs.CloudSpec, error) {
-	cloudName := g.Model.Cloud()
+	cloud, err := g.Model.Cloud()
+	if err != nil {
+		return environs.CloudSpec{}, errors.Trace(err)
+	}
 	regionName := g.Model.CloudRegion()
-	credentialTag, _ := g.Model.CloudCredential()
-	return CloudSpec(g.State, cloudName, regionName, credentialTag)
+	credentialValue, ok, err := g.Model.CloudCredential()
+	if err != nil {
+		return environs.CloudSpec{}, errors.Trace(err)
+	}
+	var credential *state.Credential
+	if ok {
+		credential = &credentialValue
+	}
+	return CloudSpec(cloud, regionName, credential)
 }
 
 // CloudSpec returns an environs.CloudSpec from a *state.State,
 // given the cloud, region and credential names.
 func CloudSpec(
-	accessor state.CloudAccessor,
-	cloudName, regionName string,
-	credentialTag names.CloudCredentialTag,
+	modelCloud cloud.Cloud,
+	regionName string,
+	credential *state.Credential,
 ) (environs.CloudSpec, error) {
-	modelCloud, err := accessor.Cloud(cloudName)
-	if err != nil {
-		return environs.CloudSpec{}, errors.Trace(err)
-	}
-
-	var credential *cloud.Credential
-	if credentialTag != (names.CloudCredentialTag{}) {
-		credentialValue, err := accessor.CloudCredential(credentialTag)
-		if err != nil {
-			return environs.CloudSpec{}, errors.Trace(err)
-		}
-		cloudCredential := cloud.NewNamedCredential(credentialValue.Name,
-			cloud.AuthType(credentialValue.AuthType),
-			credentialValue.Attributes,
-			credentialValue.Revoked,
+	var cloudCredential *cloud.Credential
+	if credential != nil {
+		cloudCredentialValue := cloud.NewNamedCredential(credential.Name,
+			cloud.AuthType(credential.AuthType),
+			credential.Attributes,
+			credential.Revoked,
 		)
-		credential = &cloudCredential
+		cloudCredential = &cloudCredentialValue
 	}
 
-	return environs.MakeCloudSpec(modelCloud, regionName, credential)
+	return environs.MakeCloudSpec(modelCloud, regionName, cloudCredential)
 }
 
 // NewEnvironFunc defines the type of a function that, given a state.State,
 // returns a new Environ.
-type NewEnvironFunc func(*state.State) (environs.Environ, error)
+type NewEnvironFunc func(Model) (environs.Environ, error)
 
 // GetNewEnvironFunc returns a NewEnvironFunc, that constructs Environs
 // using the given environs.NewEnvironFunc.
 func GetNewEnvironFunc(newEnviron environs.NewEnvironFunc) NewEnvironFunc {
-	return func(st *state.State) (environs.Environ, error) {
-		m, err := st.Model()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		g := EnvironConfigGetter{State: st, Model: m}
+	return func(m Model) (environs.Environ, error) {
+		g := EnvironConfigGetter{Model: m}
 		return environs.GetEnviron(g, newEnviron)
 	}
 }
 
 // NewCAASBrokerFunc defines the type of a function that, given a state.State,
 // returns a new CAAS broker.
-type NewCAASBrokerFunc func(*state.State) (caas.Broker, error)
+type NewCAASBrokerFunc func(Model) (caas.Broker, error)
 
 // GetNewCAASBrokerFunc returns a NewCAASBrokerFunc, that constructs CAAS brokers
 // using the given caas.NewContainerBrokerFunc.
 func GetNewCAASBrokerFunc(newBroker caas.NewContainerBrokerFunc) NewCAASBrokerFunc {
-	return func(st *state.State) (caas.Broker, error) {
-		m, err := st.Model()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		g := EnvironConfigGetter{State: st, Model: m}
+	return func(m Model) (caas.Broker, error) {
+		g := EnvironConfigGetter{Model: m}
 		cloudSpec, err := g.CloudSpec()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		cfg, err := g.ModelConfig()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		ctrlCfg, err := g.ControllerConfig()
+		cfg, err := g.Config()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		return newBroker(environs.OpenParams{
-			ControllerUUID: ctrlCfg.ControllerUUID(),
+			ControllerUUID: m.ControllerUUID(),
 			Cloud:          cloudSpec,
 			Config:         cfg,
 		})

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -30,7 +30,7 @@ func (s *environSuite) TestGetNewEnvironFunc(c *gc.C) {
 		callArgs = args
 		return nil, nil
 	}
-	_, err := stateenvirons.GetNewEnvironFunc(newEnviron)(s.State)
+	_, err := stateenvirons.GetNewEnvironFunc(newEnviron)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(calls, gc.Equals, 1)
@@ -59,7 +59,7 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	emptyCredential.Label = "empty-credential"
-	cloudSpec, err := stateenvirons.EnvironConfigGetter{State: st, Model: m}.CloudSpec()
+	cloudSpec, err := stateenvirons.EnvironConfigGetter{Model: m}.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environs.CloudSpec{
 		Type:             "dummy",
@@ -80,7 +80,7 @@ func (s *environSuite) TestGetNewCAASBrokerFunc(c *gc.C) {
 		callArgs = args
 		return nil, nil
 	}
-	_, err := stateenvirons.GetNewCAASBrokerFunc(newBroker)(s.State)
+	_, err := stateenvirons.GetNewCAASBrokerFunc(newBroker)(s.Model)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(calls, gc.Equals, 1)
 
@@ -116,7 +116,7 @@ func (s *environSuite) TestCloudAPIVersion(c *gc.C) {
 		return &fakeBroker{}, nil
 	}
 
-	envConfigGetter := stateenvirons.EnvironConfigGetter{State: st, Model: m, NewContainerBroker: newBrokerFunc}
+	envConfigGetter := stateenvirons.EnvironConfigGetter{Model: m, NewContainerBroker: newBrokerFunc}
 	cloudSpec, err := envConfigGetter.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	apiVersion, err := envConfigGetter.CloudAPIVersion(cloudSpec)

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -40,9 +40,9 @@ func (p environStatePolicy) Prechecker() (environs.InstancePrechecker, error) {
 		return nil, errors.Trace(err)
 	}
 	if model.Type() == state.ModelTypeIAAS {
-		return p.getEnviron(p.st)
+		return p.getEnviron(model)
 	}
-	return p.getBroker(p.st)
+	return p.getBroker(model)
 }
 
 // ConfigValidator implements state.Policy.
@@ -51,7 +51,7 @@ func (p environStatePolicy) ConfigValidator() (config.Validator, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cloud, err := p.st.Cloud(model.Cloud())
+	cloud, err := p.st.Cloud(model.CloudName())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting cloud")
 	}
@@ -82,13 +82,13 @@ func (p environStatePolicy) ConstraintsValidator(ctx context.ProviderCallContext
 	}
 
 	if model.Type() == state.ModelTypeIAAS {
-		env, err := p.getEnviron(p.st)
+		env, err := p.getEnviron(model)
 		if err != nil {
 			return nil, err
 		}
 		return env.ConstraintsValidator(ctx)
 	}
-	broker, err := p.getBroker(p.st)
+	broker, err := p.getBroker(model)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -105,7 +105,7 @@ func (p environStatePolicy) InstanceDistributor() (context.Distributor, error) {
 		// Only IAAS models support machines, hence distribution.
 		return nil, errors.NotImplementedf("InstanceDistributor")
 	}
-	env, err := p.getEnviron(p.st)
+	env, err := p.getEnviron(model)
 	if err != nil {
 		return nil, err
 	}
@@ -133,11 +133,11 @@ func NewStorageProviderRegistryForModel(
 ) (_ storage.ProviderRegistry, err error) {
 	var reg storage.ProviderRegistry
 	if model.Type() == state.ModelTypeIAAS {
-		if reg, err = newEnv(model.State()); err != nil {
+		if reg, err = newEnv(model); err != nil {
 			return nil, errors.Trace(err)
 		}
 	} else {
-		if reg, err = newBroker(model.State()); err != nil {
+		if reg, err = newBroker(model); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -43,7 +43,10 @@ func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 	if s.series == "kubernetes" {
 		s.st = s.Factory.MakeCAASModel(c, nil)
 		s.AddCleanup(func(_ *gc.C) { s.st.Close() })
-		broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.st)
+		var err error
+		s.Model, err = s.st.Model()
+		c.Assert(err, jc.ErrorIsNil)
+		broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(s.Model)
 		c.Assert(err, jc.ErrorIsNil)
 		registry = stateenvirons.NewStorageProviderRegistry(broker)
 	} else {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1859,7 +1859,7 @@ func UpdateInheritedControllerConfig(pool *StatePool) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	key := cloudGlobalKey(model.Cloud())
+	key := cloudGlobalKey(model.CloudName())
 
 	var ops []txn.Op
 	coll, closer := st.db().GetRawCollection(globalSettingsC)
@@ -1939,7 +1939,7 @@ func updateKubernetesStorageConfig(st *State) error {
 		// longer have settings to update.
 		return nil
 	}
-	cred, ok := model.CloudCredential()
+	cred, ok := model.CloudCredentialTag()
 	if !ok {
 		return nil
 	}
@@ -1948,13 +1948,13 @@ func updateKubernetesStorageConfig(st *State) error {
 		return errors.Trace(err)
 	}
 
-	defaults, err := st.controllerInheritedConfig(model.Cloud())()
+	defaults, err := st.controllerInheritedConfig(model.CloudName())()
 	if err != nil {
 		return errors.Annotate(err, "getting cloud config")
 	}
 	operatorStorage, haveDefaultOperatorStorage := defaults[k8s.OperatorStorageKey]
 	if !haveDefaultOperatorStorage {
-		cloudSpec, err := cloudSpec(st, model.Cloud(), model.CloudRegion(), cred)
+		cloudSpec, err := cloudSpec(st, model.CloudName(), model.CloudRegion(), cred)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1970,7 +1970,7 @@ func updateKubernetesStorageConfig(st *State) error {
 			return nil
 		}
 		operatorStorage = metadata.NominatedStorageClass.Name
-		err = st.updateConfigDefaults(model.Cloud(), cloud.Attrs{
+		err = st.updateConfigDefaults(model.CloudName(), cloud.Attrs{
 			k8s.OperatorStorageKey: operatorStorage,
 			k8s.WorkloadStorageKey: operatorStorage, // use same storage for both
 		}, nil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1967,7 +1967,7 @@ func (model *Model) WatchForModelConfigChanges() NotifyWatcher {
 // WatchCloudSpecChanges returns a NotifyWatcher waiting for the cloud
 // to change for the model.
 func (model *Model) WatchCloudSpecChanges() NotifyWatcher {
-	return newEntityWatcher(model.st, cloudsC, model.Cloud())
+	return newEntityWatcher(model.st, cloudsC, model.CloudName())
 }
 
 // WatchModelEntityReferences returns a NotifyWatcher waiting for the Model

--- a/worker/instancemutater/manifold.go
+++ b/worker/instancemutater/manifold.go
@@ -5,6 +5,7 @@ package instancemutater
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v3"
 	worker "gopkg.in/juju/worker.v1"
 	"gopkg.in/juju/worker.v1/dependency"
 
@@ -78,7 +79,7 @@ func (config ModelManifoldConfig) newWorker(environ environs.Environ, apiCaller 
 
 	w, err := config.NewWorker(cfg)
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot start machine instancemutater worker")
+		return nil, errors.Annotate(err, "cannot start model instance-mutater worker")
 	}
 	return w, nil
 }
@@ -180,14 +181,19 @@ func (config MachineManifoldConfig) newWorker(instanceBroker environs.InstanceBr
 		config.Logger.Debugf("Uninstalling worker because the broker is not a LXDProfiler %T", instanceBroker)
 		return nil, dependency.ErrUninstall
 	}
-	facade := config.NewClient(apiCaller)
 	agentConfig := agent.CurrentConfig()
+	tag := agentConfig.Tag()
+	if _, ok := tag.(names.MachineTag); !ok {
+		config.Logger.Warningf("cannot start a ContainerWorker on a %q, not starting", tag.Kind())
+		return nil, dependency.ErrUninstall
+	}
+	facade := config.NewClient(apiCaller)
 	cfg := Config{
 		Logger:      config.Logger,
 		Facade:      facade,
 		Broker:      broker,
 		AgentConfig: agentConfig,
-		Tag:         agentConfig.Tag(),
+		Tag:         tag,
 	}
 
 	w, err := config.NewWorker(cfg)

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -206,9 +206,9 @@ func (s *WorkerSuite) checkModel(c *gc.C, obtained interface{}, model *state.Mod
 	c.Check(change.Life, gc.Equals, life.Value(model.Life().String()))
 	c.Check(change.Owner, gc.Equals, model.Owner().Name())
 	c.Check(change.IsController, gc.Equals, model.IsControllerModel())
-	c.Check(change.Cloud, gc.Equals, model.Cloud())
+	c.Check(change.Cloud, gc.Equals, model.CloudName())
 	c.Check(change.CloudRegion, gc.Equals, model.CloudRegion())
-	cred, _ := model.CloudCredential()
+	cred, _ := model.CloudCredentialTag()
 	c.Check(change.CloudCredential, gc.Equals, cred.Id())
 
 	cfg, err := model.Config()


### PR DESCRIPTION
## Description of change

Merge 2.7 bringing in these PRs:

#11286 speed up juju status by handling units better
#11296 fix LP:1860083 machine availability zone
#11291 various refactorings (method renames, tools finder/getter handle k8s broker)
#11297 juju show-action-status not listing all
#11300 k8s controllers can start lxd containers
#11304 protect against nil profile from the charm
#11310 speed up processing of machines in juju status
#11306 ensure k8s juju upgrades select correct agent version
#11313 fix watcher race in ControllerAddressSuite
#11302 fix LP:1866658 jujud called in makefile before it is built

## QA steps

Run unit tests
