### PR TITLE
Ensure NetworkOrigin is always set

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -53,7 +53,7 @@ type ProvisionerAPI struct {
 	*common.InstanceIdGetter
 	*common.ToolsFinder
 	*common.ToolsGetter
-	*networkingcommon.NetworkConfigAPI
+	*networkingcommon.NetworkConfigAPIV1
 
 	st                      *state.State
 	m                       *state.Model
@@ -141,7 +141,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 		ModelWatcher:            common.NewModelWatcher(model, resources, authorizer),
 		ModelMachinesWatcher:    common.NewModelMachinesWatcher(st, resources, authorizer),
 		ControllerConfigAPI:     common.NewStateControllerConfig(st),
-		NetworkConfigAPI:        networkingcommon.NewNetworkConfigAPI(st, getCanModify),
+		NetworkConfigAPIV1:      networkingcommon.NewNetworkConfigAPIV1(st, getCanModify),
 		st:                      st,
 		m:                       model,
 		resources:               resources,


### PR DESCRIPTION
The following is a bit convoluted as we want to version bump the
MachinerAPI along with NetworkConfigAPI. It turns out that most people
don't bump the NetworkConfigAPI, instead they mark things as omitempty
and just fudge it at a later date.

I believe this is wrong and hides the fact that this is a potential for
API facade inconsistencies. Instead what we do here is bump the
NetworkingConfigAPI and force the user to pick the right API version
based on the behaviour they desire.

I actually believe the composition of these facades aren't such a great
idea for juju. Instead they should have been realised struct members.

## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

*Please replace with a description about why this change is needed, along with a description of what changed?*

## QA steps

*Please replace with how we can verify that the change works?*

```sh
QA steps here
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?*

## Bug reference

*Please add a link to any bugs that this change is related to.*
