### PR TITLE
Introduces centralised SNI tls getter.

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -686,6 +686,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Clock:                config.Clock,
 			MuxShutdownWait:      config.MuxShutdownWait,
 			LogDir:               agentConfig.LogDir(),
+			Logger:               loggo.GetLogger("juju.worker.httpserver"),
 			GetControllerConfig:  httpserver.GetControllerConfig,
 			NewTLSConfig:         httpserver.NewTLSConfig,
 			NewWorker:            httpserver.NewWorkerShim,

--- a/pki/tls/package_test.go
+++ b/pki/tls/package_test.go
@@ -1,0 +1,12 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package tls_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestSuite(t *testing.T) { gc.TestingT(t) }

--- a/pki/tls/sni.go
+++ b/pki/tls/sni.go
@@ -1,30 +1,38 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package pki
+package tls
 
 import (
 	"crypto/tls"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/pki"
 )
+
+type Logger interface {
+	Debugf(string, ...interface{})
+}
 
 // AuthoritySNITLSGetter is responsible for performing the crypto/tls get
 // function. It allows support for SNI by selecting a certificate from a
 // supplied  authority that best matches the client hellow message.
-func AuthoritySNITLSGetter(authority Authority) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+func AuthoritySNITLSGetter(authority pki.Authority, logger Logger) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		logger.Debugf("recieved tls client hello for server name %s", hello.ServerName)
 		var cert *tls.Certificate
