### PR TITLE
fix local charm validation on deploy - should allow only dispatch file too

### DIFF
--- a/api/export_test.go
+++ b/api/export_test.go
@@ -25,7 +25,7 @@ var (
 	SlideAddressToFront     = slideAddressToFront
 	BestVersion             = bestVersion
 	FacadeVersions          = &facadeVersions
-	HasHooks                = &hasHooks
+	HasHooksOrDispatch      = &hasHooksOrDispatch
 )
 
 func DialAPI(info *Info, opts DialOpts) (jsoncodec.JSONConn, string, error) {

--- a/testcharms/charm-repo/quantal/category-dispatch/metadata.yaml
+++ b/testcharms/charm-repo/quantal/category-dispatch/metadata.yaml
@@ -1,0 +1,6 @@
+name: categories
+summary: "Sample charm with a category"
+description: |
+        That's a boring charm that has a category.
+categories: ["database"]
+tags: ["openstack", "storage"]


### PR DESCRIPTION

## Description of change

Check for a populated hooks dir or a dispatch file when validating a local charm for deployment. One of these is required.  

## QA steps


```console
$ juju bootstrap localhost

# these 2 charms should succeed, have hooks dir or dispatch file
$ juju deploy ./testcharms/charm-repo/bionic/lxd-profile-alt
$ juju deploy ./testcharms/charm-repo/quantal/category-dispatch

# this charm will fail to deploy 
$ juju deploy ./testcharms/charm-repo/quantal/category
ERROR invalid charm "category": has no hooks nor dispatch file
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1881839
