### PR TITLE
Fix windows manual provisioning

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -794,6 +794,10 @@ func NewInstanceConfig(
 	if err != nil {
 		return nil, err
 	}
+	transientDataDir, err := paths.TransientDataDir(series)
+	if err != nil {
+		return nil, err
+	}
 	cloudInitOutputLog := path.Join(logDir, "cloud-init-output.log")
 	icfg := &InstanceConfig{
 		// Fixed entries.
@@ -802,6 +806,7 @@ func NewInstanceConfig(
 		MetricsSpoolDir:         metricsSpoolDir,
 		Jobs:                    []model.MachineJob{model.JobHostUnits},
 		CloudInitOutputLog:      cloudInitOutputLog,
+		TransientDataDir:        transientDataDir,
 		MachineAgentServiceName: "jujud-" + names.NewMachineTag(machineID).String(),
 		Series:                  series,
 		Tags:                    map[string]string{},

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b
 	github.com/juju/txn v0.0.0-20190416045819-5f348e78887d
 	github.com/juju/usso v0.0.0-20160401104424-68a59c96c178 // indirect
-	github.com/juju/utils v0.0.0-20200423035217-b0a7da72a5fa
+	github.com/juju/utils v0.0.0-20200424103611-54ececcc5fc7
 	github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6
 	github.com/juju/webbrowser v0.0.0-20180907093207-efb9432b2bcb
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647 h1:wQpkHVbIIpz1PCcLYku9
 github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20200423035217-b0a7da72a5fa h1:lv9vemJVV2iGalxqEOqEPw2+bBr0WyZqun7TfguD4fY=
 github.com/juju/utils v0.0.0-20200423035217-b0a7da72a5fa/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
+github.com/juju/utils v0.0.0-20200424103611-54ececcc5fc7 h1:3+lnQMg3pJ2xF57li+dsLERIgn9qaqnDZ0f4EmIAiUw=
+github.com/juju/utils v0.0.0-20200424103611-54ececcc5fc7/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/version v0.0.0-20151127203400-ef897ad7f130/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20160603194958-4ae6172c0062/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=


### PR DESCRIPTION
This change fixes the WinRM provisioning scripts, which re-enables the manual provider to work with Windows machines.

See: https://paste.ubuntu.com/p/ptZG9zgt4T/

This change depends on:

https://github.com/juju/utils/pull/310

## QA steps

  * Bootstrapped a new controller with manual provider.
  * Added a Windows Server 2019 machine.
  * Deployed the [active directory charm](https://jaas.ai/u/cloudbaseit/active-directory/9)

```sh
juju bootstrap manual --config agent-stream=devel --config agent-metadata-url=http://192.168.100.202/tools
juju add-machine winrm:Administrator@192.168.100.222
juju deploy cs:~cloudbaseit/active-directory --to 0 --config $HOME/charms/config.yaml --series win2019 --force
```

## Documentation changes

No changes to API/CLI. Functionality has been there for a while, just left behind. I will also send documentation changes that will detail the needed steps to use the manual provider with Windows machines.

## Bug reference

N/A
