### PR TITLE
Remove params.StateServingInfo and state.StateServingInfo

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -23,7 +23,7 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -241,7 +241,7 @@ type Config interface {
 	// StateServingInfo returns the details needed to run
 	// a controller and reports whether those details
 	// are available
-	StateServingInfo() (params.StateServingInfo, bool)
+	StateServingInfo() (controller.StateServingInfo, bool)
 
 	// APIInfo returns details for connecting to the API server and
 	// reports whether the details are available.
@@ -317,7 +317,7 @@ type configSetterOnly interface {
 
 	// SetStateServingInfo sets the information needed
 	// to run a controller
-	SetStateServingInfo(info params.StateServingInfo)
+	SetStateServingInfo(info controller.StateServingInfo)
 
 	// SetControllerAPIPort sets the controller API port in the config.
 	SetControllerAPIPort(port int)
@@ -399,7 +399,7 @@ type configInternal struct {
 	apiDetails         *apiDetails
 	statePassword      string
 	oldPassword        string
-	servingInfo        *params.StateServingInfo
+	servingInfo        *controller.StateServingInfo
 	loggingConfig      string
 	values             map[string]string
 	mongoVersion       string
@@ -497,7 +497,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 
 // NewStateMachineConfig returns a configuration suitable for
 // a machine running the controller.
-func NewStateMachineConfig(configParams AgentConfigParams, serverInfo params.StateServingInfo) (ConfigSetterWriter, error) {
+func NewStateMachineConfig(configParams AgentConfigParams, serverInfo controller.StateServingInfo) (ConfigSetterWriter, error) {
 	if serverInfo.Cert == "" {
 		return nil, errors.Trace(requiredError("controller cert"))
 	}
@@ -692,14 +692,14 @@ func (c *configInternal) Value(key string) string {
 	return c.values[key]
 }
 
-func (c *configInternal) StateServingInfo() (params.StateServingInfo, bool) {
+func (c *configInternal) StateServingInfo() (controller.StateServingInfo, bool) {
 	if c.servingInfo == nil {
-		return params.StateServingInfo{}, false
+		return controller.StateServingInfo{}, false
 	}
 	return *c.servingInfo, true
 }
 
-func (c *configInternal) SetStateServingInfo(info params.StateServingInfo) {
+func (c *configInternal) SetStateServingInfo(info controller.StateServingInfo) {
 	c.servingInfo = &info
 	if c.statePassword == "" && c.apiDetails != nil {
 		c.statePassword = c.apiDetails.password

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
@@ -279,8 +279,8 @@ func (*suite) TestNewAgentConfig(c *gc.C) {
 	}
 }
 
-func stateServingInfo() params.StateServingInfo {
-	return params.StateServingInfo{
+func stateServingInfo() controller.StateServingInfo {
+	return controller.StateServingInfo{
 		Cert:              "cert",
 		PrivateKey:        "key",
 		CAPrivateKey:      "ca key",
@@ -296,7 +296,7 @@ func (*suite) TestNewStateMachineConfig(c *gc.C) {
 	type testStruct struct {
 		about         string
 		params        agent.AgentConfigParams
-		servingInfo   params.StateServingInfo
+		servingInfo   controller.StateServingInfo
 		checkErr      string
 		inspectConfig func(*gc.C, agent.Config)
 	}
@@ -305,20 +305,20 @@ func (*suite) TestNewStateMachineConfig(c *gc.C) {
 		checkErr: "controller cert not found in configuration",
 	}, {
 		about: "missing controller key",
-		servingInfo: params.StateServingInfo{
+		servingInfo: controller.StateServingInfo{
 			Cert: "server cert",
 		},
 		checkErr: "controller key not found in configuration",
 	}, {
 		about: "missing ca cert key",
-		servingInfo: params.StateServingInfo{
+		servingInfo: controller.StateServingInfo{
 			Cert:       "server cert",
 			PrivateKey: "server key",
 		},
 		checkErr: "ca cert key not found in configuration",
 	}, {
 		about: "missing state port",
-		servingInfo: params.StateServingInfo{
+		servingInfo: controller.StateServingInfo{
 			Cert:         "server cert",
 			PrivateKey:   "server key",
 			CAPrivateKey: "ca key",
@@ -326,7 +326,7 @@ func (*suite) TestNewStateMachineConfig(c *gc.C) {
 		checkErr: "state port not found in configuration",
 	}, {
 		about: "params api port",
-		servingInfo: params.StateServingInfo{
+		servingInfo: controller.StateServingInfo{
 			Cert:         "server cert",
 			PrivateKey:   "server key",
 			CAPrivateKey: "ca key",
@@ -391,7 +391,7 @@ func (*suite) TestStateServingInfo(c *gc.C) {
 	gotInfo, ok := conf.StateServingInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(gotInfo, jc.DeepEquals, servingInfo)
-	newInfo := params.StateServingInfo{
+	newInfo := controller.StateServingInfo{
 		APIPort:           147,
 		ControllerAPIPort: 148,
 		StatePort:         169,

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	apiagent "github.com/juju/juju/api/agent"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloud"
@@ -191,8 +190,7 @@ func InitializeState(
 	if err = initAPIHostPorts(st, args.BootstrapMachineAddresses, servingInfo.APIPort); err != nil {
 		return nil, err
 	}
-	ssi := paramsStateServingInfoToStateStateServingInfo(servingInfo)
-	if err := st.SetStateServingInfo(ssi); err != nil {
+	if err := st.SetStateServingInfo(servingInfo); err != nil {
 		return nil, errors.Errorf("cannot set state serving info: %v", err)
 	}
 
@@ -392,18 +390,6 @@ func getEnviron(
 		return caas.Open(provider, openParams)
 	}
 	return environs.Open(provider, openParams)
-}
-
-func paramsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) state.StateServingInfo {
-	return state.StateServingInfo{
-		APIPort:        i.APIPort,
-		StatePort:      i.StatePort,
-		Cert:           i.Cert,
-		PrivateKey:     i.PrivateKey,
-		CAPrivateKey:   i.CAPrivateKey,
-		SharedSecret:   i.SharedSecret,
-		SystemIdentity: i.SystemIdentity,
-	}
 }
 
 func initRaft(agentConfig agent.Config) error {

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller"
@@ -105,7 +104,7 @@ LXC_BRIDGE="ignored"`[1:])
 		Controller:        testing.ControllerTag,
 		Model:             testing.ModelTag,
 	}
-	servingInfo := params.StateServingInfo{
+	servingInfo := controller.StateServingInfo{
 		Cert:           testing.ServerCert,
 		PrivateKey:     testing.ServerKey,
 		CAPrivateKey:   testing.CAKey,
@@ -302,7 +301,7 @@ LXC_BRIDGE="ignored"`[1:])
 	// Check that the state serving info is initialised correctly.
 	stateServingInfo, err := st.StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stateServingInfo, jc.DeepEquals, state.StateServingInfo{
+	c.Assert(stateServingInfo, jc.DeepEquals, controller.StateServingInfo{
 		APIPort:        1234,
 		StatePort:      s.mgoInst.Port(),
 		Cert:           testing.ServerCert,
@@ -393,7 +392,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	}
 	cfg, err := agent.NewAgentConfig(configParams)
 	c.Assert(err, jc.ErrorIsNil)
-	cfg.SetStateServingInfo(params.StateServingInfo{
+	cfg.SetStateServingInfo(controller.StateServingInfo{
 		APIPort:        5555,
 		StatePort:      s.mgoInst.Port(),
 		Cert:           "foo",

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/juju/names.v3"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 )
 
@@ -115,7 +115,7 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		}
 	}
 	if len(format.ControllerKey) != 0 {
-		config.servingInfo = &params.StateServingInfo{
+		config.servingInfo = &controller.StateServingInfo{
 			Cert:              format.ControllerCert,
 			PrivateKey:        format.ControllerKey,
 			CAPrivateKey:      format.CAPrivateKey,

--- a/agent/format_whitebox_test.go
+++ b/agent/format_whitebox_test.go
@@ -13,8 +13,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig/cloudinit"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -91,7 +91,7 @@ func (*formatSuite) TestRead(c *gc.C) {
 }
 
 func (*formatSuite) TestReadWriteStateConfig(c *gc.C) {
-	servingInfo := params.StateServingInfo{
+	servingInfo := controller.StateServingInfo{
 		Cert:         "some special cert",
 		PrivateKey:   "a special key",
 		CAPrivateKey: "ca special key",

--- a/agent/identity_test.go
+++ b/agent/identity_test.go
@@ -13,7 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -37,7 +37,7 @@ var attributeParams = AgentConfigParams{
 	Model:             testing.ModelTag,
 }
 
-var servingInfo = params.StateServingInfo{
+var servingInfo = controller.StateServingInfo{
 	Cert:           "old cert",
 	PrivateKey:     "old key",
 	CAPrivateKey:   "old ca key",

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -17,6 +17,7 @@ import (
 	apiagent "github.com/juju/juju/api/agent"
 	apiserveragent "github.com/juju/juju/apiserver/facades/agent/agent"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/juju/testing"
@@ -40,19 +41,12 @@ var _ = gc.Suite(&servingInfoSuite{})
 func (s *servingInfoSuite) TestStateServingInfo(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
 
-	ssi := state.StateServingInfo{
+	ssi := controller.StateServingInfo{
 		PrivateKey:   "some key",
 		Cert:         "Some cert",
 		SharedSecret: "really, really secret",
 		APIPort:      33,
 		StatePort:    44,
-	}
-	expected := params.StateServingInfo{
-		PrivateKey:   ssi.PrivateKey,
-		Cert:         ssi.Cert,
-		SharedSecret: ssi.SharedSecret,
-		APIPort:      ssi.APIPort,
-		StatePort:    ssi.StatePort,
 	}
 	err := s.State.SetStateServingInfo(ssi)
 	c.Assert(err, jc.ErrorIsNil)
@@ -60,7 +54,7 @@ func (s *servingInfoSuite) TestStateServingInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	info, err := apiSt.StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info, jc.DeepEquals, expected)
+	c.Assert(info, jc.DeepEquals, ssi)
 }
 
 func (s *servingInfoSuite) TestStateServingInfoPermission(c *gc.C) {

--- a/api/agent/state.go
+++ b/api/agent/state.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/common/cloudspec"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
@@ -60,10 +61,22 @@ func (st *State) getEntity(tag names.Tag) (*params.AgentGetEntitiesResult, error
 	return &results.Entities[0], nil
 }
 
-func (st *State) StateServingInfo() (params.StateServingInfo, error) {
+func (st *State) StateServingInfo() (controller.StateServingInfo, error) {
 	var results params.StateServingInfo
 	err := st.facade.FacadeCall("StateServingInfo", nil, &results)
-	return results, err
+	if err != nil {
+		return controller.StateServingInfo{}, errors.Trace(err)
+	}
+	return controller.StateServingInfo{
+		APIPort:           results.APIPort,
+		ControllerAPIPort: results.ControllerAPIPort,
+		StatePort:         results.StatePort,
+		Cert:              results.Cert,
+		PrivateKey:        results.PrivateKey,
+		CAPrivateKey:      results.CAPrivateKey,
+		SharedSecret:      results.SharedSecret,
+		SystemIdentity:    results.SystemIdentity,
+	}, nil
 }
 
 // IsMaster reports whether the connected machine

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -35,7 +35,7 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	ModelConfig() (*config.Config, error)
 	ControllerConfig() (controller.Config, error)
-	StateServingInfo() (state.StateServingInfo, error)
+	StateServingInfo() (controller.StateServingInfo, error)
 	RestoreInfo() *state.RestoreInfo
 	ControllerNodes() ([]state.ControllerNode, error)
 }

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	backupsAPI "github.com/juju/juju/apiserver/facades/client/backups"
-	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/backups"
@@ -44,7 +44,7 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 	ssInfo, err := s.State.StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	agentConfig := s.AgentConfigForTag(c, s.machineTag)
-	agentConfig.SetStateServingInfo(params.StateServingInfo{
+	agentConfig.SetStateServingInfo(controller.StateServingInfo{
 		PrivateKey:   ssInfo.PrivateKey,
 		Cert:         ssInfo.Cert,
 		CAPrivateKey: ssInfo.CAPrivateKey,

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -79,9 +79,9 @@ func (st *mockState) Model() (caasoperatorprovisioner.Model, error) {
 	return st.model, nil
 }
 
-func (st *mockState) StateServingInfo() (state.StateServingInfo, error) {
+func (st *mockState) StateServingInfo() (controller.StateServingInfo, error) {
 	st.MethodCall(st, "StateServingInfo")
-	return state.StateServingInfo{
+	return controller.StateServingInfo{
 		CAPrivateKey: coretesting.CAKey,
 	}, nil
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/state.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/state.go
@@ -17,7 +17,7 @@ import (
 // required by the CAAS operator provisioner facade.
 type CAASOperatorProvisionerState interface {
 	ControllerConfig() (controller.Config, error)
-	StateServingInfo() (state.StateServingInfo, error)
+	StateServingInfo() (controller.StateServingInfo, error)
 	WatchApplications() state.StringsWatcher
 	FindEntity(tag names.Tag) (state.Entity, error)
 	Addresses() ([]string, error)

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/controller"
@@ -80,14 +79,14 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	pcfg.Bootstrap.HostedModelConfig = map[string]interface{}{
 		"name": "hosted-model",
 	}
-	pcfg.Bootstrap.StateServingInfo = params.StateServingInfo{
+	pcfg.Bootstrap.StateServingInfo = controller.StateServingInfo{
 		Cert:         testing.ServerCert,
 		PrivateKey:   testing.ServerKey,
 		CAPrivateKey: testing.CAKey,
 		StatePort:    123,
 		APIPort:      456,
 	}
-	pcfg.Bootstrap.StateServingInfo = params.StateServingInfo{
+	pcfg.Bootstrap.StateServingInfo = controller.StateServingInfo{
 		Cert:         testing.ServerCert,
 		PrivateKey:   testing.ServerKey,
 		CAPrivateKey: testing.CAKey,

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -12,10 +12,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
@@ -76,7 +76,7 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 		icfg.Bootstrap.HostedModelConfig = map[string]interface{}{
 			"name": "hosted-model",
 		}
-		icfg.Bootstrap.StateServingInfo = params.StateServingInfo{
+		icfg.Bootstrap.StateServingInfo = jujucontroller.StateServingInfo{
 			Cert:         coretesting.ServerCert,
 			PrivateKey:   coretesting.ServerKey,
 			CAPrivateKey: coretesting.CAKey,
@@ -84,7 +84,7 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 			APIPort:      456,
 		}
 		icfg.Jobs = []model.MachineJob{model.JobManageModel, model.JobHostUnits}
-		icfg.Bootstrap.StateServingInfo = params.StateServingInfo{
+		icfg.Bootstrap.StateServingInfo = jujucontroller.StateServingInfo{
 			Cert:         coretesting.ServerCert,
 			PrivateKey:   coretesting.ServerKey,
 			CAPrivateKey: coretesting.CAKey,

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
@@ -238,7 +237,7 @@ type BootstrapConfig struct {
 	// This is only specified for bootstrap; controllers started
 	// subsequently will acquire their serving info from another
 	// server.
-	StateServingInfo params.StateServingInfo
+	StateServingInfo controller.StateServingInfo
 
 	// JujuDbSnapPath is the path to a .snap file that will be used as the juju-db
 	// service.

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -18,11 +18,11 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/environs/config"
@@ -191,7 +191,7 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 				ControllerConfig:      controllerCfg,
 				ControllerModelConfig: envConfig,
 			},
-			StateServingInfo: params.StateServingInfo{
+			StateServingInfo: controller.StateServingInfo{
 				StatePort:    controllerCfg.StatePort(),
 				APIPort:      controllerCfg.APIPort(),
 				Cert:         testing.ServerCert,

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/paths"
@@ -89,7 +89,7 @@ func must(s string, err error) string {
 	return s
 }
 
-var stateServingInfo = params.StateServingInfo{
+var stateServingInfo = controller.StateServingInfo{
 	Cert:         string(serverCert),
 	PrivateKey:   string(serverKey),
 	CAPrivateKey: "ca-private-key",

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/apiserver/params"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
@@ -64,7 +63,7 @@ type FakeEnsureMongo struct {
 	InitiateCount    int
 	DataDir          string
 	OplogSize        int
-	Info             state.StateServingInfo
+	Info             controller.StateServingInfo
 	InitiateParams   peergrouper.InitiateMongoParams
 	Err              error
 	ServiceInstalled bool
@@ -85,7 +84,7 @@ func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*replicaset.Config, error
 func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) (mongo.Version, error) {
 	f.EnsureCount++
 	f.DataDir, f.OplogSize = args.DataDir, args.OplogSize
-	f.Info = state.StateServingInfo{
+	f.Info = controller.StateServingInfo{
 		APIPort:        args.APIPort,
 		StatePort:      args.StatePort,
 		Cert:           args.Cert,
@@ -230,7 +229,7 @@ func (s *AgentSuite) WriteStateAgentConfig(
 			Model:              modelTag,
 			MongoMemoryProfile: controller.DefaultMongoMemoryProfile,
 		},
-		params.StateServingInfo{
+		controller.StateServingInfo{
 			Cert:         coretesting.ServerCert,
 			PrivateKey:   coretesting.ServerKey,
 			CAPrivateKey: coretesting.CAKey,

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -25,12 +25,12 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	caasprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	jujucmd "github.com/juju/juju/cmd"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
@@ -404,7 +404,7 @@ func getAddressesForMongo(
 func ensureKeys(
 	isCAAS bool,
 	args instancecfg.StateInitializationParams,
-	info *params.StateServingInfo,
+	info *controller.StateServingInfo,
 	newConfigAttrs map[string]interface{},
 ) error {
 	if isCAAS {

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -32,12 +32,11 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -317,7 +316,7 @@ func (s *BootstrapSuite) initBootstrapCommand(c *gc.C, jobs []model.MachineJob, 
 			agent.MongoOplogSize: s.mongoOplogSize,
 		},
 	}
-	servingInfo := params.StateServingInfo{
+	servingInfo := controller.StateServingInfo{
 		Cert:         "some cert",
 		PrivateKey:   "some key",
 		CAPrivateKey: "another key",
@@ -360,8 +359,7 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	c.Assert(len(servingInfo.SystemIdentity), gc.Not(gc.Equals), 0)
 	servingInfo.SharedSecret = ""
 	servingInfo.SystemIdentity = ""
-	expect := cmdutil.ParamsStateServingInfoToStateStateServingInfo(expectInfo)
-	c.Assert(servingInfo, jc.DeepEquals, expect)
+	c.Assert(servingInfo, jc.DeepEquals, expectInfo)
 	expectDialAddrs := []string{fmt.Sprintf("localhost:%d", expectInfo.StatePort)}
 	gotDialAddrs := s.fakeEnsureMongo.InitiateParams.DialInfo.Addrs
 	c.Assert(gotDialAddrs, gc.DeepEquals, expectDialAddrs)

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -14,9 +14,9 @@ import (
 	"gopkg.in/juju/worker.v1/dependency"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/agent/machine"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/testing"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/apicaller"
@@ -1121,7 +1121,7 @@ type mockConfig struct {
 	agent.ConfigSetter
 	tag      names.Tag
 	ssiSet   bool
-	ssi      params.StateServingInfo
+	ssi      controller.StateServingInfo
 	dataPath string
 }
 
@@ -1136,11 +1136,11 @@ func (mc *mockConfig) Controller() names.ControllerTag {
 	return testing.ControllerTag
 }
 
-func (mc *mockConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (mc *mockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	return mc.ssi, mc.ssiSet
 }
 
-func (mc *mockConfig) SetStateServingInfo(info params.StateServingInfo) {
+func (mc *mockConfig) SetStateServingInfo(info controller.StateServingInfo) {
 	mc.ssiSet = true
 	mc.ssi = info
 }

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -164,8 +164,7 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 		agentConfig, tools = s.PrimeStateAgentVersion(c, tag, initialMachinePassword, vers)
 		info, ok := agentConfig.StateServingInfo()
 		c.Assert(ok, jc.IsTrue)
-		ssi := cmdutil.ParamsStateServingInfoToStateStateServingInfo(info)
-		err = s.State.SetStateServingInfo(ssi)
+		err = s.State.SetStateServingInfo(info)
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
 		agentConfig, tools = s.PrimeAgentVersion(c, tag, initialMachinePassword, vers)

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -12,10 +12,8 @@ import (
 	"github.com/juju/os/series"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/state"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/upgrader"
 )
@@ -230,18 +228,4 @@ func NewEnsureServerParams(agentConfig agent.Config) (mongo.EnsureServerParams, 
 		MemoryProfile: agentConfig.MongoMemoryProfile(),
 	}
 	return params, nil
-}
-
-// ParamsStateServingInfoToStateStateServingInfo converts a
-// params.StateServingInfo to a state.StateServingInfo.
-func ParamsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) state.StateServingInfo {
-	return state.StateServingInfo{
-		APIPort:        i.APIPort,
-		StatePort:      i.StatePort,
-		Cert:           i.Cert,
-		PrivateKey:     i.PrivateKey,
-		CAPrivateKey:   i.CAPrivateKey,
-		SharedSecret:   i.SharedSecret,
-		SystemIdentity: i.SystemIdentity,
-	}
 }

--- a/controller/api.go
+++ b/controller/api.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+// StateServingInfo holds network/auth information needed by a controller.
+type StateServingInfo struct {
+	APIPort           int
+	ControllerAPIPort int
+	StatePort         int
+	Cert              string
+	PrivateKey        string
+	CAPrivateKey      string
+	// this will be passed as the KeyFile argument to MongoDB
+	SharedSecret   string
+	SystemIdentity string
+}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -25,7 +25,6 @@ import (
 	"gopkg.in/juju/names.v3"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -649,7 +648,7 @@ func finalizeInstanceBootstrapConfig(
 	if err != nil {
 		return errors.Annotate(err, "cannot generate controller certificate")
 	}
-	icfg.Bootstrap.StateServingInfo = params.StateServingInfo{
+	icfg.Bootstrap.StateServingInfo = controller.StateServingInfo{
 		StatePort:    controllerCfg.StatePort(),
 		APIPort:      controllerCfg.APIPort(),
 		Cert:         cert,
@@ -712,7 +711,7 @@ func finalizePodBootstrapConfig(
 	if err != nil {
 		return errors.Annotate(err, "cannot generate controller certificate")
 	}
-	pcfg.Bootstrap.StateServingInfo = params.StateServingInfo{
+	pcfg.Bootstrap.StateServingInfo = controller.StateServingInfo{
 		StatePort:    controllerCfg.StatePort(),
 		APIPort:      controllerCfg.APIPort(),
 		Cert:         cert,

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -293,8 +292,7 @@ func (s *upgradeSuite) configureMachine(c *gc.C, machineId string, vers version.
 		agentConfig, tools = s.PrimeStateAgentVersion(c, tag, initialMachinePassword, vers)
 		info, ok := agentConfig.StateServingInfo()
 		c.Assert(ok, jc.IsTrue)
-		ssi := cmdutil.ParamsStateServingInfoToStateStateServingInfo(info)
-		err = s.State.SetStateServingInfo(ssi)
+		err = s.State.SetStateServingInfo(info)
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
 		agentConfig, tools = s.PrimeAgentVersion(c, tag, initialMachinePassword, vers)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -638,10 +638,10 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Make sure the controller store has the controller api endpoint address set
-	controller, err := s.ControllerStore.ControllerByName(ControllerName)
+	ctrl, err := s.ControllerStore.ControllerByName(ControllerName)
 	c.Assert(err, jc.ErrorIsNil)
-	controller.APIEndpoints = []string{s.APIState.APIHostPorts()[0][0].String()}
-	err = s.ControllerStore.UpdateController(ControllerName, *controller)
+	ctrl.APIEndpoints = []string{s.APIState.APIHostPorts()[0][0].String()}
+	err = s.ControllerStore.UpdateController(ControllerName, *ctrl)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.ControllerStore.SetCurrentController(ControllerName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -649,7 +649,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.Environ = environ
 
 	// Insert expected values...
-	servingInfo := state.StateServingInfo{
+	servingInfo := controller.StateServingInfo{
 		PrivateKey:   testing.ServerKey,
 		Cert:         testing.ServerCert,
 		CAPrivateKey: testing.CAKey,

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -148,7 +148,7 @@ func (r *RestoreSuite) TestNewDialInfo(c *gc.C) {
 		}
 		statePort := 12345
 		privateAddress := "dummyPrivateAddress"
-		servingInfo := params.StateServingInfo{
+		servingInfo := controller.StateServingInfo{
 			APIPort:        1234,
 			StatePort:      statePort,
 			Cert:           coretesting.CACert,

--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/state"
 )
 
 // backupIDTimstamp is used to format the timestamp from a backup
@@ -552,7 +551,7 @@ type DB interface {
 	ControllerConfig() (controller.Config, error)
 
 	// StateServingInfo is the secrets of the controller.
-	StateServingInfo() (state.StateServingInfo, error)
+	StateServingInfo() (controller.StateServingInfo, error)
 }
 
 // NewStorage returns a new FileStorage to use for storing backup

--- a/state/controller.go
+++ b/state/controller.go
@@ -245,24 +245,43 @@ func readRawControllerInfo(session *mgo.Session) (*ControllerInfo, error) {
 
 const stateServingInfoKey = "stateServingInfo"
 
+type stateServingInfo struct {
+	APIPort      int    `bson:"apiport"`
+	StatePort    int    `bson:"stateport"`
+	Cert         string `bson:"cert"`
+	PrivateKey   string `bson:"privatekey"`
+	CAPrivateKey string `bson:"caprivatekey"`
+	// this will be passed as the KeyFile argument to MongoDB
+	SharedSecret   string `bson:"sharedsecret"`
+	SystemIdentity string `bson:"systemidentity"`
+}
+
 // StateServingInfo returns information for running a controller machine
-func (st *State) StateServingInfo() (StateServingInfo, error) {
+func (st *State) StateServingInfo() (jujucontroller.StateServingInfo, error) {
 	controllers, closer := st.db().GetCollection(controllersC)
 	defer closer()
 
-	var info StateServingInfo
+	var info stateServingInfo
 	err := controllers.Find(bson.D{{"_id", stateServingInfoKey}}).One(&info)
 	if err != nil {
-		return info, errors.Trace(err)
+		return jujucontroller.StateServingInfo{}, errors.Trace(err)
 	}
 	if info.StatePort == 0 {
-		return StateServingInfo{}, errors.NotFoundf("state serving info")
+		return jujucontroller.StateServingInfo{}, errors.NotFoundf("state serving info")
 	}
-	return info, nil
+	return jujucontroller.StateServingInfo{
+		APIPort:        info.APIPort,
+		StatePort:      info.StatePort,
+		Cert:           info.Cert,
+		PrivateKey:     info.PrivateKey,
+		CAPrivateKey:   info.CAPrivateKey,
+		SharedSecret:   info.SharedSecret,
+		SystemIdentity: info.SystemIdentity,
+	}, nil
 }
 
 // SetStateServingInfo stores information needed for running a controller
-func (st *State) SetStateServingInfo(info StateServingInfo) error {
+func (st *State) SetStateServingInfo(info jujucontroller.StateServingInfo) error {
 	if info.StatePort == 0 || info.APIPort == 0 ||
 		info.Cert == "" || info.PrivateKey == "" {
 		return errors.Errorf("incomplete state serving info set in state")
@@ -276,9 +295,17 @@ func (st *State) SetStateServingInfo(info StateServingInfo) error {
 		logger.Warningf("state serving info has no CA certificate key")
 	}
 	ops := []txn.Op{{
-		C:      controllersC,
-		Id:     stateServingInfoKey,
-		Update: bson.D{{"$set", info}},
+		C:  controllersC,
+		Id: stateServingInfoKey,
+		Update: bson.D{{"$set", stateServingInfo{
+			APIPort:        info.APIPort,
+			StatePort:      info.StatePort,
+			Cert:           info.Cert,
+			PrivateKey:     info.PrivateKey,
+			CAPrivateKey:   info.CAPrivateKey,
+			SharedSecret:   info.SharedSecret,
+			SystemIdentity: info.SystemIdentity,
+		}}},
 	}}
 	if err := st.db().RunTransaction(ops); err != nil {
 		return errors.Annotatef(err, "cannot set state serving info")

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -243,7 +243,7 @@ func (s *ControllerSuite) TestStateServingInfo(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "state serving info not found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	data := state.StateServingInfo{
+	data := controller.StateServingInfo{
 		APIPort:      69,
 		StatePort:    80,
 		Cert:         "Some cert",
@@ -258,15 +258,15 @@ func (s *ControllerSuite) TestStateServingInfo(c *gc.C) {
 	c.Assert(info, jc.DeepEquals, data)
 }
 
-var setStateServingInfoWithInvalidInfoTests = []func(info *state.StateServingInfo){
-	func(info *state.StateServingInfo) { info.APIPort = 0 },
-	func(info *state.StateServingInfo) { info.StatePort = 0 },
-	func(info *state.StateServingInfo) { info.Cert = "" },
-	func(info *state.StateServingInfo) { info.PrivateKey = "" },
+var setStateServingInfoWithInvalidInfoTests = []func(info *controller.StateServingInfo){
+	func(info *controller.StateServingInfo) { info.APIPort = 0 },
+	func(info *controller.StateServingInfo) { info.StatePort = 0 },
+	func(info *controller.StateServingInfo) { info.Cert = "" },
+	func(info *controller.StateServingInfo) { info.PrivateKey = "" },
 }
 
 func (s *ControllerSuite) TestSetStateServingInfoWithInvalidInfo(c *gc.C) {
-	origData := state.StateServingInfo{
+	origData := controller.StateServingInfo{
 		APIPort:      69,
 		StatePort:    80,
 		Cert:         "Some cert",

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -247,7 +247,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 			C:      controllersC,
 			Id:     stateServingInfoKey,
 			Assert: txn.DocMissing,
-			Insert: &StateServingInfo{},
+			Insert: &stateServingInfo{},
 		},
 		txn.Op{
 			C:      controllersC,

--- a/state/state.go
+++ b/state/state.go
@@ -32,7 +32,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	coreglobalclock "github.com/juju/juju/core/globalclock"
@@ -101,26 +100,6 @@ type State struct {
 
 	// TODO(anastasiamac 2015-07-16) As state gets broken up, remove this.
 	CloudImageMetadataStorage cloudimagemetadata.Storage
-}
-
-// StateServingInfo holds information needed by a controller.
-// This type is a copy of the type of the same name from the api/params package.
-// It is replicated here to avoid the state package depending on api/params.
-//
-// NOTE(fwereade): the api/params type exists *purely* for representing
-// this data over the wire, and has a legitimate reason to exist. This
-// type does not: it's non-implementation-specific and should be defined
-// under core/ somewhere, so it can be used both here and in the agent
-// without dragging unnecessary/irrelevant packages into scope.
-type StateServingInfo struct {
-	APIPort      int
-	StatePort    int
-	Cert         string
-	PrivateKey   string
-	CAPrivateKey string
-	// this will be passed as the KeyFile argument to MongoDB
-	SharedSecret   string
-	SystemIdentity string
 }
 
 func (st *State) newStateNoWorkers(modelUUID string) (*State, error) {
@@ -735,7 +714,7 @@ func (st *State) checkCanUpgradeIAAS(currentVersion, newVersion string) error {
 	return nil
 }
 
-var errUpgradeInProgress = errors.New(params.CodeUpgradeInProgress)
+var errUpgradeInProgress = errors.New("upgrade in progress")
 
 // IsUpgradeInProgressError returns true if the error is caused by an
 // in-progress upgrade.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -4075,7 +4076,7 @@ func (s *StateSuite) TestStateServingInfo(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "state serving info not found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	data := state.StateServingInfo{
+	data := controller.StateServingInfo{
 		APIPort:      69,
 		StatePort:    80,
 		Cert:         "Some cert",

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -22,7 +22,7 @@ import (
 // StateBackend provides an interface for upgrading the global state database.
 type StateBackend interface {
 	ControllerUUID() string
-	StateServingInfo() (state.StateServingInfo, error)
+	StateServingInfo() (controller.StateServingInfo, error)
 	ControllerConfig() (controller.Config, error)
 	LeaseNotifyTarget(io.Writer, raftleasestore.Logger) raftlease.NotifyTarget
 
@@ -101,7 +101,7 @@ func (s stateBackend) ControllerUUID() string {
 	return s.pool.SystemState().ControllerUUID()
 }
 
-func (s stateBackend) StateServingInfo() (state.StateServingInfo, error) {
+func (s stateBackend) StateServingInfo() (controller.StateServingInfo, error) {
 	return s.pool.SystemState().StateServingInfo()
 }
 

--- a/upgrades/raft_test.go
+++ b/upgrades/raft_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/raftlease"
-	"github.com/juju/juju/state"
 	raftleasestore "github.com/juju/juju/state/raftlease"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
@@ -108,7 +107,7 @@ func makeContext(dataDir string) *mockContext {
 				Tags:    map[string]string{"juju-machine-id": "7"},
 				Votes:   &noVotes,
 			}},
-			info: state.StateServingInfo{APIPort: 1234},
+			info: controller.StateServingInfo{APIPort: 1234},
 		},
 	}
 }
@@ -179,7 +178,7 @@ func (s *raftSuite) TestMigrateLegacyLeases(c *gc.C) {
 				Address: "somewhere.else:37012",
 				Tags:    map[string]string{"juju-machine-id": "42"},
 			}},
-			info: state.StateServingInfo{APIPort: 1234},
+			info: controller.StateServingInfo{APIPort: 1234},
 		},
 	}
 	err := upgrades.BootstrapRaft(context)
@@ -285,7 +284,7 @@ func (s *raftSuite) TestIgnoresBlankLeaseOrHolder(c *gc.C) {
 				Address: "somewhere.else:37012",
 				Tags:    map[string]string{"juju-machine-id": "42"},
 			}},
-			info: state.StateServingInfo{APIPort: 1234},
+			info: controller.StateServingInfo{APIPort: 1234},
 		},
 	}
 	err := upgrades.BootstrapRaft(context)
@@ -364,7 +363,7 @@ func (s *raftSuite) TestMigrateLegacyLeasesWithSnapshotAndLogs(c *gc.C) {
 				Address: "somewhere.else:37012",
 				Tags:    map[string]string{"juju-machine-id": "42"},
 			}},
-			info:   state.StateServingInfo{APIPort: 1234},
+			info:   controller.StateServingInfo{APIPort: 1234},
 			config: config,
 			leases: map[lease.Key]lease.Info{
 				{"nonagon", "m1", "gamma"}: {
@@ -467,7 +466,7 @@ func (s *raftSuite) TestMigrateLegacyLeasesBootstrapsIfNeeded(c *gc.C) {
 				Address: "somewhere.else:37012",
 				Tags:    map[string]string{"juju-machine-id": "42"},
 			}},
-			info:   state.StateServingInfo{APIPort: 1234},
+			info:   controller.StateServingInfo{APIPort: 1234},
 			config: config,
 			leases: map[lease.Key]lease.Info{
 				{"nonagon", "m1", "gamma"}: {
@@ -518,7 +517,7 @@ type mockState struct {
 	upgrades.StateBackend
 	stub    testing.Stub
 	members []replicaset.Member
-	info    state.StateServingInfo
+	info    controller.StateServingInfo
 	config  controller.Config
 	leases  map[lease.Key]lease.Info
 	target  *mockTarget
@@ -528,7 +527,7 @@ func (s *mockState) ReplicaSetMembers() ([]replicaset.Member, error) {
 	return s.members, s.stub.NextErr()
 }
 
-func (s *mockState) StateServingInfo() (state.StateServingInfo, error) {
+func (s *mockState) StateServingInfo() (controller.StateServingInfo, error) {
 	return s.info, s.stub.NextErr()
 }
 

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/mongo"
 	coretesting "github.com/juju/juju/testing"
@@ -150,7 +150,7 @@ type mockAgentConfig struct {
 	apiAddresses []string
 	values       map[string]string
 	mongoInfo    *mongo.MongoInfo
-	servingInfo  params.StateServingInfo
+	servingInfo  controller.StateServingInfo
 	modelTag     names.ModelTag
 }
 
@@ -190,11 +190,11 @@ func (mock *mockAgentConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 	return mock.mongoInfo, true
 }
 
-func (mock *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (mock *mockAgentConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	return mock.servingInfo, true
 }
 
-func (mock *mockAgentConfig) SetStateServingInfo(info params.StateServingInfo) {
+func (mock *mockAgentConfig) SetStateServingInfo(info controller.StateServingInfo) {
 	mock.servingInfo = info
 }
 

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -276,7 +276,7 @@ func (s *AgentConfigUpdaterSuite) TestJobManageEnvironNotOverwriteCert(c *gc.C) 
 	a := &mockAgent{}
 	existingCert := "some cert set by certupdater"
 	existingKey := "some key set by certupdater"
-	a.conf.SetStateServingInfo(params.StateServingInfo{
+	a.conf.SetStateServingInfo(controller.StateServingInfo{
 		Cert:       existingCert,
 		PrivateKey: existingKey,
 	})
@@ -345,7 +345,7 @@ type mockConfig struct {
 	agent.ConfigSetter
 	tag    names.Tag
 	ssiSet bool
-	ssi    params.StateServingInfo
+	ssi    controller.StateServingInfo
 
 	profile    string
 	profileSet bool
@@ -362,11 +362,11 @@ func (mc *mockConfig) Controller() names.ControllerTag {
 	return testing.ControllerTag
 }
 
-func (mc *mockConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (mc *mockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	return mc.ssi, mc.ssiSet
 }
 
-func (mc *mockConfig) SetStateServingInfo(info params.StateServingInfo) {
+func (mc *mockConfig) SetStateServingInfo(info controller.StateServingInfo) {
 	mc.ssiSet = true
 	mc.ssi = info
 }

--- a/worker/apiserver/manifold_test.go
+++ b/worker/apiserver/manifold_test.go
@@ -24,7 +24,7 @@ import (
 	coreapiserver "github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/multiwatcher"
@@ -269,7 +269,7 @@ type mockAgentConfig struct {
 	agent.Config
 	dataDir string
 	logDir  string
-	info    *params.StateServingInfo
+	info    *controller.StateServingInfo
 	values  map[string]string
 }
 
@@ -285,11 +285,11 @@ func (c *mockAgentConfig) DataDir() string {
 	return c.dataDir
 }
 
-func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (c *mockAgentConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	if c.info != nil {
 		return *c.info, true
 	}
-	return params.StateServingInfo{}, false
+	return controller.StateServingInfo{}, false
 }
 
 func (c *mockAgentConfig) Value(key string) string {

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/juju/agent"
 	coreapiserver "github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/apiserverhttp"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
@@ -49,7 +49,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.agentConfig = mockAgentConfig{
 		dataDir: c.MkDir(),
 		logDir:  c.MkDir(),
-		info: &params.StateServingInfo{
+		info: &controller.StateServingInfo{
 			APIPort: 0, // listen on any port
 		},
 	}

--- a/worker/apiservercertwatcher/manifold_test.go
+++ b/worker/apiservercertwatcher/manifold_test.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/apiservercertwatcher"
 )
@@ -39,7 +39,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 	s.agent = &mockAgent{
 		conf: mockConfig{
-			info: &params.StateServingInfo{
+			info: &controller.StateServingInfo{
 				Cert:       coretesting.ServerCert,
 				PrivateKey: coretesting.ServerKey,
 			},
@@ -184,7 +184,7 @@ type mockConfig struct {
 	agent.Config
 
 	mu     sync.Mutex
-	info   *params.StateServingInfo
+	info   *controller.StateServingInfo
 	addrs  []string
 	caCert string
 }
@@ -193,7 +193,7 @@ func (mc *mockConfig) setCert(cert, key string) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	if mc.info == nil {
-		mc.info = &params.StateServingInfo{}
+		mc.info = &controller.StateServingInfo{}
 	}
 	mc.info.Cert = cert
 	mc.info.PrivateKey = key
@@ -211,11 +211,11 @@ func (mc *mockConfig) CACert() string {
 	return mc.caCert
 }
 
-func (mc *mockConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (mc *mockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	if mc.info != nil {
 		return *mc.info, true
 	}
-	return params.StateServingInfo{}, false
+	return controller.StateServingInfo{}, false
 }

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/utils/cert"
 	"gopkg.in/juju/worker.v1"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
@@ -51,12 +50,12 @@ type ControllerConfigGetter interface {
 // StateServingInfoGetter is an interface that is provided to NewCertificateUpdater
 // whose StateServingInfo method will be invoked to get state serving info.
 type StateServingInfoGetter interface {
-	StateServingInfo() (params.StateServingInfo, bool)
+	StateServingInfo() (controller.StateServingInfo, bool)
 }
 
 // StateServingInfoSetter defines a function that is called to set a
 // StateServingInfo value with a newly generated certificate.
-type StateServingInfoSetter func(info params.StateServingInfo) error
+type StateServingInfoSetter func(info controller.StateServingInfo) error
 
 // APIHostPortsGetter is an interface that is provided to NewCertificateUpdater.
 // It returns all known API addresses.

--- a/worker/certupdater/manifold.go
+++ b/worker/certupdater/manifold.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/juju/worker.v1/dependency"
 
 	jujuagent "github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/common"
 	workerstate "github.com/juju/juju/worker/state"
@@ -73,7 +73,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	}
 
 	agentConfig := agent.CurrentConfig()
-	setStateServingInfo := func(info params.StateServingInfo) error {
+	setStateServingInfo := func(info controller.StateServingInfo) error {
 		return agent.ChangeConfig(func(config jujuagent.ConfigSetter) error {
 			config.SetStateServingInfo(info)
 			return nil

--- a/worker/certupdater/manifold_test.go
+++ b/worker/certupdater/manifold_test.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/worker/certupdater"
@@ -148,7 +148,7 @@ type mockAgentConfig struct {
 	agent.Config
 	dataDir string
 	logDir  string
-	info    *params.StateServingInfo
+	info    *controller.StateServingInfo
 	values  map[string]string
 }
 
@@ -164,11 +164,11 @@ func (c *mockAgentConfig) DataDir() string {
 	return c.dataDir
 }
 
-func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (c *mockAgentConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	if c.info != nil {
 		return *c.info, true
 	}
-	return params.StateServingInfo{}, false
+	return controller.StateServingInfo{}, false
 }
 
 func (c *mockAgentConfig) Value(key string) string {

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -8,12 +8,12 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
-	params "github.com/juju/juju/apiserver/params"
+	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names "gopkg.in/juju/names.v3"
+	names_v3 "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -42,7 +42,6 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -50,13 +49,11 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -64,7 +61,6 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -93,7 +89,6 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -102,13 +97,11 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -117,13 +110,11 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -131,27 +122,23 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names.ControllerTag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Controller() names_v3.ControllerTag {
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names.ControllerTag)
+	ret0, _ := ret[0].(names_v3.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -159,13 +146,11 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -173,13 +158,11 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -187,13 +170,11 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -201,13 +182,11 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -215,13 +194,11 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -229,27 +206,23 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names.ModelTag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Model() names_v3.ModelTag {
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(names_v3.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -258,13 +231,11 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -272,13 +243,11 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -286,13 +255,11 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -300,13 +267,11 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -314,28 +279,24 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
-func (m *MockConfig) StateServingInfo() (params.StateServingInfo, bool) {
-	m.ctrl.T.Helper()
+func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	ret := m.ctrl.Call(m, "StateServingInfo")
-	ret0, _ := ret[0].(params.StateServingInfo)
+	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -343,27 +304,23 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names.Tag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Tag() names_v3.Tag {
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names.Tag)
+	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfig) TransientDataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -371,13 +328,11 @@ func (m *MockConfig) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -385,13 +340,11 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -399,13 +352,11 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -414,6 +365,5 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }

--- a/worker/containerbroker/mocks/base_mock.go
+++ b/worker/containerbroker/mocks/base_mock.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	base "github.com/juju/juju/api/base"
-	httprequest "gopkg.in/httprequest.v1"
-	names "gopkg.in/juju/names.v3"
+	httprequest_v1 "gopkg.in/httprequest.v1"
+	names_v3 "gopkg.in/juju/names.v3"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
@@ -40,7 +40,6 @@ func (m *MockAPICaller) EXPECT() *MockAPICallerMockRecorder {
 
 // APICall mocks base method
 func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, arg5 interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APICall", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -48,13 +47,11 @@ func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, 
 
 // APICall indicates an expected call of APICall
 func (mr *MockAPICallerMockRecorder) APICall(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APICall", reflect.TypeOf((*MockAPICaller)(nil).APICall), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // BakeryClient mocks base method
 func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BakeryClient")
 	ret0, _ := ret[0].(base.MacaroonDischarger)
 	return ret0
@@ -62,13 +59,11 @@ func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
 
 // BakeryClient indicates an expected call of BakeryClient
 func (mr *MockAPICallerMockRecorder) BakeryClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BakeryClient", reflect.TypeOf((*MockAPICaller)(nil).BakeryClient))
 }
 
 // BestFacadeVersion mocks base method
 func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BestFacadeVersion", arg0)
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -76,13 +71,11 @@ func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
 
 // BestFacadeVersion indicates an expected call of BestFacadeVersion
 func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestFacadeVersion", reflect.TypeOf((*MockAPICaller)(nil).BestFacadeVersion), arg0)
 }
 
 // ConnectControllerStream mocks base method
 func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -91,13 +84,11 @@ func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, ar
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream
 func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
 }
 
 // ConnectStream mocks base method
 func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -106,13 +97,11 @@ func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream
 
 // ConnectStream indicates an expected call of ConnectStream
 func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
 }
 
 // Context mocks base method
 func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
 	return ret0
@@ -120,36 +109,31 @@ func (m *MockAPICaller) Context() context.Context {
 
 // Context indicates an expected call of Context
 func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
 }
 
 // HTTPClient mocks base method
-func (m *MockAPICaller) HTTPClient() (*httprequest.Client, error) {
-	m.ctrl.T.Helper()
+func (m *MockAPICaller) HTTPClient() (*httprequest_v1.Client, error) {
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*httprequest.Client)
+	ret0, _ := ret[0].(*httprequest_v1.Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HTTPClient indicates an expected call of HTTPClient
 func (mr *MockAPICallerMockRecorder) HTTPClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HTTPClient", reflect.TypeOf((*MockAPICaller)(nil).HTTPClient))
 }
 
 // ModelTag mocks base method
-func (m *MockAPICaller) ModelTag() (names.ModelTag, bool) {
-	m.ctrl.T.Helper()
+func (m *MockAPICaller) ModelTag() (names_v3.ModelTag, bool) {
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(names_v3.ModelTag)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // ModelTag indicates an expected call of ModelTag
 func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }

--- a/worker/containerbroker/mocks/dependency_mock.go
+++ b/worker/containerbroker/mocks/dependency_mock.go
@@ -34,7 +34,6 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 
 // Abort mocks base method
 func (m *MockContext) Abort() <-chan struct{} {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Abort")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -42,13 +41,11 @@ func (m *MockContext) Abort() <-chan struct{} {
 
 // Abort indicates an expected call of Abort
 func (mr *MockContextMockRecorder) Abort() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockContext)(nil).Abort))
 }
 
 // Get mocks base method
 func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -56,6 +53,5 @@ func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
 
 // Get indicates an expected call of Get
 func (mr *MockContextMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockContext)(nil).Get), arg0, arg1)
 }

--- a/worker/containerbroker/mocks/environs_mock.go
+++ b/worker/containerbroker/mocks/environs_mock.go
@@ -11,7 +11,7 @@ import (
 	environs "github.com/juju/juju/environs"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
-	charm "gopkg.in/juju/charm.v6"
+	charm_v6 "gopkg.in/juju/charm.v6"
 	reflect "reflect"
 )
 
@@ -40,7 +40,6 @@ func (m *MockLXDProfiler) EXPECT() *MockLXDProfilerMockRecorder {
 
 // AssignLXDProfiles mocks base method
 func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignLXDProfiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -49,13 +48,11 @@ func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []l
 
 // AssignLXDProfiles indicates an expected call of AssignLXDProfiles
 func (mr *MockLXDProfilerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignLXDProfiles", reflect.TypeOf((*MockLXDProfiler)(nil).AssignLXDProfiles), arg0, arg1, arg2)
 }
 
 // LXDProfileNames mocks base method
 func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -64,13 +61,11 @@ func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
 
 // LXDProfileNames indicates an expected call of LXDProfileNames
 func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockLXDProfiler)(nil).LXDProfileNames), arg0)
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfile) error {
-	m.ctrl.T.Helper()
+func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -78,7 +73,6 @@ func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfi
 
 // MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile
 func (mr *MockLXDProfilerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfiler)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
@@ -107,7 +101,6 @@ func (m *MockInstanceBroker) EXPECT() *MockInstanceBrokerMockRecorder {
 
 // AllInstances mocks base method
 func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -116,13 +109,11 @@ func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]i
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllInstances), arg0)
 }
 
 // AllRunningInstances mocks base method
 func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -131,13 +122,11 @@ func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContex
 
 // AllRunningInstances indicates an expected call of AllRunningInstances
 func (mr *MockInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
 // MaintainInstance mocks base method
 func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -145,13 +134,11 @@ func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, 
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockInstanceBrokerMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockInstanceBroker)(nil).MaintainInstance), arg0, arg1)
 }
 
 // StartInstance mocks base method
 func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockInstanceBrokerMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockInstanceBroker)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
 func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -178,7 +163,6 @@ func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockInstanceBrokerMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockInstanceBroker)(nil).StopInstances), varargs...)
 }

--- a/worker/containerbroker/mocks/machine_lock_mock.go
+++ b/worker/containerbroker/mocks/machine_lock_mock.go
@@ -35,7 +35,6 @@ func (m *MockLock) EXPECT() *MockLockMockRecorder {
 
 // Acquire mocks base method
 func (m *MockLock) Acquire(arg0 machinelock.Spec) (func(), error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Acquire", arg0)
 	ret0, _ := ret[0].(func())
 	ret1, _ := ret[1].(error)
@@ -44,13 +43,11 @@ func (m *MockLock) Acquire(arg0 machinelock.Spec) (func(), error) {
 
 // Acquire indicates an expected call of Acquire
 func (mr *MockLockMockRecorder) Acquire(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Acquire", reflect.TypeOf((*MockLock)(nil).Acquire), arg0)
 }
 
 // Report mocks base method
 func (m *MockLock) Report(arg0 ...machinelock.ReportOption) (string, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -63,6 +60,5 @@ func (m *MockLock) Report(arg0 ...machinelock.ReportOption) (string, error) {
 
 // Report indicates an expected call of Report
 func (mr *MockLockMockRecorder) Report(arg0 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockLock)(nil).Report), arg0...)
 }

--- a/worker/containerbroker/mocks/machine_mock.go
+++ b/worker/containerbroker/mocks/machine_mock.go
@@ -12,7 +12,7 @@ import (
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	version "github.com/juju/version"
-	names "gopkg.in/juju/names.v3"
+	names_v3 "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -41,7 +41,6 @@ func (m *MockMachineProvisioner) EXPECT() *MockMachineProvisionerMockRecorder {
 
 // AvailabilityZone mocks base method
 func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -50,13 +49,11 @@ func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
 
 // AvailabilityZone indicates an expected call of AvailabilityZone
 func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone))
 }
 
 // DistributionGroup mocks base method
 func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DistributionGroup")
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
@@ -65,13 +62,11 @@ func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
 
 // DistributionGroup indicates an expected call of DistributionGroup
 func (mr *MockMachineProvisionerMockRecorder) DistributionGroup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup))
 }
 
 // EnsureDead mocks base method
 func (m *MockMachineProvisioner) EnsureDead() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureDead")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -79,13 +74,11 @@ func (m *MockMachineProvisioner) EnsureDead() error {
 
 // EnsureDead indicates an expected call of EnsureDead
 func (mr *MockMachineProvisionerMockRecorder) EnsureDead() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead))
 }
 
 // Id mocks base method
 func (m *MockMachineProvisioner) Id() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -93,13 +86,11 @@ func (m *MockMachineProvisioner) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockMachineProvisionerMockRecorder) Id() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachineProvisioner)(nil).Id))
 }
 
 // InstanceId mocks base method
 func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
@@ -108,13 +99,11 @@ func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
 
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMachineProvisionerMockRecorder) InstanceId() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId))
 }
 
 // InstanceStatus mocks base method
 func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceStatus")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -124,13 +113,11 @@ func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error)
 
 // InstanceStatus indicates an expected call of InstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) InstanceStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus))
 }
 
 // KeepInstance mocks base method
 func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KeepInstance")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -139,13 +126,11 @@ func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
 
 // KeepInstance indicates an expected call of KeepInstance
 func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance))
 }
 
 // Life mocks base method
 func (m *MockMachineProvisioner) Life() life.Value {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
 	ret0, _ := ret[0].(life.Value)
 	return ret0
@@ -153,27 +138,23 @@ func (m *MockMachineProvisioner) Life() life.Value {
 
 // Life indicates an expected call of Life
 func (mr *MockMachineProvisionerMockRecorder) Life() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMachineProvisioner)(nil).Life))
 }
 
 // MachineTag mocks base method
-func (m *MockMachineProvisioner) MachineTag() names.MachineTag {
-	m.ctrl.T.Helper()
+func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
 	ret := m.ctrl.Call(m, "MachineTag")
-	ret0, _ := ret[0].(names.MachineTag)
+	ret0, _ := ret[0].(names_v3.MachineTag)
 	return ret0
 }
 
 // MachineTag indicates an expected call of MachineTag
 func (mr *MockMachineProvisionerMockRecorder) MachineTag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockMachineProvisioner)(nil).MachineTag))
 }
 
 // MarkForRemoval mocks base method
 func (m *MockMachineProvisioner) MarkForRemoval() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarkForRemoval")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -181,13 +162,11 @@ func (m *MockMachineProvisioner) MarkForRemoval() error {
 
 // MarkForRemoval indicates an expected call of MarkForRemoval
 func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval))
 }
 
 // ModelAgentVersion mocks base method
 func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelAgentVersion")
 	ret0, _ := ret[0].(*version.Number)
 	ret1, _ := ret[1].(error)
@@ -196,13 +175,11 @@ func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
 
 // ModelAgentVersion indicates an expected call of ModelAgentVersion
 func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion))
 }
 
 // ProvisioningInfo mocks base method
 func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo")
 	ret0, _ := ret[0].(*params.ProvisioningInfoV10)
 	ret1, _ := ret[1].(error)
@@ -211,13 +188,11 @@ func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10
 
 // ProvisioningInfo indicates an expected call of ProvisioningInfo
 func (mr *MockMachineProvisionerMockRecorder) ProvisioningInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).ProvisioningInfo))
 }
 
 // Refresh mocks base method
 func (m *MockMachineProvisioner) Refresh() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -225,13 +200,11 @@ func (m *MockMachineProvisioner) Refresh() error {
 
 // Refresh indicates an expected call of Refresh
 func (mr *MockMachineProvisionerMockRecorder) Refresh() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh))
 }
 
 // Remove mocks base method
 func (m *MockMachineProvisioner) Remove() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -239,13 +212,11 @@ func (m *MockMachineProvisioner) Remove() error {
 
 // Remove indicates an expected call of Remove
 func (mr *MockMachineProvisionerMockRecorder) Remove() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove))
 }
 
 // SetCharmProfiles mocks base method
 func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -253,13 +224,11 @@ func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0)
 }
 
 // SetInstanceInfo mocks base method
 func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 string, arg3 *instance.HardwareCharacteristics, arg4 []params.NetworkConfig, arg5 []params.Volume, arg6 map[string]params.VolumeAttachmentInfo, arg7 []string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -267,13 +236,11 @@ func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 st
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // SetInstanceStatus mocks base method
 func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -281,13 +248,11 @@ func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 stri
 
 // SetInstanceStatus indicates an expected call of SetInstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2)
 }
 
 // SetModificationStatus mocks base method
 func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -295,13 +260,11 @@ func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 
 
 // SetModificationStatus indicates an expected call of SetModificationStatus
 func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2)
 }
 
 // SetPassword mocks base method
 func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPassword", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -309,13 +272,11 @@ func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
 
 // SetPassword indicates an expected call of SetPassword
 func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0)
 }
 
 // SetStatus mocks base method
 func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -323,13 +284,11 @@ func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2)
 }
 
 // SetSupportedContainers mocks base method
 func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.ContainerType) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -341,13 +300,11 @@ func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.Contain
 
 // SetSupportedContainers indicates an expected call of SetSupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), arg0...)
 }
 
 // Status mocks base method
 func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -357,13 +314,11 @@ func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
 
 // Status indicates an expected call of Status
 func (mr *MockMachineProvisionerMockRecorder) Status() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status))
 }
 
 // String mocks base method
 func (m *MockMachineProvisioner) String() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -371,13 +326,11 @@ func (m *MockMachineProvisioner) String() string {
 
 // String indicates an expected call of String
 func (mr *MockMachineProvisionerMockRecorder) String() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockMachineProvisioner)(nil).String))
 }
 
 // SupportedContainers mocks base method
 func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType, bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportedContainers")
 	ret0, _ := ret[0].([]instance.ContainerType)
 	ret1, _ := ret[1].(bool)
@@ -387,13 +340,11 @@ func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType
 
 // SupportedContainers indicates an expected call of SupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportedContainers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers))
 }
 
 // SupportsNoContainers mocks base method
 func (m *MockMachineProvisioner) SupportsNoContainers() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsNoContainers")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -401,27 +352,23 @@ func (m *MockMachineProvisioner) SupportsNoContainers() error {
 
 // SupportsNoContainers indicates an expected call of SupportsNoContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers))
 }
 
 // Tag mocks base method
-func (m *MockMachineProvisioner) Tag() names.Tag {
-	m.ctrl.T.Helper()
+func (m *MockMachineProvisioner) Tag() names_v3.Tag {
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names.Tag)
+	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockMachineProvisionerMockRecorder) Tag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockMachineProvisioner)(nil).Tag))
 }
 
 // WatchAllContainers mocks base method
 func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchAllContainers")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -430,13 +377,11 @@ func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, e
 
 // WatchAllContainers indicates an expected call of WatchAllContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchAllContainers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAllContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchAllContainers))
 }
 
 // WatchContainers mocks base method
 func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (watcher.StringsWatcher, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchContainers", arg0)
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -445,6 +390,5 @@ func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (w
 
 // WatchContainers indicates an expected call of WatchContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0)
 }

--- a/worker/containerbroker/mocks/state_mock.go
+++ b/worker/containerbroker/mocks/state_mock.go
@@ -10,7 +10,7 @@ import (
 	params "github.com/juju/juju/apiserver/params"
 	network "github.com/juju/juju/core/network"
 	network0 "github.com/juju/juju/network"
-	names "gopkg.in/juju/names.v3"
+	names_v3 "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -39,7 +39,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 
 // ContainerConfig mocks base method
 func (m *MockState) ContainerConfig() (params.ContainerConfig, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerConfig")
 	ret0, _ := ret[0].(params.ContainerConfig)
 	ret1, _ := ret[1].(error)
@@ -48,13 +47,11 @@ func (m *MockState) ContainerConfig() (params.ContainerConfig, error) {
 
 // ContainerConfig indicates an expected call of ContainerConfig
 func (mr *MockStateMockRecorder) ContainerConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockState)(nil).ContainerConfig))
 }
 
 // ContainerManagerConfig mocks base method
 func (m *MockState) ContainerManagerConfig(arg0 params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerManagerConfig", arg0)
 	ret0, _ := ret[0].(params.ContainerManagerConfig)
 	ret1, _ := ret[1].(error)
@@ -63,13 +60,11 @@ func (m *MockState) ContainerManagerConfig(arg0 params.ContainerManagerConfigPar
 
 // ContainerManagerConfig indicates an expected call of ContainerManagerConfig
 func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockState)(nil).ContainerManagerConfig), arg0)
 }
 
 // GetContainerInterfaceInfo mocks base method
-func (m *MockState) GetContainerInterfaceInfo(arg0 names.MachineTag) ([]network.InterfaceInfo, error) {
-	m.ctrl.T.Helper()
+func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
 	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].([]network.InterfaceInfo)
 	ret1, _ := ret[1].(error)
@@ -78,13 +73,11 @@ func (m *MockState) GetContainerInterfaceInfo(arg0 names.MachineTag) ([]network.
 
 // GetContainerInterfaceInfo indicates an expected call of GetContainerInterfaceInfo
 func (mr *MockStateMockRecorder) GetContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).GetContainerInterfaceInfo), arg0)
 }
 
 // GetContainerProfileInfo mocks base method
-func (m *MockState) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
-	m.ctrl.T.Helper()
+func (m *MockState) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*provisioner.LXDProfileResult, error) {
 	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
@@ -93,13 +86,11 @@ func (m *MockState) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provision
 
 // GetContainerProfileInfo indicates an expected call of GetContainerProfileInfo
 func (mr *MockStateMockRecorder) GetContainerProfileInfo(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockState)(nil).GetContainerProfileInfo), arg0)
 }
 
 // HostChangesForContainer mocks base method
-func (m *MockState) HostChangesForContainer(arg0 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
-	m.ctrl.T.Helper()
+func (m *MockState) HostChangesForContainer(arg0 names_v3.MachineTag) ([]network0.DeviceToBridge, int, error) {
 	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
@@ -109,13 +100,11 @@ func (m *MockState) HostChangesForContainer(arg0 names.MachineTag) ([]network0.D
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer
 func (mr *MockStateMockRecorder) HostChangesForContainer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockState)(nil).HostChangesForContainer), arg0)
 }
 
 // Machines mocks base method
-func (m *MockState) Machines(arg0 ...names.MachineTag) ([]provisioner.MachineResult, error) {
-	m.ctrl.T.Helper()
+func (m *MockState) Machines(arg0 ...names_v3.MachineTag) ([]provisioner.MachineResult, error) {
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -128,13 +117,11 @@ func (m *MockState) Machines(arg0 ...names.MachineTag) ([]provisioner.MachineRes
 
 // Machines indicates an expected call of Machines
 func (mr *MockStateMockRecorder) Machines(arg0 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockState)(nil).Machines), arg0...)
 }
 
 // PrepareContainerInterfaceInfo mocks base method
-func (m *MockState) PrepareContainerInterfaceInfo(arg0 names.MachineTag) ([]network.InterfaceInfo, error) {
-	m.ctrl.T.Helper()
+func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
 	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].([]network.InterfaceInfo)
 	ret1, _ := ret[1].(error)
@@ -143,13 +130,11 @@ func (m *MockState) PrepareContainerInterfaceInfo(arg0 names.MachineTag) ([]netw
 
 // PrepareContainerInterfaceInfo indicates an expected call of PrepareContainerInterfaceInfo
 func (mr *MockStateMockRecorder) PrepareContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).PrepareContainerInterfaceInfo), arg0)
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockState) ReleaseContainerAddresses(arg0 names.MachineTag) error {
-	m.ctrl.T.Helper()
+func (m *MockState) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error {
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -157,13 +142,11 @@ func (m *MockState) ReleaseContainerAddresses(arg0 names.MachineTag) error {
 
 // ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses
 func (mr *MockStateMockRecorder) ReleaseContainerAddresses(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockState)(nil).ReleaseContainerAddresses), arg0)
 }
 
 // SetHostMachineNetworkConfig mocks base method
-func (m *MockState) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []params.NetworkConfig) error {
-	m.ctrl.T.Helper()
+func (m *MockState) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg1 []params.NetworkConfig) error {
 	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -171,6 +154,5 @@ func (m *MockState) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []pa
 
 // SetHostMachineNetworkConfig indicates an expected call of SetHostMachineNetworkConfig
 func (mr *MockStateMockRecorder) SetHostMachineNetworkConfig(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockState)(nil).SetHostMachineNetworkConfig), arg0, arg1)
 }

--- a/worker/containerbroker/mocks/worker_mock.go
+++ b/worker/containerbroker/mocks/worker_mock.go
@@ -34,19 +34,16 @@ func (m *MockWorker) EXPECT() *MockWorkerMockRecorder {
 
 // Kill mocks base method
 func (m *MockWorker) Kill() {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
 // Kill indicates an expected call of Kill
 func (mr *MockWorkerMockRecorder) Kill() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockWorker)(nil).Kill))
 }
 
 // Wait mocks base method
 func (m *MockWorker) Wait() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -54,6 +51,5 @@ func (m *MockWorker) Wait() error {
 
 // Wait indicates an expected call of Wait
 func (mr *MockWorkerMockRecorder) Wait() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockWorker)(nil).Wait))
 }

--- a/worker/controllerport/manifold_test.go
+++ b/worker/controllerport/manifold_test.go
@@ -16,7 +16,6 @@ import (
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/controllerport"
@@ -214,6 +213,6 @@ type mockAgentConfig struct {
 	port int
 }
 
-func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
-	return params.StateServingInfo{ControllerAPIPort: c.port}, true
+func (c *mockAgentConfig) StateServingInfo() (controller.StateServingInfo, bool) {
+	return controller.StateServingInfo{ControllerAPIPort: c.port}, true
 }

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -8,12 +8,12 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
-	params "github.com/juju/juju/apiserver/params"
+	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names "gopkg.in/juju/names.v3"
+	names_v3 "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -42,7 +42,6 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -50,13 +49,11 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -64,7 +61,6 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -93,7 +89,6 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -102,13 +97,11 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -117,13 +110,11 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -131,27 +122,23 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names.ControllerTag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Controller() names_v3.ControllerTag {
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names.ControllerTag)
+	ret0, _ := ret[0].(names_v3.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -159,13 +146,11 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -173,13 +158,11 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -187,13 +170,11 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -201,13 +182,11 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -215,13 +194,11 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -229,27 +206,23 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names.ModelTag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Model() names_v3.ModelTag {
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(names_v3.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -258,13 +231,11 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -272,13 +243,11 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -286,13 +255,11 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -300,13 +267,11 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -314,28 +279,24 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
-func (m *MockConfig) StateServingInfo() (params.StateServingInfo, bool) {
-	m.ctrl.T.Helper()
+func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	ret := m.ctrl.Call(m, "StateServingInfo")
-	ret0, _ := ret[0].(params.StateServingInfo)
+	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -343,27 +304,23 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names.Tag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Tag() names_v3.Tag {
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names.Tag)
+	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfig) TransientDataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -371,13 +328,11 @@ func (m *MockConfig) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -385,13 +340,11 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -399,13 +352,11 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -414,6 +365,5 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }

--- a/worker/instancemutater/mocks/base_mock.go
+++ b/worker/instancemutater/mocks/base_mock.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	base "github.com/juju/juju/api/base"
-	httprequest "gopkg.in/httprequest.v1"
-	names "gopkg.in/juju/names.v3"
+	httprequest_v1 "gopkg.in/httprequest.v1"
+	names_v3 "gopkg.in/juju/names.v3"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
@@ -40,7 +40,6 @@ func (m *MockAPICaller) EXPECT() *MockAPICallerMockRecorder {
 
 // APICall mocks base method
 func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, arg5 interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APICall", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -48,13 +47,11 @@ func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, 
 
 // APICall indicates an expected call of APICall
 func (mr *MockAPICallerMockRecorder) APICall(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APICall", reflect.TypeOf((*MockAPICaller)(nil).APICall), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // BakeryClient mocks base method
 func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BakeryClient")
 	ret0, _ := ret[0].(base.MacaroonDischarger)
 	return ret0
@@ -62,13 +59,11 @@ func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
 
 // BakeryClient indicates an expected call of BakeryClient
 func (mr *MockAPICallerMockRecorder) BakeryClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BakeryClient", reflect.TypeOf((*MockAPICaller)(nil).BakeryClient))
 }
 
 // BestFacadeVersion mocks base method
 func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BestFacadeVersion", arg0)
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -76,13 +71,11 @@ func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
 
 // BestFacadeVersion indicates an expected call of BestFacadeVersion
 func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestFacadeVersion", reflect.TypeOf((*MockAPICaller)(nil).BestFacadeVersion), arg0)
 }
 
 // ConnectControllerStream mocks base method
 func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -91,13 +84,11 @@ func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, ar
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream
 func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
 }
 
 // ConnectStream mocks base method
 func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -106,13 +97,11 @@ func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream
 
 // ConnectStream indicates an expected call of ConnectStream
 func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
 }
 
 // Context mocks base method
 func (m *MockAPICaller) Context() context.Context {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
 	return ret0
@@ -120,36 +109,31 @@ func (m *MockAPICaller) Context() context.Context {
 
 // Context indicates an expected call of Context
 func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
 }
 
 // HTTPClient mocks base method
-func (m *MockAPICaller) HTTPClient() (*httprequest.Client, error) {
-	m.ctrl.T.Helper()
+func (m *MockAPICaller) HTTPClient() (*httprequest_v1.Client, error) {
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*httprequest.Client)
+	ret0, _ := ret[0].(*httprequest_v1.Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HTTPClient indicates an expected call of HTTPClient
 func (mr *MockAPICallerMockRecorder) HTTPClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HTTPClient", reflect.TypeOf((*MockAPICaller)(nil).HTTPClient))
 }
 
 // ModelTag mocks base method
-func (m *MockAPICaller) ModelTag() (names.ModelTag, bool) {
-	m.ctrl.T.Helper()
+func (m *MockAPICaller) ModelTag() (names_v3.ModelTag, bool) {
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(names_v3.ModelTag)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // ModelTag indicates an expected call of ModelTag
 func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }

--- a/worker/instancemutater/mocks/dependency_mock.go
+++ b/worker/instancemutater/mocks/dependency_mock.go
@@ -34,7 +34,6 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 
 // Abort mocks base method
 func (m *MockContext) Abort() <-chan struct{} {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Abort")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -42,13 +41,11 @@ func (m *MockContext) Abort() <-chan struct{} {
 
 // Abort indicates an expected call of Abort
 func (mr *MockContextMockRecorder) Abort() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockContext)(nil).Abort))
 }
 
 // Get mocks base method
 func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -56,6 +53,5 @@ func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
 
 // Get indicates an expected call of Get
 func (mr *MockContextMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockContext)(nil).Get), arg0, arg1)
 }

--- a/worker/instancemutater/mocks/environs_mock.go
+++ b/worker/instancemutater/mocks/environs_mock.go
@@ -15,7 +15,7 @@ import (
 	instances "github.com/juju/juju/environs/instances"
 	storage "github.com/juju/juju/storage"
 	version "github.com/juju/version"
-	charm "gopkg.in/juju/charm.v6"
+	charm_v6 "gopkg.in/juju/charm.v6"
 	reflect "reflect"
 )
 
@@ -44,7 +44,6 @@ func (m *MockEnviron) EXPECT() *MockEnvironMockRecorder {
 
 // AdoptResources mocks base method
 func (m *MockEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -52,13 +51,11 @@ func (m *MockEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 stri
 
 // AdoptResources indicates an expected call of AdoptResources
 func (mr *MockEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdoptResources", reflect.TypeOf((*MockEnviron)(nil).AdoptResources), arg0, arg1, arg2)
 }
 
 // AllInstances mocks base method
 func (m *MockEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -67,13 +64,11 @@ func (m *MockEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instance
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockEnviron)(nil).AllInstances), arg0)
 }
 
 // AllRunningInstances mocks base method
 func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -82,13 +77,11 @@ func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]i
 
 // AllRunningInstances indicates an expected call of AllRunningInstances
 func (mr *MockEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockEnviron)(nil).AllRunningInstances), arg0)
 }
 
 // Bootstrap mocks base method
 func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
