### PR TITLE
Refactor leadership pinning API

### DIFF
--- a/apiserver/common/leadership.go
+++ b/apiserver/common/leadership.go
@@ -44,16 +44,18 @@ func (s leadershipPinningBackend) Machine(name string) (LeadershipMachine, error
 	return leadershipMachine{m}, nil
 }
 
-// API exposes leadership pinning and unpinning functionality for remote use.
+// LeadershipPinningAPI exposes leadership pinning and unpinning functionality
+// for remote use.
 type LeadershipPinningAPI interface {
 	PinMachineApplications() (params.PinApplicationsResults, error)
 	UnpinMachineApplications() (params.PinApplicationsResults, error)
 	PinnedLeadership() (params.PinnedLeadershipResult, error)
 }
 
-// NewLeadershipPinningFacade creates and returns a new leadership API.
+// NewLeadershipPinningFromContext creates and returns a new leadership from
+// a facade context.
 // This signature is suitable for facade registration.
-func NewLeadershipPinningFacade(ctx facade.Context) (LeadershipPinningAPI, error) {
+func NewLeadershipPinningFromContext(ctx facade.Context) (*LeadershipPinning, error) {
 	st := ctx.State()
 	model, err := st.Model()
 	if err != nil {
@@ -63,15 +65,15 @@ func NewLeadershipPinningFacade(ctx facade.Context) (LeadershipPinningAPI, error
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return NewLeadershipPinningAPI(leadershipPinningBackend{st}, model.ModelTag(), pinner, ctx.Auth())
+	return NewLeadershipPinning(leadershipPinningBackend{st}, model.ModelTag(), pinner, ctx.Auth())
 }
 
-// NewLeadershipPinningAPI creates and returns a new leadership API from the
+// NewLeadershipPinning creates and returns a new leadership API from the
 // input tag, Pinner implementation and facade Authorizer.
-func NewLeadershipPinningAPI(
+func NewLeadershipPinning(
 	st LeadershipPinningBackend, modelTag names.ModelTag, pinner leadership.Pinner, authorizer facade.Authorizer,
-) (LeadershipPinningAPI, error) {
-	return &leadershipPinningAPI{
+) (*LeadershipPinning, error) {
+	return &LeadershipPinning{
 		st:         st,
 		modelTag:   modelTag,
 		pinner:     pinner,
@@ -79,7 +81,9 @@ func NewLeadershipPinningAPI(
 	}, nil
 }
 
-type leadershipPinningAPI struct {
+// LeadershipPinning defines a type for pinning and unpinning application
+// leaders.
+type LeadershipPinning struct {
 	st         LeadershipPinningBackend
 	modelTag   names.ModelTag
 	pinner     leadership.Pinner
@@ -88,7 +92,7 @@ type leadershipPinningAPI struct {
 
 // PinnedLeadership returns all pinned applications and the entities that
 // require their pinned behaviour, for leadership in the current model.
-func (a *leadershipPinningAPI) PinnedLeadership() (params.PinnedLeadershipResult, error) {
+func (a *LeadershipPinning) PinnedLeadership() (params.PinnedLeadershipResult, error) {
 	result := params.PinnedLeadershipResult{}
 
 	canAccess, err := a.authorizer.HasPermission(permission.ReadAccess, a.modelTag)
@@ -103,47 +107,108 @@ func (a *leadershipPinningAPI) PinnedLeadership() (params.PinnedLeadershipResult
 	return result, nil
 }
 
-// TODO (manadart 2018-10-29): Rename the two methods below (and on the client
-// side) to be [Un]PinApplicationLeaders, and derive the list of applications
-// based on the authenticating entity.
-
-// PinMachineApplications pins leadership for applications represented by units
-// running on the auth'd machine.
-func (a *leadershipPinningAPI) PinMachineApplications() (params.PinApplicationsResults, error) {
+// PinApplicationLeaders pins leadership for applications based on the auth
+// tag provided.
+func (a *LeadershipPinning) PinApplicationLeaders() (params.PinApplicationsResults, error) {
 	if !a.authorizer.AuthMachineAgent() {
 		return params.PinApplicationsResults{}, ErrPerm
 	}
-	return a.pinMachineAppsOps(a.pinner.PinLeadership)
+
+	tag := a.authorizer.GetAuthTag()
+	switch tag.Kind() {
+	case names.MachineTagKind:
+		return a.pinMachineApplications()
+	default:
+		return params.PinApplicationsResults{}, ErrPerm
+	}
 }
 
-// UnpinMachineApplications unpins leadership for applications represented by
-// units running on the auth'd machine.
-func (a *leadershipPinningAPI) UnpinMachineApplications() (params.PinApplicationsResults, error) {
+// UnpinApplicationLeaders unpins leadership for applications based on the auth
+// tag provided.
+func (a *LeadershipPinning) UnpinApplicationLeaders() (params.PinApplicationsResults, error) {
 	if !a.authorizer.AuthMachineAgent() {
 		return params.PinApplicationsResults{}, ErrPerm
 	}
-	return a.pinMachineAppsOps(a.pinner.UnpinLeadership)
+
+	tag := a.authorizer.GetAuthTag()
+	switch tag.Kind() {
+	case names.MachineTagKind:
+		return a.unpinMachineApplications()
+	default:
+		return params.PinApplicationsResults{}, ErrPerm
+	}
+}
+
+// GetMachineApplicationNames returns the applications associated with a
+// machine.
+func (a *LeadershipPinning) GetMachineApplicationNames() ([]string, error) {
+	if !a.authorizer.AuthMachineAgent() {
+		return nil, ErrPerm
+	}
+
+	tag := a.authorizer.GetAuthTag()
+	m, err := a.st.Machine(tag.Id())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	apps, err := m.ApplicationNames()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apps, nil
+}
+
+// PinMachineApplicationsByName takes a slice of application names and attempts
+// to pin them accordingly.
+func (a *LeadershipPinning) PinMachineApplicationsByName(appNames []string) (params.PinApplicationsResults, error) {
+	if !a.authorizer.AuthMachineAgent() {
+		return params.PinApplicationsResults{}, ErrPerm
+	}
+
+	return a.pinMachineAppsOps(appNames, a.pinner.PinLeadership)
+}
+
+// UnpinMachineApplicationsByName takes a slice of application names and
+// attempts to pin them accordingly.
+func (a *LeadershipPinning) UnpinMachineApplicationsByName(appNames []string) (params.PinApplicationsResults, error) {
+	if !a.authorizer.AuthMachineAgent() {
+		return params.PinApplicationsResults{}, ErrPerm
+	}
+
+	return a.pinMachineAppsOps(appNames, a.pinner.UnpinLeadership)
+}
+
+// pinMachineApplications pins leadership for applications represented by units
+// running on the auth'd machine.
+func (a *LeadershipPinning) pinMachineApplications() (params.PinApplicationsResults, error) {
+	appNames, err := a.GetMachineApplicationNames()
+	if err != nil {
+		return params.PinApplicationsResults{}, ErrPerm
+	}
+	return a.pinMachineAppsOps(appNames, a.pinner.PinLeadership)
+}
+
+// unpinMachineApplications unpins leadership for applications represented by
+// units running on the auth'd machine.
+func (a *LeadershipPinning) unpinMachineApplications() (params.PinApplicationsResults, error) {
+	appNames, err := a.GetMachineApplicationNames()
+	if err != nil {
+		return params.PinApplicationsResults{}, ErrPerm
+	}
+	return a.pinMachineAppsOps(appNames, a.pinner.UnpinLeadership)
 }
 
 // pinMachineAppsOps runs the input pin/unpin operation against all
 // applications represented by units on the authorised machine.
 // An assumption is made that the validity of the auth tag has been verified
 // by the caller.
-func (a *leadershipPinningAPI) pinMachineAppsOps(op func(string, string) error) (params.PinApplicationsResults, error) {
-	result := params.PinApplicationsResults{}
+func (a *LeadershipPinning) pinMachineAppsOps(appNames []string, op func(string, string) error) (params.PinApplicationsResults, error) {
+	var result params.PinApplicationsResults
 
 	tag := a.authorizer.GetAuthTag()
-	m, err := a.st.Machine(tag.Id())
-	if err != nil {
-		return result, errors.Trace(err)
-	}
-	apps, err := m.ApplicationNames()
-	if err != nil {
-		return result, errors.Trace(err)
-	}
 
-	results := make([]params.PinApplicationResult, len(apps))
-	for i, app := range apps {
+	results := make([]params.PinApplicationResult, len(appNames))
+	for i, app := range appNames {
 		results[i] = params.PinApplicationResult{
 			ApplicationName: app,
 		}

--- a/apiserver/common/leadership.go
+++ b/apiserver/common/leadership.go
@@ -145,16 +145,16 @@ func (a *LeadershipPinning) GetMachineApplicationNames(id string) ([]string, err
 	return apps, nil
 }
 
-// PinMachineApplicationsByName takes a slice of application names and attempts
+// PinApplicationLeadersByName takes a slice of application names and attempts
 // to pin them accordingly.
-func (a *LeadershipPinning) PinMachineApplicationsByName(tag names.Tag, appNames []string) (params.PinApplicationsResults, error) {
-	return a.pinMachineAppsOps(tag, appNames, a.pinner.PinLeadership)
+func (a *LeadershipPinning) PinApplicationLeadersByName(tag names.Tag, appNames []string) (params.PinApplicationsResults, error) {
+	return a.pinAppLeadersOps(tag, appNames, a.pinner.PinLeadership)
 }
 
-// UnpinMachineApplicationsByName takes a slice of application names and
-// attempts to pin them accordingly.
-func (a *LeadershipPinning) UnpinMachineApplicationsByName(tag names.Tag, appNames []string) (params.PinApplicationsResults, error) {
-	return a.pinMachineAppsOps(tag, appNames, a.pinner.UnpinLeadership)
+// UnpinApplicationLeadersByName takes a slice of application names and
+// attempts to unpin them accordingly.
+func (a *LeadershipPinning) UnpinApplicationLeadersByName(tag names.Tag, appNames []string) (params.PinApplicationsResults, error) {
+	return a.pinAppLeadersOps(tag, appNames, a.pinner.UnpinLeadership)
 }
 
 // pinMachineApplications pins leadership for applications represented by units
@@ -164,7 +164,7 @@ func (a *LeadershipPinning) pinMachineApplications(tag names.Tag) (params.PinApp
 	if err != nil {
 		return params.PinApplicationsResults{}, ErrPerm
 	}
-	return a.pinMachineAppsOps(tag, appNames, a.pinner.PinLeadership)
+	return a.pinAppLeadersOps(tag, appNames, a.pinner.PinLeadership)
 }
 
 // unpinMachineApplications unpins leadership for applications represented by
@@ -174,14 +174,14 @@ func (a *LeadershipPinning) unpinMachineApplications(tag names.Tag) (params.PinA
 	if err != nil {
 		return params.PinApplicationsResults{}, ErrPerm
 	}
-	return a.pinMachineAppsOps(tag, appNames, a.pinner.UnpinLeadership)
+	return a.pinAppLeadersOps(tag, appNames, a.pinner.UnpinLeadership)
 }
 
-// pinMachineAppsOps runs the input pin/unpin operation against all
-// applications represented by units on the authorised machine.
+// pinAppLeadersOps runs the input pin/unpin operation against all
+// applications entities.
 // An assumption is made that the validity of the auth tag has been verified
 // by the caller.
-func (a *LeadershipPinning) pinMachineAppsOps(tag names.Tag, appNames []string, op func(string, string) error) (params.PinApplicationsResults, error) {
+func (a *LeadershipPinning) pinAppLeadersOps(tag names.Tag, appNames []string, op func(string, string) error) (params.PinApplicationsResults, error) {
 	var result params.PinApplicationsResults
 
 	results := make([]params.PinApplicationResult, len(appNames))

--- a/apiserver/common/leadership_test.go
+++ b/apiserver/common/leadership_test.go
@@ -140,19 +140,19 @@ func (s *LeadershipSuite) TestGetMachineApplicationNamesSuccess(c *gc.C) {
 	c.Check(appNames, gc.DeepEquals, s.machineApps)
 }
 
-func (s *LeadershipSuite) TestPinMachineApplicationsByNameSuccess(c *gc.C) {
+func (s *LeadershipSuite) TestPinApplicationLeadersByNameSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	for _, app := range s.machineApps {
 		s.pinner.EXPECT().PinLeadership(app, s.authTag.String()).Return(nil)
 	}
 
-	res, err := s.api.PinMachineApplicationsByName(s.authTag, s.machineApps)
+	res, err := s.api.PinApplicationLeadersByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.DeepEquals, params.PinApplicationsResults{Results: s.pinApplicationsSuccessResults()})
 }
 
-func (s *LeadershipSuite) TestPinMachineApplicationsByNamePartialError(c *gc.C) {
+func (s *LeadershipSuite) TestPinApplicationLeadersByNamePartialError(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	errorRes := errors.New("boom")
@@ -160,7 +160,7 @@ func (s *LeadershipSuite) TestPinMachineApplicationsByNamePartialError(c *gc.C) 
 	s.pinner.EXPECT().PinLeadership("redis", s.authTag.String()).Return(errorRes)
 	s.pinner.EXPECT().PinLeadership("wordpress", s.authTag.String()).Return(nil)
 
-	res, err := s.api.PinMachineApplicationsByName(s.authTag, s.machineApps)
+	res, err := s.api.PinApplicationLeadersByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 
 	results := s.pinApplicationsSuccessResults()
@@ -168,19 +168,19 @@ func (s *LeadershipSuite) TestPinMachineApplicationsByNamePartialError(c *gc.C) 
 	c.Check(res, gc.DeepEquals, params.PinApplicationsResults{Results: results})
 }
 
-func (s *LeadershipSuite) TestUnpinMachineApplicationsByNameSuccess(c *gc.C) {
+func (s *LeadershipSuite) TestUnpinApplicationLeadersByNameSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	for _, app := range s.machineApps {
 		s.pinner.EXPECT().UnpinLeadership(app, s.authTag.String()).Return(nil)
 	}
 
-	res, err := s.api.UnpinMachineApplicationsByName(s.authTag, s.machineApps)
+	res, err := s.api.UnpinApplicationLeadersByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.DeepEquals, params.PinApplicationsResults{Results: s.pinApplicationsSuccessResults()})
 }
 
-func (s *LeadershipSuite) TestUnpinMachineApplicationsByNamePartialError(c *gc.C) {
+func (s *LeadershipSuite) TestUnpinApplicationLeadersByNamePartialError(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	errorRes := errors.New("boom")
@@ -188,7 +188,7 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsByNamePartialError(c *gc.C
 	s.pinner.EXPECT().UnpinLeadership("redis", s.authTag.String()).Return(errorRes)
 	s.pinner.EXPECT().UnpinLeadership("wordpress", s.authTag.String()).Return(nil)
 
-	res, err := s.api.UnpinMachineApplicationsByName(s.authTag, s.machineApps)
+	res, err := s.api.UnpinApplicationLeadersByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 
 	results := s.pinApplicationsSuccessResults()

--- a/apiserver/common/leadership_test.go
+++ b/apiserver/common/leadership_test.go
@@ -130,26 +130,12 @@ func (s *LeadershipSuite) TestPinApplicationLeadersPermissionDenied(c *gc.C) {
 
 	_, err = s.api.UnpinApplicationLeaders()
 	c.Assert(err, gc.ErrorMatches, "permission denied")
-
-	_, err = s.api.PinMachineApplicationsByName(s.machineApps)
-	c.Assert(err, gc.ErrorMatches, "permission denied")
-
-	_, err = s.api.UnpinMachineApplicationsByName(s.machineApps)
-	c.Assert(err, gc.ErrorMatches, "permission denied")
-}
-
-func (s *LeadershipSuite) TestGetMachineApplicationNamesDenied(c *gc.C) {
-	s.authTag = names.NewUserTag("some-random-cat")
-	defer s.setup(c).Finish()
-
-	_, err := s.api.GetMachineApplicationNames()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
 func (s *LeadershipSuite) TestGetMachineApplicationNamesSuccess(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	appNames, err := s.api.GetMachineApplicationNames()
+	appNames, err := s.api.GetMachineApplicationNames(s.authTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(appNames, gc.DeepEquals, s.machineApps)
 }
@@ -161,7 +147,7 @@ func (s *LeadershipSuite) TestPinMachineApplicationsByNameSuccess(c *gc.C) {
 		s.pinner.EXPECT().PinLeadership(app, s.authTag.String()).Return(nil)
 	}
 
-	res, err := s.api.PinMachineApplicationsByName(s.machineApps)
+	res, err := s.api.PinMachineApplicationsByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.DeepEquals, params.PinApplicationsResults{Results: s.pinApplicationsSuccessResults()})
 }
@@ -174,7 +160,7 @@ func (s *LeadershipSuite) TestPinMachineApplicationsByNamePartialError(c *gc.C) 
 	s.pinner.EXPECT().PinLeadership("redis", s.authTag.String()).Return(errorRes)
 	s.pinner.EXPECT().PinLeadership("wordpress", s.authTag.String()).Return(nil)
 
-	res, err := s.api.PinMachineApplicationsByName(s.machineApps)
+	res, err := s.api.PinMachineApplicationsByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 
 	results := s.pinApplicationsSuccessResults()
@@ -189,7 +175,7 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsByNameSuccess(c *gc.C) {
 		s.pinner.EXPECT().UnpinLeadership(app, s.authTag.String()).Return(nil)
 	}
 
-	res, err := s.api.UnpinMachineApplicationsByName(s.machineApps)
+	res, err := s.api.UnpinMachineApplicationsByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.DeepEquals, params.PinApplicationsResults{Results: s.pinApplicationsSuccessResults()})
 }
@@ -202,7 +188,7 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsByNamePartialError(c *gc.C
 	s.pinner.EXPECT().UnpinLeadership("redis", s.authTag.String()).Return(errorRes)
 	s.pinner.EXPECT().UnpinLeadership("wordpress", s.authTag.String()).Return(nil)
 
-	res, err := s.api.UnpinMachineApplicationsByName(s.machineApps)
+	res, err := s.api.UnpinMachineApplicationsByName(s.authTag, s.machineApps)
 	c.Assert(err, jc.ErrorIsNil)
 
 	results := s.pinApplicationsSuccessResults()

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -56,14 +56,6 @@ func (s *upgradeSeriesSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *upgradeSeriesSuite) TestFacadeConformsToInterface(c *gc.C) {
-	// To preserve backwards compatibility, we ensure that the current facade
-	// aligns to the common.LeadershipPinningAPI. The actual underlying
-	// leadership type no longer does this (for good reasons), but we need to
-	// ensure the Facade still does to prevent a revision change.
-	var _ common.LeadershipPinningAPI = s.api
-}
-
 func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 	defer s.arrangeTest(c).Finish()
 

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -56,6 +56,14 @@ func (s *upgradeSeriesSuite) SetUpTest(c *gc.C) {
 	}
 }
 
+func (s *upgradeSeriesSuite) TestFacadeConformsToInterface(c *gc.C) {
+	// To preserve backwards compatibility, we ensure that the current facade
+	// aligns to the common.LeadershipPinningAPI. The actual underlying
+	// leadership type no longer does this (for good reasons), but we need to
+	// ensure the Facade still does to prevent a revision change.
+	var _ common.LeadershipPinningAPI = s.api
+}
+
 func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
 	defer s.arrangeTest(c).Finish()
 


### PR DESCRIPTION
## Description of change

The following re-works the common leadership pinning API. It removes the
idea that the API is part of a facade and instead defines its own type,
one that can move independently of a facade version. This has been an
ongoing discussion for some time, but has concretely formalised to a
discourse post[1].

The changes are relatively simple, adding new methods for taking an
application name slice, so calling Pin/Unpin doesn't require a machine
to talk to. This should give us a lot of flexibility about when and how
we can call these methods.

1. https://discourse.juju.is/t/common-facade-apis/3081

## QA steps

Test pass, this is a mechanical refactoring change

## Bug reference

https://bugs.launchpad.net/juju/+bug/1879663
