### PR TITLE
Replace a convoluted fake pointer with a simple one.

### DIFF
--- a/worker/multiwatcher/manifold_test.go
+++ b/worker/multiwatcher/manifold_test.go
@@ -4,8 +4,6 @@
 package multiwatcher_test
 
 import (
-	"unsafe"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -152,25 +150,7 @@ type fakeStateTracker struct {
 // Return an invalid but non-zero state pool pointer.
 // Is only ever used for comparison.
 func (f *fakeStateTracker) Use() (*state.StatePool, error) {
-	return f.pool(), nil
-}
-
-// pool returns a non-nil but invalid pointer to a state pool.
-func (f *fakeStateTracker) pool() *state.StatePool {
-	var out state.StatePool
-
-	// This works around unsafe pointer conversion that would normally cause
-	// panics based on compile flags for code like this:
-	// return (*state.StatePool)(unsafe.Pointer(f))
-	//
-	// We cast both types to byte arrays, slice them and copy one to the other.
-	// Having initialised the target structure first, we ensure that differing
-	// sizes do not introduce possible arbitrary memory access.
-	copy(
-		(*(*[unsafe.Sizeof(state.StatePool{})]byte)(unsafe.Pointer(&out)))[:],
-		(*(*[unsafe.Sizeof(fakeStateTracker{})]byte)(unsafe.Pointer(f)))[:],
-	)
-	return &out
+	return &state.StatePool{}, nil
 }
 
 // Done tracks that the used pool is released.


### PR DESCRIPTION
The manifold test just needs a non-nil state object. For whatever reason when I did this originally I didn't think to do the obvious thing, but instead used an unsafe pointer conversion. This was then replaced by a more complicated pointer conversion.

The simple thing is just to create a zero'ed version of the struct.

## QA steps

Run the tests.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1881845