### PR TITLE
Merge 2.7

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -278,13 +278,21 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 		logger.Debugf("getting api hostports for CAAS: public %t, addresses %v", public, addresses)
 	}()
 
-	controllerConfig, err := st.ControllerConfig()
+	// We are fetching info about the controller cloud service,
+	// so need the controller state.
+	ctrlSt, err := st.newStateNoWorkers(st.ControllerModelUUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer func() { _ = ctrlSt.Close() }()
+
+	controllerConfig, err := ctrlSt.ControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	apiPort := controllerConfig.APIPort()
-	svc, err := st.CloudService(controllerConfig.ControllerUUID())
+	svc, err := ctrlSt.CloudService(controllerConfig.ControllerUUID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -399,11 +399,16 @@ func (s *CAASAddressesSuite) TestAPIHostPortsCloudLocalOnly(c *gc.C) {
 		NetPort:      17777,
 	}}}
 
-	addrs, err := s.State.APIHostPortsForAgents()
+	// Make a new non-system state to ensure everything
+	//works from any model.
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer func() { st.Close() }()
+
+	addrs, err := st.APIHostPortsForAgents()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 
-	addrs, err = s.State.APIHostPortsForClients()
+	addrs, err = st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 }
@@ -427,11 +432,16 @@ func (s *CAASAddressesSuite) TestAPIHostPortsPublicOnly(c *gc.C) {
 		NetPort:      17777,
 	}}}
 
-	addrs, err := s.State.APIHostPortsForAgents()
+	// Make a new non-system state to ensure everything
+	//works from any model.
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer func() { st.Close() }()
+
+	addrs, err := st.APIHostPortsForAgents()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 
-	addrs, err = s.State.APIHostPortsForClients()
+	addrs, err = st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, exp)
 }
@@ -470,7 +480,12 @@ func (s *CAASAddressesSuite) TestAPIHostPortsMultiple(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	addrs, err := s.State.APIHostPortsForAgents()
+	// Make a new non-system state to ensure everything
+	//works from any model.
+	st := s.Factory.MakeCAASModel(c, nil)
+	defer func() { st.Close() }()
+
+	addrs, err := st.APIHostPortsForAgents()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local-cloud addresses must come first.
@@ -500,7 +515,7 @@ func (s *CAASAddressesSuite) TestAPIHostPortsMultiple(c *gc.C) {
 	c.Assert(addrs[0][2:], jc.SameContents, exp)
 
 	// Only the public ones should be returned.
-	addrs, err = s.State.APIHostPortsForClients()
+	addrs, err = st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, []network.SpaceHostPorts{exp})
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -90,12 +90,12 @@ func (s *MigrationBaseSuite) primeStatusHistory(c *gc.C, entity statusSetter, st
 	}, 0, "")
 }
 
