### PR TITLE
Remove state.ApplicationEndpointBindings

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -748,10 +748,10 @@ func fetchAllApplicationsAndUnits(
 		return applicationStatusInfo{}, err
 	}
 	allBindingsByApp := make(map[string]map[string]string)
-	for _, bindings := range endpointBindings {
+	for app, bindings := range endpointBindings {
 		// If the only binding is the default, and it's set to the
 		// default space, no need to print.
-		bindingMap, err := bindings.Bindings.MapWithSpaceNames()
+		bindingMap, err := bindings.MapWithSpaceNames()
 		if err != nil {
 			return applicationStatusInfo{}, err
 		}
@@ -760,7 +760,7 @@ func fetchAllApplicationsAndUnits(
 				continue
 			}
 		}
-		allBindingsByApp[bindings.AppName] = bindingMap
+		allBindingsByApp[app] = bindingMap
 	}
 
 	lxdProfiles := make(map[string]*charm.LXDProfile)

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -118,10 +118,12 @@ func (s *stateShim) AllEndpointBindings() ([]ApplicationEndpointBindingsShim, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	all := make([]ApplicationEndpointBindingsShim, len(endpointBindings))
-	for i, value := range endpointBindings {
-		all[i].AppName = value.AppName
-		all[i].Bindings = value.Bindings.Map()
+	all := make([]ApplicationEndpointBindingsShim, 0, len(endpointBindings))
+	for app, bindings := range endpointBindings {
+		all = append(all, ApplicationEndpointBindingsShim{
+			AppName:  app,
+			Bindings: bindings.Map(),
+		})
 	}
 	return all, nil
 }

--- a/state/model.go
+++ b/state/model.go
@@ -906,14 +906,9 @@ func (m *Model) AllUnits() ([]*Unit, error) {
 	return units, nil
 }
 
-// ApplicationEndpointBindings - endpointBinding->space details for each application
-type ApplicationEndpointBindings struct {
-	AppName  string
-	Bindings *Bindings
-}
-
-// AllEndpointBindings returns all endpoint->space bindings for every application
-func (m *Model) AllEndpointBindings() ([]ApplicationEndpointBindings, error) {
+// AllEndpointBindings returns all endpoint->space bindings
+// keyed by application name.
+func (m *Model) AllEndpointBindings() (map[string]*Bindings, error) {
 	endpointBindings, closer := m.st.db().GetCollection(endpointBindingsC)
 	defer closer()
 
@@ -923,27 +918,23 @@ func (m *Model) AllEndpointBindings() ([]ApplicationEndpointBindings, error) {
 		return nil, errors.Annotatef(err, "cannot get endpoint bindings")
 	}
 
-	appEndpointBindings := make([]ApplicationEndpointBindings, len(docs))
-	for i, doc := range docs {
+	appEndpointBindings := make(map[string]*Bindings, 0)
+	for _, doc := range docs {
 		var applicationName string
 		applicationKey := m.localID(doc.DocID)
-		// for each application deployed we have an instance of ApplicationEndpointBindings struct
 		if strings.HasPrefix(applicationKey, "a#") {
 			applicationName = applicationKey[2:]
 		} else {
 			return nil, errors.NotValidf("application key %v", applicationKey)
 		}
+
 		bindings, err := NewBindings(m.st, doc.Bindings)
 		if err != nil {
 			return nil, errors.Annotatef(err, "cannot make bindings")
 		}
-		endpointBindings := ApplicationEndpointBindings{
-			AppName:  applicationName,
-			Bindings: bindings,
-		}
-
-		appEndpointBindings[i] = endpointBindings
+		appEndpointBindings[applicationName] = bindings
 	}
+
 	return appEndpointBindings, nil
 }
 
@@ -960,8 +951,8 @@ func (st *State) AllEndpointBindingsSpaceNames() (set.Strings, error) {
 	}
 
 	allEndpointBindingsSpaces := set.NewStrings()
-	for _, binding := range allEndpointBindings {
-		bindingSpaceNames, err := binding.Bindings.MapWithSpaceNames()
+	for _, bindings := range allEndpointBindings {
+		bindingSpaceNames, err := bindings.MapWithSpaceNames()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -571,8 +571,7 @@ func (s *ModelSuite) TestAllEndpointBindings(c *gc.C) {
 		"monitoring-port": network.AlphaSpaceId,
 		"db":              oneSpace.Id(),
 	}
-	c.Assert(listBindings[0].AppName, gc.Equals, app.Name())
-	c.Assert(listBindings[0].Bindings.Map(), gc.DeepEquals, expected)
+	c.Assert(listBindings[app.Name()].Map(), gc.DeepEquals, expected)
 }
 
 func (s *ModelSuite) TestAllEndpointBindingsSpaceNames(c *gc.C) {


### PR DESCRIPTION
## Description of change

This patch removes the `ApplicationEndpointBindings` type from state, which can be substituted with a simpler Map.

Future changes to the facade use of `state.AllEndpointBindings` will be easier to test following this change.

## QA steps

Non-functional change - unit tests continue to pass.

## Documentation changes

None.

## Bug reference

N/A
