### PR TITLE
Ensure kill-controller command is properly initialised

### DIFF
--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -48,6 +48,7 @@ See also:
 // forceful destroy.
 func NewKillCommand() modelcmd.Command {
 	cmd := killCommand{clock: clock.WallClock}
+	cmd.controllerCredentialAPIFunc = cmd.credentialAPIForControllerModel
 	cmd.environsDestroy = environs.Destroy
 	return wrapKillCommand(&cmd)
 }


### PR DESCRIPTION
## Description of change

The controllerCredentialAPIFunc attribute of the kill controller command was not being set when the command is constructed. This leads to a nil pointer if there's a credential error killing a controller.

## QA steps

bootstrap a controller
invalidate the controller credential
kill-controller

There should be an error about invalid credentials but no nil pointer stack trace.
eg
```
$ juju kill-controller ian -t 0 -y
Unable to destroy controller through the API: invalid cloud credential, use --force
Destroying through provider
ERROR destroying managed environs: listing instances: listing instances: 
The provided credentials could not be validated and 
...
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1876779
