### PR TITLE
[dev] Enforce quota for storing charm and uniter state

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -492,11 +492,11 @@
   revision = "2e2cf381eb0406ff5edd1976dc24d3846176552b"
 
 [[projects]]
-  digest = "1:594030c0f0ed3842773b68708d4f9716d809556b9c631460051f99b15057512d"
+  digest = "1:e0275dd405fa814d870a8039712ca66c110718b653e864e2e96c65acb481d8a1"
   name = "github.com/juju/errors"
   packages = ["."]
   pruneopts = ""
-  revision = "22422dad46e14561a0854ad42497a75af9b61909"
+  revision = "3fe23663418fc1d724868c84f21b7519bbac7441"
 
 [[projects]]
   digest = "1:6ea4e90d9fc387ca27c25348e40dbe38c3606eec7f283bf98a39db59b37ed5bb"
@@ -713,14 +713,14 @@
   revision = "1f8aaeef09898fcee40fe43b8de422533b0cac2b"
 
 [[projects]]
-  digest = "1:61fdcd5ca2dcd80cd6951a72e7b291e3d40afbb3a38b02cd17d71d2859b2ed98"
+  digest = "1:b11e7ad5436035dc6d120b2877b3753d727b4111de7b437a92d46383f39b0a70"
   name = "github.com/juju/terms-client"
   packages = [
     "api",
     "api/wireformat",
   ]
   pruneopts = ""
-  revision = "d29f8efe0af6f5ed0e8d5bff8bccbecb16e653d1"
+  revision = "fab45ea044ae143a8ebb93e965de1341466bdac2"
 
 [[projects]]
   digest = "1:0eec58cdcfcc6f4a561e68d779dd136700575148459d4d435c60483a8f721d27"
@@ -1389,11 +1389,11 @@
   revision = "e057c73bd1beb18e9634151a2410c422bd2057f2"
 
 [[projects]]
-  digest = "1:941d40c0b44b5e362c762047a191ba90c439b4df492ea8a106d964155e1f3f86"
+  digest = "1:5eb58b30693186bc49635567ebd7c7e6770caa6316c141ab182345608ea129ac"
   name = "gopkg.in/juju/names.v3"
   packages = ["."]
   pruneopts = ""
-  revision = "139ecaca454cb9101eed8ea76374ddc0be8cc8e8"
+  revision = "2c9a102df21118f159a298d9419997bbe2ddab58"
 
 [[projects]]
   digest = "1:2041c73bbc755e07a90e03f149933b8ecfce5233a5afbe6b04230386a75f8fda"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -154,7 +154,7 @@
   name = "gopkg.in/juju/environschema.v1"
 
 [[constraint]]
-  revision = "139ecaca454cb9101eed8ea76374ddc0be8cc8e8"
+  revision = "2c9a102df21118f159a298d9419997bbe2ddab58"
   name = "gopkg.in/juju/names.v3"
 
 [[constraint]]
@@ -292,7 +292,7 @@
 
 [[constraint]]
   name = "github.com/juju/errors"
-  revision = "22422dad46e14561a0854ad42497a75af9b61909"
+  revision = "3fe23663418fc1d724868c84f21b7519bbac7441"
 
 [[constraint]]
   name = "github.com/juju/go-oracle-cloud"
@@ -328,7 +328,7 @@
 
 [[constraint]]
   name = "github.com/juju/terms-client"
-  revision = "d29f8efe0af6f5ed0e8d5bff8bccbecb16e653d1"
+  revision = "fab45ea044ae143a8ebb93e965de1341466bdac2"
 
 [[constraint]]
   revision = "5f348e78887d8757a402c7bb81e707c3b244c6da"

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -310,6 +310,8 @@ func ServerError(err error) *params.Error {
 			ControllerTag:   controllerTag,
 			ControllerAlias: redirErr.ControllerAlias,
 		}.AsMap()
+	case errors.IsQuotaLimitExceeded(err):
+		code = params.CodeQuotaLimitExceeded
 	default:
 		code = params.ErrCode(err)
 	}
@@ -406,6 +408,8 @@ func RestoreError(err error) error {
 	case params.ErrCode(err) == params.CodeDischargeRequired:
 		// TODO(ericsnow) Handle DischargeRequiredError here.
 		return err
+	case params.IsCodeQuotaLimitExceeded(err):
+		return errors.NewQuotaLimitExceeded(nil, msg)
 	default:
 		return err
 	}

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -210,6 +210,11 @@ var errorTransformTests = []struct {
 		return true
 	},
 }, {
+	err:        errors.QuotaLimitExceededf("mailbox full"),
+	code:       params.CodeQuotaLimitExceeded,
+	status:     http.StatusInternalServerError,
+	helperFunc: params.IsCodeQuotaLimitExceeded,
+}, {
 	err:    nil,
 	code:   "",
 	status: http.StatusOK,

--- a/apiserver/common/mocks/unitstate.go
+++ b/apiserver/common/mocks/unitstate.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/juju/juju/apiserver/common"
+	controller "github.com/juju/juju/controller"
 	state "github.com/juju/juju/state"
 	reflect "reflect"
 )
