### PR TITLE
Install missing dependencies

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -38,6 +38,10 @@ jobs:
         go get -u github.com/client9/misspell/cmd/misspell
         go get -u github.com/tsenart/deadcode
         go get -u golang.org/x/lint/golint
+        go get -u golang.org/x/tools/cmd/goimports
+        go get -u github.com/mdempsky/unconvert
+        go get -u github.com/gordonklaus/ineffassign
+        echo "##[add-path]${GOPATH}/bin"
 
     - name: "Static Analysis: Copyright"
       working-directory: src/github.com/juju/juju


### PR DESCRIPTION
## Description of change

The following lint dependencies where missing added them along with
ensuring the GOPATH bin is added as well, so they can get looked up
correctly.
