### PR TITLE
Test speedup - fast insecure KeyProfile for testing

### DIFF
--- a/pki/pki_test.go
+++ b/pki/pki_test.go
@@ -7,6 +7,16 @@ import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/pki"
+	pki_test "github.com/juju/juju/pki/test"
 )
 
-func TestSuite(t *testing.T) { gc.TestingT(t) }
+func TestSuite(t *testing.T) {
+	if pki_test.OriginalDefaultKeyProfile == nil {
+		panic("pki_test.OriginalDefaultKeyProfile not set")
+	}
+	// Restore the correct key profile.
+	pki.DefaultKeyProfile = pki_test.OriginalDefaultKeyProfile
+	gc.TestingT(t)
+}

--- a/pki/signer.go
+++ b/pki/signer.go
@@ -39,12 +39,12 @@ func ECDSAP384() (crypto.Signer, error) {
 	return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 }
 
-// ECDSA384 returns a RSA 2048 private key
+// RSA2048 returns a RSA 2048 private key
 func RSA2048() (crypto.Signer, error) {
 	return rsa.GenerateKey(rand.Reader, 2048)
 }
 
-// ECDSA384 returns a RSA 3072 private key
+// RSA3072 returns a RSA 3072 private key
 func RSA3072() (crypto.Signer, error) {
 	return rsa.GenerateKey(rand.Reader, 3072)
 }

--- a/pki/test/keyprofile.go
+++ b/pki/test/keyprofile.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package test
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"flag"
+	"math/rand"
+
+	"github.com/juju/juju/pki"
+)
+
+var insecureRand = rand.New(rand.NewSource(0))
+
+// InsecureKeyProfile for tests. Will panic if used outside tests.
+func InsecureKeyProfile() (crypto.Signer, error) {
+	if flag.Lookup("test.v") == nil {
+		panic("InsecureKeyProfile cannot be used outside tests")
+	}
+	return rsa.GenerateKey(insecureRand, 512)
+}
+
+// OriginalDefaultKeyProfile is the pre-patched pki.DefaultKeyProfile
+// value.
+var OriginalDefaultKeyProfile = pki.DefaultKeyProfile
+
+func init() {
+	pki.DefaultKeyProfile = InsecureKeyProfile
+}

--- a/testing/pki.go
+++ b/testing/pki.go
@@ -1,0 +1,9 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	// Force inclusion of pki/test for fast test keyprofiles.
+	_ "github.com/juju/juju/pki/test"
+)


### PR DESCRIPTION
## Description of change

For tests only, the pki.DefaultKeyProfile is reduced to an insecure variant.
The testing.InsecureKeyProfile will panic if used outside of a go test package.

Before:
```
~/projects/juju/cmd/juju/commands$ ./commands.test -test.v -check.f=TestBootstrapDefaultControllerName
=== RUN   TestRunMain
--- PASS: TestRunMain (0.00s)
=== RUN   TestPackage
OK: 3 passed
--- PASS: TestPackage (2.70s)
PASS
```

After:
```
~/projects/juju/cmd/juju/commands$ ./commands.test -test.v -check.f=TestBootstrapDefaultControllerName
=== RUN   TestRunMain
--- PASS: TestRunMain (0.00s)
=== RUN   TestPackage
OK: 3 passed
--- PASS: TestPackage (0.26s)
PASS
```

## QA steps

Run Unit Tests.

## Documentation changes

N/A

## Bug reference

N/A
