### PR TITLE
Add 2.7.7 upgrade step to re-run ReplaceSpaceNameWithIDEndpointBindings

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -39,6 +39,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.6.3"), stateStepsFor263()},
 		upgradeToVersion{version.MustParse("2.6.5"), stateStepsFor265()},
 		upgradeToVersion{version.MustParse("2.7.0"), stateStepsFor27()},
+		upgradeToVersion{version.MustParse("2.7.7"), stateStepsFor277()},
 	}
 	return steps
 }

--- a/upgrades/steps_277.go
+++ b/upgrades/steps_277.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor277 returns upgrade steps for Juju 2.7.7.
+func stateStepsFor277() []Step {
+	return []Step{
+		// Re-run the same step from 2.7.0 upgrade to pick up a fix in the upgrade step.
+		&upgradeStep{
+			description: "replace space name in endpointBindingDoc bindings with an space ID",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().ReplaceSpaceNameWithIDEndpointBindings()
+			},
+		},
+	}
+}

--- a/upgrades/steps_277_test.go
+++ b/upgrades/steps_277_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v277 = version.MustParse("2.7.7")
+
+type steps277Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps277Suite{})
+
+func (s *steps277Suite) TestReplaceSpaceNameWithIDEndpointBindings(c *gc.C) {
+	step := findStateStep(c, v277, "replace space name in endpointBindingDoc bindings with an space ID")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -625,6 +625,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.6.3",
 		"2.6.5",
 		"2.7.0",
+		"2.7.7",
 	})
 }
 


### PR DESCRIPTION
## Description of change

Add a 2.7.7 upgrade step to re-run the 2.7.0 upgrade step ReplaceSpaceNameWithIDEndpointBindings.

The step has had a logic fix and needs to be run again when upgrading from 2.7.x.

## QA steps

bootstrap 2.6
deploy a charm
upgrade to 2.7.6
upgrade to this PR
check that there's a default endpoint binding "":0

