### PR TITLE
Fix go deps for GitHub actions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,12 +16,13 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        go get -u github.com/client9/misspell/cmd/misspell
-        go get -u github.com/tsenart/deadcode
-        go get -u golang.org/x/lint/golint
-        go get -u golang.org/x/tools/cmd/goimports
-        go get -u github.com/mdempsky/unconvert
-        go get -u github.com/gordonklaus/ineffassign
+        GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
+        GO111MODULE=off go get -u github.com/tsenart/deadcode
+        GO111MODULE=off go get -u golang.org/x/lint/golint
+        GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
+        GO111MODULE=off go get -u github.com/mdempsky/unconvert
+        GO111MODULE=off go get -u github.com/gordonklaus/ineffassign
+        echo "##[add-path]${GOPATH}/bin"
 
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
## Description of change

Force static analysis deps to be installed outside of any go mod.
Force gopath export.

## QA steps

Check GitHub Actions

## Documentation changes

N/A

## Bug reference

N/A