### PR TITLE
Fix 1869219 jujuc missing error check

### DIFF
--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -206,7 +206,7 @@ func copyExistingJujus(dir string) error {
 	}
 	jujucLocation := filepath.Join(jujuDir, names.Jujuc)
 	jujucTarget := filepath.Join(dir, names.Jujuc)
-	if os.Stat(jujucLocation); os.IsNotExist(err) {
+	if _, err = os.Stat(jujucLocation); os.IsNotExist(err) {
 		logger.Infof("jujuc not found at %s, not including", jujucLocation)
 	} else if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
## Description of change

Error was being ignored when checking for the existence of jujuc binary.

## QA steps

```
make install
rm $GOPATH/bin/jujuc
juju bootstrap localhost
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1869219
