### PR TITLE
Optional k8s charm pv

### DIFF
--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -107,27 +107,39 @@ type OperatorProvisioningInfo struct {
 	Version      version.Number
 	APIAddresses []string
 	Tags         map[string]string
-	CharmStorage storage.KubernetesFilesystemParams
+	CharmStorage *storage.KubernetesFilesystemParams
 }
 
-// OperatorProvisioningInfo returns the info needed to provision an operator.
-func (c *Client) OperatorProvisioningInfo() (OperatorProvisioningInfo, error) {
-	var result params.OperatorProvisioningInfo
-	if err := c.facade.FacadeCall("OperatorProvisioningInfo", nil, &result); err != nil {
+// OperatorProvisioningInfo returns the info needed to provision an operator for an application.
+func (c *Client) OperatorProvisioningInfo(applicationName string) (OperatorProvisioningInfo, error) {
+	args := params.Entities{[]params.Entity{
+		{Tag: names.NewApplicationTag(applicationName).String()},
+	}}
+	var result params.OperatorProvisioningInfoResults
+	if err := c.facade.FacadeCall("OperatorProvisioningInfo", args, &result); err != nil {
 		return OperatorProvisioningInfo{}, err
 	}
-	info := OperatorProvisioningInfo{
-		ImagePath:    result.ImagePath,
-		Version:      result.Version,
-		APIAddresses: result.APIAddresses,
-		Tags:         result.Tags,
-		CharmStorage: filesystemFromParams(result.CharmStorage),
+	if len(result.Results) != 1 {
+		return OperatorProvisioningInfo{}, errors.Errorf("expected one result, got %d", len(result.Results))
 	}
-	return info, nil
+	info := result.Results[0]
+	if err := info.Error; err != nil {
+		return OperatorProvisioningInfo{}, errors.Trace(err)
+	}
+	return OperatorProvisioningInfo{
+		ImagePath:    info.ImagePath,
+		Version:      info.Version,
+		APIAddresses: info.APIAddresses,
+		Tags:         info.Tags,
+		CharmStorage: filesystemFromParams(info.CharmStorage),
+	}, nil
 }
 
-func filesystemFromParams(in params.KubernetesFilesystemParams) storage.KubernetesFilesystemParams {
-	return storage.KubernetesFilesystemParams{
+func filesystemFromParams(in *params.KubernetesFilesystemParams) *storage.KubernetesFilesystemParams {
+	if in == nil {
+		return nil
+	}
+	return &storage.KubernetesFilesystemParams{
 		StorageName:  in.StorageName,
 		Provider:     storage.ProviderType(in.Provider),
 		Size:         in.Size,

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -155,37 +155,38 @@ func (s *provisionerSuite) TestLifeCount(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
 }
 
-func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
+func (s *provisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 	vers := version.MustParse("2.99.0")
 	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
 		c.Check(objType, gc.Equals, "CAASOperatorProvisioner")
 		c.Check(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "OperatorProvisioningInfo")
-		c.Assert(a, gc.IsNil)
-		c.Assert(result, gc.FitsTypeOf, &params.OperatorProvisioningInfo{})
-		*(result.(*params.OperatorProvisioningInfo)) = params.OperatorProvisioningInfo{
-			ImagePath:    "juju-operator-image",
-			Version:      vers,
-			APIAddresses: []string{"10.0.0.1:1"},
-			Tags:         map[string]string{"foo": "bar"},
-			CharmStorage: params.KubernetesFilesystemParams{
-				Size:        10,
-				Provider:    "kubernetes",
-				StorageName: "stor",
-				Tags:        map[string]string{"model": "model-tag"},
-				Attributes:  map[string]interface{}{"key": "value"},
-			},
-		}
+		c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.OperatorProvisioningInfoResults{})
+		*(result.(*params.OperatorProvisioningInfoResults)) = params.OperatorProvisioningInfoResults{
+			Results: []params.OperatorProvisioningInfo{{
+				ImagePath:    "juju-operator-image",
+				Version:      vers,
+				APIAddresses: []string{"10.0.0.1:1"},
+				Tags:         map[string]string{"foo": "bar"},
+				CharmStorage: &params.KubernetesFilesystemParams{
+					Size:        10,
+					Provider:    "kubernetes",
+					StorageName: "stor",
+					Tags:        map[string]string{"model": "model-tag"},
+					Attributes:  map[string]interface{}{"key": "value"},
+				},
+			}}}
 		return nil
 	})
-	info, err := client.OperatorProvisioningInfo()
+	info, err := client.OperatorProvisioningInfo("gitlab")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, caasoperatorprovisioner.OperatorProvisioningInfo{
 		ImagePath:    "juju-operator-image",
 		Version:      vers,
 		APIAddresses: []string{"10.0.0.1:1"},
 		Tags:         map[string]string{"foo": "bar"},
-		CharmStorage: storage.KubernetesFilesystemParams{
+		CharmStorage: &storage.KubernetesFilesystemParams{
 			Size:         10,
 			Provider:     "kubernetes",
 			StorageName:  "stor",
@@ -193,6 +194,22 @@ func (s *provisionerSuite) OperatorProvisioningInfo(c *gc.C) {
 			Attributes:   map[string]interface{}{"key": "value"},
 		},
 	})
+}
+
+func (s *provisionerSuite) TestOperatorProvisioningInfoArity(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASOperatorProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "OperatorProvisioningInfo")
+		c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.OperatorProvisioningInfoResults{})
+		*(result.(*params.OperatorProvisioningInfoResults)) = params.OperatorProvisioningInfoResults{
+			Results: []params.OperatorProvisioningInfo{{}, {}},
+		}
+		return nil
+	})
+	_, err := client.OperatorProvisioningInfo("gitlab")
+	c.Assert(err, gc.ErrorMatches, "expected one result, got 2")
 }
 
 func (s *provisionerSuite) TestIssueOperatorCertificate(c *gc.C) {

--- a/api/client.go
+++ b/api/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/juju/errors"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	csparams "gopkg.in/juju/charmrepo.v4/csclient/params"
@@ -420,17 +421,6 @@ func (c *Client) UploadCharm(curl *charm.URL, content io.ReadSeeker) (*charm.URL
 	return curl, nil
 }
 
-type minJujuVersionErr struct {
-	*errors.Err
-}
-
-func minVersionError(minver, jujuver version.Number) error {
-	err := errors.NewErr("charm's min version (%s) is higher than this juju model's version (%s)",
-		minver, jujuver)
-	err.SetLocation(1)
-	return minJujuVersionErr{&err}
-}
-
 func (c *Client) validateCharmVersion(ch charm.Charm) error {
 	minver := ch.Meta().MinJujuVersion
 	if minver != version.Zero {
@@ -439,9 +429,7 @@ func (c *Client) validateCharmVersion(ch charm.Charm) error {
 			return errors.Trace(err)
 		}
 
-		if minver.Compare(agentver) > 0 {
-			return minVersionError(minver, agentver)
-		}
+		return jujuversion.CheckJujuMinVersion(minver, agentver)
 	}
 	return nil
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type clientSuite struct {
@@ -330,7 +331,7 @@ func (s *clientSuite) TestMinVersionLocalCharm(c *gc.C) {
 		{"1.25.0", "1.25.1", false, false},
 		{"1.25.0", "1.25.0", false, true},
 		{"1.25.0", "1.25-alpha1", false, true},
-		{"1.25-alpha1", "1.25.0", false, false},
+		{"1.25-alpha1", "1.25.0", false, true},
 		{"2.0.0", "1.0.0", true, true},
 		{"1.0.0", "2.0.0", true, false},
 		{"1.25.0", "1.24.0", true, true},
@@ -339,7 +340,7 @@ func (s *clientSuite) TestMinVersionLocalCharm(c *gc.C) {
 		{"1.25.0", "1.25.1", true, false},
 		{"1.25.0", "1.25.0", true, true},
 		{"1.25.0", "1.25-alpha1", true, true},
-		{"1.25-alpha1", "1.25.0", true, false},
+		{"1.25-alpha1", "1.25.0", true, true},
 	}
 	client := s.APIState.Client()
 	for _, t := range tests {
@@ -387,7 +388,7 @@ func testMinVer(client *api.Client, t minverTest, c *gc.C) {
 	} else {
 		if err == nil {
 			c.Errorf("Unexpected nil error for jujuver %v, minver %v", t.juju, t.charm)
-		} else if !api.IsMinVersionError(err) {
+		} else if !jujuversion.IsMinVersionError(err) {
 			c.Errorf("Wrong error for jujuver %v, minver %v: expected minVersionError, got: %#v", t.juju, t.charm, err)
 		}
 	}

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -149,13 +149,6 @@ func (f *resultCaller) RawAPICaller() base.APICaller {
 	return &rawAPICaller{}
 }
 
-// IsMinVersionError returns true if the given error was caused by the charm
-// having a minjujuversion higher than the juju model's version.
-func IsMinVersionError(err error) bool {
-	_, ok := errors.Cause(err).(minJujuVersionErr)
-	return ok
-}
-
 func ExtractMacaroons(conn Connection) ([]macaroon.Slice, error) {
 	st, ok := conn.(*state)
 	if !ok {

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -434,7 +434,9 @@ func (s *applicationSuite) TestMinJujuVersionTooHigh(c *gc.C) {
 	err := application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{
 		URL: curl.String(),
 	}, s.openRepo)
-	match := fmt.Sprintf(`charm's min version (999.999.999) is higher than this juju model's version (%s)`, jujuversion.Current)
+	vers := jujuversion.Current
+	vers.Tag = ""
+	match := fmt.Sprintf(`charm's min version (999.999.999) is higher than this juju model's version (%s)`, vers)
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(match))
 }
 

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -131,7 +131,7 @@ func AddCharmWithAuthorizationAndRepo(st State, args params.AddCharmWithAuthoriz
 		return errors.Trace(err)
 	}
 
-	if err := checkJujuMinVersion(downloadedCharm); err != nil {
+	if err := jujuversion.CheckJujuMinVersion(downloadedCharm.Meta().MinJujuVersion, jujuversion.Current); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -242,14 +242,6 @@ func openCSClient(args OpenCSRepoParams) (*csclient.Client, error) {
 	return csClient, nil
 }
 
-func checkJujuMinVersion(ch charm.Charm) (err error) {
-	minver := ch.Meta().MinJujuVersion
-	if minver != version.Zero && minver.Compare(jujuversion.Current) > 0 {
-		return minVersionError(minver, jujuversion.Current)
-	}
-	return nil
-}
-
 func checkCAASMinVersion(ch charm.Charm, caasVersion *version.Number) (err error) {
 	// check caas min version.
 	charmDeployment := ch.Meta().Deployment
@@ -271,17 +263,6 @@ func checkCAASMinVersion(ch charm.Charm, caasVersion *version.Number) (err error
 		))
 	}
 	return nil
-}
-
-type minJujuVersionErr struct {
-	*errors.Err
-}
-
-func minVersionError(minver, jujuver version.Number) error {
-	err := errors.NewErr("charm's min version (%s) is higher than this juju model's version (%s)",
-		minver, jujuver)
-	err.SetLocation(1)
-	return minJujuVersionErr{&err}
 }
 
 // CharmArchive is the data that needs to be stored for a charm archive in

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -6,6 +6,7 @@ package caasoperatorprovisioner_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/tomb.v2"
 
@@ -60,6 +61,14 @@ func (st *mockState) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
 	return []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(1, "10.0.0.1"),
 	}, nil
+}
+
+func (st *mockState) Application(appName string) (caasoperatorprovisioner.Application, error) {
+	st.MethodCall(st, "Application", appName)
+	if appName != "gitlab" {
+		return nil, errors.NotFoundf("app %v", appName)
+	}
+	return st.app, nil
 }
 
 func (st *mockState) Model() (caasoperatorprovisioner.Model, error) {
@@ -119,6 +128,7 @@ type mockApplication struct {
 	state.Authenticator
 	tag      names.Tag
 	password string
+	charm    caasoperatorprovisioner.Charm
 }
 
 func (m *mockApplication) Tag() names.Tag {
@@ -132,6 +142,18 @@ func (m *mockApplication) SetPassword(password string) error {
 
 func (a *mockApplication) Life() state.Life {
 	return state.Alive
+}
+
+func (a *mockApplication) Charm() (caasoperatorprovisioner.Charm, bool, error) {
+	return a.charm, false, nil
+}
+
+type mockCharm struct {
+	meta *charm.Meta
+}
+
+func (ch *mockCharm) Meta() *charm.Meta {
+	return ch.meta
 }
 
 type mockWatcher struct {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -337,21 +337,21 @@ func filesystemParams(
 	modelConfig *config.Config,
 	poolManager poolmanager.PoolManager,
 	registry storage.ProviderRegistry,
-) (params.KubernetesFilesystemParams, error) {
+) (*params.KubernetesFilesystemParams, error) {
 
 	filesystemTags, err := storagecommon.StorageTags(nil, modelConfig.UUID(), controllerUUID, modelConfig)
 	if err != nil {
-		return params.KubernetesFilesystemParams{}, errors.Annotate(err, "computing storage tags")
+		return nil, errors.Annotate(err, "computing storage tags")
 	}
 	filesystemTags[tags.JujuStorageOwner] = app.Name()
 
 	storageClassName, _ := modelConfig.AllAttrs()[provider.WorkloadStorageKey].(string)
 	if cons.Pool == "" && storageClassName == "" {
-		return params.KubernetesFilesystemParams{}, errors.Errorf("storage pool for %q must be specified since there's no model default storage class", storageName)
+		return nil, errors.Errorf("storage pool for %q must be specified since there's no model default storage class", storageName)
 	}
 	fsParams, err := caasoperatorprovisioner.CharmStorageParams(controllerUUID, storageClassName, modelConfig, cons.Pool, poolManager, registry)
 	if err != nil {
-		return params.KubernetesFilesystemParams{}, errors.Maskf(err, "getting filesystem storage parameters")
+		return nil, errors.Maskf(err, "getting filesystem storage parameters")
 	}
 
 	fsParams.Size = cons.Size
@@ -409,7 +409,7 @@ func (f *Facade) applicationFilesystemParams(
 				ReadOnly:   charmStorage.ReadOnly,
 			}
 			fsParams.Attachment = &filesystemAttachmentParams
-			allFilesystemParams = append(allFilesystemParams, fsParams)
+			allFilesystemParams = append(allFilesystemParams, *fsParams)
 		}
 	}
 	return allFilesystemParams, nil

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6690,8 +6690,11 @@
                 "OperatorProvisioningInfo": {
                     "type": "object",
                     "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
                         "Result": {
-                            "$ref": "#/definitions/OperatorProvisioningInfo"
+                            "$ref": "#/definitions/OperatorProvisioningInfoResults"
                         }
                     }
                 },
@@ -7090,6 +7093,9 @@
                         "charm-storage": {
                             "$ref": "#/definitions/KubernetesFilesystemParams"
                         },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
                         "image-path": {
                             "type": "string"
                         },
@@ -7109,8 +7115,22 @@
                     "required": [
                         "image-path",
                         "version",
-                        "api-addresses",
-                        "charm-storage"
+                        "api-addresses"
+                    ]
+                },
+                "OperatorProvisioningInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OperatorProvisioningInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "StringResult": {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -310,13 +310,19 @@ type ConfigResult struct {
 	Error  *Error                 `json:"error,omitempty"`
 }
 
+// OperatorProvisioningInfoResults holds OperatorProvisioningInfo results.
+type OperatorProvisioningInfoResults struct {
+	Results []OperatorProvisioningInfo `json:"results"`
+}
+
 // OperatorProvisioningInfo holds info need to provision an operator.
 type OperatorProvisioningInfo struct {
-	ImagePath    string                     `json:"image-path"`
-	Version      version.Number             `json:"version"`
-	APIAddresses []string                   `json:"api-addresses"`
-	Tags         map[string]string          `json:"tags,omitempty"`
-	CharmStorage KubernetesFilesystemParams `json:"charm-storage"`
+	ImagePath    string                      `json:"image-path"`
+	Version      version.Number              `json:"version"`
+	APIAddresses []string                    `json:"api-addresses"`
+	Tags         map[string]string           `json:"tags,omitempty"`
+	CharmStorage *KubernetesFilesystemParams `json:"charm-storage,omitempty"`
+	Error        *Error                      `json:"error,omitempty"`
 }
 
 // IssueOperatorCertificateResult contains an x509 certificate

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -371,9 +371,9 @@ type OperatorConfig struct {
 	// Version is the Juju version of the operator image.
 	Version version.Number
 
-	// CharmStorage defines parameters used to create storage
-	// for operators to use for charm state.
-	CharmStorage CharmStorageParams
+	// CharmStorage defines parameters used to optionally
+	//create storage for operators to use for charm state.
+	CharmStorage *CharmStorageParams
 
 	// AgentConf is the contents of the agent.conf file.
 	AgentConf []byte

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -372,7 +372,7 @@ type OperatorConfig struct {
 	Version version.Number
 
 	// CharmStorage defines parameters used to optionally
-	//create storage for operators to use for charm state.
+	// create storage for operators to use for charm state.
 	CharmStorage *CharmStorageParams
 
 	// AgentConf is the contents of the agent.conf file.

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -215,12 +215,47 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	podWithoutStorage := pod
 
 	numPods := int32(1)
-	statefulset := &apps.StatefulSet{
+	operatorPvc, err := k.operatorVolumeClaim(appName, operatorName, config.CharmStorage)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if operatorPvc != nil {
+		logger.Debugf("using persistent volume claim for operator %s: %+v", appName, operatorPvc)
+		statefulset := &apps.StatefulSet{
+			ObjectMeta: v1.ObjectMeta{
+				Name:        operatorName,
+				Labels:      labels,
+				Annotations: annotations.ToMap()},
+			Spec: apps.StatefulSetSpec{
+				Replicas: &numPods,
+				Selector: &v1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: core.PodTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Labels:      labels,
+						Annotations: pod.Annotations,
+					},
+				},
+				PodManagementPolicy: apps.ParallelPodManagement,
+			},
+		}
+		statefulset.Spec.VolumeClaimTemplates = []core.PersistentVolumeClaim{*operatorPvc}
+		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, core.VolumeMount{
+			Name:      operatorPvc.Name,
+			MountPath: agent.BaseDir(agentPath),
+		})
+		statefulset.Spec.Template.Spec = pod.Spec
+		err = k.ensureStatefulSet(statefulset, podWithoutStorage.Spec)
+		return errors.Annotatef(err, "creating or updating %v operator StatefulSet", appName)
+	}
+	// We have an operator that doesn't need storage so use a deployment controller.
+	deployment := &apps.Deployment{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        operatorName,
 			Labels:      labels,
 			Annotations: annotations.ToMap()},
-		Spec: apps.StatefulSetSpec{
+		Spec: apps.DeploymentSpec{
 			Replicas: &numPods,
 			Selector: &v1.LabelSelector{
 				MatchLabels: labels,
@@ -230,26 +265,12 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 					Labels:      labels,
 					Annotations: pod.Annotations,
 				},
+				Spec: pod.Spec,
 			},
-			PodManagementPolicy: apps.ParallelPodManagement,
 		},
 	}
-	operatorPvc, err := k.operatorVolumeClaim(appName, operatorName, config.CharmStorage)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if operatorPvc != nil {
-		logger.Debugf("using persistent volume claim for operator %s: %+v", appName, operatorPvc)
-		statefulset.Spec.VolumeClaimTemplates = []core.PersistentVolumeClaim{*operatorPvc}
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, core.VolumeMount{
-			Name:      operatorPvc.Name,
-			MountPath: agent.BaseDir(agentPath),
-		})
-	}
-
-	statefulset.Spec.Template.Spec = pod.Spec
-	err = k.ensureStatefulSet(statefulset, podWithoutStorage.Spec)
-	return errors.Annotatef(err, "creating or updating %v operator StatefulSet", appName)
+	err = k.ensureDeployment(deployment)
+	return errors.Annotatef(err, "creating or updating %v operator Deployment", appName)
 }
 
 func (k *kubernetesClient) operatorVolumeClaim(appName, operatorName string, storageParams *caas.CharmStorageParams) (*core.PersistentVolumeClaim, error) {
@@ -261,13 +282,13 @@ func (k *kubernetesClient) operatorVolumeClaim(appName, operatorName string, sto
 	}
 	if storageParams == nil {
 		existingClaim, err := k.getPVC(operatorVolumeClaim)
-		if err != nil && !errors.IsNotFound(err) {
-			return nil, errors.Trace(err)
-		}
-		if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debugf("no existing volume claim for operator %s", operatorName)
 			return nil, nil
+		} else if err != nil {
+			return nil, errors.Annotatef(err, "getting operator volume claim")
 		}
-		return existingClaim, errors.Trace(err)
+		return existingClaim, nil
 	}
 
 	// Charm needs storage so set it up.
