### PR TITLE
Prefer netplan over ENI when both exist.

### DIFF
--- a/container/broker/instance_broker.go
+++ b/container/broker/instance_broker.go
@@ -121,11 +121,13 @@ func prepareHost(config Config) PrepareHostFunc {
 	}
 }
 
+// defaultBridger will prefer to use netplan if there is an /etc/netplan
+// directory, falling back to ENI if the directory doesn't exist.
 func defaultBridger() (network.Bridger, error) {
-	if _, err := os.Stat(systemSbinIfup); err == nil {
-		return network.DefaultEtcNetworkInterfacesBridger(activateBridgesTimeout, systemNetworkInterfacesFile)
-	} else {
+	if _, err := os.Stat(systemNetplanDirectory); err == nil {
 		return network.DefaultNetplanBridger(activateBridgesTimeout, systemNetplanDirectory)
+	} else {
+		return network.DefaultEtcNetworkInterfacesBridger(activateBridgesTimeout, systemNetworkInterfacesFile)
 	}
 }
 


### PR DESCRIPTION
The OpenStack team encountered a problem during the dist-upgrade process. Upgrading from xenial to bionic all worked in general, but has new netplan but also as if up/down installed.

When trying to create a container on a bionic instance that also had if up/down installed, juju made the wrong decision. The intent here is to prefer netplan over the old ENI approach if both netplan and older tools are installed.

Backport of #11564.