### PR TITLE
Fix edge case in manual provisioning.

### DIFF
--- a/environs/manual/sshprovisioner/init_test.go
+++ b/environs/manual/sshprovisioner/init_test.go
@@ -133,7 +133,12 @@ func (s *initialisationSuite) TestCheckProvisioned(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provisioned, jc.IsFalse)
 
-	defer installFakeSSH(c, listCmd, "juju...", 0)()
+	defer installFakeSSH(c, listCmd, "snap.juju.fetch-oci", 0)()
+	provisioned, err = sshprovisioner.CheckProvisioned("example.com")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provisioned, jc.IsFalse)
+
+	defer installFakeSSH(c, listCmd, "jujud-machine-42", 0)()
 	provisioned, err = sshprovisioner.CheckProvisioned("example.com")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provisioned, jc.IsTrue)

--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -181,7 +181,7 @@ func checkProvisioned(host string) (bool, error) {
 	}
 
 	output := strings.TrimSpace(stdout.String())
-	provisioned := strings.Contains(output, "juju")
+	provisioned := strings.Contains(output, "jujud-machine")
 	return provisioned, nil
 }
 


### PR DESCRIPTION
If the machine that you are trying to manually provision has the
2.8/edge juju snap installed, it introduces a snap service called
"snap.juju.fetch-oci". The code was just checking for "juju" in the
returned service list.

We now look for "jujud-machine" as a service name as any machine
that we sould look to provision over SSH would have a machine agent
set up if it was provisioned.

## QA steps

```sh
lxc launch ubuntu:18.04 to-provision
Add you ssh pub key to machine's .ssh/authorized_keys
Also inside the container, 'sudo snap install juju --classic --channel 2.8/edge'
Back outside the container, run:
juju add-machine ssh:<ip-addr>
Where ip-addr is the ip address of the to-provision container
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1876959