### PR TITLE
[dev] Bump meter status facade version

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -65,7 +65,7 @@ var facadeVersions = map[string]int{
 	"MachineManager":               6,
 	"MachineUndertaker":            1,
 	"Machiner":                     2,
-	"MeterStatus":                  1,
+	"MeterStatus":                  2,
 	"MetricsAdder":                 2,
 	"MetricsDebug":                 2,
 	"MetricsManager":               1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -242,7 +242,8 @@ func AllFacades() *facade.Registry {
 	reg("Machiner", 1, machine.NewMachinerAPIV1)
 	reg("Machiner", 2, machine.NewMachinerAPI)
 
-	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacade)
+	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacadeV1)
+	reg("MeterStatus", 2, meterstatus.NewMeterStatusFacade)
 	reg("MetricsAdder", 2, metricsadder.NewMetricsAdderAPI)
 	reg("MetricsDebug", 2, metricsdebug.NewMetricsDebugAPI)
 	reg("MetricsManager", 1, metricsmanager.NewFacade)

--- a/apiserver/facades/agent/meterstatus/meterstatus.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus.go
@@ -39,8 +39,10 @@ type MeterStatusState interface {
 	Unit(id string) (*state.Unit, error)
 }
 
-// MeterStatusAPI implements the MeterStatus interface and is the concrete implementation
-// of the API endpoint.
+// MeterStatusAPI implements the MeterStatus interface and is the concrete
+// implementation of the API endpoint. Additionally, it embeds
+// common.UnitStateAPI to allow meter status workers to access their
+// controller-backed internal state.
 type MeterStatusAPI struct {
 	*common.UnitStateAPI
 
@@ -49,11 +51,29 @@ type MeterStatusAPI struct {
 	resources  facade.Resources
 }
 
+// MeterStatusAPIV1 implements V1 of the Meter Status API.
+type MeterStatusAPIV1 struct {
+	MeterStatusAPI
+}
+
+// SetState isn't on the v1 API.
+func (u *MeterStatusAPIV1) SetState(_ struct{}) {}
+
+// State isn't on the v1 API.
+func (u *MeterStatusAPIV1) State(_ struct{}) {}
+
 // NewMeterStatusFacade provides the signature required for facade registration.
 func NewMeterStatusFacade(ctx facade.Context) (*MeterStatusAPI, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
 	return NewMeterStatusAPI(ctx.State(), resources, authorizer)
+}
+
+// NewMeterStatusFacadeV1 provides the signature required for the V1 facade registration.
+func NewMeterStatusFacadeV1(ctx facade.Context) (*MeterStatusAPIV1, error) {
+	authorizer := ctx.Auth()
+	resources := ctx.Resources()
+	return NewMeterStatusAPIV1(ctx.State(), resources, authorizer)
 }
 
 // NewMeterStatusAPI creates a new API endpoint for dealing with unit meter status.
@@ -107,6 +127,22 @@ func NewMeterStatusAPI(
 			accessCheckerFn,
 			logger,
 		),
+	}, nil
+}
+
+// NewMeterStatusAPIV1 creates an instance of the V1 MeterStatus API.
+func NewMeterStatusAPIV1(
+	st MeterStatusState,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+) (*MeterStatusAPIV1, error) {
+	meterStatusAPI, err := NewMeterStatusAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &MeterStatusAPIV1{
+		MeterStatusAPI: *meterStatusAPI,
 	}, nil
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21482,7 +21482,7 @@
     },
     {
         "Name": "MeterStatus",
-        "Version": 1,
+        "Version": 2,
         "Schema": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Description of change

This PR bumps the MeterStatus facade version after the changes that landed with #11405.

This would not be required under normal circumstances as the agents that are supposed to be calling the V2 methods (provided via a mixin) are guaranteed to be upgraded after the controller. Unfortunately, pylibjuju exposes the agent facades which technically makes it possible for someone to actually try to invoke the new methods on an old controller.

## QA steps

Same as #11405 