### PR TITLE
[dev] Restore broken API server backwards compatibility

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -220,6 +220,7 @@ func AllFacades() *facade.Registry {
 	reg("InstanceMutater", 1, instancemutater.NewFacadeV1)
 	reg("InstanceMutater", 2, instancemutater.NewFacadeV2)
 
+	reg("InstancePoller", 3, instancepoller.NewFacadeV3)
 	reg("InstancePoller", 4, instancepoller.NewFacade)
 	reg("KeyManager", 1, keymanager.NewKeyManagerAPI)
 	reg("KeyUpdater", 1, keyupdater.NewKeyUpdaterAPI)
@@ -238,6 +239,7 @@ func AllFacades() *facade.Registry {
 	reg("MachineManager", 6, machinemanager.NewFacadeV6) // DestroyMachinesWithParams gains maxWait.
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
+	reg("Machiner", 1, machine.NewMachinerAPIV1)
 	reg("Machiner", 2, machine.NewMachinerAPI)
 
 	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacade)

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -484,3 +484,27 @@ func (a *InstancePollerAPI) AreManuallyProvisioned(args params.Entities) (params
 	}
 	return result, nil
 }
+
+// InstancePollerAPIV3 implements the V3 API used by the instance poller
+// worker. Compared to V4, it lacks the SetProviderNetworkConfig method.
+type InstancePollerAPIV3 struct {
+	*InstancePollerAPI
+}
+
+// NewFacadeV3 creates a new instance of the V3 InstancePoller API.
+func NewFacadeV3(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*InstancePollerAPIV3, error) {
+	m, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	api, err := NewInstancePollerAPI(st, m, resources, authorizer, clock.WallClock)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InstancePollerAPIV3{api}, nil
+}
+
+// SetProviderNetworkConfig is not available in V3.
+func (*InstancePollerAPIV3) SetProviderNetworkConfig(_, _ struct{}) {}

--- a/caas/kubernetes/provider/mocks/k8sclient_mock.go
+++ b/caas/kubernetes/provider/mocks/k8sclient_mock.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	discovery "k8s.io/client-go/discovery"
 	v1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
@@ -47,7 +49,6 @@ import (
 	v110 "k8s.io/client-go/kubernetes/typed/storage/v1"
 	v1alpha16 "k8s.io/client-go/kubernetes/typed/storage/v1alpha1"
 	v1beta114 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
-	reflect "reflect"
 )
 
 // MockInterface is a mock of Interface interface

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -13,7 +13,7 @@ import (
 	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/caas/kubernetes/provider/specs/v3.go
+++ b/caas/kubernetes/provider/specs/v3.go
@@ -13,7 +13,7 @@ import (
 	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/juju/juju/caas/specs"

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -17,7 +17,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -6,8 +6,6 @@ package backups_test
 import (
 	"bytes"
 	"fmt"
-	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/juju/osenv"
 	"io"
 	"io/ioutil"
 	"os"
@@ -21,8 +19,10 @@ import (
 
 	apibackups "github.com/juju/juju/api/backups"
 	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/backups"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujutesting "github.com/juju/juju/testing"

--- a/cmd/juju/backups/show.go
+++ b/cmd/juju/backups/show.go
@@ -5,6 +5,7 @@ package backups
 
 import (
 	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"bytes"
 	"fmt"
-	jujucloud "github.com/juju/juju/cloud"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
+	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/cloud"

--- a/state/backups/metadata_test.go
+++ b/state/backups/metadata_test.go
@@ -5,11 +5,11 @@ package backups_test
 
 import (
 	"bytes"
-	"github.com/juju/errors"
 	"os"
 	"path/filepath"
 	"time" // Only used for time types and funcs, not Now().
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"

--- a/state/backups/testing/file.go
+++ b/state/backups/testing/file.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
-	"github.com/juju/juju/state/backups"
 	"io"
 	"path"
 	"strings"
@@ -17,6 +16,8 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/version"
+
+	"github.com/juju/juju/state/backups"
 )
 
 // File represents a file during testing.

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
@@ -15,7 +17,6 @@ import (
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
 	names "gopkg.in/juju/names.v3"
-	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface

--- a/worker/upgradedatabase/mocks/lock.go
+++ b/worker/upgradedatabase/mocks/lock.go
@@ -5,8 +5,9 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockLock is a mock of Lock interface

--- a/worker/upgradedatabase/mocks/package.go
+++ b/worker/upgradedatabase/mocks/package.go
@@ -5,12 +5,13 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
 	upgradedatabase "github.com/juju/juju/worker/upgradedatabase"
 	version "github.com/juju/version"
-	reflect "reflect"
 )
 
 // MockLogger is a mock of Logger interface

--- a/worker/upgradedatabase/mocks/watcher.go
+++ b/worker/upgradedatabase/mocks/watcher.go
@@ -5,8 +5,9 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockNotifyWatcher is a mock of NotifyWatcher interface


### PR DESCRIPTION
This PR reverts the changes on develop that broke backwards compatibility for the API server.

More specifically:
- It restores the registration for MachinerV1 which was accidentally
removed by e4d719c
- It restores the registration for InstancePollerV3 which was
accidentally removed by 5aba1d1

Note that there doesn't seem to be a V1/V2 registration present for the instancepoller facade.