### PR TITLE
Feature/ci bootstrap2 aks

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/__init__.py
+++ b/acceptancetests/jujupy/k8s_provider/__init__.py
@@ -19,8 +19,7 @@
 
 from .base import K8sProviderType  # noqa
 from .factory import providers  # noqa
-# below imports are for model load to trigger provider registering,
-# it's not for outside to use, so alias them to _.
-from .kubernetes_core import KubernetesCore as _  # noqa
+# load supported providers.
 from .microk8s import MicroK8s as _  # noqa
 from .gke import GKE as _  # noqa
+from .aks import AKS as _  # noqa

--- a/acceptancetests/jujupy/k8s_provider/aks.py
+++ b/acceptancetests/jujupy/k8s_provider/aks.py
@@ -1,0 +1,352 @@
+# This file is part of JujuPy, a library for driving the Juju CLI.
+# Copyright 2013-2020 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the Lesser GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the Lesser
+# GNU General Public License for more details.
+#
+# You should have received a copy of the Lesser GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Functionality for handling installed or other juju binaries
+# (including paths etc.)
+
+
+from __future__ import print_function
+
+import logging
+import yaml
+import json
+from time import sleep
+import shutil
+import tempfile
+import os
+
+from azure.common.client_factory import get_client_from_json_dict
+from azure.mgmt import containerservice
+from msrestazure import azure_exceptions
+from jujupy.utility import until_timeout
+
+from .base import (
+    Base,
+    K8sProviderType,
+)
+from .factory import register_provider
+
+
+logger = logging.getLogger(__name__)
+# CLUSTER_STATUS = container_v1.enums.Cluster.Status
+
+
+def is_not_found(e):
+    # e: azure_exceptions.CloudError
+    # TODO!!!!
+    return True
+
+
+@register_provider
+class AKS(Base):
+
+    name = K8sProviderType.AKS
+
+    driver = None
+    ake_cluster_name = None
+
+    default_params = None
+    resource_group = None
+
+    def __init__(self, bs_manager, timeout=1800):
+        super().__init__(bs_manager, timeout)
+
+        self.ake_cluster_name = self.client.env.controller.name  # use controller name for cluster name
+        self.default_storage_class_name = ''
+        self.__init_driver(bs_manager.client.env)
+
+    def __init_driver(self, env):
+        # zone = env.get_host_cloud_region()[2] + '-b'
+        cfg = env._config
+        self.resource_group = cfg['resource-group']
+
+        cred = {
+            'clientId': cfg['application-id'],
+            'clientSecret': cfg['application-password'],
+            'subscriptionId': cfg['subscription-id'],
+            'tenantId': cfg['tenant-id'],
+            'activeDirectoryEndpointUrl': 'https://login.microsoftonline.com',
+            'resourceManagerEndpointUrl': 'https://management.azure.com/',
+            'activeDirectoryGraphResourceId': 'https://graph.windows.net/',
+            'sqlManagementEndpointUrl': 'https://management.core.windows.net:8443/',
+            'galleryEndpointUrl': 'https://gallery.azure.com/',
+            'managementEndpointUrl': 'https://management.core.windows.net/',
+        }
+
+        self.driver = get_client_from_json_dict(containerservice.ContainerServiceClient, cred)
+
+        # list all running clusters
+        running_clusters = self.driver.list_clusters()
+        logger.info('running aks clusters: %s', running_clusters)
+
+    def _ensure_cluster_stack(self):
+        self.provision_aks()
+
+    def _tear_down_substrate(self):
+        try:
+            '''
+  Deletes the specified managed container service (AKS) in the specified subscription and resource group.
+
+  :return: True
+  '''
+        print("Deleting the AKS instance {0}".format(self.ake_cluster_name))
+        try:
+            poller = self.driver.managed_clusters.delete(self.resource_group, self.ake_cluster_name)
+            self.get_poller_result(poller)
+            return True
+        # except exceptions.NotFound:
+        except Exception as e:
+            print(e)
+            raise
+
+    def get_parameters(self):
+        return self.driver.managed_clusters.models.ManagedCluster(
+            location=self.location,
+            dns_prefix=self.dns_prefix,
+            kubernetes_version=self.kubernetes_version,
+            tags=self.tags,
+            service_principal_profile=service_principal_profile,
+            agent_pool_profiles=agentpools,
+            linux_profile=self.create_linux_profile_instance(self.linux_profile),
+            enable_rbac=self.enable_rbac,
+            network_profile=self.create_network_profile_instance(self.network_profile),
+            aad_profile=self.create_aad_profile_instance(self.aad_profile),
+            addon_profiles=self.create_addon_profile_instance(self.addon)
+        )
+
+    def list_clusters(self):
+        return list(self.driver.managed_clusters.list())
+
+    def _ensure_kube_dir(self):
+        ...
+
+    def _ensure_cluster_config(self):
+        access_profile = self.driver.managed_clusters.get_access_profile(
+            resource_group_name=self.resource_group,
+            resource_name=self.ake_cluster_name,
+            role_name="clusterUser",
+        )
+        kubeconfig_content = access_profile.kube_config.decode('utf-8')
+
+        with open(self.kube_config_path, 'w') as f:
+            logger.debug('writing kubeconfig to %s\n%s', self.kube_config_path, kubeconfig_content)
+            f.write(kubeconfig_content)
+
+    def _node_address_getter(self, node):
+        return [addr['address'] for addr in node['status']['addresses'] if addr['type'] == 'ExternalIP'][0]
+
+    def _get_cluster(self, name):
+        return self.driver.managed_clusters.get(self.resource_group, name)
+
+    def provision_aks(self):
+        def log_remaining(remaining, msg=''):
+            sleep(3)
+            if remaining % 30 == 0:
+                msg += ' timeout in %ss...' % remaining
+                logger.info(msg)
+
+        # do pre cleanup;
+        self._tear_down_substrate()
+        for remaining in until_timeout(600):
+            # wait for the old cluster to be deleted.
+            try:
+                self._get_cluster(self.ake_cluster_name)
+            except exceptions.NotFound:
+                break
+            finally:
+                log_remaining(remaining)
+
+        # provision cluster.
+        logger.info('creating cluster -> %s', self.ake_cluster_name)
+        params = {'location': 'westus2',
+                  'orchestrator_profile': {'orchestrator_type': 'Kubernetes'},
+                  'agent_pool_profiles': [{'name': 'default',
+                                           'count': 2,
+                                           'vm_size': 'Standard_D2_v2',
+                                           'dns_prefix': 'acs1-rg1-e240e5master'}],
+                  'master_profile': {'count': 1,
+                                     'vm_size': 'Standard_D2_v2',
+                                     'dns_prefix': 'acs1-rg1-e240e5agent'},
+                  'linux_profile': {'ssh': {'public_keys': [{'key_data': ''}]},
+                                    'adminUsername': 'azureuser'}}
+        # params = self.get_parameters()
+        r = self.driver.managed_clusters.create_or_update(self.resource_group, self.ake_cluster_name, params)
+
+        try:
+            poller = self.driver.managed_clusters.create_or_update(
+                self.resource_group, self.name, params)
+            response = self.get_poller_result(poller)
+            response.kube_config = self.get_aks_kubeconfig()
+            return create_aks_dict(response)
+        except azure_exceptions.CloudError as e:
+            print('Error attempting to create the AKS instance.', e.message)
+            raise e
+
+        logger.info('created cluster -> %s', r)
+        # wait until cluster fully provisioned.
+        logger.info('waiting for cluster fully provisioned.')
+        for remaining in until_timeout(600):
+            try:
+                cluster = self._get_cluster(self.ake_cluster_name)
+                if cluster.status == CLUSTER_STATUS.RUNNING:
+                    return
+            except Exception as e:  # noqa
+                logger.info(e)
+            finally:
+                log_remaining(remaining)
+
+    def get_poller_result(self, poller, wait=5):
+        try:
+            delay = wait
+            while not poller.done():
+                print("Waiting for {0} sec".format(delay))
+                poller.wait(timeout=delay)
+            return poller.result()
+        except Exception as e:
+            print(str(e))
+            raise e
+
+    def create_linux_profile_instance(self, linuxprofile):
+        m = self.driver.managed_clusters.models
+        return m.ContainerServiceLinuxProfile(
+            admin_username=linuxprofile['admin_username'],
+            ssh=m.ContainerServiceSshConfiguration(public_keys=[
+                m.ContainerServiceSshPublicKey(key_data=str(linuxprofile['ssh_key']))])
+        )
+
+
+def create_agent_pool_profiles_dict(agentpoolprofiles):
+    return [dict(
+        count=profile.count,
+        vm_size=profile.vm_size,
+        name=profile.name,
+        os_disk_size_gb=profile.os_disk_size_gb,
+        storage_profile=profile.storage_profile,
+        vnet_subnet_id=profile.vnet_subnet_id,
+        os_type=profile.os_type
+    ) for profile in agentpoolprofiles] if agentpoolprofiles else None
+
+
+def create_linux_profile_dict(linuxprofile):
+    return dict(
+        ssh_key=linuxprofile.ssh.public_keys[0].key_data,
+        admin_username=linuxprofile.admin_username
+    )
+
+
+def create_aks_dict(aks):
+    return dict(
+        id=aks.id,
+        name=aks.name,
+        location=aks.location,
+        dns_prefix=aks.dns_prefix,
+        kubernetes_version=aks.kubernetes_version,
+        tags=aks.tags,
+        linux_profile=create_linux_profile_dict(aks.linux_profile),
+        service_principal_profile=create_service_principal_profile_dict(
+            aks.service_principal_profile),
+        provisioning_state=aks.provisioning_state,
+        agent_pool_profiles=create_agent_pool_profiles_dict(
+            aks.agent_pool_profiles),
+        type=aks.type,
+        kube_config=aks.kube_config,
+        enable_rbac=aks.enable_rbac,
+        network_profile=create_network_profiles_dict(aks.network_profile),
+        aad_profile=create_aad_profiles_dict(aks.aad_profile),
+        addon=create_addon_dict(aks.addon_profiles),
+        fqdn=aks.fqdn,
+        node_resource_group=aks.node_resource_group
+    )
+
+
+# class ClusterConfig(object):
+
+#     def __init__(self, project_id, cluster):
+#         self.cluster_name = cluster.name
+#         self.zone_id = cluster.zone
+#         self.project_id = project_id
+#         self.server = 'https://' + cluster.endpoint
+#         self.ca_data = cluster.master_auth.cluster_ca_certificate
+#         self.client_key_data = cluster.master_auth.client_key
+#         self.client_cert_data = cluster.master_auth.client_certificate
+#         self.context_name = 'gke_{project_id}_{zone_id}_{cluster_name}'.format(
+#             project_id=self.project_id,
+#             zone_id=self.zone_id,
+#             cluster_name=self.cluster_name,
+#         )
+
+#     def user(self, auth_provider='gcp'):
+#         if auth_provider is None:
+#             return {
+#                 'name': self.context_name,
+#                 'user': {
+#                     'client-certificate-data': self.client_cert_data,
+#                     'client-key-data': self.client_key_data
+#                 },
+#             }
+#         # TODO(ycliuhw): remove gcloud dependency once 'google-cloud-container' supports defining master-auth type.
+#         gcloud_bin_path = shutil.which('gcloud')
+#         if gcloud_bin_path is None:
+#             raise AssertionError("gcloud bin is required!")
+#         return {
+#             'name': self.context_name,
+#             'user': {
+#                 'auth-provider': {
+#                     'name': auth_provider,
+#                     'config': {
+#                         # Command for gcloud credential helper
+#                         'cmd-path': gcloud_bin_path,
+#                         # Args for gcloud credential helper
+#                         'cmd-args': 'config config-helper --format=json',
+#                         # JSONpath to the field that is the raw access token
+#                         'token-key': '{.credential.access_token}',
+#                         # JSONpath to the field that is the expiration timestamp
+#                         'expiry-key': '{.credential.token_expiry}',
+#                     }
+#                 },
+#             },
+#         }
+
+#     @property
+#     def cluster(self):
+#         return {
+#             'name': self.context_name,
+#             'cluster': {
+#                 'server': self.server,
+#                 'certificate-authority-data': self.ca_data,
+#             },
+#         }
+
+#     @property
+#     def context(self):
+#         return {
+#             'name': self.context_name,
+#             'context': {
+#                 'cluster': self.context_name,
+#                 'user': self.context_name,
+#             },
+#         }
+
+#     def dump(self):
+#         d = {
+#             'apiVersion': 'v1',
+#             'kind': 'Config',
+#             'contexts': [self.context],
+#             'clusters': [self.cluster],
+#             'current-context': self.context_name,
+#             'preferences': {},
+#             'users': [self.user()],
+#         }
+#         return yaml.dump(d)