-func (s *MigrationBaseSuite) makeApplicationWithUnits(c *gc.C, applicationname string, count int) {
+func (s *MigrationBaseSuite) makeApplicationWithUnits(c *gc.C, applicationName string, count int) {
 	units := make([]*state.Unit, count)
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{
-		Name: applicationname,
+		Name: applicationName,
 		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{
-			Name: applicationname,
+			Name: applicationName,
 		}),
 	})
 	for i := 0; i < count; i++ {
@@ -111,7 +111,7 @@ func (s *MigrationBaseSuite) makeUnitApplicationLeader(c *gc.C, unitName, applic
 		loggo.GetLogger("migration_export_test"),
 	)
 	target.Claimed(
-		lease.Key{"application-leadership", s.State.ModelUUID(), applicationName},
+		lease.Key{Namespace: "application-leadership", ModelUUID: s.State.ModelUUID(), Lease: applicationName},
 		unitName,
 	)
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -966,6 +966,11 @@ func (i *importer) parseBindings(bindingsMap map[string]string) (*Bindings, erro
 
 	// 2.6 controllers only populate the default space key if set to the
 	// non-default space whereas 2.7 controllers always set it.
+	// The application implementation in the description package has
+	// `omitempty` for bindings, so we need to create it if nil.
+	if bindingsMap == nil {
+		bindingsMap = make(map[string]string, 1)
+	}
 	if _, exists := bindingsMap[defaultEndpointName]; !exists {
 		bindingsMap[defaultEndpointName] = network.AlphaSpaceName
 	}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1305,7 +1305,7 @@ func (s *MigrationImportSuite) TestRelationsMissingStatusNoUnits(c *gc.C) {
 func (s *MigrationImportSuite) TestEndpointBindings(c *gc.C) {
 	// Endpoint bindings need both valid charms, applications, and spaces.
 	space := s.Factory.MakeSpace(c, &factory.SpaceParams{
-		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})
+		Name: "one", ProviderID: "provider", IsPublic: true})
 	state.AddTestingApplicationWithBindings(
 		c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"),
 		map[string]string{"db": space.Id()})
@@ -1321,6 +1321,24 @@ func (s *MigrationImportSuite) TestEndpointBindings(c *gc.C) {
 	// should have the AlphaSpaceId
 	c.Assert(bindings.Map()["db"], gc.Equals, space.Id())
 	c.Assert(bindings.Map()[""], gc.Equals, network.AlphaSpaceId)
+}
+
+func (s *MigrationImportSuite) TestNilEndpointBindings(c *gc.C) {
+	app := state.AddTestingApplicationWithEmptyBindings(
+		c, s.State, "dummy", state.AddTestingCharm(c, s.State, "dummy"))
+
+	bindings, err := app.EndpointBindings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bindings.Map(), gc.HasLen, 0)
+
+	_, newSt := s.importModel(c, s.State)
+
+	newApp, err := newSt.Application("dummy")
+	c.Assert(err, jc.ErrorIsNil)
+
+	newBindings, err := newApp.EndpointBindings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newBindings.Map()[""], gc.Equals, network.AlphaSpaceId)
 }
 
 func (s *MigrationImportSuite) TestUnitsOpenPorts(c *gc.C) {

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -34,6 +34,9 @@ func TestPackage(t *testing.T) {
 	coretesting.MgoTestPackage(t)
 }
 
+// SetModelTypeToCAAS can be called after SetUpTest for state suites.
+// It crudely just sets the model type to CAAS so that certain functionality
+// relying on the model type can be tested.
 func SetModelTypeToCAAS(c *gc.C, st *State, m *Model) {
 	ops := []txn.Op{{
 		C:      modelsC,
@@ -43,4 +46,17 @@ func SetModelTypeToCAAS(c *gc.C, st *State, m *Model) {
 
 	c.Assert(st.db().RunTransaction(ops), jc.ErrorIsNil)
 	c.Assert(m.refresh(m.UUID()), jc.ErrorIsNil)
+}
+
+// AddTestingApplicationWithEmptyBindings mimics an application
+// from an old version of Juju, with no bindings entry.
+func AddTestingApplicationWithEmptyBindings(c *gc.C, st *State, name string, ch *Charm) *Application {
+	app := addTestingApplication(c, addTestingApplicationParams{
+		st:   st,
+		name: name,
+		ch:   ch,
+	})
+
+	c.Assert(st.db().RunTransaction([]txn.Op{removeEndpointBindingsOp(app.globalKey())}), jc.ErrorIsNil)
+	return app
 }

--- a/testcharms/charm-repo/kubernetes/ubuntu/hooks/install
+++ b/testcharms/charm-repo/kubernetes/ubuntu/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/sh
+date=`date`
+status-set waiting "Hello from install, it is $date."
+juju-log -l INFO "Hello from install."

--- a/testcharms/charm-repo/kubernetes/ubuntu/hooks/start
+++ b/testcharms/charm-repo/kubernetes/ubuntu/hooks/start
@@ -1,0 +1,3 @@
+#!/bin/bash
+application-version-set $(grep DISTRIB_RELEASE /etc/lsb-release | cut -d= -sf2)
+juju-log -l INFO "Hello from start."

--- a/testcharms/charm-repo/kubernetes/ubuntu/hooks/update-status
+++ b/testcharms/charm-repo/kubernetes/ubuntu/hooks/update-status
@@ -1,0 +1,4 @@
+#!/bin/sh
+date=`date`
+status-set active "Hello from update-status, it is $date."
+juju-log -l INFO "Hello from update-status."

--- a/testcharms/charm-repo/kubernetes/ubuntu/metadata.yaml
+++ b/testcharms/charm-repo/kubernetes/ubuntu/metadata.yaml
@@ -1,0 +1,12 @@
+name: ubuntu-k8s
+summary: "ubuntu operating system"
+description: "A popular operating system"
+provides:
+  ubuntu:
+    interface: ubuntu
+resources:
+  ubuntu_image:
+    type: "oci-image"
+    description: "Image used for ubuntu pod."
+series:
+  - kubernetes

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -56,6 +56,7 @@ var upgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.6.3"), stepsFor263()},
 		upgradeToVersion{version.MustParse("2.7.0"), stepsFor27()},
 		upgradeToVersion{version.MustParse("2.7.2"), stepsFor272()},
+		upgradeToVersion{version.MustParse("2.7.6"), stepsFor276()},
 		upgradeToVersion{version.MustParse("2.8.0"), stepsFor28()},
 	}
 	return steps

--- a/upgrades/steps_276.go
+++ b/upgrades/steps_276.go
@@ -1,0 +1,106 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"gopkg.in/juju/names.v3"
+
+	"github.com/juju/juju/worker/uniter/operation"
+)
+
+// stateStepsFor276 returns upgrade steps for Juju 2.7.6.
+func stepsFor276() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add remote-application key to hooks in uniter state files",
+			targets:     []Target{HostMachine},
+			run:         AddRemoteApplicationToRunningHooks(uniterStateGlob),
+		},
+	}
+}
+
+const uniterStateGlob = `/var/lib/juju/agents/unit-*/state/uniter`
+
+// AddRemoteApplicationToRunningHooks finds any uniter state files on
+// the machine with running hooks, and makes sure that they contain a
+// remote-application key.
+func AddRemoteApplicationToRunningHooks(pattern string) func(Context) error {
+	return func(_ Context) error {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return errors.Annotate(err, "finding uniter state files")
+		}
+		for _, path := range matches {
+			// First, check whether the file needs rewriting.
+			stateFile := operation.NewStateFile(path)
+			_, err := stateFile.Read()
+			if err == nil {
+				// This one's fine, leave it alone.
+				logger.Debugf("state file valid: %q", path)
+				continue
+			}
+
+			err = AddRemoteApplicationToHook(path)
+			if err != nil {
+				return errors.Annotatef(err, "fixing %q", path)
+			}
+		}
+		return nil
+	}
+}
+
+// AddRemoteApplicationToHook takes a the path to a uniter state file
+// that doesn't validate, and sets hook.remote-application to the
+// remote application so that it does. (If it doesn't validate for
+// some other reason we won't change the file.)
+func AddRemoteApplicationToHook(path string) error {
+	var uniterState map[string]interface{}
+	err := utils.ReadYaml(path, &uniterState)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	hookUnconverted, found := uniterState["hook"]
+	if !found {
+		logger.Warningf("no hook found in %q, unable to fix", path)
+		return nil
+	}
+
+	hook, ok := hookUnconverted.(map[interface{}]interface{})
+	if !ok {
+		logger.Warningf("fixing %q: expected hook to be a map[interface{}]interface{}, got %T", path, hookUnconverted)
+		return nil
+	}
+
+	if val, found := hook["remote-application"]; found {
+		logger.Debugf("remote-application in %q set to %v already", path, val)
+		return nil
+	}
+
+	unitUnconverted, found := hook["remote-unit"]
+	if !found {
+		logger.Warningf("fixing %q: remote-unit not found")
+		return nil
+	}
+
+	unit, ok := unitUnconverted.(string)
+	if !ok {
+		logger.Warningf("fixing %q: expected remote-unit to be string, got %T", path, unitUnconverted)
+		return nil
+	}
+
+	appName, err := names.UnitApplication(unit)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	logger.Debugf("setting remote-application to %q in %q", appName, path)
+	hook["remote-application"] = appName
+	return errors.Annotatef(utils.WriteYaml(path, uniterState),
+		"writing updated state to %q", path)
+}

