### PR TITLE
upgrader: Remove checks in the upgrader to prevent downgrading

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -410,9 +410,9 @@ func (s *BootstrapSuite) TestInitializeEnvironmentInvalidOplogSize(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
-	// bootstrap with 1.99.1 but there will be no tools so version will be reset.
+	// bootstrap with 2.99.1 but there will be no tools so version will be reset.
 	cfg, err := s.bootstrapParams.ControllerModelConfig.Apply(map[string]interface{}{
-		"agent-version": "1.99.1",
+		"agent-version": "2.99.1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.bootstrapParams.ControllerModelConfig = cfg
@@ -433,7 +433,7 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	vers, ok := cfg.AgentVersion()
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(vers.String(), gc.Equals, "1.99.0")
+	c.Assert(vers.String(), gc.Equals, "2.99.0")
 }
 
 func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -667,7 +667,7 @@ func (s *bootstrapSuite) TestBootstrapBuildAgent(c *gc.C) {
 			BuildAgentTarball: func(build bool, ver *version.Number, _ string) (*sync.BuiltAgent, error) {
 				c.Logf("BuildAgentTarball version %s", ver)
 				c.Assert(build, jc.IsTrue)
-				c.Assert(ver.String(), gc.Equals, "1.99.0.1")
+				c.Assert(ver.String(), gc.Equals, "2.99.0.1")
 				localVer := *ver
 				return &sync.BuiltAgent{
 					Dir:      c.MkDir(),
@@ -687,7 +687,7 @@ func (s *bootstrapSuite) TestBootstrapBuildAgent(c *gc.C) {
 	cfg := env.instanceConfig.Bootstrap.ControllerModelConfig
 	agentVersion, valid := cfg.AgentVersion()
 	c.Check(valid, jc.IsTrue)
-	c.Check(agentVersion.String(), gc.Equals, "1.99.0")
+	c.Check(agentVersion.String(), gc.Equals, "2.99.0")
 }
 
 func (s *bootstrapSuite) assertBootstrapPackagedToolsAvailable(c *gc.C, clientArch string) {

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -76,8 +76,8 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 		Arch:   arch.HostArch(),
 		Series: series.MustHostSeries(),
 	}
-	s.oldVersion.Major = 1
-	s.oldVersion.Minor = 16
+	s.oldVersion.Major = 2
+	s.oldVersion.Minor = 1
 
 	// Don't wait so long in tests.
 	s.PatchValue(&upgradesteps.UpgradeStartTimeoutMaster, time.Millisecond*50)

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -37,7 +37,7 @@ var (
 )
 
 // FakeVersionNumber is a valid version number that can be used in testing.
-var FakeVersionNumber = version.MustParse("1.99.0")
+var FakeVersionNumber = version.MustParse("2.99.0")
 
 // ModelTag is a defined known valid UUID that can be used in testing.
 var ModelTag = names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -155,7 +155,6 @@ func (u *Upgrader) loop() error {
 		} else if !upgrader.AllowedTargetVersion(
 			u.config.OrigAgentVersion,
 			jujuversion.Current,
-			!u.config.UpgradeStepsWaiter.IsUnlocked(),
 			wantVersion,
 		) {
 			logger.Warningf("desired agent binary version: %s is older than current %s, refusing to downgrade",
@@ -163,7 +162,11 @@ func (u *Upgrader) loop() error {
 			u.config.InitialUpgradeCheckComplete.Unlock()
 			continue
 		}
-		logger.Debugf("upgrade requested for %v from %v to %v", u.tag, jujuversion.Current, wantVersion)
+		direction := "upgrade"
+		if wantVersion.Compare(jujuversion.Current) == -1 {
+			direction = "downgrade"
+		}
+		logger.Debugf("%s requested for %v from %v to %v", direction, u.tag, jujuversion.Current, wantVersion)
 		err = u.operatorUpgrader.Upgrade(u.tag.String(), wantVersion)
 		if err != nil {
 			return errors.Annotatef(err, "requesting upgrade for %f from %v to %v", u.tag, jujuversion.Current, wantVersion)


### PR DESCRIPTION
## Description of change

Previously the upgrader rejected a version change if the target minor or major version was less than the current version. This check has been removed to support rolling back the Juju version by restoring a backup taken before an upgrade.

The same change has been made in the caasupgrader worker - the upgrade process is different in k8s land but this check was essentially the same.

With these changes restoring a previous version of a controller automatically triggers the agents to download the required version of the agent, symlink it and update the upgradedToVersion in the agent.conf.

There was a mention of a bug in upgrading from 1.16 to 1.18: https://bugs.launchpad.net/juju-core/+bug/1299802
My understanding is that this behaviour isn't a concern any more because the unit agent no longer considers the machine agent's version; everything is driven by the model agent version instead.

## QA steps

* Bootstrap with Juju 2.7.
* Deploy some units.
* Take a backup of the controller.
```sh
juju create-backup -m controller
```
* Upgrade to 2.8 with this change, and upgrade the model as well.
```sh
juju upgrade-controller --build-agent
juju upgrade-model
```
* Run juju-restore on the controller machine. At the moment this requires a version of juju-restore hacked to remove the check requiring the same version between controller and backup.
```sh
juju scp -m controller $(which juju-restore) 0:
juju scp -m controller juju-backup-whenever-it-is.tar.gz
juju ssh -m controller 0
# On machine
sudo grep statepassword /var/lib/juju/agents/machine-0/agent.conf
./juju-restore --username machine-0 --password thepassword --verbose juju-backup-whenever.tar.gz
```
* After restore the controller agent will start complaining about downgrading state from 2.8 to 2.7.4 - this is unnecessary because the db is already at 2.7.4, it's just because the agent.conf is wrong. Stop the agent and edit agent.conf to set upgradedToVersion back to 2.7.4:
```sh
$ sudo systemctl stop jujud-machine-0.service
$ sudo vi /var/lib/juju/agents/machine-0/agent.conf
$ sudo systemctl start jujud-machine-0.service
```
(Once the version downgrade changes are made to juju-restore this will happen automatically.)

* The unit and machine agents in the model will update their symlinks to point to the 2.7.4 binary and their agent.confs with the correct upgradedToVersion.
* Their log files will show that the right version of the binary is running.

## Documentation changes

No change to documentation.

## Bug reference

None