@@ -97,13 +90,11 @@ func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.Pro
 
 // Bootstrap indicates an expected call of Bootstrap
 func (mr *MockEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockEnviron)(nil).Bootstrap), arg0, arg1, arg2)
 }
 
 // Config mocks base method
 func (m *MockEnviron) Config() *config.Config {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*config.Config)
 	return ret0
@@ -111,13 +102,11 @@ func (m *MockEnviron) Config() *config.Config {
 
 // Config indicates an expected call of Config
 func (mr *MockEnvironMockRecorder) Config() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockEnviron)(nil).Config))
 }
 
 // ConstraintsValidator mocks base method
 func (m *MockEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
 	ret1, _ := ret[1].(error)
@@ -126,13 +115,11 @@ func (m *MockEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (co
 
 // ConstraintsValidator indicates an expected call of ConstraintsValidator
 func (mr *MockEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsValidator", reflect.TypeOf((*MockEnviron)(nil).ConstraintsValidator), arg0)
 }
 
 // ControllerInstances mocks base method
 func (m *MockEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
@@ -141,13 +128,11 @@ func (m *MockEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1
 
 // ControllerInstances indicates an expected call of ControllerInstances
 func (mr *MockEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerInstances", reflect.TypeOf((*MockEnviron)(nil).ControllerInstances), arg0, arg1)
 }
 
 // Create mocks base method
 func (m *MockEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -155,13 +140,11 @@ func (m *MockEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.Cre
 
 // Create indicates an expected call of Create
 func (mr *MockEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockEnviron)(nil).Create), arg0, arg1)
 }
 
 // Destroy mocks base method
 func (m *MockEnviron) Destroy(arg0 context.ProviderCallContext) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -169,13 +152,11 @@ func (m *MockEnviron) Destroy(arg0 context.ProviderCallContext) error {
 
 // Destroy indicates an expected call of Destroy
 func (mr *MockEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockEnviron)(nil).Destroy), arg0)
 }
 
 // DestroyController mocks base method
 func (m *MockEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -183,13 +164,11 @@ func (m *MockEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 s
 
 // DestroyController indicates an expected call of DestroyController
 func (mr *MockEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyController", reflect.TypeOf((*MockEnviron)(nil).DestroyController), arg0, arg1)
 }
 
 // InstanceTypes mocks base method
 func (m *MockEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
 	ret1, _ := ret[1].(error)
@@ -198,13 +177,11 @@ func (m *MockEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 const
 
 // InstanceTypes indicates an expected call of InstanceTypes
 func (mr *MockEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceTypes", reflect.TypeOf((*MockEnviron)(nil).InstanceTypes), arg0, arg1)
 }
 
 // Instances mocks base method
 func (m *MockEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -213,13 +190,11 @@ func (m *MockEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instanc
 
 // Instances indicates an expected call of Instances
 func (mr *MockEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Instances", reflect.TypeOf((*MockEnviron)(nil).Instances), arg0, arg1)
 }
 
 // MaintainInstance mocks base method
 func (m *MockEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -227,13 +202,11 @@ func (m *MockEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 en
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockEnvironMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockEnviron)(nil).MaintainInstance), arg0, arg1)
 }
 
 // PrecheckInstance mocks base method
 func (m *MockEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -241,13 +214,11 @@ func (m *MockEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 en
 
 // PrecheckInstance indicates an expected call of PrecheckInstance
 func (mr *MockEnvironMockRecorder) PrecheckInstance(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrecheckInstance", reflect.TypeOf((*MockEnviron)(nil).PrecheckInstance), arg0, arg1)
 }
 
 // PrepareForBootstrap mocks base method
 func (m *MockEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, arg1 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareForBootstrap", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -255,13 +226,11 @@ func (m *MockEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, arg1 s
 
 // PrepareForBootstrap indicates an expected call of PrepareForBootstrap
 func (mr *MockEnvironMockRecorder) PrepareForBootstrap(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForBootstrap", reflect.TypeOf((*MockEnviron)(nil).PrepareForBootstrap), arg0, arg1)
 }
 
 // Provider mocks base method
 func (m *MockEnviron) Provider() environs.EnvironProvider {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Provider")
 	ret0, _ := ret[0].(environs.EnvironProvider)
 	return ret0
@@ -269,13 +238,11 @@ func (m *MockEnviron) Provider() environs.EnvironProvider {
 
 // Provider indicates an expected call of Provider
 func (mr *MockEnvironMockRecorder) Provider() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockEnviron)(nil).Provider))
 }
 
 // SetConfig mocks base method
 func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -283,13 +250,11 @@ func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
 
 // SetConfig indicates an expected call of SetConfig
 func (mr *MockEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0)
 }
 
 // StartInstance mocks base method
 func (m *MockEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -298,13 +263,11 @@ func (m *MockEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 envir
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockEnviron)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
 func (m *MockEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -316,14 +279,12 @@ func (m *MockEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...in
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockEnvironMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockEnviron)(nil).StopInstances), varargs...)
 }
 
 // StorageProvider mocks base method
 func (m *MockEnviron) StorageProvider(arg0 storage.ProviderType) (storage.Provider, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProvider", arg0)
 	ret0, _ := ret[0].(storage.Provider)
 	ret1, _ := ret[1].(error)
@@ -332,13 +293,11 @@ func (m *MockEnviron) StorageProvider(arg0 storage.ProviderType) (storage.Provid
 
 // StorageProvider indicates an expected call of StorageProvider
 func (mr *MockEnvironMockRecorder) StorageProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProvider", reflect.TypeOf((*MockEnviron)(nil).StorageProvider), arg0)
 }
 
 // StorageProviderTypes mocks base method
 func (m *MockEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProviderTypes")
 	ret0, _ := ret[0].([]storage.ProviderType)
 	ret1, _ := ret[1].(error)
@@ -347,7 +306,6 @@ func (m *MockEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
 
 // StorageProviderTypes indicates an expected call of StorageProviderTypes
 func (mr *MockEnvironMockRecorder) StorageProviderTypes() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProviderTypes", reflect.TypeOf((*MockEnviron)(nil).StorageProviderTypes))
 }
 
@@ -376,7 +334,6 @@ func (m *MockLXDProfiler) EXPECT() *MockLXDProfilerMockRecorder {
 
 // AssignLXDProfiles mocks base method
 func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignLXDProfiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -385,13 +342,11 @@ func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []l
 
 // AssignLXDProfiles indicates an expected call of AssignLXDProfiles
 func (mr *MockLXDProfilerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignLXDProfiles", reflect.TypeOf((*MockLXDProfiler)(nil).AssignLXDProfiles), arg0, arg1, arg2)
 }
 
 // LXDProfileNames mocks base method
 func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -400,13 +355,11 @@ func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
 
 // LXDProfileNames indicates an expected call of LXDProfileNames
 func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockLXDProfiler)(nil).LXDProfileNames), arg0)
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfile) error {
-	m.ctrl.T.Helper()
+func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -414,7 +367,6 @@ func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfi
 
 // MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile
 func (mr *MockLXDProfilerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfiler)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
@@ -443,7 +395,6 @@ func (m *MockInstanceBroker) EXPECT() *MockInstanceBrokerMockRecorder {
 
 // AllInstances mocks base method
 func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -452,13 +403,11 @@ func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]i
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllInstances), arg0)
 }
 
 // AllRunningInstances mocks base method
 func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -467,13 +416,11 @@ func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContex
 
 // AllRunningInstances indicates an expected call of AllRunningInstances
 func (mr *MockInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
 // MaintainInstance mocks base method
 func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -481,13 +428,11 @@ func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, 
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockInstanceBrokerMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockInstanceBroker)(nil).MaintainInstance), arg0, arg1)
 }
 
 // StartInstance mocks base method
 func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -496,13 +441,11 @@ func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockInstanceBrokerMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockInstanceBroker)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
 func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -514,7 +457,6 @@ func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockInstanceBrokerMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockInstanceBroker)(nil).StopInstances), varargs...)
 }

