### PR TITLE
Implement support for debug-code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1351,7 +1351,7 @@
   revision = "c390a4cc19a3efac72d6fcce80ab2984d54f1f3f"
 
 [[projects]]
-  digest = "1:f432835a8eb23aa21056c9ac8f38092b4de9d6f06671d588161d6c301dfaee68"
+  digest = "1:d4d2d7e40d11f43c095a6d1fa0b32f290f627e3b707b8e7f877eeb84aceb3640"
   name = "gopkg.in/juju/charmrepo.v4"
   packages = [
     ".",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1351,7 +1351,7 @@
   revision = "c390a4cc19a3efac72d6fcce80ab2984d54f1f3f"
 
 [[projects]]
-  digest = "1:d4d2d7e40d11f43c095a6d1fa0b32f290f627e3b707b8e7f877eeb84aceb3640"
+  digest = "1:f432835a8eb23aa21056c9ac8f38092b4de9d6f06671d588161d6c301dfaee68"
   name = "gopkg.in/juju/charmrepo.v4"
   packages = [
     ".",

--- a/cmd/juju/commands/debugcode.go
+++ b/cmd/juju/commands/debugcode.go
@@ -4,9 +4,6 @@
 package commands
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -74,7 +71,6 @@ func (c *debugCodeCommand) Init(args []string) error {
 }
 func (c *debugCodeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.debugHooksCommand.SetFlags(f)
-	fmt.Fprintf(os.Stderr, "run away\n")
 	f.StringVar(&c.debugAt, "at", "all",
 		"interpreted by the charm for where you want to stop, defaults to 'all'")
 }

--- a/cmd/juju/commands/debugcode.go
+++ b/cmd/juju/commands/debugcode.go
@@ -1,0 +1,87 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"gopkg.in/juju/names.v3"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/network/ssh"
+)
+
+func newDebugCodeCommand(hostChecker ssh.ReachableChecker) cmd.Command {
+	c := new(debugCodeCommand)
+	c.getActionAPI = c.debugHooksCommand.newActionsAPI
+	c.setHostChecker(hostChecker)
+	return modelcmd.Wrap(c)
+}
+
+// debugCodeCommand connects via SSH to a running unit, and drops into a tmux shell,
+// prepared to debug hooks/actions as they fire.
+type debugCodeCommand struct {
+	debugHooksCommand
+	debugAt string
+}
+
+const debugCodeDoc = `
+Interactively debug hooks and actions on a unit.
+
+Similar to 'juju debug-hooks' but rather than dropping you into a shell prompt, 
+it runs the hooks and sets the JUJU_DEBUG_AT environment variable. 
+Charms that implement support for this should use it to set breakpoints based on the environment
+variable.
+
+See the "juju help ssh" for information about SSH related options
+accepted by the debug-hooks command.
+`
+
+func (c *debugCodeCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "debug-code",
+		Args:    "<unit name> [hook or action names]",
+		Purpose: "Launch a tmux session to debug hooks and/or actions.",
+		Doc:     debugCodeDoc,
+		Aliases: []string{},
+	})
+}
+
+func (c *debugCodeCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.Errorf("no unit name specified")
+	}
+	c.Target = args[0]
+	if !names.IsValidUnit(c.Target) {
+		return errors.Errorf("%q is not a valid unit name", c.Target)
+	}
+
+	// If any of the hooks is "*", then debug all hooks.
+	c.hooks = append([]string{}, args[1:]...)
+	for _, h := range c.hooks {
+		if h == "*" {
+			c.hooks = nil
+			break
+		}
+	}
+	return nil
+}
+func (c *debugCodeCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.debugHooksCommand.SetFlags(f)
+	fmt.Fprintf(os.Stderr, "run away\n")
+	f.StringVar(&c.debugAt, "at", "all",
+		"interpreted by the charm for where you want to stop, defaults to 'all'")
+}
+
+// Run ensures c.Target is a unit, and resolves its address,
+// and connects to it via SSH to execute the debug-hooks
+// script.
+func (c *debugCodeCommand) Run(ctx *cmd.Context) error {
+	return c.commonRun(ctx, c.Target, c.hooks, c.debugAt)
+}

