### PR TITLE
Handle the case when there is no hook to run.

### DIFF
--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -218,7 +218,11 @@ const debugHooksHookScript = `#!/bin/bash
 echo $$ > $JUJU_DEBUG/hook.pid
 if [ -z "$JUJU_DEBUG_AT" ] ; then
 	exec /bin/bash --noprofile --init-file $JUJU_DEBUG/init.sh
+elif [ ! -x "__JUJU_HOOK_RUNNER__" ] ; then
+    juju-log --log-level INFO "debugging is enabled, but no handler for $JUJU_HOOK_NAME, skipping"
+    echo 0 > $JUJU_DEBUG/hook_exit_status
 else
+    juju-log --log-level INFO "debug running __JUJU_HOOK_RUNNER__ for $JUJU_HOOK_NAME"
 	__JUJU_HOOK_RUNNER__
 	echo $? > $JUJU_DEBUG/hook_exit_status
 fi

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -34,6 +34,11 @@ func (s *ServerSession) MatchHook(hookName string) bool {
 	return s.hooks.IsEmpty() || s.hooks.Contains(hookName)
 }
 
+// DebugAt returns the location for the charm to stop for debugging, if it is set.
+func (s *ServerSession) DebugAt() string {
+	return s.debugAt
+}
+
 // waitClientExit executes flock, waiting for the SSH client to exit.
 // This is a var so it can be replaced for testing.
 var waitClientExit = func(s *ServerSession) {
@@ -168,7 +173,7 @@ tmux new-window -t $JUJU_UNIT_NAME -n $window_name "$JUJU_DEBUG/hook.sh"
 # If we exit for whatever reason, kill the hook shell.
 exit_handler() {
     if [ -f $JUJU_DEBUG/hook.pid ]; then
-        kill -9 $(cat $JUJU_DEBUG/hook.pid) || true
+        kill -9 $(cat $JUJU_DEBUG/hook.pid) 2>/dev/null || true
     fi
 }
 trap exit_handler EXIT
@@ -219,10 +224,10 @@ echo $$ > $JUJU_DEBUG/hook.pid
 if [ -z "$JUJU_DEBUG_AT" ] ; then
 	exec /bin/bash --noprofile --init-file $JUJU_DEBUG/init.sh
 elif [ ! -x "__JUJU_HOOK_RUNNER__" ] ; then
-    juju-log --log-level INFO "debugging is enabled, but no handler for $JUJU_HOOK_NAME, skipping"
-    echo 0 > $JUJU_DEBUG/hook_exit_status
+	juju-log --log-level INFO "debugging is enabled, but no handler for $JUJU_HOOK_NAME, skipping"
+	echo 0 > $JUJU_DEBUG/hook_exit_status
 else
-    juju-log --log-level INFO "debug running __JUJU_HOOK_RUNNER__ for $JUJU_HOOK_NAME"
+	juju-log --log-level INFO "debug running __JUJU_HOOK_RUNNER__ for $JUJU_HOOK_NAME"
 	__JUJU_HOOK_RUNNER__
 	echo $? > $JUJU_DEBUG/hook_exit_status
 fi

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -334,7 +334,7 @@ exit 1`), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-// fakeJujuLog installes a script that echos its arguments to stderr,
+// fakeJujuLog installs a script that echos its arguments to stderr,
 // ending up in the subprocess output
 func (s *DebugHooksServerSuite) fakeJujuLog(c *gc.C) {
 	err := ioutil.WriteFile(filepath.Join(s.fakebin, "juju-log"), []byte(`#!/bin/bash --norc

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -101,6 +101,7 @@ func (s *DebugHooksServerSuite) TestFindSession(c *gc.C) {
 	c.Assert(session.MatchHook("bar"), jc.IsTrue)
 	c.Assert(session.MatchHook("baz"), jc.IsTrue)
 	c.Assert(session.MatchHook("foo bar baz"), jc.IsFalse)
+	c.Assert(session.DebugAt(), gc.Equals, "")
 }
 
 func (s *DebugHooksServerSuite) TestRunHookExceptional(c *gc.C) {
@@ -236,10 +237,108 @@ func (s *DebugHooksServerSuite) TestRunHook(c *gc.C) {
 	}
 }
 
+func (s *DebugHooksServerSuite) TestRunHookDebugAt(c *gc.C) {
+	s.fakeTmux(c)
+	s.fakeJujuLog(c)
+	err := ioutil.WriteFile(s.ctx.ClientFileLock(), []byte("debug-at: all\n"), 0777)
+	c.Assert(err, jc.ErrorIsNil)
+	var output bytes.Buffer
+	session, err := s.ctx.FindSessionWithWriter(&output)
+	c.Assert(session, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(session.DebugAt(), gc.Equals, "all")
+
+	const hookName = "myhook"
+	hookRunner := s.tmpdir + "/" + hookName
+	err = ioutil.WriteFile(hookRunner, []byte(`#!/bin/bash --norc
+echo ran hook >&2
+`), 0777)
+	c.Assert(err, jc.ErrorIsNil)
+
+	env := os.Environ()
+	env = append(env, "JUJU_DISPATCH_PATH=hooks/"+hookName)
+	env = append(env, "JUJU_HOOK_NAME="+hookName)
+	runHookCh := make(chan error)
+	go func() {
+		runHookCh <- session.RunHook(hookName, s.tmpdir, env, hookRunner)
+	}()
+
+	// RunHook should complete once we finish running the hook.sh
+	select {
+	case err := <-runHookCh:
+		c.Check(output.String(), gc.Equals,
+			fmt.Sprintf(`--log-level INFO debug running %s for myhook
+ran hook
+`, hookRunner))
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("RunHook did not complete")
+	}
+}
+
+func (s *DebugHooksServerSuite) TestRunHookDebugAtNoHook(c *gc.C) {
+	// see that if the hook doesn't actually exist, we exit gracefully rather than error
+	const hookName = "no-hook"
+	s.fakeTmux(c)
+	s.fakeJujuLog(c)
+	err := ioutil.WriteFile(s.ctx.ClientFileLock(), []byte("debug-at: all\n"), 0777)
+	c.Assert(err, jc.ErrorIsNil)
+	var output bytes.Buffer
+	session, err := s.ctx.FindSessionWithWriter(&output)
+	c.Assert(session, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(session.DebugAt(), gc.Equals, "all")
+
+	env := os.Environ()
+	env = append(env, "JUJU_DISPATCH_PATH=hooks/"+hookName)
+	env = append(env, "JUJU_HOOK_NAME="+hookName)
+	runHookCh := make(chan error)
+	go func() {
+		runHookCh <- session.RunHook(hookName, s.tmpdir, env, "")
+	}()
+
+	// RunHook should complete once we finish running the hook.sh
+	select {
+	case err := <-runHookCh:
+		c.Check(output.String(), gc.Equals,
+			"--log-level INFO debugging is enabled, but no handler for no-hook, skipping\n")
+		c.Assert(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("RunHook did not complete")
+	}
+}
+
 func (s *DebugHooksServerSuite) verifyEnvshFile(c *gc.C, envshPath string, hookName string) {
 	data, err := ioutil.ReadFile(envshPath)
 	c.Assert(err, jc.ErrorIsNil)
 	contents := string(data)
 	c.Assert(contents, jc.Contains, fmt.Sprintf("JUJU_UNIT_NAME=%q", s.ctx.Unit))
 	c.Assert(contents, jc.Contains, fmt.Sprintf(`PS1="%s:hooks/%s %% "`, s.ctx.Unit, hookName))
+}
+
+// fakeTmux installs a script that will respond to has-session and new-window
+func (s *DebugHooksServerSuite) fakeTmux(c *gc.C) {
+	err := ioutil.WriteFile(filepath.Join(s.fakebin, "tmux"), []byte(`#!/bin/bash --norc
+case "$1" in
+    has-session)
+        # yes, we have the session
+        exit 0
+        ;;
+    new-window)
+        # echo "running: ${@: -1}" >&2
+        # cat ${@: -1} >&2
+	    exec "${@: -1}"
+        ;;
+esac
+exit 1`), 0777)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// fakeJujuLog installes a script that echos its arguments to stderr,
+// ending up in the subprocess output
+func (s *DebugHooksServerSuite) fakeJujuLog(c *gc.C) {
+	err := ioutil.WriteFile(filepath.Join(s.fakebin, "juju-log"), []byte(`#!/bin/bash --norc
+echo "$@" >&2
+`), 0777)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -434,7 +434,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 			hookName, runner.paths.GetCharmDir(), charmLocation)
 		if session.DebugAt() != "" {
 			if hookHandlerType == InvalidHookHandler {
-				logger.Infof("debug-code active, and hook %s not implemented (skipping)", hookName)
+				logger.Infof("debug-code active, but hook %s not implemented (skipping)", hookName)
 				return InvalidHookHandler, err
 			}
 			logger.Infof("executing %s via debug-code; %s", hookName, hookHandlerType)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Charms may not implement hooks/foo and when running 'juju debug-code' it
shouldn't error out.
After talking with several people the desired behavior is to *not* act like 'debug-hooks' for hooks which aren't implemented. So now, instead of erroring out if the script isn't there, we just log a line about:
```
unit-dummy-source-2: 19:28:26 INFO juju.worker.uniter.runner debug-code active, but hook sink-relation-created not implemented (skipping)
```

Similarly we update the log message when it does exist to:
```
unit-dummy-source-2: 19:28:27 INFO juju.worker.uniter.runner executing sink-relation-joined via debug-code; explicit, bespoke hook script
unit-dummy-source-2: 19:28:27 INFO unit.dummy-source/2.juju-log sink:10: debug running /var/lib/juju/agents/unit-dummy-source-2/charm/hooks/sink-relation-joined for sink-relation-joined
```


## QA steps

```sh
$ juju bootstrap --debug lxd lxd
$ cd acceptancetests/repository/charms
$ juju deploy ./dummy-sink
$ juju deploy ./dummy-source
$ juju debug-code dummy-source/0
```
In another window run
```sh
juju debug-log --level INFO
```
and in a 3rd window run
```sh
juju add-relation dummy-sink dummy-source
```

In debug-log you should see lines about:
```
unit-dummy-source-0: 19:28:26 INFO juju.worker.uniter.runner debug-code active, and hook sink-relation-created not implemented (skipping)
```

Without this change, you would see errors on relation-created and Juju will keep retrying to execute the relation-created hook (via debug-code).

## Documentation changes

As part of documenting 'debug-code' we should note that it differs from 'debug-hooks' when the hook *doesn't* exist. Instead of dropping you into a terminal and letting you know the event happened, we just keep going until you debug actual code from your script.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1876290