### PR TITLE
Don't write errors when pubsub websocket disconnects.

### DIFF
--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -9,6 +9,7 @@ import (
 
 	gorillaws "github.com/gorilla/websocket"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/apiserver/params"
@@ -24,20 +25,22 @@ type Hub interface {
 
 func newPubSubHandler(h httpContext, hub Hub) http.Handler {
 	return &pubsubHandler{
-		ctxt: h,
-		hub:  hub,
+		ctxt:   h,
+		hub:    hub,
+		logger: loggo.GetLogger("juju.apiserver.pubsub"),
 	}
 }
 
 type pubsubHandler struct {
-	ctxt httpContext
-	hub  Hub
+	ctxt   httpContext
+	hub    Hub
+	logger loggo.Logger
 }
 
 // ServeHTTP implements the http.Handler interface.
 func (h *pubsubHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	handler := func(socket *websocket.Conn) {
-		logger.Debugf("start of *pubsubHandler.ServeHTTP")
+		h.logger.Debugf("start of *pubsubHandler.ServeHTTP")
 		defer socket.Close()
 
 		// If we get to here, no more errors to report, so we report a nil
@@ -66,14 +69,14 @@ func (h *pubsubHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				if err := socket.WriteControl(gorillaws.PingMessage, []byte{}, deadline); err != nil {
 					// This error is expected if the other end goes away. By
 					// returning we close the socket through the defer call.
-					logger.Debugf("failed to write ping: %s", err)
+					h.logger.Debugf("failed to write ping: %s", err)
 					return
 				}
 			case m := <-messageCh:
-				logger.Tracef("topic: %q, data: %v", m.Topic, m.Data)
+				h.logger.Tracef("topic: %q, data: %v", m.Topic, m.Data)
 				_, err := h.hub.Publish(m.Topic, m.Data)
 				if err != nil {
-					logger.Errorf("publish failed: %v", err)
+					h.logger.Errorf("publish failed: %v", err)
 				}
 			}
 		}
@@ -93,7 +96,13 @@ func (h *pubsubHandler) receiveMessages(socket *websocket.Conn) <-chan params.Pu
 			// unblocked when the API handler calls socket.Close as it
 			// finishes.
 			if err := socket.ReadJSON(&m); err != nil {
-				logger.Errorf("pubsub receive error: %v", err)
+				// Since we don't give a list of expected error codes,
+				// any CloseError type is considered unexpected.
+				if gorillaws.IsUnexpectedCloseError(err) {
+					h.logger.Tracef("websocket closed")
+				} else {
+					h.logger.Errorf("pubsub receive error: %v", err)
+				}
 				return
 			}
 
@@ -114,10 +123,10 @@ func (h *pubsubHandler) sendError(ws *websocket.Conn, req *http.Request, err err
 	// There is no need to log the error for normal operators as there is nothing
 	// they can action. This is for developers.
 	if err != nil && featureflag.Enabled(feature.DeveloperMode) {
-		logger.Errorf("returning error from %s %s: %s", req.Method, req.URL.Path, errors.Details(err))
+		h.logger.Errorf("returning error from %s %s: %s", req.Method, req.URL.Path, errors.Details(err))
 	}
 	if sendErr := ws.SendInitialErrorV0(err); sendErr != nil {
-		logger.Errorf("closing websocket, %v", err)
+		h.logger.Errorf("closing websocket, %v", err)
 		ws.Close()
 		return
 	}


### PR DESCRIPTION
Having the other side of the websocket go away isn't an error.
We now check to see if the error is a close error type, and if
it is, just log at trace. Only log an error if there is some other
error type.

Also had the pubsub handler use a more detailed logger for writing
errors so they can be filtered more easily.

## QA steps

```sh
# bootstrap and enable-ha
juju switch controller
juju model-config logging-config=juju=WARN:juju.apiserver.pubsub=TRACE
# in one window
juju debug-log
# in another window
juju ssh 2
sudo service jujud-machine-2 stop
```
Observe in the log that we get a "websocket closed" log line, not an error.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1759372