### PR TITLE
Filter out INFAN networks for ec2

### DIFF
--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -319,9 +319,13 @@ const InFan = "INFAN"
 func FilterInFanNetwork(networks []Id) []Id {
 	var result []Id
 	for _, network := range networks {
-		if !strings.Contains(network.String(), InFan) {
+		if !IsInFanNetwork(network) {
 			result = append(result, network)
 		}
 	}
 	return result
+}
+
+func IsInFanNetwork(network Id) bool {
+	return strings.Contains(network.String(), InFan)
 }

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -118,6 +118,37 @@ func (*subnetSuite) TestFilterInFanNetwork(c *gc.C) {
 	}
 }
 
+func (*subnetSuite) TestIsInFanNetwork(c *gc.C) {
+	testCases := []struct {
+		name     string
+		subnet   network.Id
+		expected bool
+	}{
+		{
+			name:     "empty",
+			subnet:   network.Id(""),
+			expected: false,
+		},
+		{
+			name:     "no match",
+			subnet:   network.Id("foo-1asd-fan-network"),
+			expected: false,
+		},
+		{
+			name:     "match",
+			subnet:   network.Id("foo-1asd-INFAN-network"),
+			expected: true,
+		},
+	}
+
+	for i, t := range testCases {
+		c.Logf("test %d: %s", i, t.name)
+
+		res := network.IsInFanNetwork(t.subnet)
+		c.Check(res, gc.Equals, t.expected)
+	}
+}
+
 func (*subnetSuite) TestSubnetInfosEquality(c *gc.C) {
 	s1 := network.SubnetInfos{
 		{ID: "1"},


### PR DESCRIPTION
## Description of change

Filtering out INFAN networks for ec2 prevents the change of landing on
that subnet when we know that an instance can't start there. Instead, it
should use the underlay network and that generally is at the start of
the slice.

The filtering code is rather rudimental but is generic enough that it
could be lifted into the core package and allow other providers to use
the same logic. Currently, Openstack provider implements its own
filtering but could be persuaded to use this one instead.

## QA steps

Use the logs to see that the following only has one zoned subnet instead
of two. 

```sh
juju bootstrap aws aws-test
juju add-space space-1 172.31.32.0/20
juju deploy cs:percona-cluster-290 --bind "space-1"
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1880713
