### PR TITLE
CI Manual Tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -53,6 +53,12 @@ bootstrap() {
         "localhost")
             provider="lxd"
             ;;
+        "manual")
+            manual_name=${1}
+            shift
+
+            provider="${manual_name}"
+            ;;
         *)
             echo "Unexpected bootstrap provider (${BOOTSTRAP_PROVIDER})."
             exit 1

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -37,6 +37,7 @@ TEST_NAMES="static_analysis \
             hooks \
             hook_tools \
             machine \
+            manual \
             relations \
             smoke \
             model"
@@ -94,7 +95,7 @@ show_help() {
     for test in ${TEST_NAMES}; do
         name=$(echo "${test}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
         # shellcheck disable=SC2086
-        output="${output}\n    $(green ${test})|Runs the ${name}"
+        output="${output}\n    $(green ${test})|Runs the ${name} tests"
     done
     echo "${output}" | column -t -s "|"
 

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -1,6 +1,6 @@
 test_deploy() {
     if [ "$(skip 'test_deploy')" ]; then
-        echo "==> TEST SKIPPED: CMR bundle tests"
+        echo "==> TEST SKIPPED: Deploy tests"
         return
     fi
 

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -1,0 +1,157 @@
+create_priveleged_profile() {
+    PROFILE=$(cat <<'EOF'
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+description: create privileged container
+devices: {}
+name: profile-privileged
+EOF
+)
+    echo "${PROFILE}" > "${TEST_DIR}/profile-privileged.yaml"
+
+    OUT=$(lxc profile show profile-privileged || true)
+    if [ -z "${OUT}" ]; then
+        lxc profile create profile-privileged
+        lxc profile edit profile-privileged < "${TEST_DIR}/profile-privileged.yaml"
+    fi
+}
+
+create_user_profile() {
+    local name
+
+    name=${1}
+    profile_name="profile-${name}"
+
+    public_key="${TEST_DIR}/${name}.pub"
+    key=$(cat ${public_key} | tr -d '\n')
+
+    PROFILE=$(cat <<EOF
+config:
+  user.user-data: |
+    #cloud-config
+    ssh_authorized_keys:
+      - "${key}"
+description: create user profile
+devices: {}
+name: ${profile_name}
+EOF
+)
+
+    echo "${PROFILE}" > "${TEST_DIR}/${profile_name}.yaml"
+
+    # Do not check if it already exists, we want to fail if it already exists.
+    lxc profile create "${profile_name}"
+    lxc profile edit "${profile_name}" < "${TEST_DIR}/${profile_name}.yaml"
+}
+
+run_deploy_manual_lxd() {
+    echo
+
+    name="tests-$(petname)"
+
+    ssh-keygen -f "${TEST_DIR}/${name}" \
+        -t rsa \
+        -C "ubuntu@${name}.com" \
+        -N ""
+
+    create_priveleged_profile
+    create_user_profile "${name}"
+
+    series="bionic"
+
+    controller="${name}-controller"
+    model1="${name}-m1"
+    model2="${name}-m2"
+
+    launch_and_wait_addr() {
+        local container_name addr_result
+
+        container_name=${1}
+        addr_result=${2}
+
+        lxc launch --profile default \
+             --profile profile-privileged \
+             --profile "profile-${name}" \
+             ubuntu:"${series}" "${container_name}"
+
+        local address=""
+
+        attempts=0
+        while [ ${attempts} -lt 30 ]; do
+            address=$(lxc list $1 --format json | \
+                jq --raw-output '.[0].state.network.eth0.addresses | map(select( .family == "inet")) | .[0].address')
+
+            if echo "${address}" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+$'; then
+                echo "Using container address ${address}"
+                break
+            fi
+            sleep 1
+            attempt=$((attempt+1))
+        done
+        
+        eval $addr_result="'${address}'"
+    }
+
+    launch_and_wait_addr "${controller}" addr_c
+    launch_and_wait_addr "${model1}" addr_m1
+    launch_and_wait_addr "${model2}" addr_m2
+
+    for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
+        ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"
+
+        attempts=0
+        while [ ${attempts} -lt 10 ]; do
+            OUT=$(ssh -T -n -i "${TEST_DIR}/${name}" \
+                -o StrictHostKeyChecking=no -o AddKeysToAgent=yes \
+                "ubuntu@${addr}.1" || true)
+            if echo "${OUT}" | grep -qv "Could not resolve hostname"; then
+                echo "Adding ssh key to ${addr}"
+                break
+            fi
+
+            sleep 1
+            attempt=$((attempt+1))
+        done
+    done
+
+    cloud_name="cloud-${name}"
+
+    CLOUD=$(cat <<EOF
+${cloud_name}:
+  type: manual
+  endpoint: "${addr_c}"
+EOF
+)
+
+    echo "${CLOUD}" > "${TEST_DIR}/cloud_name.yaml"
+
+    juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
+}
+
+test_deploy_manual() {
+    if [ "$(skip 'test_deploy_manual')" ]; then
+        echo "==> TEST SKIPPED: deploy manual"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        # TODO (stickupkid): We currently only support LXD in this test
+        # currently, future tests should run on aws.
+        case "${BOOTSTRAP_PROVIDER:-}" in
+            "lxd")
+                run "run_deploy_manual_lxd"
+                ;;
+            "localhost")
+                run "run_deploy_manual_lxd"
+                ;;
+            *)
+                echo "==> TEST SKIPPED: deploy manual - tests for LXD only"
+                ;;
+        esac
+    )
+}

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -45,6 +45,20 @@ EOF
     lxc profile edit "${profile_name}" < "${TEST_DIR}/${profile_name}.yaml"
 }
 
+delete_user_profile() {
+    local name
+
+    name=${1}
+    profile_name="profile-${name}"
+
+    set +e
+    OUT=$(lxc profile show profile-privileged || true)
+    if [ -n "${OUT}" ]; then
+        lxc profile delete "${profile_name}"
+    fi
+    set_verbosity
+}
+
 run_deploy_manual_lxd() {
     echo
 
@@ -154,6 +168,8 @@ EOF
     juju remove-application percona-cluster
 
     destroy_controller "test-${name}"
+
+    delete_user_profile "${name}"
 }
 
 test_deploy_manual() {

--- a/tests/suites/manual/task.sh
+++ b/tests/suites/manual/task.sh
@@ -1,0 +1,13 @@
+test_manual() {
+    if [ "$(skip 'test_manual')" ]; then
+        echo "==> TEST SKIPPED: Manual tests"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju lxd petname
+
+    test_deploy_manual
+}

--- a/tests/suites/static_analysis/copyright.sh
+++ b/tests/suites/static_analysis/copyright.sh
@@ -1,5 +1,5 @@
 run_copyright() {
-    OUT=$(find . -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig)" | sort | xargs grep -L -E '// (Copyright|Code generated)')
+    OUT=$(find . -name '*.go' | grep -v -E "(./vendor|./acceptancetests|./provider/azure/internal|./cloudconfig)" | sort | xargs grep -L -E '// (Copyright|Code generated)' || true)
     LINES=$(echo "${OUT}" | wc -w)
     if [ "$LINES" != 0 ]; then
         echo ""


### PR DESCRIPTION
## Description of change

The following starts to add manual machines so we can add a cloud, then
we can bootstrap to that cloud.

This only works for LXD for now, but at a later date, we should add AWS/GCE.

## QA steps

```sh
cd tests && ./main.sh manual
```
