### PR TITLE
Allow to set zones that contains spaces

### DIFF
--- a/core/constraints/constraints_test.go
+++ b/core/constraints/constraints_test.go
@@ -338,6 +338,12 @@ var parseConstraintsTests = []struct {
 		summary: "multiple zones",
 		args:    []string{"zones=az1,az2"},
 	}, {
+		summary: "spaced zones",
+		args:    []string{"zones=Availability zone 1"},
+	}, {
+		summary: "Multiple spaced zones",
+		args:    []string{"zones=Availability zone 1,Availability zone 2,az2"},
+	}, {
 		summary: "no zones",
 		args:    []string{"zones="},
 	},


### PR DESCRIPTION
Closes-bug: #1847259
Signed-off-by: José Pekkarinen <jose.pekkarinen@canonical.com>

## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ x ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ x ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ x ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ x ] Do comments answer the question of why design decisions were made?

----

## Description of change

It's found that in multiple environments exist policies to set availability zones
that contains spaces in the name. With the given patch, it's possible to do
so, and a test to proof it is provided.

## QA steps

go test github.com/juju/juju/core/constraints

## Bug reference

LP: #1847259

*Please add a link to any bugs that this change is related to.*

https://bugs.launchpad.net/juju/+bug/1847259