### PR TITLE
vsphere: Enable using datastores in folders

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -24,7 +24,7 @@ type Client interface {
 	ComputeResources(context.Context) ([]*mo.ComputeResource, error)
 	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
 	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
-	Datastores(context.Context) ([]*mo.Datastore, error)
+	Datastores(context.Context) ([]mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error
 	EnsureVMFolder(context.Context, string, string) (*object.Folder, error)

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -236,13 +236,13 @@ func (env *sessionEnviron) getVMFolder() string {
 	return env.environ.cloud.Credential.Attributes()[credAttrVMFolder]
 }
 
-func (env *sessionEnviron) accessibleDatastores(ctx callcontext.ProviderCallContext) ([]*mo.Datastore, error) {
+func (env *sessionEnviron) accessibleDatastores(ctx callcontext.ProviderCallContext) ([]mo.Datastore, error) {
 	datastores, err := env.client.Datastores(env.ctx)
 	if err != nil {
 		HandleCredentialError(err, env, ctx)
 		return nil, errors.Trace(err)
 	}
-	var results []*mo.Datastore
+	var results []mo.Datastore
 	for _, ds := range datastores {
 		if !ds.Summary.Accessible {
 			continue

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -112,7 +112,7 @@ func (s *environPolSuite) TestPrecheckInstanceChecksConstraintZones(c *gc.C) {
 }
 
 func (s *environPolSuite) TestPrecheckInstanceChecksConstraintDatastore(c *gc.C) {
-	s.client.datastores = []*mo.Datastore{{
+	s.client.datastores = []mo.Datastore{{
 		ManagedEntity: mo.ManagedEntity{Name: "foo"},
 	}, {
 		ManagedEntity: mo.ManagedEntity{Name: "bar"},

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -72,7 +72,7 @@ func (s *environSuite) TestDestroy(c *gc.C) {
 }
 
 func (s *environSuite) TestDestroyController(c *gc.C) {
-	s.client.datastores = []*mo.Datastore{{
+	s.client.datastores = []mo.Datastore{{
 		ManagedEntity: mo.ManagedEntity{Name: "foo"},
 	}, {
 		ManagedEntity: mo.ManagedEntity{Name: "bar"},

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -816,7 +816,9 @@ func (s *clientSuite) TestDatastores(c *gc.C) {
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeDatacenter"),
+		makeStubCall("FindByInventoryPath", "FakeSearchIndex", "/dc0/datastore"),
 		retrievePropertiesStubCall("FakeDatastoreFolder"),
+		retrievePropertiesStubCall("FakeDatastore1", "FakeDatastore2"),
 	})
 
 	c.Assert(result, gc.HasLen, 2)

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -252,12 +252,24 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		req := req.(*methods.FindByInventoryPathBody).Req
 		r.MethodCall(r, "FindByInventoryPath", req.This.Value, req.InventoryPath)
 		logger.Debugf("FindByInventoryPath ref: %q, path: %q", req.This.Value, req.InventoryPath)
-		res.Res = &types.FindByInventoryPathResponse{
-			Returnval: &types.ManagedObjectReference{
-				Type:  "ComputeResource",
-				Value: "z0",
-			},
+		var findResponse *types.FindByInventoryPathResponse
+		if req.InventoryPath == "/dc0/datastore" {
+			findResponse = &types.FindByInventoryPathResponse{
+				Returnval: &types.ManagedObjectReference{
+					Type:  "Folder",
+					Value: "FakeDatastoreFolder",
+				},
+			}
+
+		} else {
+			findResponse = &types.FindByInventoryPathResponse{
+				Returnval: &types.ManagedObjectReference{
+					Type:  "ComputeResource",
+					Value: "z0",
+				},
+			}
 		}
+		res.Res = findResponse
 	case *methods.MarkAsTemplateBody:
 		req := req.(*methods.MarkAsTemplateBody).Req
 		r.MethodCall(r, "MarkAsTemplate", req.This.Value)

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -37,7 +37,7 @@ type mockClient struct {
 	resourcePools         map[string][]*object.ResourcePool
 	createdVirtualMachine *mo.VirtualMachine
 	virtualMachines       []*mo.VirtualMachine
-	datastores            []*mo.Datastore
+	datastores            []mo.Datastore
 	vmFolder              *object.Folder
 	hasPrivilege          bool
 }
@@ -70,7 +70,7 @@ func (c *mockClient) CreateVirtualMachine(ctx context.Context, args vsphereclien
 	return c.createdVirtualMachine, c.NextErr()
 }
 
-func (c *mockClient) Datastores(ctx context.Context) ([]*mo.Datastore, error) {
+func (c *mockClient) Datastores(ctx context.Context) ([]mo.Datastore, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.MethodCall(c, "Datastores", ctx)

--- a/provider/vsphere/mocks/client_mock.go
+++ b/provider/vsphere/mocks/client_mock.go
@@ -39,6 +39,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // Close mocks base method
 func (m *MockClient) Close(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -46,11 +47,13 @@ func (m *MockClient) Close(arg0 context.Context) error {
 
 // Close indicates an expected call of Close
 func (mr *MockClientMockRecorder) Close(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close), arg0)
 }
 
 // ComputeResources mocks base method
 func (m *MockClient) ComputeResources(arg0 context.Context) ([]*mo.ComputeResource, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ComputeResources", arg0)
 	ret0, _ := ret[0].([]*mo.ComputeResource)
 	ret1, _ := ret[1].(error)
@@ -59,11 +62,13 @@ func (m *MockClient) ComputeResources(arg0 context.Context) ([]*mo.ComputeResour
 
 // ComputeResources indicates an expected call of ComputeResources
 func (mr *MockClientMockRecorder) ComputeResources(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeResources", reflect.TypeOf((*MockClient)(nil).ComputeResources), arg0)
 }
 
 // CreateVirtualMachine mocks base method
 func (m *MockClient) CreateVirtualMachine(arg0 context.Context, arg1 vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVirtualMachine", arg0, arg1)
 	ret0, _ := ret[0].(*mo.VirtualMachine)
 	ret1, _ := ret[1].(error)
@@ -72,24 +77,28 @@ func (m *MockClient) CreateVirtualMachine(arg0 context.Context, arg1 vsphereclie
 
 // CreateVirtualMachine indicates an expected call of CreateVirtualMachine
 func (mr *MockClientMockRecorder) CreateVirtualMachine(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualMachine", reflect.TypeOf((*MockClient)(nil).CreateVirtualMachine), arg0, arg1)
 }
 
 // Datastores mocks base method
-func (m *MockClient) Datastores(arg0 context.Context) ([]*mo.Datastore, error) {
+func (m *MockClient) Datastores(arg0 context.Context) ([]mo.Datastore, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Datastores", arg0)
-	ret0, _ := ret[0].([]*mo.Datastore)
+	ret0, _ := ret[0].([]mo.Datastore)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Datastores indicates an expected call of Datastores
 func (mr *MockClientMockRecorder) Datastores(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Datastores", reflect.TypeOf((*MockClient)(nil).Datastores), arg0)
 }
 
 // DeleteDatastoreFile mocks base method
 func (m *MockClient) DeleteDatastoreFile(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDatastoreFile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -97,11 +106,13 @@ func (m *MockClient) DeleteDatastoreFile(arg0 context.Context, arg1 string) erro
 
 // DeleteDatastoreFile indicates an expected call of DeleteDatastoreFile
 func (mr *MockClientMockRecorder) DeleteDatastoreFile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDatastoreFile", reflect.TypeOf((*MockClient)(nil).DeleteDatastoreFile), arg0, arg1)
 }
 
 // DestroyVMFolder mocks base method
 func (m *MockClient) DestroyVMFolder(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyVMFolder", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -109,11 +120,13 @@ func (m *MockClient) DestroyVMFolder(arg0 context.Context, arg1 string) error {
 
 // DestroyVMFolder indicates an expected call of DestroyVMFolder
 func (mr *MockClientMockRecorder) DestroyVMFolder(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyVMFolder", reflect.TypeOf((*MockClient)(nil).DestroyVMFolder), arg0, arg1)
 }
 
 // EnsureVMFolder mocks base method
 func (m *MockClient) EnsureVMFolder(arg0 context.Context, arg1, arg2 string) (*object.Folder, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureVMFolder", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*object.Folder)
 	ret1, _ := ret[1].(error)
@@ -122,11 +135,13 @@ func (m *MockClient) EnsureVMFolder(arg0 context.Context, arg1, arg2 string) (*o
 
 // EnsureVMFolder indicates an expected call of EnsureVMFolder
 func (mr *MockClientMockRecorder) EnsureVMFolder(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVMFolder", reflect.TypeOf((*MockClient)(nil).EnsureVMFolder), arg0, arg1, arg2)
 }
 
 // FindFolder mocks base method
 func (m *MockClient) FindFolder(arg0 context.Context, arg1 string) (*object.Folder, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindFolder", arg0, arg1)
 	ret0, _ := ret[0].(*object.Folder)
 	ret1, _ := ret[1].(error)
@@ -135,11 +150,13 @@ func (m *MockClient) FindFolder(arg0 context.Context, arg1 string) (*object.Fold
 
 // FindFolder indicates an expected call of FindFolder
 func (mr *MockClientMockRecorder) FindFolder(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindFolder", reflect.TypeOf((*MockClient)(nil).FindFolder), arg0, arg1)
 }
 
 // MoveVMFolderInto mocks base method
 func (m *MockClient) MoveVMFolderInto(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MoveVMFolderInto", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -147,11 +164,13 @@ func (m *MockClient) MoveVMFolderInto(arg0 context.Context, arg1, arg2 string) e
 
 // MoveVMFolderInto indicates an expected call of MoveVMFolderInto
 func (mr *MockClientMockRecorder) MoveVMFolderInto(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveVMFolderInto", reflect.TypeOf((*MockClient)(nil).MoveVMFolderInto), arg0, arg1, arg2)
 }
 
 // MoveVMsInto mocks base method
 func (m *MockClient) MoveVMsInto(arg0 context.Context, arg1 string, arg2 ...types.ManagedObjectReference) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -163,12 +182,14 @@ func (m *MockClient) MoveVMsInto(arg0 context.Context, arg1 string, arg2 ...type
 
 // MoveVMsInto indicates an expected call of MoveVMsInto
 func (mr *MockClientMockRecorder) MoveVMsInto(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveVMsInto", reflect.TypeOf((*MockClient)(nil).MoveVMsInto), varargs...)
 }
 
 // RemoveVirtualMachines mocks base method
 func (m *MockClient) RemoveVirtualMachines(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveVirtualMachines", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -176,11 +197,13 @@ func (m *MockClient) RemoveVirtualMachines(arg0 context.Context, arg1 string) er
 
 // RemoveVirtualMachines indicates an expected call of RemoveVirtualMachines
 func (mr *MockClientMockRecorder) RemoveVirtualMachines(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVirtualMachines", reflect.TypeOf((*MockClient)(nil).RemoveVirtualMachines), arg0, arg1)
 }
 
 // ResourcePools mocks base method
 func (m *MockClient) ResourcePools(arg0 context.Context, arg1 string) ([]*object.ResourcePool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResourcePools", arg0, arg1)
 	ret0, _ := ret[0].([]*object.ResourcePool)
 	ret1, _ := ret[1].(error)
@@ -189,11 +212,13 @@ func (m *MockClient) ResourcePools(arg0 context.Context, arg1 string) ([]*object
 
 // ResourcePools indicates an expected call of ResourcePools
 func (mr *MockClientMockRecorder) ResourcePools(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourcePools", reflect.TypeOf((*MockClient)(nil).ResourcePools), arg0, arg1)
 }
 
 // UpdateVirtualMachineExtraConfig mocks base method
 func (m *MockClient) UpdateVirtualMachineExtraConfig(arg0 context.Context, arg1 *mo.VirtualMachine, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateVirtualMachineExtraConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -201,11 +226,13 @@ func (m *MockClient) UpdateVirtualMachineExtraConfig(arg0 context.Context, arg1 
 
 // UpdateVirtualMachineExtraConfig indicates an expected call of UpdateVirtualMachineExtraConfig
 func (mr *MockClientMockRecorder) UpdateVirtualMachineExtraConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVirtualMachineExtraConfig", reflect.TypeOf((*MockClient)(nil).UpdateVirtualMachineExtraConfig), arg0, arg1, arg2)
 }
 
 // UserHasRootLevelPrivilege mocks base method
 func (m *MockClient) UserHasRootLevelPrivilege(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserHasRootLevelPrivilege", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -214,11 +241,13 @@ func (m *MockClient) UserHasRootLevelPrivilege(arg0 context.Context, arg1 string
 
 // UserHasRootLevelPrivilege indicates an expected call of UserHasRootLevelPrivilege
 func (mr *MockClientMockRecorder) UserHasRootLevelPrivilege(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserHasRootLevelPrivilege", reflect.TypeOf((*MockClient)(nil).UserHasRootLevelPrivilege), arg0, arg1)
 }
 
 // VirtualMachines mocks base method
 func (m *MockClient) VirtualMachines(arg0 context.Context, arg1 string) ([]*mo.VirtualMachine, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VirtualMachines", arg0, arg1)
 	ret0, _ := ret[0].([]*mo.VirtualMachine)
 	ret1, _ := ret[1].(error)
@@ -227,5 +256,6 @@ func (m *MockClient) VirtualMachines(arg0 context.Context, arg1 string) ([]*mo.V
 
 // VirtualMachines indicates an expected call of VirtualMachines
 func (mr *MockClientMockRecorder) VirtualMachines(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualMachines", reflect.TypeOf((*MockClient)(nil).VirtualMachines), arg0, arg1)
 }


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change
Update the vsphereclient Datastores method to return datastores in folders under the root folder. Without this we will reject the creation saying there's no such datastore. We don't keep track of the inventory path of the datastore - when the name of the datastore is used for creating a new vm it's looked up on the compute resource, so the fully-qualified inventory path isn't needed.

This is a backport of #11528 to the 2.7 branch - I'd intended to land it here first and then merge it forward but forgot to update the target branch.

## QA steps

* Bootstrap a vsphere controller.
* Deploy an application using the name of a datastore that's nested under a folder.
```sh
juju deploy ~jameinel/ubuntu-lite --constraints "root-disk-source=datastore-name"
``` 
The deployment succeeds and the machine is created on the specified datastore.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1874031
