### PR TITLE
2.8 Update Gorilla WebSocket Dependency

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -686,7 +686,7 @@ func gorillaDialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Con
 				)
 			}
 		}
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return jsoncodec.NewWebsocketConn(c), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/googleapis/gnostic v0.2.0
 	github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474
 	github.com/gorilla/schema v0.0.0-20160426231512-08023a0215e7
-	github.com/gorilla/websocket v1.4.0
+	github.com/gorilla/websocket v1.4.2
 	github.com/gosuri/uitable v0.0.1
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/gorilla/schema v0.0.0-20160426231512-08023a0215e7/go.mod h1:kgLaKoK1F
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuri/uitable v0.0.1 h1:M9sMNgSZPyAu1FJZJLpJ16ofL8q5ko2EDUkICsynvlY=
 github.com/gosuri/uitable v0.0.1/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=


### PR DESCRIPTION
## Description of change

This is a simple dependency update as advised by on the [project releases](https://github.com/gorilla/websocket/releases) page. 

It is the same change as made against the 2.7 branch under #11657, but accommodating go-mod rather than dep.

## QA steps

- Bootstrap and deploy some units.
- Check that things look sane.

## Documentation changes

None.

## Bug reference

N/A