### PR TITLE
update deploy integration tests when running on aws

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -156,7 +156,19 @@ test_deploy_bundles() {
         run "run_deploy_cmr_bundle"
         run "run_deploy_exported_bundle"
         run "run_deploy_trusted_bundle"
-        run "run_deploy_lxd_profile_bundle_openstack"
-        run "run_deploy_lxd_profile_bundle"
+        case "${BOOTSTRAP_PROVIDER:-}" in
+            "lxd")
+                run "run_deploy_lxd_profile_bundle_openstack"
+                run "run_deploy_lxd_profile_bundle"
+                ;;
+            "localhost")
+                run "run_deploy_lxd_profile_bundle_openstack"
+                run "run_deploy_lxd_profile_bundle"
+                ;;
+            *)
+                echo "==> TEST SKIPPED: deploy_lxd_profile_bundle_openstack - tests for LXD only"
+                echo "==> TEST SKIPPED: deploy_lxd_profile_bundle - tests for LXD only"
+                ;;
+        esac
     )
 }


### PR DESCRIPTION

## Description of change

Deploy integration tests on aws are failing on run_deploy_lxd_profile* tests  because you can't apply an lxd profile to non lxd container machines.  Update deploy integration test runs to only run lxd profile tests on lxd with one exception: run_deploy_lxd_profile_charm_container.

Add run_deploy_lxd_profile_charm_container to deploy the lxd profile charm to a container for providers other than lxd.

## QA steps
```sh
(cd tests ; main.sh -p aws deploy)
(cd tests ; main.sh -p lxd deploy)
```
