### PR TITLE
Fix 1867783 Charm deployment hangs with 2.8

### DIFF
--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -146,8 +146,11 @@ type OperatorCertificate struct {
 
 // IssueOperatorCertificate issues an x509 certificate for use by the specified application operator.
 func (c *Client) IssueOperatorCertificate(applicationName string) (OperatorCertificate, error) {
+	if !names.IsValidApplication(applicationName) {
+		return OperatorCertificate{}, errors.NotValidf("application name %q", applicationName)
+	}
 	args := params.Entities{[]params.Entity{
-		{Tag: applicationName},
+		{Tag: names.NewApplicationTag(applicationName).String()},
 	}}
 	var result params.IssueOperatorCertificateResults
 	if err := c.facade.FacadeCall("IssueOperatorCertificate", args, &result); err != nil {

--- a/api/caasoperatorprovisioner/client_test.go
+++ b/api/caasoperatorprovisioner/client_test.go
@@ -200,7 +200,7 @@ func (s *provisionerSuite) TestIssueOperatorCertificate(c *gc.C) {
 		c.Check(objType, gc.Equals, "CAASOperatorProvisioner")
 		c.Check(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "IssueOperatorCertificate")
-		c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "appymcappface"}}})
+		c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "application-appymcappface"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.IssueOperatorCertificateResults{})
 		*(result.(*params.IssueOperatorCertificateResults)) = params.IssueOperatorCertificateResults{
 			Results: []params.IssueOperatorCertificateResult{{
@@ -225,7 +225,7 @@ func (s *provisionerSuite) TestIssueOperatorCertificateArity(c *gc.C) {
 		c.Check(objType, gc.Equals, "CAASOperatorProvisioner")
 		c.Check(id, gc.Equals, "")
 		c.Assert(request, gc.Equals, "IssueOperatorCertificate")
-		c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "appymcappface"}}})
+		c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "application-appymcappface"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.IssueOperatorCertificateResults{})
 		return nil
 	})

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -383,4 +383,9 @@ type OperatorConfig struct {
 
 	// ResourceTags is a set of tags to set on the operator pod.
 	ResourceTags map[string]string
+
+	// ConfigMapGeneration is set when updating the operator config
+	// map for consistency in Read after Write and Write after Write.
+	// A value of 0 is ignored.
+	ConfigMapGeneration int64
 }

--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -101,7 +101,7 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs map[s
 		s.mockStatefulSets.EXPECT().Get("app-name", metav1.GetOptions{}).
 			Return(statefulSetArg, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
-			Return(nil, nil),
+			Return(nil, s.k8sAlreadyExistsError()),
 		s.mockStatefulSets.EXPECT().Get("app-name", metav1.GetOptions{}).
 			Return(statefulSetArg, nil),
 		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
@@ -324,10 +324,6 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs map
 		s.mockStatefulSets.EXPECT().Get("app-name", metav1.GetOptions{}).
 			Return(statefulSetArg, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
-			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", metav1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, nil),
 	}...)
 	gomock.InOrder(assertCalls...)

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -102,10 +102,6 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 			Return(statefulSetArg, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
-			Return(nil, nil),
 	}...)
 	gomock.InOrder(assertCalls...)
 
@@ -427,10 +423,6 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
 			Return(statefulSetArg, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
-			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, nil),
 	}...)
 	gomock.InOrder(assertCalls...)

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -98,10 +98,6 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 				Return(statefulSetArg, nil),
 			s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 				Return(nil, nil),
-			s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-				Return(statefulSetArg, nil),
-			s.mockStatefulSets.EXPECT().Update(statefulSetArg).
-				Return(nil, nil),
 		}...)
 	}
 	gomock.InOrder(assertCalls...)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -2814,10 +2814,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
-			Return(nil, nil),
 	)
 
 	params := &caas.ServiceParams{
@@ -2901,10 +2897,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
 			Return(statefulSetArg, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
-			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, nil),
 	)
 
@@ -4555,10 +4547,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
-			Return(nil, nil),
 	)
 
 	params := &caas.ServiceParams{
@@ -4957,10 +4945,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
-			Return(statefulSetArg, nil),
 	)
 
 	params := &caas.ServiceParams{
@@ -5041,10 +5025,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
-			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, nil),
 	)
 
@@ -5134,10 +5114,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
 			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
-			Return(nil, nil),
 	)
 
 	params := &caas.ServiceParams{
@@ -5217,10 +5193,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 		s.mockStorageClass.EXPECT().Get("workload-storage", v1.GetOptions{}).
 			Return(&storagev1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: "workload-storage"}}, nil),
 		s.mockStatefulSets.EXPECT().Create(statefulSetArg).
-			Return(nil, nil),
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(statefulSetArg, nil),
-		s.mockStatefulSets.EXPECT().Update(statefulSetArg).
 			Return(nil, nil),
 	)
 

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -95,9 +95,12 @@ func (k *kubernetesClient) ensureStatefulSet(spec *apps.StatefulSet, existingPod
 	_, err := k.createStatefulSet(spec)
 	if errors.IsNotValid(err) {
 		return errors.Annotatef(err, "ensuring stateful set %q", spec.GetName())
-	}
-	if err != nil && !errors.IsAlreadyExists(err) {
+	} else if errors.IsAlreadyExists(err) {
+		// continue
+	} else if err != nil {
 		return errors.Trace(err)
+	} else {
+		return nil
 	}
 	// The statefulset already exists so all we are allowed to update is replicas,
 	// template, update strategy. Juju may hand out info with a slightly different

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -142,6 +142,11 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C, exists, terminatin
 		ResourceTags: map[string]string{"foo": "bar"},
 		Attributes:   map[string]interface{}{"key": "value"},
 	})
+	if updateCerts {
+		c.Assert(config.ConfigMapGeneration, gc.Equals, int64(1))
+	} else {
+		c.Assert(config.ConfigMapGeneration, gc.Equals, int64(0))
+	}
 
 	agentFile := filepath.Join(c.MkDir(), "agent.config")
 	err := ioutil.WriteFile(agentFile, config.AgentConf, 0644)
@@ -247,6 +252,7 @@ oldpassword: dxKwhgZPrNzXVTrZSxY1VLHA
 values: {}
 mongoversion: "0.0"
 `[1:], strconv.Quote(coretesting.CACert))),
+		ConfigMapGeneration: 1,
 	}
 
 	w := s.assertWorker(c)


### PR DESCRIPTION
## Fix 1867783 Charm deployment hangs with 2.8

- Fixes stateful set creation to no longer immediately
update the newly created statefulset.
- Fixes OperatorExists method to check for all created resources.
- Fixes config map RAW/WAW race condition.
- Adds tests for OperatorExists which was missing before.
- Fixes tag passed to IssueOperatorCertificate facade

## QA steps

before:
1. bootstrap k8s
2. deploy an app
3. remove the app
4. repeat from 2 until deployment hangs

see bug for more info.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1867783
