### PR TITLE
Add new update-k8s command

### DIFF
--- a/cloud/validations.go
+++ b/cloud/validations.go
@@ -52,6 +52,7 @@ var cloudSchema = map[string]interface{}{
 			"type":  "array",
 			"items": map[string]interface{}{"type": "string"},
 		},
+		"host-cloud-region": map[string]interface{}{"type": "string"},
 		"endpoint":          map[string]interface{}{"type": "string"},
 		"identity-endpoint": map[string]interface{}{"type": "string"},
 		"storage-endpoint":  map[string]interface{}{"type": "string"},

--- a/cloud/validations_test.go
+++ b/cloud/validations_test.go
@@ -17,6 +17,7 @@ func (s *cloudSuite) TestValidateValidCloud(c *gc.C) {
               type: maas
               description: A mass cloud
               auth-types: [oauth1]
+              host-cloud-region: host/region
               endpoint: http://10.245.200.27/MAAS
               config:
                 default-series: trusty

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -35,7 +35,7 @@ import (
 var logger = loggo.GetLogger("juju.cmd.juju.k8s")
 
 type CloudMetadataStore interface {
-	ParseCloudMetadataFile(path string) (map[string]jujucloud.Cloud, error)
+	ReadCloudData(path string) ([]byte, error)
 	ParseOneCloud(data []byte) (jujucloud.Cloud, error)
 	PublicCloudMetadata(searchPaths ...string) (result map[string]jujucloud.Cloud, fallbackUsed bool, _ error)
 	PersonalCloudMetadata() (map[string]jujucloud.Cloud, error)

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -73,9 +73,12 @@ type fakeCloudMetadataStore struct {
 	*jujutesting.CallMocker
 }
 
-func (f *fakeCloudMetadataStore) ParseCloudMetadataFile(path string) (map[string]cloud.Cloud, error) {
-	results := f.MethodCall(f, "ParseCloudMetadataFile", path)
-	return results[0].(map[string]cloud.Cloud), jujutesting.TypeAssertError(results[1])
+func (f *fakeCloudMetadataStore) ReadCloudData(path string) ([]byte, error) {
+	results := f.MethodCall(f, "ReadCloudData", path)
+	if results[0] == nil {
+		return nil, jujutesting.TypeAssertError(results[1])
+	}
+	return []byte(results[0].(string)), jujutesting.TypeAssertError(results[1])
 }
 
 func (f *fakeCloudMetadataStore) ParseOneCloud(data []byte) (cloud.Cloud, error) {

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -1,0 +1,367 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v3"
+
+	cloudapi "github.com/juju/juju/api/cloud"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider"
+	jujucloud "github.com/juju/juju/cloud"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/jujuclient"
+)
+
+// UpdateCloudAPI - Implemented by cloudapi.Client.
+type UpdateCloudAPI interface {
+	Cloud(tag names.CloudTag) (jujucloud.Cloud, error)
+	UpdateCloud(jujucloud.Cloud) error
+	UpdateCloudsCredentials(cloudCredentials map[string]jujucloud.Credential, force bool) ([]params.UpdateCredentialResult, error)
+	Close() error
+}
+
+var usageUpdateCAASSummary = `
+Updates an existing k8s endpoint used by Juju.`[1:]
+
+var usageUpdateCAASDetails = `
+Update k8s cloud information on this client and/or on a controller.
+
+The k8s cloud can be a built-in cloud like microk8s.
+
+A k8s cloud can also be updated from a file. This requires a <cloud name> and
+a yaml file containing the cloud details.
+
+A k8s cloud on the controller can also be updated just by using a name of a k8s cloud
+from this client.
+
+Use --controller option to update a k8s cloud on a controller.
+
+Use --client to update a k8s cloud definition on this client.
+
+Examples:
+    juju update-k8s microk8s
+    juju update-k8s myk8s -f path/to/k8s.yaml
+    juju update-k8s myk8s -f path/to/k8s.yaml --controller mycontroller
+    juju update-k8s myk8s --controller mycontroller
+    juju update-k8s myk8s --client --controller mycontroller
+    juju update-k8s myk8s --client -f path/to/k8s.yaml
+
+See also:
+    add-k8s
+    remove-k8s
+`
+
+// UpdateCAASCommand is the command that allows you to update a caas cloud.
+type UpdateCAASCommand struct {
+	modelcmd.OptionalControllerCommand
+
+	// caasName is the name of the k8s cloud to update
+	caasName string
+
+	// CloudFile is the name of the cloud YAML file
+	CloudFile string
+
+	// builtInCloudsFunc is used to provide any built in clouds and their credential.
+	builtInCloudsFunc func(string) (jujucloud.Cloud, *jujucloud.Credential, string, error)
+
+	// updateCloudAPIFunc is used when updating a cluster on a controller.
+	updateCloudAPIFunc func() (UpdateCloudAPI, error)
+
+	// brokerGetter returns CAAS broker instance.
+	brokerGetter BrokerGetter
+
+	// cloudMetadataStore provides access to personal cloud metadata.
+	cloudMetadataStore CloudMetadataStore
+}
+
+// NewUpdateCAASCommand returns a command to update CAAS information.
+func NewUpdateCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
+	return newUpdateCAASCommand(cloudMetadataStore)
+}
+
+func newUpdateCAASCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
+	store := jujuclient.NewFileClientStore()
+	command := &UpdateCAASCommand{
+		OptionalControllerCommand: modelcmd.OptionalControllerCommand{
+			Store: store,
+		},
+		cloudMetadataStore: cloudMetadataStore,
+		builtInCloudsFunc:  maybeBuiltInCloud,
+	}
+	command.brokerGetter = command.newK8sClusterBroker
+	command.updateCloudAPIFunc = func() (UpdateCloudAPI, error) {
+		root, err := command.NewAPIRoot(command.Store, command.ControllerName, "")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return cloudapi.NewClient(root), nil
+	}
+	return modelcmd.WrapBase(command)
+}
+
+// Info returns help information about the command.
+func (c *UpdateCAASCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "update-k8s",
+		Args:    "<k8s name>",
+		Purpose: usageUpdateCAASSummary,
+		Doc:     usageUpdateCAASDetails,
+	})
+}
+
+// SetFlags initializes the flags supported by the command.
+func (c *UpdateCAASCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.OptionalControllerCommand.SetFlags(f)
+	f.StringVar(&c.CloudFile, "f", "", "The path to a cloud definition file")
+}
+
+// Init populates the command with the args from the command line.
+func (c *UpdateCAASCommand) Init(args []string) error {
+	if err := c.OptionalControllerCommand.Init(args); err != nil {
+		return err
+	}
+	if len(args) < 1 {
+		return errors.BadRequestf("k8s cloud name required")
+	}
+
+	c.caasName = args[0]
+	if ok := names.IsValidCloud(c.caasName); !ok {
+		return errors.NotValidf("k8s cloud name %q", c.caasName)
+	}
+	if err := cmd.CheckEmpty(args[1:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UpdateCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
+	openParams, err := provider.BaseKubeCloudOpenParams(cloud, credential)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if c.ControllerName != "" {
+		ctrlUUID, err := c.ControllerUUID(c.Store, c.ControllerName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		openParams.ControllerUUID = ctrlUUID
+	}
+	return caas.New(openParams)
+}
+
+// maybeBuiltInCloud returns a built in cloud (eg microk8s) and the relevant credential
+// if it exists, else returns a not found error.
+func maybeBuiltInCloud(cloudName string) (jujucloud.Cloud, *jujucloud.Credential, string, error) {
+	fail := func(err error) (jujucloud.Cloud, *jujucloud.Credential, string, error) {
+		return jujucloud.Cloud{}, nil, "", errors.Trace(err)
+	}
+	builtIn, err := common.BuiltInClouds()
+	if err != nil {
+		return fail(err)
+	}
+	cloud, ok := builtIn[cloudName]
+	if !ok {
+		return fail(errors.NotFoundf("built in cloud %q", cloudName))
+	}
+	p, err := environs.Provider(cloud.Type)
+	if err != nil {
+		return fail(err)
+	}
+
+	creds, err := modelcmd.RegisterCredentials(p, modelcmd.RegisterCredentialsParams{Cloud: cloud})
+	if err != nil {
+		return fail(err)
+	}
+	cred, ok := creds[cloudName]
+	if !ok {
+		return cloud, nil, "", nil
+	}
+	// Return the first named credential.
+	// There will only be one for microk8s.
+	for name, cred := range cred.AuthCredentials {
+		return cloud, &cred, name, nil
+	}
+	return cloud, nil, "", nil
+}
+
+// Run is defined on the Command interface.
+func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
+	var newCloud *jujucloud.Cloud
+	haveLocalCloud := false
+	// First, see if we're updating a built-in cloud.
+	builtinCloud, credential, credentialName, err := c.builtInCloudsFunc(c.caasName)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+	if err == nil {
+		if c.CloudFile != "" {
+			ctx.Infof("%q is a built-in cloud and does not support specifying a cloud YAML file.", c.caasName)
+			return cmd.ErrSilent
+		}
+		if c.Client {
+			ctx.Infof("%q is a built-in cloud and cannot be updated on the client.", c.caasName)
+			return cmd.ErrSilent
+		}
+		newCloud = &builtinCloud
+	} else if c.CloudFile != "" {
+		r := &cloud.CloudFileReader{
+			CloudMetadataStore: c.cloudMetadataStore,
+			CloudName:          c.caasName,
+		}
+		var err error
+		if newCloud, err = r.ReadCloudFromFile(c.CloudFile, ctx); err != nil {
+			return errors.Annotatef(err, "could not read cloud definition from provided file")
+		}
+		c.caasName = r.CloudName
+	} else {
+		personalClouds, err := c.cloudMetadataStore.PersonalCloudMetadata()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if localCloud, ok := personalClouds[c.caasName]; !ok {
+			return errors.NotFoundf("cloud %s", c.caasName)
+		} else {
+			newCloud = &localCloud
+			haveLocalCloud = true
+		}
+	}
+
+	if newCloud.Type != provider.CAASProviderType {
+		ctx.Infof("The %q cloud is a %q cloud and not a %q cloud.", c.caasName, newCloud.Type, provider.CAASProviderType)
+		return cmd.ErrSilent
+	}
+
+	if err := c.MaybePrompt(ctx, fmt.Sprintf("update k8s cloud %q on", c.caasName)); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Check the cluster only if we have a credential to use.
+	if credential != nil {
+		broker, err := c.brokerGetter(*newCloud, *credential)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		if _, err := broker.GetClusterMetadata(""); err != nil {
+			return errors.Annotate(err, "unable to update k8s cluster because the cluster is not accessible")
+		}
+	}
+
+	var returnErr error
+	processErr := func(err error, successMsg string) {
+		if err != nil {
+			ctx.Infof("%v", err)
+			returnErr = cmd.ErrSilent
+			return
+		}
+		ctx.Infof(successMsg)
+	}
+	if c.Client {
+		if newCloud == nil || haveLocalCloud {
+			ctx.Infof("To update k8s cloud %q on this client, a cloud definition file is required.", c.caasName)
+			returnErr = cmd.ErrSilent
+		} else {
+			err := updateCloudOnLocal(c.cloudMetadataStore, *newCloud)
+			processErr(err, fmt.Sprintf("k8s cloud %q updated on this client using provided file.", c.caasName))
+		}
+	}
+	if c.ControllerName != "" {
+		if err := jujuclient.ValidateControllerName(c.ControllerName); err != nil {
+			return errors.Trace(err)
+		}
+		cloudClient, err := c.updateCloudAPIFunc()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer cloudClient.Close()
+
+		existing, err := cloudClient.Cloud(names.NewCloudTag(newCloud.Name))
+		if err != nil && !errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+		if existing.Type != provider.CAASProviderType {
+			ctx.Infof("The %q cloud on the controller is a %q cloud and not a %q cloud.", c.caasName, existing.Type, provider.CAASProviderType)
+			return cmd.ErrSilent
+		}
+
+		err = cloudClient.UpdateCloud(*newCloud)
+		processErr(err, fmt.Sprintf("k8s cloud %q updated on controller %q.", c.caasName, c.ControllerName))
+		if credential != nil {
+			err = c.updateCredentialOnController(ctx, cloudClient, *credential, c.caasName, credentialName)
+			processErr(err, fmt.Sprintf("k8s cloud credential %q updated on controller %q.", credentialName, c.ControllerName))
+		}
+	}
+	return returnErr
+}
+
+func updateCloudOnLocal(cloudMetadataStore CloudMetadataStore, updatedCloud jujucloud.Cloud) error {
+	personalClouds, err := cloudMetadataStore.PersonalCloudMetadata()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if personalClouds == nil {
+		personalClouds = make(map[string]jujucloud.Cloud)
+	}
+	personalClouds[updatedCloud.Name] = updatedCloud
+	return cloudMetadataStore.WritePersonalCloudMetadata(personalClouds)
+}
+
+func (c *UpdateCAASCommand) updateCredentialOnController(ctx *cmd.Context, apiClient UpdateCloudAPI, newCredential jujucloud.Credential, cloudName, credentialName string) error {
+	_, err := c.Store.ControllerByName(c.ControllerName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	currentAccountDetails, err := c.Store.AccountDetails(c.ControllerName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	id := fmt.Sprintf("%s/%s/%s", cloudName, currentAccountDetails.User, credentialName)
+	if !names.IsValidCloudCredential(id) {
+		return errors.NotValidf("cloud credential ID %q", id)
+	}
+	cloudCredTag := names.NewCloudCredentialTag(id)
+
+	toUpdate := map[string]jujucloud.Credential{}
+	toUpdate[cloudCredTag.String()] = newCredential
+	results, err := apiClient.UpdateCloudsCredentials(toUpdate, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var resultError error
+	for _, result := range results {
+		tag, err := names.ParseCloudCredentialTag(result.CredentialTag)
+		if err != nil {
+			logger.Errorf("%v", err)
+			ctx.Warningf("Could not parse credential tag %q", result.CredentialTag)
+			resultError = cmd.ErrSilent
+		}
+		// We always want to display models information if there is any.
+		common.OutputUpdateCredentialModelResult(ctx, result.Models, true)
+		if result.Error != nil {
+			ctx.Warningf("Controller credential %q for user %q for cloud %q on controller %q not updated: %v.",
+				tag.Name(), currentAccountDetails.User, tag.Cloud().Id(), c.ControllerName, result.Error)
+			if len(result.Models) != 0 {
+				ctx.Infof("Failed models may require a different credential.")
+				ctx.Infof("Use ‘juju set-credential’ to change credential for these models before repeating this update.")
+			}
+			// We do not want to return err here as we have already displayed it on the console.
+			resultError = cmd.ErrSilent
+			continue
+		}
+	}
+	return resultError
+}

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -1,0 +1,320 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas_test
+
+import (
+	"os"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/collections/set"
+	"github.com/juju/loggo"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/apiserver/params"
+	jujucaas "github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/caas"
+	// To allow a maas cloud type to be parsed in the test data.
+	_ "github.com/juju/juju/provider/maas"
+)
+
+type updateCAASSuite struct {
+	jujutesting.IsolationSuite
+	dir                           string
+	cloudFile                     *os.File
+	fakeCloudAPI                  *fakeUpdateCloudAPI
+	fakeK8sClusterMetadataChecker *fakeK8sClusterMetadataChecker
+	cloudMetadataStore            *fakeCloudMetadataStore
+	fakeK8SConfigFunc             *clientconfig.ClientConfigFunc
+}
+
+var _ = gc.Suite(&updateCAASSuite{})
+
+type fakeUpdateCloudAPI struct {
+	*jujutesting.CallMocker
+	caas.UpdateCloudAPI
+
+	cloud jujucloud.Cloud
+}
+
+func (api *fakeUpdateCloudAPI) Close() error {
+	return nil
+}
+
+func (api *fakeUpdateCloudAPI) UpdateCloud(kloud cloud.Cloud) error {
+	api.MethodCall(api, "UpdateCloud", kloud)
+	return nil
+}
+
+func (api *fakeUpdateCloudAPI) Cloud(tag names.CloudTag) (cloud.Cloud, error) {
+	api.MethodCall(api, "Cloud", tag)
+	return api.cloud, nil
+}
+
+func (api *fakeUpdateCloudAPI) UpdateCloudsCredentials(cloudCredentials map[string]jujucloud.Credential, force bool) ([]params.UpdateCredentialResult, error) {
+	api.MethodCall(api, "UpdateCloudsCredentials", cloudCredentials, force)
+	var tag string
+	for k := range cloudCredentials {
+		tag = k
+	}
+	return []params.UpdateCredentialResult{
+		{
+			CredentialTag: tag,
+		},
+	}, nil
+}
+
+var cloudYaml = `
+clouds:
+  myk8s:
+    type: kubernetes
+    auth-types: [certificate]
+    host-cloud-region: gce/us-east1
+    endpoint: "https://6.6.6.6:8888"
+    regions:
+      us-east1:
+        endpoint: "https://1.1.1.1:8888"
+    ca-certificates:
+    - fakecadata2
+    config:
+      operator-storage: operator-sc
+      workload-storage: ""
+  mrcloud1:
+    type: maas
+    description: Metal As A Service
+  mrcloud2:
+    type: kubernetes
+    description: A Kubernetes Cluster
+`[1:]
+
+func (s *updateCAASSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.dir = c.MkDir()
+
+	var logger loggo.Logger
+	s.fakeCloudAPI = &fakeUpdateCloudAPI{
+		CallMocker: jujutesting.NewCallMocker(logger),
+	}
+	s.cloudMetadataStore = &fakeCloudMetadataStore{CallMocker: jujutesting.NewCallMocker(logger)}
+
+	defaultClusterMetadata := &jujucaas.ClusterMetadata{
+		Cloud: "gce", Regions: set.NewStrings("us-east1"),
+		OperatorStorageClass: &jujucaas.StorageProvisioner{Name: "operator-sc"},
+	}
+	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
+		CallMocker: jujutesting.NewCallMocker(logger),
+	}
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(defaultClusterMetadata, nil)
+
+	clouds, err := cloud.ParseCloudMetadata([]byte(cloudYaml))
+	c.Assert(err, jc.ErrorIsNil)
+	s.fakeCloudAPI.cloud = clouds["myk8s"]
+	s.cloudMetadataStore.Call("ReadCloudData", "mycloud.yaml").Returns(cloudYaml, nil)
+	s.cloudMetadataStore.Call("PublicCloudMetadata", []string(nil)).Returns(map[string]cloud.Cloud{}, false, nil)
+	s.cloudMetadataStore.Call("PersonalCloudMetadata").Returns(clouds, nil)
+	s.cloudMetadataStore.Call("WritePersonalCloudMetadata", clouds).Returns(nil)
+}
+
+func (s *updateCAASSuite) makeCommand() cmd.Command {
+	return caas.NewUpdateCAASCommandForTest(
+		s.cloudMetadataStore,
+		NewMockClientStore(),
+		func() (caas.UpdateCloudAPI, error) {
+			return s.fakeCloudAPI, nil
+		},
+		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (jujucaas.ClusterMetadataChecker, error) {
+			return s.fakeK8sClusterMetadataChecker, nil
+		},
+	)
+}
+
+func (s *updateCAASSuite) runCommand(c *gc.C, com cmd.Command, args ...string) (*cmd.Context, error) {
+	ctx := cmdtesting.Context(c)
+	c.Logf("run cmd with args: %v", args)
+	if err := cmdtesting.InitCommand(com, args); err != nil {
+		cmd.WriteError(ctx.Stderr, err)
+		return ctx, err
+	}
+	return ctx, com.Run(ctx)
+}
+
+func (s *updateCAASSuite) TestUpdateExtraArg(c *gc.C) {
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "k8sname", "extra")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
+}
+
+func (s *updateCAASSuite) TestMissingArgs(c *gc.C) {
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command)
+	c.Assert(err, gc.ErrorMatches, `k8s cloud name required`)
+}
+
+func (s *updateCAASSuite) TestCloudNotFound(c *gc.C) {
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "foo")
+	c.Assert(err, gc.ErrorMatches, `cloud foo not found`)
+}
+
+func (s *updateCAASSuite) assertUpdateCloudResult(
+	c *gc.C, testRun func(),
+	cloudName, cloudRegion, workloadStorage, operatorStorage string,
+	t testData,
+) {
+
+	testRun()
+
+	_, region, err := jujucloud.SplitHostCloudRegion(cloudRegion)
+	c.Assert(err, jc.ErrorIsNil)
+	s.fakeK8sClusterMetadataChecker.CheckNoCalls(c)
+	expectedCloudToUpdate := cloud.Cloud{
+		Name:             cloudName,
+		HostCloudRegion:  cloudRegion,
+		Type:             "kubernetes",
+		Description:      "A Kubernetes Cluster",
+		AuthTypes:        cloud.AuthTypes{"certificate"},
+		Endpoint:         "https://6.6.6.6:8888",
+		IdentityEndpoint: "",
+		StorageEndpoint:  "",
+		Config:           map[string]interface{}{"operator-storage": operatorStorage, "workload-storage": workloadStorage},
+		RegionConfig:     cloud.RegionConfig(nil),
+		CACertificates:   []string{"fakecadata2"},
+	}
+	if region != "" {
+		expectedCloudToUpdate.Regions = []cloud.Region{{Name: region, Endpoint: "https://1.1.1.1:8888"}}
+	}
+	if !t.controller {
+		s.fakeCloudAPI.CheckNoCalls(c)
+	} else {
+		s.fakeCloudAPI.CheckCall(c, 1, "UpdateCloud", expectedCloudToUpdate)
+	}
+	if t.client {
+		s.cloudMetadataStore.CheckCall(c, 4, "WritePersonalCloudMetadata",
+			map[string]cloud.Cloud{
+				"mrcloud1": {
+					Name:             "mrcloud1",
+					Type:             "maas",
+					Description:      "Metal As A Service",
+					AuthTypes:        cloud.AuthTypes(nil),
+					Endpoint:         "",
+					IdentityEndpoint: "",
+					StorageEndpoint:  "",
+					Regions:          []cloud.Region(nil),
+					Config:           map[string]interface{}(nil),
+					RegionConfig:     cloud.RegionConfig(nil),
+				},
+				"mrcloud2": {
+					Name:             "mrcloud2",
+					Type:             "kubernetes",
+					Description:      "A Kubernetes Cluster",
+					AuthTypes:        cloud.AuthTypes(nil),
+					Endpoint:         "",
+					IdentityEndpoint: "",
+					StorageEndpoint:  "",
+					Regions:          []cloud.Region(nil),
+					Config:           map[string]interface{}(nil),
+					RegionConfig:     cloud.RegionConfig(nil),
+				},
+				"myk8s": expectedCloudToUpdate,
+			},
+		)
+	}
+}
+
+func (s *updateCAASSuite) TestLocalOnly(c *gc.C) {
+	s.assertUpdateCloudResult(c, func() {
+		command := s.makeCommand()
+		ctx, err := s.runCommand(c, command, "myk8s", "-f", "mycloud.yaml", "--client")
+		c.Assert(err, jc.ErrorIsNil)
+		expected := `k8s cloud "myk8s" updated on this client using provided file.`
+		c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals, expected)
+	}, "myk8s", "gce/us-east1", "", "operator-sc", testData{client: true})
+}
+
+func (s *updateCAASSuite) TestCloudFileRequired(c *gc.C) {
+	command := s.makeCommand()
+	ctx, err := s.runCommand(c, command, "myk8s", "--client")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
+		`To update k8s cloud "myk8s" on this client, a cloud definition file is required.`)
+}
+
+func (s *updateCAASSuite) TestInvalidControllerCloud(c *gc.C) {
+	s.fakeCloudAPI.cloud = jujucloud.Cloud{Type: "maas"}
+	command := s.makeCommand()
+	ctx, err := s.runCommand(c, command, "myk8s", "-c", "foo")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
+		`The "myk8s" cloud on the controller is a "maas" cloud and not a "kubernetes" cloud.`)
+}
+
+func (s *updateCAASSuite) TestInvalidNewCloud(c *gc.C) {
+	command := s.makeCommand()
+	ctx, err := s.runCommand(c, command, "mrcloud1", "-c", "foo", "-f", "mycloud.yaml")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
+		`The "mrcloud1" cloud is a "maas" cloud and not a "kubernetes" cloud.`)
+}
+
+func (s *updateCAASSuite) TestControllerAndClient(c *gc.C) {
+	s.assertUpdateCloudResult(c, func() {
+		command := s.makeCommand()
+		ctx, err := s.runCommand(c, command, "myk8s", "-f", "mycloud.yaml", "-c", "foo", "--client")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
+			`k8s cloud "myk8s" updated on this client using provided file.k8s cloud "myk8s" updated on controller "foo".`)
+	}, "myk8s", "gce/us-east1", "", "operator-sc", testData{client: true, controller: true})
+}
+
+func (s *updateCAASSuite) TestBuiltinLocalNotAllowed(c *gc.C) {
+	command := s.makeCommand()
+	ctx, err := s.runCommand(c, command, "microk8s", "--client")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
+		`"microk8s" is a built-in cloud and cannot be updated on the client.`)
+}
+
+func (s *updateCAASSuite) TestBuiltinWithFile(c *gc.C) {
+	command := s.makeCommand()
+	ctx, err := s.runCommand(c, command, "microk8s", "-f", "mycloud.yaml")
+	c.Assert(err, gc.Equals, cmd.ErrSilent)
+	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
+		`"microk8s" is a built-in cloud and does not support specifying a cloud YAML file.`)
+}
+
+func (s *updateCAASSuite) TestBuiltinToController(c *gc.C) {
+	var logger loggo.Logger
+	microk8sClusterMetadata := &jujucaas.ClusterMetadata{
+		Cloud: "microk8s",
+	}
+	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
+		CallMocker: jujutesting.NewCallMocker(logger),
+	}
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(microk8sClusterMetadata, nil)
+
+	command := s.makeCommand()
+	_, err := s.runCommand(c, command, "microk8s", "-c", "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	s.fakeK8sClusterMetadataChecker.CheckCall(c, 0, "GetClusterMetadata")
+	expectedCloudToUpdate := cloud.Cloud{
+		Name:            "microk8s",
+		HostCloudRegion: "",
+		Type:            "kubernetes",
+		Description:     "",
+		RegionConfig:    cloud.RegionConfig(nil),
+		AuthTypes:       cloud.AuthTypes{"certificate"},
+	}
+	expectedCredToUpdate := map[string]cloud.Credential{
+		"cloudcred-microk8s_foouser_default": cloud.NewNamedCredential("test", "", nil, false)}
+
+	s.fakeCloudAPI.CheckCall(c, 1, "UpdateCloud", expectedCloudToUpdate)
+	s.fakeCloudAPI.CheckCall(c, 2, "UpdateCloudsCredentials", expectedCredToUpdate, false)
+}

