### PR TITLE
[2.8] Use InterfaceInfos in place of []InterfaceInfo

### DIFF
--- a/api/instancepoller/machine.go
+++ b/api/instancepoller/machine.go
@@ -153,7 +153,7 @@ func (m *Machine) SetInstanceStatus(status status.Status, message string, data m
 }
 
 // SetProviderNetworkConfig updates the provider addresses for this machine.
-func (m *Machine) SetProviderNetworkConfig(ifList []network.InterfaceInfo) (network.ProviderAddresses, bool, error) {
+func (m *Machine) SetProviderNetworkConfig(ifList network.InterfaceInfos) (network.ProviderAddresses, bool, error) {
 	var results params.SetProviderNetworkConfigResults
 	args := params.SetProviderNetworkConfig{
 		Args: []params.ProviderNetworkConfig{{

--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -226,7 +226,7 @@ func (s *MachineSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 }
 
 func (s *MachineSuite) TestSetProviderNetworkConfigSuccess(c *gc.C) {
-	cfg := []network.InterfaceInfo{{
+	cfg := network.InterfaceInfos{{
 		DeviceIndex: 0,
 		CIDR:        "10.0.0.0/24",
 		Addresses: []network.ProviderAddress{

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -245,13 +245,13 @@ func (st *State) ReleaseContainerAddresses(containerTag names.MachineTag) (err e
 
 // PrepareContainerInterfaceInfo allocates an address and returns information to
 // configure networking for a container. It accepts container tags as arguments.
-func (st *State) PrepareContainerInterfaceInfo(containerTag names.MachineTag) ([]corenetwork.InterfaceInfo, error) {
+func (st *State) PrepareContainerInterfaceInfo(containerTag names.MachineTag) (corenetwork.InterfaceInfos, error) {
 	return st.prepareOrGetContainerInterfaceInfo(containerTag, true)
 }
 
 // GetContainerInterfaceInfo returns information to configure networking
 // for a container. It accepts container tags as arguments.
-func (st *State) GetContainerInterfaceInfo(containerTag names.MachineTag) ([]corenetwork.InterfaceInfo, error) {
+func (st *State) GetContainerInterfaceInfo(containerTag names.MachineTag) (corenetwork.InterfaceInfos, error) {
 	return st.prepareOrGetContainerInterfaceInfo(containerTag, false)
 }
 
@@ -265,7 +265,7 @@ func (st *State) GetContainerInterfaceInfo(containerTag names.MachineTag) ([]cor
 func (st *State) prepareOrGetContainerInterfaceInfo(
 	containerTag names.MachineTag,
 	allocateNewAddress bool,
-) ([]corenetwork.InterfaceInfo, error) {
+) (corenetwork.InterfaceInfos, error) {
 	var result params.MachineNetworkConfigResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: containerTag.String()}},
@@ -286,7 +286,7 @@ func (st *State) prepareOrGetContainerInterfaceInfo(
 		return nil, err
 	}
 	machineConf := result.Results[0]
-	ifaceInfo := make([]corenetwork.InterfaceInfo, len(machineConf.Config))
+	ifaceInfo := make(corenetwork.InterfaceInfos, len(machineConf.Config))
 	for i, cfg := range machineConf.Config {
 		routes := make([]corenetwork.Route, len(cfg.Routes))
 		for j, route := range cfg.Routes {

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -906,7 +906,7 @@ func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoNoValues(c 
 
 	networkInfo, err := provisionerApi.PrepareContainerInterfaceInfo(s.containerTag)
 	c.Assert(err, gc.IsNil)
-	c.Check(networkInfo, jc.DeepEquals, []corenetwork.InterfaceInfo{})
+	c.Check(networkInfo, jc.DeepEquals, corenetwork.InterfaceInfos{})
 }
 
 func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoSingleNIC(c *gc.C) {
@@ -956,7 +956,7 @@ func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoSingleNIC(c
 	provisionerApi := provisioner.NewStateFromFacade(facadeCaller)
 	networkInfo, err := provisionerApi.PrepareContainerInterfaceInfo(s.containerTag)
 	c.Assert(err, gc.IsNil)
-	c.Check(networkInfo, jc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Check(networkInfo, jc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:         1,
 		MACAddress:          "de:ad:be:ff:11:22",
 		CIDR:                "192.168.0.5/24",

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -224,7 +224,7 @@ func (api *NetworkConfigAPI) getOneMachineProviderNetworkConfig(m *state.Machine
 }
 
 func (api *NetworkConfigAPI) setLinkLayerDevicesAndAddresses(
-	m *state.Machine, interfaceInfos []network.InterfaceInfo,
+	m *state.Machine, interfaceInfos network.InterfaceInfos,
 ) error {
 	devicesArgs, devicesAddrs := NetworkInterfacesToStateArgs(interfaceInfos)
 

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -155,7 +155,7 @@ func BackingSubnetToParamsSubnet(subnet BackingSubnet) params.Subnet {
 
 // NetworkInterfacesToStateArgs splits the given interface list into a slice of
 // state.LinkLayerDeviceArgs and a slice of state.LinkLayerDeviceAddress.
-func NetworkInterfacesToStateArgs(ifaces []corenetwork.InterfaceInfo) (
+func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
 	[]state.LinkLayerDeviceArgs,
 	[]state.LinkLayerDeviceAddress,
 ) {

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1090,7 +1090,7 @@ func (ctx *prepareOrGetContext) ProcessOneContainer(
 		askProviderForAddress = environs.SupportsContainerAddresses(callContext, env)
 	}
 
-	preparedInfo := make([]corenetwork.InterfaceInfo, len(containerDevices))
+	preparedInfo := make(corenetwork.InterfaceInfos, len(containerDevices))
 	for i, device := range containerDevices {
 		info, err := ctx.infoForDevice(device, askProviderForAddress)
 		if err != nil {

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -193,7 +193,7 @@ func maybeUpdateMachineProviderAddresses(m StateMachine, newSpaceAddrs network.S
 	return true, m.SetProviderAddresses(newSpaceAddrs...)
 }
 
-func backfillProviderIDs(m StateMachine, ifaces []network.InterfaceInfo) error {
+func backfillProviderIDs(m StateMachine, ifaces network.InterfaceInfos) error {
 	existingDevs, err := m.AllLinkLayerDevices()
 	if err != nil {
 		return err

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -200,7 +200,7 @@ type NetworkConfig struct {
 
 // NetworkConfigFromInterfaceInfo converts a slice of network.InterfaceInfo into
 // the equivalent NetworkConfig slice.
-func NetworkConfigFromInterfaceInfo(interfaceInfos []network.InterfaceInfo) []NetworkConfig {
+func NetworkConfigFromInterfaceInfo(interfaceInfos network.InterfaceInfos) []NetworkConfig {
 	result := make([]NetworkConfig, len(interfaceInfos))
 	for i, v := range interfaceInfos {
 		var dnsServers []string
@@ -253,8 +253,8 @@ func NetworkConfigFromInterfaceInfo(interfaceInfos []network.InterfaceInfo) []Ne
 
 // InterfaceInfoFromNetworkConfig converts a slice of NetworkConfig into the
 // equivalent network.InterfaceInfo slice.
-func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) []network.InterfaceInfo {
-	result := make([]network.InterfaceInfo, len(configs))
+func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) network.InterfaceInfos {
+	result := make(network.InterfaceInfos, len(configs))
 	for i, v := range configs {
 		routes := make([]network.Route, len(v.Routes))
 		for j, route := range v.Routes {

--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -259,6 +259,6 @@ func (cfg *centOSCloudConfig) updateProxySettings(PackageManagerProxyConfig) err
 
 // AddNetworkConfig is defined on the NetworkingConfig interface.
 // TODO(wpk) This has to be implemented for CentOS on VSphere to work properly!
-func (cfg *centOSCloudConfig) AddNetworkConfig(interfaces []corenetwork.InterfaceInfo) error {
+func (cfg *centOSCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error {
 	return nil
 }

--- a/cloudconfig/cloudinit/cloudinit_win.go
+++ b/cloudconfig/cloudinit/cloudinit_win.go
@@ -122,6 +122,6 @@ func (cfg *windowsCloudConfig) updateProxySettings(PackageManagerProxyConfig) er
 }
 
 // AddNetworkConfig is defined on the NetworkingConfig interface.
-func (cfg *windowsCloudConfig) AddNetworkConfig(interfaces []corenetwork.InterfaceInfo) error {
+func (cfg *windowsCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error {
 	return nil
 }

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -414,7 +414,7 @@ type HostnameConfig interface {
 // NetworkingConfig is the interface for managing configuration of network
 type NetworkingConfig interface {
 	// AddNetworkConfig adds network config from interfaces to the container.
-	AddNetworkConfig(interfaces []corenetwork.InterfaceInfo) error
+	AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error
 }
 
 // New returns a new Config with no options set.

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -28,7 +28,7 @@ var (
 
 // GenerateENITemplate renders an e/n/i template config for one or more network
 // interfaces, using the given non-empty interfaces list.
-func GenerateENITemplate(interfaces []corenetwork.InterfaceInfo) (string, error) {
+func GenerateENITemplate(interfaces corenetwork.InterfaceInfos) (string, error) {
 	if len(interfaces) == 0 {
 		return "", errors.Errorf("missing container network config")
 	}
@@ -137,7 +137,7 @@ func GenerateENITemplate(interfaces []corenetwork.InterfaceInfo) (string, error)
 
 // GenerateNetplan renders a netplan file for one or more network
 // interfaces, using the given non-empty list of interfaces.
-func GenerateNetplan(interfaces []corenetwork.InterfaceInfo) (string, error) {
+func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
 	if len(interfaces) == 0 {
 		return "", errors.Errorf("missing container network config")
 	}
@@ -210,7 +210,7 @@ type PreparedConfig struct {
 // PrepareNetworkConfigFromInterfaces collects the necessary information to
 // render a persistent network config from the given slice of
 // network.InterfaceInfo. The result always includes the loopback interface.
-func PrepareNetworkConfigFromInterfaces(interfaces []corenetwork.InterfaceInfo) *PreparedConfig {
+func PrepareNetworkConfigFromInterfaces(interfaces corenetwork.InterfaceInfos) *PreparedConfig {
 	dnsServers := set.NewStrings()
 	dnsSearchDomains := set.NewStrings()
 	gateway4Address := ""
@@ -296,7 +296,7 @@ func PrepareNetworkConfigFromInterfaces(interfaces []corenetwork.InterfaceInfo) 
 // AddNetworkConfig adds configuration scripts for specified interfaces
 // to cloudconfig - using boot textfiles and boot commands. It currently
 // supports e/n/i and netplan.
-func (cfg *ubuntuCloudConfig) AddNetworkConfig(interfaces []corenetwork.InterfaceInfo) error {
+func (cfg *ubuntuCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error {
 	if len(interfaces) != 0 {
 		eni, err := GenerateENITemplate(interfaces)
 		if err != nil {

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -32,7 +32,7 @@ type NetworkUbuntuSuite struct {
 	systemNetworkInterfacesFile string
 	jujuNetplanFile             string
 
-	fakeInterfaces []corenetwork.InterfaceInfo
+	fakeInterfaces corenetwork.InterfaceInfos
 
 	expectedSampleConfigHeader      string
 	expectedSampleConfigTemplate    string
@@ -66,7 +66,7 @@ func (s *NetworkUbuntuSuite) SetUpTest(c *gc.C) {
 	s.networkInterfacesPythonFile = filepath.Join(networkFolder, "system-interfaces.py")
 	s.jujuNetplanFile = filepath.Join(netplanFolder, "79-juju.yaml")
 
-	s.fakeInterfaces = []corenetwork.InterfaceInfo{{
+	s.fakeInterfaces = corenetwork.InterfaceInfos{{
 		InterfaceName:    "any0",
 		CIDR:             "0.1.2.0/24",
 		ConfigType:       corenetwork.ConfigStatic,

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -58,7 +58,7 @@ func CloudInitUserData(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	var interfaces []corenetwork.InterfaceInfo
+	var interfaces corenetwork.InterfaceInfos
 	if networkConfig != nil {
 		interfaces = networkConfig.Interfaces
 	}

--- a/container/broker/broker.go
+++ b/container/broker/broker.go
@@ -28,8 +28,8 @@ var logger = loggo.GetLogger("juju.container.broker")
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/apicalls_mock.go github.com/juju/juju/container/broker APICalls
 type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
-	PrepareContainerInterfaceInfo(names.MachineTag) ([]corenetwork.InterfaceInfo, error)
-	GetContainerInterfaceInfo(names.MachineTag) ([]corenetwork.InterfaceInfo, error)
+	PrepareContainerInterfaceInfo(names.MachineTag) (corenetwork.InterfaceInfos, error)
+	GetContainerInterfaceInfo(names.MachineTag) (corenetwork.InterfaceInfos, error)
 	GetContainerProfileInfo(names.MachineTag) ([]*apiprovisioner.LXDProfileResult, error)
 	ReleaseContainerAddresses(names.MachineTag) error
 	SetHostMachineNetworkConfig(names.MachineTag, []params.NetworkConfig) error
@@ -45,7 +45,7 @@ func prepareOrGetContainerInterfaceInfo(
 	machineID string,
 	allocateOrMaintain bool,
 	log loggo.Logger,
-) ([]corenetwork.InterfaceInfo, error) {
+) (corenetwork.InterfaceInfos, error) {
 	maintain := !allocateOrMaintain
 
 	if maintain {
@@ -73,14 +73,14 @@ func prepareOrGetContainerInterfaceInfo(
 // bridgeDevice is used for ParentInterfaceName, while the DNS config is
 // discovered using network.ParseResolvConf(). If interfaces has zero length,
 // container.FallbackInterfaceInfo() is used as fallback.
-func finishNetworkConfig(bridgeDevice string, interfaces []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func finishNetworkConfig(bridgeDevice string, interfaces corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	haveNameservers, haveSearchDomains := false, false
 	if len(interfaces) == 0 {
 		// Use the fallback network config as a last resort.
 		interfaces = container.FallbackInterfaceInfo()
 	}
 
-	results := make([]corenetwork.InterfaceInfo, len(interfaces))
+	results := make(corenetwork.InterfaceInfos, len(interfaces))
 	for i, info := range interfaces {
 		if info.ParentInterfaceName == "" {
 			info.ParentInterfaceName = bridgeDevice

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -144,20 +144,20 @@ func (f *fakeAPI) ContainerConfig() (params.ContainerConfig, error) {
 	return f.fakeContainerConfig, nil
 }
 
-func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) ([]corenetwork.InterfaceInfo, error) {
+func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) (corenetwork.InterfaceInfos, error) {
 	f.MethodCall(f, "PrepareContainerInterfaceInfo", tag)
 	if err := f.NextErr(); err != nil {
 		return nil, err
 	}
-	return []corenetwork.InterfaceInfo{f.fakeInterfaceInfo}, nil
+	return corenetwork.InterfaceInfos{f.fakeInterfaceInfo}, nil
 }
 
-func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) ([]corenetwork.InterfaceInfo, error) {
+func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) (corenetwork.InterfaceInfos, error) {
 	f.MethodCall(f, "GetContainerInterfaceInfo", tag)
 	if err := f.NextErr(); err != nil {
 		return nil, err
 	}
-	return []corenetwork.InterfaceInfo{f.fakeInterfaceInfo}, nil
+	return corenetwork.InterfaceInfos{f.fakeInterfaceInfo}, nil
 }
 
 func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {

--- a/container/broker/lxd-broker_test.go
+++ b/container/broker/lxd-broker_test.go
@@ -220,7 +220,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 	containerTag := names.NewMachineTag("1-lxd-0")
 
 	mockApi := mocks.NewMockAPICalls(ctlr)
-	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return([]corenetwork.InterfaceInfo{fakeInterfaceInfo}, nil)
+	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
 	mockApi.EXPECT().ContainerConfig().Return(fakeContainerConfig(), nil)
 
 	put := &charm.LXDProfile{
@@ -267,7 +267,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithNoNameLXDProfile(c *gc.C) {
 	containerTag := names.NewMachineTag("1-lxd-0")
 
 	mockApi := mocks.NewMockAPICalls(ctlr)
-	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return([]corenetwork.InterfaceInfo{fakeInterfaceInfo}, nil)
+	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
 	mockApi.EXPECT().ContainerConfig().Return(fakeContainerConfig(), nil)
 
 	put := &charm.LXDProfile{

--- a/container/broker/mocks/apicalls_mock.go
+++ b/container/broker/mocks/apicalls_mock.go
@@ -52,9 +52,9 @@ func (mr *MockAPICallsMockRecorder) ContainerConfig() *gomock.Call {
 }
 
 // GetContainerInterfaceInfo mocks base method
-func (m *MockAPICalls) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]corenetwork.InterfaceInfo, error) {
+func (m *MockAPICalls) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) (corenetwork.InterfaceInfos, error) {
 	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
-	ret0, _ := ret[0].([]corenetwork.InterfaceInfo)
+	ret0, _ := ret[0].(corenetwork.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -92,9 +92,9 @@ func (mr *MockAPICallsMockRecorder) HostChangesForContainer(arg0 interface{}) *g
 }
 
 // PrepareContainerInterfaceInfo mocks base method
-func (m *MockAPICalls) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]corenetwork.InterfaceInfo, error) {
+func (m *MockAPICalls) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) (corenetwork.InterfaceInfos, error) {
 	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
-	ret0, _ := ret[0].([]corenetwork.InterfaceInfo)
+	ret0, _ := ret[0].(corenetwork.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -114,7 +114,7 @@ func prepInstanceConfig(c *gc.C) *instancecfg.InstanceConfig {
 }
 
 func prepNetworkConfig() *container.NetworkConfig {
-	return container.BridgeNetworkConfig("eth0", 1500, []corenetwork.InterfaceInfo{{
+	return container.BridgeNetworkConfig("eth0", 1500, corenetwork.InterfaceInfos{{
 		InterfaceName:       "eth0",
 		InterfaceType:       corenetwork.EthernetInterface,
 		ConfigType:          corenetwork.ConfigDHCP,
@@ -208,7 +208,7 @@ func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
 
 	// Supplying config for a single device with default bridge and without a
 	// CIDR will cause the default bridge to be updated with IPv4 config.
-	netConfig := container.BridgeNetworkConfig("eth0", 1500, []corenetwork.InterfaceInfo{{
+	netConfig := container.BridgeNetworkConfig("eth0", 1500, corenetwork.InterfaceInfos{{
 		InterfaceName:       "eth0",
 		InterfaceType:       corenetwork.EthernetInterface,
 		ConfigType:          corenetwork.ConfigDHCP,
@@ -336,7 +336,7 @@ func (s *managerSuite) TestIsInitialized(c *gc.C) {
 func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	interfaces := []corenetwork.InterfaceInfo{{
+	interfaces := corenetwork.InterfaceInfos{{
 		InterfaceName: "eth1",
 		InterfaceType: "ethernet",
 		MACAddress:    "aa:bb:cc:dd:ee:f1",
@@ -354,7 +354,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C
 func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	interfaces := []corenetwork.InterfaceInfo{{
+	interfaces := corenetwork.InterfaceInfos{{
 		ParentInterfaceName: "br-eth0",
 		InterfaceName:       "eth0",
 		InterfaceType:       "ethernet",
@@ -386,7 +386,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 func (s *managerSuite) TestNetworkDevicesFromConfigUnknownCIDR(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	interfaces := []corenetwork.InterfaceInfo{{
+	interfaces := corenetwork.InterfaceInfos{{
 		ParentInterfaceName: "br-eth0",
 		InterfaceName:       "eth0",
 		InterfaceType:       "ethernet",

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -424,8 +424,8 @@ func ipv6BridgeConfigError(fileName string, installedViaSnap bool) error {
 // input LXD NIC devices.
 // The output is used to generate cloud-init user-data congruent with the NICs
 // that end up in the container.
-func InterfaceInfoFromDevices(nics map[string]device) ([]corenetwork.InterfaceInfo, error) {
-	interfaces := make([]corenetwork.InterfaceInfo, len(nics))
+func InterfaceInfoFromDevices(nics map[string]device) (corenetwork.InterfaceInfos, error) {
+	interfaces := make(corenetwork.InterfaceInfos, len(nics))
 	var i int
 	for name, device := range nics {
 		iInfo := corenetwork.InterfaceInfo{
@@ -451,7 +451,7 @@ func InterfaceInfoFromDevices(nics map[string]device) ([]corenetwork.InterfaceIn
 	return interfaces, nil
 }
 
-type interfaceInfoSlice []corenetwork.InterfaceInfo
+type interfaceInfoSlice corenetwork.InterfaceInfos
 
 func (s interfaceInfoSlice) Len() int      { return len(s) }
 func (s interfaceInfoSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
@@ -459,7 +459,7 @@ func (s interfaceInfoSlice) Less(i, j int) bool {
 	return s[i].InterfaceName < s[j].InterfaceName
 }
 
-func sortInterfacesByName(interfaces []corenetwork.InterfaceInfo) {
+func sortInterfacesByName(interfaces corenetwork.InterfaceInfos) {
 	sort.Sort(interfaceInfoSlice(interfaces))
 }
 
@@ -470,7 +470,7 @@ const errIPV6NotSupported = `socket: address family not supported by protocol`
 // DevicesFromInterfaceInfo uses the input interface info collection to create a
 // map of network device configuration in the LXD format.
 // Names for any networks without a known CIDR are returned in a slice.
-func DevicesFromInterfaceInfo(interfaces []corenetwork.InterfaceInfo) (map[string]device, []string, error) {
+func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos) (map[string]device, []string, error) {
 	nics := make(map[string]device, len(interfaces))
 	var unknown []string
 

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -370,7 +370,7 @@ func (s *networkSuite) TestInterfaceInfoFromDevices(c *gc.C) {
 	info, err := lxd.InterfaceInfoFromDevices(nics)
 	c.Assert(err, jc.ErrorIsNil)
 
-	exp := []corenetwork.InterfaceInfo{
+	exp := corenetwork.InterfaceInfos{
 		{
 			InterfaceName:       "eno9",
 			MACAddress:          "00:16:3e:00:00:3e",

--- a/container/network.go
+++ b/container/network.go
@@ -18,12 +18,12 @@ type NetworkConfig struct {
 	Device      string
 	MTU         int
 
-	Interfaces []corenetwork.InterfaceInfo
+	Interfaces corenetwork.InterfaceInfos
 }
 
 // FallbackInterfaceInfo returns a single "eth0" interface configured with DHCP.
-func FallbackInterfaceInfo() []corenetwork.InterfaceInfo {
-	return []corenetwork.InterfaceInfo{{
+func FallbackInterfaceInfo() corenetwork.InterfaceInfos {
+	return corenetwork.InterfaceInfos{{
 		InterfaceName: "eth0",
 		InterfaceType: corenetwork.EthernetInterface,
 		ConfigType:    corenetwork.ConfigDHCP,
@@ -35,7 +35,7 @@ func FallbackInterfaceInfo() []corenetwork.InterfaceInfo {
 // configuration for the container's network interfaces and default MTU to use.
 // If interfaces is empty, FallbackInterfaceInfo() is used to get the a sane
 // default
-func BridgeNetworkConfig(device string, mtu int, interfaces []corenetwork.InterfaceInfo) *NetworkConfig {
+func BridgeNetworkConfig(device string, mtu int, interfaces corenetwork.InterfaceInfos) *NetworkConfig {
 	if len(interfaces) == 0 {
 		interfaces = FallbackInterfaceInfo()
 	}

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -67,7 +67,7 @@ type StartInstanceParams struct {
 
 	// NetworkInfo is an optional list of network interface details,
 	// necessary to configure on the instance.
-	NetworkInfo []corenetwork.InterfaceInfo
+	NetworkInfo corenetwork.InterfaceInfos
 
 	// SubnetsToZones is an optional collection of maps of provider-specific
 	// subnet IDs to a list of availability zone names each subnet is available
@@ -126,7 +126,7 @@ type StartInstanceResult struct {
 	// interfaces on the instance. Depending on the provider, this
 	// might be the same StartInstanceParams.NetworkInfo or may be
 	// modified as needed.
-	NetworkInfo []corenetwork.InterfaceInfo
+	NetworkInfo corenetwork.InterfaceInfos
 
 	// Volumes contains a list of volumes created, each one having the
 	// same Name as one of the VolumeParams in StartInstanceParams.Volumes.

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -91,10 +91,10 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 []network.InterfaceInfo) ([]network.InterfaceInfo, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]network.InterfaceInfo)
+	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -266,10 +266,10 @@ func (mr *MockNetworkingEnvironMockRecorder) MaintainInstance(arg0, arg1 interfa
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([][]network.InterfaceInfo, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
-	ret0, _ := ret[0].([][]network.InterfaceInfo)
+	ret0, _ := ret[0].([]network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -41,7 +41,7 @@ type Networking interface {
 	// but not all of the instances were found, the returned slice will
 	// have some nil slots, and an ErrPartialInstances error will be
 	// returned.
-	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error)
+	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error)
 
 	// SupportsSpaces returns whether the current environment supports
 	// spaces. The returned error satisfies errors.IsNotSupported(),
@@ -91,7 +91,7 @@ type Networking interface {
 	// AllocateContainerAddresses allocates a static address for each of the
 	// container NICs in preparedInfo, hosted by the hostInstanceID. Returns the
 	// network config including all allocated addresses on success.
-	AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error)
+	AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error)
 
 	// ReleaseContainerAddresses releases the previously allocated
 	// addresses matching the interface details passed in.

--- a/environs/space/environs_mock_test.go
+++ b/environs/space/environs_mock_test.go
@@ -256,10 +256,10 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names_v3.MachineTag, arg3 []network.InterfaceInfo) ([]network.InterfaceInfo, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names_v3.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]network.InterfaceInfo)
+	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -431,10 +431,10 @@ func (mr *MockNetworkingEnvironMockRecorder) MaintainInstance(arg0, arg1 interfa
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([][]network.InterfaceInfo, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
-	ret0, _ := ret[0].([][]network.InterfaceInfo)
+	ret0, _ := ret[0].([]network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -1518,10 +1518,10 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 []network.InterfaceInfo) ([]network.InterfaceInfo, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]network.InterfaceInfo)
+	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1693,10 +1693,10 @@ func (mr *MockNetworkingEnvironMockRecorder) MaintainInstance(arg0, arg1 interfa
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([][]network.InterfaceInfo, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
-	ret0, _ := ret[0].([][]network.InterfaceInfo)
+	ret0, _ := ret[0].([]network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -98,7 +98,7 @@ func AssertStartInstance(
 func StartInstance(
 	env environs.Environ, ctx context.ProviderCallContext, controllerUUID, machineId string,
 ) (
-	instances.Instance, *instance.HardwareCharacteristics, []corenetwork.InterfaceInfo, error,
+	instances.Instance, *instance.HardwareCharacteristics, corenetwork.InterfaceInfos, error,
 ) {
 	return StartInstanceWithConstraints(env, ctx, controllerUUID, machineId, constraints.Value{})
 }
@@ -125,7 +125,7 @@ func StartInstanceWithConstraints(
 	ctx context.ProviderCallContext,
 	controllerUUID, machineId string, cons constraints.Value,
 ) (
-	instances.Instance, *instance.HardwareCharacteristics, []corenetwork.InterfaceInfo, error,
+	instances.Instance, *instance.HardwareCharacteristics, corenetwork.InterfaceInfos, error,
 ) {
 	params := environs.StartInstanceParams{ControllerUUID: controllerUUID, Constraints: cons, StatusCallback: fakeCallback}
 	result, err := StartInstanceWithParams(env, ctx, machineId, params)

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 type InterfaceInfoSuite struct {
-	info []corenetwork.InterfaceInfo
+	info corenetwork.InterfaceInfos
 }
 
 var _ = gc.Suite(&InterfaceInfoSuite{})

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -116,7 +116,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		c.Assert(args.Placement, gc.DeepEquals, checkPlacement)
@@ -289,7 +289,7 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		c.Assert(args.AvailabilityZone, gc.Equals, "derived-zone")
@@ -329,7 +329,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -371,7 +371,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -416,7 +416,7 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -459,7 +459,7 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -515,7 +515,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		icfg := args.InstanceConfig
@@ -622,7 +622,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		[]corenetwork.InterfaceInfo,
+		corenetwork.InterfaceInfos,
 		error,
 	) {
 		icfg := args.InstanceConfig
@@ -936,7 +936,7 @@ func fakeAvailableTools() tools.List {
 func fakeStartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 	instances.Instance,
 	*instance.HardwareCharacteristics,
-	[]corenetwork.InterfaceInfo,
+	corenetwork.InterfaceInfos,
 	error,
 ) {
 	checkInstanceId := "i-success"

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -20,7 +20,7 @@ import (
 
 type allInstancesFunc func(context.ProviderCallContext) ([]instances.Instance, error)
 type instancesFunc func(context.ProviderCallContext, []instance.Id) ([]instances.Instance, error)
-type startInstanceFunc func(context.ProviderCallContext, environs.StartInstanceParams) (instances.Instance, *instance.HardwareCharacteristics, []corenetwork.InterfaceInfo, error)
+type startInstanceFunc func(context.ProviderCallContext, environs.StartInstanceParams) (instances.Instance, *instance.HardwareCharacteristics, corenetwork.InterfaceInfos, error)
 type stopInstancesFunc func(context.ProviderCallContext, []instance.Id) error
 type getToolsSourcesFunc func() ([]simplestreams.DataSource, error)
 type configFunc func() *config.Config

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -181,7 +181,7 @@ type OpDestroy struct {
 type OpNetworkInterfaces struct {
 	Env        string
 	InstanceId instance.Id
-	Info       []corenetwork.InterfaceInfo
+	Info       corenetwork.InterfaceInfos
 }
 
 type OpSubnets struct {
@@ -199,7 +199,7 @@ type OpStartInstance struct {
 	Instance          instances.Instance
 	Constraints       constraints.Value
 	SubnetsToZones    map[corenetwork.Id][]string
-	NetworkInfo       []corenetwork.InterfaceInfo
+	NetworkInfo       corenetwork.InterfaceInfos
 	Volumes           []storage.Volume
 	VolumeAttachments []storage.VolumeAttachment
 	Info              *mongo.MongoInfo
@@ -1434,7 +1434,7 @@ func (env *environ) Spaces(ctx context.ProviderCallContext) ([]corenetwork.Space
 }
 
 // NetworkInterfaces implements Environ.NetworkInterfaces().
-func (env *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (env *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	if err := env.checkBroken("NetworkInterfaces"); err != nil {
 		return nil, err
 	}
@@ -1448,9 +1448,9 @@ func (env *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []ins
 
 	// Simulate 3 NICs - primary and secondary enabled plus a disabled NIC.
 	// all configured using DHCP and having fake DNS servers and gateway.
-	infos := make([][]corenetwork.InterfaceInfo, len(ids))
+	infos := make([]corenetwork.InterfaceInfos, len(ids))
 	for idIndex, instId := range ids {
-		infos[idIndex] = make([]corenetwork.InterfaceInfo, 3)
+		infos[idIndex] = make(corenetwork.InterfaceInfos, 3)
 		for i, netName := range []string{"private", "public", "disabled"} {
 			infos[idIndex][i] = corenetwork.InterfaceInfo{
 				DeviceIndex:      i,
@@ -1927,7 +1927,7 @@ func delay() {
 	}
 }
 
-func (e *environ) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func (e *environ) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("container address allocation")
 }
 

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -238,7 +238,7 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 	opc := make(chan dummy.Operation, 200)
 	dummy.Listen(opc)
 
-	expectInfo := []corenetwork.InterfaceInfo{{
+	expectInfo := corenetwork.InterfaceInfos{{
 		ProviderId:       "dummy-eth0",
 		ProviderSubnetId: "dummy-private",
 		CIDR:             "0.10.0.0/24",
@@ -348,7 +348,7 @@ func (s *suite) TestSubnets(c *gc.C) {
 	c.Assert(netInfo, gc.HasLen, 0)
 }
 
-func assertInterfaces(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectInfo []corenetwork.InterfaceInfo) {
+func assertInterfaces(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectInfo corenetwork.InterfaceInfos) {
 	select {
 	case op := <-opc:
 		netOp, ok := op.(dummy.OpNetworkInterfaces)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -993,7 +993,7 @@ func (e *environ) gatherInstances(
 }
 
 // NetworkInterfaces implements NetworkingEnviron.NetworkInterfaces.
-func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	switch len(ids) {
 	case 0:
 		return nil, environs.ErrNoInstances
@@ -1002,7 +1002,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 		if err != nil {
 			return nil, err
 		}
-		return [][]corenetwork.InterfaceInfo{ifList}, nil
+		return []corenetwork.InterfaceInfos{ifList}, nil
 	}
 
 	// Collect all available subnets into a map where keys are subnet IDs
@@ -1013,7 +1013,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 		return nil, errors.Annotate(maybeConvertCredentialError(err, ctx), "failed to retrieve subnet info")
 	}
 
-	infos := make([][]corenetwork.InterfaceInfo, len(ids))
+	infos := make([]corenetwork.InterfaceInfos, len(ids))
 	idToInfosIndex := make(map[string]int)
 	for idx, id := range ids {
 		idToInfosIndex[string(id)] = idx
@@ -1078,7 +1078,7 @@ func (e *environ) subnetMap() (map[string]ec2.Subnet, error) {
 func (e *environ) gatherNetworkInterfaceInfo(
 	ctx context.ProviderCallContext,
 	filter *ec2.Filter,
-	infos [][]corenetwork.InterfaceInfo,
+	infos []corenetwork.InterfaceInfos,
 	idToInfosIndex map[string]int,
 	subMap map[string]ec2.Subnet,
 ) error {
@@ -1122,7 +1122,7 @@ func (e *environ) gatherNetworkInterfaceInfo(
 	return nil
 }
 
-func (e *environ) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]corenetwork.InterfaceInfo, error) {
+func (e *environ) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) (corenetwork.InterfaceInfos, error) {
 	var err error
 	var networkInterfacesResp *ec2.NetworkInterfacesResp
 	for a := shortAttempt.Start(); a.Next(); {
@@ -1153,7 +1153,7 @@ func (e *environ) networkInterfacesForInstance(ctx context.ProviderCallContext, 
 		return nil, errors.Annotatef(err, "cannot get instance %q network interfaces", instId)
 	}
 	ec2Interfaces := networkInterfacesResp.Interfaces
-	result := make([]corenetwork.InterfaceInfo, len(ec2Interfaces))
+	result := make(corenetwork.InterfaceInfos, len(ec2Interfaces))
 	for i, iface := range ec2Interfaces {
 		resp, err := e.ec2.Subnets([]string{iface.SubnetId}, nil)
 		if err != nil {
@@ -2183,7 +2183,7 @@ func ec2ErrCode(err error) string {
 	return ec2err.Code
 }
 
-func (e *environ) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func (e *environ) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("container address allocation")
 }
 

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -139,7 +139,7 @@ func (e *environ) getInstanceSubnets(
 }
 
 // NetworkInterfaces implements environs.NetworkingEnviron.
-func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	if len(ids) == 0 {
 		return nil, environs.ErrNoInstances
 	}
@@ -176,7 +176,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 		return nil, errors.Trace(err)
 	}
 
-	infos := make([][]corenetwork.InterfaceInfo, len(ids))
+	infos := make([]corenetwork.InterfaceInfos, len(ids))
 	for idx, inst := range insts {
 		if inst == nil {
 			continue // no instance with this ID known by provider
@@ -341,7 +341,7 @@ func (e *environ) SupportsContainerAddresses(ctx context.ProviderCallContext) (b
 }
 
 // AllocateContainerAddresses implements environs.NetworkingEnviron.
-func (e *environ) AllocateContainerAddresses(context.ProviderCallContext, instance.Id, names.MachineTag, []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func (e *environ) AllocateContainerAddresses(context.ProviderCallContext, instance.Id, names.MachineTag, corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("container addresses")
 }
 

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -202,7 +202,7 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
 
-	c.Assert(infos, gc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		CIDR:              "10.0.10.0/24",
 		ProviderId:        "moana/somenetif",
@@ -288,7 +288,7 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 
 	// Check interfaces for first instance
 	infos := infoLists[0]
-	c.Assert(infos, gc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		CIDR:              "10.0.10.0/24",
 		ProviderId:        "i-1/somenetif",
@@ -308,7 +308,7 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 
 	// Check interfaces for second instance
 	infos = infoLists[1]
-	c.Assert(infos, gc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		CIDR:              "10.0.10.0/24",
 		ProviderId:        "i-2/netif-0",
@@ -357,7 +357,7 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 
 	// Check interfaces for first instance
 	infos := infoLists[0]
-	c.Assert(infos, gc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		CIDR:              "10.0.10.0/24",
 		ProviderId:        "i-1/somenetif",
@@ -403,7 +403,7 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
 
-	c.Assert(infos, gc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		CIDR:              "10.0.10.0/24",
 		ProviderId:        "moana/somenetif",
@@ -464,7 +464,7 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
 
-	c.Assert(infos, gc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		CIDR:              "10.240.0.0/16",
 		ProviderId:        "moana/somenetif",
@@ -510,7 +510,7 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
 
-	c.Assert(infos, gc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		CIDR:              "10.0.10.0/24",
 		ProviderId:        "moana/somenetif",

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -186,13 +186,13 @@ func (env *maasEnviron) deviceInterfaces(deviceID instance.Id) ([]maasInterface,
 
 }
 
-func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentName map[string]string) ([]corenetwork.InterfaceInfo, error) {
+func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentName map[string]string) (corenetwork.InterfaceInfos, error) {
 	interfaces, err := env.deviceInterfaces(deviceID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	interfaceInfo := make([]corenetwork.InterfaceInfo, 0, len(interfaces))
+	interfaceInfo := make(corenetwork.InterfaceInfos, 0, len(interfaces))
 	for _, nic := range interfaces {
 		nicInfo := corenetwork.InterfaceInfo{
 			InterfaceName:       nic.Name,
@@ -258,11 +258,11 @@ func (env *maasEnviron) deviceInterfaceInfo2(
 	device gomaasapi.Device,
 	nameToParentName map[string]string,
 	subnetToStaticRoutes map[string][]gomaasapi.StaticRoute,
-) ([]corenetwork.InterfaceInfo, error) {
+) (corenetwork.InterfaceInfos, error) {
 	deviceID := device.SystemID()
 	interfaces := device.InterfaceSet()
 
-	interfaceInfo := make([]corenetwork.InterfaceInfo, 0, len(interfaces))
+	interfaceInfo := make(corenetwork.InterfaceInfos, 0, len(interfaces))
 	for idx, nic := range interfaces {
 		vlanId := 0
 		vlanVid := 0
@@ -343,7 +343,7 @@ type deviceCreatorParams struct {
 	Subnet               gomaasapi.Subnet // may be nil
 	PrimaryMACAddress    string
 	PrimaryNICName       string
-	DesiredInterfaceInfo []corenetwork.InterfaceInfo
+	DesiredInterfaceInfo corenetwork.InterfaceInfos
 	CIDRToMAASSubnet     map[string]gomaasapi.Subnet
 	CIDRToStaticRoutes   map[string][]gomaasapi.StaticRoute
 	Machine              gomaasapi.Machine
@@ -502,7 +502,7 @@ func (env *maasEnviron) lookupStaticRoutes() (map[string][]gomaasapi.StaticRoute
 	return subnetToStaticRoutes, nil
 }
 
-func (env *maasEnviron) prepareDeviceDetails(name string, machine gomaasapi.Machine, preparedInfo []corenetwork.InterfaceInfo) (deviceCreatorParams, error) {
+func (env *maasEnviron) prepareDeviceDetails(name string, machine gomaasapi.Machine, preparedInfo corenetwork.InterfaceInfos) (deviceCreatorParams, error) {
 	var zeroParams deviceCreatorParams
 
 	subnetCIDRToSubnet, err := env.lookupSubnets()
@@ -547,7 +547,7 @@ func (env *maasEnviron) prepareDeviceDetails(name string, machine gomaasapi.Mach
 	return params, nil
 }
 
-func validateExistingDevice(netInfo []corenetwork.InterfaceInfo, device gomaasapi.Device) (bool, error) {
+func validateExistingDevice(netInfo corenetwork.InterfaceInfos, device gomaasapi.Device) (bool, error) {
 	// Compare the desired device characteristics with the actual device
 	interfaces := device.InterfaceSet()
 	if len(interfaces) < len(netInfo) {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1054,7 +1054,7 @@ func (env *maasEnviron) StartInstance(
 	logger.Debugf("maas user data; %d bytes", len(userdata))
 
 	var displayName string
-	var interfaces []corenetwork.InterfaceInfo
+	var interfaces corenetwork.InterfaceInfos
 	if !env.usingMAAS2() {
 		inst1 := inst.(*maas1Instance)
 		startedNode, err := env.startNode(*inst1.maasObject, series, userdata)
@@ -2087,7 +2087,7 @@ func (env *maasEnviron) nodeIdFromInstance(inst instances.Instance) (string, err
 	return nodeId, err
 }
 
-func (env *maasEnviron) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func (env *maasEnviron) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	if len(preparedInfo) == 0 {
 		return nil, errors.Errorf("no prepared info to allocate")
 	}
@@ -2098,7 +2098,7 @@ func (env *maasEnviron) AllocateContainerAddresses(ctx context.ProviderCallConte
 	return env.allocateContainerAddresses2(ctx, hostInstanceID, containerTag, preparedInfo)
 }
 
-func (env *maasEnviron) allocateContainerAddresses1(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func (env *maasEnviron) allocateContainerAddresses1(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	subnetCIDRToVLANID := make(map[string]string)
 	subnetsAPI := env.getMAASClient().GetSubObject("subnets")
 	result, err := subnetsAPI.CallGet("", nil)
@@ -2208,7 +2208,7 @@ func (env *maasEnviron) allocateContainerAddresses1(ctx context.ProviderCallCont
 	return finalInterfaces, nil
 }
 
-func (env *maasEnviron) allocateContainerAddresses2(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func (env *maasEnviron) allocateContainerAddresses2(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	args := gomaasapi.MachinesArgs{
 		AgentName: env.uuid,
 		SystemIDs: []string{string(hostInstanceID)},

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -87,7 +87,7 @@ type maasSubnet struct {
 }
 
 // NetworkInterfaces implements Environ.NetworkInterfaces.
-func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	switch len(ids) {
 	case 0:
 		return nil, environs.ErrNoInstances
@@ -96,7 +96,7 @@ func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, ids [
 		if err != nil {
 			return nil, err
 		}
-		return [][]corenetwork.InterfaceInfo{ifList}, nil
+		return []corenetwork.InterfaceInfos{ifList}, nil
 	}
 
 	// Fetch instance information for the IDs we are interested in.
@@ -114,7 +114,7 @@ func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, ids [
 		return nil, errors.Trace(err)
 	}
 
-	infos := make([][]corenetwork.InterfaceInfo, len(ids))
+	infos := make([]corenetwork.InterfaceInfos, len(ids))
 	if env.usingMAAS2() {
 		dnsSearchDomains, err := env.Domains(ctx)
 		if err != nil {
@@ -151,7 +151,7 @@ func (env *maasEnviron) NetworkInterfaces(ctx context.ProviderCallContext, ids [
 	return infos, err
 }
 
-func (env *maasEnviron) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]corenetwork.InterfaceInfo, error) {
+func (env *maasEnviron) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) (corenetwork.InterfaceInfos, error) {
 	inst, err := env.getInstance(ctx, instId)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -179,7 +179,7 @@ func (env *maasEnviron) networkInterfacesForInstance(ctx context.ProviderCallCon
 // "interface_set" node details field.
 func maasObjectNetworkInterfaces(
 	_ context.ProviderCallContext, maasObject *gomaasapi.MAASObject, subnetsMap map[string]corenetwork.Id,
-) ([]corenetwork.InterfaceInfo, error) {
+) (corenetwork.InterfaceInfos, error) {
 	interfaceSet, ok := maasObject.GetMap()["interface_set"]
 	if !ok || interfaceSet.IsNil() {
 		// This means we're using an older MAAS API.
@@ -202,7 +202,7 @@ func maasObjectNetworkInterfaces(
 		return nil, errors.Trace(err)
 	}
 
-	infos := make([]corenetwork.InterfaceInfo, 0, len(interfaces))
+	infos := make(corenetwork.InterfaceInfos, 0, len(interfaces))
 	for i, iface := range interfaces {
 		// The below works for all types except bonds and their members.
 		parentName := strings.Join(iface.Parents, "")
@@ -317,9 +317,9 @@ func maas2NetworkInterfaces(
 	instance *maas2Instance,
 	subnetsMap map[string]corenetwork.Id,
 	dnsSearchDomains ...string,
-) ([]corenetwork.InterfaceInfo, error) {
+) (corenetwork.InterfaceInfos, error) {
 	interfaces := instance.machine.InterfaceSet()
-	infos := make([]corenetwork.InterfaceInfo, 0, len(interfaces))
+	infos := make(corenetwork.InterfaceInfos, 0, len(interfaces))
 	for i, iface := range interfaces {
 
 		// The below works for all types except bonds and their members.

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -416,7 +416,7 @@ const exampleInterfaceSetJSON = `
         }
 ]`
 
-var exampleParsedInterfaceSetJSON = []corenetwork.InterfaceInfo{{
+var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	DeviceIndex:       0,
 	MACAddress:        "52:54:00:70:9b:fe",
 	CIDR:              "10.20.19.0/24",
@@ -941,7 +941,7 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 	subnetsMap["10.250.19.0/24"] = "3"
 	subnetsMap["192.168.1.0/24"] = "0"
 
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
 		CIDR:              "10.20.19.0/24",
@@ -1096,7 +1096,7 @@ func (s *interfacesSuite) TestMAAS2InterfacesNilVLAN(c *gc.C) {
 	machine := &fakeMachine{interfaceSet: exampleInterfaces}
 	instance := &maas2Instance{machine: machine}
 
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
 		CIDR:              "10.20.19.0/24",

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -982,7 +982,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 	params := environs.StartInstanceParams{ControllerUUID: suite.controllerUUID}
 	result, err := jujutesting.StartInstanceWithParams(env, suite.callCtx, "1", params)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
 		CIDR:              "10.20.19.0/24",
@@ -1151,7 +1151,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := []corenetwork.InterfaceInfo{{
+	prepared := corenetwork.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1159,7 +1159,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 	ignored := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "192.168.1.0/24",
@@ -1281,7 +1281,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := []corenetwork.InterfaceInfo{{
+	prepared := corenetwork.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1289,7 +1289,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 	ignored := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "10.20.19.0/24",
@@ -1376,7 +1376,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesStaticRoutesDenied
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := []corenetwork.InterfaceInfo{{
+	prepared := corenetwork.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1522,7 +1522,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 	suite.injectController(controller)
 	env := suite.makeEnviron(c, nil)
 
-	prepared := []corenetwork.InterfaceInfo{{
+	prepared := corenetwork.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:9b:ff",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1531,7 +1531,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		CIDR:          "192.168.1.0/24",
 		InterfaceName: "eth1",
 	}}
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "10.20.19.0/24",
@@ -1575,9 +1575,9 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, expected)
 }
 
-func (suite *maas2EnvironSuite) assertAllocateContainerAddressesFails(c *gc.C, controller *fakeController, prepared []corenetwork.InterfaceInfo, errorMatches string) {
+func (suite *maas2EnvironSuite) assertAllocateContainerAddressesFails(c *gc.C, controller *fakeController, prepared corenetwork.InterfaceInfos, errorMatches string) {
 	if prepared == nil {
-		prepared = []corenetwork.InterfaceInfo{{}}
+		prepared = corenetwork.InterfaceInfos{{}}
 	}
 	suite.injectController(controller)
 	env := suite.makeEnviron(c, nil)
@@ -1640,7 +1640,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesMachinesError(c *g
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := []corenetwork.InterfaceInfo{
+	prepared := corenetwork.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
@@ -1675,7 +1675,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDeviceError(
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := []corenetwork.InterfaceInfo{
+	prepared := corenetwork.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
@@ -1754,14 +1754,14 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := []corenetwork.InterfaceInfo{
+	prepared := corenetwork.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "", MACAddress: "DEADBEEF"},
 		{InterfaceName: "eth1", CIDR: "", MACAddress: "DEADBEEE"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
 	allocated, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(allocated, jc.DeepEquals, []corenetwork.InterfaceInfo{{
+	c.Assert(allocated, jc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:    0,
 		MACAddress:     "53:54:00:70:9b:ff",
 		ProviderId:     "93",
@@ -1818,7 +1818,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateInterfaceErr
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := []corenetwork.InterfaceInfo{
+	prepared := corenetwork.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
 		{InterfaceName: "eth1", CIDR: "10.20.20.0/24", MACAddress: "DEADBEEE"},
 	}
@@ -1868,7 +1868,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesLinkSubnetError(c 
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := []corenetwork.InterfaceInfo{
+	prepared := corenetwork.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
 		{InterfaceName: "eth1", CIDR: "10.20.20.0/24", MACAddress: "DEADBEEE"},
 	}
@@ -1982,7 +1982,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := []corenetwork.InterfaceInfo{{
+	prepared := corenetwork.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:9b:ff",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1990,7 +1990,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 	containerTag := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), containerTag, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "10.20.19.0/24",
@@ -2178,7 +2178,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := []corenetwork.InterfaceInfo{{
+	prepared := corenetwork.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:88:aa",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -2190,7 +2190,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 	containerTag := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), containerTag, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.InterfaceInfo{{
+	expected := corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:88:aa",
 		CIDR:              "10.20.19.0/24",

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -1047,9 +1047,9 @@ func (e *Environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, er
 	return nil, errors.NotSupportedf("super subnets")
 }
 
-func (e *Environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (e *Environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	var (
-		infos = make([][]corenetwork.InterfaceInfo, len(ids))
+		infos = make([]corenetwork.InterfaceInfos, len(ids))
 		err   error
 	)
 
@@ -1062,14 +1062,14 @@ func (e *Environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []in
 	return infos, nil
 }
 
-func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContext, instId instance.Id) ([]corenetwork.InterfaceInfo, error) {
+func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContext, instId instance.Id) (corenetwork.InterfaceInfos, error) {
 	oInst, err := e.getOCIInstance(ctx, instId)
 	if err != nil {
 		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
-	info := []corenetwork.InterfaceInfo{}
+	info := corenetwork.InterfaceInfos{}
 	vnics, err := oInst.getVnics()
 	if err != nil {
 		providerCommon.HandleCredentialError(err, ctx)
@@ -1147,8 +1147,8 @@ func (e *Environ) AllocateContainerAddresses(
 	ctx envcontext.ProviderCallContext,
 	hostInstanceID instance.Id,
 	containerTag names.MachineTag,
-	preparedInfo []corenetwork.InterfaceInfo,
-) ([]corenetwork.InterfaceInfo, error) {
+	preparedInfo corenetwork.InterfaceInfos,
+) (corenetwork.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("AllocateContainerAddresses")
 }
 

--- a/provider/openstack/cloud_mock_test.go
+++ b/provider/openstack/cloud_mock_test.go
@@ -5,9 +5,10 @@
 package openstack
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/core/network"
-	reflect "reflect"
 )
 
 // MockNetworkingConfig is a mock of NetworkingConfig interface
@@ -34,7 +35,7 @@ func (m *MockNetworkingConfig) EXPECT() *MockNetworkingConfigMockRecorder {
 }
 
 // AddNetworkConfig mocks base method
-func (m *MockNetworkingConfig) AddNetworkConfig(arg0 []network.InterfaceInfo) error {
+func (m *MockNetworkingConfig) AddNetworkConfig(arg0 network.InterfaceInfos) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddNetworkConfig", arg0)
 	ret0, _ := ret[0].(error)

--- a/provider/openstack/network_mock_test.go
+++ b/provider/openstack/network_mock_test.go
@@ -5,12 +5,13 @@
 package openstack
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	neutron "gopkg.in/goose.v2/neutron"
 	nova "gopkg.in/goose.v2/nova"
-	reflect "reflect"
 )
 
 // MockSSLHostnameConfig is a mock of SSLHostnameConfig interface
@@ -133,10 +134,10 @@ func (mr *MockNetworkingMockRecorder) DeletePortByID(arg0 interface{}) *gomock.C
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockNetworking) NetworkInterfaces(arg0 []instance.Id) ([][]network.InterfaceInfo, error) {
+func (m *MockNetworking) NetworkInterfaces(arg0 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0)
-	ret0, _ := ret[0].([][]network.InterfaceInfo)
+	ret0, _ := ret[0].([]network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -48,7 +48,7 @@ type Networking interface {
 	// NetworkInterfaces requests information about the network
 	// interfaces on the given list of instances.
 	// Needed for Environ.Networking
-	NetworkInterfaces(ids []instance.Id) ([][]corenetwork.InterfaceInfo, error)
+	NetworkInterfaces(ids []instance.Id) ([]corenetwork.InterfaceInfos, error)
 }
 
 // NetworkingDecorator is an interface that provides a means of overriding
@@ -394,6 +394,6 @@ func noNetConfigMsg(err error) string {
 		err.Error())
 }
 
-func (n *NeutronNetworking) NetworkInterfaces(ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (n *NeutronNetworking) NetworkInterfaces(ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("neutron network interfaces")
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1416,7 +1416,7 @@ func (e *Environ) networksForInstance(
 	// Set the subnetID on the network for all networks.
 	// For each of the subnetIDs selected, create a port for each one.
 	subnetNetworks := make([]nova.ServerNetworks, 0, len(subnetIDForZone))
-	netInfo := make([]corenetwork.InterfaceInfo, len(subnetIDsForZone))
+	netInfo := make(corenetwork.InterfaceInfos, len(subnetIDsForZone))
 	for i, subnetID := range subnetIDForZone {
 		var port *neutron.PortV2
 		port, err = e.networking.CreatePort(e.uuid, networkID, subnetID)
@@ -2238,7 +2238,7 @@ func (e *Environ) Subnets(
 }
 
 // NetworkInterfaces is specified on environs.Networking.
-func (e *Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (e *Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	infos, err := e.networking.NetworkInterfaces(ids)
 	if err != nil {
 		handleCredentialError(err, ctx)
@@ -2283,7 +2283,7 @@ func (e *Environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error
 }
 
 // AllocateContainerAddresses is specified on environs.Networking.
-func (e *Environ) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo []corenetwork.InterfaceInfo) ([]corenetwork.InterfaceInfo, error) {
+func (e *Environ) AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("allocate container address")
 }
 

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -874,7 +874,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 	expectDefaultNetworks(mockNetworking)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
-	netCfg.EXPECT().AddNetworkConfig([]corenetwork.InterfaceInfo{{
+	netCfg.EXPECT().AddNetworkConfig(corenetwork.InterfaceInfos{{
 		InterfaceName: "eth0",
 		MACAddress:    "mac-address",
 		Addresses:     corenetwork.NewProviderAddresses("10.10.10.1"),

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -161,9 +161,9 @@ func (e Environ) getSubnetInfo() ([]corenetwork.SubnetInfo, error) {
 }
 
 // NetworkInterfaces is defined on the environs.Networking interface.
-func (e Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]corenetwork.InterfaceInfo, error) {
+func (e Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error) {
 	var (
-		infos = make([][]corenetwork.InterfaceInfo, len(ids))
+		infos = make([]corenetwork.InterfaceInfos, len(ids))
 		err   error
 	)
 
@@ -176,14 +176,14 @@ func (e Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instan
 	return infos, nil
 }
 
-func (e Environ) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) ([]corenetwork.InterfaceInfo, error) {
+func (e Environ) networkInterfacesForInstance(ctx context.ProviderCallContext, instId instance.Id) (corenetwork.InterfaceInfos, error) {
 	instance, err := e.env.Details(instId)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(instance.Networking) == 0 {
-		return []corenetwork.InterfaceInfo{}, nil
+		return corenetwork.InterfaceInfos{}, nil
 	}
 	subnetInfo, err := e.getSubnetInfoAsMap()
 	if err != nil {
@@ -191,7 +191,7 @@ func (e Environ) networkInterfacesForInstance(ctx context.ProviderCallContext, i
 	}
 	nicAttributes := e.getNicAttributes(instance)
 
-	interfaces := make([]corenetwork.InterfaceInfo, 0, len(instance.Networking))
+	interfaces := make(corenetwork.InterfaceInfos, 0, len(instance.Networking))
 	idx := 0
 	for nicName, nicObj := range instance.Networking {
 		// gsamfira: While the API may hold any alphanumeric NIC name
@@ -328,8 +328,8 @@ func (e Environ) AllocateContainerAddresses(
 	ctx context.ProviderCallContext,
 	hostInstanceID instance.Id,
 	containerTag names.MachineTag,
-	preparedInfo []corenetwork.InterfaceInfo,
-) ([]corenetwork.InterfaceInfo, error) {
+	preparedInfo corenetwork.InterfaceInfos,
+) (corenetwork.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("containers")
 }
 

--- a/provider/oracle/network/environ_test.go
+++ b/provider/oracle/network/environ_test.go
@@ -123,7 +123,7 @@ func (e *environSuite) TestAllocateContainerAddress(c *gc.C) {
 	var (
 		id   instance.Id
 		tag  names.MachineTag
-		info []corenetwork.InterfaceInfo
+		info corenetwork.InterfaceInfos
 	)
 
 	addr, err := e.netEnv.AllocateContainerAddresses(e.callCtx, id, tag, info)
@@ -183,7 +183,7 @@ func (e *environSuite) TestNetworkInterfacesWithEmptyParams(c *gc.C) {
 	infoList, err := netEnv.NetworkInterfaces(e.callCtx, []instance.Id{instance.Id("0")})
 	c.Assert(err, gc.IsNil)
 	c.Assert(infoList, gc.HasLen, 1)
-	c.Assert(infoList[0], jc.DeepEquals, []corenetwork.InterfaceInfo{})
+	c.Assert(infoList[0], jc.DeepEquals, corenetwork.InterfaceInfos{})
 }
 
 func (e *environSuite) TestNetworkInterfacesWithIPAssociation(c *gc.C) {

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -150,7 +150,7 @@ func (env *sessionEnviron) newRawInstance(
 		return nil, nil, errors.Trace(err)
 	}
 
-	interfaces := []corenetwork.InterfaceInfo{{
+	interfaces := corenetwork.InterfaceInfos{{
 		InterfaceName: "eth0",
 		MACAddress:    internalMac,
 		InterfaceType: corenetwork.EthernetInterface,

--- a/worker/containerbroker/mocks/state_mock.go
+++ b/worker/containerbroker/mocks/state_mock.go
@@ -65,9 +65,9 @@ func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0 interface{}) *gomoc
 }
 
 // GetContainerInterfaceInfo mocks base method
-func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
+func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) (network.InterfaceInfos, error) {
 	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
-	ret0, _ := ret[0].([]network.InterfaceInfo)
+	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -122,9 +122,9 @@ func (mr *MockStateMockRecorder) Machines(arg0 ...interface{}) *gomock.Call {
 }
 
 // PrepareContainerInterfaceInfo mocks base method
-func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) ([]network.InterfaceInfo, error) {
+func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) (network.InterfaceInfos, error) {
 	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
-	ret0, _ := ret[0].([]network.InterfaceInfo)
+	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/worker/instancepoller/manifold.go
+++ b/worker/instancepoller/manifold.go
@@ -54,7 +54,7 @@ func (e environWithoutNetworking) Instances(ctx context.ProviderCallContext, ids
 	return e.env.Instances(ctx, ids)
 }
 
-func (e environWithoutNetworking) NetworkInterfaces(context.ProviderCallContext, []instance.Id) ([][]network.InterfaceInfo, error) {
+func (e environWithoutNetworking) NetworkInterfaces(context.ProviderCallContext, []instance.Id) ([]network.InterfaceInfos, error) {
 	return nil, errNetworkingNotSupported
 }
 

--- a/worker/instancepoller/mocks/mocks_instancepoller.go
+++ b/worker/instancepoller/mocks/mocks_instancepoller.go
@@ -54,9 +54,9 @@ func (mr *MockEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Cal
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([][]network.InterfaceInfo, error) {
+func (m *MockEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
-	ret0, _ := ret[0].([][]network.InterfaceInfo)
+	ret0, _ := ret[0].([]network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -177,7 +177,7 @@ func (mr *MockMachineMockRecorder) SetInstanceStatus(arg0, arg1, arg2 interface{
 }
 
 // SetProviderNetworkConfig mocks base method
-func (m *MockMachine) SetProviderNetworkConfig(arg0 []network.InterfaceInfo) (network.ProviderAddresses, bool, error) {
+func (m *MockMachine) SetProviderNetworkConfig(arg0 network.InterfaceInfos) (network.ProviderAddresses, bool, error) {
 	ret := m.ctrl.Call(m, "SetProviderNetworkConfig", arg0)
 	ret0, _ := ret[0].(network.ProviderAddresses)
 	ret1, _ := ret[1].(bool)

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -48,7 +48,7 @@ var (
 // poller.
 type Environ interface {
 	Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error)
-	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([][]network.InterfaceInfo, error)
+	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]network.InterfaceInfos, error)
 }
 
 // Machine specifies an interface for machine instances processed by the
@@ -56,7 +56,7 @@ type Environ interface {
 type Machine interface {
 	Id() string
 	InstanceId() (instance.Id, error)
-	SetProviderNetworkConfig([]network.InterfaceInfo) (network.ProviderAddresses, bool, error)
+	SetProviderNetworkConfig(network.InterfaceInfos) (network.ProviderAddresses, bool, error)
 	InstanceStatus() (params.StatusResult, error)
 	SetInstanceStatus(status.Status, string, map[string]interface{}) error
 	String() string
@@ -374,7 +374,7 @@ func (u *updaterWorker) pollGroupMembers(groupType pollGroupType) error {
 			continue
 		}
 
-		var ifList []network.InterfaceInfo
+		var ifList network.InterfaceInfos
 		if netList != nil {
 			ifList = netList[idx]
 		}
@@ -415,7 +415,7 @@ func (u *updaterWorker) resolveInstanceID(entry *pollGroupEntry) error {
 // addresses based on the information collected from the provider. It returns
 // back the *instance* status and the number of provider addresses currently
 // known for the machine.
-func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instances.Instance, providerIfaceList []network.InterfaceInfo) (status.Status, int, error) {
+func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instances.Instance, providerIfaceList network.InterfaceInfos) (status.Status, int, error) {
 	curStatus, err := entry.m.InstanceStatus()
 	if err != nil {
 		// This should never occur since the machine is provisioned. If
@@ -468,7 +468,7 @@ func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instance
 // instance information.
 //
 // The call returns back the count of provider addresses for the machine.
-func (u *updaterWorker) syncProviderAddresses(entry *pollGroupEntry, instInfo instances.Instance, providerIfaceList []network.InterfaceInfo) (int, error) {
+func (u *updaterWorker) syncProviderAddresses(entry *pollGroupEntry, instInfo instances.Instance, providerIfaceList network.InterfaceInfos) (int, error) {
 	// If the provider does not support NetworkInterfaces, we will get an
 	// empty providerIfaceList; if that's the case, populate a minimal
 	// interface list from the instance info
@@ -495,8 +495,8 @@ func (u *updaterWorker) syncProviderAddresses(entry *pollGroupEntry, instInfo in
 // provide us with network interface information. For these providers we fetch
 // the reported instance addresses and coerce them into a list of InterfaceInfo
 // that we can send to the instancepoller facade.
-func fakeInterfacesFromInstanceAddrs(addrs []network.ProviderAddress) []network.InterfaceInfo {
-	instIfaceList := make([]network.InterfaceInfo, len(addrs))
+func fakeInterfacesFromInstanceAddrs(addrs []network.ProviderAddress) network.InterfaceInfos {
+	instIfaceList := make(network.InterfaceInfos, len(addrs))
 	for i, addr := range addrs {
 		instIfaceList[i].DeviceIndex = i
 		switch addr.Scope {

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -40,7 +40,7 @@ var (
 		network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),
 	}
 
-	testNetIfs = []network.InterfaceInfo{
+	testNetIfs = network.InterfaceInfos{
 		{
 			DeviceIndex:   0,
 			InterfaceName: "eth0",
@@ -55,7 +55,7 @@ var (
 		},
 	}
 
-	testCoercedNetIfs = []network.InterfaceInfo{
+	testCoercedNetIfs = network.InterfaceInfos{
 		{
 			DeviceIndex: 0,
 			Addresses: network.ProviderAddresses{
@@ -440,7 +440,7 @@ func (s *workerSuite) TestBatchPollingOfGroupMembers(c *gc.C) {
 	machine1Info.EXPECT().Status(gomock.Any()).Return(instance.Status{Status: status.Running})
 	mocked.environ.EXPECT().Instances(gomock.Any(), []instance.Id{"b4dc0ffee"}).Return([]instances.Instance{machine1Info}, nil)
 	mocked.environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{"b4dc0ffee"}).Return(
-		[][]network.InterfaceInfo{testNetIfs},
+		[]network.InterfaceInfos{testNetIfs},
 		nil,
 	)
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -218,7 +218,7 @@ func (s *CommonProvisionerSuite) checkStartInstance(c *gc.C, m *state.Machine) i
 func (s *CommonProvisionerSuite) checkStartInstanceCustom(
 	c *gc.C, m *state.Machine,
 	secret string, cons constraints.Value,
-	networkInfo []corenetwork.InterfaceInfo,
+	networkInfo corenetwork.InterfaceInfos,
 	subnetsToZones map[corenetwork.Id][]string,
 	volumes []storage.Volume,
 	volumeAttachments []storage.VolumeAttachment,
@@ -241,7 +241,7 @@ func (s *CommonProvisionerSuite) checkStartInstances(c *gc.C, machines []*state.
 func (s *CommonProvisionerSuite) checkStartInstancesCustom(
 	c *gc.C, machines []*state.Machine,
 	secret string, cons constraints.Value,
-	networkInfo []corenetwork.InterfaceInfo,
+	networkInfo corenetwork.InterfaceInfos,
 	subnetsToZones map[corenetwork.Id][]string,
 	volumes []storage.Volume,
 	volumeAttachments []storage.VolumeAttachment,


### PR DESCRIPTION
## Description of change

This PR builds on top of the work from #11576 and replaces all instances of `[]network.InterfaceInfo` (from `core` pkg) to `network.InterfaceInfos`.