### PR TITLE
Mechanical changes to core/network.

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -6,30 +6,12 @@ package network
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
 	"net"
 	"sort"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 )
-
-// macAddressTemplate is suitable for generating virtual MAC addresses,
-// particularly for use by container devices.
-// The last 3 segments are randomised.
-// TODO (manadart 2018-06-21) Depending on where this is utilised,
-// ensuring MAC address uniqueness within a model might be prudent.
-const macAddressTemplate = "00:16:3e:%02x:%02x:%02x"
-
-// GenerateVirtualMACAddress creates a random MAC address within the address
-// space implied by macAddressTemplate above.
-var GenerateVirtualMACAddress = func() string {
-	digits := make([]interface{}, 3)
-	for i := range digits {
-		digits[i] = rand.Intn(256)
-	}
-	return fmt.Sprintf(macAddressTemplate, digits...)
-}
 
 // Private and special use network ranges for IPv4 and IPv6.
 // See: http://tools.ietf.org/html/rfc1918

--- a/core/network/network.go
+++ b/core/network/network.go
@@ -3,9 +3,32 @@
 
 package network
 
-import "github.com/juju/loggo"
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+
+	"github.com/juju/loggo"
+)
 
 var logger = loggo.GetLogger("juju.core.network")
+
+// macAddressTemplate is suitable for generating virtual MAC addresses,
+// particularly for use by container devices.
+// The last 3 segments are randomised.
+// TODO (manadart 2018-06-21) Depending on where this is utilised,
+// ensuring MAC address uniqueness within a model might be prudent.
+const macAddressTemplate = "00:16:3e:%02x:%02x:%02x"
+
+// GenerateVirtualMACAddress creates a random MAC address within the address
+// space implied by macAddressTemplate above.
+var GenerateVirtualMACAddress = func() string {
+	digits := make([]interface{}, 3)
+	for i := range digits {
+		digits[i] = rand.Intn(256)
+	}
+	return fmt.Sprintf(macAddressTemplate, digits...)
+}
 
 // Id defines a provider-specific network ID.
 type Id string
@@ -14,4 +37,60 @@ type Id string
 // This method helps with formatting and type inference.
 func (id Id) String() string {
 	return string(id)
+}
+
+// IDSet represents the classic "set" data structure, and contains Id.
+// IDSet is used as a typed version to prevent string -> Id -> string
+// conversion when using set.Strings
+type IDSet map[Id]struct{}
+
+// MakeIDSet creates and initializes a IDSet and populates it with
+// initial values as specified in the parameters.
+func MakeIDSet(values ...Id) IDSet {
+	set := make(map[Id]struct{}, len(values))
+	for _, id := range values {
+		set[id] = struct{}{}
+	}
+	return set
+}
+
+// Add puts a value into the set.
+func (s IDSet) Add(value Id) {
+	s[value] = struct{}{}
+}
+
+// Size returns the number of elements in the set.
+func (s IDSet) Size() int {
+	return len(s)
+}
+
+// IsEmpty is true for empty or uninitialized sets.
+func (s IDSet) IsEmpty() bool {
+	return len(s) == 0
+}
+
+// Contains returns true if the value is in the set, and false otherwise.
+func (s IDSet) Contains(id Id) bool {
+	_, exists := s[id]
+	return exists
+}
+
+// Values returns an unordered slice containing all the values in the set.
+func (s IDSet) Values() []Id {
+	result := make([]Id, len(s))
+	i := 0
+	for key := range s {
+		result[i] = key
+		i++
+	}
+	return result
+}
+
+// SortedValues returns an ordered slice containing all the values in the set.
+func (s IDSet) SortedValues() []Id {
+	values := s.Values()
+	sort.Slice(values, func(i, j int) bool {
+		return values[i] < values[j]
+	})
+	return values
 }

