### PR TITLE
2.7 - Fix Network Type Detection for Valid NIC

### DIFF
--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -22,6 +22,7 @@ const (
 	nic            = "nic"
 	nicTypeBridged = "bridged"
 	nicTypeMACVLAN = "macvlan"
+	netTypeBridge  = "bridge"
 )
 
 // device is a type alias for profile devices.
@@ -88,8 +89,8 @@ func (s *Server) EnsureIPv4(netName string) (bool, error) {
 
 // GetNICsFromProfile returns all NIC devices in the profile with the input
 // name. All returned devices have a MAC address; generated if required.
-func (s *Server) GetNICsFromProfile(profName string) (map[string]device, error) {
-	profile, _, err := s.GetProfile(lxdDefaultProfileName)
+func (s *Server) GetNICsFromProfile(profileName string) (map[string]device, error) {
+	profile, _, err := s.GetProfile(profileName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -138,7 +139,7 @@ func (s *Server) ensureDefaultNetworking(profile *api.Profile, eTag string) erro
 		}
 		req := api.NetworksPost{
 			Name:    network.DefaultLXDBridge,
-			Type:    "bridge",
+			Type:    netTypeBridge,
 			Managed: true,
 			NetworkPut: api.NetworkPut{Config: map[string]string{
 				"ipv4.address": "auto",
@@ -170,7 +171,7 @@ func (s *Server) ensureDefaultNetworking(profile *api.Profile, eTag string) erro
 
 	// Add the new device with the bridge as its parent.
 	nicType := nicTypeMACVLAN
-	if net.Type == "bridge" {
+	if net.Type == netTypeBridge {
 		nicType = nicTypeBridged
 	}
 	profile.Devices[nicName] = device{
@@ -331,7 +332,7 @@ func isValidNICType(nic device) bool {
 }
 
 func isValidNetworkType(net *api.Network) bool {
-	return net.Type == nicTypeBridged || net.Type == nicTypeMACVLAN
+	return net.Type == netTypeBridge || net.Type == nicTypeMACVLAN
 }
 
 const BridgeConfigFile = "/etc/default/lxd-bridge"
@@ -500,7 +501,7 @@ func DevicesFromInterfaceInfo(interfaces []network.InterfaceInfo) (map[string]de
 func newNICDevice(deviceName, parentDevice, hwAddr string, mtu int) device {
 	device := map[string]string{
 		"type":    "nic",
-		"nictype": "bridged",
+		"nictype": nicTypeBridged,
 		"name":    deviceName,
 		"parent":  parentDevice,
 	}

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -136,7 +136,7 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentValid(c *gc.C) {
 	net := &lxdapi.Network{
 		Name:    network.DefaultLXDBridge,
 		Managed: true,
-		Type:    "bridged",
+		Type:    "bridge",
 	}
 	cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(net, "", nil)
 


### PR DESCRIPTION
## Description of change

Follows #11333, which incorrectly attempted to look for a network type of "bridged" instead of "bridge". This is now fixed.

## QA steps

- On a fresh VM, or new install of LXD > 3.33, run `lxd init`.
- Check that the profile has a NIC device with the new format.
- Bootstrap with this patch should succeed.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1867886
https://bugs.launchpad.net/juju/+bug/1870418
