### PR TITLE
Add debug logging of lxd profile contents on write.

### DIFF
--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -528,6 +528,8 @@ func (s *managerSuite) TestMaybeWriteLXDProfile(c *gc.C) {
 	}
 	s.cSvr.EXPECT().CreateProfile(post).Return(nil)
 	s.cSvr.EXPECT().GetProfileNames().Return([]string{"default", "custom"}, nil)
+	expProfile := lxdapi.Profile{ProfilePut: lxdapi.ProfilePut(put)}
+	s.cSvr.EXPECT().GetProfile(post.Name).Return(&expProfile, "etag", nil)
 
 	err := proMgr.MaybeWriteLXDProfile("juju-default-lxd-0", &put)
 	c.Assert(err, jc.ErrorIsNil)
@@ -652,10 +654,12 @@ func (s *managerSuite) expectUpdateContainerProfiles(old, new string, newProfile
 		ProfilePut: put,
 		Name:       new,
 	}
+	expProfile := lxdapi.Profile{ProfilePut: put}
 	cExp := s.cSvr.EXPECT()
 	gomock.InOrder(
 		cExp.GetProfileNames().Return(oldProfiles, nil),
 		cExp.CreateProfile(post).Return(nil),
+		cExp.GetProfile(post.Name).Return(&expProfile, "etag", nil),
 		cExp.GetContainer(instId).Return(
 			&lxdapi.Container{
 				ContainerPut: lxdapi.ContainerPut{

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -359,6 +359,7 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 		logger.Debugf("lxd profile %q already exists, not written again", pName)
 		return nil
 	}
+	logger.Debugf("attempting to write lxd profile %q %+v", pName, put)
 	post := api.ProfilesPost{
 		Name:       pName,
 		ProfilePut: api.ProfilePut(*put),
@@ -367,6 +368,24 @@ func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) er
 		return errors.Trace(err)
 	}
 	logger.Debugf("wrote lxd profile %q", pName)
+	if err := env.verifyProfile(pName); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// verifyProfile gets the actual profile from lxd for the name provided
+// and logs the result. For informational purposes only. Returns an error
+// if the call to GetProfile fails.
+func (env *environ) verifyProfile(pName string) error {
+	// As there are configs where we do not have the option of looking at
+	// the profile on the machine to verify, verify here that what we thought
+	// was written, is what was written.
+	profile, _, err := env.server().GetProfile(pName)
+	if err != nil {
+		return err
+	}
+	logger.Debugf("lxd profile %q: received %+v ", pName, profile.ProfilePut)
 	return nil
 }
 

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -559,7 +559,7 @@ func (s *environProfileSuite) expectMaybeWriteLXDProfile(hasProfile bool, name s
 	exp := s.svr.EXPECT()
 	exp.HasProfile(name).Return(hasProfile, nil)
 	if !hasProfile {
-		exp.CreateProfile(api.ProfilesPost{
+		post := api.ProfilesPost{
 			Name: name,
 			ProfilePut: api.ProfilePut{
 				Config: map[string]string{
@@ -567,7 +567,10 @@ func (s *environProfileSuite) expectMaybeWriteLXDProfile(hasProfile bool, name s
 				},
 				Description: "test profile",
 			},
-		}).Return(nil)
+		}
+		exp.CreateProfile(post).Return(nil)
+		expProfile := api.Profile{ProfilePut: post.ProfilePut}
+		exp.GetProfile(name).Return(&expProfile, "etag", nil)
 	}
 }
 


### PR DESCRIPTION

## Description of change

Also log what lxd has as the profile contents once written, a paranoia
check for now.

## QA steps

```console
$ juju bootstrap localhost testme
$ juju model-config logging-config="<root>=INFO;juju.container.lxd=DEBUG;juju.provider.lxd=DEBUG"
$ juju model-config logging-config="<root>=INFO;juju.container.lxd=DEBUG;juju.provider.lxd=DEBUG" -m controller

# deploy to both a machine and a container
$ juju deploy ./testcharms/charm-repo/bionic/lxd-profile-alt -n 2 --to lxd

# check the logs once neutron-openvswitch is active:
$ juju debug-log --include-module juju.provider.lxd --replay
machine-0: 18:21:25 DEBUG juju.provider.lxd attempting to write lxd profile "juju-default-lxd-profile-alt-0" &{Config:map[environment.http_proxy: linux.kernel_modules:openvswitch,nbd,ip_tables,ip6_tables security.nesting:true security.privileged:true] Description:lxd profile for testing nested container profiles Devices:map[]}
machine-0: 18:21:25 DEBUG juju.provider.lxd wrote lxd profile "juju-default-lxd-profile-alt-0"
machine-0: 18:21:25 DEBUG juju.provider.lxd lxd profile "juju-default-lxd-profile-alt-0": received {Config:map[environment.http_proxy: linux.kernel_modules:openvswitch,nbd,ip_tables,ip6_tables security.nesting:true security.privileged:true] Description:lxd profile for testing nested container profiles Devices:map[]}
machine-0: 18:21:29 DEBUG juju.container.lxd new container has profiles [default juju-default juju-default-lxd-profile-alt-0]

$ juju debug-log --include-module juju.container.lxd --include machine-1 --replay 
machine-8: 18:23:01 DEBUG juju.container.lxd created new nic device "eth0" in profile "default"
machine-8: 18:23:06 DEBUG juju.container.lxd attempting to write lxd profile "juju-default-lxd-profile-alt-0" &{Config:map[environment.http_proxy: linux.kernel_modules:openvswitch,nbd,ip_tables,ip6_tables security.nesting:true security.privileged:true] Description:lxd profile for testing nested container profiles Devices:map[]}
machine-8: 18:23:06 DEBUG juju.container.lxd wrote lxd profile "juju-default-lxd-profile-alt-0"
machine-8: 18:23:06 DEBUG juju.container.lxd lxd profile "juju-default-lxd-profile-alt-0": received {Config:map[environment.http_proxy: linux.kernel_modules:openvswitch,nbd,ip_tables,ip6_tables security.nesting:true security.privileged:true] Description:lxd profile for testing nested container profiles Devices:map[]}
```

## Bug reference

https://bugs.launchpad.net/charm-neutron-openvswitch/+bug/1876849