### PR TITLE
Make vendor content addressable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ $(GOPATH)/bin/dep:
 
 # populate vendor/ from Gopkg.lock without updating it first (lock file is the single source of truth for machine).
 dep: $(GOPATH)/bin/dep
+	sh -c '. "${PROJECT_DIR}/make_functions.sh"; ensure_dep "$$@"'
 	$(GOPATH)/bin/dep ensure -vendor-only $(verbose)
 endif
 

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -euf
+
+ensure_dep() {
+    if [ ! -d vendor ]; then
+        SHA=$(sha256sum Gopkg.lock | cut -d ' ' -f 1)
+        wget -O vendor.tar.gz "https://juju-dep.s3-eu-west-1.amazonaws.com/${SHA}.tar.gz"
+        tar -xvzf vendor.tar.gz
+        rm -rf vendor.tar.gz
+    else
+        echo "Skipping..."
+    fi
+}


### PR DESCRIPTION
## Description of change

The following makes the vendor directory content addressable. It uses
the Gopkg.lock file for the sha and then downloads the content from s3
if it's available.

SO in order to update the vendor directory for CI tests, you need to
update your Gopkg.toml, which will cause the Gopkg.lock file to update.
Then run sha256sum on the Gopkg.lock and upload that to the s3 bucket,
ensuring to make it public.

## QA steps

```sh
rm -rf vendor
make dep
```