### PR TITLE
[dev] Configurable channel for mongo snap

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -285,6 +285,10 @@ type Config interface {
 	// MongoMemoryProfile returns the profile to be used when setting
 	// mongo memory usage.
 	MongoMemoryProfile() mongo.MemoryProfile
+
+	// MongoSnapChannel returns the channel for installing mongo snaps in
+	// focal or later.
+	MongoSnapChannel() string
 }
 
 type configSetterOnly interface {
@@ -328,6 +332,10 @@ type configSetterOnly interface {
 	// SetMongoMemoryProfile sets the passed policy as the one to be
 	// used.
 	SetMongoMemoryProfile(mongo.MemoryProfile)
+
+	// SetMongoSnapChannel sets the channel for installing mongo snaps
+	// when bootstrapping focal or later.
+	SetMongoSnapChannel(string)
 
 	// SetLoggingConfig sets the logging config value for the agent.
 	SetLoggingConfig(string)
@@ -404,6 +412,7 @@ type configInternal struct {
 	values             map[string]string
 	mongoVersion       string
 	mongoMemoryProfile string
+	mongoSnapChannel   string
 }
 
 // AgentConfigParams holds the parameters required to create
@@ -422,6 +431,7 @@ type AgentConfigParams struct {
 	Values             map[string]string
 	MongoVersion       mongo.Version
 	MongoMemoryProfile mongo.MemoryProfile
+	MongoSnapChannel   string
 }
 
 // NewAgentConfig returns a new config object suitable for use for a
@@ -479,6 +489,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		values:             configParams.Values,
 		mongoVersion:       configParams.MongoVersion.String(),
 		mongoMemoryProfile: configParams.MongoMemoryProfile.String(),
+		mongoSnapChannel:   configParams.MongoSnapChannel,
 	}
 	if len(configParams.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -777,6 +788,16 @@ func (c *configInternal) SetMongoVersion(v mongo.Version) {
 // SetMongoMemoryProfile implements configSetterOnly.
 func (c *configInternal) SetMongoMemoryProfile(v mongo.MemoryProfile) {
 	c.mongoMemoryProfile = v.String()
+}
+
+// MongoSnapChannel implements Config.
+func (c *configInternal) MongoSnapChannel() string {
+	return c.mongoSnapChannel
+}
+
+// SetMongoSnapChannel implements configSetterOnly.
+func (c *configInternal) SetMongoSnapChannel(snapChannel string) {
+	c.mongoSnapChannel = snapChannel
 }
 
 var validAddr = regexp.MustCompile("^.+:[0-9]+$")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -369,6 +369,7 @@ var attributeParams = agent.AgentConfigParams{
 	Nonce:             "a nonce",
 	Controller:        testing.ControllerTag,
 	Model:             testing.ModelTag,
+	MongoSnapChannel:  "4.0/stable",
 }
 
 func (*suite) TestAttributes(c *gc.C) {
@@ -382,6 +383,7 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.Dir(), gc.Equals, "/data/dir/agents/machine-1")
 	c.Assert(conf.Nonce(), gc.Equals, "a nonce")
 	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, jujuversion.Current)
+	c.Assert(conf.MongoSnapChannel(), gc.Equals, "4.0/stable")
 }
 
 func (*suite) TestStateServingInfo(c *gc.C) {
@@ -632,4 +634,16 @@ func (*suite) TestSetCACert(c *gc.C) {
 
 	conf.SetCACert("new ca cert")
 	c.Assert(conf.CACert(), gc.Equals, "new ca cert")
+}
+
+func (*suite) TestSetMongoChannel(c *gc.C) {
+	conf, err := agent.NewAgentConfig(attributeParams)
+	c.Assert(err, jc.ErrorIsNil)
+
+	snapChannel := conf.MongoSnapChannel()
+	c.Assert(snapChannel, gc.Equals, attributeParams.MongoSnapChannel)
+
+	conf.SetMongoSnapChannel("latest/candidate")
+	snapChannel = conf.MongoSnapChannel()
+	c.Assert(snapChannel, gc.Equals, "latest/candidate", gc.Commentf("mongo snap channel setting not updated"))
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -60,6 +60,7 @@ type format_2_0Serialization struct {
 	SystemIdentity     string `yaml:"systemidentity,omitempty"`
 	MongoVersion       string `yaml:"mongoversion,omitempty"`
 	MongoMemoryProfile string `yaml:"mongomemoryprofile,omitempty"`
+	MongoSnapChannel   string `yaml:"mongosnapchannel,omitempty"`
 }
 
 func init() {
@@ -156,6 +157,9 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 	if format.MongoMemoryProfile != "" {
 		config.mongoMemoryProfile = format.MongoMemoryProfile
 	}
+	if format.MongoSnapChannel != "" {
+		config.mongoSnapChannel = format.MongoSnapChannel
+	}
 	return config, nil
 }
 
@@ -198,6 +202,9 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 	}
 	if config.mongoMemoryProfile != "" {
 		format.MongoMemoryProfile = config.mongoMemoryProfile
+	}
+	if config.mongoSnapChannel != "" {
+		format.MongoSnapChannel = config.mongoSnapChannel
 	}
 	return goyaml.Marshal(format)
 }

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -270,6 +270,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		} else {
 			agentConfig.SetMongoMemoryProfile(mmprof)
 		}
+		agentConfig.SetMongoSnapChannel(args.ControllerConfig.MongoSnapChannel())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -225,7 +225,8 @@ func NewEnsureServerParams(agentConfig agent.Config) (mongo.EnsureServerParams, 
 		OplogSize:            oplogSize,
 		SetNUMAControlPolicy: numaCtlPolicy,
 
-		MemoryProfile: agentConfig.MongoMemoryProfile(),
+		MemoryProfile:    agentConfig.MongoMemoryProfile(),
+		MongoSnapChannel: agentConfig.MongoSnapChannel(),
 	}
 	return params, nil
 }

