### PR TITLE
Support multiple command arguments for juju-run

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -270,7 +270,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	var err error
 	select {
 	case err = <-errc:
-	case <-time.After(coretesting.LongWait):
+	case <-time.After(3 * coretesting.LongWait):
 		c.Fatal("timed out")
 	}
 	c.Check(s.tw.Log(), jc.LogMatches, test.logs)

--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/names/v4"
 	jujuos "github.com/juju/os"
 	"github.com/juju/os/series"
+	"github.com/juju/utils"
 	"github.com/juju/utils/exec"
 	"gopkg.in/yaml.v2"
 
@@ -37,6 +38,7 @@ type RunCommand struct {
 	cmd.CommandBase
 	dataDir               string
 	MachineLock           machinelock.Lock
+	unitName              string
 	unit                  names.UnitTag
 	commands              string
 	showHelp              bool
@@ -56,11 +58,23 @@ unit-name can be either the unit tag:
 or the unit id:
  i.e.  ubuntu/0
 
+unit-name can be specified by the -u argument.
+If -u is passed, unit-name cannot be passed as a positional argument.
+
 If --no-context is specified, the <unit-name> positional
-argument is not needed.
+argument or -u argument is not needed.
 
 If the there's one and only one unit on this host, <unit-name>
 is automatically inferred and the positional argument is not needed.
+If -u is passed an empty string, this behaviour is also observed.
+
+Examples:
+	juju-run app/0 hostname -f
+	juju-run --no-context -- hostname -f
+	juju-run "hostname -f"
+	juju-run -u "" -- hostname -f
+	juju-run -u app/0 "hostname -f"
+	juju-run -u app/0 -- hostname -f
 
 The commands are executed with '/bin/bash -s', and the output returned.
 `
@@ -69,7 +83,7 @@ The commands are executed with '/bin/bash -s', and the output returned.
 func (c *RunCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "juju-run",
-		Args:    "[<unit-name>] <commands>",
+		Args:    "[-u] [<unit-name>] <commands>",
 		Purpose: "run commands in a unit's hook context",
 		Doc:     runCommandDoc,
 	})
@@ -83,40 +97,13 @@ func (c *RunCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.remoteApplicationName, "remote-app", "", "run the commands for a specific remote application in a relation context on a unit")
 	f.BoolVar(&c.operator, "operator", false, "run the commands on the operator instead of the workload. Only supported on k8s workload charms")
 	f.BoolVar(&c.forceRemoteUnit, "force-remote-unit", false, "run the commands for a specific relation context, bypassing the remote unit check")
+	f.StringVar(&c.unitName, "u", "-", "explicit unit-name, all other arguments are commands. if -u is passed an empty string, unit-name is inferred from state")
 }
 
 func (c *RunCommand) Init(args []string) error {
 	// make sure we aren't in an existing hook context
 	if contextId, err := getenv("JUJU_CONTEXT_ID"); err == nil && contextId != "" {
 		return fmt.Errorf("juju-run cannot be called from within a hook, have context %q", contextId)
-	}
-	if !c.noContext {
-		if len(args) < 1 {
-			return fmt.Errorf("missing unit-name")
-		}
-		var unitName = args[0]
-		// If the command line param is a unit id (like application/2) we need to
-		// change it to the unit tag as that is the format of the agent directory
-		// on disk (unit-application-2).
-		if names.IsValidUnit(unitName) {
-			c.unit = names.NewUnitTag(unitName)
-			args = args[1:]
-		} else {
-			var err error
-			c.unit, err = names.ParseUnitTag(unitName)
-			if err == nil {
-				args = args[1:]
-			} else {
-				// If arg[0] is neither a unit name not unit tag, perhaps
-				// we are running where there's only one unit, in which case
-				// we can safely use that.
-				var err2 error
-				c.unit, err2 = c.maybeGetUnitTag()
-				if err2 != nil {
-					return errors.Trace(err)
-				}
-			}
-		}
 	}
 	// if remoteApplication wasn't set but remoteUnit was, infer the remoteApplication
 	if c.remoteApplicationName == "" && c.remoteUnitName != "" {
@@ -130,11 +117,68 @@ func (c *RunCommand) Init(args []string) error {
 		}
 		c.remoteApplicationName = appName
 	}
+	if c.noContext && c.unitName != "-" {
+		return fmt.Errorf("-no-context cannot be passed with an explicit unit-name (-u %q)", c.unitName)
+	} else if !c.noContext {
+		if c.unitName == "-" {
+			if len(args) < 1 {
+				return fmt.Errorf("missing unit-name")
+			}
+			var unitName = args[0]
+			// If the command line param is a unit id (like application/2) we need to
+			// change it to the unit tag as that is the format of the agent directory
+			// on disk (unit-application-2).
+			if names.IsValidUnit(unitName) {
+				c.unit = names.NewUnitTag(unitName)
+				args = args[1:]
+			} else {
+				var err error
+				c.unit, err = names.ParseUnitTag(unitName)
+				if err == nil {
+					args = args[1:]
+				} else {
+					// If arg[0] is neither a unit name not unit tag, perhaps
+					// we are running where there's only one unit, in which case
+					// we can safely use that.
+					var err2 error
+					c.unit, err2 = c.maybeGetUnitTag()
+					if err2 != nil {
+						return errors.Trace(err)
+					}
+				}
+			}
+		} else if c.unitName == "" {
+			var err error
+			c.unit, err = c.maybeGetUnitTag()
+			if err != nil {
+				return errors.Trace(err)
+			}
+		} else {
+			if names.IsValidUnit(c.unitName) {
+				c.unit = names.NewUnitTag(c.unitName)
+			} else {
+				var err error
+				c.unit, err = names.ParseUnitTag(c.unitName)
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
+		}
+	}
 	if len(args) < 1 {
 		return fmt.Errorf("missing commands")
 	}
-	c.commands, args = args[0], args[1:]
-	return cmd.CheckEmpty(args)
+	if len(args) == 1 {
+		// If just one argument is specified, we don't pass it through
+		// utils.CommandString in case it contains multiple arguments
+		// (e.g. juju-run -u "sudo whatever"). Passing it through
+		// utils.CommandString would quote the string, which the backend
+		// does not expect.
+		c.commands = args[0]
+	} else {
+		c.commands = utils.CommandString(args...)
+	}
+	return nil
 }
 
 // maybeGetUnitTag looks at the contents of the agents directory

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -68,9 +68,24 @@ func (*RunTestSuite) TestArgParsing(c *gc.C) {
 		args:     []string{"foo/2"},
 		errMatch: "missing commands",
 	}, {
+		title:    "explicit unit with no commands",
+		args:     []string{"-u", "foo/2"},
+		errMatch: "missing commands",
+	}, {
 		title:    "more than two arg",
 		args:     []string{"foo/2", "bar", "baz"},
-		errMatch: `unrecognized args: \["baz"\]`,
+		commands: "bar baz",
+		unit:     names.NewUnitTag("foo/2"),
+	}, {
+		title:    "command looks like unit id",
+		args:     []string{"-u", "foo/2", "unit-foo-2"},
+		commands: "unit-foo-2",
+		unit:     names.NewUnitTag("foo/2"),
+	}, {
+		title:    "command looks like unit name",
+		args:     []string{"-u", "foo/2", "foo/2"},
+		commands: "foo/2",
+		unit:     names.NewUnitTag("foo/2"),
 	}, {
 		title:      "unit and command assignment",
 		args:       []string{"unit-name-2", "command"},
@@ -80,6 +95,18 @@ func (*RunTestSuite) TestArgParsing(c *gc.C) {
 	}, {
 		title:      "unit id converted to tag",
 		args:       []string{"foo/1", "command"},
+		unit:       names.NewUnitTag("foo/1"),
+		commands:   "command",
+		relationId: "",
+	}, {
+		title:      "explicit unit id converted to tag",
+		args:       []string{"-u", "foo/1", "command"},
+		unit:       names.NewUnitTag("foo/1"),
+		commands:   "command",
+		relationId: "",
+	}, {
+		title:      "explicit unit name converted to tag",
+		args:       []string{"-u", "unit-foo-1", "command"},
 		unit:       names.NewUnitTag("foo/1"),
 		commands:   "command",
 		relationId: "",
@@ -131,6 +158,14 @@ func (*RunTestSuite) TestArgParsing(c *gc.C) {
 		commands:   "command",
 		relationId: "",
 		operator:   true,
+	}, {
+		title:           "execute not in a context with unit",
+		args:            []string{"--no-context", "-u", "foo/1"},
+		commands:        "command",
+		avoidContext:    true,
+		relationId:      "",
+		forceRemoteUnit: false,
+		errMatch:        `-no-context cannot be passed with an explicit unit-name \(-u "foo/1"\)`,
 	},
 	} {
 		c.Logf("%d: %s", i, test.title)

--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -336,22 +336,21 @@ func ParseWithAliases(args ...string) (cons Value, aliases map[string]string, er
 			if raw == "" {
 				continue
 			}
-			current_name, current_val, err := splitRaw(raw)
+			currentName, currentValue, err := splitRaw(raw)
 			if err != nil {
 				return Value{}, nil, errors.Trace(err)
 			}
-			if current_name == "" && name == "" {
-				return Value{}, nil, errors.Errorf("malformed constraint %q", current_val)
+			if currentName == "" && name == "" {
+				return Value{}, nil, errors.Errorf("malformed constraint %q", currentValue)
 			}
-			if current_name != "" {
-				name = current_name
-				val = current_val
-				if canonical, ok := rawAliases[current_name]; ok {
-					aliases[current_name] = canonical
-					current_name = canonical
+			if currentName != "" {
+				name = currentName
+				val = currentValue
+				if canonical, ok := rawAliases[currentName]; ok {
+					aliases[currentName] = canonical
 				}
 			} else if name != "" {
-				val += " " + current_val
+				val += " " + currentValue
 			}
 			if err := cons.setRaw(name, val); err != nil {
 				return Value{}, aliases, errors.Trace(err)

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -143,17 +143,10 @@ func (f *factory) NewFailAction(actionId string) (Operation, error) {
 
 // NewCommands is part of the Factory interface.
 func (f *factory) NewCommands(args CommandArgs, sendResponse CommandResponseFunc) (Operation, error) {
-	if args.Commands == "" {
-		return nil, errors.New("commands required")
+	if err := args.Validate(); err != nil {
+		return nil, errors.Trace(err)
 	} else if sendResponse == nil {
 		return nil, errors.New("response sender required")
-	}
-	if args.RemoteUnitName != "" {
-		if args.RelationId == -1 {
-			return nil, errors.New("remote unit not valid without relation")
-		} else if !names.IsValidUnit(args.RemoteUnitName) {
-			return nil, errors.Errorf("invalid remote unit name %q", args.RemoteUnitName)
-		}
 	}
 	return &runCommands{
 		args:          args,

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -5,6 +5,7 @@ package operation
 
 import (
 	corecharm "github.com/juju/charm/v7"
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	utilexec "github.com/juju/utils/exec"
 
@@ -146,6 +147,21 @@ type CommandArgs struct {
 	ForceRemoteUnit bool
 	// RunLocation describes where the command must run.
 	RunLocation runner.RunLocation
+}
+
+// Validate the command arguments.
+func (args CommandArgs) Validate() error {
+	if args.Commands == "" {
+		return errors.New("commands required")
+	}
+	if args.RemoteUnitName != "" {
+		if args.RelationId == -1 {
+			return errors.New("remote unit not valid without relation")
+		} else if !names.IsValidUnit(args.RemoteUnitName) {
+			return errors.Errorf("invalid remote unit name %q", args.RemoteUnitName)
+		}
+	}
+	return nil
 }
 
 // CommandResponseFunc is for marshalling command responses back to the source


### PR DESCRIPTION
## Support multiple command arguments for juju-run

- juju-run handles multiple arguments correctly
- juju-run now avoid positional argument for unit-name
- fixes issues with commands that look like a unit name/id
- fix resolver loop crashing with empty commands

Plus:
 Fix recent constraints commit #11500 
- Make sure spaces don't affect following constraint parsing
- Full check for all constraints parsing
- Fix ineffassign error
- Fix variable naming



## QA steps

Inside a unit pod/operator pod/machine run:
```
juju-run hostname -f
juju-run app/0 hostname -f
juju-run --no-context -- hostname -f
juju-run "hostname -f"
juju-run -u "" -- hostname -f
juju-run -u app/0 "hostname -f"
juju-run -u app/0 -- hostname -f
```

`juju-run hostname -f` and `juju-run "hostname -f"` should fail on operators/machines with more than one unit.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1870438
