### PR TITLE
[2.8] Bindings constraints for space topology

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -377,10 +377,6 @@ func (api *ProvisionerAPI) machineSpaces(m *state.Machine,
 		}
 	}
 
-	if _, ok := allSpaceNames[network.AlphaSpaceName]; ok {
-		delete(allSpaceNames, network.AlphaSpaceName)
-	}
-
 	var spaces []string
 	for space := range allSpaceNames {
 		spaces = append(spaces, space)
@@ -390,7 +386,10 @@ func (api *ProvisionerAPI) machineSpaces(m *state.Machine,
 
 func (api *ProvisionerAPI) machineSpaceTopology(machineID string, spaceNames []string) (params.ProvisioningNetworkTopology, error) {
 	var topology params.ProvisioningNetworkTopology
-	if len(spaceNames) < 1 {
+
+	// If there are no space names, or if there is only one space name and
+	// that's the alpha space.
+	if len(spaceNames) < 1 || (len(spaceNames) == 1 && spaceNames[0] == network.AlphaSpaceName) {
 		return topology, nil
 	}
 

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -302,8 +302,20 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 						// We expect none of the unspecified bindings in the result.
 					},
 				},
+				ProvisioningNetworkTopology: params.ProvisioningNetworkTopology{
+					SubnetAZs: map[string][]string{
+						"subnet-0": {"zone0"},
+						"subnet-1": {"zone1"},
+						"subnet-2": {"zone2"},
+					},
+					SpaceSubnets: map[string][]string{
+						"space1": {"subnet-0"},
+						"space2": {"subnet-1", "subnet-2"},
+					},
+				},
 			},
-		}}}
+		}},
+	}
 	c.Assert(result, jc.DeepEquals, expected)
 }
 

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -68,6 +68,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 						tags.JujuModel:      coretesting.ModelTag.Id(),
 						tags.JujuMachine:    "controller-machine-0",
 					},
+					EndpointBindings: make(map[string]string),
 				},
 			}},
 			{Result: &params.ProvisioningInfoV10{
@@ -82,6 +83,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 						tags.JujuModel:      coretesting.ModelTag.Id(),
 						tags.JujuMachine:    "controller-machine-5",
 					},
+					EndpointBindings: make(map[string]string),
 					Volumes: []params.VolumeParams{{
 						VolumeTag:  "volume-0",
 						Size:       1000,
@@ -164,6 +166,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithSingleNegativeAndPositi
 						tags.JujuModel:      coretesting.ModelTag.Id(),
 						tags.JujuMachine:    "controller-machine-5",
 					},
+					EndpointBindings: make(map[string]string),
 				},
 				SubnetsToZones: map[string][]string{
 					"subnet-1": {"zone1"},
@@ -208,6 +211,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithMultiplePositiveSpaceCo
 				tags.JujuModel:      coretesting.ModelTag.Id(),
 				tags.JujuMachine:    "controller-machine-5",
 			},
+			EndpointBindings: make(map[string]string),
 		},
 		ProvisioningNetworkTopology: params.ProvisioningNetworkTopology{
 			SubnetAZs: map[string][]string{
@@ -379,7 +383,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
 						tags.JujuMachine:       "controller-machine-5",
 						tags.JujuUnitsDeployed: profileUnit.Name(),
 					},
-					EndpointBindings: map[string]string{},
+					EndpointBindings: make(map[string]string),
 					CharmLXDProfiles: []string{pName},
 				},
 			},
@@ -438,6 +442,7 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 							Provider:   "static",
 						},
 					}},
+					EndpointBindings: make(map[string]string),
 				},
 			}},
 		},
@@ -569,6 +574,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 						tags.JujuModel:      coretesting.ModelTag.Id(),
 						tags.JujuMachine:    "controller-machine-0",
 					},
+					EndpointBindings: make(map[string]string),
 				},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 0/lxd/0")},

--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -67,13 +67,19 @@ func AddControllerMachine(c *gc.C, st *state.State) *state.Machine {
 //     VLANTag: 42,
 // })
 func AddSubnetsWithTemplate(c *gc.C, st *state.State, numSubnets uint, infoTemplate network.SubnetInfo) {
+	funcMap := template.FuncMap{
+		"add": func(a, b int) int {
+			return a + b
+		},
+	}
+
 	for subnetIndex := 0; subnetIndex < int(numSubnets); subnetIndex++ {
 		info := infoTemplate // make a copy each time.
 
 		// permute replaces the contents of *s with the result of interpreting
 		// *s as a template.
 		permute := func(s string) string {
-			t, err := template.New("").Parse(s)
+			t, err := template.New("").Funcs(funcMap).Parse(s)
 			c.Assert(err, jc.ErrorIsNil)
 
 			var buf bytes.Buffer


### PR DESCRIPTION
## Description of change

This supersedes https://github.com/juju/juju/pull/11611, by targeting the right base beach [2.8]

The following PR accommodates the bindings for Openstack and AWS by ensuring that binding endpoints are also considered when provisioning. The PR addresses this by updating the machineSpaceTopology and ensuring that all spaces from both endpoint bindings and the space constraints are queried for the topology.

Additionally, the way we query the information to construct the machine space topology has been enhanced to only query the `AllSpaceInfos` from state as little as possible. Lifting the call to state further up the stack and pushing the references down as a modeled dependency.

## QA steps

### Openstack via microstack

Follow the newly updated [discourse post](https://discourse.juju.is/t/openstack-multi-space-support/2672) about creating a multi-space OpenStack environment, ensuring take note of issues that microstack currently has (`--devmode` and missing router subnet interfaces).

```sh
juju bootstrap --bootstrap-series=$OS_SERIES --metadata-source=~/simplestreams \\n--model-default network=test --model-default external-network=external \\n--model-default use-floating-ip=true microstack msk --debug

juju add-space space-1 192.168.222.0/24
juju deploy cs:percona-cluster-290 --bind "db=space-1"
```
Check to ensure that two nics are correctly curated for the spaces. 

### AWS

This is a regression test to ensure that we didn't break anything on the way.

```sh
juju bootstrap aws aws-test
juju add-space space-1 172.31.32.0/20
juju deploy cs:percona-cluster-290 --bind "db="
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1878202
