### PR TITLE
2.7 Acceptance - Do Not Call "status" for Destroyed Models

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -1049,7 +1049,11 @@ class BootstrapManager:
                 with self.client.ignore_soft_deadline():
                     self.client.list_controllers()
                     self.client.list_models()
-                    for m_client in self.client.iter_model_clients():
+
+                    # Only show status for models the backend is tracking.
+                    # This prevents errors attempting to retrieve status for
+                    # models that have been issued a destroy command.
+                    for m_client in self.client._backend.added_models:
                         m_client.show_status()
         finally:
             with self.client.ignore_soft_deadline():


### PR DESCRIPTION
## Description of change

We see errors in acceptance tests from calling `juju status` on models that we have destroyed.

This change ensures that we only call status on models that the back-end is still tracking, rather than simply iterating the controller models, any of which may be in the process of removal.

The back-end stops tracking models that we call `destroy` on, so this change prevents such an error.

## QA steps

`cd acceptancetests && ./assess --juju ~/go/bin/juju --logging-config '<root>=DEBUG' multimodel`

## Documentation changes

None.

## Bug reference

N/A
