### PR TITLE
Remove view layer from core/network

### DIFF
--- a/api/spaces/spaces.go
+++ b/api/spaces/spaces.go
@@ -138,7 +138,7 @@ func (api *API) RenameSpace(oldName string, newName string) error {
 		ToSpaceTag:   names.NewSpaceTag(newName).String(),
 	}
 	spaceRenameParams[0] = spaceRename
-	args := params.RenameSpacesParams{SpacesRenames: spaceRenameParams}
+	args := params.RenameSpacesParams{Changes: spaceRenameParams}
 	err := api.facade.FacadeCall("RenameSpace", args, &response)
 	if err != nil {
 		if params.IsCodeNotSupported(err) {

--- a/api/spaces/spaces_test.go
+++ b/api/spaces/spaces_test.go
@@ -209,7 +209,7 @@ func (s *spacesSuite) TestRenameSpace(c *gc.C) {
 	from, to := "from", "to"
 	resultSource := params.ErrorResults{}
 	args := params.RenameSpacesParams{
-		SpacesRenames: []params.RenameSpaceParams{{
+		Changes: []params.RenameSpaceParams{{
 			FromSpaceTag: names.NewSpaceTag(from).String(),
 			ToSpaceTag:   names.NewSpaceTag(to).String(),
 		}},
@@ -230,7 +230,7 @@ func (s *spacesSuite) TestRenameSpaceError(c *gc.C) {
 		},
 	}}}
 	args := params.RenameSpacesParams{
-		SpacesRenames: []params.RenameSpaceParams{{
+		Changes: []params.RenameSpaceParams{{
 			FromSpaceTag: names.NewSpaceTag(from).String(),
 			ToSpaceTag:   names.NewSpaceTag(to).String(),
 		}},

--- a/api/spaces/spaces_test.go
+++ b/api/spaces/spaces_test.go
@@ -17,7 +17,6 @@ import (
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/spaces"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/network"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -59,8 +58,8 @@ func (s *spacesSuite) TestRemoveSpace(c *gc.C) {
 	s.fCaller.EXPECT().FacadeCall("RemoveSpace", args, gomock.Any()).SetArg(2, resultSource).Return(nil)
 
 	bounds, err := s.API.RemoveSpace(name, false, false)
-	c.Assert(err, gc.IsNil)
-	c.Assert(bounds, gc.DeepEquals, network.RemoveSpace{})
+	c.Assert(err, gc.ErrorMatches, "0 results, expected 1")
+	c.Assert(bounds, gc.DeepEquals, params.RemoveSpaceResult{})
 }
 
 func (s *spacesSuite) TestRemoveSpaceUnexpectedError(c *gc.C) {
@@ -83,7 +82,7 @@ func (s *spacesSuite) TestRemoveSpaceUnexpectedError(c *gc.C) {
 
 	bounds, err := s.API.RemoveSpace(name, false, false)
 	c.Assert(err, gc.ErrorMatches, "bam")
-	c.Assert(bounds, gc.DeepEquals, network.RemoveSpace{})
+	c.Assert(bounds, gc.DeepEquals, params.RemoveSpaceResult{})
 }
 
 func (s *spacesSuite) TestRemoveSpaceUnexpectedErrorAPICall(c *gc.C) {
@@ -98,7 +97,7 @@ func (s *spacesSuite) TestRemoveSpaceUnexpectedErrorAPICall(c *gc.C) {
 
 	bounds, err := s.API.RemoveSpace(name, false, false)
 	c.Assert(err, gc.ErrorMatches, bam.Error())
-	c.Assert(bounds, gc.DeepEquals, network.RemoveSpace{})
+	c.Assert(bounds, gc.DeepEquals, params.RemoveSpaceResult{})
 }
 
 func (s *spacesSuite) TestRemoveSpaceUnexpectedErrorAPICallNotSupported(c *gc.C) {
@@ -117,7 +116,7 @@ func (s *spacesSuite) TestRemoveSpaceUnexpectedErrorAPICallNotSupported(c *gc.C)
 
 	bounds, err := s.API.RemoveSpace(name, false, false)
 	c.Assert(err, gc.ErrorMatches, bam.Error())
-	c.Assert(bounds, gc.DeepEquals, network.RemoveSpace{})
+	c.Assert(bounds, gc.DeepEquals, params.RemoveSpaceResult{})
 }
 
 func (s *spacesSuite) TestRemoveSpaceConstraintsBindings(c *gc.C) {
@@ -126,20 +125,12 @@ func (s *spacesSuite) TestRemoveSpaceConstraintsBindings(c *gc.C) {
 	resultSource := params.RemoveSpaceResults{
 		Results: []params.RemoveSpaceResult{{
 			Constraints: []params.Entity{
-				{
-					Tag: "model-42c4f770-86ed-4fcc-8e39-697063d082bc:e",
-				},
-				{
-					Tag: "application-mysql",
-				},
+				{Tag: "model-42c4f770-86ed-4fcc-8e39-697063d082bc:e"},
+				{Tag: "application-mysql"},
 			},
 			Bindings: []params.Entity{
-				{
-					Tag: "application-mysql",
-				},
-				{
-					Tag: "application-mediawiki",
-				},
+				{Tag: "application-mysql"},
+				{Tag: "application-mediawiki"},
 			},
 			ControllerSettings: []string{"jujuhaspace", "juuuu-space"},
 			Error:              nil,
@@ -150,12 +141,16 @@ func (s *spacesSuite) TestRemoveSpaceConstraintsBindings(c *gc.C) {
 
 	bounds, err := s.API.RemoveSpace(name, false, false)
 
-	expectedBounds := network.RemoveSpace{
-		HasModelConstraint: true,
-		Space:              name,
-		Constraints:        []string{"mysql"},
-		Bindings:           []string{"mysql", "mediawiki"},
-		ControllerConfig:   []string{"jujuhaspace", "juuuu-space"},
+	expectedBounds := params.RemoveSpaceResult{
+		Constraints: []params.Entity{
+			{Tag: "model-42c4f770-86ed-4fcc-8e39-697063d082bc:e"},
+			{Tag: "application-mysql"},
+		},
+		Bindings: []params.Entity{
+			{Tag: "application-mysql"},
+			{Tag: "application-mediawiki"},
+		},
+		ControllerSettings: []string{"jujuhaspace", "juuuu-space"},
 	}
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bounds, jc.DeepEquals, expectedBounds)
@@ -166,11 +161,8 @@ func (s *spacesSuite) TestRemoveSpaceConstraints(c *gc.C) {
 	resultSource := params.RemoveSpaceResults{
 		Results: []params.RemoveSpaceResult{{
 			Constraints: []params.Entity{
-				{
-					Tag: "model-42c4f770-86ed-4fcc-8e39-697063d082bc:e",
-				}, {
-					Tag: "application-mysql",
-				},
+				{Tag: "model-42c4f770-86ed-4fcc-8e39-697063d082bc:e"},
+				{Tag: "application-mysql"},
 			},
 			Error: nil,
 		}}}
@@ -178,10 +170,11 @@ func (s *spacesSuite) TestRemoveSpaceConstraints(c *gc.C) {
 	s.fCaller.EXPECT().FacadeCall("RemoveSpace", args, gomock.Any()).SetArg(2, resultSource).Return(nil)
 
 	bounds, err := s.API.RemoveSpace(name, false, false)
-	expectedBounds := network.RemoveSpace{
-		HasModelConstraint: true,
-		Space:              name,
-		Constraints:        []string{"mysql"},
+	expectedBounds := params.RemoveSpaceResult{
+		Constraints: []params.Entity{
+			{Tag: "model-42c4f770-86ed-4fcc-8e39-697063d082bc:e"},
+			{Tag: "application-mysql"},
+		},
 	}
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bounds, jc.DeepEquals, expectedBounds)
@@ -198,7 +191,7 @@ func (s *spacesSuite) TestRemoveSpaceForce(c *gc.C) {
 	bounds, err := s.API.RemoveSpace(name, true, false)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(bounds, gc.DeepEquals, network.RemoveSpace{Space: name})
+	c.Assert(bounds, gc.DeepEquals, params.RemoveSpaceResult{})
 }
 
 func getRemoveSpaceArgs(spaceName string, force, dryRun bool) params.RemoveSpaceParams {
@@ -215,10 +208,12 @@ func (s *spacesSuite) TestRenameSpace(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 	from, to := "from", "to"
 	resultSource := params.ErrorResults{}
-	args := params.RenameSpacesParams{SpacesRenames: []params.RenameSpaceParams{{
-		FromSpaceTag: names.NewSpaceTag(from).String(),
-		ToSpaceTag:   names.NewSpaceTag(to).String(),
-	}}}
+	args := params.RenameSpacesParams{
+		SpacesRenames: []params.RenameSpaceParams{{
+			FromSpaceTag: names.NewSpaceTag(from).String(),
+			ToSpaceTag:   names.NewSpaceTag(to).String(),
+		}},
+	}
 	s.fCaller.EXPECT().FacadeCall("RenameSpace", args, gomock.Any()).SetArg(2, resultSource).Return(nil)
 
 	err := s.API.RenameSpace(from, to)
@@ -234,10 +229,12 @@ func (s *spacesSuite) TestRenameSpaceError(c *gc.C) {
 			Code:    "500",
 		},
 	}}}
-	args := params.RenameSpacesParams{SpacesRenames: []params.RenameSpaceParams{{
-		FromSpaceTag: names.NewSpaceTag(from).String(),
-		ToSpaceTag:   names.NewSpaceTag(to).String(),
-	}}}
+	args := params.RenameSpacesParams{
+		SpacesRenames: []params.RenameSpaceParams{{
+			FromSpaceTag: names.NewSpaceTag(from).String(),
+			ToSpaceTag:   names.NewSpaceTag(to).String(),
+		}},
+	}
 	s.fCaller.EXPECT().FacadeCall("RenameSpace", args, gomock.Any()).SetArg(2, resultSource).Return(nil)
 
 	err := s.API.RenameSpace(from, to)
@@ -374,13 +371,11 @@ func (s *SpacesSuite) testShowSpaces(c *gc.C, spaceName string, results []params
 	c.Assert(s.apiCaller.CallCount, gc.Equals, 1)
 	if expectErr != "" {
 		c.Assert(gotErr, gc.ErrorMatches, expectErr)
-		c.Assert(gotResults, jc.DeepEquals, network.ShowSpace{})
 		return
 	} else {
 		c.Assert(results, gc.NotNil)
 		c.Assert(len(results), gc.Equals, 1)
-		converted := spaces.ShowSpaceFromResult(results[0])
-		c.Assert(gotResults, jc.DeepEquals, converted)
+		c.Assert(gotResults, jc.DeepEquals, results[0])
 	}
 	if err != nil {
 		c.Assert(gotErr, jc.DeepEquals, err)

--- a/apiserver/facades/client/spaces/rename.go
+++ b/apiserver/facades/client/spaces/rename.go
@@ -142,8 +142,8 @@ func (api *API) RenameSpace(args params.RenameSpacesParams) (params.ErrorResults
 		return result, err
 	}
 
-	result.Results = make([]params.ErrorResult, len(args.SpacesRenames))
-	for i, spaceRename := range args.SpacesRenames {
+	result.Results = make([]params.ErrorResult, len(args.Changes))
+	for i, spaceRename := range args.Changes {
 		fromTag, err := names.ParseSpaceTag(spaceRename.FromSpaceTag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(errors.Trace(err))

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -556,12 +556,12 @@ func (s *APISuite) expectMachines(ctrl *gomock.Controller, addresses set.Strings
 func (s *APISuite) getRenameArgs(from, to string) params.RenameSpacesParams {
 	spaceTagFrom := names.NewSpaceTag(from)
 	spaceTagTo := names.NewSpaceTag(to)
-	args := params.RenameSpacesParams{SpacesRenames: []params.RenameSpaceParams{
-		{
+	args := params.RenameSpacesParams{
+		Changes: []params.RenameSpaceParams{{
 			FromSpaceTag: spaceTagFrom.String(),
 			ToSpaceTag:   spaceTagTo.String(),
-		},
-	}}
+		}},
+	}
 	return args
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -31537,7 +31537,7 @@
                 "RenameSpacesParams": {
                     "type": "object",
                     "properties": {
-                        "rename-spaces": {
+                        "changes": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/RenameSpaceParams"
@@ -31546,7 +31546,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "rename-spaces"
+                        "changes"
                     ]
                 },
                 "ShowSpaceResult": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -916,7 +916,7 @@ type RenameSpaceParams struct {
 
 // RenameSpacesParams holds the arguments of the RenameSpaces API call.
 type RenameSpacesParams struct {
-	SpacesRenames []RenameSpaceParams `json:"rename-spaces"`
+	Changes []RenameSpaceParams `json:"changes"`
 }
 
 // CreateSpacesParams holds the arguments of the AddSpaces API call.

--- a/cmd/juju/space/mocks/spacesapi_mock.go
+++ b/cmd/juju/space/mocks/spacesapi_mock.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
-	network "github.com/juju/juju/core/network"
 	names_v3 "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
@@ -94,10 +93,10 @@ func (mr *MockSpaceAPIMockRecorder) ReloadSpaces() *gomock.Call {
 }
 
 // RemoveSpace mocks base method
-func (m *MockSpaceAPI) RemoveSpace(arg0 string, arg1, arg2 bool) (network.RemoveSpace, error) {
+func (m *MockSpaceAPI) RemoveSpace(arg0 string, arg1, arg2 bool) (params.RemoveSpaceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSpace", arg0, arg1, arg2)
-	ret0, _ := ret[0].(network.RemoveSpace)
+	ret0, _ := ret[0].(params.RemoveSpaceResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -123,10 +122,10 @@ func (mr *MockSpaceAPIMockRecorder) RenameSpace(arg0, arg1 interface{}) *gomock.
 }
 
 // ShowSpace mocks base method
-func (m *MockSpaceAPI) ShowSpace(arg0 string) (network.ShowSpace, error) {
+func (m *MockSpaceAPI) ShowSpace(arg0 string) (params.ShowSpaceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShowSpace", arg0)
-	ret0, _ := ret[0].(network.ShowSpace)
+	ret0, _ := ret[0].(params.ShowSpaceResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -271,10 +270,10 @@ func (mr *MockAPIMockRecorder) ReloadSpaces() *gomock.Call {
 }
 
 // RemoveSpace mocks base method
-func (m *MockAPI) RemoveSpace(arg0 string, arg1, arg2 bool) (network.RemoveSpace, error) {
+func (m *MockAPI) RemoveSpace(arg0 string, arg1, arg2 bool) (params.RemoveSpaceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSpace", arg0, arg1, arg2)
-	ret0, _ := ret[0].(network.RemoveSpace)
+	ret0, _ := ret[0].(params.RemoveSpaceResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -300,10 +299,10 @@ func (mr *MockAPIMockRecorder) RenameSpace(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // ShowSpace mocks base method
-func (m *MockAPI) ShowSpace(arg0 string) (network.ShowSpace, error) {
+func (m *MockAPI) ShowSpace(arg0 string) (params.ShowSpaceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShowSpace", arg0)
-	ret0, _ := ret[0].(network.ShowSpace)
+	ret0, _ := ret[0].(params.ShowSpaceResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/cmd/juju/space/move.go
+++ b/cmd/juju/space/move.go
@@ -119,7 +119,7 @@ func (c *MoveCommand) getSpaceTag(api SpaceAPI, name string) (names.SpaceTag, er
 		return names.SpaceTag{}, errors.Annotatef(err, "failed to get space %q", name)
 	}
 
-	return names.NewSpaceTag(space.Space.ID), nil
+	return names.NewSpaceTag(space.Space.Id), nil
 }
 
 func (c *MoveCommand) getSubnetTags(ctx *cmd.Context, api SubnetAPI, cidrs set.Strings) ([]names.SubnetTag, error) {

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -150,7 +150,7 @@ type StubAPI struct {
 	Spaces  []params.Space
 	Subnets []params.Subnet
 
-	ShowSpaceResp     network.ShowSpace
+	ShowSpaceResp     params.ShowSpaceResult
 	MoveSubnetsResp   params.MoveSubnetsResult
 	SubnetsByCIDRResp []params.SubnetsResult
 }
@@ -201,11 +201,11 @@ func NewStubAPI() *StubAPI {
 		Name:    "space2",
 		Subnets: append([]params.Subnet{}, subnets[2:]...),
 	}}
-	showSpace := network.ShowSpace{
-		Space: network.SpaceInfo{
-			ID:   spaces[1].Id,
-			Name: network.SpaceName(spaces[1].Name),
-			Subnets: []network.SubnetInfo{{
+	showSpace := params.ShowSpaceResult{
+		Space: params.Space{
+			Id:   spaces[1].Id,
+			Name: spaces[1].Name,
+			Subnets: []params.Subnet{{
 				CIDR: subnets[0].CIDR,
 			}, {
 				CIDR: subnets[2].CIDR,
@@ -257,9 +257,9 @@ func (sa *StubAPI) AddSpace(name string, subnetIds []string, public bool) error 
 	return sa.NextErr()
 }
 
-func (sa *StubAPI) RemoveSpace(name string, force bool, dryRun bool) (network.RemoveSpace, error) {
+func (sa *StubAPI) RemoveSpace(name string, force bool, dryRun bool) (params.RemoveSpaceResult, error) {
 	sa.MethodCall(sa, "RemoveSpace", name)
-	return network.RemoveSpace{}, sa.NextErr()
+	return params.RemoveSpaceResult{}, sa.NextErr()
 }
 
 func (sa *StubAPI) RenameSpace(name, newName string) error {
@@ -272,10 +272,10 @@ func (sa *StubAPI) ReloadSpaces() error {
 	return sa.NextErr()
 }
 
-func (sa *StubAPI) ShowSpace(name string) (network.ShowSpace, error) {
+func (sa *StubAPI) ShowSpace(name string) (params.ShowSpaceResult, error) {
 	sa.MethodCall(sa, "ShowSpace", name)
 	if err := sa.NextErr(); err != nil {
-		return network.ShowSpace{}, err
+		return params.ShowSpaceResult{}, err
 	}
 	return sa.ShowSpaceResp, nil
 }

--- a/cmd/juju/space/show_test.go
+++ b/cmd/juju/space/show_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/space"
-	"github.com/juju/juju/core/network"
 )
 
 type ShowSuite struct {
@@ -29,12 +28,12 @@ func (s *ShowSuite) SetUpTest(c *gc.C) {
 	s.newCommand = space.NewShowSpaceCommand
 }
 
-func (s *ShowSuite) getDefaultSpace() network.ShowSpace {
-	result := network.ShowSpace{
-		Space: network.SpaceInfo{
-			ID:   "1",
+func (s *ShowSuite) getDefaultSpace() params.ShowSpaceResult {
+	return params.ShowSpaceResult{
+		Space: params.Space{
+			Id:   "1",
 			Name: "default",
-			Subnets: []network.SubnetInfo{{
+			Subnets: []params.Subnet{{
 				CIDR:       "4.3.2.0/28",
 				ProviderId: "abc",
 				VLANTag:    0,
@@ -43,7 +42,6 @@ func (s *ShowSuite) getDefaultSpace() network.ShowSpace {
 		Applications: []string{"ubuntu,mysql"},
 		MachineCount: 4,
 	}
-	return result
 }
 
 func (s *ShowSuite) TestRunShowSpaceSucceeds(c *gc.C) {
@@ -83,7 +81,7 @@ func (s *ShowSuite) TestRunWhenShowSpacesNotSupported(c *gc.C) {
 	spaceName := "default"
 
 	expectedErr := errors.NewNotSupported(nil, "spaces not supported")
-	api.EXPECT().ShowSpace(spaceName).Return(network.ShowSpace{}, expectedErr)
+	api.EXPECT().ShowSpace(spaceName).Return(params.ShowSpaceResult{}, expectedErr)
 
 	_, err := s.runCommand(c, api, spaceName)
 
@@ -96,7 +94,7 @@ func (s *ShowSuite) TestRunWhenShowSpacesAPIFails(c *gc.C) {
 	spaceName := "default"
 
 	apiErr := errors.New("API error")
-	api.EXPECT().ShowSpace(spaceName).Return(network.ShowSpace{}, apiErr)
+	api.EXPECT().ShowSpace(spaceName).Return(params.ShowSpaceResult{}, apiErr)
 
 	_, err := s.runCommand(c, api, spaceName)
 	expectedMsg := fmt.Sprintf("cannot retrieve space %q: API error", spaceName)
@@ -112,7 +110,7 @@ func (s *ShowSuite) TestRunUnauthorizedMentionsJujuGrant(c *gc.C) {
 	ctrl, api := setUpMocks(c)
 	defer ctrl.Finish()
 	spaceName := "default"
-	api.EXPECT().ShowSpace(spaceName).Return(network.ShowSpace{}, apiErr)
+	api.EXPECT().ShowSpace(spaceName).Return(params.ShowSpaceResult{}, apiErr)
 
 	_, err := s.runCommand(c, api, spaceName)
 	expectedErrMsg := fmt.Sprintf("cannot retrieve space %q: permission denied", spaceName)
@@ -126,7 +124,7 @@ func (s *ShowSuite) TestRunWhenSpacesBlocked(c *gc.C) {
 	defer ctrl.Finish()
 
 	spaceName := "default"
-	api.EXPECT().ShowSpace(spaceName).Return(network.ShowSpace{}, apiErr)
+	api.EXPECT().ShowSpace(spaceName).Return(params.ShowSpaceResult{}, apiErr)
 	ctx, err := s.runCommand(c, api, spaceName)
 
 	c.Assert(err, gc.ErrorMatches, `

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -23,31 +23,6 @@ const (
 	AlphaSpaceName = "alpha"
 )
 
-// ShowSpace represents space information output by the CLI client.
-type ShowSpace struct {
-	// Information about a given space.
-	Space SpaceInfo
-	// Application names which are bound to a given space.
-	Applications []string
-	// MachineCount is the number of machines connected to a given space.
-	MachineCount int
-}
-
-// RemoveSpace represents space information why a space could not be removed.
-type RemoveSpace struct {
-	// The space which cannot be removed. Only with --force.
-	Space string
-	// HasModelConstraint is the model constraint.
-	HasModelConstraint bool
-	// Constraints are the constraints which blocks the remove. Blocking Constraints are: Application.
-	Constraints []string
-	// Bindings are the application bindings which blocks the remove.
-	Bindings []string
-	// ControllerConfig are the config settings of the controller model which are using the space.
-	// This is only valid if the current model is a controller model.
-	ControllerConfig []string
-}
-
 // SpaceLookup describes methods for acquiring SpaceInfos
 // to translate space IDs to space names and vice versa.
 type SpaceLookup interface {

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -26,11 +26,11 @@ const (
 // ShowSpace represents space information output by the CLI client.
 type ShowSpace struct {
 	// Information about a given space.
-	Space SpaceInfo `json:"space" yaml:"space"`
+	Space SpaceInfo
 	// Application names which are bound to a given space.
-	Applications []string `json:"applications" yaml:"applications"`
+	Applications []string
 	// MachineCount is the number of machines connected to a given space.
-	MachineCount int `json:"machine-count" yaml:"machine-count"`
+	MachineCount int
 }
 
 // RemoveSpace represents space information why a space could not be removed.
@@ -40,12 +40,12 @@ type RemoveSpace struct {
 	// HasModelConstraint is the model constraint.
 	HasModelConstraint bool
 	// Constraints are the constraints which blocks the remove. Blocking Constraints are: Application.
-	Constraints []string `json:"constraints,omitempty"`
+	Constraints []string
 	// Bindings are the application bindings which blocks the remove.
-	Bindings []string `json:"bindings,omitempty"`
+	Bindings []string
 	// ControllerConfig are the config settings of the controller model which are using the space.
 	// This is only valid if the current model is a controller model.
-	ControllerConfig []string `json:"controller-settings,omitempty"`
+	ControllerConfig []string
 }
 
 // SpaceLookup describes methods for acquiring SpaceInfos
@@ -68,7 +68,7 @@ type SpaceInfo struct {
 
 	// ProviderId is the provider's unique identifier for the space,
 	// such as used by MAAS.
-	ProviderId Id `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
+	ProviderId Id
 
 	// Subnets are the subnets that have been grouped into this network space.
 	Subnets []SubnetInfo

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -33,51 +33,51 @@ func newFanCIDRs(overlay, underlay string) *FanCIDRs {
 // It may originate from state, or from a provider.
 type SubnetInfo struct {
 	// CIDR of the network, in 123.45.67.89/24 format.
-	CIDR string `json:"cidr" yaml:"cidr"`
+	CIDR string
 
 	// Memoized value for the parsed network for the above CIDR.
 	parsedCIDRNetwork *net.IPNet
 
 	// ProviderId is a provider-specific subnet ID.
-	ProviderId Id `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
+	ProviderId Id
 
 	// ProviderSpaceId holds the provider ID of the space associated
 	// with this subnet. Can be empty if not supported.
-	ProviderSpaceId Id `json:"provider-space-id,omitempty" yaml:"provider-space-id,omitempty"`
+	ProviderSpaceId Id
 
 	// ProviderNetworkId holds the provider ID of the network
 	// containing this subnet, for example VPC id for EC2.
-	ProviderNetworkId Id `json:"provider-network-id,omitempty" yaml:"provider-network-id,omitempty"`
+	ProviderNetworkId Id
 
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
 	// normal networks. It's defined by IEEE 802.1Q standard, and used
 	// to define a VLAN network. For more information, see:
 	// http://en.wikipedia.org/wiki/IEEE_802.1Q.
-	VLANTag int `json:"vlan-tag" yaml:"vlan-tag"`
+	VLANTag int
 
 	// AvailabilityZones describes which availability zones this
 	// subnet is in. It can be empty if the provider does not support
 	// availability zones.
-	AvailabilityZones []string `json:"zones,omitempty" yaml:"zones,omitempty"`
+	AvailabilityZones []string
 
 	// SpaceID is the id of the space the subnet is associated with.
 	// Default value should be AlphaSpaceId. It can be empty if
 	// the subnet is returned from an networkingEnviron. SpaceID is
 	// preferred over SpaceName in state and non networkingEnviron use.
-	SpaceID string `json:"space-id,omitempty" yaml:"space-id,omitempty"`
+	SpaceID string
 
 	// SpaceName is the name of the space the subnet is associated with.
 	// An empty string indicates it is part of the AlphaSpaceName OR
 	// if the SpaceID is set. Should primarily be used in an networkingEnviron.
-	SpaceName string `json:"space-name,omitempty" yaml:"space-name,omitempty"`
+	SpaceName string
 
 	// FanInfo describes the fan networking setup for the subnet.
 	// It may be empty if this is not a fan subnet,
 	// or if this subnet information comes from a provider.
-	FanInfo *FanCIDRs `json:"fan-info,omitempty" yaml:"fan-info,omitempty"`
+	FanInfo *FanCIDRs
 
 	// IsPublic describes whether a subnet is public or not.
-	IsPublic bool `json:"is-public,omitempty" yaml:"is-public,omitempty"`
+	IsPublic bool
 }
 
 // SetFan sets the fan networking information for the subnet.


### PR DESCRIPTION
## Description of change

The view layer ended up inside core/network and by view layer, the CLI
output. This would have locked stepped us into a scenario where it would
make it harder (over time) to change the API without changing the CLI.

This fixes that and also fixes an issue where remove wasn't correctly
showing the warnings when NOT using force.

## QA steps

Ensure that the tests pass, but the following steps can be used:

https://github.com/juju/juju/pull/11183
