### PR TITLE
Increase log level so test can find Info log

### DIFF
--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -6,6 +6,10 @@ run_start_hook_fires_after_reboot() {
 
     ensure "${model_name}" "${file}"
 
+    # the log messages the test looks for do not appear if root
+    # log level is WARNING.
+    juju model-config -m "${model_name}" logging-config="<root>=INFO;unit=DEBUG"
+
     juju deploy cs:~jameinel/ubuntu-lite-7
     wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 


### PR DESCRIPTION

## Description of change

Default root logging level for models other than controller and default is Warning.  Log messages looked for by the run-start-hook-fires-after-reboot, won't be found without a min level of Info.

## QA steps

```sh
(cd tests ;  ./main.sh -V -s test_dispatching_script hooks)
```
