### PR TITLE
Fix/remote init retry

### DIFF
--- a/caas/kubernetes/provider/exec/errors.go
+++ b/caas/kubernetes/provider/exec/errors.go
@@ -67,8 +67,8 @@ func (e execRetryableError) Error() string {
 	return e.err
 }
 
-// newExecRetryableError constructs an execRetryableError.
-func newExecRetryableError(err error) error {
+// NewExecRetryableError constructs an execRetryableError.
+func NewExecRetryableError(err error) error {
 	return &execRetryableError{
 		err: fmt.Sprintf("%q", err.Error()),
 	}
@@ -85,14 +85,14 @@ func handleExecRetryableError(err error) error {
 	if wrench.IsActive("exec", "137") {
 		fakeErr := errors.New("fake 137")
 		logger.Warningf("wrench exec 137 enabled, returns %v", fakeErr)
-		return newExecRetryableError(fakeErr)
+		return NewExecRetryableError(fakeErr)
 	}
 	if err == nil {
 		return nil
 	}
 	if exitErr, ok := errors.Cause(err).(ExitError); ok {
 		if exitErr.ExitStatus() == 137 {
-			return newExecRetryableError(exitErr)
+			return NewExecRetryableError(exitErr)
 		}
 	}
 	return err

--- a/caas/kubernetes/provider/exec/errors.go
+++ b/caas/kubernetes/provider/exec/errors.go
@@ -67,7 +67,8 @@ func (e execRetryableError) Error() string {
 	return e.err
 }
 
-func newexecRetryableError(err error) error {
+// newExecRetryableError constructs an execRetryableError.
+func newExecRetryableError(err error) error {
 	return &execRetryableError{
 		err: fmt.Sprintf("%q", err.Error()),
 	}
@@ -84,14 +85,14 @@ func handleExecRetryableError(err error) error {
 	if wrench.IsActive("exec", "137") {
 		fakeErr := errors.New("fake 137")
 		logger.Warningf("wrench exec 137 enabled, returns %v", fakeErr)
-		return newexecRetryableError(fakeErr)
+		return newExecRetryableError(fakeErr)
 	}
 	if err == nil {
 		return nil
 	}
 	if exitErr, ok := errors.Cause(err).(ExitError); ok {
 		if exitErr.ExitStatus() == 137 {
-			return newexecRetryableError(exitErr)
+			return newExecRetryableError(exitErr)
 		}
 	}
 	return err

--- a/caas/kubernetes/provider/exec/errors.go
+++ b/caas/kubernetes/provider/exec/errors.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/juju/errors"
 	"k8s.io/client-go/util/exec"
-
-	"github.com/juju/juju/wrench"
 )
 
 // ExitError exposes what we need from k8s exec.ExitError
@@ -82,11 +80,6 @@ func IsExecRetryableError(err error) bool {
 }
 
 func handleExecRetryableError(err error) error {
-	if wrench.IsActive("exec", "137") {
-		fakeErr := errors.New("fake 137")
-		logger.Warningf("wrench exec 137 enabled, returns %v", fakeErr)
-		return NewExecRetryableError(fakeErr)
-	}
 	if err == nil {
 		return nil
 	}

--- a/caas/kubernetes/provider/exec/exec.go
+++ b/caas/kubernetes/provider/exec/exec.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"github.com/kballard/go-shellquote"
-	"github.com/kr/pretty"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,9 +151,6 @@ func processEnv(env []string) (string, error) {
 
 func (c client) exec(opts ExecParams, cancel <-chan struct{}) (err error) {
 	defer func() {
-		if err != nil {
-			logger.Criticalf("Exec opts -> %s, err ->%q, %#v", pretty.Sprint(opts), err.Error(), err)
-		}
 		err = handleExecRetryableError(err)
 	}()
 	pidFile := fmt.Sprintf("/tmp/%s.pid", randomString(8, utils.LowerAlpha))

--- a/caas/kubernetes/provider/exec/exec.go
+++ b/caas/kubernetes/provider/exec/exec.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"github.com/kballard/go-shellquote"
+	"github.com/kr/pretty"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ var logger = loggo.GetLogger("juju.kubernetes.provider.exec")
 const (
 	sigkillRetryDelay = 100 * time.Millisecond
 	gracefulKillDelay = 10 * time.Second
-	maxTrys           = 10
+	maxTries          = 10
 )
 
 var randomString = utils.RandomString
@@ -149,7 +150,13 @@ func processEnv(env []string) (string, error) {
 	return out, nil
 }
 
-func (c client) exec(opts ExecParams, cancel <-chan struct{}) error {
+func (c client) exec(opts ExecParams, cancel <-chan struct{}) (err error) {
+	defer func() {
+		if err != nil {
+			logger.Criticalf("Exec opts -> %s, err ->%q, %#v", pretty.Sprint(opts), err.Error(), err)
+		}
+		err = handleExecRetryableError(err)
+	}()
 	pidFile := fmt.Sprintf("/tmp/%s.pid", randomString(8, utils.LowerAlpha))
 	cmd := ""
 	if opts.WorkingDir != "" {
@@ -237,7 +244,7 @@ func (c client) exec(opts ExecParams, cancel <-chan struct{}) error {
 	}
 
 	kill := make(chan struct{}, 1)
-	killTrys := 0
+	killTries := 0
 	var timer <-chan time.Time
 	for {
 		select {
@@ -252,9 +259,9 @@ func (c client) exec(opts ExecParams, cancel <-chan struct{}) error {
 			// Trigger SIGKILL
 			timer = time.After(gracefulKillDelay)
 		case <-kill:
-			killTrys++
-			if killTrys > maxTrys {
-				return errors.Errorf("SIGKILL failed after %d attempts", maxTrys)
+			killTries++
+			if killTries > maxTries {
+				return errors.Errorf("SIGKILL failed after %d attempts", maxTries)
 			}
 			err := sendSignal(syscall.SIGKILL, true)
 			if err != nil {

--- a/cmd/jujud/agent/caasunitinit.go
+++ b/cmd/jujud/agent/caasunitinit.go
@@ -227,12 +227,10 @@ func (c *CAASUnitInitCommand) Run(ctx *cmd.Context) (errOut error) {
 	}
 
 	for _, op := range copies {
-		logger.Infof("copy %s => %s", op.src, op.dst)
 		if err = c.copyFunc(op.src, op.dst); err != nil {
 			return errors.Annotatef(err, "failed to copy %s to %s", op.src, op.dst)
 		}
 	}
-
 	return nil
 }
 

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -627,7 +627,7 @@ func (op *caasOperator) runningStatus(unit names.UnitTag, providerID string) (*u
 
 func (op *caasOperator) remoteInit(unit names.UnitTag, runningStatus uniterremotestate.ContainerRunningStatus, cancel <-chan struct{}) error {
 	op.config.Logger.Debugf("remote init for %v %+v", unit, runningStatus)
-	params := InitializeUnitParams{
+	params := initializeUnitParams{
 		ExecClient:   op.config.ExecClient,
 		Logger:       op.config.Logger,
 		OperatorInfo: op.config.OperatorInfo,
@@ -645,7 +645,7 @@ func (op *caasOperator) remoteInit(unit names.UnitTag, runningStatus uniterremot
 	default:
 		return errors.NotFoundf("container not running")
 	}
-	err := InitializeUnit(params, cancel)
+	err := initializeUnit(params, cancel)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -636,6 +636,8 @@ func (op *caasOperator) remoteInit(unit names.UnitTag, runningStatus uniterremot
 		ProviderID:   runningStatus.PodName,
 		WriteFile:    ioutil.WriteFile,
 		TempDir:      ioutil.TempDir,
+		Clock:        op.config.Clock,
+		ReTrier:      runnerWithRetry,
 	}
 	switch {
 	case runningStatus.Initialising:

--- a/worker/caasoperator/export_test.go
+++ b/worker/caasoperator/export_test.go
@@ -10,10 +10,12 @@ import (
 var (
 	GetNewRunnerExecutor = getNewRunnerExecutor
 	JujudSymlinks        = jujudSymlinks
+	InitializeUnit       = initializeUnit
 )
 
 type (
-	CaasOperator = caasOperator
+	InitializeUnitParams = initializeUnitParams
+	CaasOperator         = caasOperator
 )
 
 func (op *caasOperator) MakeAgentSymlinks(unitTag names.UnitTag) error {

--- a/worker/caasoperator/export_test.go
+++ b/worker/caasoperator/export_test.go
@@ -11,6 +11,7 @@ var (
 	GetNewRunnerExecutor = getNewRunnerExecutor
 	JujudSymlinks        = jujudSymlinks
 	InitializeUnit       = initializeUnit
+	RunnerWithRetry      = runnerWithRetry
 )
 
 type (

--- a/worker/caasoperator/initializer_test.go
+++ b/worker/caasoperator/initializer_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -39,6 +40,9 @@ func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
 	mockExecClient := mocks.NewMockExecutor(ctrl)
 
 	params := caasoperator.InitializeUnitParams{
+		ReTrier: func(f func() error, _ caasoperator.Logger, _ clock.Clock, _ <-chan struct{}) error {
+			return f()
+		},
 		InitType: caasoperator.UnitInit,
 		UnitTag:  names.NewUnitTag("gitlab/0"),
 		Logger:   loggo.GetLogger("test"),
@@ -129,6 +133,9 @@ func (s *UnitInitializerSuite) TestInitializeUnitMissingProviderID(c *gc.C) {
 	mockExecClient := mocks.NewMockExecutor(ctrl)
 
 	params := caasoperator.InitializeUnitParams{
+		ReTrier: func(f func() error, _ caasoperator.Logger, _ clock.Clock, _ <-chan struct{}) error {
+			return f()
+		},
 		InitType: caasoperator.UnitInit,
 		UnitTag:  names.NewUnitTag("gitlab/0"),
 		Logger:   loggo.GetLogger("test"),
@@ -164,6 +171,9 @@ func (s *UnitInitializerSuite) TestInitializeContainerMissing(c *gc.C) {
 	mockExecClient := mocks.NewMockExecutor(ctrl)
 
 	params := caasoperator.InitializeUnitParams{
+		ReTrier: func(f func() error, _ caasoperator.Logger, _ clock.Clock, _ <-chan struct{}) error {
+			return f()
+		},
 		InitType: caasoperator.UnitInit,
 		UnitTag:  names.NewUnitTag("gitlab/0"),
 		Logger:   loggo.GetLogger("test"),
@@ -217,6 +227,9 @@ func (s *UnitInitializerSuite) TestInitializePodNotFound(c *gc.C) {
 	mockExecClient := mocks.NewMockExecutor(ctrl)
 
 	params := caasoperator.InitializeUnitParams{
+		ReTrier: func(f func() error, _ caasoperator.Logger, _ clock.Clock, _ <-chan struct{}) error {
+			return f()
+		},
 		InitType: caasoperator.UnitInit,
 		UnitTag:  names.NewUnitTag("gitlab/0"),
 		Logger:   loggo.GetLogger("test"),


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Added retry for copying charm exec request for remote init process if there was 137 error;


## QA steps

```console
## bootstrap and deploy a k8s workload;

$ mkubectl exec pod/mariadb-k8s-operator-0  -n t1 -it -- bash

## in the operator pod, enable the wrench
$ mkdir -p /var/lib/juju/wrench && echo '137' > /var/lib/juju/wrench/exec


## watch the operator log, we will see the copying charm request is retrying;
$ juju debug-log -m k1:t1 --color --replay --include-module=juju.worker.caasoperator

## in the operator pod, disable the wrench
$ rm /var/lib/juju/wrench/exec

## scale application, watch the new pod;
$ juju scale-application mariadb-k8s -m t1 3

```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1877515
