### PR TITLE
2.7 - Fixes branches integration test

### DIFF
--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -16,11 +16,11 @@ run_branch() {
     juju branch | check 'Active branch is "test-branch"'
 
     juju config redis password=pass --branch test-branch
-    juju config redis password --branch test-branch | check "pass"
+    check_config_command "juju config redis password --branch test-branch" "pass"
     juju config redis password --branch master | wc -c | check "0"
 
     juju commit test-branch | check 'Active branch set to "master"'
-    juju config redis password | check "pass"
+    check_config_command "juju config redis password" "pass"
 
     # Clean up!
     destroy_model "branches"
@@ -39,4 +39,26 @@ test_branch() {
 
         run "run_branch"
     )
+}
+
+# The check function reads stdout until a new-line is detected.
+# This does not work for us, because config does not include a new line at the end
+# of the output. Hence this function.
+check_config_command() {
+    local want got
+
+    want=${2}
+
+    got=$(eval "${1}")
+
+    OUT=$(echo "${got}" | grep -E "${want}" || true)
+    if [ -z "${OUT}" ]; then
+        echo "" >&2
+        # shellcheck disable=SC2059
+        printf "$(red \"Expected\"): ${want}\n" >&2
+        # shellcheck disable=SC2059
+        printf "$(red \"Recieved\"): ${got}\n" >&2
+        echo "" >&2
+        exit 1
+    fi
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Fixes the branches integration test.

Grepping for expected output was replaced by the check command, which
reads stdout until a new-line is found. Config output does not terminate
with a new-line, and so was failing the check.

The check function is replaced by a local function that suites config
output.

## QA steps

`cd tests && .main.sh branches`
