### PR TITLE
Fix 1869959 - Admission worker has no side effects

### DIFF
--- a/worker/caasadmission/admission.go
+++ b/worker/caasadmission/admission.go
@@ -59,6 +59,7 @@ func NewAdmissionCreator(
 	failurePolicy := admission.Ignore
 	matchPolicy := admission.Equivalent
 	ruleScope := admission.AllScopes
+	sideEffects := admission.SideEffectClassNone
 
 	// MutatingWebjook Obj
 	obj := admission.MutatingWebhookConfiguration{
@@ -69,6 +70,7 @@ func NewAdmissionCreator(
 		},
 		Webhooks: []admission.MutatingWebhook{
 			{
+				SideEffects: &sideEffects,
 				ClientConfig: admission.WebhookClientConfig{
 					CABundle: caPemBuffer.Bytes(),
 					Service:  service,

--- a/worker/caasadmission/admission_test.go
+++ b/worker/caasadmission/admission_test.go
@@ -63,10 +63,14 @@ func (a *AdmissionSuite) TestAdmissionCreatorObject(c *gc.C) {
 
 			c.Assert(obj.Namespace, gc.Equals, namespace)
 			c.Assert(len(obj.Webhooks), gc.Equals, 1)
-			c.Assert(obj.Webhooks[0].ClientConfig.Service.Name, gc.Equals, svcName)
-			c.Assert(obj.Webhooks[0].ClientConfig.Service.Namespace, gc.Equals, namespace)
-			c.Assert(*obj.Webhooks[0].ClientConfig.Service.Path, gc.Equals, path)
-			c.Assert(*obj.Webhooks[0].ClientConfig.Service.Port, gc.Equals, port)
+			webhook := obj.Webhooks[0]
+			c.Assert(webhook.SideEffects, gc.NotNil)
+			c.Assert(*webhook.SideEffects, gc.Equals, admission.SideEffectClassNone)
+			svc := webhook.ClientConfig.Service
+			c.Assert(svc.Name, gc.Equals, svcName)
+			c.Assert(svc.Namespace, gc.Equals, namespace)
+			c.Assert(*svc.Path, gc.Equals, path)
+			c.Assert(*svc.Port, gc.Equals, port)
 
 			return func() { ensureWebhookCleanupCalled = true }, nil
 		}, serviceRef)

--- a/worker/caasadmission/controller_test.go
+++ b/worker/caasadmission/controller_test.go
@@ -6,7 +6,6 @@ package caasadmission_test
 import (
 	"net/http"
 	"sync"
-	"testing"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -26,8 +25,6 @@ type dummyMux struct {
 }
 
 var _ = gc.Suite(&ControllerSuite{})
-
-func TestControllerSuite(t *testing.T) { gc.TestingT(t) }
 
 func (d *dummyMux) AddHandler(i, j string, h http.Handler) error {
 	if d.AddHandlerFunc == nil {

--- a/worker/caasadmission/handler_test.go
+++ b/worker/caasadmission/handler_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"testing"
 
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -33,8 +32,6 @@ type HandlerSuite struct {
 }
 
 var _ = gc.Suite(&HandlerSuite{})
-
-func TestHandlerSuite(t *testing.T) { gc.TestingT(t) }
 
 func (h *HandlerSuite) SetupTest(c *gc.C) {
 	h.logger = loggo.Logger{}

--- a/worker/caasadmission/package_test.go
+++ b/worker/caasadmission/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasadmission_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
## Fix 1869959 - Admission worker has no side effects

Tell k8s that the admission worker's webhook has no side effects
so that dry runs work.

## QA steps

use `kubectl diff` or `kubectl apply --server-dry-run`

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1869959