--- a/core/network/network_test.go
+++ b/core/network/network_test.go
@@ -4,6 +4,8 @@
 package network_test
 
 import (
+	"sort"
+
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
@@ -19,4 +21,74 @@ var _ = gc.Suite(&NetworkSuite{})
 func (s *NetworkSuite) TestGenerateVirtualMACAddress(c *gc.C) {
 	mac := network.GenerateVirtualMACAddress()
 	c.Check(mac, gc.Matches, "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
+}
+
+func (NetworkSuite) TestIDSetSize(c *gc.C) {
+	// Empty sets are empty.
+	s := network.MakeIDSet()
+	c.Assert(s.Size(), gc.Equals, 0)
+
+	// Size returns number of unique values.
+	s = network.MakeIDSet("foo", "foo", "bar")
+	c.Assert(s.Size(), gc.Equals, 2)
+}
+
+func (NetworkSuite) TestIDSetEmpty(c *gc.C) {
+	s := network.MakeIDSet()
+	assertValues(c, s)
+}
+
+func (NetworkSuite) TestIDSetInitialValues(c *gc.C) {
+	values := []network.Id{"foo", "bar", "baz"}
+	s := network.MakeIDSet(values...)
+	assertValues(c, s, values...)
+}
+
+func (NetworkSuite) TestIDSetIsEmpty(c *gc.C) {
+	// Empty sets are empty.
+	s := network.MakeIDSet()
+	c.Assert(s.IsEmpty(), gc.Equals, true)
+
+	// Non-empty sets are not empty.
+	s = network.MakeIDSet("foo")
+	c.Assert(s.IsEmpty(), gc.Equals, false)
+}
+
+func (NetworkSuite) TestIDSetAdd(c *gc.C) {
+	s := network.MakeIDSet()
+	s.Add("foo")
+	s.Add("foo")
+	s.Add("bar")
+	assertValues(c, s, "foo", "bar")
+}
+
+func (NetworkSuite) TestIDSetContains(c *gc.C) {
+	s := network.MakeIDSet("foo", "bar")
+	c.Assert(s.Contains("foo"), gc.Equals, true)
+	c.Assert(s.Contains("bar"), gc.Equals, true)
+	c.Assert(s.Contains("baz"), gc.Equals, false)
+}
+
+// Helper methods for the tests.
+func assertValues(c *gc.C, s network.IDSet, expected ...network.Id) {
+	values := s.Values()
+
+	// Expect an empty slice, not a nil slice for values.
+	if expected == nil {
+		expected = make([]network.Id, 0)
+	}
+
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i] < expected[j]
+	})
+	sort.Slice(values, func(i, j int) bool {
+		return values[i] < values[j]
+	})
+
+	c.Assert(values, gc.DeepEquals, expected)
+	c.Assert(s.Size(), gc.Equals, len(expected))
+
+	// Check the sorted values too.
+	sorted := s.SortedValues()
+	c.Assert(sorted, gc.DeepEquals, expected)
 }

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"net"
-	"sort"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -163,62 +162,6 @@ func FindSubnetIDsForAvailabilityZone(zoneName string, subnetsToZones map[Id][]s
 	}
 
 	return sorted, nil
-}
-
-// SubnetSet represents the classic "set" data structure, and contains Id.
-// SubnetSet is used as a typed version to prevent string -> Id -> string
-// conversion when using set.Strings
-type SubnetSet map[Id]struct{}
-
-// MakeSubnetSet creates and initializes a SubnetSet and populates it with
-// initial values as specified in the parameters.
-func MakeSubnetSet(values ...Id) SubnetSet {
-	set := make(map[Id]struct{}, len(values))
-	for _, id := range values {
-		set[id] = struct{}{}
-	}
-	return set
-}
-
-// Add puts a value into the set.
-func (s SubnetSet) Add(value Id) {
-	s[value] = struct{}{}
-}
-
-// Size returns the number of elements in the set.
-func (s SubnetSet) Size() int {
-	return len(s)
-}
-
-// IsEmpty is true for empty or uninitialized sets.
-func (s SubnetSet) IsEmpty() bool {
-	return len(s) == 0
-}
-
-// Contains returns true if the value is in the set, and false otherwise.
-func (s SubnetSet) Contains(id Id) bool {
-	_, exists := s[id]
-	return exists
-}
-
-// Values returns an unordered slice containing all the values in the set.
-func (s SubnetSet) Values() []Id {
-	result := make([]Id, len(s))
-	i := 0
-	for key := range s {
-		result[i] = key
-		i++
-	}
-	return result
-}
-
-// SortedValues returns an ordered slice containing all the values in the set.
-func (s SubnetSet) SortedValues() []Id {
-	values := s.Values()
-	sort.Slice(values, func(i, j int) bool {
-		return values[i] < values[j]
-	})
-	return values
 }
 
 // InFan describes a network fan type.

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -4,8 +4,6 @@
 package network_test
 
 import (
-	"sort"
-
 	"github.com/juju/errors"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/testing"
@@ -73,76 +71,6 @@ func (*subnetSuite) TestFindSubnetIDsForAZ(c *gc.C) {
 			c.Check(res, gc.DeepEquals, t.expected)
 		}
 	}
