### PR TITLE
Introduce origin to network interface info

### DIFF
--- a/api/common/network.go
+++ b/api/common/network.go
@@ -108,7 +108,7 @@ func GetObservedNetworkConfig(source NetworkConfigSource) ([]params.NetworkConfi
 	sysClassNetPath := source.SysClassNetPath()
 	for _, nic := range interfaces {
 		nicType := network.ParseInterfaceType(sysClassNetPath, nic.Name)
-		nicConfig := interfaceToNetworkConfig(nic, nicType)
+		nicConfig := interfaceToNetworkConfig(nic, nicType, corenetwork.OriginMachine)
 		if nicConfig.InterfaceName == defaultRouteDevice {
 			nicConfig.IsDefaultGateway = true
 			nicConfig.GatewayAddress = defaultRoute.String()
@@ -168,7 +168,10 @@ func GetObservedNetworkConfig(source NetworkConfigSource) ([]params.NetworkConfi
 	return observedConfig, nil
 }
 
-func interfaceToNetworkConfig(nic net.Interface, nicType corenetwork.InterfaceType) params.NetworkConfig {
+func interfaceToNetworkConfig(nic net.Interface,
+	nicType corenetwork.InterfaceType,
+	networkOrigin corenetwork.Origin,
+) params.NetworkConfig {
 	configType := corenetwork.ConfigManual // assume manual initially, until we parse the address.
 	isUp := nic.Flags&net.FlagUp > 0
 	isLoopback := nic.Flags&net.FlagLoopback > 0
@@ -191,6 +194,7 @@ func interfaceToNetworkConfig(nic net.Interface, nicType corenetwork.InterfaceTy
 		InterfaceType: string(nicType),
 		NoAutoStart:   !isUp,
 		Disabled:      !isUp,
+		NetworkOrigin: params.NetworkOrigin(networkOrigin),
 	}
 }
 

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -217,6 +217,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigNoInterfaceAddresses(c *gc.C)
 		InterfaceName: "br-eth1",
 		InterfaceType: "bridge",
 		ConfigType:    "manual",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -237,6 +238,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigLoopbackInferred(c *gc.C) {
 		InterfaceName: "lo",
 		InterfaceType: "loopback", // inferred from the flags.
 		ConfigType:    "loopback", // since it is a loopback
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:   1,
 		CIDR:          "::1/128",
@@ -245,6 +247,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigLoopbackInferred(c *gc.C) {
 		InterfaceName: "lo",
 		InterfaceType: "loopback",
 		ConfigType:    "loopback",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -270,6 +273,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 		InterfaceName: "eth0.100",
 		InterfaceType: "802.1q",
 		ConfigType:    "manual", // the IPv6 address treated as empty.
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:   13,
 		CIDR:          "10.100.19.0/24",
@@ -279,6 +283,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 		InterfaceName: "eth0.100",
 		InterfaceType: "802.1q",
 		ConfigType:    "static",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -298,6 +303,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigEthernetInfrerred(c *gc.C) {
 		InterfaceName: "eth0",
 		InterfaceType: "ethernet",
 		ConfigType:    "manual", // the IPv6 address treated as empty.
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -323,6 +329,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceType:       "ethernet",
 		ParentInterfaceName: "br-eth0",
 		ConfigType:          "manual",
+		NetworkOrigin:       params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:   10,
 		CIDR:          "10.20.19.0/24",
@@ -332,6 +339,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth0",
 		InterfaceType: "bridge",
 		ConfigType:    "static",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:   10,
 		CIDR:          "10.20.19.0/24",
@@ -341,6 +349,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth0",
 		InterfaceType: "bridge",
 		ConfigType:    "static",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:   10,
 		MACAddress:    "aa:bb:cc:dd:ee:f0",
@@ -348,6 +357,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth0",
 		InterfaceType: "bridge",
 		ConfigType:    "manual",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:   11,
 		CIDR:          "10.20.19.0/24",
@@ -357,6 +367,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth1",
 		InterfaceType: "bridge",
 		ConfigType:    "static",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:   11,
 		MACAddress:    "aa:bb:cc:dd:ee:f1",
@@ -364,6 +375,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth1",
 		InterfaceType: "bridge",
 		ConfigType:    "manual",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}, {
 		DeviceIndex:         3,
 		MACAddress:          "aa:bb:cc:dd:ee:f1",
@@ -374,6 +386,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		ConfigType:          "manual",
 		GatewayAddress:      "1.2.3.4",
 		IsDefaultGateway:    true,
+		NetworkOrigin:       params.NetworkOrigin("machine"),
 	}})
 
 	s.stubConfigSource.CheckCallNames(c,
@@ -410,6 +423,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigAddressNotInCIDRFormat(c *gc.
 		InterfaceName: "eth0",
 		InterfaceType: "ethernet",
 		ConfigType:    "static",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -432,6 +446,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigEmptyAddressValue(c *gc.C) {
 		InterfaceName: "eth0",
 		InterfaceType: "ethernet",
 		ConfigType:    "manual",
+		NetworkOrigin: params.NetworkOrigin("machine"),
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -263,8 +263,9 @@ func (st *State) GetContainerInterfaceInfo(containerTag names.MachineTag) ([]cor
 // the method and the network.InterfaceInfo type to be called
 // InterfaceConfig.
 func (st *State) prepareOrGetContainerInterfaceInfo(
-	containerTag names.MachineTag, allocateNewAddress bool) (
-	[]corenetwork.InterfaceInfo, error) {
+	containerTag names.MachineTag,
+	allocateNewAddress bool,
+) ([]corenetwork.InterfaceInfo, error) {
 	var result params.MachineNetworkConfigResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: containerTag.String()}},

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -224,9 +224,9 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 }
 
 func (api *NetworkConfigAPI) setLinkLayerDevicesAndAddresses(
-	m *state.Machine, ifaces []network.InterfaceInfo,
+	m *state.Machine, interfaceInfos []network.InterfaceInfo,
 ) error {
-	devicesArgs, devicesAddrs := NetworkInterfacesToStateArgs(ifaces)
+	devicesArgs, devicesAddrs := NetworkInterfacesToStateArgs(interfaceInfos)
 
 	logger.Debugf("setting devices: %+v", devicesArgs)
 	if err := m.SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs); err != nil {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -18380,6 +18380,9 @@
                         "no-auto-start": {
                             "type": "boolean"
                         },
+                        "origin": {
+                            "type": "string"
+                        },
                         "parent-interface-name": {
                             "type": "string"
                         },
@@ -21442,6 +21445,9 @@
                         },
                         "no-auto-start": {
                             "type": "boolean"
+                        },
+                        "origin": {
+                            "type": "string"
                         },
                         "parent-interface-name": {
                             "type": "string"
@@ -27828,6 +27834,9 @@
                         },
                         "no-auto-start": {
                             "type": "boolean"
+                        },
+                        "origin": {
+                            "type": "string"
                         },
                         "parent-interface-name": {
                             "type": "string"

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -69,6 +69,10 @@ type NetworkRoute struct {
 	Metric int `json:"metric"`
 }
 
+// NetworkOrigin specifies where an address comes from, whether it was reported
+// by a provider or by a machine.
+type NetworkOrigin string
+
 // NetworkConfig describes the necessary information to configure
 // a single network interface on a machine. This mostly duplicates
 // network.InterfaceInfo type and it's defined here so it can be kept
@@ -185,6 +189,13 @@ type NetworkConfig struct {
 
 	// IsDefaultGateway marks an interface that is a default gateway for a machine.
 	IsDefaultGateway bool `json:"is-default-gateway,omitempty"`
+
+	// NetworkOrigin represents the authoritative source of the NetworkConfig.
+	// It is expected that either the provider gave us this info or the
+	// machine gave us this info.
+	// Giving us this information allows us to reason about when a InterfaceInfo
+	// is in use.
+	NetworkOrigin NetworkOrigin `json:"origin,omitempty"`
 }
 
 // NetworkConfigFromInterfaceInfo converts a slice of network.InterfaceInfo into
@@ -234,6 +245,7 @@ func NetworkConfigFromInterfaceInfo(interfaceInfos []network.InterfaceInfo) []Ne
 			GatewayAddress:   v.GatewayAddress.Value,
 			Routes:           routes,
 			IsDefaultGateway: v.IsDefaultGateway,
+			NetworkOrigin:    NetworkOrigin(v.Origin),
 		}
 	}
 	return result
@@ -278,6 +290,7 @@ func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) []network.Interface
 			GatewayAddress:      network.NewProviderAddress(v.GatewayAddress),
 			Routes:              routes,
 			IsDefaultGateway:    v.IsDefaultGateway,
+			Origin:              network.Origin(v.NetworkOrigin),
 		}
 
 		// Compatibility layer for older clients that do not populate

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -433,6 +433,7 @@ func InterfaceInfoFromDevices(nics map[string]device) ([]corenetwork.InterfaceIn
 			ParentInterfaceName: device["parent"],
 			MACAddress:          device["hwaddr"],
 			ConfigType:          corenetwork.ConfigDHCP,
+			Origin:              corenetwork.OriginProvider,
 		}
 		if device["mtu"] != "" {
 			mtu, err := strconv.Atoi(device["mtu"])

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -376,12 +376,14 @@ func (s *networkSuite) TestInterfaceInfoFromDevices(c *gc.C) {
 			MACAddress:          "00:16:3e:00:00:3e",
 			ConfigType:          corenetwork.ConfigDHCP,
 			ParentInterfaceName: "br1",
+			Origin:              corenetwork.OriginProvider,
 		},
 		{
 			InterfaceName:       "eth0",
 			MACAddress:          "00:16:3e:00:00:00",
 			ConfigType:          corenetwork.ConfigDHCP,
 			ParentInterfaceName: network.DefaultLXDBridge,
+			Origin:              corenetwork.OriginProvider,
 		},
 	}
 	c.Check(info, jc.DeepEquals, exp)

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -182,6 +182,13 @@ type InterfaceInfo struct {
 
 	// IsDefaultGateway is set if this device is a default gw on a machine.
 	IsDefaultGateway bool
+
+	// Origin represents the authoritative source of the InterfaceInfo.
+	// It is expected that either the provider gave us this info or the
+	// machine gave us this info.
+	// Giving us this information allows us to reason about when a InterfaceInfo
+	// is in use.
+	Origin Origin
 }
 
 type interfaceInfoSlice []InterfaceInfo

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1473,6 +1473,7 @@ func (env *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []ins
 				GatewayAddress: corenetwork.NewProviderAddress(
 					fmt.Sprintf("0.%d.0.1", (i+1)*10+idIndex),
 				),
+				Origin: corenetwork.OriginProvider,
 			}
 		}
 

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -253,6 +253,7 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.10.0.2")},
 		DNSServers:       corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
 		GatewayAddress:   corenetwork.NewProviderAddress("0.10.0.1"),
+		Origin:           corenetwork.OriginProvider,
 	}, {
 		ProviderId:       "dummy-eth1",
 		ProviderSubnetId: "dummy-public",
@@ -268,6 +269,7 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.20.0.2")},
 		DNSServers:       corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
 		GatewayAddress:   corenetwork.NewProviderAddress("0.20.0.1"),
+		Origin:           corenetwork.OriginProvider,
 	}, {
 		ProviderId:       "dummy-eth2",
 		ProviderSubnetId: "dummy-disabled",
@@ -283,6 +285,7 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.30.0.2")},
 		DNSServers:       corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
 		GatewayAddress:   corenetwork.NewProviderAddress("0.30.0.1"),
+		Origin:           corenetwork.OriginProvider,
 	}}
 	infoList, err := e.NetworkInterfaces(s.callCtx, []instance.Id{instance.Id("i-42")})
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1192,6 +1192,7 @@ func mapNetworkInterface(iface ec2.NetworkInterface, subnet ec2.Subnet) corenetw
 		Addresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress(iface.PrivateIPAddress, corenetwork.ScopeCloudLocal),
 		},
