### PR TITLE
Add GetByCIDR method to SubnetInfos

### DIFF
--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -165,6 +165,22 @@ func (s SubnetInfos) GetByUnderlayCIDR(cidr string) (SubnetInfos, error) {
 	return overlays, nil
 }
 
+// GetByCIDR returns all subnets in the collection
+// with a CIDR matching the input.
+func (s SubnetInfos) GetByCIDR(cidr string) (SubnetInfos, error) {
+	if !IsValidCIDR(cidr) {
+		return nil, errors.NotValidf("CIDR %q", cidr)
+	}
+
+	var matching SubnetInfos
+	for _, sub := range s {
+		if sub.CIDR == cidr {
+			matching = append(matching, sub)
+		}
+	}
+	return matching, nil
+}
+
 // EqualTo returns true if this slice of SubnetInfo is equal to the input.
 func (s SubnetInfos) EqualTo(other SubnetInfos) bool {
 	if len(s) != len(other) {

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -176,3 +176,22 @@ func (*subnetSuite) TestSubnetInfosGetByUnderLayCIDR(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(overlays, gc.HasLen, 0)
 }
+
+func (*subnetSuite) TestSubnetInfosGetByCIDR(c *gc.C) {
+	s := network.SubnetInfos{
+		{ID: "1", CIDR: "10.10.10.0/24", ProviderId: "1"},
+		{ID: "2", CIDR: "10.10.10.0/24", ProviderId: "2"},
+		{ID: "3", CIDR: "20.20.20.0/24"},
+	}
+
+	_, err := s.GetByCIDR("invalid")
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+
+	subs, err := s.GetByCIDR("30.30.30.0/24")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subs, gc.HasLen, 0)
+
+	subs, err = s.GetByCIDR("10.10.10.0/24")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subs, gc.DeepEquals, s[:2])
+}


### PR DESCRIPTION
## Description of change

Adds GetByCIDR method to SubnetInfos, returning all from the collection that match the input CIDR.

Note that for future multi-network compatibility, multiple subnets may be returned.

## QA steps

Run the unit tests in `core/network`.
