### PR TITLE
[dev] Fix broken upgrade steps for persisting unit agent's state

### DIFF
--- a/api/upgradesteps/upgradesteps.go
+++ b/api/upgradesteps/upgradesteps.go
@@ -45,12 +45,12 @@ func (c *Client) ResetKVMMachineModificationStatusIdle(tag names.Tag) error {
 	return nil
 }
 
-// WriteUniterState writes the given internal state of the uniter for the
-// provided units.
-func (c *Client) WriteUniterState(args []params.SetUnitStateArg) error {
+// WriteAgentState writes the given internal agent state for the provided
+// units. Currently this call only handles the uniter's state.
+func (c *Client) WriteAgentState(args []params.SetUnitStateArg) error {
 	var result params.ErrorResults
 	arg := params.SetUnitStateArgs{Args: args}
-	err := c.facade.FacadeCall("WriteUniterState", arg, &result)
+	err := c.facade.FacadeCall("WriteAgentState", arg, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/upgradesteps/upgradesteps_test.go
+++ b/api/upgradesteps/upgradesteps_test.go
@@ -53,7 +53,7 @@ func (s *upgradeStepsSuite) TestResetKVMMachineModificationStatusIdleError(c *gc
 	c.Assert(err, gc.ErrorMatches, "did not find")
 }
 
-func (s *upgradeStepsSuite) TestWriteUniterState(c *gc.C) {
+func (s *upgradeStepsSuite) TestWriteAgentState(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	uTag0 := names.NewUnitTag("test/0")
@@ -64,17 +64,17 @@ func (s *upgradeStepsSuite) TestWriteUniterState(c *gc.C) {
 		{Tag: uTag0.String(), UniterState: &str0},
 		{Tag: uTag1.String(), UniterState: &str1},
 	}}
-	s.expectWriteUniterStateSuccess(c, args)
+	s.expectWriteAgentStateSuccess(c, args)
 
 	client := upgradesteps.NewClientFromFacade(s.fCaller)
-	err := client.WriteUniterState([]params.SetUnitStateArg{
+	err := client.WriteAgentState([]params.SetUnitStateArg{
 		{Tag: uTag0.String(), UniterState: &str0},
 		{Tag: uTag1.String(), UniterState: &str1},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *upgradeStepsSuite) TestWriteUniterStateError(c *gc.C) {
+func (s *upgradeStepsSuite) TestWriteAgentStateError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	uTag0 := names.NewUnitTag("test/0")
@@ -82,10 +82,10 @@ func (s *upgradeStepsSuite) TestWriteUniterStateError(c *gc.C) {
 	args := params.SetUnitStateArgs{[]params.SetUnitStateArg{
 		{Tag: uTag0.String(), UniterState: &str0},
 	}}
-	s.expectWriteUniterStateError(c, args)
+	s.expectWriteAgentStateError(c, args)
 
 	client := upgradesteps.NewClientFromFacade(s.fCaller)
-	err := client.WriteUniterState([]params.SetUnitStateArg{
+	err := client.WriteAgentState([]params.SetUnitStateArg{
 		{Tag: uTag0.String(), UniterState: &str0},
 	})
 	c.Assert(err, gc.ErrorMatches, "did not find")
@@ -114,13 +114,13 @@ func (s *upgradeStepsSuite) expectResetKVMMachineModificationStatusIdleError(res
 	fExp.FacadeCall("ResetKVMMachineModificationStatusIdle", resetArg, gomock.Any()).SetArg(2, resultSource)
 }
 
-func (s *upgradeStepsSuite) expectWriteUniterStateSuccess(c *gc.C, args params.SetUnitStateArgs) {
+func (s *upgradeStepsSuite) expectWriteAgentStateSuccess(c *gc.C, args params.SetUnitStateArgs) {
 	fExp := s.fCaller.EXPECT()
 	resultSource := params.ErrorResults{}
-	fExp.FacadeCall("WriteUniterState", unitStateMatcher{c, args}, gomock.Any()).SetArg(2, resultSource)
+	fExp.FacadeCall("WriteAgentState", unitStateMatcher{c, args}, gomock.Any()).SetArg(2, resultSource)
 }
 
-func (s *upgradeStepsSuite) expectWriteUniterStateError(c *gc.C, args params.SetUnitStateArgs) {
+func (s *upgradeStepsSuite) expectWriteAgentStateError(c *gc.C, args params.SetUnitStateArgs) {
 	fExp := s.fCaller.EXPECT()
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{{
 		Error: &params.Error{
@@ -128,7 +128,7 @@ func (s *upgradeStepsSuite) expectWriteUniterStateError(c *gc.C, args params.Set
 			Message: "did not find",
 		},
 	}}}
-	fExp.FacadeCall("WriteUniterState", unitStateMatcher{c, args}, gomock.Any()).SetArg(2, resultSource)
+	fExp.FacadeCall("WriteAgentState", unitStateMatcher{c, args}, gomock.Any()).SetArg(2, resultSource)
 }
 
 type unitStateMatcher struct {

--- a/apiserver/facades/agent/upgradesteps/interface.go
+++ b/apiserver/facades/agent/upgradesteps/interface.go
@@ -4,6 +4,7 @@
 package upgradesteps
 
 import (
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
@@ -11,6 +12,8 @@ import (
 
 type UpgradeStepsState interface {
 	state.EntityFinder
+	ControllerConfig() (controller.Config, error)
+	ApplyOperation(state.ModelOperation) error
 }
 
 // Machine represents point of use methods from the state machine object
@@ -22,7 +25,7 @@ type Machine interface {
 
 // Unit represents point of use methods from the state unit object
 type Unit interface {
-	SetState(*state.UnitState) error
+	SetStateOperation(*state.UnitState, state.UnitStateSizeLimits) state.ModelOperation
 }
 
 var (

--- a/apiserver/facades/agent/upgradesteps/interface.go
+++ b/apiserver/facades/agent/upgradesteps/interface.go
@@ -24,3 +24,12 @@ type Machine interface {
 type Unit interface {
 	SetState(*state.UnitState) error
 }
+
+var (
+	// NOTE(achilleasa): If the above interface definitions are not
+	// compatible to the equivalent implementations in state, upgrades can
+	// break due to failed cast checks. The following compile-time checks
+	// allow us to catch such issues.
+	_ Unit    = (*state.Unit)(nil)
+	_ Machine = (*state.Machine)(nil)
+)

--- a/apiserver/facades/agent/upgradesteps/mocks/state_mock.go
+++ b/apiserver/facades/agent/upgradesteps/mocks/state_mock.go
@@ -5,11 +5,10 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	state "github.com/juju/juju/state"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
+	reflect "reflect"
 )
 
 // MockEntityFinder is a mock of EntityFinder interface
@@ -36,7 +35,8 @@ func (m *MockEntityFinder) EXPECT() *MockEntityFinderMockRecorder {
 }
 
 // FindEntity mocks base method
-func (m *MockEntityFinder) FindEntity(arg0 names_v3.Tag) (state.Entity, error) {
+func (m *MockEntityFinder) FindEntity(arg0 names.Tag) (state.Entity, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindEntity", arg0)
 	ret0, _ := ret[0].(state.Entity)
 	ret1, _ := ret[1].(error)
@@ -45,6 +45,7 @@ func (m *MockEntityFinder) FindEntity(arg0 names_v3.Tag) (state.Entity, error) {
 
 // FindEntity indicates an expected call of FindEntity
 func (mr *MockEntityFinderMockRecorder) FindEntity(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindEntity", reflect.TypeOf((*MockEntityFinder)(nil).FindEntity), arg0)
 }
 
@@ -72,13 +73,15 @@ func (m *MockEntity) EXPECT() *MockEntityMockRecorder {
 }
 
 // Tag mocks base method
-func (m *MockEntity) Tag() names_v3.Tag {
+func (m *MockEntity) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockEntityMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockEntity)(nil).Tag))
 }

--- a/apiserver/facades/agent/upgradesteps/mocks/upgradesteps_mock.go
+++ b/apiserver/facades/agent/upgradesteps/mocks/upgradesteps_mock.go
@@ -6,10 +6,11 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	controller "github.com/juju/juju/controller"
 	instance "github.com/juju/juju/core/instance"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -36,8 +37,38 @@ func (m *MockUpgradeStepsState) EXPECT() *MockUpgradeStepsStateMockRecorder {
 	return m.recorder
 }
 
+// ApplyOperation mocks base method
+func (m *MockUpgradeStepsState) ApplyOperation(arg0 state.ModelOperation) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyOperation", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyOperation indicates an expected call of ApplyOperation
+func (mr *MockUpgradeStepsStateMockRecorder) ApplyOperation(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyOperation", reflect.TypeOf((*MockUpgradeStepsState)(nil).ApplyOperation), arg0)
+}
+
+// ControllerConfig mocks base method
+func (m *MockUpgradeStepsState) ControllerConfig() (controller.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret0, _ := ret[0].(controller.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerConfig indicates an expected call of ControllerConfig
+func (mr *MockUpgradeStepsStateMockRecorder) ControllerConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockUpgradeStepsState)(nil).ControllerConfig))
+}
+
 // FindEntity mocks base method
-func (m *MockUpgradeStepsState) FindEntity(arg0 names_v3.Tag) (state.Entity, error) {
+func (m *MockUpgradeStepsState) FindEntity(arg0 names.Tag) (state.Entity, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindEntity", arg0)
 	ret0, _ := ret[0].(state.Entity)
 	ret1, _ := ret[1].(error)
@@ -46,6 +77,7 @@ func (m *MockUpgradeStepsState) FindEntity(arg0 names_v3.Tag) (state.Entity, err
 
 // FindEntity indicates an expected call of FindEntity
 func (mr *MockUpgradeStepsStateMockRecorder) FindEntity(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindEntity", reflect.TypeOf((*MockUpgradeStepsState)(nil).FindEntity), arg0)
 }
 
@@ -74,6 +106,7 @@ func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 
 // ContainerType mocks base method
 func (m *MockMachine) ContainerType() instance.ContainerType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
 	ret0, _ := ret[0].(instance.ContainerType)
 	return ret0
@@ -81,11 +114,13 @@ func (m *MockMachine) ContainerType() instance.ContainerType {
 
 // ContainerType indicates an expected call of ContainerType
 func (mr *MockMachineMockRecorder) ContainerType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMachine)(nil).ContainerType))
 }
 
 // ModificationStatus mocks base method
 func (m *MockMachine) ModificationStatus() (status.StatusInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModificationStatus")
 	ret0, _ := ret[0].(status.StatusInfo)
 	ret1, _ := ret[1].(error)
@@ -94,11 +129,13 @@ func (m *MockMachine) ModificationStatus() (status.StatusInfo, error) {
 
 // ModificationStatus indicates an expected call of ModificationStatus
 func (mr *MockMachineMockRecorder) ModificationStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModificationStatus", reflect.TypeOf((*MockMachine)(nil).ModificationStatus))
 }
 
 // SetModificationStatus mocks base method
 func (m *MockMachine) SetModificationStatus(arg0 status.StatusInfo) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetModificationStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -106,6 +143,7 @@ func (m *MockMachine) SetModificationStatus(arg0 status.StatusInfo) error {
 
 // SetModificationStatus indicates an expected call of SetModificationStatus
 func (mr *MockMachineMockRecorder) SetModificationStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachine)(nil).SetModificationStatus), arg0)
 }
 
@@ -132,14 +170,16 @@ func (m *MockUnit) EXPECT() *MockUnitMockRecorder {
 	return m.recorder
 }
 
-// SetState mocks base method
-func (m *MockUnit) SetState(arg0 *state.UnitState) error {
-	ret := m.ctrl.Call(m, "SetState", arg0)
-	ret0, _ := ret[0].(error)
+// SetStateOperation mocks base method
+func (m *MockUnit) SetStateOperation(arg0 *state.UnitState, arg1 state.UnitStateSizeLimits) state.ModelOperation {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetStateOperation", arg0, arg1)
+	ret0, _ := ret[0].(state.ModelOperation)
 	return ret0
 }
 
-// SetState indicates an expected call of SetState
-func (mr *MockUnitMockRecorder) SetState(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockUnit)(nil).SetState), arg0)
+// SetStateOperation indicates an expected call of SetStateOperation
+func (mr *MockUnitMockRecorder) SetStateOperation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStateOperation", reflect.TypeOf((*MockUnit)(nil).SetStateOperation), arg0, arg1)
 }

--- a/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps_test.go
@@ -6,10 +6,12 @@ package upgradesteps_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/juju/controller"
 	jujutesting "github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v3"
+	"gopkg.in/mgo.v2/txn"
 
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/agent/upgradesteps"
@@ -118,10 +120,10 @@ func (s *unitUpgradeStepsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 }
 
-func (s *unitUpgradeStepsSuite) TestWriteUniterState(c *gc.C) {
+func (s *unitUpgradeStepsSuite) TestWriteAgentState(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectSetState(nil, nil)
+	s.expectSetAndApplyStateOperation(nil, nil)
 	s.setupFacadeAPI(c)
 
 	str1 := "foo"
@@ -133,15 +135,15 @@ func (s *unitUpgradeStepsSuite) TestWriteUniterState(c *gc.C) {
 		},
 	}
 
-	results, err := s.api.WriteUniterState(args)
+	results, err := s.api.WriteAgentState(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{}, {}}})
 }
 
-func (s *unitUpgradeStepsSuite) TestWriteUniterStateError(c *gc.C) {
+func (s *unitUpgradeStepsSuite) TestWriteAgentStateError(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectSetState(nil, errors.NotFoundf("testing"))
+	s.expectSetAndApplyStateOperation(nil, errors.NotFoundf("testing"))
 	s.setupFacadeAPI(c)
 
 	str1 := "foo"
@@ -153,7 +155,7 @@ func (s *unitUpgradeStepsSuite) TestWriteUniterStateError(c *gc.C) {
 		},
 	}
 
-	results, err := s.api.WriteUniterState(args)
+	results, err := s.api.WriteAgentState(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{
 		{},
@@ -263,15 +265,32 @@ func (s *unitUpgradeStepsSuite) expectFindEntityUnits() {
 	s.state.EXPECT().FindEntity(s.tag2.(names.UnitTag)).Return(u2Entity, nil)
 }
 
-func (s *unitUpgradeStepsSuite) expectSetState(err1, err2 error) {
+func (s *unitUpgradeStepsSuite) expectSetAndApplyStateOperation(err1, err2 error) {
+	ctrlCfg := controller.Config{
+		controller.MaxCharmStateSize: 123,
+		controller.MaxAgentStateSize: 456,
+	}
+
+	s.state.EXPECT().ControllerConfig().Return(ctrlCfg, nil)
+
+	expLimits := state.UnitStateSizeLimits{
+		MaxCharmStateSize: 123,
+		MaxAgentStateSize: 456,
+	}
+
 	us := state.NewUnitState()
 	us.SetUniterState("foo")
 	us.SetStorageState("bar")
-	s.unit1.EXPECT().SetState(us).Return(err1)
+
+	op1 := dummyOp{}
+	s.unit1.EXPECT().SetStateOperation(us, expLimits).Return(op1)
+	s.state.EXPECT().ApplyOperation(op1).Return(err1)
 
 	us = state.NewUnitState()
 	us.SetUniterState("bar")
-	s.unit2.EXPECT().SetState(us).Return(err2)
+	op2 := dummyOp{}
+	s.unit2.EXPECT().SetStateOperation(us, expLimits).Return(op2)
+	s.state.EXPECT().ApplyOperation(op2).Return(err2)
 }
 
 type machineEntityShim struct {
@@ -283,3 +302,9 @@ type unitEntityShim struct {
 	upgradesteps.Unit
 	state.Entity
 }
+
+type dummyOp struct {
+}
+
+func (d dummyOp) Build(attempt int) ([]txn.Op, error) { return nil, nil }
+func (d dummyOp) Done(_ error) error                  { return nil }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39228,7 +39228,7 @@
                         }
                     }
                 },
-                "WriteUniterState": {
+                "WriteAgentState": {
                     "type": "object",
                     "properties": {
                         "Params": {

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -10,8 +10,8 @@ var (
 	StateUpgradeOperations = &stateUpgradeOperations
 	GetUpgradeStepsClient  = &getUpgradeStepsClient
 
-	SetJujuFolderPermissionsToAdm = setJujuFolderPermissionsToAdm
-	MoveUniterStateToController   = moveUniterStateToController
+	SetJujuFolderPermissionsToAdm  = setJujuFolderPermissionsToAdm
+	MoveUnitAgentStateToController = moveUnitAgentStateToController
 )
 
 type ModelConfigUpdater environConfigUpdater

--- a/upgrades/mocks/upgradestepsclient_mock.go
+++ b/upgrades/mocks/upgradestepsclient_mock.go
@@ -33,14 +33,16 @@ func (m *MockUpgradeStepsClient) EXPECT() *MockUpgradeStepsClientMockRecorder {
 	return m.recorder
 }
 
-// WriteUniterState mocks base method
-func (m *MockUpgradeStepsClient) WriteUniterState(arg0 []params.SetUnitStateArg) error {
-	ret := m.ctrl.Call(m, "WriteUniterState", arg0)
+// WriteAgentState mocks base method
+func (m *MockUpgradeStepsClient) WriteAgentState(arg0 []params.SetUnitStateArg) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteAgentState", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WriteUniterState indicates an expected call of WriteUniterState
-func (mr *MockUpgradeStepsClientMockRecorder) WriteUniterState(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteUniterState", reflect.TypeOf((*MockUpgradeStepsClient)(nil).WriteUniterState), arg0)
+// WriteAgentState indicates an expected call of WriteAgentState
+func (mr *MockUpgradeStepsClientMockRecorder) WriteAgentState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAgentState", reflect.TypeOf((*MockUpgradeStepsClient)(nil).WriteAgentState), arg0)
 }


### PR DESCRIPTION
## Description of change

The quota-limit checks that were introduced by #11390 accidentally broke the migration steps for the agent -> controller state migration due to a mismatch (the addition of an extra argument) in the interface expected by the upgrade worker and the implicit interface implemented by `state.Unit`. 

Unfortunately, this problem was not caught by our tests and surfaced as part of the QA steps for another related chunk of work.

This PR:
- Fixes the interface incompatibility.
- Adds compile-time checks to prevent this from happening in the future.
- Switches from calling `SetState` to using the `SetStateOperation, ApplyOperation` method combo.
- Also renames the `WriteUniterState` API call to `WriteAgentState` so it better conveys its purpose which is to store the migrated agent (uniter agent for now) state that may include workers other than the uniter (e.g. the meter status worker).

## QA steps

```console
# Bootstrap 2.7.5 from snap
$ /snap/bin/juju bootstrap lxd test --no-gui

$ juju deploy  cs:~jameinel/ubuntu-lite-7

# Wait for the charm to settle and then upgrade to the code from this PR

$ juju upgrade-controller --build-agent
$ juju upgrade-model

# Verify that no upgrade-related errors pop up in the controller/model logs and
# that the agent state upgrade step has completed successfully
$ juju debug-log -m controller --level ERROR
$ juju debug-log -m default --level INFO
unit-ubuntu-lite-0: 11:12:45 INFO juju.upgrade running upgrade step: write unit agent state to controller for all running units and remove files
unit-ubuntu-lite-0: 11:12:45 INFO juju.upgrade All upgrade steps completed successfully
```