### PR TITLE
Backport integration test fix from develop

### DIFF
--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -26,10 +26,10 @@ check_not_contains() {
 
     chk=$(echo "${input}" | grep "${value}" || true)
     if [ -n "${chk}" ]; then
-        printf "Unexpected \"${value}\" found\n\n%s\n" "${input}"
+        printf "Unexpected \"${value}\" found\n\n%s\n" "${input}" >&2
         exit 1
     else
-        echo "Success: \"${value}\" not found"
+        echo "Success: \"${value}\" not found" >&2
     fi
 }
 
@@ -44,10 +44,10 @@ check_contains() {
 
     chk=$(echo "${input}" | grep "${value}" || true)
     if [ -z "${chk}" ]; then
-        printf "Expected \"${value}\" not found\n\n%s\n" "${input}"
+        printf "Expected \"${value}\" not found\n\n%s\n" "${input}" >&2
         exit 1
     else
-        echo "Success: \"${value}\" found"
+        echo "Success: \"${value}\" found" >&2
     fi
 }
 
@@ -63,12 +63,12 @@ check() {
 
     OUT=$(echo "${got}" | grep -E "${want}" || true)
     if [ -z "${OUT}" ]; then
-        echo "" 1>&2
+        echo "" >&2
         # shellcheck disable=SC2059
-        printf "$(red \"Expected\"): ${want}\n"  1>&2
+        printf "$(red \"Expected\"): ${want}\n" >&2
         # shellcheck disable=SC2059
-        printf "$(red \"Recieved\"): ${got}\n" 1>&2
-        echo "" 1>&2
+        printf "$(red \"Recieved\"): ${got}\n" >&2
+        echo "" >&2
         exit 1
     fi
 }

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -50,3 +50,25 @@ check_contains() {
         echo "Success: \"${value}\" found"
     fi
 }
