### PR TITLE
Fix bogus error for update-credential --force

### DIFF
--- a/api/cloud/cloud.go
+++ b/api/cloud/cloud.go
@@ -148,6 +148,17 @@ func (c *Client) internalUpdateCloudsCredentials(in params.UpdateCredentialArgs,
 	if len(out.Results) != count {
 		return nil, countErr(len(out.Results))
 	}
+	// Older facades incorrectly set an error if models are invalid.
+	// The model result structs themselves contain the errors.
+	for i, r := range out.Results {
+		if r.Error == nil {
+			continue
+		}
+		if r.Error.Message == "some models are no longer visible" {
+			r.Error = nil
+		}
+		out.Results[i] = r
+	}
 	return out.Results, nil
 }
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -35,7 +35,7 @@ var facadeVersions = map[string]int{
 	"Charms":                       2,
 	"Cleaner":                      2,
 	"Client":                       2,
-	"Cloud":                        6,
+	"Cloud":                        7,
 	"Controller":                   9,
 	"CredentialManager":            1,
 	"CredentialValidator":          2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -177,6 +177,7 @@ func AllFacades() *facade.Registry {
 	reg("Cloud", 4, cloud.NewFacadeV4) // adds UpdateCloud
 	reg("Cloud", 5, cloud.NewFacadeV5) // Removes DefaultCloud, handles config in AddCloud
 	reg("Cloud", 6, cloud.NewFacadeV6) // Adds validity to CredentialContent, force for AddCloud
+	reg("Cloud", 7, cloud.NewFacadeV7) // Do not set error if forcing credential update.
 
 	// CAAS related facades.
 	// Move these to the correct place above once the feature flag disappears.

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -124,7 +124,8 @@ func (s *cloudSuiteV2) setTestAPIForUser(c *gc.C, user names.UserTag) {
 	}
 	client, err := cloudfacade.NewCloudAPI(s.backend, s.backend, s.statePool, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-	s.apiv2 = &cloudfacade.CloudAPIV2{&cloudfacade.CloudAPIV3{&cloudfacade.CloudAPIV4{&cloudfacade.CloudAPIV5{client}}}}
+	s.apiv2 = &cloudfacade.CloudAPIV2{&cloudfacade.CloudAPIV3{&cloudfacade.CloudAPIV4{
+		&cloudfacade.CloudAPIV5{&cloudfacade.CloudAPIV6{client}}}}}
 }
 
 func (s *cloudSuiteV2) TestCredentialContentsAllNoSecrets(c *gc.C) {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -570,7 +570,8 @@ func (s *cloudSuite) TestCheckCredentialsModels(c *gc.C) {
 	// All we need to know is that this call does not actually update existing controller credential content.
 	s.backend.SetErrors(nil, errors.NotFoundf("cloud"))
 	s.setTestAPIForUser(c, names.NewUserTag("bruce"))
-	results, err := s.api.CheckCredentialsModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
+	apiV6 := &cloudfacade.CloudAPIV6{s.api}
+	results, err := apiV6.CheckCredentialsModels(params.TaggedCredentials{Credentials: []params.TaggedCredential{{
 		Tag: "cloudcred-meep_bruce_three",
 		Credential: params.CloudCredential{
 			AuthType:   "oauth1",
@@ -653,7 +654,6 @@ func (s *cloudSuite) TestUpdateCredentialsModelsErrorForce(c *gc.C) {
 		Results: []params.UpdateCredentialResult{
 			{
 				CredentialTag: "cloudcred-meep_julia_three",
-				Error:         &params.Error{Message: "cannot get models"},
 			},
 		}})
 }
@@ -711,6 +711,39 @@ func (s *cloudSuite) TestUpdateCredentialsModelGetError(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
+			Models: []params.UpdateCredentialModelResult{
+				{
+					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+					ModelName: "testModel1",
+					Errors:    []params.ErrorResult{{Error: &params.Error{Message: "cannot get a model", Code: ""}}},
+				},
+			},
+		}},
+	})
+}
+
+func (s *cloudSuite) TestUpdateCredentialsModelGetErrorLegacy(c *gc.C) {
+	s.backend.credentialModelsF = func(tag names.CloudCredentialTag) (map[string]string, error) {
+		return map[string]string{
+			coretesting.ModelTag.Id(): "testModel1",
+		}, nil
+	}
+	s.statePool.getF = func(modelUUID string) (credentialcommon.PersistentBackend, context.ProviderCallContext, error) {
+		return nil, nil, errors.New("cannot get a model")
+	}
+
+	apiV6 := &cloudfacade.CloudAPIV6{s.api}
+	results, err := apiV6.UpdateCredentialsCheckModels(params.UpdateCredentialArgs{
+		Force: false,
+		Credentials: []params.TaggedCredential{{
+			Tag:        "cloudcred-meep_julia_three",
+			Credential: params.CloudCredential{},
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "ControllerTag", "CredentialModels")
+	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
+		Results: []params.UpdateCredentialResult{{
+			CredentialTag: "cloudcred-meep_julia_three",
 			Error:         &params.Error{Message: "some models are no longer visible"},
 			Models: []params.UpdateCredentialModelResult{
 				{
@@ -744,7 +777,6 @@ func (s *cloudSuite) TestUpdateCredentialsModelGetErrorForce(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Error:         &params.Error{Message: "some models are no longer visible"},
 			Models: []params.UpdateCredentialModelResult{
 				{
 					ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
@@ -778,7 +810,6 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidation(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Error:         &params.Error{Message: "some models are no longer visible"},
 			Models: []params.UpdateCredentialModelResult{
 				{
 					ModelUUID: coretesting.ModelTag.Id(),
@@ -812,7 +843,6 @@ func (s *cloudSuite) TestUpdateCredentialsModelFailedValidationForce(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Error:         &params.Error{Message: "some models are no longer visible"},
 			Models: []params.UpdateCredentialModelResult{
 				{
 					ModelUUID: coretesting.ModelTag.Id(),
@@ -851,7 +881,6 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidation(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Error:         &params.Error{Message: "some models are no longer visible"},
 			Models: []params.UpdateCredentialModelResult{{
 				ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 				ModelName: "testModel1",
@@ -893,7 +922,6 @@ func (s *cloudSuite) TestUpdateCredentialsSomeModelsFailedValidationForce(c *gc.
 		Results: []params.UpdateCredentialResult{
 			{
 				CredentialTag: "cloudcred-meep_julia_three",
-				Error:         &params.Error{Message: "some models are no longer visible"},
 				Models: []params.UpdateCredentialModelResult{
 					{
 						ModelUUID: "deadbeef-0bad-400d-8000-4b1d0d06f00d",
@@ -933,7 +961,6 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidation(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Error:         &params.Error{Message: "some models are no longer visible"},
 			Models: []params.UpdateCredentialModelResult{
 				{
 					ModelUUID: coretesting.ModelTag.Id(),
@@ -973,7 +1000,6 @@ func (s *cloudSuite) TestUpdateCredentialsAllModelsFailedValidationForce(c *gc.C
 	c.Assert(results, jc.DeepEquals, params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{{
 			CredentialTag: "cloudcred-meep_julia_three",
-			Error:         &params.Error{Message: "some models are no longer visible"},
 			Models: []params.UpdateCredentialModelResult{
 				{
 					ModelUUID: coretesting.ModelTag.Id(),

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -11521,7 +11521,7 @@
     },
     {
         "Name": "Cloud",
-        "Version": 6,
+        "Version": 7,
         "Schema": {
             "type": "object",
             "properties": {
@@ -11541,17 +11541,6 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
-                        }
-                    }
-                },
-                "CheckCredentialsModels": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/TaggedCredentials"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/UpdateCredentialResults"
                         }
                     }
                 },

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -262,7 +262,9 @@ func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
 	var returnErr error
 	processErr := func(err error, successMsg string) {
 		if err != nil {
-			ctx.Infof("%v", err)
+			if err != cmd.ErrSilent {
+				ctx.Infof("%v", err)
+			}
 			returnErr = cmd.ErrSilent
 			return
 		}
@@ -351,12 +353,21 @@ func (c *UpdateCAASCommand) updateCredentialOnController(ctx *cmd.Context, apiCl
 		}
 		// We always want to display models information if there is any.
 		common.OutputUpdateCredentialModelResult(ctx, result.Models, true)
-		if result.Error != nil {
-			ctx.Warningf("Controller credential %q for user %q for cloud %q on controller %q not updated: %v.",
-				tag.Name(), currentAccountDetails.User, tag.Cloud().Id(), c.ControllerName, result.Error)
-			if len(result.Models) != 0 {
+		haveModelErrors := false
+		for _, m := range result.Models {
+			haveModelErrors = len(m.Errors) > 0
+			if haveModelErrors {
+				break
+			}
+		}
+		if haveModelErrors || result.Error != nil {
+			if haveModelErrors {
 				ctx.Infof("Failed models may require a different credential.")
 				ctx.Infof("Use ‘juju set-credential’ to change credential for these models before repeating this update.")
+			}
+			if result.Error != nil {
+				ctx.Warningf("Controller credential %q for user %q for cloud %q on controller %q not updated: %v.",
+					tag.Name(), currentAccountDetails.User, tag.Cloud().Id(), c.ControllerName, result.Error)
 			}
 			// We do not want to return err here as we have already displayed it on the console.
 			resultError = cmd.ErrSilent

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -43,7 +43,9 @@ type fakeUpdateCloudAPI struct {
 	*jujutesting.CallMocker
 	caas.UpdateCloudAPI
 
-	cloud jujucloud.Cloud
+	cloud       jujucloud.Cloud
+	modelResult []params.UpdateCredentialModelResult
+	errorResult *params.Error
 }
 
 func (api *fakeUpdateCloudAPI) Close() error {
@@ -69,6 +71,8 @@ func (api *fakeUpdateCloudAPI) UpdateCloudsCredentials(cloudCredentials map[stri
 	return []params.UpdateCredentialResult{
 		{
 			CredentialTag: tag,
+			Models:        api.modelResult,
+			Error:         api.errorResult,
 		},
 	}, nil
 }
@@ -318,4 +322,64 @@ func (s *updateCAASSuite) TestBuiltinToController(c *gc.C) {
 
 	s.fakeCloudAPI.CheckCall(c, 1, "UpdateCloud", expectedCloudToUpdate)
 	s.fakeCloudAPI.CheckCall(c, 2, "UpdateCloudsCredentials", expectedCredToUpdate, false)
+}
+
+func (s *updateCAASSuite) TestAffectedModels(c *gc.C) {
+	var logger loggo.Logger
+	s.fakeCloudAPI.modelResult = []params.UpdateCredentialModelResult{{
+		ModelName: "test",
+		ModelUUID: "uuid",
+		Errors:    []params.ErrorResult{{Error: &params.Error{Message: "error"}}},
+	}}
+	microk8sClusterMetadata := &jujucaas.ClusterMetadata{
+		Cloud: "microk8s",
+	}
+	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
+		CallMocker: jujutesting.NewCallMocker(logger),
+	}
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(microk8sClusterMetadata, nil)
+
+	command := s.makeCommand()
+	ctx, err := s.runCommand(c, command, "microk8s", "-c", "foo")
+	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+k8s cloud "microk8s" updated on controller "foo".
+Credential invalid for:
+  test:
+    error
+Failed models may require a different credential.
+Use ‘juju set-credential’ to change credential for these models before repeating this update.
+`[1:])
+}
+
+func (s *updateCAASSuite) TestUpdateCredentialError(c *gc.C) {
+	var logger loggo.Logger
+	s.fakeCloudAPI.modelResult = []params.UpdateCredentialModelResult{{
+		ModelName: "test",
+		ModelUUID: "uuid",
+		Errors:    []params.ErrorResult{{Error: &params.Error{Message: "error"}}},
+	}}
+	s.fakeCloudAPI.errorResult = &params.Error{Message: "some error"}
+	microk8sClusterMetadata := &jujucaas.ClusterMetadata{
+		Cloud: "microk8s",
+	}
+	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
+		CallMocker: jujutesting.NewCallMocker(logger),
+	}
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(microk8sClusterMetadata, nil)
+
+	command := s.makeCommand()
+	ctx, err := s.runCommand(c, command, "microk8s", "-c", "foo")
+	c.Assert(err, gc.DeepEquals, cmd.ErrSilent)
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+k8s cloud "microk8s" updated on controller "foo".
+Credential invalid for:
+  test:
+    error
+Failed models may require a different credential.
+Use ‘juju set-credential’ to change credential for these models before repeating this update.
+`[1:])
+	c.Assert(c.GetTestLog(), jc.Contains, `Controller credential "default" for user "foouser" for cloud "microk8s" on controller "foo" not updated: some error`)
 }

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -647,7 +647,7 @@ func (c *addCredentialCommand) addRemoteCredentials(ctxt *cmd.Context, all map[s
 		logger.Errorf("%v", err)
 		ctxt.Warningf("Could not upload credentials to controller %q", c.ControllerName)
 	}
-	return processUpdateCredentialResult(ctxt, accountDetails, "added", results, c.ControllerName, localError)
+	return processUpdateCredentialResult(ctxt, accountDetails, "added", results, false, c.ControllerName, localError)
 }
 
 func enterFile(name, descr string, p *interact.Pollster, expanded, optional bool) (string, error) {

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -502,7 +502,7 @@ func (c *detectCredentialsCommand) addRemoteCredentials(ctxt *cmd.Context, cloud
 	if moreCloudInfoNeeded {
 		ctxt.Infof("Use 'juju clouds' to view all available clouds and 'juju add-cloud' to add missing ones.")
 	}
-	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results, c.ControllerName, localErr)
+	return processUpdateCredentialResult(ctxt, accountDetails, "loaded", results, false, c.ControllerName, localErr)
 }
 
 func (c *detectCredentialsCommand) printCredentialOptions(ctxt *cmd.Context, discovered []discoveredCredential) {

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -390,7 +390,7 @@ func (c *updateCredentialCommand) updateRemoteCredentials(ctx *cmd.Context, upda
 		ctx.Warningf("Could not update credentials remotely, on controller %q", c.ControllerName)
 		erred = cmd.ErrSilent
 	}
-	return processUpdateCredentialResult(ctx, accountDetails, "updated", results, c.ControllerName, erred)
+	return processUpdateCredentialResult(ctx, accountDetails, "updated", results, c.Force, c.ControllerName, erred)
 }
 
 func verifyCredentialsForUpload(ctx *cmd.Context, accountDetails *jujuclient.AccountDetails, aCloud *jujucloud.Cloud, region string, all map[string]jujucloud.Credential) (map[string]jujucloud.Credential, error) {
@@ -415,7 +415,7 @@ func verifyCredentialsForUpload(ctx *cmd.Context, accountDetails *jujuclient.Acc
 	return verified, erred
 }
 
-func processUpdateCredentialResult(ctx *cmd.Context, accountDetails *jujuclient.AccountDetails, op string, results []params.UpdateCredentialResult, controllerName string, localError error) error {
+func processUpdateCredentialResult(ctx *cmd.Context, accountDetails *jujuclient.AccountDetails, op string, results []params.UpdateCredentialResult, force bool, controllerName string, localError error) error {
 	for _, result := range results {
 		tag, err := names.ParseCloudCredentialTag(result.CredentialTag)
 		if err != nil {
@@ -425,13 +425,25 @@ func processUpdateCredentialResult(ctx *cmd.Context, accountDetails *jujuclient.
 		}
 		// We always want to display models information if there is any.
 		common.OutputUpdateCredentialModelResult(ctx, result.Models, true)
-		if result.Error != nil {
-			ctx.Warningf("Controller credential %q for user %q for cloud %q on controller %q not %v: %v.", tag.Name(), accountDetails.User, tag.Cloud().Id(), controllerName, op, result.Error)
-			if len(result.Models) != 0 {
-				ctx.Infof("Failed models may require a different credential.")
-				ctx.Infof("Use ‘juju set-credential’ to change credential for these models before repeating this update.")
+		haveModelErrors := false
+		for _, m := range result.Models {
+			haveModelErrors = len(m.Errors) > 0
+			if haveModelErrors {
+				break
 			}
-			// We do not want to return err here as we have already displayed it on the console.
+		}
+		if haveModelErrors || result.Error != nil {
+			if haveModelErrors {
+				ctx.Infof("Failed models may require a different credential.")
+				msg := "Use ‘juju set-credential’ to change credential for these models."
+				if !force {
+					msg = "Use ‘juju set-credential’ to change credential for these models before repeating this update."
+				}
+				ctx.Infof(msg)
+			}
+			if result.Error != nil {
+				ctx.Warningf("Controller credential %q for user %q for cloud %q on controller %q not %v: %v.", tag.Name(), accountDetails.User, tag.Cloud().Id(), controllerName, op, result.Error)
+			}
 			localError = cmd.ErrSilent
 			continue
 		}

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -504,6 +504,50 @@ func (s *updateCredentialSuite) TestUpdateRemoteWithModels(c *gc.C) {
 						ModelName: "model-c",
 					},
 				},
+			},
+		}, nil
+	}
+	s.storeWithCredentials(c)
+
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "-c", "controller")
+	c.Assert(err, gc.DeepEquals, jujucmd.ErrSilent)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+Credential valid for:
+  model-c
+Credential invalid for:
+  model-a:
+    kaboom
+    kaboom 2
+  model-b:
+    one failure
+Failed models may require a different credential.
+Use ‘juju set-credential’ to change credential for these models before repeating this update.
+`[1:])
+}
+
+func (s *updateCredentialSuite) TestUpdateRemoteWithModelsError(c *gc.C) {
+	s.api.updateCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential, f bool) ([]params.UpdateCredentialResult, error) {
+		return []params.UpdateCredentialResult{
+			{
+				CredentialTag: names.NewCloudCredentialTag("aws/admin/my-credential").String(),
+				Models: []params.UpdateCredentialModelResult{
+					{
+						ModelName: "model-a",
+						Errors: []params.ErrorResult{
+							{common.ServerError(errors.New("kaboom"))},
+							{common.ServerError(errors.New("kaboom 2"))},
+						},
+					},
+					{
+						ModelName: "model-b",
+						Errors: []params.ErrorResult{
+							{common.ServerError(errors.New("one failure"))},
+						},
+					},
+					{
+						ModelName: "model-c",
+					},
+				},
 				Error: common.ServerError(errors.New("models issues")),
 			},
 		}, nil
@@ -524,7 +568,53 @@ Credential invalid for:
 Failed models may require a different credential.
 Use ‘juju set-credential’ to change credential for these models before repeating this update.
 `[1:])
-	c.Assert(c.GetTestLog(), jc.Contains, `Controller credential "my-credential" for user "admin@local" for cloud "aws" on controller "controller" not updated: models issues`)
+}
+
+func (s *updateCredentialSuite) TestUpdateRemoteWithModelsForce(c *gc.C) {
+	s.api.updateCloudsCredentials = func(cloudCredentials map[string]jujucloud.Credential, f bool) ([]params.UpdateCredentialResult, error) {
+		c.Assert(f, jc.IsTrue)
+		return []params.UpdateCredentialResult{
+			{
+				CredentialTag: names.NewCloudCredentialTag("aws/admin/my-credential").String(),
+				Models: []params.UpdateCredentialModelResult{
+					{
+						ModelName: "model-a",
+						Errors: []params.ErrorResult{
+							{common.ServerError(errors.New("kaboom"))},
+							{common.ServerError(errors.New("kaboom 2"))},
+						},
+					},
+					{
+						ModelName: "model-b",
+						Errors: []params.ErrorResult{
+							{common.ServerError(errors.New("one failure"))},
+						},
+					},
+					{
+						ModelName: "model-c",
+					},
+				},
+				Error: common.ServerError(errors.New("update error")),
+			},
+		}, nil
+	}
+	s.storeWithCredentials(c)
+
+	ctx, err := cmdtesting.RunCommand(c, s.testCommand, "aws", "my-credential", "-c", "controller", "--force")
+	c.Assert(err, gc.DeepEquals, jujucmd.ErrSilent)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+Credential valid for:
+  model-c
+Credential invalid for:
+  model-a:
+    kaboom
+    kaboom 2
+  model-b:
+    one failure
+Failed models may require a different credential.
+Use ‘juju set-credential’ to change credential for these models.
+`[1:])
+	c.Assert(c.GetTestLog(), jc.Contains, `Controller credential "my-credential" for user "admin@local" for cloud "aws" on controller "controller" not updated: update error`)
 }
 
 type fakeUpdateCredentialAPI struct {


### PR DESCRIPTION
## Description of change

The cloud  facade update credentials api was always setting an error value about invalid models even if force is used. As explained in the bug, this confuses the client because with force, the credential update did succeed, but there's no way to tell that as the error is always set. Also, any real error from updating the credential failing overwrites this model error anyway.

The other thing is that the result struct already contains a list of models with errors, so this can be used to see if any models are affected instead.

The PR changes the behaviour of the update credentials api to behave correctly, but also work the old way for older facades. The CLI is also tweaked to improve what's output based on the new behaviour. 

## QA steps

Because the cloud api caller has been updated to mask the old irrelevant error on older controllers, the new CLI will produce the same results on a 2.7 controller or a 2.8 one.

bootstrap a aws controller
edit the credential to contain an invalid secret
juju update-credential aws <credname>

observe the invalid models and a message explaining fix the credential

juju update-credential aws <credname>--force

observe the invalid models and a message explaining that some models need fixing since the cred was updated

update the cred to be good again

juju update-credential aws <credname>

the cred should update without issue

## Bug reference

https://bugs.launchpad.net/bugs/1873273
