### PR TITLE
acceptancetests: Change the add-cloud test to match changes in command

### DIFF
--- a/acceptancetests/assess_add_cloud.py
+++ b/acceptancetests/assess_add_cloud.py
@@ -133,7 +133,14 @@ def assess_cloud(client, cloud_name, example_cloud):
         raise JujuAssertionError('Clouds missing!')
     if clouds['clouds'].keys() != [cloud_name]:
         raise NameMismatch()
-    if clouds['clouds'][cloud_name] != example_cloud:
+
+    actual_cloud = clouds['clouds'][cloud_name]
+    # Accept the creation of a default region even though there's not one in
+    # the example cloud.
+    if 'regions' not in example_cloud and actual_cloud.get('regions') == {'default': {}}:
+        del actual_cloud['regions']
+
+    if actual_cloud != example_cloud:
         sys.stderr.write("\nMissmatch for cloud: {}\n".format(cloud_name))
         sys.stderr.write('\nExpected:\n')
         yaml.dump(example_cloud, sys.stderr)

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -2165,11 +2165,15 @@ class ModelClient:
                 self.handle_openstack(child, cloud)
             if cloud['type'] == 'vsphere':
                 self.handle_vsphere(child, cloud)
-            match = child.expect(["Do you ONLY want to add cloud", "Can't validate endpoint"])
+            match = child.expect(["Do you ONLY want to add cloud", "Can't validate endpoint", pexpect.EOF])
             if match == 0:
                 child.sendline("y")
             if match == 1:
                 raise InvalidEndpoint()
+            if match == 2:
+                # The endpoint was validated and there isn't a controller to
+                # ask about.
+                return
             child.expect([pexpect.EOF, "Can't validate endpoint"])
             if child.match != pexpect.EOF:
                 if child.match.group(0) == "Can't validate endpoint":


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change
The test for interactive add-cloud needed updating for changed behaviour of the command. It doesn't prompt for cloud-local if there are no controllers, and it always creates a default region.


## QA steps

The test passes with this change.
```sh
python assess add_cloud --clouds-yaml=/home/xtian/dev/cloud-city/example-clouds.yaml
```

## Documentation changes
None

## Bug reference
None
