### PR TITLE
[2.8] Enhance manual machine cleanup script

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -76,6 +76,7 @@ for path_to_unit in $(ls /etc/systemd/system/juju*); do
   systemctl stop "$unit"
   systemctl disable "$unit"
   systemctl daemon-reload
+  rm -f "$path_to_unit"
 done
 
 echo "removing /var/lib/juju/db/*"
@@ -86,6 +87,12 @@ rm -rf /var/lib/juju/raft/*
 
 echo "removing /var/run/juju/*"
 rm -rf /var/run/juju/*
+
+has_juju_db_snap=$(snap info juju-db | grep installed)
+if [ ! -z "$has_juju_db_snap" ]; then
+  echo "removing juju-db snap and any persisted database data"
+  snap remove --purge juju-db
+fi
 `
 )
 


### PR DESCRIPTION
## Description of change

The updated script ensures that the systemd service files for the various juju services are always deleted. Additionally, the script also detects and cleans up the juju-db snap if installed (2.8+). These two steps ensures that we can properly clean up a machine and boostrap to it again without getting the "machine already provisioned" error.

## QA steps

Bootstrap 2.8 on a manual machine and run `/sbin/remove-juju-services`. Then make sure that `snap info juju-db` does not report the snap as installed. Try to bootstrap the same machine and it should work without an issue.