### PR TITLE
Attempt to remove default installed mongo

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -41,6 +41,12 @@ jobs:
       if: (matrix.os == 'ubuntu-latest')
       working-directory: src/github.com/juju/juju
       run: |
+        # Remove the default mongo
+        sudo rm /etc/apt/sources.list.d/mongodb-org-4.2.list
+        sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y mongodb-org
+        sudo DEBIAN_FRONTEND=noninteractive apt autoremove
+        sudo rm -rf /usr/bin/mongo* || true
+
         make install-mongo-dependencies
 
     - name: "Install Mongo Dependencies: macOS-latest"


### PR DESCRIPTION
## Description of change

The github action now automatically adds mongo from multiiverse of all
places and then installs it. There is no way to say, "nope, don't want
that!" - instead we have to get out our hammer and treat everything as a
nail.

This is not great, we can't rely on a clean environment anymore.

## QA steps

Get client tests to pass.