### PR TITLE
Restore Machiner Facade V1

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -238,7 +238,8 @@ func AllFacades() *facade.Registry {
 	reg("MachineManager", 6, machinemanager.NewFacadeV6) // DestroyMachinesWithParams gains maxWait.
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
-	reg("Machiner", 2, machine.NewMachinerAPI)
+	reg("Machiner", 1, machine.NewMachinerAPIV1)
+	reg("Machiner", 2, machine.NewMachinerAPI) // Adds RecordAgentStartTime.
 
 	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacade)
 	reg("MetricsAdder", 2, metricsadder.NewMetricsAdderAPI)


### PR DESCRIPTION
## Description of change

Version 2 of the machiner facade was instituted with #10902, but V1 was not recorded in _allfacades.go_. This caused post-upgrade failures when the facade version being used by agents disappeared from the controller.

This patch Adds version 1 of the facade, restoring correct functionality.

## QA steps

TBC

## Documentation changes

None.

## Bug reference

N/A
