### PR TITLE
core/network - Enhance Collection Types to Retrieve Fan Overlays

### DIFF
--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -298,7 +298,7 @@ func (api *API) createOneSpace(args params.CreateSpaceParams) error {
 
 	subnetIDs := make([]string, len(args.CIDRs))
 	for i, cidr := range args.CIDRs {
-		if !network.IsValidCidr(cidr) {
+		if !network.IsValidCIDR(cidr) {
 			return errors.New(fmt.Sprintf("%q is not a valid CIDR", cidr))
 		}
 		subnet, err := api.backing.SubnetByCIDR(cidr)

--- a/apiserver/facades/client/subnets/cache.go
+++ b/apiserver/facades/client/subnets/cache.go
@@ -276,7 +276,7 @@ func (cache *addSubnetsCache) validateSubnet(ctx context.ProviderCallContext, ci
 		return nil, errors.Errorf("CIDR and SubnetProviderId cannot be both set")
 	}
 	if haveCidr {
-		if !network.IsValidCidr(cidr) {
+		if !network.IsValidCIDR(cidr) {
 			return nil, errors.New(fmt.Sprintf("%q is not a valid CIDR", cidr))
 		}
 	}
@@ -310,7 +310,7 @@ func (cache *addSubnetsCache) validateSubnet(ctx context.ProviderCallContext, ci
 		)
 	}
 	// Do last-call validation.
-	if !network.IsValidCidr(info.CIDR) {
+	if !network.IsValidCIDR(info.CIDR) {
 		_, ipnet, err := net.ParseCIDR(info.CIDR)
 		if err != nil && info.CIDR != "" {
 			// The underlying error is not important here, just that

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -275,7 +275,7 @@ func (api *API) SubnetsByCIDR(arg params.CIDRParams) (params.SubnetsResults, err
 
 	results := make([]params.SubnetsResult, len(arg.CIDRS))
 	for i, cidr := range arg.CIDRS {
-		if !network.IsValidCidr(cidr) {
+		if !network.IsValidCIDR(cidr) {
 			results[i].Error = common.ServerError(errors.NotValidf("CIDR %q", cidr))
 			continue
 		}

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -52,7 +52,7 @@ type SpaceInfo struct {
 	ProviderId Id
 
 	// Subnets are the subnets that have been grouped into this network space.
-	Subnets []SubnetInfo
+	Subnets SubnetInfos
 }
 
 // SpaceInfos is a collection of spaces.
@@ -78,6 +78,37 @@ func (s SpaceInfos) AllSubnetInfos() (SubnetInfos, error) {
 		}
 	}
 	return subs, nil
+}
+
+// FanOverlaysFor returns any subnets in this network topology that are
+// fan overlays for the input subnet IDs.
+func (s SpaceInfos) FanOverlaysFor(subnetIDs IDSet) (SubnetInfos, error) {
+	if len(subnetIDs) == 0 {
+		return nil, nil
+	}
+
+	var located int
+	var allOverlays SubnetInfos
+
+	for _, space := range s {
+		for _, sub := range space.Subnets {
+			if subnetIDs.Contains(sub.ID) {
+				overlays, err := space.Subnets.GetByUnderlayCIDR(sub.CIDR)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				allOverlays = append(allOverlays, overlays...)
+
+				// If we have tested all of the inputs, we can exit early.
+				located++
+				if located >= len(subnetIDs) {
+					return allOverlays, nil
+				}
+			}
+		}
+	}
+
+	return allOverlays, nil
 }
 
 // String returns returns a quoted, comma-delimited names of the spaces in the

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -143,3 +143,35 @@ func (*subnetSuite) TestSubnetInfosSpaceIDs(c *gc.C) {
 
 	c.Check(s.SpaceIDs().SortedValues(), jc.DeepEquals, []string{network.AlphaSpaceId, "666"})
 }
+
+func (*subnetSuite) TestSubnetInfosGetByUnderLayCIDR(c *gc.C) {
+	s := network.SubnetInfos{
+		{
+			ID:      "1",
+			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "10.10.10.0/24"},
+		},
+		{
+			ID:      "2",
+			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "20.20.20.0/24"},
+		},
+		{
+			ID:      "3",
+			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "20.20.20.0/24"},
+		},
+	}
+
+	_, err := s.GetByUnderlayCIDR("invalid")
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+
+	overlays, err := s.GetByUnderlayCIDR(s[0].FanLocalUnderlay())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(overlays, gc.DeepEquals, network.SubnetInfos{s[0]})
+
+	overlays, err = s.GetByUnderlayCIDR(s[1].FanLocalUnderlay())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(overlays, gc.DeepEquals, network.SubnetInfos{s[1], s[2]})
+
+	overlays, err = s.GetByUnderlayCIDR("30.30.30.0/24")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(overlays, gc.HasLen, 0)
+}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -530,7 +530,7 @@ func (i *importer) machinePortsOps(m description.Machine) ([]txn.Op, error) {
 
 	for _, ports := range m.OpenedPorts() {
 		subnetID := ports.SubnetID()
-		if network.IsValidCidr(subnetID) {
+		if network.IsValidCIDR(subnetID) {
 			// If we're migrating from a controller which has cidrs for
 			// subnetIDs, there can be only 1 of that cidr in the model.
 			subnet, err := i.st.SubnetByCIDR(subnetID)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2507,7 +2507,7 @@ func ReplacePortsDocSubnetIDCIDR(pool *StatePool) (err error) {
 		var ops []txn.Op
 		for _, oldDoc := range docs {
 			// A doc with a subnet ID has already been upgraded.
-			if !network.IsValidCidr(oldDoc.SubnetID) {
+			if !network.IsValidCIDR(oldDoc.SubnetID) {
 				continue
 			}
 


### PR DESCRIPTION
## Description of change

This patch enhances the `core/network` collection types for spaces and subnets so that fan overlays for a given underlay subnet can be retrieved.

As a drive-by, the method `IsValidCidr` is renamed to `IsValidCIDR`

## QA steps

Run unit tests in the `core/network' package.

## Documentation changes

None.

## Bug reference

N/A