--- a/controller/config.go
+++ b/controller/config.go
@@ -133,6 +133,10 @@ const (
 	// detault
 	MongoMemoryProfile = "mongo-memory-profile"
 
+	// MongoSnapChannel selects the channel to use when installing mongo
+	// snaps for focal or later. The value is ignored for older releases.
+	MongoSnapChannel = "mongo-snap-channel"
+
 	// MaxDebugLogDuration is used to provide a backstop to the execution of a debug-log
 	// command. If someone starts a debug-log session in a remote screen for example, it
 	// is very easy to disconnect from the screen while leaving the debug-log process
@@ -234,6 +238,10 @@ const (
 	// DefaultMongoMemoryProfile is the default profile used by mongo.
 	DefaultMongoMemoryProfile = MongoProfDefault
 
+	// DefaultMongoSnapChannel is the default snap channel for installing
+	// mongo in focal or later.
+	DefaultMongoSnapChannel = "4.0/stable"
+
 	// DefaultMaxDebugLogDuration is the default duration that debug-log commands
 	// can run before being terminated by the API server.
 	DefaultMaxDebugLogDuration = 24 * time.Hour
@@ -321,6 +329,7 @@ var (
 		SetNUMAControlPolicyKey,
 		StatePort,
 		MongoMemoryProfile,
+		MongoSnapChannel,
 		MaxDebugLogDuration,
 		MaxTxnLogSize,
 		MaxPruneTxnBatchSize,
@@ -685,6 +694,11 @@ func (c Config) MongoMemoryProfile() string {
 		return profile.(string)
 	}
 	return DefaultMongoMemoryProfile
+}
+
+// MongoSnapChannel returns the channel for installing mongo snaps.
+func (c Config) MongoSnapChannel() string {
+	return c.asString(MongoSnapChannel)
 }
 
 // NUMACtlPreference returns if numactl is preferred.
@@ -1085,6 +1099,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AutocertDNSNameKey:      schema.String(),
 	AllowModelAccessKey:     schema.Bool(),
 	MongoMemoryProfile:      schema.String(),
+	MongoSnapChannel:        schema.String(),
 	MaxDebugLogDuration:     schema.TimeDuration(),
 	MaxTxnLogSize:           schema.String(),
 	MaxPruneTxnBatchSize:    schema.ForceInt(),
@@ -1123,6 +1138,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AutocertDNSNameKey:      schema.Omit,
 	AllowModelAccessKey:     schema.Omit,
 	MongoMemoryProfile:      DefaultMongoMemoryProfile,
+	MongoSnapChannel:        DefaultMongoSnapChannel,
 	MaxDebugLogDuration:     DefaultMaxDebugLogDuration,
 	MaxTxnLogSize:           fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),
 	MaxPruneTxnBatchSize:    DefaultMaxPruneTxnBatchSize,
@@ -1227,6 +1243,10 @@ they don't have any access rights to the controller itself`,
 	MongoMemoryProfile: {
 		Type:        environschema.Tstring,
 		Description: `Sets mongo memory profile`,
+	},
+	MongoSnapChannel: {
+		Type:        environschema.Tstring,
+		Description: `Sets channel for installing mongo snaps when bootstrapping on focal or later`,
 	},
 	MaxDebugLogDuration: {
 		Type:        environschema.Tstring,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -730,3 +730,23 @@ func (s *ConfigSuite) TestAgentRateLimitRate(c *gc.C) {
 	cfg[controller.AgentRateLimitRate] = "500ms"
 	c.Assert(cfg.AgentRateLimitRate(), gc.Equals, 500*time.Millisecond)
 }
+
+func (s *ConfigSuite) TestMongoSnapChannel(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.MongoSnapChannel(), gc.Equals, controller.DefaultMongoSnapChannel)
+
+	cfg, err = controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			"mongo-snap-channel": "latest/candidate",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.MongoSnapChannel(), gc.Equals, "latest/candidate")
+}

--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -38,7 +38,7 @@ func PatchService(patchValue func(interface{}, interface{}), data *svctesting.Fa
 		svc.FakeServiceData = data
 		return svc, nil
 	})
