### PR TITLE
[dev] Deduplicate ingress/egress subnets and addresses for NetworkInfo results

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -238,7 +238,58 @@ func (n *NetworkInfo) ProcessAPIRequest(args params.NetworkInfoParams) (params.N
 		result.Results[endpoint] = info
 	}
 
-	return result, nil
+	return dedupNetworkInfoResults(result), nil
+}
+
+func dedupNetworkInfoResults(info params.NetworkInfoResults) params.NetworkInfoResults {
+	for epName, res := range info.Results {
+		if res.Error != nil {
+			continue
+		}
+		res.IngressAddresses = dedupStringListPreservingOrder(res.IngressAddresses)
+		res.EgressSubnets = dedupStringListPreservingOrder(res.EgressSubnets)
+		for infoIdx, info := range res.Info {
+			res.Info[infoIdx].Addresses = dedupAddrList(info.Addresses)
+		}
+		info.Results[epName] = res
+	}
+
+	return info
+}
+
+func dedupStringListPreservingOrder(values []string) []string {
+	// Ideally, we would use a set.Strings(values).Values() here but since
+	// it does not preserve the insertion order we need to do this manually.
+	seen := set.NewStrings()
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if seen.Contains(v) {
+			continue
+		}
+		seen.Add(v)
+		out = append(out, v)
+	}
+
+	return out
+}
+
+func dedupAddrList(addrList []params.InterfaceAddress) []params.InterfaceAddress {
+	if len(addrList) <= 1 {
+		return addrList
+	}
+
+	uniqueAddrList := make([]params.InterfaceAddress, 0, len(addrList))
+	seenAddrSet := set.NewStrings()
+	for _, addr := range addrList {
+		if seenAddrSet.Contains(addr.Address) {
+			continue
+		}
+
+		seenAddrSet.Add(addr.Address)
+		uniqueAddrList = append(uniqueAddrList, addr)
+	}
+
+	return uniqueAddrList
 }
 
 // getRelationNetworkInfo returns the endpoint name, network space

