### PR TITLE
2.7 - Backport CAAS API Address Fixes

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -298,12 +298,14 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 	}
 
 	// select public address.
+	publicAddr, _ := addrs.OneMatchingScope(network.ScopeMatchPublic)
 	if public {
-		addr, _ := addrs.OneMatchingScope(network.ScopeMatchPublic)
-		return addrsToHostPorts(addr), nil
+		return addrsToHostPorts(publicAddr), nil
 	}
-	// select internal address.
-	return addrsToHostPorts(addrs.AllMatchingScope(network.ScopeMatchCloudLocal)...), nil
+
+	// TODO(wallyworld) - for now, return all addresses for agents to try, public last
+	result := addrsToHostPorts(addrs.AllMatchingScope(network.ScopeMatchCloudLocal)...)
+	return append(result, addrsToHostPorts(publicAddr)...), nil
 }
 
 // apiHostPortsForKey returns API addresses extracted from the document

--- a/state/model.go
+++ b/state/model.go
@@ -1409,7 +1409,7 @@ func checkModelEntityRefsEmpty(doc *modelEntityRefsDoc) ([]txn.Op, error) {
 	isEmpty := func(attribute string) bson.DocElem {
 		// We consider it empty if the array has no entries, or if the attribute doesn't exist
 		return bson.DocElem{
-			"$or", []bson.M{{
+			Name: "$or", Value: []bson.M{{
 				attribute: bson.M{"$exists": false},
 			}, {
 				attribute: bson.M{"$size": 0},
@@ -1512,7 +1512,7 @@ func noNewStorageModelEntityRefs(doc *modelEntityRefsDoc) []txn.Op {
 		// is a subset of the previously known set.
 	}
 	noNewFilesystems := bson.DocElem{
-		"filesystems", bson.D{{
+		Name: "filesystems", Value: bson.D{{
 			"$not", bson.D{{
 				"$elemMatch", bson.D{{
 					"$nin", doc.Filesystems,

--- a/state/no_skip_test.go
+++ b/state/no_skip_test.go
@@ -3,7 +3,7 @@
 
 // +build !skip_state_tests
 
-package state_test
+package state
 
 // runStateTests controls whether to run the state tests - in this
 // case the skip_state_tests build tag hasn't been set so they'll be

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -1,17 +1,46 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state_test
+package state
 
 import (
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
 	coretesting "github.com/juju/juju/testing"
 )
+
+// TODO (manadart 2020-04-03)
+// The following refactoring should occur over time:
+// - Move export_test.go contents to this file.
+// - Rearrange packages (see state/testing) so that base suites can be
+//   implemented here without import cycling.
+// - Replace blanket exports with functions in suites here that supply
+//   behaviour to parent suites that require them.
+
+//go:generate mockgen -package state -destination migration_import_mock_test.go github.com/juju/juju/state TransactionRunner,StateDocumentFactory,DocModelNamespace
+//go:generate mockgen -package state -destination migration_import_input_mock_test.go github.com/juju/juju/state RemoteEntitiesInput,RelationNetworksInput,RemoteApplicationsInput,ApplicationOfferStateDocumentFactory,ApplicationOfferInput,ExternalControllerStateDocumentFactory,ExternalControllersInput,FirewallRulesInput
+//go:generate mockgen -package state -destination migration_description_mock_test.go github.com/juju/description ApplicationOffer,ExternalController,FirewallRule,RemoteEntity,RelationNetwork,RemoteApplication,RemoteSpace,Status
+//go:generate mockgen -package mocks -destination mocks/operation_mock.go github.com/juju/juju/state ModelOperation
 
 func TestPackage(t *testing.T) {
 	if !runStateTests {
 		t.Skip("skipping state tests since the skip_state_tests build tag was set")
 	}
 	coretesting.MgoTestPackage(t)
+}
+
+func SetModelTypeToCAAS(c *gc.C, st *State, m *Model) {
+	ops := []txn.Op{{
+		C:      modelsC,
+		Id:     m.UUID(),
+		Update: bson.D{{"$set", bson.D{{"type", ModelTypeCAAS}}}},
+	}}
+
+	c.Assert(st.db().RunTransaction(ops), jc.ErrorIsNil)
+	c.Assert(m.refresh(m.UUID()), jc.ErrorIsNil)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -321,9 +321,10 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 			}
 		}
 	}
+
 	// Logs and presence are in separate databases so don't get caught by that
 	// loop.
-	removeModelLogs(st.MongoSession(), modelUUID)
+	_ = removeModelLogs(st.MongoSession(), modelUUID)
 	err := presence.RemovePresenceForModel(st.getPresenceCollection(), st.modelTag)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -13,7 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
-	retry "gopkg.in/retry.v1"
+	"gopkg.in/retry.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs/config"
@@ -98,7 +98,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 		Clock:                     s.Clock,
 	})
 	s.AddCleanup(func(*gc.C) {
-		s.Controller.Close()
+		_ = s.Controller.Close()
 		close(s.txnSyncNotify)
 	})
 	s.StatePool = s.Controller.StatePool()
@@ -120,7 +120,7 @@ func (s *StateSuite) txnNotifyFunc() {
 	case s.txnSyncNotify <- struct{}{}:
 		// Try to send something down the channel.
 	default:
-		// However don't get stressed if noone is listening.
+		// However don't get stressed if no one is listening.
 	}
 }
 


### PR DESCRIPTION
## Description of change

Packport of commits from the following patches:
- #11398 
- #11402 

These ensure that for CAAS controllers:
- All public addresses (or fall-backs) are returned as API addresses for clients.
- Any public addresses are returned after local-cloud addresses as API addresses for agents.

## QA steps

See #11398 

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1869883