--- a/worker/instancemutater/mocks/instancebroker_mock.go
+++ b/worker/instancemutater/mocks/instancebroker_mock.go
@@ -8,7 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	instancemutater "github.com/juju/juju/api/instancemutater"
 	watcher "github.com/juju/juju/core/watcher"
-	names "gopkg.in/juju/names.v3"
+	names_v3 "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -36,8 +36,7 @@ func (m *MockInstanceMutaterAPI) EXPECT() *MockInstanceMutaterAPIMockRecorder {
 }
 
 // Machine mocks base method
-func (m *MockInstanceMutaterAPI) Machine(arg0 names.MachineTag) (instancemutater.MutaterMachine, error) {
-	m.ctrl.T.Helper()
+func (m *MockInstanceMutaterAPI) Machine(arg0 names_v3.MachineTag) (instancemutater.MutaterMachine, error) {
 	ret := m.ctrl.Call(m, "Machine", arg0)
 	ret0, _ := ret[0].(instancemutater.MutaterMachine)
 	ret1, _ := ret[1].(error)
@@ -46,13 +45,11 @@ func (m *MockInstanceMutaterAPI) Machine(arg0 names.MachineTag) (instancemutater
 
 // Machine indicates an expected call of Machine
 func (mr *MockInstanceMutaterAPIMockRecorder) Machine(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).Machine), arg0)
 }
 
 // WatchMachines mocks base method
 func (m *MockInstanceMutaterAPI) WatchMachines() (watcher.StringsWatcher, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchMachines")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -61,6 +58,5 @@ func (m *MockInstanceMutaterAPI) WatchMachines() (watcher.StringsWatcher, error)
 
 // WatchMachines indicates an expected call of WatchMachines
 func (mr *MockInstanceMutaterAPIMockRecorder) WatchMachines() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMachines", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).WatchMachines))
 }

