### PR TITLE
Statically compile juju in snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,7 @@ parts:
       github.com/juju/juju/version.GitCommit: ""
       github.com/juju/juju/version.GitTreeState: ""
       github.com/juju/juju/version.build: ""
+    go-static: true
     override-build: |
       snapcraftctl build
 


### PR DESCRIPTION
## Description of change

Statically compile juju binaries when inside snaps.

## QA steps

```
$ snapcraft remote-build
$ snap install juju_2.8-beta1_amd64.snap --dangerous --classic
$ /snap/bin/juju bootstrap localhost
$ file /snap/juju/current/bin/jujud
/snap/juju/current/bin/jujud: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=xwzubxexT-Dg_r39YwQ9/ca3TZ-3iehpDrqMcrqgP/Wl2_MfXjrcGtsnLRIBbS/NI2vPiAFr2FRYUZ7HJWM, not stripped
$ sha256sum /snap/juju/current/bin/jujud
29d530e894a8a898c701d37b3a502bddcc035cb224ba0ace5b80b3f315c9b026  jujud
$ lxc exec `lxc list | grep -o -E "juju-[[:alnum:]]*-0"` sha256sum /var/lib/juju/tools/2.8-beta1-bionic-amd64/jujud
29d530e894a8a898c701d37b3a502bddcc035cb224ba0ace5b80b3f315c9b026  /var/lib/juju/tools/2.8-beta1-bionic-amd64/jujud
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871197
