### PR TITLE
upgrades: Add a 2.7.6 step to fix hooks in uniter state files

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -55,6 +55,7 @@ var upgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.6.3"), stepsFor263()},
 		upgradeToVersion{version.MustParse("2.7.0"), stepsFor27()},
 		upgradeToVersion{version.MustParse("2.7.2"), stepsFor272()},
+		upgradeToVersion{version.MustParse("2.7.6"), stepsFor276()},
 	}
 	return steps
 }

--- a/upgrades/steps_276.go
+++ b/upgrades/steps_276.go
@@ -1,0 +1,88 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+// stateStepsFor276 returns upgrade steps for Juju 2.7.6.
+func stepsFor276() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add remote-application key to hooks in uniter state files",
+			targets:     []Target{HostMachine},
+			run:         AddRemoteApplicationToRunningHooks(uniterStateGlob),
+		},
+	}
+}
+
+const uniterStateGlob = `/var/lib/juju/agents/unit-*/state/uniter`
+
+// AddRemoteApplicationToRunningHooks finds any uniter state files on
+// the machine with running hooks, and makes sure that they contain a
+// remote-application key.
+func AddRemoteApplicationToRunningHooks(pattern string) func(Context) error {
+	return func(_ Context) error {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return errors.Annotate(err, "finding uniter state files")
+		}
+		for _, path := range matches {
+			// First, check whether the file needs rewriting.
+			stateFile := operation.NewStateFile(path)
+			_, err := stateFile.Read()
+			if err == nil {
+				// This one's fine, leave it alone.
+				logger.Debugf("state file valid: %q", path)
+				continue
+			}
+
+			err = AddRemoteApplicationToHook(path)
+			if err != nil {
+				return errors.Annotatef(err, "fixing %q", path)
+			}
+		}
+		return nil
+	}
+}
+
+// AddRemoteApplicationToHook takes a the path to a uniter state file
+// that doesn't validate, and sets hook.remote-application to the
+// remote application so that it does. (If it doesn't validate for
+// some other reason we won't change the file.)
+func AddRemoteApplicationToHook(path string) error {
+	var uniterState operation.State
+	err := utils.ReadYaml(path, &uniterState)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if uniterState.Hook == nil {
+		logger.Debugf("no hook found in %q, unable to fix", path)
+		return nil
+	}
+
+	if uniterState.Hook.RemoteApplication != "" {
+		logger.Debugf("remote-application in %q set to %q already", path,
+			uniterState.Hook.RemoteApplication)
+		return nil
+	}
+
+	appName, err := names.UnitApplication(uniterState.Hook.RemoteUnit)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	logger.Debugf("setting remote-application to %q in %q", appName, path)
+	uniterState.Hook.RemoteApplication = appName
+	return errors.Annotatef(operation.NewStateFile(path).Write(&uniterState),
+		"writing updated state to %q", path)
+}

