### PR TITLE
Feature/global cr lifecycle

### DIFF
--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1479,7 +1479,7 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 	// timer +1.
 	s.mockNamespaceableResourceClient.EXPECT().List(
 		// list all custom resources for crd "v1alpha2".
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 	).Return(&unstructured.UnstructuredList{}, nil).After(
 		s.mockDynamicClient.EXPECT().Resource(
 			schema.GroupVersionResource{
@@ -1491,7 +1491,7 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 	).After(
 		// list all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().List(
-			v1.ListOptions{LabelSelector: "juju-model=test"},
+			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 		).Return(&unstructured.UnstructuredList{}, nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -1509,7 +1509,7 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 		// delete all custom resources for crd "v1alpha2".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test"},
+			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -1523,7 +1523,7 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 		// delete all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test"},
+			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1837,7 +1837,7 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 		).Return(s.mockNamespaceableResourceClient),
 		s.mockResourceClient.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-app=test"},
+			v1.ListOptions{LabelSelector: "juju-app=test,juju-resource-lifecycle notin (model,persistent)"},
 		).Return(nil),
 		// delete all custom resources for crd "v1alpha2".
 		s.mockDynamicClient.EXPECT().Resource(
@@ -1849,7 +1849,7 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 		).Return(s.mockNamespaceableResourceClient),
 		s.mockResourceClient.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-app=test"},
+			v1.ListOptions{LabelSelector: "juju-app=test,juju-resource-lifecycle notin (model,persistent)"},
 		).Return(nil),
 
 		// delete all custom resource definitions.

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -217,6 +217,9 @@ kubernetesResources:
         password: MWYyZDFlMmU2N2Rm
   customResourceDefinitions:
     - name: tfjobs.kubeflow.org
+      labels:
+        foo: bar
+        juju-global-resource-lifecycle: model
       spec:
         group: kubeflow.org
         scope: Cluster
@@ -269,6 +272,9 @@ kubernetesResources:
         kind: "TFJob"
         metadata:
           name: "dist-mnist-for-e2e-test"
+        labels:
+          foo: bar
+          juju-global-resource-lifecycle: model
         spec:
           tfReplicaSpecs:
             PS:
