### PR TITLE
2.7 Fix Panic Migrating Application With No Bindings

### DIFF
--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -86,12 +86,12 @@ func (s *MigrationBaseSuite) primeStatusHistory(c *gc.C, entity statusSetter, st
 	}, 0, "")
 }
 
-func (s *MigrationBaseSuite) makeApplicationWithUnits(c *gc.C, applicationname string, count int) {
+func (s *MigrationBaseSuite) makeApplicationWithUnits(c *gc.C, applicationName string, count int) {
 	units := make([]*state.Unit, count)
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
-		Name: applicationname,
+		Name: applicationName,
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
-			Name: applicationname,
+			Name: applicationName,
 		}),
 	})
 	for i := 0; i < count; i++ {
@@ -107,7 +107,7 @@ func (s *MigrationBaseSuite) makeUnitApplicationLeader(c *gc.C, unitName, applic
 		loggo.GetLogger("migration_export_test"),
 	)
 	target.Claimed(
-		lease.Key{"application-leadership", s.State.ModelUUID(), applicationName},
+		lease.Key{Namespace: "application-leadership", ModelUUID: s.State.ModelUUID(), Lease: applicationName},
 		unitName,
 	)
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -929,6 +929,11 @@ func (i *importer) parseBindings(bindingsMap map[string]string) (*Bindings, erro
 
 	// 2.6 controllers only populate the default space key if set to the
 	// non-default space whereas 2.7 controllers always set it.
+	// The application implementation in the description package has
+	// `omitempty` for bindings, so we need to create it if nil.
+	if bindingsMap == nil {
+		bindingsMap = make(map[string]string, 1)
+	}
 	if _, exists := bindingsMap[defaultEndpointName]; !exists {
 		bindingsMap[defaultEndpointName] = network.AlphaSpaceName
 	}

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -34,6 +34,9 @@ func TestPackage(t *testing.T) {
 	coretesting.MgoTestPackage(t)
 }
 
+// SetModelTypeToCAAS can be called after SetUpTest for state suites.
+// It crudely just sets the model type to CAAS so that certain functionality
+// relying on the model type can be tested.
 func SetModelTypeToCAAS(c *gc.C, st *State, m *Model) {
 	ops := []txn.Op{{
 		C:      modelsC,
@@ -43,4 +46,17 @@ func SetModelTypeToCAAS(c *gc.C, st *State, m *Model) {
 
 	c.Assert(st.db().RunTransaction(ops), jc.ErrorIsNil)
 	c.Assert(m.refresh(m.UUID()), jc.ErrorIsNil)
+}
+
+// AddTestingApplicationWithEmptyBindings mimics an application
+// from an old version of Juju, with no bindings entry.
+func AddTestingApplicationWithEmptyBindings(c *gc.C, st *State, name string, ch *Charm) *Application {
+	app := addTestingApplication(c, addTestingApplicationParams{
+		st:   st,
+		name: name,
+		ch:   ch,
+	})
+
+	c.Assert(st.db().RunTransaction([]txn.Op{removeEndpointBindingsOp(app.globalKey())}), jc.ErrorIsNil)
+	return app
 }


### PR DESCRIPTION
## Description of change

We have seen that an old 2.5.1 model upgraded to 2.7.5 and then migrated is failing import with a panic.

This is due to having an empty or absent endpoint bindings document, which when serialised by the description package (with `omitempty`) is nil, resulting in a panic when we attempt to populate the default binding.

This patch simply creates the bindings map if it is nil, before setting the default binding.

## QA steps

One could test with an old version of Juju, but the easiest way is to:
- Bootstrap with this patch.
- Deploy one application.
- Delete the application's record from the `endpointbindings` collection directly.
- Migrate the model and ensure success.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871066