-	patchValue(&newService, func(name string, conf common.Conf) (mongoService, error) {
+	patchValue(&newService, func(name string, _ bool, conf common.Conf) (mongoService, error) {
 		svc := svctesting.NewFakeService(name, conf)
 		svc.FakeServiceData = data
 		return svc, nil

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -443,6 +443,9 @@ type EnsureServerParams struct {
 	// MemoryProfile determines which value is going to be used by
 	// the cache and future memory tweaks.
 	MemoryProfile MemoryProfile
+
+	// The channel for installing the mongo snap in focal and later.
+	MongoSnapChannel string
 }
 
 // EnsureServer ensures that the MongoDB server is installed,
@@ -454,38 +457,19 @@ func EnsureServer(args EnsureServerParams) (Version, error) {
 	return ensureServer(args, mongoKernelTweaks)
 }
 
-func setupDataDirectory(args EnsureServerParams) error {
-	dbDir := DbDir(args.DataDir)
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return errors.Annotate(err, "cannot create mongo database directory")
-	}
-
-	// TODO(fix): rather than copy, we should ln -s coz it could be changed later!!!
-	if err := UpdateSSLKey(args.DataDir, args.Cert, args.PrivateKey); err != nil {
-		return errors.Trace(err)
-	}
-
-	err := utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
-	if err != nil {
-		return errors.Annotatef(err, "cannot write mongod shared secret to %v", sharedSecretPath(args.DataDir))
-	}
-
-	if err := os.MkdirAll(logPath(dbDir), 0644); err != nil {
-		return errors.Annotate(err, "cannot create mongodb logging directory")
-	}
-
-	return nil
-}
-
 func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) (Version, error) {
 	var zeroVersion Version
 	tweakSysctlForMongo(mongoKernelTweaks)
+
+	hostSeries := series.MustHostSeries()
+	mongoDep := dependency.Mongo(args.SetNUMAControlPolicy, args.MongoSnapChannel)
+	usingMongoFromSnap := providesMongoAsSnap(mongoDep, hostSeries) || featureflag.Enabled(feature.MongoDbSnap)
 
 	// TODO(tsm): clean up the args.DataDir handling. When using a snap, args.DataDir should be
 	//            set earlier in the bootstrapping process. An extra variable is needed here because
 	//            cloudconfig sends local snaps to /var/lib/juju/
 	dataDir := args.DataDir
-	if featureflag.Enabled(feature.MongoDbSnap) {
+	if usingMongoFromSnap {
 		if args.DataDir != dataPathForJujuDbSnap {
 			logger.Warningf("overwriting args.dataDir (set to %v) to %v", args.DataDir, dataPathForJujuDbSnap)
 			args.DataDir = dataPathForJujuDbSnap
@@ -497,9 +481,9 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 		args.DataDir, args.StatePort,
 	)
 
-	setupDataDirectory(args)
+	setupDataDirectory(args, usingMongoFromSnap)
 
-	if err := installMongod(series.MustHostSeries(), args.SetNUMAControlPolicy, dataDir); err != nil {
+	if err := installMongod(mongoDep, hostSeries, dataDir); err != nil {
 		// This isn't treated as fatal because the Juju MongoDB
 		// package is likely to be already installed anyway. There
 		// could just be a temporary issue with apt-get/yum/whatever
@@ -536,17 +520,19 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 		}
 	}
 
-	mongoArgs := generateConfig(mongoPath, args.DataDir, args.StatePort, oplogSizeMB, args.SetNUMAControlPolicy, mongodVersion, args.MemoryProfile)
+	mongoArgs := generateConfig(mongoPath, oplogSizeMB, mongodVersion, usingMongoFromSnap, args)
 	logger.Debugf("creating mongo service configuration for mongo version: %d.%d.%d-%s at %q",
 		mongoArgs.Version.Major, mongoArgs.Version.Minor, mongoArgs.Version.Point, mongoArgs.Version.Patch, mongoArgs.MongoPath)
 
-	svc, err := mongoArgs.asService()
+	svc, err := mongoArgs.asService(usingMongoFromSnap)
 	if err != nil {
 		return zeroVersion, errors.Trace(err)
 	}
 
+	// Update configuration if we are using mongo from snap (focal+ or
+	// on an earlier series using the feature flag).
 	// TODO(tsm): refactor out to service.Configure
-	if featureflag.Enabled(feature.MongoDbSnap) {
+	if usingMongoFromSnap {
 		err = mongoArgs.writeConfig(configPath(args.DataDir))
 		if err != nil {
 			return zeroVersion, errors.Trace(err)
@@ -612,6 +598,29 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 	return mongodVersion, nil
 }
 
+func setupDataDirectory(args EnsureServerParams, usingMongoFromSnap bool) error {
+	dbDir := DbDir(args.DataDir)
+	if err := os.MkdirAll(dbDir, 0700); err != nil {
+		return errors.Annotate(err, "cannot create mongo database directory")
+	}
+
+	// TODO(fix): rather than copy, we should ln -s coz it could be changed later!!!
+	if err := UpdateSSLKey(args.DataDir, args.Cert, args.PrivateKey); err != nil {
+		return errors.Trace(err)
+	}
+
+	err := utils.AtomicWriteFile(sharedSecretPath(args.DataDir), []byte(args.SharedSecret), 0600)
+	if err != nil {
+		return errors.Annotatef(err, "cannot write mongod shared secret to %v", sharedSecretPath(args.DataDir))
+	}
+
+	if err := os.MkdirAll(logPath(dbDir, usingMongoFromSnap), 0644); err != nil {
+		return errors.Annotate(err, "cannot create mongodb logging directory")
+	}
+
+	return nil
+}
+
 func truncateAndWriteIfExists(procFile, value string) error {
 	if _, err := os.Stat(procFile); os.IsNotExist(err) {
 		logger.Debugf("%q does not exist, will not set %q", procFile, value)
@@ -669,45 +678,59 @@ func logVersion(mongoPath string) {
 	logger.Debugf("using mongod: %s --version: %q", mongoPath, output)
 }
 
-func getSnapChannel() string {
-	return fmt.Sprintf("%s/%s", SnapTrack, SnapRisk)
-}
+func installMongod(mongoDep packaging.Dependency, hostSeries, dataDir string) error {
+	// If we are not forcing a mongo snap via a feature flag, install the
+	// package list (which may also include snaps for focal+) provided by
+	// the mongo dependency for our series.
+	if !featureflag.Enabled(feature.MongoDbSnap) {
+		return packaging.InstallDependency(mongoDep, hostSeries)
+	}
 
-func installMongod(operatingsystem string, numaCtl bool, dataDir string) error {
-	if featureflag.Enabled(feature.MongoDbSnap) {
-		snapName := ServiceName
-		jujuDbLocalSnapPattern := regexp.MustCompile(`juju-db_[0-9]+\.snap`)
+	snapName := ServiceName
+	jujuDbLocalSnapPattern := regexp.MustCompile(`juju-db_[0-9]+\.snap`)
 
-		// If we're installing a local snap, then provide an absolute path
-		// as a snap <name>. snap install <name> will then do the Right Thing (TM).
-		files, err := ioutil.ReadDir(path.Join(dataDir, "snap"))
-		if err == nil {
-			for _, fullFileName := range files {
-				_, fileName := path.Split(fullFileName.Name())
-				if jujuDbLocalSnapPattern.MatchString(fileName) {
-					snapName = fullFileName.Name()
-				}
+	// If we're installing a local snap, then provide an absolute path
+	// as a snap <name>. snap install <name> will then do the Right Thing (TM).
+	files, err := ioutil.ReadDir(path.Join(dataDir, "snap"))
+	if err == nil {
+		for _, fullFileName := range files {
+			_, fileName := path.Split(fullFileName.Name())
+			if jujuDbLocalSnapPattern.MatchString(fileName) {
+				snapName = fullFileName.Name()
 			}
 		}
-
-		prerequisites := []snap.App{snap.NewApp("core")}
-		backgroundServices := []snap.BackgroundService{{"daemon", true}}
-		conf := common.Conf{Desc: ServiceName + " snap"}
-		service, err := snap.NewService(snapName, ServiceName, conf, snap.Command, getSnapChannel(), "", backgroundServices, prerequisites)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return service.Install()
 	}
 
-	if err := packaging.InstallDependency(dependency.Mongo(numaCtl), operatingsystem); err != nil {
-		return err
+	prerequisites := []snap.App{snap.NewApp("core")}
+	backgroundServices := []snap.BackgroundService{
+		{
+			Name:            "daemon",
+			EnableAtStartup: true,
+		},
+	}
+	conf := common.Conf{Desc: ServiceName + " snap"}
+	snapChannel := fmt.Sprintf("%s/%s", SnapTrack, SnapRisk)
+	service, err := snap.NewService(snapName, ServiceName, conf, snap.Command, snapChannel, "", backgroundServices, prerequisites)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
-	return nil
+	return service.Install()
 }
 
 // DbDir returns the dir where mongo storage is.
 func DbDir(dataDir string) string {
 	return filepath.Join(dataDir, "db")
+}
+
+// providesMongoAsSnap returns true if a mongo dependency provides mongo
+// as a snap for the specified OS series.
+func providesMongoAsSnap(mongoDep packaging.Dependency, series string) bool {
+	pkgList, _ := mongoDep.PackageList(series)
+	for _, pkg := range pkgList {
+		if pkg.PackageManager == packaging.SnapPackageManager && pkg.Name == JujuDbSnap {
+			return true
+		}
+	}
+	return false
 }

--- a/mongo/mongodfinder.go
+++ b/mongo/mongodfinder.go
@@ -10,9 +10,6 @@ import (
 	"strconv"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/featureflag"
-
-	"github.com/juju/juju/feature"
 )
 
 // SearchTools represents the OS functionality we need to find the correct MongoDB executable.
@@ -40,11 +37,14 @@ func NewMongodFinder() *MongodFinder {
 
 // FindBest tries to find the mongo version that best fits what we want to use.
 func (m *MongodFinder) FindBest() (string, Version, error) {
-	if featureflag.Enabled(feature.MongoDbSnap) {
+	// Look for the snap version; focal and beyond OR if the relevant snap
+	// feature flag is enabled.
+	if m.search.Exists(JujuDbSnapMongodPath) {
 		v, err := m.findVersion(JujuDbSnapMongodPath)
 		if err != nil {
 			return "", Version{}, errors.NotFoundf("%s snap not installed correctly. Executable %s", JujuDbSnap, JujuDbSnapMongodPath)
 		}
+
 		return JujuDbSnapMongodPath, v, nil
 	}
 

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -15,9 +15,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/utils"
-	"github.com/juju/utils/featureflag"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
@@ -84,15 +82,15 @@ type mongoService interface {
 	service.ServiceActions
 }
 
-var newService = func(name string, conf common.Conf) (mongoService, error) {
-	if featureflag.Enabled(feature.MongoDbSnap) {
+var newService = func(name string, usingSnap bool, conf common.Conf) (mongoService, error) {
+	if usingSnap {
 		return snap.NewServiceFromName(name, conf)
 	}
 	return service.DiscoverService(name, conf)
 }
 
 var discoverService = func(name string) (mongoService, error) {
-	return newService(name, common.Conf{})
+	return newService(name, false, common.Conf{})
 }
 
 // IsServiceInstalled returns whether the MongoDB init service
@@ -170,8 +168,8 @@ func sharedSecretPath(dataDir string) string {
 	return filepath.Join(dataDir, SharedSecretFile)
 }
 
-func logPath(dataDir string) string {
-	if featureflag.Enabled(feature.MongoDbSnap) {
+func logPath(dataDir string, usingMongoFromSnap bool) string {
+	if usingMongoFromSnap {
 		return filepath.Join(dataDir, "logs", "mongodb.log")
 	}
 	return mongoLogPath
@@ -359,12 +357,12 @@ func (mongoArgs *ConfigArgs) asMap() configArgsConverter {
 	return result
 }
 
-func (mongoArgs *ConfigArgs) asService() (mongoService, error) {
-	return newService(ServiceName, mongoArgs.asServiceConf())
+func (mongoArgs *ConfigArgs) asService(usingMongoFromSnap bool) (mongoService, error) {
+	return newService(ServiceName, usingMongoFromSnap, mongoArgs.asServiceConf(usingMongoFromSnap))
 }
 
 // asServiceConf returns the init system config for the mongo state service.
-func (mongoArgs *ConfigArgs) asServiceConf() common.Conf {
+func (mongoArgs *ConfigArgs) asServiceConf(usingMongoFromSnap bool) common.Conf {
 	// See https://docs.mongodb.com/manual/reference/ulimit/.
 	limits := map[string]string{
 		"fsize":   "unlimited", // file size
@@ -378,8 +376,8 @@ func (mongoArgs *ConfigArgs) asServiceConf() common.Conf {
 		Desc:        "juju state database",
 		Limit:       limits,
 		Timeout:     serviceTimeout,
-		ExecStart:   mongoArgs.startCommand(),
-		ExtraScript: mongoArgs.extraScript(),
+		ExecStart:   mongoArgs.startCommand(usingMongoFromSnap),
+		ExtraScript: mongoArgs.extraScript(usingMongoFromSnap),
 	}
 	return conf
 }
@@ -392,8 +390,8 @@ func (mongoArgs *ConfigArgs) asCommandLineArguments() string {
 	return mongoArgs.MongoPath + " " + mongoArgs.asMap().asCommandLineArguments()
 }
 
-func (mongoArgs *ConfigArgs) startCommand() string {
-	if featureflag.Enabled(feature.MongoDbSnap) {
+func (mongoArgs *ConfigArgs) startCommand(usingMongoFromSnap bool) string {
+	if usingMongoFromSnap {
 		// TODO(tsm): work out how to bridge mongoService and service.Service
 		// to access the StartCommands method, rather than duplicating code
 		return snap.Command + " start --enable " + ServiceName
@@ -406,8 +404,8 @@ func (mongoArgs *ConfigArgs) startCommand() string {
 	return cmd + mongoArgs.asCommandLineArguments()
 }
 
-func (mongoArgs *ConfigArgs) extraScript() string {
-	if featureflag.Enabled(feature.MongoDbSnap) {
+func (mongoArgs *ConfigArgs) extraScript(usingMongoFromSnap bool) string {
+	if usingMongoFromSnap {
 		return ""
 	}
 
@@ -438,30 +436,30 @@ func (mongoArgs *ConfigArgs) writeConfig(path string) error {
 
 // newMongoDBArgsWithDefaults returns *mongoDbConfigArgs
 // under the assumption that MongoDB 3.4 or later is running.
-func generateConfig(mongoPath string, dataDir string, statePort int, oplogSizeMB int, setNUMAControlPolicy bool, version Version, memProfile MemoryProfile) *ConfigArgs {
+func generateConfig(mongoPath string, oplogSizeMB int, version Version, usingMongoFromSnap bool, args EnsureServerParams) *ConfigArgs {
 	usingWiredTiger := version.StorageEngine == WiredTiger
 	usingMongo2 := version.Major == 2
 	usingMongo4orAbove := version.Major > 3
 	usingMongo36orAbove := usingMongo4orAbove || (version.Major == 3 && version.Minor >= 6)
 	usingMongo34orAbove := usingMongo36orAbove || (version.Major == 3 && version.Minor >= 4)
-	useLowMemory := memProfile == MemoryProfileLow
+	useLowMemory := args.MemoryProfile == MemoryProfileLow
 
 	mongoArgs := &ConfigArgs{
-		DataDir:          dataDir,
-		DBDir:            DbDir(dataDir),
+		DataDir:          args.DataDir,
+		DBDir:            DbDir(args.DataDir),
 		MongoPath:        mongoPath,
-		Port:             statePort,
+		Port:             args.StatePort,
 		OplogSizeMB:      oplogSizeMB,
-		WantNUMACtl:      setNUMAControlPolicy,
+		WantNUMACtl:      args.SetNUMAControlPolicy,
 		Version:          version,
 		IPv6:             network.SupportsIPv6(),
-		MemoryProfile:    memProfile,
+		MemoryProfile:    args.MemoryProfile,
 		Syslog:           true,
 		Journal:          true,
 		Quiet:            true,
 		ReplicaSet:       ReplicaSetName,
-		AuthKeyFile:      sharedSecretPath(dataDir),
-		PEMKeyFile:       sslKeyPath(dataDir),
+		AuthKeyFile:      sharedSecretPath(args.DataDir),
+		PEMKeyFile:       sslKeyPath(args.DataDir),
 		PEMKeyPassword:   "ignored", // used as boilerplate later
 		SSLOnNormalPorts: false,
 		//BindIP:                "127.0.0.1", // TODO(tsm): use machine's actual IP address via dialInfo
@@ -490,12 +488,12 @@ func generateConfig(mongoPath string, dataDir string, statePort int, oplogSizeMB
 		mongoArgs.SSLMode = "requireSSL"
 	}
 
-	if featureflag.Enabled(feature.MongoDbSnap) {
+	if usingMongoFromSnap {
 		// Switch from syslog to appending to dataDir, because snaps don't
 		// have the same permissions.
 		mongoArgs.Syslog = false
 		mongoArgs.LogAppend = true
-		mongoArgs.LogPath = logPath(dataDir)
+		mongoArgs.LogPath = logPath(args.DataDir, true)
 		mongoArgs.BindToAllIP = true // TODO(tsm): disable when not needed
 	}
 
@@ -504,7 +502,8 @@ func generateConfig(mongoPath string, dataDir string, statePort int, oplogSizeMB
 
 // newConf returns the init system config for the mongo state service.
 func newConf(args *ConfigArgs) common.Conf {
-	return args.asServiceConf()
+	usingMongoSnap := args.DataDir == dataPathForJujuDbSnap
+	return args.asServiceConf(usingMongoSnap)
 }
 
 func ensureDirectoriesMade(dataDir string) error {
@@ -526,6 +525,8 @@ func EnsureServiceInstalled(dataDir string, statePort int, oplogSizeMB int, setN
 		return errors.Trace(err)
 	}
 
+	usingMongoFromSnap := dataDir == dataPathForJujuDbSnap
+
 	mongoPath, err := Path(version)
 	if err != nil {
 		return errors.NewNotFound(err, "unable to find path to mongod")
@@ -533,19 +534,22 @@ func EnsureServiceInstalled(dataDir string, statePort int, oplogSizeMB int, setN
 
 	mongoArgs := generateConfig(
 		mongoPath,
-		dataDir,
-		statePort,
 		oplogSizeMB,
-		setNUMAControlPolicy,
 		version,
-		memProfile,
+		usingMongoFromSnap,
+		EnsureServerParams{
+			DataDir:              dataDir,
+			StatePort:            statePort,
+			SetNUMAControlPolicy: setNUMAControlPolicy,
+			MemoryProfile:        memProfile,
+		},
 	)
 
 	if !auth {
 		mongoArgs.AuthKeyFile = ""
 	}
 
-	service, err := mongoArgs.asService()
+	service, err := mongoArgs.asService(usingMongoFromSnap)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -31,15 +31,18 @@ func (s *serviceSuite) TestNewConf24(c *gc.C) {
 	mongodVersion := mongo.Mongo24
 	port := 12345
 	oplogSizeMB := 10
+	usingMongoFromSnap := false
 
 	confArgs := mongo.GenerateConf(
 		mongodPath,
-		dataDir,
-		port,
 		oplogSizeMB,
-		false,
 		mongodVersion,
-		mongo.MemoryProfileDefault,
+		usingMongoFromSnap,
+		mongo.EnsureServerParams{
+			DataDir:       dataDir,
+			StatePort:     port,
+			MemoryProfile: mongo.MemoryProfileDefault,
+		},
 	)
 	conf := mongo.NewConf(confArgs)
 
@@ -98,14 +101,17 @@ func (s *serviceSuite) TestNewConf32(c *gc.C) {
 	mongodVersion := mongo.Mongo32wt
 	port := 12345
 	oplogSizeMB := 10
+	usingMongoFromSnap := false
 	confArgs := mongo.GenerateConf(
 		mongodPath,
-		dataDir,
-		port,
 		oplogSizeMB,
-		false,
 		mongodVersion,
-		mongo.MemoryProfileDefault,
+		usingMongoFromSnap,
+		mongo.EnsureServerParams{
+			DataDir:       dataDir,
+			StatePort:     port,
+			MemoryProfile: mongo.MemoryProfileDefault,
+		},
 	)
 	conf := mongo.NewConf(confArgs)
 
@@ -136,15 +142,18 @@ func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
 	mongodVersion := mongo.Mongo32wt
 	port := 12345
 	oplogSizeMB := 10
+	usingMongoFromSnap := false
 
 	confArgs := mongo.GenerateConf(
 		mongodPath,
-		dataDir,
-		port,
 		oplogSizeMB,
-		false,
 		mongodVersion,
-		mongo.MemoryProfileLow,
+		usingMongoFromSnap,
+		mongo.EnsureServerParams{
+			DataDir:       dataDir,
+			StatePort:     port,
+			MemoryProfile: mongo.MemoryProfileLow,
+		},
 	)
 	conf := mongo.NewConf(confArgs)
 

--- a/packaging/dependency/mongo.go
+++ b/packaging/dependency/mongo.go
@@ -4,40 +4,70 @@
 package dependency
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/packaging"
 )
 
 type mongoDependency struct {
-	useNUMA bool
+	useNUMA     bool
+	snapChannel string
 }
 
 // Mongo returns a dependency for installing mongo server using the specified
-// NUMA settings.
-func Mongo(useNUMA bool) packaging.Dependency {
-	return mongoDependency{useNUMA: useNUMA}
+// NUMA settings and snap channel preferences (applies to focal or later).
+func Mongo(useNUMA bool, snapChannel string) packaging.Dependency {
+	return mongoDependency{
+		useNUMA:     useNUMA,
+		snapChannel: snapChannel,
+	}
 }
 
 // PackageList implements packaging.Dependency.
 func (dep mongoDependency) PackageList(series string) ([]packaging.Package, error) {
-	var pkgList []string
-	var pm = packaging.AptPackageManager
+	var (
+		aptPkgList []string
+		snapList   []packaging.Package
+		pm         = packaging.AptPackageManager
+	)
 
 	if dep.useNUMA {
-		pkgList = append(pkgList, "numactl")
+		aptPkgList = append(aptPkgList, "numactl")
 	}
 
 	switch series {
 	case "centos7", "opensuseleap", "precise":
 		return nil, errors.NotSupportedf("installing mongo on series %q", series)
 	case "trusty":
-		pkgList = append(pkgList, "juju-mongodb")
+		aptPkgList = append(aptPkgList, "juju-mongodb")
 	case "xenial":
 		// The tools package provides mongodump and friends.
-		pkgList = append(pkgList, "juju-mongodb3.2", "juju-mongo-tools3.2")
-	default: // Bionic and newer
-		pkgList = append(pkgList, "mongodb-server-core", "mongodb-clients")
+		aptPkgList = append(aptPkgList, "juju-mongodb3.2", "juju-mongo-tools3.2")
+	case "bionic", "cosmic", "disco", "eoan":
+		aptPkgList = append(aptPkgList, "mongodb-server-core", "mongodb-clients")
+	default: // Focal and beyond always use snaps
+		if dep.snapChannel == "" {
+			return nil, errors.NotValidf("snap channel for mongo dependency")
+		}
+
+		snapList = append(
+			snapList,
+			packaging.Package{
+				Name:           "core",
+				PackageManager: packaging.SnapPackageManager,
+			},
+			packaging.Package{
+				Name:           "juju-db",
+				InstallOptions: fmt.Sprintf("--channel %s", dep.snapChannel),
+				PackageManager: packaging.SnapPackageManager,
+			},
+		)
 	}
 
-	return packaging.MakePackageList(pm, "", pkgList...), nil
+	return append(
+		packaging.MakePackageList(pm, "", aptPkgList...),
+		snapList...,
+	), nil
 }

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -53,6 +53,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.ModelLogfileMaxBackups,
 		controller.ModelLogfileMaxSize,
 		controller.MongoMemoryProfile,
+		controller.MongoSnapChannel,
 		controller.PruneTxnQueryCount,
 		controller.PruneTxnSleepTime,
 		controller.MaxCharmStateSize,

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -95,6 +95,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configMongoMemoryProfile := mongo.MemoryProfile(controllerConfig.MongoMemoryProfile())
 			mongoProfileChanged := agentsMongoMemoryProfile != configMongoMemoryProfile
 
+			agentsMongoSnapChannel := agent.CurrentConfig().MongoSnapChannel()
+			configMongoSnapChannel := controllerConfig.MongoSnapChannel()
+			mongoSnapChannelChanged := agentsMongoSnapChannel != configMongoSnapChannel
+
 			info, err := apiState.StateServingInfo()
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
@@ -117,6 +121,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 					logger.Debugf("setting agent config mongo memory profile: %q => %q", agentsMongoMemoryProfile, configMongoMemoryProfile)
 					config.SetMongoMemoryProfile(configMongoMemoryProfile)
 				}
+				if mongoSnapChannelChanged {
+					logger.Debugf("setting agent config mongo snap channel: %q => %q", agentsMongoSnapChannel, configMongoSnapChannel)
+					config.SetMongoSnapChannel(configMongoSnapChannel)
+				}
 				return nil
 			})
 			if err != nil {
@@ -125,6 +133,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			// If we need a restart, return the fatal error.
 			if mongoProfileChanged {
 				logger.Infof("restarting agent for new mongo memory profile")
+				return nil, jworker.ErrRestartAgent
+			} else if mongoSnapChannelChanged {
+				logger.Infof("restarting agent for new mongo snap channel")
 				return nil, jworker.ErrRestartAgent
 			}
 
@@ -137,10 +148,11 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				Agent:        agent,
-				Hub:          hub,
-				MongoProfile: configMongoMemoryProfile,
-				Logger:       config.Logger,
+				Agent:            agent,
+				Hub:              hub,
+				MongoProfile:     configMongoMemoryProfile,
+				MongoSnapChannel: configMongoSnapChannel,
+				Logger:           config.Logger,
 			})
 		},
 	}

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -139,6 +139,7 @@ func (s *AgentConfigUpdaterSuite) TestCentralHubMissing(c *gc.C) {
 				*result = params.ControllerConfigResult{
 					Config: map[string]interface{}{
 						"mongo-memory-profile": "default",
+						"mongo-snap-channel":   controller.DefaultMongoSnapChannel,
 					},
 				}
 			default:
@@ -223,6 +224,7 @@ func (s *AgentConfigUpdaterSuite) startManifold(c *gc.C, a agent.Agent, mockAPIP
 				*result = params.ControllerConfigResult{
 					Config: map[string]interface{}{
 						"mongo-memory-profile": "default",
+						"mongo-snap-channel":   controller.DefaultMongoSnapChannel,
 					},
 				}
 			default:
@@ -349,6 +351,9 @@ type mockConfig struct {
 
 	profile    string
 	profileSet bool
+
+	snapChannel    string
+	snapChannelSet bool
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -381,6 +386,18 @@ func (mc *mockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 func (mc *mockConfig) SetMongoMemoryProfile(profile mongo.MemoryProfile) {
 	mc.profile = string(profile)
 	mc.profileSet = true
+}
+
+func (mc *mockConfig) MongoSnapChannel() string {
+	if mc.snapChannel == "" {
+		return controller.DefaultMongoSnapChannel
+	}
+	return mc.snapChannel
+}
+
+func (mc *mockConfig) SetMongoSnapChannel(snapChannel string) {
+	mc.snapChannel = snapChannel
+	mc.snapChannelSet = true
 }
 
 func (mc *mockConfig) LogDir() string {

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -13,7 +13,7 @@ import (
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -42,6 +42,7 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -49,11 +50,13 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -61,6 +64,7 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -89,6 +93,7 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -97,11 +102,13 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -110,11 +117,13 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -122,23 +131,27 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names_v3.ControllerTag {
+func (m *MockConfig) Controller() names.ControllerTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -146,11 +159,13 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -158,11 +173,13 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -170,11 +187,13 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -182,11 +201,13 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -194,11 +215,13 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -206,23 +229,27 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names_v3.ModelTag {
+func (m *MockConfig) Model() names.ModelTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -231,11 +258,13 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -243,11 +272,27 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
+}
+
+// MongoSnapChannel mocks base method
+func (m *MockConfig) MongoSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MongoSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// MongoSnapChannel indicates an expected call of MongoSnapChannel
+func (mr *MockConfigMockRecorder) MongoSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoSnapChannel", reflect.TypeOf((*MockConfig)(nil).MongoSnapChannel))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -255,11 +300,13 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -267,11 +314,13 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -279,11 +328,13 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
 func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
 	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
@@ -292,11 +343,13 @@ func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -304,23 +357,27 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names_v3.Tag {
+func (m *MockConfig) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfig) TransientDataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -328,11 +385,13 @@ func (m *MockConfig) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -340,11 +399,13 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -352,11 +413,13 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -365,5 +428,6 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -13,7 +13,7 @@ import (
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -42,6 +42,7 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -49,11 +50,13 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -61,6 +64,7 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -89,6 +93,7 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -97,11 +102,13 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -110,11 +117,13 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -122,23 +131,27 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names_v3.ControllerTag {
+func (m *MockConfig) Controller() names.ControllerTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -146,11 +159,13 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -158,11 +173,13 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -170,11 +187,13 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -182,11 +201,13 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -194,11 +215,13 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -206,23 +229,27 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names_v3.ModelTag {
+func (m *MockConfig) Model() names.ModelTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -231,11 +258,13 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -243,11 +272,27 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
+}
+
+// MongoSnapChannel mocks base method
+func (m *MockConfig) MongoSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MongoSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// MongoSnapChannel indicates an expected call of MongoSnapChannel
+func (mr *MockConfigMockRecorder) MongoSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoSnapChannel", reflect.TypeOf((*MockConfig)(nil).MongoSnapChannel))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -255,11 +300,13 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -267,11 +314,13 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -279,11 +328,13 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
 func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
 	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
@@ -292,11 +343,13 @@ func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -304,23 +357,27 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names_v3.Tag {
+func (m *MockConfig) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfig) TransientDataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -328,11 +385,13 @@ func (m *MockConfig) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -340,11 +399,13 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -352,11 +413,13 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -365,5 +428,6 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -14,7 +14,7 @@ import (
 	mongo "github.com/juju/juju/mongo"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
-	names_v3 "gopkg.in/juju/names.v3"
+	names "gopkg.in/juju/names.v3"
 	reflect "reflect"
 )
 
@@ -43,6 +43,7 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 
 // ChangeConfig mocks base method
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -50,11 +51,13 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 
 // ChangeConfig indicates an expected call of ChangeConfig
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
 // CurrentConfig mocks base method
 func (m *MockAgent) CurrentConfig() agent.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -62,6 +65,7 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 
 // CurrentConfig indicates an expected call of CurrentConfig
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
@@ -90,6 +94,7 @@ func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfig) APIAddresses() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -98,11 +103,13 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -111,11 +118,13 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfig) CACert() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -123,23 +132,27 @@ func (m *MockConfig) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
 // Controller mocks base method
-func (m *MockConfig) Controller() names_v3.ControllerTag {
+func (m *MockConfig) Controller() names.ControllerTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfig) DataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -147,11 +160,13 @@ func (m *MockConfig) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfig) Dir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -159,11 +174,13 @@ func (m *MockConfig) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfig) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -171,11 +188,13 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -183,11 +202,13 @@ func (m *MockConfig) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfig) LoggingConfig() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -195,11 +216,13 @@ func (m *MockConfig) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfig) MetricsSpoolDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -207,23 +230,27 @@ func (m *MockConfig) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfig) Model() names_v3.ModelTag {
+func (m *MockConfig) Model() names.ModelTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -232,11 +259,13 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -244,11 +273,27 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
+}
+
+// MongoSnapChannel mocks base method
+func (m *MockConfig) MongoSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MongoSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// MongoSnapChannel indicates an expected call of MongoSnapChannel
+func (mr *MockConfigMockRecorder) MongoSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoSnapChannel", reflect.TypeOf((*MockConfig)(nil).MongoSnapChannel))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -256,11 +301,13 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfig) Nonce() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -268,11 +315,13 @@ func (m *MockConfig) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfig) OldPassword() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -280,11 +329,13 @@ func (m *MockConfig) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
 // StateServingInfo mocks base method
 func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
 	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
@@ -293,11 +344,13 @@ func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfig) SystemIdentityPath() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -305,23 +358,27 @@ func (m *MockConfig) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfig) Tag() names_v3.Tag {
+func (m *MockConfig) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfig) TransientDataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -329,11 +386,13 @@ func (m *MockConfig) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfig) UpgradedToVersion() version.Number {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -341,11 +400,13 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfig) Value(arg0 string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -353,11 +414,13 @@ func (m *MockConfig) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -366,6 +429,7 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }
 
@@ -394,6 +458,7 @@ func (m *MockConfigSetter) EXPECT() *MockConfigSetterMockRecorder {
 
 // APIAddresses mocks base method
 func (m *MockConfigSetter) APIAddresses() ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -402,11 +467,13 @@ func (m *MockConfigSetter) APIAddresses() ([]string, error) {
 
 // APIAddresses indicates an expected call of APIAddresses
 func (mr *MockConfigSetterMockRecorder) APIAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfigSetter)(nil).APIAddresses))
 }
 
 // APIInfo mocks base method
 func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
 	ret0, _ := ret[0].(*api.Info)
 	ret1, _ := ret[1].(bool)
@@ -415,11 +482,13 @@ func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
 
 // APIInfo indicates an expected call of APIInfo
 func (mr *MockConfigSetterMockRecorder) APIInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfigSetter)(nil).APIInfo))
 }
 
 // CACert mocks base method
 func (m *MockConfigSetter) CACert() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -427,11 +496,13 @@ func (m *MockConfigSetter) CACert() string {
 
 // CACert indicates an expected call of CACert
 func (mr *MockConfigSetterMockRecorder) CACert() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfigSetter)(nil).CACert))
 }
 
 // Clone mocks base method
 func (m *MockConfigSetter) Clone() agent.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clone")
 	ret0, _ := ret[0].(agent.Config)
 	return ret0
@@ -439,23 +510,27 @@ func (m *MockConfigSetter) Clone() agent.Config {
 
 // Clone indicates an expected call of Clone
 func (mr *MockConfigSetterMockRecorder) Clone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockConfigSetter)(nil).Clone))
 }
 
 // Controller mocks base method
-func (m *MockConfigSetter) Controller() names_v3.ControllerTag {
+func (m *MockConfigSetter) Controller() names.ControllerTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
-	ret0, _ := ret[0].(names_v3.ControllerTag)
+	ret0, _ := ret[0].(names.ControllerTag)
 	return ret0
 }
 
 // Controller indicates an expected call of Controller
 func (mr *MockConfigSetterMockRecorder) Controller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfigSetter)(nil).Controller))
 }
 
 // DataDir mocks base method
 func (m *MockConfigSetter) DataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -463,11 +538,13 @@ func (m *MockConfigSetter) DataDir() string {
 
 // DataDir indicates an expected call of DataDir
 func (mr *MockConfigSetterMockRecorder) DataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfigSetter)(nil).DataDir))
 }
 
 // Dir mocks base method
 func (m *MockConfigSetter) Dir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -475,11 +552,13 @@ func (m *MockConfigSetter) Dir() string {
 
 // Dir indicates an expected call of Dir
 func (mr *MockConfigSetterMockRecorder) Dir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfigSetter)(nil).Dir))
 }
 
 // Jobs mocks base method
 func (m *MockConfigSetter) Jobs() []model.MachineJob {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
 	ret0, _ := ret[0].([]model.MachineJob)
 	return ret0
@@ -487,11 +566,13 @@ func (m *MockConfigSetter) Jobs() []model.MachineJob {
 
 // Jobs indicates an expected call of Jobs
 func (mr *MockConfigSetterMockRecorder) Jobs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfigSetter)(nil).Jobs))
 }
 
 // LogDir mocks base method
 func (m *MockConfigSetter) LogDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -499,11 +580,13 @@ func (m *MockConfigSetter) LogDir() string {
 
 // LogDir indicates an expected call of LogDir
 func (mr *MockConfigSetterMockRecorder) LogDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfigSetter)(nil).LogDir))
 }
 
 // LoggingConfig mocks base method
 func (m *MockConfigSetter) LoggingConfig() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -511,11 +594,13 @@ func (m *MockConfigSetter) LoggingConfig() string {
 
 // LoggingConfig indicates an expected call of LoggingConfig
 func (mr *MockConfigSetterMockRecorder) LoggingConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).LoggingConfig))
 }
 
 // MetricsSpoolDir mocks base method
 func (m *MockConfigSetter) MetricsSpoolDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -523,23 +608,27 @@ func (m *MockConfigSetter) MetricsSpoolDir() string {
 
 // MetricsSpoolDir indicates an expected call of MetricsSpoolDir
 func (mr *MockConfigSetterMockRecorder) MetricsSpoolDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfigSetter)(nil).MetricsSpoolDir))
 }
 
 // Model mocks base method
-func (m *MockConfigSetter) Model() names_v3.ModelTag {
+func (m *MockConfigSetter) Model() names.ModelTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
 // Model indicates an expected call of Model
 func (mr *MockConfigSetterMockRecorder) Model() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfigSetter)(nil).Model))
 }
 
 // MongoInfo mocks base method
 func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
 	ret0, _ := ret[0].(*mongo.MongoInfo)
 	ret1, _ := ret[1].(bool)