+
+check() {
+    local want got
+
+    want=${1}
+
+    got=
+    while read -r d; do
+        got="${got}\n${d}"
+    done
+
+    OUT=$(echo "${got}" | grep -E "${want}" || true)
+    if [ -z "${OUT}" ]; then
+        echo "" 1>&2
+        # shellcheck disable=SC2059
+        printf "Expected: ${want}\n" 1>&2
+        # shellcheck disable=SC2059
+        printf "Recieved: ${got}\n" 1>&2
+        echo "" 1>&2
+        exit 1
+    fi
+}

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -65,9 +65,9 @@ check() {
     if [ -z "${OUT}" ]; then
         echo "" 1>&2
         # shellcheck disable=SC2059
-        printf "Expected: ${want}\n" 1>&2
+        printf "$(red \"Expected\"): ${want}\n"  1>&2
         # shellcheck disable=SC2059
-        printf "Recieved: ${got}\n" 1>&2
+        printf "$(red \"Recieved\"): ${got}\n" 1>&2
         echo "" 1>&2
         exit 1
     fi

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -232,20 +232,24 @@ destroy_controller() {
     remove_controller_offers "${name}"
     echo "====> Removed offers"
 
+    set_verbosity
+
     output="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ($(green "${name}"))"
     echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+
+    set +e
     CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
         cat "${output}"
         exit 1
     fi
+    set_verbosity
+
     sed -i "/^${name}$/d" "${TEST_DIR}/jujus"
     echo "====> Destroyed juju ($(green "${name}"))"
-
-    set_verbosity
 }
 
 # cleanup_jujus is used to destroy all the known controllers the test suite
@@ -258,7 +262,7 @@ cleanup_jujus() {
         while read -r juju_name; do
             destroy_controller "${juju_name}"
         done < "${TEST_DIR}/jujus"
-        rm -f "${TEST_DIR}/jujus"
+        rm -f "${TEST_DIR}/jujus" || true
     fi
     echo "====> Completed cleaning up jujus"
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -236,7 +236,7 @@ destroy_controller() {
 
     echo "====> Destroying juju ($(green "${name}"))"
     echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
-    CHK=$(cat "${OUT}" | grep -i "ERROR" || true)
+    CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
         cat "${output}"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -180,7 +180,7 @@ destroy_model() {
     output="${TEST_DIR}/${name}-destroy.txt"
 
     echo "====> Destroying juju model ${name}"
-    echo "${name}" | xargs -I % juju destroy-model --force -y % 2>&1 | add_date >"${output}"
+    echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
     CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
@@ -213,37 +213,30 @@ destroy_controller() {
         echo "====> Destroying model ($(green "${name}"))"
 
         output="${TEST_DIR}/${name}-destroy-model.txt"
-        echo "${name}" | xargs -I % juju destroy-model --force -y % 2>&1 | add_date >"${output}"
+        echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
 
         echo "====> Destroyed model ($(green "${name}"))"
         return
     fi
 
-    echo "====> Introspection gathering"
-
     set +e
-    introspect_controller "${name}" || true
-    set_verbosity
 
+    echo "====> Introspection gathering"
+    introspect_controller "${name}" || true
     echo "====> Introspection gathered"
 
     # Unfortunately having any offers on a model, leads to failure to clean
     # up a controller.
     # See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
     echo "====> Removing offers"
-
-    set +e
     remove_controller_offers "${name}"
-    set_verbosity
-
     echo "====> Removed offers"
-
 
     output="${TEST_DIR}/${name}-destroy-controller.txt"
 
     echo "====> Destroying juju ($(green "${name}"))"
-    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % 2>&1 | add_date >"${output}"
-    CHK=$(cat "${output}" | grep -i "ERROR" || true)
+    echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+    CHK=$(cat "${OUT}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
         cat "${output}"
@@ -251,6 +244,8 @@ destroy_controller() {
     fi
     sed -i "/^${name}$/d" "${TEST_DIR}/jujus"
     echo "====> Destroyed juju ($(green "${name}"))"
+
+    set_verbosity
 }
 
 # cleanup_jujus is used to destroy all the known controllers the test suite
@@ -265,6 +260,7 @@ cleanup_jujus() {
         done < "${TEST_DIR}/jujus"
         rm -f "${TEST_DIR}/jujus"
     fi
+    echo "====> Completed cleaning up jujus"
 }
 
 introspect_controller() {

--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -6,21 +6,21 @@ run_branch() {
     file="${TEST_DIR}/test-branches.txt"
     ensure "branches" "${file}"
 
-    juju branch | grep -q 'Active branch is "master"'
+    juju branch | check 'Active branch is "master"'
 
     juju deploy redis
 
     wait_for "redis" "$(idle_condition "redis")"
 
     juju add-branch test-branch
-    juju branch | grep -q 'Active branch is "test-branch"'
+    juju branch | check 'Active branch is "test-branch"'
 
     juju config redis password=pass --branch test-branch
-    juju config redis password --branch test-branch | grep -q "pass"
-    juju config redis password --branch master | wc -c | grep -q "0"
+    juju config redis password --branch test-branch | check "pass"
+    juju config redis password --branch master | wc -c | check "0"
 
-    juju commit test-branch | grep -q 'Active branch set to "master"'
-    juju config redis password | grep -q "pass"
+    juju commit test-branch | check 'Active branch set to "master"'
+    juju config redis password | check "pass"
 
     # Clean up!
     destroy_model "branches"

--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -18,7 +18,7 @@ run_mongo_memory_profile() {
 
     attempt=0
     # shellcheck disable=SC2046,SC2143,SC2091
-    until $(check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB 2>&1 >/dev/null); do
+    until $(check_contains "$(cat_mongo_service)" wiredTigerCacheSizeGB >/dev/null 2>&1); do
         echo "[+] (attempt ${attempt}) polling mongo service"
         cat_mongo_service | sed 's/^/    | /g'
         # This will attempt to wait for 2 minutes before failing out.

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -155,5 +155,8 @@ test_deploy_bundles() {
         run "run_deploy_bundle"
         run "run_deploy_cmr_bundle"
         run "run_deploy_exported_bundle"
+        run "run_deploy_trusted_bundle"
+        run "run_deploy_lxd_profile_bundle_openstack"
+        run "run_deploy_lxd_profile_bundle"
     )
 }

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -62,7 +62,7 @@ run_deploy_trusted_bundle() {
 
     bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
     OUT=$(juju deploy ${bundle} 2>&1 || true)
-    echo "${OUT}" | check "FAIL!!: repeat the deploy command with the --trust argument"
+    echo "${OUT}" | check "repeat the deploy command with the --trust argument"
 
     juju deploy --trust ${bundle}
 

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -53,6 +53,94 @@ run_deploy_exported_bundle() {
     destroy_model test-export-bundles-deploy
 }
 
+run_deploy_trusted_bundle() {
+    echo
+
+    file="${TEST_DIR}/test-trusted-bundles-deploy.txt"
+
+    ensure "test-trusted-bundles-deploy" "${file}"
+
+    bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
+    OUT=$(juju deploy ${bundle} 2>&1 || true)
+    echo "${OUT}" | check "repeat the deploy command with the --trust argument"
+
+    juju deploy --trust ${bundle}
+
+    wait_for "trust-checker" "$(idle_condition "trust-checker")"
+
+    destroy_model test-trusted-bundles-deploy
+}
+
+# run_deploy_lxd_profile_bundle_openstack is to test a more
+# real world scenario of a minimal openstack bundle with a
+# charm using an lxd profile.
+run_deploy_lxd_profile_bundle_openstack() {
+    echo
+
+    model_name="test-deploy-lxd-profile-bundle-o7k"
+    file="${TEST_DIR}/${model_name}.txt"
+
+    ensure "${model_name}" "${file}"
+
+    bundle=cs:~juju-qa/bundle/basic-openstack-lxd-0
+    juju deploy "${bundle}"
+
+    wait_for "mysql" "$(idle_condition "mysql" 3)"
+    wait_for "rabbitmq-server" "$(idle_condition "rabbitmq-server" 9)"
+    wait_for "glance" "$(idle_condition "glance" 0)"
+    wait_for "keystone" "$(idle_condition "keystone" 1)"
+    wait_for "neutron-api" "$(idle_condition "neutron-api" 4)"
+    wait_for "neutron-gateway" "$(idle_condition "neutron-gateway" 5)"
+    wait_for "nova-compute" "$(idle_condition "nova-compute" 8)"
+    wait_for "lxd" "$(idle_subordinate_condition "lxd" "nova-compute" 2)"
+    wait_for "neutron-openvswitch" "$(idle_subordinate_condition "neutron-openvswitch" "nova-compute" 6)"
+    wait_for "nova-cloud-controller" "$(idle_condition "nova-cloud-controller" 7)"
+
+    lxd_profile_name="juju-${model_name}-neutron-openvswitch"
+    machine_6="$(machine_path 6)"
+    juju status --format=json | jq "${machine_6}" | check "${lxd_profile_name}"
+
+    destroy_model "${model_name}"
+}
+
+# run_deploy_lxd_profile_bundle is to deploy multiple units of the
+# same charm which has an lxdprofile in a bundle.  The scenario
+# created by the bundle was found to produce failure cases during
+# development of the lxd profile feature.
+run_deploy_lxd_profile_bundle() {
+    echo
+
+    model_name="test-deploy-lxd-profile-bundle"
+    file="${TEST_DIR}/${model_name}.txt"
+
+    ensure "${model_name}" "${file}"
+
+    bundle=./tests/suites/deploy/bundles/lxd-profile-bundle.yaml
+    juju deploy "${bundle}"
+
+    # 8 units of lxd-profile
+    for i in 0 1 2 3 4 5 6 7
+    do
+        wait_for "lxd-profile" "$(idle_condition "lxd-profile" 0 "${i}")"
+    done
+    # 4 units of ubuntu
+    for i in 0 1 2 3
+    do
+        wait_for "ubuntu" "$(idle_condition "ubuntu" 1 "${i}")"
+    done
+
+    lxd_profile_name="juju-${model_name}-lxd-profile"
+    for i in 0 1 2 3
+    do
+        machine_n_lxd0="$(machine_container_path "${i}" "${i}"/lxd/0)"
+        juju status --format=json | jq "${machine_n_lxd0}" | check "${lxd_profile_name}"
+        machine_n_lxd1="$(machine_container_path "${i}" "${i}"/lxd/1)"
+        juju status --format=json | jq "${machine_n_lxd1}" | check "${lxd_profile_name}"
+    done
+
+    destroy_model "${model_name}"
+}
+
 test_deploy_bundles() {
     if [ "$(skip 'test_deploy_bundles')" ]; then
         echo "==> TEST SKIPPED: deploy bundles"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -62,7 +62,7 @@ run_deploy_trusted_bundle() {
 
     bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
     OUT=$(juju deploy ${bundle} 2>&1 || true)
-    echo "${OUT}" | check "repeat the deploy command with the --trust argument"
+    echo "${OUT}" | check "FAIL!!: repeat the deploy command with the --trust argument"
 
     juju deploy --trust ${bundle}
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -1,14 +1,14 @@
 run_deploy_charm() {
     echo
 
-    file="${TEST_DIR}/test-deploy.txt"
+    file="${TEST_DIR}/test-deploy-charm.txt"
 
-    ensure "test-deploy" "${file}"
+    ensure "test-deploy-charm" "${file}"
 
     juju deploy cs:~jameinel/ubuntu-lite-7
     wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-    destroy_model "test-deploy"
+    destroy_model "test-deploy-charm"
 }
 
 run_deploy_lxd_profile_charm() {

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -21,7 +21,7 @@ run_deploy_lxd_profile_charm() {
     juju deploy cs:~juju-qa/bionic/lxd-profile-without-devices-5
     wait_for "lxd-profile" "$(idle_condition "lxd-profile")"
 
-    juju status --format=json | jq ".machines | .[\"0\"] | .[\"lxd-profiles\"] | keys[0]" | grep -q "juju-test-deploy-lxd-profile-lxd-profile"
+    juju status --format=json | jq ".machines | .[\"0\"] | .[\"lxd-profiles\"] | keys[0]" | check "juju-test-deploy-lxd-profile-lxd-profile"
 
     destroy_model "test-deploy-lxd-profile"
 }
@@ -47,24 +47,24 @@ run_deploy_local_lxd_profile_charm() {
     machine_0="$(machine_path 0)"
     wait_for "${lxd_profile_sub_name}" "${machine_0}"
 
-    juju status --format=json | jq "${machine_0}" | grep -q "${lxd_profile_name}"
-    juju status --format=json | jq "${machine_0}" | grep -q "${lxd_profile_sub_name}"
+    juju status --format=json | jq "${machine_0}" | check "${lxd_profile_name}"
+    juju status --format=json | jq "${machine_0}" | check "${lxd_profile_sub_name}"
 
     juju add-unit "lxd-profile"
 
     machine_1="$(machine_path 1)"
     wait_for "${lxd_profile_sub_name}" "${machine_1}"
 
-    juju status --format=json | jq "${machine_1}" | grep -q "${lxd_profile_name}"
-    juju status --format=json | jq "${machine_1}" | grep -q "${lxd_profile_sub_name}"
+    juju status --format=json | jq "${machine_1}" | check "${lxd_profile_name}"
+    juju status --format=json | jq "${machine_1}" | check "${lxd_profile_sub_name}"
 
     juju add-unit "lxd-profile" --to lxd
 
     machine_2="$(machine_container_path 2 2/lxd/0)"
     wait_for "${lxd_profile_sub_name}" "${machine_2}"
 
-    juju status --format=json | jq "${machine_2}" | grep -q "${lxd_profile_name}"
-    juju status --format=json | jq "${machine_2}" | grep -q "${lxd_profile_sub_name}"
+    juju status --format=json | jq "${machine_2}" | check "${lxd_profile_name}"
+    juju status --format=json | jq "${machine_2}" | check "${lxd_profile_sub_name}"
 
     destroy_model "test-deploy-local-lxd-profile"
 }

--- a/tests/suites/deploy/export_overlay.sh
+++ b/tests/suites/deploy/export_overlay.sh
@@ -31,8 +31,8 @@ EOT
 
     # did the annotations and overlay get exported?
     echo "${OUT}" | grep -- "--- # overlay.yaml"
-    echo "${OUT}" | grep "enc: bXktaW5jbHVkZQ=="
-    echo "${OUT}" | grep "raw: my-include"
+    echo "${OUT}" | check "enc: bXktaW5jbHVkZQ=="
+    echo "${OUT}" | check "raw: my-include"
 
     destroy_model "cmr-bundles-test-export-overlay"
     destroy_model "test1"

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -9,13 +9,13 @@ test_deploy() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-cmr-bundles.txt"
+    file="${TEST_DIR}/test-deploy-ctl.txt"
 
-    bootstrap "test-cmr-bundles" "${file}"
+    bootstrap "test-deploy-ctl" "${file}"
 
     test_deploy_charms
     test_deploy_bundles
     test_cmr_bundles_export_overlay
 
-    destroy_controller "test-cmr-bundles"
+    destroy_controller "test-deploy-ctl"
 }

--- a/tests/suites/examples/example.sh
+++ b/tests/suites/examples/example.sh
@@ -7,7 +7,7 @@ run_example1() {
     ensure "example1" "${file}"
 
     # Run your checks here
-    echo "Hello example 1!"
+    echo "Hello example 1!" | check "Hello example 1!"
 
     # Clean up!
     destroy_model "example1"
@@ -16,9 +16,10 @@ run_example1() {
 run_example2() {
     echo
 
+    file="${TEST_DIR}/test-example2.txt"
     ensure "example2" "${file}"
 
-    echo "Hello example 2!"
+    echo "Hello example 2!" | check "Hello example 2!"
 
     destroy_model "example2"
 }

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -20,7 +20,7 @@ run_whitespace() {
 }
 
 run_trailing_whitespace() {
-  OUT=$(grep -r " $" tests/ | grep '\.sh:' || true)
+  OUT=$(grep -nr " $" tests/ | grep '\.sh:' || true)
   if [ -n "${OUT}" ]; then
     echo ""
     echo "$(red 'Found some issues:')"


### PR DESCRIPTION
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

This is a backport of #11282 to the 2.7 branch - it includes a fix for the bug that is causing the test-controller-lxd test to fail even though the Mongo memory profile is being correctly updated.
(See https://jenkins.juju.canonical.com/job/test-controller-lxd/96/consoleFull for an example.)

There was one conflict cherry-picking the commands back in tests/suites/deploy/deploy_bundles.sh - it modified some test functions that were added in develop. As far as I can tell these work, so I added a commit to call them from the main deploy test.

## QA steps

Run the tests.

```sh
# In the juju top-level dir...
tests/main.sh -v controller
tests/main.sh -v deploy
```

They should all pass.

## Documentation changes
None
## Bug reference
None