### PR TITLE
vsphere: Remove code to delete cached VMDKs from all datastores

### DIFF
--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -4,7 +4,6 @@
 package vsphere
 
 import (
-	"fmt"
 	"path"
 	"sync"
 
@@ -229,22 +228,6 @@ func (env *sessionEnviron) DestroyController(ctx callcontext.ProviderCallContext
 	if err := env.client.DestroyVMFolder(env.ctx, path.Join(env.getVMFolder(), controllerFolderName)); err != nil {
 		HandleCredentialError(err, env, ctx)
 		return errors.Annotate(err, "destroying VM folder")
-	}
-
-	// Remove VMDK cache(s). The user can specify the datastore, and can
-	// change it over time; or if not specified, any accessible datastore
-	// will be used. We must check them all.
-	datastores, err := env.accessibleDatastores(ctx)
-	if err != nil {
-		return errors.Annotate(err, "listing datastores")
-	}
-	for _, ds := range datastores {
-		datastorePath := fmt.Sprintf("[%s] %s", ds.Name, path.Join(env.getVMFolder(), templateDirectoryName(controllerUUID)))
-		logger.Debugf("deleting: %s", datastorePath)
-		if err := env.client.DeleteDatastoreFile(env.ctx, datastorePath); err != nil {
-			HandleCredentialError(err, env, ctx)
-			return errors.Annotatef(err, "deleting VMDK cache from datastore %q", ds.Name)
-		}
 	}
 	return nil
 }

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -99,7 +99,6 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	s.dialStub.CheckCallNames(c, "Dial")
 	s.client.CheckCallNames(c,
 		"DestroyVMFolder", "RemoveVirtualMachines", "DestroyVMFolder",
-		"Datastores", "DeleteDatastoreFile", "DeleteDatastoreFile",
 		"Close",
 	)
 
@@ -121,16 +120,6 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	c.Assert(destroyControllerVMFolderCall.Args, gc.HasLen, 2)
 	c.Assert(destroyControllerVMFolderCall.Args[0], gc.Implements, new(context.Context))
 	c.Assert(destroyControllerVMFolderCall.Args[1], gc.Equals, `Juju Controller (foo)`)
-
-	deleteDatastoreFileCall1 := s.client.Calls()[4]
-	c.Assert(deleteDatastoreFileCall1.Args, gc.HasLen, 2)
-	c.Assert(deleteDatastoreFileCall1.Args[0], gc.Implements, new(context.Context))
-	c.Assert(deleteDatastoreFileCall1.Args[1], gc.Equals, "[bar] foo/templates")
-
-	deleteDatastoreFileCall2 := s.client.Calls()[5]
-	c.Assert(deleteDatastoreFileCall2.Args, gc.HasLen, 2)
-	c.Assert(deleteDatastoreFileCall2.Args[0], gc.Implements, new(context.Context))
-	c.Assert(deleteDatastoreFileCall2.Args[1], gc.Equals, "[baz] foo/templates")
 }
 
 func (s *environSuite) TestAdoptResources(c *gc.C) {


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

This is vestigial code that should have been removed a while ago - we no longer cache VMDKs in the datastore, instead they're used to create a template VM that new VMs are cloned from.

This deletion is causing problems if the user doesn't have access to the datastore - in that case it fails and blocks controller teardown.

## QA steps

Bootstrap a vsphere controller. Tear it down with `--debug` - there shouldn't be any logging from `juju.provider.vmware` about deleting from datastores.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1872552