--- a/upgrades/steps_276_test.go
+++ b/upgrades/steps_276_test.go
@@ -1,0 +1,82 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/upgrades"
+)
+
+var v276 = version.MustParse("2.7.6")
+
+type steps276Suite struct {
+	testing.IsolationSuite
+
+	dir string
+}
+
+var _ = gc.Suite(&steps276Suite{})
+
+func (s *steps276Suite) SetUpTest(c *gc.C) {
+	s.dir = c.MkDir()
+	files, err := filepath.Glob("testdata/uniter-state-*")
+	c.Assert(err, jc.ErrorIsNil)
+	copyCommand := exec.Command("/bin/cp", append(files, s.dir)...)
+	err = copyCommand.Run()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = loggo.ConfigureLoggers("<root>=TRACE")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *steps276Suite) TestStepRegistered(c *gc.C) {
+	step := findStep(c, v276, "add remote-application key to hooks in uniter state files")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.HostMachine})
+}
+
+func (s *steps276Suite) readStateFile(c *gc.C, dir, file string) string {
+	contents, err := ioutil.ReadFile(filepath.Join(dir, fmt.Sprintf("uniter-state-%s.yaml", file)))
+	c.Assert(err, jc.ErrorIsNil)
+	return string(contents)
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToHookSuccess(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToHook(filepath.Join(s.dir, "uniter-state-no-app.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	// The no-app file should now be identical to the app file.
+	c.Assert(s.readStateFile(c, s.dir, "no-app"), gc.Equals, s.readStateFile(c, s.dir, "app"))
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToHookNoHook(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToHook(filepath.Join(s.dir, "uniter-state-no-hook.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	// The no-hook file hasn't changed from the original.
+	c.Assert(s.readStateFile(c, s.dir, "no-hook"), gc.Equals, s.readStateFile(c, "testdata", "no-hook"))
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToHookRemoteApplicationSet(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToHook(filepath.Join(s.dir, "uniter-state-app.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	// The app file hasn't changed from the original.
+	c.Assert(s.readStateFile(c, s.dir, "app"), gc.Equals, s.readStateFile(c, "testdata", "app"))
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToRunningHooks(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToRunningHooks(filepath.Join(s.dir, "uniter-state-*.yaml"))(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// The no-app file's been updated but the others have been left alone.
+	c.Assert(s.readStateFile(c, s.dir, "no-app"), gc.Equals, s.readStateFile(c, s.dir, "app"))
+	c.Assert(s.readStateFile(c, s.dir, "no-hook"), gc.Equals, s.readStateFile(c, "testdata", "no-hook"))
+	c.Assert(s.readStateFile(c, s.dir, "app"), gc.Equals, s.readStateFile(c, "testdata", "app"))
+}

--- a/upgrades/testdata/uniter-state-app.yaml
+++ b/upgrades/testdata/uniter-state-app.yaml
@@ -1,0 +1,13 @@
+leader: true
+started: true
+stopped: false
+installed: true
+status-set: true
+op: run-hook
+opstep: pending
+hook:
+  kind: relation-changed
+  relation-id: 494
+  remote-unit: foo/0
+  remote-application: foo
+  change-version: 130

--- a/upgrades/testdata/uniter-state-no-app.yaml
+++ b/upgrades/testdata/uniter-state-no-app.yaml
@@ -1,0 +1,12 @@
+leader: true
+started: true
+stopped: false
+installed: true
+status-set: true
+op: run-hook
+opstep: pending
+hook:
+  kind: relation-changed
+  relation-id: 494
+  remote-unit: foo/0
+  change-version: 130

--- a/upgrades/testdata/uniter-state-no-hook.yaml
+++ b/upgrades/testdata/uniter-state-no-hook.yaml
@@ -1,0 +1,2 @@
+op: run-hook
+opstep: pending

--- a/upgrades/testdata/uniter-state-something-else.notyaml
+++ b/upgrades/testdata/uniter-state-something-else.notyaml
@@ -1,0 +1,1 @@
+This isn't even a valid yaml document, I don't think.

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -631,7 +631,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"2.0.0", "2.2.0", "2.4.0", "2.4.5", "2.6.3", "2.7.0", "2.7.2",
+		"2.0.0", "2.2.0", "2.4.0", "2.4.5", "2.6.3", "2.7.0", "2.7.2", "2.7.6",
 	})
 }
 


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

If an upgrade happens while a hook is queued, the uniter state file will contain details about that hook execution so it can be run once the unit agent is running again. In 2.7 the hook was extended to include `remote-application`, and validation requires it. But if the hook was written by the 2.6 uniter and then the agent is upgraded to 2.7, the uniter won't start because the state file is invalid.

Run an upgrade step when going to 2.7.6 to update any hooks that don't have `remote-application` set to be the application from the remote-unit field. (We're running it in the 2.7.6 upgrade because there could be agents stuck in this state since upgrading from 2.6.x.)

## QA steps

Bootstrap a 2.6 controller, deploy dummy-source and set its token to a value.
```sh
/snap/bin/juju bootstrap lxd n
juju deploy ~/juju/acceptancetests/repository/charms/dummy-source
juju config dummy-source token=hey
```
Modify the dummy-sink so that its `source-relation-changed` hook fails if `token` is set to "block".
```bash
#!/bin/bash
set -eux

mkdir -p /var/run/dummy-sink
token=$(relation-get token)
echo "$token" > /var/run/dummy-sink/token

if [[ "$token" == "block" ]]; then
  juju-log -l WARNING "Blocking: hook won't succeed while token is block"
  status-set blocked "Token is block, change it" || true
  exit 1
fi

if [[ -z "$token" ]]; then
  juju-log -l INFO "Waiting for token"
  status-set waiting "Waiting for token" || true
else
  juju-log -l INFO "Token is $token"
  status-set active "Token is $(echo $token | cut -c 1-20)" || true
fi
```
Deploy that charm and relate it to the source.
```sh
juju deploy ./blocker-sink && juju relate dummy-source blocker-sink
```

Update token to "block" - blocker-sink should get stuck.
```sh
juju config dummy-source token=block
```
Check that the hook is in `/var/lib/juju/agents/unit-blocker-sink-0/state/uniter` without `remote-application`.
Once the charm is blocked, upgrade to 2.7.6.

```sh
juju upgrade-controller --build-agent
juju upgrade-model
```

Watch the blocker-sink machine agent log to see the upgrade step report updating the file.
See that the hook in the state file is updated with the application.
Check that the uniter is started and hook executions are running.
```sh
juju config dummy-source token=fine
juju resolve blocker-sink/0
```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1869275
