### PR TITLE
Add support for bootstrapping to EKS;

### DIFF
--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -105,6 +105,9 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			newLabelRequirements(
 				requirementParams{"manufacturer", selection.Equals, []string{"amazon_ec2"}},
 			),
+			newLabelRequirements(
+				requirementParams{"eks.amazonaws.com/nodegroup", selection.Exists, nil},
+			),
 			// CDK on AWS.
 			newLabelRequirements(
 				requirementParams{"juju.io/cloud", selection.Equals, []string{"ec2"}},

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -132,6 +132,13 @@ var hostRegionsTestCases = []hostRegionTestcase{
 		}),
 	},
 	{
+		expectedCloud:   "ec2",
+		expectedRegions: set.NewStrings(""),
+		nodes: newNodeList(map[string]string{
+			"eks.amazonaws.com/nodegroup": "any-node-group",
+		}),
+	},
+	{
 		expectedRegions: set.NewStrings(),
 		nodes: newNodeList(map[string]string{
 			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -285,7 +285,7 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 				return errors.Errorf("do not specify --cloud when adding a GKE, EKS or AKS cluster")
 			}
 			if strings.Contains(c.hostCloudRegion, "/") {
-				return errors.Errorf("only specify region, not cloud/region, when adding a GKE or AKS cluster")
+				return errors.Errorf("only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster")
 			}
 		} else {
 			c.hostCloudRegion, err = c.tryEnsureCloudTypeForHostRegion(c.hostCloud, c.hostCloudRegion)

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -175,6 +175,7 @@ type AddCAASCommand struct {
 
 	gke        bool
 	aks        bool
+	eks        bool
 	k8sCluster k8sCluster
 
 	cloudMetadataStore    CloudMetadataStore
@@ -241,6 +242,16 @@ func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.resourceGroup, "resource-group", "", "the Azure resource group of the AKS cluster")
 	f.BoolVar(&c.gke, "gke", false, "used when adding a GKE cluster")
 	f.BoolVar(&c.aks, "aks", false, "used when adding an AKS cluster")
+	f.BoolVar(&c.eks, "eks", false, "used when adding an EKS cluster")
+}
+
+func countTrue(items ...bool) (count int) {
+	for _, item := range items {
+		if item {
+			count++
+		}
+	}
+	return count
 }
 
 // Init populates the command with the args from the command line.
@@ -251,8 +262,16 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 	if len(args) == 0 {
 		return errors.Errorf("missing k8s name.")
 	}
-	if c.gke && c.aks {
-		return errors.BadRequestf("only one of '--gke' or '--aks' can be supplied")
+
+	switch count := countTrue(c.aks, c.gke, c.eks); count {
+	case 1:
+		if c.contextName != "" {
+			return errors.New("do not specify context name when adding a AKS/GKE/EKS cluster")
+		}
+	default:
+		if count > 1 {
+			return errors.BadRequestf("only one of '--gke', '--eks' or '--aks' can be supplied")
+		}
 	}
 	c.caasType = "kubernetes"
 	c.caasName = args[0]
@@ -261,9 +280,9 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 		return errors.New("only specify one of cluster-name or context-name, not both")
 	}
 	if c.hostCloudRegion != "" || c.hostCloud != "" {
-		if c.gke || c.aks {
+		if c.gke || c.aks || c.eks {
 			if c.hostCloud != "" {
-				return errors.Errorf("do not specify --cloud when adding a GKE or AKS cluster")
+				return errors.Errorf("do not specify --cloud when adding a GKE, EKS or AKS cluster")
 			}
 			if strings.Contains(c.hostCloudRegion, "/") {
 				return errors.Errorf("only specify region, not cloud/region, when adding a GKE or AKS cluster")
@@ -278,15 +297,11 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 		c.givenHostCloudRegion = c.hostCloudRegion
 	}
 
+	// TODO(caas): consider to change --gke|--aks|--eks flag to sub commands in future version then we can move these
+	// cloud specific options/flags' validation to sub commands level.
 	if c.gke {
-		if c.contextName != "" {
-			return errors.New("do not specify context name when adding a GKE cluster")
-		}
 		if c.k8sCluster == nil {
 			c.k8sCluster = newGKECluster()
-		}
-		if err := c.k8sCluster.ensureExecutable(); err != nil {
-			return errors.Trace(err)
 		}
 	} else {
 		if c.project != "" {
@@ -295,16 +310,25 @@ func (c *AddCAASCommand) Init(args []string) (err error) {
 		if c.credential != "" {
 			return errors.New("do not specify credential unless adding a GKE cluster")
 		}
-		if c.aks {
-			if c.contextName != "" {
-				return errors.New("do not specify context name when adding a AKS cluster")
-			}
-			if c.k8sCluster == nil {
-				c.k8sCluster = newAKSCluster()
-			}
-			if err := c.k8sCluster.ensureExecutable(); err != nil {
-				return errors.Trace(err)
-			}
+	}
+
+	if c.aks {
+		if c.k8sCluster == nil {
+			c.k8sCluster = newAKSCluster()
+		}
+	} else {
+		if c.resourceGroup != "" {
+			return errors.New("do not specify resource-group unless adding a AKS cluster")
+		}
+	}
+
+	if c.eks && c.k8sCluster == nil {
+		c.k8sCluster = newEKSCluster()
+	}
+
+	if c.k8sCluster != nil {
+		if err := c.k8sCluster.ensureExecutable(); err != nil {
+			return errors.Trace(err)
 		}
 	}
 	return cmd.CheckEmpty(args[1:])
@@ -337,6 +361,9 @@ func (c *AddCAASCommand) getConfigReader(ctx *cmd.Context) (io.Reader, string, e
 	if c.aks {
 		return c.getAKSKubeConfig(ctx)
 	}
+	if c.eks {
+		return c.getEKSKubeConfig(ctx)
+	}
 	rdr, err := getStdinPipe(ctx)
 	return rdr, c.clusterName, err
 }
@@ -352,6 +379,29 @@ func (c *AddCAASCommand) getGKEKubeConfig(ctx *cmd.Context) (io.Reader, string, 
 	// If any items are missing, prompt for them.
 	if p.name == "" || p.project == "" || p.region == "" {
 		var err error
+		p, err = c.k8sCluster.interactiveParams(ctx, p)
+		if err != nil {
+			return nil, "", errors.Trace(err)
+		}
+	}
+	c.clusterName = p.name
+	c.hostCloudRegion = c.k8sCluster.cloud() + "/" + p.region
+	return c.k8sCluster.getKubeConfig(p)
+}
+
+func (c *AddCAASCommand) getEKSKubeConfig(ctx *cmd.Context) (io.Reader, string, error) {
+	p := &clusterParams{
+		name: c.clusterName,
+	}
+	var err error
+	if len(c.hostCloudRegion) > 0 {
+		if _, p.region, err = jujucloud.SplitHostCloudRegion(c.hostCloudRegion); err != nil {
+			return nil, "", errors.Annotatef(err, "getting region from host cloud region")
+		}
+	}
+
+	// If any items are missing, prompt for them.
+	if p.name == "" || p.region == "" {
 		p, err = c.k8sCluster.interactiveParams(ctx, p)
 		if err != nil {
 			return nil, "", errors.Trace(err)

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -449,7 +449,39 @@ func (s *addCAASSuite) TestInit(c *gc.C) {
 		},
 		{
 			args:           []string{"--gke", "--context-name", "a"},
-			expectedErrStr: "do not specify context name when adding a GKE cluster",
+			expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
+		},
+		{
+			args:           []string{"--aks", "--context-name", "a"},
+			expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
+		},
+		{
+			args:           []string{"--eks", "--context-name", "a"},
+			expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
+		},
+		{
+			args:           []string{"--gke", "--cloud", "a"},
+			expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
+		},
+		{
+			args:           []string{"--aks", "--cloud", "a"},
+			expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
+		},
+		{
+			args:           []string{"--eks", "--cloud", "a"},
+			expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
+		},
+		{
+			args:           []string{"--gke", "--region", "cloud/region"},
+			expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
+		},
+		{
+			args:           []string{"--aks", "--region", "cloud/region"},
+			expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
+		},
+		{
+			args:           []string{"--eks", "--region", "cloud/region"},
+			expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
 		},
 		{
 			args:           []string{"--project", "a"},
@@ -458,6 +490,30 @@ func (s *addCAASSuite) TestInit(c *gc.C) {
 		{
 			args:           []string{"--credential", "a"},
 			expectedErrStr: "do not specify credential unless adding a GKE cluster",
+		},
+		{
+			args:           []string{"--project", "a", "--aks"},
+			expectedErrStr: "do not specify project unless adding a GKE cluster",
+		},
+		{
+			args:           []string{"--credential", "a", "--aks"},
+			expectedErrStr: "do not specify credential unless adding a GKE cluster",
+		},
+		{
+			args:           []string{"--project", "a", "--eks"},
+			expectedErrStr: "do not specify project unless adding a GKE cluster",
+		},
+		{
+			args:           []string{"--credential", "a", "--eks"},
+			expectedErrStr: "do not specify credential unless adding a GKE cluster",
+		},
+		{
+			args:           []string{"--resource-group", "rg1", "--gke"},
+			expectedErrStr: "do not specify resource-group unless adding a AKS cluster",
+		},
+		{
+			args:           []string{"--resource-group", "rg1", "--eks"},
+			expectedErrStr: "do not specify resource-group unless adding a AKS cluster",
 		},
 	} {
 		args := append([]string{"myk8s"}, ts.args...)
@@ -513,17 +569,17 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 			title:          "specify cloud with gke",
 			cloud:          "aws",
 			gke:            true,
-			expectedErrStr: `do not specify --cloud when adding a GKE or AKS cluster`,
+			expectedErrStr: `do not specify --cloud when adding a GKE, EKS or AKS cluster`,
 		}, {
 			title:          "specify cloud with aks",
 			cloud:          "aws",
 			aks:            true,
-			expectedErrStr: `do not specify --cloud when adding a GKE or AKS cluster`,
+			expectedErrStr: `do not specify --cloud when adding a GKE, EKS or AKS cluster`,
 		}, {
 			title:          "specify cloud/region with gke",
 			region:         "gce/us-east",
 			gke:            true,
-			expectedErrStr: `only specify region, not cloud/region, when adding a GKE or AKS cluster`,
+			expectedErrStr: `only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster`,
 		}, {
 			title: "missing region --cloud=teststack but cloud has default region",
 			cloud: "teststack",
@@ -1281,5 +1337,5 @@ func (s *addCAASSuite) TestCorrectSelectContext(c *gc.C) {
 func (s *addCAASSuite) TestOnlyOneClusterProvider(c *gc.C) {
 	command := s.makeCommand(c, true, false, true)
 	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--aks", "--gke")
-	c.Assert(err, gc.ErrorMatches, "only one of '--gke' or '--aks' can be supplied")
+	c.Assert(err, gc.ErrorMatches, "only one of '--gke', '--eks' or '--aks' can be supplied")
 }

--- a/cmd/juju/caas/aks_test.go
+++ b/cmd/juju/caas/aks_test.go
@@ -50,7 +50,7 @@ func (s *aksSuite) TestGetKubeConfig(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks get-credentials --name mycluster --resource-group resourceGroup --overwrite-existing -f " + configFile,
-			Environment: []string{"KUBECONFIG=" + configFile, "PATH=/path/to/here"},
+			Environment: mergeEnv(os.Environ(), []string{"KUBECONFIG=" + configFile}),
 		}).
 			Return(&exec.ExecResponse{
 				Code: 0,
@@ -104,7 +104,7 @@ func (s *aksSuite) TestInteractiveParam(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -114,7 +114,7 @@ func (s *aksSuite) TestInteractiveParam(c *gc.C) {
 			Commands: fmt.Sprintf(
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -177,7 +177,7 @@ func (s *aksSuite) TestInteractiveParamResourceGroupDefined(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json --resource-group " + resourceGroup,
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -187,7 +187,7 @@ func (s *aksSuite) TestInteractiveParamResourceGroupDefined(c *gc.C) {
 			Commands: fmt.Sprintf(
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -254,7 +254,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedSingleResourceGr
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -264,7 +264,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedSingleResourceGr
 			Commands: fmt.Sprintf(
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -331,7 +331,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGro
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -341,7 +341,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGro
 			Commands: fmt.Sprintf(
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -407,7 +407,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -417,7 +417,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 			Commands: fmt.Sprintf(
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -497,7 +497,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az aks list --output json",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -505,7 +505,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 			}, nil),
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    `az group list --output json --query "[?properties.provisioningState=='Succeeded']"`,
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -515,7 +515,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 			Commands: fmt.Sprintf(
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -572,7 +572,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedResourceGroupSpecified(c
 			Commands: fmt.Sprintf(
 				`az group list --output json --query "[?properties.provisioningState=='Succeeded'] | [?name=='%s']"`,
 				resourceGroup),
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -612,7 +612,7 @@ func (s *aksSuite) TestEnsureExecutablePicksAZ(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which az",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -620,7 +620,7 @@ func (s *aksSuite) TestEnsureExecutablePicksAZ(c *gc.C) {
 			}, nil),
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "az account show",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -641,7 +641,7 @@ func (s *aksSuite) TestEnsureExecutableNotFound(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which az",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code: 1,

--- a/cmd/juju/caas/cluster.go
+++ b/cmd/juju/caas/cluster.go
@@ -49,10 +49,12 @@ func collapseRunError(result *exec.ExecResponse, err error) error {
 var runCommand = func(runner CommandRunner, params []string, kubeconfig string) (*exec.ExecResponse, error) {
 	cmd := strings.Join(params, " ")
 
-	path := getEnv("path")
 	execParams := exec.RunParams{
 		Commands:    cmd,
-		Environment: []string{"KUBECONFIG=" + kubeconfig, "PATH=" + path},
+		Environment: os.Environ(),
+	}
+	if len(kubeconfig) > 0 {
+		execParams.Environment = append(execParams.Environment, "KUBECONFIG="+kubeconfig)
 	}
 	return runner.RunCommands(execParams)
 }

--- a/cmd/juju/caas/cluster.go
+++ b/cmd/juju/caas/cluster.go
@@ -4,11 +4,13 @@
 package caas
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/utils/exec"
 )
@@ -46,6 +48,24 @@ func collapseRunError(result *exec.ExecResponse, err error) error {
 	return nil
 }
 
+func mergeEnv(envs ...[]string) (out []string) {
+	m := map[string]string{}
+	keys := set.NewStrings()
+	for _, env := range envs {
+		for _, val := range env {
+			kv := strings.SplitN(val, "=", 2)
+			k := kv[0]
+			m[k] = kv[1]
+			keys.Add(k)
+		}
+	}
+	// sort keys for test.
+	for _, k := range keys.SortedValues() {
+		out = append(out, fmt.Sprintf("%s=%s", k, m[k]))
+	}
+	return out
+}
+
 var runCommand = func(runner CommandRunner, params []string, kubeconfig string) (*exec.ExecResponse, error) {
 	cmd := strings.Join(params, " ")
 
@@ -54,7 +74,7 @@ var runCommand = func(runner CommandRunner, params []string, kubeconfig string) 
 		Environment: os.Environ(),
 	}
 	if len(kubeconfig) > 0 {
-		execParams.Environment = append(execParams.Environment, "KUBECONFIG="+kubeconfig)
+		execParams.Environment = mergeEnv(execParams.Environment, []string{"KUBECONFIG=" + kubeconfig})
 	}
 	return runner.RunCommands(execParams)
 }

--- a/cmd/juju/caas/eks.go
+++ b/cmd/juju/caas/eks.go
@@ -17,6 +17,8 @@ import (
 	"github.com/juju/juju/cmd/juju/interact"
 )
 
+const eksDomain = "eksctl.io"
+
 type eks struct {
 	tool string
 	CommandRunner
@@ -42,10 +44,8 @@ func (e *eks) ensureExecutable() error {
 	}
 
 	// check that we are logged in, there is no way to provide login details to a separate command.
-	cmd = []string{e.tool, "get", "cluster", "-v", "5"}
-	logger.Criticalf("cmd -> %v", cmd)
+	cmd = []string{e.tool, "get", "cluster"}
 	err = collapseRunError(runCommand(e, cmd, ""))
-	logger.Criticalf("cmd -> %v, err -> %#v", cmd, err)
 	if err != nil {
 		return errors.Errorf("please ensure the account has been setup and re-run this command")
 	}
@@ -68,7 +68,7 @@ func (e *eks) getKubeConfig(p *clusterParams) (io.ReadCloser, string, error) {
 		return nil, "", errors.Trace(err)
 	}
 	reader, err := os.Open(kubeconfig)
-	return reader, p.name, err
+	return reader, fmt.Sprintf("%s.%s.%s", p.name, p.region, eksDomain), err
 }
 
 func (e *eks) interactiveParams(ctx *cmd.Context, p *clusterParams) (*clusterParams, error) {

--- a/cmd/juju/caas/eks.go
+++ b/cmd/juju/caas/eks.go
@@ -1,0 +1,128 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/cmd/juju/interact"
+)
+
+type eks struct {
+	tool string
+	CommandRunner
+}
+
+func newEKSCluster() k8sCluster {
+	return &eks{
+		tool:          "eksctl",
+		CommandRunner: &defaultRunner{},
+	}
+}
+
+func (e *eks) cloud() string {
+	return caas.K8sCloudEC2
+}
+
+func (e *eks) ensureExecutable() error {
+	cmd := []string{"which", e.tool}
+	err := collapseRunError(runCommand(e, cmd, ""))
+	errAnnotationMessage := fmt.Sprintf("%q not found. Please install %q (see: https://eksctl.io/introduction/#installation, login, and try again", e.tool, e.tool)
+	if err != nil {
+		return errors.Errorf(errAnnotationMessage)
+	}
+
+	// check that we are logged in, there is no way to provide login details to a separate command.
+	cmd = []string{e.tool, "get", "cluster", "-v", "5"}
+	logger.Criticalf("cmd -> %v", cmd)
+	err = collapseRunError(runCommand(e, cmd, ""))
+	logger.Criticalf("cmd -> %v, err -> %#v", cmd, err)
+	if err != nil {
+		return errors.Errorf("please ensure the account has been setup and re-run this command")
+	}
+	return nil
+}
+
+func (e *eks) getKubeConfig(p *clusterParams) (io.ReadCloser, string, error) {
+	kubeconfig := clientconfig.GetKubeConfigPath()
+	cmd := []string{
+		e.tool, "utils", "write-kubeconfig",
+		"--cluster", p.name,
+		"--kubeconfig", kubeconfig,
+	}
+	if len(p.region) > 0 {
+		cmd = append(cmd, "--region", p.region)
+	}
+
+	err := collapseRunError(runCommand(e, cmd, kubeconfig))
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	reader, err := os.Open(kubeconfig)
+	return reader, p.name, err
+}
+
+func (e *eks) interactiveParams(ctx *cmd.Context, p *clusterParams) (*clusterParams, error) {
+	errout := interact.NewErrWriter(ctx.Stdout)
+	pollster := interact.New(ctx.Stdin, ctx.Stdout, errout)
+
+	if len(p.region) == 0 {
+		var err error
+		if p.region, err = pollster.Enter("region"); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	if len(p.name) == 0 {
+		clusters, err := e.listClusters(p.region)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		if p.name, err = pollster.Select(interact.List{
+			Singular: "cluster",
+			Plural:   "Available clusters",
+			Options:  clusters,
+			Default:  clusters[0],
+		}); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	return p, nil
+}
+
+type eksDetail struct {
+	Name   string `json:"name"`
+	Region string `json:"region"`
+}
+
+func (e *eks) listClusters(region string) (clusters []string, err error) {
+	cmd := []string{
+		e.tool, "get", "cluster", "--region", region, "-o", "json",
+	}
+	result, err := runCommand(e, cmd, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if result.Code != 0 {
+		return nil, errors.New(string(result.Stderr))
+	}
+
+	var eksClusters []eksDetail
+	if err := json.Unmarshal(result.Stdout, &eksClusters); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	for _, item := range eksClusters {
+		clusters = append(clusters, item.Name)
+	}
+	return clusters, nil
+}

--- a/cmd/juju/caas/eks_test.go
+++ b/cmd/juju/caas/eks_test.go
@@ -1,0 +1,265 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caas
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/caas/mocks"
+)
+
+type eksSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&eksSuite{})
+
+func (s *eksSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	err := os.Setenv("PATH", "/path/to/here")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *eksSuite) TestGetKubeConfig(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	configFile := filepath.Join(c.MkDir(), "config")
+	err := os.Setenv("KUBECONFIG", configFile)
+	c.Assert(err, jc.ErrorIsNil)
+	eksCMD := &eks{
+		tool:          "eksctl",
+		CommandRunner: mockRunner,
+	}
+	err = ioutil.WriteFile(configFile, []byte("data"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "eksctl utils write-kubeconfig --cluster mycluster --kubeconfig " + configFile + " --region ap-southeast-2",
+			Environment: mergeEnv(os.Environ(), []string{"KUBECONFIG=" + configFile}),
+		}).
+			Return(&exec.ExecResponse{
+				Code: 0,
+			}, nil),
+	)
+
+	rdr, clusterName, err := eksCMD.getKubeConfig(&clusterParams{
+		name:   "mycluster",
+		region: "ap-southeast-2",
+	})
+	c.Check(err, jc.ErrorIsNil)
+	defer rdr.Close()
+
+	c.Assert(clusterName, gc.Equals, "mycluster.ap-southeast-2.eksctl.io")
+	data, err := ioutil.ReadAll(rdr)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.DeepEquals, "data")
+}
+
+func (s *eksSuite) TestInteractiveParam(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	eksCMD := &eks{
+		tool:          "eksctl",
+		CommandRunner: mockRunner,
+	}
+	clusterJSONResp := `
+[
+    {
+        "name": "mycluster",
+        "region": "ap-southeast-2"
+    }
+]`
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "eksctl get cluster --region ap-southeast-2 -o json",
+			Environment: os.Environ(),
+		}).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("ap-southeast-2\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Enter region: 
+`[1:]
+
+	outParams, err := eksCMD.interactiveParams(ctx, &clusterParams{})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:   "mycluster",
+		region: "ap-southeast-2",
+	})
+}
+
+func (s *eksSuite) TestInteractiveParamNoClusterFound(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	eksCMD := &eks{
+		tool:          "eksctl",
+		CommandRunner: mockRunner,
+	}
+	clusterJSONResp := `
+[]`
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "eksctl get cluster --region ap-southeast-2 -o json",
+			Environment: os.Environ(),
+		}).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("ap-southeast-2\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Enter region: 
+`[1:]
+
+	_, err := eksCMD.interactiveParams(ctx, &clusterParams{})
+	c.Check(err, gc.ErrorMatches, `no cluster found in region "ap-southeast-2"`)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+}
+
+func (s *eksSuite) TestInteractiveParamMultiClusters(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	eksCMD := &eks{
+		tool:          "eksctl",
+		CommandRunner: mockRunner,
+	}
+	clusterJSONResp := `
+[
+    {
+        "name": "mycluster",
+        "region": "ap-southeast-2"
+	},
+	{
+        "name": "mycluster2",
+        "region": "ap-southeast-2"
+    }
+]`
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "eksctl get cluster --region ap-southeast-2 -o json",
+			Environment: os.Environ(),
+		}).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("ap-southeast-2\nmycluster\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Enter region: 
+Available Clusters In Ap-Southeast-2
+  mycluster
+  mycluster2
+
+Select cluster [mycluster]: 
+`[1:]
+
+	outParams, err := eksCMD.interactiveParams(ctx, &clusterParams{})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:   "mycluster",
+		region: "ap-southeast-2",
+	})
+}
+
+func (s *eksSuite) TestEnsureExecutable(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	eksCMD := &eks{tool: "eksctl", CommandRunner: mockRunner}
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "which eksctl",
+			Environment: os.Environ(),
+		}).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(""),
+			}, nil),
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "eksctl get cluster",
+			Environment: os.Environ(),
+		}).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(""),
+			}, nil),
+	)
+	err := eksCMD.ensureExecutable()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *eksSuite) TestEnsureExecutableNotFound(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	eksCMD := &eks{tool: "eksctl", CommandRunner: mockRunner}
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "which eksctl",
+			Environment: os.Environ(),
+		}).
+			Return(&exec.ExecResponse{
+				Code: 1,
+			}, nil),
+	)
+	err := eksCMD.ensureExecutable()
+	c.Assert(err, gc.ErrorMatches, `"eksctl" not found. Please install "eksctl" \(see: .*\).*`)
+}

--- a/cmd/juju/caas/gke_test.go
+++ b/cmd/juju/caas/gke_test.go
@@ -43,7 +43,7 @@ func (s *gkeSuite) TestInteractiveParams(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud auth list --format value\\(account,status\\)",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -51,7 +51,7 @@ func (s *gkeSuite) TestInteractiveParams(c *gc.C) {
 			}, nil),
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud projects list --account mysecret --filter lifecycleState:ACTIVE --format value\\(projectId\\)",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -59,7 +59,7 @@ func (s *gkeSuite) TestInteractiveParams(c *gc.C) {
 			}, nil),
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters list --filter status:RUNNING --account mysecret --project myproject --format value\\(name,zone\\)",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -113,7 +113,7 @@ func (s *gkeSuite) TestInteractiveParamsProjectSpecified(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters list --filter status:RUNNING --account mysecret --project myproject --format value\\(name,zone\\)",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -161,7 +161,7 @@ func (s *gkeSuite) TestInteractiveParamsProjectAndRegionSpecified(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters list --filter status:RUNNING --account mysecret --project myproject --format value\\(name,zone\\)",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code:   0,
@@ -215,7 +215,7 @@ func (s *gkeSuite) TestGetKubeConfig(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "gcloud container clusters get-credentials mycluster --account mysecret --project myproject --zone asia-southeast1-a",
-			Environment: []string{"KUBECONFIG=" + configFile, "PATH=/path/to/here"},
+			Environment: mergeEnv(os.Environ(), []string{"KUBECONFIG=" + configFile}),
 		}).
 			Return(&exec.ExecResponse{
 				Code: 0,
@@ -247,7 +247,7 @@ func (s *gkeSuite) TestEnsureExecutableGcloudFound(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which gcloud",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code: 0,
@@ -267,7 +267,7 @@ func (s *gkeSuite) TestEnsureExecutableGcloudNotFound(c *gc.C) {
 	gomock.InOrder(
 		mockRunner.EXPECT().RunCommands(exec.RunParams{
 			Commands:    "which gcloud",
-			Environment: []string{"KUBECONFIG=", "PATH=/path/to/here"},
+			Environment: os.Environ(),
 		}).
 			Return(&exec.ExecResponse{
 				Code: 1,


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Add support for bootstrapping to EKS without `Fargate` enabled;

## QA steps

```console
## create an EKS using `eksctl`

$ juju add-k8s kubetest --cluster-name prod.ap-southeast-2.eksctl.io

$ juju bootstrap kubetest k1

$ juju add-model t1 kubetest --debug

$ juju deploy kubeflow --channel stable --debug

$ juju kill-controller -t 0 -y k1 --debug

```

## Documentation changes

Yes

## Bug reference

No
