### PR TITLE
Increase the max wait time for WaitAdvance.

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -787,7 +787,7 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 		errChan <- controllerStacker.Deploy()
 	}()
 
-	err = s.clock.WaitAdvance(3*time.Second, testing.ShortWait, 1)
+	err = s.clock.WaitAdvance(3*time.Second, testing.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -756,10 +756,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 	s.assertCustomerResources(
 		c, crs,
 		func() {
-			err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
+			err := s.clock.WaitAdvance(time.Second, testing.LongWait, 1)
 			c.Assert(err, jc.ErrorIsNil)
 
-			err = s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
+			err = s.clock.WaitAdvance(time.Second, testing.LongWait, 1)
 			c.Assert(err, jc.ErrorIsNil)
 		},
 		// waits CRD stablised.
@@ -1084,10 +1084,10 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 		resultChan <- result
 	}(s.broker)
 
-	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
+	err := s.clock.WaitAdvance(time.Second, testing.LongWait, 2)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
+	err = s.clock.WaitAdvance(time.Second, testing.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -1125,7 +1125,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsFailEarly(c *gc.C) {
 		resultChan <- result
 	}(s.broker)
 
-	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
+	err := s.clock.WaitAdvance(time.Second, testing.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1997,7 +1997,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
 		})
 	}()
-	err = s.clock.WaitAdvance(2*time.Second, testing.ShortWait, 1)
+	err = s.clock.WaitAdvance(2*time.Second, testing.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -2349,7 +2349,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
 		})
 	}()
-	err = s.clock.WaitAdvance(2*time.Second, testing.ShortWait, 1)
+	err = s.clock.WaitAdvance(2*time.Second, testing.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -606,7 +606,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorUpdate(c *gc.C) {
 			},
 		})
 	}()
-	err := s.clock.WaitAdvance(2*time.Second, testing.ShortWait, 1)
+	err := s.clock.WaitAdvance(2*time.Second, testing.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {


### PR DESCRIPTION
Under load, or on slow instances, the testing.ShortWait time (50ms)
is not sufficient for the dependent code to get to the required situation
of waiting on the clock.

There is no real impact for changing testing.ShortWait for testing.LongWait.
The WaitAdvance code will still check every 10ms for the appropriate number
of waiters.

Backporting fix that landed in develop by mistake.