### PR TITLE
2.8 - Gate Port Operations on Correct Model Life

### DIFF
--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -159,7 +159,7 @@ func (s *MachineSuite) TestAddMachineInsideMachineModelDying(c *gc.C) {
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}, s.machine.Id(), instance.LXD)
-	c.Assert(err, gc.ErrorMatches, `model "testmodel" is no longer alive`)
+	c.Assert(err, gc.ErrorMatches, `model "testmodel" is dying`)
 }
 
 func (s *MachineSuite) TestAddMachineInsideMachineModelMigrating(c *gc.C) {

--- a/state/ports_ops.go
+++ b/state/ports_ops.go
@@ -114,7 +114,7 @@ func (op *openClosePortsOperation) Build(attempt int) ([]txn.Op, error) {
 	return ops, nil
 }
 
-// Done implements ModelOperartion.
+// Done implements ModelOperation.
 func (op *openClosePortsOperation) Done(err error) error {
 	if err != nil {
 		return err

--- a/state/ports_ops.go
+++ b/state/ports_ops.go
@@ -22,11 +22,11 @@ type openClosePortsOperation struct {
 	updatedPortList []PortRange
 }
 
-// Build implements ModelOperartion.
+// Build implements ModelOperation.
 func (op *openClosePortsOperation) Build(attempt int) ([]txn.Op, error) {
 	var createPortsDoc = op.p.areNew
 	if attempt > 0 {
-		if err := checkModelActive(op.p.st); err != nil {
+		if err := checkModelNotDead(op.p.st); err != nil {
 			return nil, errors.Annotate(err, "cannot open/close ports")
 		}
 		if err := op.verifySubnetAliveWhenSet(); err != nil {
@@ -43,7 +43,7 @@ func (op *openClosePortsOperation) Build(attempt int) ([]txn.Op, error) {
 	}
 
 	ops := []txn.Op{
-		assertModelActiveOp(op.p.st.ModelUUID()),
+		assertModelNotDeadOp(op.p.st.ModelUUID()),
 	}
 
 	// Start with a clean copy of the ranges from the ports document

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -1027,7 +1027,7 @@ func (s *remoteApplicationSuite) TestAddApplicationModelDiesAfterInitial(c *gc.C
 	}).Check()
 	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name: "s1", SourceModel: s.Model.ModelTag()})
-	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": model "testmodel" is no longer alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot add remote application "s1": model "testmodel" is dying`)
 }
 
 func (s *remoteApplicationSuite) TestWatchRemoteApplications(c *gc.C) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -907,15 +907,15 @@ func (s *StateSuite) TestAddMachines(c *gc.C) {
 	c.Assert(string(instId), gc.Equals, "inst-id")
 }
 
-func (s *StateSuite) TestAddMachinesmodelDying(c *gc.C) {
+func (s *StateSuite) TestAddMachinesModelDying(c *gc.C) {
 	err := s.Model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Check that machines cannot be added if the model is initially Dying.
 	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, gc.ErrorMatches, `cannot add a new machine: model "testmodel" is no longer alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot add a new machine: model "testmodel" is dying`)
 }
 
-func (s *StateSuite) TestAddMachinesmodelDyingAfterInitial(c *gc.C) {
+func (s *StateSuite) TestAddMachinesModelDyingAfterInitial(c *gc.C) {
 	// Check that machines cannot be added if the model is initially
 	// Alive but set to Dying immediately before the transaction is run.
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -923,10 +923,10 @@ func (s *StateSuite) TestAddMachinesmodelDyingAfterInitial(c *gc.C) {
 		c.Assert(s.Model.Destroy(state.DestroyModelParams{}), gc.IsNil)
 	}).Check()
 	_, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, gc.ErrorMatches, `cannot add a new machine: model "testmodel" is no longer alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot add a new machine: model "testmodel" is dying`)
 }
 
-func (s *StateSuite) TestAddMachinesmodelMigrating(c *gc.C) {
+func (s *StateSuite) TestAddMachinesModelMigrating(c *gc.C) {
 	err := s.Model.SetMigrationMode(state.MigrationModeExporting)
 	c.Assert(err, jc.ErrorIsNil)
 	// Check that machines cannot be added if the model is initially Dying.
@@ -1653,7 +1653,7 @@ func (s *StateSuite) TestAddApplicationModelDying(c *gc.C) {
 	err = model.Destroy(state.DestroyModelParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
-	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": model "testmodel" is no longer alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": model "testmodel" is dying`)
 }
 
 func (s *StateSuite) TestAddApplicationModelMigrating(c *gc.C) {
@@ -1717,7 +1717,7 @@ func (s *StateSuite) TestAddApplicationModelDyingAfterInitial(c *gc.C) {
 		c.Assert(s.Model.Destroy(state.DestroyModelParams{}), gc.IsNil)
 	}).Check()
 	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
-	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": model "testmodel" is no longer alive`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": model "testmodel" is dying`)
 }
 
 func (s *StateSuite) TestApplicationNotFound(c *gc.C) {


### PR DESCRIPTION
## Description of change

Destroying models with established relations has been seen to fail, with the following message appearing in logs:
```
ERROR juju.worker.uniter.operation runhook.go:136 hook "db-relation-departed" (via explicit, bespoke hook script) failed: cannot apply changes: cannot open/close ports: model "test" is no longer alive
```

This patch ensures that port operations are gated on the model not being dead (alive or dying) rather than only alive.

## QA steps

- Bootstrap to LXD
- `juju deploy mediawiki-single` and wait for quiescence.
- `juju destroy-model default -y` should succeed without timing out.

## Documentation changes

None

## Bug reference

N/A
