### PR TITLE
[dev] Access local application's data-bag from k8s charms

### DIFF
--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -289,6 +289,7 @@ func (s *relationUnitSuite) TestReadApplicationSettings(c *gc.C) {
 		"app": "settings",
 	})
 }
+
 func (s *relationUnitSuite) TestReadSettingsInvalidUnitTag(c *gc.C) {
 	// First try to read the settings which are not set.
 	myRelUnit, err := s.stateRelation.Unit(s.mysqlUnit)
@@ -433,10 +434,10 @@ func (s *relationUnitSuite) TestUpdateRelationSettingsForApplicationNotLeader(c 
 	wpRelUnit, apiRelUnit := s.getRelationUnits(c)
 	c.Assert(wpRelUnit.EnterScope(nil), jc.ErrorIsNil)
 	_, err := apiRelUnit.ApplicationSettings()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(err, gc.ErrorMatches, "permission denied.*")
 
 	err = apiRelUnit.UpdateRelationSettings(nil, params.Settings{"some": "value"})
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(err, gc.ErrorMatches, "permission denied.*")
 }
 
 func (s *relationUnitSuite) TestUpdateRelationSettingsForUnitAndApplication(c *gc.C) {
@@ -481,5 +482,5 @@ func (s *relationUnitSuite) TestUpdateRelationSettingsForUnitAndApplicationNotLe
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotSettings.Map(), gc.DeepEquals, params.Settings{"foo": "bar"})
 	gotSettings, err = apiRelUnit.ApplicationSettings()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(err, gc.ErrorMatches, "permission denied.*")
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2417,6 +2417,140 @@ func (s *uniterSuite) TestReadSettingsForApplicationInPeerRelation(c *gc.C) {
 	})
 }
 
