### PR TITLE
Generate docs (man page) as python 3

### DIFF
--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2013 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -6,6 +6,13 @@ python2 -c "" 2>/dev/null && exec python2 $0 ${1+"$@"}
 echo "Could not find a python interpreter."
 exit 1
 """
+# The above will attempt to find a the best available python interpreter
+# available to run the docs. This a requirement because this is built on
+# multiple series and there is no standard python to install for each one.
+#
+# The code will first run as shell (sh), find the correct python interpreter
+# then run the same file as python, which will ignore the shell, because it's
+# seen as a python doc string.
 
 # Copyright 2013 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python
+#!/bin/sh
+"""":
+python  -c "" 2>/dev/null && exec python  $0 ${1+"$@"}
+python3 -c "" 2>/dev/null && exec python3 $0 ${1+"$@"}
+python2 -c "" 2>/dev/null && exec python2 $0 ${1+"$@"}
+echo "Could not find a python interpreter."
+exit 1
+"""
 
 # Copyright 2013 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.

--- a/scripts/jujuman.py
+++ b/scripts/jujuman.py
@@ -19,7 +19,7 @@ class JujuMan(object):
 
     def run_juju(self, *args):
         cmd = ['juju'] + list(args)
-        return subprocess.check_output(cmd).strip()
+        return subprocess.check_output(cmd).strip().decode('utf-8')
 
     def _version(self):
         juju_version = self.run_juju('version')


### PR DESCRIPTION
## Description of change

Generating man page for juju uses python 2 via a hash bang. Python 2 is
deprecated, we instead should be using python 3.

The problem will come with older releases (xenial, et al), as how do we
use the right python version.

## QA steps

Run them and view the output.

#### Python 2

```sh
lxc launch ubuntu:16.04 test
lxc file push -p scripts/generate-docs.py /root
lxc file push -p scripts/jujuman.py /root
lxc file push -p ~/go/bin/juju /root/bin

lxc exec -t test -- bash

sudo apt install python-minimal

export PATH=/root/bin:$PATH

./generate-docs.py man
```

#### Python 3

I'm already running focal, so it becomes (it assumes that juju is in your $PATH):

```sh
./scripts/generate-docs.py man
```

