### PR TITLE
Remove image metadata feature flag and query of outdataed image metadata

### DIFF
--- a/api/facadeversions_test.go
+++ b/api/facadeversions_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
-	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -19,11 +18,6 @@ type facadeVersionSuite struct {
 }
 
 var _ = gc.Suite(&facadeVersionSuite{})
-
-func (s *facadeVersionSuite) SetUpTest(c *gc.C) {
-	s.SetInitialFeatureFlags(feature.ImageMetadata)
-	s.BaseSuite.SetUpTest(c)
-}
 
 func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	// The client side code doesn't want to directly import the server side

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -254,9 +254,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Set model constraints")
 	f.StringVar(&c.BootstrapConstraintsStr, "bootstrap-constraints", "", "Specify bootstrap machine constraints")
 	f.StringVar(&c.BootstrapSeries, "bootstrap-series", "", "Specify the series of the bootstrap machine")
-	if featureflag.Enabled(feature.ImageMetadata) {
-		f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine")
-	}
+	f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine")
 	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build local version of agent binary before bootstrapping")
 	if featureflag.Enabled(feature.MongoDbSnap) {
 		f.StringVar(&c.JujuDbSnapPath, "db-snap", "", "Path to a locally built .snap to use as the internal juju-db service.")

--- a/cmd/plugins/juju-metadata/metadata.go
+++ b/cmd/plugins/juju-metadata/metadata.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/all"
@@ -54,11 +53,9 @@ func NewSuperCommand() cmd.Command {
 	metadatacmd.Register(newToolsMetadataCommand())
 	metadatacmd.Register(newValidateToolsMetadataCommand())
 	metadatacmd.Register(newSignMetadataCommand())
-	if featureflag.Enabled(feature.ImageMetadata) {
-		metadatacmd.Register(newListImagesCommand())
-		metadatacmd.Register(newAddImageMetadataCommand())
-		metadatacmd.Register(newDeleteImageMetadataCommand())
-	}
+	metadatacmd.Register(newListImagesCommand())
+	metadatacmd.Register(newAddImageMetadataCommand())
+	metadatacmd.Register(newDeleteImageMetadataCommand())
 	return metadatacmd
 }
 

--- a/cmd/plugins/juju-metadata/metadataplugin_test.go
+++ b/cmd/plugins/juju-metadata/metadataplugin_test.go
@@ -15,7 +15,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 )
 
@@ -83,22 +82,10 @@ func (s *MetadataSuite) TestHelpCommands(c *gc.C) {
 	// Check that we have correctly registered all the sub commands
 	// by checking the help output.
 
-	// Remove add/list-image for the first test because the feature is not
-	// enabled by default.
-	devFeatures := set.NewStrings("add-image", "list-images", "delete-image")
+	cmdSet := set.NewStrings(metadataCommandNames...)
 
-	// Remove features behind dev_flag for the first test since they are not
-	// enabled.
-	cmdSet := set.NewStrings(metadataCommandNames...).Difference(devFeatures)
-
-	// Test default commands.
 	// The names should be output in alphabetical order, so don't sort.
 	c.Assert(getHelpCommandNames(c), jc.SameContents, cmdSet.Values())
-
-	// Enable development features, and test again. We should now see the
-	// development commands.
-	s.SetFeatureFlags(feature.ImageMetadata)
-	c.Assert(getHelpCommandNames(c), jc.SameContents, metadataCommandNames)
 }
 
 func (s *MetadataSuite) assertHelpOutput(c *gc.C, cmd string) {
@@ -121,16 +108,13 @@ func (s *MetadataSuite) TestHelpGenerateImage(c *gc.C) {
 }
 
 func (s *MetadataSuite) TestHelpListImages(c *gc.C) {
-	s.SetFeatureFlags(feature.ImageMetadata)
 	s.assertHelpOutput(c, "list-images")
 }
 
 func (s *MetadataSuite) TestHelpAddImage(c *gc.C) {
-	s.SetFeatureFlags(feature.ImageMetadata)
 	s.assertHelpOutput(c, "add-image")
 }
 
 func (s *MetadataSuite) TestHelpDeleteImage(c *gc.C) {
-	s.SetFeatureFlags(feature.ImageMetadata)
 	s.assertHelpOutput(c, "delete-image")
 }

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1099,7 +1099,7 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 
 	datasources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(datasources, gc.HasLen, 3)
+	c.Assert(datasources, gc.HasLen, 2)
 	c.Assert(datasources[0].Description(), gc.Equals, "bootstrap metadata")
 	// This data source does not require to contain signed data.
 	// However, it may still contain it.
@@ -1156,7 +1156,7 @@ func (s *bootstrapSuite) TestBootstrapMetadataImagesNoTools(c *gc.C) {
 
 		datasources, err := environs.ImageMetadataSources(env)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(datasources, gc.HasLen, 3)
+		c.Assert(datasources, gc.HasLen, 2)
 		c.Assert(datasources[0].Description(), gc.Equals, "bootstrap metadata")
 	}
 }
