### PR TITLE
Use all addresses for configuring k8s agents

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -301,12 +301,14 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 	}
 
 	// select public address.
+	publicAddr, _ := addrs.OneMatchingScope(network.ScopeMatchPublic)
 	if public {
-		addr, _ := addrs.OneMatchingScope(network.ScopeMatchPublic)
-		return addrsToHostPorts(addr), nil
+		return addrsToHostPorts(publicAddr), nil
 	}
-	// select internal address.
-	return addrsToHostPorts(addrs.AllMatchingScope(network.ScopeMatchCloudLocal)...), nil
+
+	// TODO(wallyworld) - for now, return all addresses for agents to try, public last
+	result := addrsToHostPorts(addrs.AllMatchingScope(network.ScopeMatchCloudLocal)...)
+	return append(result, addrsToHostPorts(publicAddr)...), nil
 }
 
 // apiHostPortsForKey returns API addresses extracted from the document


### PR DESCRIPTION
## Description of change

When juju configures the agents, it records in the agent config what address(es) to use to talk back to the controller. On k8s, we use the cluster addresses but these are not reachable from external agents where a second cloud has been added to the controller. So for agents, we now always include any public IP at the end of the address list as a fallback.

## QA steps

bootstrap a controller with a loadbalancer service type
deploy a k8s charm.
kubecutl exec into the charm operator pod
cat the application agent.conf file and see that the cluster and lb adddress are listed
check the client controllers.yaml to see that just the lb address is listed

## Bug reference

https://bugs.launchpad.net/juju/+bug/1869883
