### PR TITLE
[2.8] Add controller option to avoid fsync between writes to the raft log

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -286,6 +286,10 @@ type Config interface {
 	// JujuDBSnapChannel returns the channel for installing mongo snaps in
 	// focal or later.
 	JujuDBSnapChannel() string
+
+	// NonSyncedWritesToRaftLog returns true if an fsync calls should not be
+	// performed after each write to the raft log.
+	NonSyncedWritesToRaftLog() bool
 }
 
 type configSetterOnly interface {
@@ -336,6 +340,10 @@ type configSetterOnly interface {
 
 	// SetLoggingConfig sets the logging config value for the agent.
 	SetLoggingConfig(string)
+
+	// SetNonSyncedWritesToRaftLog selects whether fsync calls are performed
+	// after each write to the raft log.
+	SetNonSyncedWritesToRaftLog(bool)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -392,43 +400,45 @@ func (d *apiDetails) clone() *apiDetails {
 }
 
 type configInternal struct {
-	configFilePath     string
-	paths              Paths
-	tag                names.Tag
-	nonce              string
-	controller         names.ControllerTag
-	model              names.ModelTag
-	jobs               []model.MachineJob
-	upgradedToVersion  version.Number
-	caCert             string
-	apiDetails         *apiDetails
-	statePassword      string
-	oldPassword        string
-	servingInfo        *controller.StateServingInfo
-	loggingConfig      string
-	values             map[string]string
-	mongoVersion       string
-	mongoMemoryProfile string
-	jujuDBSnapChannel  string
+	configFilePath           string
+	paths                    Paths
+	tag                      names.Tag
+	nonce                    string
+	controller               names.ControllerTag
+	model                    names.ModelTag
+	jobs                     []model.MachineJob
+	upgradedToVersion        version.Number
+	caCert                   string
+	apiDetails               *apiDetails
+	statePassword            string
+	oldPassword              string
+	servingInfo              *controller.StateServingInfo
+	loggingConfig            string
+	values                   map[string]string
+	mongoVersion             string
+	mongoMemoryProfile       string
+	jujuDBSnapChannel        string
+	nonSyncedWritesToRaftLog bool
 }
 
 // AgentConfigParams holds the parameters required to create
 // a new AgentConfig.
 type AgentConfigParams struct {
-	Paths              Paths
-	Jobs               []model.MachineJob
-	UpgradedToVersion  version.Number
-	Tag                names.Tag
-	Password           string
-	Nonce              string
-	Controller         names.ControllerTag
-	Model              names.ModelTag
-	APIAddresses       []string
-	CACert             string
-	Values             map[string]string
-	MongoVersion       mongo.Version
-	MongoMemoryProfile mongo.MemoryProfile
-	JujuDBSnapChannel  string
+	Paths                    Paths
+	Jobs                     []model.MachineJob
+	UpgradedToVersion        version.Number
+	Tag                      names.Tag
+	Password                 string
+	Nonce                    string
+	Controller               names.ControllerTag
+	Model                    names.ModelTag
+	APIAddresses             []string
+	CACert                   string
+	Values                   map[string]string
+	MongoVersion             mongo.Version
+	MongoMemoryProfile       mongo.MemoryProfile
+	JujuDBSnapChannel        string
+	NonSyncedWritesToRaftLog bool
 }
 
 // NewAgentConfig returns a new config object suitable for use for a
@@ -478,19 +488,20 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 	// When/if this connection is successful, apicaller worker will generate
 	// a new secure password and update this agent's config.
 	config := &configInternal{
-		paths:              NewPathsWithDefaults(configParams.Paths),
-		jobs:               configParams.Jobs,
-		upgradedToVersion:  configParams.UpgradedToVersion,
-		tag:                configParams.Tag,
-		nonce:              configParams.Nonce,
-		controller:         configParams.Controller,
-		model:              configParams.Model,
-		caCert:             configParams.CACert,
-		oldPassword:        configParams.Password,
-		values:             configParams.Values,
-		mongoVersion:       configParams.MongoVersion.String(),
-		mongoMemoryProfile: configParams.MongoMemoryProfile.String(),
-		jujuDBSnapChannel:  configParams.JujuDBSnapChannel,
+		paths:                    NewPathsWithDefaults(configParams.Paths),
+		jobs:                     configParams.Jobs,
+		upgradedToVersion:        configParams.UpgradedToVersion,
+		tag:                      configParams.Tag,
+		nonce:                    configParams.Nonce,
+		controller:               configParams.Controller,
+		model:                    configParams.Model,
+		caCert:                   configParams.CACert,
+		oldPassword:              configParams.Password,
+		values:                   configParams.Values,
+		mongoVersion:             configParams.MongoVersion.String(),
+		mongoMemoryProfile:       configParams.MongoMemoryProfile.String(),
+		jujuDBSnapChannel:        configParams.JujuDBSnapChannel,
+		nonSyncedWritesToRaftLog: configParams.NonSyncedWritesToRaftLog,
 	}
 	if len(configParams.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -799,6 +810,16 @@ func (c *configInternal) JujuDBSnapChannel() string {
 // SetJujuDBSnapChannel implements configSetterOnly.
 func (c *configInternal) SetJujuDBSnapChannel(snapChannel string) {
 	c.jujuDBSnapChannel = snapChannel
+}
+
+// NonSyncedWritesToRaftLog implements Config.
+func (c *configInternal) NonSyncedWritesToRaftLog() bool {
+	return c.nonSyncedWritesToRaftLog
+}
+
+// SetNonSyncedWritesToRaftLog implements configSetterOnly.
+func (c *configInternal) SetNonSyncedWritesToRaftLog(nonSyncedWrites bool) {
+	c.nonSyncedWritesToRaftLog = nonSyncedWrites
 }
 
 var validAddr = regexp.MustCompile("^.+:[0-9]+$")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -376,15 +376,16 @@ var attributeParams = agent.AgentConfigParams{
 	Paths: agent.Paths{
 		DataDir: "/data/dir",
 	},
-	Tag:               names.NewMachineTag("1"),
-	UpgradedToVersion: jujuversion.Current,
-	Password:          "sekrit",
-	CACert:            "ca cert",
-	APIAddresses:      []string{"localhost:1235"},
-	Nonce:             "a nonce",
-	Controller:        testing.ControllerTag,
-	Model:             testing.ModelTag,
-	JujuDBSnapChannel: "4.0/stable",
+	Tag:                      names.NewMachineTag("1"),
+	UpgradedToVersion:        jujuversion.Current,
+	Password:                 "sekrit",
+	CACert:                   "ca cert",
+	APIAddresses:             []string{"localhost:1235"},
+	Nonce:                    "a nonce",
+	Controller:               testing.ControllerTag,
+	Model:                    testing.ModelTag,
+	JujuDBSnapChannel:        "4.0/stable",
+	NonSyncedWritesToRaftLog: false,
 }
 
 func (*suite) TestAttributes(c *gc.C) {
@@ -399,6 +400,7 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.Nonce(), gc.Equals, "a nonce")
 	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, jujuversion.Current)
 	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "4.0/stable")
+	c.Assert(conf.NonSyncedWritesToRaftLog(), jc.IsFalse)
 }
 
 func (*suite) TestStateServingInfo(c *gc.C) {
@@ -661,4 +663,16 @@ func (*suite) TestSetMongoChannel(c *gc.C) {
 	conf.SetJujuDBSnapChannel("latest/candidate")
 	snapChannel = conf.JujuDBSnapChannel()
 	c.Assert(snapChannel, gc.Equals, "latest/candidate", gc.Commentf("mongo snap channel setting not updated"))
+}
+
+func (*suite) TestSetSyncWritesToRaftLog(c *gc.C) {
+	conf, err := agent.NewAgentConfig(attributeParams)
+	c.Assert(err, jc.ErrorIsNil)
+
+	nonSyncedWritesToRaftLog := conf.NonSyncedWritesToRaftLog()
+	c.Assert(nonSyncedWritesToRaftLog, jc.IsFalse)
+
+	conf.SetNonSyncedWritesToRaftLog(true)
+	nonSyncedWritesToRaftLog = conf.NonSyncedWritesToRaftLog()
+	c.Assert(nonSyncedWritesToRaftLog, jc.IsTrue, gc.Commentf("sync writes to raft log settings not updated"))
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -50,17 +50,18 @@ type format_2_0Serialization struct {
 	Values        map[string]string `yaml:"values"`
 
 	// Only controller machines have these next items set.
-	ControllerCert     string `yaml:"controllercert,omitempty"`
-	ControllerKey      string `yaml:"controllerkey,omitempty"`
-	CAPrivateKey       string `yaml:"caprivatekey,omitempty"`
-	APIPort            int    `yaml:"apiport,omitempty"`
-	ControllerAPIPort  int    `yaml:"controllerapiport,omitempty"`
-	StatePort          int    `yaml:"stateport,omitempty"`
-	SharedSecret       string `yaml:"sharedsecret,omitempty"`
-	SystemIdentity     string `yaml:"systemidentity,omitempty"`
-	MongoVersion       string `yaml:"mongoversion,omitempty"`
-	MongoMemoryProfile string `yaml:"mongomemoryprofile,omitempty"`
-	JujuDBSnapChannel  string `yaml:"juju-db-snap-channel,omitempty"`
+	ControllerCert           string `yaml:"controllercert,omitempty"`
+	ControllerKey            string `yaml:"controllerkey,omitempty"`
+	CAPrivateKey             string `yaml:"caprivatekey,omitempty"`
+	APIPort                  int    `yaml:"apiport,omitempty"`
+	ControllerAPIPort        int    `yaml:"controllerapiport,omitempty"`
+	StatePort                int    `yaml:"stateport,omitempty"`
+	SharedSecret             string `yaml:"sharedsecret,omitempty"`
+	SystemIdentity           string `yaml:"systemidentity,omitempty"`
+	MongoVersion             string `yaml:"mongoversion,omitempty"`
+	MongoMemoryProfile       string `yaml:"mongomemoryprofile,omitempty"`
+	JujuDBSnapChannel        string `yaml:"juju-db-snap-channel,omitempty"`
+	NonSyncedWritesToRaftLog bool   `yaml:"no-sync-writes-to-raft-log,omitempty"`
 }
 
 func init() {
@@ -98,16 +99,17 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 			LogDir:           format.LogDir,
 			MetricsSpoolDir:  format.MetricsSpoolDir,
 		}),
-		jobs:              format.Jobs,
-		upgradedToVersion: *format.UpgradedToVersion,
-		nonce:             format.Nonce,
-		controller:        controllerTag,
-		model:             modelTag,
-		caCert:            format.CACert,
-		statePassword:     format.StatePassword,
-		oldPassword:       format.OldPassword,
-		loggingConfig:     format.LoggingConfig,
-		values:            format.Values,
+		jobs:                     format.Jobs,
+		upgradedToVersion:        *format.UpgradedToVersion,
+		nonce:                    format.Nonce,
+		controller:               controllerTag,
+		model:                    modelTag,
+		caCert:                   format.CACert,
+		statePassword:            format.StatePassword,
+		oldPassword:              format.OldPassword,
+		loggingConfig:            format.LoggingConfig,
+		values:                   format.Values,
+		nonSyncedWritesToRaftLog: format.NonSyncedWritesToRaftLog,
 	}
 	if len(format.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -181,6 +183,8 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		OldPassword:       config.oldPassword,
 		LoggingConfig:     config.loggingConfig,
 		Values:            config.values,
+
+		NonSyncedWritesToRaftLog: config.nonSyncedWritesToRaftLog,
 	}
 	if config.servingInfo != nil {
 		format.ControllerCert = config.servingInfo.Cert

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -271,6 +271,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 			agentConfig.SetMongoMemoryProfile(mmprof)
 		}
 		agentConfig.SetJujuDBSnapChannel(args.ControllerConfig.JujuDBSnapChannel())
+		agentConfig.SetNonSyncedWritesToRaftLog(args.ControllerConfig.NonSyncedWritesToRaftLog())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -333,6 +333,12 @@ var newConfigTests = []struct {
 		controller.MaxAgentStateSize: "3000000",
 	},
 	expectError: `invalid max charm/agent state sizes: combined value should not exceed mongo's 16M per-document limit, got 17000000`,
+}, {
+	about: "invalid non-synced-writes-to-raft-log - string",
+	config: controller.Config{
+		controller.NonSyncedWritesToRaftLog: "I live dangerously",
+	},
+	expectError: `non-synced-writes-to-raft-log: expected bool, got string\("I live dangerously"\)`,
 }, {}}
 
 func (s *ConfigSuite) TestNewConfig(c *gc.C) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -58,6 +58,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.PruneTxnSleepTime,
 		controller.MaxCharmStateSize,
 		controller.MaxAgentStateSize,