@@ -1189,7 +1189,7 @@ func (s *bootstrapSuite) TestBootstrapMetadataToolsNoImages(c *gc.C) {
 		c.Assert(envtools.DefaultBaseURL, gc.Equals, metadataDir)
 		datasources, err := environs.ImageMetadataSources(env)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(datasources, gc.HasLen, 2)
+		c.Assert(datasources, gc.HasLen, 1)
 		c.Assert(datasources[0].Description(), gc.Not(gc.Equals), "bootstrap metadata")
 	}
 }
@@ -1319,9 +1319,8 @@ func (s *bootstrapSuite) TestBootstrapMetadataImagesMissing(c *gc.C) {
 
 	datasources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(datasources, gc.HasLen, 2)
-	c.Assert(datasources[0].Description(), gc.Equals, "default cloud images")
-	c.Assert(datasources[1].Description(), gc.Equals, "default ubuntu cloud images")
+	c.Assert(datasources, gc.HasLen, 1)
+	c.Assert(datasources[0].Description(), gc.Equals, "default ubuntu cloud images")
 }
 
 func (s *bootstrapSuite) setupBootstrapSpecificVersion(c *gc.C, clientMajor, clientMinor int, toolsVersion *version.Number) (error, int, version.Number) {

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -123,16 +123,11 @@ func (s *simplestreamsSuite) TestOfficialSources(c *gc.C) {
 	}()
 	ds, err := imagemetadata.OfficialDataSources("daily")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ds, gc.HasLen, 2)
+	c.Assert(ds, gc.HasLen, 1)
 	url, err := ds[0].URL("")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(url, gc.Equals, "https://streams.canonical.com/juju/images/daily/")
