### PR TITLE
Add MoveSubnets to SpaceInfos

### DIFF
--- a/core/network/network.go
+++ b/core/network/network.go
@@ -75,6 +75,20 @@ func (s IDSet) Contains(id Id) bool {
 	return exists
 }
 
+// Difference returns a new IDSet representing all the values in the
+// target that are not in the parameter.
+func (s IDSet) Difference(other IDSet) IDSet {
+	result := make(IDSet)
+	// Use the internal map rather than going through the friendlier functions
+	// to avoid extra allocation of slices.
+	for value := range s {
+		if !other.Contains(value) {
+			result[value] = struct{}{}
+		}
+	}
+	return result
+}
+
 // Values returns an unordered slice containing all the values in the set.
 func (s IDSet) Values() []Id {
 	result := make([]Id, len(s))
@@ -93,18 +107,4 @@ func (s IDSet) SortedValues() []Id {
 		return values[i] < values[j]
 	})
 	return values
-}
-
-// Difference returns a new IDSet representing all the values in the
-// target that are not in the parameter.
-func (s IDSet) Difference(other IDSet) IDSet {
-	result := make(IDSet)
-	// Use the internal map rather than going through the friendlier functions
-	// to avoid extra allocation of slices.
-	for value := range s {
-		if !other.Contains(value) {
-			result[value] = struct{}{}
-		}
-	}
-	return result
 }

--- a/core/network/network_test.go
+++ b/core/network/network_test.go
@@ -69,7 +69,7 @@ func (NetworkSuite) TestIDSetContains(c *gc.C) {
 	c.Assert(s.Contains("baz"), gc.Equals, false)
 }
 