--- a/worker/instancemutater/mocks/logger_mock.go
+++ b/worker/instancemutater/mocks/logger_mock.go
@@ -34,7 +34,6 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 
 // Debugf mocks base method
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -44,14 +43,12 @@ func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 
 // Debugf indicates an expected call of Debugf
 func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
 // Errorf mocks base method
 func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -61,14 +58,12 @@ func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
 
 // Errorf indicates an expected call of Errorf
 func (mr *MockLoggerMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLogger)(nil).Errorf), varargs...)
 }
 
 // Infof mocks base method
 func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -78,14 +73,12 @@ func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
 
 // Infof indicates an expected call of Infof
 func (mr *MockLoggerMockRecorder) Infof(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLogger)(nil).Infof), varargs...)
 }
 
 // Tracef mocks base method
 func (m *MockLogger) Tracef(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -95,14 +88,12 @@ func (m *MockLogger) Tracef(arg0 string, arg1 ...interface{}) {
 
 // Tracef indicates an expected call of Tracef
 func (mr *MockLoggerMockRecorder) Tracef(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockLogger)(nil).Tracef), varargs...)
 }
 
 // Warningf mocks base method
 func (m *MockLogger) Warningf(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -112,7 +103,6 @@ func (m *MockLogger) Warningf(arg0 string, arg1 ...interface{}) {
 
 // Warningf indicates an expected call of Warningf
 func (mr *MockLoggerMockRecorder) Warningf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warningf", reflect.TypeOf((*MockLogger)(nil).Warningf), varargs...)
 }

--- a/worker/instancemutater/mocks/machinemutater_mock.go
+++ b/worker/instancemutater/mocks/machinemutater_mock.go
@@ -11,7 +11,7 @@ import (
 	life "github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
-	names "gopkg.in/juju/names.v3"
+	names_v3 "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -40,7 +40,6 @@ func (m *MockMutaterMachine) EXPECT() *MockMutaterMachineMockRecorder {
 
 // CharmProfilingInfo mocks base method
 func (m *MockMutaterMachine) CharmProfilingInfo() (*instancemutater.UnitProfileInfo, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmProfilingInfo")
 	ret0, _ := ret[0].(*instancemutater.UnitProfileInfo)
 	ret1, _ := ret[1].(error)
@@ -49,13 +48,11 @@ func (m *MockMutaterMachine) CharmProfilingInfo() (*instancemutater.UnitProfileI
 
 // CharmProfilingInfo indicates an expected call of CharmProfilingInfo
 func (mr *MockMutaterMachineMockRecorder) CharmProfilingInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfilingInfo", reflect.TypeOf((*MockMutaterMachine)(nil).CharmProfilingInfo))
 }
 
 // ContainerType mocks base method
 func (m *MockMutaterMachine) ContainerType() (instance.ContainerType, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
 	ret0, _ := ret[0].(instance.ContainerType)
 	ret1, _ := ret[1].(error)
@@ -64,13 +61,11 @@ func (m *MockMutaterMachine) ContainerType() (instance.ContainerType, error) {
 
 // ContainerType indicates an expected call of ContainerType
 func (mr *MockMutaterMachineMockRecorder) ContainerType() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMutaterMachine)(nil).ContainerType))
 }
 
 // InstanceId mocks base method
 func (m *MockMutaterMachine) InstanceId() (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -79,13 +74,11 @@ func (m *MockMutaterMachine) InstanceId() (string, error) {
 
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMutaterMachineMockRecorder) InstanceId() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMutaterMachine)(nil).InstanceId))
 }
 
 // Life mocks base method
 func (m *MockMutaterMachine) Life() life.Value {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
 	ret0, _ := ret[0].(life.Value)
 	return ret0
@@ -93,13 +86,11 @@ func (m *MockMutaterMachine) Life() life.Value {
 
 // Life indicates an expected call of Life
 func (mr *MockMutaterMachineMockRecorder) Life() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMutaterMachine)(nil).Life))
 }
 
 // Refresh mocks base method
 func (m *MockMutaterMachine) Refresh() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -107,13 +98,11 @@ func (m *MockMutaterMachine) Refresh() error {
 
 // Refresh indicates an expected call of Refresh
 func (mr *MockMutaterMachineMockRecorder) Refresh() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMutaterMachine)(nil).Refresh))
 }
 
 // SetCharmProfiles mocks base method
 func (m *MockMutaterMachine) SetCharmProfiles(arg0 []string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -121,13 +110,11 @@ func (m *MockMutaterMachine) SetCharmProfiles(arg0 []string) error {
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMutaterMachineMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMutaterMachine)(nil).SetCharmProfiles), arg0)
 }
 
 // SetModificationStatus mocks base method
 func (m *MockMutaterMachine) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -135,27 +122,23 @@ func (m *MockMutaterMachine) SetModificationStatus(arg0 status.Status, arg1 stri
 
 // SetModificationStatus indicates an expected call of SetModificationStatus
 func (mr *MockMutaterMachineMockRecorder) SetModificationStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMutaterMachine)(nil).SetModificationStatus), arg0, arg1, arg2)
 }
 
 // Tag mocks base method