--- a/cmd/juju/commands/debugcode_test.go
+++ b/cmd/juju/commands/debugcode_test.go
@@ -1,0 +1,57 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"encoding/base64"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/juju/cmd/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v2"
+)
+
+var _ = gc.Suite(&DebugCodeSuite{})
+
+type DebugCodeSuite struct {
+	SSHCommonSuite
+}
+
+func (s *DebugCodeSuite) TestArgFormatting(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("bug 1403084: Skipping on windows for now")
+	}
+	s.setupModel(c)
+	s.setHostChecker(validAddresses("0.public"))
+	ctx, err := cmdtesting.RunCommand(c, newDebugCodeCommand(s.hostChecker),
+		"--at=foo,bar", "mysql/0", "install", "start")
+	c.Assert(err, jc.ErrorIsNil)
+	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")
+	c.Check(err, jc.ErrorIsNil)
+	rawContent := base64Regex.FindString(cmdtesting.Stdout(ctx))
+	c.Check(rawContent, gc.Not(gc.Equals), "")
+	// Strip off the "echo " and " | base64"
+	prefix := "echo "
+	suffix := " | base64"
+	c.Check(strings.HasPrefix(rawContent, prefix), jc.IsTrue)
+	c.Check(strings.HasSuffix(rawContent, suffix), jc.IsTrue)
+	b64content := rawContent[len(prefix) : len(rawContent)-len(suffix)]
+	scriptContent, err := base64.StdEncoding.DecodeString(b64content)
+	c.Assert(string(scriptContent), gc.Not(gc.Equals), "")
+	// Inside the script is another base64 encoded string telling us the debug-hook args
+	debugArgsRegex := regexp.MustCompile(`echo "([A-Z-a-z0-9+/]+=*)" \| base64.*-debug-hooks`)
+	debugArgsCommand := debugArgsRegex.FindString(string(scriptContent))
+	debugArgsB64 := debugArgsCommand[len(`echo "`):strings.Index(debugArgsCommand, `" | base64`)]
+	yamlContent, err := base64.StdEncoding.DecodeString(string(debugArgsB64))
+	var args map[string]interface{}
+	err = goyaml.Unmarshal(yamlContent, &args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(args, gc.DeepEquals, map[string]interface{}{
+		"hooks":    []interface{}{"install", "start"},
+		"debug-at": "foo,bar",
+	})
+}

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -4,12 +4,15 @@
 package commands
 
 import (
+	"encoding/base64"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	jujussh "github.com/juju/juju/network/ssh"
 )
@@ -152,4 +155,39 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 			}
 		}
 	}
+}
+
+func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("bug 1403084: Skipping on windows for now")
+	}
+	s.setupModel(c)
+	s.setHostChecker(validAddresses("0.public"))
+	ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker),
+		"--breakpoint=foo,bar", "mysql/0", "install", "start")
+	c.Check(err, jc.ErrorIsNil)
+	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")
+	c.Check(err, jc.ErrorIsNil)
+	rawContent := base64Regex.FindString(cmdtesting.Stdout(ctx))
+	c.Check(rawContent, gc.Not(gc.Equals), "")
+	// Strip off the "echo " and " | base64"
+	prefix := "echo "
+	suffix := " | base64"
+	c.Check(strings.HasPrefix(rawContent, prefix), jc.IsTrue)
+	c.Check(strings.HasSuffix(rawContent, suffix), jc.IsTrue)
+	b64content := rawContent[len(prefix) : len(rawContent)-len(suffix)]
+	scriptContent, err := base64.StdEncoding.DecodeString(b64content)
+	c.Assert(string(scriptContent), gc.Not(gc.Equals), "")
+	// Inside the script is another base64 encoded string telling us the debug-hook args
+	debugArgsRegex := regexp.MustCompile(`echo "([A-Z-a-z0-9+/]+=*)" \| base64.*-debug-hooks`)
+	debugArgsCommand := debugArgsRegex.FindString(string(scriptContent))
+	debugArgsB64 := debugArgsCommand[len(`echo "`):strings.Index(debugArgsCommand, `" | base64`)]
+	yamlContent, err := base64.StdEncoding.DecodeString(string(debugArgsB64))
+	var args map[string]interface{}
+	err = goyaml.Unmarshal(yamlContent, &args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(args, gc.DeepEquals, map[string]interface{}{
+		"hooks":      []interface{}{"install", "start"},
+		"breakpoint": "foo,bar",
+	})
 }

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -164,7 +164,7 @@ func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *gc.C) {
 	s.setupModel(c)
 	s.setHostChecker(validAddresses("0.public"))
 	ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker),
