### PR TITLE
Hook retry worker should use ErrBounce

### DIFF
--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -255,6 +255,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 			NewFacade:     retrystrategy.NewFacade,
 			NewWorker:     retrystrategy.NewRetryStrategyWorker,
+			Logger:        loggo.GetLogger("juju.worker.retrystrategy"),
 		})),
 
 		// The operator installs and deploys charm containers;

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -302,6 +302,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 			NewFacade:     retrystrategy.NewFacade,
 			NewWorker:     retrystrategy.NewRetryStrategyWorker,
+			Logger:        loggo.GetLogger("juju.worker.retrystrategy"),
 		})),
 
 		// The uniter installs charms; manages the unit's presence in its

--- a/worker/retrystrategy/fixture_test.go
+++ b/worker/retrystrategy/fixture_test.go
@@ -7,6 +7,7 @@ package retrystrategy_test
 import (
 	"time"
 
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,6 +42,7 @@ func (fix *fixture) Run(c *gc.C, test func(worker.Worker)) {
 		Facade:        stubFacade,
 		AgentTag:      stubTag,
 		RetryStrategy: stubRetryStrategy,
+		Logger:        loggo.GetLogger("test"),
 	}
 
 	w, err := retrystrategy.NewRetryStrategyWorker(stubConfig)

--- a/worker/retrystrategy/manifold.go
+++ b/worker/retrystrategy/manifold.go
@@ -15,12 +15,22 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 )
 
+// Logger represents the methods used by the worker to log information.
+type Logger interface {
+	Debugf(string, ...interface{})
+}
+
+// logger is here to stop the desire of creating a package level logger.
+// Don't do this, instead use the one passed as manifold config.
+var logger interface{}
+
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
 type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
 	NewFacade     func(base.APICaller) Facade
 	NewWorker     func(WorkerConfig) (worker.Worker, error)
+	Logger        Logger
 }
 
 // Manifold returns a dependency manifold that runs a hook retry strategy worker,
@@ -46,6 +56,7 @@ func (mc ManifoldConfig) start(a agent.Agent, apiCaller base.APICaller) (worker.
 		Facade:        retryStrategyFacade,
 		AgentTag:      agentTag,
 		RetryStrategy: initialRetryStrategy,
+		Logger:        mc.Logger,
 	})
 }
 

--- a/worker/retrystrategy/worker.go
+++ b/worker/retrystrategy/worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v3"
 	"gopkg.in/juju/worker.v1"
+	"gopkg.in/juju/worker.v1/dependency"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/watcher"
@@ -24,6 +25,7 @@ type WorkerConfig struct {
 	Facade        Facade
 	AgentTag      names.Tag
 	RetryStrategy params.RetryStrategy
+	Logger        Logger
 }
 
 // Validate returns an error if the configuration is not complete.
@@ -87,7 +89,8 @@ func (h retryStrategyHandler) Handle(_ <-chan struct{}) error {
 		return errors.Trace(err)
 	}
 	if newRetryStrategy != h.config.RetryStrategy {
-		return errors.Errorf("bouncing retrystrategy worker to get new values")
+		h.config.Logger.Debugf("bouncing retrystrategy worker to get new values")
+		return dependency.ErrBounce
 	}
 	return nil
 }

--- a/worker/retrystrategy/worker_test.go
+++ b/worker/retrystrategy/worker_test.go
@@ -73,7 +73,7 @@ func (s WorkerSuite) TestBounce(c *gc.C) {
 	fix := newFixture(c, nil, nil, nil)
 	fix.Run(c, func(w worker.Worker) {
 		err := w.Wait()
-		c.Assert(err, gc.ErrorMatches, "bouncing retrystrategy worker to get new values")
+		c.Assert(err, gc.ErrorMatches, "restart immediately")
 	})
 	fix.CheckCallNames(c, "WatchRetryStrategy", "RetryStrategy", "RetryStrategy")
 }


### PR DESCRIPTION
## Description of change

As seen in recent QA runs, when updating the hook retry strategy, the worker bounces but logs an error since it doesn't use ErrBounce. This PR fixes that so that there's not a confusing ERROR logged.

## QA steps

deploy a charm
juju model-config automatically-retry-hooks=false
look at the logs and observe the worker has restarted

## Bug
https://bugs.launchpad.net/charm-kubernetes-master/+bug/1869388