### PR TITLE
Fix a logic error in the database upgrade worker.

### DIFF
--- a/worker/upgradedatabase/worker_test.go
+++ b/worker/upgradedatabase/worker_test.go
@@ -176,9 +176,53 @@ func (s *workerSuite) TestNotPrimaryWatchForCompletionSuccess(c *gc.C) {
 	changes <- struct{}{}
 	s.watcher.EXPECT().Changes().Return(changes).MinTimes(1)
 
-	// Primary completes the upgrade.
+	// Initial state is UpgradePending
 	s.upgradeInfo.EXPECT().Refresh().Return(nil).MinTimes(1)
+	s.upgradeInfo.EXPECT().Status().Return(state.UpgradePending)
+	// After the first change is retrieved from the chanel above, we then say the upgrade is complete
 	s.upgradeInfo.EXPECT().Status().Return(state.UpgradeDBComplete)
+
+	s.pool.EXPECT().SetStatus("0", status.Started, "confirmed primary database upgrade to "+ver)
+
+	// We don't want to kill the worker while we are in the status observation
+	// loop, so we gate on this final expectation.
+	finished := make(chan struct{})
+	s.lock.EXPECT().Unlock().Do(func() {
+		finished <- struct{}{}
+	})
+
+	w, err := upgradedatabase.NewWorker(s.getConfig())
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-finished:
+	case <-time.After(testing.LongWait):
+	}
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestNotPrimaryWatchForCompletionSuccessFinishing(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.ignoreLogging(c)
+
+	s.expectUpgradeRequired(false)
+
+	ver := jujuversion.Current.String()
+	s.pool.EXPECT().SetStatus("0", status.Started, "waiting on primary database upgrade to "+ver)
+
+	// Expect a watcher that will fire a change for the initial event
+	// and then a change for the watch loop.
+	s.upgradeInfo.EXPECT().Watch().Return(s.watcher)
+	changes := make(chan struct{}, 2)
+	changes <- struct{}{}
+	changes <- struct{}{}
+	s.watcher.EXPECT().Changes().Return(changes).MinTimes(1)
+
+	// Initial state is UpgradePending
+	s.upgradeInfo.EXPECT().Refresh().Return(nil).MinTimes(1)
+	s.upgradeInfo.EXPECT().Status().Return(state.UpgradePending)
+	// After the first change is retrieved from the chanel above, we then say the upgrade is complete
+	s.upgradeInfo.EXPECT().Status().Return(state.UpgradeFinishing)
 
 	s.pool.EXPECT().SetStatus("0", status.Started, "confirmed primary database upgrade to "+ver)
 
@@ -234,6 +278,44 @@ func (s *workerSuite) TestNotPrimaryWatchForCompletionTimeout(c *gc.C) {
 	// Advance the clock beyond the time-out duration for waiting on primary.
 	c.Assert(clk.WaitAdvance(time.Hour, 1*time.Second, 1), jc.ErrorIsNil)
 
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestNotPrimaryButPrimaryFinished(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.ignoreLogging(c)
+
+	s.expectUpgradeRequired(false)
+
+	ver := jujuversion.Current.String()
+	s.pool.EXPECT().SetStatus("0", status.Started, "waiting on primary database upgrade to "+ver)
+
+	// Expect the watcher to be created, and then the Status is examined.
+	// If the status is already complete, there are no calls to the Changes for the watcher.
+
+	// Expect a watcher that will fire a change for the initial event
+	// and then a change for the watch loop.
+	s.upgradeInfo.EXPECT().Watch().Return(s.watcher)
+	// Primary already completed the upgrade.
+	s.upgradeInfo.EXPECT().Refresh().Return(nil).MinTimes(1)
+	s.upgradeInfo.EXPECT().Status().Return(state.UpgradeDBComplete)
+
+	s.pool.EXPECT().SetStatus("0", status.Started, "confirmed primary database upgrade to "+ver)
+
+	// We don't want to kill the worker while we are in the status observation
+	// loop, so we gate on this final expectation.
+	finished := make(chan struct{})
+	s.lock.EXPECT().Unlock().Do(func() {
+		finished <- struct{}{}
+	})
+
+	w, err := upgradedatabase.NewWorker(s.getConfig())
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-finished:
+	case <-time.After(testing.LongWait):
+	}
 	workertest.CleanKill(c, w)
 }
 


### PR DESCRIPTION
If one of the HA secondary controllers fails to process the upgrade steps
for whatever reason, like disk space issues, then the upgrade got stuck
unrecoverably.

This is because the worker assumed that the changes to the upgrade info
record in the database would be happening while it was watching. So if the
agent had been bounced, and it wasn't the primary, it would start watching
for changes to the doc, and time out after ten minutes. However the primary
and the other controller had already finished, and the upgrade info doc
had a status of "finishing".

The fix here is two-fold. First, once the watcher has been started,
reread the upgrade info document and check the status before waiting on
the changes from the watcher. If the status is "db-complete" or "finishing"
then the worker records success and is done. Otherwise it waits for the
watcher.

## QA steps

* Bootstrap a 2.7.6 controller using the snap, and enable-ha.
* Choose a machine that isn't the primary, and add a file `/var/lib/juju/wrench/database-upgrade` with a single line with the value `watch-upgrade`. This sets up the wrench.
```sh
juju upgrade-controller --build-agent
```
* `juju status` should show the machine with the wrench as `down`
* Remove the wrench file and restart the machine agent.
* The upgrade should resume and recover. Agent will show as running.
* Could confim the database record `db.upgradeInfo.find().pretty()` should show one completed upgrade. The _id will be an object id and NOT "current", and the `controllersReady` and `controllersDone` should both contain all three machine IDs.

## Documentation changes

Internal implementation only.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1876652