### PR TITLE
Fix/caas uniter restart

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -520,6 +520,8 @@ func (op *caasOperator) loop() (err error) {
 					case <-op.catacomb.Dying():
 						return op.catacomb.ErrDying()
 					case runningChan <- struct{}{}:
+					default:
+						logger.Warningf("runningChan[%q] is blocked", unitID)
 					}
 				}
 			}

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -138,7 +138,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		UniterFacadeFunc:      s.uniterFacadeFunc,
 		RunListenerSocketFunc: s.runListenerSocketFunc,
 		StartUniterFunc:       func(runner *worker.Runner, params *uniter.UniterParams) error { return nil },
-		ExecClient:            s.mockExecutor,
+		ExecClientGetter:      func() (exec.Executor, error) { return s.mockExecutor, nil },
 		Logger:                loggo.GetLogger("test"),
 	}
 

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -188,11 +188,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				}
 			}
 
-			execClient, err := config.NewExecClient(os.Getenv(provider.OperatorNamespaceEnvName))
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-
 			wCfg := Config{
 				Logger:                config.Logger,
 				ModelUUID:             agentConfig.Model().Id(),
@@ -213,7 +208,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				RunListenerSocketFunc: runListenerSocketFunc,
 				LeadershipTrackerFunc: leadershipTrackerFunc,
 				UniterFacadeFunc:      newUniterFunc,
-				ExecClient:            execClient,
+				ExecClientGetter: func() (exec.Executor, error) {
+					return config.NewExecClient(os.Getenv(provider.OperatorNamespaceEnvName))
+				},
 			}
 
 			loadOperatorInfoFunc := config.LoadOperatorInfo

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -181,7 +181,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(config.UniterParams.UpdateStatusSignal, gc.NotNil)
 	c.Assert(config.UniterParams.NewOperationExecutor, gc.NotNil)
 	c.Assert(config.Logger, gc.NotNil)
-	c.Assert(config.ExecClient, gc.NotNil)
+	c.Assert(config.ExecClientGetter, gc.NotNil)
 	config.LeadershipTrackerFunc = nil
 	config.StartUniterFunc = nil
 	config.UniterFacadeFunc = nil
@@ -189,7 +189,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.UniterParams.UpdateStatusSignal = nil
 	config.UniterParams.NewOperationExecutor = nil
 	config.Logger = nil
-	config.ExecClient = nil
+	config.ExecClientGetter = nil
 
 	c.Assert(config.UniterParams.SocketConfig.TLSConfig, gc.NotNil)
 	config.UniterParams.SocketConfig.TLSConfig = nil

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -87,6 +87,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err := context.Get(config.LeadershipTrackerName, &leadershipTracker); err != nil {
 				return nil, err
 			}
