### PR TITLE
Fix a couple of small issues: deploy bundle, remove storage pool

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -519,7 +519,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		if series == "" {
 			series = h.data.Series
 		}
-		ch, curl, err := charmrepo.NewCharmAtPath(charmPath, series)
+		ch, curl, err := charmrepo.NewCharmAtPathForceSeries(charmPath, series, h.force)
 		if err != nil && !os.IsNotExist(err) {
 			return errors.Annotatef(err, "cannot deploy local charm at %q", charmPath)
 		}

--- a/cmd/juju/storage/pooldelete.go
+++ b/cmd/juju/storage/pooldelete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -77,5 +78,10 @@ func (c *poolRemoveCommand) Run(ctx *cmd.Context) (err error) {
 	if api.BestAPIVersion() < 5 {
 		return errors.New("removing storage pools is not supported by this version of Juju")
 	}
-	return api.RemovePool(c.poolName)
+	err = api.RemovePool(c.poolName)
+	if params.IsCodeNotFound(err) {
+		ctx.Infof("removing storage pool %s failed: %s", c.poolName, err)
+		return cmd.ErrSilent
+	}
+	return err
 }

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -697,13 +697,10 @@ func (s *StorageStateSuite) TestRemoveStoragePoolInUse(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pool.Name(), gc.Equals, poolName)
 
-	// pool does not exist at all, poolmanager swallows NotFound errors.
 	_, err = s.pm.Get("nope-pool")
 	c.Assert(err, gc.ErrorMatches, `pool "nope-pool" not found`)
 	err = s.storageBackend.RemoveStoragePool("nope-pool")
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.pm.Get("nope-pool")
-	c.Assert(err, gc.ErrorMatches, `pool "nope-pool" not found`)
+	c.Assert(err, gc.ErrorMatches, `storage pool "nope-pool" not found`)
 }
 
 func (s *StorageStateSuite) TestStorageAttachments(c *gc.C) {

--- a/storage/poolmanager/poolmanager.go
+++ b/storage/poolmanager/poolmanager.go
@@ -81,8 +81,8 @@ func (pm *poolManager) validatedConfig(name string, providerType storage.Provide
 // Delete is defined on PoolManager interface.
 func (pm *poolManager) Delete(name string) error {
 	err := pm.settings.RemoveSettings(globalKey(name))
-	if err == nil || errors.IsNotFound(err) {
-		return nil
+	if errors.IsNotFound(err) {
+		return errors.NotFoundf("storage pool %q", name)
 	}
 	return errors.Annotatef(err, "deleting pool %q", name)
 }

--- a/storage/poolmanager/poolmanager_test.go
+++ b/storage/poolmanager/poolmanager_test.go
@@ -180,7 +180,6 @@ func (s *poolSuite) TestDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.poolManager.Get("testpool")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	// Delete again, no error.
 	err = s.poolManager.Delete("testpool")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }


### PR DESCRIPTION
## Description of change

1. deploy a bundle with local charms should honour --force
2. print a message when removing a non existent storage pool

## QA steps
```
$ juju remove-storage-pool foo
removing storage pool foo failed: storage pool "foo" not found

$ juju deploy somebundlewithocalcharmandunsupportedseries --force
Executing changes:
- upload charm ./ubuntu-lite for series focal
- deploy application ubuntu-lite on focal using ./ubuntu-lite
Deploy of bundle completed.
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1863686
https://bugs.launchpad.net/juju/+bug/1866212