### PR TITLE
add trusted_bundle.yaml for use by run_deploy_trusted_bundle

### DIFF
--- a/tests/suites/deploy/bundles/trusted_bundle.yaml
+++ b/tests/suites/deploy/bundles/trusted_bundle.yaml
@@ -1,0 +1,5 @@
+applications:
+    trust-checker:
+        charm: cs:~juju-qa/bionic/trust-checker-0
+        num_units: 1
+        trust: true


### PR DESCRIPTION

## Description of change

Fix deploy integration test in 2.7, the bundle was missing for run_deploy_trusted_bundle.

## QA steps
```sh
(cd tests ; ./main.sh -V  -s test_deploy_charms,test_cmr_bundles_export_overlay deploy )
```
