### PR TITLE
fix create profile race when multiple controller bootstrapping at same time in new lxd config

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -98,7 +98,26 @@ func (env *environ) initProfile() error {
 		"boot.autostart":   "true",
 		"security.nesting": "true",
 	}
-	return env.serverUnlocked.CreateProfileWithConfig(pName, cfg)
+
+	// In ci, perhaps other places, there can be a race if more than one
+	// controller is starting up, where we try to create the profile more
+	// than once and get: The profile already exists.  LXD does not have
+	// typed errors. Therefore if CreateProfile fails, check to see if the
+	// profile exists.  No need to fail if it does.
+	err = env.serverUnlocked.CreateProfileWithConfig(pName, cfg)
+	if err == nil {
+		return nil
+	}
+	hasProfile, hasErr := env.serverUnlocked.HasProfile(pName)
+	if hasErr != nil {
+		logger.Errorf("%s", err)
+		return errors.Trace(hasErr)
+	}
+	if hasProfile {
+		logger.Debugf("received %q, but no need to fail", err)
+		return nil
+	}
+	return err
 }
 
 func (env *environ) profileName() string {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -770,6 +770,34 @@ func (s *EnvironSuite) NewEnviron(c *gc.C, svr Server, cfgEdit map[string]interf
 	}
 }
 
+func (s *EnvironSuite) NewEnvironWithServerFactory(c *gc.C, svr ServerFactory, cfgEdit map[string]interface{}) environs.Environ {
+	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	if cfgEdit != nil {
+		var err error
+		cfg, err = cfg.Apply(cfgEdit)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	eCfg, err := newValidConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	namespace, err := instance.NewNamespace(cfg.UUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	provid := environProvider{
+		serverFactory: svr,
+	}
+
+	return &environ{
+		name:         "controller",
+		provider:     &provid,
+		ecfgUnlocked: eCfg,
+		namespace:    namespace,
+	}
+}
+
 func (s *EnvironSuite) GetStartInstanceArgs(c *gc.C, series string) environs.StartInstanceParams {
 	tools := []*coretools.Tools{
 		{


### PR DESCRIPTION


## Description of change

There is a race creating juju- lxd profiles when multiple controllers are bootstrapping at once, like in CI recently.  Between the time juju checks to see if a profile has been created and creates it, a different controller as already created the juju-controller profile.  Thus the 2nd controller fails bootstrap.  Fix by checking for the profile if create profile fails.  IF the profile exists, we're good.   The profile always has the same contents. 

## QA steps

Not a good way to test the actual race.  Delete the juju-controller profile on one of the CI test boxes and kick off a CI run using this build?

```sh
lxd profile delete juju-controller
juju bootstrap lxd testme
```

Profiles are also named via model.  If you could time it so that multiple models with the same name in different controller are created at the same time successfully?

