### PR TITLE
Store machineID on subordinate unit document.

### DIFF
--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -486,10 +486,6 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 		err = wu.AssignToMachine(m)
 		c.Assert(err, jc.ErrorIsNil)
 
-		deployer, ok := wu.DeployerTag()
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(deployer, gc.Equals, names.NewMachineTag(fmt.Sprintf("%d", i+1)))
-
 		wru, err := rel.Unit(wu)
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -521,9 +517,6 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 		lu, err := s.State.Unit(fmt.Sprintf("logging/%d", i))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(lu.IsPrincipal(), jc.IsFalse)
-		deployer, ok = lu.DeployerTag()
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(deployer, gc.Equals, names.NewUnitTag(fmt.Sprintf("wordpress/%d", i)))
 		setDefaultPassword(c, lu)
 		s.setAgentPresence(c, wu)
 		add(lu)

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -93,6 +93,11 @@ type MachineInfo struct {
 	Addresses                []network.ProviderAddress
 	HasVote                  bool
 	WantsVote                bool
+
+	// The preferred public and preferred private address are
+	// only stored on the machine info to populate the unit info.
+	PreferredPublicAddress  network.SpaceAddress
+	PreferredPrivateAddress network.SpaceAddress
 }
 
 // EntityID returns a unique identifier for a machine across
