### PR TITLE
CMR relation remove

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -403,7 +403,7 @@ func (s *watcherSuite) TestRelationStatusWatcherDeadRelation(c *gc.C) {
 
 func (s *watcherSuite) setupOfferStatusWatch(
 	c *gc.C,
-) (func(status status.Status, message string), func()) {
+) (func(status status.Status, message string), func(), func()) {
 	// Create the offer connection details.
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
 	offers := state.NewApplicationOffers(s.State)
@@ -474,32 +474,33 @@ func (s *watcherSuite) setupOfferStatusWatch(
 		case <-time.After(coretesting.LongWait):
 			c.Fatalf("watcher didn't emit an event")
 		}
-		assertNoChange()
 	}
 
 	// Initial event.
 	assertChange(status.Waiting, "waiting for machine")
-	return assertChange, stop
+	return assertChange, assertNoChange, stop
 }
 
 func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
 	// Create a pair of services and a relation between them.
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
 
-	assertChange, stop := s.setupOfferStatusWatch(c)
+	assertChange, assertNoChange, stop := s.setupOfferStatusWatch(c)
 	defer stop()
 
 	err := mysql.SetStatus(status.StatusInfo{Status: status.Waiting, Message: "another message"})
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(status.Waiting, "another message")
 
-	// Deleting the offer results in an empty change set.
+	// Removing offer and application both trigger events.
 	offers := state.NewApplicationOffers(s.State)
 	err = offers.Remove("hosted-mysql", false)
 	c.Assert(err, jc.ErrorIsNil)
+	assertChange("terminated", "offer has been removed")
 	err = mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	assertChange("", "")
