### PR TITLE
Provide clock and logger to upgrader worker.

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -955,6 +955,8 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeStepsGateName: upgradeStepsGateName,
 			UpgradeCheckGateName: upgradeCheckGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
+			Logger:               loggo.GetLogger("juju.worker.upgrader"),
+			Clock:                config.Clock,
 		}),
 
 		upgradeSeriesWorkerName: ifNotMigrating(upgradeseries.Manifold(upgradeseries.ManifoldConfig{

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -199,6 +199,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeStepsGateName: upgradeStepsGateName,
 			UpgradeCheckGateName: upgradeCheckGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
+			Logger:               loggo.GetLogger("juju.worker.upgrader"),
+			Clock:                config.Clock,
 		}),
 
 		// The upgradesteps worker runs soon after the unit agent

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -103,7 +103,7 @@ func AgentDone(logger loggo.Logger, err error) error {
 		err = nil
 	}
 	if ug, ok := err.(*upgrader.UpgradeReadyError); ok {
-		if err := ug.ChangeAgentTools(); err != nil {
+		if err := ug.ChangeAgentTools(logger); err != nil {
 			// Return and let the init system deal with the restart.
 			err = errors.Annotate(err, "cannot change agent binaries")
 			logger.Infof(err.Error())

--- a/worker/upgrader/error.go
+++ b/worker/upgrader/error.go
@@ -25,7 +25,7 @@ func (e *UpgradeReadyError) Error() string {
 // ChangeAgentTools does the actual agent upgrade.
 // It should be called just before an agent exits, so that
 // it will restart running the new tools.
-func (e *UpgradeReadyError) ChangeAgentTools() error {
+func (e *UpgradeReadyError) ChangeAgentTools(logger Logger) error {
 	agentTools, err := tools.ChangeAgentTools(e.DataDir, e.AgentName, e.NewTools)
 	if err != nil {
 		return err

--- a/worker/upgrader/export_test.go
+++ b/worker/upgrader/export_test.go
@@ -1,8 +1,0 @@
-// Copyright 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package upgrader
-
-var (
-	RetryAfter = &retryAfter
-)


### PR DESCRIPTION
Some upcoming work was going to need to tweak some upgrader
behaviour. It seemed reasonable to bring the worker more up
to standard before that work was started.

Unit tests cover all changes, nothing user facing at all.