### PR TITLE
Use provider eksctl method to run eksctl because the binary is not in…

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -27,6 +27,7 @@ import subprocess
 from contextlib import contextmanager
 from enum import Enum
 from pprint import pformat
+from shlex import quote
 from time import sleep
 
 from jujupy.client import temp_bootstrap_env
@@ -211,13 +212,14 @@ class Base(object):
         cm['data'] = data
         self.kubectl_apply(json.dumps(cm))
 
-    def sh(self, *args):
-        args = [str(arg) for arg in args]
+    def sh(self, *args, shell=False):
+        args = [quote(str(arg)) if shell else str(arg) for arg in args]
         logger.debug('sh -> %s', ' '.join(args))
         return subprocess.check_output(
             # cmd should be a list of str.
             args,
             stderr=subprocess.STDOUT,
+            shell=shell,
         ).decode('UTF-8').strip()
 
     def _ensure_kubectl_bin(self):


### PR DESCRIPTION

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Use EKS provider's eksctl method to run eksctl command because the binary was put to juju home but not in PATH;

