### PR TITLE
move relations state server side

### DIFF
--- a/state/unit_ops.go
+++ b/state/unit_ops.go
@@ -193,9 +193,8 @@ func (op *unitSetStateOperation) fields(currentDoc unitStateDoc) (bson.D, bson.D
 		if len(rState) == 0 {
 			unsetFields = append(unsetFields, bson.DocElem{Name: "relation-state"})
 		} else if matches := currentDoc.relationStateMatches(rState); !matches {
-			newRState := mergeRelations(currentDoc.RelationState, rState)
-			setFields = append(setFields, bson.DocElem{"relation-state", newRState})
-			quotaChecker.Check(newRState)
+			setFields = append(setFields, bson.DocElem{"relation-state", rState})
+			quotaChecker.Check(rState)
 		}
 	} else {
 		quotaChecker.Check(currentDoc.RelationState)
@@ -242,26 +241,6 @@ func (op *unitSetStateOperation) getUniterStateQuotaChecker() quota.Checker {
 	return quota.NewMultiChecker(
 		quota.NewBSONTotalSizeChecker(op.limits.MaxAgentStateSize),
 	)
-}
-
-func mergeRelations(currentRelations map[string]string, newRelations map[string]string) map[string]string {
-	// For keys in newRelations:
-	// if key not in currentDoc, add key/value
-	// if key in currentDoc, if value == "", remove
-	// if key in currentDoc, if value != "", replace
-	for id, newValue := range newRelations {
-		_, found := currentRelations[id]
-		switch {
-		case found && newValue == "":
-			delete(currentRelations, id)
-		default:
-			if currentRelations == nil {
-				currentRelations = make(map[string]string)
-			}
-			currentRelations[id] = newValue
-		}
-	}
-	return currentRelations
 }
 
 // Done implements ModelOperation.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -236,45 +236,19 @@ func (s *UnitSuite) TestUnitStateMutateUniterState(c *gc.C) {
 	assertUnitStateMeterStatusState(c, uState, initState.meterStatusState)
 }
 
