### PR TITLE
Fix unit removal when a credential is missing

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -2126,32 +2126,30 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	ops = append(ops, hostOps...)
 
 	m, err := a.st.Model()
-	if op.FatalError(err) {
+	if err != nil {
 		return nil, errors.Trace(err)
-	} else {
-		if m.Type() == ModelTypeCAAS {
-			ops = append(ops, u.removeCloudContainerOps()...)
-		}
-		branchOps, err := unassignUnitFromBranchOp(u.doc.Name, a.doc.Name, m)
-		if err != nil {
-			if !op.Force {
-				return nil, errors.Trace(err)
-			}
-			op.AddError(err)
-		}
-		ops = append(ops, branchOps...)
 	}
-
-	sb, err := NewStorageBackend(a.st)
-	if op.FatalError(err) {
-		return nil, errors.Trace(err)
-	} else {
-		storageInstanceOps, err := removeStorageInstancesOps(sb, u.Tag(), op.Force)
-		if op.FatalError(err) {
+	if m.Type() == ModelTypeCAAS {
+		ops = append(ops, u.removeCloudContainerOps()...)
+	}
+	branchOps, err := unassignUnitFromBranchOp(u.doc.Name, a.doc.Name, m)
+	if err != nil {
+		if !op.Force {
 			return nil, errors.Trace(err)
 		}
-		ops = append(ops, storageInstanceOps...)
+		op.AddError(err)
 	}
+	ops = append(ops, branchOps...)
+
+	sb, err := NewStorageBackend(a.st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	storageInstanceOps, err := removeStorageInstancesOps(sb, u.Tag(), op.Force)
+	if op.FatalError(err) {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, storageInstanceOps...)
 
 	if u.doc.CharmURL != nil {
 		// If the unit has a different URL to the application, allow any final


### PR DESCRIPTION
## Description of change

There was an error is handling errors getting the storage backend when a removal with --force was done. The error was being ignored and a nil storage backend resulted in a panic.
In this case, --force should not have ignored this sort of error so that was fixed.
Plus, the storage backend did not even need the storage provider what was erroring out, so add a function to lazily get the registry only when needed.

## QA steps

bootstrap aws
deploy postgresql with ebs volume
with mongo client, remove the credential from cloudCredentials collection
remove postgresql
check debug-log for expected errors about credential missing trying to do stuff
application will still be deleted

## Bug reference

https://bugs.launchpad.net/juju/+bug/1873070
