### PR TITLE
Fix query tracker tests.

### DIFF
--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -106,15 +106,14 @@ func (s *statusSuite) TestFullStatusUnitScaling(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{
 		Machine: machine,
 	})
-
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-	tracker := s.State.TrackQueries()
+	tracker := s.State.TrackQueries("FullStatus")
 
 	client := s.APIState.Client()
 	_, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	queryCount := tracker.ReadCount()
+	c.Logf("initial query count: %d", queryCount)
 
 	// Add several more units of the same application to the
 	// same machine. We do this because we want to isolate to
@@ -129,7 +128,6 @@ func (s *statusSuite) TestFullStatusUnitScaling(c *gc.C) {
 		})
 	}
 
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	tracker.Reset()
 
 	_, err = client.Status(nil)
@@ -143,22 +141,19 @@ func (s *statusSuite) TestFullStatusUnitScaling(c *gc.C) {
 
 func (s *statusSuite) TestFullStatusMachineScaling(c *gc.C) {
 	s.Factory.MakeMachine(c, nil)
-
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-	tracker := s.State.TrackQueries()
+	tracker := s.State.TrackQueries("FullStatus")
 
 	client := s.APIState.Client()
 	_, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	queryCount := tracker.ReadCount()
+	c.Logf("initial query count: %d", queryCount)
 
 	// Add several more machines to the model.
 	for i := 0; i < 5; i++ {
 		s.Factory.MakeMachine(c, nil)
 	}
-
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	tracker.Reset()
 
 	_, err = client.Status(nil)
@@ -175,15 +170,14 @@ func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
 	s.createSpaceAndSubnetWithProviderID(c, "public", "10.0.0.0/24", "prov-0000")
 	s.createSpaceAndSubnetWithProviderID(c, "private", "10.20.0.0/24", "prov-ffff")
 	s.createSpaceAndSubnetWithProviderID(c, "dmz", "10.30.0.0/24", "prov-abcd")
-
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-	tracker := s.State.TrackQueries()
+	tracker := s.State.TrackQueries("FullStatus")
 
 	client := s.APIState.Client()
 	_, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	queryCount := tracker.ReadCount()
+	c.Logf("initial query count: %d", queryCount)
 
 	// Add a bunch of interfaces to the machine.
 	s.createNICWithIP(c, machine, "eth0", "10.0.0.11/24")
@@ -208,7 +202,6 @@ func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	tracker.Reset()
 
 	_, err = client.Status(nil)


### PR DESCRIPTION
All of the tests that were using the query tracker were subject to races
in other goroutines that may also be hitting the database. Since the
query tracker was loaded globally onto the state object the fix for
this is to initialize the query tracker with the method that we are
interested in tracking.

For the status tests, this is "client.(*Client).FullStatus" as it needs
to match the string that is found in the traceback.

Prior to this fix using stress-ng would always cause the test to fail,
with the fix I'm unable to cause a race failure. Also the wait for model
idle methods are now not needed as that was an attempt to deal with
the above problem of other goroutines hitting the database. Now that we
are filtering them out, we don't need to wait any more.

## QA steps

```sh
# Run the tests with forced verbose logging to ensure we are getting counts:
go test -check.vv -check.f TestFullStatusMachineScaling 
# observe that we have 19 queries initially

# Run the tests with stress-race in one terminal:
stress-race  -check.f TestFullStatusMachineScaling
# Run stress-ng in another
stress-ng --cpu 8 --io 4 --vm 2 --vm-bytes 128M --fork 4 --timeout 30s
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1878220