### PR TITLE
[2.8] Improve logging for failing to apply commands using raft

### DIFF
--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -4,6 +4,7 @@
 package raftlease
 
 import (
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -683,6 +684,27 @@ func (c *Command) LeaseKey() lease.Key {
 // Marshal converts this command to a byte slice.
 func (c *Command) Marshal() ([]byte, error) {
 	return yaml.Marshal(c)
+}
+
+// String implements fmt.Stringer for the Command type.
+func (c *Command) String() string {
+	switch c.Operation {
+	case OperationSetTime:
+		return fmt.Sprintf(
+			"Command(ver: %d, op: %s, new time: %v)",
+			c.Version, c.Operation, c.NewTime,
+		)
+	case OperationPin, OperationUnpin:
+		return fmt.Sprintf(
+			"Command(ver: %d, op: %s, ns: %s, model: %s, lease: %s, holder: %s, pin entity: %s)",
+			c.Version, c.Operation, c.Namespace, c.ModelUUID, c.Lease, c.Holder, c.PinEntity,
+		)
+	default:
+		return fmt.Sprintf(
+			"Command(ver: %d, op: %s, ns: %s, model: %.6s, lease: %s, holder: %s)",
+			c.Version, c.Operation, c.Namespace, c.ModelUUID, c.Lease, c.Holder,
+		)
+	}
 }
 
 // UnmarshalCommand converts a marshalled command []byte into a


### PR DESCRIPTION
## Description of change

This PR attempts to improve the quality of the raft-related error messages that juju emits. This is achieved by implementing `fmt.Stringer` on the raft `Command` type used by juju and including it (with additional context) in generated error messages.

The attached bug seems to be caused by lack of disk space. Unfortunately, such an error would be generated when the `raft-forwarder` worker calls `raft.Apply` and while it would be returned back to the caller (e.g. the `core/raftlease` package), it would be logged at TRACE level which is probably the reason why we don't see it in the attached log output! The PR changes the TRACE call to an ERROR call which should let us see something like this in the logs (assuming there is still enough room to write them):

```
 write /var/lib/juju/raft/logs: no space left on device
```

## QA steps

No functional changes to existing behavior.

## Bug reference

These changes should help us collect more information for diagnosing scenarios like: https://bugs.launchpad.net/juju/+bug/1879992