### PR TITLE
2.7 - Kill Test Workers with Thread-Safe gc.C

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -30,8 +30,6 @@ import (
 
 var hostSeries = series.HostSeries
 
-var requiredPackages = []string{"lxd"}
-
 type containerInitialiser struct {
 	getExecCommand func(string, ...string) *exec.Cmd
 }


### PR DESCRIPTION
## Description of change

This patch changes the worker stop/assert logic for the presence pruner tests.

Instead of accessing a `gc.C` reference from a Goroutine, we use the same pattern for error-free worker stoppage as `workertest.CleanKill`. The only difference is that here, the timeout is `testing.ShortWait` instead of `testing.LongWait`.

## QA steps

From _state/presence_, run `TestDeepStressStaysSane` in a loop.
