### PR TITLE
Add manual deploy tests for AWS

### DIFF
--- a/tests/includes/cleanup.sh
+++ b/tests/includes/cleanup.sh
@@ -1,0 +1,18 @@
+add_clean_func() {
+    local name
+
+    name=${1}
+
+    echo "${name}" > "${TEST_DIR}/cleanup"
+}
+
+# cleanup_funcs attempts to clean up with functions.
+cleanup_funcs() {
+    if [ -f "${TEST_DIR}/cleanup" ]; then
+        while read -r CMD; do
+            echo "====> Running clean up func: ${CMD}"
+            $CMD
+            echo "====> Finished cleaning up func: ${CMD}"
+        done < "${TEST_DIR}/cleanup"
+    fi
+}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -225,6 +225,7 @@ cleanup() {
     echo "==> Cleaning up"
 
     cleanup_jujus
+    cleanup_funcs
 
     echo ""
     if [ "${TEST_RESULT}" != "success" ]; then

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -279,7 +279,8 @@ run_test() {
 
     import_subdir_files "suites/${TEST_CURRENT_NAME}"
 
-    echo "==> TEST BEGIN: ${TEST_CURRENT_DESCRIPTION}"
+    # shellcheck disable=SC2046,SC2086
+    echo "==> TEST BEGIN: ${TEST_CURRENT_DESCRIPTION} ($(green $(basename ${TEST_DIR})))"
     START_TIME=$(date +%s)
     ${TEST_CURRENT}
     END_TIME=$(date +%s)

--- a/tests/suites/appdata/appdata.sh
+++ b/tests/suites/appdata/appdata.sh
@@ -1,18 +1,3 @@
-test_appdata_int() {
-  if [ "$(skip 'test_appdata_int')" ]; then
-    echo "==> TEST SKIPPED: appdata int tests"
-    return
-  fi
-
-  (
-      set_verbosity
-
-      cd suites/appdata || exit
-
-      run "run_appdata_basic"
-  )
-}
-
 run_appdata_basic() {
     echo
 
@@ -56,4 +41,19 @@ run_appdata_basic() {
     check_contains "$output" "appdata-source/1 value2"
 
     destroy_model "appdata-basic"
+}
+
+test_appdata_int() {
+  if [ "$(skip 'test_appdata_int')" ]; then
+    echo "==> TEST SKIPPED: appdata int tests"
+    return
+  fi
+
+  (
+      set_verbosity
+
+      cd suites/appdata || exit
+
+      run "run_appdata_basic"
+  )
 }

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -1,177 +1,3 @@
-create_priveleged_profile() {
-    PROFILE=$(cat <<'EOF'
-config:
-  security.nesting: "true"
-  security.privileged: "true"
-description: create privileged container
-devices: {}
-name: profile-privileged
-EOF
-)
-    echo "${PROFILE}" > "${TEST_DIR}/profile-privileged.yaml"
-
-    OUT=$(lxc profile show profile-privileged || true)
-    if [ -z "${OUT}" ]; then
-        lxc profile create profile-privileged
-        lxc profile edit profile-privileged < "${TEST_DIR}/profile-privileged.yaml"
-    fi
-}
-
-create_user_profile() {
-    local name
-
-    name=${1}
-    profile_name="profile-${name}"
-
-    public_key="${TEST_DIR}/${name}.pub"
-    key=$(cat "${public_key}" | tr -d '\n')
-
-    PROFILE=$(cat <<EOF
-config:
-  user.user-data: |
-    #cloud-config
-    ssh_authorized_keys:
-      - "${key}"
-description: create user profile
-devices: {}
-name: ${profile_name}
-EOF
-)
-
-    echo "${PROFILE}" > "${TEST_DIR}/${profile_name}.yaml"
-
-    # Do not check if it already exists, we want to fail if it already exists.
-    lxc profile create "${profile_name}"
-    lxc profile edit "${profile_name}" < "${TEST_DIR}/${profile_name}.yaml"
-}
-
-delete_user_profile() {
-    local name
-
-    name=${1}
-    profile_name="profile-${name}"
-
-    set +e
-    OUT=$(lxc profile show profile-privileged || true)
-    if [ -n "${OUT}" ]; then
-        lxc profile delete "${profile_name}"
-    fi
-    set_verbosity
-}
-
-run_deploy_manual_lxd() {
-    echo
-
-    name="tests-$(petname)"
-
-    ssh-keygen -f "${TEST_DIR}/${name}" \
-        -t rsa \
-        -C "ubuntu@${name}.com" \
-        -N ""
-
-    create_priveleged_profile
-    create_user_profile "${name}"
-
-    series="bionic"
-
-    controller="${name}-controller"
-    model1="${name}-m1"
-    model2="${name}-m2"
-
-    launch_and_wait_addr() {
-        local container_name addr_result
-
-        container_name=${1}
-        addr_result=${2}
-
-        lxc launch --profile default \
-             --profile profile-privileged \
-             --profile "profile-${name}" \
-             ubuntu:"${series}" "${container_name}"
-
-        local address=""
-
-        attempt=0
-        while [ ${attempt} -lt 30 ]; do
-            address=$(lxc list "$1" --format json | \
-                jq --raw-output '.[0].state.network.eth0.addresses | map(select( .family == "inet")) | .[0].address')
-
-            if echo "${address}" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+$'; then
-                echo "Using container address ${address}"
-                break
-            fi
-            sleep 1
-            attempt=$((attempt+1))
-        done
-
-        # shellcheck disable=SC2086
-        eval $addr_result="'${address}'"
-    }
-
-    launch_and_wait_addr "${controller}" addr_c
-    launch_and_wait_addr "${model1}" addr_m1
-    launch_and_wait_addr "${model2}" addr_m2
-
-    # shellcheck disable=SC2154
-    for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
-        ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"
-
-        attempt=0
-        while [ ${attempt} -lt 10 ]; do
-            OUT=$(ssh -T -n -i "${TEST_DIR}/${name}" \
-                -o IdentitiesOnly=yes \
-                -o StrictHostKeyChecking=no \
-                -o AddKeysToAgent=yes \
-                ubuntu@"${addr}" 2>&1 || true)
-            if echo "${OUT}" | grep -q -v "Could not resolve hostname"; then
-                echo "Adding ssh key to ${addr}"
-                break
-            fi
-
-            sleep 1
-            attempt=$((attempt+1))
-        done
-
-        if [ "${attempt}" -ge 10 ]; then
-            echo "Failed to add key to ${addr}"
-            exit 1
-        fi
-    done
-
-    cloud_name="cloud-${name}"
-
-    CLOUD=$(cat <<EOF
-clouds:
-  ${cloud_name}:
-    type: manual
-    endpoint: "ubuntu@${addr_c}"
-EOF
-)
-
-    echo "${CLOUD}" > "${TEST_DIR}/cloud_name.yaml"
-
-    juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
-
-    file="${TEST_DIR}/test-${name}.txt"
-
-    bootstrap "${cloud_name}" "test-${name}" "${file}"
-
-    juju add-machine ssh:ubuntu@"${addr_m1}" >"${TEST_DIR}/add-machine-1.log" 2>&1
-    juju add-machine ssh:ubuntu@"${addr_m2}" >"${TEST_DIR}/add-machine-2.log" 2>&1
-
-    juju enable-ha >"${TEST_DIR}/enable-ha.log" 2>&1
-
-    juju deploy percona-cluster
-
-    wait_for "percona-cluster" "$(idle_condition "percona-cluster" 0 0)"
-
-    juju remove-application percona-cluster
-
-    destroy_controller "test-${name}"
-
-    delete_user_profile "${name}"
-}
-
 test_deploy_manual() {
     if [ "$(skip 'test_deploy_manual')" ]; then
         echo "==> TEST SKIPPED: deploy manual"
@@ -194,9 +20,43 @@ test_deploy_manual() {
                 export BOOTSTRAP_PROVIDER="manual"
                 run "run_deploy_manual_lxd"
                 ;;
+            "aws")
+                export BOOTSTRAP_PROVIDER="manual"
+                run "run_deploy_manual_aws"
+                ;;
             *)
                 echo "==> TEST SKIPPED: deploy manual - tests for LXD only"
                 ;;
         esac
     )
+}
+
+manual_deploy() {
+    local cloud_name name addr_m1 addr_m2
+
+    cloud_name=${1}
+    name=${2}
+    addr_m1=${3}
+    addr_m2=${3}
+
+    juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
+
+    file="${TEST_DIR}/test-${name}.txt"
+
+    bootstrap "${cloud_name}" "test-${name}" "${file}"
+
+    juju add-machine ssh:ubuntu@"${addr_m1}" >"${TEST_DIR}/add-machine-1.log" 2>&1
+    juju add-machine ssh:ubuntu@"${addr_m2}" >"${TEST_DIR}/add-machine-2.log" 2>&1
+
+    juju enable-ha >"${TEST_DIR}/enable-ha.log" 2>&1
+
+    juju deploy percona-cluster
+
+    wait_for "percona-cluster" "$(idle_condition "percona-cluster" 0 0)"
+
+    juju remove-application percona-cluster
+
+    destroy_controller "test-${name}"
+
+    delete_user_profile "${name}"
 }

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -37,7 +37,7 @@ manual_deploy() {
     cloud_name=${1}
     name=${2}
     addr_m1=${3}
-    addr_m2=${3}
+    addr_m2=${4}
 
     juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
 

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -1,0 +1,101 @@
+run_deploy_manual_aws() {
+    echo
+
+    echo "==> Checking for dependencies"
+    check_dependencies aws
+
+    name="tests-$(petname)"
+
+    ssh-keygen -f "${TEST_DIR}/${name}" \
+        -t rsa \
+        -C "ubuntu@${name}.com" \
+        -N ""
+    
+    series="bionic"
+
+    controller="${name}-controller"
+    model1="${name}-m1"
+    model2="${name}-m2"
+
+    launch_and_wait_addr() {
+        local instance_name addr_result
+
+        instance_name=${1}
+        addr_result=${2}
+
+        tags="ResourceType=instance,Tags=[{Key=Name,Value=${instance_name}}]"
+        reservation_id=$(aws ec2 run-instances --image-id ami-03d8261f577d71b6a \
+            --count 1 \
+            --instance-type t2.medium \
+            --associate-public-ip-address \
+            --tag-specifications "${tags}" | \
+            jq -r ".ReservationId")
+
+        local address=""
+
+        attempt=0
+        while [ ${attempt} -lt 30 ]; do
+            address=$(aws ec2 describe-instances \
+                --query "Reservations[?ReservationId=='${reservation_id}'].Instances[*].{Instance:PublicIpAddress}" | \
+                jq -r ".[] | .[] | .Instance" || true)
+
+            if echo "${address}" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+$'; then
+                echo "Using instance address ${address}"
+                break
+            fi
+            sleep 1
+            attempt=$((attempt+1))
+        done
+
+        # shellcheck disable=SC2086
+        eval $addr_result="'${address}'"
+    }
+
+    launch_and_wait_addr "${controller}" addr_c
+    launch_and_wait_addr "${model1}" addr_m1
+    launch_and_wait_addr "${model2}" addr_m2
+
+    # shellcheck disable=SC2154
+    for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
+        ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"
+
+        attempt=0
+        while [ ${attempt} -lt 10 ]; do
+            OUT=$(ssh -T -n -i "${TEST_DIR}/${name}" \
+                -o IdentitiesOnly=yes \
+                -o StrictHostKeyChecking=no \
+                -o AddKeysToAgent=yes \
+                ubuntu@"${addr}" 2>&1 || true)
+            if echo "${OUT}" | grep -q -v "Could not resolve hostname"; then
+                echo "Adding ssh key to ${addr}"
+                break
+            fi
+
+            sleep 1
+            attempt=$((attempt+1))
+        done
+
+        if [ "${attempt}" -ge 10 ]; then
+            echo "Failed to add key to ${addr}"
+            exit 1
+        fi
+    done
+
+
+    cloud_name="cloud-${name}"
+
+    CLOUD=$(cat <<EOF
+clouds:
+  ${cloud_name}:
+    type: manual
+    endpoint: "ubuntu@${addr_c}"
+    regions:
+      default:
+        endpoint: "ubuntu@${addr_c}"
+EOF
+)
+
+    echo "${CLOUD}" > "${TEST_DIR}/cloud_name.yaml"
+
+    manual_deploy "${cloud_name}" "${name}" "${addr_m1}" "${addr_m2}"
+}

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -5,7 +5,6 @@ run_deploy_manual_aws() {
     check_dependencies aws
 
     name="tests-$(petname)"
-    series="bionic"
 
     controller="${name}-controller"
     model1="${name}-m1"

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -120,7 +120,7 @@ run_deploy_manual_aws() {
 
     # shellcheck disable=SC2154
     for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
-        ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"
+        ssh-keygen -f "${HOME}/.ssh/known_hosts" -R ubuntu@"${addr}"
 
         attempt=0
         while [ ${attempt} -lt 10 ]; do
@@ -128,6 +128,7 @@ run_deploy_manual_aws() {
                 -o IdentitiesOnly=yes \
                 -o StrictHostKeyChecking=no \
                 -o AddKeysToAgent=yes \
+                -o UserKnownHostsFile="${HOME}/.ssh/known_hosts" \
                 ubuntu@"${addr}" 2>&1 || true)
             if echo "${OUT}" | grep -q -v "Could not resolve hostname"; then
                 echo "Adding ssh key to ${addr}"

--- a/tests/suites/manual/deploy_manual_lxd.sh
+++ b/tests/suites/manual/deploy_manual_lxd.sh
@@ -1,0 +1,157 @@
+create_priveleged_profile() {
+    PROFILE=$(cat <<'EOF'
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+description: create privileged container
+devices: {}
+name: profile-privileged
+EOF
+)
+    echo "${PROFILE}" > "${TEST_DIR}/profile-privileged.yaml"
+
+    OUT=$(lxc profile show profile-privileged || true)
+    if [ -z "${OUT}" ]; then
+        lxc profile create profile-privileged
+        lxc profile edit profile-privileged < "${TEST_DIR}/profile-privileged.yaml"
+    fi
+}
+
+create_user_profile() {
+    local name
+
+    name=${1}
+    profile_name="profile-${name}"
+
+    public_key="${TEST_DIR}/${name}.pub"
+    key=$(cat "${public_key}" | tr -d '\n')
+
+    PROFILE=$(cat <<EOF
+config:
+  user.user-data: |
+    #cloud-config
+    ssh_authorized_keys:
+      - "${key}"
+description: create user profile
+devices: {}
+name: ${profile_name}
+EOF
+)
+
+    echo "${PROFILE}" > "${TEST_DIR}/${profile_name}.yaml"
+
+    # Do not check if it already exists, we want to fail if it already exists.
+    lxc profile create "${profile_name}"
+    lxc profile edit "${profile_name}" < "${TEST_DIR}/${profile_name}.yaml"
+}
+
+delete_user_profile() {
+    local name
+
+    name=${1}
+    profile_name="profile-${name}"
+
+    set +e
+    OUT=$(lxc profile show profile-privileged || true)
+    if [ -n "${OUT}" ]; then
+        lxc profile delete "${profile_name}"
+    fi
+    set_verbosity
+}
+
+run_deploy_manual_lxd() {
+    echo
+
+    echo "==> Checking for dependencies"
+    check_dependencies lxd
+
+    name="tests-$(petname)"
+
+    ssh-keygen -f "${TEST_DIR}/${name}" \
+        -t rsa \
+        -C "ubuntu@${name}.com" \
+        -N ""
+
+    create_priveleged_profile
+    create_user_profile "${name}"
+
+    series="bionic"
+
+    controller="${name}-controller"
+    model1="${name}-m1"
+    model2="${name}-m2"
+
+    launch_and_wait_addr() {
+        local container_name addr_result
+
+        container_name=${1}
+        addr_result=${2}
+
+        lxc launch --profile default \
+             --profile profile-privileged \
+             --profile "profile-${name}" \
+             ubuntu:"${series}" "${container_name}"
+
+        local address=""
+
+        attempt=0
+        while [ ${attempt} -lt 30 ]; do
+            address=$(lxc list "$1" --format json | \
+                jq --raw-output '.[0].state.network.eth0.addresses | map(select( .family == "inet")) | .[0].address')
+
+            if echo "${address}" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+$'; then
+                echo "Using container address ${address}"
+                break
+            fi
+            sleep 1
+            attempt=$((attempt+1))
+        done
+
+        # shellcheck disable=SC2086
+        eval $addr_result="'${address}'"
+    }
+
+    launch_and_wait_addr "${controller}" addr_c
+    launch_and_wait_addr "${model1}" addr_m1
+    launch_and_wait_addr "${model2}" addr_m2
+
+    # shellcheck disable=SC2154
+    for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
+        ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"
+
+        attempt=0
+        while [ ${attempt} -lt 10 ]; do
+            OUT=$(ssh -T -n -i "${TEST_DIR}/${name}" \
+                -o IdentitiesOnly=yes \
+                -o StrictHostKeyChecking=no \
+                -o AddKeysToAgent=yes \
+                ubuntu@"${addr}" 2>&1 || true)
+            if echo "${OUT}" | grep -q -v "Could not resolve hostname"; then
+                echo "Adding ssh key to ${addr}"
+                break
+            fi
+
+            sleep 1
+            attempt=$((attempt+1))
+        done
+
+        if [ "${attempt}" -ge 10 ]; then
+            echo "Failed to add key to ${addr}"
+            exit 1
+        fi
+    done
+
+    cloud_name="cloud-${name}"
+
+    CLOUD=$(cat <<EOF
+clouds:
+  ${cloud_name}:
+    type: manual
+    endpoint: "ubuntu@${addr_c}"
+EOF
+)
+
+    echo "${CLOUD}" > "${TEST_DIR}/cloud_name.yaml"
+
+    manual_deploy "${cloud_name}" "${name}" "${addr_m1}" "${addr_m2}"
+}

--- a/tests/suites/manual/task.sh
+++ b/tests/suites/manual/task.sh
@@ -7,7 +7,7 @@ test_manual() {
     set_verbosity
 
     echo "==> Checking for dependencies"
-    check_dependencies juju lxd petname
+    check_dependencies juju petname
 
     test_deploy_manual
 }

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -36,30 +36,6 @@ run_trailing_whitespace() {
   fi
 }
 
-run_test_setup() {
-  # shellcheck disable=SC2038
-  OUT=$(find tests/suites -iname '*.sh' | xargs grep -rEoh '^run_\w+\s?[^\(]' | sort)
-  echo "${OUT}" | while read -r subtest; do
-    S=$(grep -owr "${subtest}" tests/suites)
-    COUNT=$(echo "${S}" | wc -l)
-    TEST_FILE=$(echo "${S}" | cut -f1 -d":")
-    if ${COUNT} % 2 == 0 ; then
-      echo ""
-      echo "$(red 'Found some issues:')"
-      echo "Expected subtest (${subtest}) to be in the same file as test (${TEST_FILE})."
-      exit 1
-    fi
-    H=$(echo "${S}" | head -n 1)
-    T=$(echo "${S}" | tail -n 1)
-    if [ "${H}" != "${T}" ]; then
-      echo ""
-      echo "$(red 'Found some issues:')"
-      echo "Expected subtest (${subtest}) to be in the same file as test (${TEST_FILE})."
-      exit 1
-    fi
-  done
-}
-
 test_static_analysis_shell() {
   if [ "$(skip 'test_static_analysis_shell')" ]; then
       echo "==> TEST SKIPPED: static shell analysis"
@@ -83,8 +59,5 @@ test_static_analysis_shell() {
 
     ## Trailing whitespace in scripts
     run "run_trailing_whitespace"
-
-    ## Tests are wired up
-    run "run_test_setup"
   )
 }


### PR DESCRIPTION
### Checklist

 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?

----

## Description of change

This tests the manual deployment of a HA `percona-cluster` and ensures 
that it has deployed to the correct machine.

This uses the same `manual_deploy` test as LXD so that we can verify that
the high level juju commands are identical between the substrates.

---

Unfortunately the process of bringing up an aws instance with the right
ingress and egress rules are somewhat convoluted but required to show
that manual provisioning is possible.

---

I've tried to ensure that we clean up the VPC as much as possible, but
we may, in the end, require to reuse the VPC that we already have, which
maybe be better off?

## QA steps

You need to ensure that you've correctly setup the AWS CLI and that you
have a **default** region that probably isn't `us-east-1`.

Ensure you have a valid Juju.

```sh
BOOTSTRAP_PROVIDER=aws ./main.sh -v manual
```

Let it run, it takes time.