--- a/upgrades/steps_276_test.go
+++ b/upgrades/steps_276_test.go
@@ -1,0 +1,83 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/upgrades"
+)
+
+var v276 = version.MustParse("2.7.6")
+
+type steps276Suite struct {
+	testing.IsolationSuite
+
+	dir string
+}
+
+var _ = gc.Suite(&steps276Suite{})
+
+func (s *steps276Suite) SetUpTest(c *gc.C) {
+	s.dir = c.MkDir()
+	files, err := filepath.Glob("testdata/uniter-state-*")
+	c.Assert(err, jc.ErrorIsNil)
+	copyCommand := exec.Command("/bin/cp", append(files, s.dir)...)
+	err = copyCommand.Run()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = loggo.ConfigureLoggers("<root>=TRACE")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *steps276Suite) TestStepRegistered(c *gc.C) {
+	step := findStep(c, v276, "add remote-application key to hooks in uniter state files")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.HostMachine})
+}
+
+func (s *steps276Suite) readStateFile(c *gc.C, dir, file string) map[string]interface{} {
+	var result map[string]interface{}
+	err := utils.ReadYaml(filepath.Join(dir, fmt.Sprintf("uniter-state-%s.yaml", file)), &result)
+	c.Assert(err, jc.ErrorIsNil)
+	return result
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToHookSuccess(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToHook(filepath.Join(s.dir, "uniter-state-no-app.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	// The no-app file should now be identical to the app file.
+	c.Assert(s.readStateFile(c, s.dir, "no-app"), gc.DeepEquals, s.readStateFile(c, s.dir, "app"))
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToHookNoHook(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToHook(filepath.Join(s.dir, "uniter-state-no-hook.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	// The no-hook file hasn't changed from the original.
+	c.Assert(s.readStateFile(c, s.dir, "no-hook"), gc.DeepEquals, s.readStateFile(c, "testdata", "no-hook"))
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToHookRemoteApplicationSet(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToHook(filepath.Join(s.dir, "uniter-state-app.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	// The app file hasn't changed from the original.
+	c.Assert(s.readStateFile(c, s.dir, "app"), gc.DeepEquals, s.readStateFile(c, "testdata", "app"))
+}
+
+func (s *steps276Suite) TestAddRemoteApplicationToRunningHooks(c *gc.C) {
+	err := upgrades.AddRemoteApplicationToRunningHooks(filepath.Join(s.dir, "uniter-state-*.yaml"))(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	// The no-app file's been updated but the others have been left alone.
+	c.Assert(s.readStateFile(c, s.dir, "no-app"), gc.DeepEquals, s.readStateFile(c, s.dir, "app"))
+	c.Assert(s.readStateFile(c, s.dir, "no-hook"), gc.DeepEquals, s.readStateFile(c, "testdata", "no-hook"))
+	c.Assert(s.readStateFile(c, s.dir, "app"), gc.DeepEquals, s.readStateFile(c, "testdata", "app"))
+}

--- a/upgrades/testdata/uniter-state-app.yaml
+++ b/upgrades/testdata/uniter-state-app.yaml
@@ -1,0 +1,13 @@
+leader: true
+started: true
+stopped: false
+installed: true
+status-set: true
+op: run-hook
+opstep: pending
+hook:
+  kind: relation-changed
+  relation-id: 494
+  remote-unit: foo/0
+  remote-application: foo
+  change-version: 130

--- a/upgrades/testdata/uniter-state-no-app.yaml
+++ b/upgrades/testdata/uniter-state-no-app.yaml
@@ -1,0 +1,12 @@
+leader: true
+started: true
+stopped: false
+installed: true
+status-set: true
+op: run-hook
+opstep: pending
+hook:
+  kind: relation-changed
+  relation-id: 494
+  remote-unit: foo/0
+  change-version: 130

--- a/upgrades/testdata/uniter-state-no-hook.yaml
+++ b/upgrades/testdata/uniter-state-no-hook.yaml
@@ -1,0 +1,2 @@
+op: run-hook
+opstep: pending

--- a/upgrades/testdata/uniter-state-something-else.notyaml
+++ b/upgrades/testdata/uniter-state-something-else.notyaml
@@ -1,0 +1,1 @@
+This isn't even a valid yaml document, I don't think.

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -636,7 +636,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"2.0.0", "2.2.0", "2.4.0", "2.4.5", "2.6.3", "2.7.0", "2.7.2", "2.8.0",
+		"2.0.0", "2.2.0", "2.4.0", "2.4.5", "2.6.3", "2.7.0", "2.7.2", "2.7.6", "2.8.0",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Merge 2.7 with these PRs:

#11415 destroy extra models created in migration CI test
#11421 fix panic migrating application with no bindings
#11424 backport k8s install hook
#11426 add 2.7.6 upgrade step to fix uniter state files
#11427 fix regression deploying k8s charms

## QA steps

run unit tests
