### PR TITLE
Add api client calls for the watching of model summaries.

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -189,6 +189,27 @@ func (c *Client) WatchAllModels() (*api.AllWatcher, error) {
 	return api.NewAllModelWatcher(c.facade.RawAPICaller(), &info.AllWatcherId), nil
 }
 
+// WatchModelSummaries returns a SummaryWatcher, from which you can request
+// the Next set of ModelAbstracts for all models the user can see.
+func (c *Client) WatchModelSummaries() (*SummaryWatcher, error) {
+	var info params.SummaryWatcherID
+	if err := c.facade.FacadeCall("WatchModelSummaries", nil, &info); err != nil {
+		return nil, err
+	}
+	return NewSummaryWatcher(c.facade.RawAPICaller(), &info.WatcherID), nil
+}
+
+// WatchAllModelSummaries returns a SummaryWatcher, from which you can request
+// the Next set of ModelAbstracts. This method is only valid for controller
+// superusers and returns abstracts for all models in the controller.
+func (c *Client) WatchAllModelSummaries() (*SummaryWatcher, error) {
+	var info params.SummaryWatcherID
+	if err := c.facade.FacadeCall("WatchAllModelSummaries", nil, &info); err != nil {
+		return nil, err
+	}
+	return NewSummaryWatcher(c.facade.RawAPICaller(), &info.WatcherID), nil
+}
+
 // GrantController grants a user access to the controller.
 func (c *Client) GrantController(user, access string) error {
 	return c.modifyControllerUser(params.GrantControllerAccess, user, access)

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -383,3 +383,39 @@ func (s *Suite) TestConfigSetAgainstOlderAPIVersion(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, "this controller version doesn't support updating controller config")
 }
+
+func (s *Suite) TestWatchModelSummaries(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 9,
+		APICallerFunc: func(objType string, version int, id, request string, args, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(version, gc.Equals, 9)
+			c.Check(request, gc.Equals, "WatchModelSummaries")
+			c.Check(result, gc.FitsTypeOf, &params.SummaryWatcherID{})
+			c.Check(args, gc.IsNil)
+			return errors.New("some error")
+		},
+	}
+	client := controller.NewClient(apiCaller)
+	watcher, err := client.WatchModelSummaries()
+	c.Assert(err, gc.ErrorMatches, "some error")
+	c.Assert(watcher, gc.IsNil)
+}
+
+func (s *Suite) TestWatchAllModelSummaries(c *gc.C) {
+	apiCaller := apitesting.BestVersionCaller{
+		BestVersion: 9,
+		APICallerFunc: func(objType string, version int, id, request string, args, result interface{}) error {
+			c.Check(objType, gc.Equals, "Controller")
+			c.Check(version, gc.Equals, 9)
+			c.Check(request, gc.Equals, "WatchAllModelSummaries")
+			c.Check(result, gc.FitsTypeOf, &params.SummaryWatcherID{})
+			c.Check(args, gc.IsNil)
+			return errors.New("some error")
+		},
+	}
+	client := controller.NewClient(apiCaller)
+	watcher, err := client.WatchAllModelSummaries()
+	c.Assert(err, gc.ErrorMatches, "some error")
+	c.Assert(watcher, gc.IsNil)
+}

--- a/api/controller/summarywatcher.go
+++ b/api/controller/summarywatcher.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// SummaryWatcher holds information allowing us to get ModelAbstract
+// results for the models the user can see.
+type SummaryWatcher struct {
+	objType string
+	caller  base.APICaller
+	id      *string
+}
+
+// NewSummaryWatcher returns a SummaryWatcher instance which is in response
+// to either a WatchModelSummaries call for all models a user can see, or
+// WatchAllModelSummaries by a controller superuser.
+func NewSummaryWatcher(caller base.APICaller, id *string) *SummaryWatcher {
+	return newSummaryWatcher("ModelSummaryWatcher", caller, id)
+}
+
+func newSummaryWatcher(objType string, caller base.APICaller, id *string) *SummaryWatcher {
+	return &SummaryWatcher{
+		objType: objType,
+		caller:  caller,
+		id:      id,
+	}
+}
+
+// Next returns a slice of ModelAbstracts. A new abstract is returned for a
+// model if any part of the abstract changes. No indication is given however to
+// which bit has changed. It will block until there is information to return.
+func (watcher *SummaryWatcher) Next() ([]params.ModelAbstract, error) {
+	var info params.SummaryWatcherNextResults
+	err := watcher.caller.APICall(
+		watcher.objType,
+		watcher.caller.BestFacadeVersion(watcher.objType),
+		*watcher.id,
+		"Next",
+		nil, &info,
+	)
+	return info.Models, err
+}
+
+// Stop shutdowns down a summary watcher.
+func (watcher *SummaryWatcher) Stop() error {
+	return watcher.caller.APICall(
+		watcher.objType,
+		watcher.caller.BestFacadeVersion(watcher.objType),
+		*watcher.id,
+		"Stop",
+		nil, nil,
+	)
+}

--- a/featuretests/api_controller_test.go
+++ b/featuretests/api_controller_test.go
@@ -1,0 +1,82 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/controller"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/juju/testing"
+)
+
+// This suite only exists because no user facing calls exercise
+// the WatchModelSummaries or WatchAllModelSummaries.
+// The primary caller is the JAAS dashboard which uses the javascript
+// library. It is expected that JIMM will call these methods using
+// the Go API.
+
+type ControllerSuite struct {
+	testing.JujuConnSuite
+	client *controller.Client
+}
+
+var _ = gc.Suite(&ControllerSuite{})
+
+func (s *ControllerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	userConn := s.OpenControllerAPI(c)
+	s.client = controller.NewClient(userConn)
+	s.AddCleanup(func(*gc.C) { s.client.Close() })
+}
+
+func (s *ControllerSuite) TestWatchModelSummaries(c *gc.C) {
+
+	watcher, err := s.client.WatchModelSummaries()
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		c.Check(watcher.Stop(), jc.ErrorIsNil)
+	}()
+
+	summaries, err := watcher.Next()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(summaries, jc.DeepEquals, []params.ModelAbstract{
+		{
+			UUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+			Name:       "controller",
+			Admins:     []string{"admin"},
+			Cloud:      "dummy",
+			Region:     "dummy-region",
+			Credential: "dummy/admin/cred",
+			Status:     "green",
+		},
+	})
+}
+
+func (s *ControllerSuite) TestWatchAllModelSummaries(c *gc.C) {
+
+	watcher, err := s.client.WatchAllModelSummaries()
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		c.Check(watcher.Stop(), jc.ErrorIsNil)
+	}()
+
+	summaries, err := watcher.Next()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(summaries, jc.DeepEquals, []params.ModelAbstract{
+		{
+			UUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+			Name:       "controller",
+			Admins:     []string{"admin"},
+			Cloud:      "dummy",
+			Region:     "dummy-region",
+			Credential: "dummy/admin/cred",
+			Status:     "green",
+		},
+	})
+}


### PR DESCRIPTION
Even though there is no current Juju API client for this, it is expected
that the Juju Intelligent Model Manager (JIMM) component of JAAS will
be calling this.

## QA steps

Just the tests.

## Documentation changes

We don't really have any API client documentation. Perhaps we should look into this at some stage.

