### PR TITLE
Delete Unused Child Link-Layer Devices Before Parents

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -49,18 +49,21 @@ func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetw
 		return nil
 	}
 
-	providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
-	if errors.IsNotProvisioned(err) {
-		logger.Infof("not updating machine %q network config: %v", m.Id(), err)
-		return nil
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
+	// Do not ask the provider about containers in machines.
 	mergedConfig := observedConfig
-	if len(providerConfig) != 0 {
-		mergedConfig = MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
-		logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), mergedConfig)
+	if !m.IsContainer() {
+		providerConfig, err := api.getOneMachineProviderNetworkConfig(m)
+		if errors.IsNotProvisioned(err) {
+			logger.Infof("not updating machine %q network config: %v", m.Id(), err)
+			return nil
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(providerConfig) != 0 {
+			mergedConfig = MergeProviderAndObservedNetworkConfigs(providerConfig, observedConfig)
+			logger.Tracef("merged observed and provider network config for machine %q: %+v", m.Id(), mergedConfig)
+		}
 	}
 
 	mergedConfig, err = api.fixUpFanSubnets(mergedConfig)
@@ -122,6 +125,7 @@ func (api *NetworkConfigAPI) SetProviderNetworkConfig(args params.Entities) (par
 		}
 
 		if m.IsContainer() {
+			logger.Debugf("not updating network config for container %q", m.Id())
 			continue
 		}
 
@@ -161,10 +165,6 @@ func (api *NetworkConfigAPI) getMachineForSettingNetworkConfig(machineTag string
 		return nil, errors.Trace(common.ErrPerm)
 	} else if err != nil {
 		return nil, errors.Trace(err)
-	}
-
-	if m.IsContainer() {
-		logger.Debugf("not updating network config for container %q", m.Id())
 	}
 
 	return m, nil

--- a/network/containerizer/shim.go
+++ b/network/containerizer/shim.go
@@ -74,7 +74,7 @@ type Machine interface {
 	// A better approach could be sought that does not require their
 	// presence here.
 	SetDevicesAddresses(devicesAddresses ...state.LinkLayerDeviceAddress) (err error)
-	SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs []state.LinkLayerDeviceArgs) error
+	SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs state.LinkLayerDevicesArgs) error
 	SetConstraints(cons constraints.Value) (err error)
 	RemoveAllAddresses() error
 	Raw() *state.Machine

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -1028,6 +1028,17 @@ func (m *Machine) removeUnusedLinkLayerDevices(devicesArgs LinkLayerDevicesArgs)
 		}
 	}
 
+	// Treat devices with parents not also being deleted as not having parents.
+	// This is so that when the hierarchy for batching is generated below,
+	// such devices are deleted last, with the other top-level parents.
+	unusedNames := unusedArgs.deviceNames()
+	for i, args := range unusedArgs {
+		if unusedNames.Contains(args.ParentName) {
+			continue
+		}
+		unusedArgs[i].ParentName = ""
+	}
+
 	// Batch up the unused args, then iterate in reverse order
 	// so that groups of children are deleted before parents.
 	unusedGroups := unusedArgs.batchParentsFirst()

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -163,6 +163,53 @@ type LinkLayerDeviceArgs struct {
 	ParentName string
 }
 
