### PR TITLE
caas workers handle app not found better

### DIFF
--- a/api/caasoperator/client.go
+++ b/api/caasoperator/client.go
@@ -135,6 +135,9 @@ func (c *Client) Charm(application string) (*CharmInfo, error) {
 		return nil, errors.Trace(err)
 	}
 	if err := results.Results[0].Error; err != nil {
+		if params.IsCodeNotFound(err) {
+			return nil, errors.NotFoundf("application %q", application)
+		}
 		return nil, errors.Trace(err)
 	}
 	result := results.Results[0].Result

--- a/api/caasoperator/client_test.go
+++ b/api/caasoperator/client_test.go
@@ -103,13 +103,13 @@ func (s *operatorSuite) TestCharm(c *gc.C) {
 func (s *operatorSuite) TestCharmError(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ApplicationCharmResults)) = params.ApplicationCharmResults{
-			Results: []params.ApplicationCharmResult{{Error: &params.Error{Message: "bletch"}}},
+			Results: []params.ApplicationCharmResult{{Error: &params.Error{Code: params.CodeNotFound}}},
 		}
 		return nil
 	})
 	client := caasoperator.NewClient(apiCaller)
 	_, err := client.Charm("gitlab")
-	c.Assert(err, gc.ErrorMatches, "bletch")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *operatorSuite) TestCharmInvalidApplicationName(c *gc.C) {

--- a/worker/caasoperator/remotestate/mock_test.go
+++ b/worker/caasoperator/remotestate/mock_test.go
@@ -56,6 +56,7 @@ func newMockNotifyWatcher() *mockNotifyWatcher {
 type mockNotifyWatcher struct {
 	*mockWatcher
 	changes chan struct{}
+	err     error
 }
 
 func (w *mockNotifyWatcher) Changes() watcher.NotifyChannel {
@@ -70,7 +71,7 @@ func (s *mockApplicationWatcher) Watch(application string) (watcher.NotifyWatche
 	if application != "gitlab" {
 		return nil, errors.NotFoundf(application)
 	}
-	return s.watcher, nil
+	return s.watcher, s.watcher.err
 }
 
 type mockCharmGetter struct {

--- a/worker/caasoperator/remotestate/watcher.go
+++ b/worker/caasoperator/remotestate/watcher.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/worker.v1/catacomb"
+
+	jworker "github.com/juju/juju/worker"
 )
 
 // logger is here to stop the desire of creating a package level logger.
@@ -89,8 +91,8 @@ func (w *RemoteStateWatcher) Snapshot() Snapshot {
 func (w *RemoteStateWatcher) loop() (err error) {
 	defer func() {
 		if errors.IsNotFound(err) {
-			w.config.Logger.Debugf("ignoring error %v and exit", err)
-			err = nil
+			w.config.Logger.Debugf("application %q removed, terminating agent", w.application)
+			err = jworker.ErrTerminateAgent
 		}
 	}()
 


### PR DESCRIPTION
## Description of change

The caas firewaller and operator workers were logging errors and restarting if their app was removed. The operator worker needs to terminate, and the  parent firewaller worker simply needs to clean up without logging any error.

## QA steps

deploy a k8s charm
debug-log
remove the app
ensure app is removed from the model and k8s
ensure there's no warnings or errors logged about missing app or workers restarting

