### PR TITLE
Ensure specified region is always used for add-model

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -215,7 +215,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 
 	// Find a local credential to use with the new model.
 	// If credential was found on the controller, it will be nil in return.
-	credential, credentialTag, cloudRegion, err := c.findCredential(ctx, cloudClient, &findCredentialParams{
+	credential, credentialTag, credentialRegion, err := c.findCredential(ctx, cloudClient, &findCredentialParams{
 		cloudTag:    cloudTag,
 		cloudRegion: cloudRegion,
 		cloud:       cloud,
@@ -228,6 +228,12 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 			"* 'juju add-model --credential' to use a local credential.\n" +
 			"Use 'juju credentials' to list all available credentials.\n")
 		return cmd.ErrSilent
+	}
+
+	// If the use has not specified an explicit cloud region,
+	// use any default region from the credential.
+	if cloudRegion == "" {
+		cloudRegion = credentialRegion
 	}
 
 	// Upload the credential if it was explicitly set and we have found it locally.

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -499,6 +499,21 @@ func (s *AddModelSuite) TestCloudDefaultRegionUsedIfSet(c *gc.C) {
 	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-west-1")
 }
 
+func (s *AddModelSuite) TestExplicitCloudRegionUsed(c *gc.C) {
+	// When a controller credential is used, any explicit region is honoured.
+
+	// Delete all local credentials, so we don't choose
+	// any of them to upload. This will force a credential
+	// to be retrieved from the controller.
+	delete(s.store.Credentials, "aws")
+
+	_, err := s.run(c, "test", "aws/us-east-1", "--credential", "other/secrets")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.fakeAddModelAPI.cloudName, gc.Equals, "aws")
+	c.Assert(s.fakeAddModelAPI.cloudRegion, gc.Equals, "us-east-1")
+}
+
 func (s *AddModelSuite) TestInvalidCloudOrRegionName(c *gc.C) {
 	ctx, err := s.run(c, "test", "oro")
 	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)


### PR DESCRIPTION
## Description of change

When using
juju add-model somecloud/someregion --credential mine

id the credential did not exist locally and was just in the controller, we would set the cloud region to "" instead of using the one specifed.

## QA steps

bootstrap an aws controller
delete the local credential
add-model aws/us-west-2 --credential mine

ensure the model is created in us-west-2 and not the default region (see bug)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1849916
