### PR TITLE
[dev] Rename max-uniter-state-size to max-agent-state-size

### DIFF
--- a/apiserver/common/unitstate.go
+++ b/apiserver/common/unitstate.go
@@ -182,8 +182,8 @@ func (u *UnitStateAPI) SetState(args params.SetUnitStateArgs) (params.ErrorResul
 		ops := unit.SetStateOperation(
 			unitState,
 			state.UnitStateSizeLimits{
-				MaxCharmStateSize:  ctrlCfg.MaxCharmStateSize(),
-				MaxUniterStateSize: ctrlCfg.MaxUniterStateSize(),
+				MaxCharmStateSize: ctrlCfg.MaxCharmStateSize(),
+				MaxAgentStateSize: ctrlCfg.MaxAgentStateSize(),
 			},
 		)
 		if err = u.backend.ApplyOperation(ops); err != nil {

--- a/apiserver/common/unitstate_test.go
+++ b/apiserver/common/unitstate_test.go
@@ -98,16 +98,16 @@ func (s *unitStateSuite) expectSetStateOperation() string {
 	// Mock controller config which provides the limits passed to SetStateOperation.
 	s.mockBackend.EXPECT().ControllerConfig().Return(
 		controller.Config{
-			"max-charm-state-size":  123,
-			"max-uniter-state-size": 456,
+			"max-charm-state-size": 123,
+			"max-agent-state-size": 456,
 		}, nil)
 
 	exp := s.mockUnit.EXPECT()
 	exp.SetStateOperation(
 		unitState,
 		state.UnitStateSizeLimits{
-			MaxCharmStateSize:  123,
-			MaxUniterStateSize: 456,
+			MaxCharmStateSize: 123,
+			MaxAgentStateSize: 456,
 		},
 	).Return(s.mockOp)
 	return expUniterState

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -3426,8 +3426,8 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 			modelOp := unit.SetStateOperation(
 				newUS,
 				state.UnitStateSizeLimits{
-					MaxCharmStateSize:  ctrlCfg.MaxCharmStateSize(),
-					MaxUniterStateSize: ctrlCfg.MaxUniterStateSize(),
+					MaxCharmStateSize: ctrlCfg.MaxCharmStateSize(),
+					MaxAgentStateSize: ctrlCfg.MaxAgentStateSize(),
 				},
 			)
 			modelOps = append(modelOps, modelOp)

--- a/controller/config.go
+++ b/controller/config.go
@@ -186,11 +186,11 @@ const (
 	// principle, mongo imposes a hard (but configurable) limit of 16M.
 	MaxCharmStateSize = "max-charm-state-size"
 
-	// MaxUniterStateSize is the maximum allowed size of internal uniter
-	// data that units can store to the controller in bytes. A value of 0
+	// MaxAgentStateSize is the maximum allowed size of internal state
+	// data that agents can store to the controller in bytes. A value of 0
 	// disables the quota checks although in principle, mongo imposes a
 	// hard (but configurable) limit of 16M.
-	MaxUniterStateSize = "max-uniter-state-size"
+	MaxAgentStateSize = "max-agent-state-size"
 
 	// Attribute Defaults
 
@@ -273,9 +273,9 @@ const (
 	// state data that each unit can store to the controller.
 	DefaultMaxCharmStateSize = 2 * 1024 * 1024
 
-	// DefaultMaxUniterStateSize is the maximum size (in bytes) of internal
-	// uniter state data that each unit can store to the controller.
-	DefaultMaxUniterStateSize = 512 * 1024
+	// DefaultMaxAgentStateSize is the maximum size (in bytes) of internal
+	// state data that agents can store to the controller.
+	DefaultMaxAgentStateSize = 512 * 1024
 
 	// JujuHASpace is the network space within which the MongoDB replica-set
 	// should communicate.
@@ -343,7 +343,7 @@ var (
 		Features,
 		MeteringURL,
 		MaxCharmStateSize,
-		MaxUniterStateSize,
+		MaxAgentStateSize,
 	}
 
 	// AllowedUpdateConfigAttributes contains all of the controller
@@ -375,7 +375,7 @@ var (
 		CAASImageRepo,
 		Features,
 		MaxCharmStateSize,
-		MaxUniterStateSize,
+		MaxAgentStateSize,
 	)
 
 	// DefaultAuditLogExcludeMethods is the default list of methods to
@@ -793,11 +793,10 @@ func (c Config) MaxCharmStateSize() int {
 	return c.intOrDefault(MaxCharmStateSize, DefaultMaxCharmStateSize)
 }
 
-// MaxUniterStateSize returns the max size (in bytes) of internal uniter state
-// that each unit can store to the controller. A value of zero indicates no
-// limit.
-func (c Config) MaxUniterStateSize() int {
-	return c.intOrDefault(MaxUniterStateSize, DefaultMaxUniterStateSize)
+// MaxAgentStateSize returns the max size (in bytes) of state data that agents
+// can store to the controller. A value of zero indicates no limit.
+func (c Config) MaxAgentStateSize() int {
+	return c.intOrDefault(MaxAgentStateSize, DefaultMaxAgentStateSize)
 }
 
 // Validate ensures that config is a valid configuration.
@@ -988,17 +987,17 @@ func Validate(c Config) error {
 		maxUnitStateSize += DefaultMaxCharmStateSize
 	}
 
-	if v, ok := c[MaxUniterStateSize].(int); ok {
+	if v, ok := c[MaxAgentStateSize].(int); ok {
 		if v < 0 {
-			return errors.Errorf("invalid max uniter state size: should be a number of bytes (or 0 to disable limit), got %d", v)
+			return errors.Errorf("invalid max agent state size: should be a number of bytes (or 0 to disable limit), got %d", v)
 		}
 		maxUnitStateSize += v
 	} else {
-		maxUnitStateSize += DefaultMaxUniterStateSize
+		maxUnitStateSize += DefaultMaxAgentStateSize
 	}
 
 	if mongoMax := 16 * 1024 * 1024; maxUnitStateSize > mongoMax {
-		return errors.Errorf("invalid max charm/uniter state sizes: combined value should not exceed mongo's 16M per-document limit, got %d", maxUnitStateSize)
+		return errors.Errorf("invalid max charm/agent state sizes: combined value should not exceed mongo's 16M per-document limit, got %d", maxUnitStateSize)
 	}
 
 	return nil
@@ -1096,7 +1095,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	CharmStoreURL:           schema.String(),
 	MeteringURL:             schema.String(),
 	MaxCharmStateSize:       schema.ForceInt(),
-	MaxUniterStateSize:      schema.ForceInt(),
+	MaxAgentStateSize:       schema.ForceInt(),
 }, schema.Defaults{
 	AgentRateLimitMax:       schema.Omit,
 	AgentRateLimitRate:      schema.Omit,
@@ -1134,7 +1133,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	CharmStoreURL:           csclient.ServerURL,
 	MeteringURL:             romulus.DefaultAPIRoot,
 	MaxCharmStateSize:       DefaultMaxCharmStateSize,
-	MaxUniterStateSize:      DefaultMaxUniterStateSize,
+	MaxAgentStateSize:       DefaultMaxAgentStateSize,
 })
 
 // ConfigSchema holds information on all the fields defined by
@@ -1291,8 +1290,8 @@ Use "caas-image-repo" instead.`,
 		Type:        environschema.Tint,
 		Description: `The maximum size (in bytes) of charm-specific state that units can store to the controller`,
 	},
-	MaxUniterStateSize: {
+	MaxAgentStateSize: {
 		Type:        environschema.Tint,
-		Description: `The maximum size (in bytes) of internal uniter state that units can store to the controller`,
+		Description: `The maximum size (in bytes) of internal state data that agents can store to the controller`,
 	},
 }

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -356,24 +356,24 @@ var newConfigTests = []struct {
 	},
 	expectError: `invalid max charm state size: should be a number of bytes \(or 0 to disable limit\), got -42`,
 }, {
-	about: "max-uniter-state-size non-int",
+	about: "max-agent-state-size non-int",
 	config: controller.Config{
-		controller.MaxUniterStateSize: "ten",
+		controller.MaxAgentStateSize: "ten",
 	},
-	expectError: `max-uniter-state-size: expected number, got string\("ten"\)`,
+	expectError: `max-agent-state-size: expected number, got string\("ten"\)`,
 }, {
-	about: "max-uniter-state-size cannot be negative",
+	about: "max-agent-state-size cannot be negative",
 	config: controller.Config{
-		controller.MaxUniterStateSize: "-42",
+		controller.MaxAgentStateSize: "-42",
 	},
-	expectError: `invalid max uniter state size: should be a number of bytes \(or 0 to disable limit\), got -42`,
+	expectError: `invalid max agent state size: should be a number of bytes \(or 0 to disable limit\), got -42`,
 }, {
-	about: "combined charm/unit state cannot exceed mongo's 16M limit/doc",
+	about: "combined charm/agent state cannot exceed mongo's 16M limit/doc",
 	config: controller.Config{
-		controller.MaxCharmStateSize:  "14000000",
-		controller.MaxUniterStateSize: "3000000",
+		controller.MaxCharmStateSize: "14000000",
+		controller.MaxAgentStateSize: "3000000",
 	},
-	expectError: `invalid max charm/uniter state sizes: combined value should not exceed mongo's 16M per-document limit, got 17000000`,
+	expectError: `invalid max charm/agent state sizes: combined value should not exceed mongo's 16M per-document limit, got 17000000`,
 }, {}}
 
 func (s *ConfigSuite) TestNewConfig(c *gc.C) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -56,7 +56,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.PruneTxnQueryCount,
 		controller.PruneTxnSleepTime,
 		controller.MaxCharmStateSize,
-		controller.MaxUniterStateSize,
+		controller.MaxAgentStateSize,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1157,8 +1157,8 @@ func (i *importer) unit(s description.Application, u description.Unit, ctrlCfg c
 		us := NewUnitState()
 		us.SetState(unitState)
 		limits := UnitStateSizeLimits{
-			MaxCharmStateSize:  ctrlCfg.MaxCharmStateSize(),
-			MaxUniterStateSize: ctrlCfg.MaxUniterStateSize(),
+			MaxCharmStateSize: ctrlCfg.MaxCharmStateSize(),
+			MaxAgentStateSize: ctrlCfg.MaxAgentStateSize(),
 		}
 		if err := unit.SetState(us, limits); err != nil {
 			return errors.Trace(err)

--- a/state/unit_ops.go
+++ b/state/unit_ops.go
@@ -226,7 +226,7 @@ func (op *unitSetStateOperation) getCharmStateQuotaChecker() quota.Checker {
 
 func (op *unitSetStateOperation) getUniterStateQuotaChecker() quota.Checker {
 	return quota.NewMultiChecker(
-		quota.NewBSONTotalSizeChecker(op.limits.MaxUniterStateSize),
+		quota.NewBSONTotalSizeChecker(op.limits.MaxAgentStateSize),
 	)
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -123,7 +123,7 @@ func (s *UnitSuite) TestCombinedUnitStateQuotaLimit(c *gc.C) {
 	newState.SetStorageState("storage is cheap")
 
 	err := s.unit.SetState(newState, state.UnitStateSizeLimits{
-		MaxUniterStateSize: 640000,
+		MaxAgentStateSize: 640000,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -132,7 +132,7 @@ func (s *UnitSuite) TestCombinedUnitStateQuotaLimit(c *gc.C) {
 	newState.SetRelationState(map[int]string{42: "a fresh serialized blob"})
 	newState.SetStorageState("storage")
 	err = s.unit.SetState(newState, state.UnitStateSizeLimits{
-		MaxUniterStateSize: 42,
+		MaxAgentStateSize: 42,
 	})
 	c.Assert(errors.IsQuotaLimitExceeded(err), jc.IsTrue)
 }
@@ -149,8 +149,8 @@ func (s *UnitSuite) TestUnitStateWithDualQuotaLimits(c *gc.C) {
 	})
 
 	err := s.unit.SetState(newState, state.UnitStateSizeLimits{
-		MaxCharmStateSize:  4096,
-		MaxUniterStateSize: 128,
+		MaxCharmStateSize: 4096,
+		MaxAgentStateSize: 128,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/unitstate.go
+++ b/state/unitstate.go
@@ -258,5 +258,5 @@ type UnitStateSizeLimits struct {
 
 	// The maximum allowed size for the uniter's state. It can be set to
 	// zero to bypass the uniter state quota checks.
-	MaxUniterStateSize int
+	MaxAgentStateSize int
 }


### PR DESCRIPTION
This PR renames the controller config option for setting a limit on the internal uniter state (originally introduced by #11390 ) to make the configuration setting a bit more intuitive and congruent with future work to unify the various agents.