### PR TITLE
Replace calls to panic with errors in uniter relations

### DIFF
--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -212,8 +212,8 @@ func (s *relationerSuite) TestSetDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we cannot rejoin the relation.
-	f := func() { _ = r.Join() }
-	c.Assert(f, gc.PanicMatches, "dying relationer must not join!")
+	err = r.Join()
+	c.Assert(err, gc.ErrorMatches, "dying relationer must not join!")
 
 	// Simulate a RelationBroken hook.
 	err = r.CommitHook(hook.Info{Kind: hooks.RelationBroken})
@@ -289,10 +289,10 @@ func (s *relationerImplicitSuite) TestImplicitRelationer(c *gc.C) {
 	c.Assert(r, jc.Satisfies, (*relation.Relationer).IsImplicit)
 
 	// Hooks are not allowed.
-	f := func() { _, _ = r.PrepareHook(hook.Info{}) }
-	c.Assert(f, gc.PanicMatches, "implicit relations must not run hooks")
-	f = func() { _ = r.CommitHook(hook.Info{}) }
-	c.Assert(f, gc.PanicMatches, "implicit relations must not run hooks")
+	_, err = r.PrepareHook(hook.Info{})
+	c.Assert(err, gc.ErrorMatches, `restart immediately`)
+	err = r.CommitHook(hook.Info{})
+	c.Assert(err, gc.ErrorMatches, `restart immediately`)
 
 	// Set it to Dying; check that the ops is removed immediately.
 	err = r.SetDying()


### PR DESCRIPTION

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Requested drive-by from #11414 

Exchanging ErrBounce for panics in PrepareCommit CommitHook as NextOp
should weed out hooks for implicit relations.  If it does not, there
are potentially other issues, so restart the worker.  Close to the
former behavior.  No need to restart the entire unit agent.

## QA steps

It's not clear how to trigger the failures being replaced.  Recommend bootstrapping and playing with creating and removing units requiring relations, as well as those that do not.
