### PR TITLE
Fixes watcher issuer with controller brokers.

### DIFF
--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -219,8 +219,8 @@ func (s *BaseSuite) setupBroker(c *gc.C, ctrl *gomock.Controller,
 		})
 
 	var err error
-	s.broker, err = provider.NewK8sBroker(testing.ControllerTag.Id(), s.k8sRestConfig, s.cfg, newK8sRestClientFunc,
-		watcherFn, stringsWatcherFn, randomPrefixFunc, s.clock)
+	s.broker, err = provider.NewK8sBroker(testing.ControllerTag.Id(), s.k8sRestConfig, s.cfg, s.getNamespace(),
+		newK8sRestClientFunc, watcherFn, stringsWatcherFn, randomPrefixFunc, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	return ctrl
 }

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -28,7 +28,6 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
-	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/mongo"
 )
 
@@ -121,10 +120,7 @@ type controllerStacker interface {
 	Deploy() error
 }
 
-func controllerCorelation(broker *kubernetesClient) (*kubernetesClient, error) {
-	if broker.Config().Name() != environsbootstrap.ControllerModelName {
-		return broker, nil
-	}
+func controllerCorelation(broker *kubernetesClient) (string, error) {
 	// ensure controller specific annotations.
 	_ = broker.addAnnotations(annotationControllerIsControllerKey, "true")
 
@@ -133,16 +129,12 @@ func controllerCorelation(broker *kubernetesClient) (*kubernetesClient, error) {
 		// No existing controller found on the cluster.
 		// A controller must be bootstrapping now.
 		// It will reply on setControllerNamespace in controller stack to set namespace name.
-		return broker, nil
+		return "", errors.NewNotFound(err, "controller")
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return "", errors.Trace(err)
 	}
-	// This is an existing controller.
-	// Now, link it back.
-	// It should be always one record here based on current annotation design.
-	broker.SetNamespace(ns[0].GetName())
-	return broker, nil
+	return ns[0].GetName(), nil
 }
 
 // DecideControllerNamespace decides the namespace name to use for a new controller.

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -116,7 +116,7 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 		"juju.io/is-controller": "true",
 	})
 
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller")
+	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, s.getNamespace())
 	c.Assert(s.broker.GetAnnotations().ToMap(), jc.DeepEquals, map[string]string{
 		"juju.io/model":      s.cfg.UUID(),
 		"juju.io/controller": testing.ControllerTag.Id(),
@@ -126,8 +126,7 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 		s.mockNamespaces.EXPECT().List(v1.ListOptions{}).
 			Return(&core.NamespaceList{Items: []core.Namespace{existingNs}}, nil),
 	)
-	var err error
-	s.broker, err = provider.ControllerCorelation(s.broker)
+	ns, err := provider.ControllerCorelation(s.broker)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(
@@ -140,7 +139,7 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 		},
 	)
 	// controller namespace linked back(changed from 'controller' to 'controller-1')
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller-1")
+	c.Assert(ns, jc.DeepEquals, "controller-1")
 }
 
 func (s *bootstrapSuite) TestGetControllerSvcSpec(c *gc.C) {
@@ -189,9 +188,10 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	randomPrefixFunc := func() (string, error) {
 		return "appuuid", nil
 	}
+	s.namespace = "controller-1"
 	s.setupBroker(c, ctrl, newK8sRestClientFunc, randomPrefixFunc)
 	// Broker's namespace is "controller" now - controllerModelConfig.Name()
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller")
+	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, s.getNamespace())
 	c.Assert(
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
@@ -200,25 +200,13 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		},
 	)
 
-	// These two are done in broker.Bootstrap method actually.
-	s.broker.SetNamespace("controller-1")
+	// Done in broker.Bootstrap method actually.
 	s.broker.GetAnnotations().Add("juju.io/is-controller", "true")
 
 	s.pcfg.Bootstrap.Timeout = 10 * time.Minute
 	s.pcfg.Bootstrap.ControllerExternalIPs = []string{"10.0.0.1"}
 
 	controllerStacker := s.controllerStackerGetter()
