### PR TITLE
Clean up more package level loggers.

### DIFF
--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -348,6 +348,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:            apiCallerName,
 			MachineLock:              config.MachineLock,
 			Clock:                    config.Clock,
+			Logger:                   loggo.GetLogger("juju.worker.meterstatus"),
 			NewHookRunner:            meterstatus.NewHookRunner,
 			NewMeterStatusAPIClient:  msapi.NewClient,
 			NewUniterStateAPIClient:  commonapi.NewUniterStateAPI,

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -337,6 +337,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:       agentName,
 			MetricSpoolName: metricSpoolName,
 			CharmDirName:    charmDirName,
+			Clock:           config.Clock,
+			Logger:          loggo.GetLogger("juju.worker.metrics.collect"),
 		})),
 
 		// The meter status worker executes the meter-status-changed hook when it detects

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/juju/gomaasapi v0.0.0-20190826212825-0ab1eb636aba
 	github.com/juju/jsonschema v0.0.0-20161102181919-a0ef8b74ebcf
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2
-	github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8
+	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e
 	github.com/juju/lru v0.0.0-20181205132344-305dec07bf2f // indirect
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200424054733-9a8294627524

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVE
 github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 h1:UUHMLvzt/31azWTN/ifGWef4WUqvXk0iRqdhdy/2uzI=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
+github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e h1:FdDd7bdI6cjq5vaoYlK1mfQYfF9sF2VZw8VEZMsl5t8=
+github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/lru v0.0.0-20181205132344-305dec07bf2f h1:M+fqsY4ToeSEXuW+yOvd+tVAjuAZCoLEA5WPrbhG2zI=
 github.com/juju/lru v0.0.0-20181205132344-305dec07bf2f/go.mod h1:RI/7Oj7RFK3hzCrjmJVrEeMryn8PEzl6kiIz4QFb48Y=
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7LYjAfMZm+i6+VzOUBGhku+iOYeh0ohjIy7N9zd7JR4=

--- a/worker/meterstatus/export_test.go
+++ b/worker/meterstatus/export_test.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
+)
+
+func NewLimitedContext(unitName string) *limitedContext {
+	return newLimitedContext(hookConfig{
+		unitName: unitName,
+		clock:    clock.WallClock,
+		logger:   loggo.GetLogger("test"),
+	})
+}

--- a/worker/meterstatus/isolated_test.go
+++ b/worker/meterstatus/isolated_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
+	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/worker.v1/workertest"
 
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/common/charmrunner"

--- a/worker/meterstatus/manifold.go
+++ b/worker/meterstatus/manifold.go
@@ -156,6 +156,7 @@ func newStatusWorker(config ManifoldConfig, context dependency.Context) (worker.
 		Runner:          runner,
 		StateReadWriter: stateReadWriter,
 		Status:          status,
+		Logger:          config.Logger,
 	}
 	return config.NewConnectedStatusWorker(cfg)
 }