-func (NetworkSuite) TestDifference(c *gc.C) {
+func (NetworkSuite) TestIDSetDifference(c *gc.C) {
 	s1 := network.MakeIDSet("foo", "bar")
 	s2 := network.MakeIDSet("foo", "baz", "bang")
 	diff1 := s1.Difference(s2)

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -114,18 +114,26 @@ func (s SpaceInfos) FanOverlaysFor(subnetIDs IDSet) (SubnetInfos, error) {
 // MoveSubnets returns a new topology representing
 // the movement of subnets to a new network space.
 func (s SpaceInfos) MoveSubnets(subnetIDs IDSet, spaceName string) (SpaceInfos, error) {
-	var movers SubnetInfos
-
 	newSpace := s.GetByName(spaceName)
 	if newSpace == nil {
 		return nil, errors.NotFoundf("space with name %q", spaceName)
 	}
 
+	var movers SubnetInfos
+	found := MakeIDSet()
+
 	// First accrue the moving subnets and remove them from their old spaces.
 	for i, space := range s {
 		subs := space.Subnets
 		for j, sub := range subs {
-			if subnetIDs.Contains(sub.ID) && string(space.Name) != spaceName {
+			if subnetIDs.Contains(sub.ID) {
+				// Indicate that we found the subnet,
+				// but don't do anything if it is already in the space.
+				found.Add(sub.ID)
+				if string(space.Name) == spaceName {
+					continue
+				}
+
 				sub.SpaceID = newSpace.ID
 				sub.SpaceName = spaceName
 				sub.ProviderSpaceId = newSpace.ProviderId
@@ -136,12 +144,18 @@ func (s SpaceInfos) MoveSubnets(subnetIDs IDSet, spaceName string) (SpaceInfos, 
 		}
 	}
 
+	// Ensure that the input did not include subnets not in this collection.
+	if diff := subnetIDs.Difference(found); len(diff) != 0 {
+		return nil, errors.NotFoundf("subnet IDs %v", diff.SortedValues())
+	}
+
 	// Then put them against the new one.
 	// We have to find the space again in this collection,
 	// because newSpace was returned from a copy.
 	for i, space := range s {
 		if string(space.Name) == spaceName {
 			s[i].Subnets = append(space.Subnets, movers...)
+			break
 		}
 	}
 	return s, nil

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -111,6 +111,42 @@ func (s SpaceInfos) FanOverlaysFor(subnetIDs IDSet) (SubnetInfos, error) {
 	return allOverlays, nil
 }
 
+// MoveSubnets returns a new topology representing
+// the movement of subnets to a new network space.
+func (s SpaceInfos) MoveSubnets(subnetIDs IDSet, spaceName string) (SpaceInfos, error) {
+	var movers SubnetInfos
+
+	newSpace := s.GetByName(spaceName)
+	if newSpace == nil {
+		return nil, errors.NotFoundf("space with name %q", spaceName)
+	}
+
+	// First accrue the moving subnets and remove them from their old spaces.
+	for i, space := range s {
+		subs := space.Subnets
+		for j, sub := range subs {
+			if subnetIDs.Contains(sub.ID) && string(space.Name) != spaceName {
+				sub.SpaceID = newSpace.ID
+				sub.SpaceName = spaceName
+				sub.ProviderSpaceId = newSpace.ProviderId
+
+				movers = append(movers, sub)
+				s[i].Subnets = append(subs[:j], subs[j+1:]...)
+			}
+		}
+	}
+
+	// Then put them against the new one.
+	// We have to find the space again in this collection,
+	// because newSpace was returned from a copy.
+	for i, space := range s {
+		if string(space.Name) == spaceName {
+			s[i].Subnets = append(space.Subnets, movers...)
+		}
+	}
+	return s, nil
+}
+
 // String returns returns a quoted, comma-delimited names of the spaces in the
 // collection, or <none> if the collection is empty.
 func (s SpaceInfos) String() string {

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -5,6 +5,7 @@ package network_test
 
 import (
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -167,6 +168,27 @@ func (s *spaceSuite) TestFanOverlaysFor(c *gc.C) {
 	overlays, err = s.spaces.FanOverlaysFor(network.MakeIDSet("14"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(overlays, gc.DeepEquals, network.SubnetInfos{overlay})
+}
+
+func (s *spaceSuite) TestMoveSubnets(c *gc.C) {
+	_, err := s.spaces.MoveSubnets(network.MakeIDSet("11", "12"), "space4")
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+
+	spaces, err := s.spaces.MoveSubnets(network.MakeIDSet("11", "12"), "space3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spaces, gc.DeepEquals, network.SpaceInfos{
+		{ID: "1", Name: "space1", Subnets: []network.SubnetInfo{}},
+		{ID: "2", Name: "space2", Subnets: []network.SubnetInfo{}},
+		{
+			ID:   "3",
+			Name: "space3",
+			Subnets: network.SubnetInfos{
+				{ID: "13", CIDR: "10.0.2.0/24"},
+				{ID: "11", CIDR: "10.0.0.0/24", SpaceID: "3", SpaceName: "space3"},
+				{ID: "12", CIDR: "10.0.1.0/24", SpaceID: "3", SpaceName: "space3"},
+			},
+		},
+	})
 }
 
 func (s *spaceSuite) TestConvertSpaceName(c *gc.C) {

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -174,6 +174,9 @@ func (s *spaceSuite) TestMoveSubnets(c *gc.C) {
 	_, err := s.spaces.MoveSubnets(network.MakeIDSet("11", "12"), "space4")
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 
+	_, err = s.spaces.MoveSubnets(network.MakeIDSet("666"), "space3")
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+
 	spaces, err := s.spaces.MoveSubnets(network.MakeIDSet("11", "12"), "space3")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spaces, gc.DeepEquals, network.SpaceInfos{

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -5,10 +5,11 @@ package network_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
 )
 
 type subnetSuite struct {


### PR DESCRIPTION
## Description of change

This patch adds a new method, `MoveSubnets` to `SpaceInfos` in `core/network`.

This is useful in getting a new space/subnet topology resulting from moving a collection of subnets into a new space.

## QA steps

Run unit tests in `core/network`

## Documentation changes

None.

## Bug reference

N/A
