### PR TITLE
Various fixes to image metadata commands.

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -99,7 +98,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/singular"
 	"github.com/juju/juju/apiserver/facades/controller/statushistory"
 	"github.com/juju/juju/apiserver/facades/controller/undertaker"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 )
 
@@ -215,9 +213,7 @@ func AllFacades() *facade.Registry {
 	reg("ImageManager", 2, imagemanager.NewImageManagerAPI)
 	reg("ImageMetadata", 3, imagemetadata.NewAPI)
 
-	if featureflag.Enabled(feature.ImageMetadata) {
-		reg("ImageMetadataManager", 1, imagemetadatamanager.NewAPI)
-	}
+	reg("ImageMetadataManager", 1, imagemetadatamanager.NewAPI)
 
 	reg("InstanceMutater", 1, instancemutater.NewFacadeV1)
 	reg("InstanceMutater", 2, instancemutater.NewFacadeV2)

--- a/apiserver/common/imagecommon/imagemetadata.go
+++ b/apiserver/common/imagecommon/imagemetadata.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/state/cloudimagemetadata"
 )
 
@@ -59,6 +60,9 @@ func ParseMetadataListFromParams(p params.CloudImageMetadataList, cfg *config.Co
 			},
 			Priority: metadata.Priority,
 			ImageId:  metadata.ImageId,
+		}
+		if metadata.Source == "custom" && metadata.Priority == 0 {
+			results[i].Priority = simplestreams.CUSTOM_CLOUD_DATA
 		}
 		// TODO (anastasiamac 2016-08-24) This is a band-aid solution.
 		// Once correct value is read from simplestreams, this needs to go.

