### PR TITLE
2.8 - Add GetByHardwareAddress to InterfaceInfos

### DIFF
--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -282,6 +282,18 @@ func (s InterfaceInfos) Children(parentName string) InterfaceInfos {
 	return children
 }
 
+// GetByHardwareAddress returns a reference to the interface with the input
+// hardware address (such as a MAC address) if it exists in the collection,
+// otherwise nil is returned.
+func (s InterfaceInfos) GetByHardwareAddress(hwAddr string) *InterfaceInfo {
+	for _, dev := range s {
+		if dev.MACAddress == hwAddr {
+			return &dev
+		}
+	}
+	return nil
+}
+
 // ProviderInterfaceInfo holds enough information to identify an
 // interface or link layer device to a provider so that it can be
 // queried or manipulated. Its initial purpose is to pass to

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -19,7 +19,7 @@ var _ = gc.Suite(&nicSuite{})
 
 func (s *nicSuite) SetUpTest(_ *gc.C) {
 	s.info = network.InterfaceInfos{
-		{VLANTag: 1, DeviceIndex: 0, InterfaceName: "eth0"},
+		{VLANTag: 1, DeviceIndex: 0, InterfaceName: "eth0", MACAddress: "00:16:3e:aa:bb:cc"},
 		{VLANTag: 0, DeviceIndex: 1, InterfaceName: "eth1"},
 		{VLANTag: 42, DeviceIndex: 2, InterfaceName: "br2"},
 		{ConfigType: network.ConfigDHCP, NoAutoStart: true},
@@ -131,6 +131,14 @@ func (*nicSuite) TestInterfaceInfosIterHierarchy(c *gc.C) {
 		"bond0:eth1",
 		":eth2",
 	})
+}
+
+func (s *nicSuite) TestInterfaceInfosGetByHardwareAddress(c *gc.C) {
+	dev := s.info.GetByHardwareAddress("not-there")
+	c.Assert(dev, gc.IsNil)
+
+	dev = s.info.GetByHardwareAddress("00:16:3e:aa:bb:cc")
+	c.Assert(dev.InterfaceName, gc.Equals, "eth0")
 }
 
 func getInterFaceInfos() network.InterfaceInfos {


### PR DESCRIPTION
## Description of change

This patch adds a simple utility method for retrieving a device by MAC address from `InterfaceInfos`.

## QA steps

Covered by unit tests. QA to follow with a patch using this method.

## Documentation changes

None.

## Bug reference

N/A
