### PR TITLE
Backport #11400 from hpidcock/fix-hook-context

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -884,6 +884,14 @@
   revision = "77a895ad01ebc98a4dc95d8355bc825ce80a56f6"
 
 [[projects]]
+  branch = "master"
+  digest = "1:63e7368fcf6b54804076eaec26fd9cf0c4466166b272393db4b93102e1e962df"
+  name = "github.com/kballard/go-shellquote"
+  packages = ["."]
+  pruneopts = ""
+  revision = "95032a82bc518f77982ea72343cc1ade730072f0"
+
+[[projects]]
   digest = "1:591a2778aa6e896980757ea87e659b3aa13d8c0e790310614028463a31c0998b"
   name = "github.com/kr/pretty"
   packages = ["."]
@@ -2199,6 +2207,7 @@
     "github.com/juju/version",
     "github.com/juju/webbrowser",
     "github.com/julienschmidt/httprouter",
+    "github.com/kballard/go-shellquote",
     "github.com/kr/pretty",
     "github.com/lxc/lxd/client",
     "github.com/lxc/lxd/shared",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -544,3 +544,7 @@
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "1.29.7"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/kballard/go-shellquote"

--- a/caas/kubernetes/provider/exec/exec.go
+++ b/caas/kubernetes/provider/exec/exec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/kballard/go-shellquote"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,12 +120,18 @@ func (c client) Exec(params ExecParams, cancel <-chan struct{}) error {
 	return errors.Trace(c.exec(params, cancel))
 }
 