-		"--breakpoint=foo,bar", "mysql/0", "install", "start")
+		"mysql/0", "install", "start")
 	c.Check(err, jc.ErrorIsNil)
 	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")
 	c.Check(err, jc.ErrorIsNil)
@@ -187,7 +187,6 @@ func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *gc.C) {
 	err = goyaml.Unmarshal(yamlContent, &args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(args, gc.DeepEquals, map[string]interface{}{
-		"hooks":      []interface{}{"install", "start"},
-		"breakpoint": "foo,bar",
+		"hooks": []interface{}{"install", "start"},
 	})
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -313,6 +313,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewResolvedCommand())
 	r.Register(newDebugLogCommand(nil))
 	r.Register(newDebugHooksCommand(nil))
+	r.Register(newDebugCodeCommand(nil))
 
 	// Configuration commands.
 	r.Register(model.NewModelGetConstraintsCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -502,6 +502,7 @@ var commandNames = []string{
 	"create-storage-pool",
 	"create-wallet",
 	"credentials",
+	"debug-code",
 	"debug-hook",
 	"debug-hooks",
 	"debug-log",

--- a/worker/uniter/runner/debug/client.go
+++ b/worker/uniter/runner/debug/client.go
@@ -31,10 +31,16 @@ func ClientScript(c *HooksContext, match []string, breakpoint string) string {
 	s = strings.Replace(s, "{entry_flock}", c.ClientFileLock(), -1)
 	s = strings.Replace(s, "{exit_flock}", c.ClientExitFileLock(), -1)
 
-	yamlArgs := encodeArgs(match, breakpoint)
-	base64Args := base64.StdEncoding.EncodeToString(yamlArgs)
+	base64Args := Base64HookArgs(match, breakpoint)
 	s = strings.Replace(s, "{hook_args}", base64Args, 1)
 	return s
+}
+
+// Base64HookArgs returns the encoded arguments for defining debug-hook behavior.
+// This is a base64 encoded yaml blob containing serialized arguments.
+func Base64HookArgs(match []string, breakpoint string) string {
+	yamlArgs := encodeArgs(match, breakpoint)
+	return base64.StdEncoding.EncodeToString(yamlArgs)
 }
 
 func encodeArgs(args []string, breakpoint string) []byte {

--- a/worker/uniter/runner/debug/client.go
+++ b/worker/uniter/runner/debug/client.go
@@ -11,12 +11,13 @@ import (
 )
 
 type hookArgs struct {
-	Hooks []string `yaml:"hooks,omitempty"`
+	Hooks      []string `yaml:"hooks,omitempty"`
+	Breakpoint string   `yaml:"breakpoint,omitempty"`
 }
 
 // ClientScript returns a bash script suitable for executing
 // on the unit system to intercept matching hooks or actions via tmux shell.
-func ClientScript(c *HooksContext, match []string) string {
+func ClientScript(c *HooksContext, match []string, breakpoint string) string {
 	// If any argument is "*", then the client is interested in all.
 	for _, m := range match {
 		if m == "*" {
@@ -30,15 +31,15 @@ func ClientScript(c *HooksContext, match []string) string {
 	s = strings.Replace(s, "{entry_flock}", c.ClientFileLock(), -1)
 	s = strings.Replace(s, "{exit_flock}", c.ClientExitFileLock(), -1)
 
-	yamlArgs := encodeArgs(match)
+	yamlArgs := encodeArgs(match, breakpoint)
 	base64Args := base64.StdEncoding.EncodeToString(yamlArgs)
 	s = strings.Replace(s, "{hook_args}", base64Args, 1)
 	return s
 }
 
-func encodeArgs(args []string) []byte {
+func encodeArgs(args []string, breakpoint string) []byte {
 	// Marshal to YAML, then encode in base64 to avoid shell escapes.
-	yamlArgs, err := goyaml.Marshal(hookArgs{Hooks: args})
+	yamlArgs, err := goyaml.Marshal(hookArgs{Hooks: args, Breakpoint: breakpoint})
 	if err != nil {
 		// This should not happen: we're in full control.
 		panic(err)

--- a/worker/uniter/runner/debug/client.go
+++ b/worker/uniter/runner/debug/client.go
@@ -11,13 +11,13 @@ import (
 )
 
 type hookArgs struct {
-	Hooks      []string `yaml:"hooks,omitempty"`
-	Breakpoint string   `yaml:"breakpoint,omitempty"`
+	Hooks   []string `yaml:"hooks,omitempty"`
+	DebugAt string   `yaml:"debug-at,omitempty"`
 }
 
 // ClientScript returns a bash script suitable for executing
 // on the unit system to intercept matching hooks or actions via tmux shell.
-func ClientScript(c *HooksContext, match []string, breakpoint string) string {
+func ClientScript(c *HooksContext, match []string, debugAt string) string {
 	// If any argument is "*", then the client is interested in all.
 	for _, m := range match {
 		if m == "*" {
@@ -31,21 +31,21 @@ func ClientScript(c *HooksContext, match []string, breakpoint string) string {
 	s = strings.Replace(s, "{entry_flock}", c.ClientFileLock(), -1)
 	s = strings.Replace(s, "{exit_flock}", c.ClientExitFileLock(), -1)
 
-	base64Args := Base64HookArgs(match, breakpoint)
+	base64Args := Base64HookArgs(match, debugAt)
 	s = strings.Replace(s, "{hook_args}", base64Args, 1)
 	return s
 }
 
 // Base64HookArgs returns the encoded arguments for defining debug-hook behavior.
 // This is a base64 encoded yaml blob containing serialized arguments.
-func Base64HookArgs(match []string, breakpoint string) string {
-	yamlArgs := encodeArgs(match, breakpoint)
+func Base64HookArgs(match []string, debugAt string) string {
+	yamlArgs := encodeArgs(match, debugAt)
 	return base64.StdEncoding.EncodeToString(yamlArgs)
 }
 
-func encodeArgs(args []string, breakpoint string) []byte {
+func encodeArgs(args []string, debugAt string) []byte {
 	// Marshal to YAML, then encode in base64 to avoid shell escapes.
-	yamlArgs, err := goyaml.Marshal(hookArgs{Hooks: args, Breakpoint: breakpoint})
+	yamlArgs, err := goyaml.Marshal(hookArgs{Hooks: args, DebugAt: debugAt})
 	if err != nil {
 		// This should not happen: we're in full control.
 		panic(err)

--- a/worker/uniter/runner/debug/client_test.go
+++ b/worker/uniter/runner/debug/client_test.go
@@ -6,9 +6,9 @@ package debug_test
 import (
 	"encoding/base64"
 	"fmt"
-	jc "github.com/juju/testing/checkers"
 	"regexp"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 

--- a/worker/uniter/runner/debug/client_test.go
+++ b/worker/uniter/runner/debug/client_test.go
@@ -4,10 +4,13 @@
 package debug_test
 
 import (
+	"encoding/base64"
 	"fmt"
+	jc "github.com/juju/testing/checkers"
 	"regexp"
 
 	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/worker/uniter/runner/debug"
 )
@@ -20,7 +23,7 @@ func (*DebugHooksClientSuite) TestClientScript(c *gc.C) {
 	ctx := debug.NewHooksContext("foo/8")
 
 	// Test the variable substitutions.
-	result := debug.ClientScript(ctx, nil)
+	result := debug.ClientScript(ctx, nil, "")
 	// No variables left behind.
 	c.Assert(result, gc.Not(gc.Matches), "(.|\n)*{unit_name}(.|\n)*")
 	c.Assert(result, gc.Not(gc.Matches), "(.|\n)*{tmux_conf}(.|\n)*")
@@ -36,15 +39,74 @@ func (*DebugHooksClientSuite) TestClientScript(c *gc.C) {
 	// nil is the same as empty slice is the same as "*".
 	// Also, if "*" is present as well as a named hook,
 	// it is equivalent to "*".
-	c.Assert(debug.ClientScript(ctx, nil), gc.Equals, debug.ClientScript(ctx, []string{}))
-	c.Assert(debug.ClientScript(ctx, []string{"*"}), gc.Equals, debug.ClientScript(ctx, nil))
-	c.Assert(debug.ClientScript(ctx, []string{"*", "something"}), gc.Equals, debug.ClientScript(ctx, []string{"*"}))
+	c.Check(debug.ClientScript(ctx, nil, ""),
+		gc.Equals, debug.ClientScript(ctx, []string{}, ""))
+	c.Check(debug.ClientScript(ctx, []string{"*"}, ""),
+		gc.Equals, debug.ClientScript(ctx, nil, ""))
+	c.Check(debug.ClientScript(ctx, []string{"*", "something"}, ""),
+		gc.Equals, debug.ClientScript(ctx, []string{"*"}, ""))
 
 	// debug.ClientScript does not validate hook names, as it doesn't have
 	// a full state API connection to determine valid relation hooks.
+	// Note: jam 2020-04-01, This is a very easy to get wrong test.
+	//  Without escaping the '|' it was actually just asserting that 'base64 -d' existed in the
+	//  file.
+	c.Check(debug.Base64HookArgs([]string{"something somethingelse"}, ""),
+		gc.Equals, "aG9va3M6Ci0gc29tZXRoaW5nIHNvbWV0aGluZ2Vsc2UK")
 	expected := fmt.Sprintf(
-		`(.|\n)*echo "aG9va3M6Ci0gc29tZXRoaW5nIHNvbWV0aGluZ2Vsc2UK" | base64 -d > %s(.|\n)*`,
+		`(.|\n)*echo "aG9va3M6Ci0gc29tZXRoaW5nIHNvbWV0aGluZ2Vsc2UK" \| base64 -d > %s(.|\n)*`,
 		regexp.QuoteMeta(ctx.ClientFileLock()),
 	)
-	c.Assert(debug.ClientScript(ctx, []string{"something somethingelse"}), gc.Matches, expected)
+	c.Assert(debug.ClientScript(ctx, []string{"something somethingelse"}, ""), gc.Matches, expected)
+	expected = fmt.Sprintf(
+		`(.|\n)*echo "%s" \| base64 -d > %s(.|\n)*`,
+		debug.Base64HookArgs(nil, "breakpoint-string"),
+		regexp.QuoteMeta(ctx.ClientFileLock()),
+	)
+	c.Assert(debug.ClientScript(ctx, []string{}, "breakpoint-string"),
+		gc.Matches, expected)
+}
+
+func (*DebugHooksClientSuite) TestBase64HookArgsNoValues(c *gc.C) {
+	// Tests of how we encode parameters for how debug-hooks will operate
+	base64Args := debug.Base64HookArgs(nil, "")
+	args := decodeArgs(c, base64Args)
+	c.Check(args, gc.DeepEquals, map[string]interface{}{})
+}
+
+func (*DebugHooksClientSuite) TestBase64HookArgsHookList(c *gc.C) {
+	// Tests of how we encode parameters for how debug-hooks will operate
+	base64Args := debug.Base64HookArgs([]string{"install", "start"}, "")
+	args := decodeArgs(c, base64Args)
+	c.Check(args, gc.DeepEquals, map[string]interface{}{
+		"hooks": []interface{}{"install", "start"},
+	})
+}
+
+func (*DebugHooksClientSuite) TestBase64HookArgsBreakpoint(c *gc.C) {
+	// Tests of how we encode parameters for how debug-hooks will operate
+	base64Args := debug.Base64HookArgs([]string{}, "all,broken")
+	args := decodeArgs(c, base64Args)
+	c.Check(args, gc.DeepEquals, map[string]interface{}{
+		"breakpoint": "all,broken",
+	})
+}
+
+func (*DebugHooksClientSuite) TestBase64HookArgsBoth(c *gc.C) {
+	// Tests of how we encode parameters for how debug-hooks will operate
+	base64Args := debug.Base64HookArgs([]string{"db-relation-changed", "stop"}, "brokepoint")
+	args := decodeArgs(c, base64Args)
+	c.Check(args, gc.DeepEquals, map[string]interface{}{
+		"hooks":      []interface{}{"db-relation-changed", "stop"},
+		"breakpoint": "brokepoint",
+	})
+}
+
+func decodeArgs(c *gc.C, base64Args string) map[string]interface{} {
+	c.Assert(base64Args, gc.Not(gc.Equals), "")
+	yamlArgs, err := base64.StdEncoding.DecodeString(base64Args)
+	c.Assert(err, jc.ErrorIsNil)
+	var decoded map[string]interface{}
+	c.Assert(goyaml.Unmarshal(yamlArgs, &decoded), jc.ErrorIsNil)
+	return decoded
 }

--- a/worker/uniter/runner/debug/client_test.go
+++ b/worker/uniter/runner/debug/client_test.go
@@ -79,10 +79,10 @@ func (*DebugHooksClientSuite) TestBase64HookArgsHookList(c *gc.C) {
 	})
 }
 
-func (*DebugHooksClientSuite) TestBase64HookArgsBreakpoint(c *gc.C) {
+func (*DebugHooksClientSuite) TestBase64HookArgsDebugAt(c *gc.C) {
 	// Tests of how we encode parameters for how debug-hooks will operate
 	testEncodeRoundTrips(c, nil, "all,broken", map[string]interface{}{
-		"breakpoint": "all,broken",
+		"debug-at": "all,broken",
 	})
 }
 
@@ -90,13 +90,13 @@ func (*DebugHooksClientSuite) TestBase64HookArgsBoth(c *gc.C) {
 	// Tests of how we encode parameters for how debug-hooks will operate
 	testEncodeRoundTrips(c, []string{"db-relation-changed", "stop"}, "brokepoint",
 		map[string]interface{}{
-			"hooks":      []interface{}{"db-relation-changed", "stop"},
-			"breakpoint": "brokepoint",
+			"hooks":    []interface{}{"db-relation-changed", "stop"},
+			"debug-at": "brokepoint",
 		})
 }
 
-func testEncodeRoundTrips(c *gc.C, match []string, breakpoint string, decoded map[string]interface{}) {
-	base64Args := debug.Base64HookArgs(match, breakpoint)
+func testEncodeRoundTrips(c *gc.C, match []string, debugAt string, decoded map[string]interface{}) {
+	base64Args := debug.Base64HookArgs(match, debugAt)
 	args := decodeArgs(c, base64Args)
 	c.Check(args, gc.DeepEquals, decoded)
 }

--- a/worker/uniter/runner/debug/client_test.go
+++ b/worker/uniter/runner/debug/client_test.go
@@ -69,37 +69,36 @@ func (*DebugHooksClientSuite) TestClientScript(c *gc.C) {
 
 func (*DebugHooksClientSuite) TestBase64HookArgsNoValues(c *gc.C) {
 	// Tests of how we encode parameters for how debug-hooks will operate
-	base64Args := debug.Base64HookArgs(nil, "")
-	args := decodeArgs(c, base64Args)
-	c.Check(args, gc.DeepEquals, map[string]interface{}{})
+	testEncodeRoundTrips(c, nil, "", map[string]interface{}{})
 }
 
 func (*DebugHooksClientSuite) TestBase64HookArgsHookList(c *gc.C) {
 	// Tests of how we encode parameters for how debug-hooks will operate
-	base64Args := debug.Base64HookArgs([]string{"install", "start"}, "")
-	args := decodeArgs(c, base64Args)
-	c.Check(args, gc.DeepEquals, map[string]interface{}{
+	testEncodeRoundTrips(c, []string{"install", "start"}, "", map[string]interface{}{
 		"hooks": []interface{}{"install", "start"},
 	})
 }
 
 func (*DebugHooksClientSuite) TestBase64HookArgsBreakpoint(c *gc.C) {
 	// Tests of how we encode parameters for how debug-hooks will operate
-	base64Args := debug.Base64HookArgs([]string{}, "all,broken")
-	args := decodeArgs(c, base64Args)
-	c.Check(args, gc.DeepEquals, map[string]interface{}{
+	testEncodeRoundTrips(c, nil, "all,broken", map[string]interface{}{
 		"breakpoint": "all,broken",
 	})
 }
 
 func (*DebugHooksClientSuite) TestBase64HookArgsBoth(c *gc.C) {
 	// Tests of how we encode parameters for how debug-hooks will operate
-	base64Args := debug.Base64HookArgs([]string{"db-relation-changed", "stop"}, "brokepoint")
+	testEncodeRoundTrips(c, []string{"db-relation-changed", "stop"}, "brokepoint",
+		map[string]interface{}{
+			"hooks":      []interface{}{"db-relation-changed", "stop"},
+			"breakpoint": "brokepoint",
+		})
+}
+
+func testEncodeRoundTrips(c *gc.C, match []string, breakpoint string, decoded map[string]interface{}) {
+	base64Args := debug.Base64HookArgs(match, breakpoint)
 	args := decodeArgs(c, base64Args)
-	c.Check(args, gc.DeepEquals, map[string]interface{}{
-		"hooks":      []interface{}{"db-relation-changed", "stop"},
-		"breakpoint": "brokepoint",
-	})
+	c.Check(args, gc.DeepEquals, decoded)
 }
 
 func decodeArgs(c *gc.C, base64Args string) map[string]interface{} {

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -22,8 +22,8 @@ import (
 // ServerSession represents a "juju debug-hooks" session.
 type ServerSession struct {
 	*HooksContext
-	hooks      set.Strings
-	breakpoint string
+	hooks   set.Strings
+	debugAt string
 
 	output io.Writer
 }
@@ -58,8 +58,8 @@ func (s *ServerSession) RunHook(hookName, charmDir string, env []string, hookRun
 	}
 
 	env = utils.Setenv(env, "JUJU_DEBUG="+debugDir)
-	if s.breakpoint != "" {
-		env = utils.Setenv(env, "JUJU_BREAKPOINT="+s.breakpoint)
+	if s.debugAt != "" {
+		env = utils.Setenv(env, "JUJU_DEBUG_AT="+s.debugAt)
 	}
 
 	cmd := exec.Command("/bin/bash", "-s")
@@ -144,7 +144,7 @@ func (c *HooksContext) FindSession() (*ServerSession, error) {
 		return nil, err
 	}
 	hooks := set.NewStrings(args.Hooks...)
-	session := &ServerSession{HooksContext: c, hooks: hooks, breakpoint: args.Breakpoint}
+	session := &ServerSession{HooksContext: c, hooks: hooks, debugAt: args.DebugAt}
 	return session, nil
 }
 

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -211,12 +211,12 @@ trap 'echo $? > $JUJU_DEBUG/hook_exit_status' EXIT
 // hook.pid that the rest of the server is waiting for. Without BREAKPOINT, we then exec an
 // interactive shell with an init.sh that displays a welcome message and traps its exit code into
 // hook_exit_status.
-// With JUJU_BREAKPOINT, we just exec the hook directly, and record its exit status before exit.
-// It is the responsibility of the code handling JUJU_BREAKPOINT to handle prompting.
+// With JUJU_DEBUG_AT, we just exec the hook directly, and record its exit status before exit.
+// It is the responsibility of the code handling JUJU_DEBUG_AT to handle prompting.
 const debugHooksHookScript = `#!/bin/bash
 . __JUJU_DEBUG__/env.sh
 echo $$ > $JUJU_DEBUG/hook.pid
-if [ -z "$JUJU_BREAKPOINT" ] ; then
+if [ -z "$JUJU_DEBUG_AT" ] ; then
 	exec /bin/bash --noprofile --init-file $JUJU_DEBUG/init.sh
 else
 	__JUJU_HOOK_RUNNER__

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -149,9 +149,9 @@ func (s *DebugHooksServerSuite) TestRunHookExceptional(c *gc.C) {
 
 func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	const hookName = "myhook"
-	// JUJU_HOOK_NAME is written in context.HookVars and not part of
+	// JUJU_DISPATCH_PATH is written in context.HookVars and not part of
 	// what's being tested here.
-	s.PatchEnvironment("JUJU_HOOK_NAME", hookName)
+	s.PatchEnvironment("JUJU_DISPATCH_PATH", "hooks/"+hookName)
 	err := ioutil.WriteFile(s.ctx.ClientFileLock(), []byte{}, 0777)
 	c.Assert(err, jc.ErrorIsNil)
 	var output bytes.Buffer
@@ -241,5 +241,5 @@ func (s *DebugHooksServerSuite) verifyEnvshFile(c *gc.C, envshPath string, hookN
 	c.Assert(err, jc.ErrorIsNil)
 	contents := string(data)
 	c.Assert(contents, jc.Contains, fmt.Sprintf("JUJU_UNIT_NAME=%q", s.ctx.Unit))
-	c.Assert(contents, jc.Contains, fmt.Sprintf(`PS1="%s:%s %% "`, s.ctx.Unit, hookName))
+	c.Assert(contents, jc.Contains, fmt.Sprintf(`PS1="%s:hooks/%s %% "`, s.ctx.Unit, hookName))
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -373,7 +373,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 		// Note: hookScript might be relative but the debug session only requires its name
 		hookHandlerType, hookScript, _ := runner.discoverHookHandler(hookName, runner.paths.GetCharmDir(), charmLocation)
 		logger.Infof("executing %s via debug-hooks; %s", hookName, hookHandlerType)
-		return hookHandlerType, session.RunHook(hookName, runner.paths.GetCharmDir(), env, filepath.Base(hookScript))
+		return hookHandlerType, session.RunHook(hookName, runner.paths.GetCharmDir(), env, hookScript)
 	}
 
 	charmDir := runner.paths.GetCharmDir()


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

This supports debugging both actions and hooks, and fixes a small bug in
how we trigger the shell when debugging actions.

This implements the protocol described in https://docs.google.com/document/d/e/2PACX-1vSyHGCgpxyGZPNWnmq__AVz8LZi9xw4HOVZIpeMogo2FhEM0RVQGTQm5iVziMRuFQ2fo7crtBTRG8Pt/pub

The idea is that `juju debug-code` is added which functions similarly to `juju debug-hooks` but runs the hooks in the terminal with the env var JUJU_DEBUG_AT set. This gives the charm itself the opportunity to drop into a debugger at the appropriate place in the code.

It also fixes a bug in 2.8 that running `juju debug-hooks` on an action doesn't actually drop you into the shell correctly.

The big thing about the protocol is that however we `JUJU_DEBUG_AT` is interpreted by the charm. This is the code I wrote to test it:
```
$ cat actions/breakpoint-test
#!/usr/bin/env python3

import os
import subprocess

def main():
    debug_at = os.getenv('JUJU_DEBUG_AT', None)
    if debug_at:
        import pdb; pdb.set_trace()
    print('hello')

if __name__ == '__main__':
    main()
```


## QA steps

With the above action, you can do:

```sh
window1$ juju debug-code charm
window2$ juju run-action breakpoint-test --wait
```

You should also be able to change the value of the env var with
```sh
$ juju debug-code --at foo charm
```

In the first window, you'll end up in a tmux shell, and when the action finally triggers, you end up in the PDB debug line. You, unfortunately, don't end up with the nice help text, but since the interpretation of JUJU_DEBUG_AT is up to the charm, the helpful message also belongs as part of the charm. (documenting basics of how pdb works isn't Juju's purview, it is the responsibility of the charm.)

To test that we still handle exit codes correctly, I also did:
```
$ cat hooks/config-changed
#!/bin/sh
if [ -n "$JUJU_DEBUG_AT" ] ; then
    status-set blocked "config-changed blocked due to JUJU_DEBUG_AT"
    exit 1
fi

status-set active "config-changed run: $(config-get foo)"
```

With that, I was able to see that the config-changed hook properly recorded that it exited with a failure.
## Documentation changes

We'll definitely want to update the documentation of debug-code around this new behavior.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1870029