-}
-
-func (subnetSuite) TestSubnetSetSize(c *gc.C) {
-	// Empty sets are empty.
-	s := network.MakeSubnetSet()
-	c.Assert(s.Size(), gc.Equals, 0)
-
-	// Size returns number of unique values.
-	s = network.MakeSubnetSet("foo", "foo", "bar")
-	c.Assert(s.Size(), gc.Equals, 2)
-}
-
-func (subnetSuite) TestSubnetSetEmpty(c *gc.C) {
-	s := network.MakeSubnetSet()
-	assertValues(c, s)
-}
-
-func (subnetSuite) TestSubnetSetInitialValues(c *gc.C) {
-	values := []network.Id{"foo", "bar", "baz"}
-	s := network.MakeSubnetSet(values...)
-	assertValues(c, s, values...)
-}
-
-func (subnetSuite) TestSubnetSetIsEmpty(c *gc.C) {
-	// Empty sets are empty.
-	s := network.MakeSubnetSet()
-	c.Assert(s.IsEmpty(), gc.Equals, true)
-
-	// Non-empty sets are not empty.
-	s = network.MakeSubnetSet("foo")
-	c.Assert(s.IsEmpty(), gc.Equals, false)
-}
-
-func (subnetSuite) TestSubnetSetAdd(c *gc.C) {
-	s := network.MakeSubnetSet()
-	s.Add("foo")
-	s.Add("foo")
-	s.Add("bar")
-	assertValues(c, s, "foo", "bar")
-}
-
-func (subnetSuite) TestSubnetSetContains(c *gc.C) {
-	s := network.MakeSubnetSet("foo", "bar")
-	c.Assert(s.Contains("foo"), gc.Equals, true)
-	c.Assert(s.Contains("bar"), gc.Equals, true)
-	c.Assert(s.Contains("baz"), gc.Equals, false)
-}
-
-// Helper methods for the tests.
-func assertValues(c *gc.C, s network.SubnetSet, expected ...network.Id) {
-	values := s.Values()
-
-	// Expect an empty slice, not a nil slice for values.
-	if expected == nil {
-		expected = make([]network.Id, 0)
-	}
-
-	sort.Slice(expected, func(i, j int) bool {
-		return expected[i] < expected[j]
-	})
-	sort.Slice(values, func(i, j int) bool {
-		return values[i] < values[j]
-	})
-
-	c.Assert(values, gc.DeepEquals, expected)
-	c.Assert(s.Size(), gc.Equals, len(expected))
-
-	// Check the sorted values too.
-	sorted := s.SortedValues()
-	c.Assert(sorted, gc.DeepEquals, expected)
 }
 
 func (*subnetSuite) TestFilterInFanNetwork(c *gc.C) {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -592,7 +592,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 			corenetwork.FindSubnetIDsForAvailabilityZone(availabilityZone, subnetZones)
 
 		if subnetErr == nil && placementSubnetID != "" {
-			asSet := corenetwork.MakeSubnetSet(subnetIDsForZone...)
+			asSet := corenetwork.MakeIDSet(subnetIDsForZone...)
 			if asSet.Contains(placementSubnetID) {
 				subnetIDsForZone = []corenetwork.Id{placementSubnetID}
 			} else {

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -454,7 +454,7 @@ func getVPCSubnetIDsForAvailabilityZone(
 	vpcID, zoneName string,
 	allowedSubnetIDs []corenetwork.Id,
 ) ([]corenetwork.Id, error) {
-	allowedSubnets := corenetwork.MakeSubnetSet(allowedSubnetIDs...)
+	allowedSubnets := corenetwork.MakeIDSet(allowedSubnetIDs...)
 	vpc := &ec2.VPC{Id: vpcID}
 	subnets, err := getVPCSubnets(apiClient, ctx, vpc)
 	if err != nil && !isVPCNotUsableError(err) {
@@ -467,7 +467,7 @@ func getVPCSubnetIDsForAvailabilityZone(
 		return nil, errors.NewNotFound(err, message)
 	}
 
-	matchingSubnetIDs := corenetwork.MakeSubnetSet()
+	matchingSubnetIDs := corenetwork.MakeIDSet()
 	for _, subnet := range subnets {
 		if subnet.AvailZone != zoneName {
 			logger.Debugf("skipping subnet %q (in VPC %q): not in the chosen AZ %q", subnet.Id, vpcID, zoneName)


### PR DESCRIPTION
## Description of change

Minor reorganisation inside `core/network`:
- Move `GenerateVirtualMACAddress` out of the address module and into network.
- Rename `SubnetSet` to `IDSet`, as it is a generic for `network.Id` and move its tests into the network suite.

## QA steps

Nothing functional. Unit tests pass.
