### PR TITLE
Disable scale-application, add-unit, remove-unit for daemonset;

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1746,8 +1746,13 @@ func (api *APIBase) ScaleApplications(args params.ScaleApplicationsParams) (para
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if ch.Meta().Deployment != nil && ch.Meta().Deployment.DeploymentMode == charm.ModeOperator {
-			return nil, errors.New("cannot scale an operator charm")
+		if ch.Meta().Deployment != nil {
+			if ch.Meta().Deployment.DeploymentMode == charm.ModeOperator {
+				return nil, errors.NotSupportedf("scale an %q application", charm.ModeOperator)
+			}
+			if ch.Meta().Deployment.DeploymentType == charm.DeploymentDaemon {
+				return nil, errors.NotSupportedf("scale a %q application", charm.DeploymentDaemon)
+			}
 		}
 
 		var info params.ScaleApplicationInfo

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1019,7 +1019,31 @@ func (s *ApplicationSuite) TestScaleApplicationsNotAllowedForOperator(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.NotNil)
 	msg := strings.Replace(result.Results[0].Error.Error(), "\n", "", -1)
-	c.Assert(msg, gc.Matches, `cannot scale an operator charm`)
+	c.Assert(msg, gc.Matches, `scale an "operator" application not supported`)
+}
+
+func (s *ApplicationSuite) TestScaleApplicationsNotAllowedForDaemonSet(c *gc.C) {
+	s.model.modelType = state.ModelTypeCAAS
+	s.setAPIUser(c, names.NewUserTag("admin"))
+	s.backend.applications["postgresql"].charm = &mockCharm{
+		meta: &charm.Meta{
+			Deployment: &charm.Deployment{
+				DeploymentType: charm.DeploymentDaemon,
+			},
+		},
+	}
+	args := params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{{
+			ApplicationTag: "application-postgresql",
+			Scale:          5,
+		}},
+	}
+	result, err := s.api.ScaleApplications(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.NotNil)
+	msg := strings.Replace(result.Results[0].Error.Error(), "\n", "", -1)
+	c.Assert(msg, gc.Matches, `scale a "daemon" application not supported`)
 }
 
 func (s *ApplicationSuite) TestScaleApplicationsBlocked(c *gc.C) {

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -255,6 +255,12 @@ func (c *addUnitCommand) Run(ctx *cmd.Context) error {
 			ApplicationName: c.ApplicationName,
 			ScaleChange:     c.NumUnits,
 		})
+		if err == nil {
+			return nil
+		}
+		if params.IsCodeNotSupported(err) {
+			return errors.Annotate(err, "can not add unit")
+		}
 		if params.IsCodeUnauthorized(err) {
 			common.PermissionsMessage(ctx.Stderr, "scale an application")
 		}

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -275,6 +275,15 @@ func (s *AddUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *AddUnitSuite) TestCAASAddUnitNotSupported(c *gc.C) {
+	m := s.store.Models["arthur"].Models["king/sword"]
+	m.ModelType = model.CAAS
+	s.store.Models["arthur"].Models["king/sword"] = m
+
+	s.fake.err = common.ServerError(errors.NotSupportedf(`scale a "daemon" charm`))
+	err := s.runAddUnit(c, "some-application-name")
+	c.Check(err, gc.ErrorMatches, `can not add unit: scale a "daemon" charm not supported`)
+}
 func (s *AddUnitSuite) TestUnknownModelCallsRefresh(c *gc.C) {
 	called := false
 	refresh := func(jujuclient.ClientStore, string) error {

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/storage"
+	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -331,6 +332,9 @@ func (c *removeUnitCommand) removeCaasUnits(ctx *cmd.Context, client RemoveAppli
 		ScaleChange:     -c.NumUnits,
 		Force:           c.Force,
 	})
+	if params.IsCodeNotSupported(err) {
+		return errors.Annotate(err, "can not remove unit")
+	}
 	if err != nil {
 		return block.ProcessBlockedError(err, block.BlockRemove)
 	}

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -174,6 +175,17 @@ func (s *RemoveUnitSuite) TestCAASRemoveUnit(c *gc.C) {
 	c.Assert(stderr, gc.Equals, `
 scaling down to 3 units
 `[1:])
+}
+
+func (s *RemoveUnitSuite) TestCAASRemoveUnitNotSupported(c *gc.C) {
+	m := s.store.Models["arthur"].Models["king/sword"]
+	m.ModelType = model.CAAS
+	s.store.Models["arthur"].Models["king/sword"] = m
+
+	s.fake.err = common.ServerError(errors.NotSupportedf(`scale a "daemon" charm`))
+
+	_, err := s.runRemoveUnit(c, "some-application-name", "--num-units", "2")
+	c.Assert(err, gc.ErrorMatches, `can not remove unit: scale a "daemon" charm not supported`)
 }
 
 func (s *RemoveUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - ~[ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [ x] Do comments answer the question of why design decisions were made?

----

## Description of change

Disable scale-application, add-unit, remove-unit for daemonset;

## QA steps

```console
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml --pretty | jq '.deployment'
{
  "type": "daemon",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju add-model t1 microk8s && juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb

$ juju add-unit mariadb-k8s -n 3
ERROR can not add unit: scale a "daemon" charm not supported

$ juju remove-unit mariadb-k8s --num-units 3
ERROR can not remove unit: scale a "daemon" charm not supported

$ juju scale-application mariadb-k8s 3 -m t1
ERROR could not scale application "mariadb-k8s": scale a "daemon" charm not supported

```

## Documentation changes

Yes

## Bug reference

None
