### PR TITLE
Add operations to the model export/import

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -485,11 +485,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:4e0797209852d8675c9a6d17d49a543428f7182eef8b6f2ee9c12e4f4648bc4f"
+  digest = "1:8835d6bbeb647a441c134c3c41881a59ea21527bddd016195847a6fb9fbab909"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "d884fa94b91060a8995d85aca929f96fd100e935"
+  revision = "2e2cf381eb0406ff5edd1976dc24d3846176552b"
 
 [[projects]]
   digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "d884fa94b91060a8995d85aca929f96fd100e935"
+  revision = "2e2cf381eb0406ff5edd1976dc24d3846176552b"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1680,7 +1680,28 @@ func (s *MigrationImportSuite) TestAction(c *gc.C) {
 	action := actions[0]
 	c.Check(action.Receiver(), gc.Equals, machine.Id())
 	c.Check(action.Name(), gc.Equals, "foo")
+	c.Check(state.ActionOperationId(action), gc.Equals, operationID)
 	c.Check(action.Status(), gc.Equals, state.ActionPending)
+}
+
+func (s *MigrationImportSuite) TestOperation(c *gc.C) {
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	operationID, err := m.EnqueueOperation("a test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	newModel, newState := s.importModel(c, s.State)
+	defer func() {
+		c.Assert(newState.Close(), jc.ErrorIsNil)
+	}()
+
+	operations, _ := newModel.AllOperations()
+	c.Assert(operations, gc.HasLen, 1)
+	op := operations[0]
+	c.Check(op.Summary(), gc.Equals, "a test")
+	c.Check(op.Id(), gc.Equals, operationID)
+	c.Check(op.Status(), gc.Equals, state.ActionPending)
 }
 
 func (s *MigrationImportSuite) TestVolumes(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -64,6 +64,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// actions
 		actionsC,
+		operationsC,
 
 		// storage
 		filesystemsC,
@@ -225,8 +226,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// sure the leader units' leases are claimed in the target
 		// controller when leases are managed in raft.
 		leaseHoldersC,
-		// TODO(wallyworld) - migrate operations
-		operationsC,
 	)
 
 	modelCollections := set.NewStrings()
@@ -724,13 +723,12 @@ func (s *MigrationSuite) TestSSHHostKeyDocFields(c *gc.C) {
 func (s *MigrationSuite) TestActionDocFields(c *gc.C) {
 	ignored := set.NewStrings(
 		"ModelUUID",
-		// TODO(wallyworld) - migrate operations
-		"Operation",
 	)
 	migrated := set.NewStrings(
 		"DocId",
 		"Receiver",
 		"Name",
+		"Operation",
 		"Enqueued",
 		"Started",
 		"Completed",


### PR DESCRIPTION
## Description of change

model import/export now supports operations

## QA steps

deploy a model
run an action or 2
$ juju dump-model and see that operations are included and action records have an operation field
bootstrap another controller
migrate the model
run dump-model on the new controller