+		Origin: corenetwork.OriginProvider,
 	}
 
 	for _, privAddr := range iface.PrivateIPs {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1719,6 +1719,7 @@ func (t *localServerSuite) assertInterfaceLooksValid(c *gc.C, expIfaceID, expDev
 			),
 		},
 		AvailabilityZones: zones,
+		Origin:            corenetwork.OriginProvider,
 	}
 	c.Assert(iface, gc.DeepEquals, expectedInterface)
 }

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -223,6 +223,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 				Disabled:        false,
 				NoAutoStart:     false,
 				ConfigType:      corenetwork.ConfigDHCP,
+				Origin:          corenetwork.OriginProvider,
 			})
 		}
 	}

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -217,6 +217,7 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 		Addresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
 		},
+		Origin: corenetwork.OriginProvider,
 	}})
 }
 
@@ -302,6 +303,7 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		Addresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
 		},
+		Origin: corenetwork.OriginProvider,
 	}})
 
 	// Check interfaces for second instance
@@ -324,6 +326,7 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
 		},
+		Origin: corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		CIDR:              "10.0.20.0/24",
@@ -339,6 +342,7 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		Addresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("10.0.20.42", corenetwork.ScopeCloudLocal),
 		},
+		Origin: corenetwork.OriginProvider,
 	}})
 }
 
