### PR TITLE
Use goose os-interface endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1282,7 +1282,7 @@
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:605d4b873b46c5cdb3460706be5b969445b9f69aea006a0cbe2bb44cf493f3de"
+  digest = "1:e7a1623e8e21da8494df88a3f8d841148180cc628f921e2e2332af8ed14c4e31"
   name = "gopkg.in/goose.v2"
   packages = [
     ".",
@@ -1308,7 +1308,7 @@
     "testservices/swiftservice",
   ]
   pruneopts = ""
-  revision = "cc624cc0ae77ab888b42b3084ad915c9e5e12bbc"
+  revision = "ab914003d547f0dc01c26ac8421c55c6b1d66ace"
 
 [[projects]]
   digest = "1:445becf3878aa9bd50dfa972bd65f974ed2468c09350ab9ce28b1e4adce464df"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -468,7 +468,7 @@
 
 [[constraint]]
   name = "gopkg.in/goose.v2"
-  revision = "cc624cc0ae77ab888b42b3084ad915c9e5e12bbc"
+  revision = "ab914003d547f0dc01c26ac8421c55c6b1d66ace"
 
 [[override]]
   name = "gopkg.in/httprequest.v1"

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -971,6 +971,16 @@ func (s *localServerSuite) TestDestroyControllerSpaceConstraints(c *gc.C) {
 }
 
 func (s *localServerSuite) assignDeviceIdToPort(c *gc.C, portId, deviceId string) {
+	err := s.srv.Nova.AddOSInterface(deviceId, nova.OSInterface{
+		FixedIPs: []nova.PortFixedIP{
+			{
+				IPAddress: "10.0.0.1",
+			},
+		},
+		IPAddress: "10.0.0.1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
 	model := s.srv.Neutron.NeutronModel()
 	port, err := model.Port("1")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

The following adds code to get the os-interfaces from a server and
walk over the ports to then delete each one. Ensuring we do a better job
of cleaning up of ports after we created them.

## QA steps

 - bootstrap to microstack
 - add a machine to space
 - destroy controller
