### PR TITLE
[dev] Detect OVS bridges

### DIFF
--- a/container/broker/broker.go
+++ b/container/broker/broker.go
@@ -4,6 +4,7 @@
 package broker
 
 import (
+	"os/exec"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -24,6 +25,9 @@ import (
 )
 
 var logger = loggo.GetLogger("juju.container.broker")
+
+// Overridden by tests
+var getCommandOutput = func(cmd *exec.Cmd) ([]byte, error) { return cmd.Output() }
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/apicalls_mock.go github.com/juju/juju/container/broker APICalls
 type APICalls interface {
@@ -260,4 +264,34 @@ func proxyConfigurationFromContainerCfg(cfg params.ContainerConfig) instancecfg.
 		SnapStoreProxyID:    cfg.SnapStoreProxyID,
 		SnapStoreProxyURL:   cfg.SnapStoreProxyURL,
 	}
+}
+
+// ovsManagedBridges returns a filtered version of ifaceList that only contains
+// bridge interfaces managed by openvswitch.
+func ovsManagedBridges(ifaceList corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error) {
+	if _, err := exec.LookPath("ovs-vsctl"); err != nil {
+		// ovs tools not installed; nothing to do
+		if execErr, isExecErr := err.(*exec.Error); isExecErr && execErr.Unwrap() == exec.ErrNotFound {
+			return nil, nil
+		}
+
+		return nil, errors.Annotate(err, "ovsManagedBridges: looking for ovs-vsctl")
+	}
+
+	// Query list of ovs-managed device names
+	res, err := getCommandOutput(exec.Command("ovs-vsctl", "list-br"))
+	if err != nil {
+		return nil, errors.Annotate(err, "querying ovs-managed bridges via ovs-vsctl")
+	}
+
+	ovsBridges := set.NewStrings()
+	for _, iface := range strings.Split(string(res), "\n") {
+		if iface = strings.TrimSpace(iface); iface != "" {
+			ovsBridges.Add(iface)
+		}
+	}
+
+	return ifaceList.Filter(func(iface corenetwork.InterfaceInfo) bool {
+		return ovsBridges.Contains(iface.InterfaceName)
+	}), nil
 }

--- a/container/broker/broker_internal_test.go
+++ b/container/broker/broker_internal_test.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package broker
+
+import (
+	"os/exec"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+)
+
+type brokerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&brokerSuite{})
+
+func (s *brokerSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+}
+
+func (s *brokerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+}
+
+func (s *brokerSuite) TestExistingOVSManagedBridges(c *gc.C) {
+	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
+	// detect it in the path
+	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
+	s.PatchValue(&getCommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
+		c.Assert(cmd.Args, gc.DeepEquals, []string{"ovs-vsctl", "list-br"}, gc.Commentf("expected ovs-vsctl to be invoked with 'list-br' as an argument"))
+		return []byte("ovsbr1" + "\n"), nil
+	})
+
+	ifaces := network.InterfaceInfos{
+		{InterfaceName: "eth0"},
+		{InterfaceName: "eth1"},
+		{InterfaceName: "lxdbr0"},
+		{InterfaceName: "ovsbr1"},
+	}
+
+	ovsIfaces, err := ovsManagedBridges(ifaces)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ovsIfaces, gc.HasLen, 1, gc.Commentf("expected ovs-managed bridge list to contain a single entry"))
+	c.Assert(ovsIfaces[0].InterfaceName, gc.Equals, "ovsbr1", gc.Commentf("expected ovs-managed bridge list to contain iface 'ovsbr1'"))
+}
+
+func (s *brokerSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
+	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
+	// detect it in the path
+	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
+	s.PatchValue(&getCommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
+		c.Assert(cmd.Args, gc.DeepEquals, []string{"ovs-vsctl", "list-br"}, gc.Commentf("expected ovs-vsctl to be invoked with 'list-br' as an argument"))
+		return []byte("\n"), nil
+	})
+
+	ifaces := network.InterfaceInfos{
+		{InterfaceName: "eth0"},
+		{InterfaceName: "eth1"},
+		{InterfaceName: "lxdbr0"},
+	}
+
+	ovsIfaces, err := ovsManagedBridges(ifaces)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
+}
+
+func (s *brokerSuite) TestMissingOVSTools(c *gc.C) {
+	ifaces := network.InterfaceInfos{{InterfaceName: "eth0"}}
+	ovsIfaces, err := ovsManagedBridges(ifaces)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
+}

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -282,6 +282,25 @@ func (s InterfaceInfos) Children(parentName string) InterfaceInfos {
 	return children
 }
 
+// InterfaceFilterFunc is a function that can be applied to filter a slice of
+// InterfaceInfo instances. Calls to this function should return false if
+// the specified InterfaceInfo should be filtered out.
+type InterfaceFilterFunc func(InterfaceInfo) bool
+
+// Filter applies keepFn to each entry in a InterfaceInfos list and returns
+// back a filtered list containing the entries for which predicateFn returned
+// true.
+func (s InterfaceInfos) Filter(predicateFn InterfaceFilterFunc) InterfaceInfos {
+	var out InterfaceInfos
+	for _, iface := range s {
+		if !predicateFn(iface) {
+			continue
+		}
+		out = append(out, iface)
+	}
+	return out
+}
+
 // ProviderInterfaceInfo holds enough information to identify an
 // interface or link layer device to a provider so that it can be
 // queried or manipulated. Its initial purpose is to pass to


### PR DESCRIPTION
## Description of change

This PR is part of the OVS/bond work. In order to be able to configure lxd/kvm to work with OVS-managed bridge devices we must first detect their presence. 

The PR queries the list of OVS bridge names via the `ovs-vsctl` tool (if present) and uses this information to select the appropriate `InterfaceInfo` entries that correspond to them.

## QA steps

Coming up in a followup PR..