@@ -368,6 +372,7 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 		Addresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
 		},
+		Origin: corenetwork.OriginProvider,
 	}})
 
 	// Check that the slot for the second instance is nil
@@ -413,6 +418,7 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		Addresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
 		},
+		Origin: corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		CIDR:              "10.0.20.0/24",
@@ -431,6 +437,7 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
 		},
+		Origin: corenetwork.OriginProvider,
 	}})
 }
 
@@ -475,6 +482,7 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
 		},
+		Origin: corenetwork.OriginProvider,
 	}})
 }
 
@@ -517,6 +525,7 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		Addresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
 		},
+		Origin: corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		CIDR:              "10.0.10.0/24",
@@ -535,5 +544,6 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
 		},
+		Origin: corenetwork.OriginProvider,
 	}})
 }

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -205,6 +205,7 @@ func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentNa
 			Disabled:            !nic.Enabled,
 			NoAutoStart:         !nic.Enabled,
 			ParentInterfaceName: nameToParentName[nic.Name],
+			Origin:              corenetwork.OriginProvider,
 		}
 
 		if len(nic.Links) == 0 {
@@ -282,6 +283,7 @@ func (env *maasEnviron) deviceInterfaceInfo2(
 			Disabled:            !nic.Enabled(),
 			NoAutoStart:         !nic.Enabled(),
 			ParentInterfaceName: nameToParentName[nic.Name()],
+			Origin:              corenetwork.OriginProvider,
 		}
 		for _, link := range nic.Links() {
 			subnet := link.Subnet()

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -236,6 +236,7 @@ func maasObjectNetworkInterfaces(
 			ParentInterfaceName: parentName,
 			Disabled:            !iface.Enabled,
 			NoAutoStart:         !iface.Enabled,
+			Origin:              corenetwork.OriginProvider,
 		}
 
 		if len(iface.Links) == 0 {
@@ -357,6 +358,7 @@ func maas2NetworkInterfaces(
 			ParentInterfaceName: parentName,
 			Disabled:            !iface.Enabled(),
 			NoAutoStart:         !iface.Enabled(),
+			Origin:              corenetwork.OriginProvider,
 		}
 
 		if len(iface.Links()) == 0 {

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -436,6 +436,7 @@ var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
 	DNSSearchDomains:  nil,
 	MTU:               1500,
 	GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
+	Origin:            corenetwork.OriginProvider,
 }, {
 	DeviceIndex:       0,
 	MACAddress:        "52:54:00:70:9b:fe",
@@ -456,6 +457,7 @@ var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
 	DNSSearchDomains:  nil,
 	MTU:               1500,
 	GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
+	Origin:            corenetwork.OriginProvider,
 }, {
 	DeviceIndex:         1,
 	MACAddress:          "52:54:00:70:9b:fe",
@@ -477,6 +479,7 @@ var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
 	DNSSearchDomains:    nil,
 	MTU:                 1500,
 	GatewayAddress:      corenetwork.NewProviderAddressInSpace("admin", "10.50.19.2"),
+	Origin:              corenetwork.OriginProvider,
 }, {
 	DeviceIndex:         2,
 	MACAddress:          "52:54:00:70:9b:fe",
@@ -498,6 +501,7 @@ var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
 	DNSSearchDomains:    nil,
 	MTU:                 1500,
 	GatewayAddress:      corenetwork.NewProviderAddressInSpace("public", "10.100.19.2"),
+	Origin:              corenetwork.OriginProvider,
 }, {
 	DeviceIndex:         3,
 	MACAddress:          "52:54:00:70:9b:fe",
@@ -520,6 +524,7 @@ var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
 	DNSSearchDomains:    nil,
 	MTU:                 1500,
 	GatewayAddress:      newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
+	Origin:              corenetwork.OriginProvider,
 }, {
 	DeviceIndex:         4,
 	MACAddress:          "52:54:00:08:24:2d",
@@ -539,6 +544,7 @@ var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
 	DNSServers:          nil,
 	DNSSearchDomains:    nil,
 	MTU:                 0,
+	Origin:              corenetwork.OriginProvider,
 }, {
 	DeviceIndex:         5,
 	MACAddress:          "52:54:00:08:24:2d",
@@ -561,6 +567,7 @@ var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
 	DNSSearchDomains:    nil,
 	MTU:                 1500,
 	GatewayAddress:      newAddressOnSpaceWithId("space-0", "4", "192.168.20.2"),
+	Origin:              corenetwork.OriginProvider,
 }}
 
 func (s *interfacesSuite) TestParseInterfacesNoJSON(c *gc.C) {
@@ -954,6 +961,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:  nil,
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:            corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
@@ -974,6 +982,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:  nil,
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:            corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:         1,
 		MACAddress:          "52:54:00:70:9b:fe",
@@ -995,6 +1004,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:    nil,
 		MTU:                 1500,
 		GatewayAddress:      corenetwork.NewProviderAddressInSpace("admin", "10.50.19.2"),
+		Origin:              corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:         2,
 		MACAddress:          "52:54:00:70:9b:fe",
@@ -1016,6 +1026,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:    nil,
 		MTU:                 1500,
 		GatewayAddress:      corenetwork.NewProviderAddressInSpace("public", "10.100.19.2"),
+		Origin:              corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:         3,
 		MACAddress:          "52:54:00:70:9b:fe",
@@ -1038,6 +1049,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:    nil,
 		MTU:                 1500,
 		GatewayAddress:      newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
+		Origin:              corenetwork.OriginProvider,
 	}}
 	machine := &fakeMachine{interfaceSet: exampleInterfaces}
 	instance := &maas2Instance{machine: machine}
@@ -1104,6 +1116,7 @@ func (s *interfacesSuite) TestMAAS2InterfacesNilVLAN(c *gc.C) {
 		DNSSearchDomains:  nil,
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:            corenetwork.OriginProvider,
 	}}
 
 	infos, err := maas2NetworkInterfaces(s.callCtx, instance, map[string]corenetwork.Id{})

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1002,6 +1002,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:  nil,
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:            corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
@@ -1022,6 +1023,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:  nil,
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:            corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:         1,
 		MACAddress:          "52:54:00:70:9b:fe",
