### PR TITLE
[2.7] Ensure kvm images are pulled from the configured image URL

### DIFF
--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -63,7 +63,7 @@ func (c *kvmContainer) EnsureCachedImage(params StartParams) error {
 			_ = params.StatusCallback(status.Provisioning, msg, nil)
 		}
 	}
-	if err := Sync(sp, nil, callback); err != nil {
+	if err := Sync(sp, nil, params.ImageDownloadURL, callback); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return errors.Trace(err)
 		}

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -36,7 +36,7 @@ func (syncInternalSuite) TestFetcher(c *gc.C) {
 	ts := newTestServer()
 	defer ts.Close()
 
-	md := newTestMetadata(ts.URL)
+	md := newTestMetadata()
 
 	tmpdir, pathfinder, ok := newTmpdir()
 	if !ok {
@@ -51,7 +51,7 @@ func (syncInternalSuite) TestFetcher(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
+	fetcher, err := newDefaultFetcher(md, ts.URL, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// setup a fake command runner.
@@ -74,7 +74,7 @@ func (syncInternalSuite) TestFetcherWriteFails(c *gc.C) {
 	ts := newTestServer()
 	defer ts.Close()
 
-	md := newTestMetadata(ts.URL)
+	md := newTestMetadata()
 
 	tmpdir, pathfinder, ok := newTmpdir()
 	if !ok {
@@ -89,7 +89,7 @@ func (syncInternalSuite) TestFetcherWriteFails(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
+	fetcher, err := newDefaultFetcher(md, ts.URL, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// setup a fake command runner.
@@ -110,7 +110,7 @@ func (syncInternalSuite) TestFetcherInvalidSHA(c *gc.C) {
 	ts := newTestServer()
 	defer ts.Close()
 
-	md := newTestMetadata(ts.URL)
+	md := newTestMetadata()
 	md.SHA256 = "invalid"
 
 	tmpdir, pathfinder, ok := newTmpdir()
@@ -126,7 +126,7 @@ func (syncInternalSuite) TestFetcherInvalidSHA(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
+	fetcher, err := newDefaultFetcher(md, ts.URL, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = fetcher.Fetch()
@@ -137,7 +137,7 @@ func (syncInternalSuite) TestFetcherNotFound(c *gc.C) {
 	ts := newTestServer()
 	defer ts.Close()
 
-	md := newTestMetadata(ts.URL)
+	md := newTestMetadata()
 	md.Path = "not-there"
 
 	tmpdir, pathfinder, ok := newTmpdir()
@@ -153,7 +153,7 @@ func (syncInternalSuite) TestFetcherNotFound(c *gc.C) {
 		}
 	}()
 
-	fetcher, err := newDefaultFetcher(md, pathfinder, nil)
+	fetcher, err := newDefaultFetcher(md, ts.URL, pathfinder, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = fetcher.Fetch()
@@ -161,7 +161,7 @@ func (syncInternalSuite) TestFetcherNotFound(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `got 404 fetching image "not-there" not found`)
 }
 
-func newTestMetadata(base string) *imagedownloads.Metadata {
+func newTestMetadata() *imagedownloads.Metadata {
 	return &imagedownloads.Metadata{
 		Arch:    "archless",
 		Release: "spammy",
@@ -170,7 +170,6 @@ func newTestMetadata(base string) *imagedownloads.Metadata {
 		SHA256:  "5e8467e6732923e74de52ef60134ba747aeeb283812c60f69b67f4f79aca1475",
 		Path:    "server.img",
 		Size:    int64(len(imageContents)),
-		BaseURL: base,
 	}
 }
 

--- a/container/kvm/sync_test.go
+++ b/container/kvm/sync_test.go
@@ -26,7 +26,7 @@ var _ = gc.Suite(&cacheSuite{})
 func (cacheSuite) TestSyncOnerErrors(c *gc.C) {
 	o := fakeParams{FakeData: nil, Err: errors.New("oner failed")}
 	u := fakeFetcher{}
-	got := Sync(o, u, nil)
+	got := Sync(o, u, "", nil)
 	c.Assert(got, gc.ErrorMatches, "oner failed")
 }
 
@@ -35,21 +35,21 @@ func (cacheSuite) TestSyncOnerExists(c *gc.C) {
 		FakeData: nil,
 		Err:      errors.AlreadyExistsf("exists")}
 	u := fakeFetcher{}
-	got := Sync(o, u, nil)
+	got := Sync(o, u, "", nil)
 	c.Assert(got, jc.ErrorIsNil)
 }
 
 func (cacheSuite) TestSyncUpdaterErrors(c *gc.C) {
 	o := fakeParams{FakeData: &imagedownloads.Metadata{}, Err: nil}
 	u := fakeFetcher{Err: errors.New("updater failed")}
-	got := Sync(o, u, nil)
+	got := Sync(o, u, "", nil)
 	c.Assert(got, gc.ErrorMatches, "updater failed")
 }
 
 func (cacheSuite) TestSyncSucceeds(c *gc.C) {
 	o := fakeParams{FakeData: &imagedownloads.Metadata{}}
 	u := fakeFetcher{}
-	got := Sync(o, u, nil)
+	got := Sync(o, u, "", nil)
 	c.Assert(got, jc.ErrorIsNil)
 }
 

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -66,7 +66,7 @@ func (s *LibVertSuite) TestSyncImagesUtilizesSimpleStreamsSource(c *gc.C) {
 		srcFunc: func() simplestreams.DataSource { return imagedownloads.NewDataSource(source) },
 		success: true,
 	}
-	err := Sync(p, fakeFetcher{}, nil)
+	err := Sync(p, fakeFetcher{}, source, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	url, err := p.sourceURL()

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -58,12 +58,7 @@ func newDataSourceFunc(baseURL string) func() simplestreams.DataSource {
 // Metadata models the information about a particular cloud image download
 // product.
 type Metadata struct {
-	Arch string `json:"arch,omitempty"`
-	// For testing.
-	// TODO(ro) 2016-12-07 BaseURL was jammed on to allow for testing in
-	// juju/container/kvm/sync_internal_test. Refactor to pass it in rather
-	// than setting it on an otherwise needlessly exported member.
-	BaseURL string `json:"-"`
+	Arch    string `json:"arch,omitempty"`
 	Release string `json:"release,omitempty"`
 	Version string `json:"version,omitempty"`
 	FType   string `json:"ftype,omitempty"`
@@ -73,11 +68,11 @@ type Metadata struct {
 }
 
 // DownloadURL returns the URL representing the image.
-func (m *Metadata) DownloadURL() (*url.URL, error) {
-	if m.BaseURL == "" {
-		m.BaseURL = imagemetadata.UbuntuCloudImagesURL
+func (m *Metadata) DownloadURL(baseURL string) (*url.URL, error) {
+	if baseURL == "" {
+		baseURL = imagemetadata.UbuntuCloudImagesURL
 	}
-	u, err := url.Parse(m.BaseURL + "/" + m.Path)
+	u, err := url.Parse(baseURL + "/" + m.Path)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to create url")
 	}


### PR DESCRIPTION
## Description of change

While the image fetch code always queries the correct index url (as
specified by the image-metadata model config) for discovering kvm
images, it did not make use of it when fetching the actual images. As a
result, juju would always fall back to using the built in default
(cloud-images.ubuntu.com).

This PR threads the value of the image URL parameter through the
image fetching code and uses it when constructing the URL to pull the
image from.

## QA steps

You will need access to a MAAS instance *and* an http server which can be accessed by it. Prepare your http server as follows:

```console
# Assuming that files are served from /srv/www
$ cd /srv/www
$ mkdir -p releases/streams/v1
$ cd releases/streams/v1
$ wget https://cloud-images.ubuntu.com/releases/streams/v1/index.sjson
$ wget https://cloud-images.ubuntu.com/releases/streams/v1/com.ubuntu.cloud:released:download.sjson

$ cd /srv/www/releases
$ mkdir -p server/releases/bionic/release-20200506
$ cd server/releases/bionic/release-20200506
$ wget http://cloud-images.ubuntu.com/server/releases/bionic/release-20200506/ubuntu-18.04-server-cloudimg-amd64.img
```

Boostrap on maas and deploy a kvm workload (replace `$REMOTE` with the address of your web-server)

```console
$ juju bootstrap maas kvm-test --debug --no-gui
$ juju model-config logging-config='<root>=DEBUG;juju.environs.simplestreams=TRACE;juju.container.kvm=TRACE'
$ juju model-config container-image-metadata-url=$REMOTE/releases image-metadata-url=$REMOTE/releases

$ juju deploy  cs:~jameinel/ubuntu-lite-7 --to kvm

# Watch *both* juju status and tail the server access logs to verify that the image is pulled from $REMOTE 
# and not from "cloud-images.ubuntu.com"

$ juju status | grep copying
0/kvm/0  pending             pending    bionic           copying http://$REMOTE/server/releases/bionic/release-20200506/ubuntu-18.04-server-cloudimg-amd64.img 76% (3.5MB/s)

# NEXT: reset the model config params and deploy again; this time the images should
# be pulled from "cloud-images.ubuntu.com"
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1859121