### PR TITLE
Better Handling of Address Parsing Errors

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -187,25 +187,17 @@ func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
 			devicesArgs = append(devicesArgs, args)
 		}
 
-		if iface.CIDR == "" || iface.PrimaryAddress().Value == "" {
-			logger.Tracef(
-				"skipping empty CIDR %q and/or Address %q of %q",
-				iface.CIDR, iface.PrimaryAddress(), iface.InterfaceName,
-			)
-			continue
-		}
-		_, ipNet, err := net.ParseCIDR(iface.CIDR)
+		cidrAddress, err := iface.CIDRAddress()
 		if err != nil {
-			logger.Warningf("FIXME: ignoring unexpected CIDR format %q: %v", iface.CIDR, err)
+			logger.Warningf("ignoring unexpected address/CIDR format: %q/%q, %v",
+				iface.PrimaryAddress(), iface.CIDR, err)
 			continue
 		}
-		ipAddr := net.ParseIP(iface.PrimaryAddress().Value)
-		if ipAddr == nil {
-			logger.Warningf("FIXME: ignoring unexpected Address format %q", iface.PrimaryAddress().Value)
+		if cidrAddress == "" {
+			logger.Tracef("skipping empty CIDR %q and/or Address %q of %q",
+				iface.CIDR, iface.PrimaryAddress(), iface.InterfaceName)
 			continue
 		}
-		ipNet.IP = ipAddr
-		cidrAddress := ipNet.String()
 
 		var derivedConfigMethod corenetwork.AddressConfigMethod
 		switch method := corenetwork.AddressConfigMethod(iface.ConfigType); method {

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -189,13 +189,7 @@ func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
 
 		cidrAddress, err := iface.CIDRAddress()
 		if err != nil {
-			logger.Warningf("ignoring unexpected address/CIDR format: %q/%q, %v",
-				iface.PrimaryAddress(), iface.CIDR, err)
-			continue
-		}
-		if cidrAddress == "" {
-			logger.Tracef("skipping empty CIDR %q and/or Address %q of %q",
-				iface.CIDR, iface.PrimaryAddress(), iface.InterfaceName)
+			logger.Warningf("ignoring address for device %q: %v", iface.InterfaceName, err)
 			continue
 		}
 

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -151,7 +151,7 @@ func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
 	for _, info := range interfaces {
 		var iface netplan.Ethernet
 		cidr, err := info.CIDRAddress()
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return "", errors.Trace(err)
 		}
 		if cidr != "" {
@@ -255,7 +255,7 @@ func PrepareNetworkConfigFromInterfaces(interfaces corenetwork.InterfaceInfos) (
 		}
 
 		cidr, err := info.CIDRAddress()
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}
 		if cidr != "" {

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -560,6 +560,12 @@ func (s *NetworkUbuntuSuite) TestPrepareNetworkConfigFromInterfacesBadCIDRError(
 	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: invalid`)
 }
 
+func (s *NetworkUbuntuSuite) TestGenerateNetplanBadAddressError(c *gc.C) {
+	s.fakeInterfaces[0].Addresses[0].Value = "invalid"
+	_, err := cloudinit.PrepareNetworkConfigFromInterfaces(s.fakeInterfaces)
+	c.Assert(err, gc.ErrorMatches, `cannot parse IP address "invalid"`)
+}
+
 func (s *NetworkUbuntuSuite) runENIScriptWithAllPythons(c *gc.C, ipCommand, input, expectedOutput string, wait, retries int) {
 	for _, python := range s.pythonVersions {
 		c.Logf("test using %s", python)

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -554,12 +554,17 @@ func (s *NetworkUbuntuSuite) TestENIScriptHotplug(c *gc.C) {
 	}
 }
 
+func (s *NetworkUbuntuSuite) TestPrepareNetworkConfigFromInterfacesBadCIDRError(c *gc.C) {
+	s.fakeInterfaces[0].CIDR = "invalid"
+	_, err := cloudinit.PrepareNetworkConfigFromInterfaces(s.fakeInterfaces)
+	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: invalid`)
+}
+
 func (s *NetworkUbuntuSuite) runENIScriptWithAllPythons(c *gc.C, ipCommand, input, expectedOutput string, wait, retries int) {
 	for _, python := range s.pythonVersions {
 		c.Logf("test using %s", python)
 		s.runENIScript(c, python, ipCommand, input, expectedOutput, wait, retries)
 	}
-
 }
 
 func (s *NetworkUbuntuSuite) runENIScript(c *gc.C, pythonBinary, ipCommand, input, expectedOutput string, wait, retries int) {

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -139,6 +139,11 @@ func (a MachineAddress) String() string {
 	return prefix + a.Value
 }
 
+// IP returns the net.IP representation of this address.
+func (a MachineAddress) IP() net.IP {
+	return net.ParseIP(a.Value)
+}
+
 // sortOrder calculates the "weight" of the address when sorting:
 // - public IPs first;
 // - hostnames after that, but "localhost" will be last if present;

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -213,17 +213,21 @@ func (i *InterfaceInfo) IsVLAN() bool {
 // CIDRAddress returns Address.Value combined with CIDR mask.
 func (i *InterfaceInfo) CIDRAddress() (string, error) {
 	primaryAddr := i.PrimaryAddress()
+
 	if i.CIDR == "" || primaryAddr.Value == "" {
-		return "", nil
+		return "", errors.NotFoundf("address and CIDR pair (%q, %q)", primaryAddr.Value, i.CIDR)
 	}
+
 	_, ipNet, err := net.ParseCIDR(i.CIDR)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+
 	ip := primaryAddr.IP()
 	if ip == nil {
 		return "", errors.Errorf("cannot parse IP address %q", primaryAddr.Value)
 	}
+
 	ipNet.IP = ip
 	return ipNet.String(), nil
 }

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -162,7 +162,7 @@ type InterfaceInfo struct {
 	DNSServers ProviderAddresses
 
 	// MTU is the Maximum Transmission Unit controlling the maximum size of the
-	// protocol packats that the interface can pass through. It is only used
+	// protocol packets that the interface can pass through. It is only used
 	// when > 0.
 	MTU int
 
@@ -211,21 +211,21 @@ func (i *InterfaceInfo) IsVLAN() bool {
 }
 
 // CIDRAddress returns Address.Value combined with CIDR mask.
-func (i *InterfaceInfo) CIDRAddress() string {
+func (i *InterfaceInfo) CIDRAddress() (string, error) {
 	primaryAddr := i.PrimaryAddress()
 	if i.CIDR == "" || primaryAddr.Value == "" {
-		return ""
+		return "", nil
 	}
 	_, ipNet, err := net.ParseCIDR(i.CIDR)
 	if err != nil {
-		return errors.Trace(err).Error()
+		return "", errors.Trace(err)
 	}
-	ip := net.ParseIP(primaryAddr.Value)
+	ip := primaryAddr.IP()
 	if ip == nil {
-		return errors.Errorf("cannot parse IP address %q", primaryAddr.Value).Error()
+		return "", errors.Errorf("cannot parse IP address %q", primaryAddr.Value)
 	}
 	ipNet.IP = ip
-	return ipNet.String()
+	return ipNet.String(), nil
 }
 
 // PrimaryAddress returns the primary address for the interface.

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -66,6 +66,44 @@ func (s *nicSuite) TestAdditionalFields(c *gc.C) {
 	}})
 }
 
+func (*nicSuite) TestCIDRAddress(c *gc.C) {
+	dev := network.InterfaceInfo{
+		Addresses: network.NewProviderAddresses("10.0.0.10"),
+		CIDR:      "10.0.0.0/24",
+	}
+	addr, err := dev.CIDRAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(addr, gc.Equals, "10.0.0.10/24")
+
+	dev = network.InterfaceInfo{
+		Addresses: network.NewProviderAddresses("10.0.0.10"),
+	}
+	addr, err = dev.CIDRAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(addr, gc.Equals, "")
+
+	dev = network.InterfaceInfo{
+		CIDR: "10.0.0.0/24",
+	}
+	addr, err = dev.CIDRAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(addr, gc.Equals, "")
+
+	dev = network.InterfaceInfo{
+		Addresses: network.NewProviderAddresses("invalid"),
+		CIDR:      "10.0.0.0/24",
+	}
+	_, err = dev.CIDRAddress()
+	c.Assert(err, gc.ErrorMatches, `cannot parse IP address "invalid"`)
+
+	dev = network.InterfaceInfo{
+		Addresses: network.NewProviderAddresses("10.0.0.10"),
+		CIDR:      "invalid",
+	}
+	_, err = dev.CIDRAddress()
+	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: invalid`)
+}
+
 func (*nicSuite) TestInterfaceInfosChildren(c *gc.C) {
 	interfaces := getInterFaceInfos()
 

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -4,6 +4,7 @@
 package network_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -79,14 +80,14 @@ func (*nicSuite) TestCIDRAddress(c *gc.C) {
 		Addresses: network.NewProviderAddresses("10.0.0.10"),
 	}
 	addr, err = dev.CIDRAddress()
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(addr, gc.Equals, "")
 
 	dev = network.InterfaceInfo{
 		CIDR: "10.0.0.0/24",
 	}
 	addr, err = dev.CIDRAddress()
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(addr, gc.Equals, "")
 
 	dev = network.InterfaceInfo{


### PR DESCRIPTION
## Description of change

The `InterfaceInfo.CIDRAddress` method previously returned any raised errors as the result of the method. This means callers could receive a stringified error without any indication that it was not actually a parsed address.

This has probably not been being encountered in the wild, because we would have seen such error messages rendered in the `ip.addresses` Mongo collection and/or rendered as invalid netplan/ENI config.

This patch adds an error return to the method, which is handled at the various call sites.

## QA steps

Execute the following and check logs for errors.

- Bootstrap to LXD (uses the method when rendering network config).
  - Add a machine.
- Bootstrap to OpenStack (uses the method when rendering network config).
  - Add a machine and then a container machine (container broker uses the method).

## Documentation changes

None.

## Bug reference

N/A
