### PR TITLE
Fix goimports

### DIFF
--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -6,8 +6,6 @@ package backups_test
 import (
 	"bytes"
 	"fmt"
-	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/juju/osenv"
 	"io"
 	"io/ioutil"
 	"os"
@@ -21,8 +19,10 @@ import (
 
 	apibackups "github.com/juju/juju/api/backups"
 	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/backups"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujutesting "github.com/juju/juju/testing"

--- a/cmd/juju/backups/show.go
+++ b/cmd/juju/backups/show.go
@@ -5,6 +5,7 @@ package backups
 
 import (
 	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"bytes"
 	"fmt"
-	jujucloud "github.com/juju/juju/cloud"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
+	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/cloud"

--- a/state/backups/metadata_test.go
+++ b/state/backups/metadata_test.go
@@ -5,11 +5,11 @@ package backups_test
 
 import (
 	"bytes"
-	"github.com/juju/errors"
 	"os"
 	"path/filepath"
 	"time" // Only used for time types and funcs, not Now().
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"

--- a/state/backups/testing/file.go
+++ b/state/backups/testing/file.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
-	"github.com/juju/juju/state/backups"
 	"io"
 	"path"
 	"strings"
@@ -17,6 +16,8 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/version"
+
+	"github.com/juju/juju/state/backups"
 )
 
 // File represents a file during testing.


### PR DESCRIPTION
## Description of change

Fix some import stanzas which go missed when go imports was not installed for the GitHub-static-analysis-go job.

