### PR TITLE
Prevent builds on draft PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ jobs:
   linux-amd64:
     name: linux-amd64
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: Set up Go 1.10
       uses: actions/setup-go@v1
@@ -30,9 +31,11 @@ jobs:
       working-directory: src/github.com/juju/juju
       run: |
         GOOS=linux GOARCH=amd64 make go-install
+
   linux-arm64:
     name: linux-arm64
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: Set up Go 1.10
       uses: actions/setup-go@v1
@@ -59,9 +62,11 @@ jobs:
       working-directory: src/github.com/juju/juju
       run: |
         GOOS=linux GOARCH=arm64 make go-install
+
   linux-s390x:
     name: linux-s390x
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: Set up Go 1.10
       uses: actions/setup-go@v1
@@ -88,9 +93,11 @@ jobs:
       working-directory: src/github.com/juju/juju
       run: |
         GOOS=linux GOARCH=s390x make go-install
+
   linux-ppc64le:
     name: linux-ppc64le
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: Set up Go 1.10
       uses: actions/setup-go@v1
@@ -117,9 +124,11 @@ jobs:
       working-directory: src/github.com/juju/juju
       run: |
         GOOS=linux GOARCH=ppc64le make go-install
+
   windows-amd64:
     name: windows-amd64
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: Set up Go 1.10
       uses: actions/setup-go@v1
@@ -146,9 +155,11 @@ jobs:
       working-directory: src/github.com/juju/juju
       run: |
         GOOS=windows GOARCH=amd64 make go-install
+
   darwin-amd64:
     name: darwin-amd64
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: Set up Go 1.10
       uses: actions/setup-go@v1

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -5,6 +5,7 @@ jobs:
   test-client-ubuntu:
     name: "Client Tests"
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -4,6 +4,7 @@ jobs:
   snap:
     name: linux-amd64
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: Install Dependencies
       shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,6 +5,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
 
     - name: Set up Go 1.12
@@ -69,6 +70,7 @@ jobs:
   schema:
     name: Schema
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
 
     - name: Set up Go 1.12


### PR DESCRIPTION
## Description of change

The following adds a config to prevent the building of PRs on the draft type.

It's a shame you have `on: [push, pull_request]`, when in fact you really
want `on: [pull_request_init, pull_request_push]`.

Ah well.


## QA steps

See that it runs.

