### PR TITLE
move storage state server side

### DIFF
--- a/api/upgradesteps/upgradesteps.go
+++ b/api/upgradesteps/upgradesteps.go
@@ -47,15 +47,8 @@ func (c *Client) ResetKVMMachineModificationStatusIdle(tag names.Tag) error {
 
 // WriteUniterState writes the given internal state of the uniter for the
 // provided units.
-func (c *Client) WriteUniterState(uniterStates map[names.Tag]string) error {
+func (c *Client) WriteUniterState(args []params.SetUnitStateArg) error {
 	var result params.ErrorResults
-	args := []params.SetUnitStateArg{}
-	for unitTag, data := range uniterStates {
-		// get a new variable so we can create a new ptr each time
-		// thru the loop.
-		newData := data
-		args = append(args, params.SetUnitStateArg{Tag: unitTag.String(), UniterState: &newData})
-	}
 	arg := params.SetUnitStateArgs{Args: args}
 	err := c.facade.FacadeCall("WriteUniterState", arg, &result)
 	if err != nil {

--- a/api/upgradesteps/upgradesteps_test.go
+++ b/api/upgradesteps/upgradesteps_test.go
@@ -67,12 +67,10 @@ func (s *upgradeStepsSuite) TestWriteUniterState(c *gc.C) {
 	s.expectWriteUniterStateSuccess(c, args)
 
 	client := upgradesteps.NewClientFromFacade(s.fCaller)
-	err := client.WriteUniterState(
-		map[names.Tag]string{
-			uTag0: str0,
-			uTag1: str1,
-		},
-	)
+	err := client.WriteUniterState([]params.SetUnitStateArg{
+		{Tag: uTag0.String(), UniterState: &str0},
+		{Tag: uTag1.String(), UniterState: &str1},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -87,11 +85,9 @@ func (s *upgradeStepsSuite) TestWriteUniterStateError(c *gc.C) {
 	s.expectWriteUniterStateError(c, args)
 
 	client := upgradesteps.NewClientFromFacade(s.fCaller)
-	err := client.WriteUniterState(
-		map[names.Tag]string{
-			uTag0: str0,
-		},
-	)
+	err := client.WriteUniterState([]params.SetUnitStateArg{
+		{Tag: uTag0.String(), UniterState: &str0},
+	})
 	c.Assert(err, gc.ErrorMatches, "did not find")
 }
 

--- a/apiserver/facades/agent/upgradesteps/upgradesteps.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps.go
@@ -155,8 +155,11 @@ func (api *UpgradeStepsAPI) WriteUniterState(args params.SetUnitStateArgs) (para
 			us.SetUniterState(*data.UniterState)
 		} else {
 			logger.Warningf("no uniter state provided for %q", uTag)
-			continue
 		}
+		if data.StorageState != nil {
+			us.SetStorageState(*data.StorageState)
+		}
+
 		err = u.SetState(us)
 		results.Results[i].Error = common.ServerError(err)
 	}

--- a/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
@@ -121,14 +121,14 @@ func (s *unitUpgradeStepsSuite) SetUpTest(c *gc.C) {
 func (s *unitUpgradeStepsSuite) TestWriteUniterState(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectUnitState(nil, nil)
+	s.expectSetState(nil, nil)
 	s.setupFacadeAPI(c)
 
 	str1 := "foo"
 	str2 := "bar"
 	args := params.SetUnitStateArgs{
 		Args: []params.SetUnitStateArg{
-			{Tag: s.tag1.String(), UniterState: &str1},
+			{Tag: s.tag1.String(), UniterState: &str1, StorageState: &str2},
 			{Tag: s.tag2.String(), UniterState: &str2},
 		},
 	}
@@ -141,14 +141,14 @@ func (s *unitUpgradeStepsSuite) TestWriteUniterState(c *gc.C) {
 func (s *unitUpgradeStepsSuite) TestWriteUniterStateError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectUnitState(nil, errors.NotFoundf("testing"))
+	s.expectSetState(nil, errors.NotFoundf("testing"))
 	s.setupFacadeAPI(c)
 
 	str1 := "foo"
 	str2 := "bar"
 	args := params.SetUnitStateArgs{
 		Args: []params.SetUnitStateArg{
-			{Tag: s.tag1.String(), UniterState: &str1},
+			{Tag: s.tag1.String(), UniterState: &str1, StorageState: &str2},
 			{Tag: s.tag2.String(), UniterState: &str2},
 		},
 	}
@@ -263,9 +263,10 @@ func (s *unitUpgradeStepsSuite) expectFindEntityUnits() {
 	s.state.EXPECT().FindEntity(s.tag2.(names.UnitTag)).Return(u2Entity, nil)
 }
 
-func (s *unitUpgradeStepsSuite) expectUnitState(err1, err2 error) {
+func (s *unitUpgradeStepsSuite) expectSetState(err1, err2 error) {
 	us := state.NewUnitState()
 	us.SetUniterState("foo")
+	us.SetStorageState("bar")
 	s.unit1.EXPECT().SetState(us).Return(err1)
 
 	us = state.NewUnitState()

--- a/upgrades/mocks/upgradestepsclient_mock.go
+++ b/upgrades/mocks/upgradestepsclient_mock.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	names_v3 "gopkg.in/juju/names.v3"
+	params "github.com/juju/juju/apiserver/params"
 	reflect "reflect"
 )
 
@@ -34,7 +34,7 @@ func (m *MockUpgradeStepsClient) EXPECT() *MockUpgradeStepsClientMockRecorder {
 }
 
 // WriteUniterState mocks base method
-func (m *MockUpgradeStepsClient) WriteUniterState(arg0 map[names_v3.Tag]string) error {
+func (m *MockUpgradeStepsClient) WriteUniterState(arg0 []params.SetUnitStateArg) error {
 	ret := m.ctrl.Call(m, "WriteUniterState", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/upgrades/steps_28.go
+++ b/upgrades/steps_28.go
@@ -4,6 +4,7 @@
 package upgrades
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,9 +14,11 @@ import (
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/yaml.v2"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/upgradesteps"
+	"github.com/juju/juju/apiserver/params"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/worker/common/reboot"
@@ -99,6 +102,10 @@ func prepopulateRebootHandledFlagsForDeployedUnits(ctx Context) error {
 func moveUniterStateToController(ctx Context) error {
 	// Lookup the names of all unit agents installed on this machine.
 	agentConf := ctx.AgentConfig()
+	ctxTag := agentConf.Tag()
+	if ctxTag.Kind() != names.MachineTagKind {
+		return nil
+	}
 	_, unitNames, _, err := service.FindAgents(agentConf.DataDir())
 	if err != nil {
 		return errors.Annotate(err, "looking up unit agents")
@@ -121,6 +128,16 @@ func moveUniterStateToController(ctx Context) error {
 
 	// Saving uniter state in the controller succeeded, now clean up
 	// the now unused state files.
+	//
+	// TODO: hml 30-mar-2020
+	// Once the final piece of the upgrade is done, this can be changed to
+	// remove:
+	//     /var/lib/juju/agents/unit-ubuntu-0/state/uniter
+	//     /var/lib/juju/agents/unit-ubuntu-0/state/storage
+	//     /var/lib/juju/agents/unit-ubuntu-0/state/relations
+	//     /var/lib/juju/agents/unit-ubuntu-0/state/metrics
+	// and the caas operator file.  Any not found is fine.
+	// Keep /var/lib/juju/agents/unit-ubuntu-0/state for non persistent needs.
 	for _, name := range fileNames {
 		if err = os.RemoveAll(name); err != nil {
 			// Log the error, but no need to fail the upgrade.  Juju
@@ -139,47 +156,51 @@ var getUpgradeStepsClient = func(caller base.APICaller) UpgradeStepsClient {
 
 //go:generate mockgen -package mocks -destination mocks/upgradestepsclient_mock.go github.com/juju/juju/upgrades UpgradeStepsClient
 type UpgradeStepsClient interface {
-	WriteUniterState(uniterStates map[names.Tag]string) error
+	WriteUniterState([]params.SetUnitStateArg) error
 }
 
 func iaasUniterState(ctx Context, unitNames []string) ([]string, error) {
 	// Read the uniter state for each unit on this machine.
 	// Leave in yaml format as a string to push to the controller.
-	fileNames := []string{}
-	uniterStates := make(map[names.Tag]string, len(unitNames))
+	fileNames := set.NewStrings()
+	uniterStates := make([]params.SetUnitStateArg, len(unitNames))
 	dataDir := ctx.AgentConfig().DataDir()
-	for _, unitName := range unitNames {
+	for i, unitName := range unitNames {
 		tag, err := names.ParseUnitTag(unitName)
 		if err != nil {
 			return nil, errors.Annotatef(err, "unable to parse unit agent tag %q", unitName)
 		}
 
+		uniterStates[i].Tag = tag.String()
 		// e.g. /var/lib/juju/agents/unit-ubuntu-0/state/uniter
-		uniterStateFile := filepath.Join(agent.BaseDir(dataDir), unitName, "state", "uniter")
+		uniterStateDir := filepath.Join(agent.BaseDir(dataDir), unitName, "state")
 
-		// Read into a State as we can validate the data.
-		var st operation.State
-		if err = utils.ReadYaml(uniterStateFile, &st); err != nil {
-			// No file available, move on.
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, errors.Annotatef(err, "failed to read uniter state from %q", uniterStateFile)
-		}
-		fileNames = append(fileNames, uniterStateFile)
-		if err = st.Validate(); err != nil {
-			return nil, errors.Annotatef(err, "failed to validate uniter state from %q", uniterStateFile)
+		uniterSt, filename, err := readUniterState(uniterStateDir)
+		if err != nil && !os.IsNotExist(err) {
+			// Note: we may want to error on NotExist.  Something is very
+			// broken if the uniter state files does not exist.  On the
+			// other hand, all that will happen is that the uniter will act
+			// like the unit is just starting with regards to hook execution.
+			// With properly written idempotent charms, this is not an issue.
+			return nil, err
+		} else if err == nil {
+			fileNames.Add(filename)
+			uniterStates[i].UniterState = &uniterSt
 		}
 
-		data, err := yaml.Marshal(st)
-		if err != nil {
-			return nil, errors.Annotatef(err, "failed to unmarshal uniter state from %q", uniterStateFile)
+		storageData, err := readStorageState(uniterStateDir)
+		if err != nil && !os.IsNotExist(err) && !errors.IsNotFound(err) {
+			return nil, err
+		} else if err == nil {
+			uniterStates[i].StorageState = &storageData.dataString
 		}
-		uniterStates[tag] = string(data)
+		if storageData.filename != "" {
+			fileNames.Add(storageData.filename)
+		}
 	}
 
 	// No state files, nothing to do.
-	if len(fileNames) == 0 {
+	if fileNames.IsEmpty() {
 		return nil, nil
 	}
 
@@ -187,11 +208,113 @@ func iaasUniterState(ctx Context, unitNames []string) ([]string, error) {
 	if err := client.WriteUniterState(uniterStates); err != nil {
 		return nil, errors.Annotatef(err, "unable to set state for units %q", strings.Join(unitNames, ", "))
 	}
-	return fileNames, nil
+	return fileNames.Values(), nil
+}
+
+// readUniterState reads uniter state, validates it, then returns a
+// yaml string of the dataString and the filename.  If no error is returned,
+// the yaml string is valid and non empty.
+func readUniterState(uniterStateDir string) (string, string, error) {
+	uniterStateFile := filepath.Join(uniterStateDir, "uniter")
+	// Read into a State so we can validate the dataString.
+	var st operation.State
+	if err := utils.ReadYaml(uniterStateFile, &st); err != nil {
+		// No file available, move on.
+		if os.IsNotExist(err) {
+			return "", "", err
+		}
+		return "", "", errors.Annotatef(err, "failed to read uniter state from %q", uniterStateFile)
+	}
+	if err := st.Validate(); err != nil {
+		return "", "", errors.Annotatef(err, "failed to validate uniter state from %q", uniterStateFile)
+	}
+
+	data, err := yaml.Marshal(st)
+	if err != nil {
+		return "", "", errors.Annotatef(err, "failed to unmarshal uniter state from %q", uniterStateFile)
+	}
+
+	return string(data), uniterStateFile, nil
 }
 
 func caasOperatorLocalState(ctx Context, unitNames []string) ([]string, error) {
 	// TODO: (hml) 27-Mar-2020.
 	// Implement when relations, storage, metrics and the operator state are moved.
 	return nil, nil
+}
+
+type data struct {
+	dataString string
+	filename   string
+}
+
+func readStorageState(uniterStateDir string) (data, error) {
+	storageStateDir := filepath.Join(uniterStateDir, "storage")
+	storage, err := readAllStorageStateFiles(storageStateDir)
+	if err != nil {
+		return data{}, err
+	}
+	if len(storage) < 1 {
+		return data{filename: storageStateDir}, errors.NotFoundf("storage state")
+	}
+	dataYaml, err := yaml.Marshal(storage)
+	if err != nil {
+		return data{}, errors.Annotatef(err, "failed to unmarshal storage state from %q", storageStateDir)
+	}
+	return data{dataString: string(dataYaml), filename: storageStateDir}, nil
+}
+
+// readAllStorageStateFiles loads and returns every storage stateFile persisted inside
+func readAllStorageStateFiles(dirPath string) (map[string]bool, error) {
+	if _, err := os.Stat(dirPath); err != nil {
+		return nil, err
+	}
+	fis, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	files := make(map[string]bool)
+	for _, fi := range fis {
+		if fi.IsDir() {
+			continue
+		}
+		storageId := fi.Name()
+		i := strings.LastIndex(storageId, "-")
+		if i <= 0 {
+			// Lack of "-" means it's not a valid storage ID.
+			continue
+		}
+		storageId = storageId[:i] + "/" + storageId[i+1:]
+		if !names.IsValidStorage(storageId) {
+			logger.Warningf("ignoring storage file with invalid name %q", filepath.Join(dirPath, fi.Name()))
+			continue
+		}
+		tag := names.NewStorageTag(storageId)
+		f, err := readStorageStateFile(dirPath, tag)
+		if err != nil {
+			return nil, err
+		}
+		files[tag.Id()] = f
+	}
+	return files, nil
+}
+
+// readStorageStateFile loads a storage stateFile from the subdirectory of dirPath named
+// is returned.
+func readStorageStateFile(dirPath string, tag names.StorageTag) (bool, error) {
+	filename := strings.Replace(tag.Id(), "/", "-", -1)
+	filePath := filepath.Join(dirPath, filename)
+
+	var info storageDiskInfo
+	if err := utils.ReadYaml(filePath, &info); err != nil {
+		return false, errors.Annotatef(err, "cannot read from storage state file %q", filePath)
+	}
+	if info.Attached == nil {
+		return false, errors.Errorf("invalid storage state file %q: missing 'attached'", filePath)
+	}
+	return *info.Attached, nil
+}
+
+type storageDiskInfo struct {
+	Attached *bool `yaml:"attached,omitempty"`
 }

--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
@@ -19,6 +20,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	apicallermocks "github.com/juju/juju/api/base/mocks"
+	"github.com/juju/juju/apiserver/params"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
@@ -59,9 +61,10 @@ func (s *steps28Suite) TestMoveUniterStateToControllerStep(c *gc.C) {
 type mockSteps28Suite struct {
 	testing.BaseSuite
 
-	dataDir string
-	tagOne  names.Tag
-	tagTwo  names.Tag
+	dataDir    string
+	tagOne     names.Tag
+	tagTwo     names.Tag
+	storTagOne names.Tag
 
 	opStateOne         operation.State
 	opStateTwo         operation.State
@@ -69,6 +72,10 @@ type mockSteps28Suite struct {
 	opStateTwoYaml     string
 	opStateOneFileName string
 	opStateTwoFileName string
+
+	opStorOne         bool
+	opStorOneYaml     string
+	opStorOneFileName string
 
 	mockCtx         *mocks.MockContext
 	mockClient      *mocks.MockUpgradeStepsClient
@@ -83,6 +90,7 @@ func (s *mockSteps28Suite) SetUpTest(c *gc.C) {
 
 	s.tagOne = names.NewUnitTag("testing/0")
 	s.tagTwo = names.NewUnitTag("testing/1")
+	s.storTagOne = names.NewStorageTag("data/3")
 
 	s.opStateOne = operation.State{
 		Leader: true,
@@ -96,11 +104,21 @@ func (s *mockSteps28Suite) SetUpTest(c *gc.C) {
 		Hook: &hook.Info{Kind: hooks.ConfigChanged},
 	}
 
+	s.opStorOne = true
+
 	s.dataDir = c.MkDir()
 	agentDir := agent.BaseDir(s.dataDir)
-	unitOneStateDir := filepath.Join(agentDir, s.tagOne.String())
+
+	unitOneStateDir := filepath.Join(agentDir, s.tagOne.String(), "state")
+	err := os.MkdirAll(unitOneStateDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
 	s.opStateOneYaml, s.opStateOneFileName = writeUnitStateFile(c, unitOneStateDir, s.opStateOne)
-	unitTwoStateDir := filepath.Join(agentDir, s.tagTwo.String())
+
+	s.opStorOneYaml, s.opStorOneFileName = writeStorageState(c, unitOneStateDir, s.storTagOne, s.opStorOne)
+
+	unitTwoStateDir := filepath.Join(agentDir, s.tagTwo.String(), "state")
+	err = os.MkdirAll(unitTwoStateDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
 	s.opStateTwoYaml, s.opStateTwoFileName = writeUnitStateFile(c, unitTwoStateDir, s.opStateTwo)
 }
 
@@ -108,12 +126,9 @@ func (s *mockSteps28Suite) SetUpTest(c *gc.C) {
 // path/uniter/state file.  It returns the yaml in string form and the
 // full path to the file written.
 func writeUnitStateFile(c *gc.C, path string, st operation.State) (string, string) {
-	dir := filepath.Join(path, "state")
-	err := os.MkdirAll(dir, 0755)
-	c.Assert(err, jc.ErrorIsNil)
-	filePath := filepath.Join(dir, "uniter")
+	filePath := filepath.Join(path, "uniter")
 
-	err = st.Validate()
+	err := st.Validate()
 	c.Assert(err, jc.ErrorIsNil)
 	content, err := yaml.Marshal(st)
 	c.Assert(err, jc.ErrorIsNil)
@@ -124,11 +139,45 @@ func writeUnitStateFile(c *gc.C, path string, st operation.State) (string, strin
 	return string(content), filePath
 }
 
+func writeStorageState(c *gc.C, path string, storTag names.Tag, attached bool) (string, string) {
+	storDir := filepath.Join(path, "storage")
+	err := os.MkdirAll(storDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+
+	storFileName := strings.Replace(storTag.Id(), "/", "-", -1)
+	filePath := filepath.Join(storDir, storFileName)
+
+	data := diskInfo{Attached: &attached}
+	content, err := yaml.Marshal(data)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = ioutil.WriteFile(filePath, content, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedYaml, err := yaml.Marshal(map[string]bool{storTag.Id(): attached})
+	c.Assert(err, jc.ErrorIsNil)
+
+	return string(expectedYaml), filePath
+}
+
+type diskInfo struct {
+	Attached *bool `yaml:"attached,omitempty"`
+}
+
+func (s *mockSteps28Suite) TestMoveUniterStateToControllerNotMachine(c *gc.C) {
+	defer s.setup(c).Finish()
+	s.expectAPIState()
+	s.expectAgentConfigUnitTag()
+	s.patchClient()
+	err := upgrades.MoveUniterStateToController(s.mockCtx)
+	c.Assert(err, jc.ErrorIsNil)
+}
 func (s *mockSteps28Suite) TestMoveUniterStateToControllerIAAS(c *gc.C) {
 	defer s.setup(c).Finish()
 	s.expectAPIState()
+	s.expectAgentConfigMachineTag()
 	s.expectAgentConfigValueIAAS()
-	s.expectWriteTwoUniterState()
+	s.expectWriteTwoUniterState(c)
 	s.patchClient()
 
 	err := upgrades.MoveUniterStateToController(s.mockCtx)
@@ -136,6 +185,8 @@ func (s *mockSteps28Suite) TestMoveUniterStateToControllerIAAS(c *gc.C) {
 	_, err = os.Stat(s.opStateOneFileName)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 	_, err = os.Stat(s.opStateTwoFileName)
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+	_, err = os.Stat(s.opStorOneFileName)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 
 	// Check idempotent
@@ -148,6 +199,7 @@ func (s *mockSteps28Suite) TestMoveUniterStateToControllerCAASDoesNothing(c *gc.
 	// remove when uniterstate moved for CAAS units and/or relations etc
 	// added to move.
 	defer s.setup(c).Finish()
+	s.expectAgentConfigMachineTag()
 	s.expectAgentConfigValueCAAS()
 	s.patchClient()
 
@@ -155,10 +207,6 @@ func (s *mockSteps28Suite) TestMoveUniterStateToControllerCAASDoesNothing(c *gc.
 	for i := 0; i < 2; i += 1 {
 		c.Logf("round %d", i)
 		err := upgrades.MoveUniterStateToController(s.mockCtx)
-		c.Assert(err, jc.ErrorIsNil)
-		_, err = os.Stat(s.opStateOneFileName)
-		c.Assert(err, jc.ErrorIsNil)
-		_, err = os.Stat(s.opStateTwoFileName)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -182,7 +230,7 @@ func (s *mockSteps28Suite) expectAgentConfig() {
 }
 
 func (s *mockSteps28Suite) expectAPIState() {
-	s.mockCtx.EXPECT().APIState().Return(s.mockAPICaller)
+	s.mockCtx.EXPECT().APIState().Return(s.mockAPICaller).AnyTimes()
 }
 
 func (s *mockSteps28Suite) expectDataDir() {
@@ -197,17 +245,86 @@ func (s *mockSteps28Suite) expectAgentConfigValueIAAS() {
 	s.mockAgentConfig.EXPECT().Value(agent.ProviderType).Return("IAAS").AnyTimes()
 }
 
+func (s *mockSteps28Suite) expectAgentConfigMachineTag() {
+	s.mockAgentConfig.EXPECT().Tag().Return(names.NewMachineTag("0")).AnyTimes()
+}
+
+func (s *mockSteps28Suite) expectAgentConfigUnitTag() {
+	s.mockAgentConfig.EXPECT().Tag().Return(names.NewUnitTag("test/0"))
+}
+
 func (s *mockSteps28Suite) patchClient() {
 	s.PatchValue(upgrades.GetUpgradeStepsClient, func(_ base.APICaller) upgrades.UpgradeStepsClient {
 		return s.mockClient
 	})
 }
 
-func (s *mockSteps28Suite) expectWriteTwoUniterState() {
-	writeMap := map[names.Tag]string{
-		s.tagOne: s.opStateOneYaml,
-		s.tagTwo: s.opStateTwoYaml,
+func (s *mockSteps28Suite) expectWriteTwoUniterState(c *gc.C) {
+	args := []params.SetUnitStateArg{{
+		Tag:          s.tagOne.String(),
+		UniterState:  &s.opStateOneYaml,
+		StorageState: &s.opStorOneYaml,
+	}, {
+		Tag:         s.tagTwo.String(),
+		UniterState: &s.opStateTwoYaml,
+	},
 	}
 	cExp := s.mockClient.EXPECT()
-	cExp.WriteUniterState(writeMap).Return(nil)
+	cExp.WriteUniterState(unitStateMatcher{c, args}).Return(nil)
+}
+
+type unitStateMatcher struct {
+	c        *gc.C
+	expected []params.SetUnitStateArg
+}
+
+func (m unitStateMatcher) Matches(x interface{}) bool {
+	obtained, ok := x.([]params.SetUnitStateArg)
+	m.c.Assert(ok, jc.IsTrue)
+	if !ok {
+		return false
+	}
+
+	m.c.Assert(obtained, gc.HasLen, len(m.expected))
+
+	for _, obtainedArg := range obtained {
+		var matched bool
+		for _, expectedArg := range m.expected {
+			if obtainedArg.Tag != expectedArg.Tag {
+				continue
+			}
+			assertSetUnitStateArg(m.c, expectedArg, obtainedArg)
+			matched = true
+		}
+		m.c.Assert(matched, jc.IsTrue)
+	}
+	return true
+}
+
+func assertSetUnitStateArg(c *gc.C, expectedArg, obtainedArg params.SetUnitStateArg) {
+	if expectedArg.State != nil {
+		c.Assert(obtainedArg.State, gc.NotNil)
+		c.Assert(*obtainedArg.State, gc.DeepEquals, *expectedArg.State)
+	} else {
+		c.Assert(obtainedArg.State, gc.IsNil)
+	}
+	if expectedArg.UniterState != nil {
+		c.Assert(*obtainedArg.UniterState, gc.Equals, *expectedArg.UniterState)
+	} else {
+		c.Assert(obtainedArg.UniterState, gc.IsNil)
+	}
+	if expectedArg.RelationState != nil {
+		c.Assert(*obtainedArg.RelationState, gc.DeepEquals, *expectedArg.RelationState)
+	} else {
+		c.Assert(obtainedArg.State, gc.IsNil)
+	}
+	if expectedArg.StorageState != nil {
+		c.Assert(*obtainedArg.StorageState, gc.Equals, *expectedArg.StorageState)
+	} else {
+		c.Assert(obtainedArg.StorageState, gc.IsNil)
+	}
+}
+
+func (m unitStateMatcher) String() string {
+	return "Match the contents of the UniterState pointer in params.SetUnitStateArg"
 }

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -200,7 +200,7 @@ func (change stateChange) apply(state State) *State {
 	return &state
 }
 
-// StateReadWriter reads and writes uniter state from/to the controller.
+// StateOps reads and writes uniter state from/to the controller.
 type StateOps struct {
 	unitStateRW UnitStateReadWriter
 }

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -70,7 +70,7 @@ func (s *resolverSuite) SetUpTest(c *gc.C) {
 	}
 	s.opFactory = operation.NewFactory(operation.FactoryParams{})
 
-	attachments, err := storage.NewAttachments(&dummyStorageAccessor{}, names.NewUnitTag("u/0"), c.MkDir(), nil)
+	attachments, err := storage.NewAttachments(&dummyStorageAccessor{}, names.NewUnitTag("u/0"), &fakeRW{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.clearResolved = func() error {
@@ -424,4 +424,18 @@ func (s *resolverSuite) TestNoOperationIfHashesAllMatch(c *gc.C) {
 
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+}
+
+// fakeRW implements the storage.UnitStateReadWriter interface
+// so SetUpTests can call storage.NewAttachments.  It doesn't
+// need to do anything.
+type fakeRW struct {
+}
+
+func (m *fakeRW) State() (params.UnitStateResult, error) {
+	return params.UnitStateResult{}, nil
+}
+
+func (m *fakeRW) SetState(_ params.SetUnitStateArg) error {
+	return nil
 }

--- a/worker/uniter/storage/export_test.go
+++ b/worker/uniter/storage/export_test.go
@@ -3,39 +3,6 @@
 
 package storage
 
-import (
-	"gopkg.in/juju/names.v3"
-
-	"github.com/juju/juju/worker/uniter/hook"
-)
-
-type State interface {
-	hook.Committer
-	hook.Validator
-}
-
-func StateAttached(s State) bool {
-	return s.(*stateFile).attached
-}
-
-func ValidateHook(tag names.StorageTag, attached bool, hi hook.Info) error {
-	st := &state{tag, attached}
-	return st.ValidateHook(hi)
-}
-
-func ReadStateFile(dirPath string, tag names.StorageTag) (d State, err error) {
-	state, err := readStateFile(dirPath, tag)
-	return state, err
-}
-
-func ReadAllStateFiles(dirPath string) (map[names.StorageTag]State, error) {
-	files, err := readAllStateFiles(dirPath)
-	if err != nil {
-		return nil, err
-	}
-	states := make(map[names.StorageTag]State)
-	for tag, f := range files {
-		states[tag] = f
-	}
-	return states, nil
+func Storage(st *State) map[string]bool {
+	return st.storage
 }

--- a/worker/uniter/storage/mockstateopssuite_test.go
+++ b/worker/uniter/storage/mockstateopssuite_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	"github.com/juju/testing/checkers"
+	jc "github.com/juju/testing/checkers"
+	"gopkg.in/check.v1"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker/uniter/operation/mocks"
+	"github.com/juju/juju/worker/uniter/storage"
+)
+
+type mockStateOpsSuite struct {
+	storSt *storage.State
+
+	mockStateOps *mocks.MockUnitStateReadWriter
+}
+
+func (s *mockStateOpsSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctlr := gomock.NewController(c)
+	s.mockStateOps = mocks.NewMockUnitStateReadWriter(ctlr)
+	return ctlr
+}
+
+func (s *mockStateOpsSuite) expectSetState(c *gc.C, errStr string) {
+	data, err := yaml.Marshal(storage.Storage(s.storSt))
+	c.Assert(err, jc.ErrorIsNil)
+	strStorageState := string(data)
+	if errStr != "" {
+		err = errors.New(`validation of uniter state: invalid operation state: ` + errStr)
+	}
+
+	mExp := s.mockStateOps.EXPECT()
+	mExp.SetState(unitStateMatcher{c: c, expected: strStorageState}).Return(err)
+}
+
+func (s *mockStateOpsSuite) expectSetStateEmpty(c *gc.C) {
+	var strStorageState string
+	mExp := s.mockStateOps.EXPECT()
+	mExp.SetState(unitStateMatcher{c: c, expected: strStorageState}).Return(nil)
+}
+
+func (s *mockStateOpsSuite) expectState(c *check.C) {
+	data, err := yaml.Marshal(storage.Storage(s.storSt))
+	c.Assert(err, checkers.ErrorIsNil)
+	strStorageState := string(data)
+
+	mExp := s.mockStateOps.EXPECT()
+	mExp.State().Return(params.UnitStateResult{StorageState: strStorageState}, nil)
+}
+
+func (s *mockStateOpsSuite) expectStateNotFound() {
+	mExp := s.mockStateOps.EXPECT()
+	mExp.State().Return(params.UnitStateResult{StorageState: ""}, nil)
+}
+
+type unitStateMatcher struct {
+	c        *gc.C
+	expected string
+}
+
+func (m unitStateMatcher) Matches(x interface{}) bool {
+	obtained, ok := x.(params.SetUnitStateArg)
+	if !ok {
+		return false
+	}
+
+	if obtained.StorageState == nil || m.expected != *obtained.StorageState {
+		m.c.Fatalf("unitStateMatcher: expected (%s) obtained (%s)", m.expected, *obtained.StorageState)
+		return false
+	}
+
+	return true
+}
+
+func (m unitStateMatcher) String() string {
+	return "Match the contents of the StorageState pointer in params.SetUnitStateArg"
+}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -596,7 +596,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	u.commandChannel = make(chan string)
 
 	storageAttachments, err := storage.NewAttachments(
-		u.st, unitTag, u.paths.State.StorageDir, u.catacomb.Dying(),
+		u.st, unitTag, u.unit, u.catacomb.Dying(),
 	)
 	if err != nil {
 		return errors.Annotatef(err, "cannot create storage hook source")


### PR DESCRIPTION
## Description of change

Move the uniter's internal storage state from files on the unit to the controller.

The uniter's internal storage state keeps track of which storage has been attached to this unit already

Migration steps for all of the uniter internal state moving server side will be handled together.

## QA steps

```console
$ juju bootstrap localhost testme
$ juju deploy postgresql 
$ juju add-storage  postgresql/0  pgdata=10G

# once the unit is up and running, verify the storage
$ juju show-status-log postgresql/0
...
30 Mar 2020 18:07:29Z  juju-unit  executing    running pgdata-storage-attached hook
...
$ juju storage
Unit          Storage id  Type        Pool    Size    Status    Message
postgresql/0  pgdata/0    filesystem  rootfs  457GiB  attached

# check the db
$ juju-db.bash
juju:PRIMARY> db.unitstates.find().pretty()
{
	...
	"storage-state" : "pgdata/0: true\n"
}

# kill the jujud unit process on the unit, verify that the storage-attached hook is not called again
$ juju show-status-log postgresql/0
...
30 Mar 2020 18:07:29Z  juju-unit  executing    running pgdata-storage-attached hook
...

# remove the storage and verify false in db.
$ juju detach-storage pgdata/0
detaching pgdata/0
$ juju-db.bash
juju:PRIMARY> db.unitstates.find().pretty()
{
	...
	"storage-state" : "pgdata/0: false\n"
}
```
Run upgrade from juju 2.7.4

Test on microk8s
```console
$ make microk8s-operator-update
$ juju bootstrap microk8s mk8s --no-gui
$ juju add-model testme
$ juju create-storage-pool operator-storage kubernetes storage-class=microk8s-hostpath
$ juju create-storage-pool mariadb-pv kubernetes storage-class=microk8s-hostpath
$ juju deploy cs:~juju/mariadb-k8s --storage database=mariadb-pv,10M
$ juju storage
Unit           Storage id  Type        Pool        Size   Status    Message
mariadb-k8s/0  database/0  filesystem  mariadb-pv  35MiB  attached  Successfully provisioned volume pvc-2318d44d-c9be-4abb-beb7-462ac1e2de5f

# see no storage dir in state.
$ juju run --unit mariadb-k8s/0 --operator -- ls -la ../state
total 20
drwxr-xr-x 4 root root 4096 Mar 31 20:14 .
drwxr-xr-x 4 root root 4096 Mar 31 20:14 ..
drwxr-xr-x 3 root root 4096 Mar 31 20:14 bundles
drwxr-xr-x 3 root root 4096 Mar 31 20:14 deployer
-rw-r--r-- 1 root root   57 Mar 31 20:14 operator
```
