### PR TITLE
Core Network Type Enhancements

### DIFF
--- a/core/network/space.go
+++ b/core/network/space.go
@@ -23,10 +23,15 @@ const (
 	AlphaSpaceName = "alpha"
 )
 
-// SpaceLookup describes methods for acquiring SpaceInfos
-// to translate space IDs to space names and vice versa.
+// SpaceLookup describes the ability to get a complete
+// network topology, as understood by Juju.
 type SpaceLookup interface {
 	AllSpaceInfos() (SpaceInfos, error)
+}
+
+// SubnetLookup describes retrieving all subnets within a known set of spaces.
+type SubnetLookup interface {
+	AllSubnetInfos() (SubnetInfos, error)
 }
 
 // SpaceName is the name of a network space.
@@ -58,6 +63,21 @@ type SpaceInfos []SpaceInfo
 // materialised and don't need to pull them from the DB again.
 func (s SpaceInfos) AllSpaceInfos() (SpaceInfos, error) {
 	return s, nil
+}
+
+// AllSubnetInfos returns all subnets contained in this collection of spaces.
+// Since a subnet can only be in one space, we can simply accrue them all
+// with the need for duplicate checking.
+// As with AllSpaceInfos, it implements an interface that can be used to
+// indirect state.
+func (s SpaceInfos) AllSubnetInfos() (SubnetInfos, error) {
+	subs := make(SubnetInfos, 0)
+	for _, space := range s {
+		for _, sub := range space.Subnets {
+			subs = append(subs, sub)
+		}
+	}
+	return subs, nil
 }
 
 // String returns returns a quoted, comma-delimited names of the spaces in the
@@ -163,7 +183,8 @@ nextSpace:
 					continue nextSpace
 				}
 
-				return nil, errors.Errorf("unable to infer space for address %q: address matches the same CIDR in multiple spaces", addr)
+				return nil, errors.Errorf(
+					"unable to infer space for address %q: address matches the same CIDR in multiple spaces", addr)
 			}
 		}
 	}
@@ -183,7 +204,8 @@ func (s SpaceInfos) InferSpaceFromCIDRAndSubnetID(cidr, providerSubnetID string)
 		}
 	}
 