-func (s *UnitSuite) TestUnitStateMutateAddRelationState(c *gc.C) {
-	// Set initial state; this should create a new unitstate doc
-	initState := s.testUnitSuite(c)
-
-	// Mutate relation state again with an existing state doc
-	// by adding a new value.
-	newRelationState := map[int]string{3: "three"}
-	newUS := state.NewUnitState()
-	newUS.SetRelationState(newRelationState)
-	err := s.unit.SetState(newUS, state.UnitStateSizeLimits{})
-	c.Assert(err, gc.IsNil)
-
-	expectedRelationState := initState.relationState
-	expectedRelationState[3] = "three"
-	// Ensure relation state changed
-	uState, err := s.unit.State()
-	c.Assert(err, gc.IsNil)
-	assertUnitStateRelationState(c, uState, expectedRelationState)
-
-	// Ensure the other state did not.
-	assertUnitStateCharmState(c, uState, initState.charmState)
-	assertUnitStateUniterState(c, uState, initState.uniterState)
-	assertUnitStateStorageState(c, uState, initState.storageState)
-}
-
 func (s *UnitSuite) TestUnitStateMutateChangeRelationState(c *gc.C) {
 	// Set initial state; this should create a new unitstate doc
 	initState := s.testUnitSuite(c)
 
 	// Mutate relation state again with an existing state doc
 	// by changing a value.
-	newRelationState := map[int]string{1: "five"}
+	expectedRelationState := initState.relationState
+	expectedRelationState[1] = "five"
 	newUS := state.NewUnitState()
-	newUS.SetRelationState(newRelationState)
+	newUS.SetRelationState(expectedRelationState)
 	err := s.unit.SetState(newUS, state.UnitStateSizeLimits{})
 	c.Assert(err, gc.IsNil)
 
-	expectedRelationState := initState.relationState
-	expectedRelationState[1] = "five"
 	// Ensure relation state changed
 	uState, err := s.unit.State()
 	c.Assert(err, gc.IsNil)
@@ -292,14 +266,13 @@ func (s *UnitSuite) TestUnitStateMutateDeleteRelationState(c *gc.C) {
 
 	// Mutate relation state again with an existing state doc
 	// by deleting value.
-	newRelationState := map[int]string{2: ""}
+	expectedRelationState := initState.relationState
+	delete(expectedRelationState, 2)
 	newUS := state.NewUnitState()
-	newUS.SetRelationState(newRelationState)
+	newUS.SetRelationState(expectedRelationState)
 	err := s.unit.SetState(newUS, state.UnitStateSizeLimits{})
 	c.Assert(err, gc.IsNil)
 
-	expectedRelationState := initState.relationState
-	delete(expectedRelationState, 2)
 	// Ensure relation state changed
 	uState, err := s.unit.State()
 	c.Assert(err, gc.IsNil)

--- a/state/unitstate.go
+++ b/state/unitstate.go
@@ -78,12 +78,14 @@ func (d *unitStateDoc) relationData() (map[int]string, error) {
 }
 
 // relationStateMatches returns true if the RelationState map within the
-// unitStateDoc matches the provided newRS argument.  Assumes that
-// IgnoreRelationsState has been called first, therefore if arg is empty,
-// returns a nil map to be set.
+// unitStateDoc contains all of the provided newRS map.  Assumes that
+// relationStateBSONFriendly has been called first.
 func (d *unitStateDoc) relationStateMatches(newRS map[string]string) bool {
-	for k, v := range d.RelationState {
-		if newRS[k] != v {
+	if len(d.RelationState) != len(newRS) {
+		return false
+	}
+	for k, v := range newRS {
+		if d.RelationState[k] != v {
 			return false
 		}
 	}

--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6/hooks"
@@ -77,6 +78,9 @@ type mockSteps28Suite struct {
 	opStorOneYaml     string
 	opStorOneFileName string
 
+	opRelationYaml     map[int]string
+	opRelationFileName string
+
 	mockCtx         *mocks.MockContext
 	mockClient      *mocks.MockUpgradeStepsClient
 	mockAgentConfig *configsettermocks.MockConfigSetter
@@ -116,6 +120,8 @@ func (s *mockSteps28Suite) SetUpTest(c *gc.C) {
 
 	s.opStorOneYaml, s.opStorOneFileName = writeStorageState(c, unitOneStateDir, s.storTagOne, s.opStorOne)
 
+	s.opRelationYaml, s.opRelationFileName = setupRelationState(c, unitOneStateDir)
+
 	unitTwoStateDir := filepath.Join(agentDir, s.tagTwo.String(), "state")
 	err = os.MkdirAll(unitTwoStateDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
@@ -123,7 +129,7 @@ func (s *mockSteps28Suite) SetUpTest(c *gc.C) {
 }
 
 // writeUnitStateFile writes the operation.State in yaml format to the
-// path/uniter/state file.  It returns the yaml in string form and the
+// path/state/uniter file.  It returns the yaml in string form and the
 // full path to the file written.
 func writeUnitStateFile(c *gc.C, path string, st operation.State) (string, string) {
 	filePath := filepath.Join(path, "uniter")
@@ -147,7 +153,7 @@ func writeStorageState(c *gc.C, path string, storTag names.Tag, attached bool) (
 	storFileName := strings.Replace(storTag.Id(), "/", "-", -1)
 	filePath := filepath.Join(storDir, storFileName)
 
-	data := diskInfo{Attached: &attached}
+	data := storDiskInfo{Attached: &attached}
 	content, err := yaml.Marshal(data)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -160,8 +166,65 @@ func writeStorageState(c *gc.C, path string, storTag names.Tag, attached bool) (
 	return string(expectedYaml), filePath
 }
 
-type diskInfo struct {
+type storDiskInfo struct {
 	Attached *bool `yaml:"attached,omitempty"`
+}
+
+func setupRelationState(c *gc.C, path string) (map[int]string, string) {
+	data := map[int]string{
+		0: "id: 0\napplication-members:\n  keystone: 0\n",
+		2: "id: 2\nmembers:\n  mysql/0: 1\napplication-members:\n  mysql: 0\n",
+	}
+	relationsDir := filepath.Join(path, "relations")
+	keystoneCfg := relationConfig{
+		relationsDir: relationsDir,
+		relId:        "0",
+		changeVer:    int64(0),
+		kind:         hooks.RelationCreated,
+		remoteUnit:   "",
+		remoteApp:    "keystone",
+	}
+	writeRelationState(c, keystoneCfg)
+	keystoneCfg.relId = "2"
+	keystoneCfg.remoteApp = "mysql"
+	writeRelationState(c, keystoneCfg)
+	keystoneCfg.remoteApp = ""
+	keystoneCfg.changeVer = int64(1)
+	keystoneCfg.remoteUnit = "mysql/0"
+	writeRelationState(c, keystoneCfg)
+
+	return data, relationsDir
+}
+
+type relationConfig struct {
+	relationsDir          string
+	relId                 string
+	changeVer             int64
+	kind                  hooks.Kind
+	remoteUnit, remoteApp string
+}
+
+// writeRelationState writes relation data in yaml format to the
+// path/state/relations dir.  It returns the yaml in string form and the
+// full path to the file written.
+func writeRelationState(c *gc.C, cfg relationConfig) {
+	relDir := filepath.Join(cfg.relationsDir, cfg.relId)
+	err := os.MkdirAll(relDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+
+	name := strings.Replace(cfg.remoteUnit, "/", "-", 1)
+	if cfg.remoteUnit == "" {
+		name = cfg.remoteApp + "-app"
+	}
+
+	di := relDiskInfo{ChangeVersion: &cfg.changeVer, ChangedPending: cfg.kind == hooks.RelationJoined}
+	err = utils.WriteYaml(filepath.Join(relDir, name), &di)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type relDiskInfo struct {
+	ChangeVersion  *int64 `yaml:"change-version"`
+	ChangedPending bool   `yaml:"changed-pending,omitempty"`
 }
 
 func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerNotMachine(c *gc.C) {
@@ -172,6 +235,7 @@ func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerNotMachine(c *gc.C)
 	err := upgrades.MoveUnitAgentStateToController(s.mockCtx)
 	c.Assert(err, jc.ErrorIsNil)
 }
+
 func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerIAAS(c *gc.C) {
 	defer s.setup(c).Finish()
 	s.expectAPIState()
@@ -187,6 +251,8 @@ func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerIAAS(c *gc.C) {
 	_, err = os.Stat(s.opStateTwoFileName)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 	_, err = os.Stat(s.opStorOneFileName)
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+	_, err = os.Stat(s.opRelationFileName)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 
 	// Check idempotent
@@ -261,14 +327,14 @@ func (s *mockSteps28Suite) patchClient() {
 
 func (s *mockSteps28Suite) expectWriteTwoAgentState(c *gc.C) {
 	args := []params.SetUnitStateArg{{
-		Tag:          s.tagOne.String(),
-		UniterState:  &s.opStateOneYaml,
-		StorageState: &s.opStorOneYaml,
+		Tag:           s.tagOne.String(),
+		UniterState:   &s.opStateOneYaml,
+		StorageState:  &s.opStorOneYaml,
+		RelationState: &s.opRelationYaml,
 	}, {
 		Tag:         s.tagTwo.String(),
 		UniterState: &s.opStateTwoYaml,
-	},
-	}
+	}}
 	cExp := s.mockClient.EXPECT()
 	cExp.WriteAgentState(unitStateMatcher{c, args}).Return(nil)
 }

--- a/worker/uniter/relation/mock_test.go
+++ b/worker/uniter/relation/mock_test.go
@@ -57,3 +57,7 @@ func (m *mockOperation) Commit(state operation.State) (*operation.State, error) 
 
 func (m *mockOperation) RemoteStateChanged(snapshot remotestate.Snapshot) {
 }
+
+func (m *mockOperation) HookInfo() hook.Info {
+	return m.hookInfo
+}

--- a/worker/uniter/relation/mocks/mock_statetracker.go
+++ b/worker/uniter/relation/mocks/mock_statetracker.go
@@ -39,7 +39,6 @@ func (m *MockRelationStateTracker) EXPECT() *MockRelationStateTrackerMockRecorde
 
 // CommitHook mocks base method
 func (m *MockRelationStateTracker) CommitHook(arg0 hook.Info) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitHook", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -47,13 +46,11 @@ func (m *MockRelationStateTracker) CommitHook(arg0 hook.Info) error {
 
 // CommitHook indicates an expected call of CommitHook
 func (mr *MockRelationStateTrackerMockRecorder) CommitHook(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockRelationStateTracker)(nil).CommitHook), arg0)
 }
 
 // GetInfo mocks base method
 func (m *MockRelationStateTracker) GetInfo() map[int]*context.RelationInfo {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInfo")
 	ret0, _ := ret[0].(map[int]*context.RelationInfo)
 	return ret0
@@ -61,13 +58,11 @@ func (m *MockRelationStateTracker) GetInfo() map[int]*context.RelationInfo {
 
 // GetInfo indicates an expected call of GetInfo
 func (mr *MockRelationStateTrackerMockRecorder) GetInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfo", reflect.TypeOf((*MockRelationStateTracker)(nil).GetInfo))
 }
 
 // HasContainerScope mocks base method
 func (m *MockRelationStateTracker) HasContainerScope(arg0 int) (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasContainerScope", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -76,13 +71,11 @@ func (m *MockRelationStateTracker) HasContainerScope(arg0 int) (bool, error) {
 
 // HasContainerScope indicates an expected call of HasContainerScope
 func (mr *MockRelationStateTrackerMockRecorder) HasContainerScope(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasContainerScope", reflect.TypeOf((*MockRelationStateTracker)(nil).HasContainerScope), arg0)
 }
 
 // IsImplicit mocks base method
 func (m *MockRelationStateTracker) IsImplicit(arg0 int) (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsImplicit", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -91,13 +84,11 @@ func (m *MockRelationStateTracker) IsImplicit(arg0 int) (bool, error) {
 
 // IsImplicit indicates an expected call of IsImplicit
 func (mr *MockRelationStateTrackerMockRecorder) IsImplicit(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsImplicit", reflect.TypeOf((*MockRelationStateTracker)(nil).IsImplicit), arg0)
 }
 
 // IsKnown mocks base method
 func (m *MockRelationStateTracker) IsKnown(arg0 int) bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsKnown", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -105,13 +96,11 @@ func (m *MockRelationStateTracker) IsKnown(arg0 int) bool {
 
 // IsKnown indicates an expected call of IsKnown
 func (mr *MockRelationStateTrackerMockRecorder) IsKnown(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsKnown", reflect.TypeOf((*MockRelationStateTracker)(nil).IsKnown), arg0)
 }
 
 // IsPeerRelation mocks base method
 func (m *MockRelationStateTracker) IsPeerRelation(arg0 int) (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPeerRelation", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -120,13 +109,11 @@ func (m *MockRelationStateTracker) IsPeerRelation(arg0 int) (bool, error) {
 
 // IsPeerRelation indicates an expected call of IsPeerRelation
 func (mr *MockRelationStateTrackerMockRecorder) IsPeerRelation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPeerRelation", reflect.TypeOf((*MockRelationStateTracker)(nil).IsPeerRelation), arg0)
 }
 
 // LocalUnitAndApplicationLife mocks base method
 func (m *MockRelationStateTracker) LocalUnitAndApplicationLife() (life.Value, life.Value, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalUnitAndApplicationLife")
 	ret0, _ := ret[0].(life.Value)
 	ret1, _ := ret[1].(life.Value)
@@ -136,13 +123,11 @@ func (m *MockRelationStateTracker) LocalUnitAndApplicationLife() (life.Value, li
 
 // LocalUnitAndApplicationLife indicates an expected call of LocalUnitAndApplicationLife
 func (mr *MockRelationStateTrackerMockRecorder) LocalUnitAndApplicationLife() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalUnitAndApplicationLife", reflect.TypeOf((*MockRelationStateTracker)(nil).LocalUnitAndApplicationLife))
 }
 
 // LocalUnitName mocks base method
 func (m *MockRelationStateTracker) LocalUnitName() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalUnitName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -150,13 +135,11 @@ func (m *MockRelationStateTracker) LocalUnitName() string {
 
 // LocalUnitName indicates an expected call of LocalUnitName
 func (mr *MockRelationStateTrackerMockRecorder) LocalUnitName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalUnitName", reflect.TypeOf((*MockRelationStateTracker)(nil).LocalUnitName))
 }
 
 // Name mocks base method
 func (m *MockRelationStateTracker) Name(arg0 int) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -165,13 +148,11 @@ func (m *MockRelationStateTracker) Name(arg0 int) (string, error) {
 
 // Name indicates an expected call of Name
 func (mr *MockRelationStateTrackerMockRecorder) Name(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockRelationStateTracker)(nil).Name), arg0)
 }
 
 // PrepareHook mocks base method
 func (m *MockRelationStateTracker) PrepareHook(arg0 hook.Info) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareHook", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -180,13 +161,11 @@ func (m *MockRelationStateTracker) PrepareHook(arg0 hook.Info) (string, error) {
 
 // PrepareHook indicates an expected call of PrepareHook
 func (mr *MockRelationStateTrackerMockRecorder) PrepareHook(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHook", reflect.TypeOf((*MockRelationStateTracker)(nil).PrepareHook), arg0)
 }
 
 // RelationCreated mocks base method
 func (m *MockRelationStateTracker) RelationCreated(arg0 int) bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RelationCreated", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -194,13 +173,11 @@ func (m *MockRelationStateTracker) RelationCreated(arg0 int) bool {
 
 // RelationCreated indicates an expected call of RelationCreated
 func (mr *MockRelationStateTrackerMockRecorder) RelationCreated(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationCreated", reflect.TypeOf((*MockRelationStateTracker)(nil).RelationCreated), arg0)
 }
 
 // RemoteApplication mocks base method
 func (m *MockRelationStateTracker) RemoteApplication(arg0 int) string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteApplication", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -208,28 +185,36 @@ func (m *MockRelationStateTracker) RemoteApplication(arg0 int) string {
 
 // RemoteApplication indicates an expected call of RemoteApplication
 func (mr *MockRelationStateTrackerMockRecorder) RemoteApplication(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplication", reflect.TypeOf((*MockRelationStateTracker)(nil).RemoteApplication), arg0)
 }
 
-// StateDir mocks base method
-func (m *MockRelationStateTracker) StateDir(arg0 int) (*relation.StateDir, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateDir", arg0)
-	ret0, _ := ret[0].(*relation.StateDir)
+// State mocks base method
+func (m *MockRelationStateTracker) State(arg0 int) (*relation.State, error) {
+	ret := m.ctrl.Call(m, "State", arg0)
+	ret0, _ := ret[0].(*relation.State)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// StateDir indicates an expected call of StateDir
-func (mr *MockRelationStateTrackerMockRecorder) StateDir(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateDir", reflect.TypeOf((*MockRelationStateTracker)(nil).StateDir), arg0)
+// State indicates an expected call of State
+func (mr *MockRelationStateTrackerMockRecorder) State(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockRelationStateTracker)(nil).State), arg0)
+}
+
+// StateFound mocks base method
+func (m *MockRelationStateTracker) StateFound(arg0 int) bool {
+	ret := m.ctrl.Call(m, "StateFound", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// StateFound indicates an expected call of StateFound
+func (mr *MockRelationStateTrackerMockRecorder) StateFound(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateFound", reflect.TypeOf((*MockRelationStateTracker)(nil).StateFound), arg0)
 }
 
 // SynchronizeScopes mocks base method
 func (m *MockRelationStateTracker) SynchronizeScopes(arg0 remotestate.Snapshot) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SynchronizeScopes", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -237,6 +222,5 @@ func (m *MockRelationStateTracker) SynchronizeScopes(arg0 remotestate.Snapshot) 
 
 // SynchronizeScopes indicates an expected call of SynchronizeScopes
 func (mr *MockRelationStateTrackerMockRecorder) SynchronizeScopes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchronizeScopes", reflect.TypeOf((*MockRelationStateTracker)(nil).SynchronizeScopes), arg0)
 }

--- a/worker/uniter/relation/mocks/mock_subordinate_destroyer.go
+++ b/worker/uniter/relation/mocks/mock_subordinate_destroyer.go
@@ -34,7 +34,6 @@ func (m *MockSubordinateDestroyer) EXPECT() *MockSubordinateDestroyerMockRecorde
 
 // DestroyAllSubordinates mocks base method
 func (m *MockSubordinateDestroyer) DestroyAllSubordinates() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyAllSubordinates")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -42,6 +41,5 @@ func (m *MockSubordinateDestroyer) DestroyAllSubordinates() error {
 
 // DestroyAllSubordinates indicates an expected call of DestroyAllSubordinates
 func (mr *MockSubordinateDestroyerMockRecorder) DestroyAllSubordinates() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyAllSubordinates", reflect.TypeOf((*MockSubordinateDestroyer)(nil).DestroyAllSubordinates))
 }

--- a/worker/uniter/relation/state_test.go
+++ b/worker/uniter/relation/state_test.go
@@ -5,10 +5,6 @@ package relation_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strconv"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -18,96 +14,12 @@ import (
 	"github.com/juju/juju/worker/uniter/relation"
 )
 
-type StateDirSuite struct{}
+type stateSuite struct {
+}
 
 type msi map[string]int64
 
-var _ = gc.Suite(&StateDirSuite{})
-
-func (s *StateDirSuite) TestReadStateDirEmpty(c *gc.C) {
-	basedir := c.MkDir()
-	reldir := filepath.Join(basedir, "123")
-
-	dir, err := relation.ReadStateDir(basedir, 123)
-	c.Assert(err, jc.ErrorIsNil)
-	state := dir.State()
-	c.Assert(state.RelationId, gc.Equals, 123)
-	c.Assert(msi(state.Members), gc.DeepEquals, msi{})
-	c.Assert(msi(state.ApplicationMembers), gc.DeepEquals, msi{})
-	c.Assert(state.ChangedPending, gc.Equals, "")
-
-	_, err = os.Stat(reldir)
-	c.Assert(err, jc.Satisfies, os.IsNotExist)
-
-	exists := dir.Exists()
-	c.Assert(exists, jc.IsFalse)
-	err = dir.Ensure()
-	c.Assert(err, jc.ErrorIsNil)
-	exists = dir.Exists()
-	c.Assert(exists, jc.IsTrue)
-	fi, err := os.Stat(reldir)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(fi, jc.Satisfies, os.FileInfo.IsDir)
-}
-
-func (s *StateDirSuite) TestReadStateDirValid(c *gc.C) {
-	basedir := c.MkDir()
-	reldir := setUpDir(c, basedir, "123", map[string]string{
-		"foo-bar-1":           "change-version: 99\n",
-		"foo-bar-1.preparing": "change-version: 100\n",
-		"baz-qux-7":           "change-version: 101\nchanged-pending: true\n",
-		"nonsensical":         "blah",
-		"27":                  "blah",
-	})
-	setUpDir(c, reldir, "ignored", nil)
-
-	dir, err := relation.ReadStateDir(basedir, 123)
-	c.Assert(err, jc.ErrorIsNil)
-	state := dir.State()
-	c.Assert(state.RelationId, gc.Equals, 123)
-	c.Assert(msi(state.Members), gc.DeepEquals, msi{"foo-bar/1": 99, "baz-qux/7": 101})
-	c.Assert(state.ChangedPending, gc.Equals, "baz-qux/7")
-}
-
-var badRelationsTests = []struct {
-	contents map[string]string
-	subdirs  []string
-	err      string
-}{
-	{
-		nil, []string{"foo-bar-1"},
-		`.* (is a directory|handle is invalid.)`,
-	}, {
-		map[string]string{"foo-1": "'"}, nil,
-		`invalid unit file "foo-1": yaml: found unexpected end of stream`,
-	}, {
-		map[string]string{"foo-1": "blah: blah\n"}, nil,
-		`invalid unit file "foo-1": "changed-version" not set`,
-	}, {
-		map[string]string{
-			"foo-1": "change-version: 123\nchanged-pending: true\n",
-			"foo-2": "change-version: 456\nchanged-pending: true\n",
-		}, nil,
-		`"foo/1" and "foo/2" both have pending changed hooks`,
-	},
-}
-
-func (s *StateDirSuite) TestBadRelations(c *gc.C) {
-	for i, t := range badRelationsTests {
-		c.Logf("test %d", i)
-		basedir := c.MkDir()
-		reldir := setUpDir(c, basedir, "123", t.contents)
-		for _, subdir := range t.subdirs {
-			setUpDir(c, reldir, subdir, nil)
-		}
-		_, err := relation.ReadStateDir(basedir, 123)
-		expect := `cannot load relation state from ".*": ` + t.err
-		c.Assert(err, gc.ErrorMatches, expect)
-	}
-}
-
-var defaultMembers = msi{"foo/1": 0, "foo/2": 0}
-var defaultAppMembers = msi{"foo": 0}
+var _ = gc.Suite(&stateSuite{})
 
 // writeTests verify the behaviour of sequences of HookInfos on a relation
 // state that starts off containing defaultMembers.
@@ -142,20 +54,6 @@ var writeTests = []struct {
 		members: msi{"foo/1": 0, "foo/2": 0, "foo/3": 0},
 		pending: "foo/3",
 	}, {
-		description: "relation-joined foo/3 and relation-changed foo/3",
-		hooks: []hook.Info{{
-			Kind:              hooks.RelationJoined,
-			RelationId:        123,
-			RemoteUnit:        "foo/3",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationChanged,
-			RelationId:        123,
-			RemoteUnit:        "foo/3",
-			RemoteApplication: "foo",
-		}},
-		members: msi{"foo/1": 0, "foo/2": 0, "foo/3": 0},
-	}, {
 		description: "relation-departed foo/1",
 		hooks: []hook.Info{{
 			Kind:              hooks.RelationDeparted,
@@ -164,57 +62,6 @@ var writeTests = []struct {
 			RemoteApplication: "foo",
 		}},
 		members: msi{"foo/2": 0},
-	}, {
-		description: "relation-departed foo/1 and relation-joined foo/1",
-		hooks: []hook.Info{{
-			Kind:              hooks.RelationDeparted,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationJoined,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}},
-		members: msi{"foo/1": 0, "foo/2": 0},
-		pending: "foo/1",
-	}, {
-		description: "relation-departed foo/1 and relation-joined foo/1 and relation-changed foo/1",
-		hooks: []hook.Info{{
-			Kind:              hooks.RelationDeparted,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}, {
-			Kind:       hooks.RelationJoined,
-			RelationId: 123,
-			RemoteUnit: "foo/1",
-		}, {
-			Kind:              hooks.RelationChanged,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}},
-		members: msi{"foo/1": 0, "foo/2": 0},
-	}, {
-		description: "relation-departed foo/1 and relation-departed foo/2 and relation-broken",
-		hooks: []hook.Info{{
-			Kind:              hooks.RelationDeparted,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationDeparted,
-			RelationId:        123,
-			RemoteUnit:        "foo/2",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationBroken,
-			RelationId:        123,
-			RemoteApplication: "foo",
-		}},
-		deleted: true,
 	},
 	// Verify detection of various error conditions.
 	{
@@ -226,38 +73,6 @@ var writeTests = []struct {
 			RemoteApplication: "foo",
 		}},
 		err: "expected relation 123, got relation 456",
-	}, {
-		description: "relation-changed foo/3 must follow relation-joined foo/3 (before relation-joined of another unit)",
-		hooks: []hook.Info{{
-			Kind:              hooks.RelationJoined,
-			RelationId:        123,
-			RemoteUnit:        "foo/3",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationJoined,
-			RelationId:        123,
-			RemoteUnit:        "foo/4",
-			RemoteApplication: "foo",
-		}},
-		members: msi{"foo/1": 0, "foo/2": 0, "foo/3": 0},
-		pending: "foo/3",
-		err:     `expected "relation-changed" for "foo/3"`,
-	}, {
-		description: "relation-changed foo/3 must follow relation-joined foo/3 (not relation-changed for another unit)",
-		hooks: []hook.Info{{
-			Kind:              hooks.RelationJoined,
-			RelationId:        123,
-			RemoteUnit:        "foo/3",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationChanged,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}},
-		members: msi{"foo/1": 0, "foo/2": 0, "foo/3": 0},
-		pending: "foo/3",
-		err:     `expected "relation-changed" for "foo/3"`,
 	}, {
 		description: "relation-joined of a joined unit",
 		hooks: []hook.Info{{
@@ -292,182 +107,267 @@ var writeTests = []struct {
 			RelationId: 123,
 		}},
 		err: `cannot run "relation-broken" while units still present`,
-	}, {
-		description: "relation-joined after relation has been broken",
-		hooks: []hook.Info{{
-			Kind:              hooks.RelationDeparted,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationDeparted,
-			RelationId:        123,
-			RemoteUnit:        "foo/2",
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationBroken,
-			RelationId:        123,
-			RemoteApplication: "foo",
-		}, {
-			Kind:              hooks.RelationJoined,
-			RelationId:        123,
-			RemoteUnit:        "foo/1",
-			RemoteApplication: "foo",
-		}},
-		err:     `relation is broken and cannot be changed further`,
-		deleted: true,
 	},
 }
 
-func (s *StateDirSuite) TestWrite(c *gc.C) {
+func (s *stateSuite) TestWriteOrValidateSingleHook(c *gc.C) {
 	for i, t := range writeTests {
 		c.Logf("test %d: %v", i, t.description)
-		basedir := c.MkDir()
-		setUpDir(c, basedir, "123", map[string]string{
-			"foo-1":   "change-version: 0\n",
-			"foo-2":   "change-version: 0\n",
-			"foo-app": "change-version: 0\n",
-		})
-		dir, err := relation.ReadStateDir(basedir, 123)
-		c.Assert(err, jc.ErrorIsNil)
 		for i, hi := range t.hooks {
+			st := s.setupTestState()
 			c.Logf("  hook %d %v %v %v", i, hi.Kind, hi.RemoteUnit, hi.RemoteApplication)
 			if i == len(t.hooks)-1 && t.err != "" {
-				err = dir.State().Validate(hi)
+				err := st.Validate(hi)
 				expect := fmt.Sprintf(`inappropriate %q for %q: %s`, hi.Kind, hi.RemoteUnit, t.err)
 				c.Assert(err, gc.ErrorMatches, expect)
 			} else {
-				err = dir.State().Validate(hi)
-				c.Assert(err, jc.ErrorIsNil)
-				err = dir.Write(hi)
-				c.Assert(err, jc.ErrorIsNil)
-				// Check that writing the same change again is OK.
-				err = dir.Write(hi)
-				c.Assert(err, jc.ErrorIsNil)
+				expectedState := s.setupTestState()
+				if t.pending != "" {
+					expectedState.ChangedPending = t.pending
+				}
+				if t.members != nil {
+					expectedState.Members = t.members
+
+				}
+				if t.appMembers != nil {
+					expectedState.ApplicationMembers = t.appMembers
+				}
+				runWriteHookTest(c, st, expectedState, hi)
 			}
 		}
-		members := t.members
-		if members == nil && !t.deleted {
-			members = defaultMembers
-		}
-		appMembers := t.appMembers
-		if appMembers == nil && !t.deleted {
-			appMembers = defaultAppMembers
-		}
-		assertState(c, dir, basedir, 123, members, appMembers, t.pending, t.deleted)
 	}
 }
 
-func (s *StateDirSuite) TestRemove(c *gc.C) {
-	basedir := c.MkDir()
-	dir, err := relation.ReadStateDir(basedir, 1)
-	c.Assert(err, jc.ErrorIsNil)
-	err = dir.Ensure()
-	c.Assert(err, jc.ErrorIsNil)
-	err = dir.Remove()
-	c.Assert(err, jc.ErrorIsNil)
-	err = dir.Remove()
-	c.Assert(err, jc.ErrorIsNil)
+func (s *stateSuite) TestWriteMultiHookJoinedChanged(c *gc.C) {
+	c.Log("relation - joined foo / 3 and relation - changed foo / 3")
 
-	setUpDir(c, basedir, "99", map[string]string{
-		"foo-1": "change-version: 0\n",
-	})
-	dir, err = relation.ReadStateDir(basedir, 99)
-	c.Assert(err, jc.ErrorIsNil)
-	err = dir.Remove()
-	// Windows message is The directory is not empty
-	// Unix message is directory not empty
-	c.Assert(err, gc.ErrorMatches, ".* directory (is )?not empty.?")
-}
+	// Setup initial state
+	st := s.setupTestState()
 
-type ReadAllStateDirsSuite struct{}
-
-var _ = gc.Suite(&ReadAllStateDirsSuite{})
-
-func (s *ReadAllStateDirsSuite) TestNoDir(c *gc.C) {
-	basedir := c.MkDir()
-	relsdir := filepath.Join(basedir, "relations")
-
-	dirs, err := relation.ReadAllStateDirs(relsdir)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dirs, gc.HasLen, 0)
-
-	_, err = os.Stat(relsdir)
-	c.Assert(err, jc.Satisfies, os.IsNotExist)
-}
-
-func (s *ReadAllStateDirsSuite) TestBadStateDir(c *gc.C) {
-	basedir := c.MkDir()
-	relsdir := setUpDir(c, basedir, "relations", nil)
-	setUpDir(c, relsdir, "123", map[string]string{
-		"bad-0": "blah: blah\n",
-	})
-	_, err := relation.ReadAllStateDirs(relsdir)
-	c.Assert(err, gc.ErrorMatches, `cannot load relations state from .*: cannot load relation state from .*: invalid unit file "bad-0": "changed-version" not set`)
-}
-
-func (s *ReadAllStateDirsSuite) TestReadAllStateDirs(c *gc.C) {
-	basedir := c.MkDir()
-	relsdir := setUpDir(c, basedir, "relations", map[string]string{
-		"ignored":     "blah",
-		"foo-bar-123": "gibberish",
-	})
-	setUpDir(c, relsdir, "123", map[string]string{
-		"foo-0":     "change-version: 1\n",
-		"foo-1":     "change-version: 2\nchanged-pending: true\n",
-		"gibberish": "gibberish",
-	})
-	setUpDir(c, relsdir, "456", map[string]string{
-		"bar-0": "change-version: 3\n",
-		"bar-1": "change-version: 4\n",
-	})
-	setUpDir(c, relsdir, "789", nil)
-	setUpDir(c, relsdir, "10", map[string]string{
-		"baz-app": "change-version: 2\n",
-	})
-	setUpDir(c, relsdir, "onethousand", map[string]string{
-		"baz-0": "change-version: 3\n",
-		"baz-1": "change-version: 4\n",
-	})
-
-	dirs, err := relation.ReadAllStateDirs(relsdir)
-	c.Assert(err, jc.ErrorIsNil)
-	for id, dir := range dirs {
-		c.Logf("%d: %#v", id, dir)
+	// Setup Joined Hook
+	hiJoined := hook.Info{
+		Kind:              hooks.RelationJoined,
+		RelationId:        123,
+		RemoteUnit:        "foo/3",
+		RemoteApplication: "foo",
 	}
-	assertState(c, dirs[123], relsdir, 123, msi{"foo/0": 1, "foo/1": 2}, msi{}, "foo/1", false)
-	assertState(c, dirs[456], relsdir, 456, msi{"bar/0": 3, "bar/1": 4}, msi{}, "", false)
-	assertState(c, dirs[789], relsdir, 789, msi{}, msi{}, "", false)
-	assertState(c, dirs[10], relsdir, 10, msi{}, msi{"baz": 2}, "", false)
-	c.Assert(dirs, gc.HasLen, 4)
+	expectedState := s.setupTestState()
+	expectedState.Members["foo/3"] = 0
+	expectedState.ChangedPending = "foo/3"
+
+	runWriteHookTest(c, st, expectedState, hiJoined)
+
+	// Setup Changed Hook
+	hiChanged := hook.Info{
+		Kind:              hooks.RelationChanged,
+		RelationId:        123,
+		RemoteUnit:        "foo/3",
+		RemoteApplication: "foo",
+	}
+	expectedState.ChangedPending = ""
+
+	runWriteHookTest(c, st, expectedState, hiChanged)
 }
 
-func setUpDir(c *gc.C, basedir, name string, contents map[string]string) string {
-	reldir := filepath.Join(basedir, name)
-	err := os.Mkdir(reldir, 0777)
+func (s *stateSuite) TestWriteMultiHookDepartedJoinedJoined(c *gc.C) {
+	c.Log("relation-departed foo/1 and relation-joined foo/1")
+
+	// Setup initial state
+	st := s.setupTestState()
+
+	// Setup Departed Hook mocks
+	hiDeparted := hook.Info{
+		Kind:              hooks.RelationDeparted,
+		RelationId:        123,
+		RemoteUnit:        "foo/1",
+		RemoteApplication: "foo",
+	}
+	expectedState := s.setupTestState()
+	delete(expectedState.Members, "foo/1")
+
+	runWriteHookTest(c, st, expectedState, hiDeparted)
+
+	// Setup Changed Hook mocks
+	hiJoined := hook.Info{
+		Kind:              hooks.RelationJoined,
+		RelationId:        123,
+		RemoteUnit:        "foo/1",
+		RemoteApplication: "foo",
+	}
+	expectedState.Members["foo/1"] = 0
+	expectedState.ChangedPending = "foo/1"
+
+	runWriteHookTest(c, st, expectedState, hiJoined)
+}
+
+func (s *stateSuite) TestWriteMultiHookDepartedJoinedChanged(c *gc.C) {
+	c.Logf("relation-departed foo/1 and relation-joined foo/1 and relation-changed foo/1")
+
+	// Setup initial state
+	st := s.setupTestState()
+
+	// Setup Departed Hook mocks
+	hiDeparted := hook.Info{
+		Kind:              hooks.RelationDeparted,
+		RelationId:        123,
+		RemoteUnit:        "foo/1",
+		RemoteApplication: "foo",
+	}
+	expectedState := s.setupTestState()
+	delete(expectedState.Members, "foo/1")
+
+	runWriteHookTest(c, st, expectedState, hiDeparted)
+
+	// Setup Joined Hook mocks
+	hiJoined := hook.Info{
+		Kind:       hooks.RelationJoined,
+		RelationId: 123,
+		RemoteUnit: "foo/1",
+	}
+	expectedState.Members["foo/1"] = 0
+	expectedState.ChangedPending = "foo/1"
+
+	runWriteHookTest(c, st, expectedState, hiJoined)
+
+	// Setup Changed Hook
+	hiChanged := hook.Info{
+		Kind:              hooks.RelationChanged,
+		RelationId:        123,
+		RemoteUnit:        "foo/1",
+		RemoteApplication: "foo",
+	}
+	expectedState.ChangedPending = ""
+
+	runWriteHookTest(c, st, expectedState, hiChanged)
+}
+
+func (s *stateSuite) TestWriteMultiHookDepartedDepartedBroken(c *gc.C) {
+	c.Logf("relation-departed foo/1 and relation-departed foo/2 and relation-broken")
+
+	// Setup initial state
+	st := s.setupTestState()
+
+	// Setup Departed Hook mocks
+	hiDeparted := hook.Info{
+		Kind:              hooks.RelationDeparted,
+		RelationId:        123,
+		RemoteUnit:        "foo/1",
+		RemoteApplication: "foo",
+	}
+	expectedState := s.setupTestState()
+	delete(expectedState.Members, "foo/1")
+
+	runWriteHookTest(c, st, expectedState, hiDeparted)
+
+	// Setup 2nd Departed Hook mocks
+	hiDeparted2 := hook.Info{
+		Kind:              hooks.RelationDeparted,
+		RelationId:        123,
+		RemoteUnit:        "foo/2",
+		RemoteApplication: "foo",
+	}
+	delete(expectedState.Members, "foo/2")
+
+	runWriteHookTest(c, st, expectedState, hiDeparted2)
+
+	// Setup Broken Hook mocks
+	hiBroken := hook.Info{
+		Kind:              hooks.RelationBroken,
+		RelationId:        123,
+		RemoteApplication: "foo",
+	}
+
+	err := st.UpdateStateForHook(hiBroken)
+	c.Assert(err, gc.NotNil)
+}
+
+func (s *stateSuite) setupTestState() *relation.State {
+	return &relation.State{
+		RelationId: 123,
+		Members: map[string]int64{
+			"foo/1": 0,
+			"foo/2": 0,
+		},
+		ApplicationMembers: map[string]int64{
+			"foo": 0,
+		},
+	}
+}
+
+func runWriteHookTest(c *gc.C, st, expectedState *relation.State, hi hook.Info) {
+	err := st.Validate(hi)
 	c.Assert(err, jc.ErrorIsNil)
-	for name, content := range contents {
-		path := filepath.Join(reldir, name)
-		err := ioutil.WriteFile(path, []byte(content), 0777)
-		c.Assert(err, jc.ErrorIsNil)
-	}
-	return reldir
+	err = st.UpdateStateForHook(hi)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*expectedState, jc.DeepEquals, *st)
+	// Check that writing the same change again is OK.
+	err = st.UpdateStateForHook(hi)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*expectedState, jc.DeepEquals, *st)
 }
 
-func assertState(c *gc.C, dir *relation.StateDir, relsdir string, relationId int, members msi, appmembers msi, pending string, deleted bool) {
-	expect := &relation.State{
-		RelationId:         relationId,
-		Members:            map[string]int64(members),
-		ApplicationMembers: map[string]int64(appmembers),
-		ChangedPending:     pending,
+func (s *stateSuite) TestStateValidateErrorJoinedJoined(c *gc.C) {
+	c.Logf("relation-changed foo/3 must follow relation-joined foo/3 (before relation-joined of another unit)")
+	// Setup 2nd Joined Hook
+	hiInfo := hook.Info{
+		Kind:              hooks.RelationJoined,
+		RelationId:        123,
+		RemoteUnit:        "foo/4",
+		RemoteApplication: "foo",
 	}
-	c.Assert(dir.State(), gc.DeepEquals, expect)
-	if deleted {
-		_, err := os.Stat(filepath.Join(relsdir, strconv.Itoa(relationId)))
-		c.Assert(err, jc.Satisfies, os.IsNotExist)
-	} else {
-		fresh, err := relation.ReadStateDir(relsdir, relationId)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(fresh.State(), gc.DeepEquals, expect)
+	s.testStateValidateErrorAfterJoined(c, hiInfo)
+}
+
+func (s *stateSuite) TestStateValidateErrorJoined3Joined1(c *gc.C) {
+	c.Logf("relation-changed foo/3 must follow relation-joined foo/3 (not relation-changed for another unit)")
+	// Setup relation changed for a different unit.
+	hiInfo := hook.Info{
+		Kind:              hooks.RelationChanged,
+		RelationId:        123,
+		RemoteUnit:        "foo/1",
+		RemoteApplication: "foo",
 	}
+	s.testStateValidateErrorAfterJoined(c, hiInfo)
+}
+
+func (s *stateSuite) testStateValidateErrorAfterJoined(c *gc.C, hiInfo hook.Info) {
+	// Setup state post relation-changed foo/3
+	st := &relation.State{
+		RelationId: 123,
+		Members: map[string]int64{
+			"foo/1": 0,
+			"foo/2": 0,
+			"foo/3": 0,
+		},
+		ApplicationMembers: map[string]int64{
+			"foo": 0,
+		},
+		ChangedPending: "foo/3",
+	}
+
+	// Run hook
+	err := st.Validate(hiInfo)
+	expect := fmt.Sprintf(`inappropriate %q for %q: expected "relation-changed" for "foo/3"`, hiInfo.Kind, hiInfo.RemoteUnit)
+	c.Assert(err, gc.ErrorMatches, expect)
+}
+
+func (s *stateSuite) TestStateValidateErrorBrokenJoined(c *gc.C) {
+	c.Logf("relation-joined after relation has been broken")
+
+	// Setup state post broken relation app foo
+	st := &relation.State{
+		RelationId: 123,
+	}
+
+	// Setup relation joined on same app
+	hiInfo := hook.Info{
+		Kind:              hooks.RelationJoined,
+		RelationId:        123,
+		RemoteUnit:        "foo/1",
+		RemoteApplication: "foo",
+	}
+
+	err := st.Validate(hiInfo)
+	expect := fmt.Sprintf(`inappropriate %q for %q: relation is broken and cannot be changed further`, hiInfo.Kind, hiInfo.RemoteUnit)
+	c.Assert(err, gc.ErrorMatches, expect)
 }

--- a/worker/uniter/relation/statemanager.go
+++ b/worker/uniter/relation/statemanager.go
@@ -1,0 +1,178 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package relation
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// StateManager encapsulates methods required to handle relation
+// state.
+type StateManager interface {
+	// KnownIDs returns a slice of relation ids, known to the
+	// state manager.
+	KnownIDs() []int
+
+	// Relation returns a copy of the relation state for the given id.
+	Relation(int) (*State, error)
+
+	// SetRelation persists the given state, overwriting the previous
+	// state for a given id or creating state at a new id.
+	SetRelation(*State) error
+
+	// RelationFound returns true if the state manager has a
+	// state for the given id.
+	RelationFound(id int) bool
+
+	// RemoveRelation removes the state for the given id from the
+	// manager.
+	RemoveRelation(id int) error
+}
+
+// UnitStateReadWriter encapsulates the methods from a state.Unit
+// required to set and get unit state.
+type UnitStateReadWriter interface {
+	State() (params.UnitStateResult, error)
+	SetState(unitState params.SetUnitStateArg) error
+}
+
+// NewStateManager
+func NewStateManager(rw UnitStateReadWriter) (StateManager, error) {
+	mgr := &stateManager{unitStateRW: rw}
+	return mgr, mgr.initialize()
+}
+
+type stateManager struct {
+	unitStateRW   UnitStateReadWriter
+	relationState map[int]State
+	mu            sync.Mutex
+}
+
+// RelationState returns a copy of the relation state for
+// the given id. Returns NotFound.
+func (m *stateManager) Relation(id int) (*State, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.relationState[id]; ok {
+		return s.copy(), nil
+	}
+	return nil, errors.NotFoundf("relation %d", id)
+}
+
+// RemoveRelation removes the state for the given id from the
+// manager.  The change to the manager is only made when the
+// data is successfully saved.
+func (m *stateManager) RemoveRelation(id int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st, ok := m.relationState[id]
+	if !ok {
+		return errors.NotFoundf("relation %d", id)
+	}
+	if len(st.Members) != 0 {
+		return errors.New(fmt.Sprintf("cannot remove persisted state, relation %d has members", id))
+	}
+	if err := m.remove(id); err != nil {
+		return err
+	}
+	delete(m.relationState, id)
+	return nil
+}
+
+// KnownIDs returns a slice of relation ids, known to the
+// state manager.
+func (m *stateManager) KnownIDs() []int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ids := make([]int, len(m.relationState))
+	// 0 is a valid id, and it's the initial value of an int
+	// ensure the only 0 is the slice should be there.
+	i := 0
+	for k := range m.relationState {
+		ids[i] = k
+		i += 1
+	}
+	return ids
+}
+
+// SetRelationState persists the given state, overwriting the previous
+// state for a given id or creating state at a new id. The change to
+//the manager is only made when the data is successfully saved.
+func (m *stateManager) SetRelation(st *State) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.write(st); err != nil {
+		return errors.Annotatef(err, "could not persist relation %d state", st.RelationId)
+	}
+	m.relationState[st.RelationId] = *st
+	return nil
+}
+
+// RelationFound returns true if the state manager has a
+// state for the given id.
+func (m *stateManager) RelationFound(id int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.relationState[id]
+	return ok
+}
+
+// initialize loads the current state into the manager.
+func (m *stateManager) initialize() error {
+	unitState, err := m.unitStateRW.State()
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+	m.relationState = make(map[int]State, len(unitState.RelationState))
+	for k, v := range unitState.RelationState {
+		var state State
+		if err = yaml.Unmarshal([]byte(v), &state); err != nil {
+			return errors.Annotatef(err, "cannot unmarshall relation %d state", k)
+		}
+		m.relationState[k] = state
+	}
+	return nil
+}
+
+func (m *stateManager) write(st *State) error {
+	newSt, err := m.stateToPersist()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	str, err := st.YamlString()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newSt[st.RelationId] = str
+	return m.unitStateRW.SetState(params.SetUnitStateArg{RelationState: &newSt})
+}
+
+func (m *stateManager) remove(id int) error {
+	newSt, err := m.stateToPersist()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	delete(newSt, id)
+	return m.unitStateRW.SetState(params.SetUnitStateArg{RelationState: &newSt})
+}
+
+// stateToPersist transforms the relationState of this manager
+// into a form used for UnitStateReadWriter SetState.
+func (m *stateManager) stateToPersist() (map[int]string, error) {
+	newSt := make(map[int]string, len(m.relationState))
+	for k, v := range m.relationState {
+		str, err := v.YamlString()
+		if err != nil {
+			return newSt, errors.Trace(err)
+		}
+		newSt[k] = str
+	}
+	return newSt, nil
+}

--- a/worker/uniter/relation/statemanager_test.go
+++ b/worker/uniter/relation/statemanager_test.go
@@ -1,0 +1,286 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package relation_test
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker/uniter/operation/mocks"
+	"github.com/juju/juju/worker/uniter/relation"
+)
+
+type stateManagerSuite struct {
+	mockUnitRW *mocks.MockUnitStateReadWriter
+}
+
+func (s *stateManagerSuite) TestNewStateManagerHasState(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	states := s.setupFourStates(c)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, st := range states {
+		v, err := mgr.Relation(st.RelationId)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(*v, gc.DeepEquals, st)
+	}
+}
+
+func (s *stateManagerSuite) TestNewStateManagerNoState(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectStateEmpty()
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mgr.KnownIDs(), gc.HasLen, 0)
+}
+
+func (s *stateManagerSuite) TestNewStateManagerErr(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectStateEmptyError()
+
+	_, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
+}
+
+func (s *stateManagerSuite) TestKnownIds(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	states := s.setupFourStates(c)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	ids := mgr.KnownIDs()
+	intSet := set.NewInts(ids...)
+	c.Assert(intSet.Size(), gc.Equals, 4, gc.Commentf("obtained %v", intSet.Values()))
+	for _, exp := range states {
+		c.Assert(intSet.Contains(exp.RelationId), jc.IsTrue)
+	}
+}
+
+func (s *stateManagerSuite) TestRelation(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	states := s.setupFourStates(c)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	st, err := mgr.Relation(states[1].RelationId)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*st, gc.DeepEquals, states[1])
+}
+
+func (s *stateManagerSuite) TestRelationNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	_ = s.setupFourStates(c)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = mgr.Relation(42)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *stateManagerSuite) TestSetNew(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectStateEmpty()
+	st2 := &relation.State{RelationId: 456}
+	st2.Members = map[string]int64{
+		"bar/0": 3,
+		"bar/1": 4,
+	}
+	s.expectSetState(c, *st2)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mgr.SetRelation(st2)
+	c.Assert(err, jc.ErrorIsNil)
+	found := mgr.RelationFound(456)
+	c.Assert(found, jc.IsTrue)
+}
+
+func (s *stateManagerSuite) TestSetChangeExisting(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	states := s.setupFourStates(c)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+
+	states[3].ChangedPending = "foo/1"
+	s.expectSetState(c, states...)
+	st := states[3]
+
+	err = mgr.SetRelation(&st)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained, err := mgr.Relation(st.RelationId)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*obtained, gc.DeepEquals, st)
+}
+
+func (s *stateManagerSuite) TestSetChangeExistingFail(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	states := s.setupFourStates(c)
+	s.expectSetStateError()
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+
+	st := states[3]
+	st.ChangedPending = "foo/1"
+	err = mgr.SetRelation(&st)
+	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
+
+	obtained, err := mgr.Relation(st.RelationId)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*obtained, gc.DeepEquals, states[3])
+}
+
+func (s *stateManagerSuite) TestRemove(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	state := relation.State{RelationId: 1}
+	s.expectState(c, state)
+	s.expectSetStateEmpty(c)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mgr.RemoveRelation(1)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateManagerSuite) TestRemoveNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	stateTwo := relation.State{RelationId: 99}
+	stateTwo.Members = map[string]int64{"foo/1": 0}
+	s.expectState(c, stateTwo)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mgr.RemoveRelation(1)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *stateManagerSuite) TestRemoveFailHasMembers(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	stateTwo := relation.State{RelationId: 99}
+	stateTwo.Members = map[string]int64{"foo/1": 0}
+	s.expectState(c, stateTwo)
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mgr.RemoveRelation(99)
+	c.Assert(err, gc.ErrorMatches, `*has members`)
+}
+
+func (s *stateManagerSuite) TestRemoveFailRequest(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	stateTwo := relation.State{RelationId: 99}
+	s.expectState(c, stateTwo)
+	s.expectSetStateError()
+
+	mgr, err := relation.NewStateManager(s.mockUnitRW)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mgr.RemoveRelation(99)
+	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
+	found := mgr.RelationFound(99)
+	c.Assert(found, jc.IsTrue)
+}
+
+var _ = gc.Suite(&stateManagerSuite{})
+
+func (s *stateManagerSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctlr := gomock.NewController(c)
+	s.mockUnitRW = mocks.NewMockUnitStateReadWriter(ctlr)
+	return ctlr
+}
+
+func (s *stateManagerSuite) setupFourStates(c *gc.C) []relation.State {
+	st1 := relation.State{RelationId: 123}
+	st1.Members = map[string]int64{
+		"foo/0": 1,
+		"foo/1": 2,
+	}
+	st1.ChangedPending = "foo/1"
+	st2 := relation.State{RelationId: 456}
+	st2.Members = map[string]int64{
+		"bar/0": 3,
+		"bar/1": 4,
+	}
+	st3 := relation.State{RelationId: 789}
+	st4 := relation.State{RelationId: 10}
+	st4.ApplicationMembers = map[string]int64{
+		"baz-app": 2,
+	}
+	states := []relation.State{st1, st2, st3, st4}
+	s.expectState(c, states...)
+	return states
+}
+
+func (s *stateManagerSuite) expectStateEmpty() {
+	exp := s.mockUnitRW.EXPECT()
+	exp.State().Return(params.UnitStateResult{}, nil)
+}
+
+func (s *stateManagerSuite) expectStateEmptyError() {
+	exp := s.mockUnitRW.EXPECT()
+	exp.State().Return(params.UnitStateResult{}, errors.BadRequestf("testing"))
+}
+
+func (s *stateManagerSuite) expectSetState(c *gc.C, states ...relation.State) {
+	expectedStates := make(map[int]string, len(states))
+	for _, s := range states {
+		str, err := s.YamlString()
+		c.Assert(err, jc.ErrorIsNil)
+		expectedStates[s.RelationId] = str
+	}
+	exp := s.mockUnitRW.EXPECT()
+	exp.SetState(unitStateMatcher{c: c, expected: expectedStates}).Return(nil)
+}
+
+func (s *stateManagerSuite) expectSetStateEmpty(c *gc.C) {
+	exp := s.mockUnitRW.EXPECT()
+	exp.SetState(unitStateMatcher{c: c, expected: map[int]string{}}).Return(nil)
+}
+
+func (s *stateManagerSuite) expectSetStateError() {
+	exp := s.mockUnitRW.EXPECT()
+	exp.SetState(gomock.Any()).Return(errors.BadRequestf("testing"))
+}
+
+func (s *stateManagerSuite) expectState(c *gc.C, states ...relation.State) {
+	relationMap := make(map[int]string, len(states))
+	for _, state := range states {
+		data, err := yaml.Marshal(state)
+		c.Assert(err, jc.ErrorIsNil)
+		strState := string(data)
+		relationMap[state.RelationId] = strState
+	}
+	exp := s.mockUnitRW.EXPECT()
+	exp.State().Return(params.UnitStateResult{
+		RelationState: relationMap,
+	}, nil)
+}
+
+type unitStateMatcher struct {
+	c        *gc.C
+	expected map[int]string
+}
+
+func (m unitStateMatcher) Matches(x interface{}) bool {
+	obtained, ok := x.(params.SetUnitStateArg)
+	if !ok {
+		return false
+	}
+
+	m.c.Assert(*obtained.RelationState, gc.DeepEquals, m.expected)
+
+	return true
+}
+
+func (m unitStateMatcher) String() string {
+	return "Match the contents of the RelationState pointer in params.SetUnitStateArg"
+}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -575,17 +575,13 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	if err := tools.EnsureSymlinks(u.paths.ToolsDir, u.paths.ToolsDir, jujuc.CommandNames()); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(u.paths.State.RelationsDir, 0755); err != nil {
-		return errors.Trace(err)
-	}
 	relStateTracker, err := relation.NewRelationStateTracker(
 		relation.RelationStateTrackerConfig{
 			State:                u.st,
-			UnitTag:              unitTag,
+			Unit:                 u.unit,
 			Tracker:              u.leadershipTracker,
 			NewLeadershipContext: context.NewLeadershipContext,
 			CharmDir:             u.paths.State.CharmDir,
-			RelationsDir:         u.paths.State.RelationsDir,
 			Abort:                u.catacomb.Dying(),
 		})
 	if err != nil {
@@ -683,6 +679,10 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	}
 	u.operationExecutor = operationExecutor
 
+	// Ensure we have an agent directory to to write the socket.
+	if err := os.MkdirAll(u.paths.State.BaseDir, 0755); err != nil {
+		return errors.Trace(err)
+	}
 	socket := u.paths.Runtime.LocalJujuRunSocket.Server
 	logger.Debugf("starting local juju-run listener on %v", socket)
 	u.localRunListener, err = NewRunListener(socket)


### PR DESCRIPTION
## Description of change

Move the uniter's internal relation state from files on the unit to the controller.

The uniter's internal relation state keeps track of relations made for this unit.  The entire relation.State structure will now be saved, rather than pieces and complicated ways of interpreting files to come with a relation.State.  

Upgrade steps included.  Migration steps for all of the uniter internal state moving server side will be handled together.

## QA steps
```console
$ juju bootstrap
$ juju deploy keystone 
$ juju deploy percona-cluster mysql 
$ juju add-relation keystone:shared-db mysql:shared-db 

# once the units stable, check the juju db
juju-db.bash
juju:PRIMARY> db.unitstates.find({},{"relation-state":1}).pretty()

# add a few units and relate them:
$ juju deploy glance -n 2 ; juju add-relation glance keystone  ; juju add-relation glance mysql

# once the units stable, check the juju db as above

# remove a glance unit
$ juju remove-unit glance/1

# once the units stable, check the juju db as above
```

Run same config upgrading from 2.7.5 to develop
