### PR TITLE
Merge 2.7 into develop

### DIFF
--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -4,7 +4,6 @@
 package vsphere
 
 import (
-	"fmt"
 	"path"
 	"sync"
 
@@ -229,22 +228,6 @@ func (env *sessionEnviron) DestroyController(ctx callcontext.ProviderCallContext
 	if err := env.client.DestroyVMFolder(env.ctx, path.Join(env.getVMFolder(), controllerFolderName)); err != nil {
 		HandleCredentialError(err, env, ctx)
 		return errors.Annotate(err, "destroying VM folder")
-	}
-
-	// Remove VMDK cache(s). The user can specify the datastore, and can
-	// change it over time; or if not specified, any accessible datastore
-	// will be used. We must check them all.
-	datastores, err := env.accessibleDatastores(ctx)
-	if err != nil {
-		return errors.Annotate(err, "listing datastores")
-	}
-	for _, ds := range datastores {
-		datastorePath := fmt.Sprintf("[%s] %s", ds.Name, path.Join(env.getVMFolder(), templateDirectoryName(controllerUUID)))
-		logger.Debugf("deleting: %s", datastorePath)
-		if err := env.client.DeleteDatastoreFile(env.ctx, datastorePath); err != nil {
-			HandleCredentialError(err, env, ctx)
-			return errors.Annotatef(err, "deleting VMDK cache from datastore %q", ds.Name)
-		}
 	}
 	return nil
 }

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -99,7 +99,6 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	s.dialStub.CheckCallNames(c, "Dial")
 	s.client.CheckCallNames(c,
 		"DestroyVMFolder", "RemoveVirtualMachines", "DestroyVMFolder",
-		"Datastores", "DeleteDatastoreFile", "DeleteDatastoreFile",
 		"Close",
 	)
 
@@ -121,16 +120,6 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	c.Assert(destroyControllerVMFolderCall.Args, gc.HasLen, 2)
 	c.Assert(destroyControllerVMFolderCall.Args[0], gc.Implements, new(context.Context))
 	c.Assert(destroyControllerVMFolderCall.Args[1], gc.Equals, `Juju Controller (foo)`)
-
-	deleteDatastoreFileCall1 := s.client.Calls()[4]
-	c.Assert(deleteDatastoreFileCall1.Args, gc.HasLen, 2)
-	c.Assert(deleteDatastoreFileCall1.Args[0], gc.Implements, new(context.Context))
-	c.Assert(deleteDatastoreFileCall1.Args[1], gc.Equals, "[bar] foo/templates")
-
-	deleteDatastoreFileCall2 := s.client.Calls()[5]
-	c.Assert(deleteDatastoreFileCall2.Args, gc.HasLen, 2)
-	c.Assert(deleteDatastoreFileCall2.Args[0], gc.Implements, new(context.Context))
-	c.Assert(deleteDatastoreFileCall2.Args[1], gc.Equals, "[baz] foo/templates")
 }
 
 func (s *environSuite) TestAdoptResources(c *gc.C) {


### PR DESCRIPTION
## Description of change

This brings the vsphere change from #11439 into the develop branch. No conflicts.

## QA steps

Bootstrap on vsphere, destroy the controller with `--debug` - there shouldn't be any logging about deleting files from datastores.

## Documentation changes

None

## Bug reference

None
