### PR TITLE
ignore tests/main.sh output file in static analysis lint checks.

### DIFF
--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -12,7 +12,7 @@ run_whitespace() {
   # Ensure we capture filename.sh and linenumber and nothing else.
   # filename.sh:<linenumber>:filename.sh<error>
   # shellcheck disable=SC2063
-  OUT=$(grep -n -r --include "*.sh" "$(printf '\t')" tests/ | grep -oP "^.*:\d+" || true)
+  OUT=$(grep -n -r --include "*.sh" "$(printf '\t')" tests/ | grep -v "tmp\.*" | grep -oP "^.*:\d+" || true)
   if [ -n "${OUT}" ]; then
     echo ""
     echo "$(red 'Found some issues:')"
@@ -26,7 +26,7 @@ run_trailing_whitespace() {
   # Ensure we capture filename.sh and linenumber and nothing else.
   # filename.sh:<linenumber>:filename.sh<error>
   # shellcheck disable=SC2063
-  OUT=$(grep -n -r --include "*.sh" " $" tests/ | grep -oP "^.*:\d+" || true)
+  OUT=$(grep -n -r --include "*.sh" " $" tests/ | grep -v "tmp\.*" | grep -oP "^.*:\d+" || true)
   if [ -n "${OUT}" ]; then
     echo ""
     echo "$(red 'Found some issues:')"


### PR DESCRIPTION


## Description of change

Ignore tests/tmp* files in checking whitespace.  They are integration test run default output directories.

## QA steps

Run static_analysis twice.
```sh
$ (cd tests ;  ./main.sh -v -s test_static_analysis_go,test_schema static_analysis)
$ (cd tests ;  ./main.sh -v -s test_static_analysis_go,test_schema static_analysis)
```