### PR TITLE
Fix typo in app status params struct

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9704,7 +9704,7 @@
                         "charm-profile": {
                             "type": "string"
                         },
-                        "charm-verion": {
+                        "charm-version": {
                             "type": "string"
                         },
                         "endpoint-bindings": {
@@ -9789,7 +9789,7 @@
                         "meter-statuses",
                         "status",
                         "workload-version",
-                        "charm-verion",
+                        "charm-version",
                         "charm-profile",
                         "endpoint-bindings",
                         "public-address"

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -6,6 +6,7 @@ package params
 // TODO(ericsnow) Eliminate the juju-related imports.
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/juju/juju/core/instance"
@@ -151,7 +152,7 @@ type ApplicationStatus struct {
 	MeterStatuses    map[string]MeterStatus `json:"meter-statuses"`
 	Status           DetailedStatus         `json:"status"`
 	WorkloadVersion  string                 `json:"workload-version"`
-	CharmVersion     string                 `json:"charm-verion"`
+	CharmVersion     string                 `json:"charm-version"`
 	CharmProfile     string                 `json:"charm-profile"`
 	EndpointBindings map[string]string      `json:"endpoint-bindings"`
 
@@ -159,6 +160,19 @@ type ApplicationStatus struct {
 	Scale         int    `json:"int,omitempty"`
 	ProviderId    string `json:"provider-id,omitempty"`
 	PublicAddress string `json:"public-address"`
+}
+
+// TODO(wallyworld) - remove in Juju 3
+// MarshalJSON marshals a status with a typo left in for compatibility.
+func (as ApplicationStatus) MarshalJSON() ([]byte, error) {
+	type Alias ApplicationStatus
+	return json.Marshal(&struct {
+		LegacyCharmVersion string `json:"charm-verion"`
+		Alias
+	}{
+		LegacyCharmVersion: as.CharmVersion,
+		Alias:              Alias(as),
+	})
 }
 
 // RemoteApplicationStatus holds status info about a remote application.

--- a/apiserver/params/status_test.go
+++ b/apiserver/params/status_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params_test
+
+import (
+	"encoding/json"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+type StatusSuite struct{}
+
+var _ = gc.Suite(&StatusSuite{})
+
+func (s *StatusSuite) TestMarshallApplicationStatusCharmVersion(c *gc.C) {
+	as := params.ApplicationStatus{
+		CharmVersion: "666",
+	}
+	data, err := json.Marshal(as)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, strings.Replace(`
+{"charm-verion":"666","charm":"","series":"","exposed":false,"life":"","relations":null,"can-upgrade-to":"","subordinate-to":null,
+"units":null,"meter-statuses":null,"status":{"status":"","info":"","data":null,"since":null,"kind":"",
+"version":"","life":""},"workload-version":"","charm-version":"666",
+"charm-profile":"","endpoint-bindings":null,"public-address":""}`, "\n", "", -1))
+}


### PR DESCRIPTION
## Description of change

The json tag for the CharmVersion attribute in the ApplicationStatus params struct had a typo.
To maintain compatibility with existing CLI clients, fix the struct and use custom json marshalling to include the typo.

## QA steps

Run juju status with an old and new CLI client and check charm version.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871622
