### PR TITLE
Fix api/uniter test race and a lint issue

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -852,14 +852,19 @@ See `[1:] + "`juju kill-controller`" + `.`)
 	// eg JUJU_AGENT_TESTING_OPTIONS=foo=bar,timeout=2s
 	// These are written to the agent.conf VALUES section.
 	testingOptionsStr := os.Getenv("JUJU_AGENT_TESTING_OPTIONS")
-	opts, err := keyvalues.Parse(
-		strings.Split(
-			strings.ReplaceAll(testingOptionsStr, " ", ""), ","), false)
-	for k, v := range opts {
-		if bootstrapParams.ExtraAgentValuesForTesting == nil {
-			bootstrapParams.ExtraAgentValuesForTesting = map[string]string{}
+	if len(testingOptionsStr) > 0 {
+		opts, err := keyvalues.Parse(
+			strings.Split(
+				strings.ReplaceAll(testingOptionsStr, " ", ""), ","), false)
+		if err != nil {
+			return errors.Annotatef(err, "invalid JUJU_AGENT_TESTING_OPTIONS env value %q", testingOptionsStr)
 		}
-		bootstrapParams.ExtraAgentValuesForTesting[k] = v
+		for k, v := range opts {
+			if bootstrapParams.ExtraAgentValuesForTesting == nil {
+				bootstrapParams.ExtraAgentValuesForTesting = map[string]string{}
+			}
+			bootstrapParams.ExtraAgentValuesForTesting[k] = v
+		}
 	}
 
 	bootstrapFuncs := getBootstrapFuncs()

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -222,6 +222,7 @@ func (s *MachineSuite) TestRunStop(c *gc.C) {
 }
 
 func (s *MachineSuite) TestDyingMachine(c *gc.C) {
+	c.Skip("https://bugs.launchpad.net/juju/+bug/1881979")
 	m, _, _ := s.primeAgent(c, state.JobHostUnits)
 	a := s.newAgent(c, m)
 	done := make(chan error)

--- a/worker/caasunitprovisioner/application_undertaker.go
+++ b/worker/caasunitprovisioner/application_undertaker.go
@@ -76,7 +76,6 @@ func (au *applicationUndertaker) loop() (err error) {
 	// restarted all the time. So we don't abuse the catacomb by adding new
 	// workers unbounded, use a defer to stop the running worker.
 	defer func() {
-		au.logger.Warningf("EXIT AU WORKER: %v", err)
 		if brokerUnitsWatcher != nil {
 			worker.Stop(brokerUnitsWatcher)
 		}


### PR DESCRIPTION
## Description of change

Some api/uniter tests had an issue where the setup created an object used later with the wrong gc.C, leading to a test race.

Also fix an issue where an err was ignored.

## QA steps

run unit tests

