### PR TITLE
Fix regression deploying k8s charms

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -275,13 +275,21 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 		logger.Debugf("getting api hostports for CAAS: public %t, addresses %v", public, addresses)
 	}()
 
-	controllerConfig, err := st.ControllerConfig()
+	// We are fetching info about the controller cloud service,
+	// so need the controller state.
+	ctrlSt, err := st.newStateNoWorkers(st.ControllerModelUUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer func() { _ = ctrlSt.Close() }()
+
+	controllerConfig, err := ctrlSt.ControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	apiPort := controllerConfig.APIPort()
-	svc, err := st.CloudService(controllerConfig.ControllerUUID())
+	svc, err := ctrlSt.CloudService(controllerConfig.ControllerUUID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -399,11 +399,16 @@ func (s *CAASAddressesSuite) TestAPIHostPortsCloudLocalOnly(c *gc.C) {
 		NetPort:      17777,
 	}}}
 
-	addrs, err := s.State.APIHostPortsForAgents()
+	// Make a new non-system state to ensure everything
+	//works from any model.
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer func() { st.Close() }()
+
+	addrs, err := st.APIHostPortsForAgents()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 
-	addrs, err = s.State.APIHostPortsForClients()
+	addrs, err = st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 }
@@ -427,11 +432,16 @@ func (s *CAASAddressesSuite) TestAPIHostPortsPublicOnly(c *gc.C) {
 		NetPort:      17777,
 	}}}
 
-	addrs, err := s.State.APIHostPortsForAgents()
+	// Make a new non-system state to ensure everything
+	//works from any model.
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer func() { st.Close() }()
+
+	addrs, err := st.APIHostPortsForAgents()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 
-	addrs, err = s.State.APIHostPortsForClients()
+	addrs, err = st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 }
@@ -470,7 +480,12 @@ func (s *CAASAddressesSuite) TestAPIHostPortsMultiple(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	addrs, err := s.State.APIHostPortsForAgents()
+	// Make a new non-system state to ensure everything
+	//works from any model.
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer func() { st.Close() }()
+
+	addrs, err := st.APIHostPortsForAgents()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local-cloud addresses must come first.
@@ -500,7 +515,7 @@ func (s *CAASAddressesSuite) TestAPIHostPortsMultiple(c *gc.C) {
 	c.Assert(addrs[0][2:], jc.SameContents, exp)
 
 	// Only the public ones should be returned.
-	addrs, err = s.State.APIHostPortsForClients()
+	addrs, err = st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, []network.SpaceHostPorts{exp})
 }


### PR DESCRIPTION

## Description of change

#11407 introduced a regression when looking up controller API addresses.
This PR ensures we use the controller state when needed to get the cloud service.

## QA steps

bootstrap k8s controller
deploy any k8s charm (would fail previously)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871496
