### PR TITLE
Bootstrap focal if requested

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -89,8 +89,8 @@ bootstrap() {
         fi
     fi
     if [ "${BOOTSTRAP_REUSE}" = "true" ]; then
-        OUT=$(juju show-machine -m controller --format=json | jq -r ".machines | .[] | .series")
-        if [ -z "${OUT}" ]; then
+        OUT=$(juju show-machine -m "${bootstrapped_name}":controller --format=json | jq -r ".machines | .[] | .series")
+        if [ -n "${OUT}" ]; then
             OUT=$(echo "${OUT}" | grep -oh "${BOOTSTRAP_SERIES}" || true)
             if [ "${OUT}" != "${BOOTSTRAP_SERIES}" ]; then
                 echo "====> Unable to reuse bootstrapped juju"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -177,9 +177,15 @@ juju_bootstrap() {
         debug="true"
     fi
 
+
     if [ -n "${output}" ]; then
+        # When double quotes are added to ${series}, the juju bootstrap
+        # command looks correct, and works outside of the harness, but
+        # does not run, goes directly to cleanup.
+        #shellcheck disable=SC2086
         juju bootstrap ${series} --debug="${debug}" "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
     else
+        #shellcheck disable=SC2086
         juju bootstrap ${series} --debug="${debug}" "${provider}" "${name}" -d "${model}" "$@"
     fi
     echo "${name}" >> "${TEST_DIR}/jujus"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -87,7 +87,7 @@ show_help() {
     echo "    $(green 'cmd -r')        Reuse bootstrapped controller between testing suites"
     echo "    $(green 'cmd -l')        Local bootstrapped controller name to reuse"
     echo "    $(green 'cmd -p')        Bootstrap provider to use when bootstrapping <lxd|aws>"
-    echo "    $(green 'cmd -S')        Bootstrap series to use <default is host>"
+    echo "    $(green 'cmd -S')        Bootstrap series to use <default is host>, priority over -l"
     echo ""
     echo "Tests:"
     echo "¯¯¯¯¯¯"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -6,7 +6,10 @@ export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005"
 export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
 export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
 export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"
+export BOOTSTRAP_SERIES="${BOOTSTRAP_SERIES:-}"
 export RUN_SUBTEST="${RUN_SUBTEST:-}"
+
+export CURRENT_LTS="focal"
 
 OPTIND=1
 VERBOSE=1
@@ -84,6 +87,7 @@ show_help() {
     echo "    $(green 'cmd -r')        Reuse bootstrapped controller between testing suites"
     echo "    $(green 'cmd -l')        Local bootstrapped controller name to reuse"
     echo "    $(green 'cmd -p')        Bootstrap provider to use when bootstrapping <lxd|aws>"
+    echo "    $(green 'cmd -S')        Bootstrap series to use <default is host>"
     echo ""
     echo "Tests:"
     echo "¯¯¯¯¯¯"
@@ -118,7 +122,7 @@ show_help() {
     exit 1
 }
 
-while getopts "hH?:vVtAsaxrlp" opt; do
+while getopts "hH?:vVtAsaxrlpS" opt; do
     case "${opt}" in
     h|\?)
         show_help
@@ -169,6 +173,10 @@ while getopts "hH?:vVtAsaxrlp" opt; do
         ;;
     p)
         export BOOTSTRAP_PROVIDER="${2}"
+        shift 2
+        ;;
+    S)
+        export BOOTSTRAP_SERIES="${2}"
         shift 2
         ;;
     *)


### PR DESCRIPTION
## Description of change

This will attempt to bootstrap focal if you provide BOOTSTRAP_SERIES.
If you attempt to reuse a bootstrapped controller that doesn't match
series you're after it will attempt to bootstrap another in the
right series.

I've not tested this but should work in theory.

## QA steps

```sh
BOOTSTRAP_SERIES=focal ./main.sh deploy
```