-		authority.LeafRange(func(leaf Leaf) bool {
+		authority.LeafRange(func(leaf pki.Leaf) bool {
 			if err := hello.SupportsCertificate(leaf.TLSCertificate()); err == nil {
 				cert = leaf.TLSCertificate()
-				return true
+				return false
 			}
-			return false
+			return true
 		})
 
 		if cert == nil {
-			leaf, err := authority.LeafForGroup(DefaultLeafGroup)
+			logger.Debugf("no matching certificate found for tls client hello %s, using default certificate", hello.ServerName)
+			leaf, err := authority.LeafForGroup(pki.DefaultLeafGroup)
 			if err != nil {
 				return nil, errors.New("tls: no certificates configured")
 			}

--- a/pki/tls/sni_test.go
+++ b/pki/tls/sni_test.go
@@ -1,0 +1,115 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package tls_test
+
+import (
+	"crypto/tls"
+	"net"
+
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/pki"
+	pkitest "github.com/juju/juju/pki/test"
+	pkitls "github.com/juju/juju/pki/tls"
+)
+
+type SNISuite struct {
+	authority pki.Authority
+	sniGetter func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+}
+
+var _ = gc.Suite(&SNISuite{})
+
+func (s *SNISuite) SetUpSuite(c *gc.C) {
+	pki.DefaultKeyProfile = pkitest.OriginalDefaultKeyProfile
+	authority, err := pkitest.NewTestAuthority()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.authority = authority
+	s.sniGetter = pkitls.AuthoritySNITLSGetter(authority, loggo.Logger{})
+}
+
+func TLSCertificatesEqual(c *gc.C, cert1, cert2 *tls.Certificate) {
+	c.Assert(len(cert1.Certificate), gc.Equals, len(cert2.Certificate))
+	for i := range cert1.Certificate {
+		c.Assert(cert1.Certificate[i], jc.DeepEquals, cert2.Certificate[i])
+	}
+}
+
+func (s *SNISuite) TestAuthorityTLSGetter(c *gc.C) {
+	tests := []struct {
+		DNSNames      []string
+		ExpectedGroup string
+		Group         string
+		IPAddresses   []net.IP
+		ServerName    string
+	}{
+		{
+			// Testing 1 to 1 mapping
+			DNSNames:      []string{"juju.is"},
+			ExpectedGroup: "test1",
+			Group:         "test1",
+			ServerName:    "juju.is",
+		},
+		{
+			// Testing v4 address mapping
+			ExpectedGroup: "test2",
+			Group:         "test2",
+			IPAddresses:   []net.IP{net.ParseIP("10.0.0.1")},
+			ServerName:    "10.0.0.1",
+		},
+		{
+			// Testing wild card certificates
+			DNSNames:      []string{"*.juju.is"},
+			ExpectedGroup: "test3",
+			Group:         "test3",
+			ServerName:    "tlm.juju.is",
+		},
+		{
+			// Testing v6 address mapping
+			ExpectedGroup: "test4",
+			Group:         "test4",
+			IPAddresses:   []net.IP{net.ParseIP("fe80:abcd::1")},
+			ServerName:    "fe80:abcd::1",
+		},
+		{
+			// Test Prevision wild card cert
+			ExpectedGroup: "test3",
+			Group:         "test5",
+			IPAddresses:   []net.IP{net.ParseIP("fe80:abcd::2")},
+			ServerName:    "wallyworld.juju.is",
+		},
+		{
+			// Testing default certificate
+			DNSNames:      []string{"juju-apiserver"},
+			ExpectedGroup: pki.DefaultLeafGroup,
+			Group:         pki.DefaultLeafGroup,
+			ServerName:    "doesnotexist.juju.example",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := s.authority.LeafRequestForGroup(test.Group).
+			AddDNSNames(test.DNSNames...).
+			AddIPAddresses(test.IPAddresses...).
+			Commit()
+		c.Assert(err, jc.ErrorIsNil)
+
+		helloRequest := &tls.ClientHelloInfo{
+			ServerName:        test.ServerName,
+			SignatureSchemes:  []tls.SignatureScheme{tls.PSSWithSHA256},
+			SupportedVersions: []uint16{tls.VersionTLS13, tls.VersionTLS12},
+		}
+
+		cert, err := s.sniGetter(helloRequest)
+		c.Assert(err, jc.ErrorIsNil)
+
+		leaf, err := s.authority.LeafForGroup(test.ExpectedGroup)
+		c.Assert(err, jc.ErrorIsNil)
+
+		TLSCertificatesEqual(c, cert, leaf.TLSCertificate())
+	}
+}

--- a/worker/httpserver/cert_test.go
+++ b/worker/httpserver/cert_test.go
@@ -24,8 +24,8 @@ type certSuite struct {
 
 var _ = gc.Suite(&certSuite{})
 
-func testSNIGetter(cert *tls.Certificate) httpserver.SNIGetter {
-	return httpserver.SNIGetterFn(func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func testSNIGetter(cert *tls.Certificate) httpserver.SNIGetterFunc {
+	return httpserver.SNIGetterFunc(func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		return cert, nil
 	})
 }
@@ -37,6 +37,7 @@ func (s *certSuite) SetUpTest(c *gc.C) {
 		"https://0.1.2.3/no-autocert-here",
 		nil,
 		testSNIGetter(coretesting.ServerTLSCert),
+		loggo.GetLogger("test"),
 	)
 	// Copy the root CAs across.
 	tlsConfig.RootCAs = s.config.TLSConfig.RootCAs
@@ -74,6 +75,7 @@ func (s *certSuite) TestAutocertFailure(c *gc.C) {
 		"https://0.1.2.3/no-autocert-here",
 		nil,
 		testSNIGetter(coretesting.ServerTLSCert),
+		loggo.GetLogger("test"),
 	)
 	s.config.TLSConfig = tlsConfig
 
@@ -114,6 +116,7 @@ func (s *certSuite) TestAutocertNameMismatch(c *gc.C) {
 		"https://0.1.2.3/no-autocert-here",
 		nil,
 		testSNIGetter(coretesting.ServerTLSCert),
+		loggo.GetLogger("test"),
 	)
 	s.config.TLSConfig = tlsConfig
 

--- a/worker/httpserver/logging.go
+++ b/worker/httpserver/logging.go
@@ -11,7 +11,7 @@ import "github.com/juju/loggo"
 // the string content. For now, we just want to get the messages into the log
 // file.
 type loggoWrapper struct {
-	logger loggo.Logger
+	logger Logger
 	level  loggo.Level
 }
 

--- a/worker/httpserver/manifold_test.go
+++ b/worker/httpserver/manifold_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -82,6 +83,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		GetControllerConfig:  s.getControllerConfig,
 		NewTLSConfig:         s.newTLSConfig,
 		NewWorker:            s.newWorker,
+		Logger:               loggo.GetLogger("test"),
 	}
 	s.manifold = httpserver.Manifold(s.config)
 }
@@ -111,7 +113,8 @@ func (s *ManifoldSuite) getControllerConfig(st *state.State) (controller.Config,
 
 func (s *ManifoldSuite) newTLSConfig(
 	st *state.State,
-	_ httpserver.SNIGetter,
+	_ httpserver.SNIGetterFunc,
+	_ httpserver.Logger,
 ) (*tls.Config, error) {
 	s.stub.MethodCall(s, "NewTLSConfig", st)
 	if err := s.stub.NextErr(); err != nil {
@@ -173,6 +176,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		ControllerAPIPort:    2048,
 		MuxShutdownWait:      1 * time.Minute,
 		LogDir:               "log-dir",
+		Logger:               s.config.Logger,
 	})
 }
 

--- a/worker/httpserver/tls.go
+++ b/worker/httpserver/tls.go
@@ -11,26 +11,17 @@ import (
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 
-	"github.com/juju/juju/pki"
 	"github.com/juju/juju/state"
 )
 
-type SNIGetter interface {
-	GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
-}
+type SNIGetterFunc func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 
-type SNIGetterFn func(*tls.ClientHelloInfo) (*tls.Certificate, error)
-
-func (fn SNIGetterFn) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	return fn(hello)
-}
-
-func aggregateSNIGetter(getters ...SNIGetter) SNIGetter {
-	return SNIGetterFn(func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func aggregateSNIGetter(getters ...SNIGetterFunc) SNIGetterFunc {
+	return SNIGetterFunc(func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		lastErr := errors.Errorf("unable to find certificate for %s",
 			hello.ServerName)
 		for _, getter := range getters {
-			cert, err := getter.GetCertificate(hello)
+			cert, err := getter(hello)
 			if err != nil {
 				lastErr = err
 				continue
@@ -43,39 +34,9 @@ func aggregateSNIGetter(getters ...SNIGetter) SNIGetter {
 	})
 }
 
-func authoritySNIGetter(authority pki.Authority) SNIGetter {
-	return SNIGetterFn(func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-		var cert *tls.Certificate
-		if hello.ServerName != "" {
-			authority.LeafRange(func(leaf pki.Leaf) bool {
-				// TODO when juju is upgraded to go 1.14 we should change this to
-				// use ClientHelloInfo.SupportsCertificate
-
-				tlsCert := leaf.TLSCertificate()
-				if tlsCert.Leaf == nil {
-					return true
-				} else if err := tlsCert.Leaf.VerifyHostname(hello.ServerName); err == nil {
-					cert = leaf.TLSCertificate()
-					return false
-				}
-				return true
-			})
-		}
-
-		if cert == nil {
-			leaf, err := authority.LeafForGroup(pki.DefaultLeafGroup)
-			if err != nil {
-				return nil, errors.New("tls: no certificates configured")
-			}
-			cert = leaf.TLSCertificate()
-		}
-		return cert, nil
-	})
-}
-
 // NewTLSConfig returns the TLS configuration for the HTTP server to use
 // based on controller configuration stored in the state database.
-func NewTLSConfig(st *state.State, defaultSNI SNIGetter) (*tls.Config, error) {
+func NewTLSConfig(st *state.State, defaultSNI SNIGetterFunc, logger Logger) (*tls.Config, error) {
 	controllerConfig, err := st.ControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -85,18 +46,20 @@ func NewTLSConfig(st *state.State, defaultSNI SNIGetter) (*tls.Config, error) {
 		controllerConfig.AutocertURL(),
 		st.AutocertCache(),
 		defaultSNI,
+		logger,
 	), nil
 }
 
 func newTLSConfig(
 	autocertDNSName, autocertURL string,
 	autocertCache autocert.Cache,
-	defaultSNI SNIGetter,
+	defaultSNI SNIGetterFunc,
+	logger Logger,
 ) *tls.Config {
 	tlsConfig := utils.SecureTLSConfig()
 	if autocertDNSName == "" {
 		// No official DNS name, no certificate.
-		tlsConfig.GetCertificate = defaultSNI.GetCertificate
+		tlsConfig.GetCertificate = defaultSNI
 		return tlsConfig
 	}
 
@@ -110,12 +73,12 @@ func newTLSConfig(
 			DirectoryURL: autocertURL,
 		}
 	}
-	certLogger := SNIGetterFn(func(h *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	certLogger := SNIGetterFunc(func(h *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		logger.Infof("getting certificate for server name %q", h.ServerName)
 		return nil, nil
 	})
 
-	autoCertGetter := SNIGetterFn(func(h *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	autoCertGetter := SNIGetterFunc(func(h *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		c, err := m.GetCertificate(h)
 		if err != nil {
 			logger.Errorf("cannot get autocert certificate for %q: %v",
@@ -125,7 +88,7 @@ func newTLSConfig(
 	})
 
 	tlsConfig.GetCertificate = aggregateSNIGetter(
-		certLogger, autoCertGetter, defaultSNI).GetCertificate
+		certLogger, autoCertGetter, defaultSNI)
 	tlsConfig.NextProtos = []string{
 		"h2", "http/1.1", // Enable HTTP/2.
 		acme.ALPNProto, // Enable TLS-ALPN ACME challenges.

--- a/worker/httpserver/tls_state_test.go
+++ b/worker/httpserver/tls_state_test.go
@@ -9,10 +9,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/juju/juju/worker/httpserver"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/crypto/acme"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/httpserver"
 )
 
 type tlsStateFixture struct {
@@ -40,7 +42,11 @@ type TLSStateSuite struct {
 var _ = gc.Suite(&TLSStateSuite{})
 
 func (s *TLSStateSuite) TestNewTLSConfig(c *gc.C) {
-	tlsConfig, err := httpserver.NewTLSConfig(s.State, testSNIGetter(s.cert))
+	tlsConfig, err := httpserver.NewTLSConfig(
+		s.State,
+		testSNIGetter(s.cert),
+		loggo.GetLogger("test"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cert, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{
@@ -76,7 +82,11 @@ func (s *TLSStateAutocertSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *TLSStateAutocertSuite) TestAutocertExceptions(c *gc.C) {
-	tlsConfig, err := httpserver.NewTLSConfig(s.State, testSNIGetter(s.cert))
+	tlsConfig, err := httpserver.NewTLSConfig(
+		s.State,
+		testSNIGetter(s.cert),
+		loggo.GetLogger("test"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.testGetCertificate(c, tlsConfig, "127.0.0.1")
 	s.testGetCertificate(c, tlsConfig, "juju-apiserver")
@@ -85,7 +95,11 @@ func (s *TLSStateAutocertSuite) TestAutocertExceptions(c *gc.C) {
 }
 
 func (s *TLSStateAutocertSuite) TestAutocert(c *gc.C) {
-	tlsConfig, err := httpserver.NewTLSConfig(s.State, testSNIGetter(s.cert))
+	tlsConfig, err := httpserver.NewTLSConfig(
+		s.State,
+		testSNIGetter(s.cert),
+		loggo.GetLogger("test"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.testGetCertificate(c, tlsConfig, "public.invalid")
 	c.Assert(s.autocertQueried, jc.IsTrue)
@@ -93,7 +107,11 @@ func (s *TLSStateAutocertSuite) TestAutocert(c *gc.C) {
 }
 
 func (s *TLSStateAutocertSuite) TestAutocertHostPolicy(c *gc.C) {
-	tlsConfig, err := httpserver.NewTLSConfig(s.State, testSNIGetter(s.cert))
+	tlsConfig, err := httpserver.NewTLSConfig(
+		s.State,
+		testSNIGetter(s.cert),
+		loggo.GetLogger("test"),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.testGetCertificate(c, tlsConfig, "always.invalid")
 	c.Assert(s.autocertQueried, jc.IsFalse)

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -67,6 +68,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		APIPort:              0,
 		APIPortOpenDelay:     0,
 		ControllerAPIPort:    0,
+		Logger:               loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/muxhttpserver/server.go
+++ b/worker/muxhttpserver/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/pki"
+	pkitls "github.com/juju/juju/pki/tls"
 )
 
 type Config struct {
@@ -21,6 +22,7 @@ type Config struct {
 }
 
 type Logger interface {
+	Debugf(string, ...interface{})
 	Errorf(string, ...interface{})
 	Infof(string, ...interface{})
 }
@@ -40,7 +42,7 @@ func NewServer(authority pki.Authority, logger Logger, conf Config) (*Server, er
 	mux := apiserverhttp.NewMux()
 
 	tlsConfig := &tls.Config{
-		GetCertificate: pki.AuthoritySNITLSGetter(authority),
+		GetCertificate: pkitls.AuthoritySNITLSGetter(authority, logger),
 	}
 
 	httpServ := &http.Server{


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Aggregating SNI getter methods for all http servers onto a pki Authority.

## QA steps

Run tests in pki/tls and worker/httpserver

Bootstrap a controller and talk to it over it's API via client and deploying apps