### PR TITLE
[dev] Ensure that reboot requests are queued correctly

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -130,6 +130,7 @@ type HookUnit interface {
 	OpenPorts(protocol string, fromPort, toPort int) error
 	RequestReboot() error
 	SetUnitStatus(unitStatus status.Status, info string, data map[string]interface{}) error
+	SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error
 	State() (params.UnitStateResult, error)
 	Tag() names.UnitTag
 	UnitStatus() (params.StatusResult, error)
@@ -566,6 +567,17 @@ func (ctx *HookContext) SetUnitStatus(unitStatus jujuc.StatusInfo) error {
 		status.Status(unitStatus.Status),
 		unitStatus.Info,
 		unitStatus.Data,
+	)
+}
+
+// SetAgentStatus will set the given status for this unit's agent.
+// Implements jujuc.HookContext.ContextStatus, part of runner.Context.
+func (ctx *HookContext) SetAgentStatus(agentStatus jujuc.StatusInfo) error {
+	logger.Tracef("[AGENT-STATUS] %s: %s", agentStatus.Status, agentStatus.Info)
+	return ctx.unit.SetAgentStatus(
+		status.Status(agentStatus.Status),
+		agentStatus.Info,
+		agentStatus.Data,
 	)
 }
 
@@ -1023,14 +1035,14 @@ func (ctx *HookContext) handleReboot(ctxErr error) error {
 		if ctxErr != nil {
 			return ctxErr
 		}
-		return ErrReboot
+		ctxErr = ErrReboot
 	case jujuc.RebootNow:
-		return ErrRequeueAndReboot
+		ctxErr = ErrRequeueAndReboot
 	}
 
-	// Do a best-effort attempt to set the unit status; we don't care if it
-	// fails as we will request a reboot anyway.
-	if err := ctx.unit.SetUnitStatus(status.Rebooting, "", nil); err != nil {
+	// Do a best-effort attempt to set the unit agent status; we don't care
+	// if it fails as we will request a reboot anyway.
+	if err := ctx.unit.SetAgentStatus(status.Rebooting, "", nil); err != nil {
 		logger.Errorf("updating agent status: %v", err)
 	}
 

--- a/worker/uniter/runner/context/mocks/hookunit_mock.go
+++ b/worker/uniter/runner/context/mocks/hookunit_mock.go
@@ -5,14 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
+	charm "github.com/juju/charm/v7"
 	uniter "github.com/juju/juju/api/uniter"
 	params "github.com/juju/juju/apiserver/params"
 	status "github.com/juju/juju/core/status"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockHookUnit is a mock of HookUnit interface
@@ -96,10 +95,10 @@ func (mr *MockHookUnitMockRecorder) CommitHookChanges(arg0 interface{}) *gomock.
 }
 
 // ConfigSettings mocks base method
-func (m *MockHookUnit) ConfigSettings() (charm_v6.Settings, error) {
+func (m *MockHookUnit) ConfigSettings() (charm.Settings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigSettings")
-	ret0, _ := ret[0].(charm_v6.Settings)
+	ret0, _ := ret[0].(charm.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -111,7 +110,7 @@ func (mr *MockHookUnitMockRecorder) ConfigSettings() *gomock.Call {
 }
 
 // LogActionMessage mocks base method
-func (m *MockHookUnit) LogActionMessage(arg0 names_v3.ActionTag, arg1 string) error {
+func (m *MockHookUnit) LogActionMessage(arg0 names.ActionTag, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogActionMessage", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -181,6 +180,20 @@ func (mr *MockHookUnitMockRecorder) RequestReboot() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockHookUnit)(nil).RequestReboot))
 }
 
+// SetAgentStatus mocks base method
+func (m *MockHookUnit) SetAgentStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetAgentStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetAgentStatus indicates an expected call of SetAgentStatus
+func (mr *MockHookUnitMockRecorder) SetAgentStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAgentStatus", reflect.TypeOf((*MockHookUnit)(nil).SetAgentStatus), arg0, arg1, arg2)
+}
+
 // SetUnitStatus mocks base method
 func (m *MockHookUnit) SetUnitStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
 	m.ctrl.T.Helper()
@@ -211,10 +224,10 @@ func (mr *MockHookUnitMockRecorder) State() *gomock.Call {
 }
 
 // Tag mocks base method
-func (m *MockHookUnit) Tag() names_v3.UnitTag {
+func (m *MockHookUnit) Tag() names.UnitTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.UnitTag)
+	ret0, _ := ret[0].(names.UnitTag)
 	return ret0
 }
 


### PR DESCRIPTION
## Description of change

A commit which was part of the 2.8 refactoring work (https://github.com/juju/juju/pull/11204/commits/5fe18b0b3d853545c150ed6f24aed770f874780c) messed up the implementation of the `handleReboot` method. While the method would return the correct error (`ErrReboot` or `ErrRequeAndReboot`), the actual reboot request was never queued due to an early return logic bug.

This PR makes everything work again and includes additional tests to prevent future regressions.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1877065