### PR TITLE
Fix the wrong doc message for update-public-clouds command;

### DIFF
--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -103,7 +103,7 @@ func (c *updatePublicCloudsCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	if sameCloudInfo {
-		fmt.Fprintln(ctxt.Stderr, "This client's list of public clouds is up to date, see `juju clouds --client-only`.")
+		fmt.Fprintln(ctxt.Stderr, "This client's list of public clouds is up to date, see `juju clouds --client`.")
 		return nil
 	}
 	if err := jujucloud.WritePublicCloudMetadata(newPublicClouds); err != nil {

--- a/cmd/juju/cloud/updatepublicclouds_test.go
+++ b/cmd/juju/cloud/updatepublicclouds_test.go
@@ -131,7 +131,7 @@ func (s *updatePublicCloudsSuite) TestNoNewData(c *gc.C) {
 	defer ts.Close()
 
 	msg := s.run(c, ts.URL, "")
-	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...This client's list of public clouds is up to date, see `juju clouds --client-only`.")
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, "Fetching latest public cloud list...This client's list of public clouds is up to date, see `juju clouds --client`.")
 }
 
 func (s *updatePublicCloudsSuite) TestFirstRun(c *gc.C) {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [ ] ~Do comments answer the question of why design decisions were made?~

----

## Description of change

Fix the wrong doc message for update-public-clouds command;

## QA steps

```console
$ juju update-public-clouds
Fetching latest public cloud list...
This client's list of public clouds is up to date, see `juju clouds --client`.
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871793