-	c.Assert(ds[0].PublicSigningKey(), gc.Equals, sstesting.SignedMetadataPublicKey)
-
-	url, err = ds[1].URL("")
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.Equals, "http://cloud-images.ubuntu.com/daily/")
-	c.Assert(ds[1].PublicSigningKey(), gc.Equals, sstesting.SignedMetadataPublicKey)
+	c.Assert(ds[0].PublicSigningKey(), gc.Equals, sstesting.SignedMetadataPublicKey)
 }
 
 var fetchTests = []struct {

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -24,8 +24,7 @@ import (
 // We replace one of the urls with the supplied value
 // and prevent the other from being used.
 func PatchOfficialDataSources(s *testing.CleanupSuite, url string) {
-	s.PatchValue(&imagemetadata.DefaultUbuntuBaseURL, "")
-	s.PatchValue(&imagemetadata.DefaultJujuBaseURL, url)
+	s.PatchValue(&imagemetadata.DefaultUbuntuBaseURL, url)
 }
 
 // ParseMetadataFromDir loads ImageMetadata from the specified directory.

--- a/environs/imagemetadata/urls.go
+++ b/environs/imagemetadata/urls.go
@@ -18,7 +18,7 @@ func ImageMetadataURL(source, stream string) (string, error) {
 	}
 	// If the image metadata is coming from the official cloud images site,
 	// set up the correct path according to the images stream requested.
-	if source == UbuntuCloudImagesURL || source == JujuStreamsImagesURL {
+	if source == UbuntuCloudImagesURL {
 		cloudImagesPath := ReleasedImagesPath
 		if stream != "" && stream != ReleasedStream {
 			cloudImagesPath = stream

--- a/environs/imagemetadata/urls_test.go
+++ b/environs/imagemetadata/urls_test.go
@@ -53,11 +53,7 @@ func (s *URLsSuite) TestImageMetadataURL(c *gc.C) {
 }
 
 func (s *URLsSuite) TestImageMetadataURLOfficialSource(c *gc.C) {
-	s.assertImageMetadataURLOfficialSource(c, imagemetadata.UbuntuCloudImagesURL)
-	s.assertImageMetadataURLOfficialSource(c, imagemetadata.JujuStreamsImagesURL)
-}
-
-func (s *URLsSuite) assertImageMetadataURLOfficialSource(c *gc.C, baseURL string) {
+	baseURL := imagemetadata.UbuntuCloudImagesURL
 	// Released streams.
 	URL, err := imagemetadata.ImageMetadataURL(baseURL, "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
-	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -66,7 +65,6 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNoConfigURL(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"https://streams.canonical.com/juju/images/releases/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
@@ -77,7 +75,6 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
 		{"config-image-metadata-url/", ""},
-		{"https://streams.canonical.com/juju/images/releases/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
@@ -119,7 +116,6 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 		{"config-image-metadata-url/", ""},
 		{"foobar/", ""},
 		{"betwixt/releases/", ""},
-		{"https://streams.canonical.com/juju/images/releases/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
@@ -140,7 +136,6 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNonReleaseStream(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"https://streams.canonical.com/juju/images/daily/", keys.JujuPublicKey},
 		{"http://cloud-images.ubuntu.com/daily/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -23,9 +23,6 @@ const LogErrorStack = "log-error-stack"
 // instead of systemd for vivid and newer.
 const LegacyUpstart = "legacy-upstart"
 
-// ImageMetadata allows custom image metadata to be recorded in state.
-const ImageMetadata = "image-metadata"
-
 // DeveloperMode allows access to developer specific commands and behaviour.
 const DeveloperMode = "developer-mode"
 

--- a/featuretests/cloudimagemetadata_test.go
+++ b/featuretests/cloudimagemetadata_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/api/imagemetadatamanager"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/rpc"
@@ -22,7 +21,6 @@ type cloudImageMetadataSuite struct {
 }
 
 func (s *cloudImageMetadataSuite) SetUpTest(c *gc.C) {
-	s.SetInitialFeatureFlags(feature.ImageMetadata)
 	s.JujuConnSuite.SetUpTest(c)
 	s.client = imagemetadatamanager.NewClient(s.APIState)
 	c.Assert(s.client, gc.NotNil)

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -420,7 +420,6 @@ func (s *environBrokerSuite) TestImageSourcesDefault(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkSources(c, sources, []string{
-		"https://streams.canonical.com/juju/images/releases/",
 		"https://cloud-images.ubuntu.com/releases/",
 	})
 }
@@ -439,7 +438,6 @@ func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://my-test.com/images/",
-		"https://streams.canonical.com/juju/images/releases/",
 		"https://cloud-images.ubuntu.com/releases/",
 	})
 }
@@ -459,7 +457,6 @@ func (s *environBrokerSuite) TestImageMetadataURLEnsuresHTTPS(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://my-test.com/images/",
-		"https://streams.canonical.com/juju/images/releases/",
 		"https://cloud-images.ubuntu.com/releases/",
 	})
 }
@@ -477,7 +474,6 @@ func (s *environBrokerSuite) TestImageStreamReleased(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkSources(c, sources, []string{
-		"https://streams.canonical.com/juju/images/releases/",
 		"https://cloud-images.ubuntu.com/releases/",
 	})
 }
@@ -495,7 +491,6 @@ func (s *environBrokerSuite) TestImageStreamDaily(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkSources(c, sources, []string{
-		"https://streams.canonical.com/juju/images/daily/",
 		"https://cloud-images.ubuntu.com/daily/",
 	})
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1222,7 +1222,7 @@ func (s *localServerSuite) assertGetImageMetadataSources(c *gc.C, stream, offici
 
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, gc.HasLen, 4)
+	c.Assert(sources, gc.HasLen, 3)
 	var urls = make([]string, len(sources))
 	for i, source := range sources {
 		imageURL, err := source.URL("")
@@ -1233,8 +1233,7 @@ func (s *localServerSuite) assertGetImageMetadataSources(c *gc.C, stream, offici
 	c.Check(strings.HasSuffix(urls[0], "/juju-dist-test/"), jc.IsTrue)
 	// The product-streams URL ends with "/imagemetadata".
 	c.Check(strings.HasSuffix(urls[1], "/imagemetadata/"), jc.IsTrue)
-	c.Assert(urls[2], gc.Equals, fmt.Sprintf("https://streams.canonical.com/juju/images/%s/", officialSourcePath))
-	c.Assert(urls[3], gc.Equals, fmt.Sprintf("http://cloud-images.ubuntu.com/%s/", officialSourcePath))
+	c.Assert(urls[2], gc.Equals, fmt.Sprintf("http://cloud-images.ubuntu.com/%s/", officialSourcePath))
 }
 
 func (s *localServerSuite) TestGetImageMetadataSources(c *gc.C) {
@@ -1250,12 +1249,11 @@ func (s *localServerSuite) TestGetImageMetadataSourcesNoProductStreams(c *gc.C) 
 	env := s.Open(c, s.env.Config())
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, gc.HasLen, 3)
+	c.Assert(sources, gc.HasLen, 2)
 
 	// Check that data sources are in the right order
 	c.Check(sources[0].Description(), gc.Equals, "image-metadata-url")
-	c.Check(sources[1].Description(), gc.Equals, "default cloud images")
-	c.Check(sources[2].Description(), gc.Equals, "default ubuntu cloud images")
+	c.Check(sources[1].Description(), gc.Equals, "default ubuntu cloud images")
 }
 
 func (s *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {
@@ -1773,7 +1771,7 @@ func (s *localServerSuite) TestImageMetadataSourceOrder(c *gc.C) {
 		sourceIds = append(sourceIds, s.Description())
 	}
 	c.Assert(sourceIds, jc.DeepEquals, []string{
-		"image-metadata-url", "my datasource", "keystone catalog", "default cloud images", "default ubuntu cloud images"})
+		"image-metadata-url", "my datasource", "keystone catalog", "default ubuntu cloud images"})
 }
 
 // To compare found and expected SecurityGroupRules, convert the rules to RuleInfo, minus
@@ -2052,7 +2050,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	sources, err := environs.ImageMetadataSources(s.env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, gc.HasLen, 4)
+	c.Assert(sources, gc.HasLen, 3)
 
 	// Make sure there is something to download from each location
 	metadata := "metadata-content"
@@ -2111,7 +2109,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSourcesWithCertificate
 	c.Assert(err, jc.ErrorIsNil)
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sources, gc.HasLen, 4)
+	c.Assert(sources, gc.HasLen, 3)
 
 	// Make sure there is something to download from each location
 	metadata := "metadata-content"

--- a/provider/vsphere/fixture_test.go
+++ b/provider/vsphere/fixture_test.go
@@ -69,7 +69,6 @@ func (s *EnvironFixture) SetUpTest(c *gc.C) {
 
 	// Make sure we don't fall back to the public image sources.
 	s.PatchValue(&imagemetadata.DefaultUbuntuBaseURL, "")
-	s.PatchValue(&imagemetadata.DefaultJujuBaseURL, "")
 	s.callCtx = context.NewCloudCallContext()
 }
 


### PR DESCRIPTION
## Description of change

Remove the image-metadata feature flag to expose the metadata image commands by default.
Also remove the outdated non-Ubuntu image metadata datasource.

## QA steps

Ensure juju metadata add-image and friends run without the feature flag.
bootstrap to azure
bootstrap to aws