--- a/apiserver/facades/agent/uniter/networkinfo_internal_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_internal_test.go
@@ -1,0 +1,139 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+type networkInfoSuite struct {
+}
+
+var _ = gc.Suite(&networkInfoSuite{})
+
+// TestNetworkInfoDedupLogic ensures that we don't get a regression for
+// LP1864072.
+func (s *networkInfoSuite) TestNetworkInfoDedupLogic(c *gc.C) {
+	resWithDups := params.NetworkInfoResults{
+		Results: map[string]params.NetworkInfoResult{
+			"ep0": {
+				Error: &params.Error{Message: "these are not the interfaces you are looking for"},
+			},
+			"ep1": {
+				EgressSubnets: []string{
+					"8.8.8.8/32",
+					"172.31.46.122/32",
+					"172.31.46.122/32",
+				},
+				IngressAddresses: []string{
+					"1.2.3.4",
+					"172.31.46.122",
+					"172.31.46.122",
+				},
+			},
+			"ep2": {
+				EgressSubnets: []string{
+					"8.8.8.8/32",
+				},
+				IngressAddresses: []string{
+					"1.1.1.1",
+				},
+				Info: []params.NetworkInfo{
+					{
+						MACAddress:    "ee:19:50:1f:3e:9a",
+						InterfaceName: "es0",
+						Addresses: []params.InterfaceAddress{
+							{
+								Hostname: "foo",
+								Address:  "172.31.10.10",
+								CIDR:     "172.31.10.10/32",
+							},
+							{
+								Hostname: "foo",
+								Address:  "172.31.10.10",
+								CIDR:     "172.31.10.10/32",
+							},
+							{
+								Hostname: "bar",
+								Address:  "172.31.10.11",
+								CIDR:     "172.31.10.11/32",
+							},
+						},
+					},
+					{
+						MACAddress:    "ee:18:40:1f:3e:fe",
+						InterfaceName: "es1",
+						Addresses: []params.InterfaceAddress{
+							{
+								Hostname: "foo",
+								Address:  "172.31.42.10",
+								CIDR:     "172.31.42.10/32",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expRes := params.NetworkInfoResults{
+		Results: map[string]params.NetworkInfoResult{
+			"ep0": {
+				Error: &params.Error{Message: "these are not the interfaces you are looking for"},
+			},
+			"ep1": {
+				EgressSubnets: []string{
+					"8.8.8.8/32",
+					"172.31.46.122/32",
+				},
+				IngressAddresses: []string{
+					"1.2.3.4",
+					"172.31.46.122",
+				},
+			},
+			"ep2": {
+				EgressSubnets: []string{
+					"8.8.8.8/32",
+				},
+				IngressAddresses: []string{
+					"1.1.1.1",
+				},
+				Info: []params.NetworkInfo{
+					{
+						MACAddress:    "ee:19:50:1f:3e:9a",
+						InterfaceName: "es0",
+						Addresses: []params.InterfaceAddress{
+							{
+								Hostname: "foo",
+								Address:  "172.31.10.10",
+								CIDR:     "172.31.10.10/32",
+							},
+							{
+								Hostname: "bar",
+								Address:  "172.31.10.11",
+								CIDR:     "172.31.10.11/32",
+							},
+						},
+					},
+					{
+						MACAddress:    "ee:18:40:1f:3e:fe",
+						InterfaceName: "es1",
+						Addresses: []params.InterfaceAddress{
+							{
+								Hostname: "foo",
+								Address:  "172.31.42.10",
+								CIDR:     "172.31.42.10/32",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	filteredRes := dedupNetworkInfoResults(resWithDups)
+	c.Assert(filteredRes, gc.DeepEquals, expRes)
+}


### PR DESCRIPTION
## Description of change

Due to the way that addresses are being collected and merged together by the machiner and instancepoller workers, we may end up with duplicate entries for the public IP addresses when running on aws substrates (for more information see [this](https://bugs.launchpad.net/juju/+bug/1855263) related bug).

As a result, `network-get` may potentially return duplicate entries as shown in https://bugs.launchpad.net/juju/+bug/1864072 which this PR **masks** by filtering the output of the `NetworkInfo` API call at the facade level to remove duplicates before returning the result back to the client.

This particular route (deduplication vs fixing the problem at the core) was chosen after considering the fact that there is active ongoing (longer-term) work with networking internals which will _eventually_ fix the problem. The proposed solution ensures that consumers get the right result while still buying us additional time to land a better fix.

## QA steps

```console
# Install juju from snap
$ /snap/bin/juju bootstrap aws --credential aws --no-gui
$ /snap/bin/juju deploy percona-cluster
$ /snap/bin/juju run --unit percona-cluster/0 'printenv JUJU_VERSION'
2.7.6

# Notice that network-get returns duplicate entries for bind/ingress addresses
$ /snap/bin/juju run --unit percona-cluster/0 'network-get cluster'
bind-addresses:
- macaddress: 0e:c7:44:73:f3:07
  interfacename: ens3
  addresses:
  - hostname: ""
    address: 172.31.46.122            <--+
    cidr: 172.31.32.0/20                 | Dup
  - hostname: ""                         |
    address: 172.31.46.122            <--+
    cidr: 172.31.32.0/20
- macaddress: ee:19:50:1f:3e:9a
  interfacename: fan-252
  addresses:
  - hostname: ""
    address: 252.46.122.1
    cidr: 252.32.0.0/12
egress-subnets:
- 172.31.46.122/32
ingress-addresses:
- 172.31.46.122                      <--| Dup
- 172.31.46.122                      <--+
- 252.46.122.1

# Upgrade your controller to the version from this PR
$ juju upgrade-controller --build-agent

# Notice that network-get filters duplicates
$ juju run --unit percona-cluster/0 'network-get cluster'
bind-addresses:
- macaddress: 0e:c7:44:73:f3:07
  interfacename: ens3
  addresses:
  - hostname: ""
    address: 172.31.46.122
    cidr: 172.31.32.0/20
- macaddress: ee:19:50:1f:3e:9a
  interfacename: fan-252
  addresses:
  - hostname: ""
    address: 252.46.122.1
    cidr: 252.32.0.0/12
egress-subnets:
- 172.31.46.122/32
ingress-addresses:
- 252.46.122.1
- 172.31.46.122
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1864072