### PR TITLE
Machine agent tests: increase timeout in TestJobManageModelRunsMinUnitsWorker

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -688,7 +688,7 @@ func (s *MachineSuite) TestJobManageModelRunsMinUnitsWorker(c *gc.C) {
 		// Trigger a sync on the state used by the agent, and wait for the unit
 		// to be created.
 		agentState.StartSync()
-		timeout := time.After(coretesting.LongWait)
+		timeout := time.After(longerWait)
 		for {
 			select {
 			case <-timeout:


### PR DESCRIPTION
## Description of change

Now that the agent that gets run in the machine agent tests uses raft leases, the raft workers sometimes take too long to get started and ready, which made `TestJobManageModelRunsMinUnitsWorker` sometimes fail. Use the longer timeout (double the LongWait) that other tests in the suite already use.

## QA steps

Running the test under stress doesn't fail after a lot of runs.


## Documentation changes

None

## Bug reference

None