-func processEnv(env []string) string {
+func processEnv(env []string) (string, error) {
 	out := ""
-	for _, v := range env {
-		out += fmt.Sprintf("export %s; ", v)
+	for _, s := range env {
+		values := strings.SplitN(s, "=", 2)
+		if len(values) != 2 {
+			return "", errors.NotValidf("env %q", s)
+		}
+		key := values[0]
+		value := values[1]
+		out += fmt.Sprintf("export %s=%s; ", key, shellquote.Join(value))
 	}
-	return out
+	return out, nil
 }
 
 func (c client) exec(opts ExecParams, cancel <-chan struct{}) error {
@@ -133,11 +140,15 @@ func (c client) exec(opts ExecParams, cancel <-chan struct{}) error {
 		cmd += fmt.Sprintf("cd %s; ", opts.WorkingDir)
 	}
 	if len(opts.Env) > 0 {
-		cmd += processEnv(opts.Env)
+		env, err := processEnv(opts.Env)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		cmd += env
 	}
-	cmd += fmt.Sprintf("%s; ", strings.Join(opts.Commands, " "))
+	cmd += fmt.Sprintf("exec sh -c %s; ", shellquote.Join(strings.Join(opts.Commands, " ")))
 	cmdArgs := []string{"sh", "-c", cmd}
-	logger.Debugf("exec on pod %q for cmd %v", opts.PodName, cmdArgs)
+	logger.Debugf("exec on pod %q for cmd %+q", opts.PodName, cmdArgs)
 	req := c.clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(opts.PodName).

--- a/caas/kubernetes/provider/exec/exec_test.go
+++ b/caas/kubernetes/provider/exec/exec_test.go
@@ -81,11 +81,13 @@ func (s *execSuite) TestProcessEnv(c *gc.C) {
 	ctrl := s.setupExecClient(c)
 	defer ctrl.Finish()
 
-	c.Assert(exec.ProcessEnv(
+	res, err := exec.ProcessEnv(
 		[]string{
-			"AAA=1", "BBB=1", "CCC=1", "DDD=1", "EEE=1",
+			"AAA=1", "BBB=1 2", "CCC=1\n2", "DDD=1='2'", "EEE=1;2;\"foo\"",
 		},
-	), gc.Equals, "export AAA=1; export BBB=1; export CCC=1; export DDD=1; export EEE=1; ")
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.Equals, "export AAA=1; export BBB='1 2'; export CCC='1\n2'; export DDD=1=\\'2\\'; export EEE=1\\;2\\;\\\"foo\\\"; ")
 }
 
 func (s *execSuite) TestExecParamsValidatePodContainerExistence(c *gc.C) {

--- a/worker/caasoperator/action.go
+++ b/worker/caasoperator/action.go
@@ -34,7 +34,7 @@ func remoteExecute(execClient exec.Executor,
 	}
 	providerID := providerIDGetter.ProviderID()
 	unitName := providerIDGetter.Name()
-	logger.Debugf("exec on pod %q for unit %q, cmd %v", providerID, unitName, params.Commands)
+	logger.Debugf("exec on pod %q for unit %q, cmd %+q", providerID, unitName, params.Commands)
 	if providerID == "" {
 		return nil, errors.NotFoundf("pod for %q", unitName)
 	}

--- a/worker/meterstatus/context.go
+++ b/worker/meterstatus/context.go
@@ -35,7 +35,7 @@ func NewLimitedContext(unitName string) *limitedContext {
 }
 
 // HookVars implements runner.Context.
-func (ctx *limitedContext) HookVars(paths context.Paths, remote bool) ([]string, error) {
+func (ctx *limitedContext) HookVars(paths context.Paths, remote bool, getEnv context.GetEnvFunc) ([]string, error) {
 	vars := []string{
 		"CHARM_DIR=" + paths.GetCharmDir(), // legacy
 		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),
@@ -52,7 +52,7 @@ func (ctx *limitedContext) HookVars(paths context.Paths, remote bool) ([]string,
 	for key, val := range ctx.env {
 		vars = append(vars, fmt.Sprintf("%s=%s", key, val))
 	}
-	return append(vars, context.OSDependentEnvVars(paths)...), nil
+	return append(vars, context.OSDependentEnvVars(paths, getEnv)...), nil
 }
 
 // SetEnvVars sets additional environment variables to be exported by the context.

--- a/worker/meterstatus/context_test.go
+++ b/worker/meterstatus/context_test.go
@@ -35,7 +35,15 @@ func (*dummyPaths) ComponentDir(name string) string { return "/dummy/" + name }
 func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 	ctx := meterstatus.NewLimitedContext("u/0")
 	paths := &dummyPaths{}
-	vars, err := ctx.HookVars(paths, false)
+	vars, err := ctx.HookVars(paths, false, func(k string) string {
+		switch k {
+		case "PATH", "Path":
+			return "pathy"
+		default:
+			c.Errorf("unexpected get env call for %q", k)
+		}
+		return ""
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -58,7 +66,15 @@ func (s *ContextSuite) TestHookContextSetEnv(c *gc.C) {
 	}
 	ctx.SetEnvVars(setVars)
 	paths := &dummyPaths{}
-	vars, err := ctx.HookVars(paths, false)
+	vars, err := ctx.HookVars(paths, false, func(k string) string {
+		switch k {
+		case "PATH", "Path":
+			return "pathy"
+		default:
+			c.Errorf("unexpected get env call for %q", k)
+		}
+		return ""
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -33,7 +33,7 @@ func newHookContext(unitName string, recorder spool.MetricRecorder) *hookContext
 }
 
 // HookVars implements runner.Context.
-func (ctx *hookContext) HookVars(paths context.Paths, remote bool) ([]string, error) {
+func (ctx *hookContext) HookVars(paths context.Paths, remote bool, getEnv context.GetEnvFunc) ([]string, error) {
 	vars := []string{
 		"CHARM_DIR=" + paths.GetCharmDir(), // legacy
 		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),
@@ -47,7 +47,7 @@ func (ctx *hookContext) HookVars(paths context.Paths, remote bool) ([]string, er
 			"JUJU_AGENT_CA_CERT="+path.Join(paths.GetBaseDir(), caas.CACertFile),
 		)
 	}
-	return append(vars, context.OSDependentEnvVars(paths)...), nil
+	return append(vars, context.OSDependentEnvVars(paths, getEnv)...), nil
 }
 
 // UnitName implements runner.Context.

--- a/worker/metrics/collect/context_test.go
+++ b/worker/metrics/collect/context_test.go
@@ -65,7 +65,15 @@ func (*dummyPaths) ComponentDir(name string) string { return "/dummy/" + name }
 func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 	ctx := collect.NewHookContext("u/0", s.recorder)
 	paths := &dummyPaths{}
-	vars, err := ctx.HookVars(paths, false)
+	vars, err := ctx.HookVars(paths, false, func(k string) string {
+		switch k {
+		case "PATH", "Path":
+			return "pathy"
+		default:
+			c.Errorf("unexpected get env call for %q", k)
+		}
+		return ""
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -689,7 +689,7 @@ func (c *HookContext) ActionData() (*ActionData, error) {
 // HookVars returns an os.Environ-style list of strings necessary to run a hook
 // such that it can know what environment it's operating in, and can call back
 // into context.
-func (context *HookContext) HookVars(paths Paths, remote bool) ([]string, error) {
+func (context *HookContext) HookVars(paths Paths, remote bool, getEnv GetEnvFunc) ([]string, error) {
 	vars := context.legacyProxySettings.AsEnvironmentValues()
 	// TODO(thumper): as work on proxies progress, there will be additional
 	// proxy settings to be added.
@@ -751,8 +751,7 @@ func (context *HookContext) HookVars(paths Paths, remote bool) ([]string, error)
 			"JUJU_ACTION_TAG="+context.actionData.Tag.String(),
 		)
 	}
-
-	return append(vars, OSDependentEnvVars(paths)...), nil
+	return append(vars, OSDependentEnvVars(paths, getEnv)...), nil
 }
 
 func (ctx *HookContext) handleReboot(err *error) {

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -137,7 +137,7 @@ func (s *EnvSuite) setRelation(ctx *context.HookContext) (expectVars []string) {
 }
 
 func (s *EnvSuite) TestEnvSetsPath(c *gc.C) {
-	paths := context.OSDependentEnvVars(MockEnvPaths{})
+	paths := context.OSDependentEnvVars(MockEnvPaths{}, os.Getenv)
 	c.Assert(paths, gc.Not(gc.HasLen), 0)
 	vars, err := keyvalues.Parse(paths, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -151,8 +151,6 @@ func (s *EnvSuite) TestEnvSetsPath(c *gc.C) {
 func (s *EnvSuite) TestEnvWindows(c *gc.C) {
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Windows })
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
-	os.Setenv("Path", "foo;bar")
-	os.Setenv("PSModulePath", "ping;pong")
 	windowsVars := []string{
 		"Path=path-to-tools;foo;bar",
 		"PSModulePath=ping;pong;" + filepath.FromSlash("path-to-charm/lib/Modules"),
@@ -160,12 +158,32 @@ func (s *EnvSuite) TestEnvWindows(c *gc.C) {
 
 	ctx, contextVars := s.getContext(false)
 	paths, pathsVars := s.getPaths()
-	actualVars, err := ctx.HookVars(paths, false)
+	actualVars, err := ctx.HookVars(paths, false, func(k string) string {
+		switch k {
+		case "Path":
+			return "foo;bar"
+		case "PSModulePath":
+			return "ping;pong"
+		default:
+			c.Errorf("unexpected get env call for %q", k)
+		}
+		return ""
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, windowsVars)
 
 	relationVars := s.setRelation(ctx)
-	actualVars, err = ctx.HookVars(paths, false)
+	actualVars, err = ctx.HookVars(paths, false, func(k string) string {
+		switch k {
+		case "Path":
+			return "foo;bar"
+		case "PSModulePath":
+			return "ping;pong"
+		default:
+			c.Errorf("unexpected get env call for %q", k)
+		}
+		return ""
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, windowsVars, relationVars)
 }
@@ -177,7 +195,6 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 	// As TERM is series-specific we need to make sure all supported versions are covered.
 	for _, testSeries := range series.OSSupportedSeries(jujuos.Ubuntu) {
 		s.PatchValue(&series.MustHostSeries, func() string { return testSeries })
-		os.Setenv("PATH", "foo:bar")
 		ubuntuVars := []string{
 			"APT_LISTCHANGES_FRONTEND=none",
 			"DEBIAN_FRONTEND=noninteractive",
@@ -193,12 +210,28 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 
 		ctx, contextVars := s.getContext(false)
 		paths, pathsVars := s.getPaths()
-		actualVars, err := ctx.HookVars(paths, false)
+		actualVars, err := ctx.HookVars(paths, false, func(k string) string {
+			switch k {
+			case "PATH":
+				return "foo:bar"
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return ""
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, ubuntuVars)
 
 		relationVars := s.setRelation(ctx)
-		actualVars, err = ctx.HookVars(paths, false)
+		actualVars, err = ctx.HookVars(paths, false, func(k string) string {
+			switch k {
+			case "PATH":
+				return "foo:bar"
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return ""
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, ubuntuVars, relationVars)
 	}
@@ -211,7 +244,6 @@ func (s *EnvSuite) TestEnvCentos(c *gc.C) {
 	// As TERM is series-specific we need to make sure all supported versions are covered.
 	for _, testSeries := range series.OSSupportedSeries(jujuos.CentOS) {
 		s.PatchValue(&series.MustHostSeries, func() string { return testSeries })
-		os.Setenv("PATH", "foo:bar")
 		centosVars := []string{
 			"LANG=C.UTF-8",
 			"PATH=path-to-tools:foo:bar",
@@ -225,12 +257,28 @@ func (s *EnvSuite) TestEnvCentos(c *gc.C) {
 
 		ctx, contextVars := s.getContext(false)
 		paths, pathsVars := s.getPaths()
-		actualVars, err := ctx.HookVars(paths, false)
+		actualVars, err := ctx.HookVars(paths, false, func(k string) string {
+			switch k {
+			case "PATH":
+				return "foo:bar"
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return ""
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, centosVars)
 
 		relationVars := s.setRelation(ctx)
-		actualVars, err = ctx.HookVars(paths, false)
+		actualVars, err = ctx.HookVars(paths, false, func(k string) string {
+			switch k {
+			case "PATH":
+				return "foo:bar"
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return ""
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, centosVars, relationVars)
 	}
@@ -243,7 +291,6 @@ func (s *EnvSuite) TestEnvOpenSUSE(c *gc.C) {
 	// As TERM is series-specific we need to make sure all supported versions are covered.
 	for _, testSeries := range series.OSSupportedSeries(jujuos.OpenSUSE) {
 		s.PatchValue(&series.MustHostSeries, func() string { return testSeries })
-		os.Setenv("PATH", "foo:bar")
 		openSUSEVars := []string{
 			"LANG=C.UTF-8",
 			"PATH=path-to-tools:foo:bar",
@@ -257,12 +304,28 @@ func (s *EnvSuite) TestEnvOpenSUSE(c *gc.C) {
 
 		ctx, contextVars := s.getContext(false)
 		paths, pathsVars := s.getPaths()
-		actualVars, err := ctx.HookVars(paths, false)
+		actualVars, err := ctx.HookVars(paths, false, func(k string) string {
+			switch k {
+			case "PATH":
+				return "foo:bar"
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return ""
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, openSUSEVars)
 
 		relationVars := s.setRelation(ctx)
-		actualVars, err = ctx.HookVars(paths, false)
+		actualVars, err = ctx.HookVars(paths, false, func(k string) string {
+			switch k {
+			case "PATH":
+				return "foo:bar"
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return ""
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertVars(c, actualVars, contextVars, pathsVars, openSUSEVars, relationVars)
 	}
@@ -272,7 +335,6 @@ func (s *EnvSuite) TestEnvGenericLinux(c *gc.C) {
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.GenericLinux })
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
 
-	os.Setenv("PATH", "foo:bar")
 	genericLinuxVars := []string{
 		"LANG=C.UTF-8",
 		"PATH=path-to-tools:foo:bar",
@@ -281,12 +343,28 @@ func (s *EnvSuite) TestEnvGenericLinux(c *gc.C) {
 
 	ctx, contextVars := s.getContext(false)
 	paths, pathsVars := s.getPaths()
-	actualVars, err := ctx.HookVars(paths, false)
+	actualVars, err := ctx.HookVars(paths, false, func(k string) string {
+		switch k {
+		case "PATH":
+			return "foo:bar"
+		default:
+			c.Errorf("unexpected get env call for %q", k)
+		}
+		return ""
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, genericLinuxVars)
 
 	relationVars := s.setRelation(ctx)
-	actualVars, err = ctx.HookVars(paths, false)
+	actualVars, err = ctx.HookVars(paths, false, func(k string) string {
+		switch k {
+		case "PATH":
+			return "foo:bar"
+		default:
+			c.Errorf("unexpected get env call for %q", k)
+		}
+		return ""
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertVars(c, actualVars, contextVars, pathsVars, genericLinuxVars, relationVars)
 }

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -247,7 +247,15 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 			Params:     test.payload,
 			ResultsMap: map[string]interface{}{},
 		})
-		vars, err := ctx.HookVars(s.paths, false)
+		vars, err := ctx.HookVars(s.paths, false, func(k string) string {
+			switch k {
+			case "PATH", "Path":
+				return "pathy"
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return ""
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(len(vars) > 0, jc.IsTrue, gc.Commentf("expected HookVars but found none"))
 		combined := strings.Join(vars, "|")

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -24,6 +25,7 @@ import (
 	jujuos "github.com/juju/os"
 	"github.com/juju/utils"
 	utilexec "github.com/juju/utils/exec"
+	"github.com/kballard/go-shellquote"
 
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/model"
@@ -62,7 +64,7 @@ type Runner interface {
 type Context interface {
 	jujuc.Context
 	Id() string
-	HookVars(paths context.Paths, remote bool) ([]string, error)
+	HookVars(paths context.Paths, remote bool, getEnvFunc context.GetEnvFunc) ([]string, error)
 	ActionData() (*context.ActionData, error)
 	SetProcess(process context.HookProcess)
 	HasExecutionSetUnitStatus() bool
@@ -166,7 +168,19 @@ func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Durat
 	}
 	defer srv.Close()
 
-	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote)
+	getEnv := os.Getenv
+	if rMode == runOnRemote {
+		var cancel <-chan struct{}
+		env, err := runner.getRemoteEnviron(cancel)
+		if err != nil {
+			return nil, errors.Annotatef(err, "getting remote environ")
+		}
+		getEnv = func(k string) string {
+			v, _ := env[k]
+			return v
+		}
+	}
+	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote, getEnv)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -321,7 +335,20 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 	}
 	defer srv.Close()
 
-	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote)
+	getEnv := os.Getenv
+	if rMode == runOnRemote {
+		var cancel <-chan struct{}
+		env, err := runner.getRemoteEnviron(cancel)
+		if err != nil {
+			return errors.Annotatef(err, "getting remote environ")
+		}
+		getEnv = func(k string) string {
+			v, _ := env[k]
+			return v
+		}
+	}
+
+	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote, getEnv)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -576,6 +603,46 @@ func (runner *runner) startJujucServer(token string, rMode runMode) (*jujuc.Serv
 
 func (runner *runner) getLogger(hookName string) loggo.Logger {
 	return loggo.GetLogger(fmt.Sprintf("unit.%s.%s", runner.context.UnitName(), hookName))
+}
+
+var exportLineRegexp = regexp.MustCompile("(?m)^export ([^=]+)=(.*)$")
+
+func (runner *runner) getRemoteEnviron(abort <-chan struct{}) (map[string]string, error) {
+	remoteExecutor, err := runner.getRemoteExecutor(runOnRemote)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	res, err := remoteExecutor(ExecParams{
+		Commands: []string{"unset _; export"},
+		Cancel:   abort,
+		Stdout:   &stdout,
+		Stderr:   &stderr,
+	})
+	if err != nil {
+		return nil, errors.Annotatef(err, "stdout: %q stderr: %q", string(res.Stdout), string(res.Stderr))
+	}
+	matches := exportLineRegexp.FindAllStringSubmatch(string(res.Stdout), -1)
+	env := map[string]string{}
+	for _, values := range matches {
+		if len(values) != 3 {
+			return nil, errors.Errorf("regex returned incorrect submatch count")
+		}
+		key := values[1]
+		value := values[2]
+		unquoted, err := shellquote.Split(value)
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to unquote %s", value)
+		}
+		if len(unquoted) != 1 {
+			return nil, errors.Errorf("shellquote returned too many strings")
+		}
+		unquotedValue := unquoted[0]
+		env[key] = unquotedValue
+	}
+	logger.Debugf("fetched remote env %+q", env)
+	return env, nil
 }
 
 type hookProcess struct {

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -174,8 +174,16 @@ func (ctx *MockContext) UnitName() string {
 	return "some-unit/999"
 }
 
-func (ctx *MockContext) HookVars(paths context.Paths, _ bool) ([]string, error) {
-	return []string{"VAR=value"}, nil
+func (ctx *MockContext) HookVars(paths context.Paths, _ bool, getEnv context.GetEnvFunc) ([]string, error) {
+	pathKey := ""
+	if runtime.GOOS == "windows" {
+		pathKey = "Path"
+	} else {
+		pathKey = "PATH"
+	}
+	path := getEnv(pathKey)
+	newPath := fmt.Sprintf("%s=pathypathpath;%s", pathKey, path)
+	return []string{"VAR=value", newPath}, nil
 }
 
 func (ctx *MockContext) ActionData() (*context.ActionData, error) {
@@ -310,17 +318,23 @@ func (s *RunMockContextSuite) TestRunActionFlushCharmActionsCAASSuccess(c *gc.C)
 		perm: 0700,
 	}, s.paths.GetCharmDir())
 
-	execFuncCalled := false
-	c.Assert(execFuncCalled, jc.IsFalse)
+	execCount := 0
 	execFunc := func(params runner.ExecParams) (*exec.ExecResponse, error) {
-		execFuncCalled = true
-		return &exec.ExecResponse{
-			Stdout: bytes.NewBufferString("hello").Bytes(),
-			Stderr: bytes.NewBufferString("world").Bytes(),
-		}, nil
+		execCount++
+		switch execCount {
+		case 1:
+			return &exec.ExecResponse{}, nil
+		case 2:
+			return &exec.ExecResponse{
+				Stdout: bytes.NewBufferString("hello").Bytes(),
+				Stderr: bytes.NewBufferString("world").Bytes(),
+			}, nil
+		}
+		c.Fatal("invalid count")
+		return nil, nil
 	}
 	actualErr := runner.NewRunner(ctx, s.paths, execFunc).RunAction("something-happened")
-	c.Assert(execFuncCalled, jc.IsTrue)
+	c.Assert(execCount, gc.Equals, 2)
 	c.Assert(actualErr, gc.Equals, expectErr)
 	c.Assert(ctx.flushBadge, gc.Equals, "something-happened")
 	c.Assert(ctx.flushFailure, gc.IsNil)
@@ -340,10 +354,23 @@ func (s *RunMockContextSuite) TestRunActionFlushCharmActionsCAASFailed(c *gc.C) 
 		name: hookName,
 		perm: 0700,
 	}, s.paths.GetCharmDir())
-	actualErr := runner.NewRunner(ctx, s.paths, nil).RunAction("something-happened")
+	execCount := 0
+	execFunc := func(params runner.ExecParams) (*exec.ExecResponse, error) {
+		execCount++
+		switch execCount {
+		case 1:
+			return &exec.ExecResponse{}, nil
+		case 2:
+			return nil, errors.Errorf("failed exec")
+		}
+		c.Fatal("invalid count")
+		return nil, nil
+	}
+	actualErr := runner.NewRunner(ctx, s.paths, execFunc).RunAction("something-happened")
+	c.Assert(execCount, gc.Equals, 2)
 	c.Assert(actualErr, gc.Equals, ctx.flushResult)
 	c.Assert(ctx.flushBadge, gc.Equals, "something-happened")
-	c.Assert(ctx.flushFailure, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(ctx.flushFailure, gc.ErrorMatches, "failed exec")
 }
 
 func (s *RunMockContextSuite) TestRunActionFlushFailure(c *gc.C) {
@@ -466,12 +493,72 @@ func (s *RunMockContextSuite) TestRunActionCAASSuccess(c *gc.C) {
 		},
 		actionResults: map[string]interface{}{},
 	}
+	execCount := 0
 	execFunc := func(params runner.ExecParams) (*exec.ExecResponse, error) {
-		return &exec.ExecResponse{
-			Stdout: bytes.NewBufferString("1").Bytes(),
-		}, nil
+		execCount++
+		switch execCount {
+		case 1:
+			return &exec.ExecResponse{}, nil
+		case 2:
+			return &exec.ExecResponse{
+				Stdout: bytes.NewBufferString("1").Bytes(),
+			}, nil
+		}
+		c.Fatal("invalid count")
+		return nil, nil
 	}
 	err := runner.NewRunner(ctx, s.paths, execFunc).RunAction("juju-run")
+	c.Assert(execCount, gc.Equals, 2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.actionResults["Code"], gc.Equals, "0")
+	c.Assert(strings.TrimRight(ctx.actionResults["Stdout"].(string), "\r\n"), gc.Equals, "1")
+	c.Assert(ctx.actionResults["Stderr"], gc.Equals, nil)
+}
+
+func (s *RunMockContextSuite) TestRunActionCAASCorrectEnv(c *gc.C) {
+	params := map[string]interface{}{
+		"command":          "echo 1",
+		"timeout":          0,
+		"workload-context": true,
+	}
+	ctx := &MockContext{
+		modelType: model.CAAS,
+		actionData: &context.ActionData{
+			Params: params,
+		},
+		actionParams:  params,
+		actionResults: map[string]interface{}{},
+	}
+	execCount := 0
+	execFunc := func(params runner.ExecParams) (*exec.ExecResponse, error) {
+		execCount++
+		switch execCount {
+		case 1:
+			c.Assert(params.Commands, gc.DeepEquals, []string{"unset _; export"})
+			return &exec.ExecResponse{
+				Stdout: []byte(`
+export BLA='bla'
+export PATH='important-path'
+`[1:]),
+			}, nil
+		case 2:
+			path := ""
+			for _, v := range params.Env {
+				if strings.HasPrefix(v, "PATH=") {
+					path = v
+				}
+			}
+			c.Assert(path, gc.Equals, "PATH=pathypathpath;important-path")
+			return &exec.ExecResponse{
+				Stdout: bytes.NewBufferString("1").Bytes(),
+			}, nil
+		}
+		c.Fatal("invalid count")
+		return nil, nil
+	}
+	err := runner.NewRunner(ctx, s.paths, execFunc).RunAction("juju-run")
+	c.Assert(execCount, gc.Equals, 2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
 	c.Assert(ctx.actionResults["Code"], gc.Equals, "0")


### PR DESCRIPTION
## Description of change

Backport #11400

Correctly pull env from the remote to build the correct env for hook context.
Fix executing multicommands.

## QA steps

Deploy charm using a container with sh or other command to a different directory than PATH variables on the operator image.
Make sure the command is in the PATH of the workload container.

Then run:
`juju run --unit app/0 -- command`

Regression tested on a lxd unit also
```
$ juju exec --unit ubuntu-lite/0 "status-get"
active
$ juju exec --unit ubuntu-lite/0 'echo $PATH'
/var/lib/juju/tools/unit-ubuntu-lite-0:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
$ juju ssh 0
ubuntu@juju-57bf27-0:~$ sudo juju-run status-get
active
```

## Bug

https://bugs.launchpad.net/juju/+bug/1870478
