### PR TITLE
2.7 - Network Device Detection for New LXD Versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -956,7 +956,7 @@
   revision = "4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36"
 
 [[projects]]
-  digest = "1:a452f9fca3583eb87f1d18d8a184ab818df034f13115c9dd9992d5653e9c70ac"
+  digest = "1:9f5f778932e8ad13128e382c5240de66a99041edd79ae3c7450fb0296eaad620"
   name = "github.com/lxc/lxd"
   packages = [
     "client",
@@ -971,7 +971,7 @@
     "shared/version",
   ]
   pruneopts = ""
-  revision = "3a5f63bc49591c4cb62268f210b07ff8e74b727d"
+  revision = "582edb00c72c6bedfa55c2191bbd395512cb0823"
 
 [[projects]]
   digest = "1:f95025d583786875a71183888acc9d0987fc96f12d4f5afab3d7558797ea1c5a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -127,7 +127,7 @@
 
 [[constraint]]
   name = "github.com/lxc/lxd"
-  revision = "3a5f63bc49591c4cb62268f210b07ff8e74b727d"
+  revision = "582edb00c72c6bedfa55c2191bbd395512cb0823"
 
 [[constraint]]
   name = "github.com/oracle/oci-go-sdk"

--- a/container/lxd/certificate.go
+++ b/container/lxd/certificate.go
@@ -30,7 +30,7 @@ type Certificate struct {
 // GenerateClientCertificate creates and returns a new certificate for client
 // communication with an LXD server.
 func GenerateClientCertificate() (*Certificate, error) {
-	cert, key, err := shared.GenerateMemCert(true)
+	cert, key, err := shared.GenerateMemCert(true, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -406,7 +406,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigNoInputGetsProfileNICs(c *gc.
 	defer s.setup(c).Finish()
 	s.patch()
 
-	s.cSvr.EXPECT().GetProfile("default").Return(defaultProfileWithNIC(), lxdtesting.ETag, nil)
+	s.cSvr.EXPECT().GetProfile("default").Return(defaultLegacyProfileWithNIC(), lxdtesting.ETag, nil)
 
 	s.makeManager(c)
 	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{})

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -32,6 +32,20 @@ func defaultProfileWithNIC() *lxdapi.Profile {
 		ProfilePut: lxdapi.ProfilePut{
 			Devices: map[string]map[string]string{
 				"eth0": {
+					"network": network.DefaultLXDBridge,
+					"type":    "nic",
+				},
+			},
+		},
+	}
+}
+
+func defaultLegacyProfileWithNIC() *lxdapi.Profile {
+	return &lxdapi.Profile{
+		Name: "default",
+		ProfilePut: lxdapi.ProfilePut{
+			Devices: map[string]map[string]string{
+				"eth0": {
 					"parent":  network.DefaultLXDBridge,
 					"type":    "nic",
 					"nictype": "bridged",
@@ -94,7 +108,7 @@ func (s *networkSuite) TestGetNICsFromProfile(c *gc.C) {
 	defer ctrl.Finish()
 	cSvr := s.NewMockServer(ctrl)
 
-	cSvr.EXPECT().GetProfile("default").Return(defaultProfileWithNIC(), lxdtesting.ETag, nil)
+	cSvr.EXPECT().GetProfile("default").Return(defaultLegacyProfileWithNIC(), lxdtesting.ETag, nil)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -119,7 +133,12 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentValid(c *gc.C) {
 	defer ctrl.Finish()
 	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
 
-	cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(&lxdapi.Network{}, "", nil)
+	net := &lxdapi.Network{
+		Name:    network.DefaultLXDBridge,
+		Managed: true,
+		Type:    "bridged",
+	}
+	cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(net, "", nil)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -128,12 +147,26 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentValid(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *networkSuite) TestVerifyNetworkDevicePresentValidLegacy(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
+
+	cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(&lxdapi.Network{}, "", nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = jujuSvr.VerifyNetworkDevice(defaultLegacyProfileWithNIC(), "")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *networkSuite) TestVerifyNetworkDeviceMultipleNICsOneValid(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	cSvr := s.NewMockServerClustered(ctrl, "cluster-1")
 
-	profile := defaultProfileWithNIC()
+	profile := defaultLegacyProfileWithNIC()
 	profile.Devices["eno1"] = profile.Devices["eth0"]
 	profile.Devices["eno1"]["parent"] = "valid-net"
 
@@ -165,8 +198,15 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentBadNicType(c *gc.C) {
 	defer ctrl.Finish()
 	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
 
-	profile := defaultProfileWithNIC()
+	profile := defaultLegacyProfileWithNIC()
 	profile.Devices["eth0"]["nictype"] = "not-bridge-or-macvlan"
+
+	net := &lxdapi.Network{
+		Name:    network.DefaultLXDBridge,
+		Managed: true,
+		Type:    "not-bridge-or-macvlan",
+	}
+	cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(net, "", nil)
 
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -198,7 +238,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = jujuSvr.VerifyNetworkDevice(defaultProfileWithNIC(), "")
+	err = jujuSvr.VerifyNetworkDevice(defaultLegacyProfileWithNIC(), "")
 	c.Assert(err, gc.ErrorMatches,
 		`profile "default": juju does not support IPv6. Disable IPv6 in LXD via:\n`+
 			`\tlxc network set lxdbr0 ipv6.address none\n`+
@@ -234,10 +274,10 @@ func (s *networkSuite) TestVerifyNetworkDeviceNotPresentCreated(c *gc.C) {
 		cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(nil, "", errors.New("not found")),
 		cSvr.EXPECT().CreateNetwork(netCreateReq).Return(nil),
 		cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(newNet, "", nil),
-		cSvr.EXPECT().UpdateProfile("default", defaultProfileWithNIC().Writable(), lxdtesting.ETag).Return(nil),
+		cSvr.EXPECT().UpdateProfile("default", defaultLegacyProfileWithNIC().Writable(), lxdtesting.ETag).Return(nil),
 	)
 
-	profile := defaultProfileWithNIC()
+	profile := defaultLegacyProfileWithNIC()
 	delete(profile.Devices, "eth0")
 
 	jujuSvr, err := lxd.NewServer(cSvr)
@@ -284,7 +324,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceNotPresentCreatedWithUnusedName(c 
 		cSvr.EXPECT().UpdateProfile("default", devReq, lxdtesting.ETag).Return(nil),
 	)
 
-	profile := defaultProfileWithNIC()
+	profile := defaultLegacyProfileWithNIC()
 	profile.Devices["eth0"] = map[string]string{}
 	profile.Devices["eth1"] = map[string]string{}
 
@@ -300,7 +340,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceNotPresentErrorForCluster(c *gc.C)
 	defer ctrl.Finish()
 	cSvr := s.NewMockServerClustered(ctrl, "cluster-1")
 
-	profile := defaultProfileWithNIC()
+	profile := defaultLegacyProfileWithNIC()
 	delete(profile.Devices, "eth0")
 
 	jujuSvr, err := lxd.NewServer(cSvr)
@@ -445,7 +485,7 @@ func (s *networkSuite) TestVerifyNICsWithConfigFileNICFound(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = lxd.VerifyNICsWithConfigFile(jujuSvr, defaultProfileWithNIC().Devices, validBridgeConfig)
+	err = lxd.VerifyNICsWithConfigFile(jujuSvr, defaultLegacyProfileWithNIC().Devices, validBridgeConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(jujuSvr.LocalBridgeName(), gc.Equals, "lxdbr0")
 }
@@ -458,7 +498,7 @@ func (s *networkSuite) TestVerifyNICsWithConfigFileNICNotFound(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	nics := defaultProfileWithNIC().Devices
+	nics := defaultLegacyProfileWithNIC().Devices
 	nics["eth0"]["parent"] = "br0"
 
 	err = lxd.VerifyNICsWithConfigFile(jujuSvr, nics, validBridgeConfig)

--- a/container/lxd/testing/lxd_mock.go
+++ b/container/lxd/testing/lxd_mock.go
@@ -7,7 +7,7 @@ package testing
 import (
 	gomock "github.com/golang/mock/gomock"
 	websocket "github.com/gorilla/websocket"
-	client "github.com/lxc/lxd/client"
+	lxd "github.com/lxc/lxd/client"
 	api "github.com/lxc/lxd/shared/api"
 	io "io"
 	http "net/http"
@@ -38,10 +38,10 @@ func (m *MockOperation) EXPECT() *MockOperationMockRecorder {
 }
 
 // AddHandler mocks base method
-func (m *MockOperation) AddHandler(arg0 func(api.Operation)) (*client.EventTarget, error) {
+func (m *MockOperation) AddHandler(arg0 func(api.Operation)) (*lxd.EventTarget, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddHandler", arg0)
-	ret0, _ := ret[0].(*client.EventTarget)
+	ret0, _ := ret[0].(*lxd.EventTarget)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -110,7 +110,7 @@ func (mr *MockOperationMockRecorder) Refresh() *gomock.Call {
 }
 
 // RemoveHandler mocks base method
-func (m *MockOperation) RemoveHandler(arg0 *client.EventTarget) error {
+func (m *MockOperation) RemoveHandler(arg0 *lxd.EventTarget) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveHandler", arg0)
 	ret0, _ := ret[0].(error)
@@ -161,10 +161,10 @@ func (m *MockRemoteOperation) EXPECT() *MockRemoteOperationMockRecorder {
 }
 
 // AddHandler mocks base method
-func (m *MockRemoteOperation) AddHandler(arg0 func(api.Operation)) (*client.EventTarget, error) {
+func (m *MockRemoteOperation) AddHandler(arg0 func(api.Operation)) (*lxd.EventTarget, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddHandler", arg0)
-	ret0, _ := ret[0].(*client.EventTarget)
+	ret0, _ := ret[0].(*lxd.EventTarget)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -241,11 +241,23 @@ func (m *MockServer) EXPECT() *MockServerMockRecorder {
 	return m.recorder
 }
 
+// Disconnect mocks base method
+func (m *MockServer) Disconnect() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Disconnect")
+}
+
+// Disconnect indicates an expected call of Disconnect
+func (mr *MockServerMockRecorder) Disconnect() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockServer)(nil).Disconnect))
+}
+
 // GetConnectionInfo mocks base method
-func (m *MockServer) GetConnectionInfo() (*client.ConnectionInfo, error) {
+func (m *MockServer) GetConnectionInfo() (*lxd.ConnectionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnectionInfo")
-	ret0, _ := ret[0].(*client.ConnectionInfo)
+	ret0, _ := ret[0].(*lxd.ConnectionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -294,11 +306,23 @@ func (m *MockImageServer) EXPECT() *MockImageServerMockRecorder {
 	return m.recorder
 }
 
+// Disconnect mocks base method
+func (m *MockImageServer) Disconnect() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Disconnect")
+}
+
+// Disconnect indicates an expected call of Disconnect
+func (mr *MockImageServerMockRecorder) Disconnect() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockImageServer)(nil).Disconnect))
+}
+
 // GetConnectionInfo mocks base method
-func (m *MockImageServer) GetConnectionInfo() (*client.ConnectionInfo, error) {
+func (m *MockImageServer) GetConnectionInfo() (*lxd.ConnectionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnectionInfo")
-	ret0, _ := ret[0].(*client.ConnectionInfo)
+	ret0, _ := ret[0].(*lxd.ConnectionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -356,6 +380,21 @@ func (mr *MockImageServerMockRecorder) GetImageAlias(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageAlias", reflect.TypeOf((*MockImageServer)(nil).GetImageAlias), arg0)
 }
 
+// GetImageAliasArchitectures mocks base method
+func (m *MockImageServer) GetImageAliasArchitectures(arg0, arg1 string) (map[string]*api.ImageAliasesEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageAliasArchitectures", arg0, arg1)
+	ret0, _ := ret[0].(map[string]*api.ImageAliasesEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageAliasArchitectures indicates an expected call of GetImageAliasArchitectures
+func (mr *MockImageServerMockRecorder) GetImageAliasArchitectures(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageAliasArchitectures", reflect.TypeOf((*MockImageServer)(nil).GetImageAliasArchitectures), arg0, arg1)
+}
+
 // GetImageAliasNames mocks base method
 func (m *MockImageServer) GetImageAliasNames() ([]string, error) {
 	m.ctrl.T.Helper()
@@ -403,10 +442,10 @@ func (mr *MockImageServerMockRecorder) GetImageAliases() *gomock.Call {
 }
 
 // GetImageFile mocks base method
-func (m *MockImageServer) GetImageFile(arg0 string, arg1 client.ImageFileRequest) (*client.ImageFileResponse, error) {
+func (m *MockImageServer) GetImageFile(arg0 string, arg1 lxd.ImageFileRequest) (*lxd.ImageFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageFile", arg0, arg1)
-	ret0, _ := ret[0].(*client.ImageFileResponse)
+	ret0, _ := ret[0].(*lxd.ImageFileResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -479,10 +518,10 @@ func (mr *MockImageServerMockRecorder) GetPrivateImage(arg0, arg1 interface{}) *
 }
 
 // GetPrivateImageFile mocks base method
-func (m *MockImageServer) GetPrivateImageFile(arg0, arg1 string, arg2 client.ImageFileRequest) (*client.ImageFileResponse, error) {
+func (m *MockImageServer) GetPrivateImageFile(arg0, arg1 string, arg2 lxd.ImageFileRequest) (*lxd.ImageFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPrivateImageFile", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*client.ImageFileResponse)
+	ret0, _ := ret[0].(*lxd.ImageFileResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -517,10 +556,10 @@ func (m *MockContainerServer) EXPECT() *MockContainerServerMockRecorder {
 }
 
 // ConsoleContainer mocks base method
-func (m *MockContainerServer) ConsoleContainer(arg0 string, arg1 api.ContainerConsolePost, arg2 *client.ContainerConsoleArgs) (client.Operation, error) {
+func (m *MockContainerServer) ConsoleContainer(arg0 string, arg1 api.ContainerConsolePost, arg2 *lxd.ContainerConsoleArgs) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConsoleContainer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -532,10 +571,10 @@ func (mr *MockContainerServerMockRecorder) ConsoleContainer(arg0, arg1, arg2 int
 }
 
 // ConsoleInstance mocks base method
-func (m *MockContainerServer) ConsoleInstance(arg0 string, arg1 api.InstanceConsolePost, arg2 *client.InstanceConsoleArgs) (client.Operation, error) {
+func (m *MockContainerServer) ConsoleInstance(arg0 string, arg1 api.InstanceConsolePost, arg2 *lxd.InstanceConsoleArgs) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConsoleInstance", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -547,10 +586,10 @@ func (mr *MockContainerServerMockRecorder) ConsoleInstance(arg0, arg1, arg2 inte
 }
 
 // CopyContainer mocks base method
-func (m *MockContainerServer) CopyContainer(arg0 client.InstanceServer, arg1 api.Container, arg2 *client.ContainerCopyArgs) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CopyContainer(arg0 lxd.InstanceServer, arg1 api.Container, arg2 *lxd.ContainerCopyArgs) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyContainer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -562,10 +601,10 @@ func (mr *MockContainerServerMockRecorder) CopyContainer(arg0, arg1, arg2 interf
 }
 
 // CopyContainerSnapshot mocks base method
-func (m *MockContainerServer) CopyContainerSnapshot(arg0 client.InstanceServer, arg1 string, arg2 api.ContainerSnapshot, arg3 *client.ContainerSnapshotCopyArgs) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CopyContainerSnapshot(arg0 lxd.InstanceServer, arg1 string, arg2 api.ContainerSnapshot, arg3 *lxd.ContainerSnapshotCopyArgs) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyContainerSnapshot", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -577,10 +616,10 @@ func (mr *MockContainerServerMockRecorder) CopyContainerSnapshot(arg0, arg1, arg
 }
 
 // CopyImage mocks base method
-func (m *MockContainerServer) CopyImage(arg0 client.ImageServer, arg1 api.Image, arg2 *client.ImageCopyArgs) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CopyImage(arg0 lxd.ImageServer, arg1 api.Image, arg2 *lxd.ImageCopyArgs) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyImage", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -592,10 +631,10 @@ func (mr *MockContainerServerMockRecorder) CopyImage(arg0, arg1, arg2 interface{
 }
 
 // CopyInstance mocks base method
-func (m *MockContainerServer) CopyInstance(arg0 client.InstanceServer, arg1 api.Instance, arg2 *client.InstanceCopyArgs) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CopyInstance(arg0 lxd.InstanceServer, arg1 api.Instance, arg2 *lxd.InstanceCopyArgs) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyInstance", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -607,10 +646,10 @@ func (mr *MockContainerServerMockRecorder) CopyInstance(arg0, arg1, arg2 interfa
 }
 
 // CopyInstanceSnapshot mocks base method
-func (m *MockContainerServer) CopyInstanceSnapshot(arg0 client.InstanceServer, arg1 string, arg2 api.InstanceSnapshot, arg3 *client.InstanceSnapshotCopyArgs) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CopyInstanceSnapshot(arg0 lxd.InstanceServer, arg1 string, arg2 api.InstanceSnapshot, arg3 *lxd.InstanceSnapshotCopyArgs) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyInstanceSnapshot", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -622,10 +661,10 @@ func (mr *MockContainerServerMockRecorder) CopyInstanceSnapshot(arg0, arg1, arg2
 }
 
 // CopyStoragePoolVolume mocks base method
-func (m *MockContainerServer) CopyStoragePoolVolume(arg0 string, arg1 client.InstanceServer, arg2 string, arg3 api.StorageVolume, arg4 *client.StoragePoolVolumeCopyArgs) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CopyStoragePoolVolume(arg0 string, arg1 lxd.InstanceServer, arg2 string, arg3 api.StorageVolume, arg4 *lxd.StoragePoolVolumeCopyArgs) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyStoragePoolVolume", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -651,10 +690,10 @@ func (mr *MockContainerServerMockRecorder) CreateCertificate(arg0 interface{}) *
 }
 
 // CreateContainer mocks base method
-func (m *MockContainerServer) CreateContainer(arg0 api.ContainersPost) (client.Operation, error) {
+func (m *MockContainerServer) CreateContainer(arg0 api.ContainersPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainer", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -666,10 +705,10 @@ func (mr *MockContainerServerMockRecorder) CreateContainer(arg0 interface{}) *go
 }
 
 // CreateContainerBackup mocks base method
-func (m *MockContainerServer) CreateContainerBackup(arg0 string, arg1 api.ContainerBackupsPost) (client.Operation, error) {
+func (m *MockContainerServer) CreateContainerBackup(arg0 string, arg1 api.ContainerBackupsPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainerBackup", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -681,7 +720,7 @@ func (mr *MockContainerServerMockRecorder) CreateContainerBackup(arg0, arg1 inte
 }
 
 // CreateContainerFile mocks base method
-func (m *MockContainerServer) CreateContainerFile(arg0, arg1 string, arg2 client.ContainerFileArgs) error {
+func (m *MockContainerServer) CreateContainerFile(arg0, arg1 string, arg2 lxd.ContainerFileArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainerFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -695,10 +734,10 @@ func (mr *MockContainerServerMockRecorder) CreateContainerFile(arg0, arg1, arg2 
 }
 
 // CreateContainerFromBackup mocks base method
-func (m *MockContainerServer) CreateContainerFromBackup(arg0 client.ContainerBackupArgs) (client.Operation, error) {
+func (m *MockContainerServer) CreateContainerFromBackup(arg0 lxd.ContainerBackupArgs) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainerFromBackup", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -710,10 +749,10 @@ func (mr *MockContainerServerMockRecorder) CreateContainerFromBackup(arg0 interf
 }
 
 // CreateContainerFromImage mocks base method
-func (m *MockContainerServer) CreateContainerFromImage(arg0 client.ImageServer, arg1 api.Image, arg2 api.ContainersPost) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CreateContainerFromImage(arg0 lxd.ImageServer, arg1 api.Image, arg2 api.ContainersPost) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainerFromImage", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -725,10 +764,10 @@ func (mr *MockContainerServerMockRecorder) CreateContainerFromImage(arg0, arg1, 
 }
 
 // CreateContainerSnapshot mocks base method
-func (m *MockContainerServer) CreateContainerSnapshot(arg0 string, arg1 api.ContainerSnapshotsPost) (client.Operation, error) {
+func (m *MockContainerServer) CreateContainerSnapshot(arg0 string, arg1 api.ContainerSnapshotsPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainerSnapshot", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -754,10 +793,10 @@ func (mr *MockContainerServerMockRecorder) CreateContainerTemplateFile(arg0, arg
 }
 
 // CreateImage mocks base method
-func (m *MockContainerServer) CreateImage(arg0 api.ImagesPost, arg1 *client.ImageCreateArgs) (client.Operation, error) {
+func (m *MockContainerServer) CreateImage(arg0 api.ImagesPost, arg1 *lxd.ImageCreateArgs) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateImage", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -783,10 +822,10 @@ func (mr *MockContainerServerMockRecorder) CreateImageAlias(arg0 interface{}) *g
 }
 
 // CreateImageSecret mocks base method
-func (m *MockContainerServer) CreateImageSecret(arg0 string) (client.Operation, error) {
+func (m *MockContainerServer) CreateImageSecret(arg0 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateImageSecret", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -798,10 +837,10 @@ func (mr *MockContainerServerMockRecorder) CreateImageSecret(arg0 interface{}) *
 }
 
 // CreateInstance mocks base method
-func (m *MockContainerServer) CreateInstance(arg0 api.InstancesPost) (client.Operation, error) {
+func (m *MockContainerServer) CreateInstance(arg0 api.InstancesPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstance", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -813,10 +852,10 @@ func (mr *MockContainerServerMockRecorder) CreateInstance(arg0 interface{}) *gom
 }
 
 // CreateInstanceBackup mocks base method
-func (m *MockContainerServer) CreateInstanceBackup(arg0 string, arg1 api.InstanceBackupsPost) (client.Operation, error) {
+func (m *MockContainerServer) CreateInstanceBackup(arg0 string, arg1 api.InstanceBackupsPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceBackup", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -828,7 +867,7 @@ func (mr *MockContainerServerMockRecorder) CreateInstanceBackup(arg0, arg1 inter
 }
 
 // CreateInstanceFile mocks base method
-func (m *MockContainerServer) CreateInstanceFile(arg0, arg1 string, arg2 client.InstanceFileArgs) error {
+func (m *MockContainerServer) CreateInstanceFile(arg0, arg1 string, arg2 lxd.InstanceFileArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -842,10 +881,10 @@ func (mr *MockContainerServerMockRecorder) CreateInstanceFile(arg0, arg1, arg2 i
 }
 
 // CreateInstanceFromBackup mocks base method
-func (m *MockContainerServer) CreateInstanceFromBackup(arg0 client.InstanceBackupArgs) (client.Operation, error) {
+func (m *MockContainerServer) CreateInstanceFromBackup(arg0 lxd.InstanceBackupArgs) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceFromBackup", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -857,10 +896,10 @@ func (mr *MockContainerServerMockRecorder) CreateInstanceFromBackup(arg0 interfa
 }
 
 // CreateInstanceFromImage mocks base method
-func (m *MockContainerServer) CreateInstanceFromImage(arg0 client.ImageServer, arg1 api.Image, arg2 api.InstancesPost) (client.RemoteOperation, error) {
+func (m *MockContainerServer) CreateInstanceFromImage(arg0 lxd.ImageServer, arg1 api.Image, arg2 api.InstancesPost) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceFromImage", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -872,10 +911,10 @@ func (mr *MockContainerServerMockRecorder) CreateInstanceFromImage(arg0, arg1, a
 }
 
 // CreateInstanceSnapshot mocks base method
-func (m *MockContainerServer) CreateInstanceSnapshot(arg0 string, arg1 api.InstanceSnapshotsPost) (client.Operation, error) {
+func (m *MockContainerServer) CreateInstanceSnapshot(arg0 string, arg1 api.InstanceSnapshotsPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceSnapshot", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -971,10 +1010,10 @@ func (mr *MockContainerServerMockRecorder) CreateStoragePoolVolume(arg0, arg1 in
 }
 
 // CreateStoragePoolVolumeSnapshot mocks base method
-func (m *MockContainerServer) CreateStoragePoolVolumeSnapshot(arg0, arg1, arg2 string, arg3 api.StorageVolumeSnapshotsPost) (client.Operation, error) {
+func (m *MockContainerServer) CreateStoragePoolVolumeSnapshot(arg0, arg1, arg2 string, arg3 api.StorageVolumeSnapshotsPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1014,10 +1053,10 @@ func (mr *MockContainerServerMockRecorder) DeleteClusterMember(arg0, arg1 interf
 }
 
 // DeleteContainer mocks base method
-func (m *MockContainerServer) DeleteContainer(arg0 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteContainer(arg0 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteContainer", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1029,10 +1068,10 @@ func (mr *MockContainerServerMockRecorder) DeleteContainer(arg0 interface{}) *go
 }
 
 // DeleteContainerBackup mocks base method
-func (m *MockContainerServer) DeleteContainerBackup(arg0, arg1 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteContainerBackup(arg0, arg1 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteContainerBackup", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1044,7 +1083,7 @@ func (mr *MockContainerServerMockRecorder) DeleteContainerBackup(arg0, arg1 inte
 }
 
 // DeleteContainerConsoleLog mocks base method
-func (m *MockContainerServer) DeleteContainerConsoleLog(arg0 string, arg1 *client.ContainerConsoleLogArgs) error {
+func (m *MockContainerServer) DeleteContainerConsoleLog(arg0 string, arg1 *lxd.ContainerConsoleLogArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteContainerConsoleLog", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1086,10 +1125,10 @@ func (mr *MockContainerServerMockRecorder) DeleteContainerLogfile(arg0, arg1 int
 }
 
 // DeleteContainerSnapshot mocks base method
-func (m *MockContainerServer) DeleteContainerSnapshot(arg0, arg1 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteContainerSnapshot(arg0, arg1 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteContainerSnapshot", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1115,10 +1154,10 @@ func (mr *MockContainerServerMockRecorder) DeleteContainerTemplateFile(arg0, arg
 }
 
 // DeleteImage mocks base method
-func (m *MockContainerServer) DeleteImage(arg0 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteImage(arg0 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteImage", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1144,10 +1183,10 @@ func (mr *MockContainerServerMockRecorder) DeleteImageAlias(arg0 interface{}) *g
 }
 
 // DeleteInstance mocks base method
-func (m *MockContainerServer) DeleteInstance(arg0 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteInstance(arg0 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInstance", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1159,10 +1198,10 @@ func (mr *MockContainerServerMockRecorder) DeleteInstance(arg0 interface{}) *gom
 }
 
 // DeleteInstanceBackup mocks base method
-func (m *MockContainerServer) DeleteInstanceBackup(arg0, arg1 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteInstanceBackup(arg0, arg1 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInstanceBackup", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1174,7 +1213,7 @@ func (mr *MockContainerServerMockRecorder) DeleteInstanceBackup(arg0, arg1 inter
 }
 
 // DeleteInstanceConsoleLog mocks base method
-func (m *MockContainerServer) DeleteInstanceConsoleLog(arg0 string, arg1 *client.InstanceConsoleLogArgs) error {
+func (m *MockContainerServer) DeleteInstanceConsoleLog(arg0 string, arg1 *lxd.InstanceConsoleLogArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInstanceConsoleLog", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1216,10 +1255,10 @@ func (mr *MockContainerServerMockRecorder) DeleteInstanceLogfile(arg0, arg1 inte
 }
 
 // DeleteInstanceSnapshot mocks base method
-func (m *MockContainerServer) DeleteInstanceSnapshot(arg0, arg1 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteInstanceSnapshot(arg0, arg1 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInstanceSnapshot", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1329,10 +1368,10 @@ func (mr *MockContainerServerMockRecorder) DeleteStoragePoolVolume(arg0, arg1, a
 }
 
 // DeleteStoragePoolVolumeSnapshot mocks base method
-func (m *MockContainerServer) DeleteStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string) (client.Operation, error) {
+func (m *MockContainerServer) DeleteStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1343,11 +1382,23 @@ func (mr *MockContainerServerMockRecorder) DeleteStoragePoolVolumeSnapshot(arg0,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStoragePoolVolumeSnapshot", reflect.TypeOf((*MockContainerServer)(nil).DeleteStoragePoolVolumeSnapshot), arg0, arg1, arg2, arg3)
 }
 
+// Disconnect mocks base method
+func (m *MockContainerServer) Disconnect() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Disconnect")
+}
+
+// Disconnect indicates an expected call of Disconnect
+func (mr *MockContainerServerMockRecorder) Disconnect() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockContainerServer)(nil).Disconnect))
+}
+
 // ExecContainer mocks base method
-func (m *MockContainerServer) ExecContainer(arg0 string, arg1 api.ContainerExecPost, arg2 *client.ContainerExecArgs) (client.Operation, error) {
+func (m *MockContainerServer) ExecContainer(arg0 string, arg1 api.ContainerExecPost, arg2 *lxd.ContainerExecArgs) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecContainer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1359,10 +1410,10 @@ func (mr *MockContainerServerMockRecorder) ExecContainer(arg0, arg1, arg2 interf
 }
 
 // ExecInstance mocks base method
-func (m *MockContainerServer) ExecInstance(arg0 string, arg1 api.InstanceExecPost, arg2 *client.InstanceExecArgs) (client.Operation, error) {
+func (m *MockContainerServer) ExecInstance(arg0 string, arg1 api.InstanceExecPost, arg2 *lxd.InstanceExecArgs) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecInstance", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1482,10 +1533,10 @@ func (mr *MockContainerServerMockRecorder) GetClusterMembers() *gomock.Call {
 }
 
 // GetConnectionInfo mocks base method
-func (m *MockContainerServer) GetConnectionInfo() (*client.ConnectionInfo, error) {
+func (m *MockContainerServer) GetConnectionInfo() (*lxd.ConnectionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnectionInfo")
-	ret0, _ := ret[0].(*client.ConnectionInfo)
+	ret0, _ := ret[0].(*lxd.ConnectionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1529,10 +1580,10 @@ func (mr *MockContainerServerMockRecorder) GetContainerBackup(arg0, arg1 interfa
 }
 
 // GetContainerBackupFile mocks base method
-func (m *MockContainerServer) GetContainerBackupFile(arg0, arg1 string, arg2 *client.BackupFileRequest) (*client.BackupFileResponse, error) {
+func (m *MockContainerServer) GetContainerBackupFile(arg0, arg1 string, arg2 *lxd.BackupFileRequest) (*lxd.BackupFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerBackupFile", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*client.BackupFileResponse)
+	ret0, _ := ret[0].(*lxd.BackupFileResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1574,7 +1625,7 @@ func (mr *MockContainerServerMockRecorder) GetContainerBackups(arg0 interface{})
 }
 
 // GetContainerConsoleLog mocks base method
-func (m *MockContainerServer) GetContainerConsoleLog(arg0 string, arg1 *client.ContainerConsoleLogArgs) (io.ReadCloser, error) {
+func (m *MockContainerServer) GetContainerConsoleLog(arg0 string, arg1 *lxd.ContainerConsoleLogArgs) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerConsoleLog", arg0, arg1)
 	ret0, _ := ret[0].(io.ReadCloser)
@@ -1589,11 +1640,11 @@ func (mr *MockContainerServerMockRecorder) GetContainerConsoleLog(arg0, arg1 int
 }
 
 // GetContainerFile mocks base method
-func (m *MockContainerServer) GetContainerFile(arg0, arg1 string) (io.ReadCloser, *client.ContainerFileResponse, error) {
+func (m *MockContainerServer) GetContainerFile(arg0, arg1 string) (io.ReadCloser, *lxd.ContainerFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerFile", arg0, arg1)
 	ret0, _ := ret[0].(io.ReadCloser)
-	ret1, _ := ret[1].(*client.ContainerFileResponse)
+	ret1, _ := ret[1].(*lxd.ContainerFileResponse)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -1788,10 +1839,10 @@ func (mr *MockContainerServerMockRecorder) GetContainersFull() *gomock.Call {
 }
 
 // GetEvents mocks base method
-func (m *MockContainerServer) GetEvents() (*client.EventListener, error) {
+func (m *MockContainerServer) GetEvents() (*lxd.EventListener, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEvents")
-	ret0, _ := ret[0].(*client.EventListener)
+	ret0, _ := ret[0].(*lxd.EventListener)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1849,6 +1900,21 @@ func (mr *MockContainerServerMockRecorder) GetImageAlias(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageAlias", reflect.TypeOf((*MockContainerServer)(nil).GetImageAlias), arg0)
 }
 
+// GetImageAliasArchitectures mocks base method
+func (m *MockContainerServer) GetImageAliasArchitectures(arg0, arg1 string) (map[string]*api.ImageAliasesEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageAliasArchitectures", arg0, arg1)
+	ret0, _ := ret[0].(map[string]*api.ImageAliasesEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageAliasArchitectures indicates an expected call of GetImageAliasArchitectures
+func (mr *MockContainerServerMockRecorder) GetImageAliasArchitectures(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageAliasArchitectures", reflect.TypeOf((*MockContainerServer)(nil).GetImageAliasArchitectures), arg0, arg1)
+}
+
 // GetImageAliasNames mocks base method
 func (m *MockContainerServer) GetImageAliasNames() ([]string, error) {
 	m.ctrl.T.Helper()
@@ -1896,10 +1962,10 @@ func (mr *MockContainerServerMockRecorder) GetImageAliases() *gomock.Call {
 }
 
 // GetImageFile mocks base method
-func (m *MockContainerServer) GetImageFile(arg0 string, arg1 client.ImageFileRequest) (*client.ImageFileResponse, error) {
+func (m *MockContainerServer) GetImageFile(arg0 string, arg1 lxd.ImageFileRequest) (*lxd.ImageFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImageFile", arg0, arg1)
-	ret0, _ := ret[0].(*client.ImageFileResponse)
+	ret0, _ := ret[0].(*lxd.ImageFileResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1988,10 +2054,10 @@ func (mr *MockContainerServerMockRecorder) GetInstanceBackup(arg0, arg1 interfac
 }
 
 // GetInstanceBackupFile mocks base method
-func (m *MockContainerServer) GetInstanceBackupFile(arg0, arg1 string, arg2 *client.BackupFileRequest) (*client.BackupFileResponse, error) {
+func (m *MockContainerServer) GetInstanceBackupFile(arg0, arg1 string, arg2 *lxd.BackupFileRequest) (*lxd.BackupFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceBackupFile", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*client.BackupFileResponse)
+	ret0, _ := ret[0].(*lxd.BackupFileResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2033,7 +2099,7 @@ func (mr *MockContainerServerMockRecorder) GetInstanceBackups(arg0 interface{}) 
 }
 
 // GetInstanceConsoleLog mocks base method
-func (m *MockContainerServer) GetInstanceConsoleLog(arg0 string, arg1 *client.InstanceConsoleLogArgs) (io.ReadCloser, error) {
+func (m *MockContainerServer) GetInstanceConsoleLog(arg0 string, arg1 *lxd.InstanceConsoleLogArgs) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceConsoleLog", arg0, arg1)
 	ret0, _ := ret[0].(io.ReadCloser)
@@ -2048,11 +2114,11 @@ func (mr *MockContainerServerMockRecorder) GetInstanceConsoleLog(arg0, arg1 inte
 }
 
 // GetInstanceFile mocks base method
-func (m *MockContainerServer) GetInstanceFile(arg0, arg1 string) (io.ReadCloser, *client.InstanceFileResponse, error) {
+func (m *MockContainerServer) GetInstanceFile(arg0, arg1 string) (io.ReadCloser, *lxd.InstanceFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceFile", arg0, arg1)
 	ret0, _ := ret[0].(io.ReadCloser)
-	ret1, _ := ret[1].(*client.InstanceFileResponse)
+	ret1, _ := ret[1].(*lxd.InstanceFileResponse)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -2416,10 +2482,10 @@ func (mr *MockContainerServerMockRecorder) GetPrivateImage(arg0, arg1 interface{
 }
 
 // GetPrivateImageFile mocks base method
-func (m *MockContainerServer) GetPrivateImageFile(arg0, arg1 string, arg2 client.ImageFileRequest) (*client.ImageFileResponse, error) {
+func (m *MockContainerServer) GetPrivateImageFile(arg0, arg1 string, arg2 lxd.ImageFileRequest) (*lxd.ImageFileResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPrivateImageFile", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*client.ImageFileResponse)
+	ret0, _ := ret[0].(*lxd.ImageFileResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2735,10 +2801,10 @@ func (mr *MockContainerServerMockRecorder) IsClustered() *gomock.Call {
 }
 
 // MigrateContainer mocks base method
-func (m *MockContainerServer) MigrateContainer(arg0 string, arg1 api.ContainerPost) (client.Operation, error) {
+func (m *MockContainerServer) MigrateContainer(arg0 string, arg1 api.ContainerPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateContainer", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2750,10 +2816,10 @@ func (mr *MockContainerServerMockRecorder) MigrateContainer(arg0, arg1 interface
 }
 
 // MigrateContainerSnapshot mocks base method
-func (m *MockContainerServer) MigrateContainerSnapshot(arg0, arg1 string, arg2 api.ContainerSnapshotPost) (client.Operation, error) {
+func (m *MockContainerServer) MigrateContainerSnapshot(arg0, arg1 string, arg2 api.ContainerSnapshotPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateContainerSnapshot", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2765,10 +2831,10 @@ func (mr *MockContainerServerMockRecorder) MigrateContainerSnapshot(arg0, arg1, 
 }
 
 // MigrateInstance mocks base method
-func (m *MockContainerServer) MigrateInstance(arg0 string, arg1 api.InstancePost) (client.Operation, error) {
+func (m *MockContainerServer) MigrateInstance(arg0 string, arg1 api.InstancePost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateInstance", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2780,10 +2846,10 @@ func (mr *MockContainerServerMockRecorder) MigrateInstance(arg0, arg1 interface{
 }
 
 // MigrateInstanceSnapshot mocks base method
-func (m *MockContainerServer) MigrateInstanceSnapshot(arg0, arg1 string, arg2 api.InstanceSnapshotPost) (client.Operation, error) {
+func (m *MockContainerServer) MigrateInstanceSnapshot(arg0, arg1 string, arg2 api.InstanceSnapshotPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateInstanceSnapshot", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2795,10 +2861,10 @@ func (mr *MockContainerServerMockRecorder) MigrateInstanceSnapshot(arg0, arg1, a
 }
 
 // MigrateStoragePoolVolume mocks base method
-func (m *MockContainerServer) MigrateStoragePoolVolume(arg0 string, arg1 api.StorageVolumePost) (client.Operation, error) {
+func (m *MockContainerServer) MigrateStoragePoolVolume(arg0 string, arg1 api.StorageVolumePost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateStoragePoolVolume", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2810,10 +2876,10 @@ func (mr *MockContainerServerMockRecorder) MigrateStoragePoolVolume(arg0, arg1 i
 }
 
 // MoveStoragePoolVolume mocks base method
-func (m *MockContainerServer) MoveStoragePoolVolume(arg0 string, arg1 client.InstanceServer, arg2 string, arg3 api.StorageVolume, arg4 *client.StoragePoolVolumeMoveArgs) (client.RemoteOperation, error) {
+func (m *MockContainerServer) MoveStoragePoolVolume(arg0 string, arg1 lxd.InstanceServer, arg2 string, arg3 api.StorageVolume, arg4 *lxd.StoragePoolVolumeMoveArgs) (lxd.RemoteOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MoveStoragePoolVolume", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(client.RemoteOperation)
+	ret0, _ := ret[0].(lxd.RemoteOperation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2825,10 +2891,10 @@ func (mr *MockContainerServerMockRecorder) MoveStoragePoolVolume(arg0, arg1, arg
 }
 
 // RawOperation mocks base method
-func (m *MockContainerServer) RawOperation(arg0, arg1 string, arg2 interface{}, arg3 string) (client.Operation, string, error) {
+func (m *MockContainerServer) RawOperation(arg0, arg1 string, arg2 interface{}, arg3 string) (lxd.Operation, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RawOperation", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -2872,10 +2938,10 @@ func (mr *MockContainerServerMockRecorder) RawWebsocket(arg0 interface{}) *gomoc
 }
 
 // RefreshImage mocks base method
-func (m *MockContainerServer) RefreshImage(arg0 string) (client.Operation, error) {
+func (m *MockContainerServer) RefreshImage(arg0 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshImage", arg0)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2901,10 +2967,10 @@ func (mr *MockContainerServerMockRecorder) RenameClusterMember(arg0, arg1 interf
 }
 
 // RenameContainer mocks base method
-func (m *MockContainerServer) RenameContainer(arg0 string, arg1 api.ContainerPost) (client.Operation, error) {
+func (m *MockContainerServer) RenameContainer(arg0 string, arg1 api.ContainerPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameContainer", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2916,10 +2982,10 @@ func (mr *MockContainerServerMockRecorder) RenameContainer(arg0, arg1 interface{
 }
 
 // RenameContainerBackup mocks base method
-func (m *MockContainerServer) RenameContainerBackup(arg0, arg1 string, arg2 api.ContainerBackupPost) (client.Operation, error) {
+func (m *MockContainerServer) RenameContainerBackup(arg0, arg1 string, arg2 api.ContainerBackupPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameContainerBackup", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2931,10 +2997,10 @@ func (mr *MockContainerServerMockRecorder) RenameContainerBackup(arg0, arg1, arg
 }
 
 // RenameContainerSnapshot mocks base method
-func (m *MockContainerServer) RenameContainerSnapshot(arg0, arg1 string, arg2 api.ContainerSnapshotPost) (client.Operation, error) {
+func (m *MockContainerServer) RenameContainerSnapshot(arg0, arg1 string, arg2 api.ContainerSnapshotPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameContainerSnapshot", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2960,10 +3026,10 @@ func (mr *MockContainerServerMockRecorder) RenameImageAlias(arg0, arg1 interface
 }
 
 // RenameInstance mocks base method
-func (m *MockContainerServer) RenameInstance(arg0 string, arg1 api.InstancePost) (client.Operation, error) {
+func (m *MockContainerServer) RenameInstance(arg0 string, arg1 api.InstancePost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameInstance", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2975,10 +3041,10 @@ func (mr *MockContainerServerMockRecorder) RenameInstance(arg0, arg1 interface{}
 }
 
 // RenameInstanceBackup mocks base method
-func (m *MockContainerServer) RenameInstanceBackup(arg0, arg1 string, arg2 api.InstanceBackupPost) (client.Operation, error) {
+func (m *MockContainerServer) RenameInstanceBackup(arg0, arg1 string, arg2 api.InstanceBackupPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameInstanceBackup", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2990,10 +3056,10 @@ func (mr *MockContainerServerMockRecorder) RenameInstanceBackup(arg0, arg1, arg2
 }
 
 // RenameInstanceSnapshot mocks base method
-func (m *MockContainerServer) RenameInstanceSnapshot(arg0, arg1 string, arg2 api.InstanceSnapshotPost) (client.Operation, error) {
+func (m *MockContainerServer) RenameInstanceSnapshot(arg0, arg1 string, arg2 api.InstanceSnapshotPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameInstanceSnapshot", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3033,10 +3099,10 @@ func (mr *MockContainerServerMockRecorder) RenameProfile(arg0, arg1 interface{})
 }
 
 // RenameProject mocks base method
-func (m *MockContainerServer) RenameProject(arg0 string, arg1 api.ProjectPost) (client.Operation, error) {
+func (m *MockContainerServer) RenameProject(arg0 string, arg1 api.ProjectPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameProject", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3062,10 +3128,10 @@ func (mr *MockContainerServerMockRecorder) RenameStoragePoolVolume(arg0, arg1, a
 }
 
 // RenameStoragePoolVolumeSnapshot mocks base method
-func (m *MockContainerServer) RenameStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string, arg4 api.StorageVolumeSnapshotPost) (client.Operation, error) {
+func (m *MockContainerServer) RenameStoragePoolVolumeSnapshot(arg0, arg1, arg2, arg3 string, arg4 api.StorageVolumeSnapshotPost) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameStoragePoolVolumeSnapshot", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3131,10 +3197,10 @@ func (mr *MockContainerServerMockRecorder) UpdateCertificate(arg0, arg1, arg2 in
 }
 
 // UpdateCluster mocks base method
-func (m *MockContainerServer) UpdateCluster(arg0 api.ClusterPut, arg1 string) (client.Operation, error) {
+func (m *MockContainerServer) UpdateCluster(arg0 api.ClusterPut, arg1 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCluster", arg0, arg1)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3146,10 +3212,10 @@ func (mr *MockContainerServerMockRecorder) UpdateCluster(arg0, arg1 interface{})
 }
 
 // UpdateContainer mocks base method
-func (m *MockContainerServer) UpdateContainer(arg0 string, arg1 api.ContainerPut, arg2 string) (client.Operation, error) {
+func (m *MockContainerServer) UpdateContainer(arg0 string, arg1 api.ContainerPut, arg2 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3161,10 +3227,10 @@ func (mr *MockContainerServerMockRecorder) UpdateContainer(arg0, arg1, arg2 inte
 }
 
 // UpdateContainerSnapshot mocks base method
-func (m *MockContainerServer) UpdateContainerSnapshot(arg0, arg1 string, arg2 api.ContainerSnapshotPut, arg3 string) (client.Operation, error) {
+func (m *MockContainerServer) UpdateContainerSnapshot(arg0, arg1 string, arg2 api.ContainerSnapshotPut, arg3 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerSnapshot", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3176,10 +3242,10 @@ func (mr *MockContainerServerMockRecorder) UpdateContainerSnapshot(arg0, arg1, a
 }
 
 // UpdateContainerState mocks base method
-func (m *MockContainerServer) UpdateContainerState(arg0 string, arg1 api.ContainerStatePut, arg2 string) (client.Operation, error) {
+func (m *MockContainerServer) UpdateContainerState(arg0 string, arg1 api.ContainerStatePut, arg2 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerState", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3233,10 +3299,10 @@ func (mr *MockContainerServerMockRecorder) UpdateImageAlias(arg0, arg1, arg2 int
 }
 
 // UpdateInstance mocks base method
-func (m *MockContainerServer) UpdateInstance(arg0 string, arg1 api.InstancePut, arg2 string) (client.Operation, error) {
+func (m *MockContainerServer) UpdateInstance(arg0 string, arg1 api.InstancePut, arg2 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateInstance", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3248,10 +3314,10 @@ func (mr *MockContainerServerMockRecorder) UpdateInstance(arg0, arg1, arg2 inter
 }
 
 // UpdateInstanceSnapshot mocks base method
-func (m *MockContainerServer) UpdateInstanceSnapshot(arg0, arg1 string, arg2 api.InstanceSnapshotPut, arg3 string) (client.Operation, error) {
+func (m *MockContainerServer) UpdateInstanceSnapshot(arg0, arg1 string, arg2 api.InstanceSnapshotPut, arg3 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateInstanceSnapshot", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3263,10 +3329,10 @@ func (mr *MockContainerServerMockRecorder) UpdateInstanceSnapshot(arg0, arg1, ar
 }
 
 // UpdateInstanceState mocks base method
-func (m *MockContainerServer) UpdateInstanceState(arg0 string, arg1 api.InstanceStatePut, arg2 string) (client.Operation, error) {
+func (m *MockContainerServer) UpdateInstanceState(arg0 string, arg1 api.InstanceStatePut, arg2 string) (lxd.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateInstanceState", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Operation)
+	ret0, _ := ret[0].(lxd.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3390,10 +3456,10 @@ func (mr *MockContainerServerMockRecorder) UpdateStoragePoolVolumeSnapshot(arg0,
 }
 
 // UseProject mocks base method
-func (m *MockContainerServer) UseProject(arg0 string) client.InstanceServer {
+func (m *MockContainerServer) UseProject(arg0 string) lxd.InstanceServer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UseProject", arg0)
-	ret0, _ := ret[0].(client.InstanceServer)
+	ret0, _ := ret[0].(lxd.InstanceServer)
 	return ret0
 }
 
@@ -3404,10 +3470,10 @@ func (mr *MockContainerServerMockRecorder) UseProject(arg0 interface{}) *gomock.
 }
 
 // UseTarget mocks base method
-func (m *MockContainerServer) UseTarget(arg0 string) client.InstanceServer {
+func (m *MockContainerServer) UseTarget(arg0 string) lxd.InstanceServer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UseTarget", arg0)
-	ret0, _ := ret[0].(client.InstanceServer)
+	ret0, _ := ret[0].(lxd.InstanceServer)
 	return ret0
 }
 

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -50,7 +50,7 @@ type CertificateReadWriter interface {
 type CertificateGenerator interface {
 	// Generate creates client or server certificate and key pair,
 	// returning them as byte arrays in memory.
-	Generate(client bool) (certPEM, keyPEM []byte, err error)
+	Generate(client bool, addHosts bool) (certPEM, keyPEM []byte, err error)
 }
 
 // NetLookup groups methods for looking up hosts and interface addresses.
@@ -248,7 +248,7 @@ func (p environProviderCredentials) readOrGenerateCert(logf func(string, ...inte
 	// No certs were found, so generate one and cache it in the
 	// Juju XDG_DATA dir. We cache the certificate so that we
 	// avoid uploading a new certificate each time we bootstrap.
-	certPEM, keyPEM, err = p.certGenerator.Generate(true)
+	certPEM, keyPEM, err = p.certGenerator.Generate(true, true)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -570,8 +570,8 @@ func (certificateReadWriter) Write(path string, certPEM, keyPEM []byte) error {
 // certificate if it's not found on disk.
 type certificateGenerator struct{}
 
-func (certificateGenerator) Generate(client bool) (certPEM, keyPEM []byte, err error) {
-	return shared.GenerateMemCert(client)
+func (certificateGenerator) Generate(client bool, addHosts bool) (certPEM, keyPEM []byte, err error) {
+	return shared.GenerateMemCert(client, addHosts)
 }
 
 type netLookup struct{}

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -13,8 +13,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/juju/juju/provider/lxd/lxdnames"
-
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/lxc/lxd/shared"
@@ -24,6 +22,7 @@ import (
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/provider/lxd/lxdnames"
 )
 
 const (

--- a/provider/lxd/credentials_mock_test.go
+++ b/provider/lxd/credentials_mock_test.go
@@ -35,6 +35,7 @@ func (m *MockCertificateReadWriter) EXPECT() *MockCertificateReadWriterMockRecor
 
 // Read mocks base method
 func (m *MockCertificateReadWriter) Read(arg0 string) ([]byte, []byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", arg0)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].([]byte)
@@ -44,11 +45,13 @@ func (m *MockCertificateReadWriter) Read(arg0 string) ([]byte, []byte, error) {
 
 // Read indicates an expected call of Read
 func (mr *MockCertificateReadWriterMockRecorder) Read(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockCertificateReadWriter)(nil).Read), arg0)
 }
 
 // Write mocks base method
 func (m *MockCertificateReadWriter) Write(arg0 string, arg1, arg2 []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -56,6 +59,7 @@ func (m *MockCertificateReadWriter) Write(arg0 string, arg1, arg2 []byte) error 
 
 // Write indicates an expected call of Write
 func (mr *MockCertificateReadWriterMockRecorder) Write(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockCertificateReadWriter)(nil).Write), arg0, arg1, arg2)
 }
 
@@ -83,8 +87,9 @@ func (m *MockCertificateGenerator) EXPECT() *MockCertificateGeneratorMockRecorde
 }
 
 // Generate mocks base method
-func (m *MockCertificateGenerator) Generate(arg0 bool) ([]byte, []byte, error) {
-	ret := m.ctrl.Call(m, "Generate", arg0)
+func (m *MockCertificateGenerator) Generate(arg0, arg1 bool) ([]byte, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Generate", arg0, arg1)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -92,8 +97,9 @@ func (m *MockCertificateGenerator) Generate(arg0 bool) ([]byte, []byte, error) {
 }
 
 // Generate indicates an expected call of Generate
-func (mr *MockCertificateGeneratorMockRecorder) Generate(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockCertificateGenerator)(nil).Generate), arg0)
+func (mr *MockCertificateGeneratorMockRecorder) Generate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockCertificateGenerator)(nil).Generate), arg0, arg1)
 }
 
 // MockNetLookup is a mock of NetLookup interface
@@ -121,6 +127,7 @@ func (m *MockNetLookup) EXPECT() *MockNetLookupMockRecorder {
 
 // InterfaceAddrs mocks base method
 func (m *MockNetLookup) InterfaceAddrs() ([]net.Addr, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InterfaceAddrs")
 	ret0, _ := ret[0].([]net.Addr)
 	ret1, _ := ret[1].(error)
@@ -129,11 +136,13 @@ func (m *MockNetLookup) InterfaceAddrs() ([]net.Addr, error) {
 
 // InterfaceAddrs indicates an expected call of InterfaceAddrs
 func (mr *MockNetLookupMockRecorder) InterfaceAddrs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InterfaceAddrs", reflect.TypeOf((*MockNetLookup)(nil).InterfaceAddrs))
 }
 
 // LookupHost mocks base method
 func (m *MockNetLookup) LookupHost(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LookupHost", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -142,5 +151,6 @@ func (m *MockNetLookup) LookupHost(arg0 string) ([]string, error) {
 
 // LookupHost indicates an expected call of LookupHost
 func (mr *MockNetLookupMockRecorder) LookupHost(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupHost", reflect.TypeOf((*MockNetLookup)(nil).LookupHost), arg0)
 }

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -122,7 +122,7 @@ func (s *credentialsSuite) TestDetectCredentialsGeneratesCertFailsToWriteOnError
 	path = filepath.Join(utils.Home(), ".config", "lxc")
 	deps.certReadWriter.EXPECT().Read(path).Return(nil, nil, os.ErrNotExist)
 
-	deps.certGenerator.EXPECT().Generate(true).Return(nil, nil, errors.Errorf("bad"))
+	deps.certGenerator.EXPECT().Generate(true, true).Return(nil, nil, errors.Errorf("bad"))
 
 	_, err := deps.provider.DetectCredentials()
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "bad")
@@ -141,7 +141,7 @@ func (s *credentialsSuite) TestDetectCredentialsGeneratesCertFailsToGetCertifica
 	path = filepath.Join(utils.Home(), ".config", "lxc")
 	deps.certReadWriter.EXPECT().Read(path).Return(nil, nil, os.ErrNotExist)
 
-	deps.certGenerator.EXPECT().Generate(true).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
+	deps.certGenerator.EXPECT().Generate(true, true).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
 
 	_, err := deps.provider.DetectCredentials()
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "bad")
@@ -269,7 +269,7 @@ func (s *credentialsSuite) TestRegisterCredentials(c *gc.C) {
 
 	path = filepath.Join(utils.Home(), ".config", "lxc")
 	deps.certReadWriter.EXPECT().Read(path).Return(nil, nil, os.ErrNotExist)
-	deps.certGenerator.EXPECT().Generate(true).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
+	deps.certGenerator.EXPECT().Generate(true, true).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
 
 	expected := cloud.NewCredential(
 		cloud.CertificateAuthType,
@@ -311,7 +311,7 @@ func (s *credentialsSuite) TestRegisterCredentialsWithAlternativeCloudName(c *gc
 
 	path = filepath.Join(utils.Home(), ".config", "lxc")
 	deps.certReadWriter.EXPECT().Read(path).Return(nil, nil, os.ErrNotExist)
-	deps.certGenerator.EXPECT().Generate(true).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
+	deps.certGenerator.EXPECT().Generate(true, true).Return([]byte(coretesting.CACert), []byte(coretesting.CAKey), nil)
 
 	expected := cloud.NewCredential(
 		cloud.CertificateAuthType,

--- a/provider/lxd/net_mock_test.go
+++ b/provider/lxd/net_mock_test.go
@@ -34,6 +34,7 @@ func (m *MockAddr) EXPECT() *MockAddrMockRecorder {
 
 // Network mocks base method
 func (m *MockAddr) Network() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Network")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -41,11 +42,13 @@ func (m *MockAddr) Network() string {
 
 // Network indicates an expected call of Network
 func (mr *MockAddrMockRecorder) Network() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Network", reflect.TypeOf((*MockAddr)(nil).Network))
 }
 
 // String mocks base method
 func (m *MockAddr) String() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -53,5 +56,6 @@ func (m *MockAddr) String() string {
 
 // String indicates an expected call of String
 func (mr *MockAddrMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockAddr)(nil).String))
 }

--- a/provider/lxd/provider_mock_test.go
+++ b/provider/lxd/provider_mock_test.go
@@ -34,6 +34,7 @@ func (m *MockLXCConfigReader) EXPECT() *MockLXCConfigReaderMockRecorder {
 
 // ReadCert mocks base method
 func (m *MockLXCConfigReader) ReadCert(arg0 string) ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadCert", arg0)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -42,11 +43,13 @@ func (m *MockLXCConfigReader) ReadCert(arg0 string) ([]byte, error) {
 
 // ReadCert indicates an expected call of ReadCert
 func (mr *MockLXCConfigReaderMockRecorder) ReadCert(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadCert", reflect.TypeOf((*MockLXCConfigReader)(nil).ReadCert), arg0)
 }
 
 // ReadConfig mocks base method
 func (m *MockLXCConfigReader) ReadConfig(arg0 string) (LXCConfig, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadConfig", arg0)
 	ret0, _ := ret[0].(LXCConfig)
 	ret1, _ := ret[1].(error)
@@ -55,5 +58,6 @@ func (m *MockLXCConfigReader) ReadConfig(arg0 string) (LXCConfig, error) {
 
 // ReadConfig indicates an expected call of ReadConfig
 func (mr *MockLXCConfigReaderMockRecorder) ReadConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadConfig", reflect.TypeOf((*MockLXCConfigReader)(nil).ReadConfig), arg0)
 }

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -9,7 +9,7 @@ import (
 	lxd "github.com/juju/juju/container/lxd"
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
-	client "github.com/lxc/lxd/client"
+	lxd1 "github.com/lxc/lxd/client"
 	api "github.com/lxc/lxd/shared/api"
 	reflect "reflect"
 )
@@ -39,6 +39,7 @@ func (m *MockServer) EXPECT() *MockServerMockRecorder {
 
 // AliveContainers mocks base method
 func (m *MockServer) AliveContainers(arg0 string) ([]lxd.Container, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AliveContainers", arg0)
 	ret0, _ := ret[0].([]lxd.Container)
 	ret1, _ := ret[1].(error)
@@ -47,11 +48,13 @@ func (m *MockServer) AliveContainers(arg0 string) ([]lxd.Container, error) {
 
 // AliveContainers indicates an expected call of AliveContainers
 func (mr *MockServerMockRecorder) AliveContainers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AliveContainers", reflect.TypeOf((*MockServer)(nil).AliveContainers), arg0)
 }
 
 // ContainerAddresses mocks base method
 func (m *MockServer) ContainerAddresses(arg0 string) ([]network.ProviderAddress, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerAddresses", arg0)
 	ret0, _ := ret[0].([]network.ProviderAddress)
 	ret1, _ := ret[1].(error)
@@ -60,11 +63,13 @@ func (m *MockServer) ContainerAddresses(arg0 string) ([]network.ProviderAddress,
 
 // ContainerAddresses indicates an expected call of ContainerAddresses
 func (mr *MockServerMockRecorder) ContainerAddresses(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerAddresses", reflect.TypeOf((*MockServer)(nil).ContainerAddresses), arg0)
 }
 
 // CreateCertificate mocks base method
 func (m *MockServer) CreateCertificate(arg0 api.CertificatesPost) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCertificate", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -72,11 +77,13 @@ func (m *MockServer) CreateCertificate(arg0 api.CertificatesPost) error {
 
 // CreateCertificate indicates an expected call of CreateCertificate
 func (mr *MockServerMockRecorder) CreateCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCertificate", reflect.TypeOf((*MockServer)(nil).CreateCertificate), arg0)
 }
 
 // CreateClientCertificate mocks base method
 func (m *MockServer) CreateClientCertificate(arg0 *lxd.Certificate) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateClientCertificate", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -84,11 +91,13 @@ func (m *MockServer) CreateClientCertificate(arg0 *lxd.Certificate) error {
 
 // CreateClientCertificate indicates an expected call of CreateClientCertificate
 func (mr *MockServerMockRecorder) CreateClientCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientCertificate", reflect.TypeOf((*MockServer)(nil).CreateClientCertificate), arg0)
 }
 
 // CreateContainerFromSpec mocks base method
 func (m *MockServer) CreateContainerFromSpec(arg0 lxd.ContainerSpec) (*lxd.Container, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainerFromSpec", arg0)
 	ret0, _ := ret[0].(*lxd.Container)
 	ret1, _ := ret[1].(error)
@@ -97,11 +106,13 @@ func (m *MockServer) CreateContainerFromSpec(arg0 lxd.ContainerSpec) (*lxd.Conta
 
 // CreateContainerFromSpec indicates an expected call of CreateContainerFromSpec
 func (mr *MockServerMockRecorder) CreateContainerFromSpec(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainerFromSpec", reflect.TypeOf((*MockServer)(nil).CreateContainerFromSpec), arg0)
 }
 
 // CreatePool mocks base method
 func (m *MockServer) CreatePool(arg0, arg1 string, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePool", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -109,11 +120,13 @@ func (m *MockServer) CreatePool(arg0, arg1 string, arg2 map[string]string) error
 
 // CreatePool indicates an expected call of CreatePool
 func (mr *MockServerMockRecorder) CreatePool(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePool", reflect.TypeOf((*MockServer)(nil).CreatePool), arg0, arg1, arg2)
 }
 
 // CreateProfile mocks base method
 func (m *MockServer) CreateProfile(arg0 api.ProfilesPost) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateProfile", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -121,11 +134,13 @@ func (m *MockServer) CreateProfile(arg0 api.ProfilesPost) error {
 
 // CreateProfile indicates an expected call of CreateProfile
 func (mr *MockServerMockRecorder) CreateProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfile", reflect.TypeOf((*MockServer)(nil).CreateProfile), arg0)
 }
 
 // CreateProfileWithConfig mocks base method
 func (m *MockServer) CreateProfileWithConfig(arg0 string, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateProfileWithConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -133,11 +148,13 @@ func (m *MockServer) CreateProfileWithConfig(arg0 string, arg1 map[string]string
 
 // CreateProfileWithConfig indicates an expected call of CreateProfileWithConfig
 func (mr *MockServerMockRecorder) CreateProfileWithConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProfileWithConfig", reflect.TypeOf((*MockServer)(nil).CreateProfileWithConfig), arg0, arg1)
 }
 
 // CreateVolume mocks base method
 func (m *MockServer) CreateVolume(arg0, arg1 string, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVolume", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -145,11 +162,13 @@ func (m *MockServer) CreateVolume(arg0, arg1 string, arg2 map[string]string) err
 
 // CreateVolume indicates an expected call of CreateVolume
 func (mr *MockServerMockRecorder) CreateVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockServer)(nil).CreateVolume), arg0, arg1, arg2)
 }
 
 // DeleteCertificate mocks base method
 func (m *MockServer) DeleteCertificate(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCertificate", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -157,11 +176,13 @@ func (m *MockServer) DeleteCertificate(arg0 string) error {
 
 // DeleteCertificate indicates an expected call of DeleteCertificate
 func (mr *MockServerMockRecorder) DeleteCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCertificate", reflect.TypeOf((*MockServer)(nil).DeleteCertificate), arg0)
 }
 
 // DeleteProfile mocks base method
 func (m *MockServer) DeleteProfile(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteProfile", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -169,11 +190,13 @@ func (m *MockServer) DeleteProfile(arg0 string) error {
 
 // DeleteProfile indicates an expected call of DeleteProfile
 func (mr *MockServerMockRecorder) DeleteProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProfile", reflect.TypeOf((*MockServer)(nil).DeleteProfile), arg0)
 }
 
 // DeleteStoragePoolVolume mocks base method
 func (m *MockServer) DeleteStoragePoolVolume(arg0, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStoragePoolVolume", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -181,11 +204,13 @@ func (m *MockServer) DeleteStoragePoolVolume(arg0, arg1, arg2 string) error {
 
 // DeleteStoragePoolVolume indicates an expected call of DeleteStoragePoolVolume
 func (mr *MockServerMockRecorder) DeleteStoragePoolVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStoragePoolVolume", reflect.TypeOf((*MockServer)(nil).DeleteStoragePoolVolume), arg0, arg1, arg2)
 }
 
 // EnableHTTPSListener mocks base method
 func (m *MockServer) EnableHTTPSListener() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableHTTPSListener")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -193,11 +218,13 @@ func (m *MockServer) EnableHTTPSListener() error {
 
 // EnableHTTPSListener indicates an expected call of EnableHTTPSListener
 func (mr *MockServerMockRecorder) EnableHTTPSListener() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableHTTPSListener", reflect.TypeOf((*MockServer)(nil).EnableHTTPSListener))
 }
 
 // EnsureDefaultStorage mocks base method
 func (m *MockServer) EnsureDefaultStorage(arg0 *api.Profile, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureDefaultStorage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -205,11 +232,13 @@ func (m *MockServer) EnsureDefaultStorage(arg0 *api.Profile, arg1 string) error 
 
 // EnsureDefaultStorage indicates an expected call of EnsureDefaultStorage
 func (mr *MockServerMockRecorder) EnsureDefaultStorage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDefaultStorage", reflect.TypeOf((*MockServer)(nil).EnsureDefaultStorage), arg0, arg1)
 }
 
 // FilterContainers mocks base method
 func (m *MockServer) FilterContainers(arg0 string, arg1 ...string) ([]lxd.Container, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -222,12 +251,14 @@ func (m *MockServer) FilterContainers(arg0 string, arg1 ...string) ([]lxd.Contai
 
 // FilterContainers indicates an expected call of FilterContainers
 func (mr *MockServerMockRecorder) FilterContainers(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterContainers", reflect.TypeOf((*MockServer)(nil).FilterContainers), varargs...)
 }
 
 // FindImage mocks base method
 func (m *MockServer) FindImage(arg0, arg1 string, arg2 []lxd.ServerSpec, arg3 bool, arg4 environs.StatusCallbackFunc) (lxd.SourcedImage, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(lxd.SourcedImage)
 	ret1, _ := ret[1].(error)
@@ -236,11 +267,13 @@ func (m *MockServer) FindImage(arg0, arg1 string, arg2 []lxd.ServerSpec, arg3 bo
 
 // FindImage indicates an expected call of FindImage
 func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetCertificate mocks base method
 func (m *MockServer) GetCertificate(arg0 string) (*api.Certificate, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCertificate", arg0)
 	ret0, _ := ret[0].(*api.Certificate)
 	ret1, _ := ret[1].(string)
@@ -250,11 +283,13 @@ func (m *MockServer) GetCertificate(arg0 string) (*api.Certificate, string, erro
 
 // GetCertificate indicates an expected call of GetCertificate
 func (mr *MockServerMockRecorder) GetCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertificate", reflect.TypeOf((*MockServer)(nil).GetCertificate), arg0)
 }
 
 // GetClusterMembers mocks base method
 func (m *MockServer) GetClusterMembers() ([]api.ClusterMember, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterMembers")
 	ret0, _ := ret[0].([]api.ClusterMember)
 	ret1, _ := ret[1].(error)
@@ -263,24 +298,28 @@ func (m *MockServer) GetClusterMembers() ([]api.ClusterMember, error) {
 
 // GetClusterMembers indicates an expected call of GetClusterMembers
 func (mr *MockServerMockRecorder) GetClusterMembers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMembers", reflect.TypeOf((*MockServer)(nil).GetClusterMembers))
 }
 
 // GetConnectionInfo mocks base method
-func (m *MockServer) GetConnectionInfo() (*client.ConnectionInfo, error) {
+func (m *MockServer) GetConnectionInfo() (*lxd1.ConnectionInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnectionInfo")
-	ret0, _ := ret[0].(*client.ConnectionInfo)
+	ret0, _ := ret[0].(*lxd1.ConnectionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetConnectionInfo indicates an expected call of GetConnectionInfo
 func (mr *MockServerMockRecorder) GetConnectionInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionInfo", reflect.TypeOf((*MockServer)(nil).GetConnectionInfo))
 }
 
 // GetContainerProfiles mocks base method
 func (m *MockServer) GetContainerProfiles(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerProfiles", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -289,11 +328,13 @@ func (m *MockServer) GetContainerProfiles(arg0 string) ([]string, error) {
 
 // GetContainerProfiles indicates an expected call of GetContainerProfiles
 func (mr *MockServerMockRecorder) GetContainerProfiles(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfiles", reflect.TypeOf((*MockServer)(nil).GetContainerProfiles), arg0)
 }
 
 // GetNICsFromProfile mocks base method
 func (m *MockServer) GetNICsFromProfile(arg0 string) (map[string]map[string]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNICsFromProfile", arg0)
 	ret0, _ := ret[0].(map[string]map[string]string)
 	ret1, _ := ret[1].(error)
@@ -302,11 +343,13 @@ func (m *MockServer) GetNICsFromProfile(arg0 string) (map[string]map[string]stri
 
 // GetNICsFromProfile indicates an expected call of GetNICsFromProfile
 func (mr *MockServerMockRecorder) GetNICsFromProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNICsFromProfile", reflect.TypeOf((*MockServer)(nil).GetNICsFromProfile), arg0)
 }
 
 // GetProfile mocks base method
 func (m *MockServer) GetProfile(arg0 string) (*api.Profile, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProfile", arg0)
 	ret0, _ := ret[0].(*api.Profile)
 	ret1, _ := ret[1].(string)
@@ -316,11 +359,13 @@ func (m *MockServer) GetProfile(arg0 string) (*api.Profile, string, error) {
 
 // GetProfile indicates an expected call of GetProfile
 func (mr *MockServerMockRecorder) GetProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfile", reflect.TypeOf((*MockServer)(nil).GetProfile), arg0)
 }
 
 // GetServer mocks base method
 func (m *MockServer) GetServer() (*api.Server, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServer")
 	ret0, _ := ret[0].(*api.Server)
 	ret1, _ := ret[1].(string)
@@ -330,11 +375,13 @@ func (m *MockServer) GetServer() (*api.Server, string, error) {
 
 // GetServer indicates an expected call of GetServer
 func (mr *MockServerMockRecorder) GetServer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServer", reflect.TypeOf((*MockServer)(nil).GetServer))
 }
 
 // GetStoragePool mocks base method
 func (m *MockServer) GetStoragePool(arg0 string) (*api.StoragePool, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStoragePool", arg0)
 	ret0, _ := ret[0].(*api.StoragePool)
 	ret1, _ := ret[1].(string)
@@ -344,11 +391,13 @@ func (m *MockServer) GetStoragePool(arg0 string) (*api.StoragePool, string, erro
 
 // GetStoragePool indicates an expected call of GetStoragePool
 func (mr *MockServerMockRecorder) GetStoragePool(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePool", reflect.TypeOf((*MockServer)(nil).GetStoragePool), arg0)
 }
 
 // GetStoragePoolVolume mocks base method
 func (m *MockServer) GetStoragePoolVolume(arg0, arg1, arg2 string) (*api.StorageVolume, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStoragePoolVolume", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*api.StorageVolume)
 	ret1, _ := ret[1].(string)
@@ -358,11 +407,13 @@ func (m *MockServer) GetStoragePoolVolume(arg0, arg1, arg2 string) (*api.Storage
 
 // GetStoragePoolVolume indicates an expected call of GetStoragePoolVolume
 func (mr *MockServerMockRecorder) GetStoragePoolVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolume", reflect.TypeOf((*MockServer)(nil).GetStoragePoolVolume), arg0, arg1, arg2)
 }
 
 // GetStoragePoolVolumes mocks base method
 func (m *MockServer) GetStoragePoolVolumes(arg0 string) ([]api.StorageVolume, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStoragePoolVolumes", arg0)
 	ret0, _ := ret[0].([]api.StorageVolume)
 	ret1, _ := ret[1].(error)
@@ -371,11 +422,13 @@ func (m *MockServer) GetStoragePoolVolumes(arg0 string) ([]api.StorageVolume, er
 
 // GetStoragePoolVolumes indicates an expected call of GetStoragePoolVolumes
 func (mr *MockServerMockRecorder) GetStoragePoolVolumes(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePoolVolumes", reflect.TypeOf((*MockServer)(nil).GetStoragePoolVolumes), arg0)
 }
 
 // GetStoragePools mocks base method
 func (m *MockServer) GetStoragePools() ([]api.StoragePool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStoragePools")
 	ret0, _ := ret[0].([]api.StoragePool)
 	ret1, _ := ret[1].(error)
@@ -384,11 +437,13 @@ func (m *MockServer) GetStoragePools() ([]api.StoragePool, error) {
 
 // GetStoragePools indicates an expected call of GetStoragePools
 func (mr *MockServerMockRecorder) GetStoragePools() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePools", reflect.TypeOf((*MockServer)(nil).GetStoragePools))
 }
 
 // HasProfile mocks base method
 func (m *MockServer) HasProfile(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasProfile", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -397,11 +452,13 @@ func (m *MockServer) HasProfile(arg0 string) (bool, error) {
 
 // HasProfile indicates an expected call of HasProfile
 func (mr *MockServerMockRecorder) HasProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProfile", reflect.TypeOf((*MockServer)(nil).HasProfile), arg0)
 }
 
 // HostArch mocks base method
 func (m *MockServer) HostArch() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostArch")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -409,11 +466,13 @@ func (m *MockServer) HostArch() string {
 
 // HostArch indicates an expected call of HostArch
 func (mr *MockServerMockRecorder) HostArch() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostArch", reflect.TypeOf((*MockServer)(nil).HostArch))
 }
 
 // IsClustered mocks base method
 func (m *MockServer) IsClustered() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsClustered")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -421,11 +480,13 @@ func (m *MockServer) IsClustered() bool {
 
 // IsClustered indicates an expected call of IsClustered
 func (mr *MockServerMockRecorder) IsClustered() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClustered", reflect.TypeOf((*MockServer)(nil).IsClustered))
 }
 
 // LocalBridgeName mocks base method
 func (m *MockServer) LocalBridgeName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalBridgeName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -433,11 +494,13 @@ func (m *MockServer) LocalBridgeName() string {
 
 // LocalBridgeName indicates an expected call of LocalBridgeName
 func (mr *MockServerMockRecorder) LocalBridgeName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalBridgeName", reflect.TypeOf((*MockServer)(nil).LocalBridgeName))
 }
 
 // Name mocks base method
 func (m *MockServer) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -445,11 +508,13 @@ func (m *MockServer) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockServerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockServer)(nil).Name))
 }
 
 // RemoveContainer mocks base method
 func (m *MockServer) RemoveContainer(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveContainer", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -457,11 +522,13 @@ func (m *MockServer) RemoveContainer(arg0 string) error {
 
 // RemoveContainer indicates an expected call of RemoveContainer
 func (mr *MockServerMockRecorder) RemoveContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainer", reflect.TypeOf((*MockServer)(nil).RemoveContainer), arg0)
 }
 
 // RemoveContainers mocks base method
 func (m *MockServer) RemoveContainers(arg0 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveContainers", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -469,11 +536,13 @@ func (m *MockServer) RemoveContainers(arg0 []string) error {
 
 // RemoveContainers indicates an expected call of RemoveContainers
 func (mr *MockServerMockRecorder) RemoveContainers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainers", reflect.TypeOf((*MockServer)(nil).RemoveContainers), arg0)
 }
 
 // ReplaceOrAddContainerProfile mocks base method
 func (m *MockServer) ReplaceOrAddContainerProfile(arg0, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceOrAddContainerProfile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -481,11 +550,13 @@ func (m *MockServer) ReplaceOrAddContainerProfile(arg0, arg1, arg2 string) error
 
 // ReplaceOrAddContainerProfile indicates an expected call of ReplaceOrAddContainerProfile
 func (mr *MockServerMockRecorder) ReplaceOrAddContainerProfile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceOrAddContainerProfile", reflect.TypeOf((*MockServer)(nil).ReplaceOrAddContainerProfile), arg0, arg1, arg2)
 }
 
 // ServerCertificate mocks base method
 func (m *MockServer) ServerCertificate() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServerCertificate")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -493,11 +564,13 @@ func (m *MockServer) ServerCertificate() string {
 
 // ServerCertificate indicates an expected call of ServerCertificate
 func (mr *MockServerMockRecorder) ServerCertificate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerCertificate", reflect.TypeOf((*MockServer)(nil).ServerCertificate))
 }
 
 // ServerVersion mocks base method
 func (m *MockServer) ServerVersion() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServerVersion")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -505,11 +578,13 @@ func (m *MockServer) ServerVersion() string {
 
 // ServerVersion indicates an expected call of ServerVersion
 func (mr *MockServerMockRecorder) ServerVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerVersion", reflect.TypeOf((*MockServer)(nil).ServerVersion))
 }
 
 // StorageSupported mocks base method
 func (m *MockServer) StorageSupported() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageSupported")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -517,11 +592,13 @@ func (m *MockServer) StorageSupported() bool {
 
 // StorageSupported indicates an expected call of StorageSupported
 func (mr *MockServerMockRecorder) StorageSupported() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageSupported", reflect.TypeOf((*MockServer)(nil).StorageSupported))
 }
 
 // UpdateContainerConfig mocks base method
 func (m *MockServer) UpdateContainerConfig(arg0 string, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -529,11 +606,13 @@ func (m *MockServer) UpdateContainerConfig(arg0 string, arg1 map[string]string) 
 
 // UpdateContainerConfig indicates an expected call of UpdateContainerConfig
 func (mr *MockServerMockRecorder) UpdateContainerConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerConfig", reflect.TypeOf((*MockServer)(nil).UpdateContainerConfig), arg0, arg1)
 }
 
 // UpdateContainerProfiles mocks base method
 func (m *MockServer) UpdateContainerProfiles(arg0 string, arg1 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerProfiles", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -541,11 +620,13 @@ func (m *MockServer) UpdateContainerProfiles(arg0 string, arg1 []string) error {
 
 // UpdateContainerProfiles indicates an expected call of UpdateContainerProfiles
 func (mr *MockServerMockRecorder) UpdateContainerProfiles(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerProfiles", reflect.TypeOf((*MockServer)(nil).UpdateContainerProfiles), arg0, arg1)
 }
 
 // UpdateServerConfig mocks base method
 func (m *MockServer) UpdateServerConfig(arg0 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServerConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -553,11 +634,13 @@ func (m *MockServer) UpdateServerConfig(arg0 map[string]string) error {
 
 // UpdateServerConfig indicates an expected call of UpdateServerConfig
 func (mr *MockServerMockRecorder) UpdateServerConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServerConfig", reflect.TypeOf((*MockServer)(nil).UpdateServerConfig), arg0)
 }
 
 // UpdateStoragePoolVolume mocks base method
 func (m *MockServer) UpdateStoragePoolVolume(arg0, arg1, arg2 string, arg3 api.StorageVolumePut, arg4 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStoragePoolVolume", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -565,11 +648,13 @@ func (m *MockServer) UpdateStoragePoolVolume(arg0, arg1, arg2 string, arg3 api.S
 
 // UpdateStoragePoolVolume indicates an expected call of UpdateStoragePoolVolume
 func (mr *MockServerMockRecorder) UpdateStoragePoolVolume(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStoragePoolVolume", reflect.TypeOf((*MockServer)(nil).UpdateStoragePoolVolume), arg0, arg1, arg2, arg3, arg4)
 }
 
 // UseTargetServer mocks base method
 func (m *MockServer) UseTargetServer(arg0 string) (*lxd.Server, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UseTargetServer", arg0)
 	ret0, _ := ret[0].(*lxd.Server)
 	ret1, _ := ret[1].(error)
@@ -578,11 +663,13 @@ func (m *MockServer) UseTargetServer(arg0 string) (*lxd.Server, error) {
 
 // UseTargetServer indicates an expected call of UseTargetServer
 func (mr *MockServerMockRecorder) UseTargetServer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseTargetServer", reflect.TypeOf((*MockServer)(nil).UseTargetServer), arg0)
 }
 
 // VerifyNetworkDevice mocks base method
 func (m *MockServer) VerifyNetworkDevice(arg0 *api.Profile, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyNetworkDevice", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -590,11 +677,13 @@ func (m *MockServer) VerifyNetworkDevice(arg0 *api.Profile, arg1 string) error {
 
 // VerifyNetworkDevice indicates an expected call of VerifyNetworkDevice
 func (mr *MockServerMockRecorder) VerifyNetworkDevice(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyNetworkDevice", reflect.TypeOf((*MockServer)(nil).VerifyNetworkDevice), arg0, arg1)
 }
 
 // WriteContainer mocks base method
 func (m *MockServer) WriteContainer(arg0 *lxd.Container) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteContainer", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -602,6 +691,7 @@ func (m *MockServer) WriteContainer(arg0 *lxd.Container) error {
 
 // WriteContainer indicates an expected call of WriteContainer
 func (mr *MockServerMockRecorder) WriteContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteContainer", reflect.TypeOf((*MockServer)(nil).WriteContainer), arg0)
 }
 
@@ -630,6 +720,7 @@ func (m *MockServerFactory) EXPECT() *MockServerFactoryMockRecorder {
 
 // InsecureRemoteServer mocks base method
 func (m *MockServerFactory) InsecureRemoteServer(arg0 environs.CloudSpec) (Server, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsecureRemoteServer", arg0)
 	ret0, _ := ret[0].(Server)
 	ret1, _ := ret[1].(error)
@@ -638,11 +729,13 @@ func (m *MockServerFactory) InsecureRemoteServer(arg0 environs.CloudSpec) (Serve
 
 // InsecureRemoteServer indicates an expected call of InsecureRemoteServer
 func (mr *MockServerFactoryMockRecorder) InsecureRemoteServer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsecureRemoteServer", reflect.TypeOf((*MockServerFactory)(nil).InsecureRemoteServer), arg0)
 }
 
 // LocalServer mocks base method
 func (m *MockServerFactory) LocalServer() (Server, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalServer")
 	ret0, _ := ret[0].(Server)
 	ret1, _ := ret[1].(error)
@@ -651,11 +744,13 @@ func (m *MockServerFactory) LocalServer() (Server, error) {
 
 // LocalServer indicates an expected call of LocalServer
 func (mr *MockServerFactoryMockRecorder) LocalServer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalServer", reflect.TypeOf((*MockServerFactory)(nil).LocalServer))
 }
 
 // LocalServerAddress mocks base method
 func (m *MockServerFactory) LocalServerAddress() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalServerAddress")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -664,11 +759,13 @@ func (m *MockServerFactory) LocalServerAddress() (string, error) {
 
 // LocalServerAddress indicates an expected call of LocalServerAddress
 func (mr *MockServerFactoryMockRecorder) LocalServerAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalServerAddress", reflect.TypeOf((*MockServerFactory)(nil).LocalServerAddress))
 }
 
 // RemoteServer mocks base method
 func (m *MockServerFactory) RemoteServer(arg0 environs.CloudSpec) (Server, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteServer", arg0)
 	ret0, _ := ret[0].(Server)
 	ret1, _ := ret[1].(error)
@@ -677,6 +774,7 @@ func (m *MockServerFactory) RemoteServer(arg0 environs.CloudSpec) (Server, error
 
 // RemoteServer indicates an expected call of RemoteServer
 func (mr *MockServerFactoryMockRecorder) RemoteServer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteServer", reflect.TypeOf((*MockServerFactory)(nil).RemoteServer), arg0)
 }
 
@@ -705,6 +803,7 @@ func (m *MockInterfaceAddress) EXPECT() *MockInterfaceAddressMockRecorder {
 
 // InterfaceAddress mocks base method
 func (m *MockInterfaceAddress) InterfaceAddress(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InterfaceAddress", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -713,5 +812,6 @@ func (m *MockInterfaceAddress) InterfaceAddress(arg0 string) (string, error) {
 
 // InterfaceAddress indicates an expected call of InterfaceAddress
 func (mr *MockInterfaceAddressMockRecorder) InterfaceAddress(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InterfaceAddress", reflect.TypeOf((*MockInterfaceAddress)(nil).InterfaceAddress), arg0)
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The latest release of LXD (3.22) changed the default format of the profile for NIC devices, though the old format is still valid.

Old example:
```yaml
devices:
  eth0:
    name: eth0
    parent: lxdbr0
    type: nic
    nictype: bridged
```
New example:
```yaml
devices:
  eth0:
    name: eth0
    network: lxdbr0
    type: nic
```

This patch updates the LXD dependency to the hash that corresponds with the 3.22 tag, regenerates mocks and accommodates the new profile schema.

One change brought in with the new dependency is certificate generation, which takes and additional argument for whether to include host names in the certificate. This is always passed as `true` by Juju.

## QA steps

Localhost:
- `juju bootstrap lxd new-profile-test --debug --no-gui` should succeed.

Machine-In-Machine:
- `juju bootstrap aws new-profile-test --debug --no-gui --bootstrap-series focal --force --config image-stream=daily`.
- `juju add-machine --series focal`
- `juju add-machine lxd:0`
- Verify that we are using the 2.33 LXD Snap with: `juju run --machine 0 -- snap info lxd`.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1867886
