### PR TITLE
Backport k8s install hook

### DIFF
--- a/testcharms/charm-repo/kubernetes/ubuntu/hooks/install
+++ b/testcharms/charm-repo/kubernetes/ubuntu/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/sh
+date=`date`
+status-set waiting "Hello from install, it is $date."
+juju-log -l INFO "Hello from install."

--- a/testcharms/charm-repo/kubernetes/ubuntu/hooks/start
+++ b/testcharms/charm-repo/kubernetes/ubuntu/hooks/start
@@ -1,0 +1,3 @@
+#!/bin/bash
+application-version-set $(grep DISTRIB_RELEASE /etc/lsb-release | cut -d= -sf2)
+juju-log -l INFO "Hello from start."

--- a/testcharms/charm-repo/kubernetes/ubuntu/hooks/update-status
+++ b/testcharms/charm-repo/kubernetes/ubuntu/hooks/update-status
@@ -1,0 +1,4 @@
+#!/bin/sh
+date=`date`
+status-set active "Hello from update-status, it is $date."
+juju-log -l INFO "Hello from update-status."

--- a/testcharms/charm-repo/kubernetes/ubuntu/metadata.yaml
+++ b/testcharms/charm-repo/kubernetes/ubuntu/metadata.yaml
@@ -1,0 +1,12 @@
+name: ubuntu-k8s
+summary: "ubuntu operating system"
+description: "A popular operating system"
+provides:
+  ubuntu:
+    interface: ubuntu
+resources:
+  ubuntu_image:
+    type: "oci-image"
+    description: "Image used for ubuntu pod."
+series:
+  - kubernetes

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -316,11 +316,3 @@ func (s *uniterResolver) nextOp(
 
 	return nil, resolver.ErrNoOperation
 }
-
-// NopResolver is a resolver that does nothing.
-type NopResolver struct{}
-
-// The NopResolver's NextOp operation should always return the no operation error.
-func (NopResolver) NextOp(resolver.LocalState, remotestate.Snapshot, operation.Factory) (operation.Operation, error) {
-	return nil, resolver.ErrNoOperation
-}

