### PR TITLE
Add GetByAddress to SubnetInfos

### DIFF
--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -197,6 +197,27 @@ func (s SubnetInfos) GetByCIDR(cidr string) (SubnetInfos, error) {
 	return matching, nil
 }
 
+// Get by address returns subnets that based on IP range,
+// include the input IP address.
+func (s SubnetInfos) GetByAddress(addr string) (SubnetInfos, error) {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return nil, errors.NotValidf("%q as IP address", addr)
+	}
+
+	var subs SubnetInfos
+	for _, sub := range s {
+		_, ipNet, err := net.ParseCIDR(sub.CIDR)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if ipNet.Contains(ip) {
+			subs = append(subs, sub)
+		}
+	}
+	return subs, nil
+}
+
 // EqualTo returns true if this slice of SubnetInfo is equal to the input.
 func (s SubnetInfos) EqualTo(other SubnetInfos) bool {
 	if len(s) != len(other) {

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -207,7 +207,7 @@ func (s SubnetInfos) GetByAddress(addr string) (SubnetInfos, error) {
 
 	var subs SubnetInfos
 	for _, sub := range s {
-		_, ipNet, err := net.ParseCIDR(sub.CIDR)
+		ipNet, err := sub.ParsedCIDRNetwork()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -209,3 +209,22 @@ func (*subnetSuite) TestSubnetInfosGetByID(c *gc.C) {
 	c.Check(s.GetByID("9"), gc.IsNil)
 	c.Check(s.ContainsID("9"), jc.IsFalse)
 }
+
+func (*subnetSuite) TestSubnetInfosGetByAddress(c *gc.C) {
+	s := network.SubnetInfos{
+		{ID: "1", CIDR: "10.10.10.0/24", ProviderId: "1"},
+		{ID: "2", CIDR: "10.10.10.0/24", ProviderId: "2"},
+		{ID: "3", CIDR: "20.20.20.0/24"},
+	}
+
+	_, err := s.GetByAddress("invalid")
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+
+	subs, err := s.GetByAddress("10.10.10.5")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subs, gc.DeepEquals, s[:2])
+
+	subs, err = s.GetByAddress("30.30.30.5")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subs, gc.HasLen, 0)
+}

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -222,7 +222,12 @@ func (*subnetSuite) TestSubnetInfosGetByAddress(c *gc.C) {
 
 	subs, err := s.GetByAddress("10.10.10.5")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(subs, gc.DeepEquals, s[:2])
+
+	// We need to check these explicitly, because the IPNets of the original
+	// members will now be populated, making them differ.
+	c.Assert(subs, gc.HasLen, 2)
+	c.Check(subs[0].ProviderId, gc.Equals, network.Id("1"))
+	c.Check(subs[1].ProviderId, gc.Equals, network.Id("2"))
 
 	subs, err = s.GetByAddress("30.30.30.5")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
## Description of change

Adds GetByAddress to SubnetInfos for returning subnets containing an IP address.

## QA steps

Utility not recruited yet; see accompanying unit test.

## Documentation changes

None.

## Bug reference

N/A
