### PR TITLE
[2.7] Handle slash-escaped spaces in constraint strings

### DIFF
--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -259,6 +259,12 @@ func (v Value) String() string {
 		s := strings.Join(*v.Zones, ",")
 		strs = append(strs, "zones="+s)
 	}
+
+	// Ensure constraint values with spaces are properly escaped
+	for i := 0; i < len(strs); i++ {
+		strs[i] = strings.Replace(strs[i], " ", `\ `, -1)
+	}
+
 	return strings.Join(strs, " ")
 }
 
@@ -330,28 +336,23 @@ func Parse(args ...string) (Value, error) {
 func ParseWithAliases(args ...string) (cons Value, aliases map[string]string, err error) {
 	aliases = make(map[string]string)
 	for _, arg := range args {
-		name, val := "", ""
+		// Replace slash-escaped spaces with a null byte so we can
+		// safely split on remaining whitespace.
+		arg = strings.Replace(arg, `\ `, "\x00", -1)
 		raws := strings.Split(strings.TrimSpace(arg), " ")
 		for _, raw := range raws {
+			// Replace null bytes back to spaces
+			raw = strings.TrimSpace(strings.Replace(raw, "\x00", " ", -1))
 			if raw == "" {
 				continue
 			}
-			current_name, current_val, err := splitRaw(raw)
+			name, val, err := splitRaw(raw)
 			if err != nil {
 				return Value{}, nil, errors.Trace(err)
 			}
-			if current_name == "" && name == "" {
-				return Value{}, nil, errors.Errorf("malformed constraint %q", current_val)
-			}
-			if current_name != "" {
-				name = current_name
-				val = current_val
-				if canonical, ok := rawAliases[name]; ok {
-					aliases[name] = canonical
-					name = canonical
-				}
-			} else if name != "" {
-				val += " " + current_val
+			if canonical, ok := rawAliases[name]; ok {
+				aliases[name] = canonical
+				name = canonical
 			}
 			if err := cons.setRaw(name, val); err != nil {
 				return Value{}, aliases, errors.Trace(err)
@@ -442,7 +443,7 @@ func (v *Value) without(attrTags ...string) Value {
 func splitRaw(s string) (name, val string, err error) {
 	eq := strings.Index(s, "=")
 	if eq <= 0 {
-		return "", s, nil
+		return "", "", errors.Errorf("malformed constraint %q", s)
 	}
 	return s[:eq], s[eq+1:], nil
 }
@@ -602,6 +603,9 @@ func (v *Value) setCpuPower(str string) (err error) {
 }
 
 func (v *Value) setInstanceType(str string) error {
+	if v.InstanceType != nil {
+		return errors.Errorf("already set")
+	}
 	v.InstanceType = &str
 	return nil
 }
@@ -672,6 +676,9 @@ func (v *Value) setVirtType(str string) error {
 }
 
 func (v *Value) setZones(str string) error {
+	if v.Zones != nil {
+		return errors.Errorf("already set")
+	}
 	v.Zones = parseCommaDelimited(str)
 	return nil
 }

--- a/core/constraints/constraints_test.go
+++ b/core/constraints/constraints_test.go
@@ -309,8 +309,8 @@ var parseConstraintsTests = []struct {
 		summary: "instance type empty",
 		args:    []string{"instance-type="},
 	}, {
-		summary: "instance type with spaces",
-		args:    []string{"instance-type=something with spaces"},
+		summary: "instance type with slash-escaped spaces",
+		args:    []string{`instance-type=something\ with\ spaces`},
 	},
 
 	// "virt-type" in detail.
@@ -341,11 +341,11 @@ var parseConstraintsTests = []struct {
 		summary: "multiple zones",
 		args:    []string{"zones=az1,az2"},
 	}, {
-		summary: "spaced zones",
-		args:    []string{"zones=Availability zone 1"},
+		summary: "zones with slash-escaped spaces",
+		args:    []string{`zones=Availability\ zone\ 1`},
 	}, {
-		summary: "Multiple spaced zones",
-		args:    []string{"zones=Availability zone 1,Availability zone 2,az2"},
+		summary: "Multiple zones with slash-escaped spaces",
+		args:    []string{`zones=Availability\ zone\ 1,Availability\ zone\ 2,az2`},
 	}, {
 		summary: "no zones",
 		args:    []string{"zones="},
@@ -429,9 +429,9 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	c.Assert(merged, jc.DeepEquals, constraints.Value{})
 }
 
-func (s *ConstraintsSuite) TestParseZoneWithSpaces(c *gc.C) {
+func (s *ConstraintsSuite) TestParseInstanceTypeWithSpaces(c *gc.C) {
 	con := constraints.MustParse(
-		"arch=amd64 instance-type=with spaces cores=1",
+		`arch=amd64 instance-type=with\ spaces cores=1`,
 	)
 	c.Assert(con.Arch, gc.Not(gc.IsNil))
 	c.Assert(con.InstanceType, gc.Not(gc.IsNil))


### PR DESCRIPTION
## Description of change

A fix that landed previously (see #11500 and its 2.7 backport #11511) allowed unescaped constraint values with spaces but made the constraint-parsing code more convoluted and relied
on the removal of already-set checks to function properly. This made the implementation flaky as 
the operator would now be allowed to provide a constraint such as `zones=a zones=b` and receive no error from juju (last write wins semantics).

This PR reverts the previous set of changes and introduces a better way for dealing with constraint values with spaces by expecting the operator to slash-escape them as you would normally do in a shell. The fix applies to all constraint values and does not require any modifications to the rest of the validation logic.

To this end, the operator can now enter constraints such as:
`--constraint arch=amd64 zones=zone\ 1,zone2 instance-type=general\ purpose`

## QA steps

```console
$ juju bootstrap rackspace test --constraints instance-type=1 GB General Purpose v1
```

## Documentation changes

We should update the docs to reflect the fact that spaces are now supported if properly escaped.

## Bug reference

Followup fix for:
- https://bugs.launchpad.net/juju/+bug/1875590
- https://bugs.launchpad.net/juju/+bug/1847259