### PR TITLE
Add HasResources attr for k8s apps to model export format

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -485,11 +485,11 @@
   revision = "9be91dc79b7c185fa8b08e7ceceee40562055c83"
 
 [[projects]]
-  digest = "1:c6afb3b8e5f596b1f88e5e604d8afb951cfb4553ef4008c976c8bf3a7e805e98"
+  digest = "1:458304cdbea3f8a25008a08603375b42aab2444dc8f1d2e35dfc550dc892c8f8"
   name = "github.com/juju/description"
   packages = ["."]
   pruneopts = ""
-  revision = "cb183d728f9d6dc45b78ad38cbbf39e06144f9b6"
+  revision = "f165dd5374c290d2b5453a7908b78c196139e916"
 
 [[projects]]
   digest = "1:e0275dd405fa814d870a8039712ca66c110718b653e864e2e96c65acb481d8a1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
   name = "github.com/juju/bundlechanges"
 
 [[constraint]]
-  revision = "cb183d728f9d6dc45b78ad38cbbf39e06144f9b6"
+  revision = "f165dd5374c290d2b5453a7908b78c196139e916"
   name = "github.com/juju/description"
 
 [[constraint]]

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -812,6 +812,7 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		Exposed:              application.doc.Exposed,
 		PasswordHash:         application.doc.PasswordHash,
 		Placement:            application.doc.Placement,
+		HasResources:         application.doc.HasResources,
 		DesiredScale:         application.doc.DesiredScale,
 		MinUnits:             application.doc.MinUnits,
 		EndpointBindings:     map[string]string(ctx.endpoingBindings[globalKey]),

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -537,6 +537,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 		c.Assert(exported.CloudService().ProviderId(), gc.Equals, "provider-id")
 		c.Assert(exported.DesiredScale(), gc.Equals, 3)
 		c.Assert(exported.Placement(), gc.Equals, "")
+		c.Assert(exported.HasResources(), jc.IsTrue)
 		addresses := exported.CloudService().Addresses()
 		addr := addresses[0]
 		c.Assert(addr.Value(), gc.Equals, "192.168.1.1")

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1247,8 +1247,7 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 		MetricCredentials:    a.MetricsCredentials(),
 		DesiredScale:         a.DesiredScale(),
 		Placement:            a.Placement(),
-		// TODO(caas)
-		HasResources: i.model.Type() == description.CAAS,
+		HasResources:         a.HasResources(),
 	}, nil
 }
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -708,6 +708,7 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	c.Assert(cloudService.Addresses(), jc.DeepEquals, network.SpaceAddresses{addr})
 	c.Assert(newApp.GetScale(), gc.Equals, 3)
 	c.Assert(newApp.GetPlacement(), gc.Equals, "")
+	c.Assert(state.GetApplicationHasResources(newApp), jc.IsTrue)
 }
 
 func (s *MigrationImportSuite) TestCAASApplicationStatus(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -398,8 +398,6 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		// RelationCount is handled by the number of times the application name
 		// appears in relation endpoints.
 		"RelationCount",
-		// TODO(caas)
-		"HasResources",
 	)
 	migrated := set.NewStrings(
 		"Name",
@@ -416,6 +414,7 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		"Tools",
 		"DesiredScale",
 		"Placement",
+		"HasResources",
 	)
 	s.AssertExportedFields(c, applicationDoc{}, migrated.Union(ignored))
 }


### PR DESCRIPTION
## Description of change

k8s apps have a new HasResources attribute.
This PR adds the attribute to the model export format.

## QA steps

deploy a k8s charm
juju dump-model

check that has-resources is true.

Testing migration failed due to a new, unrelated controller tag related error. Will be fixed separately.