@@ -548,11 +637,13 @@ func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
 
 // MongoInfo indicates an expected call of MongoInfo
 func (mr *MockConfigSetterMockRecorder) MongoInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfigSetter)(nil).MongoInfo))
 }
 
 // MongoMemoryProfile mocks base method
 func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
 	ret0, _ := ret[0].(mongo.MemoryProfile)
 	return ret0
@@ -560,11 +651,27 @@ func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
 
 // MongoMemoryProfile indicates an expected call of MongoMemoryProfile
 func (mr *MockConfigSetterMockRecorder) MongoMemoryProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).MongoMemoryProfile))
+}
+
+// MongoSnapChannel mocks base method
+func (m *MockConfigSetter) MongoSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MongoSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// MongoSnapChannel indicates an expected call of MongoSnapChannel
+func (mr *MockConfigSetterMockRecorder) MongoSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).MongoSnapChannel))
 }
 
 // MongoVersion mocks base method
 func (m *MockConfigSetter) MongoVersion() mongo.Version {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
 	ret0, _ := ret[0].(mongo.Version)
 	return ret0
@@ -572,11 +679,13 @@ func (m *MockConfigSetter) MongoVersion() mongo.Version {
 
 // MongoVersion indicates an expected call of MongoVersion
 func (mr *MockConfigSetterMockRecorder) MongoVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).MongoVersion))
 }
 
 // Nonce mocks base method
 func (m *MockConfigSetter) Nonce() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -584,11 +693,13 @@ func (m *MockConfigSetter) Nonce() string {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockConfigSetterMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfigSetter)(nil).Nonce))
 }
 
 // OldPassword mocks base method
 func (m *MockConfigSetter) OldPassword() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -596,121 +707,157 @@ func (m *MockConfigSetter) OldPassword() string {
 
 // OldPassword indicates an expected call of OldPassword
 func (mr *MockConfigSetterMockRecorder) OldPassword() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfigSetter)(nil).OldPassword))
 }
 
 // SetAPIHostPorts mocks base method
 func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAPIHostPorts", arg0)
 }
 
 // SetAPIHostPorts indicates an expected call of SetAPIHostPorts
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
 }
 
 // SetCACert mocks base method
 func (m *MockConfigSetter) SetCACert(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCACert", arg0)
 }
 
 // SetCACert indicates an expected call of SetCACert
 func (mr *MockConfigSetterMockRecorder) SetCACert(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCACert", reflect.TypeOf((*MockConfigSetter)(nil).SetCACert), arg0)
 }
 
 // SetControllerAPIPort mocks base method
 func (m *MockConfigSetter) SetControllerAPIPort(arg0 int) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetControllerAPIPort", arg0)
 }
 
 // SetControllerAPIPort indicates an expected call of SetControllerAPIPort
 func (mr *MockConfigSetterMockRecorder) SetControllerAPIPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetControllerAPIPort", reflect.TypeOf((*MockConfigSetter)(nil).SetControllerAPIPort), arg0)
 }
 
 // SetLoggingConfig mocks base method
 func (m *MockConfigSetter) SetLoggingConfig(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetLoggingConfig", arg0)
 }
 
 // SetLoggingConfig indicates an expected call of SetLoggingConfig
 func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).SetLoggingConfig), arg0)
 }
 
 // SetMongoMemoryProfile mocks base method
 func (m *MockConfigSetter) SetMongoMemoryProfile(arg0 mongo.MemoryProfile) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoMemoryProfile", arg0)
 }
 
 // SetMongoMemoryProfile indicates an expected call of SetMongoMemoryProfile
 func (mr *MockConfigSetterMockRecorder) SetMongoMemoryProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoMemoryProfile), arg0)