+type LinkLayerDevicesArgs []LinkLayerDeviceArgs
+
+// batchParentsFirst returns the devices args as sub-divided collections,
+// ensuring that each group consists only of devices who's parents (if any)
+// are contained in a group with an earlier index.
+func (a LinkLayerDevicesArgs) batchParentsFirst() []LinkLayerDevicesArgs {
+	var allDevs []LinkLayerDevicesArgs
+
+	// Collect the device names that we see, starting with the empty string as
+	// a proxy the root devices - those without a parent.
+	seen := set.NewStrings("")
+	for {
+		var groupDevs LinkLayerDevicesArgs
+
+		// Get all devices who's parents we have already seen.
+		for _, args := range a {
+			if seen.Contains(args.Name) {
+				continue
+			}
+			if seen.Contains(args.ParentName) {
+				groupDevs = append(groupDevs, args)
+			}
+		}
+
+		if len(groupDevs) == 0 {
+			break
+		}
+
+		// Mark as seen only after we have accrued the full group.
+		for _, args := range groupDevs {
+			seen.Add(args.Name)
+		}
+
+		allDevs = append(allDevs, groupDevs)
+	}
+
+	return allDevs
+}
+
+func (a LinkLayerDevicesArgs) deviceNames() set.Strings {
+	deviceNames := set.NewStrings()
+	for _, dev := range a {
+		deviceNames.Add(dev.Name)
+	}
+	return deviceNames
+}
+
 // SetLinkLayerDevices sets link-layer devices on the machine, adding or
 // updating existing devices as needed, in a single transaction. ProviderID
 // field can be empty if not supported by the provider, but when set must be
@@ -223,31 +270,6 @@ func (m *Machine) SetLinkLayerDevices(devicesArgs ...LinkLayerDeviceArgs) (err e
 			return nil, jujutxn.ErrNoOperations
 		}
 		return append(ops, setDevicesOps...), nil
