### PR TITLE
Fix intermittent failure in upgradeStepsSuite.TestWriteUniterState

### DIFF
--- a/api/upgradesteps/upgradesteps_test.go
+++ b/api/upgradesteps/upgradesteps_test.go
@@ -146,7 +146,19 @@ func (m unitStateMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	m.c.Assert(obtained.Args, jc.DeepEquals, m.expected.Args)
+	m.c.Assert(obtained.Args, gc.HasLen, len(m.expected.Args))
+
+	for _, obt := range obtained.Args {
+		var found bool
+		for _, exp := range m.expected.Args {
+			if obt.Tag == exp.Tag {
+				m.c.Assert(obt, jc.DeepEquals, exp)
+				found = true
+			}
+		}
+		m.c.Assert(found, jc.IsTrue, gc.Commentf("obtained tag %s, not found in expected data", obt.Tag))
+	}
+
 	return true
 }
 


### PR DESCRIPTION

## Description of change

Fix intermittent failure in TestWriteUniterState.

DeepEquals doesn't work on []params.SetUnitStateArg due to potential
for different order.  SameContents does not work with pointers.  Use
DeepEquals on one SetUnitStateArg after verifying both have the same
tag.  Ensure the two slices have the same length first.

## QA steps

```sh
$ cd api/upgradesteps/
# run the juju stress test for a count of 100 or more
```
