### PR TITLE
Move go vet github actions tests to own run

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -33,11 +33,13 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
+        export PATH=/snap/bin:$PATH
         sudo snap install *.snap --dangerous --classic
 
     - name: Test bootstrap
       shell: bash
       run: |
         set -euxo pipefail
+        export PATH=/snap/bin:$PATH
         lxc network set lxdbr0 ipv6.address none
         juju bootstrap localhost

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -9,24 +9,32 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        sudo apt-get remove lxd lxd-client
+        sudo apt-get remove --purge lxd lxd-client
+
         sudo snap install snapcraft --classic
         sudo snap install lxd
-        sudo lxd waitready
+
         sudo lxd init --auto
+        sudo lxd waitready
+
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Build snap
       shell: bash
       run: |
         set -euxo pipefail
+        export PATH=/snap/bin:$PATH
         snapcraft --use-lxd
+
     - name: Install snap
       shell: bash
       run: |
         set -euxo pipefail
         sudo snap install *.snap --dangerous --classic
+
     - name: Test bootstrap
       shell: bash
       run: |

--- a/.github/workflows/static-analysis-go-vet.yml
+++ b/.github/workflows/static-analysis-go-vet.yml
@@ -1,9 +1,9 @@
-name: "Go Vet Static Analysis"
+name: "Static Analysis: Go Vet"
 on: [push, pull_request]
 jobs:
 
-  lint-vet:
-    name: Lint Vet
+  lint-go-vet:
+    name: "Lint: Go Vet"
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/static-analysis-go-vet.yml
+++ b/.github/workflows/static-analysis-go-vet.yml
@@ -1,0 +1,39 @@
+name: "Go Vet Static Analysis"
+on: [push, pull_request]
+jobs:
+
+  lint-vet:
+    name: Lint Vet
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Set GOPATH
+      # temporary fix
+      # see https://github.com/actions/setup-go/issues/14
+      run: |
+        echo "##[set-env name=GOPATH;]$GITHUB_WORKSPACE"
+        echo "##[add-path]$GITHUB_WORKSPACE/bin"
+      shell: bash
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/juju/juju
+
+    - name: Install Vendor dependencies
+      working-directory: src/github.com/juju/juju
+      run: |
+        make dep
+      shell: bash
+
+    - name: "Static Analysis: Go Check"
+      working-directory: src/github.com/juju/juju
+      run: |
+        STATIC_ANALYSIS_JOB=test_static_analysis_go_vet make static-analysis
+      shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -101,4 +101,3 @@ jobs:
       run: |
         STATIC_ANALYSIS_JOB=test_schema make static-analysis
       shell: bash
-

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -8,16 +8,6 @@ run_dep_check() {
   fi
 }
 
-run_go_vet() {
-  OUT=$(go vet -composites=false ./... 2>&1 || true)
-  if [ -n "${OUT}" ]; then
-    echo ""
-    echo "$(red 'Found some issues:')"
-    echo "\\n${OUT}" >&2
-    exit 1
-  fi
-}
-
 run_go_lint() {
   OUT=$(golint -set_exit_status ./ 2>&1 || true)
   if [ -n "${OUT}" ]; then
@@ -120,13 +110,7 @@ test_static_analysis_go() {
       run "run_dep_check"
     else
       echo "dep not found, dep static analysis disabled"
-    fi
-
-    ## go vet, if it exists
-    if go help vet >/dev/null 2>&1; then
-      run "run_go_vet" "${FOLDERS}"
-    else
-      echo "vet not found, vet static analysis disabled"
+      exit 1
     fi
 
     ## golint
@@ -134,6 +118,7 @@ test_static_analysis_go() {
       run "run_go_lint"
     else
       echo "golint not found, golint static analysis disabled"
+      exit 1
     fi
 
     ## goimports
@@ -141,6 +126,7 @@ test_static_analysis_go() {
       run "run_go_imports" "${FOLDERS}"
     else
       echo "goimports not found, goimports static analysis disabled"
+      exit 1
     fi
 
     ## deadcode
@@ -148,6 +134,7 @@ test_static_analysis_go() {
       run "run_deadcode"
     else
       echo "deadcode not found, deadcode static analysis disabled"
+      exit 1
     fi
 
     ## misspell
@@ -155,6 +142,7 @@ test_static_analysis_go() {
       run "run_misspell" "${FILES}"
     else
       echo "misspell not found, misspell static analysis disabled"
+      exit 1
     fi
 
     ## unconvert
@@ -162,6 +150,7 @@ test_static_analysis_go() {
       run "run_unconvert"
     else
       echo "unconvert not found, unconvert static analysis disabled"
+      exit 1
     fi
 
     ## ineffassign
@@ -169,6 +158,7 @@ test_static_analysis_go() {
       run "run_ineffassign"
     else
       echo "ineffassign not found, ineffassign static analysis disabled"
+      exit 1
     fi
 
     ## go fmt

--- a/tests/suites/static_analysis/lint_go_vet.sh
+++ b/tests/suites/static_analysis/lint_go_vet.sh
@@ -1,0 +1,37 @@
+run_go_vet() {
+  OUT=$(go vet -composites=false ./... 2>&1 || true)
+  if [ -n "${OUT}" ]; then
+    echo ""
+    echo "$(red 'Found some issues:')"
+    echo "\\n${OUT}" >&2
+    exit 1
+  fi
+}
+
+test_static_analysis_go_vet() {
+  if [ "$(skip 'test_static_analysis_go_vet')" ]; then
+      echo "==> TEST SKIPPED: static go vet analysis"
+      return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    FILES=$(find ./* -name '*.go' -not -name '.#*' -not -name '*_mock.go' | grep -v vendor/ | grep -v acceptancetests/)
+    FOLDERS=$(echo "${FILES}" | sed s/^\.//g | xargs dirname | awk -F "/" '{print $2}' | uniq | sort)
+
+    ## Functions starting by empty line
+    # turned off until we get approval of test suite
+    # run "func vet"
+
+    ## go vet, if it exists
+    if go help vet >/dev/null 2>&1; then
+      run "run_go_vet" "${FOLDERS}"
+    else
+      echo "vet not found, vet static analysis disabled"
+      exit 1
+    fi
+  )
+}

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -8,6 +8,7 @@ test_static_analysis() {
 
     test_copyright
     test_static_analysis_go
+    test_static_analysis_go_vet
     test_static_analysis_shell
     test_static_analysis_python
     test_schema


### PR DESCRIPTION
## Description of change

The issue is that we're running out of swap space when attempting to run
go vet. This seems like a 2.8 (develop) issue over 2.7. Something has
changed in 2.8 that blows the testing/building of juju out of the
water.

We really should investigate this as it's only going to get worse in the
future.