--- a/worker/uniter/storage/attachments_test.go
+++ b/worker/uniter/storage/attachments_test.go
@@ -310,11 +310,11 @@ func (s *caasAttachmentsSuite) TestAttachmentsStorageNotStarted(c *gc.C) {
 		Started:   false,
 	}}
 	_, err = r.NextOp(localState, remotestate.Snapshot{
-		Life: life.Alive,
+		Life: params.Alive,
 		Storage: map[names.StorageTag]remotestate.StorageSnapshot{
 			storageTag: {
 				Kind:     params.StorageKindBlock,
-				Life:     life.Alive,
+				Life:     params.Alive,
 				Location: "/dev/sdb",
 				Attached: true,
 			},

--- a/worker/uniter/storage/resolver.go
+++ b/worker/uniter/storage/resolver.go
@@ -65,32 +65,51 @@ func (s *storageResolver) NextOp(
 		return nil, errors.Trace(err)
 	}
 
-	// Only IAAS models need to first run the install hook.
-	// For CAAS models, storage is specified in the pod config
-	// and mounted as the pod in started.
-	blockedWaitingForInstall := !localState.Installed && s.modelType == model.IAAS
-
+	// The decision making below with regard to when to run the storage hooks for
+	// the first time after a charm is deployed is applicable only to IAAS models.
+	// For IAAS models, we do not run install hook before any storage provisioned
+	// with the deployment of the unit is available. The presumption is that IAAS
+	// charms may need storage on which to install their workloads.
+	//
+	// For CAAS models, it's different because we need to create the pod before
+	// any storage is provisioned. See in-line explanation below.
+	//
+	// TODO(juju3) - allow storage hooks to run after install for IAAS models
+	// This will make IAAS and CAAS behaviour the same, and charms should be
+	// resilient to resources such as storage not being ready at any given time.
 	var runStorageHooks bool
 	switch {
 	case localState.Kind == operation.Continue:
 		// There's nothing in progress.
-		fallthrough
-	case blockedWaitingForInstall && localState.Kind == operation.RunHook && localState.Step == operation.Queued:
-		// The install operation completed, and there's an install
-		// hook queued. Run storage-attached hooks first.
-		fallthrough
-	case s.modelType == model.CAAS:
-		// CAAS models skip the uniter Install operation, but do run the
-		// install hook. No need to wait for the install hook to be run
-		// as storage is mounted when a pod is started.  This will keep
-		// behavior consistent with before CAAS units run an install hook,
 		runStorageHooks = true
+	case localState.Kind == operation.RunHook && localState.Step == operation.Queued:
+		// There's a hook queued.
+		switch s.modelType {
+		case model.CAAS:
+			// For CAAS models, we wait until after the start hook has run before
+			// running storage-attached hooks since storage is provisioned only
+			// after the pod has been created.
+			//
+			// NB we must be careful here. The initial hook sequence is
+			// install->leader-elected->config-changed->started
+			// This chain is activated by each preceding hook queuing the next.
+			// If we allow a storage-attached hook to run before the start hook, we
+			// will potentially overwrite the state to initiate the next hook.
+			// So we need to get to at least started. This means that any charm logic
+			// that needs storage cannot be in install or start and if in config-changed,
+			// needs to be deferred until storage is available.
+			runStorageHooks = localState.Started
+		case model.IAAS:
+			// For IAAS models, we run storage-attached hooks before install.
+			runStorageHooks = !localState.Installed
+		}
 	}
 	if !runStorageHooks {
 		return nil, resolver.ErrNoOperation
 	}
 
-	if !localState.Installed && s.storage.Pending() == 0 {
+	// This message is only interesting for IAAS models.
+	if s.modelType == model.IAAS && !localState.Installed && s.storage.Pending() == 0 {
 		logger.Infof("initial storage attachments ready")
 	}
 
@@ -103,11 +122,13 @@ func (s *storageResolver) NextOp(
 	}
 	if s.storage.Pending() > 0 {
 		logger.Debugf("still pending %v", s.storage.pending.SortedValues())
-		if blockedWaitingForInstall {
-			// We only wait for pending storage before
-			// the install hook runs; we should not block
-			// other hooks from running while storage is
-			// being provisioned.
+		// For IAAS models, storage hooks are run before install.
+		// If the install hook has not yet run and there's still
+		// pending storage, we wait. We don't wait after the
+		// install hook has run as we should not block other
+		// hooks from running while new storage added post install
+		// is being provisioned.
+		if !localState.Installed && s.modelType == model.IAAS {
 			return nil, resolver.ErrWaiting
 		}
 	}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -618,24 +618,25 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		return errors.Trace(err)
 	}
 
-	var initialState operation.State
-	if u.modelType == model.IAAS {
+	initialState := operation.State{
+		Kind:     operation.Install,
+		Step:     operation.Queued,
+		CharmURL: charmURL,
+	}
+
+	if u.modelType == model.CAAS {
+		// For CAAS, run the install hook, but not the
+		// full install operation.
 		initialState = operation.State{
-			Kind:     operation.Install,
-			Step:     operation.Queued,
-			CharmURL: charmURL,
-		}
-	} else {
-		initialState = operation.State{
-			Hook:      &hook.Info{Kind: hooks.Start},
-			Kind:      operation.RunHook,
-			Step:      operation.Queued,
-			Installed: true,
+			Hook: &hook.Info{Kind: hooks.Install},
+			Kind: operation.RunHook,
+			Step: operation.Queued,
 		}
 		if err := u.unit.SetCharmURL(charmURL); err != nil {
 			return errors.Trace(err)
 		}
 	}
+
 	operationExecutor, err := u.newOperationExecutor(u.paths.State.OperationsFile, initialState, u.acquireExecutionLock)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
## Description of change

Backport of PR 11119:

Enable install hook for k8s charms while skipping the install operation done by the uniter. It is not required due to the k8s pods.

Do not block storage hooks based on the install hook not having been run for CAAS units, other wise it will hang if there is storage.

## QA steps

Please see qa steps from #11119 

## Documentation changes

https://discourse.juju.is/t/install-hook-now-called-for-kubernetes-charms/2585/2

## Bug reference

https://bugs.launchpad.net/juju/+bug/1854635
