### PR TITLE
Fix 1867525 uniter exit on juju-run error

### DIFF
--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -103,7 +103,7 @@ func (s *FactorySuite) TestNewActionString(c *gc.C) {
 	c.Check(op.String(), gc.Equals, "run action "+someActionId)
 }
 
-func panicSendResponse(*utilexec.ExecResponse, error) {
+func panicSendResponse(*utilexec.ExecResponse, error) bool {
 	panic("don't call this")
 }
 

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -137,7 +137,7 @@ type CommandArgs struct {
 
 // CommandResponseFunc is for marshalling command responses back to the source
 // of the original request.
-type CommandResponseFunc func(*utilexec.ExecResponse, error)
+type CommandResponseFunc func(*utilexec.ExecResponse, error) bool
 
 // Callbacks exposes all the uniter code that's required by the various operations.
 // It's far from cohesive, and fundamentally represents inappropriate coupling, so

--- a/worker/uniter/operation/runcommands.go
+++ b/worker/uniter/operation/runcommands.go
@@ -76,7 +76,10 @@ func (rc *runCommands) Execute(state State) (*State, error) {
 		rc.sendResponse(response, nil)
 		err = ErrNeedsReboot
 	default:
-		rc.sendResponse(response, err)
+		errorHandled := rc.sendResponse(response, err)
+		if errorHandled {
+			return nil, nil
+		}
 	}
 	return nil, err
 }

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -456,11 +456,13 @@ func NewRunHookRunnerFactory(runErr error, contextOps ...func(*MockContext)) *Mo
 type MockSendResponse struct {
 	gotResponse **utilexec.ExecResponse
 	gotErr      *error
+	eatError    bool
 }
 
-func (mock *MockSendResponse) Call(response *utilexec.ExecResponse, err error) {
+func (mock *MockSendResponse) Call(response *utilexec.ExecResponse, err error) bool {
 	mock.gotResponse = &response
 	mock.gotErr = &err
+	return mock.eatError
 }
 
 var curl = corecharm.MustParseURL

--- a/worker/uniter/runlistener.go
+++ b/worker/uniter/runlistener.go
@@ -300,10 +300,12 @@ func (c *ChannelCommandRunner) RunCommands(args RunCommandsArgs) (results *exec.
 	// response is received before the uniter resumes operation, and
 	// potentially aborts. This prevents a race when rebooting.
 	responseChan := make(chan responseInfo)
-	responseFunc := func(response *exec.ExecResponse, err error) {
+	responseFunc := func(response *exec.ExecResponse, err error) bool {
 		select {
 		case <-c.config.Abort:
+			return false
 		case responseChan <- responseInfo{response, err}:
+			return true
 		}
 	}
 


### PR DESCRIPTION
## Fix 1867525 uniter exit on juju-run error

Allow SendResponse method to consume error rather than returning to the
resolver.

## QA steps

bootstrap microk8s
deploy an app
`kubectl exec -it bash` into app
`juju-run app/0 hostname` should succeed
`juju-run app/0 badcmd` should error with 127 exit code
`juju-run app/0 hostname` should succeed again

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1867525