--- a/acceptancetests/jujupy/k8s_provider/aks.py
+++ b/acceptancetests/jujupy/k8s_provider/aks.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import logging
 import os
+import shutil
 import yaml
 from pprint import pformat
 
@@ -151,6 +152,17 @@ class AKS(Base):
         with open(self.kube_config_path, 'w') as f:
             logger.debug('writing kubeconfig to %s\n%s', self.kube_config_path, kubeconfig_content)
             f.write(kubeconfig_content)
+
+        # ensure kubectl
+        kubectl_bin_path = shutil.which('kubectl')
+        if kubectl_bin_path is not None:
+            self.kubectl_path = kubectl_bin_path
+        else:
+            self.sh(
+                'curl', 'https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl',
+                '-o', self.kubectl_path
+            )
+            os.chmod(self.kubectl_path, 0o774)
 
     def _ensure_cluster_config(self):
         ...

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -57,6 +57,7 @@ class K8sProviderType(Enum):
     MICROK8S = 1
     K8S_CORE = 2
     GKE = 3
+    AKS = 4
 
     @classmethod
     def keys(cls):
@@ -124,7 +125,7 @@ class Base(object):
 
         self.timeout = timeout
         old_environment = bs_manager.client.env.environment
-    
+
         bs_manager.client.env.environment = bs_manager.temp_env_name
         with temp_bootstrap_env(bs_manager.client.env.juju_home, bs_manager.client) as tm_h:
             self.client.env.juju_home = tm_h

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -32,10 +32,7 @@ from jujupy.utility import (
     ensure_dir,
     until_timeout,
 )
