### PR TITLE
EC2 OptIn errors are not invalid credentials

### DIFF
--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -167,12 +167,6 @@ These keys are obtained via the "Security Credentials"
 page in the AWS console.
 `
 
-const unauthorized = `
-Please subscribe to the requested Amazon service. 
-You are currently not authorized to use it.
-New Amazon accounts might take some time to be activated while 
-your details are being verified.`
-
 // verifyCredentials issues a cheap, non-modifying/idempotent request to EC2 to
 // verify the configured credentials. If verification fails, a user-friendly
 // error will be returned, and the original error will be logged at debug
@@ -218,10 +212,6 @@ var maybeConvertCredentialError = func(err error, ctx context.ProviderCallContex
 			return convert(common.CredentialNotValidf(err, "\nYour account is pending verification by Amazon."))
 		case "SignatureDoesNotMatch":
 			return convert(common.CredentialNotValidf(err, badKeys))
-		case "OptInRequired":
-			return convert(common.CredentialNotValidf(err, unauthorized))
-		case "UnauthorizedOperation":
-			return convert(common.CredentialNotValidf(err, unauthorized))
 		default:
 			// This error is unrelated to access keys, account or credentials...
 			return err

--- a/provider/ec2/provider_test.go
+++ b/provider/ec2/provider_test.go
@@ -4,8 +4,6 @@
 package ec2_test
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -165,18 +163,14 @@ func (s *ProviderSuite) TestMaybeConvertCredentialErrorConvertsCredentialRelated
 	}
 }
 
-func (s *ProviderSuite) TestMaybeConvertCredentialErrorAppendsAuthorisationFailureMessage(c *gc.C) {
+func (s *ProviderSuite) TestMaybeConvertCredentialErrorNotInvalidCredential(c *gc.C) {
 	for _, code := range []string{
 		"OptInRequired",
 		"UnauthorizedOperation",
 	} {
 		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code}, context.NewCloudCallContext())
 		c.Assert(err, gc.NotNil)
-		c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
-		c.Assert(err.Error(), jc.Contains, fmt.Sprintf("\nPlease subscribe to the requested Amazon service. \n"+
-			"You are currently not authorized to use it.\n"+
-			"New Amazon accounts might take some time to be activated while \n"+
-			"your details are being verified.:  (%v)", code))
+		c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
 	}
 }
 


### PR DESCRIPTION
## Description of change

On AWS cloud, if trying to add a machine where the AMI is not accessible to the account being used, an OptIn error is returned and Juju incorrectly was assuming this was an invalid credential.

## QA steps

bootstrap and add a new ami that is not subscribed to using add-image
`juju metadata add-image --series centos7 ami-0b2045146eb00b617`
add a machine using that ami
`juju add-machine --series centos7`
check juju status to see that it still contains a useful message but the credential is not shown as invalid
```
$ juju status
Model       Controller  Cloud/Region        Version  SLA          Timestamp
controller  ian         aws/ap-southeast-2  2.7.6.1  unsupported  01:17:12+10:00

Machine  State    DNS          Inst id              Series   AZ               Message
0        started  3.106.54.77  i-05409ae79bf492f8b  bionic   ap-southeast-2a  running
1        down                  pending              centos7                   cannot run instances: In order to use this AWS Marketplace product you need to accept terms and subscribe. To do so please visit https://aws.amazon.com/marketplace/pp?sku=aw0evgkw8e5c1q413zgy5pjce (OptInRequired)
```

## Bug reference

https://bugs.launchpad.net/bugs/1875928
