### PR TITLE
Reject k8s charms with block storage

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -529,6 +529,11 @@ func caasPrecheck(
 			len(args.Placement),
 		)
 	}
+	for _, s := range ch.Meta().Storage {
+		if s.Type == charm.StorageBlock {
+			return errors.Errorf("block storage %q is not supported for k8s charms", s.Name)
+		}
+	}
 
 	cfg, err := model.ModelConfig()
 	if err != nil {


### PR DESCRIPTION
## Description of change

k8s charms with block storage are not supported, so reject them.

## QA steps

juju deploy k9scharmwithblockstorage
ERROR block storage "logs" is not supported for k8s charms

## Bug reference

https://bugs.launchpad.net/juju/+bug/1855181
