### PR TITLE
Expose the engine worker restart time as a package variable.

### DIFF
--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -24,6 +24,11 @@ import (
 	"github.com/juju/juju/cmd/jujud/util"
 )
 
+// EngineErrorDelay is the amount of time the dependency engine waits
+// between getting an error from a worker, and restarting it. It is exposed
+// here so tests can make it smaller.
+var EngineErrorDelay = 3 * time.Second
+
 // AgentConf is a terribly confused interface.
 //
 // Parts of it are a mixin for cmd.Command implementations; others are a mixin
@@ -163,7 +168,7 @@ func dependencyEngineConfig() dependency.EngineConfig {
 	return dependency.EngineConfig{
 		IsFatal:          util.IsFatal,
 		WorstError:       util.MoreImportantError,
-		ErrorDelay:       3 * time.Second,
+		ErrorDelay:       EngineErrorDelay,
 		BounceDelay:      10 * time.Millisecond,
 		BackoffFactor:    1.2,
 		BackoffResetTime: 1 * time.Minute,

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -100,6 +100,9 @@ func (s *MachineSuite) SetUpTest(c *gc.C) {
 	s.commonMachineSuite.SetUpTest(c)
 	bootstrapRaft(c, s.DataDir())
 
+	// Restart failed workers much faster for the tests.
+	s.PatchValue(&EngineErrorDelay, 100*time.Millisecond)
+
 	// Most of these tests normally finish sub-second on a fast machine.
 	// If any given test hits a minute, we have almost certainly become
 	// wedged, so dump the logs.


### PR DESCRIPTION
This allows tests to change the restart time so older wall clock
type tests don't have to wait three seconds for workers to restart.

In particular some of the MachineSuite tests are impacted by this as
the api caller worker is restarted when the addresses change. Which is
signalled by another worker.

Without this patch, the TestManageModelRunsCleaner test ran in approx
six seconds, ten seconds, or timed out about one in 12. With this patch
the test is a consistent six seconds, which is still too long, but
at least consistent.

## QA steps

```sh
cd cmd/jujud/agent
stress -check.v -check.f TestManageModelRunsCleaner
```

## Documentation changes

Test change only.