+			leadershipTrackerFunc := func(_ names.UnitTag) leadership.TrackerWorker {
+				return leadershipTracker
+			}
 			var charmDirGuard fortress.Guard
 			if err := context.Get(config.CharmDirName, &charmDirGuard); err != nil {
 				return nil, err
@@ -109,21 +112,21 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			uniterFacade := uniter.NewState(apiConn, unitTag)
 			uniter, err := NewUniter(&UniterParams{
-				UniterFacade:         uniterFacade,
-				UnitTag:              unitTag,
-				ModelType:            model.IAAS,
-				LeadershipTracker:    leadershipTracker,
-				DataDir:              agentConfig.DataDir(),
-				Downloader:           downloader,
-				MachineLock:          manifoldConfig.MachineLock,
-				CharmDirGuard:        charmDirGuard,
-				UpdateStatusSignal:   NewUpdateStatusTimer(),
-				HookRetryStrategy:    hookRetryStrategy,
-				NewOperationExecutor: operation.NewExecutor,
-				TranslateResolverErr: config.TranslateResolverErr,
-				Clock:                manifoldConfig.Clock,
-				RebootQuerier:        reboot.NewMonitor(agentConfig.TransientDataDir()),
-				Logger:               config.Logger,
+				UniterFacade:          uniterFacade,
+				UnitTag:               unitTag,
+				ModelType:             model.IAAS,
+				LeadershipTrackerFunc: leadershipTrackerFunc,
+				DataDir:               agentConfig.DataDir(),
+				Downloader:            downloader,
+				MachineLock:           manifoldConfig.MachineLock,
+				CharmDirGuard:         charmDirGuard,
+				UpdateStatusSignal:    NewUpdateStatusTimer(),
+				HookRetryStrategy:     hookRetryStrategy,
+				NewOperationExecutor:  operation.NewExecutor,
+				TranslateResolverErr:  config.TranslateResolverErr,
+				Clock:                 manifoldConfig.Clock,
+				RebootQuerier:         reboot.NewMonitor(agentConfig.TransientDataDir()),
+				Logger:                config.Logger,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -204,9 +204,8 @@ func (w *RemoteStateWatcher) CommandCompleted(completed string) {
 	}
 }
 
-func (w *RemoteStateWatcher) setUp(unitTag names.UnitTag) error {
+func (w *RemoteStateWatcher) setUp(unitTag names.UnitTag) (err error) {
 	// TODO(axw) move this logic
-	var err error
 	defer func() {
 		cause := errors.Cause(err)
 		if params.IsCodeNotFoundOrCodeUnauthorized(cause) {
@@ -465,7 +464,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			}
 			runningStatus, err := w.containerRunningStatusFunc(w.current.ProviderID)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Annotatef(err, "getting container running status for %q", unitTag.String())
 			}
 			w.containerRunningStatus(*runningStatus)
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -263,14 +263,16 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 
 	defer func() {
 		// If this is a CAAS unit, then dead errors are fairly normal ways to exit
-		// the uniter main loop, but the actual agent needs to keep running.
+		// the uniter main loop, but the parent operator agent needs to keep running.
 		if errors.Cause(err) == ErrCAASUnitDead {
 			err = nil
 		}
 		if u.runListener != nil {
 			u.runListener.UnregisterRunner(u.unit.Name())
 		}
-		u.localRunListener.UnregisterRunner(u.unit.Name())
+		if u.localRunListener != nil {
+			u.localRunListener.UnregisterRunner(u.unit.Name())
+		}
 		u.logger.Infof("unit %q shutting down: %s", u.unit, err)
 	}()
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -153,7 +153,7 @@ type UniterParams struct {
 	UniterFacade                  *uniter.State
 	UnitTag                       names.UnitTag
 	ModelType                     model.ModelType
-	LeadershipTracker             leadership.TrackerWorker
+	LeadershipTrackerFunc         func(names.UnitTag) leadership.TrackerWorker
 	DataDir                       string
 	Downloader                    charm.Downloader
 	MachineLock                   machinelock.Lock
@@ -215,31 +215,31 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 	if translateResolverErr == nil {
 		translateResolverErr = func(err error) error { return err }
 	}
-	u := &Uniter{
-		st:                            uniterParams.UniterFacade,
-		paths:                         NewPaths(uniterParams.DataDir, uniterParams.UnitTag, uniterParams.SocketConfig),
-		modelType:                     uniterParams.ModelType,
-		hookLock:                      uniterParams.MachineLock,
-		leadershipTracker:             uniterParams.LeadershipTracker,
-		charmDirGuard:                 uniterParams.CharmDirGuard,
-		updateStatusAt:                uniterParams.UpdateStatusSignal,
-		hookRetryStrategy:             uniterParams.HookRetryStrategy,
-		newOperationExecutor:          uniterParams.NewOperationExecutor,
-		newRemoteRunnerExecutor:       uniterParams.NewRemoteRunnerExecutor,
-		remoteInitFunc:                uniterParams.RemoteInitFunc,
-		translateResolverErr:          translateResolverErr,
-		observer:                      uniterParams.Observer,
-		clock:                         uniterParams.Clock,
-		downloader:                    uniterParams.Downloader,
-		applicationChannel:            uniterParams.ApplicationChannel,
-		containerRunningStatusChannel: uniterParams.ContainerRunningStatusChannel,
-		containerRunningStatusFunc:    uniterParams.ContainerRunningStatusFunc,
-		isRemoteUnit:                  uniterParams.IsRemoteUnit,
-		runListener:                   uniterParams.RunListener,
-		rebootQuerier:                 uniterParams.RebootQuerier,
-		logger:                        uniterParams.Logger,
-	}
 	startFunc := func() (worker.Worker, error) {
+		u := &Uniter{
+			st:                            uniterParams.UniterFacade,
+			paths:                         NewPaths(uniterParams.DataDir, uniterParams.UnitTag, uniterParams.SocketConfig),
+			modelType:                     uniterParams.ModelType,
+			hookLock:                      uniterParams.MachineLock,
+			leadershipTracker:             uniterParams.LeadershipTrackerFunc(uniterParams.UnitTag),
+			charmDirGuard:                 uniterParams.CharmDirGuard,
+			updateStatusAt:                uniterParams.UpdateStatusSignal,
+			hookRetryStrategy:             uniterParams.HookRetryStrategy,
+			newOperationExecutor:          uniterParams.NewOperationExecutor,
+			newRemoteRunnerExecutor:       uniterParams.NewRemoteRunnerExecutor,
+			remoteInitFunc:                uniterParams.RemoteInitFunc,
+			translateResolverErr:          translateResolverErr,
+			observer:                      uniterParams.Observer,
+			clock:                         uniterParams.Clock,
+			downloader:                    uniterParams.Downloader,
+			applicationChannel:            uniterParams.ApplicationChannel,
+			containerRunningStatusChannel: uniterParams.ContainerRunningStatusChannel,
+			containerRunningStatusFunc:    uniterParams.ContainerRunningStatusFunc,
+			isRemoteUnit:                  uniterParams.IsRemoteUnit,
+			runListener:                   uniterParams.RunListener,
+			rebootQuerier:                 uniterParams.RebootQuerier,
+			logger:                        uniterParams.Logger,
+		}
 		plan := catacomb.Plan{
 			Site: &u.catacomb,
 			Work: func() error {
@@ -260,6 +260,20 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 }
 
 func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
+
+	defer func() {
+		// If this is a CAAS unit, then dead errors are fairly normal ways to exit
+		// the uniter main loop, but the actual agent needs to keep running.
+		if errors.Cause(err) == ErrCAASUnitDead {
+			err = nil
+		}
+		if u.runListener != nil {
+			u.runListener.UnregisterRunner(u.unit.Name())
+		}
+		u.localRunListener.UnregisterRunner(u.unit.Name())
+		u.logger.Infof("unit %q shutting down: %s", u.unit, err)
+	}()
+
 	if err := u.init(unitTag); err != nil {
 		switch cause := errors.Cause(err); cause {
 		case resolver.ErrLoopAborted:
@@ -512,17 +526,6 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			break
 		}
 	}
-
-	// If this is a CAAS unit, then dead errors are fairly normal ways to exit
-	// the uniter main loop, but the actual agent needs to keep running.
-	if errors.Cause(err) == ErrCAASUnitDead {
-		err = nil
-	}
-	if u.runListener != nil {
-		u.runListener.UnregisterRunner(u.unit.Name())
-	}
-	u.localRunListener.UnregisterRunner(u.unit.Name())
-	u.logger.Infof("unit %q shutting down: %s", u.unit, err)
 	return err
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -498,10 +498,12 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 	}
 
 	uniterParams := uniter.UniterParams{
-		UniterFacade:         ctx.api,
-		UnitTag:              tag,
-		ModelType:            model.IAAS,
-		LeadershipTracker:    ctx.leaderTracker,
+		UniterFacade: ctx.api,
+		UnitTag:      tag,
+		ModelType:    model.IAAS,
+		LeadershipTrackerFunc: func(_ names.UnitTag) leadership.TrackerWorker {
+			return ctx.leaderTracker
+		},
 		CharmDirGuard:        ctx.charmDirGuard,
 		DataDir:              ctx.dataDir,
 		Downloader:           downloader,


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Fixes:
1. Uniter should not block the `containerStartChan` in operator;
2. Change to use sharing exec client for uniters;
3. CAAS uniter now can restart itself correctly;

## QA steps

```console
$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb --storage database=100M

## exec into operator to enable wrench
$ mkubectl exec pod/mariadb-k8s-operator-0  -n t1 -it -- bash

## enable wrench
$ mkdir wrench && echo "fatal-error" > wrench/remote-init

## scale application to 2 to create a new unit
$ juju scale-application mariadb-k8s -m t1 2

## from the log we can see uniter tries to restart itself because the wrench returns an error in remote init process
$ juju debug-log -m k1:t1 --color --replay --level WARNING

## remove wrench in the operator pod;
$ rm wrench/remote-init

## now we can see the uniter restarts successfully;

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1878329
