### PR TITLE
Refactor worker/uniter/relation for interfaces

### DIFF
--- a/api/uniter/relation.go
+++ b/api/uniter/relation.go
@@ -4,8 +4,6 @@
 package uniter
 
 import (
-	"fmt"
-
 	"github.com/juju/charm/v7"
 
 	"github.com/juju/juju/apiserver/params"
@@ -114,18 +112,16 @@ func (r *Relation) Endpoint() (*Endpoint, error) {
 	return &Endpoint{r.toCharmRelation(result.Endpoint.Relation)}, nil
 }
 
-// Unit returns a RelationUnit for the supplied unit.
-func (r *Relation) Unit(u *Unit) (*RelationUnit, error) {
-	if u == nil {
-		return nil, fmt.Errorf("unit is nil")
-	}
-	result, err := r.st.relation(r.tag, u.tag)
+// Unit returns a RelationUnit for the supplied unitTag and applicationTag.
+func (r *Relation) Unit(uTag names.UnitTag, aTag names.ApplicationTag) (*RelationUnit, error) {
+	result, err := r.st.relation(r.tag, uTag)
 	if err != nil {
 		return nil, err
 	}
 	return &RelationUnit{
 		relation: r,
-		unit:     u,
+		unitTag:  uTag,
+		appTag:   aTag,
 		endpoint: Endpoint{r.toCharmRelation(result.Endpoint.Relation)},
 		st:       r.st,
 	}, nil

--- a/api/uniter/relation.go
+++ b/api/uniter/relation.go
@@ -5,11 +5,12 @@ package uniter
 
 import (
 	"github.com/juju/charm/v7"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
-	"github.com/juju/names/v4"
 )
 
 // This module implements a subset of the interface provided by
@@ -112,16 +113,20 @@ func (r *Relation) Endpoint() (*Endpoint, error) {
 	return &Endpoint{r.toCharmRelation(result.Endpoint.Relation)}, nil
 }
 
-// Unit returns a RelationUnit for the supplied unitTag and applicationTag.
-func (r *Relation) Unit(uTag names.UnitTag, aTag names.ApplicationTag) (*RelationUnit, error) {
+// Unit returns a RelationUnit for the supplied unitTag.
+func (r *Relation) Unit(uTag names.UnitTag) (*RelationUnit, error) {
+	appName, err := names.UnitApplication(uTag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	result, err := r.st.relation(r.tag, uTag)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return &RelationUnit{
 		relation: r,
 		unitTag:  uTag,
-		appTag:   aTag,
+		appTag:   names.NewApplicationTag(appName),
 		endpoint: Endpoint{r.toCharmRelation(result.Endpoint.Relation)},
 		st:       r.st,
 	}, nil

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -117,12 +117,9 @@ func (s *relationSuite) TestEndpoint(c *gc.C) {
 }
 
 func (s *relationSuite) TestUnit(c *gc.C) {
-	_, err := s.apiRelation.Unit(nil)
-	c.Assert(err, gc.ErrorMatches, "unit is nil")
-
 	apiUnit, err := s.uniter.Unit(names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := s.apiRelation.Unit(apiUnit)
+	apiRelUnit, err := s.apiRelation.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiRelUnit, gc.NotNil)
 	// We just ensure we get the correct type, more tests

--- a/api/uniter/relation_test.go
+++ b/api/uniter/relation_test.go
@@ -119,7 +119,7 @@ func (s *relationSuite) TestEndpoint(c *gc.C) {
 func (s *relationSuite) TestUnit(c *gc.C) {
 	apiUnit, err := s.uniter.Unit(names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := s.apiRelation.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	apiRelUnit, err := s.apiRelation.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apiRelUnit, gc.NotNil)
 	// We just ensure we get the correct type, more tests

--- a/api/uniter/relationunit.go
+++ b/api/uniter/relationunit.go
@@ -21,7 +21,8 @@ import (
 type RelationUnit struct {
 	st       *State
 	relation *Relation
-	unit     *Unit
+	unitTag  names.UnitTag
+	appTag   names.ApplicationTag
 	endpoint Endpoint
 	scope    string
 }
@@ -61,7 +62,7 @@ func (ru *RelationUnit) EnterScope() error {
 	args := params.RelationUnits{
 		RelationUnits: []params.RelationUnit{{
 			Relation: ru.relation.tag.String(),
-			Unit:     ru.unit.tag.String(),
+			Unit:     ru.unitTag.String(),
 		}},
 	}
 	err := ru.st.facade.FacadeCall("EnterScope", args, &result)
@@ -81,7 +82,7 @@ func (ru *RelationUnit) LeaveScope() error {
 	args := params.RelationUnits{
 		RelationUnits: []params.RelationUnit{{
 			Relation: ru.relation.tag.String(),
-			Unit:     ru.unit.tag.String(),
+			Unit:     ru.unitTag.String(),
 		}},
 	}
 	err := ru.st.facade.FacadeCall("LeaveScope", args, &result)
@@ -98,7 +99,7 @@ func (ru *RelationUnit) Settings() (*Settings, error) {
 	args := params.RelationUnits{
 		RelationUnits: []params.RelationUnit{{
 			Relation: ru.relation.tag.String(),
-			Unit:     ru.unit.tag.String(),
+			Unit:     ru.unitTag.String(),
 		}},
 	}
 	err := ru.st.facade.FacadeCall("ReadSettings", args, &results)
@@ -112,7 +113,7 @@ func (ru *RelationUnit) Settings() (*Settings, error) {
 	if result.Error != nil {
 		return nil, errors.Trace(result.Error)
 	}
-	return newSettings(ru.st, ru.relation.tag.String(), ru.unit.tag.String(), result.Settings), nil
+	return newSettings(ru.st, ru.relation.tag.String(), ru.unitTag.String(), result.Settings), nil
 }
 
 // ApplicationSettings returns a Settings which allows access to this unit's
@@ -122,14 +123,14 @@ func (ru *RelationUnit) ApplicationSettings() (*Settings, error) {
 	var result params.SettingsResult
 	arg := params.RelationUnit{
 		Relation: ru.relation.tag.String(),
-		Unit:     ru.unit.Tag().String(),
+		Unit:     ru.unitTag.String(),
 	}
 	if err := ru.st.facade.FacadeCall("ReadLocalApplicationSettings", arg, &result); err != nil {
 		return nil, errors.Trace(err)
 	} else if result.Error != nil {
 		return nil, errors.Trace(result.Error)
 	}
-	return newSettings(ru.st, ru.relation.tag.String(), ru.unit.ApplicationTag().String(), result.Settings), nil
+	return newSettings(ru.st, ru.relation.tag.String(), ru.appTag.String(), result.Settings), nil
 }
 
 // ReadSettings returns a map holding the settings of the unit with the
@@ -152,7 +153,7 @@ func (ru *RelationUnit) ReadSettings(name string) (params.Settings, error) {
 	args := params.RelationUnitPairs{
 		RelationUnitPairs: []params.RelationUnitPair{{
 			Relation:   ru.relation.tag.String(),
-			LocalUnit:  ru.unit.tag.String(),
+			LocalUnit:  ru.unitTag.String(),
 			RemoteUnit: tag.String(),
 		}},
 	}
@@ -178,7 +179,7 @@ func (ru *RelationUnit) UpdateRelationSettings(unit, application params.Settings
 	args := params.RelationUnitsSettings{
 		RelationUnits: []params.RelationUnitSettings{{
 			Relation:            ru.relation.tag.String(),
-			Unit:                ru.unit.tag.String(),
+			Unit:                ru.unitTag.String(),
 			Settings:            unit,
 			ApplicationSettings: application,
 		}},

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -65,7 +65,7 @@ func (s *relationUnitSuite) getRelationUnits(c *gc.C) (*state.RelationUnit, *uni
 	// TODO(dfc)
 	apiUnit, err := s.uniter.Unit(s.wordpressUnit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRelation.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	apiRelUnit, err := apiRelation.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	return wpRelUnit, apiRelUnit
 }
@@ -155,7 +155,7 @@ func (s *relationUnitSuite) TestEnterScopeErrCannotEnterScopeYet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiRel, err := s.uniter.Relation(subRel.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRel.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	apiRelUnit, err := apiRel.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = apiRelUnit.EnterScope()
 	c.Assert(err, gc.NotNil)
@@ -317,7 +317,7 @@ func (s *relationUnitSuite) setupMysqlRelatedToWordpress(c *gc.C) (*state.Relati
 	c.Assert(err, jc.ErrorIsNil)
 	apiUnit, err := s.uniter.Unit(names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = apiRel.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	_, err = apiRel.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We just created the wordpress unit, make sure its event isn't still in the queue

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -65,7 +65,7 @@ func (s *relationUnitSuite) getRelationUnits(c *gc.C) (*state.RelationUnit, *uni
 	// TODO(dfc)
 	apiUnit, err := s.uniter.Unit(s.wordpressUnit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRelation.Unit(apiUnit)
+	apiRelUnit, err := apiRelation.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
 	c.Assert(err, jc.ErrorIsNil)
 	return wpRelUnit, apiRelUnit
 }
@@ -155,7 +155,7 @@ func (s *relationUnitSuite) TestEnterScopeErrCannotEnterScopeYet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiRel, err := s.uniter.Relation(subRel.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRel.Unit(apiUnit)
+	apiRelUnit, err := apiRel.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
 	c.Assert(err, jc.ErrorIsNil)
 	err = apiRelUnit.EnterScope()
 	c.Assert(err, gc.NotNil)
@@ -317,7 +317,7 @@ func (s *relationUnitSuite) setupMysqlRelatedToWordpress(c *gc.C) (*state.Relati
 	c.Assert(err, jc.ErrorIsNil)
 	apiUnit, err := s.uniter.Unit(names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = apiRel.Unit(apiUnit)
+	_, err = apiRel.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We just created the wordpress unit, make sure its event isn't still in the queue

--- a/api/uniter/settings_test.go
+++ b/api/uniter/settings_test.go
@@ -110,7 +110,7 @@ func (s *settingsSuite) TestWrite(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiRelation, err := s.uniter.Relation(s.stateRelation.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRelation.Unit(apiUnit)
+	apiRelUnit, err := apiRelation.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err := apiRelUnit.Settings()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/uniter/settings_test.go
+++ b/api/uniter/settings_test.go
@@ -110,7 +110,7 @@ func (s *settingsSuite) TestWrite(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiRelation, err := s.uniter.Relation(s.stateRelation.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRelation.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	apiRelUnit, err := apiRelation.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err := apiRelUnit.Settings()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/relation/interface.go
+++ b/worker/uniter/relation/interface.go
@@ -213,7 +213,7 @@ type Relation interface {
 	Tag() names.RelationTag
 
 	// Unit returns a uniter.RelationUnit for the supplied unit.
-	Unit(names.UnitTag, names.ApplicationTag) (RelationUnit, error)
+	Unit(names.UnitTag) (RelationUnit, error)
 
 	// UpdateSuspended updates the in memory value of the
 	// relation's suspended attribute.

--- a/worker/uniter/relation/interface.go
+++ b/worker/uniter/relation/interface.go
@@ -1,0 +1,260 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package relation
+
+import (
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/remotestate"
+	"github.com/juju/juju/worker/uniter/runner/context"
+)
+
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mock_statetracker.go github.com/juju/juju/worker/uniter/relation RelationStateTracker
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mock_subordinate_destroyer.go github.com/juju/juju/worker/uniter/relation SubordinateDestroyer
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mock_state_tracker_state.go github.com/juju/juju/worker/uniter/relation StateTrackerState
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mock_uniter_api.go github.com/juju/juju/worker/uniter/relation Unit,Application,Relation,RelationUnit
+
+type RelationStateTracker interface {
+	// PrepareHook returns the name of the supplied relation hook, or an error
+	// if the hook is unknown or invalid given current state.
+	PrepareHook(hook.Info) (string, error)
+
+	// CommitHook persists the state change encoded in the supplied relation
+	// hook, or returns an error if the hook is unknown or invalid given
+	// current relation state.
+	CommitHook(hook.Info) error
+
+	// SyncronizeScopes ensures that the locally tracked relation scopes
+	// reflect the contents of the remote state snapshot by entering or
+	// exiting scopes as required.
+	SynchronizeScopes(remotestate.Snapshot) error
+
+	// IsKnown returns true if the relation ID is known by the tracker.
+	IsKnown(int) bool
+
+	// IsImplicit returns true if the endpoint for a relation ID is implicit.
+	IsImplicit(int) (bool, error)
+
+	// IsPeerRelation returns true if the endpoint for a relation ID has a
+	// Peer role.
+	IsPeerRelation(int) (bool, error)
+
+	// HasContainerScope returns true if the specified relation ID has a
+	// container scope.
+	HasContainerScope(int) (bool, error)
+
+	// RelationCreated returns true if a relation created hook has been
+	// fired for the specified relation ID.
+	RelationCreated(int) bool
+
+	// RemoteApplication returns the remote application name associated
+	// with the specified relation ID.
+	RemoteApplication(int) string
+
+	// State returns a State instance for accessing the local state
+	// for a relation ID.
+	State(int) (*State, error)
+
+	// StateFound returns a true if there is a state for the given in
+	// in the state manager.
+	StateFound(int) bool
+
+	// GetInfo returns information about current relation state.
+	GetInfo() map[int]*context.RelationInfo
+
+	// Name returns the name of the relation with the supplied id, or an error
+	// if the relation is unknown.
+	Name(id int) (string, error)
+
+	// LocalUnitName returns the name for the local unit.
+	LocalUnitName() string
+
+	// LocalUnitAndApplicationLife returns the life values for the local
+	// unit and application.
+	LocalUnitAndApplicationLife() (life.Value, life.Value, error)
+}
+
+// SubordinateDestroyer destroys all subordinates of a unit.
+type SubordinateDestroyer interface {
+	DestroyAllSubordinates() error
+}
+
+// StateManager encapsulates methods required to handle relation
+// state.
+type StateManager interface {
+	// KnownIDs returns a slice of relation ids, known to the
+	// state manager.
+	KnownIDs() []int
+
+	// Relation returns a copy of the relation state for the given id.
+	Relation(int) (*State, error)
+
+	// SetRelation persists the given state, overwriting the previous
+	// state for a given id or creating state at a new id.
+	SetRelation(*State) error
+
+	// RelationFound returns true if the state manager has a
+	// state for the given id.
+	RelationFound(id int) bool
+
+	// RemoveRelation removes the state for the given id from the
+	// manager.
+	RemoveRelation(id int) error
+}
+
+// UnitStateReadWriter encapsulates the methods from a state.Unit
+// required to set and get unit state.
+type UnitStateReadWriter interface {
+	// SetState sets the state persisted by the charm running in this unit
+	// and the state internal to the uniter for this unit.
+	SetState(unitState params.SetUnitStateArg) error
+
+	// State returns the state persisted by the charm running in this unit
+	// and the state internal to the uniter for this unit.
+	State() (params.UnitStateResult, error)
+}
+
+// StateTrackerState encapsulates the methods from state
+// required by a relationStateTracker.
+type StateTrackerState interface {
+	// Relation returns the existing relation with the given tag.
+	Relation(tag names.RelationTag) (Relation, error)
+
+	// RelationById returns the existing relation with the given id.
+	RelationById(int) (Relation, error)
+}
+
+// Unit encapsulates the methods from state.Unit
+// required by a relationStateTracker.
+type Unit interface {
+	UnitStateReadWriter
+
+	// Tag returns the tag for this unit.
+	Tag() names.UnitTag
+
+	// ApplicationTag returns the tag for this unit's application.
+	ApplicationTag() names.ApplicationTag
+
+	// RelationsStatus returns the tags of the relations the unit has joined
+	// and entered scope, or the relation is suspended.
+	RelationsStatus() ([]uniter.RelationStatus, error)
+
+	// Watch returns a watcher for observing changes to the unit.
+	Watch() (watcher.NotifyWatcher, error)
+
+	// Destroy, when called on a Alive unit, advances its lifecycle as far as
+	// possible; it otherwise has no effect. In most situations, the unit's
+	// life is just set to Dying; but if a principal unit that is not assigned
+	// to a provisioned machine is Destroyed, it will be removed from state
+	// directly.
+	Destroy() error
+
+	// Name returns the name of the unit.
+	Name() string
+
+	// Refresh updates the cached local copy of the unit's data.
+	Refresh() error
+
+	// Application returns the unit's application.
+	Application() (Application, error)
+
+	// Life returns the unit's lifecycle value.
+	Life() life.Value
+}
+
+// Application encapsulates the methods from
+// state.Application required by a relationStateTracker.
+type Application interface {
+	Life() life.Value
+}
+
+// Relation encapsulates the methods from
+// state.Relation required by a relationStateTracker.
+type Relation interface {
+	// Endpoint returns the endpoint of the relation for the application the
+	// uniter's managed unit belongs to.
+	Endpoint() (*uniter.Endpoint, error)
+
+	// Id returns the integer internal relation key. This is exposed
+	// because the unit agent needs to expose a value derived from this
+	// (as JUJU_RELATION_ID) to allow relation hooks to differentiate
+	// between relations with different applications.
+	Id() int
+
+	// Life returns the relation's current life state.
+	Life() life.Value
+
+	// OtherApplication returns the name of the application on the other
+	// end of the relation (from this unit's perspective).
+	OtherApplication() string
+
+	// Refresh refreshes the contents of the relation from the underlying
+	// state. It returns an error that satisfies errors.IsNotFound if the
+	// relation has been removed.
+	Refresh() error
+
+	// SetStatus updates the status of the relation.
+	SetStatus(relation.Status) error
+
+	// String returns the relation as a string.
+	String() string
+
+	// Suspended returns the relation's current suspended status.
+	Suspended() bool
+
+	// Tag returns the relation tag.
+	Tag() names.RelationTag
+
+	// Unit returns a uniter.RelationUnit for the supplied unit.
+	Unit(names.UnitTag, names.ApplicationTag) (RelationUnit, error)
+
+	// UpdateSuspended updates the in memory value of the
+	// relation's suspended attribute.
+	UpdateSuspended(bool)
+}
+
+// RelationUnit encapsulates the methods from
+// state.RelationUnit required by a relationer.
+type RelationUnit interface {
+	// ApplicationSettings returns a Settings which allows access to this
+	// unit's application settings within the relation. This can only be
+	// used from the leader unit.
+	ApplicationSettings() (*uniter.Settings, error)
+
+	// Endpoint returns the endpoint of the relation for the application the
+	// uniter's managed unit belongs to.
+	Endpoint() uniter.Endpoint
+
+	// EnterScope ensures that the unit has entered its scope in the relation.
+	// When the unit has already entered its relation scope, EnterScope will
+	// report success but make no changes to state.
+	EnterScope() error
+
+	// LeaveScope signals that the unit has left its scope in the relation.
+	// After the unit has left its relation scope, it is no longer a member
+	// of the relation.
+	LeaveScope() error
+
+	// Relation returns the relation associated with the unit.
+	Relation() Relation
+
+	// ReadSettings returns a map holding the settings of the unit with the
+	// supplied name within this relation.
+	ReadSettings(name string) (params.Settings, error)
+
+	// Settings returns a Settings which allows access to the unit's settings
+	// within the relation.
+	Settings() (*uniter.Settings, error)
+
+	// UpdateRelationSettings is used to record any changes to settings for
+	// this unit and application. It is only valid to update application
+	// settings if this unit is the leader.
+	UpdateRelationSettings(unit, application params.Settings) error
+}

--- a/worker/uniter/relation/relationer.go
+++ b/worker/uniter/relation/relationer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/worker/v2/dependency"
 
-	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
@@ -18,14 +17,14 @@ import (
 // Relationer manages a unit's presence in a relation.
 type Relationer struct {
 	relationId int
-	ru         *apiuniter.RelationUnit
+	ru         RelationUnit
 	stateMgr   StateManager
 	dying      bool
 }
 
 // NewRelationer creates a new Relationer. The unit will not join the
 // relation until explicitly requested.
-func NewRelationer(ru *apiuniter.RelationUnit, stateMgr StateManager) *Relationer {
+func NewRelationer(ru RelationUnit, stateMgr StateManager) *Relationer {
 	return &Relationer{
 		relationId: ru.Relation().Id(),
 		ru:         ru,
@@ -44,7 +43,11 @@ func (r *Relationer) ContextInfo() *context.RelationInfo {
 	for memberName := range members {
 		memberNames = append(memberNames, memberName)
 	}
-	return &context.RelationInfo{r.ru, memberNames}
+	sh, _ := r.ru.(*RelationUnitShim)
+	return &context.RelationInfo{
+		RelationUnit: &context.RelationUnitShim{sh.RelationUnit},
+		MemberNames:  memberNames,
+	}
 }
 
 // IsImplicit returns whether the local relation endpoint is implicit. Implicit
@@ -54,7 +57,7 @@ func (r *Relationer) IsImplicit() bool {
 }
 
 // RelationUnit returns the relation unit associated with this relationer instance.
-func (r *Relationer) RelationUnit() *apiuniter.RelationUnit {
+func (r *Relationer) RelationUnit() RelationUnit {
 	return r.ru
 }
 

--- a/worker/uniter/relation/relationer_test.go
+++ b/worker/uniter/relation/relationer_test.go
@@ -65,7 +65,7 @@ func (s *relationerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiRel, err := s.uniter.Relation(s.rel.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRel.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	apiRelUnit, err := apiRel.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.relUnit = &relation.RelationUnitShim{apiRelUnit}
 	s.mgr, err = relation.NewStateManager(apiUnit)
@@ -282,7 +282,7 @@ func (s *relationerImplicitSuite) TestImplicitRelationer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiRel, err := uniterState.Relation(rel.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRel.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	apiRelUnit, err := apiRel.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	relUnit := &relation.RelationUnitShim{apiRelUnit}
 

--- a/worker/uniter/relation/resolver.go
+++ b/worker/uniter/relation/resolver.go
@@ -19,13 +19,6 @@ import (
 
 var logger = loggo.GetLogger("juju.worker.uniter.relation")
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mock_subordinate_destroyer.go github.com/juju/juju/worker/uniter/relation SubordinateDestroyer
-
-// SubordinateDestroyer destroys all subordinates of a unit.
-type SubordinateDestroyer interface {
-	DestroyAllSubordinates() error
-}
-
 // NewRelationResolver returns a resolver that handles all relation-related
 // hooks (except relation-created) and is wired to the provided RelationStateTracker
 // instance.

--- a/worker/uniter/relation/shim.go
+++ b/worker/uniter/relation/shim.go
@@ -34,8 +34,8 @@ type relationShim struct {
 	*uniter.Relation
 }
 
-func (s *relationShim) Unit(uTag names.UnitTag, aTag names.ApplicationTag) (RelationUnit, error) {
-	u, err := s.Relation.Unit(uTag, aTag)
+func (s *relationShim) Unit(uTag names.UnitTag) (RelationUnit, error) {
+	u, err := s.Relation.Unit(uTag)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/uniter/relation/shim.go
+++ b/worker/uniter/relation/shim.go
@@ -1,0 +1,67 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package relation
+
+import (
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/api/uniter"
+)
+
+type stateTrackerStateShim struct {
+	*uniter.State
+}
+
+func (s *stateTrackerStateShim) Relation(tag names.RelationTag) (Relation, error) {
+	rel, err := s.State.Relation(tag)
+	if err != nil {
+		return nil, err
+	}
+	return &relationShim{rel}, nil
+}
+
+// RelationById returns the existing relation with the given id.
+func (s *stateTrackerStateShim) RelationById(id int) (Relation, error) {
+	rel, err := s.State.RelationById(id)
+	if err != nil {
+		return nil, err
+	}
+	return &relationShim{rel}, nil
+}
+
+type relationShim struct {
+	*uniter.Relation
+}
+
+func (s *relationShim) Unit(uTag names.UnitTag, aTag names.ApplicationTag) (RelationUnit, error) {
+	u, err := s.Relation.Unit(uTag, aTag)
+	if err != nil {
+		return nil, err
+	}
+	return &RelationUnitShim{u}, nil
+}
+
+type unitShim struct {
+	*uniter.Unit
+}
+
+func (s *unitShim) Application() (Application, error) {
+	app, err := s.Unit.Application()
+	if err != nil {
+		return nil, err
+	}
+	return &applicationShim{app}, nil
+}
+
+type applicationShim struct {
+	*uniter.Application
+}
+
+type RelationUnitShim struct {
+	*uniter.RelationUnit
+}
+
+func (r *RelationUnitShim) Relation() Relation {
+	return &relationShim{r.RelationUnit.Relation()}
+}

--- a/worker/uniter/relation/statemanager.go
+++ b/worker/uniter/relation/statemanager.go
@@ -13,36 +13,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 )
 
-// StateManager encapsulates methods required to handle relation
-// state.
-type StateManager interface {
-	// KnownIDs returns a slice of relation ids, known to the
-	// state manager.
-	KnownIDs() []int
-
-	// Relation returns a copy of the relation state for the given id.
-	Relation(int) (*State, error)
-
-	// SetRelation persists the given state, overwriting the previous
-	// state for a given id or creating state at a new id.
-	SetRelation(*State) error
-
-	// RelationFound returns true if the state manager has a
-	// state for the given id.
-	RelationFound(id int) bool
-
-	// RemoveRelation removes the state for the given id from the
-	// manager.
-	RemoveRelation(id int) error
-}
-
-// UnitStateReadWriter encapsulates the methods from a state.Unit
-// required to set and get unit state.
-type UnitStateReadWriter interface {
-	State() (params.UnitStateResult, error)
-	SetState(unitState params.SetUnitStateArg) error
-}
-
 // NewStateManager
 func NewStateManager(rw UnitStateReadWriter) (StateManager, error) {
 	mgr := &stateManager{unitStateRW: rw}

--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -5,7 +5,6 @@ package relation
 
 import (
 	"github.com/juju/charm/v7"
-	corecharm "github.com/juju/charm/v7"
 	"github.com/juju/charm/v7/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -21,68 +20,6 @@ import (
 	"github.com/juju/juju/worker/uniter/resolver"
 	"github.com/juju/juju/worker/uniter/runner/context"
 )
-
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mock_statetracker.go github.com/juju/juju/worker/uniter/relation RelationStateTracker
-
-type RelationStateTracker interface {
-	// PrepareHook returns the name of the supplied relation hook, or an error
-	// if the hook is unknown or invalid given current state.
-	PrepareHook(hook.Info) (string, error)
-
-	// CommitHook persists the state change encoded in the supplied relation
-	// hook, or returns an error if the hook is unknown or invalid given
-	// current relation state.
-	CommitHook(hook.Info) error
-
-	// SyncronizeScopes ensures that the locally tracked relation scopes
-	// reflect the contents of the remote state snapshot by entering or
-	// exiting scopes as required.
-	SynchronizeScopes(remotestate.Snapshot) error
-
-	// IsKnown returns true if the relation ID is known by the tracker.
-	IsKnown(int) bool
-
-	// IsImplicit returns true if the endpoint for a relation ID is implicit.
-	IsImplicit(int) (bool, error)
-
-	// IsPeerRelation returns true if the endpoint for a relation ID has a
-	// Peer role.
-	IsPeerRelation(int) (bool, error)
-
-	// HasContainerScope returns true if the specified relation ID has a
-	// container scope.
-	HasContainerScope(int) (bool, error)
-
-	// RelationCreated returns true if a relation created hook has been
-	// fired for the specified relation ID.
-	RelationCreated(int) bool
-
-	// RemoteApplication returns the remote application name associated
-	// with the specified relation ID.
-	RemoteApplication(int) string
-
-	// State returns a State instance for accessing the local state
-	// for a relation ID.
-	State(int) (*State, error)
-
-	// StateFound returns a true if there is a state for the given in
-	// in the state manager.
-	StateFound(int) bool
-
-	// GetInfo returns information about current relation state.
-	GetInfo() map[int]*context.RelationInfo
-
-	// Name returns the name of the relation with the supplied id, or an error
-	// if the relation is unknown.
-	Name(id int) (string, error)
-
-	// LocalUnitName returns the name for the local unit.
-	LocalUnitName() string
-
-	// LocalUnitAndApplicationLife returns the life values for the local
-	// unit and application.
-	LocalUnitAndApplicationLife() (life.Value, life.Value, error)
-}
 
 // LeadershipContextFunc is a function that returns a leadership context.
 type LeadershipContextFunc func(accessor context.LeadershipSettingsAccessor, tracker leadership.Tracker, unitName string) context.LeadershipContext
@@ -100,8 +37,8 @@ type RelationStateTrackerConfig struct {
 
 // relationStateTracker implements RelationStateTracker.
 type relationStateTracker struct {
-	st              *uniter.State
-	unit            *uniter.Unit
+	st              StateTrackerState
+	unit            Unit
 	leaderCtx       context.LeadershipContext
 	abort           <-chan struct{}
 	subordinate     bool
@@ -127,8 +64,8 @@ func NewRelationStateTracker(cfg RelationStateTrackerConfig) (RelationStateTrack
 	)
 
 	r := &relationStateTracker{
-		st:              cfg.State,
-		unit:            cfg.Unit,
+		st:              &stateTrackerStateShim{cfg.State},
+		unit:            &unitShim{cfg.Unit},
 		leaderCtx:       leadershipContext,
 		subordinate:     subordinate,
 		principalName:   principalName,
@@ -160,7 +97,7 @@ func (r *relationStateTracker) loadInitialState() error {
 
 	// Keep the relations ordered for reliable testing.
 	var orderedIds []int
-	activeRelations := make(map[int]*uniter.Relation)
+	activeRelations := make(map[int]Relation)
 	relationSuspended := make(map[int]bool)
 	for _, rs := range relationStatus {
 		if !rs.InScope {
@@ -212,9 +149,9 @@ func (r *relationStateTracker) loadInitialState() error {
 // store persistent state. It will block until the
 // operation succeeds or fails; or until the abort chan is closed, in which
 // case it will return resolver.ErrLoopAborted.
-func (r *relationStateTracker) joinRelation(rel *uniter.Relation) (err error) {
+func (r *relationStateTracker) joinRelation(rel Relation) (err error) {
 	logger.Infof("joining relation %q", rel)
-	ru, err := rel.Unit(r.unit)
+	ru, err := rel.Unit(r.unit.Tag(), r.unit.ApplicationTag())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -346,7 +283,7 @@ func (r *relationStateTracker) SynchronizeScopes(remote remotestate.Snapshot) er
 			continue
 		}
 		scope := relationer.ru.Endpoint().Scope
-		if scope == corecharm.ScopeContainer && !relationer.dying {
+		if scope == charm.ScopeContainer && !relationer.dying {
 			return nil
 		}
 	}

--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -151,7 +151,7 @@ func (r *relationStateTracker) loadInitialState() error {
 // case it will return resolver.ErrLoopAborted.
 func (r *relationStateTracker) joinRelation(rel Relation) (err error) {
 	logger.Infof("joining relation %q", rel)
-	ru, err := rel.Unit(r.unit.Tag(), r.unit.ApplicationTag())
+	ru, err := rel.Unit(r.unit.Tag())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -109,7 +109,7 @@ func (s *ContextFactorySuite) getRelationInfos() map[int]*context.RelationInfo {
 	info := map[int]*context.RelationInfo{}
 	for relId, relUnit := range s.apiRelunits {
 		info[relId] = &context.RelationInfo{
-			RelationUnit: relUnit,
+			RelationUnit: &relUnitShim{relUnit},
 			MemberNames:  s.membership[relId],
 		}
 	}

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -15,14 +15,66 @@ import (
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
+type Relation interface {
+	// Id returns the integer internal relation key.
+	Id() int
+
+	// Refresh refreshes the contents of the relation from the underlying
+	// state.
+	Refresh() error
+
+	// Suspended returns the relation's current suspended status.
+	Suspended() bool
+
+	// Refresh refreshes the contents of the relation from the underlying
+	// state.
+	SetStatus(status relation.Status) error
+
+	// Tag returns the relation tag.
+	Tag() names.RelationTag
+}
+
+type RelationUnit interface {
+	// ApplicationSettings returns a Settings which allows access to this unit's
+	// application settings within the relation.
+	ApplicationSettings() (*uniter.Settings, error)
+
+	// Endpoint returns the relation endpoint that defines the unit's
+	// participation in the relation.
+	Endpoint() uniter.Endpoint
+
+	// ReadSettings returns a map holding the settings of the unit with the
+	// supplied name within this relation.
+	ReadSettings(name string) (params.Settings, error)
+
+	// Relation returns the relation associated with the unit.
+	Relation() Relation
+
+	// Settings returns a Settings which allows access to the unit's settings
+	// within the relation.
+	Settings() (*uniter.Settings, error)
+
+	// UpdateRelationSettings is used to record any changes to settings for
+	// this unit and application.
+	UpdateRelationSettings(unit, application params.Settings) error
+}
+
+type RelationUnitShim struct {
+	*uniter.RelationUnit
+}
+
+func (r *RelationUnitShim) Relation() Relation {
+	return r.RelationUnit.Relation()
+}
+
 type RelationInfo struct {
-	RelationUnit *uniter.RelationUnit
+	RelationUnit RelationUnit
 	MemberNames  []string
 }
 
 // ContextRelation is the implementation of hooks.ContextRelation.
 type ContextRelation struct {
-	ru           *uniter.RelationUnit
+	ru           RelationUnit
 	relationId   int
 	endpointName string
 
@@ -38,7 +90,7 @@ type ContextRelation struct {
 
 // NewContextRelation creates a new context for the given relation unit.
 // The unit-name keys of members supplies the initial membership.
-func NewContextRelation(ru *uniter.RelationUnit, cache *RelationCache) *ContextRelation {
+func NewContextRelation(ru RelationUnit, cache *RelationCache) *ContextRelation {
 	return &ContextRelation{
 		ru:           ru,
 		relationId:   ru.Relation().Id(),

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -73,7 +73,7 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	apiUnit, err := s.uniter.Unit(unit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
-	relUnit, err := apiRel.Unit(apiUnit.Tag(), apiUnit.ApplicationTag())
+	relUnit, err := apiRel.Unit(apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.relUnit = &relUnitShim{relUnit}
 }

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -178,7 +178,7 @@ func (s *HookContextSuite) AddContextRelation(c *gc.C, name string) {
 	s.relunits[rel.Id()] = ru
 	apiRel, err := s.uniter.Relation(rel.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRel.Unit(s.apiUnit)
+	apiRelUnit, err := apiRel.Unit(s.apiUnit.Tag(), s.apiUnit.ApplicationTag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.apiRelunits[rel.Id()] = apiRelUnit
 }
@@ -194,7 +194,7 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int, remot
 	relctxs := map[int]*context.ContextRelation{}
 	for relId, relUnit := range s.apiRelunits {
 		cache := context.NewRelationCache(relUnit.ReadSettings, nil)
-		relctxs[relId] = context.NewContextRelation(relUnit, cache)
+		relctxs[relId] = context.NewContextRelation(&relUnitShim{relUnit}, cache)
 	}
 
 	env, err := s.State.Model()
@@ -235,7 +235,7 @@ func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int
 	relctxs := map[int]*context.ContextRelation{}
 	for relId, relUnit := range s.apiRelunits {
 		cache := context.NewRelationCache(relUnit.ReadSettings, nil)
-		relctxs[relId] = context.NewContextRelation(relUnit, cache)
+		relctxs[relId] = context.NewContextRelation(&relUnitShim{relUnit}, cache)
 	}
 
 	context, err := context.NewHookContext(context.HookContextParams{

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -178,7 +178,7 @@ func (s *HookContextSuite) AddContextRelation(c *gc.C, name string) {
 	s.relunits[rel.Id()] = ru
 	apiRel, err := s.uniter.Relation(rel.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRel.Unit(s.apiUnit.Tag(), s.apiUnit.ApplicationTag())
+	apiRelUnit, err := apiRel.Unit(s.apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.apiRelunits[rel.Id()] = apiRelUnit
 }

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -136,7 +136,7 @@ func (s *ContextSuite) AddContextRelation(c *gc.C, name string) {
 	s.relunits[rel.Id()] = ru
 	apiRel, err := s.uniter.Relation(rel.Tag().(names.RelationTag))
 	c.Assert(err, jc.ErrorIsNil)
-	apiRelUnit, err := apiRel.Unit(s.apiUnit)
+	apiRelUnit, err := apiRel.Unit(s.apiUnit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	s.apiRelunits[rel.Id()] = apiRelUnit
 }
@@ -181,7 +181,7 @@ func (s *ContextSuite) getRelationInfos() map[int]*context.RelationInfo {
 	info := map[int]*context.RelationInfo{}
 	for relId, relUnit := range s.apiRelunits {
 		info[relId] = &context.RelationInfo{
-			RelationUnit: relUnit,
+			RelationUnit: &relUnitShim{relUnit},
 			MemberNames:  s.membership[relId],
 		}
 	}
@@ -251,4 +251,12 @@ func makeCharm(c *gc.C, spec hookSpec, charmDir string) {
 		printf("(sleep 0.2; echo %s; sleep 10) &", spec.background)
 	}
 	printf("exit %d", spec.code)
+}
+
+type relUnitShim struct {
+	*uniter.RelationUnit
+}
+
+func (r *relUnitShim) Relation() context.Relation {
+	return r.RelationUnit.Relation()
 }


### PR DESCRIPTION
Prep work for mocking uniter/relation tests.

The api/uniter Relation changes were necessary to make a usable Relation interface which could retrieve a RelationUnit.

Interface changes in uniter/relation, flowed over into runner/context to allow for calling NewContextRelation.