+		controller.NonSyncedWritesToRaftLog,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)

--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -34,7 +34,8 @@ func BootstrapRaft(context Context) error {
 	agentConfig := context.AgentConfig()
 	storageDir := raftDir(agentConfig)
 
-	logStore, err := raftworker.NewLogStore(storageDir)
+	// Always sync raft log writes when upgrading.
+	logStore, err := raftworker.NewLogStore(storageDir, raftworker.SyncAfterWrite)
 	if err != nil {
 		return errors.Annotate(err, "making log store")
 	}
@@ -149,7 +150,8 @@ func MigrateLegacyLeases(context Context) error {
 
 	storageDir := raftDir(context.AgentConfig())
 
-	logStore, err := raftworker.NewLogStore(storageDir)
+	// Always sync raft log writes when upgrading.
+	logStore, err := raftworker.NewLogStore(storageDir, raftworker.SyncAfterWrite)
 	if err != nil {
 		return errors.Annotate(err, "opening log store")
 	}

--- a/upgrades/raft_test.go
+++ b/upgrades/raft_test.go
@@ -72,7 +72,7 @@ func (s *raftSuite) TestBootStrapRaftWithEmptyLog(c *gc.C) {
 	raftDir := filepath.Join(dataDir, "raft")
 	c.Assert(os.Mkdir(raftDir, 0777), jc.ErrorIsNil)
 
-	logStore, err := raftworker.NewLogStore(raftDir)
+	logStore, err := raftworker.NewLogStore(raftDir, raftworker.SyncAfterWrite)
 	c.Assert(err, jc.ErrorIsNil)
 	// Have to close it here or the open in the code hangs!
 	logStore.Close()
@@ -386,7 +386,7 @@ func (s *raftSuite) TestMigrateLegacyLeasesWithSnapshotAndLogs(c *gc.C) {
 	raftDir := filepath.Join(dataDir, "raft")
 	c.Assert(os.Mkdir(raftDir, 0777), jc.ErrorIsNil)
 
-	logStore, err := raftworker.NewLogStore(raftDir)
+	logStore, err := raftworker.NewLogStore(raftDir, raftworker.SyncAfterWrite)
 	c.Assert(err, jc.ErrorIsNil)
 
 	logger := loggo.GetLogger("raft_upgrades")

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -99,6 +99,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configJujuDBSnapChannel := controllerConfig.JujuDBSnapChannel()
 			jujuDBSnapChannelChanged := agentsJujuDBSnapChannel != configJujuDBSnapChannel
 
+			agentsNonSyncedWritesToRaftLog := agent.CurrentConfig().NonSyncedWritesToRaftLog()
+			configNonSyncedWritesToRaftLog := controllerConfig.NonSyncedWritesToRaftLog()
+			nonSyncedWritesToRaftLogChanged := agentsNonSyncedWritesToRaftLog != configNonSyncedWritesToRaftLog
+
 			info, err := apiState.StateServingInfo()
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
@@ -125,6 +129,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 					logger.Debugf("setting agent config mongo snap channel: %q => %q", agentsJujuDBSnapChannel, configJujuDBSnapChannel)
 					config.SetJujuDBSnapChannel(configJujuDBSnapChannel)
 				}
+				if nonSyncedWritesToRaftLogChanged {
+					logger.Debugf("setting non synced writes to raft log: %t => %t", agentsNonSyncedWritesToRaftLog, configNonSyncedWritesToRaftLog)
+					config.SetNonSyncedWritesToRaftLog(configNonSyncedWritesToRaftLog)
+				}
 				return nil
 			})
 			if err != nil {
@@ -148,11 +156,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				Agent:             agent,
-				Hub:               hub,
-				MongoProfile:      configMongoMemoryProfile,
-				JujuDBSnapChannel: configJujuDBSnapChannel,
-				Logger:            config.Logger,
+				Agent:                    agent,
+				Hub:                      hub,
+				MongoProfile:             configMongoMemoryProfile,
+				JujuDBSnapChannel:        configJujuDBSnapChannel,
+				NonSyncedWritesToRaftLog: configNonSyncedWritesToRaftLog,
+				Logger:                   config.Logger,
 			})
 		},
 	}

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -354,6 +354,9 @@ type mockConfig struct {
 
 	snapChannel    string
 	snapChannelSet bool
+
+	nonSyncedWritesToRaftLog    bool
+	nonSyncedWritesToRaftLogSet bool
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -398,6 +401,15 @@ func (mc *mockConfig) JujuDBSnapChannel() string {
 func (mc *mockConfig) SetJujuDBSnapChannel(snapChannel string) {
 	mc.snapChannel = snapChannel
 	mc.snapChannelSet = true
+}
+
+func (mc *mockConfig) NonSyncedWritesToRaftLog() bool {
+	return mc.nonSyncedWritesToRaftLog
+}
+
+func (mc *mockConfig) SetNonSyncedWritesToRaftLog(nonSynced bool) {
+	mc.nonSyncedWritesToRaftLog = nonSynced
+	mc.nonSyncedWritesToRaftLogSet = true
 }
 
 func (mc *mockConfig) LogDir() string {

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
@@ -16,6 +14,7 @@ import (
 	names "github.com/juju/names/v4"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface
@@ -192,6 +191,20 @@ func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
+// JujuDBSnapChannel mocks base method
+func (m *MockConfig) JujuDBSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
+func (mr *MockConfigMockRecorder) JujuDBSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfig)(nil).JujuDBSnapChannel))
+}
+
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
 	m.ctrl.T.Helper()
