### PR TITLE
Fixes bug for empty label maps in metadata

### DIFF
--- a/worker/caasadmission/handler.go
+++ b/worker/caasadmission/handler.go
@@ -181,6 +181,14 @@ func patchForLabels(labels map[string]string, appName string) []patchOperation {
 
 	neededLabels := provider.LabelsForApp(appName)
 
+	if len(labels) == 0 {
+		patches = append(patches, patchOperation{
+			Op:    addOp,
+			Path:  "/metadata/labels",
+			Value: map[string]string{},
+		})
+	}
+
 	for k, v := range neededLabels {
 		if extVal, found := labels[k]; found && extVal != v {
 			patches = append(patches, patchOperation{

--- a/worker/caasadmission/handler_test.go
+++ b/worker/caasadmission/handler_test.go
@@ -213,8 +213,23 @@ func (h *HandlerSuite) TestPatchLabelsAdd(c *gc.C) {
 	err = json.Unmarshal(outReview.Response.Patch, &patchOperations)
 	c.Assert(err, jc.ErrorIsNil)
 
+	c.Assert(len(patchOperations), gc.Equals, 2)
+	c.Assert(patchOperations[0].Op, gc.Equals, "add")
+	c.Assert(patchOperations[0].Path, gc.Equals, "/metadata/labels")
+
 	expectedLabels := provider.LabelsForApp(appName)
-	c.Assert(len(expectedLabels), gc.Equals, len(patchOperations))
+	for k, v := range expectedLabels {
+		found := false
+		for _, patchOp := range patchOperations[1:] {
+			if patchOp.Path == fmt.Sprintf("/metadata/labels/%s", k) {
+				c.Assert(patchOp.Op, gc.Equals, "add")
+				c.Assert(patchOp.Value, jc.DeepEquals, v)
+				found = true
+				break
+			}
+		}
+		c.Assert(found, gc.Equals, true)
+	}
 
 	for k, v := range expectedLabels {
 		found := false
@@ -281,9 +296,21 @@ func (h *HandlerSuite) TestPatchLabelsReplace(c *gc.C) {
 	patchOperations := []patchOperation{}
 	err = json.Unmarshal(outReview.Response.Patch, &patchOperations)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(patchOperations), gc.Equals, 1)
 
 	expectedLabels := provider.LabelsForApp(appName)
-	c.Assert(len(expectedLabels), gc.Equals, len(patchOperations))
+	for k, v := range expectedLabels {
+		found := false
+		for _, patchOp := range patchOperations {
+			if patchOp.Path == fmt.Sprintf("/metadata/labels/%s", k) {
+				c.Assert(patchOp.Op, gc.Equals, "replace")
+				c.Assert(patchOp.Value, jc.DeepEquals, v)
+				found = true
+				break
+			}
+		}
+		c.Assert(found, gc.Equals, true)
+	}
 
 	for k, v := range expectedLabels {
 		found := false


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

When we process a k8s obj with an empty labels map we need to patch add
this before adding keys

## QA steps

Run unit tests or create a new obj in a model namespace using a k8s service account from juju


## Bug reference

https://bugs.launchpad.net/juju/+bug/1871894