@@ -1043,8 +1045,8 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		DNSSearchDomains:    nil,
 		MTU:                 1500,
 		GatewayAddress:      corenetwork.NewProviderAddressInSpace("admin", "10.50.19.2"),
-	},
-	}
+		Origin:              corenetwork.OriginProvider,
+	}}
 	c.Assert(result.NetworkInfo, jc.DeepEquals, expected)
 }
 
@@ -1178,6 +1180,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 			GatewayIP:       "192.168.1.1",
 			Metric:          100,
 		}},
+		Origin: corenetwork.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -1303,6 +1306,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.2"),
 		Routes:            []corenetwork.Route{},
+		Origin:            corenetwork.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -1542,6 +1546,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		DNSServers:        corenetwork.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.2"),
+		Origin:            corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		MACAddress:        "52:54:00:70:9b:f4",
@@ -1562,6 +1567,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 			GatewayIP:       "192.168.1.1",
 			Metric:          100,
 		}},
+		Origin: corenetwork.OriginProvider,
 	}}
 	ignored := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
@@ -1767,6 +1773,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		NoAutoStart:    false,
 		ConfigType:     "manual",
 		MTU:            1500,
+		Origin:         corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:    1,
 		MACAddress:     "53:54:00:70:9b:f1",
@@ -1779,6 +1786,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		NoAutoStart:    false,
 		ConfigType:     "manual",
 		MTU:            1500,