+}
+
+// SetMongoSnapChannel mocks base method
+func (m *MockConfigSetter) SetMongoSnapChannel(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMongoSnapChannel", arg0)
+}
+
+// SetMongoSnapChannel indicates an expected call of SetMongoSnapChannel
+func (mr *MockConfigSetterMockRecorder) SetMongoSnapChannel(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoSnapChannel), arg0)
 }
 
 // SetMongoVersion mocks base method
 func (m *MockConfigSetter) SetMongoVersion(arg0 mongo.Version) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoVersion", arg0)
 }
 
 // SetMongoVersion indicates an expected call of SetMongoVersion
 func (mr *MockConfigSetterMockRecorder) SetMongoVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoVersion), arg0)
 }
 
 // SetOldPassword mocks base method
 func (m *MockConfigSetter) SetOldPassword(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetOldPassword", arg0)
 }
 
 // SetOldPassword indicates an expected call of SetOldPassword
 func (mr *MockConfigSetterMockRecorder) SetOldPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOldPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetOldPassword), arg0)
 }
 
 // SetPassword mocks base method
 func (m *MockConfigSetter) SetPassword(arg0 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPassword", arg0)
 }
 
 // SetPassword indicates an expected call of SetPassword
 func (mr *MockConfigSetterMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetPassword), arg0)
 }
 
 // SetStateServingInfo mocks base method
 func (m *MockConfigSetter) SetStateServingInfo(arg0 controller.StateServingInfo) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetStateServingInfo", arg0)
 }
 
 // SetStateServingInfo indicates an expected call of SetStateServingInfo
 func (mr *MockConfigSetterMockRecorder) SetStateServingInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).SetStateServingInfo), arg0)
 }
 
 // SetUpgradedToVersion mocks base method
 func (m *MockConfigSetter) SetUpgradedToVersion(arg0 version.Number) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetUpgradedToVersion", arg0)
 }
 
 // SetUpgradedToVersion indicates an expected call of SetUpgradedToVersion
 func (mr *MockConfigSetterMockRecorder) SetUpgradedToVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetUpgradedToVersion), arg0)
 }
 
 // SetValue mocks base method
 func (m *MockConfigSetter) SetValue(arg0, arg1 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetValue", arg0, arg1)
 }
 
 // SetValue indicates an expected call of SetValue
 func (mr *MockConfigSetterMockRecorder) SetValue(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValue", reflect.TypeOf((*MockConfigSetter)(nil).SetValue), arg0, arg1)
 }
 
 // StateServingInfo mocks base method
 func (m *MockConfigSetter) StateServingInfo() (controller.StateServingInfo, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
 	ret0, _ := ret[0].(controller.StateServingInfo)
 	ret1, _ := ret[1].(bool)
@@ -719,11 +866,13 @@ func (m *MockConfigSetter) StateServingInfo() (controller.StateServingInfo, bool
 
 // StateServingInfo indicates an expected call of StateServingInfo
 func (mr *MockConfigSetterMockRecorder) StateServingInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).StateServingInfo))
 }
 
 // SystemIdentityPath mocks base method
 func (m *MockConfigSetter) SystemIdentityPath() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -731,23 +880,27 @@ func (m *MockConfigSetter) SystemIdentityPath() string {
 
 // SystemIdentityPath indicates an expected call of SystemIdentityPath
 func (mr *MockConfigSetterMockRecorder) SystemIdentityPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfigSetter)(nil).SystemIdentityPath))
 }
 
 // Tag mocks base method