-func (m *MockMutaterMachine) Tag() names.MachineTag {
-	m.ctrl.T.Helper()
+func (m *MockMutaterMachine) Tag() names_v3.MachineTag {
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names.MachineTag)
+	ret0, _ := ret[0].(names_v3.MachineTag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockMutaterMachineMockRecorder) Tag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockMutaterMachine)(nil).Tag))
 }
 
 // WatchContainers mocks base method
 func (m *MockMutaterMachine) WatchContainers() (watcher.StringsWatcher, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchContainers")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -164,13 +147,11 @@ func (m *MockMutaterMachine) WatchContainers() (watcher.StringsWatcher, error) {
 
 // WatchContainers indicates an expected call of WatchContainers
 func (mr *MockMutaterMachineMockRecorder) WatchContainers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMutaterMachine)(nil).WatchContainers))
 }
 
 // WatchLXDProfileVerificationNeeded mocks base method
 func (m *MockMutaterMachine) WatchLXDProfileVerificationNeeded() (watcher.NotifyWatcher, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationNeeded")
 	ret0, _ := ret[0].(watcher.NotifyWatcher)
 	ret1, _ := ret[1].(error)
@@ -179,13 +160,11 @@ func (m *MockMutaterMachine) WatchLXDProfileVerificationNeeded() (watcher.Notify
 
 // WatchLXDProfileVerificationNeeded indicates an expected call of WatchLXDProfileVerificationNeeded
 func (mr *MockMutaterMachineMockRecorder) WatchLXDProfileVerificationNeeded() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationNeeded", reflect.TypeOf((*MockMutaterMachine)(nil).WatchLXDProfileVerificationNeeded))
 }
 
 // WatchUnits mocks base method
 func (m *MockMutaterMachine) WatchUnits() (watcher.StringsWatcher, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchUnits")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -194,6 +173,5 @@ func (m *MockMutaterMachine) WatchUnits() (watcher.StringsWatcher, error) {
 
 // WatchUnits indicates an expected call of WatchUnits
 func (mr *MockMutaterMachineMockRecorder) WatchUnits() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUnits", reflect.TypeOf((*MockMutaterMachine)(nil).WatchUnits))
 }

--- a/worker/instancemutater/mocks/mutatercontext_mock.go
+++ b/worker/instancemutater/mocks/mutatercontext_mock.go
@@ -9,8 +9,8 @@ import (
 	instancemutater "github.com/juju/juju/api/instancemutater"
 	environs "github.com/juju/juju/environs"
 	instancemutater0 "github.com/juju/juju/worker/instancemutater"
-	names "gopkg.in/juju/names.v3"
-	worker "gopkg.in/juju/worker.v1"
+	names_v3 "gopkg.in/juju/names.v3"
+	worker_v1 "gopkg.in/juju/worker.v1"
 	reflect "reflect"
 )
 
@@ -39,19 +39,16 @@ func (m *MockMutaterContext) EXPECT() *MockMutaterContextMockRecorder {
 
 // KillWithError mocks base method
 func (m *MockMutaterContext) KillWithError(arg0 error) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "KillWithError", arg0)
 }
 
 // KillWithError indicates an expected call of KillWithError
 func (mr *MockMutaterContextMockRecorder) KillWithError(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KillWithError", reflect.TypeOf((*MockMutaterContext)(nil).KillWithError), arg0)
 }
 
 // add mocks base method