@@ -277,20 +290,6 @@ func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
-// JujuDBSnapChannel mocks base method
-func (m *MockConfig) JujuDBSnapChannel() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
-func (mr *MockConfigMockRecorder) JujuDBSnapChannel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfig)(nil).JujuDBSnapChannel))
-}
-
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
 	m.ctrl.T.Helper()
@@ -303,6 +302,20 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
+}
+
+// NonSyncedWritesToRaftLog mocks base method
+func (m *MockConfig) NonSyncedWritesToRaftLog() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NonSyncedWritesToRaftLog")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog
+func (mr *MockConfigMockRecorder) NonSyncedWritesToRaftLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfig)(nil).NonSyncedWritesToRaftLog))
 }
 
 // Nonce mocks base method

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
@@ -16,6 +14,7 @@ import (
 	names "github.com/juju/names/v4"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface
@@ -192,6 +191,20 @@ func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
+// JujuDBSnapChannel mocks base method
+func (m *MockConfig) JujuDBSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
+func (mr *MockConfigMockRecorder) JujuDBSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfig)(nil).JujuDBSnapChannel))
+}
+
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
 	m.ctrl.T.Helper()
@@ -277,20 +290,6 @@ func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
-// JujuDBSnapChannel mocks base method
-func (m *MockConfig) JujuDBSnapChannel() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
-func (mr *MockConfigMockRecorder) JujuDBSnapChannel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfig)(nil).JujuDBSnapChannel))
-}
-
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
 	m.ctrl.T.Helper()