-func (m *MockConfigSetter) Tag() names_v3.Tag {
+func (m *MockConfigSetter) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockConfigSetterMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfigSetter)(nil).Tag))
 }
 
 // TransientDataDir mocks base method
 func (m *MockConfigSetter) TransientDataDir() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -755,11 +908,13 @@ func (m *MockConfigSetter) TransientDataDir() string {
 
 // TransientDataDir indicates an expected call of TransientDataDir
 func (mr *MockConfigSetterMockRecorder) TransientDataDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfigSetter)(nil).TransientDataDir))
 }
 
 // UpgradedToVersion mocks base method
 func (m *MockConfigSetter) UpgradedToVersion() version.Number {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
 	ret0, _ := ret[0].(version.Number)
 	return ret0
@@ -767,11 +922,13 @@ func (m *MockConfigSetter) UpgradedToVersion() version.Number {
 
 // UpgradedToVersion indicates an expected call of UpgradedToVersion
 func (mr *MockConfigSetterMockRecorder) UpgradedToVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).UpgradedToVersion))
 }
 
 // Value mocks base method
 func (m *MockConfigSetter) Value(arg0 string) string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -779,11 +936,13 @@ func (m *MockConfigSetter) Value(arg0 string) string {
 
 // Value indicates an expected call of Value
 func (mr *MockConfigSetterMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfigSetter)(nil).Value), arg0)
 }
 
 // WriteCommands mocks base method
 func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -792,5 +951,6 @@ func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) 
 
 // WriteCommands indicates an expected call of WriteCommands
 func (mr *MockConfigSetterMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfigSetter)(nil).WriteCommands), arg0)
 }


