### PR TITLE
[Draft] Convert 'gui' command to 'dashboard'

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -129,7 +129,7 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "unknown command with match",
 		args:    []string{"discombobulate"},
 		code:    1,
-		out:     missingCommandMessage("discombobulate", "diff-bundle"),
+		out:     missingCommandMessage("discombobulate", "dashboard"),
 	}, {
 		summary: "unknown command",
 		args:    []string{"pseudopseudohypoparathyroidism"},
@@ -502,6 +502,7 @@ var commandNames = []string{
 	"create-storage-pool",
 	"create-wallet",
 	"credentials",
+	"dashboard",
 	"debug-hook",
 	"debug-hooks",
 	"debug-log",

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Canonical Ltd.
+// Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package gui
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -28,15 +27,9 @@ func NewGUICommand() cmd.Command {
 	return modelcmd.Wrap(&guiCommand{})
 }
 
-// guiCommand opens the Juju GUI in the default browser.
+// guiCommand opens the Juju Dashboard in the default browser.
 type guiCommand struct {
 	modelcmd.ModelCommandBase
-
-	// Deprecated - used with --no-browser
-	noBrowser bool
-
-	// Deprecated - used with --show-credentials
-	showCreds bool
 
 	hideCreds bool
 	browser   bool
@@ -44,42 +37,40 @@ type guiCommand struct {
 	getGUIVersions func(connection api.Connection) ([]params.GUIArchiveVersion, error)
 }
 
-const guiDoc = `
-Print the Juju GUI URL and show admin credential to use to log into it:
+const dashboardDoc = `
+Print the Juju Dashboard URL and show admin credential to use to log into it:
 
-	juju gui
+	juju dashboard
 
-Print the Juju GUI URL only:
+Print the Juju Dashboard URL only:
 
-	juju gui --hide-credential
+	juju dashboard --hide-credential
 
-Open the Juju GUI in the default browser and show admin credential to use to log into it:
+Open the Juju Dashboard in the default browser and show admin credential to use to log into it:
 
-	juju gui --browser
+	juju dashboard --browser
 
-Open the Juju GUI in the default browser without printing the login credential:
+Open the Juju Dashboard in the default browser without printing the login credential:
 
-	juju gui --hide-credential --browser
+	juju dashboard --hide-credential --browser
 
-An error is returned if the Juju GUI is not available in the controller.
+An error is returned if the Juju Dashboard is not available in the controller.
 `
 
 // Info implements the cmd.Command interface.
 func (c *guiCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "gui",
-		Purpose: "Print the Juju GUI URL, or open the Juju GUI in the default browser.",
-		Doc:     guiDoc,
+		Name:    "dashboard",
+		Purpose: "Print the Juju Dashboard URL, or open the Juju Dashboard in the default browser.",
+		Doc:     dashboardDoc,
 	})
 }
 
 // SetFlags implements the cmd.Command interface.
 func (c *guiCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.hideCreds, "hide-credential", false, "Do not show admin credential to use for logging into the Juju GUI")
-	f.BoolVar(&c.showCreds, "show-credentials", true, "DEPRECATED. Show admin credential to use for logging into the Juju GUI")
-	f.BoolVar(&c.noBrowser, "no-browser", true, "DEPRECATED. --no-browser is now the default. Use --browser to open the web browser")
-	f.BoolVar(&c.browser, "browser", false, "Open the web browser, instead of just printing the Juju GUI URL")
+	f.BoolVar(&c.hideCreds, "hide-credential", false, "Do not show the admin credential to use for logging into the Juju Dashboard")
+	f.BoolVar(&c.browser, "browser", false, "Open the web browser, instead of just printing the Juju Dashboard URL")
 }
 
 func (c *guiCommand) guiVersions(conn api.Connection) ([]params.GUIArchiveVersion, error) {
@@ -99,39 +90,17 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 	}
 	defer conn.Close()
 
-	store, ok := c.ClientStore().(modelcmd.QualifyingClientStore)
-	if !ok {
-		store = modelcmd.QualifyingClientStore{
-			ClientStore: c.ClientStore(),
-		}
-	}
-	controllerName, err := c.ControllerName()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	modelName, details, err := c.ModelCommandBase.ModelDetails()
-	if err != nil {
-		return errors.Annotate(err, "cannot retrieve model details: please make sure you switched to a valid model")
-	}
-
 	// Make 2 URLs to try - the old and the new.
 	addr := guiAddr(conn)
-	rawURL := fmt.Sprintf("https://%s/gui/%s/", addr, details.ModelUUID)
-	qualifiedModelName, err := store.QualifiedModelName(controllerName, modelName)
-	if err != nil {
-		return errors.Annotate(err, "cannot construct model name")
-	}
-	// Do not include any possible "@external" fragment in the path.
-	qualifiedModelName = strings.Replace(qualifiedModelName, "@external/", "/", 1)
-	newRawURL := fmt.Sprintf("https://%s/gui/u/%s", addr, qualifiedModelName)
+	generatedDashboardURL := fmt.Sprintf("https://%s/dashboard", addr)
 
-	// Check that the Juju GUI is available.
-	var guiURL string
-	if guiURL, err = c.checkAvailable(rawURL, newRawURL, conn); err != nil {
+	// Check that the Juju Dashboard is available.
+	var dashboardURL string
+	if dashboardURL, err = c.checkAvailable(generatedDashboardURL, conn); err != nil {
 		return errors.Trace(err)
 	}
 
-	// Get the GUI version to print.
+	// Get the Dashboard version to print.
 	versions, err := c.guiVersions(conn)
 	if err != nil {
 		return errors.Trace(err)
@@ -144,8 +113,8 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	// Open the Juju GUI in the browser.
-	if err = c.openBrowser(ctx, guiURL, vers); err != nil {
+	// Open the Juju Dashboard in the browser.
+	if err = c.openBrowser(ctx, dashboardURL, vers); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -156,7 +125,7 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-// guiAddr returns an address where the GUI is available.
+// guiAddr returns an address where the Dashboard is available.
 func guiAddr(conn api.Connection) string {
 	if dnsName := conn.PublicDNSName(); dnsName != "" {
 		return dnsName
@@ -164,18 +133,15 @@ func guiAddr(conn api.Connection) string {
 	return conn.Addr()
 }
 
-// checkAvailable ensures the Juju GUI is available on the controller at
+// checkAvailable ensures the Juju Dashboard is available on the controller at
 // one of the given URLs, returning the successful URL.
-func (c *guiCommand) checkAvailable(rawURL, newRawURL string, conn api.Connection) (string, error) {
+func (c *guiCommand) checkAvailable(rawURL string, conn api.Connection) (string, error) {
 	client, err := conn.HTTPClient()
 	if err != nil {
 		return "", errors.Annotate(err, "cannot retrieve HTTP client")
 	}
-	if err = clientGet(c.StdContext, client, newRawURL); err == nil {
-		return newRawURL, nil
-	}
 	if err = clientGet(c.StdContext, client, rawURL); err != nil {
-		return "", errors.Annotate(err, "Juju GUI is not available")
+		return "", errors.Annotate(err, "Juju Dashboard is not available")
 	}
 	return rawURL, nil
 }
@@ -184,23 +150,25 @@ func (c *guiCommand) checkAvailable(rawURL, newRawURL string, conn api.Connectio
 func (c *guiCommand) openBrowser(ctx *cmd.Context, rawURL string, vers *version.Number) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return errors.Annotate(err, "cannot parse Juju GUI URL")
+		return errors.Annotate(err, "cannot parse Juju Dashboard URL")
 	}
-	if c.noBrowser && !c.browser {
+	if !c.browser {
 		versInfo := ""
 		if vers != nil {
-			versInfo = fmt.Sprintf("%v ", vers)
+			versInfo = fmt.Sprintf("%v", vers)
 		}
-		modelName, err := c.ModelIdentifier()
+
+		controllerName, err := c.ControllerName()
 		if err != nil {
 			return errors.Trace(err)
 		}
-		ctx.Infof("GUI %sfor model %q is enabled at:\n  %s", versInfo, modelName, u.String())
+
+		ctx.Infof("Dashboard %s for controller %q is enabled at:\n  %s", versInfo, controllerName, u.String())
 		return nil
 	}
 	err = webbrowserOpen(u)
 	if err == nil {
-		ctx.Infof("Opening the Juju GUI in your browser.")
+		ctx.Infof("Opening the Juju Dashboard in your browser.")
 		ctx.Infof("If it does not open, open this URL:\n%s", u)
 		return nil
 	}
@@ -213,7 +181,7 @@ func (c *guiCommand) openBrowser(ctx *cmd.Context, rawURL string, vers *version.
 
 // showCredentials shows the admin username and password.
 func (c *guiCommand) showCredentials(ctx *cmd.Context) error {
-	if c.hideCreds || !c.showCreds {
+	if c.hideCreds {
 		return nil
 	}
 	// TODO(wallyworld) - what to do if we are using a macaroon.

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -63,6 +63,7 @@ func (c *guiCommand) Info() *cmd.Info {
 		Name:    "dashboard",
 		Purpose: "Print the Juju Dashboard URL, or open the Juju Dashboard in the default browser.",
 		Doc:     dashboardDoc,
+		Aliases: []string{"gui"},
 	})
 }
 

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Canonical Ltd.
+// Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package gui_test
@@ -70,12 +70,7 @@ var _ = gc.Suite(&guiSuite{})
 
 func (s *guiSuite) guiURL(c *gc.C) string {
 	info := s.APIInfo(c)
-	return fmt.Sprintf("https://%s/gui/u/%s/%s", info.Addrs[0], "admin", "controller")
-}
-
-func (s *guiSuite) guiOldURL(c *gc.C) string {
-	info := s.APIInfo(c)
-	return fmt.Sprintf("https://%s/gui/%s/", info.Addrs[0], s.State.ModelUUID())
+	return fmt.Sprintf("https://%s/dashboard", info.Addrs[0])
 }
 
 func (s *guiSuite) TestGUISuccessWithBrowser(c *gc.C) {
@@ -91,7 +86,7 @@ func (s *guiSuite) TestGUISuccessWithBrowser(c *gc.C) {
 	out, err := s.run(c, "--browser", "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	guiURL := s.guiURL(c)
-	expectOut := "Opening the Juju GUI in your browser.\nIf it does not open, open this URL:\n" + guiURL
+	expectOut := "Opening the Juju Dashboard in your browser.\nIf it does not open, open this URL:\n" + guiURL
 	c.Assert(out, gc.Equals, expectOut)
 	c.Assert(clientURL, gc.Equals, guiURL)
 	c.Assert(browserURL, gc.Equals, guiURL)
@@ -122,32 +117,7 @@ func (s *guiSuite) TestGUISuccessNoBrowser(c *gc.C) {
 	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "controller" is enabled at:
-  %s`[1:], s.guiURL(c)))
-}
-
-func (s *guiSuite) TestGUISuccessOldGUI(c *gc.C) {
-	s.patchClient(func(_ context.Context, client *httprequest.Client, u string) error {
-		if strings.Contains(u, "/u/") {
-			return errors.New("bad wolf")
-		}
-		return nil
-	})
-	// There is no need to patch the browser open function here.
-	out, err := s.run(c, "--hide-credential")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "controller" is enabled at:
-  %s`[1:], s.guiOldURL(c)))
-}
-
-func (s *guiSuite) TestGUISuccessNoBrowserDeprecated(c *gc.C) {
-	s.patchClient(nil)
-	// There is no need to patch the browser open function here.
-	out, err := s.run(c, "--no-browser", "--hide-credential")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, fmt.Sprintf(`
-GUI 4.5.6 for model "controller" is enabled at:
+Dashboard 4.5.6 for controller "kontroll" is enabled at:
   %s`[1:], s.guiURL(c)))
 }
 
@@ -177,7 +147,7 @@ func (s *guiSuite) TestGUIErrorUnavailable(c *gc.C) {
 		return errors.New("bad wolf")
 	})
 	out, err := s.run(c, "--browser")
-	c.Assert(err, gc.ErrorMatches, "Juju GUI is not available: bad wolf")
+	c.Assert(err, gc.ErrorMatches, "Juju Dashboard is not available: bad wolf")
 	c.Assert(out, gc.Equals, "")
 }
 
@@ -202,6 +172,6 @@ func (s *guiDNSSuite) TestGUISuccess(c *gc.C) {
 	out, err := s.run(c, "--hide-credential")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, `
-GUI 4.5.6 for model "controller" is enabled at:
-  https://example.com/gui/u/admin/controller`[1:])
+Dashboard 4.5.6 for controller "kontroll" is enabled at:
+  https://example.com/dashboard`[1:])
 }


### PR DESCRIPTION
## Description of change

With the switch from the Juju GUI to the Juju Dashboard the command is being changed from `gui` to `dashboard`.

## QA steps

- run the `juju dashboard` command it should output an error that it cannot find a dashboard as the server components have not yet been updated.
- the `juju gui` command will no longer exist.

## Documentation changes

All of the old `juju gui` commands are now `juju dashboard` commands but the deprecated options have been removed.
