### PR TITLE
Remove deadwood code related to caas operator upgrades for uniter state.

### DIFF
--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/api/base"
 	apicallermocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/apiserver/params"
-	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/upgrades/mocks"
@@ -236,11 +235,10 @@ func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerNotMachine(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerIAAS(c *gc.C) {
+func (s *mockSteps28Suite) TestMoveUnitAgentStateToController(c *gc.C) {
 	defer s.setup(c).Finish()
 	s.expectAPIState()
 	s.expectAgentConfigMachineTag()
-	s.expectAgentConfigValueIAAS()
 	s.expectWriteTwoAgentState(c)
 	s.patchClient()
 
@@ -258,23 +256,6 @@ func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerIAAS(c *gc.C) {
 	// Check idempotent
 	err = upgrades.MoveUnitAgentStateToController(s.mockCtx)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerCAASDoesNothing(c *gc.C) {
-	// TODO: (hml) 27-03-2020
-	// remove when uniterstate moved for CAAS units and/or relations etc
-	// added to move.
-	defer s.setup(c).Finish()
-	s.expectAgentConfigMachineTag()
-	s.expectAgentConfigValueCAAS()
-	s.patchClient()
-
-	// Check idempotent
-	for i := 0; i < 2; i += 1 {
-		c.Logf("round %d", i)
-		err := upgrades.MoveUnitAgentStateToController(s.mockCtx)
-		c.Assert(err, jc.ErrorIsNil)
-	}
 }
 
 func (s *mockSteps28Suite) setup(c *gc.C) *gomock.Controller {
@@ -301,14 +282,6 @@ func (s *mockSteps28Suite) expectAPIState() {
 
 func (s *mockSteps28Suite) expectDataDir() {
 	s.mockAgentConfig.EXPECT().DataDir().Return(s.dataDir).AnyTimes()
-}
-
-func (s *mockSteps28Suite) expectAgentConfigValueCAAS() {
-	s.mockAgentConfig.EXPECT().Value(agent.ProviderType).Return(k8sprovider.CAASProviderType).AnyTimes()
-}
-
-func (s *mockSteps28Suite) expectAgentConfigValueIAAS() {
-	s.mockAgentConfig.EXPECT().Value(agent.ProviderType).Return("IAAS").AnyTimes()
 }
 
 func (s *mockSteps28Suite) expectAgentConfigMachineTag() {


### PR DESCRIPTION
## Description of change

Clean up moveUnitAgentStateToController regard upgrading CAAS models.
Not needed as the operator pods will be replaced with new images.  Added
checks like in steps_27 to ensure not run for CAAS model, just in case.

## QA steps
Run upgrade steps for iaas and caas configs.
```console 
# bootstrap and deploy units with storage and relations
$ sudo snap refresh juju --stable
$ /snap/bin/juju bootstrap microk8s mk8s-snap  ; /snap/bin/juju add-model one ;juju create-storage-pool operator-storage; juju create-storage-pool mariadb-pv ; juju deploy cs:~juju/mariadb-k8s --storage database=mariadb-pv,10M ; juju deploy cs:~juju/mediawiki-k8s-3  ; juju relate mariadb-k8s mediawiki-k8s:db

# build and deploy a k8s charm with no relations.
$ cd $GOPATH/src/github.com/juju/juju/testcharms/charm-repo/kubernetes/
$ charm build -o /tmp ubuntu-plus
$ docker pull ubuntu
$ ( cd ~ ; juju deploy /tmp/builds/ubuntu-plus-k8s --resource ubuntu_image=ubuntu )

# build and push a juju operator to upgrade to, to docker hub
$ export DOCKER_USERNAME=xxxx
$ make push-operator-image

# upgrade to juju 2.8-beta1
$ juju controller-config caas-image-repo=$DOCKER_USERNAME
$ juju upgrade-controller --agent-stream develop
$ juju upgrade-model --agent-stream develop

# once everything settles, check the controller db:
juju:PRIMARY> db.unitstates.find({},{"relation-state":1,"uniter-state":1,"storage-state":1}).pretty()
{
	"_id" : "25532c1c-466c-4e11-85d5-52b2afad5d08:u#mediawiki-k8s/1#charm",
	"relation-state" : {
		"0" : "id: 0\nmembers:\n  mariadb-k8s/0: 1\n"
	},
	"uniter-state" : "leader: true\nstarted: true\nstopped: false\ninstalled: true\nremoved: false\nstatus-set: true\nop: continue\nopstep: pending\nconfig-hash: 1f559fc7e2c0cec6de260eb29d8536d47f1943c806685286af45447106ebe612\ntrust-hash: eee5162874af645880e953d98a9dcbbe85752b88861770510bea3e3f44597a17\naddresses-hash: d52dec03f2d8bcb7eb6128bbff26f96c32173dd085aaa6123fd823e3bc4461ce\n"
}
{
	"_id" : "25532c1c-466c-4e11-85d5-52b2afad5d08:u#ubuntu-plus-k8s/1#charm",
	"uniter-state" : "leader: true\nstarted: true\nstopped: false\ninstalled: true\nremoved: false\nstatus-set: true\nop: continue\nopstep: pending\nconfig-hash: 22122d662310a66f61a031024232be76459214e9192ea87f11666b73726f212e\ntrust-hash: eb38bb77f1d8362dafb79acdd2f63ecee9c00f115e855b6aa340d2c90eaedafd\naddresses-hash: 6884233276ace6bb722fa963fa513ac3bb56fffacce30e38c7c805c3b5ddb941\n"
}
{
	"_id" : "25532c1c-466c-4e11-85d5-52b2afad5d08:u#mariadb-k8s/0#charm",
	"relation-state" : {
		"0" : "id: 0\nmembers:\n  mediawiki-k8s/1: 0\n"
	},
	"uniter-state" : "leader: true\nstarted: true\nstopped: false\ninstalled: true\nremoved: false\nstatus-set: true\nop: continue\nopstep: pending\nconfig-hash: aa6a94e5b2809d33dacc4f586a2dd9bcfa9e877f7f904a66e0662b7d40cb35e0\ntrust-hash: 2f4cfe0d424e92aa6770f383b763a5887372429a9fc5ce9d9ae8579d8285878e\naddresses-hash: 85882be889babd0759718b871650486c111d4b99d1130a04602ae53a37bdeb2a\n",
	"storage-state" : "database/0: true\n"
}

```