@@ -303,6 +302,20 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
+}
+
+// NonSyncedWritesToRaftLog mocks base method
+func (m *MockConfig) NonSyncedWritesToRaftLog() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NonSyncedWritesToRaftLog")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog
+func (mr *MockConfigMockRecorder) NonSyncedWritesToRaftLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfig)(nil).NonSyncedWritesToRaftLog))
 }
 
 // Nonce mocks base method

--- a/worker/raft/manifold.go
+++ b/worker/raft/manifold.go
@@ -92,13 +92,14 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	raftDir := filepath.Join(agentConfig.DataDir(), "raft")
 
 	return config.NewWorker(Config{
-		FSM:                  config.FSM,
-		Logger:               config.Logger,
-		StorageDir:           raftDir,
-		LocalID:              raft.ServerID(agentConfig.Tag().Id()),
-		Transport:            transport,
-		Clock:                clk,
-		PrometheusRegisterer: config.PrometheusRegisterer,
+		FSM:                      config.FSM,
+		Logger:                   config.Logger,
+		StorageDir:               raftDir,
+		LocalID:                  raft.ServerID(agentConfig.Tag().Id()),
+		Transport:                transport,
+		Clock:                    clk,
+		PrometheusRegisterer:     config.PrometheusRegisterer,
+		NonSyncedWritesToRaftLog: agentConfig.NonSyncedWritesToRaftLog(),
 	})
 }
 

