### PR TITLE
Fixes test composition in WatcherSuite

### DIFF
--- a/worker/caasoperator/remotestate/mock_test.go
+++ b/worker/caasoperator/remotestate/mock_test.go
@@ -57,23 +57,10 @@ type mockNotifyWatcher struct {
 	*mockWatcher
 	changes chan struct{}
 	err     error
-	mu      sync.Mutex
 }
 
 func (w *mockNotifyWatcher) Changes() watcher.NotifyChannel {
 	return w.changes
-}
-
-func (w *mockNotifyWatcher) Err() error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.err
-}
-
-func (w *mockNotifyWatcher) SetErr(err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.err = err
 }
 
 type mockApplicationWatcher struct {
@@ -84,7 +71,7 @@ func (s *mockApplicationWatcher) Watch(application string) (watcher.NotifyWatche
 	if application != "gitlab" {
 		return nil, errors.NotFoundf(application)
 	}
-	return s.watcher, s.watcher.Err()
+	return s.watcher, s.watcher.err
 }
 
 type mockCharmGetter struct {


### PR DESCRIPTION
## Description of change

Lock protection introduced in #11452 was the wrong approach.

The real issue was overwriting suite-level variables in `TestApplicationRemovalTerminatesAgent`, which cause unpredictable behaviour killing the suite-level worker in `TearDownTest`.

This ensures that each suite watcher is only set up once, and the previously introduced lock protection is removed.

## QA steps

Run `WatcherSuite` tests in a loop under `worker/caasoperator/remotestate`.