-	// Broker's namespace should be set to controller name now.
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller-1")
-	c.Assert(
-		// "is-controller" is set as well.
-		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
-		map[string]string{
-			"juju.io/model":         s.cfg.UUID(),
-			"juju.io/controller":    testing.ControllerTag.Id(),
-			"juju.io/is-controller": "true",
-		},
-	)
 
 	sharedSecret, sslKey := controllerStacker.GetSharedSecretAndSSLKey(c)
 

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -189,6 +189,7 @@ func newK8sBroker(
 	controllerUUID string,
 	k8sRestConfig *rest.Config,
 	cfg *config.Config,
+	namespace string,
 	newClient NewK8sClientFunc,
 	newWatcher NewK8sWatcherFunc,
 	newStringsWatcher NewK8sStringsWatcherFunc,
@@ -208,6 +209,7 @@ func newK8sBroker(
 	if modelUUID == "" {
 		return nil, errors.NotValidf("modelUUID is required")
 	}
+
 	client := &kubernetesClient{
 		clock:                       clock,
 		clientUnlocked:              k8sClient,
@@ -217,9 +219,9 @@ func newK8sBroker(
 		informerFactoryUnlocked: informers.NewSharedInformerFactoryWithOptions(
 			k8sClient,
 			InformerResyncPeriod,
-			informers.WithNamespace(newCfg.Name()),
+			informers.WithNamespace(namespace),
 		),
-		namespace:         newCfg.Name(),
+		namespace:         namespace,
 		modelUUID:         modelUUID,
 		newWatcher:        newWatcher,
 		newStringsWatcher: newStringsWatcher,
@@ -439,7 +441,6 @@ please choose a different hosted model name then try again.`, hostedModelName),
 			_, err := broker.GetNamespace(nsName)
 			if errors.IsNotFound(err) {
 				// all good.
-				broker.SetNamespace(nsName)
 				// ensure controller specific annotations.
 				_ = broker.addAnnotations(annotationControllerIsControllerKey, "true")
 				return nil

--- a/caas/kubernetes/provider/namespaces.go
+++ b/caas/kubernetes/provider/namespaces.go
@@ -74,12 +74,6 @@ func (k *kubernetesClient) getNamespaceByName(name string) (*core.Namespace, err
 	return ns, nil
 }
 
-// SetNamespace sets current namespace to the specified name.
-// Note: this does not ensure related namespace resources.
-func (k *kubernetesClient) SetNamespace(name string) {
-	k.namespace = name
-}
-
 // listNamespacesByAnnotations filters namespaces by annotations.
 func (k *kubernetesClient) listNamespacesByAnnotations(annotations k8sannotations.Annotation) ([]core.Namespace, error) {
 	namespaces, err := k.client().CoreV1().Namespaces().List(v1.ListOptions{})

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
+	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 )
@@ -115,14 +116,34 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	// Guinea Pig broker to hunt for the namespace where a controller lives. We
+	// disregard this one in favour of a new one pinned to the correct
+	// controller namespace when we find it.
 	broker, err := newK8sBroker(
-		args.ControllerUUID, k8sRestConfig, args.Config, newK8sClient,
-		newKubernetesNotifyWatcher, newKubernetesStringsWatcher, randomPrefix,
-		jujuclock.WallClock)
+		args.ControllerUUID, k8sRestConfig, args.Config, args.Config.Name(),
+		newK8sClient, newKubernetesNotifyWatcher, newKubernetesStringsWatcher,
+		randomPrefix, jujuclock.WallClock)
+
 	if err != nil {
 		return nil, err
 	}
-	return controllerCorelation(broker)
+
+	if args.Config.Name() != environsbootstrap.ControllerModelName {
+		return broker, nil
+	}
+
+	ns, err := controllerCorelation(broker)
+	if errors.IsNotFound(err) {
+		return broker, nil
+	} else if err != nil {
+		return broker, err
+	}
+
+	return newK8sBroker(
+		args.ControllerUUID, k8sRestConfig, args.Config, ns,
+		newK8sClient, newKubernetesNotifyWatcher, newKubernetesStringsWatcher,
+		randomPrefix, jujuclock.WallClock)
 }
 
 // CloudSchema returns the schema for adding new clouds of this type.


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Change so namespace can not change on the kubernetes broker. It is set once per broker. This allows shared informers not to be broken.

## QA steps

Bootstrap controller into k8s, add models and deploy.