--- a/worker/raft/mock_test.go
+++ b/worker/raft/mock_test.go
@@ -23,8 +23,9 @@ func (ma *mockAgent) CurrentConfig() agent.Config {
 
 type mockAgentConfig struct {
 	agent.Config
-	dataDir string
-	tag     names.Tag
+	dataDir                  string
+	tag                      names.Tag
+	nonSyncedWritesToRaftLog bool
 }
 
 func (c *mockAgentConfig) Tag() names.Tag {
@@ -33,6 +34,10 @@ func (c *mockAgentConfig) Tag() names.Tag {
 
 func (c *mockAgentConfig) DataDir() string {
 	return c.dataDir
+}
+
+func (c *mockAgentConfig) NonSyncedWritesToRaftLog() bool {
+	return c.nonSyncedWritesToRaftLog
 }
 
 type mockRaftWorker struct {

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	api "github.com/juju/juju/api"
@@ -17,6 +15,7 @@ import (
 	names "github.com/juju/names/v4"
 	shell "github.com/juju/utils/shell"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockAgent is a mock of Agent interface
@@ -193,6 +192,20 @@ func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
+// JujuDBSnapChannel mocks base method
+func (m *MockConfig) JujuDBSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
+func (mr *MockConfigMockRecorder) JujuDBSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfig)(nil).JujuDBSnapChannel))
+}
+
 // LogDir mocks base method
 func (m *MockConfig) LogDir() string {
 	m.ctrl.T.Helper()
@@ -278,20 +291,6 @@ func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
-// JujuDBSnapChannel mocks base method
-func (m *MockConfig) JujuDBSnapChannel() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
-func (mr *MockConfigMockRecorder) JujuDBSnapChannel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfig)(nil).JujuDBSnapChannel))
-}
-
 // MongoVersion mocks base method
 func (m *MockConfig) MongoVersion() mongo.Version {
 	m.ctrl.T.Helper()
@@ -304,6 +303,20 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
+}
+
+// NonSyncedWritesToRaftLog mocks base method
+func (m *MockConfig) NonSyncedWritesToRaftLog() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NonSyncedWritesToRaftLog")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog
+func (mr *MockConfigMockRecorder) NonSyncedWritesToRaftLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfig)(nil).NonSyncedWritesToRaftLog))
 }
 
 // Nonce mocks base method
