### PR TITLE
[2.7] Support spaces in zones and instance type constraints

### DIFF
--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -361,6 +361,9 @@ func (api *InstanceMutaterAPI) machineLXDProfileInfo(m Machine) (lxdProfileInfo,
 		return empty, errors.Trace(err)
 	}
 	machineProfiles, err := m.CharmProfiles()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
 	changeResults := make([]params.ProfileInfoResult, len(units))
 	for i, unit := range units {
 		appName := unit.Application()

--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -346,9 +346,9 @@ func ParseWithAliases(args ...string) (cons Value, aliases map[string]string, er
 			if current_name != "" {
 				name = current_name
 				val = current_val
-				if canonical, ok := rawAliases[current_name]; ok {
-					aliases[current_name] = canonical
-					current_name = canonical
+				if canonical, ok := rawAliases[name]; ok {
+					aliases[name] = canonical
+					name = canonical
 				}
 			} else if name != "" {
 				val += " " + current_val

--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -602,9 +602,6 @@ func (v *Value) setCpuPower(str string) (err error) {
 }
 
 func (v *Value) setInstanceType(str string) error {
-	if v.InstanceType != nil {
-		return errors.Errorf("already set")
-	}
 	v.InstanceType = &str
 	return nil
 }

--- a/core/constraints/constraints_test.go
+++ b/core/constraints/constraints_test.go
@@ -338,6 +338,12 @@ var parseConstraintsTests = []struct {
 		summary: "multiple zones",
 		args:    []string{"zones=az1,az2"},
 	}, {
+		summary: "spaced zones",
+		args:    []string{"zones=Availability zone 1"},
+	}, {
+		summary: "Multiple spaced zones",
+		args:    []string{"zones=Availability zone 1,Availability zone 2,az2"},
+	}, {
 		summary: "no zones",
 		args:    []string{"zones="},
 	},

--- a/core/constraints/constraints_test.go
+++ b/core/constraints/constraints_test.go
@@ -308,6 +308,9 @@ var parseConstraintsTests = []struct {
 	}, {
 		summary: "instance type empty",
 		args:    []string{"instance-type="},
+	}, {
+		summary: "instance type with spaces",
+		args:    []string{"instance-type=something with spaces"},
 	},
 
 	// "virt-type" in detail.
@@ -424,6 +427,18 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, gc.ErrorMatches, `bad "arch" constraint: already set`)
 	c.Assert(merged, jc.DeepEquals, constraints.Value{})
+}
+
+func (s *ConstraintsSuite) TestParseZoneWithSpaces(c *gc.C) {
+	con := constraints.MustParse(
+		"arch=amd64 instance-type=with spaces cores=1",
+	)
+	c.Assert(con.Arch, gc.Not(gc.IsNil))
+	c.Assert(con.InstanceType, gc.Not(gc.IsNil))
+	c.Assert(con.CpuCores, gc.Not(gc.IsNil))
+	c.Check(*con.Arch, gc.Equals, "amd64")
+	c.Check(*con.InstanceType, gc.Equals, "with spaces")
+	c.Check(*con.CpuCores, gc.Equals, uint64(1))
 }
 
 func (s *ConstraintsSuite) TestParseMissingTagsAndSpaces(c *gc.C) {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -1126,7 +1126,7 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string]Machine
 	// when we have subnets populated for all providers.
 	if r, ok := results[corenetwork.AlphaSpaceId]; !ok && spaces.Contains(corenetwork.AlphaSpaceId) {
 		if privateLinkLayerAddress != nil {
-			r.NetworkInfos, err = addAddressToResult(r.NetworkInfos, privateLinkLayerAddress)
+			r.NetworkInfos, _ = addAddressToResult(r.NetworkInfos, privateLinkLayerAddress)
 		} else {
 			r.NetworkInfos = []network.NetworkInfo{{
 				Addresses: []network.InterfaceAddress{{

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -148,11 +148,11 @@ func (c *RelationSetCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	var settings Settings
 	if c.Application {
-		isLeader, err := c.ctx.IsLeader()
-		if err != nil {
-			return errors.Annotate(err, "cannot determine leadership status")
+		isLeader, lErr := c.ctx.IsLeader()
+		if lErr != nil {
+			return errors.Annotate(lErr, "cannot determine leadership status")
 		} else if isLeader == false {
-			return errors.Annotate(err, "cannot write relation settings")
+			return errors.Errorf("cannot write relation settings")
 		}
 		settings, err = r.ApplicationSettings()
 	} else {


### PR DESCRIPTION
## Description of change

This PR back-ports the fix for zones with spaces from #11500 and also applies the same change for values passed to `instance-type` constraints.

## QA steps

`juju bootstrap rackspace test --constraints instance-type=1 GB General Purpose v1`

## Bug reference

- https://bugs.launchpad.net/juju/+bug/1875590
- https://bugs.launchpad.net/juju/+bug/1847259