### PR TITLE
 Add metrics around the queue length and age for the multiwatcher worker.

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -83,6 +83,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 	s.mux = apiserverhttp.NewMux()
 
 	multiWatcherWorker, err := multiwatcher.NewWorker(multiwatcher.Config{
+		Clock:                clock.WallClock,
 		Logger:               loggo.GetLogger("test"),
 		Backing:              state.NewAllWatcherBacking(s.StatePool),
 		PrometheusRegisterer: noopRegisterer{},

--- a/apiserver/basesuite_test.go
+++ b/apiserver/basesuite_test.go
@@ -6,6 +6,7 @@ package apiserver_test
 import (
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
 	"github.com/juju/testing"
@@ -38,6 +39,7 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
 
 	multiWatcherWorker, err := multiwatcher.NewWorker(multiwatcher.Config{
+		Clock:                clock.WallClock,
 		Logger:               loggo.GetLogger("test"),
 		Backing:              state.NewAllWatcherBacking(s.StatePool),
 		PrometheusRegisterer: noopRegisterer{},

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -62,6 +63,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 
 	multiWatcherWorker, err := multiwatcher.NewWorker(multiwatcher.Config{
+		Clock:                clock.WallClock,
 		Logger:               loggo.GetLogger("test"),
 		Backing:              state.NewAllWatcherBacking(s.StatePool),
 		PrometheusRegisterer: noopRegisterer{},

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -41,6 +41,7 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 
 	multiWatcherWorker, err := multiwatcher.NewWorker(multiwatcher.Config{
+		Clock:                clock.WallClock,
 		Logger:               loggo.GetLogger("test"),
 		Backing:              state.NewAllWatcherBacking(s.StatePool),
 		PrometheusRegisterer: noopRegisterer{},

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -406,6 +406,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// through the AllWatcherBacking and manages notifying the multiwatchers.
 		multiwatcherName: ifDatabaseUpgradeComplete(ifController(multiwatcher.Manifold(multiwatcher.ManifoldConfig{
 			StateName:            stateName,
+			Clock:                config.Clock,
 			Logger:               loggo.GetLogger("juju.worker.multiwatcher"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            multiwatcher.NewWorkerShim,

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
-	github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c
+	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
 	github.com/juju/description/v2 v2.0.0-20200514032006-b515a22fe74e
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/juju/collections v0.0.0-20180515203731-520e0549d51a/go.mod h1:Ep+c0vn
 github.com/juju/collections v0.0.0-20180516022642-90152009b5f3/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c h1:m/Uo8B7nrH3K6nvk66Y67T7cbHcyY101rW24vGuMON8=
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
+github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
+github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
 github.com/juju/description/v2 v2.0.0-20200424074546-907f299eeafe/go.mod h1:5CKxYQKZCqzv6+dokJVLL7bCCeFZHi1j3i2iLb/X7Z8=
 github.com/juju/description/v2 v2.0.0-20200514032006-b515a22fe74e h1:YewjT3e0KpdGM/3k5cJTAD7vPzKe9/PEd7qSlUwaxPY=
 github.com/juju/description/v2 v2.0.0-20200514032006-b515a22fe74e/go.mod h1:5CKxYQKZCqzv6+dokJVLL7bCCeFZHi1j3i2iLb/X7Z8=
@@ -388,6 +390,7 @@ github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae h1:wGk/zIPORIC
 github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae/go.mod h1:oGYNRVtU+5D99X5rPRaSwzKCc0mqF8A/L2a2UZycbQg=
 github.com/juju/testing v0.0.0-20160404094317-162fafccebf2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20161031103713-b8689951f6db/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
+github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180807043854-177f846b8501/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180820040200-b0b89ba330f2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -940,6 +940,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			}
 
 			multiWatcherWorker, err := multiwatcher.NewWorker(multiwatcher.Config{
+				Clock:                clock.WallClock,
 				Logger:               loggo.GetLogger("dummy.multiwatcher"),
 				Backing:              state.NewAllWatcherBacking(statePool),
 				PrometheusRegisterer: noopRegisterer{},

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -87,6 +87,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	})
 	w, err := multiworker.NewWorker(
 		multiworker.Config{
+			Clock:                clock.WallClock,
 			Logger:               s.logger,
 			Backing:              state.NewAllWatcherBacking(s.StatePool),
 			PrometheusRegisterer: noopRegisterer{},

--- a/worker/multiwatcher/manifold_test.go
+++ b/worker/multiwatcher/manifold_test.go
@@ -4,6 +4,7 @@
 package multiwatcher_test
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -30,6 +31,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.config = multiwatcher.ManifoldConfig{
 		StateName:            "state",
+		Clock:                clock.WallClock,
 		Logger:               loggo.GetLogger("test"),
 		PrometheusRegisterer: noopRegisterer{},
 		NewWorker: func(multiwatcher.Config) (worker.Worker, error) {
@@ -66,6 +68,13 @@ func (s *ManifoldSuite) TestConfigValidationMissingPrometheusRegisterer(c *gc.C)
 	err := s.config.Validate()
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, "missing PrometheusRegisterer not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Clock not valid")
 }
 
 func (s *ManifoldSuite) TestConfigValidationMissingLogger(c *gc.C) {

--- a/worker/multiwatcher/watcher_test.go
+++ b/worker/multiwatcher/watcher_test.go
@@ -6,6 +6,7 @@ package multiwatcher_test
 import (
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -29,6 +30,7 @@ func (s *watcherSuite) startWorker(c *gc.C, backing state.AllWatcherBacking) *mw
 	logger := loggo.GetLogger("test")
 	logger.SetLogLevel(loggo.TRACE)
 	config := mwWorker.Config{
+		Clock:                clock.WallClock,
 		Logger:               logger,
 		Backing:              backing,
 		PrometheusRegisterer: noopRegisterer{},

--- a/worker/multiwatcher/worker_internal_test.go
+++ b/worker/multiwatcher/worker_internal_test.go
@@ -6,6 +6,7 @@ package multiwatcher
 import (
 	"fmt"
 
+	"github.com/juju/clock"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -24,6 +25,7 @@ var _ = gc.Suite(&workerSuite{})
 func (*workerSuite) TestHandle(c *gc.C) {
 	sm := &Worker{
 		config: Config{
+			Clock:   clock.WallClock,
 			Logger:  loggo.GetLogger("test.worker"),
 			Backing: testbacking.New(nil),
 		},
@@ -86,6 +88,7 @@ func (*workerSuite) TestHandle(c *gc.C) {
 func (*workerSuite) TestRespondMultiple(c *gc.C) {
 	sm := &Worker{
 		config: Config{
+			Clock:   clock.WallClock,
 			Logger:  loggo.GetLogger("test.worker"),
 			Backing: testbacking.New(nil),
 		},
@@ -210,6 +213,7 @@ func (s *workerSuite) TestRespondResults(c *gc.C) {
 
 			sm := &Worker{
 				config: Config{
+					Clock:   clock.WallClock,
 					Logger:  loggo.GetLogger("test.worker"),
 					Backing: testbacking.New(nil),
 				},

--- a/worker/multiwatcher/worker_test.go
+++ b/worker/multiwatcher/worker_test.go
@@ -4,6 +4,7 @@
 package multiwatcher_test
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -30,10 +31,18 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.logger.SetLogLevel(loggo.TRACE)
 
 	s.config = multiwatcher.Config{
+		Clock:                clock.WallClock,
 		Logger:               s.logger,
 		Backing:              state.NewAllWatcherBacking(s.StatePool),
 		PrometheusRegisterer: noopRegisterer{},
 	}
+}
+
+func (s *WorkerSuite) TestConfigMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Clock not valid")
 }
 
 func (s *WorkerSuite) TestConfigMissingLogger(c *gc.C) {


### PR DESCRIPTION
This required passing a clock into the worker, which means all the sources
that were using the worker now also need to pass in a clock.

Adds a number of metrics for monitoring the queue length and age, along
with summaries that give us timings for adding items to the pending deque
and how long things are taking to process.

When adding events to the deque, the worker now checks to see if there is already
a pending event, and if there is, we don't need to add another event as when the
event is being processed, it is using the latest information.

## QA steps

```sh
juju bootstrap lxd test
juju ssh -m controller 0
# look at multiwatcher worker report to observe updates
juju_engine_report
# look at the multiwatcher metrics
juju_metrics
```

Internal changes only.
