### PR TITLE
2.7 - Remove Machine Series Upgrade Lock

### DIFF
--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -594,6 +594,40 @@ func (s *CleanupSuite) TestForceDestroyMachineSchedulesRemove(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *CleanupSuite) TestForceDestroyMachineRemovesUpgradeSeriesLock(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProvisioned("inst-id", "", "fake_nonce", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertDoesNotNeedCleanup(c)
+
+	err = machine.CreateUpgradeSeriesLock(nil, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.ForceDestroy(time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertNeedsCleanup(c)
+	s.assertCleanupRuns(c)
+
+	assertLifeIs(c, machine, state.Dead)
+
+	// Running a cleanup pass succeeds but doesn't get rid of cleanups
+	// because there's a scheduled one.
+	s.assertCleanupRuns(c)
+	assertLifeIs(c, machine, state.Dead)
+	s.assertNeedsCleanup(c)
+
+	locked, err := machine.IsLockedForSeriesUpgrade()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(locked, jc.IsFalse)
+
+	s.Clock.Advance(time.Minute)
+	s.assertCleanupCount(c, 1)
+	err = machine.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *CleanupSuite) TestCleanupDyingUnit(c *gc.C) {
 	// Create active unit, in a relation.
 	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeGlobal)

--- a/state/machine.go
+++ b/state/machine.go
@@ -587,7 +587,7 @@ func (m *Machine) PasswordValid(password string) bool {
 // If the machine has assigned units, Destroy will return
 // a HasAssignedUnitsError.
 func (m *Machine) Destroy() error {
-	return m.advanceLifecycle(Dying, false, 0)
+	return errors.Trace(m.advanceLifecycle(Dying, false, 0))
 }
 
 // ForceDestroy queues the machine for complete removal, including the
@@ -756,6 +756,15 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 			ContainerIds: containers,
 		}
 	}
+
+	locked, err := original.IsLockedForSeriesUpgrade()
+	if err != nil {
+		return errors.Annotatef(err, "reading machine %s upgrade-series lock", original.Id())
+	}
+	if locked {
+		return errors.Errorf("machine %s is locked for series upgrade", original.Id())
+	}
+
 	m := original
 	defer func() {
 		if err == nil {
@@ -776,13 +785,7 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 		Id:     m.doc.DocID,
 		Update: bson.D{{"$set", bson.D{{"life", life}}}},
 	}
-	// noUnits asserts that the machine has no principal units.
-	noUnits := bson.DocElem{
-		Name: "$or", Value: []bson.D{
-			{{"principals", bson.D{{"$size", 0}}}},
-			{{"principals", bson.D{{"$exists", false}}}},
-		},
-	}
+
 	cleanupOp := newCleanupOp(cleanupDyingMachine, m.doc.Id, force, maxWait)
 	// multiple attempts: one with original data, one with refreshed data, and a final
 	// one intended to determine the cause of failure of the preceding attempt.
@@ -841,6 +844,7 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 		default:
 			panic(fmt.Errorf("cannot advance lifecycle to %v", life))
 		}
+
 		// Check that the machine does not have any responsibilities that
 		// prevent a lifecycle change.
 		// If there are no alive units left on the machine, or all the applications are dying,
@@ -869,9 +873,10 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 				ops = append(ops, controllerOp)
 				ops = append(ops, setControllerWantsVoteOp(m.st, m.doc.Id, false))
 			}
-			var principalUnitnames []string
+
+			var principalUnitNames []string
 			for _, principalUnit := range m.doc.Principals {
-				principalUnitnames = append(principalUnitnames, principalUnit)
+				principalUnitNames = append(principalUnitNames, principalUnit)
 				u, err := m.st.Unit(principalUnit)
 				if err != nil {
 					return nil, errors.Annotatef(err, "reading machine %s principal unit %v", m, m.doc.Principals[0])
@@ -885,6 +890,7 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 					break
 				}
 			}
+
 			if canDie {
 				containers, err := m.Containers()
 				if err != nil {
@@ -901,16 +907,18 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 				}
 				ops = append(ops, containerCheck)
 			}
+
 			if canDie {
 				checkUnits := bson.DocElem{
 					Name: "$or", Value: []bson.D{
-						{{Name: "principals", Value: principalUnitnames}},
+						{{Name: "principals", Value: principalUnitNames}},
 						{{Name: "principals", Value: bson.D{{"$size", 0}}}},
 						{{Name: "principals", Value: bson.D{{"$exists", false}}}},
 					},
 				}
 				ops[0].Assert = append(asserts, checkUnits)
 				ops = append(ops, cleanupOp)
+
 				txnLogger.Debugf("txn moving machine %q to %s", m.Id(), life)
 				return ops, nil
 			}
@@ -922,7 +930,12 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 				UnitNames: m.doc.Principals,
 			}
 		}
-		asserts = append(asserts, noUnits)
+		asserts = append(asserts, bson.DocElem{
+			Name: "$or", Value: []bson.D{
+				{{"principals", bson.D{{"$size", 0}}}},
+				{{"principals", bson.D{{"$exists", false}}}},
+			},
+		})
 
 		if life == Dead {
 			if isController(&m.doc) {
@@ -942,6 +955,7 @@ func (original *Machine) advanceLifecycle(life Life, force bool, maxWait time.Du
 		ops = append(ops, cleanupOp)
 		return ops, nil
 	}
+
 	if err = m.st.db().Run(buildTxn); err == jujutxn.ErrExcessiveContention {
 		err = errors.Annotatef(err, "machine %s cannot advance lifecycle", m)
 	}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -331,6 +331,18 @@ func (s *MachineSuite) TestLifeMachineWithContainer(c *gc.C) {
 	c.Assert(s.machine.Life(), gc.Equals, state.Alive)
 }
 
+func (s *MachineSuite) TestLifeMachineLockedForSeriesUpgrade(c *gc.C) {
+	err := s.machine.CreateUpgradeSeriesLock(nil, "xenial")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.machine.Destroy()
+	c.Assert(err, gc.ErrorMatches, `machine 1 is locked for series upgrade`)
+
+	err = s.machine.EnsureDead()
+	c.Assert(err, gc.ErrorMatches, `machine 1 is locked for series upgrade`)
+	c.Assert(s.machine.Life(), gc.Equals, state.Alive)
+}
+
 func (s *MachineSuite) TestLifeJobHostUnits(c *gc.C) {
 	// A machine with an assigned unit must not advance lifecycle.
 	app := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))


### PR DESCRIPTION
## Description of change

This patch does 2 things:
- Prevents (non-forced) removal of a machine that is locked for series upgrade.
- Ensures that force removal always deletes any associated series upgrade locks.

## QA steps

- Bootstrap and add a Xenial machine.
- `juju upgrade-series 0 prepare bionic`.
- `juju remove-machine 0` fails due to the lock.
- `juju remove-machine 0 --force` succeeds.
- Connect to Mongo and check that the collection `machineUpgradeSeriesLocks` is empty.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1879663