--- a/worker/meterstatus/manifold_test.go
+++ b/worker/meterstatus/manifold_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -108,7 +107,7 @@ func (s *PatchedManifoldSuite) SetUpTest(c *gc.C) {
 	newMSClient := func(_ base.APICaller, _ names.UnitTag) msapi.MeterStatusClient {
 		return s.msClient
 	}
-	newHookRunner := func(_ names.UnitTag, _ machinelock.Lock, _ agent.Config, _ clock.Clock) meterstatus.HookRunner {
+	newHookRunner := func(_ meterstatus.HookRunnerConfig) meterstatus.HookRunner {
 		return &stubRunner{stub: s.stub}
 	}
 

--- a/worker/meterstatus/triggers.go
+++ b/worker/meterstatus/triggers.go
@@ -5,11 +5,9 @@ package meterstatus
 
 import (
 	"time"
-
-	"github.com/juju/clock"
 )
 
-type TriggerCreator func(WorkerState, string, time.Time, clock.Clock, time.Duration, time.Duration) (<-chan time.Time, <-chan time.Time)
+type TriggerCreator func(WorkerState, string, time.Time, Clock, time.Duration, time.Duration) (<-chan time.Time, <-chan time.Time)
 
 // GetTriggers returns the signal channels for state transitions based on the current state.
 // It controls the transitions of the inactive meter status worker.
@@ -28,7 +26,7 @@ func GetTriggers(
 	wst WorkerState,
 	status string,
 	disconnectedAt time.Time,
-	clk clock.Clock,
+	clk Clock,
 	amberGracePeriod time.Duration,
 	redGracePeriod time.Duration) (<-chan time.Time, <-chan time.Time) {
 

--- a/worker/metrics/collect/export_test.go
+++ b/worker/metrics/collect/export_test.go
@@ -4,6 +4,9 @@
 package collect
 
 import (
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
+
 	"github.com/juju/juju/worker/metrics/spool"
 	"github.com/juju/juju/worker/uniter/runner"
 )
@@ -15,10 +18,6 @@ var (
 
 	// NewRecorder allows patching the function that creates the metric recorder.
 	NewRecorder = &newRecorder
-
-	// NewHookContext returns a new hook context used to collect metrics.
-	// It is exported here for calling from tests, but not patching.
-	NewHookContext = newHookContext
 
 	// ReadCharm reads the charm directory and returns the charm url and
 	// metrics declared by the charm.
@@ -42,4 +41,15 @@ func NewSocketListenerFnc(listener handlerSetterStopper) func(string, spool.Conn
 		listener.SetHandler(handler)
 		return listener, nil
 	}
+}
+
+// NewHookContext returns a new hook context used to collect metrics.
+// It is exported here for calling from tests, but not patching.
+func NewHookContext(unitName string, recorder spool.MetricRecorder) runner.Context {
+	return newHookContext(hookConfig{
+		unitName: unitName,
+		recorder: recorder,
+		clock:    clock.WallClock,
+		logger:   loggo.GetLogger("test"),
+	})
 }

--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	corecharm "github.com/juju/charm/v7"
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -45,6 +47,8 @@ func (s *handlerSuite) SetUpTest(c *gc.C) {
 		AgentName:       "agent-name",
 		MetricSpoolName: "metric-spool-name",
 		CharmDirName:    "charmdir-name",
+		Clock:           clock.WallClock,
+		Logger:          loggo.GetLogger("test"),
 	}
 	s.manifold = collect.Manifold(s.manifoldConfig)
 	s.dataDir = c.MkDir()

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	// Logger is here to stop the desire of creating a package level Logger.
-	// Don't do this, instead use the context passed into the manifold.
+	// Don't do this, instead use the logger passed into the manifold.
 	logger interface{}
 
 	defaultPeriod = 5 * time.Minute

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -38,7 +38,10 @@ const (
 )
 
 var (
-	logger        = loggo.GetLogger("juju.worker.metrics.collect")
+	// Logger is here to stop the desire of creating a package level Logger.
+	// Don't do this, instead use the context passed into the manifold.
+	logger interface{}
+
 	defaultPeriod = 5 * time.Minute
 
 	// errMetricsNotDefined is returned when the charm the uniter is running does
@@ -84,6 +87,19 @@ type stopper interface {
 	Stop() error
 }
 
+// Clock represents time methods used by this package.
+type Clock interface {
+	Now() time.Time
+}
+
+// Logger represents the logging methods used in this package.
+type Logger interface {
+	Debugf(string, ...interface{})
+	Tracef(string, ...interface{})
+
+	Root() loggo.Logger
+}
+
 // ManifoldConfig identifies the resource names upon which the collect manifold
 // depends.
 type ManifoldConfig struct {
@@ -92,6 +108,9 @@ type ManifoldConfig struct {
 	AgentName       string
 	MetricSpoolName string
 	CharmDirName    string
+
+	Clock  Clock
+	Logger Logger
 }
 
 // Manifold returns a collect-metrics manifold.
@@ -158,6 +177,8 @@ func newCollect(config ManifoldConfig, context dependency.Context) (*collect, er
 	runner := &hookRunner{
 		unitTag: unitTag.String(),
 		paths:   paths,
+		clock:   config.Clock,
+		logger:  config.Logger,
 	}
 	var listener stopper
 	charmURL, validMetrics, err := readCharm(unitTag, paths)
@@ -185,6 +206,7 @@ func newCollect(config ManifoldConfig, context dependency.Context) (*collect, er
 		charmdir:      charmdir,
 		listener:      listener,
 		runner:        runner,
+		logger:        config.Logger,
 	}
 
 	return collector, nil
@@ -197,6 +219,7 @@ type collect struct {
 	charmdir      fortress.Guest
 	listener      stopper
 	runner        *hookRunner
+	logger        Logger
 }
 
 func (w *collect) stop() {
@@ -227,7 +250,7 @@ func (w *collect) Do(stop <-chan struct{}) (err error) {
 
 	recorder, err := newRecorder(unitTag, paths, w.metricFactory)
 	if errors.Cause(err) == errMetricsNotDefined {
-		logger.Tracef("%v", err)
+		w.logger.Tracef("%v", err)
 		return nil
 	} else if err != nil {
 		return errors.Annotate(err, "failed to instantiate metric recorder")
@@ -237,11 +260,11 @@ func (w *collect) Do(stop <-chan struct{}) (err error) {
 		return w.runner.do(recorder)
 	}, stop)
 	if err == fortress.ErrAborted {
-		logger.Tracef("cannot execute collect-metrics: %v", err)
+		w.logger.Tracef("cannot execute collect-metrics: %v", err)
 		return nil
 	}
 	if spool.IsMetricsDataError(err) {
-		logger.Debugf("cannot record metrics: %v", err)
+		w.logger.Debugf("cannot record metrics: %v", err)
 		return nil
 	}
 	return err
@@ -252,14 +275,22 @@ type hookRunner struct {
 
 	unitTag string
 	paths   uniter.Paths
+
+	clock  Clock
+	logger Logger
 }
 
 func (h *hookRunner) do(recorder spool.MetricRecorder) error {
 	h.m.Lock()
 	defer h.m.Unlock()
-	logger.Debugf("recording metrics")
+	h.logger.Debugf("recording metrics")
 
-	ctx := newHookContext(h.unitTag, recorder)
+	ctx := newHookContext(hookConfig{
+		unitName: h.unitTag,
+		recorder: recorder,
+		clock:    h.clock,
+		logger:   h.logger,
+	})
 	err := ctx.addJujuUnitsMetric()
 	if err != nil {
 		return errors.Annotatef(err, "error adding 'juju-units' metric")
@@ -271,11 +302,11 @@ func (h *hookRunner) do(recorder spool.MetricRecorder) error {
 	case charmrunner.IsMissingHookError(errors.Cause(err)):
 		fallthrough
 	case err == nil && handlerType == runner.InvalidHookHandler:
-		logger.Debugf("skipped %q hook (missing)", hooks.CollectMetrics)
+		h.logger.Debugf("skipped %q hook (missing)", hooks.CollectMetrics)
 	case err != nil:
 		return errors.Annotatef(err, "error running %q hook", hooks.CollectMetrics)
 	default:
-		logger.Debugf("ran %q hook (via %s)", hooks.CollectMetrics, handlerType)
+		h.logger.Debugf("ran %q hook (via %s)", hooks.CollectMetrics, handlerType)
 	}
 
 	return nil

--- a/worker/metrics/collect/manifold_test.go
+++ b/worker/metrics/collect/manifold_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
+
 	corecharm "github.com/juju/charm/v7"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -45,6 +48,8 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		AgentName:       "agent-name",
 		MetricSpoolName: "metric-spool-name",
 		CharmDirName:    "charmdir-name",
+		Clock:           clock.WallClock,
+		Logger:          loggo.GetLogger("test"),
 	}
 	s.manifold = collect.Manifold(s.manifoldConfig)
 	s.dataDir = c.MkDir()

--- a/worker/uniter/manifold_test.go
+++ b/worker/uniter/manifold_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/worker/uniter"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	config uniter.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = uniter.ManifoldConfig{
+		Clock:       testclock.NewClock(time.Now()),
+		MachineLock: fakeLock{},
+		Logger:      loggo.GetLogger("test"),
+	}
+}
+
+func (s *ManifoldSuite) TestConfigValidation(c *gc.C) {
+	err := s.config.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Clock not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingMachineLock(c *gc.C) {
+	s.config.MachineLock = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing MachineLock not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Logger not valid")
+}
+
+type fakeLock struct {
+	machinelock.Lock
+}

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/charm/v7/hooks"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -62,6 +63,7 @@ func (s *ContextFactorySuite) SetUpTest(c *gc.C) {
 		Storage:          s.storage,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
+		Logger:           loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.factory = contextFactory
@@ -255,6 +257,7 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 		Storage:          s.storage,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
+		Logger:           loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := contextFactory.HookContext(hook.Info{
@@ -329,6 +332,7 @@ func (s *ContextFactorySuite) setupPodSpec(c *gc.C) (*state.State, context.Conte
 		Storage:          s.storage,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
+		Logger:           loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st, contextFactory, unit.ApplicationName()
@@ -536,6 +540,7 @@ func (s *ContextFactorySuite) TestNewHookContextCAASModel(c *gc.C) {
 		Storage:          s.storage,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
+		Logger:           loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := contextFactory.HookContext(hook.Info{

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -6,6 +6,7 @@ package context
 import (
 	"github.com/juju/charm/v7"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/proxy"
 
@@ -60,6 +61,7 @@ func NewHookContext(hcParams HookContextParams) (*HookContext, error) {
 		pendingPorts:        make(map[PortRange]PortRangeInfo),
 		assignedMachineTag:  hcParams.AssignedMachineTag,
 		clock:               hcParams.Clock,
+		logger:              loggo.GetLogger("test"),
 	}
 	// Get and cache the addresses.
 	var err error
@@ -93,14 +95,16 @@ func NewHookContext(hcParams HookContextParams) (*HookContext, error) {
 
 func NewMockUnitHookContext(mockUnit *mocks.MockHookUnit) *HookContext {
 	return &HookContext{
-		unit: mockUnit,
+		unit:   mockUnit,
+		logger: loggo.GetLogger("test"),
 	}
 }
 
 func NewMockUnitHookContextWithState(mockUnit *mocks.MockHookUnit, state *uniter.State) *HookContext {
 	return &HookContext{
-		unit:  mockUnit,
-		state: state,
+		unit:   mockUnit,
+		state:  state,
+		logger: loggo.GetLogger("test"),
 	}
 }
 
@@ -195,6 +199,7 @@ func NewModelHookContext(p ModelHookContextParams) *HookContext {
 		slaLevel:           p.SLALevel,
 		principal:          p.UnitName,
 		cloudAPIVersion:    "6.66",
+		logger:             loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/charm/v7/hooks"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -175,6 +176,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 		Storage:          s.storage,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
+		Logger:           loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	factory, err := runner.NewFactory(

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/charm/v7/hooks"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/proxy"
 	envtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -194,6 +195,10 @@ type MockContext struct {
 	flushFailure    error
 	flushResult     error
 	modelType       model.ModelType
+}
+
+func (ctx *MockContext) GetLogger(module string) loggo.Logger {
+	return loggo.GetLogger(module)
 }
 
 func (ctx *MockContext) UnitName() string {

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -110,6 +111,7 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 		Storage:          s.storage,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
+		Logger:           loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -144,8 +144,7 @@ type Uniter struct {
 	// rebootQuerier allows the uniter to detect when the machine has
 	// rebooted so we can notify the charms accordingly.
 	rebootQuerier RebootQuerier
-
-	logger Logger
+	logger        Logger
 }
 
 // UniterParams hold all the necessary parameters for a new Uniter.
@@ -204,7 +203,6 @@ func NewUniter(uniterParams *UniterParams) (*Uniter, error) {
 // StartUniter creates a new Uniter and starts it using the specified runner.
 func StartUniter(runner *worker.Runner, params *UniterParams) error {
 	startFunc := newUniter(params)
-
 	params.Logger.Debugf("starting uniter for  %q", params.UnitTag.Id())
 	err := runner.StartWorker(params.UnitTag.Id(), startFunc)
 	return errors.Annotate(err, "error starting uniter worker")
@@ -660,6 +658,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		Storage:          u.storage,
 		Paths:            u.paths,
 		Clock:            u.clock,
+		Logger:           u.logger.Child("context"),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Yet more prepatory work for the merging of agents. This time the target was just dealing with worker/uniter/runner package. However this quickly leaked into the worker/uniter/runner/context package, which then impacted worker/meterstatus and worker/metrics/collect.

Using a new method on the loggo.Logger to get access to the Root logger, we can then use the Child method to get a completely unassociated logger but still have the same logging context. This is necessary for the logging of unit hook output and ensuring it goes into the right log file.

As a drive by I updated some of the validation tests to be more how we do things now.

## QA steps

Unit tests, and deploy something to show all things are hooked up.

## Documentation changes

Everything is internal, nothing to see here.