### PR TITLE
[dev] enforce correct naming convention for charm state

### DIFF
--- a/api/common/unitstate_test.go
+++ b/api/common/unitstate_test.go
@@ -33,7 +33,7 @@ func (s *unitStateSuite) TestSetStateSingleResult(c *gc.C) {
 		c.Assert(name, gc.Equals, "SetState")
 		c.Assert(args.(params.SetUnitStateArgs).Args, gc.HasLen, 1)
 		c.Assert(args.(params.SetUnitStateArgs).Args[0].Tag, gc.Equals, s.tag.String())
-		c.Assert(*args.(params.SetUnitStateArgs).Args[0].State, jc.DeepEquals, map[string]string{"one": "two"})
+		c.Assert(*args.(params.SetUnitStateArgs).Args[0].CharmState, jc.DeepEquals, map[string]string{"one": "two"})
 		*(response.(*params.ErrorResults)) = params.ErrorResults{
 			Results: []params.ErrorResult{{
 				Error: nil,
@@ -43,7 +43,7 @@ func (s *unitStateSuite) TestSetStateSingleResult(c *gc.C) {
 	}
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
 	err := api.SetState(params.SetUnitStateArg{
-		State: &map[string]string{"one": "two"},
+		CharmState: &map[string]string{"one": "two"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -61,7 +61,7 @@ func (s *unitStateSuite) TestSetStateReturnsQuotaExceededError(c *gc.C) {
 	// The client should reconstruct the quota error from the server response
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
 	err := api.SetState(params.SetUnitStateArg{
-		State: &map[string]string{"one": "two"},
+		CharmState: &map[string]string{"one": "two"},
 	})
 	c.Assert(err, jc.Satisfies, errors.IsQuotaLimitExceeded, gc.Commentf("expected the client to reconstruct QuotaLimitExceeded error from server response"))
 }
@@ -72,7 +72,7 @@ func (s *unitStateSuite) TestSetStateMultipleReturnsError(c *gc.C) {
 		c.Assert(name, gc.Equals, "SetState")
 		c.Assert(args.(params.SetUnitStateArgs).Args, gc.HasLen, 1)
 		c.Assert(args.(params.SetUnitStateArgs).Args[0].Tag, gc.Equals, s.tag.String())
-		c.Assert(*args.(params.SetUnitStateArgs).Args[0].State, jc.DeepEquals, map[string]string{"one": "two"})
+		c.Assert(*args.(params.SetUnitStateArgs).Args[0].CharmState, jc.DeepEquals, map[string]string{"one": "two"})
 		*(response.(*params.ErrorResults)) = params.ErrorResults{
 			Results: []params.ErrorResult{
 				{Error: nil},
@@ -84,13 +84,13 @@ func (s *unitStateSuite) TestSetStateMultipleReturnsError(c *gc.C) {
 
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
 	err := api.SetState(params.SetUnitStateArg{
-		State: &map[string]string{"one": "two"},
+		CharmState: &map[string]string{"one": "two"},
 	})
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
 func (s *unitStateSuite) TestStateSingleResult(c *gc.C) {
-	expectedUnitState := map[string]string{
+	expectedCharmState := map[string]string{
 		"one":   "two",
 		"three": "four",
 	}
@@ -102,7 +102,7 @@ func (s *unitStateSuite) TestStateSingleResult(c *gc.C) {
 		*(response.(*params.UnitStateResults)) = params.UnitStateResults{
 			Results: []params.UnitStateResult{{
 				UniterState: expectedUniterState,
-				State:       expectedUnitState,
+				CharmState:  expectedCharmState,
 			}}}
 		return nil
 	}
@@ -110,7 +110,7 @@ func (s *unitStateSuite) TestStateSingleResult(c *gc.C) {
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
 	obtainedUnitState, err := api.State()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(expectedUnitState, gc.DeepEquals, obtainedUnitState.State)
+	c.Assert(expectedCharmState, gc.DeepEquals, obtainedUnitState.CharmState)
 	c.Assert(expectedUniterState, gc.DeepEquals, obtainedUnitState.UniterState)
 }
 

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -926,13 +926,13 @@ func (b *CommitHookParamsBuilder) UpdateNetworkInfo() {
 	b.arg.UpdateNetworkInfo = true
 }
 
-// UpdateUnitState records a request to update the server-persisted charm state.
-func (b *CommitHookParamsBuilder) UpdateUnitState(state map[string]string) {
+// UpdateCharmState records a request to update the server-persisted charm state.
+func (b *CommitHookParamsBuilder) UpdateCharmState(state map[string]string) {
 	b.arg.SetUnitState = &params.SetUnitStateArg{
 		// The Tag is optional as the call uses the Tag from the
 		// CommitHookChangesArg; it is included here for consistency.
-		Tag:   b.arg.Tag,
-		State: &state,
+		Tag:        b.arg.Tag,
+		CharmState: &state,
 	}
 }
 

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -1018,14 +1018,14 @@ func (s *unitSuite) TestUpgradeSeriesStatusSingleResult(c *gc.C) {
 
 func (s *unitSuite) TestUnitState(c *gc.C) {
 	err := s.apiUnit.SetState(params.SetUnitStateArg{
-		State: &map[string]string{"one": "two"},
+		CharmState: &map[string]string{"one": "two"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedUnitState, err := s.apiUnit.State()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedUnitState.State, gc.HasLen, 1)
-	c.Assert(obtainedUnitState.State, jc.DeepEquals, map[string]string{"one": "two"})
+	c.Assert(obtainedUnitState.CharmState, gc.HasLen, 1)
+	c.Assert(obtainedUnitState.CharmState, jc.DeepEquals, map[string]string{"one": "two"})
 	c.Assert(obtainedUnitState.UniterState, gc.Equals, "")
 }
 

--- a/apiserver/common/unitstate.go
+++ b/apiserver/common/unitstate.go
@@ -119,7 +119,8 @@ func (u *UnitStateAPI) State(args params.Entities) (params.UnitStateResults, err
 			res[i].Error = ServerError(err)
 			continue
 		}
-		res[i].State, _ = unitState.CharmState()
+
+		res[i].CharmState, _ = unitState.CharmState()
 		res[i].UniterState, _ = unitState.UniterState()
 		res[i].RelationState, _ = unitState.RelationState()
 		res[i].StorageState, _ = unitState.StorageState()
@@ -162,8 +163,8 @@ func (u *UnitStateAPI) SetState(args params.SetUnitStateArgs) (params.ErrorResul
 		}
 
 		unitState := state.NewUnitState()
-		if arg.State != nil {
-			unitState.SetCharmState(*arg.State)
+		if arg.CharmState != nil {
+			unitState.SetCharmState(*arg.CharmState)
 		}
 		if arg.UniterState != nil {
 			unitState.SetUniterState(*arg.UniterState)

--- a/apiserver/common/unitstate.go
+++ b/apiserver/common/unitstate.go
@@ -119,7 +119,7 @@ func (u *UnitStateAPI) State(args params.Entities) (params.UnitStateResults, err
 			res[i].Error = ServerError(err)
 			continue
 		}
-		res[i].State, _ = unitState.State()
+		res[i].State, _ = unitState.CharmState()
 		res[i].UniterState, _ = unitState.UniterState()
 		res[i].RelationState, _ = unitState.RelationState()
 		res[i].StorageState, _ = unitState.StorageState()
@@ -163,7 +163,7 @@ func (u *UnitStateAPI) SetState(args params.SetUnitStateArgs) (params.ErrorResul
 
 		unitState := state.NewUnitState()
 		if arg.State != nil {
-			unitState.SetState(*arg.State)
+			unitState.SetCharmState(*arg.State)
 		}
 		if arg.UniterState != nil {
 			unitState.SetUniterState(*arg.UniterState)

--- a/apiserver/common/unitstate_test.go
+++ b/apiserver/common/unitstate_test.go
@@ -121,7 +121,7 @@ func (s *unitStateSuite) expectApplyOperation() {
 func (s *unitStateSuite) TestState(c *gc.C) {
 	defer s.assertBackendApi(c).Finish()
 	s.expectUnit()
-	expState, expUniterState, expRelationState, expStorageState := s.expectState()
+	expCharmState, expUniterState, expRelationState, expStorageState := s.expectState()
 
 	args := params.Entities{
 		Entities: []params.Entity{
@@ -138,7 +138,7 @@ func (s *unitStateSuite) TestState(c *gc.C) {
 			{Error: &params.Error{Message: `"not-a-unit-tag" is not a valid tag`}},
 			{
 				Error:         nil,
-				State:         expState,
+				CharmState:    expCharmState,
 				UniterState:   expUniterState,
 				RelationState: expRelationState,
 				StorageState:  expStorageState,

--- a/apiserver/common/unitstate_test.go
+++ b/apiserver/common/unitstate_test.go
@@ -62,7 +62,7 @@ func (s *unitStateSuite) assertBackendApi(c *gc.C) *gomock.Controller {
 }
 
 func (s *unitStateSuite) expectState() (map[string]string, string, map[int]string, string) {
-	expState := map[string]string{
+	expCharmState := map[string]string{
 		"foo.bar":  "baz",
 		"payload$": "enc0d3d",
 	}
@@ -74,7 +74,7 @@ func (s *unitStateSuite) expectState() (map[string]string, string, map[int]strin
 	expStorageState := "storage testing"
 
 	unitState := state.NewUnitState()
-	unitState.SetState(expState)
+	unitState.SetCharmState(expCharmState)
 	unitState.SetUniterState(expUniterState)
 	unitState.SetRelationState(expRelationState)
 	unitState.SetStorageState(expStorageState)
@@ -82,7 +82,7 @@ func (s *unitStateSuite) expectState() (map[string]string, string, map[int]strin
 	exp := s.mockUnit.EXPECT()
 	exp.State().Return(unitState, nil)
 
-	return expState, expUniterState, expRelationState, expStorageState
+	return expCharmState, expUniterState, expRelationState, expStorageState
 }
 
 func (s *unitStateSuite) expectUnit() {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -3423,7 +3423,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 
 		newUS := state.NewUnitState()
 		if changes.SetUnitState.State != nil {
-			newUS.SetState(*changes.SetUnitState.State)
+			newUS.SetCharmState(*changes.SetUnitState.State)
 		}
 
 		// NOTE(achilleasa): The following state fields are not

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -3422,8 +3422,8 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 		}
 
 		newUS := state.NewUnitState()
-		if changes.SetUnitState.State != nil {
-			newUS.SetCharmState(*changes.SetUnitState.State)
+		if changes.SetUnitState.CharmState != nil {
+			newUS.SetCharmState(*changes.SetUnitState.CharmState)
 		}
 
 		// NOTE(achilleasa): The following state fields are not

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4753,8 +4753,8 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChanges(c *gc.C) {
 
 	unitState, err := s.wordpressUnit.State()
 	c.Assert(err, jc.ErrorIsNil)
-	uState, _ := unitState.State()
-	c.Assert(uState, jc.DeepEquals, map[string]string{"charm-key": "charm-value"}, gc.Commentf("state doc not updated"))
+	charmState, _ := unitState.CharmState()
+	c.Assert(charmState, jc.DeepEquals, map[string]string{"charm-key": "charm-value"}, gc.Commentf("state doc not updated"))
 
 	appCfg, err := relList[0].ApplicationSettings(s.wordpress.Name())
 	c.Assert(err, jc.ErrorIsNil)
@@ -4839,8 +4839,8 @@ func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 
 	unitState, err := unit.State()
 	c.Assert(err, jc.ErrorIsNil)
-	uState, _ := unitState.State()
-	c.Assert(uState, jc.DeepEquals, map[string]string{"charm-key": "charm-value"}, gc.Commentf("state doc not updated"))
+	charmState, _ := unitState.CharmState()
+	c.Assert(charmState, jc.DeepEquals, map[string]string{"charm-key": "charm-value"}, gc.Commentf("state doc not updated"))
 
 	newVolumeAttachments, err := machine.VolumeAttachments()
 	c.Assert(err, jc.ErrorIsNil)
@@ -4879,8 +4879,8 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesCAAS(c *gc.C) {
 
 	unitState, err := gitlabUnit.State()
 	c.Assert(err, jc.ErrorIsNil)
-	uState, _ := unitState.State()
-	c.Assert(uState, jc.DeepEquals, map[string]string{"charm-key": "charm-value"}, gc.Commentf("state doc not updated"))
+	charmState, _ := unitState.CharmState()
+	c.Assert(charmState, jc.DeepEquals, map[string]string{"charm-key": "charm-value"}, gc.Commentf("state doc not updated"))
 }
 
 func (s *uniterNetworkInfoSuite) TestCommitHookChangesCAASNotLeader(c *gc.C) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4706,7 +4706,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChanges(c *gc.C) {
 	b.OpenPortRange("tcp", 80, 81)
 	b.OpenPortRange("tcp", 7337, 7337) // same port closed below; this should be a no-op
 	b.ClosePortRange("tcp", 7337, 7337)
-	b.UpdateUnitState(map[string]string{"charm-key": "charm-value"})
+	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
 	req, _ := b.Build()
 
 	// Add some extra args to test error handling
@@ -4810,7 +4810,7 @@ func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	b.OpenPortRange("tcp", 80, 81)
 	b.OpenPortRange("tcp", 7337, 7337) // same port closed below; this should be a no-op
 	b.ClosePortRange("tcp", 7337, 7337)
-	b.UpdateUnitState(map[string]string{"charm-key": "charm-value"})
+	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
 	b.AddStorage(map[string][]params.StorageConstraints{
 		"multi1to10": {{Count: &stCount}},
 	})
@@ -4855,7 +4855,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesCAAS(c *gc.C) {
 
 	b := apiuniter.NewCommitHookParamsBuilder(gitlabUnit.UnitTag())
 	b.UpdateNetworkInfo()
-	b.UpdateUnitState(map[string]string{"charm-key": "charm-value"})
+	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
 	b.SetPodSpec(gitlab.ApplicationTag(), &podSpec)
 	req, _ := b.Build()
 
@@ -4897,7 +4897,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesCAASNotLeader(c *gc.C) {
 
 	b := apiuniter.NewCommitHookParamsBuilder(gitlabUnit.UnitTag())
 	b.UpdateNetworkInfo()
-	b.UpdateUnitState(map[string]string{"charm-key": "charm-value"})
+	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
 	b.SetPodSpec(gitlab.ApplicationTag(), &podSpec)
 	req, _ := b.Build()
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21675,10 +21675,7 @@
                 "SetUnitStateArg": {
                     "type": "object",
                     "properties": {
-                        "meter-status-state": {
-                            "type": "string"
-                        },
-                        "relation-state": {
+                        "charm-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -21686,7 +21683,10 @@
                                 }
                             }
                         },
-                        "state": {
+                        "meter-status-state": {
+                            "type": "string"
+                        },
+                        "relation-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -21727,13 +21727,7 @@
                 "UnitStateResult": {
                     "type": "object",
                     "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "meter-status-state": {
-                            "type": "string"
-                        },
-                        "relation-state": {
+                        "charm-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -21741,7 +21735,13 @@
                                 }
                             }
                         },
-                        "state": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "meter-status-state": {
+                            "type": "string"
+                        },
+                        "relation-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -38153,10 +38153,7 @@
                 "SetUnitStateArg": {
                     "type": "object",
                     "properties": {
-                        "meter-status-state": {
-                            "type": "string"
-                        },
-                        "relation-state": {
+                        "charm-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -38164,7 +38161,10 @@
                                 }
                             }
                         },
-                        "state": {
+                        "meter-status-state": {
+                            "type": "string"
+                        },
+                        "relation-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -38629,13 +38629,7 @@
                 "UnitStateResult": {
                     "type": "object",
                     "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "meter-status-state": {
-                            "type": "string"
-                        },
-                        "relation-state": {
+                        "charm-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -38643,7 +38637,13 @@
                                 }
                             }
                         },
-                        "state": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "meter-status-state": {
+                            "type": "string"
+                        },
+                        "relation-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -39305,10 +39305,7 @@
                 "SetUnitStateArg": {
                     "type": "object",
                     "properties": {
-                        "meter-status-state": {
-                            "type": "string"
-                        },
-                        "relation-state": {
+                        "charm-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {
@@ -39316,7 +39313,10 @@
                                 }
                             }
                         },
-                        "state": {
+                        "meter-status-state": {
+                            "type": "string"
+                        },
+                        "relation-state": {
                             "type": "object",
                             "patternProperties": {
                                 ".*": {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -254,8 +254,8 @@ type ConfigSettingsResults struct {
 // UnitStateResult holds a unit's state map or an error.
 type UnitStateResult struct {
 	Error *Error `json:"error,omitempty"`
-	// Specific state set by the unit via hook tool.
-	State map[string]string `json:"state,omitempty"`
+	// Charm state set by the unit via hook tool.
+	CharmState map[string]string `json:"charm-state,omitempty"`
 	// Uniter internal state for this unit.
 	UniterState string `json:"uniter-state,omitempty"`
 	// RelationState is a internal relation state for this unit.
@@ -286,7 +286,7 @@ type SetUnitStateArgs struct {
 // empty data will cause the persisted data to be deleted.
 type SetUnitStateArg struct {
 	Tag              string             `json:"tag"`
-	State            *map[string]string `json:"state,omitempty"`
+	CharmState       *map[string]string `json:"charm-state,omitempty"`
 	UniterState      *string            `json:"uniter-state,omitempty"`
 	RelationState    *map[int]string    `json:"relation-state,omitempty"`
 	StorageState     *string            `json:"storage-state,omitempty"`

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -923,11 +923,13 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		}
 		// TODO: hml 18-mar-2020
 		// add the rest of unit.State() to model migration
+		// TODO(achilleasa): rename args.State to args.CharmState
+		// while resolving previous TODO.
 		unitState, err := unit.State()
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if us, found := unitState.State(); found {
+		if us, found := unitState.CharmState(); found {
 			args.State = us
 		}
 		exUnit := exApplication.AddUnit(args)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -759,7 +759,7 @@ func (s *MigrationExportSuite) assertMigrateUnits(c *gc.C, st *state.State) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	us := state.NewUnitState()
-	us.SetState(map[string]string{"payload": "b4dc0ffee"})
+	us.SetCharmState(map[string]string{"payload": "b4dc0ffee"})
 	err = unit.SetState(us, state.UnitStateSizeLimits{})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1153,9 +1153,11 @@ func (i *importer) unit(s description.Application, u description.Unit, ctrlCfg c
 	if err := i.importStatusHistory(unit.globalWorkloadVersionKey(), u.WorkloadVersionHistory()); err != nil {
 		return errors.Trace(err)
 	}
-	if unitState := u.State(); len(unitState) != 0 {
+	// TODO(achilleasa): rename u.State in juju/description to CharmState
+	// and import the rest of the uniter state bits.
+	if charmState := u.State(); len(charmState) != 0 {
 		us := NewUnitState()
-		us.SetState(unitState)
+		us.SetCharmState(charmState)
 		limits := UnitStateSizeLimits{
 			MaxCharmStateSize: ctrlCfg.MaxCharmStateSize(),
 			MaxAgentStateSize: ctrlCfg.MaxAgentStateSize(),

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1016,7 +1016,7 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, st *state.State, con
 	err = testModel.SetAnnotations(exported, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
 	us := state.NewUnitState()
-	us.SetState(map[string]string{"payload": "0xb4c0ffee"})
+	us.SetCharmState(map[string]string{"payload": "0xb4c0ffee"})
 	err = exported.SetState(us, state.UnitStateSizeLimits{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1093,8 +1093,8 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, st *state.State, con
 
 	unitState, err := imported.State()
 	c.Assert(err, jc.ErrorIsNil)
-	uState, _ := unitState.State()
-	c.Assert(uState, jc.DeepEquals, map[string]string{"payload": "0xb4c0ffee"}, gc.Commentf("persisted charm state not migrated"))
+	charmState, _ := unitState.CharmState()
+	c.Assert(charmState, jc.DeepEquals, map[string]string{"payload": "0xb4c0ffee"}, gc.Commentf("persisted charm state not migrated"))
 
 	newCons, err := imported.Constraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -302,11 +302,11 @@ func (m unitStateMatcher) Matches(x interface{}) bool {
 }
 
 func assertSetUnitStateArg(c *gc.C, expectedArg, obtainedArg params.SetUnitStateArg) {
-	if expectedArg.State != nil {
-		c.Assert(obtainedArg.State, gc.NotNil)
-		c.Assert(*obtainedArg.State, gc.DeepEquals, *expectedArg.State)
+	if expectedArg.CharmState != nil {
+		c.Assert(obtainedArg.CharmState, gc.NotNil)
+		c.Assert(*obtainedArg.CharmState, gc.DeepEquals, *expectedArg.CharmState)
 	} else {
-		c.Assert(obtainedArg.State, gc.IsNil)
+		c.Assert(obtainedArg.CharmState, gc.IsNil)
 	}
 	if expectedArg.UniterState != nil {
 		c.Assert(*obtainedArg.UniterState, gc.Equals, *expectedArg.UniterState)
@@ -316,7 +316,7 @@ func assertSetUnitStateArg(c *gc.C, expectedArg, obtainedArg params.SetUnitState
 	if expectedArg.RelationState != nil {
 		c.Assert(*obtainedArg.RelationState, gc.DeepEquals, *expectedArg.RelationState)
 	} else {
-		c.Assert(obtainedArg.State, gc.IsNil)
+		c.Assert(obtainedArg.RelationState, gc.IsNil)
 	}
 	if expectedArg.StorageState != nil {
 		c.Assert(*obtainedArg.StorageState, gc.Equals, *expectedArg.StorageState)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -389,17 +389,17 @@ func (ctx *HookContext) ensureStateValuesLoaded() error {
 	}
 
 	// Load from controller
-	var state map[string]string
+	var charmState map[string]string
 	unitState, err := ctx.unit.State()
 	if err != nil {
 		return errors.Annotate(err, "loading unit state from database")
 	}
-	if unitState.State == nil {
-		state = make(map[string]string)
+	if unitState.CharmState == nil {
+		charmState = make(map[string]string)
 	} else {
-		state = unitState.State
+		charmState = unitState.CharmState
 	}
-	ctx.cacheValues = state
+	ctx.cacheValues = charmState
 	return nil
 }
 
@@ -1057,7 +1057,7 @@ func (ctx *HookContext) doFlush(process string) error {
 	}
 
 	if ctx.cacheDirty {
-		b.UpdateUnitState(ctx.cacheValues)
+		b.UpdateCharmState(ctx.cacheValues)
 	}
 
 	for _, rctx := range ctx.relations {

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -571,15 +571,15 @@ type mockHookContextSuite struct {
 	mockCache params.UnitStateResult
 }
 
-func (s *mockHookContextSuite) TestDeleteCacheValue(c *gc.C) {
+func (s *mockHookContextSuite) TestDeleteCharmStateValue(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	err := hookContext.DeleteCacheValue("one")
+	err := hookContext.DeleteCharmStateValue("one")
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedCache, err := hookContext.GetCache()
+	obtainedCache, err := hookContext.GetCharmState()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedCache, gc.DeepEquals, s.mockCache.CharmState)
 }
@@ -589,65 +589,65 @@ func (s *mockHookContextSuite) TestDeleteCacheStateErr(c *gc.C) {
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	err := hookContext.DeleteCacheValue("five")
+	err := hookContext.DeleteCharmStateValue("five")
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
 
-func (s *mockHookContextSuite) TestGetCache(c *gc.C) {
+func (s *mockHookContextSuite) TestGetCharmState(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	obtainedCache, err := hookContext.GetCache()
+	obtainedCache, err := hookContext.GetCharmState()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedCache, gc.DeepEquals, s.mockCache.CharmState)
 }
 
-func (s *mockHookContextSuite) TestGetCacheStateErr(c *gc.C) {
+func (s *mockHookContextSuite) TestGetCharmStateStateErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	_, err := hookContext.GetCache()
+	_, err := hookContext.GetCharmState()
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
 
-func (s *mockHookContextSuite) TestGetSingleCacheValue(c *gc.C) {
+func (s *mockHookContextSuite) TestGetCharmStateValue(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	obtainedVale, err := hookContext.GetSingleCacheValue("one")
+	obtainedVale, err := hookContext.GetCharmStateValue("one")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedVale, gc.Equals, "two")
 }
 
-func (s *mockHookContextSuite) TestGetSingleCacheValueEmpty(c *gc.C) {
+func (s *mockHookContextSuite) TestGetCharmStateValueEmpty(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	obtainedVale, err := hookContext.GetSingleCacheValue("seven")
+	obtainedVale, err := hookContext.GetCharmStateValue("seven")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedVale, gc.Equals, "")
 }
 
-func (s *mockHookContextSuite) TestGetSingleCacheValueNotFound(c *gc.C) {
+func (s *mockHookContextSuite) TestGetCharmStateValueNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	obtainedCache, err := hookContext.GetSingleCacheValue("five")
+	obtainedCache, err := hookContext.GetCharmStateValue("five")
 	c.Assert(err, gc.ErrorMatches, "\"five\" not found")
 	c.Assert(obtainedCache, gc.Equals, "")
 }
 
-func (s *mockHookContextSuite) TestGetSingleCacheValueStateErr(c *gc.C) {
+func (s *mockHookContextSuite) TestGetCharmStateValueStateErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	_, err := hookContext.GetSingleCacheValue("key")
+	_, err := hookContext.GetCharmStateValue("key")
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
 
@@ -665,7 +665,7 @@ func (s *mockHookContextSuite) TestSetCache(c *gc.C) {
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
 
 	// Test key len limit
-	err := hookContext.SetCacheValue(
+	err := hookContext.SetCharmStateValue(
 		strings.Repeat("a", quota.MaxCharmStateKeySize+1),
 		"lol",
 	)
@@ -673,7 +673,7 @@ func (s *mockHookContextSuite) TestSetCache(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ".*max allowed key.*")
 
 	// Test value len limit
-	err = hookContext.SetCacheValue(
+	err = hookContext.SetCharmStateValue(
 		"lol",
 		strings.Repeat("a", quota.MaxCharmStateValueSize+1),
 	)
@@ -690,9 +690,9 @@ func (s *mockHookContextSuite) TestSetCacheEmptyStartState(c *gc.C) {
 
 func (s *mockHookContextSuite) testSetCache(c *gc.C) {
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	err := hookContext.SetCacheValue("five", "six")
+	err := hookContext.SetCharmStateValue("five", "six")
 	c.Assert(err, jc.ErrorIsNil)
-	obtainedCache, err := hookContext.GetCache()
+	obtainedCache, err := hookContext.GetCharmState()
 	c.Assert(err, jc.ErrorIsNil)
 	value, ok := obtainedCache["five"]
 	c.Assert(ok, jc.IsTrue)
@@ -704,7 +704,7 @@ func (s *mockHookContextSuite) TestSetCacheStateErr(c *gc.C) {
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
-	err := hookContext.SetCacheValue("five", "six")
+	err := hookContext.SetCharmStateValue("five", "six")
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
 
@@ -715,9 +715,9 @@ func (s *mockHookContextSuite) TestFlushWithNonDirtyCache(c *gc.C) {
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0"))
 
 	// The following commands are no-ops as they don't mutate the cache.
-	err := hookContext.SetCacheValue("one", "two") // no-op: KV already present
+	err := hookContext.SetCharmStateValue("one", "two") // no-op: KV already present
 	c.Assert(err, jc.ErrorIsNil)
-	err = hookContext.DeleteCacheValue("not-there") // no-op: key not present
+	err = hookContext.DeleteCharmStateValue("not-there") // no-op: key not present
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Flush the context with a success. As the cache is not dirty we do
@@ -752,7 +752,7 @@ func (s *mockHookContextSuite) TestSequentialFlushOfCacheValues(c *gc.C) {
 
 	// Mutate cache and flush; this should call out to SetState and reset
 	// the dirty flag
-	err := hookContext.SetCacheValue("lorem", "ipsum")
+	err := hookContext.SetCharmStateValue("lorem", "ipsum")
 	c.Assert(err, jc.ErrorIsNil)
 	err = hookContext.Flush("success", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -581,7 +581,7 @@ func (s *mockHookContextSuite) TestDeleteCacheValue(c *gc.C) {
 
 	obtainedCache, err := hookContext.GetCache()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedCache, gc.DeepEquals, s.mockCache.State)
+	c.Assert(obtainedCache, gc.DeepEquals, s.mockCache.CharmState)
 }
 
 func (s *mockHookContextSuite) TestDeleteCacheStateErr(c *gc.C) {
@@ -600,7 +600,7 @@ func (s *mockHookContextSuite) TestGetCache(c *gc.C) {
 	hookContext := context.NewMockUnitHookContext(s.mockUnit)
 	obtainedCache, err := hookContext.GetCache()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedCache, gc.DeepEquals, s.mockCache.State)
+	c.Assert(obtainedCache, gc.DeepEquals, s.mockCache.CharmState)
 }
 
 func (s *mockHookContextSuite) TestGetCacheStateErr(c *gc.C) {
@@ -739,7 +739,7 @@ func (s *mockHookContextSuite) TestSequentialFlushOfCacheValues(c *gc.C) {
 				Tag: "unit-wordpress-0",
 				SetUnitState: &params.SetUnitStateArg{
 					Tag: "unit-wordpress-0",
-					State: &map[string]string{
+					CharmState: &map[string]string{
 						"one":   "two",
 						"three": "four",
 						"lorem": "ipsum",
@@ -770,7 +770,7 @@ func (s *mockHookContextSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *mockHookContextSuite) expectStateValues() {
 	s.mockCache = params.UnitStateResult{
-		State: map[string]string{
+		CharmState: map[string]string{
 			"one":   "two",
 			"three": "four",
 			"seven": "",

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -27,7 +27,7 @@ type Context interface {
 	HookContext
 	relationHookContext
 	actionHookContext
-	unitCacheContext
+	unitCharmStateContext
 }
 
 // HookContext represents the information and functionality that is
@@ -97,20 +97,20 @@ type actionHookContext interface {
 	LogActionMessage(string) error
 }
 
-// unitCacheContext is cache for charm state to be held in the context.
-type unitCacheContext interface {
-	// GetCache returns a copy of the cache.
-	GetCache() (map[string]string, error)
+// unitCharmStateContext provides helper for interacting with the charm state
+// that is stored within the context.
+type unitCharmStateContext interface {
+	// GetCharmState returns a copy of the charm state.
+	GetCharmState() (map[string]string, error)
 
-	// GetSingleCacheValue returns the value of the given key.
-	GetSingleCacheValue(string) (string, error)
+	// GetCharmStateValue returns the value of the given key.
+	GetCharmStateValue(string) (string, error)
 
-	// DeleteCacheValue deletes the key/value pair for the given key from
-	// the cache.
-	DeleteCacheValue(string) error
+	// DeleteCharmStateValue deletes the key/value pair for the given key.
+	DeleteCharmStateValue(string) error
 
-	// SetCacheValue sets the key/value pair provided in the cache.
-	SetCacheValue(string, string) error
+	// SetCharmStateValue sets the key to the specified value.
+	SetCharmStateValue(string, string) error
 }
 
 // ContextUnit is the part of a hook context related to the unit.

--- a/worker/uniter/runner/jujuc/jujuctesting/context.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/context.go
@@ -12,7 +12,7 @@ import (
 // ContextInfo holds the values for the hook context.
 type ContextInfo struct {
 	Unit
-	UnitCache
+	UnitCharmState
 	Status
 	Instance
 	NetworkInterface
@@ -58,7 +58,7 @@ type contextBase struct {
 // Context is a test double for jujuc.Context.
 type Context struct {
 	ContextUnit
-	ContextUnitCache
+	ContextUnitCharmState
 	ContextStatus
 	ContextInstance
 	ContextNetworking
@@ -99,7 +99,7 @@ func NewContext(stub *testing.Stub, info *ContextInfo) *Context {
 	ctx.ContextActionHook.info = &info.ActionHook
 	ctx.ContextVersion.stub = stub
 	ctx.ContextVersion.info = &info.Version
-	ctx.ContextUnitCache.stub = stub
-	ctx.ContextUnitCache.info = &info.UnitCache
+	ctx.ContextUnitCharmState.stub = stub
+	ctx.ContextUnitCharmState.info = &info.UnitCharmState
 	return &ctx
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/unitcachehook.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/unitcachehook.go
@@ -7,26 +7,26 @@ import (
 	"sync"
 )
 
-type UnitCache struct {
+type UnitCharmState struct {
 	values map[string]string
 	mu     sync.Mutex
 }
 
-// ContextUnitCache is a test double for jujuc.unitCacheContext.
-type ContextUnitCache struct {
+// ContextUnitCharmState is a test double for jujuc.unitCharmStateContext.
+type ContextUnitCharmState struct {
 	contextBase
-	info *UnitCache
+	info *UnitCharmState
 }
 
-func (u *UnitCache) SetCache(newCache map[string]string) {
+func (u *UnitCharmState) SetCharmState(newCharmState map[string]string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	u.values = newCache
+	u.values = newCharmState
 }
 
-// GetCache implements jujuc.unitCacheContext.
-func (c *ContextUnitCache) GetCache() (map[string]string, error) {
-	c.stub.AddCall("GetCache")
+// GetCharmState implements jujuc.unitCharmStateContext.
+func (c *ContextUnitCharmState) GetCharmState() (map[string]string, error) {
+	c.stub.AddCall("GetCharmState")
 	_ = c.stub.NextErr()
 	c.info.mu.Lock()
 	defer c.info.mu.Unlock()
@@ -42,9 +42,9 @@ func (c *ContextUnitCache) GetCache() (map[string]string, error) {
 	return retVal, nil
 }
 
-// Implements jujuc.HookContext.unitCacheContext, part of runner.Context.
-func (c *ContextUnitCache) GetSingleCacheValue(key string) (string, error) {
-	c.stub.AddCall("GetSingleCacheValue")
+// GetCharmStateValue implements jujuc.unitCharmStateContext.
+func (c *ContextUnitCharmState) GetCharmStateValue(key string) (string, error) {
+	c.stub.AddCall("GetSCharmStateValue")
 	c.info.mu.Lock()
 	defer c.info.mu.Unlock()
 
@@ -52,9 +52,9 @@ func (c *ContextUnitCache) GetSingleCacheValue(key string) (string, error) {
 	return c.info.values[key], nil
 }
 
-// GetCache implements jujuc.unitCacheContext.
-func (c *ContextUnitCache) DeleteCacheValue(key string) error {
-	c.stub.AddCall("DeleteCacheValue")
+// DeleteCharmStateValue implements jujuc.unitCharmStateContext.
+func (c *ContextUnitCharmState) DeleteCharmStateValue(key string) error {
+	c.stub.AddCall("DeleteCharmStateValue")
 	_ = c.stub.NextErr()
 	c.info.mu.Lock()
 	defer c.info.mu.Unlock()
@@ -64,9 +64,9 @@ func (c *ContextUnitCache) DeleteCacheValue(key string) error {
 	return nil
 }
 
-// GetCache implements jujuc.unitCacheContext.
-func (c *ContextUnitCache) SetCacheValue(key string, value string) error {
-	c.stub.AddCall("SetCacheValue")
+// SetCharmStateValue implements jujuc.unitCharmStateContext.
+func (c *ContextUnitCharmState) SetCharmStateValue(key string, value string) error {
+	c.stub.AddCall("SetCharmStateValue")
 	_ = c.stub.NextErr()
 	c.info.mu.Lock()
 	defer c.info.mu.Unlock()
@@ -76,7 +76,7 @@ func (c *ContextUnitCache) SetCacheValue(key string, value string) error {
 	return nil
 }
 
-func (c *ContextUnitCache) ensureValues() {
+func (c *ContextUnitCharmState) ensureValues() {
 	if c.info.values == nil {
 		c.info.values = make(map[string]string)
 	}

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -10,8 +10,8 @@ import (
 	application "github.com/juju/juju/core/application"
 	network "github.com/juju/juju/core/network"
 	jujuc "github.com/juju/juju/worker/uniter/runner/jujuc"
-	charm_v6 "gopkg.in/juju/charm.v6"
-	names_v3 "gopkg.in/juju/names.v3"
+	charm "gopkg.in/juju/charm.v6"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 	time "time"
 )
@@ -41,6 +41,7 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 
 // ActionParams mocks base method
 func (m *MockContext) ActionParams() (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActionParams")
 	ret0, _ := ret[0].(map[string]interface{})
 	ret1, _ := ret[1].(error)
@@ -49,11 +50,13 @@ func (m *MockContext) ActionParams() (map[string]interface{}, error) {
 
 // ActionParams indicates an expected call of ActionParams
 func (mr *MockContextMockRecorder) ActionParams() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionParams", reflect.TypeOf((*MockContext)(nil).ActionParams))
 }
 
 // AddMetric mocks base method
 func (m *MockContext) AddMetric(arg0, arg1 string, arg2 time.Time) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddMetric", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -61,11 +64,13 @@ func (m *MockContext) AddMetric(arg0, arg1 string, arg2 time.Time) error {
 
 // AddMetric indicates an expected call of AddMetric
 func (mr *MockContextMockRecorder) AddMetric(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetric", reflect.TypeOf((*MockContext)(nil).AddMetric), arg0, arg1, arg2)
 }
 
 // AddMetricLabels mocks base method
 func (m *MockContext) AddMetricLabels(arg0, arg1 string, arg2 time.Time, arg3 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddMetricLabels", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -73,11 +78,13 @@ func (m *MockContext) AddMetricLabels(arg0, arg1 string, arg2 time.Time, arg3 ma
 
 // AddMetricLabels indicates an expected call of AddMetricLabels
 func (mr *MockContextMockRecorder) AddMetricLabels(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetricLabels", reflect.TypeOf((*MockContext)(nil).AddMetricLabels), arg0, arg1, arg2, arg3)
 }
 
 // AddUnitStorage mocks base method
 func (m *MockContext) AddUnitStorage(arg0 map[string]params.StorageConstraints) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUnitStorage", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -85,11 +92,13 @@ func (m *MockContext) AddUnitStorage(arg0 map[string]params.StorageConstraints) 
 
 // AddUnitStorage indicates an expected call of AddUnitStorage
 func (mr *MockContextMockRecorder) AddUnitStorage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUnitStorage", reflect.TypeOf((*MockContext)(nil).AddUnitStorage), arg0)
 }
 
 // ApplicationStatus mocks base method
 func (m *MockContext) ApplicationStatus() (jujuc.ApplicationStatusInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationStatus")
 	ret0, _ := ret[0].(jujuc.ApplicationStatusInfo)
 	ret1, _ := ret[1].(error)
@@ -98,11 +107,13 @@ func (m *MockContext) ApplicationStatus() (jujuc.ApplicationStatusInfo, error) {
 
 // ApplicationStatus indicates an expected call of ApplicationStatus
 func (mr *MockContextMockRecorder) ApplicationStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationStatus", reflect.TypeOf((*MockContext)(nil).ApplicationStatus))
 }
 
 // AvailabilityZone mocks base method
 func (m *MockContext) AvailabilityZone() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -111,11 +122,13 @@ func (m *MockContext) AvailabilityZone() (string, error) {
 
 // AvailabilityZone indicates an expected call of AvailabilityZone
 func (mr *MockContextMockRecorder) AvailabilityZone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockContext)(nil).AvailabilityZone))
 }
 
 // ClosePorts mocks base method
 func (m *MockContext) ClosePorts(arg0 string, arg1, arg2 int) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClosePorts", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -123,11 +136,13 @@ func (m *MockContext) ClosePorts(arg0 string, arg1, arg2 int) error {
 
 // ClosePorts indicates an expected call of ClosePorts
 func (mr *MockContextMockRecorder) ClosePorts(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePorts", reflect.TypeOf((*MockContext)(nil).ClosePorts), arg0, arg1, arg2)
 }
 
 // CloudSpec mocks base method
 func (m *MockContext) CloudSpec() (*params.CloudSpec, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudSpec")
 	ret0, _ := ret[0].(*params.CloudSpec)
 	ret1, _ := ret[1].(error)
@@ -136,11 +151,13 @@ func (m *MockContext) CloudSpec() (*params.CloudSpec, error) {
 
 // CloudSpec indicates an expected call of CloudSpec
 func (mr *MockContextMockRecorder) CloudSpec() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockContext)(nil).CloudSpec))
 }
 
 // Component mocks base method
 func (m *MockContext) Component(arg0 string) (jujuc.ContextComponent, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Component", arg0)
 	ret0, _ := ret[0].(jujuc.ContextComponent)
 	ret1, _ := ret[1].(error)
@@ -149,49 +166,72 @@ func (m *MockContext) Component(arg0 string) (jujuc.ContextComponent, error) {
 
 // Component indicates an expected call of Component
 func (mr *MockContextMockRecorder) Component(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Component", reflect.TypeOf((*MockContext)(nil).Component), arg0)
 }
 
 // ConfigSettings mocks base method
-func (m *MockContext) ConfigSettings() (charm_v6.Settings, error) {
+func (m *MockContext) ConfigSettings() (charm.Settings, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigSettings")
-	ret0, _ := ret[0].(charm_v6.Settings)
+	ret0, _ := ret[0].(charm.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigSettings indicates an expected call of ConfigSettings
 func (mr *MockContextMockRecorder) ConfigSettings() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockContext)(nil).ConfigSettings))
 }
 
-// DeleteCacheValue mocks base method
-func (m *MockContext) DeleteCacheValue(arg0 string) error {
-	ret := m.ctrl.Call(m, "DeleteCacheValue", arg0)
+// DeleteCharmStateValue mocks base method
+func (m *MockContext) DeleteCharmStateValue(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCharmStateValue", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteCacheValue indicates an expected call of DeleteCacheValue
-func (mr *MockContextMockRecorder) DeleteCacheValue(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCacheValue", reflect.TypeOf((*MockContext)(nil).DeleteCacheValue), arg0)
+// DeleteCharmStateValue indicates an expected call of DeleteCharmStateValue
+func (mr *MockContextMockRecorder) DeleteCharmStateValue(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCharmStateValue", reflect.TypeOf((*MockContext)(nil).DeleteCharmStateValue), arg0)
 }
 
-// GetCache mocks base method
-func (m *MockContext) GetCache() (map[string]string, error) {
-	ret := m.ctrl.Call(m, "GetCache")
+// GetCharmState mocks base method
+func (m *MockContext) GetCharmState() (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCharmState")
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetCache indicates an expected call of GetCache
-func (mr *MockContextMockRecorder) GetCache() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCache", reflect.TypeOf((*MockContext)(nil).GetCache))
+// GetCharmState indicates an expected call of GetCharmState
+func (mr *MockContextMockRecorder) GetCharmState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmState", reflect.TypeOf((*MockContext)(nil).GetCharmState))
+}
+
+// GetCharmStateValue mocks base method
+func (m *MockContext) GetCharmStateValue(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCharmStateValue", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCharmStateValue indicates an expected call of GetCharmStateValue
+func (mr *MockContextMockRecorder) GetCharmStateValue(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStateValue", reflect.TypeOf((*MockContext)(nil).GetCharmStateValue), arg0)
 }
 
 // GetPodSpec mocks base method
 func (m *MockContext) GetPodSpec() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPodSpec")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -200,24 +240,13 @@ func (m *MockContext) GetPodSpec() (string, error) {
 
 // GetPodSpec indicates an expected call of GetPodSpec
 func (mr *MockContextMockRecorder) GetPodSpec() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodSpec", reflect.TypeOf((*MockContext)(nil).GetPodSpec))
-}
-
-// GetSingleCacheValue mocks base method
-func (m *MockContext) GetSingleCacheValue(arg0 string) (string, error) {
-	ret := m.ctrl.Call(m, "GetSingleCacheValue", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSingleCacheValue indicates an expected call of GetSingleCacheValue
-func (mr *MockContextMockRecorder) GetSingleCacheValue(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSingleCacheValue", reflect.TypeOf((*MockContext)(nil).GetSingleCacheValue), arg0)
 }
 
 // GoalState mocks base method
 func (m *MockContext) GoalState() (*application.GoalState, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GoalState")
 	ret0, _ := ret[0].(*application.GoalState)
 	ret1, _ := ret[1].(error)
@@ -226,11 +255,13 @@ func (m *MockContext) GoalState() (*application.GoalState, error) {
 
 // GoalState indicates an expected call of GoalState
 func (mr *MockContextMockRecorder) GoalState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockContext)(nil).GoalState))
 }
 
 // HookRelation mocks base method
 func (m *MockContext) HookRelation() (jujuc.ContextRelation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HookRelation")
 	ret0, _ := ret[0].(jujuc.ContextRelation)
 	ret1, _ := ret[1].(error)
@@ -239,11 +270,13 @@ func (m *MockContext) HookRelation() (jujuc.ContextRelation, error) {
 
 // HookRelation indicates an expected call of HookRelation
 func (mr *MockContextMockRecorder) HookRelation() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookRelation", reflect.TypeOf((*MockContext)(nil).HookRelation))
 }
 
 // HookStorage mocks base method
 func (m *MockContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HookStorage")
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
 	ret1, _ := ret[1].(error)
@@ -252,11 +285,13 @@ func (m *MockContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
 
 // HookStorage indicates an expected call of HookStorage
 func (mr *MockContextMockRecorder) HookStorage() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookStorage", reflect.TypeOf((*MockContext)(nil).HookStorage))
 }
 
 // IsLeader mocks base method
 func (m *MockContext) IsLeader() (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsLeader")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -265,11 +300,13 @@ func (m *MockContext) IsLeader() (bool, error) {
 
 // IsLeader indicates an expected call of IsLeader
 func (mr *MockContextMockRecorder) IsLeader() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLeader", reflect.TypeOf((*MockContext)(nil).IsLeader))
 }
 
 // LeaderSettings mocks base method
 func (m *MockContext) LeaderSettings() (map[string]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LeaderSettings")
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
@@ -278,11 +315,13 @@ func (m *MockContext) LeaderSettings() (map[string]string, error) {
 
 // LeaderSettings indicates an expected call of LeaderSettings
 func (mr *MockContextMockRecorder) LeaderSettings() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaderSettings", reflect.TypeOf((*MockContext)(nil).LeaderSettings))
 }
 
 // LogActionMessage mocks base method
 func (m *MockContext) LogActionMessage(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogActionMessage", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -290,11 +329,13 @@ func (m *MockContext) LogActionMessage(arg0 string) error {
 
 // LogActionMessage indicates an expected call of LogActionMessage
 func (mr *MockContextMockRecorder) LogActionMessage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockContext)(nil).LogActionMessage), arg0)
 }
 
 // NetworkInfo mocks base method
 func (m *MockContext) NetworkInfo(arg0 []string, arg1 int) (map[string]params.NetworkInfoResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
 	ret0, _ := ret[0].(map[string]params.NetworkInfoResult)
 	ret1, _ := ret[1].(error)
@@ -303,11 +344,13 @@ func (m *MockContext) NetworkInfo(arg0 []string, arg1 int) (map[string]params.Ne
 
 // NetworkInfo indicates an expected call of NetworkInfo
 func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1)
 }
 
 // OpenPorts mocks base method
 func (m *MockContext) OpenPorts(arg0 string, arg1, arg2 int) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenPorts", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -315,11 +358,13 @@ func (m *MockContext) OpenPorts(arg0 string, arg1, arg2 int) error {
 
 // OpenPorts indicates an expected call of OpenPorts
 func (mr *MockContextMockRecorder) OpenPorts(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPorts", reflect.TypeOf((*MockContext)(nil).OpenPorts), arg0, arg1, arg2)
 }
 
 // OpenedPorts mocks base method
 func (m *MockContext) OpenedPorts() []network.PortRange {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenedPorts")
 	ret0, _ := ret[0].([]network.PortRange)
 	return ret0
@@ -327,11 +372,13 @@ func (m *MockContext) OpenedPorts() []network.PortRange {
 
 // OpenedPorts indicates an expected call of OpenedPorts
 func (mr *MockContextMockRecorder) OpenedPorts() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedPorts", reflect.TypeOf((*MockContext)(nil).OpenedPorts))
 }
 
 // PrivateAddress mocks base method
 func (m *MockContext) PrivateAddress() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrivateAddress")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -340,11 +387,13 @@ func (m *MockContext) PrivateAddress() (string, error) {
 
 // PrivateAddress indicates an expected call of PrivateAddress
 func (mr *MockContextMockRecorder) PrivateAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateAddress", reflect.TypeOf((*MockContext)(nil).PrivateAddress))
 }
 
 // PublicAddress mocks base method
 func (m *MockContext) PublicAddress() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PublicAddress")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -353,11 +402,13 @@ func (m *MockContext) PublicAddress() (string, error) {
 
 // PublicAddress indicates an expected call of PublicAddress
 func (mr *MockContextMockRecorder) PublicAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockContext)(nil).PublicAddress))
 }
 
 // Relation mocks base method
 func (m *MockContext) Relation(arg0 int) (jujuc.ContextRelation, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Relation", arg0)
 	ret0, _ := ret[0].(jujuc.ContextRelation)
 	ret1, _ := ret[1].(error)
@@ -366,11 +417,13 @@ func (m *MockContext) Relation(arg0 int) (jujuc.ContextRelation, error) {
 
 // Relation indicates an expected call of Relation
 func (mr *MockContextMockRecorder) Relation(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relation", reflect.TypeOf((*MockContext)(nil).Relation), arg0)
 }
 
 // RelationIds mocks base method
 func (m *MockContext) RelationIds() ([]int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RelationIds")
 	ret0, _ := ret[0].([]int)
 	ret1, _ := ret[1].(error)
@@ -379,11 +432,13 @@ func (m *MockContext) RelationIds() ([]int, error) {
 
 // RelationIds indicates an expected call of RelationIds
 func (mr *MockContextMockRecorder) RelationIds() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationIds", reflect.TypeOf((*MockContext)(nil).RelationIds))
 }
 
 // RemoteApplicationName mocks base method
 func (m *MockContext) RemoteApplicationName() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteApplicationName")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -392,11 +447,13 @@ func (m *MockContext) RemoteApplicationName() (string, error) {
 
 // RemoteApplicationName indicates an expected call of RemoteApplicationName
 func (mr *MockContextMockRecorder) RemoteApplicationName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplicationName", reflect.TypeOf((*MockContext)(nil).RemoteApplicationName))
 }
 
 // RemoteUnitName mocks base method
 func (m *MockContext) RemoteUnitName() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteUnitName")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -405,11 +462,13 @@ func (m *MockContext) RemoteUnitName() (string, error) {
 
 // RemoteUnitName indicates an expected call of RemoteUnitName
 func (mr *MockContextMockRecorder) RemoteUnitName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteUnitName", reflect.TypeOf((*MockContext)(nil).RemoteUnitName))
 }
 
 // RequestReboot mocks base method
 func (m *MockContext) RequestReboot(arg0 jujuc.RebootPriority) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestReboot", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -417,11 +476,13 @@ func (m *MockContext) RequestReboot(arg0 jujuc.RebootPriority) error {
 
 // RequestReboot indicates an expected call of RequestReboot
 func (mr *MockContextMockRecorder) RequestReboot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockContext)(nil).RequestReboot), arg0)
 }
 
 // SetActionFailed mocks base method
 func (m *MockContext) SetActionFailed() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetActionFailed")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -429,11 +490,13 @@ func (m *MockContext) SetActionFailed() error {
 
 // SetActionFailed indicates an expected call of SetActionFailed
 func (mr *MockContextMockRecorder) SetActionFailed() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetActionFailed", reflect.TypeOf((*MockContext)(nil).SetActionFailed))
 }
 
 // SetActionMessage mocks base method
 func (m *MockContext) SetActionMessage(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetActionMessage", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -441,11 +504,13 @@ func (m *MockContext) SetActionMessage(arg0 string) error {
 
 // SetActionMessage indicates an expected call of SetActionMessage
 func (mr *MockContextMockRecorder) SetActionMessage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetActionMessage", reflect.TypeOf((*MockContext)(nil).SetActionMessage), arg0)
 }
 
 // SetApplicationStatus mocks base method
 func (m *MockContext) SetApplicationStatus(arg0 jujuc.StatusInfo) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetApplicationStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -453,23 +518,27 @@ func (m *MockContext) SetApplicationStatus(arg0 jujuc.StatusInfo) error {
 
 // SetApplicationStatus indicates an expected call of SetApplicationStatus
 func (mr *MockContextMockRecorder) SetApplicationStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationStatus", reflect.TypeOf((*MockContext)(nil).SetApplicationStatus), arg0)
 }
 
-// SetCacheValue mocks base method
-func (m *MockContext) SetCacheValue(arg0, arg1 string) error {
-	ret := m.ctrl.Call(m, "SetCacheValue", arg0, arg1)
+// SetCharmStateValue mocks base method
+func (m *MockContext) SetCharmStateValue(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetCharmStateValue", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetCacheValue indicates an expected call of SetCacheValue
-func (mr *MockContextMockRecorder) SetCacheValue(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCacheValue", reflect.TypeOf((*MockContext)(nil).SetCacheValue), arg0, arg1)
+// SetCharmStateValue indicates an expected call of SetCharmStateValue
+func (mr *MockContextMockRecorder) SetCharmStateValue(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmStateValue", reflect.TypeOf((*MockContext)(nil).SetCharmStateValue), arg0, arg1)
 }
 
 // SetPodSpec mocks base method
 func (m *MockContext) SetPodSpec(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPodSpec", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -477,11 +546,13 @@ func (m *MockContext) SetPodSpec(arg0 string) error {
 
 // SetPodSpec indicates an expected call of SetPodSpec
 func (mr *MockContextMockRecorder) SetPodSpec(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPodSpec", reflect.TypeOf((*MockContext)(nil).SetPodSpec), arg0)
 }
 
 // SetUnitStatus mocks base method
 func (m *MockContext) SetUnitStatus(arg0 jujuc.StatusInfo) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUnitStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -489,11 +560,13 @@ func (m *MockContext) SetUnitStatus(arg0 jujuc.StatusInfo) error {
 
 // SetUnitStatus indicates an expected call of SetUnitStatus
 func (mr *MockContextMockRecorder) SetUnitStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockContext)(nil).SetUnitStatus), arg0)
 }
 
 // SetUnitWorkloadVersion mocks base method
 func (m *MockContext) SetUnitWorkloadVersion(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUnitWorkloadVersion", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -501,11 +574,13 @@ func (m *MockContext) SetUnitWorkloadVersion(arg0 string) error {
 
 // SetUnitWorkloadVersion indicates an expected call of SetUnitWorkloadVersion
 func (mr *MockContextMockRecorder) SetUnitWorkloadVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).SetUnitWorkloadVersion), arg0)
 }
 
 // Storage mocks base method
-func (m *MockContext) Storage(arg0 names_v3.StorageTag) (jujuc.ContextStorageAttachment, error) {
+func (m *MockContext) Storage(arg0 names.StorageTag) (jujuc.ContextStorageAttachment, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Storage", arg0)
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
 	ret1, _ := ret[1].(error)
@@ -514,24 +589,28 @@ func (m *MockContext) Storage(arg0 names_v3.StorageTag) (jujuc.ContextStorageAtt
 
 // Storage indicates an expected call of Storage
 func (mr *MockContextMockRecorder) Storage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Storage", reflect.TypeOf((*MockContext)(nil).Storage), arg0)
 }
 
 // StorageTags mocks base method
-func (m *MockContext) StorageTags() ([]names_v3.StorageTag, error) {
+func (m *MockContext) StorageTags() ([]names.StorageTag, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageTags")
-	ret0, _ := ret[0].([]names_v3.StorageTag)
+	ret0, _ := ret[0].([]names.StorageTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StorageTags indicates an expected call of StorageTags
 func (mr *MockContextMockRecorder) StorageTags() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageTags", reflect.TypeOf((*MockContext)(nil).StorageTags))
 }
 
 // UnitName mocks base method
 func (m *MockContext) UnitName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -539,11 +618,13 @@ func (m *MockContext) UnitName() string {
 
 // UnitName indicates an expected call of UnitName
 func (mr *MockContextMockRecorder) UnitName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitName", reflect.TypeOf((*MockContext)(nil).UnitName))
 }
 
 // UnitStatus mocks base method
 func (m *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitStatus")
 	ret0, _ := ret[0].(*jujuc.StatusInfo)
 	ret1, _ := ret[1].(error)
@@ -552,11 +633,13 @@ func (m *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
 
 // UnitStatus indicates an expected call of UnitStatus
 func (mr *MockContextMockRecorder) UnitStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockContext)(nil).UnitStatus))
 }
 
 // UnitWorkloadVersion mocks base method
 func (m *MockContext) UnitWorkloadVersion() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitWorkloadVersion")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -565,11 +648,13 @@ func (m *MockContext) UnitWorkloadVersion() (string, error) {
 
 // UnitWorkloadVersion indicates an expected call of UnitWorkloadVersion
 func (mr *MockContextMockRecorder) UnitWorkloadVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitWorkloadVersion", reflect.TypeOf((*MockContext)(nil).UnitWorkloadVersion))
 }
 
 // UpdateActionResults mocks base method
 func (m *MockContext) UpdateActionResults(arg0 []string, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateActionResults", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -577,11 +662,13 @@ func (m *MockContext) UpdateActionResults(arg0 []string, arg1 string) error {
 
 // UpdateActionResults indicates an expected call of UpdateActionResults
 func (mr *MockContextMockRecorder) UpdateActionResults(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActionResults", reflect.TypeOf((*MockContext)(nil).UpdateActionResults), arg0, arg1)
 }
 
 // WriteLeaderSettings mocks base method
 func (m *MockContext) WriteLeaderSettings(arg0 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteLeaderSettings", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -589,5 +676,6 @@ func (m *MockContext) WriteLeaderSettings(arg0 map[string]string) error {
 
 // WriteLeaderSettings indicates an expected call of WriteLeaderSettings
 func (mr *MockContextMockRecorder) WriteLeaderSettings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLeaderSettings", reflect.TypeOf((*MockContext)(nil).WriteLeaderSettings), arg0)
 }

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -31,23 +31,23 @@ func (*RestrictedContext) GoalState() (*application.GoalState, error) {
 	return &application.GoalState{}, ErrRestrictedContext
 }
 
-// GetCache implements jujuc.unitCacheContext.
-func (*RestrictedContext) GetCache() (map[string]string, error) {
+// GetCharmState implements jujuc.unitCharmStateContext.
+func (*RestrictedContext) GetCharmState() (map[string]string, error) {
 	return nil, ErrRestrictedContext
 }
 
-// GetSingleCacheValue implements jujuc.unitCacheContext.
-func (*RestrictedContext) GetSingleCacheValue(string) (string, error) {
+// GetSingleCharmStateValue implements jujuc.unitCharmStateContext.
+func (*RestrictedContext) GetCharmStateValue(string) (string, error) {
 	return "", ErrRestrictedContext
 }
 
-// DeleteCacheValue implements jujuc.unitCacheContext.
-func (*RestrictedContext) DeleteCacheValue(string) error {
+// DeleteCharmStateValue implements jujuc.unitCharmStateContext.
+func (*RestrictedContext) DeleteCharmStateValue(string) error {
 	return ErrRestrictedContext
 }
 
-// SetCacheValue implements jujuc.unitCacheContext.
-func (*RestrictedContext) SetCacheValue(string, string) error {
+// SetCharmStateValue implements jujuc.unitCharmStateContext.
+func (*RestrictedContext) SetCharmStateValue(string, string) error {
 	return ErrRestrictedContext
 }
 

--- a/worker/uniter/runner/jujuc/state-delete.go
+++ b/worker/uniter/runner/jujuc/state-delete.go
@@ -56,7 +56,7 @@ func (c *StateDeleteCommand) Run(ctx *cmd.Context) error {
 	if c.Key == "" {
 		return nil
 	}
-	err := c.ctx.DeleteCacheValue(c.Key)
+	err := c.ctx.DeleteCharmStateValue(c.Key)
 	if err != nil {
 		return err
 	}

--- a/worker/uniter/runner/jujuc/state-get.go
+++ b/worker/uniter/runner/jujuc/state-get.go
@@ -73,14 +73,14 @@ func (c *StateGetCommand) Init(args []string) error {
 // Run implements part of the cmd.Command interface.
 func (c *StateGetCommand) Run(ctx *cmd.Context) error {
 	if c.key == "" {
-		cache, err := c.ctx.GetCache()
+		cache, err := c.ctx.GetCharmState()
 		if err != nil {
 			return err
 		}
 		return c.out.Write(ctx, cache)
 	}
 
-	value, err := c.ctx.GetSingleCacheValue(c.key)
+	value, err := c.ctx.GetCharmStateValue(c.key)
 	notFound := errors.IsNotFound(err)
 	if err != nil && (!notFound || (notFound && c.strict)) {
 		return err

--- a/worker/uniter/runner/jujuc/state-set.go
+++ b/worker/uniter/runner/jujuc/state-set.go
@@ -93,7 +93,7 @@ func (c *StateSetCommand) Run(ctx *cmd.Context) error {
 	}
 
 	for k, v := range c.StateValues {
-		if err := c.ctx.SetCacheValue(k, v); err != nil {
+		if err := c.ctx.SetCharmStateValue(k, v); err != nil {
 			return err
 		}
 	}

--- a/worker/uniter/runner/jujuc/state_test.go
+++ b/worker/uniter/runner/jujuc/state_test.go
@@ -22,20 +22,20 @@ func (s *stateSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *stateSuite) expectStateSetOne() {
-	s.mockContext.EXPECT().SetCacheValue("one", "two").Return(nil)
+	s.mockContext.EXPECT().SetCharmStateValue("one", "two").Return(nil)
 }
 
 func (s *stateSuite) expectStateSetOneEmpty() {
-	s.mockContext.EXPECT().SetCacheValue("one", "").Return(nil)
+	s.mockContext.EXPECT().SetCharmStateValue("one", "").Return(nil)
 }
 
 func (s *stateSuite) expectStateSetTwo() {
 	s.expectStateSetOne()
-	s.mockContext.EXPECT().SetCacheValue("three", "four").Return(nil)
+	s.mockContext.EXPECT().SetCharmStateValue("three", "four").Return(nil)
 }
 
 func (s *stateSuite) expectStateDeleteOne() {
-	s.mockContext.EXPECT().DeleteCacheValue("five").Return(nil)
+	s.mockContext.EXPECT().DeleteCharmStateValue("five").Return(nil)
 }
 
 func (s *stateSuite) expectStateGetTwo() {
@@ -43,17 +43,17 @@ func (s *stateSuite) expectStateGetTwo() {
 		"one":   "two",
 		"three": "four",
 	}
-	s.mockContext.EXPECT().GetCache().Return(setupCache, nil)
+	s.mockContext.EXPECT().GetCharmState().Return(setupCache, nil)
 }
 
 func (s *stateSuite) expectStateGetValueOne() {
-	s.mockContext.EXPECT().GetSingleCacheValue("one").Return("two", nil)
+	s.mockContext.EXPECT().GetCharmStateValue("one").Return("two", nil)
 }
 
 func (s *stateSuite) expectStateGetValueNotFound() {
-	s.mockContext.EXPECT().GetSingleCacheValue("five").Return("", errors.NotFoundf("%q", "five"))
+	s.mockContext.EXPECT().GetCharmStateValue("five").Return("", errors.NotFoundf("%q", "five"))
 }
 
 func (s *stateSuite) expectStateGetValueEmpty() {
-	s.mockContext.EXPECT().GetSingleCacheValue("five").Return("", nil)
+	s.mockContext.EXPECT().GetCharmStateValue("five").Return("", nil)
 }


### PR DESCRIPTION
## Description of change

Now that most bits of work for persisting the uniter state to the controller have landed, we need to be able to clearly reason about which kind of unit state (charm, uniter, uniter relations, uniter storage, meter status) we are referring to in our code.

The codebase correctly (and unambiguously) prefixes most of the above state types with the exception of the charm state (which landed first) for which the ambiguous term _state_ was used. The same problem is also evident in the payload for reading/writing unit state and in the uniter's hook context implementation where it was referred to as `cachedState`.

This PR applies a sequence of rename refactorings to make the naming for the charm state congruent to the other kinds of state that are being stored.