### PR TITLE
Ignore test tmp directories

### DIFF
--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -9,6 +9,8 @@ run_shellcheck() {
 }
 
 run_whitespace() {
+  # Ensure we capture filename.sh and linenumber and nothing else.
+  # filename.sh:<linenumber>:filename.sh<error>
   # shellcheck disable=SC2063
   OUT=$(grep -n -r --include "*.sh" "$(printf '\t')" tests/ | grep -oP "^.*:\d+" || true)
   if [ -n "${OUT}" ]; then
@@ -21,6 +23,8 @@ run_whitespace() {
 }
 
 run_trailing_whitespace() {
+  # Ensure we capture filename.sh and linenumber and nothing else.
+  # filename.sh:<linenumber>:filename.sh<error>
   # shellcheck disable=SC2063
   OUT=$(grep -n -r --include "*.sh" " $" tests/ | grep -oP "^.*:\d+" || true)
   if [ -n "${OUT}" ]; then

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -1,5 +1,5 @@
 run_shellcheck() {
-  OUT=$(shellcheck --shell sh tests/*.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
+  OUT=$(shellcheck --shell sh tests/main.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
   if [ -n "${OUT}" ]; then
     echo ""
     echo "$(red 'Found some issues:')"
@@ -9,7 +9,8 @@ run_shellcheck() {
 }
 
 run_whitespace() {
-  OUT=$(grep -Pr '\t' tests/ | grep '\.sh:' || true)
+  # shellcheck disable=SC2063
+  OUT=$(grep -n -r --include "*.sh" "$(printf '\t')" tests/ | grep -oP "^.*:\d+" || true)
   if [ -n "${OUT}" ]; then
     echo ""
     echo "$(red 'Found some issues:')"
@@ -20,7 +21,8 @@ run_whitespace() {
 }
 
 run_trailing_whitespace() {
-  OUT=$(grep -nr " $" tests/ | grep '\.sh:' || true)
+  # shellcheck disable=SC2063
+  OUT=$(grep -n -r --include "*.sh" " $" tests/ | grep -oP "^.*:\d+" || true)
   if [ -n "${OUT}" ]; then
     echo ""
     echo "$(red 'Found some issues:')"


### PR DESCRIPTION
## Description of change

Attempting to iterate hard over some shell scripts can lead to
frustration when running static analysis. The problem occurs when you
either accidentally add a tab to a shell file or a trailing white space
character. Re-running the shellcheck then picks up the tmp.XXX
directories as you didn't delete them.

Deleting the directories shouldn't be mandatory as you may want to
analyze them again in the future. Instead, we should tell the checks to
ignore those tmp directories and move along.

## QA steps

Make an error in a shell file, or add a tab character.

Previously running these twice would pick up the tmp dir. The new
updates prevent this from happening.
```sh
make static-analysis
make static-analysis
```