-	}
-	if err := m.st.db().Run(buildTxn); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
-// removeUnusedLinkLayerDevices removes any link layer devices that
-// exist in state but not in the supplied args.
-func (m *Machine) removeUnusedLinkLayerDevices(devicesArgs ...LinkLayerDeviceArgs) (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot remove unused link-layer devices on machine %q", m.doc.Id)
-
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		if m.doc.Life != Alive {
-			return nil, errors.Errorf("machine %q not alive", m.doc.Id)
-		}
-		removeDevicesOps, err := m.removeUnusedLinkLayerDevicesOps(devicesArgs)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if len(removeDevicesOps) == 0 {
-			logger.Debugf("no LinkLayerDevices to remove for machine %q", m.Id())
-			return nil, jujutxn.ErrNoOperations
-		}
-		return append([]txn.Op{m.assertAliveOp()}, removeDevicesOps...), nil
 	}
 	if err := m.st.db().Run(buildTxn); err != nil {
 		return errors.Trace(err)
@@ -492,49 +514,6 @@ func (m *Machine) setDevicesFromDocsOps(newDocs []linkLayerDeviceDoc) ([]txn.Op,
 		} else {
 			return nil, errors.Trace(err)
 		}
-	}
-	return ops, nil
-}
-
-// removeUnusedLinkLayerDevicesOps removes link-layer devices that
-// are not in the in-use list.
-func (m *Machine) removeUnusedLinkLayerDevicesOps(inUse []LinkLayerDeviceArgs) ([]txn.Op, error) {
-	devices, closer := m.st.db().GetCollection(linkLayerDevicesC)
-	defer closer()
-
-	existingToDelete := make(map[string]linkLayerDeviceDoc)
-	filter := bson.D{{
-		"_id", bson.D{{"$regex", "^" + linkLayerDeviceGlobalKey(m.Id(), "")}},
-	}}
-	var docs []linkLayerDeviceDoc
-	err := devices.Find(filter).All(&docs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, d := range docs {
-		existingToDelete[d.Name] = d
-	}
-
-	var ops []txn.Op
-	for _, arg := range inUse {
-		delete(existingToDelete, arg.Name)
-	}
-	for _, devDoc := range existingToDelete {
-		dev := LinkLayerDevice{st: m.st, doc: devDoc}
-		removeOps, err := removeLinkLayerDeviceOps(m.st, dev.DocID(), dev.parentDocID())
-		// TODO(wallyworld) - do we need to remove parent devices also?
-		if IsParentDeviceHasChildrenError(err) {
-			logger.Debugf("not removing link layer device %q on machine %q as it has children", dev.Name(), m.Id())
-			continue
-		}
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if dev.ProviderID() != "" {
-			op := dev.st.networkEntityGlobalKeyRemoveOp("linklayerdevice", dev.ProviderID())
-			removeOps = append(removeOps, op)
-		}
-		ops = append(ops, removeOps...)
 	}
 	return ops, nil
 }
@@ -1001,44 +980,111 @@ func (m *Machine) AllNetworkAddresses() (corenetwork.SpaceAddresses, error) {
 // SetParentLinkLayerDevicesBeforeTheirChildren splits the given devicesArgs
 // into multiple sets of args and calls SetLinkLayerDevices() for each set, such
 // that child devices are set only after their parents.
-func (m *Machine) SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs []LinkLayerDeviceArgs) error {
+func (m *Machine) SetParentLinkLayerDevicesBeforeTheirChildren(devicesArgs LinkLayerDevicesArgs) error {
 	// TODO(wallyworld) - ideally this entire method would be done as a model op
-	seenNames := set.NewStrings("") // sentinel for empty ParentName.
-	for {
-		argsToSet := []LinkLayerDeviceArgs{}
-		for _, args := range devicesArgs {
-			if seenNames.Contains(args.Name) {
-				// Already added earlier.
-				continue
-			}
-			if seenNames.Contains(args.ParentName) {
-				argsToSet = append(argsToSet, args)
-			}
-		}
-		if len(argsToSet) == 0 {
-			// We're done.
-			break
-		}
-		logger.Debugf("setting link-layer devices %+v", argsToSet)
-		if err := m.SetLinkLayerDevices(argsToSet...); IsProviderIDNotUniqueError(err) {
+	for _, groupedArgs := range devicesArgs.batchParentsFirst() {
+		logger.Debugf("setting link-layer devices %+v", groupedArgs)
+		if err := m.SetLinkLayerDevices(groupedArgs...); IsProviderIDNotUniqueError(err) {
 			// FIXME: Make updating devices with unchanged ProviderID idempotent.
 			// FIXME: this obliterates the ProviderID of *all*
 			// devices if any *one* of them is not unique.
-			for i, args := range argsToSet {
-				args.ProviderID = ""
-				argsToSet[i] = args
+			for i := range groupedArgs {
+				groupedArgs[i].ProviderID = ""
 			}
-			if err := m.SetLinkLayerDevices(argsToSet...); err != nil {
+			if err := m.SetLinkLayerDevices(groupedArgs...); err != nil {
 				return errors.Trace(err)
 			}
 		} else if err != nil {
 			return errors.Trace(err)
 		}
-		for _, args := range argsToSet {
-			seenNames.Add(args.Name)
+	}
+
+	return m.removeUnusedLinkLayerDevices(devicesArgs)
+}
+
+// removeUnusedLinkLayerDevices removes any link layer devices that
+// exist in state but not in the supplied args.
+func (m *Machine) removeUnusedLinkLayerDevices(devicesArgs LinkLayerDevicesArgs) (err error) {
+	defer errors.DeferredAnnotatef(&err, "removing unused link-layer devices on machine %q", m.doc.Id)
+
+	unused, err := m.unusedLinkLayerDevices(devicesArgs)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(unused) == 0 {
+		return nil
+	}
+
+	// Do some transformations to prepare for deleting children before parents.
+	// Index the unused devices by name, and create a dummy
+	// LinkLayerDevicesArgs collection so we can lever it to drive the batches.
+	unusedByName := make(map[string]*LinkLayerDevice, len(unused))
+	unusedArgs := make(LinkLayerDevicesArgs, len(unused))
+	for i, dev := range unused {
+		unusedByName[dev.Name()] = dev
+		unusedArgs[i] = LinkLayerDeviceArgs{
+			Name:       dev.Name(),
+			ParentName: dev.ParentName(),
 		}
 	}
-	return m.removeUnusedLinkLayerDevices(devicesArgs...)
+
+	// Batch up the unused args, then iterate in reverse order
+	// so that groups of children are deleted before parents.
+	unusedGroups := unusedArgs.batchParentsFirst()
+	for i := len(unusedGroups) - 1; i >= 0; i-- {
+		// Gather the ops for deleting this batch of children.
+		var ops []txn.Op
+		for _, devArgs := range unusedGroups[i] {
+			dev := unusedByName[devArgs.Name]
+			removeOps, err := removeLinkLayerDeviceOps(m.st, dev.DocID(), dev.parentDocID())
+			if err != nil {
+				return errors.Trace(err)
+			}
+			ops = append(ops, removeOps...)
+		}
+
+		// Run the transaction.
+		// We have to do this each time, because the transaction op generation
+		// above checks the integrity of the existing hierarchy in Mongo.
+		// This would cause errors if attempting to delete any parents in a
+		// single transaction, even if we were also deleting the children.
+		buildTxn := func(attempt int) ([]txn.Op, error) {
+			if m.doc.Life != Alive {
+				return nil, errors.Errorf("machine %q not alive", m.doc.Id)
+			}
+
+			if len(ops) == 0 {
+				logger.Debugf("no LinkLayerDevices to remove for machine %q", m.Id())
+				return nil, jujutxn.ErrNoOperations
+			}
+
+			return append([]txn.Op{m.assertAliveOp()}, ops...), nil
+		}
+		if err := m.st.db().Run(buildTxn); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}
+
+// unusedLinkLayerDevices returns all link-layer devices for the machine
+// that are not represented in the input arguments.
+func (m *Machine) unusedLinkLayerDevices(seen LinkLayerDevicesArgs) ([]*LinkLayerDevice, error) {
+	seenNames := seen.deviceNames()
+
+	allDevs, err := m.AllLinkLayerDevices()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var unused []*LinkLayerDevice
+	for _, dev := range allDevs {
+		if !seenNames.Contains(dev.Name()) {
+			unused = append(unused, dev)
+		}
+	}
+	return unused, nil
 }
 
 // SetDevicesAddressesIdempotently calls SetDevicesAddresses() and if it fails


### PR DESCRIPTION
Instead of attempting to delete all unobserved link-layer devices in a single transaction, batch them in the same fashion as for insert/update, but in reverse order. I.e. children before parents.

The batching is extracted from `SetParentLinkLayerDevicesBeforeTheirChildren` and encapsulated in a new type, `LinkLayerDevicesArgs`. Using this we can recruit the same logic in two places.

Loosing the single transaction for deletion is not ideal, but we never really had it for the encapsulating method anyway.

All this is necessary due to the way that these methods interrogate state, requiring integrity of the device hierarchy at rest rather than making this determination using a comparison of incoming/existing data.

It is hoped that we can improve this area of the code during current feature work on 2.8+ branches. These changes will not be forward ported, so will subside with the 2.7 track.

This also addresses an error for providers that supply a networking environ. On MAAS, errors like this were observed:
```
machine-0-kvm-0: 14:17:06 DEBUG juju.worker.dependency "machiner" manifold worker stopped: cannot update observed network config: cannot get network interfaces of "juju-ef8b23-0-kvm-0": instance "juju-ef8b23-0-kvm-0" not found (not found)
machine-0-kvm-0: 14:17:06 ERROR juju.worker.dependency "machiner" manifold worker returned unexpected error: cannot update observed network config: cannot get network interfaces of "juju-ef8b23-0-kvm-0": instance "juju-ef8b23-0-kvm-0" not found (not found)
machine-0-kvm-0: 14:17:06 DEBUG juju.worker.dependency stack trace:
cannot get network interfaces of "juju-ef8b23-0-kvm-0": instance "juju-ef8b23-0-kvm-0" not found (not found)
/home/joseph/go/src/github.com/juju/juju/rpc/client.go:178:
/home/joseph/go/src/github.com/juju/juju/api/apiclient.go:1187:
/home/joseph/go/src/github.com/juju/juju/api/machiner/machine.go:122:
/home/joseph/go/src/github.com/juju/juju/worker/machiner/machiner.go:177: cannot update observed network config
```
The solution is not to ask the provider about container instances.