### PR TITLE
Add support for running k8s operator actions on the charm operator pod.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ ifeq ($(OPERATOR_IMAGE_TAG),)
 endif
 	rm -rf ${JUJUD_STAGING_DIR}
 	mkdir -p ${JUJUD_STAGING_DIR}
-	cp ${JUJUD_BIN_DIR}/jujuc ${JUJUD_STAGING_DIR}
+	cp ${JUJUD_BIN_DIR}/jujuc ${JUJUD_STAGING_DIR} || true
 	cp ${JUJUD_BIN_DIR}/jujud ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-dockerfile ${JUJUD_STAGING_DIR}
 	cp caas/jujud-operator-requirements.txt ${JUJUD_STAGING_DIR}

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -232,6 +232,10 @@ func (ch *mockCharm) BundleSha256() string {
 	return ch.sha256
 }
 
+func (ch *mockCharm) Meta() *charm.Meta {
+	return &charm.Meta{Deployment: &charm.Deployment{DeploymentMode: charm.ModeOperator}}
+}
+
 type mockBroker struct {
 	testing.Stub
 	watcher corewatcher.StringsWatcher

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -5,6 +5,7 @@ package caasoperator
 
 import (
 	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/apiserver/common"
@@ -172,16 +173,20 @@ func (f *Facade) Charm(args params.Entities) (params.ApplicationCharmResults, er
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		charm, force, err := application.Charm()
+		ch, force, err := application.Charm()
 		if err != nil {
 			results.Results[i].Error = common.ServerError(err)
 			continue
 		}
 		results.Results[i].Result = &params.ApplicationCharm{
-			URL:                  charm.URL().String(),
+			URL:                  ch.URL().String(),
 			ForceUpgrade:         force,
-			SHA256:               charm.BundleSha256(),
+			SHA256:               ch.BundleSha256(),
 			CharmModifiedVersion: application.CharmModifiedVersion(),
+			DeploymentMode:       string(charm.ModeWorkload),
+		}
+		if d := ch.Meta().Deployment; d != nil {
+			results.Results[i].Result.DeploymentMode = string(d.DeploymentMode)
 		}
 	}
 	return results, nil

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -118,6 +118,7 @@ func (s *CAASOperatorSuite) TestCharm(c *gc.C) {
 				ForceUpgrade:         false,
 				SHA256:               "fake-sha256",
 				CharmModifiedVersion: 666,
+				DeploymentMode:       "operator",
 			},
 		}, {
 			Error: &params.Error{

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -52,6 +52,7 @@ type Application interface {
 type Charm interface {
 	URL() *charm.URL
 	BundleSha256() string
+	Meta() *charm.Meta
 }
 
 type stateShim struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6112,6 +6112,9 @@
                         "charm-modified-version": {
                             "type": "integer"
                         },
+                        "deployment-mode": {
+                            "type": "string"
+                        },
                         "force-upgrade": {
                             "type": "boolean"
                         },

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -31,6 +31,9 @@ type ApplicationCharm struct {
 
 	// CharmModifiedVersion increases when the charm changes in some way.
 	CharmModifiedVersion int `json:"charm-modified-version"`
+
+	// DeploymentMode is either "operator" or "workload"
+	DeploymentMode string `json:"deployment-mode,omitempty"`
 }
 
 // CharmsList stores parameters for a charms.List call

--- a/state/application.go
+++ b/state/application.go
@@ -1245,9 +1245,14 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		return errors.Trace(err)
 	}
 	if cfg.Charm.Meta().Deployment != currentCharm.Meta().Deployment {
-		if currentCharm.Meta().Deployment == nil ||
-			cfg.Charm.Meta().Deployment.DeploymentType != currentCharm.Meta().Deployment.DeploymentType {
+		if currentCharm.Meta().Deployment == nil || currentCharm.Meta().Deployment == nil {
+			return errors.New("cannot change a charm's deployment info")
+		}
+		if cfg.Charm.Meta().Deployment.DeploymentType != currentCharm.Meta().Deployment.DeploymentType {
 			return errors.New("cannot change a charm's deployment type")
+		}
+		if cfg.Charm.Meta().Deployment.DeploymentMode != currentCharm.Meta().Deployment.DeploymentMode {
+			return errors.New("cannot change a charm's deployment mode")
 		}
 	}
 	// For old style charms written for only one series, we still retain

--- a/state/unit.go
+++ b/state/unit.go
@@ -2875,6 +2875,21 @@ func (u *Unit) AddAction(operationID, name string, payload map[string]interface{
 		return nil, err
 	}
 
+	// For k8s operators, we run the action on the operator pod by default.
+	if _, ok := payloadWithDefaults["workload-context"]; !ok {
+		app, err := u.Application()
+		if err != nil {
+			return nil, err
+		}
+		ch, _, err := app.Charm()
+		if err != nil {
+			return nil, err
+		}
+		if ch.Meta().Deployment != nil && ch.Meta().Deployment.DeploymentMode == charm.ModeOperator {
+			payloadWithDefaults["workload-context"] = false
+		}
+	}
+
 	m, err := u.st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -171,10 +171,6 @@ func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
 	}, `missing UniterFacadeFunc not valid`)
 
 	s.testValidateConfig(c, func(config *caasoperator.Config) {
-		config.RunListenerSocketFunc = nil
-	}, `missing RunListenerSocketFunc not valid`)
-
-	s.testValidateConfig(c, func(config *caasoperator.Config) {
 		config.UniterParams = nil
 	}, `missing UniterParams not valid`)
 

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
-	"github.com/juju/juju/caas"
 	"github.com/juju/os/series"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -27,6 +26,7 @@ import (
 
 	agenttools "github.com/juju/juju/agent/tools"
 	apiuniter "github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"

--- a/worker/caasoperator/client.go
+++ b/worker/caasoperator/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6"
 
+	caasoperatorapi "github.com/juju/juju/api/caasoperator"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
@@ -31,7 +32,7 @@ type Client interface {
 // the URL and SHA256 hash of the charm currently
 // assigned to the application.
 type CharmGetter interface {
-	Charm(application string) (_ *charm.URL, force bool, sha256 string, vers int, _ error)
+	Charm(application string) (*caasoperatorapi.CharmInfo, error)
 }
 
 // UnitGetter provides an interface for watching for

--- a/worker/caasoperator/download.go
+++ b/worker/caasoperator/download.go
@@ -33,11 +33,13 @@ func (c *charmInfo) ArchiveSha256() (string, error) {
 }
 
 func (op *caasOperator) ensureCharm(localState *LocalState) error {
-	curl, _, sha256, vers, err := op.config.CharmGetter.Charm(op.config.Application)
+	dbCharmInfo, err := op.config.CharmGetter.Charm(op.config.Application)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	localState.CharmModifiedVersion = vers
+	op.deploymentMode = dbCharmInfo.DeploymentMode
+	localState.CharmModifiedVersion = dbCharmInfo.CharmModifiedVersion
+	curl := dbCharmInfo.URL
 	if localState.CharmURL == curl {
 		logger.Debugf("charm %s already downloaded", curl)
 		return nil
@@ -46,7 +48,7 @@ func (op *caasOperator) ensureCharm(localState *LocalState) error {
 		return errors.Trace(err)
 	}
 
-	info := &charmInfo{curl: curl, sha256: sha256}
+	info := &charmInfo{curl: curl, sha256: dbCharmInfo.SHA256}
 	if err := op.deployer.Stage(info, op.catacomb.Dying()); err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/caasoperator/remotestate/interface.go
+++ b/worker/caasoperator/remotestate/interface.go
@@ -4,9 +4,9 @@
 package remotestate
 
 import (
-	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/worker.v1"
 
+	caasoperatorapi "github.com/juju/juju/api/caasoperator"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -22,7 +22,7 @@ type Watcher interface {
 }
 
 type charmGetter interface {
-	Charm(application string) (_ *charm.URL, force bool, sha256 string, vers int, _ error)
+	Charm(application string) (*caasoperatorapi.CharmInfo, error)
 }
 
 type applicationWatcher interface {

--- a/worker/caasoperator/remotestate/mock_test.go
+++ b/worker/caasoperator/remotestate/mock_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6"
 
+	caasoperatorapi "github.com/juju/juju/api/caasoperator"
 	"github.com/juju/juju/core/watcher"
 )
 
@@ -79,6 +80,11 @@ type mockCharmGetter struct {
 	version int
 }
 
-func (m *mockCharmGetter) Charm(application string) (_ *charm.URL, force bool, sha256 string, vers int, _ error) {
-	return m.curl, m.force, m.sha256, m.version, nil
+func (m *mockCharmGetter) Charm(application string) (*caasoperatorapi.CharmInfo, error) {
+	return &caasoperatorapi.CharmInfo{
+		URL:                  m.curl,
+		ForceUpgrade:         m.force,
+		SHA256:               m.sha256,
+		CharmModifiedVersion: m.version,
+	}, nil
 }

--- a/worker/caasoperator/remotestate/watcher.go
+++ b/worker/caasoperator/remotestate/watcher.go
@@ -143,14 +143,14 @@ func (w *RemoteStateWatcher) loop() (err error) {
 
 // applicationChanged responds to changes in the application.
 func (w *RemoteStateWatcher) applicationChanged() error {
-	url, force, _, ver, err := w.config.CharmGetter.Charm(w.application)
+	info, err := w.config.CharmGetter.Charm(w.application)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	w.mu.Lock()
-	w.current.CharmURL = url
-	w.current.ForceCharmUpgrade = force
-	w.current.CharmModifiedVersion = ver
+	w.current.CharmURL = info.URL
+	w.current.ForceCharmUpgrade = info.ForceUpgrade
+	w.current.CharmModifiedVersion = info.CharmModifiedVersion
 	w.mu.Unlock()
 	return nil
 }

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -74,11 +74,10 @@ func (w WatcherConfig) validate() error {
 		if w.ApplicationChannel == nil {
 			return errors.NotValidf("watcher config for CAAS model with nil application channel")
 		}
-		if w.RunningStatusChannel == nil {
-			return errors.NotValidf("watcher config for CAAS model with nil running status channel")
-		}
-		if w.RunningStatusFunc == nil {
-			return errors.NotValidf("watcher config for CAAS model with nil running status func")
+		if w.RunningStatusFunc != nil {
+			if w.RunningStatusChannel == nil {
+				return errors.NotValidf("watcher config for CAAS model with nil running status channel")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
### Checklist

 - [X] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?

This is an agent only facade.

## Description of change

The newly added k8s operator charms don't have a workload pod - their actions need to execute in the charm operator. To do this, the "workload-context" parameter for k8s operator actions is set to false, so that the uniter runs the action locally. Also, the Charm() api call is extended to return the deployment mode so that the uniter can avoid the mechanics of blocking actions for a workload pod startup which will never happen.

## QA steps

deploy both a "normal" charm and an operator charm on k8s and ensure actions run as expected.