-	return nil, errors.NewNotFound(nil, fmt.Sprintf("unable to infer space for CIDR %q and provider subnet ID %q", cidr, providerSubnetID))
+	return nil, errors.NewNotFound(
+		nil, fmt.Sprintf("unable to infer space for CIDR %q and provider subnet ID %q", cidr, providerSubnetID))
 }
 
 var (

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -35,6 +35,7 @@ type SpaceName string
 // SpaceInfo defines a network space.
 type SpaceInfo struct {
 	// ID is the unique identifier for the space.
+	// TODO (manadart 2020-04-10): This should be a typed ID.
 	ID string
 
 	// Name is the name of the space.
@@ -125,8 +126,8 @@ func (s SpaceInfos) ContainsName(name string) bool {
 }
 
 // Minus returns a new SpaceInfos representing all the
-// values in the target that are not in the parameter. Value
-// matching is done by ID.
+// values in the target that are not in the parameter.
+// Value matching is done by ID.
 func (s SpaceInfos) Minus(other SpaceInfos) SpaceInfos {
 	result := make(SpaceInfos, 0)
 	for _, value := range s {

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -31,6 +32,9 @@ func newFanCIDRs(overlay, underlay string) *FanCIDRs {
 // SubnetInfo is a source-agnostic representation of a subnet.
 // It may originate from state, or from a provider.
 type SubnetInfo struct {
+	// ID is the unique ID of the subnet.
+	ID Id
+
 	// CIDR of the network, in 123.45.67.89/24 format.
 	CIDR string
 
@@ -130,7 +134,36 @@ func (s *SubnetInfo) ParsedCIDRNetwork() (*net.IPNet, error) {
 	return s.parsedCIDRNetwork, nil
 }
 
+// SubnetInfos is a collection of subnets.
 type SubnetInfos []SubnetInfo
+
+// EqualTo returns true if this slice of SubnetInfo is equal to the input.
+func (s SubnetInfos) EqualTo(other SubnetInfos) bool {
+	if len(s) != len(other) {
+		return false
+	}
+
+	SortSubnetInfos(s)
+	SortSubnetInfos(other)
+	for i := 0; i < len(s); i++ {
+		if s[i].ID != other[i].ID {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s SubnetInfos) Len() int      { return len(s) }
+func (s SubnetInfos) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s SubnetInfos) Less(i, j int) bool {
+	return s[i].ID < s[j].ID
+}
+
+// SortSubnetInfos sorts subnets by ID.
+func SortSubnetInfos(s SubnetInfos) {
+	sort.Sort(s)
+}
 
 // IsValidCidr returns whether cidr is a valid subnet CIDR.
 func IsValidCidr(cidr string) bool {

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -137,6 +137,15 @@ func (s *SubnetInfo) ParsedCIDRNetwork() (*net.IPNet, error) {
 // SubnetInfos is a collection of subnets.
 type SubnetInfos []SubnetInfo
 
+// SpaceIDs returns the set of space IDs that these subnets are in.
+func (s SubnetInfos) SpaceIDs() set.Strings {
+	spaceIDs := set.NewStrings()
+	for _, sub := range s {
+		spaceIDs.Add(sub.SpaceID)
+	}
+	return spaceIDs
+}
+
 // EqualTo returns true if this slice of SubnetInfo is equal to the input.
 func (s SubnetInfos) EqualTo(other SubnetInfos) bool {
 	if len(s) != len(other) {

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -119,17 +119,27 @@ func (*subnetSuite) TestFilterInFanNetwork(c *gc.C) {
 
 func (*subnetSuite) TestSubnetInfosEquality(c *gc.C) {
 	s1 := network.SubnetInfos{
-		{ID: network.Id(1)},
-		{ID: network.Id(2)},
+		{ID: "1"},
+		{ID: "2"},
 	}
 
 	s2 := network.SubnetInfos{
-		{ID: network.Id(2)},
-		{ID: network.Id(1)},
+		{ID: "2"},
+		{ID: "1"},
 	}
 
-	s3 := append(s2, network.SubnetInfo{ID: network.Id(3)})
+	s3 := append(s2, network.SubnetInfo{ID: "3"})
 
 	c.Check(s1.EqualTo(s2), jc.IsTrue)
 	c.Check(s1.EqualTo(s3), jc.IsFalse)
+}
+
+func (*subnetSuite) TestSubnetInfosSpaceIDs(c *gc.C) {
+	s := network.SubnetInfos{
+		{ID: "1", SpaceID: network.AlphaSpaceId},
+		{ID: "2", SpaceID: network.AlphaSpaceId},
+		{ID: "3", SpaceID: "666"},
+	}
+
+	c.Check(s.SpaceIDs().SortedValues(), jc.DeepEquals, []string{network.AlphaSpaceId, "666"})
 }

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -116,3 +116,20 @@ func (*subnetSuite) TestFilterInFanNetwork(c *gc.C) {
 		c.Check(res, gc.DeepEquals, t.expected)
 	}
 }
+
+func (*subnetSuite) TestSubnetInfosEquality(c *gc.C) {
+	s1 := network.SubnetInfos{
+		{ID: network.Id(1)},
+		{ID: network.Id(2)},
+	}
+
+	s2 := network.SubnetInfos{
+		{ID: network.Id(2)},
+		{ID: network.Id(1)},
+	}
+
+	s3 := append(s2, network.SubnetInfo{ID: network.Id(3)})
+
+	c.Check(s1.EqualTo(s2), jc.IsTrue)
+	c.Check(s1.EqualTo(s3), jc.IsFalse)
+}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -649,6 +649,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 		ProviderId: args.ProviderId,
 		Subnets: []network.SubnetInfo{
 			{
+				ID:                "0",
 				SpaceID:           space.Id(),
 				SpaceName:         "space1",
 				CIDR:              "1.1.1.0/24",
@@ -657,6 +658,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 				ProviderSpaceId:   "some id 2",
 			},
 			{
+				ID:                "2",
 				SpaceID:           space.Id(),
 				SpaceName:         "space1",
 				CIDR:              "253.1.0.0/16",
@@ -669,6 +671,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 				ProviderSpaceId: "some id 2",
 			},
 			{
+				ID:                "1",
 				SpaceID:           space.Id(),
 				SpaceName:         "space1",
 				CIDR:              "2001:cbd0::/32",

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -333,6 +333,7 @@ func (s *Subnet) NetworkSubnet() network.SubnetInfo {
 	}
 
 	sInfo := network.SubnetInfo{
+		ID:                network.Id(s.doc.ID),
 		CIDR:              s.doc.CIDR,
 		ProviderId:        network.Id(s.doc.ProviderId),
 		ProviderNetworkId: network.Id(s.doc.ProviderNetworkId),


### PR DESCRIPTION
## Description of change

This patch strengthens the `core/network` types for spaces and subnets.
- `SubnetInfo` includes an `ID` field populated by the `state` package.
- `SubnetInfos` can be sorted and tested for equality on the basis of subnet ID.
- `SubnetInfos` has a `SpaceIDs` method to retrieve IDs for all spaces the subnets are in.
- `SpaceInfos` has a method `AllSubnetInfos` that returns all subnets in the set of spaces.

## QA steps

QA steps will follow with a subsequent patch that recruits this new capability. Unit tests cover the changes.

## Documentation changes

None.

## Bug reference

N/A