-func (m *MockMutaterContext) add(arg0 worker.Worker) error {
-	m.ctrl.T.Helper()
+func (m *MockMutaterContext) add(arg0 worker_v1.Worker) error {
 	ret := m.ctrl.Call(m, "add", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -59,13 +56,11 @@ func (m *MockMutaterContext) add(arg0 worker.Worker) error {
 
 // add indicates an expected call of add
 func (mr *MockMutaterContextMockRecorder) add(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "add", reflect.TypeOf((*MockMutaterContext)(nil).add), arg0)
 }
 
 // dying mocks base method
 func (m *MockMutaterContext) dying() <-chan struct{} {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "dying")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -73,13 +68,11 @@ func (m *MockMutaterContext) dying() <-chan struct{} {
 
 // dying indicates an expected call of dying
 func (mr *MockMutaterContextMockRecorder) dying() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "dying", reflect.TypeOf((*MockMutaterContext)(nil).dying))
 }
 
 // errDying mocks base method
 func (m *MockMutaterContext) errDying() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "errDying")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -87,13 +80,11 @@ func (m *MockMutaterContext) errDying() error {
 
 // errDying indicates an expected call of errDying
 func (mr *MockMutaterContextMockRecorder) errDying() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "errDying", reflect.TypeOf((*MockMutaterContext)(nil).errDying))
 }
 
 // getBroker mocks base method
 func (m *MockMutaterContext) getBroker() environs.LXDProfiler {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getBroker")
 	ret0, _ := ret[0].(environs.LXDProfiler)
 	return ret0
@@ -101,13 +92,11 @@ func (m *MockMutaterContext) getBroker() environs.LXDProfiler {
 
 // getBroker indicates an expected call of getBroker
 func (mr *MockMutaterContextMockRecorder) getBroker() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getBroker", reflect.TypeOf((*MockMutaterContext)(nil).getBroker))
 }
 
 // getMachine mocks base method
-func (m *MockMutaterContext) getMachine(arg0 names.MachineTag) (instancemutater.MutaterMachine, error) {
-	m.ctrl.T.Helper()
+func (m *MockMutaterContext) getMachine(arg0 names_v3.MachineTag) (instancemutater.MutaterMachine, error) {
 	ret := m.ctrl.Call(m, "getMachine", arg0)
 	ret0, _ := ret[0].(instancemutater.MutaterMachine)
 	ret1, _ := ret[1].(error)
@@ -116,13 +105,11 @@ func (m *MockMutaterContext) getMachine(arg0 names.MachineTag) (instancemutater.
 
 // getMachine indicates an expected call of getMachine
 func (mr *MockMutaterContextMockRecorder) getMachine(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getMachine", reflect.TypeOf((*MockMutaterContext)(nil).getMachine), arg0)
 }
 
 // getRequiredLXDProfiles mocks base method
 func (m *MockMutaterContext) getRequiredLXDProfiles(arg0 string) []string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getRequiredLXDProfiles", arg0)
 	ret0, _ := ret[0].([]string)
 	return ret0
@@ -130,13 +117,11 @@ func (m *MockMutaterContext) getRequiredLXDProfiles(arg0 string) []string {
 
 // getRequiredLXDProfiles indicates an expected call of getRequiredLXDProfiles
 func (mr *MockMutaterContextMockRecorder) getRequiredLXDProfiles(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getRequiredLXDProfiles", reflect.TypeOf((*MockMutaterContext)(nil).getRequiredLXDProfiles), arg0)
 }
 
 // newMachineContext mocks base method
 func (m *MockMutaterContext) newMachineContext() instancemutater0.MachineContext {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "newMachineContext")
 	ret0, _ := ret[0].(instancemutater0.MachineContext)
 	return ret0
@@ -144,6 +129,5 @@ func (m *MockMutaterContext) newMachineContext() instancemutater0.MachineContext
 
 // newMachineContext indicates an expected call of newMachineContext
 func (mr *MockMutaterContextMockRecorder) newMachineContext() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newMachineContext", reflect.TypeOf((*MockMutaterContext)(nil).newMachineContext))
 }

--- a/worker/instancemutater/mocks/namestag_mock.go
+++ b/worker/instancemutater/mocks/namestag_mock.go
@@ -34,7 +34,6 @@ func (m *MockTag) EXPECT() *MockTagMockRecorder {
 
 // Id mocks base method
 func (m *MockTag) Id() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -42,13 +41,11 @@ func (m *MockTag) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockTagMockRecorder) Id() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockTag)(nil).Id))
 }
 
 // Kind mocks base method
 func (m *MockTag) Kind() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Kind")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -56,13 +53,11 @@ func (m *MockTag) Kind() string {
 
 // Kind indicates an expected call of Kind
 func (mr *MockTagMockRecorder) Kind() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kind", reflect.TypeOf((*MockTag)(nil).Kind))
 }
 
 // String mocks base method
 func (m *MockTag) String() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -70,6 +65,5 @@ func (m *MockTag) String() string {
 
 // String indicates an expected call of String
 func (mr *MockTagMockRecorder) String() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockTag)(nil).String))
 }