@@ -318,9 +339,17 @@ func (k *kubernetesClient) validateOperatorStorage() (string, error) {
 // application exists, and whether the operator is terminating.
 func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, error) {
 	operatorName := k.operatorName(appName)
-	exists, terminating, err := k.operatorStatefulSetExists(appName, operatorName)
+	// Operator may be deployed as either a statefulset or deployment.
+	// Check for deployment first as new charms will use a deployment.
+	exists, terminating, err := k.operatorDeploymentExists(appName, operatorName)
 	if err != nil {
 		return caas.OperatorState{}, errors.Trace(err)
+	}
+	if !exists {
+		exists, terminating, err = k.operatorStatefulSetExists(appName, operatorName)
+		if err != nil {
+			return caas.OperatorState{}, errors.Trace(err)
+		}
 	}
 	if exists || terminating {
 		if terminating {
@@ -332,7 +361,7 @@ func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, e
 	}
 	checks := []struct {
 		label string
-		check func(appName string, operatorName string) (bool, error)
+		check func(appName string, operatorName string) (bool, bool, error)
 	}{
 		{"rbac", k.operatorRBACResourcesRemaining},
 		{"config map", k.operatorConfigMapExists},
@@ -340,14 +369,17 @@ func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, e
 		{"service", k.operatorServiceExists},
 		{"secret", k.operatorSecretExists},
 		{"deployment", k.operatorDeploymentExists},
+		{"statefulset", k.operatorStatefulSetExists},
 		{"pods", k.operatorPodExists},
 	}
 	for _, c := range checks {
-		exists, err := c.check(appName, operatorName)
+		exists, _, err := c.check(appName, operatorName)
 		if err != nil {
 			return caas.OperatorState{}, errors.Annotatef(err, "%s resource check", c.label)
 		}
 		if exists {
+			// Terminating is always set to true regardless of whether the resource is falled as terminating
+			// since it's the overall state that is reported back.
 			logger.Debugf("operator %q exists and is terminating due to dangling %s resource(s)", c.label)
 			return caas.OperatorState{Exists: true, Terminating: true}, nil
 		}
@@ -367,109 +399,109 @@ func (k *kubernetesClient) operatorStatefulSetExists(appName string, operatorNam
 	return true, operator.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorRBACResourcesRemaining(appName string, operatorName string) (bool, error) {
-	_, err := k.getServiceAccount(operatorName)
+func (k *kubernetesClient) operatorRBACResourcesRemaining(appName string, operatorName string) (exists bool, terminating bool, err error) {
+	sa, err := k.getServiceAccount(operatorName)
 	if errors.IsNotFound(err) {
 		// continue
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	} else {
-		return true, nil
+		return true, sa.DeletionTimestamp != nil, nil
 	}
-	_, err = k.getRole(operatorName)
+	r, err := k.getRole(operatorName)
 	if errors.IsNotFound(err) {
 		// continue
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	} else {
-		return true, nil
+		return true, r.DeletionTimestamp != nil, nil
 	}
-	_, err = k.getRoleBinding(operatorName)
+	rb, err := k.getRoleBinding(operatorName)
 	if errors.IsNotFound(err) {
 		// continue
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	} else {
-		return true, nil
+		return true, rb.DeletionTimestamp != nil, nil
 	}
-	return false, nil
+	return false, false, nil
 }
 
-func (k *kubernetesClient) operatorConfigMapExists(appName string, operatorName string) (bool, error) {
+func (k *kubernetesClient) operatorConfigMapExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
 	configMaps := k.client().CoreV1().ConfigMaps(k.namespace)
 	configMapName := operatorConfigMapName(operatorName)
-	_, err := configMaps.Get(configMapName, v1.GetOptions{})
+	cm, err := configMaps.Get(configMapName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		return false, nil
+		return false, false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return true, nil
+	return true, cm.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorConfigurationsConfigMapExists(appName string, operatorName string) (bool, error) {
+func (k *kubernetesClient) operatorConfigurationsConfigMapExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
 	legacy := isLegacyName(operatorName)
 	configMaps := k.client().CoreV1().ConfigMaps(k.namespace)
 	configMapName := appName + "-configurations-config"
 	if legacy {
 		configMapName = "juju-" + configMapName
 	}
-	_, err := configMaps.Get(configMapName, v1.GetOptions{})
+	cm, err := configMaps.Get(configMapName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		return false, nil
+		return false, false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return true, nil
+	return true, cm.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorServiceExists(appName string, operatorName string) (bool, error) {
+func (k *kubernetesClient) operatorServiceExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
 	services := k.client().CoreV1().Services(k.namespace)
-	_, err := services.Get(operatorName, v1.GetOptions{})
+	s, err := services.Get(operatorName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		return false, nil
+		return false, false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return true, nil
+	return true, s.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorSecretExists(appName string, operatorName string) (bool, error) {
+func (k *kubernetesClient) operatorSecretExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
 	legacy := isLegacyName(operatorName)
 	deploymentName := appName
 	if legacy {
 		deploymentName = "juju-" + appName
 	}
 	secretName := appSecretName(deploymentName, operatorContainerName)
-	_, err := k.getSecret(secretName)
+	s, err := k.getSecret(secretName)
 	if errors.IsNotFound(err) {
-		return false, nil
+		return false, false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return true, nil
+	return true, s.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorDeploymentExists(appName string, operatorName string) (bool, error) {
+func (k *kubernetesClient) operatorDeploymentExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
 	deployments := k.client().AppsV1().Deployments(k.namespace)
-	_, err := deployments.Get(operatorName, v1.GetOptions{})
+	operator, err := deployments.Get(operatorName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		return false, nil
+		return false, false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return true, nil
+	return true, operator.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorPodExists(appName string, operatorName string) (bool, error) {
+func (k *kubernetesClient) operatorPodExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
 	pods := k.client().CoreV1().Pods(k.namespace)
 	podList, err := pods.List(v1.ListOptions{
 		LabelSelector: operatorSelector(appName),
 	})
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return len(podList.Items) != 0, nil
+	return len(podList.Items) != 0, false, nil
 }
 
 // DeleteOperator deletes the specified operator.

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -50,8 +50,8 @@ var operatorServiceArg = &core.Service{
 	},
 }
 
-func operatorStatefulSetArg(numUnits int32, scName, serviceAccountName string) *appsv1.StatefulSet {
-	operatorPodspec := core.PodSpec{
+func operatorPodSpec(serviceAccountName string, withStorage bool) core.PodSpec {
+	spec := core.PodSpec{
 		ServiceAccountName:           serviceAccountName,
 		AutomountServiceAccountToken: boolPtr(true),
 		Containers: []core.Container{{
@@ -101,9 +101,6 @@ $JUJU_TOOLS_DIR/jujud caasoperator --application-name=test --debug
 				Name:      "test-operator-config",
 				MountPath: "path/to/agent/agents/application-test/operator.yaml",
 				SubPath:   "operator.yaml",
-			}, {
-				Name:      "charm",
-				MountPath: "path/to/agent/agents",
 			}},
 		}},
 		Volumes: []core.Volume{{
@@ -124,6 +121,16 @@ $JUJU_TOOLS_DIR/jujud caasoperator --application-name=test --debug
 			},
 		}},
 	}
+	if withStorage {
+		spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, core.VolumeMount{
+			Name:      "charm",
+			MountPath: "path/to/agent/agents",
+		})
+	}
+	return spec
+}
+
+func operatorStatefulSetArg(numUnits int32, scName, serviceAccountName string) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test-operator",
@@ -150,7 +157,7 @@ $JUJU_TOOLS_DIR/jujud caasoperator --application-name=test --debug
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 					},
 				},
-				Spec: operatorPodspec,
+				Spec: operatorPodSpec(serviceAccountName, true),
 			},
 			VolumeClaimTemplates: []core.PersistentVolumeClaim{{
 				ObjectMeta: v1.ObjectMeta{
@@ -169,6 +176,39 @@ $JUJU_TOOLS_DIR/jujud caasoperator --application-name=test --debug
 				},
 			}},
 			PodManagementPolicy: apps.ParallelPodManagement,
+		},
+	}
+}
+
+func operatorDeploymentArg(numUnits int32, serviceAccountName string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-operator",
+			Labels: map[string]string{
+				"juju-operator": "test",
+			},
+			Annotations: operatorAnnotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &numUnits,
+			Selector: &v1.LabelSelector{
+				MatchLabels: map[string]string{"juju-operator": "test"},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"juju-operator": "test",
+					},
+					Annotations: map[string]string{
+						"fred":               "mary",
+						"juju-version":       "2.99.0",
+						"juju.io/controller": testing.ControllerTag.Id(),
+						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
+						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
+					},
+				},
+				Spec: operatorPodSpec(serviceAccountName, false),
+			},
 		},
 	}
 }
@@ -615,7 +655,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorUpdate(c *gc.C) {
 	}
 }
 
-func (s *K8sBrokerSuite) TestEnsureOperatorNoStorage(c *gc.C) {
+func (s *K8sBrokerSuite) TestEnsureOperatorNoStorageExistingPVC(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
@@ -727,10 +767,122 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoStorage(c *gc.C) {
 			Return(existingCharmPvc, nil),
 
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
-			Return(statefulSetArg, nil),
+			Return(nil, s.k8sAlreadyExistsError()),
 		s.mockStatefulSets.EXPECT().Get("test-operator", v1.GetOptions{}).
 			Return(statefulSetArg, nil),
 		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
+			Return(nil, nil),
+	)
+
+	err := s.broker.EnsureOperator("test", "path/to/agent", &caas.OperatorConfig{
+		OperatorImagePath: "/path/to/image",
+		Version:           version.MustParse("2.99.0"),
+		AgentConf:         []byte("agent-conf-data"),
+		OperatorInfo:      []byte("operator-info-data"),
+		ResourceTags: map[string]string{
+			"fred":                 "mary",
+			"juju-controller-uuid": testing.ControllerTag.Id(),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *K8sBrokerSuite) TestEnsureOperatorNoStorage(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	configMapArg := &core.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "test-operator-config",
+			Labels:      map[string]string{"juju-app": "test"},
+			Annotations: operatorAnnotations,
+		},
+		Data: map[string]string{
+			"test-agent.conf": "agent-conf-data",
+			"operator.yaml":   "operator-info-data",
+		},
+	}
+
+	svcAccount := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "test-operator",
+			Namespace:   "test",
+			Labels:      map[string]string{"juju-operator": "test"},
+			Annotations: operatorAnnotations,
+		},
+		AutomountServiceAccountToken: boolPtr(true),
+	}
+	role := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "test-operator",
+			Namespace:   "test",
+			Labels:      map[string]string{"juju-operator": "test"},
+			Annotations: operatorAnnotations,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/exec"},
+				Verbs:     []string{"create"},
+			},
+		},
+	}
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        "test-operator",
+			Namespace:   "test",
+			Labels:      map[string]string{"juju-operator": "test"},
+			Annotations: operatorAnnotations,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "test-operator",
+			Kind: "Role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "test-operator",
+				Namespace: "test",
+			},
+		},
+	}
+	deploymentArg := operatorDeploymentArg(1, "test-operator")
+
+	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get("juju-operator-test", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Update(operatorServiceArg).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockServices.EXPECT().Create(operatorServiceArg).
+			Return(nil, nil),
+		s.mockServices.EXPECT().Get("test-operator", v1.GetOptions{}).
+			Return(&core.Service{Spec: core.ServiceSpec{ClusterIP: "10.1.2.3"}}, nil),
+
+		// ensure RBAC resources.
+		s.mockServiceAccounts.EXPECT().Create(svcAccount).Return(svcAccount, nil),
+		s.mockRoles.EXPECT().Create(role).Return(role, nil),
+		s.mockRoleBindings.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator=test"}).
+			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
+		s.mockRoleBindings.EXPECT().Create(rb).Return(rb, nil),
+		s.mockConfigMaps.EXPECT().Update(configMapArg).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockConfigMaps.EXPECT().Create(configMapArg).
+			Return(configMapArg, nil),
+
+		// check for existing PVC in case of charm upgrade
+		s.mockPersistentVolumeClaims.EXPECT().Get("charm", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+
+		s.mockDeployments.EXPECT().Update(deploymentArg).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockDeployments.EXPECT().Create(deploymentArg).
 			Return(nil, nil),
 	)
 
@@ -996,6 +1148,8 @@ func (s *K8sBrokerSuite) TestOperatorExists(c *gc.C) {
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
+		s.mockDeployments.EXPECT().Get("test-app-operator", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{}).
 			Return(&apps.StatefulSet{}, nil),
 	)
@@ -1014,6 +1168,8 @@ func (s *K8sBrokerSuite) TestOperatorExistsTerminating(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockDeployments.EXPECT().Get("test-app-operator", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{}).
 			Return(&apps.StatefulSet{
@@ -1038,6 +1194,8 @@ func (s *K8sBrokerSuite) TestOperatorExistsTerminated(c *gc.C) {
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
+		s.mockDeployments.EXPECT().Get("test-app-operator", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockServiceAccounts.EXPECT().Get("test-app-operator", v1.GetOptions{}).
@@ -1055,6 +1213,8 @@ func (s *K8sBrokerSuite) TestOperatorExistsTerminated(c *gc.C) {
 		s.mockSecrets.EXPECT().Get("test-app-juju-operator-secret", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockDeployments.EXPECT().Get("test-app-operator", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockPods.EXPECT().List(v1.ListOptions{
 			LabelSelector: "juju-operator=test-app",
@@ -1076,6 +1236,8 @@ func (s *K8sBrokerSuite) TestOperatorExistsTerminatedMostly(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-test-app", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockDeployments.EXPECT().Get("test-app-operator", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Get("test-app-operator", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),

--- a/caas/kubernetes/provider/providerconfig.go
+++ b/caas/kubernetes/provider/providerconfig.go
@@ -7,15 +7,33 @@ import (
 	"fmt"
 
 	"github.com/juju/schema"
+	"github.com/juju/version"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs/config"
 )
 
 const (
+	// WorkloadStorageKey is the model config attribute used to specify
+	//the storage class for provisioning workload storage.
 	WorkloadStorageKey = "workload-storage"
+
+	// OperatorStorageKey is the model config attribute used to specify
+	//the storage class for provisioning operator storage.
 	OperatorStorageKey = "operator-storage"
 )
+
+var (
+	// jujuVersionForControllerStorage is the Juju version which first
+	// added the ability to store charm state in the controller.
+	jujuVersionForControllerStorage = version.MustParse("2.8.0")
+)
+
+// RequireOperatorStorage returns true if the specified min-juju-version
+// defined by a charm is such that the charm requires operator storage.
+func RequireOperatorStorage(charmMinJujuVersion version.Number) bool {
+	return charmMinJujuVersion.Compare(jujuVersionForControllerStorage) < 0
+}
 
 var configSchema = environschema.Fields{
 	WorkloadStorageKey: {

--- a/caas/kubernetes/provider/providerconfig.go
+++ b/caas/kubernetes/provider/providerconfig.go
@@ -15,11 +15,11 @@ import (
 
 const (
 	// WorkloadStorageKey is the model config attribute used to specify
-	//the storage class for provisioning workload storage.
+	// the storage class for provisioning workload storage.
 	WorkloadStorageKey = "workload-storage"
 
 	// OperatorStorageKey is the model config attribute used to specify
-	//the storage class for provisioning operator storage.
+	// the storage class for provisioning operator storage.
 	OperatorStorageKey = "operator-storage"
 )
 

--- a/state/charm.go
+++ b/state/charm.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
-	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/macaroon.v2"
@@ -608,7 +607,7 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
 
-	if err := validateCharmVersion(info.Charm); err != nil {
+	if err := jujuversion.CheckJujuMinVersion(info.Charm.Meta().MinJujuVersion, jujuversion.Current); err != nil {
 		return nil, errors.Trace(err)
 	}
 	model, err := st.Model()
@@ -652,16 +651,6 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 
 type hasMeta interface {
 	Meta() *charm.Meta
-}
-
-func validateCharmVersion(ch hasMeta) error {
-	minver := ch.Meta().MinJujuVersion
-	if minver != version.Zero {
-		if minver.Compare(jujuversion.Current) > 0 {
-			return errors.Errorf("Charm's min version (%s) is higher than this juju model's version (%s)", minver, jujuversion.Current)
-		}
-	}
-	return nil
 }
 
 func validateCharmSeries(modelType ModelType, series string, ch hasMeta) error {

--- a/state/state.go
+++ b/state/state.go
@@ -1230,7 +1230,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return nil, errors.Errorf("AttachStorage is non-empty but NumUnits is %d, must be 1", args.NumUnits)
 	}
 
-	if err := validateCharmVersion(args.Charm); err != nil {
+	if err := jujuversion.CheckJujuMinVersion(args.Charm.Meta().MinJujuVersion, jujuversion.Current); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -4,8 +4,10 @@
 package version
 
 import (
+	"fmt"
 	"runtime"
 
+	jc "github.com/juju/testing/checkers"
 	semversion "github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -63,4 +65,52 @@ func (*suite) TestIsDev(c *gc.C) {
 
 func (s *suite) TestCompiler(c *gc.C) {
 	c.Assert(Compiler, gc.Equals, runtime.Compiler)
+}
+
+func (s *suite) TestCheckJujuMinVersion(c *gc.C) {
+	for _, test := range []struct {
+		toCheck     semversion.Number
+		jujuVersion semversion.Number
+		error       bool
+	}{
+		{
+			toCheck:     semversion.Zero,
+			jujuVersion: semversion.MustParse("2.8.0"),
+			error:       false,
+		}, {
+			toCheck:     semversion.MustParse("2.8.0"),
+			jujuVersion: semversion.MustParse("2.8.0"),
+			error:       false,
+		}, {
+			toCheck:     semversion.MustParse("2.8.0"),
+			jujuVersion: semversion.MustParse("2.8.1"),
+			error:       false,
+		}, {
+			toCheck:     semversion.MustParse("2.8.0"),
+			jujuVersion: semversion.MustParse("2.9.0"),
+			error:       false,
+		}, {
+			toCheck:     semversion.MustParse("2.8.0"),
+			jujuVersion: semversion.MustParse("3.0.0"),
+			error:       false,
+		}, {
+			toCheck:     semversion.MustParse("2.8.0"),
+			jujuVersion: semversion.MustParse("2.8-beta1"),
+			error:       false,
+		}, {
+			toCheck:     semversion.MustParse("2.8.0"),
+			jujuVersion: semversion.MustParse("2.7.0"),
+			error:       true,
+		},
+	} {
+		err := CheckJujuMinVersion(test.toCheck, test.jujuVersion)
+		if test.error {
+			c.Assert(err, jc.Satisfies, IsMinVersionError)
+			c.Assert(err.Error(), gc.Equals,
+				fmt.Sprintf("charm's min version (%s) is higher than this juju model's version (%s)",
+					test.toCheck, test.jujuVersion))
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
 }

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -136,12 +136,16 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C, exists, terminatin
 	c.Assert(config.OperatorImagePath, gc.Equals, "juju-operator-image")
 	c.Assert(config.Version, gc.Equals, version.MustParse("2.99.0"))
 	c.Assert(config.ResourceTags, jc.DeepEquals, map[string]string{"fred": "mary"})
-	c.Assert(config.CharmStorage, jc.DeepEquals, caas.CharmStorageParams{
-		Provider:     "kubernetes",
-		Size:         uint64(1024),
-		ResourceTags: map[string]string{"foo": "bar"},
-		Attributes:   map[string]interface{}{"key": "value"},
-	})
+	if s.provisionerFacade.withStorage {
+		c.Assert(config.CharmStorage, jc.DeepEquals, &caas.CharmStorageParams{
+			Provider:     "kubernetes",
+			Size:         uint64(1024),
+			ResourceTags: map[string]string{"foo": "bar"},
+			Attributes:   map[string]interface{}{"key": "value"},
+		})
+	} else {
+		c.Assert(config.CharmStorage, gc.IsNil)
+	}
 	if updateCerts {
 		c.Assert(config.ConfigMapGeneration, gc.Equals, int64(1))
 	} else {
@@ -177,6 +181,7 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C, exists, terminatin
 		}
 		s.provisionerFacade.stub.CheckCallNames(c, callNames...)
 		c.Assert(s.provisionerFacade.stub.Calls()[0].Args[0], gc.Equals, "myapp")
+		c.Assert(s.provisionerFacade.stub.Calls()[1].Args[0], gc.Equals, "myapp")
 		return
 	}
 
@@ -190,6 +195,14 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C, exists, terminatin
 }
 
 func (s *CAASProvisionerSuite) TestNewApplicationCreatesNewOperator(c *gc.C) {
+	w := s.assertWorker(c)
+	defer workertest.CleanKill(c, w)
+
+	s.assertOperatorCreated(c, false, false, false)
+}
+
+func (s *CAASProvisionerSuite) TestNewApplicationNoStorage(c *gc.C) {
+	s.provisionerFacade.withStorage = false
 	w := s.assertWorker(c)
 	defer workertest.CleanKill(c, w)
 


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?

There's a change to api parameters but it's for a controller facade.

----

## Description of change

A k8s charm can now signal that it does not require a PV to be created for charm state storage. It does this by setting min-juju-version=2.8.0. Existing charms which do require PV storage are still catered for, and if a charm is upgraded, any PV is retained.

The first commit factors out the min version check to a common function. It has been tweaked to allow a charm specifying a major.minor.0 version to work with a beta/rc (to allow testing).

## QA steps

Deploy a k8s charm
Edit the charm to add min-juju-version=2.8.0
upgrade the charm and check the PV and PVC are still used
deploy the edited charm again as a different application
check that no operator PV is created

