### PR TITLE
Add origin to ip addresses

### DIFF
--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -64,7 +64,7 @@ type ipAddressDoc struct {
 	// IsDefaultGateway is set to true if that device/subnet is the default gw for the machine
 	IsDefaultGateway bool `bson:"is-default-gateway,omitempty"`
 
-	// Origin represents whom owns or identifies with this ipAddress.
+	// Origin represents the authoritative source of the ipAddress.
 	// It is expected that either the provider gave us this address or the
 	// machine gave us this address.
 	// Giving us this information allows us to reason about when a ipAddress is
@@ -211,7 +211,7 @@ func (addr *Address) IsDefaultGateway() bool {
 	return addr.doc.IsDefaultGateway
 }
 
-// Origin represents whom owns or identifies with this ipAddress.
+// Origin represents the authoritative source of the ipAddress.
 // It is expected that either the provider gave us this address or the
 // machine gave us this address.
 // Giving us this information allows us to reason about when a ipAddress is

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -63,6 +63,15 @@ type ipAddressDoc struct {
 
 	// IsDefaultGateway is set to true if that device/subnet is the default gw for the machine
 	IsDefaultGateway bool `bson:"is-default-gateway,omitempty"`
+
+	// Origin represents whom owns or identifies with this ipAddress.
+	// It is expected that either the provider gave us this address or the
+	// machine gave us this address.
+	// Giving us this information allows us to reason about when a ipAddress is
+	// in use.
+	// This should always be required, hence the lack of omitempty (upgrade
+	// steps should correctly assign this for all addresses)
+	Origin network.Origin `bson:"origin"`
 }
 
 // AddressConfigMethod is the method used to configure a link-layer device's IP
@@ -196,9 +205,19 @@ func (addr *Address) GatewayAddress() string {
 	return addr.doc.GatewayAddress
 }
 
-// IsDefaultGateway returns true if this address is used for the default gw on the machine.
+// IsDefaultGateway returns true if this address is used for the default gw on
+// the machine.
 func (addr *Address) IsDefaultGateway() bool {
 	return addr.doc.IsDefaultGateway
+}
+
+// Origin represents whom owns or identifies with this ipAddress.
+// It is expected that either the provider gave us this address or the
+// machine gave us this address.
+// Giving us this information allows us to reason about when a ipAddress is
+// in use.
+func (addr *Address) Origin() network.Origin {
+	return addr.doc.Origin
 }
 
 // String returns a human-readable representation of the IP address.

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -689,6 +689,7 @@ func (s *MigrationSuite) TestIPAddressDocFields(c *gc.C) {
 		"SubnetCIDR",
 		"ConfigMethod",
 		"Value",
+		"Origin",
 	)
 	s.AssertExportedFields(c, ipAddressDoc{}, migrated.Union(ignored))
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2953,6 +2953,17 @@ func AddOriginToIPAddresses(pool *StatePool) error {
 			continue
 		}
 
+		// Set the origin to OriginProvider as the default ip address origin.
+		// The expectation is that the instancepoller will set all ip addresses
+		// that it knows about as a OriginProvier and anything it doesn't as a
+		// OriginMachine.
+		// The instancepoller will quiesce on the right value after the first
+		// run.
+		//
+		// The state of the network.Origin is a statemachine as follows:
+		//
+		//     OriginProvier -> OriginMachine -> Dead
+		//
 		ops = append(ops, txn.Op{
 			C:      ipAddressesC,
 			Id:     ipAddress.DocID,

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -78,6 +78,7 @@ type StateBackend interface {
 	RemoveControllerConfigMaxLogAgeAndSize() error
 	IncrementTasksSequence() error
 	AddMachineIDToSubordinates() error
+	AddOriginToIPAddresses() error
 	DropPresenceDatabase() error
 }
 
@@ -318,6 +319,10 @@ func (s stateBackend) IncrementTasksSequence() error {
 
 func (s stateBackend) AddMachineIDToSubordinates() error {
 	return state.AddMachineIDToSubordinates(s.pool)
+}
+
+func (s stateBackend) AddOriginToIPAddresses() error {
+	return state.AddOriginToIPAddresses(s.pool)
 }
 
 func (s stateBackend) DropPresenceDatabase() error {

--- a/upgrades/steps_28.go
+++ b/upgrades/steps_28.go
@@ -50,6 +50,13 @@ func stateStepsFor28() []Step {
 				return context.State().AddMachineIDToSubordinates()
 			},
 		},
+		&upgradeStep{
+			description: "add origin to ip addresses",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddOriginToIPAddresses()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -48,6 +48,11 @@ func (s *steps28Suite) TestAddMachineIDToSubordinates(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
+func (s *steps28Suite) TestAddOriginToIPAddresses(c *gc.C) {
+	step := findStateStep(c, v280, "add origin to ip addresses")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 func (s *steps28Suite) TestPopulateRebootHandledFlagsForDeployedUnits(c *gc.C) {
 	step := findStep(c, v280, "ensure currently running units do not fire start hooks thinking a reboot has occurred")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.HostMachine})


### PR DESCRIPTION
## Description of change

Adding an origin field to all ip address with upgrade steps to always be
provider by default, should allow us to reason about whom owns the ip
address.

Once we know about the owner of the ip address we can then think about
the deletion of the ip address if it's no longer used.

The upgrade steps in this PR ensure that we always have on and that it's
always set to the default origin; Provider.

----

Technically we expect the machiner (worker) to never delete any ip
addresses it doesn't own (origin in this case). So if a machiner sees
that the owner is a "provider" we skip this. If it sees the owner is a
"machine" and the ip address is no longer in use, the machiner can then
delete it from the database.

## QA steps

 - Bootstrap 2.7 and deploy a workload.
 - Upgrade to 2.8 and ensure that we now have the default `origin` on ip addresses.  

## Bug reference

This doesn't solve the bug but starts to land the foundations for fixing it.

https://bugs.launchpad.net/juju/+bug/1733968