-from jujupy.client import (
-    temp_bootstrap_env,
-    JujuData,
-)
+from jujupy.client import temp_bootstrap_env
 
 
 logger = logging.getLogger(__name__)
@@ -177,6 +174,7 @@ class Base(object):
             args += (
                 '--controller', self.client.env.controller.name,
             )
+        logger.info("running add-k8s %s", args)
         self.client._backend.juju(
             'add-k8s', args,
             used_feature_flags=self.client.used_feature_flags, juju_home=juju_home,

--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -47,17 +47,15 @@ CLUSTER_STATUS = container_v1.enums.Cluster.Status
 class GKE(Base):
 
     name = K8sProviderType.GKE
+    cluster_name = None
 
     driver = None
-    gke_cluster_name = None
-    gke_cluster = None
-
     default_params = None
 
     def __init__(self, bs_manager, timeout=1800):
         super().__init__(bs_manager, timeout)
 
-        self.gke_cluster_name = self.client.env.controller.name  # use controller name for cluster name
+        self.cluster_name = self.client.env.controller.name  # use controller name for cluster name
         self.default_storage_class_name = ''
         self.__init_driver(bs_manager.client.env)
 
@@ -72,7 +70,7 @@ class GKE(Base):
         self.driver = container_v1.ClusterManagerClient(
             credentials=service_account.Credentials.from_service_account_info(cfg)
         )
-        
+
         self.__ensure_gcloud(cfg)
 
         # list all running clusters
@@ -81,7 +79,7 @@ class GKE(Base):
 
     def _ensure_cluster_stack(self):
         self.provision_gke()
-        
+
     def __ensure_gcloud(self, cfg):
         gcloud_bin = shutil.which('gcloud')
         if gcloud_bin is None:
@@ -89,17 +87,17 @@ class GKE(Base):
             self.sh('sudo', 'snap', 'install', 'google-cloud-sdk', '--classic')
             logger.debug("gcloud installed successfully")
             gcloud_bin = shutil.which('gcloud')
-        
+
         cred = {
             k: cfg[k] for k in (
-                'project_id', 
-                'private_key_id', 
-                'private_key', 
-                'client_email', 
-                'client_id', 
-                'auth_uri', 
-                'token_uri', 
-                'auth_provider_x509_cert_url', 
+                'project_id',
+                'private_key_id',
+                'private_key',
+                'client_email',
+                'client_id',
+                'auth_uri',
+                'token_uri',
+                'auth_provider_x509_cert_url',
                 'client_x509_cert_url',
             )
         }
@@ -108,7 +106,7 @@ class GKE(Base):
         try:
             with open(cred_file.name, 'w') as f:
                 json.dump(cred, f)
-                
+
             # set credential;
             o = self.sh(gcloud_bin, 'auth', 'activate-service-account', '--key-file', cred_file.name)
             logger.debug(o)
@@ -121,13 +119,13 @@ class GKE(Base):
     def _tear_down_substrate(self):
         try:
             self.driver.delete_cluster(
-                cluster_id=self.gke_cluster_name, **self.default_params,
+                cluster_id=self.cluster_name, **self.default_params,
             )
         except exceptions.NotFound:
             pass
 
     def _ensure_kube_dir(self):
-        cluster = self._get_cluster(self.gke_cluster_name)
+        cluster = self._get_cluster(self.cluster_name)
         cluster_config = ClusterConfig(
             project_id=self.default_params['project_id'],
             cluster=cluster,
@@ -157,7 +155,7 @@ class GKE(Base):
 
     def _get_cluster(self, name):
         return self.driver.get_cluster(
-            cluster_id=self.gke_cluster_name, **self.default_params,
+            cluster_id=self.cluster_name, **self.default_params,
         )
 
     def provision_gke(self):
@@ -172,7 +170,7 @@ class GKE(Base):
         for remaining in until_timeout(600):
             # wait for the old cluster to be deleted.
             try:
-                self._get_cluster(self.gke_cluster_name)
+                self._get_cluster(self.cluster_name)
             except exceptions.NotFound:
                 break
             finally:
@@ -180,7 +178,7 @@ class GKE(Base):
 
         # provision cluster.
         cluster = dict(
-            name=self.gke_cluster_name,
+            name=self.cluster_name,
             node_pools=[dict(
                 name='default-pool',
                 initial_node_count=1,
@@ -204,10 +202,10 @@ class GKE(Base):
         logger.info('waiting for cluster fully provisioned.')
         for remaining in until_timeout(600):
             try:
-                cluster = self._get_cluster(self.gke_cluster_name)
+                cluster = self._get_cluster(self.cluster_name)
                 if cluster.status == CLUSTER_STATUS.RUNNING:
                     return
-            except Exception as e: # noqa
+            except Exception as e:  # noqa
                 logger.info(e)
             finally:
                 log_remaining(remaining)


### PR DESCRIPTION

## Description of change

Setup aks provider for CI test - bootstrapping to `AKS`;

## QA steps

```console
$ ./assess_caas_deploy_charms.py aks $GOPATH/bin/juju /tmp/artifacts nw-deploy-bionic-aks --caas-image-repo=jujuqabot --caas-provider=AKS --k8s-controller
2020-04-06 02:30:25 INFO creating cluster -> aks
2020-04-06 02:30:40 INFO current status: InProgress, waiting for 15 sec
2020-04-06 02:30:55 INFO current status: InProgress, waiting for 15 sec
...
2020-04-06 02:35:54 INFO cluster aks has been successfully provisioned ->
{'agent_pool_profiles': [{'count': 2,
                          'max_pods': 110,
                          'name': 'default',
                          'os_disk_size_gb': 100,
                          'os_type': 'Linux',
                          'storage_profile': 'ManagedDisks',
                          'vm_size': 'Standard_D2_v2'}],
...
2020-04-06 02:35:55 INFO running add-k8s ('k8cloud', '--local', '--cluster-name', 'aks')
2020-04-06 02:36:01 INFO juju --show-log bootstrap k8cloud/westus2 nw-deploy-bionic-aks --config /tmp/tmphwo9ni98.yaml
...

```

