### PR TITLE
Exit 0 if anything was wrong in OCI image fetching;

### DIFF
--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -20,7 +20,11 @@ if ! which $container_cmd; then
 fi
 
 echo "Wait for microk8s to be ready if needed."
-microk8s.status --wait-ready --timeout 30
+wait_result=$(microk8s.status --wait-ready --timeout 30 2>&1)
+if [ $? -ne 0 ]; then
+    echo "${wait_result}"
+    exit 0
+fi
 
 juju_version=$(/snap/bin/juju version | rev | cut -d- -f3- | rev)
 oci_image="docker.io/jujusolutions/jujud-operator:$juju_version"


### PR DESCRIPTION

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Exit 0 if anything was failed in OCI image pre-caching process;

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1881769