### PR DESCRIPTION
## Description of change

This PR ensures that any newly bootstrapped controller using focal (or later) uses the [juju-db](https://snapcraft.io/juju-db) snap. A new **read-only** controller configuration option (`mongo-snap-channel`) allows the operator to select the channel for the mongo snap. The default value for this option is set to `4.0/stable`.

**Notes**:
- We don't care about upgrading mongo from 2.7.x -> 2.8. The recommended procedure is to create a new controller and migrate the models over.
- The `mongodb-snap` feature flag has been retained for development purposes (install a custom snap and/or force-installing a snap when bootstrapping older releases). However, if we are happy with using channels for testing new releases we can remove the flag via a separate PR

**Open questions**:
- How are we going to handle manual machines?

## QA steps

### 1) Bootstrap non-focal

```console
$ juju bootstrap lxd test-non-focal --no-gui
$ juju show-controller | grep mongo-version
    mongo-version: 3.6.3

# Ensure deploys still work
$ juju deploy  cs:~jameinel/ubuntu-lite-7
```

### 2) Bootstrap focal with default channel

```console
$ juju bootstrap lxd test-focal-with-stable-mongo-snap --bootstrap-series=focal --force --no-gui --config image-stream=daily
$ juju show-controller | grep mongo-version
    mongo-version: 4.0.9

# Ensure deploys still work
$ juju deploy  cs:~jameinel/ubuntu-lite-7
```

### 3) Bootstrap focal and specify snap channel

```console
$ juju bootstrap lxd test-focal-with-candidate-mongo-snap --bootstrap-series=focal --force --no-gui --config image-stream=daily --config mongo-snap-channel=4.0/candidate
$ juju show-controller | grep mongo-version
    mongo-version: 4.0.18

# Ensure deploys still work
$ juju deploy  cs:~jameinel/ubuntu-lite-7
```

### 4) Bootstrap focal, specify snap channel and enable HA

```console
$ juju bootstrap lxd test-focal-with-candidate-mongo-snap --bootstrap-series=focal --force --no-gui --config image-stream=daily --config mongo-snap-channel=4.0/candidate
$ juju show-controller | grep mongo-version
    mongo-version: 4.0.18

# Enable HA and check 'juju show-controller' to ensure all nodes are healthy
$ juju enable ha -n3
$ juju show-controller | grep -A10 controller-machines
  controller-machines:
    "0":
      instance-id: juju-7c83d1-0
      ha-status: ha-enabled
      ha-primary: true
    "1":
      instance-id: juju-7c83d1-1
      ha-status: ha-enabled
    "2":
      instance-id: juju-7c83d1-2
      ha-status: ha-enabled
```

Also do a `juju ssh -m controller $x 'snap info juju-db | grep tracking:'` where $x = [0, 1, 2] and make sure that everything tracks `4.0/candidate`

### 5) Moar QA fun

- Try the above with different clouds
- Upgrade from 2.7 -> 2.8 and ensure nothing breaks
- Ensure that CAAS workloads are unaffected by these changes.

## Documentation changes

Document `mongo-snap-channel` configuration parameter.