### PR TITLE
2.7 - Hostname resolution in network-get omits loopback IPs

### DIFF
--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -26,7 +26,7 @@ var _ = gc.Suite(&NetworkGetSuite{})
 func (s *NetworkGetSuite) SetUpSuite(c *gc.C) {
 	s.ContextSuite.SetUpSuite(c)
 	lookupHost := func(host string) (addrs []string, err error) {
-		return []string{"10.3.3.3"}, nil
+		return []string{"127.0.1.1", "10.3.3.3"}, nil
 	}
 	testing.PatchValue(&jujuc.LookupHost, lookupHost)
 }


### PR DESCRIPTION
## Description of change

When a manual machine is provisioned using a FQDN, that name is what is returned by the instance-poller for provider addresses. This means that this name is often also returned as the preferred private and public machine addresses.

In turn, when `network-get` runs for a unit on such a machine, the FQDN is resolved before returning an address result. When it resolves addresses, it returns the first it finds.

We have observed cases where the machine hosts file has an entry like this:
```
127.0.1.1 hostname.fqdn hostname
```
This means that the IP returned by `network-get` is not usable by relations to the unit.

This patch ensures that where possible, we filter `127.*.*.*` addresses before returning host-name resolved addresses. If filtering removes all addresses, we log a warning message to give the operator some information for possible resolution.

## QA steps

To do this, I have a LXD profile that includes my Juju SSH key in authorised keys for the "ubuntu" user.

- Create 2 LXD machines with the profile. I named them `manual-ctrl` and `manual-m1`.
- `juju bootstrap manual/ssh:ubuntu@<manual-ctrl IP> net-get-test --debug --no-gui`.
- Use `lxc exec manual-m1 bash` and add an entry to the hosts file like this:
  `127.0.1.1 manual-m1.lxd manual-m1`.
- Add an entry to _/etc/hosts_ on the _host_ machine:
  `<manual-m1 IP> manual-m1`.
- `juju add-machine ssh:ubuntu@manual-m1`.
- `juju deploy percona-cluster mysql --to 0` and await quiescence.
- `juju run --unit mysql/0 "network-get --format yaml db"`.
- Result should show the hostname, but not the IP from the container host file:
```yaml
bind-addresses:
- macaddress: ""
  interfacename: ""
  addresses:
  - hostname: manual-m1
    address: ""
    cidr: ""
...
```
- `juju debug-log --include mysql/0` should include a warning entry like this:
```
unit-mysql-0: 13:36:00 WARNING worker.uniter.jujuc no usable addresses resolved for host "manual-m1"
        resolved: [127.0.1.1]
        consider editing the hosts file, or changing host resolution order via /etc/nsswitch.conf
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1831580
