### PR TITLE
[2.7] fix infinite loop bug in bundlechanges

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -484,11 +484,11 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:ef49e9c114183e3d64d2ed7602dfb175213eb1ba5edcf822376104c4ba9e6e42"
+  digest = "1:f5add820715da7d59ad24add46e9b2e9236da2d2ab14b680504321a6cf83c9fe"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "4ca814a87a328d089e9e610538fc205d7bed3987"
+  revision = "0854974e644486efb72b4c6eb164861c089c581a"
 
 [[projects]]
   digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/hashicorp/raft-boltdb"
 
 [[constraint]]
-  revision = "4ca814a87a328d089e9e610538fc205d7bed3987"
+  revision = "0854974e644486efb72b4c6eb164861c089c581a"
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]


### PR DESCRIPTION
## Description of change

If an overlay attempts to create an offer for an application that has already been deployed, `bundlechanges.FromData` would enter an infinite loop looking for a dependency requirement (the deployment) that doesn't exist.

To replicate:

```console
$ cat bundle.yaml
series: trusty
applications:
  apache2:
    charm: cs:apache2-26
    num_units: 1

$ cat overlay.yaml
applications:
  apache2:
    offers:
      my-offer:
        endpoints:
        - apache-website
        acl:
          admin: admin

$ juju deploy  ./bundle.yaml

# This command gets stuck forever with existing juju clients
$ juju deploy --debug ./bundle.yaml --overlay overlay.yaml
```

To avoid the infinite loop, the offer-handling code in this package will obtain a list of applications already deployed to the controller (and present in the bundle being deployed) and check whether the application is already deployed; if so, the add-offer change does not have any dependencies and can be executed at any time.

# QA steps

Running the above commands with a juju client from snap/HEAD should block; using a juju client from this PR should work as expected.