### PR TITLE
Fix random string order in TestProvisioningInfoWithEndpointBindingsAndNoAlphaSpace

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -291,6 +291,14 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 	result, err := s.provisioner.ProvisioningInfo(args)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Check SpaceSubnets string array with multiple elements.
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Result, gc.NotNil)
+	topo := &result.Results[0].Result.ProvisioningNetworkTopology
+	c.Assert(topo.SpaceSubnets, gc.NotNil)
+	c.Assert(topo.SpaceSubnets["space2"], jc.SameContents, []string{"subnet-1", "subnet-2"})
+	delete(topo.SpaceSubnets, "space2")
+
 	controllerCfg := s.ControllerConfig
 	expected := params.ProvisioningInfoResultsV10{
 		Results: []params.ProvisioningInfoResultV10{{
@@ -322,7 +330,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 					},
 					SpaceSubnets: map[string][]string{
 						"space1": {"subnet-0"},
-						"space2": {"subnet-1", "subnet-2"},
 						"alpha":  {"subnet-alpha"},
 					},
 				},


### PR DESCRIPTION
## Description of change

Fix random string order in TestProvisioningInfoWithEndpointBindingsAndNoAlphaSpace

## QA steps

Unit Tests

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1882186
