### PR TITLE
Do not exclude containers when updating link layer device info

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -42,9 +42,6 @@ func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetw
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if m.IsContainer() {
-		return nil
-	}
 	observedConfig := args.Config
 	logger.Tracef("observed network config of machine %q: %+v", m.Id(), observedConfig)
 	if len(observedConfig) == 0 {

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -1175,6 +1175,12 @@ func (s *linkLayerDevicesStateSuite) TestMachineSetParentLinkLayerDevicesBeforeT
 }
 
 func (s *linkLayerDevicesStateSuite) TestMachineSetParentLinkLayerDevicesBeforeTheirChildrenIdempotent(c *gc.C) {
+	willBeDeleted := []state.LinkLayerDeviceArgs{{
+		Name: "obsolete",
+		Type: corenetwork.BridgeDevice,
+	}}
+	err := s.machine.SetParentLinkLayerDevicesBeforeTheirChildren(willBeDeleted)
+	c.Assert(err, jc.ErrorIsNil)
 	s.testMachineSetParentLinkLayerDevicesBeforeTheirChildren(c)
 	s.testMachineSetParentLinkLayerDevicesBeforeTheirChildren(c)
 }
@@ -1290,6 +1296,7 @@ func (s *linkLayerDevicesStateSuite) testMachineSetParentLinkLayerDevicesBeforeT
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allDevices, gc.HasLen, len(nestedDevicesArgs))
 	for _, device := range allDevices {
+		c.Check(device.Name(), gc.Not(gc.Equals), "obsolete")
 		if device.Type() != corenetwork.LoopbackDevice && device.Type() != corenetwork.BridgeDevice {
 			c.Check(device.ProviderID(), gc.Not(gc.Equals), corenetwork.Id(""))
 		}


### PR DESCRIPTION
## Description of change

The machine agent informs the controller when link layer devices have changed on the machine, and these are updated in the link layer devices collection for the machine.

Or not. Not when the machine is a container. Not sure why there's this restriction? It means that if udev renames a device from say eth0 to eno0s2 on a kvm container, Juju will lie to a charm which asks for network-info.

This PR removes the restriction, and also adds an extra step to remove any link layer devices from mongo which are not in the set to be updated from the machine.

Currently, parent devices with child devices are not removed. Is this correct?

## QA steps

bootstrap on maas and deploy

```
machines:
  "0":
    constraints: tags=micro

applications:
  ubuntu:
    charm: cs:ubuntu
    num_units: 1
    to:
      - kvm:0
```

look at linklayerdevices collection and ensure that devices for 0/kvm/0 match 
` juju exec --machine 0/kvm/0 -- ip address`

deploy a charm like mariadb --to 0/kvm/0 and check that
`juju exec --unit mariadb/0 -- network-get db`

contains the address info for the device on 0/kvm/0 and not something like eth0 which was renamed.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1882564