--- a/cmd/juju/cloud/updatecloud.go
+++ b/cmd/juju/cloud/updatecloud.go
@@ -128,15 +128,15 @@ func (c *updateCloudCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *updateCloudCommand) Run(ctxt *cmd.Context) error {
 	var newCloud *jujucloud.Cloud
 	if c.CloudFile != "" {
-		r := &cloudFileReader{
-			cloudMetadataStore: c.cloudMetadataStore,
-			cloudName:          c.Cloud,
+		r := &CloudFileReader{
+			CloudMetadataStore: c.cloudMetadataStore,
+			CloudName:          c.Cloud,
 		}
 		var err error
-		if newCloud, err = r.readCloudFromFile(c.CloudFile, ctxt); err != nil {
+		if newCloud, err = r.ReadCloudFromFile(c.CloudFile, ctxt); err != nil {
 			return errors.Annotatef(err, "could not read cloud definition from provided file")
 		}
-		c.Cloud = r.cloudName
+		c.Cloud = r.CloudName
 	}
 	if err := c.MaybePrompt(ctxt, fmt.Sprintf("update cloud %q on", c.Cloud)); err != nil {
 		return errors.Trace(err)
@@ -182,13 +182,6 @@ func (c *updateCloudCommand) isPublicCloud(cloudName string) bool {
 		}
 	}
 	return false
-}
-
-func (c *updateCloudCommand) updateLocalCache(ctxt *cmd.Context, newCloud *jujucloud.Cloud) error {
-	if err := addLocalCloud(c.cloudMetadataStore, *newCloud); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (c *updateCloudCommand) updateControllerCacheFromLocalCache() error {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -534,7 +534,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	var hostedModel *jujuclient.ModelDetails
 	defer func() {
 		resultErr = handleChooseCloudRegionError(ctx, resultErr)
-		if resultErr == nil {
+		if !c.showClouds && resultErr == nil {
 			var msg string
 			if hostedModel == nil {
 				msg = `

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1924,6 +1924,7 @@ You will need to have a credential if you want to bootstrap on a cloud, see
 ‘juju autoload-credentials’ and ‘juju add-credential’. The first credential
 listed is the default. Add more clouds with ‘juju add-cloud’.
 `[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *BootstrapSuite) TestBootstrapPrintCloudsInvalidCredential(c *gc.C) {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -499,6 +500,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// CAAS commands
 	r.Register(caas.NewAddCAASCommand(&cloudToCommandAdapter{}))
+	r.Register(caas.NewUpdateCAASCommand(&cloudToCommandAdapter{}))
 	r.Register(caas.NewRemoveCAASCommand(&cloudToCommandAdapter{}))
 	r.Register(application.NewScaleApplicationCommand())
 
@@ -547,8 +549,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 type cloudToCommandAdapter struct{}
 
-func (cloudToCommandAdapter) ParseCloudMetadataFile(path string) (map[string]cloudfile.Cloud, error) {
-	return cloudfile.ParseCloudMetadataFile(path)
+func (cloudToCommandAdapter) ReadCloudData(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
 }
 func (cloudToCommandAdapter) ParseOneCloud(data []byte) (cloudfile.Cloud, error) {
 	return cloudfile.ParseOneCloud(data)

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -649,6 +649,7 @@ var commandNames = []string{
 	"unexpose",
 	"unregister",
 	"update-cloud",
+	"update-k8s",
 	"update-public-clouds",
 	"update-credential",
 	"update-credentials",


### PR DESCRIPTION
## Description of change

Add a new update-k8s command.
The command can either accept a built-in cloud name like "microk8s", or else
behaves the same as update-cloud where a cloud file is used to pass in the updated info.

The CloudFileReader from cmd/juju/cloud/add.go was reused so was exported. The CloudMetadataStore used in the cmd/juju/cloud had a ParseCloudMetadataFile() method but this caused duplicate test data to be needed in tests/mocks and didn't work well with the new cass/update-k8s tests. So it was reworked to have a ReadCloudData() method instead.

Also remove from unused code from update-cloud.
And a driveby fix for https://bugs.launchpad.net/juju/+bug/1865894

## QA steps

Run the command for microk8s and also a bespoke clouds.yaml file
$ juju update-k8s microk8s

$ juju update-k8s mytestk8s -f clouds.yaml

Do it for both --client and a k8s added to a lxd controller
Check cloud is updated with show-cloud

## Bug reference

https://bugs.launchpad.net/juju/+bug/1864259
