### PR TITLE
Add SubnetInfos to core/network

### DIFF
--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -130,6 +130,8 @@ func (s *SubnetInfo) ParsedCIDRNetwork() (*net.IPNet, error) {
 	return s.parsedCIDRNetwork, nil
 }
 
+type SubnetInfos []SubnetInfo
+
 // IsValidCidr returns whether cidr is a valid subnet CIDR.
 func IsValidCidr(cidr string) bool {
 	_, ipNet, err := net.ParseCIDR(cidr)

--- a/state/controller.go
+++ b/state/controller.go
@@ -166,6 +166,10 @@ func (st *State) checkSpaceIsAvailableToAllControllers(spaceName string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	netSpace, err := space.NetworkSpace()
+	if err != nil {
+		return errors.Annotate(err, "getting network space")
+	}
 
 	var missing []string
 	for _, id := range controllerIds {
@@ -173,11 +177,6 @@ func (st *State) checkSpaceIsAvailableToAllControllers(spaceName string) error {
 		if err != nil {
 			return errors.Annotate(err, "cannot get machine")
 		}
-		netSpace, err := space.NetworkSpace()
-		if err != nil {
-			return errors.Annotate(err, "cannot get network space")
-		}
-
 		if _, ok := m.Addresses().InSpaces(netSpace); !ok {
 			missing = append(missing, id)
 		}

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -104,9 +104,10 @@ func (s *Space) NetworkSpace() (network.SpaceInfo, error) {
 
 	mappedSubnets := make([]network.SubnetInfo, len(subnets))
 	for i, subnet := range subnets {
-		mappedSubnet := subnet.networkSubnet()
+		mappedSubnet := subnet.NetworkSubnet()
 		mappedSubnet.SpaceID = s.Id()
 		mappedSubnet.SpaceName = s.Name()
+		mappedSubnet.ProviderSpaceId = s.ProviderId()
 		mappedSubnets[i] = mappedSubnet
 	}
 
@@ -284,7 +285,12 @@ func (st *State) SpaceByName(name string) (*Space, error) {
 	return &Space{st, doc}, nil
 }
 
-// AllSpaceInfos return SpaceInfos for all spaces in the model.
+// AllSpaceInfos returns SpaceInfos for all spaces in the model.
+// TODO (manadart 2020-04-09): Instead of calling NetworkSpace here,
+// load all the SubnetInfos once and retrieve the space subnets and
+// overlays from there.
+// This method is inefficient in that it hits the DB 1-2 times for
+// each space to retrieve subnets.
 func (st *State) AllSpaceInfos() (network.SpaceInfos, error) {
 	spaces, err := st.AllSpaces()
 	if err != nil {

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -117,7 +117,6 @@ func (s *SpacesSuite) TestAddSpaceWithNoSubnetsAndEmptyProviderId(c *gc.C) {
 	space, err := s.addSpaceWithSubnets(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSpaceMatchesArgs(c, space, args)
-
 }
 
 func (s *SpacesSuite) TestAddSpaceWithNoSubnetsAndNonEmptyProviderId(c *gc.C) {
@@ -655,6 +654,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 				CIDR:              "1.1.1.0/24",
 				VLANTag:           79,
 				AvailabilityZones: []string{"AvailabilityZone"},
+				ProviderSpaceId:   "some id 2",
 			},
 			{
 				SpaceID:           space.Id(),
@@ -666,6 +666,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 					FanLocalUnderlay: "1.1.1.0/24",
 					FanOverlay:       "253.0.0.0/8",
 				},
+				ProviderSpaceId: "some id 2",
 			},
 			{
 				SpaceID:           space.Id(),
@@ -673,6 +674,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 				CIDR:              "2001:cbd0::/32",
 				VLANTag:           79,
 				AvailabilityZones: []string{"AvailabilityZone"},
+				ProviderSpaceId:   "some id 2",
 			},
 		},
 	}

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -332,16 +332,31 @@ func (s *Subnet) networkSubnet() network.SubnetInfo {
 		}
 	}
 
-	return network.SubnetInfo{
+	sInfo := network.SubnetInfo{
 		CIDR:              s.doc.CIDR,
 		ProviderId:        network.Id(s.doc.ProviderId),
 		ProviderNetworkId: network.Id(s.doc.ProviderNetworkId),
 		VLANTag:           s.doc.VLANTag,
 		AvailabilityZones: s.doc.AvailabilityZones,
-		// SpaceName and ID will be populated by space.NetworkSpace
-		FanInfo:  fanInfo,
-		IsPublic: s.doc.IsPublic,
+		FanInfo:           fanInfo,
+		IsPublic:          s.doc.IsPublic,
+		SpaceID:           s.doc.SpaceID,
+		// SpaceName and ProviderSpaceID are populated by Space.NetworkSpace().
+		// For now, we do not look them up here.
 	}
+
+	// If this is a fan overlay, it will have a (numeric) space ID of 0.
+	// This is because it inherits the space of its underlay.
+	// In this case we replace it with an empty string so as not to cause
+	// confusion.
+	// Space.NetworkSpace() sets this correctly as expected.
+	// TODO (manadart 2020-04-09): We will probably need to populate this at
+	// some point.
+	if sInfo.FanLocalUnderlay() != "" {
+		sInfo.SpaceID = ""
+	}
+
+	return sInfo
 }
 
 // SubnetUpdate adds new info to the subnet based on provided info.

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -322,8 +322,8 @@ func (s *Subnet) updateSpaceName(spaceName string) (bool, error) {
 	return spaceNameChange && spaceName != "" && s.doc.FanLocalUnderlay == "", nil
 }
 
-// networkSubnet maps the subnet fields into a network.SubnetInfo.
-func (s *Subnet) networkSubnet() network.SubnetInfo {
+// NetworkSubnet maps the subnet fields into a network.SubnetInfo.
+func (s *Subnet) NetworkSubnet() network.SubnetInfo {
 	var fanInfo *network.FanCIDRs
 	if s.doc.FanLocalUnderlay != "" || s.doc.FanOverlay != "" {
 		fanInfo = &network.FanCIDRs{
@@ -357,6 +357,20 @@ func (s *Subnet) networkSubnet() network.SubnetInfo {
 	}
 
 	return sInfo
+}
+
+// AllSubnetInfos returns SubnetInfos for all subnets in the model.
+func (st *State) AllSubnetInfos() (network.SubnetInfos, error) {
+	subs, err := st.AllSubnets()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	result := make(network.SubnetInfos, len(subs))
+	for i, sub := range subs {
+		result[i] = sub.NetworkSubnet()
+	}
+	return result, nil
 }
 
 // SubnetUpdate adds new info to the subnet based on provided info.


### PR DESCRIPTION
## Description of change

This patch makes some changes around retrieving spaces and networks from state:
- For non-fan subnets, the space ID is now populated when calling `NetworkSubnet` directly.
- `NetworkSpace` also sets the provider space ID on the space's subnets.
- A new state method `AllNetworkSubnets` returns a new type `SubnetInfos` representing all subnets in the model.
- A small inefficiency for controller space testing is addressed.

## QA steps

This new functionality is not yet recruited. Unit tests cover the changes, with more QA steps to follow in forthcoming patches

## Documentation changes

None.

## Bug reference

N/A
