### PR TITLE
Fix 1862026 - inconsistent output from action-get

### DIFF
--- a/worker/uniter/runner/jujuc/action-get.go
+++ b/worker/uniter/runner/jujuc/action-get.go
@@ -116,7 +116,13 @@ func (c *ActionGetCommand) Run(ctx *cmd.Context) error {
 	var answer interface{}
 
 	if len(c.keys) == 0 {
-		answer = params
+		// If no parameters were returned we still want to print an
+		// empty object, not nil.
+		if params == nil {
+			answer = make(map[string]interface{})
+		} else {
+			answer = params
+		}
 	} else {
 		answer, _ = recurseMapOnKeys(c.keys, params)
 	}

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -116,7 +116,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 	}, {
 		summary: "a simple empty map with nil key",
 		args:    []string{"--format", "json"},
-		out:     "null\n",
+		out:     "{}\n",
 	}, {
 		summary: "a nonexistent key",
 		args:    []string{"foo"},


### PR DESCRIPTION
## Fix 1862026 - inconsistent output from action-get

Using --format=json and empty parameters results in null not
empty dictionary.

## QA steps

Unit tests should suffice. But you can run an action that returns the result of action-get --format=json
The action must have no params defined.

## Documentation changes

N/A - I think this change is in line with expected use.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1862026
