### PR TITLE
small refactor of uniter's context FactoryConfig.

### DIFF
--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -90,7 +90,7 @@ type contextFactory struct {
 // for the context factory.
 type FactoryConfig struct {
 	State            *uniter.State
-	UnitTag          names.UnitTag
+	Unit             *uniter.Unit
 	Tracker          leadership.Tracker
 	GetRelationInfos RelationsFunc
 	Storage          StorageContextAccessor
@@ -101,10 +101,6 @@ type FactoryConfig struct {
 // NewContextFactory returns a ContextFactory capable of creating execution contexts backed
 // by the supplied unit's supplied API connection.
 func NewContextFactory(config FactoryConfig) (ContextFactory, error) {
-	unit, err := config.State.Unit(config.UnitTag)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	m, err := config.State.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -114,17 +110,17 @@ func NewContextFactory(config FactoryConfig) (ContextFactory, error) {
 		zone       string
 	)
 	if m.ModelType == model.IAAS {
-		machineTag, err = unit.AssignedMachine()
+		machineTag, err = config.Unit.AssignedMachine()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
-		zone, err = unit.AvailabilityZone()
+		zone, err = config.Unit.AvailabilityZone()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
-	principal, ok, err := unit.PrincipalName()
+	principal, ok, err := config.Unit.PrincipalName()
 	if err != nil {
 		return nil, errors.Trace(err)
 	} else if !ok {
@@ -132,7 +128,7 @@ func NewContextFactory(config FactoryConfig) (ContextFactory, error) {
 	}
 
 	f := &contextFactory{
-		unit:             unit,
+		unit:             config.Unit,
 		state:            config.State,
 		tracker:          config.Tracker,
 		paths:            config.Paths,

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -50,7 +50,7 @@ func (s *ContextFactorySuite) SetUpTest(c *gc.C) {
 
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
 		State:            s.uniter,
-		UnitTag:          s.unit.Tag().(names.UnitTag),
+		Unit:             s.apiUnit,
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
@@ -237,10 +237,13 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 	st := s.OpenAPIAs(c, unit.Tag(), password)
 	uniter, err := st.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uniter, gc.NotNil)
+	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
+	c.Assert(err, jc.ErrorIsNil)
 
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
 		State:            uniter,
-		UnitTag:          unit.Tag().(names.UnitTag),
+		Unit:             apiUnit,
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
@@ -306,10 +309,13 @@ func (s *ContextFactorySuite) setupPodSpec(c *gc.C) (*state.State, context.Conte
 	c.Assert(err, jc.ErrorIsNil)
 	uniter, err := apiState.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uniter, gc.NotNil)
+	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
+	c.Assert(err, jc.ErrorIsNil)
 
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
-		State:   uniter,
-		UnitTag: unit.UnitTag(),
+		State: uniter,
+		Unit:  apiUnit,
 		Tracker: &runnertesting.FakeTracker{
 			AllowClaimLeader: true,
 		},
@@ -411,10 +417,13 @@ func (s *ContextFactorySuite) TestNewHookContextCAASModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	uniter, err := apiState.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uniter, gc.NotNil)
+	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
+	c.Assert(err, jc.ErrorIsNil)
 
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
-		State:   uniter,
-		UnitTag: unit.Tag().(names.UnitTag),
+		State: uniter,
+		Unit:  apiUnit,
 		Tracker: &runnertesting.FakeTracker{
 			AllowClaimLeader: true,
 		},

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -163,10 +163,13 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	st := s.OpenAPIAs(c, unit.Tag(), password)
 	uniter, err := st.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.uniter, gc.NotNil)
+	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
+	c.Assert(err, jc.ErrorIsNil)
 
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
 		State:            uniter,
-		UnitTag:          unit.Tag().(names.UnitTag),
+		Unit:             apiUnit,
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -104,7 +104,7 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 
 	s.contextFactory, err = context.NewContextFactory(context.FactoryConfig{
 		State:            s.uniter,
-		UnitTag:          s.unit.Tag().(names.UnitTag),
+		Unit:             s.apiUnit,
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -618,7 +618,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	}
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
 		State:            u.st,
-		UnitTag:          unitTag,
+		Unit:             u.unit,
 		Tracker:          u.leadershipTracker,
 		GetRelationInfos: u.relations.GetInfo,
 		Storage:          u.storage,


### PR DESCRIPTION
## Description of change

Replace UnitTag with Unit in context.FactoryConfig.  The caller of context.NewContextFactory already has a unit from state. No need to get a second copy of it, just pass as a config value.

## QA steps

There should be no visible change to juju operation.
```console
juju bootstrap localhost
juju deploy ubuntu

# once the unit is deployed, check the logs.
juju debug-log
```


