### PR TITLE
Migrating a model from an old controller with incomplete endpoint bin…

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -921,8 +921,10 @@ func (i *importer) application(a description.Application) error {
 // of space names as the map values and can safely be passed to the NewBindings
 // c-tor.
 func (i *importer) parseBindings(bindingsMap map[string]string) (*Bindings, error) {
+	defaultMappingsAreIds := true
 	for epName, spNameOrID := range bindingsMap {
 		if spNameOrID == "" {
+			defaultMappingsAreIds = false
 			bindingsMap[epName] = network.AlphaSpaceName
 		}
 	}
@@ -931,11 +933,19 @@ func (i *importer) parseBindings(bindingsMap map[string]string) (*Bindings, erro
 	// non-default space whereas 2.7 controllers always set it.
 	// The application implementation in the description package has
 	// `omitempty` for bindings, so we need to create it if nil.
+	// There's an added complication. Coming from a 2.6 controller, the
+	// mapping is endpoint -> spaceName. If the 2.6 controller has been
+	// upgraded to 2.7.x (x < 7), the mapping is endpoint -> spaceID.
+	// We need to ensure that a consistent mapping value is used.
 	if bindingsMap == nil {
 		bindingsMap = make(map[string]string, 1)
 	}
 	if _, exists := bindingsMap[defaultEndpointName]; !exists {
-		bindingsMap[defaultEndpointName] = network.AlphaSpaceName
+		if defaultMappingsAreIds {
+			bindingsMap[defaultEndpointName] = network.AlphaSpaceId
+		} else {
+			bindingsMap[defaultEndpointName] = network.AlphaSpaceName
+		}
 	}
 
 	return NewBindings(i.st, bindingsMap)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2777,6 +2777,9 @@ func ReplaceSpaceNameWithIDEndpointBindings(pool *StatePool) error {
 				}
 				updatedMap[k] = v
 			}
+			if _, haveDefault := updatedMap[""]; !haveDefault {
+				updatedMap[""] = network.AlphaSpaceId
+			}
 			ops = append(ops, txn.Op{
 				C:      endpointBindingsC,
 				Id:     doc.DocID,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4041,6 +4041,7 @@ func (s *upgradesSuite) TestReplaceSpaceNameWithIDEndpointBindings(c *gc.C) {
 		"model-uuid": uuid1,
 		"bindings": bindingsMap{
 			"one": space1.Name(),
+			"": space1.Name(),
 		},
 	}, bson.M{
 		"_id":        ensureModelUUID(uuid2, "a#ubuntu"),
@@ -4056,15 +4057,15 @@ func (s *upgradesSuite) TestReplaceSpaceNameWithIDEndpointBindings(c *gc.C) {
 		{
 			"_id":        uuid1 + ":a#ubuntu",
 			"model-uuid": uuid1,
-			"bindings":   bson.M{"one": space1.Id(), "two": network.AlphaSpaceId},
+			"bindings":   bson.M{"one": space1.Id(), "two": network.AlphaSpaceId, "": network.AlphaSpaceId},
 		}, {
 			"_id":        uuid1 + ":a#ghost",
 			"model-uuid": uuid1,
-			"bindings":   bson.M{"one": space1.Id()},
+			"bindings":   bson.M{"one": space1.Id(), "": space1.Id()},
 		}, {
 			"_id":        uuid2 + ":a#ubuntu",
 			"model-uuid": uuid2,
-			"bindings":   bson.M{"one": space2.Id()},
+			"bindings":   bson.M{"one": space2.Id(), "": network.AlphaSpaceId},
 		},
 	}
 


### PR DESCRIPTION
## Description of change

There was a missing upgrade step when processing endpoint bindings coming from 2.6->2.7. The default binding was not added. This then confused the handling endpoint bindings when importing a model = a default space name was added where in some cases it should have been the id, depending on the import source.

This PR fixes the upgrade and also leaves in place extra logic to handle imports from broken models on controllers upgraded to 2.7.6 or earlier.

## QA steps

3 scenarios to check, all migrating a model to a 2.7 controller built off this PR
The model to be migrated has a single charm with at least one endpoint deployed

1. 2.6 controller
2. 2.6 controller upgraded to 2.7.6
3. 2.6 controller upgraded to 2.7 from this PR

In the latter case, you can also show-application prior to migrating to see that the default endpoint binding has been added when upgrading.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1880797
