### PR TITLE
Remove unused StatePaths

### DIFF
--- a/worker/caasoperator/paths.go
+++ b/worker/caasoperator/paths.go
@@ -90,10 +90,6 @@ type StatePaths struct {
 	// been installed.
 	DeployerDir string
 
-	// RelationsDir holds relation-specific information about what the
-	// operator is doing and/or has done.
-	RelationsDir string
-
 	// MetricsSpoolDir acts as temporary storage for metrics being sent from
 	// the operator to state.
 	MetricsSpoolDir string
@@ -114,7 +110,6 @@ func NewPaths(dataDir string, applicationTag names.ApplicationTag) Paths {
 			CharmDir:        join(baseDir, "charm"),
 			BundlesDir:      join(stateDir, "bundles"),
 			DeployerDir:     join(stateDir, "deployer"),
-			RelationsDir:    join(stateDir, "relations"),
 			OperationsFile:  join(stateDir, "operator"),
 			MetricsSpoolDir: join(stateDir, "spool", "metrics"),
 		},

--- a/worker/caasoperator/paths_test.go
+++ b/worker/caasoperator/paths_test.go
@@ -38,7 +38,6 @@ func (s *PathsSuite) TestPaths(c *gc.C) {
 		State: caasoperator.StatePaths{
 			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
-			RelationsDir:    relAgent("state", "relations"),
 			BundlesDir:      relAgent("state", "bundles"),
 			DeployerDir:     relAgent("state", "deployer"),
 			OperationsFile:  relAgent("state", "operator"),

--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -114,24 +114,12 @@ type StatePaths struct {
 	// CharmDir is the directory to which the charm the uniter runs is deployed.
 	CharmDir string
 
-	// OperationsFile holds information about what the uniter is doing
-	// and/or has done.
-	OperationsFile string
-
-	// RelationsDir holds relation-specific information about what the
-	// uniter is doing and/or has done.
-	RelationsDir string
-
 	// BundlesDir holds downloaded charms.
 	BundlesDir string
 
 	// DeployerDir holds metadata about charms that are installing or have
 	// been installed.
 	DeployerDir string
-
-	// StorageDir holds storage-specific information about what the
-	// uniter is doing and/or has done.
-	StorageDir string
 
 	// MetricsSpoolDir acts as temporary storage for metrics being sent from
 	// the uniter to state.
@@ -207,11 +195,8 @@ func NewWorkerPaths(dataDir string, unitTag names.UnitTag, worker string, socket
 		State: StatePaths{
 			BaseDir:         baseDir,
 			CharmDir:        join(baseDir, "charm"),
-			OperationsFile:  join(stateDir, "uniter"),
-			RelationsDir:    join(stateDir, "relations"),
 			BundlesDir:      join(stateDir, "bundles"),
 			DeployerDir:     join(stateDir, "deployer"),
-			StorageDir:      join(stateDir, "storage"),
 			MetricsSpoolDir: join(stateDir, "spool", "metrics"),
 		},
 	}

--- a/worker/uniter/paths_test.go
+++ b/worker/uniter/paths_test.go
@@ -50,11 +50,8 @@ func (s *PathsSuite) TestWindows(c *gc.C) {
 		State: uniter.StatePaths{
 			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
-			OperationsFile:  relAgent("state", "uniter"),
-			RelationsDir:    relAgent("state", "relations"),
 			BundlesDir:      relAgent("state", "bundles"),
 			DeployerDir:     relAgent("state", "deployer"),
-			StorageDir:      relAgent("state", "storage"),
 			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})
@@ -82,11 +79,8 @@ func (s *PathsSuite) TestWorkerPathsWindows(c *gc.C) {
 		State: uniter.StatePaths{
 			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
-			OperationsFile:  relAgent("state", "uniter"),
-			RelationsDir:    relAgent("state", "relations"),
 			BundlesDir:      relAgent("state", "bundles"),
 			DeployerDir:     relAgent("state", "deployer"),
-			StorageDir:      relAgent("state", "storage"),
 			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})
@@ -114,11 +108,8 @@ func (s *PathsSuite) TestOther(c *gc.C) {
 		State: uniter.StatePaths{
 			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
-			OperationsFile:  relAgent("state", "uniter"),
-			RelationsDir:    relAgent("state", "relations"),
 			BundlesDir:      relAgent("state", "bundles"),
 			DeployerDir:     relAgent("state", "deployer"),
-			StorageDir:      relAgent("state", "storage"),
 			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})
@@ -157,11 +148,8 @@ func (s *PathsSuite) TestTCPRemote(c *gc.C) {
 		State: uniter.StatePaths{
 			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
-			OperationsFile:  relAgent("state", "uniter"),
-			RelationsDir:    relAgent("state", "relations"),
 			BundlesDir:      relAgent("state", "bundles"),
 			DeployerDir:     relAgent("state", "deployer"),
-			StorageDir:      relAgent("state", "storage"),
 			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})
@@ -188,11 +176,8 @@ func (s *PathsSuite) TestWorkerPaths(c *gc.C) {
 		State: uniter.StatePaths{
 			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
-			OperationsFile:  relAgent("state", "uniter"),
-			RelationsDir:    relAgent("state", "relations"),
 			BundlesDir:      relAgent("state", "bundles"),
 			DeployerDir:     relAgent("state", "deployer"),
-			StorageDir:      relAgent("state", "storage"),
 			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
 		},
 	})


### PR DESCRIPTION
## Description of change

Remove unused elements of StatePaths structures in the uniter and caasoperator workers.  Their use has been removed removed in a series of PRs to move internal uniter state from local files on the unit to the controller.

## QA steps 

There will be no impact on current behavior.  Bootstrap and deploy units with relations and storage.
