### PR TITLE
Thread a logging context through the agent initialization.

### DIFF
--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -125,12 +125,12 @@ func (c *agentConf) CurrentConfig() agent.Config {
 	return c._config.Clone()
 }
 
-func setupAgentLogging(config agent.Config) {
-
+func setupAgentLogging(context *loggo.Context, config agent.Config) {
+	logger := context.GetLogger("juju.agent.setup")
 	if loggingOverride := config.Value(agent.LoggingOverride); loggingOverride != "" {
 		logger.Infof("logging override set for this agent: %q", loggingOverride)
-		loggo.DefaultContext().ResetLoggerLevels()
-		err := loggo.ConfigureLoggers(loggingOverride)
+		context.ResetLoggerLevels()
+		err := context.ConfigureLoggers(loggingOverride)
 		if err != nil {
 			logger.Errorf("setting logging override %v", err)
 		}
@@ -138,8 +138,8 @@ func setupAgentLogging(config agent.Config) {
 		logger.Infof("setting logging config to %q", loggingConfig)
 		// There should only be valid logging configuration strings saved
 		// in the logging config section in the agent.conf file.
-		loggo.DefaultContext().ResetLoggerLevels()
-		err := loggo.ConfigureLoggers(loggingConfig)
+		context.ResetLoggerLevels()
+		err := context.ConfigureLoggers(loggingConfig)
 		if err != nil {
 			logger.Errorf("problem setting logging config %v", err)
 		}

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -78,31 +78,34 @@ var _ = gc.Suite(&agentLoggingSuite{})
 
 func (*agentLoggingSuite) TestNoLoggingConfig(c *gc.C) {
 	f := &fakeLoggingConfig{}
-	initial := loggo.LoggerInfo()
+	context := loggo.NewContext(loggo.WARNING)
+	initial := context.Config().String()
 
-	setupAgentLogging(f)
+	setupAgentLogging(context, f)
 
-	c.Assert(loggo.LoggerInfo(), gc.Equals, initial)
+	c.Assert(context.Config().String(), gc.Equals, initial)
 }
 
 func (*agentLoggingSuite) TestLoggingOverride(c *gc.C) {
 	f := &fakeLoggingConfig{
 		loggingOverride: "test=INFO",
 	}
+	context := loggo.NewContext(loggo.WARNING)
 
-	setupAgentLogging(f)
+	setupAgentLogging(context, f)
 
-	c.Assert(loggo.LoggerInfo(), gc.Equals, "<root>=WARNING;test=INFO")
+	c.Assert(context.Config().String(), gc.Equals, "<root>=WARNING;test=INFO")
 }
 
 func (*agentLoggingSuite) TestLoggingConfig(c *gc.C) {
 	f := &fakeLoggingConfig{
 		loggingConfig: "test=INFO",
 	}
+	context := loggo.NewContext(loggo.WARNING)
 
-	setupAgentLogging(f)
+	setupAgentLogging(context, f)
 
-	c.Assert(loggo.LoggerInfo(), gc.Equals, "<root>=WARNING;test=INFO")
+	c.Assert(context.Config().String(), gc.Equals, "<root>=WARNING;test=INFO")
 }
 
 type fakeLoggingConfig struct {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -470,7 +470,7 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 		return errors.Errorf("cannot read agent configuration: %v", err)
 	}
 
-	setupAgentLogging(a.CurrentConfig())
+	setupAgentLogging(loggo.DefaultContext(), a.CurrentConfig())
 
 	if err := introspection.WriteProfileFunctions(introspection.ProfileDir); err != nil {
 		// This isn't fatal, just annoying.

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -161,7 +161,7 @@ func (a *UnitAgent) Run(ctx *cmd.Context) (err error) {
 	if err := a.ReadConfig(a.Tag().String()); err != nil {
 		return err
 	}
-	setupAgentLogging(a.CurrentConfig())
+	setupAgentLogging(loggo.DefaultContext(), a.CurrentConfig())
 
 	a.runner.StartWorker("api", a.APIWorkers)
 	err = cmdutil.AgentDone(logger, a.runner.Wait())

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -196,7 +196,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	// Assuming an average of 200 bytes per log message, use up to
 	// 200MB for the log buffer.
 	defer logger.Debugf("jujud complete, code %d, err %v", code, err)
-	bufferedLogger, err := logsender.InstallBufferedLogWriter(1048576)
+	bufferedLogger, err := logsender.InstallBufferedLogWriter(loggo.DefaultContext(), 1048576)
 	if err != nil {
 		return 1, errors.Trace(err)
 	}

--- a/core/watcher/strings.go
+++ b/core/watcher/strings.go
@@ -5,6 +5,7 @@ package watcher
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 )
 
@@ -138,4 +139,12 @@ func (sw *StringsWorker) Kill() {
 // Wait is part of the worker.Worker interface.
 func (sw *StringsWorker) Wait() error {
 	return sw.catacomb.Wait()
+}
+
+// Report implements dependency.Reporter.
+func (sw *StringsWorker) Report() map[string]interface{} {
+	if r, ok := sw.config.Handler.(worker.Reporter); ok {
+		return r.Report()
+	}
+	return nil
 }

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -83,7 +83,7 @@ func (s *dblogSuite) assertAgentLogsGoToDB(c *gc.C, tag names.Tag, isCaas bool) 
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
 	err := agentConf.ReadConfig(tag.String())
 	c.Assert(err, jc.ErrorIsNil)
-	logger, err := logsender.InstallBufferedLogWriter(1000)
+	logger, err := logsender.InstallBufferedLogWriter(loggo.DefaultContext(), 1000)
 	c.Assert(err, jc.ErrorIsNil)
 	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
 		agentConf,
@@ -111,7 +111,7 @@ func (s *dblogSuite) TestUnitAgentLogsGoToDB(c *gc.C) {
 	// Create a unit and an agent for it.
 	u, password := s.Factory.MakeUnitReturningPassword(c, nil)
 	s.PrimeAgent(c, u.Tag(), password)
-	logger, err := logsender.InstallBufferedLogWriter(1000)
+	logger, err := logsender.InstallBufferedLogWriter(loggo.DefaultContext(), 1000)
 	c.Assert(err, jc.ErrorIsNil)
 	a, err := agentcmd.NewUnitAgent(nil, logger)
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -10,8 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/juju/agent"
-	"github.com/juju/juju/state"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
@@ -20,9 +19,11 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/agent"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/introspect"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	jujuversion "github.com/juju/juju/version"
@@ -47,7 +48,7 @@ func (s *introspectionSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 
 	var err error
-	s.logger, err = logsender.InstallBufferedLogWriter(1000)
+	s.logger, err = logsender.InstallBufferedLogWriter(loggo.DefaultContext(), 1000)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
 		err := logsender.UninstallBufferedLogWriter()

--- a/worker/logsender/bufferedlogwriter.go
+++ b/worker/logsender/bufferedlogwriter.go
@@ -47,9 +47,9 @@ const writerName = "buffered-logs"
 
 // InstallBufferedLogWriter creates and returns a new BufferedLogWriter,
 // registering it with Loggo.
-func InstallBufferedLogWriter(maxLen int) (*BufferedLogWriter, error) {
+func InstallBufferedLogWriter(context *loggo.Context, maxLen int) (*BufferedLogWriter, error) {
 	writer := NewBufferedLogWriter(maxLen)
-	err := loggo.RegisterWriter(writerName, writer)
+	err := context.AddWriter(writerName, writer)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to set up log buffering")
 	}

--- a/worker/logsender/bufferedlogwriter_test.go
+++ b/worker/logsender/bufferedlogwriter_test.go
@@ -146,7 +146,7 @@ func (s *bufferedLogWriterSuite) TestClose(c *gc.C) {
 }
 
 func (s *bufferedLogWriterSuite) TestInstallBufferedLogWriter(c *gc.C) {
-	bufferedLogger, err := logsender.InstallBufferedLogWriter(10)
+	bufferedLogger, err := logsender.InstallBufferedLogWriter(loggo.DefaultContext(), 10)
 	c.Assert(err, jc.ErrorIsNil)
 	defer logsender.UninstallBufferedLogWriter()
 
@@ -168,7 +168,7 @@ func (s *bufferedLogWriterSuite) TestInstallBufferedLogWriter(c *gc.C) {
 }
 
 func (s *bufferedLogWriterSuite) TestUninstallBufferedLogWriter(c *gc.C) {
-	_, err := logsender.InstallBufferedLogWriter(10)
+	_, err := logsender.InstallBufferedLogWriter(loggo.DefaultContext(), 10)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = logsender.UninstallBufferedLogWriter()


### PR DESCRIPTION
This is more prepatory work for the merging of the machine and unit agents.
In the future some of the methods used will have a different logging context.
For now we just pass through the default logging context, which has the
same existing behaviour.

As a drive by there is a Report method added to a StringsWorker. This will
call the Report method of the handler if there is one.

## QA steps

Unit tests should continue to pass.

## Documentation changes

Only internal refactoring.