@@ -725,6 +731,10 @@ password: shhhh`[1:],
 				CustomResourceDefinitions: []k8sspecs.K8sCustomResourceDefinitionSpec{
 					{
 						Name: "tfjobs.kubeflow.org",
+						Labels: map[string]string{
+							"foo":                            "bar",
+							"juju-global-resource-lifecycle": "model",
+						},
 						Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 							Group:   "kubeflow.org",
 							Version: "v1",
@@ -798,6 +808,10 @@ password: shhhh`[1:],
 								"apiVersion": "kubeflow.org/v1",
 								"metadata": map[string]interface{}{
 									"name": "dist-mnist-for-e2e-test",
+								},
+								"labels": map[string]interface{}{
+									"foo":                            "bar",
+									"juju-global-resource-lifecycle": "model",
 								},
 								"kind": "TFJob",
 								"spec": map[string]interface{}{

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -93,6 +93,8 @@ func (k *kubernetesClient) deleteClusterScopeAPIExtensionResourcesModelTeardown(
 	var subwg sync.WaitGroup
 	subwg.Add(2)
 	defer subwg.Wait()
+
+	selector = mergeSelectors(selector, lifecycleModelTeardownSelector)
 	// Delete CRs first then CRDs.
 	k.deleteClusterScopeCustomResourcesModelTeardown(ctx, selector, clk, &subwg, errChan)
 	k.deleteCustomResourceDefinitionsModelTeardown(ctx, selector, clk, &subwg, errChan)
@@ -130,7 +132,6 @@ func (k *kubernetesClient) deleteCustomResourceDefinitionsModelTeardown(
 	wg *sync.WaitGroup,
 	errChan chan<- error,
 ) {
-	selector = mergeSelectors(selector, lifecycleModelTeardownSelector)
 	ensureResourcesDeletedFunc(ctx, selector, clk, wg, errChan,
 		k.deleteCustomResourceDefinitions, func(selector k8slabels.Selector) error {
 			_, err := k.listCustomResourceDefinitions(selector)

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -115,10 +115,10 @@ func (k *kubernetesClient) deleteClusterScopeCustomResourcesModelTeardown(
 		return k8slabels.NewSelector()
 	}
 	ensureResourcesDeletedFunc(ctx, selector, clk, wg, errChan,
-		func(selector k8slabels.Selector) error {
+		func(_ k8slabels.Selector) error {
 			return k.deleteCustomResources(getSelector)
 		},
-		func(selector k8slabels.Selector) error {
+		func(_ k8slabels.Selector) error {
 			_, err := k.listCustomResources(getSelector)
 			return err
 		},

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -162,7 +162,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	// timer +1.
 	s.mockNamespaceableResourceClient.EXPECT().List(
 		// list all custom resources for crd "v1alpha2".
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 	).Return(&unstructured.UnstructuredList{}, nil).After(
 		s.mockDynamicClient.EXPECT().Resource(
 			schema.GroupVersionResource{
@@ -174,7 +174,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	).After(
 		// list all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().List(
-			v1.ListOptions{LabelSelector: "juju-model=test"},
+			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 		).Return(&unstructured.UnstructuredList{}, nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -192,7 +192,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 		// delete all custom resources for crd "v1alpha2".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test"},
+			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -206,7 +206,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 		// delete all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test"},
+			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -416,7 +416,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 	// delete all custom resources for crd "v1alpha2".
 	s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 	).Return(nil).After(
 		s.mockDynamicClient.EXPECT().Resource(
 			schema.GroupVersionResource{
@@ -429,7 +429,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 		// delete all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test"},
+			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - ~[ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Introduce the CR lifecycle. Now charmers can decide when the CR gets deleted by specifying proper labels.

```json
{
    "juju-resource-lifecycle": "model | persistent"
}
```

1. If no `juju-resource-lifecycle` label set, the CR gets deleted with the application together.

2. If `juju-resource-lifecycle` sets to `model`, the CR will not get deleted when the application is removed until the model is destroyed.

3. If `juju-resource-lifecycle` sets to `persistent`, the CR will never get deleted by Juju even the model is gone.

## QA steps

deploy a charm has below spec:

```yaml
version: 3
kubernetesResources:
  customResourceDefinitions:
    - name: tfjob1s.kubeflow.org1
      labels:
        juju-resource-lifecycle: persistent  # to test CR lifecycle, the CRD's lifecyle has to be `persistent`
      spec:
        group: kubeflow.org1
        scope: Cluster  # to test CR lifecycle, the scope has to be `Cluster`
        names:
          kind: TFJob1
          singular: tfjob1
          plural: tfjob1s
        versions:
          - name: v1
            served: true
            storage: true
        subresources:
          status: {}
        validation:
          openAPIV3Schema:
            properties:
              spec:
                properties:
                  tfReplicaSpecs:
                    properties:
                      Worker:
                        properties:
                          replicas:
                            type: integer
                            minimum: 1
                      PS:
                        properties:
                          replicas:
                            type: integer
                            minimum: 1
                      Chief:
                        properties:
                          replicas:
                            type: integer
                            minimum: 1
                            maximum: 1
  customResources:
    tfjob1s.kubeflow.org1:
      - apiVersion: "kubeflow.org1/v1"
        kind: "TFJob1"
        metadata:   # removed if the application gets removed;
          name: "dist-mnist-for-e2e-test11"
        spec:
          tfReplicaSpecs:
            PS:
              replicas: 2
              restartPolicy: Never
              template:
                spec:
                  containers:
                    - name: tensorflow
                      image: kubeflow/tf-dist-mnist-test:1.0
            Worker:
              replicas: 8
              restartPolicy: Never
              template:
                spec:
                  containers:
                    - name: tensorflow
                      image: kubeflow/tf-dist-mnist-test:1.0
      - apiVersion: "kubeflow.org1/v1"
        kind: "TFJob1"
        metadata:
          name: "dist-mnist-for-e2e-test12"
          labels:    # removed if the model gets removed;
            juju-resource-lifecycle: model
        spec:
          tfReplicaSpecs:
            PS:
              replicas: 2
              restartPolicy: Never
              template:
                spec:
                  containers:
                    - name: tensorflow
                      image: kubeflow/tf-dist-mnist-test:1.0
            Worker:
              replicas: 11
              restartPolicy: Never
              template:
                spec:
                  containers:
                    - name: tensorflow
                      image: kubeflow/tf-dist-mnist-test:1.0
      - apiVersion: "kubeflow.org1/v1"
        kind: "TFJob1"
        metadata:
          name: "dist-mnist-for-e2e-test13"
          labels:    # never removed;
            juju-resource-lifecycle: persistent
        spec:
          tfReplicaSpecs:
            PS:
              replicas: 2
              restartPolicy: Never
              template:
                spec:
                  containers:
                    - name: tensorflow
                      image: kubeflow/tf-dist-mnist-test:1.0
            Worker:
              replicas: 11
              restartPolicy: Never
              template:
                spec:
                  containers:
                    - name: tensorflow
                      image: kubeflow/tf-dist-mnist-test:1.0
```

```console
$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb

$ mkubectl get crds tfjob1s.kubeflow.org1 -o json | jq ' .metadata | {name: .name,"juju-resource-lifecycle": (.labels | ."juju-resource-lifecycle")}'
{
  "name": "tfjob1s.kubeflow.org1",
  "juju-resource-lifecycle": "persistent"
}

$ mkubectl get tfjob1s.kubeflow.org1 -o json | jq '.items[] | .metadata | {name: .name,"juju-resource-lifecycle":(.labels | ."juju-resource-lifecycle")}'
{
  "name": "dist-mnist-for-e2e-test11",
  "juju-resource-lifecycle": null
}
{
  "name": "dist-mnist-for-e2e-test12",
  "juju-resource-lifecycle": "model"
}
{
  "name": "dist-mnist-for-e2e-test13",
  "juju-resource-lifecycle": "persistent"
}

$ juju remove-application mariadb-k8s -m k1:t1 --destroy-storage --force
removing application mariadb-k8s
- will remove storage database/0

$ mkubectl get tfjob1s.kubeflow.org1 -o json | jq '.items[] | .metadata | {name: .name,"juju-resource-lifecycle":(.labels | ."juju-resource-lifecycle")}'
{
  "name": "dist-mnist-for-e2e-test12",
  "juju-resource-lifecycle": "model"
}
{
  "name": "dist-mnist-for-e2e-test13",
  "juju-resource-lifecycle": "persistent"
}

$ juju destroy-model t1 --destroy-storage -y --debug --force

$ mkubectl get tfjob1s.kubeflow.org1 -o json | jq '.items[] | .metadata | {name: .name,"juju-resource-lifecycle":(.labels | ."juju-resource-lifecycle")}'
{
  "name": "dist-mnist-for-e2e-test13",
  "juju-resource-lifecycle": "persistent"
}

```

## Documentation changes

Yes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1862390