### PR TITLE
Lift leader pinning API to be a member

### DIFF
--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -122,7 +122,7 @@ func offerForUbuntuSeries(series string) (string, string, error) {
 	if oldSeries.Contains(series) {
 		return ubuntuOffering, seriesVersion, nil
 	}
-	seriesVersion = strings.ReplaceAll(seriesVersion, ".", "_")
+	seriesVersion = strings.Replace(seriesVersion, ".", "_", -1)
 	return fmt.Sprintf("0001-com-ubuntu-server-%s", series), seriesVersion, nil
 }
 


### PR DESCRIPTION
## Description of change

This is a VERY mechanical change but is the embodiment of don't let
common functionality determine your Facade API[1].

The change from the outset is to allow the changes of the common
leadership pinning functionality methods, without having to change the
API. As in the future we want to expose methods from that package
without adding them to the Facade API.

Ensuring that this is the same API is done via the usage of
`make schema`, which will be different if any of the methods/params are
different.

 1. https://discourse.juju.is/t/common-facade-apis/3081

## QA steps

Rebuild the schema to ensure that there are no facade changes. 

```sh
make schema
git diff # is empty
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1879663