--- a/worker/instancemutater/mocks/worker_mock.go
+++ b/worker/instancemutater/mocks/worker_mock.go
@@ -34,19 +34,16 @@ func (m *MockWorker) EXPECT() *MockWorkerMockRecorder {
 
 // Kill mocks base method
 func (m *MockWorker) Kill() {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
 // Kill indicates an expected call of Kill
 func (mr *MockWorkerMockRecorder) Kill() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockWorker)(nil).Kill))
 }
 
 // Wait mocks base method
 func (m *MockWorker) Wait() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -54,6 +51,5 @@ func (m *MockWorker) Wait() error {
 
 // Wait indicates an expected call of Wait
 func (mr *MockWorkerMockRecorder) Wait() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockWorker)(nil).Wait))
 }

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/juju/worker.v1/workertest"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/worker/peergrouper"
@@ -45,7 +45,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 
 	s.clock = testclock.NewClock(time.Time{})
 	s.agent = &mockAgent{conf: mockAgentConfig{
-		info: &params.StateServingInfo{
+		info: &controller.StateServingInfo{
 			StatePort: 1234,
 			APIPort:   5678,
 		},
@@ -179,14 +179,14 @@ func (ma *mockAgent) CurrentConfig() agent.Config {
 
 type mockAgentConfig struct {
 	agent.Config
-	info *params.StateServingInfo
+	info *controller.StateServingInfo
 }
 
-func (c *mockAgentConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (c *mockAgentConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	if c.info != nil {
 		return *c.info, true
 	}
-	return params.StateServingInfo{}, false
+	return controller.StateServingInfo{}, false
 }
 
 type mockHub struct {

--- a/worker/stateconfigwatcher/manifold_test.go
+++ b/worker/stateconfigwatcher/manifold_test.go
@@ -17,7 +17,7 @@ import (
 	dt "gopkg.in/juju/worker.v1/dependency/testing"
 
 	coreagent "github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/stateconfigwatcher"
 )
@@ -243,10 +243,10 @@ func (mc *mockConfig) setStateServingInfo(isSet bool) {
 	mc.ssInfoIsSet = isSet
 }
 
-func (mc *mockConfig) StateServingInfo() (params.StateServingInfo, bool) {
+func (mc *mockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
-	return params.StateServingInfo{}, mc.ssInfoIsSet
+	return controller.StateServingInfo{}, mc.ssInfoIsSet
 }
 
 type dummyWorker struct {

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -5,18 +5,17 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
-	params "github.com/juju/juju/apiserver/params"
+	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names "gopkg.in/juju/names.v3"
+	names_v3 "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface
@@ -44,7 +43,6 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -52,13 +50,11 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -66,7 +62,6 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -95,7 +90,6 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -104,13 +98,11 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -119,13 +111,11 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -133,27 +123,23 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names.ControllerTag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Controller() names_v3.ControllerTag {
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names.ControllerTag)
+	ret0, _ := ret[0].(names_v3.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -161,13 +147,11 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -175,13 +159,11 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -189,13 +171,11 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -203,13 +183,11 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -217,13 +195,11 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -231,27 +207,23 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names.ModelTag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Model() names_v3.ModelTag {
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(names_v3.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -260,13 +232,11 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -274,13 +244,11 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -288,13 +256,11 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -302,13 +268,11 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -316,28 +280,24 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
-func (m *MockConfig) StateServingInfo() (params.StateServingInfo, bool) {
-	m.ctrl.T.Helper()
+func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	ret := m.ctrl.Call(m, "StateServingInfo")
-	ret0, _ := ret[0].(params.StateServingInfo)
+	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -345,27 +305,23 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names.Tag {
-	m.ctrl.T.Helper()
+func (m *MockConfig) Tag() names_v3.Tag {
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names.Tag)
+	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfig) TransientDataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -373,13 +329,11 @@ func (m *MockConfig) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -387,13 +341,11 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -401,13 +353,11 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -416,7 +366,6 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }
 
@@ -445,7 +394,6 @@ func (m *MockConfigSetter) EXPECT() *MockConfigSetterMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfigSetter) APIAddresses() ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -454,13 +402,11 @@ func (m *MockConfigSetter) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigSetterMockRecorder) APIAddresses() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfigSetter)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -469,13 +415,11 @@ func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigSetterMockRecorder) APIInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfigSetter)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfigSetter) CACert() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -483,13 +427,11 @@ func (m *MockConfigSetter) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigSetterMockRecorder) CACert() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfigSetter)(nil).CACert))
 }
 
 // Clone mocks base method
 func (m *MockConfigSetter) Clone() agent.Config {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clone")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -497,27 +439,23 @@ func (m *MockConfigSetter) Clone() agent.Config {
 
 // Clone indicates an expected call of Clone
 func (mr *MockConfigSetterMockRecorder) Clone() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockConfigSetter)(nil).Clone))
 }
 
 // Controller mocks base method
