### PR TITLE
Make fetch-oci script handle errors by itself;

### DIFF
--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/sh
 
 PATH=/snap/bin:$PATH
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Make `fetch-oci` script handle errors by itself rather than exit immediately;

## Bug reference

https://bugs.launchpad.net/juju/+bug/1881769