+	assertChange("terminated", "offer has been removed")
+	assertNoChange()
 }
 
 type migrationSuite struct {

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -489,10 +489,7 @@ type offerGetter interface {
 // struct for a specified offer name.
 func GetOfferStatusChange(st offerGetter, offerUUID, offerName string) (*params.OfferStatusChange, error) {
 	offer, err := st.ApplicationOfferForUUID(offerUUID)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, errors.Trace(err)
-	}
-	if err != nil {
+	if errors.IsNotFound(err) {
 		return &params.OfferStatusChange{
 			OfferName: offerName,
 			Status: params.EntityStatus{
@@ -500,13 +497,12 @@ func GetOfferStatusChange(st offerGetter, offerUUID, offerName string) (*params.
 				Info:   "offer has been removed",
 			},
 		}, nil
+	} else if err != nil {
+		return nil, errors.Trace(err)
 	}
 	// TODO(wallyworld) - for now, offer status is just the application status
 	app, err := st.Application(offer.ApplicationName)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, errors.Trace(err)
-	}
-	if err != nil {
+	if errors.IsNotFound(err) {
 		return &params.OfferStatusChange{
 			OfferName: offerName,
 			Status: params.EntityStatus{
@@ -514,7 +510,10 @@ func GetOfferStatusChange(st offerGetter, offerUUID, offerName string) (*params.
 				Info:   "application has been removed",
 			},
 		}, nil
+	} else if err != nil {
+		return nil, errors.Trace(err)
 	}
+
 	status, err := app.Status()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -86,6 +86,10 @@ type Backend interface {
 	// of the offer.
 	WatchOfferStatus(offerUUID string) (state.NotifyWatcher, error)
 
+	// WatchOffer returns a watcher that notifies of changes to the
+	// lifecycle of the offer.
+	WatchOffer(offerName string) state.NotifyWatcher
+
 	// FirewallRule returns the firewall rule for the specified service.
 	FirewallRule(service state.WellKnownServiceType) (*state.FirewallRule, error)
 
@@ -109,6 +113,9 @@ type Relation interface {
 
 	// Tag returns the relation's tag.
 	Tag() names.Tag
+
+	// UnitCount is the number of units still in relation scope.
+	UnitCount() int
 
 	// RemoteUnit returns a RelationUnit for the remote application unit
 	// with the supplied ID.

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -78,7 +78,7 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	offerStatusWatcher := func(st crossmodelrelations.CrossModelRelationsState, offerUUID string) (crossmodelrelations.OfferWatcher, error) {
 		c.Assert(s.st, gc.Equals, st)
 		s.watchedOffers = []string{offerUUID}
-		w := &mockOfferStatusWatcher{offerUUID: offerUUID, changes: make(chan struct{}, 1)}
+		w := &mockOfferStatusWatcher{offerUUID: offerUUID, offerName: "mysql", changes: make(chan struct{}, 1)}
 		w.changes <- struct{}{}
 		return w, nil
 	}
@@ -528,6 +528,10 @@ func (s *crossmodelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, len(args.Args))
 	c.Assert(results.Results[0].Error.ErrorCode(), gc.Equals, params.CodeUnauthorized)
 	c.Assert(results.Results[1].Error, gc.IsNil)
+	c.Assert(results.Results[1].Changes, jc.DeepEquals, []params.OfferStatusChange{{
+		OfferName: "mysql",
+		Status:    params.EntityStatus{Status: status.Terminated},
+	}})
 	c.Assert(results.Results[2].Error.ErrorCode(), gc.Equals, params.CodeUnauthorized)
 	c.Assert(s.watchedOffers, jc.DeepEquals, []string{"mysql-uuid"})
 	s.st.CheckCalls(c, []testing.StubCall{
@@ -666,6 +670,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	uc := 666
 	c.Assert(result, gc.DeepEquals, params.RemoteRelationWatchResults{
 		Results: []params.RemoteRelationWatchResult{{
 			RemoteRelationWatcherId: "1",
@@ -673,6 +678,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationChanges(c *gc.C) {
 				RelationToken:    "token-db2:db django:db",
 				ApplicationToken: "token-offer-django",
 				Macaroons:        nil,
+				UnitCount:        &uc,
 				ApplicationSettings: map[string]interface{}{
 					"majoribanks": "mt victoria",
 				},

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -304,6 +304,7 @@ func (w *mockRelationStatusWatcher) Changes() <-chan []string {
 type mockOfferStatusWatcher struct {
 	*mockWatcher
 	offerUUID string
+	offerName string
 	changes   chan struct{}
 }
 
@@ -313,6 +314,10 @@ func (w *mockOfferStatusWatcher) Changes() <-chan struct{} {
 
 func (w *mockOfferStatusWatcher) OfferUUID() string {
 	return w.offerUUID
+}
+
+func (w *mockOfferStatusWatcher) OfferName() string {
+	return w.offerName
 }
 
 type mockModel struct {
@@ -367,6 +372,10 @@ func (r *mockRelation) Destroy() error {
 
 func (r *mockRelation) Life() state.Life {
 	return state.Alive
+}
+
+func (r *mockRelation) UnitCount() int {
+	return 666
 }
 
 func (r *mockRelation) SetStatus(statusInfo status.StatusInfo) error {
@@ -499,7 +508,7 @@ func (a *mockApplication) Life() state.Life {
 
 func (a *mockApplication) Status() (status.StatusInfo, error) {
 	a.MethodCall(a, "Status")
-	return status.StatusInfo{}, nil
+	return status.StatusInfo{Status: status.Terminated}, nil
 }
 
 type mockOfferConnection struct {

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -261,6 +261,11 @@ func (r *mockRelation) Life() state.Life {
 	return r.life
 }
 
+func (r *mockRelation) UnitCount() int {
+	r.MethodCall(r, "UnitCount")
+	return 666
+}
+
 func (r *mockRelation) Suspended() bool {
 	r.MethodCall(r, "Suspended")
 	return r.suspended

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -205,12 +205,14 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 		{"machine-42"},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
+	uc := 666
 	c.Assert(results.Results, jc.DeepEquals, []params.RemoteRelationWatchResult{{
 		RemoteRelationWatcherId: "1",
 		Changes: params.RemoteRelationChangeEvent{
 			RelationToken:    "token-relation-django.db#db2.db",
 			ApplicationToken: "token-application-django",
 			Macaroons:        nil,
+			UnitCount:        &uc,
 			ApplicationSettings: map[string]interface{}{
 				"sunday": "roast",
 			},
@@ -256,6 +258,7 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 		{"Endpoints", []interface{}{}},
 		{"ApplicationSettings", []interface{}{"django"}},
 		{"Unit", []interface{}{"django/0"}},
+		{"UnitCount", []interface{}{}},
 	})
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14227,6 +14227,9 @@
                         },
                         "suspended-reason": {
                             "type": "string"
+                        },
+                        "unit-count": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,
@@ -28250,6 +28253,9 @@
                         },
                         "suspended-reason": {
                             "type": "string"
+                        },
+                        "unit-count": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,
@@ -28880,6 +28886,9 @@
                         },
                         "suspended-reason": {
                             "type": "string"
+                        },
+                        "unit-count": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -362,6 +362,9 @@ type RemoteRelationChangeEvent struct {
 	// ensure that all relation units have left scope.
 	ForceCleanup *bool `json:"force-cleanup,omitempty"`
 
+	// UnitCount is the number of units still in relation scope.
+	UnitCount *int `json:"unit-count,omitempty"`
+
 	// Suspended is the current suspended status of the relation.
 	Suspended *bool `json:"suspended,omitempty"`
 

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -381,7 +381,8 @@ func newOfferStatusWatcher(context facade.Context) (facade.Facade, error) {
 // or the Watch call that created the srvOfferStatusWatcher.
 func (w *srvOfferStatusWatcher) Next() (params.OfferStatusWatchResult, error) {
 	if _, ok := <-w.watcher.Changes(); ok {
-		change, err := crossmodel.GetOfferStatusChange(crossmodel.GetBackend(w.st), w.watcher.OfferUUID())
+		change, err := crossmodel.GetOfferStatusChange(
+			crossmodel.GetBackend(w.st), w.watcher.OfferUUID(), w.watcher.OfferName())
 		if err != nil {
 			return params.OfferStatusWatchResult{
 				Error: common.ServerError(err),

--- a/featuretests/remoterelations_test.go
+++ b/featuretests/remoterelations_test.go
@@ -156,9 +156,11 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 		c.Assert(worker.Stop(w), jc.ErrorIsNil)
 	}()
 
+	uc := 0
 	assertRelationUnitsChange(c, s.BackingState, w, params.RemoteRelationChangeEvent{
 		RelationToken:    relToken,
 		ApplicationToken: appToken,
+		UnitCount: &uc,
 	})
 	assertNoRelationUnitsChange(c, s.BackingState, w)
 
@@ -170,6 +172,7 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = ru.EnterScope(settings)
 	c.Assert(err, jc.ErrorIsNil)
+	uc = 1
 	expect := params.RemoteRelationChangeEvent{
 		RelationToken:    relToken,
 		ApplicationToken: appToken,
@@ -179,6 +182,7 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 				"key": "value",
 			},
 		}},
+		UnitCount: &uc,
 	}
 	assertRelationUnitsChange(c, s.BackingState, w, expect)
 	assertNoRelationUnitsChange(c, s.BackingState, w)
@@ -202,6 +206,7 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 				"quay": float64(123),
 			},
 		}},
+		UnitCount: &uc,
 	}
 	assertRelationUnitsChange(c, s.BackingState, w, expect)
 	assertNoRelationUnitsChange(c, s.BackingState, w)
@@ -209,10 +214,12 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationChanges(c *gc.C) {
 	// Remove a unit of wordpress, expect a change.
 	err = ru.LeaveScope()
 	c.Assert(err, jc.ErrorIsNil)
+	uc = 0
 	expect = params.RemoteRelationChangeEvent{
 		RelationToken:    relToken,
 		ApplicationToken: appToken,
 		DepartedUnits:    []int{0},
+		UnitCount: &uc,
 	}
 	assertRelationUnitsChange(c, s.BackingState, w, expect)
 	assertNoRelationUnitsChange(c, s.BackingState, w)

--- a/state/application.go
+++ b/state/application.go
@@ -295,7 +295,13 @@ func (op *DestroyApplicationOperation) Done(err error) error {
 		if err2 != nil {
 			err = errors.Trace(err2)
 		} else {
-			err = errors.Errorf("application is used by %d offer%s", len(rels), plural(len(rels)))
+			n := 0
+			for _, r := range rels {
+				if _, isCrossModel, err := r.RemoteApplication(); err == nil && isCrossModel {
+					n++
+				}
+			}
+			err = errors.Errorf("application is used by %d consumer%s", n, plural(n))
 		}
 	} else {
 		err = errors.NewNotSupported(err, "change to the application detected")

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -807,3 +807,16 @@ func (st *State) WatchOfferStatus(offerUUID string) (NotifyWatcher, error) {
 	}
 	return newNotifyCollWatcher(st, statusesC, filter), nil
 }
+
+// WatchOffer returns a new NotifyWatcher watching for
+// changes to the specified offer.
+func (st *State) WatchOffer(offerName string) NotifyWatcher {
+	filter := func(rawId interface{}) bool {
+		id, err := st.strictLocalID(rawId.(string))
+		if err != nil {
+			return false
+		}
+		return offerName == id
+	}
+	return newNotifyCollWatcher(st, applicationOffersC, filter)
+}

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -759,7 +759,6 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
 	// Initial event.
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 
 	app, err := s.State.Application(offer.ApplicationName)
 	c.Assert(err, jc.ErrorIsNil)
@@ -769,7 +768,6 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 
 	u := s.Factory.MakeUnit(c, &factory.UnitParams{
 		Application: app,
@@ -779,11 +777,9 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 	err = u.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 
 	err = ao.Remove(offer.OfferName, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -792,7 +788,6 @@ func (s *applicationOffersSuite) TestWatchOfferStatus(c *gc.C) {
 	err = app.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 }
 
 func (s *applicationOffersSuite) TestWatchOffer(c *gc.C) {
@@ -820,12 +815,10 @@ func (s *applicationOffersSuite) TestWatchOffer(c *gc.C) {
 	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
 	// Initial event.
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 
 	err = ao.Remove(offer.OfferName, false)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
-	wc.AssertNoChange()
 
 	err = ao.Remove(anotherOffer.OfferName, false)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/relation.go
+++ b/state/relation.go
@@ -73,6 +73,11 @@ func (r *Relation) Tag() names.Tag {
 	return names.NewRelationTag(r.doc.Key)
 }
 
+// UnitCount is the number of units still in relation scope.
+func (r *Relation) UnitCount() int {
+	return r.doc.UnitCount
+}
+
 // Suspended returns true if the relation is suspended.
 func (r *Relation) Suspended() bool {
 	return r.doc.Suspended

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -94,15 +94,23 @@ func (s *RelationSuite) TestRetrieveSuccess(c *gc.C) {
 	wordpressEP, err := wordpress.Endpoint("db")
 	c.Assert(err, jc.ErrorIsNil)
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	mysqlUnit, err := mysql.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
 	mysqlEP, err := mysql.Endpoint("server")
 	c.Assert(err, jc.ErrorIsNil)
 	expect, err := s.State.AddRelation(wordpressEP, mysqlEP)
 	c.Assert(err, jc.ErrorIsNil)
+	mysqlru, err := expect.Unit(mysqlUnit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = mysqlru.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	rel, err := s.State.EndpointsRelation(wordpressEP, mysqlEP)
 	check := func() {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(rel.Id(), gc.Equals, expect.Id())
 		c.Assert(rel.String(), gc.Equals, expect.String())
+		c.Assert(rel.UnitCount(), gc.Equals, 1)
 	}
 	check()
 	rel, err = s.State.EndpointsRelation(mysqlEP, wordpressEP)

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -30,8 +30,8 @@ type remoteApplicationWorker struct {
 	localModelUUID        string // uuid of the model hosting the local application
 	remoteModelUUID       string // uuid of the model hosting the remote offer
 	isConsumerProxy       bool
-	localRelationChanges  chan params.RemoteRelationChangeEvent
-	remoteRelationChanges chan params.RemoteRelationChangeEvent
+	localRelationChanges  chan RelationUnitChangeEvent
+	remoteRelationChanges chan RelationUnitChangeEvent
 
 	// offerMacaroon is used to confirm that permission has been granted to consume
 	// the remote application to which this worker pertains.
@@ -51,6 +51,7 @@ type remoteApplicationWorker struct {
 // relation between a local app and a remote offer.
 type relation struct {
 	relationId int
+	localDead  bool
 	suspended  bool
 	localRuw   *relationUnitsWorker
 	remoteRuw  *relationUnitsWorker
@@ -182,8 +183,9 @@ func (w *remoteApplicationWorker) loop() (err error) {
 				key := change[i]
 				if err := w.relationChanged(key, result, relations); err != nil {
 					if params.IsCodeNotFound(err) {
-						w.logger.Tracef("not found from relationChanged for %#v: %s", result, errors.ErrorStack(err))
-						return w.remoteOfferRemoved()
+						// Relation has been deleted, cleanup will occur
+						// via additional events arriving.
+						continue
 					}
 					return errors.Annotatef(err, "handling change for relation %q", key)
 				}
@@ -192,16 +194,24 @@ func (w *remoteApplicationWorker) loop() (err error) {
 			w.logger.Debugf("local relation units changed -> publishing: %#v", change)
 			// TODO(babbageclunk): add macaroons to event here instead
 			// of in the relation units worker.
-			if err := w.remoteModelFacade.PublishRelationChange(change); err != nil {
+			if err := w.remoteModelFacade.PublishRelationChange(change.RemoteRelationChangeEvent); err != nil {
 				w.checkOfferPermissionDenied(err, change.ApplicationToken, change.RelationToken)
 				if params.IsCodeNotFound(err) || params.IsCodeCannotEnterScope(err) {
-					return w.remoteOfferRemoved()
+					w.logger.Debugf("relation %v changed but remote side already removed", change.Tag.Id())
+					continue
 				}
 				return errors.Annotatef(err, "publishing relation change %+v to remote model %v", change, w.remoteModelUUID)
 			}
+			if err := w.localRelationChanged(change.Tag.Id(), change.UnitCount, relations); err != nil {
+				return errors.Annotatef(err, "processing local relation change for %v", change.Tag.Id())
+			}
 		case change := <-w.remoteRelationChanges:
 			w.logger.Debugf("remote relation units changed -> consuming: %#v", change)
-			if err := w.localModelFacade.ConsumeRemoteRelationChange(change); err != nil {
+			if err := w.localModelFacade.ConsumeRemoteRelationChange(change.RemoteRelationChangeEvent); err != nil {
+				if params.IsCodeNotFound(err) || params.IsCodeCannotEnterScope(err) {
+					w.logger.Debugf("relation %v changed but local side already removed", change.Tag.Id())
+					continue
+				}
 				return errors.Annotatef(err, "consuming relation change %+v from remote model %v", change, w.remoteModelUUID)
 			}
 		case changes := <-offerStatusChanges:
@@ -235,7 +245,7 @@ func (w *remoteApplicationWorker) processRelationDying(key string, r *relation, 
 		if err := w.remoteModelFacade.PublishRelationChange(change); err != nil {
 			w.checkOfferPermissionDenied(err, r.applicationToken, r.relationToken)
 			if params.IsCodeNotFound(err) {
-				w.logger.Debugf("relation %v dying but offer already removed", key)
+				w.logger.Debugf("relation %v dying but remote side already removed", key)
 				return nil
 			}
 			return errors.Annotatef(err, "publishing relation dying %+v to remote model %v", change, w.remoteModelUUID)
@@ -244,21 +254,24 @@ func (w *remoteApplicationWorker) processRelationDying(key string, r *relation, 
 	return nil
 }
 
-func (w *remoteApplicationWorker) processRelationSuspended(key string, relations map[string]*relation) error {
-	w.logger.Debugf("relation %v suspended", key)
+func (w *remoteApplicationWorker) processRelationSuspended(key string, relLife params.Life, relations map[string]*relation) error {
+	w.logger.Debugf("(%v) relation %v suspended", relLife, key)
 	relation, ok := relations[key]
 	if !ok {
 		return nil
 	}
 
-	// For suspended relations on the consuming side
-	// we want to keep the remote lifecycle watcher
-	// so we know when the relation is resumed.
+	// Only stop the watchers for relation unit changes if relation is alive,
+	// as we need to always deal with units leaving scope etc if the relation is dying.
+	if relLife != params.Alive {
+		return nil
+	}
+
+	// On the offering side, if the relation is resumed,
+	// it will be treated like the relation has been joined
+	// for the first time; all workers will be restarted.
+	// The offering side has isConsumerProxy = true.
 	if w.isConsumerProxy {
-		if err := worker.Stop(relation.remoteRrw); err != nil {
-			w.logger.Warningf("stopping remote relations worker for %v: %v", key, err)
-		}
-		relation.remoteRuw = nil
 		delete(relations, key)
 	}
 
@@ -268,21 +281,57 @@ func (w *remoteApplicationWorker) processRelationSuspended(key string, relations
 		}
 		relation.localRuw = nil
 	}
+	if relation.remoteRuw != nil {
+		if err := worker.Stop(relation.remoteRuw); err != nil {
+			w.logger.Warningf("stopping remote relation unit worker for %v: %v", key, err)
+		}
+		relation.remoteRuw = nil
+	}
 	return nil
 }
 
-func (w *remoteApplicationWorker) processRelationRemoved(key string, relations map[string]*relation) error {
-	w.logger.Debugf("relation %v removed", key)
+// processLocalRelationRemoved is called when a change event arrives from the remote model
+// but the relation in the local model has been removed.
+func (w *remoteApplicationWorker) processLocalRelationRemoved(key string, relations map[string]*relation) error {
+	w.logger.Debugf("local relation %v removed", key)
 	relation, ok := relations[key]
 	if !ok {
 		return nil
 	}
 
-	if err := worker.Stop(relation.remoteRrw); err != nil {
-		w.logger.Warningf("stopping remote relations worker for %v: %v", key, err)
+	// Stop the worker which watches remote status/life.
+	if relation.remoteRrw != nil {
+		if err := worker.Stop(relation.remoteRrw); err != nil {
+			w.logger.Warningf("stopping remote relations worker for %v: %v", key, err)
+		}
+		relation.remoteRrw = nil
+		relations[key] = relation
 	}
-	relation.remoteRuw = nil
+
+	w.logger.Debugf("remote relation %v removed from remote model", key)
+	return nil
+}
+
+// localRelationChanged processes changes to the relation
+// as recorded in the local model; the primary function
+// is to shut down workers when the relation is dead.
+func (w *remoteApplicationWorker) localRelationChanged(
+	key string, unitCount *int, relations map[string]*relation,
+) error {
+	w.logger.Debugf("local relation %v changed", key)
+	relation, ok := relations[key]
+	if !ok {
+		return nil
+	}
+	if !relation.localDead {
+		return nil
+	}
+	if unitCount != nil && *unitCount > 1 {
+		w.logger.Debugf("relation dead but still has %d units in scope", *unitCount)
+		return nil
+	}
 	delete(relations, key)
+	w.logger.Debugf("local relation %v is dead", key)
 
 	// For the unit watchers, check to see if these are nil before stopping.
 	// They will be nil if the relation was suspended and then we kill it for real.
@@ -292,33 +341,48 @@ func (w *remoteApplicationWorker) processRelationRemoved(key string, relations m
 		}
 		relation.localRuw = nil
 	}
+	if relation.remoteRuw != nil {
+		if err := worker.Stop(relation.remoteRuw); err != nil {
+			w.logger.Warningf("stopping remote relation unit worker for %v: %v", key, err)
+		}
+		relation.remoteRuw = nil
+	}
 
-	w.logger.Debugf("remote relation %v removed from remote model", key)
+	w.logger.Debugf("remote relation %v removed from local model", key)
 	return nil
 }
 
+// relationChanged processes changes to the relation as recorded in the
+// local model when a change event arrives from the remote model.
 func (w *remoteApplicationWorker) relationChanged(
-	key string, result params.RemoteRelationResult, relations map[string]*relation,
+	key string, localRelation params.RemoteRelationResult, relations map[string]*relation,
 ) error {
-	w.logger.Debugf("relation %q changed: %+v", key, result)
-	if result.Error != nil {
-		if params.IsCodeNotFound(result.Error) {
-			return w.processRelationRemoved(key, relations)
+	w.logger.Debugf("relation %q changed in local model: %#v", key, localRelation)
+	if localRelation.Error != nil {
+		if !params.IsCodeNotFound(localRelation.Error) {
+			return localRelation.Error
 		}
-		return result.Error
+		if err := w.processLocalRelationRemoved(key, relations); err != nil {
+			return errors.Annotate(err, "processing local relation removed")
+		}
+		if r := relations[key]; r != nil {
+			r.localDead = true
+			relations[key] = r
+		}
+		return nil
 	}
-	remoteRelation := result.Result
+	localRelationInfo := localRelation.Result
 
 	// If we have previously started the watcher and the
 	// relation is now suspended, stop the watcher.
 	if r := relations[key]; r != nil {
 		wasSuspended := r.suspended
-		r.suspended = remoteRelation.Suspended
+		r.suspended = localRelationInfo.Suspended
 		relations[key] = r
-		if remoteRelation.Suspended {
-			return w.processRelationSuspended(key, relations)
+		if localRelationInfo.Suspended {
+			return w.processRelationSuspended(key, localRelationInfo.Life, relations)
 		}
-		if !wasSuspended && remoteRelation.Life == params.Alive {
+		if !wasSuspended && localRelationInfo.Life == params.Alive {
 			// Nothing to do, we have previously started the watcher.
 			return nil
 		}
@@ -328,7 +392,7 @@ func (w *remoteApplicationWorker) relationChanged(
 		// Nothing else to do on the offering side.
 		return nil
 	}
-	return w.processConsumingRelation(key, relations, remoteRelation)
+	return w.processConsumingRelation(key, relations, localRelationInfo)
 }
 
 // startUnitsWorkers starts 2 workers to watch for unit settings or departed changes;
@@ -351,6 +415,7 @@ func (w *remoteApplicationWorker) startUnitsWorkers(
 		localRelationUnitsWatcher,
 		w.localRelationChanges,
 		w.logger,
+		"local",
 	)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -376,6 +441,7 @@ func (w *remoteApplicationWorker) startUnitsWorkers(
 		remoteRelationUnitsWatcher,
 		w.remoteRelationChanges,
 		w.logger,
+		"remote",
 	)
 	if err != nil {
 		return nil, nil, errors.Trace(err)

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -157,8 +157,8 @@ func New(config Config) (*Worker, error) {
 			// prevent the others from running.
 			IsFatal: func(error) bool { return false },
 
-			// For any failures, try again in 1 minute.
-			RestartDelay: time.Minute,
+			// For any failures, try again in 15 seconds.
+			RestartDelay: 15 * time.Second,
 		}),
 	}
 	err := catacomb.Invoke(catacomb.Plan{
@@ -254,8 +254,8 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 				remoteModelUUID:                   remoteApp.ModelUUID,
 				isConsumerProxy:                   remoteApp.IsConsumerProxy,
 				offerMacaroon:                     remoteApp.Macaroon,
-				localRelationChanges:              make(chan params.RemoteRelationChangeEvent),
-				remoteRelationChanges:             make(chan params.RemoteRelationChangeEvent),
+				localRelationChanges:              make(chan RelationUnitChangeEvent),
+				remoteRelationChanges:             make(chan RelationUnitChangeEvent),
 				localModelFacade:                  w.config.RelationsFacade,
 				newRemoteModelRelationsFacadeFunc: w.config.NewRemoteModelFacadeFunc,
 				logger:                            logger,

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -72,7 +72,7 @@ func waitForStubCalls(c *gc.C, stub *jujutesting.Stub, expected []jujutesting.St
 			return
 		}
 	}
-	c.Fatalf("failed to see expected calls.\nexpected: %v\nobserved: %v", expected, calls)
+	c.Fatalf("failed to see expected calls.\nexpected: %#v\nobserved: %#v", expected, calls)
 }
 
 func (s *remoteRelationsSuite) assertRemoteApplicationWorkers(c *gc.C) worker.Worker {
@@ -253,8 +253,6 @@ func (s *remoteRelationsSuite) TestRemoteNotFoundTerminatesOnChange(c *gc.C) {
 			LocalEndpointName: "data",
 			Macaroons:         macaroon.Slice{mac},
 		}}}},
-		{"SetRemoteApplicationStatus", []interface{}{"db2", "terminated", "offer has been removed"}},
-		{"Close", nil},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }
@@ -456,8 +454,8 @@ func (s *remoteRelationsSuite) TestRemoteRelationsDying(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
-	// Checks that when a remote relation goes away, the relation units
-	// worker is killed.
+	// Checks that when a remote relation goes away, and all units have
+	// left scope, the relation units worker is killed.
 	w := s.assertRemoteRelationsWorkers(c)
 	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
@@ -471,11 +469,60 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 			break
 		}
 	}
-	c.Assert(unitsWatcher.killed(), jc.IsTrue)
+	// Not killed yet because we are still waiting for units to leave scope.
+	c.Assert(unitsWatcher.killed(), jc.IsFalse)
 	expected := []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
+
+	// We get an event with unit count indicating there are
+	// still units in scope.
+	s.stub.ResetCalls()
+	intPtr := func(i int) *int {
+		return &i
+	}
+	event := params.RemoteRelationChangeEvent{
+		RelationToken:    "token-db2:db django:db",
+		ApplicationToken: "token-django",
+		UnitCount:        intPtr(2),
+		DepartedUnits:    []int{1},
+	}
+	unitsWatcher.changes <- event
+	mac, err := apitesting.NewMacaroon("apimac")
+	c.Assert(err, jc.ErrorIsNil)
+	expected = []jujutesting.StubCall{
+		{"PublishRelationChange", []interface{}{
+			params.RemoteRelationChangeEvent{
+				ApplicationToken: "token-django",
+				RelationToken:    "token-db2:db django:db",
+				UnitCount:        intPtr(2),
+				DepartedUnits:    []int{1},
+				Macaroons:        macaroon.Slice{mac},
+			},
+		}},
+	}
+	s.waitForWorkerStubCalls(c, expected)
+	c.Assert(unitsWatcher.killed(), jc.IsFalse)
+
+	// Next event is for last remaining unit.
+	s.stub.ResetCalls()
+	event.UnitCount = intPtr(1)
+	event.DepartedUnits = []int{0}
+	unitsWatcher.changes <- event
+	expected = []jujutesting.StubCall{
+		{"PublishRelationChange", []interface{}{
+			params.RemoteRelationChangeEvent{
+				ApplicationToken: "token-django",
+				RelationToken:    "token-db2:db django:db",
+				UnitCount:        intPtr(1),
+				DepartedUnits:    []int{0},
+				Macaroons:        macaroon.Slice{mac},
+			},
+		}},
+	}
+	s.waitForWorkerStubCalls(c, expected)
+	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 }
 
 func (s *remoteRelationsSuite) TestLocalRelationsChangedNotifies(c *gc.C) {
@@ -546,8 +593,6 @@ func (s *remoteRelationsSuite) TestRemoteNotFoundTerminatesOnPublish(c *gc.C) {
 				Macaroons:     macaroon.Slice{mac},
 			},
 		}},
-		{"SetRemoteApplicationStatus", []interface{}{"db2", "terminated", "offer has been removed"}},
-		{"Close", nil},
 	}
 	s.waitForWorkerStubCalls(c, expected)
 }
@@ -773,6 +818,9 @@ func (s *remoteRelationsSuite) TestRemoteRelationSuspended(c *gc.C) {
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
+	unitsWatcher, ok := s.relationsFacade.remoteRelationWatchers["db2:db django:db"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	s.stub.ResetCalls()
 
 	// Now resume the relation.
@@ -810,4 +858,24 @@ func (s *remoteRelationsSuite) TestRemoteRelationSuspended(c *gc.C) {
 		{"WatchRelationChanges", []interface{}{"token-db2:db django:db", "token-offer-db2-uuid", macaroon.Slice{apiMac}}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
+}
+
+func (s *remoteRelationsSuite) TestDyingRelationSuspended(c *gc.C) {
+	w := s.assertRemoteRelationsWorkers(c)
+	defer workertest.CleanKill(c, w)
+	s.stub.ResetCalls()
+
+	s.relationsFacade.relations["db2:db django:db"].life = params.Dying
+	s.relationsFacade.relations["db2:db django:db"].SetSuspended(true)
+	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
+	relWatcher.changes <- []string{"db2:db django:db"}
+
+	expected := []jujutesting.StubCall{
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+	}
+	s.waitForWorkerStubCalls(c, expected)
+	// Suspending a dying relation does not stop workers.
+	unitsWatcher, ok := s.relationsFacade.remoteRelationWatchers["db2:db django:db"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(unitsWatcher.killed(), jc.IsFalse)
 }


### PR DESCRIPTION
## Description of change

There's a few issues for CMR relations. The main one is the workers in the consuming model are stopped as soon as the relation dead event arrives, but there could still be a unit scope change event to arrive (different watchers are used). So ensure that the watchers are only stopped when all units have left scope. This is done by adding unit count to the relation-unit change event. Also, when a relation is suspended, only stop the watchers if the relation is alive, otherwise we might miss departing events.

Reduce the cmr worker restart delay to 15 seconds, as 1 minute seems too long (we want to avoid spamming when using cross controller calls hence it's not the standard 3 seconds).

We were also marking the saas status as terminated if the offering side had removed the relation, but this should only be done if the offer (or app) is removed. So add a new watcher to provide that information. Extra unit tests in various places were added also.

There's 3 commits:
- state changes
- apiserver changes
- cmr worker changes

## QA steps

```sh
juju bootstrap lxd
juju add-model database
juju deploy percona-cluster mysql --config min-cluster-size=3 -n 3
juju offer mysql:shared-db
juju switch default
juju deploy vault -n 3
juju consume database.mysql rmysql
juju relate rmysql vault
```

wait for things to settle, then 
juju remove-relation vault rmysql
The relation should be removed both consuming side and offering side.

Remove the offer.
The saas status on the consuming side should go to "terminated".

## Bug reference

https://bugs.launchpad.net/bugs/1879645