@@ -571,6 +584,20 @@ func (mr *MockConfigSetterMockRecorder) Jobs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfigSetter)(nil).Jobs))
 }
 
+// JujuDBSnapChannel mocks base method
+func (m *MockConfigSetter) JujuDBSnapChannel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
+func (mr *MockConfigSetterMockRecorder) JujuDBSnapChannel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).JujuDBSnapChannel))
+}
+
 // LogDir mocks base method
 func (m *MockConfigSetter) LogDir() string {
 	m.ctrl.T.Helper()
@@ -656,20 +683,6 @@ func (mr *MockConfigSetterMockRecorder) MongoMemoryProfile() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).MongoMemoryProfile))
 }
 
-// JujuDBSnapChannel mocks base method
-func (m *MockConfigSetter) JujuDBSnapChannel() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
-func (mr *MockConfigSetterMockRecorder) JujuDBSnapChannel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).JujuDBSnapChannel))
-}
-
 // MongoVersion mocks base method
 func (m *MockConfigSetter) MongoVersion() mongo.Version {
 	m.ctrl.T.Helper()
@@ -682,6 +695,20 @@ func (m *MockConfigSetter) MongoVersion() mongo.Version {
 func (mr *MockConfigSetterMockRecorder) MongoVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).MongoVersion))
+}
+
+// NonSyncedWritesToRaftLog mocks base method
+func (m *MockConfigSetter) NonSyncedWritesToRaftLog() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NonSyncedWritesToRaftLog")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog
+func (mr *MockConfigSetterMockRecorder) NonSyncedWritesToRaftLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfigSetter)(nil).NonSyncedWritesToRaftLog))
 }
 
 // Nonce mocks base method