@@ -36,6 +37,7 @@ func (m *MockUnitStateBackend) EXPECT() *MockUnitStateBackendMockRecorder {
 
 // ApplyOperation mocks base method
 func (m *MockUnitStateBackend) ApplyOperation(arg0 state.ModelOperation) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyOperation", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +45,28 @@ func (m *MockUnitStateBackend) ApplyOperation(arg0 state.ModelOperation) error {
 
 // ApplyOperation indicates an expected call of ApplyOperation
 func (mr *MockUnitStateBackendMockRecorder) ApplyOperation(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyOperation", reflect.TypeOf((*MockUnitStateBackend)(nil).ApplyOperation), arg0)
+}
+
+// ControllerConfig mocks base method
+func (m *MockUnitStateBackend) ControllerConfig() (controller.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret0, _ := ret[0].(controller.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerConfig indicates an expected call of ControllerConfig
+func (mr *MockUnitStateBackendMockRecorder) ControllerConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockUnitStateBackend)(nil).ControllerConfig))
 }
 
 // Unit mocks base method
 func (m *MockUnitStateBackend) Unit(arg0 string) (common.UnitStateUnit, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unit", arg0)
 	ret0, _ := ret[0].(common.UnitStateUnit)
 	ret1, _ := ret[1].(error)
@@ -56,6 +75,7 @@ func (m *MockUnitStateBackend) Unit(arg0 string) (common.UnitStateUnit, error) {
 
 // Unit indicates an expected call of Unit
 func (mr *MockUnitStateBackendMockRecorder) Unit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockUnitStateBackend)(nil).Unit), arg0)
 }
 
@@ -83,19 +103,22 @@ func (m *MockUnitStateUnit) EXPECT() *MockUnitStateUnitMockRecorder {
 }
 
 // SetStateOperation mocks base method
-func (m *MockUnitStateUnit) SetStateOperation(arg0 *state.UnitState) state.ModelOperation {
-	ret := m.ctrl.Call(m, "SetStateOperation", arg0)
+func (m *MockUnitStateUnit) SetStateOperation(arg0 *state.UnitState, arg1 state.UnitStateSizeLimits) state.ModelOperation {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetStateOperation", arg0, arg1)
 	ret0, _ := ret[0].(state.ModelOperation)
 	return ret0
 }
 
 // SetStateOperation indicates an expected call of SetStateOperation
-func (mr *MockUnitStateUnitMockRecorder) SetStateOperation(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStateOperation", reflect.TypeOf((*MockUnitStateUnit)(nil).SetStateOperation), arg0)
+func (mr *MockUnitStateUnitMockRecorder) SetStateOperation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStateOperation", reflect.TypeOf((*MockUnitStateUnit)(nil).SetStateOperation), arg0, arg1)
 }
 
 // State mocks base method
 func (m *MockUnitStateUnit) State() (*state.UnitState, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State")
 	ret0, _ := ret[0].(*state.UnitState)
 	ret1, _ := ret[1].(error)
@@ -104,5 +127,6 @@ func (m *MockUnitStateUnit) State() (*state.UnitState, error) {
 
 // State indicates an expected call of State
 func (mr *MockUnitStateUnitMockRecorder) State() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockUnitStateUnit)(nil).State))
 }

--- a/apiserver/common/unitstate_test.go
+++ b/apiserver/common/unitstate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/common/mocks"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -94,8 +95,21 @@ func (s *unitStateSuite) expectSetStateOperation() string {
 	expUniterState := "testing"
 	unitState.SetUniterState(expUniterState)
 
+	// Mock controller config which provides the limits passed to SetStateOperation.
+	s.mockBackend.EXPECT().ControllerConfig().Return(
+		controller.Config{
+			"max-charm-state-size":  123,
+			"max-uniter-state-size": 456,
+		}, nil)
+
 	exp := s.mockUnit.EXPECT()
-	exp.SetStateOperation(unitState).Return(s.mockOp)
+	exp.SetStateOperation(
+		unitState,
+		state.UnitStateSizeLimits{
+			MaxCharmStateSize:  123,
+			MaxUniterStateSize: 456,
+		},
+	).Return(s.mockOp)
 	return expUniterState
 }
 

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -185,6 +185,7 @@ const (
 	CodeIncompatibleSeries        = "incompatible series"
 	CodeCloudRegionRequired       = "cloud region required"
 	CodeIncompatibleClouds        = "incompatible clouds"
+	CodeQuotaLimitExceeded        = "quota limit exceeded"
 )
 
 // ErrCode returns the error code associated with
