### PR TITLE
Introduce mutex to fix a race in caasoperator unit test

### DIFF
--- a/worker/caasoperator/remotestate/mock_test.go
+++ b/worker/caasoperator/remotestate/mock_test.go
@@ -57,10 +57,23 @@ type mockNotifyWatcher struct {
 	*mockWatcher
 	changes chan struct{}
 	err     error
+	mu      sync.Mutex
 }
 
 func (w *mockNotifyWatcher) Changes() watcher.NotifyChannel {
 	return w.changes
+}
+
+func (w *mockNotifyWatcher) Err() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.err
+}
+
+func (w *mockNotifyWatcher) SetErr(err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.err = err
 }
 
 type mockApplicationWatcher struct {
@@ -71,7 +84,7 @@ func (s *mockApplicationWatcher) Watch(application string) (watcher.NotifyWatche
 	if application != "gitlab" {
 		return nil, errors.NotFoundf(application)
 	}
-	return s.watcher, s.watcher.err
+	return s.watcher, s.watcher.Err()
 }
 
 type mockCharmGetter struct {

--- a/worker/caasoperator/remotestate/watcher_test.go
+++ b/worker/caasoperator/remotestate/watcher_test.go
@@ -90,7 +90,7 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 }
 
 func (s *WatcherSuite) TestApplicationRemovalTerminatesAgent(c *gc.C) {
-	s.appWatcher.err = errors.NotFoundf("app")
+	s.appWatcher.SetErr(errors.NotFoundf("app"))
 	w, err := remotestate.NewWatcher(remotestate.WatcherConfig{
 		Application:        "gitlab",
 		ApplicationWatcher: &mockApplicationWatcher{s.appWatcher},


### PR DESCRIPTION
## Description of change

Fixes a test race for `TestApplicationRemovalTerminatesAgent` in `worker/caasoperator/remotestate` by protecting member access with a mutex.

## QA steps

Run tests for `worker/caasoperator/remotestate` with `-race`.
