### PR TITLE
integretion tests: change underscore to hypen in model name

### DIFF
--- a/tests/suites/hook_tools/state_tools.sh
+++ b/tests/suites/hook_tools/state_tools.sh
@@ -29,7 +29,7 @@ run_state_delete_get_set() {
 run_state_set_clash_uniter_state() {
     echo
 
-    model_name="test-state_set_clash_uniter_state"
+    model_name="test-state-set-clash-uniter-state"
     file="${TEST_DIR}/${model_name}.txt"
 
     ensure "${model_name}" "${file}"


### PR DESCRIPTION
## Description of change

Juju model names cannot have underscores in them.  Finish replacement of underscore to hyphen.

## QA steps

```sh
(cd tests ; ./main.sh hook_tools)
```
