### PR TITLE
Ensure resource gets support controller agent tags

### DIFF
--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -48,7 +48,7 @@ type ResourcesHandler struct {
 
 // ServeHTTP implements http.Handler.
 func (h *ResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	backend, poolhelper, tag, err := h.StateAuthFunc(req, names.UserTagKind, names.MachineTagKind, names.ApplicationTagKind)
+	backend, poolhelper, tag, err := h.StateAuthFunc(req, names.UserTagKind, names.MachineTagKind, names.ControllerAgentTagKind, names.ApplicationTagKind)
 	if err != nil {
 		api.SendHTTPError(resp, err)
 		return


### PR DESCRIPTION
## Description of change

The http endpoint to fetch resources did not support controller agent tags.
This prevented k8s model migrations from working.

## QA steps

migrate a k8s model with a k8s charm deployed

## Bug reference

https://bugs.launchpad.net/juju/+bug/1874033
