### PR TITLE
[dev] Use OVS-managed bridge (if present) for lxd workloads

### DIFF
--- a/container/broker/lxd-broker_internal_test.go
+++ b/container/broker/lxd-broker_internal_test.go
@@ -1,0 +1,108 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package broker
+
+import (
+	"runtime"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/network"
+	jujunetwork "github.com/juju/juju/network"
+	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+)
+
+type lxdBridgeSelectionSuite struct {
+	coretesting.BaseSuite
+	agentCfg agent.ConfigSetterWriter
+
+	ovsBridges set.Strings
+}
+
+var _ = gc.Suite(&lxdBridgeSelectionSuite{})
+
+func (s *lxdBridgeSelectionSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	if runtime.GOOS == "windows" {
+		c.Skip("Skipping lxd tests on windows")
+	}
+
+	var err error
+	s.agentCfg, err = agent.NewAgentConfig(agent.AgentConfigParams{
+		Paths:             agent.NewPathsWithDefaults(agent.Paths{DataDir: "/not/used/here"}),
+		Tag:               names.NewMachineTag("1"),
+		UpgradedToVersion: jujuversion.Current,
+		Password:          "dummy-secret",
+		Nonce:             "nonce",
+		APIAddresses:      []string{"10.0.0.1:1234"},
+		CACert:            coretesting.CACert,
+		Controller:        coretesting.ControllerTag,
+		Model:             coretesting.ModelTag,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.ovsBridges = set.NewStrings()
+	lookupOvsManagedBridges = func() (set.Strings, error) { return s.ovsBridges, nil }
+}
+
+func (s *lxdBridgeSelectionSuite) TearDownTest(c *gc.C) {
+	lookupOvsManagedBridges = network.OvsManagedBridges
+}
+
+func (s *lxdBridgeSelectionSuite) TestPreferredBridgeConfigPriority(c *gc.C) {
+	s.agentCfg.SetValue(agent.LxdBridge, "the-lxD-bridge")
+	s.agentCfg.SetValue(agent.LxcBridge, "the-lxC-bridge")
+
+	// With both a preferred lxd and lxc bridge, we should pick the lxd one
+	got, err := selectBridgeDevice(s.agentCfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.Equals, "the-lxD-bridge", gc.Commentf("expected LxdBridge setting value to be picked"))
+
+	// With only a preferred lxc bridge we pick that by default.
+	s.agentCfg.SetValue(agent.LxdBridge, "")
+	got, err = selectBridgeDevice(s.agentCfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.Equals, "the-lxC-bridge", gc.Commentf("expected LxcBridge setting value to be picked"))
+}
+
+func (s *lxdBridgeSelectionSuite) TestSelectBridgeOVSBridges(c *gc.C) {
+	s.agentCfg.SetValue(agent.LxdBridge, "the-lxD-bridge")
+	s.ovsBridges.Add("ovsbr0")
+
+	// With both a preferred lxd and an OVS-managed bridge, the lxd one has priority.
+	got, err := selectBridgeDevice(s.agentCfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.Equals, "the-lxD-bridge", gc.Commentf("expected LxdBridge setting value to be picked"))
+
+	// A single OVS-managed bridge should be picked by default if no
+	// preferred bridge options were passed to the agent by the
+	// operator.
+	s.agentCfg.SetValue(agent.LxdBridge, "")
+	got, err = selectBridgeDevice(s.agentCfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.Equals, "ovsbr0", gc.Commentf("expected the single OVS-managed bridge to be picked"))
+
+	// With no OVS bridges present and no preferred bridge options passed
+	// in by the operator we should pick a sane default.
+	s.ovsBridges.Remove("ovsbr0")
+	got, err = selectBridgeDevice(s.agentCfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.Equals, jujunetwork.DefaultLXDBridge, gc.Commentf("expected the default LXD bridge to be picked as a fallback"))
+}
+
+func (s *lxdBridgeSelectionSuite) TestSelectBridgeWithMultipleOVSBridges(c *gc.C) {
+	s.ovsBridges.Add("ovsbr0")
+	s.ovsBridges.Add("ovsbr1")
+
+	// With multiple OVS-bridges present and no operator preference we
+	// should fall back to the default LXD bridge
+	got, err := selectBridgeDevice(s.agentCfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.Equals, jujunetwork.DefaultLXDBridge, gc.Commentf("expected the default LXD bridge to be picked as a fallback"))
+}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -75,6 +75,11 @@ func NewContainerManager(cfg container.ManagerConfig, svr *Server) (container.Ma
 	imageMetaDataURL := cfg.PopValue(config.ContainerImageMetadataURLKey)
 	imageStream := cfg.PopValue(config.ContainerImageStreamKey)
 
+	// This value is also popped by the provisioner worker; the following
+	// dummy pop operation ensures that we don't get a spurious warning
+	// for it when calling WarnAboutUnused() below.
+	_ = cfg.PopValue(config.LXDSnapChannel)
+
 	cfg.WarnAboutUnused()
 	return &containerManager{
 		server:           svr,

--- a/core/network/ovs.go
+++ b/core/network/ovs.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
+
+// Overridden by tests
+var getCommandOutput = func(cmd *exec.Cmd) ([]byte, error) { return cmd.Output() }
+
+// OvsManagedBridges returns a filtered version of ifaceList that only contains
+// bridge interfaces managed by openvswitch.
+func OvsManagedBridges(ifaceList InterfaceInfos) (InterfaceInfos, error) {
+	if _, err := exec.LookPath("ovs-vsctl"); err != nil {
+		// ovs tools not installed; nothing to do
+		if execErr, isExecErr := err.(*exec.Error); isExecErr && execErr.Unwrap() == exec.ErrNotFound {
+			return nil, nil
+		}
+
+		return nil, errors.Annotate(err, "ovsManagedBridges: looking for ovs-vsctl")
+	}
+
+	// Query list of ovs-managed device names
+	res, err := getCommandOutput(exec.Command("ovs-vsctl", "list-br"))
+	if err != nil {
+		return nil, errors.Annotate(err, "querying ovs-managed bridges via ovs-vsctl")
+	}
+
+	ovsBridges := set.NewStrings()
+	for _, iface := range strings.Split(string(res), "\n") {
+		if iface = strings.TrimSpace(iface); iface != "" {
+			ovsBridges.Add(iface)
+		}
+	}
+
+	return ifaceList.Filter(func(iface InterfaceInfo) bool {
+		return ovsBridges.Contains(iface.InterfaceName)
+	}), nil
+}

--- a/core/network/ovs_internal_test.go
+++ b/core/network/ovs_internal_test.go
@@ -25,7 +25,7 @@ func (s *ovsSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 }
 
-func (s *ovsSuite) TestExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestExistingOVSManagedBridgeInterfaces(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -41,13 +41,13 @@ func (s *ovsSuite) TestExistingOVSManagedBridges(c *gc.C) {
 		{InterfaceName: "ovsbr1"},
 	}
 
-	ovsIfaces, err := OvsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridgeInterfaces(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 1, gc.Commentf("expected ovs-managed bridge list to contain a single entry"))
 	c.Assert(ovsIfaces[0].InterfaceName, gc.Equals, "ovsbr1", gc.Commentf("expected ovs-managed bridge list to contain iface 'ovsbr1'"))
 }
 
-func (s *ovsSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestNonExistingOVSManagedBridgeInterfaces(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -62,14 +62,14 @@ func (s *ovsSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
 		{InterfaceName: "lxdbr0"},
 	}
 
-	ovsIfaces, err := OvsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridgeInterfaces(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }
 
 func (s *ovsSuite) TestMissingOVSTools(c *gc.C) {
 	ifaces := InterfaceInfos{{InterfaceName: "eth0"}}
-	ovsIfaces, err := OvsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridgeInterfaces(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }

--- a/core/network/ovs_internal_test.go
+++ b/core/network/ovs_internal_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package broker
+package network
 
 import (
 	"os/exec"
@@ -9,25 +9,23 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/core/network"
 )
 
-type brokerSuite struct {
+type ovsSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&brokerSuite{})
+var _ = gc.Suite(&ovsSuite{})
 
-func (s *brokerSuite) SetUpSuite(c *gc.C) {
+func (s *ovsSuite) SetUpSuite(c *gc.C) {
 	s.IsolationSuite.SetUpSuite(c)
 }
 
-func (s *brokerSuite) SetUpTest(c *gc.C) {
+func (s *ovsSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 }
 
-func (s *brokerSuite) TestExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestExistingOVSManagedBridges(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -36,20 +34,20 @@ func (s *brokerSuite) TestExistingOVSManagedBridges(c *gc.C) {
 		return []byte("ovsbr1" + "\n"), nil
 	})
 
-	ifaces := network.InterfaceInfos{
+	ifaces := InterfaceInfos{
 		{InterfaceName: "eth0"},
 		{InterfaceName: "eth1"},
 		{InterfaceName: "lxdbr0"},
 		{InterfaceName: "ovsbr1"},
 	}
 
-	ovsIfaces, err := ovsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridges(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 1, gc.Commentf("expected ovs-managed bridge list to contain a single entry"))
 	c.Assert(ovsIfaces[0].InterfaceName, gc.Equals, "ovsbr1", gc.Commentf("expected ovs-managed bridge list to contain iface 'ovsbr1'"))
 }
 
-func (s *brokerSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -58,20 +56,20 @@ func (s *brokerSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
 		return []byte("\n"), nil
 	})
 
-	ifaces := network.InterfaceInfos{
+	ifaces := InterfaceInfos{
 		{InterfaceName: "eth0"},
 		{InterfaceName: "eth1"},
 		{InterfaceName: "lxdbr0"},
 	}
 
-	ovsIfaces, err := ovsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridges(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }
 
-func (s *brokerSuite) TestMissingOVSTools(c *gc.C) {
-	ifaces := network.InterfaceInfos{{InterfaceName: "eth0"}}
-	ovsIfaces, err := ovsManagedBridges(ifaces)
+func (s *ovsSuite) TestMissingOVSTools(c *gc.C) {
+	ifaces := InterfaceInfos{{InterfaceName: "eth0"}}
+	ovsIfaces, err := OvsManagedBridges(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }


### PR DESCRIPTION
## Description of change

This PR enables juju to detect and make use of OVS-managed bridges as the parent of the NICs that are used by LXD workloads.

The bridge selection logic has been extracted into a standalone function for better testing and selects the bridge device to use via the following set of rules:

- If the operator specified a preferred LXD bridge, use that
- If the operator specified a preferred LXC bridge, use that
- If a **single** OVS-managed bridge exists, use that
- If **no** OVS bridges are detected OR **more than one** OVS-bridges are
available, fallback to default LXD bridge (lxdbr0). In the latter case, a warning is emitted advising the operator to explicitly specify their preferred (if any) bridge device to use.

Finally, the PR also includes some drive-by fixes for:
- an ineff. err assignment (https://github.com/juju/juju/commit/f9b4a96bcfda6477b26cd2b4afa4957459dce2d2)
- a spurious warning from the lxd container manager about 'lxd-snap-channel' not being used (it actually is used but from the provisioner worker; see https://github.com/juju/juju/commit/b004673fd2c811bd1c135351e9e2b34ded96479b)

## QA steps

Some of the QA steps require access to a MAAS instance which can provision dual-NIC machines. For my local testing, I opted to set up a virtual maas (https://discourse.juju.is/t/local-maas-development-setup/1319) and provision machines via KVM.

For the following test you will need to provision two machines which are then used as manual provisioning targets by juju:
- Machine A (single NIC) which will host the controller.
- Machine B (single NIC) which will run the lxd workloads for the QA steps.

⚠️ **Important** ⚠️ : before setting up the OVS bridge using the steps below make sure to ssh into the box, set a root password and ensure that you can access the machine's console via `virsh console $machine-name`. The OVS bridge steps will temporarily kill networking and you need to be logged in to the machine to see which IP gets assigned to the bridge device!

To set up an OVS bridge, access the dual-NIC machine via the console and type the following commands (remember to replace ensX with the names of the NICs on your machine!)

```console
# ssh into kvm-1 
apt-get -y install openvswitch-switch iptraf-ng net-tools
ovs-vsctl add-br ovsbr0
ovs-vsctl add-port ovsbr0 ens4
ifconfig ens4 0

ip link set ovsbr0 up && dhclient -v ovsbr0
# Note the IP assigned to ovsbr0

ip route delete 10.0.0.0/24 dev ens4
ip route replace default via 10.0.0.1 dev ovsbr0

# Connect over ssh to the ovsbr0 IP fire up 'iptraf-ng' and monitor the ovsbr0 device
# Then from the console, run something like 'curl canonical.com' and verify that the packets flow through the device
```

## # QA scenario 1: OVS bridge with single interface

```console
# Bootstrap controller on machine 1
$ juju bootstrap manual/ubuntu@10.0.0.1 --no-gui

# Add a machine and deploy an lxd workload to it
$ juju add-machine ssh:ubuntu@$ip-assigned-to-ovsbr0
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to lxd:0

# ssh to the machine you just added and verify that the veth device used by lxd has been added to the switch by running:
$ ovs-vsctl show

# Check that ovsbr0 is the parent of eth0 veth device used by the lxd container
$ lxc profile show default
```

### QA scenario 2: OVS bridge with bonded interfaces

For this step you will need a **dual-NIC** machine. The bond (balanced-slb mode although you can use balanced-tcp if you have a router that supports LACP) can be set up as follows (remember to replace ensX with the names of the NICs on your machine!):

```console
# ssh into kvm-1 
apt-get -y install openvswitch-switch iptraf-ng net-tools
ovs-vsctl add-br ovsbr0
ovs-vsctl add-bond ovsbr0 bond0 ens4 ens7
ovs-vsctl set port bond0 bond_mode=balance-slb
ip addr flush dev ens4
ip addr flush dev ens7
ip link set ens4 up
ip link set ens7 up

ip link set ovsbr0 up && dhclient -v ovsbr0
# Note the IP assigned to ovsbr0

# Check that both links are enabled
ovs-appctl bond/show bond0

# Use curl to verify connectivity
```

Follow the same steps as the previous test to add the machine and deploy an lxd workload.