### PR TITLE
Fix go tooling usage inside code for vendored mods

### DIFF
--- a/cmd/jujuc/main_windows.go
+++ b/cmd/jujuc/main_windows.go
@@ -5,19 +5,16 @@
 package main
 
 import (
+	"os"
+
 	"github.com/juju/featureflag"
 
 	"github.com/juju/juju/juju/osenv"
 )
 
-// FLAGSFROMENVIRONMENT can control whether we read featureflags from the
-// environment or from the registry. This is only needed because we build the
-// jujud binary in uniter tests and we cannot mock the registry out easily.
-// Once uniter tests are fixed this should be removed.
-var FLAGSFROMENVIRONMENT string
-
 func init() {
-	if FLAGSFROMENVIRONMENT == "true" {
+	// If feature flags have been set on env, use them instead.
+	if os.Getenv(osenv.JujuFeatureFlagEnvKey) != "" {
 		featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	} else {
 		featureflag.SetFlagsFromRegistry(osenv.JujuRegistryKey, osenv.JujuFeatureFlagEnvKey)

--- a/cmd/jujud/main_windows.go
+++ b/cmd/jujud/main_windows.go
@@ -17,14 +17,9 @@ import (
 	"github.com/juju/juju/juju/osenv"
 )
 
-// FLAGSFROMENVIRONMENT can control whether we read featureflags from the
-// environment or from the registry. This is only needed because we build the
-// jujud binary in uniter tests and we cannot mock the registry out easily.
-// Once uniter tests are fixed this should be removed.
-var FLAGSFROMENVIRONMENT string
-
 func init() {
-	if FLAGSFROMENVIRONMENT == "true" {
+	// If feature flags have been set on env, use them instead.
+	if os.Getenv(osenv.JujuFeatureFlagEnvKey) != "" {
 		featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	} else {
 		featureflag.SetFlagsFromRegistry(osenv.JujuRegistryKey, osenv.JujuFeatureFlagEnvKey)

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/juju/rpcreflect v0.0.0-20200416001309-bb46e9ba1476
 	github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989
 	github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae
-	github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b
+	github.com/juju/testing v0.0.0-20200508032009-c4045af1c73f
 	github.com/juju/txn v0.0.0-20190416045819-5f348e78887d
 	github.com/juju/usso v0.0.0-20160401104424-68a59c96c178 // indirect
 	github.com/juju/utils v0.0.0-20200424103611-54ececcc5fc7
@@ -82,6 +82,7 @@ require (
 	github.com/juju/worker/v2 v2.0.0-20200424114111-8c6ac8046912
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.1.0
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lestrrat/go-jspointer v0.0.0-20160229021354-f4881e611bdb // indirect
 	github.com/lestrrat/go-jsref v0.0.0-20160601013240-e452c7b5801d // indirect
 	github.com/lestrrat/go-jsschema v0.0.0-20160903131957-b09d7650b822 // indirect
@@ -106,8 +107,8 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	golang.org/x/crypto v0.0.0-20200422194213-44a606286825
-	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd
+	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
+	golang.org/x/net v0.0.0-20200506145744-7e3656a0809f
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
 	google.golang.org/api v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -392,6 +393,8 @@ github.com/juju/testing v0.0.0-20180820040200-b0b89ba330f2/go.mod h1:63prj8cnj0t
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b h1:Rrp0ByJXEjhREMPGTt3aWYjoIsUGCbt21ekbeJcTWv0=
 github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
+github.com/juju/testing v0.0.0-20200508032009-c4045af1c73f h1:TBmNwEOh8TI5i0Mh6KUQ/qQmQZC374yvozM4g7hmcZc=
+github.com/juju/testing v0.0.0-20200508032009-c4045af1c73f/go.mod h1:hpGvhGHPVbNBraRLZEhoQwFLMrjK8PSlO4D3nDjKYXo=
 github.com/juju/txn v0.0.0-20190416045819-5f348e78887d h1:8I8WXDHbmcN+HJP4y1O42f2eYuN8U3CeP/y3LVboZZI=
 github.com/juju/txn v0.0.0-20190416045819-5f348e78887d/go.mod h1:ZgVptALKKa9UUv7ItEJVQjFWNG/0bs+tAu0ad0O8DAE=
 github.com/juju/usso v0.0.0-20160401104424-68a59c96c178 h1:+Hw/cvdgko8DzBM+qI+HsEphk08NyNM0ONPFDg5cGis=
@@ -400,6 +403,7 @@ github.com/juju/utils v0.0.0-20160526025251-ffea6ead0c37/go.mod h1:6/KLg8Wz/y2KV
 github.com/juju/utils v0.0.0-20161003233226-28c01ec2ad93/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180619112806-c746c6e86f4f/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
+github.com/juju/utils v0.0.0-20180808125547-9dfc6dbfb02b/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647 h1:wQpkHVbIIpz1PCcLYku9KFWsJ7aEMQXHBBmLy3tRBTk=
 github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
@@ -441,6 +445,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lestrrat/go-jspointer v0.0.0-20160229021354-f4881e611bdb h1:ZWuRImtpQp2QxwzMFDYqSgym24d7N0HE38JRVoJ/Piw=
 github.com/lestrrat/go-jspointer v0.0.0-20160229021354-f4881e611bdb/go.mod h1:QNUDfTLPkT8YBZrQUlk2Ppk2KrQXIZlWIhqy+0jWKf4=
 github.com/lestrrat/go-jsref v0.0.0-20160601013240-e452c7b5801d h1:fpSi20MDrP/+apGjCI2BddUKM/cnxOT9dVaYuFub4Tw=
@@ -620,6 +626,8 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200422194213-44a606286825 h1:dSChiwOTvzwbHFTMq2l6uRardHH7/E6SqEkqccinS/o=
 golang.org/x/crypto v0.0.0-20200422194213-44a606286825/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79 h1:IaQbIIB2X/Mp/DKctl6ROxz1KyMlKp4uyvL6+kQ7C88=
+golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -654,6 +662,8 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjut
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd h1:QPwSajcTUrFriMF1nJ3XzgoqakqQEsnZf9LdXdi2nkI=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200506145744-7e3656a0809f h1:QBjCr1Fz5kw158VqdE9JfI9cJnl/ymnJWAdMuinqL7Y=
+golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=

--- a/testing/bins.go
+++ b/testing/bins.go
@@ -1,0 +1,120 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+	"sync"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type buildDetails struct {
+	Pkg     string
+	Bin     string
+	BuildID string
+}
+
+var binMap = map[string]buildDetails{
+	"jujud": {
+		Pkg:     "github.com/juju/juju/cmd/jujud",
+		Bin:     "jujud",
+		BuildID: os.Getenv("JUJU_TESTING_JUJUD_BUILDID"),
+	},
+	"jujuc": {
+		Pkg:     "github.com/juju/juju/cmd/jujuc",
+		Bin:     "jujuc",
+		BuildID: os.Getenv("JUJU_TESTING_JUJUC_BUILDID"),
+	},
+	"juju": {
+		Pkg:     "github.com/juju/juju/cmd/juju",
+		Bin:     "juju",
+		BuildID: os.Getenv("JUJU_TESTING_JUJU_BUILDID"),
+	},
+}
+
+var (
+	modParamCacheMutex sync.Mutex
+	modParamCache      string
+)
+
+func getModParam(c *gc.C) string {
+	modParamCacheMutex.Lock()
+	defer modParamCacheMutex.Unlock()
+	if modParamCache != "" {
+		return modParamCache
+	}
+
+	// Check to see if we are vendored, then use the vendored modules.
+	cmd := exec.Command("go", "list", "-mod=vendor", "github.com/juju/juju")
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	_, err := cmd.CombinedOutput()
+	if err == nil {
+		modParamCache = "-mod=vendor"
+	} else {
+		// We don't want any tests to ever pull modules, so if we don't have vendored
+		// modules, then we expect modules to be in the go module cache.
+		modParamCache = "-mod=readonly"
+	}
+
+	return modParamCache
+}
+
+// CopyOrBuildJujuBins from PATH or build the binaries from source.
+// If buildids are present in env for the binary, only ever copy and assert if the
+// buildids don't match.
+func CopyOrBuildJujuBins(c *gc.C, targetDir string, bins ...string) {
+	for _, bin := range bins {
+		details, ok := binMap[bin]
+		if !ok {
+			c.Fatalf("unknown juju binary request %q", bin)
+			return
+		}
+
+		targetPath := path.Join(targetDir, bin)
+
+		if details.BuildID != "" {
+			fullPath, err := exec.LookPath(bin)
+			if err == exec.ErrNotFound {
+				c.Fatalf("could not find %q binary with build id %q", bin, details.BuildID)
+				return
+			}
+			c.Assert(err, jc.ErrorIsNil)
+
+			cmd := exec.Command("go", "tool", "buildid", fullPath)
+			out, err := cmd.CombinedOutput()
+			c.Assert(err, jc.ErrorIsNil)
+			buildID := strings.TrimSpace(string(out))
+			c.Assert(buildID, gc.Equals, details.BuildID)
+
+			// If we can avoid a copy with a hard link, lets do that.
+			if err := os.Link(fullPath, targetPath); err == nil {
+				continue
+			}
+
+			if runtime.GOOS == "windows" {
+				// For now just symlink it across.
+				err := os.Symlink(fullPath, targetPath)
+				c.Assert(err, jc.ErrorIsNil)
+			} else {
+				// Invoke cp
+				cmd = exec.Command("cp", "-f", "-p", "-L", fullPath, targetPath)
+				out, err = cmd.CombinedOutput()
+				c.Logf("copying %q to %q: %s", fullPath, targetPath, string(out))
+				c.Assert(err, jc.ErrorIsNil)
+			}
+			continue
+		}
+
+		cmd := exec.Command("go", "build", "-o", targetPath, getModParam(c), details.Pkg)
+		out, err := cmd.CombinedOutput()
+		c.Logf("building %q: %s", details.Pkg, string(out))
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -57,12 +56,9 @@ func (s *UniterSuite) SetUpSuite(c *gc.C) {
 	toolsDir := tools.ToolsDir(s.dataDir, "unit-u-0")
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO(fwereade) GAAAAAAAAAAAAAAAAAH this is LUDICROUS.
-	// TODO(hpidcock): Seriously? This is disgusting.
-	cmd := exec.Command("go", append([]string{"build", "-o", toolsDir, "-mod=readonly"}, jujudBuildArgs...)...)
-	out, err := cmd.CombinedOutput()
-	c.Logf(string(out))
-	c.Assert(err, jc.ErrorIsNil)
+
+	coretesting.CopyOrBuildJujuBins(c, toolsDir, "jujud", "jujuc")
+
 	s.oldLcAll = os.Getenv("LC_ALL")
 	os.Setenv("LC_ALL", "en_US")
 	s.unitDir = filepath.Join(s.dataDir, "agents", "unit-u-0")

--- a/worker/uniter/util_unix_test.go
+++ b/worker/uniter/util_unix_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 var (
-	jujudBuildArgs = []string{"github.com/juju/juju/cmd/jujud"}
-
 	// Command suffix for the hooks
 	cmdSuffix = ""
 

--- a/worker/uniter/util_windows_test.go
+++ b/worker/uniter/util_windows_test.go
@@ -14,12 +14,6 @@ import (
 )
 
 var (
-	// We use -ldflags -X main.FLAGSFROMENVIRONMENT=true to toggle a
-	// variable that will force windows to read flags from the environment
-	// instead of the registry.
-	// If this gets removed FLAGSFROMENVIRONMENT should also be abolished.
-	jujudBuildArgs = []string{"-ldflags", "-X main.FLAGSFROMENVIRONMENT=true", "github.com/juju/juju/cmd/jujud"}
-
 	// Command suffix for the hooks
 	cmdSuffix = ".cmd"
 


### PR DESCRIPTION
## Fix go tooling usage inside code for vendored mods

- Correctly use vendored deps when available.
- Avoid builds when supplied jujud/jujuc is matching buildid.
- Update testing package with juju-db snap fixes.

NOTE: we don't allow -mod to be auto because tests and --build-agent should never connect off to download packages automatically.

## QA steps

```
go mod vendor
go test github.com/worker/uniter
```

```
rm -Rf vendor/
go test github.com/worker/uniter
```

```
make install
export JUJU_TESTING_JUJUD_BUILDID=$(go tool buildid `which jujud`)
export JUJU_TESTING_JUJUC_BUILDID=$(go tool buildid `which jujuc`)
export JUJU_TESTING_JUJU_BUILDID=$(go tool buildid `which juju`)
go test github.com/worker/uniter
```

```
snap install juju-db --channel=stable/candidate
make test
```

## Documentation changes

N/A

## Bug reference

See failing unit tests in ci-run
