### PR TITLE
Fix 1877228 CAAS operator charms blocked actions

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -560,8 +560,9 @@ func (op *caasOperator) loop() (err error) {
 				params.UniterFacade = op.config.UniterFacadeFunc(unitTag)
 				params.LeadershipTracker = op.config.LeadershipTrackerFunc(unitTag)
 				params.ApplicationChannel = aliveUnits[unitID]
-				params.ContainerRunningStatusChannel = unitRunningChannels[unitID]
 				if op.deploymentMode != caas.ModeOperator {
+					params.IsRemoteUnit = true
+					params.ContainerRunningStatusChannel = unitRunningChannels[unitID]
 					params.ContainerRunningStatusFunc = func(providerID string) (*uniterremotestate.ContainerRunningStatus, error) {
 						return op.runningStatus(unitTag, providerID)
 					}

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -82,10 +82,9 @@ func (w WatcherConfig) validate() error {
 		if w.ApplicationChannel == nil {
 			return errors.NotValidf("watcher config for CAAS model with nil application channel")
 		}
-		if w.ContainerRunningStatusFunc != nil {
-			if w.ContainerRunningStatusChannel == nil {
-				return errors.NotValidf("watcher config for CAAS model with nil container running status channel")
-			}
+		if w.ContainerRunningStatusChannel != nil &&
+			w.ContainerRunningStatusFunc == nil {
+			return errors.NotValidf("watcher config for CAAS model with nil container running status func")
 		}
 	}
 	return nil
@@ -119,7 +118,7 @@ func NewWatcher(config WatcherConfig) (*RemoteStateWatcher, error) {
 		current: Snapshot{
 			Relations:      make(map[int]RelationSnapshot),
 			Storage:        make(map[names.StorageTag]StorageSnapshot),
-			ActionsBlocked: config.ContainerRunningStatusFunc != nil,
+			ActionsBlocked: config.ContainerRunningStatusChannel != nil,
 			ActionChanged:  make(map[string]int),
 		},
 	}

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -131,6 +131,9 @@ type Uniter struct {
 	// remoteInitFunc is used to init remote charm state.
 	remoteInitFunc RemoteInitFunc
 
+	// isRemoteUnit is true when the unit is remotely deployed.
+	isRemoteUnit bool
+
 	// hookRetryStrategy represents configuration for hook retries
 	hookRetryStrategy params.RetryStrategy
 
@@ -166,6 +169,7 @@ type UniterParams struct {
 	ApplicationChannel            watcher.NotifyChannel
 	ContainerRunningStatusChannel watcher.NotifyChannel
 	ContainerRunningStatusFunc    remotestate.ContainerRunningStatusFunc
+	IsRemoteUnit                  bool
 	SocketConfig                  *SocketConfig
 	// TODO (mattyw, wallyworld, fwereade) Having the observer here make this approach a bit more legitimate, but it isn't.
 	// the observer is only a stop gap to be used in tests. A better approach would be to have the uniter tests start hooks
@@ -230,6 +234,7 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 		applicationChannel:            uniterParams.ApplicationChannel,
 		containerRunningStatusChannel: uniterParams.ContainerRunningStatusChannel,
 		containerRunningStatusFunc:    uniterParams.ContainerRunningStatusFunc,
+		isRemoteUnit:                  uniterParams.IsRemoteUnit,
 		runListener:                   uniterParams.RunListener,
 		rebootQuerier:                 uniterParams.RebootQuerier,
 		logger:                        uniterParams.Logger,
@@ -401,6 +406,13 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				return errors.Trace(err)
 			}
 		}
+	} else if u.modelType == model.CAAS && u.isRemoteUnit {
+		if u.containerRunningStatusChannel == nil {
+			return errors.NotValidf("ContainerRunningStatusChannel missing for CAAS remote unit")
+		}
+		if u.containerRunningStatusFunc == nil {
+			return errors.NotValidf("ContainerRunningStatusFunc missing for CAAS remote unit")
+		}
 	}
 
 	for {
@@ -431,7 +443,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			),
 			Logger: u.logger,
 		}
-		if u.modelType == model.CAAS {
+		if u.modelType == model.CAAS && u.isRemoteUnit {
 			cfg.Container = container.NewResolver()
 		}
 		uniterResolver := NewUniterResolver(cfg)
@@ -449,8 +461,8 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			CharmURL:             charmURL,
 			CharmModifiedVersion: charmModifiedVersion,
 			UpgradeSeriesStatus:  model.UpgradeSeriesNotStarted,
-			// CAAS models should trigger remote update of the charm every start.
-			OutdatedRemoteCharm: u.modelType == model.CAAS,
+			// CAAS remote units should trigger remote update of the charm every start.
+			OutdatedRemoteCharm: u.isRemoteUnit,
 		}
 		for err == nil {
 			err = resolver.Loop(resolver.LoopConfig{


### PR DESCRIPTION
## Fix 1877228 CAAS operator charms blocked actions

Action resolver was blocking on remote container init but
CAAS operator charms do not have a remote container and will never
init.

## QA steps

Deploy both a CAAS operator charm and CAAS workload charm.
Make sure juju run can execute commands on both.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1877228