### PR TITLE
Change the default log level to INFO everywhere.

### DIFF
--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -89,7 +89,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			"default-series":            "bionic",
 			"firewall-mode":             "instance",
 			"ssl-hostname-verification": true,
-			"logging-config":            "<root>=DEBUG;unit=DEBUG",
+			"logging-config":            "<root>=DEBUG",
 			"secret":                    "pork",
 			"authorized-keys":           testing.FakeAuthKeys,
 			"type":                      "dummy",

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -519,14 +519,6 @@ func (c *Config) ensureUnitLogging() error {
 			loggingConfig = loggo.LoggerInfo()
 		}
 	}
-	levels, err := loggo.ParseConfigString(loggingConfig)
-	if err != nil {
-		return err
-	}
-	// If there is is no specified level for "unit", then set one.
-	if _, ok := levels["unit"]; !ok {
-		loggingConfig = loggingConfig + ";unit=DEBUG"
-	}
 	c.defined["logging-config"] = loggingConfig
 	return nil
 }

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -799,7 +799,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// These attributes are added if not set.
-	attrs["logging-config"] = "<root>=WARNING;unit=DEBUG"
+	attrs["logging-config"] = "<root>=WARNING"
 
 	// Default firewall mode is instance
 	attrs["firewall-mode"] = string(config.FwInstance)
@@ -1076,7 +1076,7 @@ func (s *ConfigSuite) TestLoggingConfig(c *gc.C) {
 	s.addJujuFiles(c)
 	config := newTestConfig(c, testing.Attrs{
 		"logging-config": "<root>=WARNING;juju=DEBUG"})
-	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=WARNING;juju=DEBUG;unit=DEBUG")
+	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=WARNING;juju=DEBUG")
 }
 
 func (s *ConfigSuite) TestLoggingConfigWithUnit(c *gc.C) {
@@ -1091,7 +1091,7 @@ func (s *ConfigSuite) TestLoggingConfigFromEnvironment(c *gc.C) {
 	s.PatchEnvironment(osenv.JujuLoggingConfigEnvKey, "<root>=INFO")
 
 	config := newTestConfig(c, nil)
-	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=INFO;unit=DEBUG")
+	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=INFO")
 }
 
 func (s *ConfigSuite) TestBackupDir(c *gc.C) {

--- a/featuretests/api_logger_test.go
+++ b/featuretests/api_logger_test.go
@@ -23,7 +23,7 @@ func (s *apiLoggerSuite) TestLoggingConfig(c *gc.C) {
 
 	obtained, err := logging.LoggingConfig(machine.Tag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtained, gc.Equals, "<root>=DEBUG;unit=DEBUG")
+	c.Assert(obtained, gc.Equals, "<root>=DEBUG")
 }
 
 func (s *apiLoggerSuite) TestWatchLoggingConfig(c *gc.C) {

--- a/tests/suites/hooks/dispatch.sh
+++ b/tests/suites/hooks/dispatch.sh
@@ -9,7 +9,7 @@ run_hook_dispatching_script() {
 
     # the log messages the test looks for do not appear if root
     # log level is WARNING.
-    juju model-config logging-config="<root>=INFO;unit=DEBUG"
+    juju model-config logging-config="<root>=INFO"
 
     juju deploy cs:~juju-qa/bionic/ubuntu-plus-0
     wait_for "ubuntu-plus" "$(idle_condition "ubuntu-plus")"

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -296,7 +296,7 @@ func (s *WorkerSuite) TestModelConfigChange(c *gc.C) {
 	c.Logf("\nupdating status\n\n")
 
 	// Add a different logging config value.
-	expected := "juju=INFO;missing=DEBUG;unit=DEBUG"
+	expected := "juju=INFO;missing=DEBUG"
 	err = model.UpdateModelConfig(map[string]interface{}{
 		"logging-config": expected,
 	}, nil)


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Rather than being unit=DEBUG, let operators set DEBUG if they really
want it. We don't seem to have any log messages that we generate that
should be INFO instead of DEBUG.

## QA steps

```sh
$ juju bootstrap lxd lxd
$ juju model-config logging-config
<root>=INFO
$ juju model-config logging-config=DEBUG
$ juju model-config logging-config
<root>=DEBUG
```

Previously we would always tack on "unit=DEBUG" if unit was not set.

## Documentation changes

I don't think we explicitly document that unit=DEBUG is default, though we could add an item to the 2.8 patch notes that say we are removing the unit=DEBUG default.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1874000