-func (m *MockConfigSetter) Controller() names.ControllerTag {
-	m.ctrl.T.Helper()
+func (m *MockConfigSetter) Controller() names_v3.ControllerTag {
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names.ControllerTag)
+	ret0, _ := ret[0].(names_v3.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigSetterMockRecorder) Controller() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfigSetter)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfigSetter) DataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -525,13 +463,11 @@ func (m *MockConfigSetter) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigSetterMockRecorder) DataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfigSetter)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfigSetter) Dir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -539,13 +475,11 @@ func (m *MockConfigSetter) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigSetterMockRecorder) Dir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfigSetter)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfigSetter) Jobs() []model.MachineJob {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -553,13 +487,11 @@ func (m *MockConfigSetter) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigSetterMockRecorder) Jobs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfigSetter)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfigSetter) LogDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -567,13 +499,11 @@ func (m *MockConfigSetter) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigSetterMockRecorder) LogDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfigSetter)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfigSetter) LoggingConfig() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -581,13 +511,11 @@ func (m *MockConfigSetter) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigSetterMockRecorder) LoggingConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfigSetter) MetricsSpoolDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -595,27 +523,23 @@ func (m *MockConfigSetter) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigSetterMockRecorder) MetricsSpoolDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfigSetter)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfigSetter) Model() names.ModelTag {
-	m.ctrl.T.Helper()
+func (m *MockConfigSetter) Model() names_v3.ModelTag {
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(names_v3.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigSetterMockRecorder) Model() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfigSetter)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -624,13 +548,11 @@ func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigSetterMockRecorder) MongoInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfigSetter)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -638,13 +560,11 @@ func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigSetterMockRecorder) MongoMemoryProfile() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).MongoMemoryProfile))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfigSetter) MongoVersion() mongo.Version {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -652,13 +572,11 @@ func (m *MockConfigSetter) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigSetterMockRecorder) MongoVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfigSetter) Nonce() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -666,13 +584,11 @@ func (m *MockConfigSetter) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigSetterMockRecorder) Nonce() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfigSetter)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfigSetter) OldPassword() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -680,160 +596,134 @@ func (m *MockConfigSetter) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigSetterMockRecorder) OldPassword() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfigSetter)(nil).OldPassword))
 }
 
 // SetAPIHostPorts mocks base method
 func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAPIHostPorts", arg0)
 }
 
 // SetAPIHostPorts indicates an expected call of SetAPIHostPorts
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
 }
 
 // SetCACert mocks base method
 func (m *MockConfigSetter) SetCACert(arg0 string) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCACert", arg0)
 }
 
 // SetCACert indicates an expected call of SetCACert
 func (mr *MockConfigSetterMockRecorder) SetCACert(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCACert", reflect.TypeOf((*MockConfigSetter)(nil).SetCACert), arg0)
 }
 
 // SetControllerAPIPort mocks base method
 func (m *MockConfigSetter) SetControllerAPIPort(arg0 int) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetControllerAPIPort", arg0)
 }
 
 // SetControllerAPIPort indicates an expected call of SetControllerAPIPort
 func (mr *MockConfigSetterMockRecorder) SetControllerAPIPort(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetControllerAPIPort", reflect.TypeOf((*MockConfigSetter)(nil).SetControllerAPIPort), arg0)
 }
 
 // SetLoggingConfig mocks base method
 func (m *MockConfigSetter) SetLoggingConfig(arg0 string) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetLoggingConfig", arg0)
 }
 
 // SetLoggingConfig indicates an expected call of SetLoggingConfig
 func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).SetLoggingConfig), arg0)
 }
 
 // SetMongoMemoryProfile mocks base method
 func (m *MockConfigSetter) SetMongoMemoryProfile(arg0 mongo.MemoryProfile) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoMemoryProfile", arg0)
 }
 
 // SetMongoMemoryProfile indicates an expected call of SetMongoMemoryProfile
 func (mr *MockConfigSetterMockRecorder) SetMongoMemoryProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoMemoryProfile), arg0)
 }
 
 // SetMongoVersion mocks base method
 func (m *MockConfigSetter) SetMongoVersion(arg0 mongo.Version) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoVersion", arg0)
 }
 
 // SetMongoVersion indicates an expected call of SetMongoVersion
 func (mr *MockConfigSetterMockRecorder) SetMongoVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoVersion), arg0)
 }
 
 // SetOldPassword mocks base method
 func (m *MockConfigSetter) SetOldPassword(arg0 string) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetOldPassword", arg0)
 }
 
 // SetOldPassword indicates an expected call of SetOldPassword
 func (mr *MockConfigSetterMockRecorder) SetOldPassword(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOldPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetOldPassword), arg0)
 }
 
 // SetPassword mocks base method
 func (m *MockConfigSetter) SetPassword(arg0 string) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPassword", arg0)
 }
 
 // SetPassword indicates an expected call of SetPassword
 func (mr *MockConfigSetterMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetPassword), arg0)
 }
 
 // SetStateServingInfo mocks base method
-func (m *MockConfigSetter) SetStateServingInfo(arg0 params.StateServingInfo) {
-	m.ctrl.T.Helper()
+func (m *MockConfigSetter) SetStateServingInfo(arg0 controller.StateServingInfo) {
 	m.ctrl.Call(m, "SetStateServingInfo", arg0)
 }
 
 // SetStateServingInfo indicates an expected call of SetStateServingInfo
 func (mr *MockConfigSetterMockRecorder) SetStateServingInfo(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).SetStateServingInfo), arg0)
 }
 
 // SetUpgradedToVersion mocks base method
 func (m *MockConfigSetter) SetUpgradedToVersion(arg0 version.Number) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetUpgradedToVersion", arg0)
 }
 
 // SetUpgradedToVersion indicates an expected call of SetUpgradedToVersion
 func (mr *MockConfigSetterMockRecorder) SetUpgradedToVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetUpgradedToVersion), arg0)
 }
 
 // SetValue mocks base method
 func (m *MockConfigSetter) SetValue(arg0, arg1 string) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetValue", arg0, arg1)
 }
 
 // SetValue indicates an expected call of SetValue
 func (mr *MockConfigSetterMockRecorder) SetValue(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValue", reflect.TypeOf((*MockConfigSetter)(nil).SetValue), arg0, arg1)
 }
 
 // StateServingInfo mocks base method
-func (m *MockConfigSetter) StateServingInfo() (params.StateServingInfo, bool) {
-	m.ctrl.T.Helper()
+func (m *MockConfigSetter) StateServingInfo() (controller.StateServingInfo, bool) {
 	ret := m.ctrl.Call(m, "StateServingInfo")
-	ret0, _ := ret[0].(params.StateServingInfo)
+	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigSetterMockRecorder) StateServingInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfigSetter) SystemIdentityPath() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -841,27 +731,23 @@ func (m *MockConfigSetter) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigSetterMockRecorder) SystemIdentityPath() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfigSetter)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfigSetter) Tag() names.Tag {
-	m.ctrl.T.Helper()
+func (m *MockConfigSetter) Tag() names_v3.Tag {
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names.Tag)
+	ret0, _ := ret[0].(names_v3.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigSetterMockRecorder) Tag() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfigSetter)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfigSetter) TransientDataDir() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -869,13 +755,11 @@ func (m *MockConfigSetter) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigSetterMockRecorder) TransientDataDir() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfigSetter)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfigSetter) UpgradedToVersion() version.Number {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -883,13 +767,11 @@ func (m *MockConfigSetter) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigSetterMockRecorder) UpgradedToVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfigSetter) Value(arg0 string) string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -897,13 +779,11 @@ func (m *MockConfigSetter) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigSetterMockRecorder) Value(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfigSetter)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -912,6 +792,5 @@ func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) 
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigSetterMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfigSetter)(nil).WriteCommands), arg0)
 }

--- a/worker/upgradedatabase/mocks/lock.go
+++ b/worker/upgradedatabase/mocks/lock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLock is a mock of Lock interface
@@ -35,7 +34,6 @@ func (m *MockLock) EXPECT() *MockLockMockRecorder {
 
 // IsUnlocked mocks base method
 func (m *MockLock) IsUnlocked() bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUnlocked")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -43,25 +41,21 @@ func (m *MockLock) IsUnlocked() bool {
 
 // IsUnlocked indicates an expected call of IsUnlocked
 func (mr *MockLockMockRecorder) IsUnlocked() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnlocked", reflect.TypeOf((*MockLock)(nil).IsUnlocked))
 }
 
 // Unlock mocks base method
 func (m *MockLock) Unlock() {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Unlock")
 }
 
 // Unlock indicates an expected call of Unlock
 func (mr *MockLockMockRecorder) Unlock() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlock", reflect.TypeOf((*MockLock)(nil).Unlock))
 }
 
 // Unlocked mocks base method
 func (m *MockLock) Unlocked() <-chan struct{} {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unlocked")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -69,6 +63,5 @@ func (m *MockLock) Unlocked() <-chan struct{} {
 
 // Unlocked indicates an expected call of Unlocked
 func (mr *MockLockMockRecorder) Unlocked() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlocked", reflect.TypeOf((*MockLock)(nil).Unlocked))
 }

--- a/worker/upgradedatabase/mocks/package.go
+++ b/worker/upgradedatabase/mocks/package.go
@@ -5,13 +5,12 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
 	upgradedatabase "github.com/juju/juju/worker/upgradedatabase"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockLogger is a mock of Logger interface
@@ -39,7 +38,6 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 
 // Debugf mocks base method
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -49,14 +47,12 @@ func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 
 // Debugf indicates an expected call of Debugf
 func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
 // Errorf mocks base method
 func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -66,14 +62,12 @@ func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
 
 // Errorf indicates an expected call of Errorf
 func (mr *MockLoggerMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLogger)(nil).Errorf), varargs...)
 }
 
 // Infof mocks base method
 func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -83,7 +77,6 @@ func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
 
 // Infof indicates an expected call of Infof
 func (mr *MockLoggerMockRecorder) Infof(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLogger)(nil).Infof), varargs...)
 }
@@ -113,7 +106,6 @@ func (m *MockPool) EXPECT() *MockPoolMockRecorder {
 
 // Close mocks base method
 func (m *MockPool) Close() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -121,13 +113,11 @@ func (m *MockPool) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockPoolMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPool)(nil).Close))
 }
 
 // EnsureUpgradeInfo mocks base method
 func (m *MockPool) EnsureUpgradeInfo(arg0 string, arg1, arg2 version.Number) (upgradedatabase.UpgradeInfo, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureUpgradeInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(upgradedatabase.UpgradeInfo)
 	ret1, _ := ret[1].(error)
@@ -136,13 +126,11 @@ func (m *MockPool) EnsureUpgradeInfo(arg0 string, arg1, arg2 version.Number) (up
 
 // EnsureUpgradeInfo indicates an expected call of EnsureUpgradeInfo
 func (mr *MockPoolMockRecorder) EnsureUpgradeInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureUpgradeInfo", reflect.TypeOf((*MockPool)(nil).EnsureUpgradeInfo), arg0, arg1, arg2)
 }
 
 // IsPrimary mocks base method
 func (m *MockPool) IsPrimary(arg0 string) (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPrimary", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -151,13 +139,11 @@ func (m *MockPool) IsPrimary(arg0 string) (bool, error) {
 
 // IsPrimary indicates an expected call of IsPrimary
 func (mr *MockPoolMockRecorder) IsPrimary(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrimary", reflect.TypeOf((*MockPool)(nil).IsPrimary), arg0)
 }
 
 // SetStatus mocks base method
 func (m *MockPool) SetStatus(arg0 string, arg1 status.Status, arg2 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -165,7 +151,6 @@ func (m *MockPool) SetStatus(arg0 string, arg1 status.Status, arg2 string) error
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockPoolMockRecorder) SetStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockPool)(nil).SetStatus), arg0, arg1, arg2)
 }
 
@@ -194,7 +179,6 @@ func (m *MockUpgradeInfo) EXPECT() *MockUpgradeInfoMockRecorder {
 
 // Refresh mocks base method
 func (m *MockUpgradeInfo) Refresh() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -202,13 +186,11 @@ func (m *MockUpgradeInfo) Refresh() error {
 
 // Refresh indicates an expected call of Refresh
 func (mr *MockUpgradeInfoMockRecorder) Refresh() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockUpgradeInfo)(nil).Refresh))
 }
 
 // SetStatus mocks base method
 func (m *MockUpgradeInfo) SetStatus(arg0 state.UpgradeStatus) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -216,13 +198,11 @@ func (m *MockUpgradeInfo) SetStatus(arg0 state.UpgradeStatus) error {
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockUpgradeInfoMockRecorder) SetStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockUpgradeInfo)(nil).SetStatus), arg0)
 }
 
 // Status mocks base method
 func (m *MockUpgradeInfo) Status() state.UpgradeStatus {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(state.UpgradeStatus)
 	return ret0
@@ -230,13 +210,11 @@ func (m *MockUpgradeInfo) Status() state.UpgradeStatus {
 
 // Status indicates an expected call of Status
 func (mr *MockUpgradeInfoMockRecorder) Status() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockUpgradeInfo)(nil).Status))
 }
 
 // Watch mocks base method
 func (m *MockUpgradeInfo) Watch() state.NotifyWatcher {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch")
 	ret0, _ := ret[0].(state.NotifyWatcher)
 	return ret0
@@ -244,6 +222,5 @@ func (m *MockUpgradeInfo) Watch() state.NotifyWatcher {
 
 // Watch indicates an expected call of Watch
 func (mr *MockUpgradeInfoMockRecorder) Watch() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockUpgradeInfo)(nil).Watch))
 }

--- a/worker/upgradedatabase/mocks/watcher.go
+++ b/worker/upgradedatabase/mocks/watcher.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockNotifyWatcher is a mock of NotifyWatcher interface
@@ -35,7 +34,6 @@ func (m *MockNotifyWatcher) EXPECT() *MockNotifyWatcherMockRecorder {
 
 // Changes mocks base method
 func (m *MockNotifyWatcher) Changes() <-chan struct{} {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Changes")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -43,13 +41,11 @@ func (m *MockNotifyWatcher) Changes() <-chan struct{} {
 
 // Changes indicates an expected call of Changes
 func (mr *MockNotifyWatcherMockRecorder) Changes() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Changes", reflect.TypeOf((*MockNotifyWatcher)(nil).Changes))
 }
 
 // Err mocks base method
 func (m *MockNotifyWatcher) Err() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Err")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -57,25 +53,21 @@ func (m *MockNotifyWatcher) Err() error {
 
 // Err indicates an expected call of Err
 func (mr *MockNotifyWatcherMockRecorder) Err() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockNotifyWatcher)(nil).Err))
 }
 
 // Kill mocks base method
 func (m *MockNotifyWatcher) Kill() {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
 // Kill indicates an expected call of Kill
 func (mr *MockNotifyWatcherMockRecorder) Kill() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockNotifyWatcher)(nil).Kill))
 }
 
 // Stop mocks base method
 func (m *MockNotifyWatcher) Stop() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -83,13 +75,11 @@ func (m *MockNotifyWatcher) Stop() error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockNotifyWatcherMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockNotifyWatcher)(nil).Stop))
 }
 
 // Wait mocks base method
 func (m *MockNotifyWatcher) Wait() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -97,6 +87,5 @@ func (m *MockNotifyWatcher) Wait() error {
 
 // Wait indicates an expected call of Wait
 func (mr *MockNotifyWatcherMockRecorder) Wait() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockNotifyWatcher)(nil).Wait))
 }


### PR DESCRIPTION
## Description of change

The last remaining dependency of the state package on apiserver/params was the use of params.StateServingInfo. Plus, the state package itself declared its own copy. The type is generic and associated with a controller so a new copy of the struct was defined in the existing top level controller package.

There was also an upgrade error in state that just used a string from params that was also fixed.

A lot of the churn here is regeneration of mocks.

## QA steps

bootstrap a controller
enable ha
deploy a charm
check for errors