+func (s *uniterSuite) TestReadLocalApplicationSettingsWhenNotLeader(c *gc.C) {
+	rel := s.addRelation(c, "wordpress", "mysql")
+	relUnit, err := rel.Unit(s.wordpressUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	settings := map[string]interface{}{
+		"some": "settings",
+	}
+	err = relUnit.EnterScope(settings)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, relUnit, true)
+
+	// This is a unit that doesn't exist.
+	err = s.State.LeadershipClaimer().ClaimLeadership("wordpress", "wordpress/1", time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+
+	token := s.State.LeadershipChecker().LeadershipCheck("wordpress", "wordpress/1")
+
+	err = rel.UpdateApplicationSettings("wordpress", token, map[string]interface{}{
+		"wanda": "firebaugh",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	arg := params.RelationUnit{
+		Relation: rel.Tag().String(),
+		Unit:     "unit-wordpress-1",
+	}
+	_, err = s.uniter.ReadLocalApplicationSettings(arg)
+	c.Assert(errors.Cause(err), gc.Equals, common.ErrPerm)
+}
+
+func (s *uniterSuite) TestReadLocalApplicationSettingsForAnotherApplicationAsAnOperator(c *gc.C) {
+	rel := s.addRelation(c, "wordpress", "mysql")
+	relUnit, err := rel.Unit(s.wordpressUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	settings := map[string]interface{}{
+		"some": "settings",
+	}
+	err = relUnit.EnterScope(settings)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertInScope(c, relUnit, true)
+
+	// The agent has logged in as the "riak" application; this simulates a k8s operator.
+	auth := apiservertesting.FakeAuthorizer{Tag: names.NewApplicationTag("application-riak-k8s")}
+	uniter := s.newUniterAPI(c, s.State, auth)
+
+	// As the operator for riak, try to read the application data on behalf
+	// of another application unit; the facade should reject this request
+	// with a permission error as the inferred app from the unit name below
+	// does not match our login credentials.
+	arg := params.RelationUnit{
+		Relation: rel.Tag().String(),
+		Unit:     "unit-wordpress-0",
+	}
+	_, err = uniter.ReadLocalApplicationSettings(arg)
+	c.Assert(errors.Cause(err), gc.Equals, common.ErrPerm, gc.Commentf("expected ErrPerm due to mismatch in logged in app and inferred app from provided unit name"))
+}
+
+func (s *uniterSuite) TestReadLocalApplicationSettingsInPeerRelation(c *gc.C) {
+	riak := s.AddTestingApplication(c, "riak", s.AddTestingCharm(c, "riak"))
+	ep, err := riak.Endpoint("ring")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.EndpointsRelation(ep)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = rel.UpdateApplicationSettings("riak", &fakeToken{}, map[string]interface{}{
+		"deerhoof": "little hollywood",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	riakUnit := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: riak,
+		Machine:     s.machine0,
+	})
+
+	relUnit, err := rel.Unit(riakUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = relUnit.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	auth := apiservertesting.FakeAuthorizer{Tag: riakUnit.Tag()}
+	uniter := s.newUniterAPI(c, s.State, auth)
+
+	arg := params.RelationUnit{
+		Relation: rel.Tag().String(),
+		Unit:     "unit-riak-0",
+	}
+	result, err := uniter.ReadLocalApplicationSettings(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.SettingsResult{
+		Settings: params.Settings{
+			"deerhoof": "little hollywood",
+		},
+	})
+}
+
+func (s *uniterSuite) TestReadLocalApplicationSettingsInPeerRelationAsAnOperator(c *gc.C) {
+	riak := s.AddTestingApplication(c, "riak", s.AddTestingCharm(c, "riak"))
+	ep, err := riak.Endpoint("ring")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.EndpointsRelation(ep)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = rel.UpdateApplicationSettings("riak", &fakeToken{}, map[string]interface{}{
+		"deerhoof": "little hollywood",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	riakUnit := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: riak,
+		Machine:     s.machine0,
+	})
+
+	relUnit, err := rel.Unit(riakUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = relUnit.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The agent has logged in as the application; this simulates a k8s operator.
+	auth := apiservertesting.FakeAuthorizer{Tag: riak.Tag()}
+	uniter := s.newUniterAPI(c, s.State, auth)
+
+	arg := params.RelationUnit{
+		Relation: rel.Tag().String(),
+		Unit:     "unit-riak-0",
+	}
+	result, err := uniter.ReadLocalApplicationSettings(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.SettingsResult{
+		Settings: params.Settings{
+			"deerhoof": "little hollywood",
+		},
+	})
+}
+
 func (s *uniterSuite) TestReadSettingsWithNonStringValuesFails(c *gc.C) {
 	rel := s.addRelation(c, "wordpress", "mysql")
 	relUnit, err := rel.Unit(s.wordpressUnit)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -36334,6 +36334,17 @@
                         }
                     }
                 },
+                "ReadLocalApplicationSettings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnit"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SettingsResult"
+                        }
+                    }
+                },
                 "ReadRemoteSettings": {
                     "type": "object",
                     "properties": {

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -821,7 +821,7 @@ func (s *ContextFactorySuite) TestReadApplicationSettings(c *gc.C) {
 	rel, err := ctx.Relation(0)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = rel.ApplicationSettings()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(err, gc.ErrorMatches, "permission denied.*")
 	// Now claim leadership and try again
 	claimer, err := s.LeaseManager.Claimer("application-leadership", s.State.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

The fix from #11233 allows leader charms (non-k8s ones) to read their own application's data bag (the local application). However, that fix does not apply to k8s charms due to the way that the leadership checks are performed by the uniter facade.

More specifically, so as to implement a leadership check prior to reading the application's data bag contents, the controller needs two pieces of information: the application and the unit tag. Prior to this change, in order to fetch the application settings, the code abused the `ReadSettings` API call (which normally expects a relation and a **unit** tag as arguments) and passed an **application** tag instead of a unit tag. The facade implementation examined the type of the tag and used a different code path for applications (which ultimately leads to a leadership check).

For **non-k8s** workloads, each unit runs its own agent which logs in to the controller as the unit. To this end, the facade code pulls the unit tag from the authentication details. If the unit is indeed the leader everything works as expected; otherwise, a permission error is returned.

K8s workloads work differently: for each application, we deploy a single operator instance which executes any required operation on behalf of a particular unit. The operator logs in as the **application** which makes it impossible to figure out a unit tag for the leadership check. As a result, attempts to read the application data bag would always fail with a permission error.

The fix implemented by this PR is to create a new API call (`ReadLocalApplicationSettings`) that receives a `RelationUnit` as an argument and infers the application to be accessed from the unit tag. Note that contrary to other API calls that expect a list of things to operate on, no client will ever be able to read the local application data for another application and therefore, the call expects a **single** argument.

The previous API call has been modified to redirect to the new implementation when reading application data thus preserving the previous behavior when an older (e.g. 2.7.x agent) is talking to a newer controller. Of course, this means that older models will still not be able to read the local application data (for k8s charms) **unless they get upgraded**.

:warning: This fix comes with a security caveat: since there is no way for the controller to verify the validity of the unit tag passed by the client (remember, the operator logs in as the application), the controller assumes that application-level logins should be trusted implicitly and therefore uses the unit-tag, _as-is_ for performing the leadership check. This makes it possible for charm authors that have access to the operator credentials to use pylibjuju and read/write the application data by spoofing the unit-tag to the one that is currently the leader.

## QA steps

### k8s charms

```console
# Initial setup
$ make microk8s-operator-update
$ juju bootstrap microk8s mk8s
$ juju deploy cs:~aisrael/bundle/mediawiki-k8s-0
$ juju add-unit mediawiki-k8s

# Leader should be able to write and read the data bag
$ juju run --unit mediawiki-k8s/0 'relation-set -r 0 --app myapp=mediawiki'
$ juju run --unit mediawiki-k8s/0 'relation-get -r 0 --app - mediawiki-k8s'
myapp: mediawiki

# Non-leaders should not be allowed to read or write the *local* data bag
$ juju run --unit mediawiki-k8s/1 'relation-set -r 0 --app myapp=mediawiki'                                                                                                                    
ERROR cannot write relation settings
$ juju run --unit mediawiki-k8s/1 'relation-get -r 0 --app - mediawiki-k8s'
ERROR permission denied

# Note that any remote unit in this relation should be able to read the mediawiki's data bag
$ juju run --unit mariadb-k8s/0 'relation-get -r 0 --app - mediawiki-k8s'
myapp: mediawiki
```

### non-k8s charms

```console
# Initial setup
$ juju bootstrap lxd test --no-gui
$ juju deploy cs:bundle/mediawiki-single-9
$ juju add-unit mediawiki

# Leader should be able to write and read the data bag
$ juju run --unit mediawiki/0 'relation-set -r 1 --app myapp=mediawiki'
$ juju run --unit mediawiki/0 'relation-get -r 1 --app - mediawiki'
myapp: mediawiki

# Non-leaders should not be allowed to read or write the *local* data bag
$ juju run --unit mediawiki/1 'relation-set -r 1 --app myapp=mediawiki'                                                                                                                    
ERROR cannot write relation settings
$ juju run --unit mediawiki/1 'relation-get -r 1 --app - mediawiki'
ERROR permission denied

# Note that any remote unit in this relation should be able to read the mediawiki's data bag
$ juju run --unit mysql/0 'relation-get -r 1 --app - mediawiki'
myapp: mediawiki
```

### 2.8 controller with 2.7 model and non-k8s charm still works using the deprectated API call

```console
# Initial setup (install juju 2.7.6 from snap)
$ /snap/bin/juju bootstrap lxd test --no-gui
$ /snap/bin/juju deploy cs:bundle/mediawiki-single-9
$ /snap/bin/juju add-unit mediawiki

# Run the same set of steps as the previous test
$ /snap/bin/juju run --unit mediawiki/0 'relation-set -r 1 --app myapp=mediawiki'
$ /snap/bin/juju run --unit mediawiki/0 'relation-get -r 1 --app - mediawiki'
myapp: mediawiki

# Note this one silently fails; no data is actually written.
$ /snap/bin/juju run --unit mediawiki/1 'relation-set -r 1 --app myapp=mediawiki999'          
$ /snap/bin/juju run --unit mediawiki/1 'relation-get -r 1 --app - mediawiki'                                                                                                                  
ERROR permission denied

# Verify that data did not get mutated!
$ /snap/bin/juju run --unit mediawiki/0 'relation-get -r 1 --app - mediawiki'
myapp: mediawiki

# Upgrade controller (note: model is still 2.7.6)
$ juju upgrade-controller --build-agent

# TODO: Run the same steps as above and ensure that output remains consistent

# Now, upgrade the model to 2.8
$ juju upgrade-model

# TODO: Run the same steps as above and ensure that output remains consistent
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1876097