@@ -357,4 +358,10 @@ func IsCodeForbidden(err error) bool {
 
 func IsCodeCloudRegionRequired(err error) bool {
 	return ErrCode(err) == CodeCloudRegionRequired
+}
+
+// IsCodeQuotaLimitExceeded returns true if err includes a QuotaLimitExceeded
+// error code.
+func IsCodeQuotaLimitExceeded(err error) bool {
+	return ErrCode(err) == CodeQuotaLimitExceeded
 }

--- a/controller/config.go
+++ b/controller/config.go
@@ -180,6 +180,18 @@ const (
 	// to not sleep at all.
 	PruneTxnSleepTime = "prune-txn-sleep-time"
 
+	// MaxCharmStateSize is the maximum allowed size of charm-specific
+	// per-unit state data that charms can store to the controller in
+	// bytes. A value of 0 disables the quota checks although in
+	// principle, mongo imposes a hard (but configurable) limit of 16M.
+	MaxCharmStateSize = "max-charm-state-size"
+
+	// MaxUniterStateSize is the maximum allowed size of internal uniter
+	// data that units can store to the controller in bytes. A value of 0
+	// disables the quota checks although in principle, mongo imposes a
+	// hard (but configurable) limit of 16M.
+	MaxUniterStateSize = "max-uniter-state-size"
+
 	// Attribute Defaults
 
 	// DefaultAgentRateLimitMax allows the first 10 agents to connect without any
@@ -257,6 +269,14 @@ const (
 	// other systems to operate concurrently.
 	DefaultPruneTxnSleepTime = "10ms"
 
+	// DefaultMaxCharmStateSize is the maximum size (in bytes) of charm
+	// state data that each unit can store to the controller.
+	DefaultMaxCharmStateSize = 2 * 1024 * 1024
+
+	// DefaultMaxUniterStateSize is the maximum size (in bytes) of internal
+	// uniter state data that each unit can store to the controller.
+	DefaultMaxUniterStateSize = 512 * 1024
+
 	// JujuHASpace is the network space within which the MongoDB replica-set
 	// should communicate.
 	JujuHASpace = "juju-ha-space"
@@ -322,6 +342,8 @@ var (
 		CAASImageRepo,
 		Features,
 		MeteringURL,
+		MaxCharmStateSize,
+		MaxUniterStateSize,
 	}
 
 	// AllowedUpdateConfigAttributes contains all of the controller
@@ -352,6 +374,8 @@ var (
 		CAASOperatorImagePath,
 		CAASImageRepo,
 		Features,
+		MaxCharmStateSize,
+		MaxUniterStateSize,
 	)
 
 	// DefaultAuditLogExcludeMethods is the default list of methods to
@@ -762,6 +786,20 @@ func (c Config) MeteringURL() string {
 	return url
 }
 
+// MaxCharmStateSize returns the max size (in bytes) of charm-specific state
+// that each unit can store to the controller. A value of zero indicates no
+// limit.
+func (c Config) MaxCharmStateSize() int {
+	return c.intOrDefault(MaxCharmStateSize, DefaultMaxCharmStateSize)
+}
+
+// MaxUniterStateSize returns the max size (in bytes) of internal uniter state
+// that each unit can store to the controller. A value of zero indicates no
+// limit.
+func (c Config) MaxUniterStateSize() int {
+	return c.intOrDefault(MaxUniterStateSize, DefaultMaxUniterStateSize)
+}
+
 // Validate ensures that config is a valid configuration.
 func Validate(c Config) error {
 	if v, ok := c[IdentityPublicKey].(string); ok {
@@ -937,6 +975,32 @@ func Validate(c Config) error {
 		}
 	}
 
+	// Each unit stores the charm and uniter state in a single document.
+	// Given that mongo by default enforces a 16M limit for documents we
+	// should also verify that the combined limits don't exceed 16M.
+	var maxUnitStateSize int
+	if v, ok := c[MaxCharmStateSize].(int); ok {
+		if v < 0 {
+			return errors.Errorf("invalid max charm state size: should be a number of bytes (or 0 to disable limit), got %d", v)
+		}
+		maxUnitStateSize += v
+	} else {
+		maxUnitStateSize += DefaultMaxCharmStateSize
+	}
+
+	if v, ok := c[MaxUniterStateSize].(int); ok {
+		if v < 0 {
+			return errors.Errorf("invalid max uniter state size: should be a number of bytes (or 0 to disable limit), got %d", v)
+		}
+		maxUnitStateSize += v
+	} else {
+		maxUnitStateSize += DefaultMaxUniterStateSize
+	}
+
+	if mongoMax := 16 * 1024 * 1024; maxUnitStateSize > mongoMax {
+		return errors.Errorf("invalid max charm/uniter state sizes: combined value should not exceed mongo's 16M per-document limit, got %d", maxUnitStateSize)
+	}
+
 	return nil
 }
 
@@ -1031,6 +1095,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	Features:                schema.List(schema.String()),
 	CharmStoreURL:           schema.String(),
 	MeteringURL:             schema.String(),
+	MaxCharmStateSize:       schema.ForceInt(),
+	MaxUniterStateSize:      schema.ForceInt(),
 }, schema.Defaults{
 	AgentRateLimitMax:       schema.Omit,
 	AgentRateLimitRate:      schema.Omit,
@@ -1067,6 +1133,8 @@ var configChecker = schema.FieldMap(schema.Fields{
 	Features:                schema.Omit,
 	CharmStoreURL:           csclient.ServerURL,
 	MeteringURL:             romulus.DefaultAPIRoot,
+	MaxCharmStateSize:       DefaultMaxCharmStateSize,
+	MaxUniterStateSize:      DefaultMaxUniterStateSize,
 })
 
 // ConfigSchema holds information on all the fields defined by
@@ -1218,5 +1286,13 @@ Use "caas-image-repo" instead.`,
 	MeteringURL: {
 		Type:        environschema.Tstring,
 		Description: `The url for metrics`,
+	},
+	MaxCharmStateSize: {
+		Type:        environschema.Tint,
+		Description: `The maximum size (in bytes) of charm-specific state that units can store to the controller`,
+	},
+	MaxUniterStateSize: {
+		Type:        environschema.Tint,
+		Description: `The maximum size (in bytes) of internal uniter state that units can store to the controller`,
 	},
 }

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -343,7 +343,38 @@ var newConfigTests = []struct {
 		controller.AgentRateLimitRate: "4h",
 	},
 	expectError: `agent-ratelimit-rate must be between 0..1m`,
-}}
+}, {
+	about: "max-charm-state-size non-int",
+	config: controller.Config{
+		controller.MaxCharmStateSize: "ten",
+	},
+	expectError: `max-charm-state-size: expected number, got string\("ten"\)`,
+}, {
+	about: "max-charm-state-size cannot be negative",
+	config: controller.Config{
+		controller.MaxCharmStateSize: "-42",
+	},
+	expectError: `invalid max charm state size: should be a number of bytes \(or 0 to disable limit\), got -42`,
+}, {
+	about: "max-uniter-state-size non-int",
+	config: controller.Config{
+		controller.MaxUniterStateSize: "ten",
+	},
+	expectError: `max-uniter-state-size: expected number, got string\("ten"\)`,
+}, {
+	about: "max-uniter-state-size cannot be negative",
+	config: controller.Config{
+		controller.MaxUniterStateSize: "-42",
+	},
+	expectError: `invalid max uniter state size: should be a number of bytes \(or 0 to disable limit\), got -42`,
+}, {
+	about: "combined charm/unit state cannot exceed mongo's 16M limit/doc",
+	config: controller.Config{
+		controller.MaxCharmStateSize:  "14000000",
+		controller.MaxUniterStateSize: "3000000",
+	},
+	expectError: `invalid max charm/uniter state sizes: combined value should not exceed mongo's 16M per-document limit, got 17000000`,
+}, {}}
 
 func (s *ConfigSuite) TestNewConfig(c *gc.C) {
 	for i, test := range newConfigTests {

--- a/core/quota/bson.go
+++ b/core/quota/bson.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota
+
+import (
+	"github.com/juju/errors"
+)
+
+var _ Checker = (*BSONTotalSizeChecker)(nil)
+
+// BSONTotalSizeChecker can be used to verify that the total bson-encoded size
+// of one or more items does not exceed a particular limit.
+type BSONTotalSizeChecker struct {
+	maxSize int
+	total   int
+	lastErr error
+}
+
+// NewBSONTotalSizeChecker returns a BSONTotalSizeChecker instance with the
+// specified maxSize limit. The maxSize parameter may also be set to zero to
+// disable quota checks.
+func NewBSONTotalSizeChecker(maxSize int) *BSONTotalSizeChecker {
+	return &BSONTotalSizeChecker{
+		maxSize: maxSize,
+	}
+}
+
+// Check adds the serialized size of v to the current tally and updates the
+// checker's error state.
+func (c *BSONTotalSizeChecker) Check(v interface{}) {
+	if c.lastErr != nil {
+		return
+	}
+
+	size, err := effectiveSize(v)
+	if err != nil {
+		c.lastErr = err
+		return
+	} else if c.maxSize > 0 && c.total+size > c.maxSize {
+		c.lastErr = errors.QuotaLimitExceededf("max allowed size (%d) exceeded", c.maxSize)
+	}
+
+	c.total += size
+}
+
+// Outcome returns the check outcome or whether an error occurred within a call
+// to the Check method.
+func (c *BSONTotalSizeChecker) Outcome() error {
+	return c.lastErr
+}

--- a/core/quota/bson_test.go
+++ b/core/quota/bson_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/quota"
+)
+
+var _ = gc.Suite(&BSONTotalSizeCheckerSuite{})
+
+type BSONTotalSizeCheckerSuite struct {
+}
+
+func (s *BSONTotalSizeCheckerSuite) TestSuccessfulCheck(c *gc.C) {
+	chk := quota.NewBSONTotalSizeChecker(256)
+	chk.Check(map[string]string{
+		"a long key": "bar",
+		"key":        "val",
+	})
+	chk.Check("some string")
+
+	err := chk.Outcome()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BSONTotalSizeCheckerSuite) TestExceedMaxSize(c *gc.C) {
+	chk := quota.NewBSONTotalSizeChecker(24)
+	chk.Check(map[string]string{
+		"a long key": "bar",
+		"key":        "val",
+	})
+	chk.Check("some string")
+
+	err := chk.Outcome()
+	c.Assert(err, jc.Satisfies, errors.IsQuotaLimitExceeded)
+	c.Assert(err, gc.ErrorMatches, "max allowed size.*", gc.Commentf("expected error about exceeding max size"))
+}
+
+func (s *BSONTotalSizeCheckerSuite) TestQuotaBypass(c *gc.C) {
+	chk := quota.NewBSONTotalSizeChecker(0)
+	chk.Check(map[string]string{
+		"a long key": "bar",
+		"key":        "val",
+	})
+	chk.Check("some string")
+
+	err := chk.Outcome()
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/core/quota/fixed_limits.go
+++ b/core/quota/fixed_limits.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota
+
+const (
+	// MaxCharmStateKeySize describes the max allowed key length for each
+	// entry that a charm attempts to persist to the controller.
+	MaxCharmStateKeySize = 256
+
+	// MaxCharmStateValueSize describes the max allowed value length for
+	// each entry that a charm attempts to persist to the controller.
+	MaxCharmStateValueSize = 64 * 1024
+)

--- a/core/quota/kv.go
+++ b/core/quota/kv.go
@@ -1,0 +1,99 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota
+
+import (
+	"reflect"
+
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var _ Checker = (*MapKeyValueSizeChecker)(nil)
+
+// A MapKeyValueSizeChecker can be used to verify that none of the keys and
+// values in a map exceed a particular limit.
+type MapKeyValueSizeChecker struct {
+	maxKeySize   int
+	maxValueSize int
+	lastErr      error
+}
+
+// NewMapKeyValueSizeChecker returns a new MapKeyValueSizeChecker instance that
+// limits map keys to maxKeySize and map values to maxValueSize. Any of the
+// max values may also set to 0 to disable quota checks.
+func NewMapKeyValueSizeChecker(maxKeySize, maxValueSize int) *MapKeyValueSizeChecker {
+	return &MapKeyValueSizeChecker{
+		maxKeySize:   maxKeySize,
+		maxValueSize: maxValueSize,
+	}
+}
+
+// Check applies the configured size checks to v and updates the checker's
+// internal state. Check expects a map as an argument where both the keys and
+// the values can be serialized to BSON; any other value will cause an error
+// to be returned when Outcome is called.
+func (c *MapKeyValueSizeChecker) Check(v interface{}) {
+	if v == nil || c.lastErr != nil {
+		return
+	}
+
+	reflMap := reflect.ValueOf(v)
+	if reflMap.Kind() != reflect.Map {
+		c.lastErr = errors.NotImplementedf("key/value size check for non map-values")
+		return
+	}
+
+	for _, mapKey := range reflMap.MapKeys() {
+		mapVal := reflMap.MapIndex(mapKey)
+		if err := CheckTupleSize(mapKey.Interface(), mapVal.Interface(), c.maxKeySize, c.maxValueSize); err != nil {
+			c.lastErr = err
+			return
+		}
+	}
+}
+
+// Outcome returns the check outcome or whether an error occurred within a call
+// to the Check method.
+func (c *MapKeyValueSizeChecker) Outcome() error {
+	return c.lastErr
+}
+
+// CheckTupleSize checks whether the length of the provided key-value pair is
+// within the provided limits. If the key or value is a string, then its length
+// will be used for comparison purposes. Otherwise, the effective length is
+// calculated by serializing to BSON and counting the length of the serialized
+// data.
+//
+// Any of the max values can be set to zero to bypass the size check.
+func CheckTupleSize(key, value interface{}, maxKeyLen, maxValueLen int) error {
+	size, err := effectiveSize(key)
+	if err != nil {
+		return err
+	} else if maxKeyLen > 0 && size > maxKeyLen {
+		return errors.QuotaLimitExceededf("max allowed key length (%d) exceeded", maxKeyLen)
+	}
+
+	size, err = effectiveSize(value)
+	if err != nil {
+		return err
+	} else if maxValueLen > 0 && size > maxValueLen {
+		return errors.QuotaLimitExceededf("max allowed value length (%d) exceeded", maxValueLen)
+	}
+
+	return nil
+}
+
+func effectiveSize(v interface{}) (int, error) {
+	switch rawValue := v.(type) {
+	case string:
+		return len(rawValue), nil
+	default: // marshal non-string values to bson and return the serialized length
+		d, err := bson.Marshal(rawValue)
+		if err != nil {
+			return -1, errors.Annotatef(err, "marshaling value to BSON")
+		}
+		return len(d), nil
+	}
+}

--- a/core/quota/kv_test.go
+++ b/core/quota/kv_test.go
@@ -1,0 +1,86 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/quota"
+)
+
+var _ = gc.Suite(&MapKeyValueCheckerSuite{})
+
+type MapKeyValueCheckerSuite struct {
+}
+
+func (s *MapKeyValueCheckerSuite) TestNonMapValue(c *gc.C) {
+	chk := quota.NewMapKeyValueSizeChecker(24, 42)
+	chk.Check("not-a-map")
+
+	err := chk.Outcome()
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+}
+
+func (s *MapKeyValueCheckerSuite) TestMapWithMixedValueTypes(c *gc.C) {
+	chk := quota.NewMapKeyValueSizeChecker(10, 30)
+	chk.Check(map[string]interface{}{
+		"key": map[string]string{
+			"hello": "world",
+		},
+		"got-time?": time.Now(),
+	})
+
+	err := chk.Outcome()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MapKeyValueCheckerSuite) TestMapWithStringKeyValues(c *gc.C) {
+	chk := quota.NewMapKeyValueSizeChecker(5, 3)
+	chk.Check(map[string]string{
+		"key":  "val",
+		"foof": "bar",
+	})
+
+	err := chk.Outcome()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MapKeyValueCheckerSuite) TestQuotaBypass(c *gc.C) {
+	chk := quota.NewMapKeyValueSizeChecker(0, 0)
+	chk.Check(map[string]string{
+		"key":  "val",
+		"foof": "bar",
+	})
+
+	err := chk.Outcome()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MapKeyValueCheckerSuite) TestExceedMaxKeySize(c *gc.C) {
+	chk := quota.NewMapKeyValueSizeChecker(5, 3)
+	chk.Check(map[string]string{
+		"a long key": "bar",
+		"key":        "val",
+	})
+
+	err := chk.Outcome()
+	c.Assert(err, jc.Satisfies, errors.IsQuotaLimitExceeded)
+	c.Assert(err, gc.ErrorMatches, "max allowed key length.*", gc.Commentf("expected error about exceeding max key length"))
+}
+
+func (s *MapKeyValueCheckerSuite) TestExceedMaxValueSize(c *gc.C) {
+	chk := quota.NewMapKeyValueSizeChecker(5, 3)
+	chk.Check(map[string]string{
+		"key1": "val",
+		"key2": "a long value",
+	})
+
+	err := chk.Outcome()
+	c.Assert(err, jc.Satisfies, errors.IsQuotaLimitExceeded)
+	c.Assert(err, gc.ErrorMatches, "max allowed value length.*", gc.Commentf("expected error about exceeding max value length"))
+}

--- a/core/quota/multichecker.go
+++ b/core/quota/multichecker.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota
+
+// Checker is implemented by types that can perform quota limit checks.
+type Checker interface {
+	Check(interface{})
+	Outcome() error
+}
+
+var _ Checker = (*MultiChecker)(nil)
+
+// MultiChecker composes a list of individual Checker instances.
+type MultiChecker struct {
+	checkers []Checker
+}
+
+// NewMultiChecker retuns a Checker that composes the Check/Outcome logic for
+// the specified list of Checkers.
+func NewMultiChecker(checkers ...Checker) *MultiChecker {
+	return &MultiChecker{
+		checkers: checkers,
+	}
+}
+
+// Check passes v to the Check method for each one of the composed Checkers.
+func (c MultiChecker) Check(v interface{}) {
+	for _, checker := range c.checkers {
+		checker.Check(v)
+	}
+}
+
+// Outcome invokes Outcome on each composed Checker and returns back any
+// obtained error or nil if all checks succeeded.
+func (c MultiChecker) Outcome() error {
+	for _, checker := range c.checkers {
+		if err := checker.Outcome(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/core/quota/multichecker_test.go
+++ b/core/quota/multichecker_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/quota"
+)
+
+var _ = gc.Suite(&MultiCheckerSuite{})
+
+type MultiCheckerSuite struct {
+}
+
+func (s *MultiCheckerSuite) TestSuccessfulCheck(c *gc.C) {
+	chk := quota.NewMultiChecker(
+		quota.NewMapKeyValueSizeChecker(5, 10),
+		quota.NewBSONTotalSizeChecker(50),
+	)
+	chk.Check(map[string]string{
+		"key0": "0123456789",
+		"key":  "0123456789",
+	})
+
+	err := chk.Outcome()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MultiCheckerSuite) TestExceedMaxSize(c *gc.C) {
+	chk := quota.NewMultiChecker(
+		quota.NewMapKeyValueSizeChecker(5, 10),
+		quota.NewBSONTotalSizeChecker(24),
+	)
+	chk.Check(map[string]string{
+		"key0": "0123456789",
+		"key":  "0123456789",
+		"moar": "data", // passes key/value check but fails total size check
+	})
+
+	err := chk.Outcome()
+	c.Assert(err, jc.Satisfies, errors.IsQuotaLimitExceeded)
+}

--- a/core/quota/package_test.go
+++ b/core/quota/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package quota_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -288,8 +288,12 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid", "machineid"},
 			}},
 		},
-		unitStatesC: {},
-		minUnitsC:   {},
+		unitStatesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
+		minUnitsC: {},
 
 		// This collection holds documents that indicate units which are queued
 		// to be assigned to machines. It is used exclusively by the

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -55,6 +55,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MongoMemoryProfile,
 		controller.PruneTxnQueryCount,
 		controller.PruneTxnSleepTime,
+		controller.MaxCharmStateSize,
+		controller.MaxUniterStateSize,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -760,7 +760,7 @@ func (s *MigrationExportSuite) assertMigrateUnits(c *gc.C, st *state.State) {
 	}
 	us := state.NewUnitState()
 	us.SetState(map[string]string{"payload": "b4dc0ffee"})
-	err = unit.SetState(us)
+	err = unit.SetState(us, state.UnitStateSizeLimits{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dbModel, err := st.Model()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1150,7 +1150,7 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 	if unitState := u.State(); len(unitState) != 0 {
 		us := NewUnitState()
 		us.SetState(unitState)
-		if err := unit.SetState(us); err != nil {
+		if err := unit.SetState(us, UnitStateSizeLimits{}); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
@@ -739,6 +740,11 @@ func (i *importer) makeAddresses(addrs []description.Address) []address {
 func (i *importer) applications() error {
 	i.logger.Debugf("importing applications")
 
+	ctrlCfg, err := i.st.ControllerConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// Ensure we import principal applications first, so that
 	// subordinate units can refer to the principal ones.
 	var principals, subordinates []description.Application
@@ -751,7 +757,7 @@ func (i *importer) applications() error {
 	}
 
 	for _, s := range append(principals, subordinates...) {
-		if err := i.application(s); err != nil {
+		if err := i.application(s, ctrlCfg); err != nil {
 			i.logger.Errorf("error importing application %s: %s", s.Name(), err)
 			return errors.Annotate(err, s.Name())
 		}
@@ -799,7 +805,7 @@ func (i *importer) makeStatusDoc(statusVal description.Status) statusDoc {
 	}
 }
 
-func (i *importer) application(a description.Application) error {
+func (i *importer) application(a description.Application, ctrlCfg controller.Config) error {
 	// Import this application, then its units.
 	i.logger.Debugf("importing application %s", a.Name())
 
@@ -898,7 +904,7 @@ func (i *importer) application(a description.Application) error {
 	}
 
 	for _, unit := range a.Units() {
-		if err := i.unit(a, unit); err != nil {
+		if err := i.unit(a, unit, ctrlCfg); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -1037,7 +1043,7 @@ func (i *importer) storageConstraints(cons map[string]description.StorageConstra
 	return result
 }
 
-func (i *importer) unit(s description.Application, u description.Unit) error {
+func (i *importer) unit(s description.Application, u description.Unit, ctrlCfg controller.Config) error {
 	i.logger.Debugf("importing unit %s", u.Name())
 
 	// 1. construct a unitDoc
@@ -1150,7 +1156,11 @@ func (i *importer) unit(s description.Application, u description.Unit) error {
 	if unitState := u.State(); len(unitState) != 0 {
 		us := NewUnitState()
 		us.SetState(unitState)
-		if err := unit.SetState(us, UnitStateSizeLimits{}); err != nil {
+		limits := UnitStateSizeLimits{
+			MaxCharmStateSize:  ctrlCfg.MaxCharmStateSize(),
+			MaxUniterStateSize: ctrlCfg.MaxUniterStateSize(),
+		}
+		if err := unit.SetState(us, limits); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1017,7 +1017,7 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, st *state.State, con
 	c.Assert(err, jc.ErrorIsNil)
 	us := state.NewUnitState()
 	us.SetState(map[string]string{"payload": "0xb4c0ffee"})
-	err = exported.SetState(us)
+	err = exported.SetState(us, state.UnitStateSizeLimits{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	if testModel.Type() == state.ModelTypeCAAS {

--- a/state/unitstate.go
+++ b/state/unitstate.go
@@ -191,15 +191,15 @@ func (u *UnitState) StorageState() (string, bool) {
 // of the provided UnitState.
 //
 // Use this for testing, otherwise use SetStateOperation.
-func (u *Unit) SetState(unitState *UnitState) error {
-	modelOp := u.SetStateOperation(unitState)
+func (u *Unit) SetState(unitState *UnitState, limits UnitStateSizeLimits) error {
+	modelOp := u.SetStateOperation(unitState, limits)
 	return u.st.ApplyOperation(modelOp)
 }
 
 // SetStateOperation returns a ModelOperation for replacing the currently
 // stored state for a unit with the contents of the provided UnitState.
-func (u *Unit) SetStateOperation(unitState *UnitState) ModelOperation {
-	return &unitSetStateOperation{u: u, newState: unitState}
+func (u *Unit) SetStateOperation(unitState *UnitState, limits UnitStateSizeLimits) ModelOperation {
+	return &unitSetStateOperation{u: u, newState: unitState, limits: limits}
 }
 
 // State returns the persisted state for a unit.
@@ -246,4 +246,17 @@ func (u *Unit) State() (*UnitState, error) {
 	us.SetStorageState(stDoc.StorageState)
 
 	return us, nil
+}
+
+// UnitStateSizeLimits defines the quota limits that are enforced when updating
+// the state (charm and uniter) of a unit.
+type UnitStateSizeLimits struct {
+	// The maximum allowed size for the charm state. It can be set to zero
+	// to bypass the charm state quota checks.
+	// quota checks will be
+	MaxCharmStateSize int
+
+	// The maximum allowed size for the uniter's state. It can be set to
+	// zero to bypass the uniter state quota checks.
+	MaxUniterStateSize int
 }

--- a/testcharms/charm-repo/bionic/ubuntu-plus/actions.yaml
+++ b/testcharms/charm-repo/bionic/ubuntu-plus/actions.yaml
@@ -16,3 +16,15 @@
     "filename":
       "type": "string"
       "description": "Filename of old dispatch file."
+"write-charm-state":
+  "description": "Set a CLOB of size n as the charm state"
+  "params":
+    "num-entries":
+      "type": "number"
+      "description": "Number of key/value pairs to write."
+    "key-len":
+      "type": "number"
+      "description": "Size of each key."
+    "value-len":
+      "type": "number"
+      "description": "Size of each value."

--- a/testcharms/charm-repo/bionic/ubuntu-plus/actions/write-charm-state
+++ b/testcharms/charm-repo/bionic/ubuntu-plus/actions/write-charm-state
@@ -1,0 +1,6 @@
+#!/bin/bash
+num_entries="$(action-get num-entries)"
+key_len="$(action-get key-len)"
+val_len="$(action-get val-len)"
+
+tools/write-charm-state ${num_entries} ${key_len} ${val_len}

--- a/testcharms/charm-repo/bionic/ubuntu-plus/tools/write-charm-state
+++ b/testcharms/charm-repo/bionic/ubuntu-plus/tools/write-charm-state
@@ -1,0 +1,11 @@
+#!/bin/bash
+num_entries=$1
+key_len=$2
+val_len=$3
+
+echo "attempting to write a payload with ${num_entries} entries where keys have length ${key_len} and values have length ${val_len}"
+(
+  for key in `seq -f"%0${key_len}g" 1 ${num_entries}`; do
+    echo "  ${key}: "`head -c ${val_len} /dev/zero | tr '\0' 'a'`;
+  done;
+) | state-set --file -

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/quota"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/version"
@@ -339,6 +340,13 @@ func (ctx *HookContext) SetCacheValue(key, value string) error {
 	defer ctx.mu.Unlock()
 	if err := ctx.ensureStateValuesLoaded(); err != nil {
 		return err
+	}
+
+	// Enforce fixed quota limit for key/value sizes. Performing this check
+	// as early as possible allows us to provide feedback to charm authors
+	// who might be tempted to exploit this feature for storing CLOBs/BLOBs.
+	if err := quota.CheckTupleSize(key, value, quota.MaxCharmStateKeySize, quota.MaxCharmStateValueSize); err != nil {
+		return errors.Trace(err)
 	}
 
 	curValue, exists := ctx.cacheValues[key]

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1109,6 +1109,14 @@ func (ctx *HookContext) finalizeAction(err, unhandledErr error) error {
 		}
 	}
 
+	// If the action completed without an error but we failed to flush the
+	// charm state changes due to a quota limit, we should attach the error
+	// to the action.
+	if err == nil && errors.IsQuotaLimitExceeded(unhandledErr) {
+		err = unhandledErr
+		unhandledErr = nil
+	}
+
 	// If we had an action error, we'll simply encapsulate it in the response
 	// and discard the error state.  Actions should not error the uniter.
 	if err != nil {

--- a/worker/uniter/runner/jujuc/state-set.go
+++ b/worker/uniter/runner/jujuc/state-set.go
@@ -4,12 +4,15 @@
 package jujuc
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/utils/keyvalues"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/core/quota"
 )
 
 // StateSetCommand implements the state-set command.
@@ -38,6 +41,10 @@ the settings as strings.  Settings in the file will be overridden
 by any duplicate key-value arguments. A value of "-" for the filename
 means <stdin>.
 
+The following fixed size limits apply:
+- Length of stored keys cannot exceed %d bytes.
+- Length of stored values cannot exceed %d bytes.
+
 See also:
     state-delete
     state-get
@@ -46,7 +53,11 @@ See also:
 		Name:    "state-set",
 		Args:    "key=value [key=value ...]",
 		Purpose: "set server-side-state values",
-		Doc:     doc,
+		Doc: fmt.Sprintf(
+			doc,
+			quota.MaxCharmStateKeySize,
+			quota.MaxCharmStateValueSize,
+		),
 	})
 }
 

--- a/worker/uniter/runner/jujuc/state-set_test.go
+++ b/worker/uniter/runner/jujuc/state-set_test.go
@@ -49,6 +49,10 @@ the settings as strings.  Settings in the file will be overridden
 by any duplicate key-value arguments. A value of "-" for the filename
 means <stdin>.
 
+The following fixed size limits apply:
+- Length of stored keys cannot exceed 256 bytes.
+- Length of stored values cannot exceed 65536 bytes.
+
 See also:
     state-delete
     state-get


### PR DESCRIPTION
## Description of change

This PR introduces multi-level quota checks when attempting to update the charm and internal uniter state stored on the controller. 

The quota checks for **charm** state (modified via calls to the `state-set` tool ) operate on two different levels:
- Each entry in the state map is allowed to have:
  - A maximum key length of **256** bytes.
  - A maximum value length of **65536** bytes (64k).
- The total serialized size of the state cannot exceed a particular threshold (configured at the controller level via a setting).

The first quota check is always performed by the uniter when `state-set` is invoked so we can offer early feedback to charms if charm authors are attempting to abuse this feature to store BLOB/CLOB data to the controller instead of using a mechanism such as resources.

Both checks are always performed by the controller when attempting to use the `SetState` or `CommitHookChanges` API calls. If the quota checks fail,  a typed error (QuotaLimitExceeded from `juju/errors`) is returned and reconstructed by the API client.

A **separate**, quota check is also performed when setting the **uniter** (uniter, per-relation and storage) state. The threshold for this check is also configured at the controller level by the operator.

The rationale behind having separate checks for the charm and uniter state is to allow us to block misbehaving charms but at the same time still allow the unit to persist its internal state (e.g. the hook that failed etc.)

The two quotas are controlled by the following controller options:

| option                | default value | notes                           |
|-----------------------|---------------|---------------------------------|
| max-charm-state-size  | 2M            | Can be set to 0 to bypass check |
| max-uniter-state-size | 512K          | Can be set to 0 to bypass check |

The values where guestimated to provide charms with enough breathing room for storing an ample amount of data but to discourage charm authors from mis-using the feature. Note that the maximum **combined** quota cannot exceed 16M which is the hard-limit imposed by mongo for each document.

To enforce the quota, we _approximate_ the total size of stored data by serializing to BSON and counting the length of the serialized data. The logic for the quota checks has been placed in `core/quota` because:
- It is generic and potentially re-usable by future work.
- It needs to be used by both the controller and the uniter worker.

Fun spelunking facts: If you were to import `apiserver/common` from `api/uniter` (a common use-case since the `RestoreError` code lives in there) you will cause an import cycle! See the comments at the end of `api/uniter/uniter.go` for more details.

## QA steps

### With actions

```console
# Trigger max-key limit
$ juju run-action ubuntu-plus/0 write-charm-state num-entries=1 key-len=300 val-len=100
Action queued with id: "2"

$ juju show-action-output 2
UnitId: ubuntu-plus/0
id: "2"
message: exit status 1
results:
  ReturnCode: 1
  Stderr: |
    ERROR max allowed key length (256) exceeded
  Stdout: |
    attempting to write a payload with 1 entries where keys have length 300 and values have length 100
status: failed
timing:
  completed: 2020-04-01 15:45:05 +0000 UTC
  enqueued: 2020-04-01 15:45:01 +0000 UTC
  started: 2020-04-01 15:45:04 +0000 UTC

# Trigger max-value-limit
$ juju run-action ubuntu-plus/0 write-charm-state num-entries=1 key-len=10 val-len=65537
Action queued with id: "4"

$ juju show-action-output 4
UnitId: ubuntu-plus/0
id: "4"
message: exit status 1
results:
  ReturnCode: 1
  Stderr: |
    ERROR max allowed value length (65536) exceeded
  Stdout: |
    attempting to write a payload with 1 entries where keys have length 10 and values have length 65537
status: failed
timing:
  completed: 2020-04-01 15:47:04 +0000 UTC
  enqueued: 2020-04-01 15:47:00 +0000 UTC
  started: 2020-04-01 15:47:04 +0000 UTC

# List default limits
$ juju controller-config | grep state-size
max-charm-state-size       2.097152e+06
max-uniter-state-size      524288

# Trigger max state limit
$ juju controller-config max-charm-state-size=1337
$ juju run-action ubuntu-plus/0 write-charm-state num-entries=5 key-len=10 val-len=1000
Action queued with id: "6"

$ juju show-action-output 6
UnitId: ubuntu-plus/0
id: "6"
message: 'cannot apply changes: persisting charm state: max allowed size (1337) exceeded'
results:
  Stdout: |
    attempting to write a payload with 5 entries where keys have length 10 and values have length 1000
status: failed
timing:
  completed: 2020-04-01 15:51:00 +0000 UTC
  enqueued: 2020-04-01 15:50:58 +0000 UTC
  started: 2020-04-01 15:50:59 +0000 UTC

# Make sure we can still write to the state; 640k should be enough for everyone ;-)
$ juju controller-config max-charm-state-size=640000
$ juju run-action ubuntu-plus/0 write-charm-state num-entries=5 key-len=10 val-len=1000
Action queued with id: "8"

$ juju show-action-output 8  
UnitId: ubuntu-plus/0
id: "8"
results:
  Stdout: |
    attempting to write a payload with 5 entries where keys have length 10 and values have length 1000
status: completed
timing:
  completed: 2020-04-01 15:53:12 +0000 UTC
  enqueued: 2020-04-01 15:53:08 +0000 UTC
  started: 2020-04-01 15:53:11 +0000 UTC

$ juju run --unit ubuntu-plus/0 'state-get'
"0000000001": aaaaaaa ...
...
"0000000005": aaaaaaa ...
```

### With regular hooks

Besides actions we should test a similar scenario for hooks by running the `write-charm-state` tool via juju run, e.g:

```console
$ juju run --unit ubuntu-plus/0 'tools/write-charm-state 5 10 1000'
attempting to write a payload with 5 entries where keys have length 10 and values have length 1000
```

## Documentation changes

We need to update the charm author resources to communicate the fixed limits per key/value as well as that there is an operator-configurable knob for the total state size and its default value.