@@ -546,6 +551,7 @@ func (i *BlockInfo) Clone() EntityInfo {
 // tracked by multiwatcherStore.
 type ModelInfo struct {
 	ModelUUID       string
+	Type            model.ModelType
 	Name            string
 	Life            life.Value
 	Owner           string

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -340,10 +340,6 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		err = wu.AssignToMachine(m)
 		c.Assert(err, jc.ErrorIsNil)
 
-		deployer, ok := wu.DeployerTag()
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(deployer, gc.Equals, names.NewMachineTag(fmt.Sprintf("%d", i+1)))
-
 		wru, err := rel.Unit(wu)
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -355,10 +351,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		lu, err := st.Unit(fmt.Sprintf("logging/%d", i))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(lu.IsPrincipal(), jc.IsFalse)
-		deployer, ok = lu.DeployerTag()
-		c.Assert(ok, jc.IsTrue)
 		unitName := fmt.Sprintf("wordpress/%d", i)
-		c.Assert(deployer, gc.Equals, names.NewUnitTag(unitName))
 		add(&multiwatcher.UnitInfo{
 			ModelUUID:   modelUUID,
 			Name:        fmt.Sprintf("logging/%d", i),
@@ -2557,8 +2550,6 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			fw.AssertOpenUnitPort(c, u, emptySubnet, "tcp", 12345)
 			publicAddress := network.NewScopedSpaceAddress("public", network.ScopePublic)
 			privateAddress := network.NewScopedSpaceAddress("private", network.ScopeCloudLocal)
-			//err = m.SetProviderAddresses(publicAddress, privateAddress)
-			//c.Assert(err, jc.ErrorIsNil)
 			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,

--- a/state/application.go
+++ b/state/application.go
@@ -1735,6 +1735,9 @@ func (a *Application) addUnitOps(
 		if err != nil {
 			return "", nil, errors.Trace(err)
 		}
+		if args.machineID != "" {
+			return "", nil, errors.NotSupportedf("non-empty machineID")
+		}
 	}
 	storageCons, err := a.StorageConstraints()
 	if err != nil {

--- a/state/application.go
+++ b/state/application.go
@@ -1741,13 +1741,14 @@ func (a *Application) addUnitOps(
 		return "", nil, errors.Trace(err)
 	}
 	uNames, ops, err := a.addUnitOpsWithCons(applicationAddUnitOpsArgs{
-		cons:          cons,
-		principalName: principalName,
-		storageCons:   storageCons,
-		attachStorage: args.AttachStorage,
-		providerId:    args.ProviderId,
-		address:       args.Address,
-		ports:         args.Ports,
+		cons:               cons,
+		principalName:      principalName,
+		principalMachineID: args.machineID,
+		storageCons:        storageCons,
+		attachStorage:      args.AttachStorage,
+		providerId:         args.ProviderId,
+		address:            args.Address,
+		ports:              args.Ports,
 	})
 	if err != nil {
 		return uNames, ops, errors.Trace(err)
@@ -1759,7 +1760,9 @@ func (a *Application) addUnitOps(
 }
 
 type applicationAddUnitOpsArgs struct {
-	principalName string
+	principalName      string
+	principalMachineID string
+
 	cons          constraints.Value
 	storageCons   map[string]StorageConstraints
 	attachStorage []names.StorageTag
@@ -1814,6 +1817,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 		Series:                 a.doc.Series,
 		Life:                   Alive,
 		Principal:              args.principalName,
+		MachineId:              args.principalMachineID,
 		StorageAttachmentCount: numStorageAttachments,
 	}
 	now := a.st.clock().Now()
@@ -2060,6 +2064,10 @@ type AddUnitParams struct {
 
 	// Ports are the open ports on the container.
 	Ports *[]string
+
+	// machineID is only passed in if the unit being created is
+	// a subordinate and refers to the machine that is hosting the principal.
+	machineID string
 }
 
 // AddUnit adds a new principal unit to the application.

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -184,38 +184,6 @@ func (s *AssignSuite) TestAssignSubordinatesToMachine(c *gc.C) {
 	c.Check(id, gc.Equals, machine.Id())
 }
 
-func (s *AssignSuite) TestDeployerTag(c *gc.C) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	principal, err := s.wordpress.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	subordinate := s.addSubordinate(c, principal)
-
-	assertDeployer := func(u *state.Unit, d state.Entity) {
-		err := u.Refresh()
-		c.Assert(err, jc.ErrorIsNil)
-		name, ok := u.DeployerTag()
-		if d == nil {
-			c.Assert(ok, jc.IsFalse)
-		} else {
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(name, gc.Equals, d.Tag())
-		}
-	}
-	assertDeployer(subordinate, principal)
-	assertDeployer(principal, nil)
-
-	err = principal.AssignToMachine(machine)
-	c.Assert(err, jc.ErrorIsNil)
-	assertDeployer(subordinate, principal)
-	assertDeployer(principal, machine)
-
-	err = principal.UnassignFromMachine()
-	c.Assert(err, jc.ErrorIsNil)
-	assertDeployer(subordinate, principal)
-	assertDeployer(principal, nil)
-}
-
 func (s *AssignSuite) TestDirectAssignIgnoresConstraints(c *gc.C) {
 	// Set up constraints.
 	scons := constraints.MustParse("mem=2G cpu-power=400")

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -522,14 +522,9 @@ func (s *CleanupSuite) TestCleanupForceDestroyedMachineWithContainer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create active units (in relation scope, with subordinates).
-	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeContainer)
+	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeContainer, machine, container)
 	prr.allEnterScope(c)
 
-	// Assign the various units to machines.
-	err = prr.pu0.AssignToMachine(machine)
-	c.Assert(err, jc.ErrorIsNil)
-	err = prr.pu1.AssignToMachine(container)
-	c.Assert(err, jc.ErrorIsNil)
 	preventProReqUnitsDestroyRemove(c, prr)
 	s.assertDoesNotNeedCleanup(c)
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -1324,14 +1324,6 @@ func (m *Machine) Units() (units []*Unit, err error) {
 	}
 	for _, pudoc := range pudocs {
 		units = append(units, newUnit(m.st, model.Type(), &pudoc))
-		docs := []unitDoc{}
-		err = unitsCollection.Find(bson.D{{"principal", pudoc.Name}}).All(&docs)
-		if err != nil {
-			return nil, err
-		}
-		for _, doc := range docs {
-			units = append(units, newUnit(m.st, model.Type(), &doc))
-		}
 	}
 	return units, nil
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1616,14 +1616,10 @@ func (e *exporter) readAllUnits() (map[string][]*Unit, error) {
 		return nil, errors.Annotate(err, "cannot get all units")
 	}
 	e.logger.Debugf("found %d unit docs", len(docs))
-	model, err := e.st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	result := make(map[string][]*Unit)
 	for _, doc := range docs {
 		units := result[doc.Application]
-		result[doc.Application] = append(units, newUnit(e.st, model.Type(), &doc))
+		result[doc.Application] = append(units, newUnit(e.st, e.dbModel.Type(), &doc))
 	}
 	return result, nil
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1235,6 +1235,7 @@ func (i *importer) getPrincipalMachineID(principal names.UnitTag) string {
 	}
 	// We should never get here, but if we do, just return an empty
 	// machine ID.
+	i.logger.Warningf("unable to find principal %q", principal.Id())
 	return ""
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1176,18 +1176,6 @@ func (u *Unit) relations(predicate relationPredicate) ([]*Relation, error) {
 	return filtered, nil
 }
 
-// DeployerTag returns the tag of the agent responsible for deploying
-// the unit. If no such entity can be determined, false is returned.
-// XXX: this method is only used in tests, we should probably kill it.
-func (u *Unit) DeployerTag() (names.Tag, bool) {
-	if u.doc.Principal != "" {
-		return names.NewUnitTag(u.doc.Principal), true
-	} else if u.doc.MachineId != "" {
-		return names.NewMachineTag(u.doc.MachineId), true
-	}
-	return nil, false
-}
-
 // PrincipalName returns the name of the unit's principal.
 // If the unit is not a subordinate, false is returned.
 func (u *Unit) PrincipalName() (string, bool) {
@@ -1368,7 +1356,7 @@ func (u *Unit) Refresh() error {
 		return errors.NotFoundf("unit %q", u)
 	}
 	if err != nil {
-		return fmt.Errorf("cannot refresh unit %q: %v", u, err)
+		return errors.Annotatef(err, "cannot refresh unit %q", u)
 	}
 	return nil
 }
@@ -1644,7 +1632,7 @@ func (u *Unit) CharmURL() (*charm.URL, bool) {
 // An error will be returned if the unit is dead, or the charm URL not known.
 func (u *Unit) SetCharmURL(curl *charm.URL) error {
 	if curl == nil {
-		return fmt.Errorf("cannot set nil charm url")
+		return errors.Errorf("cannot set nil charm url")
 	}
 
 	db, closer := u.st.newDB()

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -237,7 +237,7 @@ func (s *UnitAssignmentSuite) TestAssignUnitCleanMachineUpgradeSeriesLockError(c
 
 	unit := units[0]
 	_, err = unit.AssignToCleanEmptyMachine()
-	c.Assert(err, gc.ErrorMatches, "all eligible machines in use")
+	c.Assert(err, gc.ErrorMatches, eligibleMachinesInUse)
 }
 
 func (s *UnitAssignmentSuite) TestAssignUnitMachinePlacementUpgradeSeriesLockError(c *gc.C) {

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -423,13 +423,11 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 }
 
 func (s *UnitSuite) TestPublicAddressSubordinate(c *gc.C) {
+	// A subordinate unit will never be created without the principal
+	// being assigned to a machine.
+	s.setAssignedMachineAddresses(c, s.unit)
 	subUnit := s.addSubordinateUnit(c)
 	address, err := subUnit.PublicAddress()
-	c.Assert(err, gc.Not(gc.IsNil))
-	c.Assert(address.Value, gc.Equals, "")
-
-	s.setAssignedMachineAddresses(c, s.unit)
-	address, err = subUnit.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(address.Value, gc.Equals, "public.address.example.com")
 }
@@ -527,13 +525,11 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 }
 
 func (s *UnitSuite) TestPrivateAddressSubordinate(c *gc.C) {
+	// A subordinate unit will never be created without the principal
+	// being assigned to a machine.
+	s.setAssignedMachineAddresses(c, s.unit)
 	subUnit := s.addSubordinateUnit(c)
 	address, err := subUnit.PrivateAddress()
-	c.Assert(err, gc.Not(gc.IsNil))
-	c.Assert(address.Value, gc.Equals, "")
-
-	s.setAssignedMachineAddresses(c, s.unit)
-	address, err = subUnit.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(address.Value, gc.Equals, "private.address.example.com")
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -77,6 +77,7 @@ type StateBackend interface {
 	EnsureDefaultSpaceSetting() error
 	RemoveControllerConfigMaxLogAgeAndSize() error
 	IncrementTasksSequence() error
+	AddMachineIDToSubordinates() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -312,4 +313,8 @@ func (s stateBackend) RemoveControllerConfigMaxLogAgeAndSize() error {
 
 func (s stateBackend) IncrementTasksSequence() error {
 	return state.IncrementTasksSequence(s.pool)
+}
+
+func (s stateBackend) AddMachineIDToSubordinates() error {
+	return state.AddMachineIDToSubordinates(s.pool)
 }

--- a/upgrades/steps_28.go
+++ b/upgrades/steps_28.go
@@ -5,9 +5,10 @@ package upgrades
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/names.v3"
+
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/worker/common/reboot"
-	"gopkg.in/juju/names.v3"
 )
 
 // stateStepsFor28 returns upgrade steps for Juju 2.8.0.
@@ -18,6 +19,13 @@ func stateStepsFor28() []Step {
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return context.State().IncrementTasksSequence()
+			},
+		},
+		&upgradeStep{
+			description: "add machine ID to subordinate units",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddMachineIDToSubordinates()
 			},
 		},
 	}

--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -25,6 +25,11 @@ func (s *steps28Suite) TestIncrementTasksSequence(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
+func (s *steps28Suite) TestAddMachineIDToSubordinates(c *gc.C) {
+	step := findStateStep(c, v280, "add machine ID to subordinate units")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 func (s *steps28Suite) TestPopulateRebootHandledFlagsForDeployedUnits(c *gc.C) {
 	step := findStep(c, v280, "ensure currently running units do not fire start hooks thinking a reboot has occurred")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.HostMachine})


### PR DESCRIPTION
Subordinate units are created when the principal unit enters the relation scope. At this time, the machine ID is known and never changes. Rather than have the subordinate unit always going throught the principal unit document to work out the assigned machine ID, have the subordinate document created with the machine ID from the principal.

There was quite a bit of test fallout with this change as many of the tests did not follow the real world and didn't bother assigning the principal unit to a machine before creating the subordinate. These tests have been updated.

One of the primary reasons for doing this piece of work is to allow the allwatcher to be able to process the initial units of a model without additional queries per unit. Before this change a principal unit would have read the machine document twice, once for the public address, and once for the private address. A subordinate would have read the principal document twice in addition to the machine document. The allwatcher change now stores the public and private address on the core/multiwatcher type, and the unit handling now doesn't need additional queries to get the machine ID. CAAS units still get the addresses directly from the unit itself as the logic there is more complicated and deals with entities that aren't yet stored in the multiwatcher store.

## QA steps

```sh
juju deploy ~jameinel/ubuntu-lite
juju deploy telegraf
juju relate ubuntu-lite telegraf
```
Observe that the telegraf unit gets an address in juju status.

## Documentation changes

Internal change only.
