### PR TITLE
2.7 - Fix Intermittent Failure in TestConfigSettings

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -846,7 +846,7 @@ func (u *UniterAPI) SetCharmURL(args params.EntitiesCharmURL) (params.ErrorResul
 				}
 				if err == nil {
 					// Wait for the change to propagate to the cache controller.
-					err = u.waitForControllerCharmURL(unit.Name(), curl.String())
+					err = u.waitForCacheCharmURL(unit.Name(), curl.String())
 				}
 			}
 		}
@@ -855,7 +855,7 @@ func (u *UniterAPI) SetCharmURL(args params.EntitiesCharmURL) (params.ErrorResul
 	return result, nil
 }
 
-func (u *UniterAPI) waitForControllerCharmURL(unit, curl string) error {
+func (u *UniterAPI) waitForCacheCharmURL(unit, curl string) error {
 	// One minute is excessively long, but the cache may need to refresh.
 	// In any normal operation, this should be sub-second, although if no changes
 	// were happening recently, it could be theoretically up to five seconds.


### PR DESCRIPTION
## Description of change

`WaitForModelWatchersIdle` helps, but does not *guarantee* cache synchronisation. We have observed that the uniter config test fails the race job, due to the charm URL not being set in the cache.

This patch makes that assurance so that the test passes consistently.

## QA steps

Unit tests pass consistently with `-race`.
