### PR TITLE
Run commands in operator or workload for CAAS.

### DIFF
--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -45,6 +45,7 @@ type RunCommand struct {
 	relationId            string
 	remoteUnitName        string
 	remoteApplicationName string
+	operator              bool
 }
 
 const runCommandDoc = `
@@ -80,6 +81,7 @@ func (c *RunCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.relationId, "relation", "", "")
 	f.StringVar(&c.remoteUnitName, "remote-unit", "", "run the commands for a specific remote unit in a relation context on a unit")
 	f.StringVar(&c.remoteApplicationName, "remote-app", "", "run the commands for a specific remote application in a relation context on a unit")
+	f.BoolVar(&c.operator, "operator", false, "run the commands on the operator instead of the workload. Only supported on k8s workload charms")
 	f.BoolVar(&c.forceRemoteUnit, "force-remote-unit", false, "run the commands for a specific relation context, bypassing the remote unit check")
 }
 
@@ -270,6 +272,7 @@ func (c *RunCommand) executeInUnitContext() (*exec.ExecResponse, error) {
 		RemoteUnitName:        c.remoteUnitName,
 		RemoteApplicationName: c.remoteApplicationName,
 		ForceRemoteUnit:       c.forceRemoteUnit,
+		Operator:              c.operator,
 	}
 	if operatorClientInfo != nil {
 		args.Token = operatorClientInfo.Token

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -55,6 +55,7 @@ func (*RunTestSuite) TestArgParsing(c *gc.C) {
 		remoteUnit      string
 		remoteApp       string
 		forceRemoteUnit bool
+		operator        bool
 	}{{
 		title:    "no args",
 		errMatch: "missing unit-name",
@@ -123,6 +124,13 @@ func (*RunTestSuite) TestArgParsing(c *gc.C) {
 		relationId:      "mongodb:1",
 		remoteApp:       "app",
 		forceRemoteUnit: false,
+	}, {
+		title:      "unit id converted to tag",
+		args:       []string{"--operator", "foo/1", "command"},
+		unit:       names.NewUnitTag("foo/1"),
+		commands:   "command",
+		relationId: "",
+		operator:   true,
 	},
 	} {
 		c.Logf("%d: %s", i, test.title)
@@ -137,6 +145,7 @@ func (*RunTestSuite) TestArgParsing(c *gc.C) {
 			c.Assert(runCommand.remoteUnitName, gc.Equals, test.remoteUnit)
 			c.Assert(runCommand.remoteApplicationName, gc.Equals, test.remoteApp)
 			c.Assert(runCommand.forceRemoteUnit, gc.Equals, test.forceRemoteUnit)
+			c.Assert(runCommand.operator, gc.Equals, test.operator)
 		} else {
 			c.Assert(err, gc.ErrorMatches, test.errMatch)
 		}

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -560,6 +560,7 @@ func (op *caasOperator) loop() (err error) {
 					params.RemoteInitFunc = func(runningStatus uniterremotestate.ContainerRunningStatus, cancel <-chan struct{}) error {
 						return op.remoteInit(unitTag, runningStatus, cancel)
 					}
+					params.NewRemoteRunnerExecutor = getNewRunnerExecutor(op.config.Logger, op.config.ExecClient)
 				}
 				if err := op.config.StartUniterFunc(op.runner, params); err != nil {
 					return errors.Trace(err)

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -448,6 +448,7 @@ func (s *WorkerSuite) TestContainerStart(c *gc.C) {
 		go func() {
 			close(uniterStarted)
 			c.Assert(params.UnitTag.Id(), gc.Equals, "gitlab/0")
+			c.Assert(params.NewRemoteRunnerExecutor, gc.NotNil)
 			select {
 			case <-params.ContainerRunningStatusChannel:
 			case <-time.After(coretesting.LongWait):

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -225,15 +225,14 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			wCfg.OperatorInfo = *operatorInfo
 			wCfg.UniterParams = &uniter.UniterParams{
-				NewOperationExecutor:    operation.NewExecutor,
-				NewRemoteRunnerExecutor: getNewRunnerExecutor(config.Logger, execClient),
-				DataDir:                 agentConfig.DataDir(),
-				Clock:                   clock,
-				MachineLock:             config.MachineLock,
-				CharmDirGuard:           charmDirGuard,
-				UpdateStatusSignal:      uniter.NewUpdateStatusTimer(),
-				HookRetryStrategy:       hookRetryStrategy,
-				TranslateResolverErr:    config.TranslateResolverErr,
+				NewOperationExecutor: operation.NewExecutor,
+				DataDir:              agentConfig.DataDir(),
+				Clock:                clock,
+				MachineLock:          config.MachineLock,
+				CharmDirGuard:        charmDirGuard,
+				UpdateStatusSignal:   uniter.NewUpdateStatusTimer(),
+				HookRetryStrategy:    hookRetryStrategy,
+				TranslateResolverErr: config.TranslateResolverErr,
 			}
 			wCfg.UniterParams.SocketConfig, err = socketConfig(operatorInfo)
 			if err != nil {

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -180,7 +180,6 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(config.RunListenerSocketFunc, gc.NotNil)
 	c.Assert(config.UniterParams.UpdateStatusSignal, gc.NotNil)
 	c.Assert(config.UniterParams.NewOperationExecutor, gc.NotNil)
-	c.Assert(config.UniterParams.NewRemoteRunnerExecutor, gc.NotNil)
 	c.Assert(config.Logger, gc.NotNil)
 	c.Assert(config.ExecClient, gc.NotNil)
 	config.LeadershipTrackerFunc = nil
@@ -189,7 +188,6 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.RunListenerSocketFunc = nil
 	config.UniterParams.UpdateStatusSignal = nil
 	config.UniterParams.NewOperationExecutor = nil
-	config.UniterParams.NewRemoteRunnerExecutor = nil
 	config.Logger = nil
 	config.ExecClient = nil
 

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -138,6 +138,8 @@ type CommandArgs struct {
 	// TODO(jam): 2019-10-24 Include RemoteAppName
 	// ForceRemoteUnit skips unit inference and existence validation.
 	ForceRemoteUnit bool
+	// RunLocation describes where the command must run.
+	RunLocation runner.RunLocation
 }
 
 // CommandResponseFunc is for marshalling command responses back to the source

--- a/worker/uniter/operation/runcommands.go
+++ b/worker/uniter/operation/runcommands.go
@@ -68,7 +68,7 @@ func (rc *runCommands) Execute(state State) (*State, error) {
 		return nil, errors.Trace(err)
 	}
 
-	response, err := rc.runner.RunCommands(rc.args.Commands)
+	response, err := rc.runner.RunCommands(rc.args.Commands, rc.args.RunLocation)
 	switch err {
 	case context.ErrRequeueAndReboot:
 		logger.Warningf("cannot requeue external commands")

--- a/worker/uniter/operation/runcommands_test.go
+++ b/worker/uniter/operation/runcommands_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
 
@@ -111,6 +112,7 @@ func (s *RunCommandsSuite) TestExecuteRebootErrors(c *gc.C) {
 		c.Assert(newState, gc.IsNil)
 		c.Assert(err, gc.Equals, operation.ErrNeedsReboot)
 		c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
+		c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotRunLocation, gc.Equals, runner.Workload)
 		c.Assert(*sendResponse.gotResponse, gc.DeepEquals, &utilexec.ExecResponse{Code: 101})
 		c.Assert(*sendResponse.gotErr, jc.ErrorIsNil)
 	}
@@ -135,6 +137,7 @@ func (s *RunCommandsSuite) TestExecuteOtherError(c *gc.C) {
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "sneh")
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
+	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotRunLocation, gc.Equals, runner.Workload)
 	c.Assert(*sendResponse.gotResponse, gc.IsNil)
 	c.Assert(*sendResponse.gotErr, gc.ErrorMatches, "sneh")
 }
@@ -160,6 +163,7 @@ func (s *RunCommandsSuite) TestExecuteConsumeOtherError(c *gc.C) {
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
+	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotRunLocation, gc.Equals, runner.Workload)
 	c.Assert(*sendResponse.gotResponse, gc.IsNil)
 	c.Assert(*sendResponse.gotErr, gc.ErrorMatches, "sneh")
 }
@@ -183,6 +187,33 @@ func (s *RunCommandsSuite) TestExecuteSuccess(c *gc.C) {
 	c.Assert(newState, gc.IsNil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
+	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotRunLocation, gc.Equals, runner.Workload)
+	c.Assert(*sendResponse.gotResponse, gc.DeepEquals, &utilexec.ExecResponse{Code: 222})
+	c.Assert(*sendResponse.gotErr, jc.ErrorIsNil)
+}
+
+func (s *RunCommandsSuite) TestExecuteSuccessOperator(c *gc.C) {
+	runnerFactory := NewRunCommandsRunnerFactory(
+		&utilexec.ExecResponse{Code: 222}, nil,
+	)
+	callbacks := &RunCommandsCallbacks{}
+	factory := operation.NewFactory(operation.FactoryParams{
+		RunnerFactory: runnerFactory,
+		Callbacks:     callbacks,
+	})
+	sendResponse := &MockSendResponse{}
+	commandArgs := someCommandArgs
+	commandArgs.RunLocation = runner.Operator
+	op, err := factory.NewCommands(commandArgs, sendResponse.Call)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = op.Prepare(operation.State{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newState, err := op.Execute(operation.State{})
+	c.Assert(newState, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotCommands, gc.Equals, "do something")
+	c.Assert(*runnerFactory.MockNewCommandRunner.runner.MockRunCommands.gotRunLocation, gc.Equals, runner.Operator)
 	c.Assert(*sendResponse.gotResponse, gc.DeepEquals, &utilexec.ExecResponse{Code: 222})
 	c.Assert(*sendResponse.gotErr, jc.ErrorIsNil)
 }

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -387,13 +387,15 @@ func (mock *MockRunAction) Call(actionName string) error {
 }
 
 type MockRunCommands struct {
-	gotCommands *string
-	response    *utilexec.ExecResponse
-	err         error
+	gotCommands    *string
+	gotRunLocation *runner.RunLocation
+	response       *utilexec.ExecResponse
+	err            error
 }
 
-func (mock *MockRunCommands) Call(commands string) (*utilexec.ExecResponse, error) {
+func (mock *MockRunCommands) Call(commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
 	mock.gotCommands = &commands
+	mock.gotRunLocation = &runLocation
 	return mock.response, mock.err
 }
 
@@ -423,8 +425,8 @@ func (r *MockRunner) RunAction(actionName string) (runner.HookHandlerType, error
 	return runner.ExplicitHookHandler, r.MockRunAction.Call(actionName)
 }
 
-func (r *MockRunner) RunCommands(commands string) (*utilexec.ExecResponse, error) {
-	return r.MockRunCommands.Call(commands)
+func (r *MockRunner) RunCommands(commands string, runLocation runner.RunLocation) (*utilexec.ExecResponse, error) {
+	return r.MockRunCommands.Call(commands, runLocation)
 }
 
 func (r *MockRunner) RunHook(hookName string) (runner.HookHandlerType, error) {
@@ -560,6 +562,7 @@ var someCommandArgs = operation.CommandArgs{
 	RelationId:      123,
 	RemoteUnitName:  "foo/456",
 	ForceRemoteUnit: true,
+	RunLocation:     runner.Workload,
 }
 
 type RemoteInitCallbacks struct {

--- a/worker/uniter/runcommands/mock_test.go
+++ b/worker/uniter/runcommands/mock_test.go
@@ -23,15 +23,15 @@ func (f *mockRunnerFactory) NewCommandRunner(info context.CommandInfo) (runner.R
 
 type mockRunner struct {
 	runner.Runner
-	runCommands func(string) (*exec.ExecResponse, error)
+	runCommands func(string, runner.RunLocation) (*exec.ExecResponse, error)
 }
 
 func (r *mockRunner) Context() runner.Context {
 	return &mockRunnerContext{}
 }
 
-func (r *mockRunner) RunCommands(commands string) (*exec.ExecResponse, error) {
-	return r.runCommands(commands)
+func (r *mockRunner) RunCommands(commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+	return r.runCommands(commands, runLocation)
 }
 
 type mockRunnerContext struct {

--- a/worker/uniter/runcommands/runcommands_test.go
+++ b/worker/uniter/runcommands/runcommands_test.go
@@ -26,7 +26,7 @@ type runcommandsSuite struct {
 	opFactory        operation.Factory
 	resolver         resolver.Resolver
 	commands         runcommands.Commands
-	runCommands      func(string) (*exec.ExecResponse, error)
+	runCommands      func(string, runner.RunLocation) (*exec.ExecResponse, error)
 	commandCompleted func(string)
 }
 
@@ -37,8 +37,8 @@ func (s *runcommandsSuite) SetUpTest(c *gc.C) {
 	s.remoteState = remotestate.Snapshot{
 		CharmURL: s.charmURL,
 	}
-	s.mockRunner = mockRunner{runCommands: func(commands string) (*exec.ExecResponse, error) {
-		return s.runCommands(commands)
+	s.mockRunner = mockRunner{runCommands: func(commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+		return s.runCommands(commands, runLocation)
 	}}
 	s.callbacks = &mockCallbacks{}
 	s.opFactory = operation.NewFactory(operation.FactoryParams{
@@ -69,7 +69,8 @@ func (s *runcommandsSuite) TestRunCommands(c *gc.C) {
 		},
 	}
 	id := s.commands.AddCommand(operation.CommandArgs{
-		Commands: "echo foxtrot",
+		Commands:    "echo foxtrot",
+		RunLocation: runner.Operator,
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
@@ -84,7 +85,8 @@ func (s *runcommandsSuite) TestRunCommandsCallbacks(c *gc.C) {
 	}
 
 	var run []string
-	s.runCommands = func(commands string) (*exec.ExecResponse, error) {
+	s.runCommands = func(commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+		c.Assert(runLocation, gc.Equals, runner.Operator)
 		run = append(run, commands)
 		return &exec.ExecResponse{}, nil
 	}
@@ -96,7 +98,8 @@ func (s *runcommandsSuite) TestRunCommandsCallbacks(c *gc.C) {
 	}
 
 	id := s.commands.AddCommand(operation.CommandArgs{
-		Commands: "echo foxtrot",
+		Commands:    "echo foxtrot",
+		RunLocation: runner.Operator,
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
 
@@ -130,7 +133,8 @@ func (s *runcommandsSuite) TestRunCommandsCommitErrorNoCompletedCallback(c *gc.C
 	}
 
 	var run []string
-	s.runCommands = func(commands string) (*exec.ExecResponse, error) {
+	s.runCommands = func(commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+		c.Assert(runLocation, gc.Equals, runner.Operator)
 		run = append(run, commands)
 		return &exec.ExecResponse{}, nil
 	}
@@ -142,7 +146,8 @@ func (s *runcommandsSuite) TestRunCommandsCommitErrorNoCompletedCallback(c *gc.C
 	}
 
 	id := s.commands.AddCommand(operation.CommandArgs{
-		Commands: "echo foxtrot",
+		Commands:    "echo foxtrot",
+		RunLocation: runner.Operator,
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
 
@@ -171,13 +176,15 @@ func (s *runcommandsSuite) TestRunCommandsError(c *gc.C) {
 			Kind: operation.Continue,
 		},
 	}
-	s.runCommands = func(commands string) (*exec.ExecResponse, error) {
+	s.runCommands = func(commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+		c.Assert(runLocation, gc.Equals, runner.Operator)
 		return nil, errors.Errorf("executing commands: %s", commands)
 	}
 
 	var execErr error
 	id := s.commands.AddCommand(operation.CommandArgs{
-		Commands: "echo foxtrot",
+		Commands:    "echo foxtrot",
+		RunLocation: runner.Operator,
 	}, func(_ *exec.ExecResponse, err error) bool {
 		execErr = err
 		return false
@@ -203,13 +210,15 @@ func (s *runcommandsSuite) TestRunCommandsErrorConsumed(c *gc.C) {
 			Kind: operation.Continue,
 		},
 	}
-	s.runCommands = func(commands string) (*exec.ExecResponse, error) {
+	s.runCommands = func(commands string, runLocation runner.RunLocation) (*exec.ExecResponse, error) {
+		c.Assert(runLocation, gc.Equals, runner.Operator)
 		return nil, errors.Errorf("executing commands: %s", commands)
 	}
 
 	var execErr error
 	id := s.commands.AddCommand(operation.CommandArgs{
-		Commands: "echo foxtrot",
+		Commands:    "echo foxtrot",
+		RunLocation: runner.Operator,
 	}, func(_ *exec.ExecResponse, err error) bool {
 		execErr = err
 		return true
@@ -237,7 +246,8 @@ func (s *runcommandsSuite) TestRunCommandsStatus(c *gc.C) {
 	}
 
 	id := s.commands.AddCommand(operation.CommandArgs{
-		Commands: "echo foxtrot",
+		Commands:    "echo foxtrot",
+		RunLocation: runner.Operator,
 	}, func(*exec.ExecResponse, error) bool { return false })
 	s.remoteState.Commands = []string{id}
 

--- a/worker/uniter/runlistener.go
+++ b/worker/uniter/runlistener.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/runcommands"
+	"github.com/juju/juju/worker/uniter/runner"
 )
 
 const JujuRunEndpoint = "JujuRunServer.RunCommands"
@@ -48,6 +49,9 @@ type RunCommandsArgs struct {
 	UnitName string
 	// Token is the unit token when run under CAAS environments for auth.
 	Token string
+	// Operator is true when the command should be run on the operator.
+	// This only affects k8s workload charms.
+	Operator bool
 }
 
 // A CommandRunner is something that will actually execute the commands and
@@ -309,6 +313,11 @@ func (c *ChannelCommandRunner) RunCommands(args RunCommandsArgs) (results *exec.
 		}
 	}
 
+	runLocation := runner.Workload
+	if args.Operator {
+		runLocation = runner.Operator
+	}
+
 	id := c.config.Commands.AddCommand(
 		operation.CommandArgs{
 			Commands:       args.Commands,
@@ -316,6 +325,7 @@ func (c *ChannelCommandRunner) RunCommands(args RunCommandsArgs) (results *exec.
 			RemoteUnitName: args.RemoteUnitName,
 			// TODO(jam): 2019-10-24 Include RemoteAppName
 			ForceRemoteUnit: args.ForceRemoteUnit,
+			RunLocation:     runLocation,
 		},
 		responseFunc,
 	)

--- a/worker/uniter/runlistener_test.go
+++ b/worker/uniter/runlistener_test.go
@@ -38,10 +38,13 @@ func (s *ListenerSuite) SetUpTest(c *gc.C) {
 }
 
 // Mirror the params to uniter.NewRunListener, but add cleanup to close it.
-func (s *ListenerSuite) NewRunListener(c *gc.C) *uniter.RunListener {
+func (s *ListenerSuite) NewRunListener(c *gc.C, operator bool) *uniter.RunListener {
 	listener, err := uniter.NewRunListener(s.socketPath)
 	c.Assert(err, jc.ErrorIsNil)
-	listener.RegisterRunner("test/0", &mockRunner{c})
+	listener.RegisterRunner("test/0", &mockRunner{
+		c:        c,
+		operator: operator,
+	})
 	s.AddCleanup(func(*gc.C) {
 		c.Assert(listener.Close(), jc.ErrorIsNil)
 	})
@@ -52,12 +55,12 @@ func (s *ListenerSuite) TestNewRunListenerOnExistingSocketRemovesItAndSucceeds(c
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: Current named pipes implementation does not support this")
 	}
-	s.NewRunListener(c)
-	s.NewRunListener(c)
+	s.NewRunListener(c, false)
+	s.NewRunListener(c, false)
 }
 
 func (s *ListenerSuite) TestClientCall(c *gc.C) {
-	s.NewRunListener(c)
+	s.NewRunListener(c, false)
 
 	client, err := sockets.Dial(s.socketPath)
 	c.Assert(err, jc.ErrorIsNil)
@@ -80,7 +83,7 @@ func (s *ListenerSuite) TestClientCall(c *gc.C) {
 }
 
 func (s *ListenerSuite) TestUnregisterRunner(c *gc.C) {
-	listener := s.NewRunListener(c)
+	listener := s.NewRunListener(c, false)
 	listener.UnregisterRunner("test/0")
 
 	client, err := sockets.Dial(s.socketPath)
@@ -97,6 +100,30 @@ func (s *ListenerSuite) TestUnregisterRunner(c *gc.C) {
 	}
 	err = client.Call(uniter.JujuRunEndpoint, args, &result)
 	c.Assert(err, gc.ErrorMatches, ".*no runner is registered for unit test/0")
+}
+
+func (s *ListenerSuite) TestOperatorFlag(c *gc.C) {
+	s.NewRunListener(c, true)
+
+	client, err := sockets.Dial(s.socketPath)
+	c.Assert(err, jc.ErrorIsNil)
+	defer client.Close()
+
+	var result exec.ExecResponse
+	args := uniter.RunCommandsArgs{
+		Commands:        "some-command",
+		RelationId:      -1,
+		RemoteUnitName:  "",
+		ForceRemoteUnit: false,
+		UnitName:        "test/0",
+		Operator:        true,
+	}
+	err = client.Call(uniter.JujuRunEndpoint, args, &result)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(string(result.Stdout), gc.Equals, "some-command stdout")
+	c.Assert(string(result.Stderr), gc.Equals, "some-command stderr")
+	c.Assert(result.Code, gc.Equals, 42)
 }
 
 type ChannelCommandRunnerSuite struct {
@@ -132,13 +159,15 @@ func (s *ChannelCommandRunnerSuite) TestCommandsAborted(c *gc.C) {
 }
 
 type mockRunner struct {
-	c *gc.C
+	c        *gc.C
+	operator bool
 }
 
 var _ uniter.CommandRunner = (*mockRunner)(nil)
 
 func (r *mockRunner) RunCommands(args uniter.RunCommandsArgs) (results *exec.ExecResponse, err error) {
 	r.c.Log("mock runner: " + args.Commands)
+	r.c.Assert(args.Operator, gc.Equals, r.operator)
 	return &exec.ExecResponse{
 		Code:   42,
 		Stdout: []byte(args.Commands + " stdout"),


### PR DESCRIPTION
## Description of change

Adds --operator argument to juju-run to allow the caller to optionally specify if the commands must run where the operator is.

This allows CAAS workload charms to call back to the operator or to itself (vice versa on the operator).

## QA steps

Bootstrap k8s, deploy workload caas charm, kubectl exec into the operator then:

```
root@mariadb-k8s-operator-0:/var/lib/juju# juju-run "hostname"
mariadb-k8s-0
root@mariadb-k8s-operator-0:/var/lib/juju# juju-run --operator "hostname"
mariadb-k8s-operator-0
```

Also test from the workload pod and test operator charms only run on the operator.

## Documentation changes

Possibly need to update this https://discourse.juju.is/t/the-hook-environment-hook-tools-and-how-hooks-are-run/1047

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871940
