### PR TITLE
Fix machine space order for tests.

### DIFF
--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1107,7 +1107,7 @@ func (s *ProvisionerSuite) testProvisioningFailsAndSetsErrorStatusForConstraints
 
 func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithUnknownSpaces(c *gc.C) {
 	cons := constraints.MustParse(
-		s.defaultConstraints.String(), "spaces=missing,ignored,^ignored-too",
+		s.defaultConstraints.String(), "spaces=missing,missing-too,^ignored-too",
 	)
 	expectedErrorStatus := `matching subnets to zones: space "missing" not found`
 	s.testProvisioningFailsAndSetsErrorStatusForConstraints(c, cons, expectedErrorStatus)


### PR DESCRIPTION
## Description of change

#11621 introduces a map ordering issue in ProvisionerSuite.TestProvisioningMachinesFailsWithUnknownSpaces

## QA steps

Run unit tests.

## Documentation changes

N/A

## Bug reference

N/A