@@ -748,6 +775,18 @@ func (mr *MockConfigSetterMockRecorder) SetControllerAPIPort(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetControllerAPIPort", reflect.TypeOf((*MockConfigSetter)(nil).SetControllerAPIPort), arg0)
 }
 
+// SetJujuDBSnapChannel mocks base method
+func (m *MockConfigSetter) SetJujuDBSnapChannel(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetJujuDBSnapChannel", arg0)
+}
+
+// SetJujuDBSnapChannel indicates an expected call of SetJujuDBSnapChannel
+func (mr *MockConfigSetterMockRecorder) SetJujuDBSnapChannel(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetJujuDBSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).SetJujuDBSnapChannel), arg0)
+}
+
 // SetLoggingConfig mocks base method
 func (m *MockConfigSetter) SetLoggingConfig(arg0 string) {
 	m.ctrl.T.Helper()
@@ -772,18 +811,6 @@ func (mr *MockConfigSetterMockRecorder) SetMongoMemoryProfile(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoMemoryProfile), arg0)
 }
 
-// SetJujuDBSnapChannel mocks base method
-func (m *MockConfigSetter) SetJujuDBSnapChannel(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetJujuDBSnapChannel", arg0)
-}
-
-// SetJujuDBSnapChannel indicates an expected call of SetJujuDBSnapChannel
-func (mr *MockConfigSetterMockRecorder) SetJujuDBSnapChannel(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetJujuDBSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).SetJujuDBSnapChannel), arg0)
-}
-
 // SetMongoVersion mocks base method
 func (m *MockConfigSetter) SetMongoVersion(arg0 mongo.Version) {
 	m.ctrl.T.Helper()
@@ -794,6 +821,18 @@ func (m *MockConfigSetter) SetMongoVersion(arg0 mongo.Version) {
 func (mr *MockConfigSetterMockRecorder) SetMongoVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoVersion), arg0)
+}
+
+// SetNonSyncedWritesToRaftLog mocks base method
+func (m *MockConfigSetter) SetNonSyncedWritesToRaftLog(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNonSyncedWritesToRaftLog", arg0)
+}
+
+// SetNonSyncedWritesToRaftLog indicates an expected call of SetNonSyncedWritesToRaftLog
+func (mr *MockConfigSetterMockRecorder) SetNonSyncedWritesToRaftLog(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfigSetter)(nil).SetNonSyncedWritesToRaftLog), arg0)
 }
 
 // SetOldPassword mocks base method


### PR DESCRIPTION
## Description of change

Currently, each time juju appends an entry to the raft log (backed by a bolt-db instance), an fsync syscall is performed to ensure that the data gets flushed to disk. However, in some cases it might be beneficial to disable fsyncs if the operator is interested in trading performance for data consistency. Given that our log primarily tracks leadership leases and those are extended frequently, tolerating a potential loss of data (which will be corrected at the next lease renewal) for 
a boost in performance might be an acceptable compromise.

To this end, this PR introduces a new controller config option called `non-synced-writes-to-raft-log` (defaults to `false`) which can be toggled by operators either at bootstrap or while the controller is up and running. In the latter case, the agents will automatically restart once the setting changes.

NOTES:
- To avoid fetching the controller settings from within the worker, the value is passed as an agent config value; this also allows us to hook to the agentconfigupdater and get hot reloading for free.
- The _name_ of the option was intentionally chosen so that its off/false value indicates that we **want** fsyncs by default. I find that this plays nicely with omitempty and prevents juju from accidentally turning fsync off due to a missing value in the agent conf (this is probably not an issue since they get overwritten when upgrading but it's good to be a bit extra paranoid when data integrity is at stake).

## QA steps

```consoel
$ juju bootstrap lxd test
$ juju controller-config non-synced-writes-to-raft-log
True

$ juju controller-config non-synced-writes-to-raft-log=true

# Wait for the controllers to restart and run
$ juju debug-log -m controller --level WARN | grep non-synced
machine-0: 18:02:30 WARNING juju.worker.raft disabling fsync calls between raft log writes as instructed by the "non-synced-writes-to-raft-log option"

# Turn it back off and watch the agents restart again
$ juju controller-config non-synced-writes-to-raft-log=false
```

## Documentation changes

We should document the new option.