--- a/apiserver/common/imagecommon/imagemetadata_test.go
+++ b/apiserver/common/imagecommon/imagemetadata_test.go
@@ -91,6 +91,7 @@ func (s *imageMetadataSuite) TestSave(c *gc.C) {
 	expectedMetadata1 := imagecommon.ParseMetadataListFromParams(params.CloudImageMetadataList{
 		Metadata: []params.CloudImageMetadata{m},
 	}, nil)
+	c.Assert(expectedMetadata1[0].Priority, gc.Equals, 50)
 	expectedMetadata2 := imagecommon.ParseMetadataListFromParams(params.CloudImageMetadataList{
 		Metadata: []params.CloudImageMetadata{m, m},
 	}, nil)

--- a/apiserver/facades/client/imagemetadatamanager/metadata.go
+++ b/apiserver/facades/client/imagemetadatamanager/metadata.go
@@ -103,6 +103,18 @@ func (api *API) List(filter params.ImageMetadataFilter) (params.ListCloudImageMe
 // Save stores given cloud image metadata.
 // It supports bulk calls.
 func (api *API) Save(metadata params.MetadataSaveParams) (params.ErrorResults, error) {
+	model, err := api.metadata.Model()
+	if err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
+	}
+	for _, mList := range metadata.Metadata {
+		for i, m := range mList.Metadata {
+			if m.Region == "" {
+				m.Region = model.CloudRegion()
+				mList.Metadata[i] = m
+			}
+		}
+	}
 	all, err := imagecommon.Save(api.metadata, metadata)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)

--- a/apiserver/facades/client/imagemetadatamanager/package_test.go
+++ b/apiserver/facades/client/imagemetadatamanager/package_test.go
@@ -66,6 +66,7 @@ const (
 	deleteMetadata = "deleteMetadata"
 	modelConfig    = "modelConfig"
 	controllerTag  = "controllerTag"
+	model          = "model"
 )
 
 func (s *baseImageMetadataSuite) constructState(cfg *config.Config) *mockState {
@@ -122,6 +123,17 @@ func (st *mockState) ModelConfig() (*config.Config, error) {
 func (st *mockState) ControllerTag() names.ControllerTag {
 	st.Stub.MethodCall(st, controllerTag)
 	return st.controllerTag()
+}
+
+func (st *mockState) Model() (imagemetadatamanager.Model, error) {
+	st.Stub.MethodCall(st, model)
+	return &mockModel{}, nil
+}
+
+type mockModel struct{}
+
+func (*mockModel) CloudRegion() string {
+	return "some-region"
 }
 
 func testConfig(c *gc.C) *config.Config {

--- a/apiserver/facades/client/imagemetadatamanager/state.go
+++ b/apiserver/facades/client/imagemetadatamanager/state.go
@@ -18,6 +18,7 @@ type metadataAccess interface {
 	DeleteMetadata(imageId string) error
 	ModelConfig() (*config.Config, error)
 	ControllerTag() names.ControllerTag
+	Model() (Model, error)
 }
 
 type Model interface {
@@ -42,6 +43,11 @@ func (s stateShim) SaveMetadata(m []cloudimagemetadata.Metadata) error {
 
 func (s stateShim) DeleteMetadata(imageId string) error {
 	return s.State.CloudImageMetadataStorage.DeleteMetadata(imageId)
+}
+
+// Model returns the Model for this state.
+func (s stateShim) Model() (Model, error) {
+	return s.State.Model()
 }
 
 // ModelConfig implements the metadataAccess method as an expedient until the

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -17488,6 +17488,231 @@
         }
     },
     {
+        "Name": "ImageMetadataManager",
+        "Version": 1,
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Delete": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MetadataImageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "List": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ImageMetadataFilter"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ListCloudImageMetadataResult"
+                        }
+                    }
+                },
+                "Save": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MetadataSaveParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "CloudImageMetadata": {
+                    "type": "object",
+                    "properties": {
+                        "arch": {
+                            "type": "string"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "priority": {
+                            "type": "integer"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "root-storage-size": {
+                            "type": "integer"
+                        },
+                        "root-storage-type": {
+                            "type": "string"
+                        },
+                        "series": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "stream": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "image-id",
+                        "region",
+                        "version",
+                        "series",
+                        "arch",
+                        "source",
+                        "priority"
+                    ]
+                },
+                "CloudImageMetadataList": {
+                    "type": "object",
+                    "properties": {
+                        "metadata": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadata"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ImageMetadataFilter": {
+                    "type": "object",
+                    "properties": {
+                        "arches": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "root-storage-type": {
+                            "type": "string"
+                        },
+                        "series": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "stream": {
+                            "type": "string"
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ListCloudImageMetadataResult": {
+                    "type": "object",
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadata"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "MetadataImageIds": {
+                    "type": "object",
+                    "properties": {
+                        "image-ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "image-ids"
+                    ]
+                },
+                "MetadataSaveParams": {
+                    "type": "object",
+                    "properties": {
+                        "metadata": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadataList"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
         "Name": "InstanceMutater",
         "Version": 2,
         "Schema": {

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -632,7 +632,7 @@ func storeImageMetadataInState(st *state.State, env environs.BootstrapEnviron, s
 		}
 		metadataState[i] = m
 	}
-	if err := st.CloudImageMetadataStorage.SaveMetadataNoExpiry(metadataState); err != nil {
+	if err := st.CloudImageMetadataStorage.SaveMetadata(metadataState); err != nil {
 		return errors.Annotatef(err, "cannot cache image metadata")
 	}
 	return nil

--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/os/series"
 
 	"github.com/juju/juju/apiserver/params"
@@ -146,6 +147,7 @@ func (c *addImageMetadataCommand) constructMetadataParam() params.CloudImageMeta
 		RootStorageType: c.RootStorageType,
 		Stream:          c.Stream,
 		Source:          "custom",
+		Priority:        simplestreams.CUSTOM_CLOUD_DATA,
 	}
 	if c.RootStorageSize != 0 {
 		info.RootStorageSize = &c.RootStorageSize

--- a/cmd/plugins/juju-metadata/addimage_test.go
+++ b/cmd/plugins/juju-metadata/addimage_test.go
@@ -148,10 +148,11 @@ func (s *addImageSuite) assertAddImageMetadataErr(c *gc.C, m params.CloudImageMe
 
 func constructTestImageMetadata() params.CloudImageMetadata {
 	return params.CloudImageMetadata{
-		ImageId: "im-33333",
-		Series:  "trusty",
-		Arch:    "arch",
-		Source:  "custom",
+		ImageId:  "im-33333",
+		Series:   "trusty",
+		Arch:     "arch",
+		Source:   "custom",
+		Priority: 50,
 	}
 }
 

--- a/featuretests/cloudimagemetadata_test.go
+++ b/featuretests/cloudimagemetadata_test.go
@@ -58,6 +58,7 @@ func (s *cloudImageMetadataSuite) TestSaveAndFindAndDeleteMetadata(c *gc.C) {
 		VirtType:        "virtType",
 		RootStorageType: "rootStorageType",
 		ImageId:         imageId,
+		Priority:        50,
 	}
 
 	err = s.client.Save([]params.CloudImageMetadata{m})

--- a/state/cloudimagemetadata/interface.go
+++ b/state/cloudimagemetadata/interface.go
@@ -60,13 +60,9 @@ type Metadata struct {
 // Storage provides methods for storing and retrieving cloud image metadata.
 type Storage interface {
 	// SaveMetadata adds cloud images metadata into state if it's new or
-	// updates metadata if it already exists. The records will expire
-	// after a set time.
+	// updates metadata if it already exists.
+	// Non custom records will expire after a set time.
 	SaveMetadata([]Metadata) error
-
-	// SaveMetadataNoExpiry adds cloud images metadata into state if it's new or
-	// updates metadata if it already exists. The records will not expire.
-	SaveMetadataNoExpiry([]Metadata) error
 
 	// DeleteMetadata deletes cloud image metadata from state.
 	DeleteMetadata(imageId string) error

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2182,7 +2182,7 @@ func (s *upgradesSuite) TestDeleteCloudImageMetadata(c *gc.C) {
 		{attrs1, 0, "1", now},
 		{attrs2, 0, "2", now},
 	}
-	err := stor.SaveMetadataNoExpiry(added)
+	err := stor.SaveMetadata(added)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []bson.M{{


### PR DESCRIPTION
## Description of change

Create the facade always - it was behind a feature flag
Ensure default region is set correctly - when not specified, it needs to be set to the model region.
Do not expire custom image metadata - all metadata added via add-image was being expired but custom metadata needs to be kept.

## QA steps

bootstrap on aws
export JUJU_FEATURES=image-metadata

ensure that juju metadata add-image can be used to add metadata for say centos7, and that if region is left off, the model region is used.
metadata can be viewed with juju metadata list-images
wait 5 minutes ahd list again to ensure it doesn't expire