### PR TITLE
2.8 - Back-Fill Origin When Setting Network Config With Old Facade Versions

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -85,7 +85,7 @@ var facadeVersions = map[string]int{
 	"Payloads":                     1,
 	"PayloadsHookContext":          1,
 	"Pinger":                       1,
-	"Provisioner":                  10,
+	"Provisioner":                  11,
 	"ProxyUpdater":                 2,
 	"Reboot":                       2,
 	"RelationStatusWatcher":        1,

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -65,7 +65,7 @@ var facadeVersions = map[string]int{
 	"MachineActions":               1,
 	"MachineManager":               6,
 	"MachineUndertaker":            1,
-	"Machiner":                     2,
+	"Machiner":                     3,
 	"MeterStatus":                  2,
 	"MetricsAdder":                 2,
 	"MetricsDebug":                 2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -263,8 +263,8 @@ func AllFacades() *facade.Registry {
 	reg("ModelManager", 2, modelmanager.NewFacadeV2)
 	reg("ModelManager", 3, modelmanager.NewFacadeV3)
 	reg("ModelManager", 4, modelmanager.NewFacadeV4)
-	reg("ModelManager", 5, modelmanager.NewFacadeV5) // adds ChangeModelCredential
-	reg("ModelManager", 6, modelmanager.NewFacadeV6) // adds cloud specific default config
+	reg("ModelManager", 5, modelmanager.NewFacadeV5) // Adds ChangeModelCredential
+	reg("ModelManager", 6, modelmanager.NewFacadeV6) // Adds cloud specific default config
 	reg("ModelManager", 7, modelmanager.NewFacadeV7) // DestroyModels gains 'force' and max-wait' parameters.
 	reg("ModelManager", 8, modelmanager.NewFacadeV8) // ModelInfo gains credential validity in return.
 	reg("ModelUpgrader", 1, modelupgrader.NewStateFacade)
@@ -279,12 +279,13 @@ func AllFacades() *facade.Registry {
 	reg("Pinger", 1, NewPinger)
 	reg("Provisioner", 3, provisioner.NewProvisionerAPIV4) // Yes this is weird.
 	reg("Provisioner", 4, provisioner.NewProvisionerAPIV4)
-	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5)   // v5 adds DistributionGroupByMachineId()
-	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6)   // v6 adds more proxy settings
-	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7)   // v7 adds charm profile watcher
-	reg("Provisioner", 8, provisioner.NewProvisionerAPIV8)   // v8 adds changes charm profile and modification status
-	reg("Provisioner", 9, provisioner.NewProvisionerAPIV9)   // v9 adds supported containers
-	reg("Provisioner", 10, provisioner.NewProvisionerAPIV10) // v10 adds support for multiple space constraints.
+	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5)   // Adds DistributionGroupByMachineId()
+	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6)   // Adds more proxy settings
+	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7)   // Adds charm profile watcher
+	reg("Provisioner", 8, provisioner.NewProvisionerAPIV8)   // Adds changes charm profile and modification status
+	reg("Provisioner", 9, provisioner.NewProvisionerAPIV9)   // Adds supported containers
+	reg("Provisioner", 10, provisioner.NewProvisionerAPIV10) // Adds support for multiple space constraints.
+	reg("Provisioner", 11, provisioner.NewProvisionerAPIV11) // Relies on agent-set origin in SetHostMachineNetworkConfig.
 
 	reg("ProxyUpdater", 1, proxyupdater.NewFacadeV1)
 	reg("ProxyUpdater", 2, proxyupdater.NewFacadeV2)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -239,7 +239,8 @@ func AllFacades() *facade.Registry {
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
 	reg("Machiner", 1, machine.NewMachinerAPIV1)
-	reg("Machiner", 2, machine.NewMachinerAPI)
+	reg("Machiner", 2, machine.NewMachinerAPIV2) // Adds RecordAgentStartTime.
+	reg("Machiner", 3, machine.NewMachinerAPI)   // Relies on agent-set origin in SetObservedNetworkConfig.
 
 	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacadeV1)
 	reg("MeterStatus", 2, meterstatus.NewMeterStatusFacade)

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -153,17 +153,45 @@ func (api *MachinerAPI) RecordAgentStartTime(args params.Entities) (params.Error
 // MachinerAPIV1 implements the V1 API used by the machiner worker. Compared to
 // V2, it lacks the RecordAgentStartTime method.
 type MachinerAPIV1 struct {
+	*MachinerAPIV2
+}
+
+// MachinerAPIV2 implements the V1 API used by the machiner worker. Compared to
+// V2, it back-fills the missing origin in NetworkConfig.
+type MachinerAPIV2 struct {
 	*MachinerAPI
 }
 
 // NewMachinerAPIV1 creates a new instance of the V1 Machiner API.
-func NewMachinerAPIV1(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*MachinerAPIV1, error) {
+func NewMachinerAPIV1(
+	st *state.State, resources facade.Resources, authorizer facade.Authorizer,
+) (*MachinerAPIV1, error) {
 	api, err := NewMachinerAPI(st, resources, authorizer)
 	if err != nil {
 		return nil, err
 	}
 
-	return &MachinerAPIV1{api}, nil
+	return &MachinerAPIV1{&MachinerAPIV2{api}}, nil
+}
+
+// NewMachinerAPIV2 creates a new instance of the V2 Machiner API.
+func NewMachinerAPIV2(
+	st *state.State, resources facade.Resources, authorizer facade.Authorizer,
+) (*MachinerAPIV2, error) {
+	api, err := NewMachinerAPI(st, resources, authorizer)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MachinerAPIV2{api}, nil
+}
+
+// SetObservedNetworkConfig back-fills machine origin before calling through to
+// the networking common method of the same name.
+// Older agents do not set the origin, so we must do it for them.
+func (api *MachinerAPIV2) SetObservedNetworkConfig(args params.SetMachineNetworkConfig) error {
+	args.BackFillMachineOrigin()
+	return api.NetworkConfigAPI.SetObservedNetworkConfig(args)
 }
 
 // RecordAgentStartTime is not available in V1.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21203,7 +21203,7 @@
     },
     {
         "Name": "Machiner",
-        "Version": 2,
+        "Version": 3,
         "Schema": {
             "type": "object",
             "properties": {
@@ -26475,7 +26475,7 @@
     },
     {
         "Name": "Provisioner",
-        "Version": 10,
+        "Version": 11,
         "Schema": {
             "type": "object",
             "properties": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -681,6 +681,20 @@ type SetMachineNetworkConfig struct {
 	Config []NetworkConfig `json:"config"`
 }
 
+// BackfillMachineOrigin sets all empty NetworkOrigin entries to indicate that
+// they are sourced from the local machine.
+// TODO (manadart 2020-05-12): This is used by superseded methods on the
+// Machiner and NetworkConfig APIs, which along with this should considered for
+// removing for Juju 3.0.
+func (c *SetMachineNetworkConfig) BackFillMachineOrigin() {
+	for i := range c.Config {
+		if c.Config[i].NetworkOrigin != "" {
+			continue
+		}
+		c.Config[i].NetworkOrigin = NetworkOrigin(network.OriginMachine)
+	}
+}
+
 // MachineAddressesResult holds a list of machine addresses or an
 // error.
 type MachineAddressesResult struct {


### PR DESCRIPTION
## Description of change

This patch ensures that `SetMachineNetworkConfig` backfills empty `NetworkOrigin` members indicating machine origin on old versions of the `Machiner` and `Provisioner` API facades.

This is in preparation for distinguishing link-layer device responsibility between the machiner and instance-poller workers, which in turn will allow us to safely remove interfaces that are no longer observed on the machine.

## QA steps

QA steps will follow when implementing device responsibility transfer and deletion. The backfill is covered by a new unit test.

## Documentation changes

None.

## Bug reference

Progress towards a resolution for https://bugs.launchpad.net/juju/+bug/1733968