+		Origin:         corenetwork.OriginProvider,
 	}})
 }
 
@@ -1999,6 +2007,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("space-1", "10.20.19.2"),
 		Routes:            []corenetwork.Route{},
+		Origin:            corenetwork.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -2198,6 +2207,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.2"),
 		Routes:            []corenetwork.Route{},
+		Origin:            corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		MACAddress:        "53:54:00:70:88:bb",
@@ -2215,6 +2225,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		MTU:               1500,
 		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "192.168.1.1"),
 		Routes:            []corenetwork.Route{},
+		Origin:            corenetwork.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -1102,6 +1102,7 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 			InterfaceType:    corenetwork.EthernetInterface,
 			ProviderSubnetId: corenetwork.Id(*iface.Vnic.SubnetId),
 			CIDR:             *subnet.CidrBlock,
+			Origin:           corenetwork.OriginProvider,
 		}
 		if iface.Vnic.PublicIp != nil {
 			nic.ShadowAddresses = append(nic.ShadowAddresses,

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1442,6 +1442,7 @@ func (e *Environ) networksForInstance(
 			MACAddress:    port.MACAddress,
 			Addresses:     corenetwork.NewProviderAddresses(ips...),
 			ConfigType:    corenetwork.ConfigDHCP,
+			Origin:        corenetwork.OriginProvider,
 		}
 	}
 

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -879,6 +879,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 		MACAddress:    "mac-address",
 		Addresses:     corenetwork.NewProviderAddresses("10.10.10.1"),
 		ConfigType:    corenetwork.ConfigDHCP,
+		Origin:        corenetwork.OriginProvider,
 	}}).Return(nil)
 
 	siParams := environs.StartInstanceParams{

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -227,6 +227,7 @@ func (e Environ) networkInterfacesForInstance(ctx context.ProviderCallContext, i
 				corenetwork.NewScopedProviderAddress(ip, corenetwork.ScopeCloudLocal),
 			},
 			InterfaceType: corenetwork.EthernetInterface,
+			Origin:        corenetwork.OriginProvider,
 		}
 
 		for _, ipAssocName := range deviceAttributes.Ipassociations {

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -155,6 +155,7 @@ func (env *sessionEnviron) newRawInstance(
 		MACAddress:    internalMac,
 		InterfaceType: corenetwork.EthernetInterface,
 		ConfigType:    corenetwork.ConfigDHCP,
+		Origin:        corenetwork.OriginProvider,
 	}}
 	networkDevices := []vsphereclient.NetworkDevice{{MAC: internalMac, Network: env.ecfg.primaryNetwork()}}
 
@@ -171,6 +172,7 @@ func (env *sessionEnviron) newRawInstance(
 			MACAddress:    externalMac,
 			InterfaceType: corenetwork.EthernetInterface,
 			ConfigType:    corenetwork.ConfigDHCP,
+			Origin:        corenetwork.OriginProvider,
 		})
 		networkDevices = append(networkDevices, vsphereclient.NetworkDevice{MAC: externalMac, Network: externalNetwork})
 	}


### PR DESCRIPTION
## Description of change

In order to propagate network.Origin throughout we need to propagate the
origin via the api server. To do this correctly means updating all the
call sites to spit out the origin. That way we can then consume the
interface info correctly for further processing.

## QA steps

Tests pass, this is a mechanical change.

