### PR TITLE
Show unit command

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -1020,3 +1020,24 @@ func (c *Client) MergeBindings(req params.ApplicationMergeBindingsArgs) error {
 	}
 	return results.OneError()
 }
+
+// UnitsInfo retrieves units information.
+func (c *Client) UnitsInfo(units []names.UnitTag) ([]params.UnitInfoResult, error) {
+	if apiVersion := c.BestAPIVersion(); apiVersion < 12 {
+		return nil, errors.NotSupportedf("UnitsInfo for Application facade v%v", apiVersion)
+	}
+	all := make([]params.Entity, len(units))
+	for i, one := range units {
+		all[i] = params.Entity{Tag: one.String()}
+	}
+	in := params.Entities{Entities: all}
+	var out params.UnitInfoResults
+	err := c.facade.FacadeCall("UnitsInfo", in, &out)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if resultsLen := len(out.Results); resultsLen != len(units) {
+		return nil, errors.Errorf("expected %d results, got %d", len(units), resultsLen)
+	}
+	return out.Results, nil
+}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1559,3 +1559,148 @@ func (s *applicationSuite) TestApplicationsInfoResultMismatch(c *gc.C) {
 	c.Check(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "expected 2 results, got 3")
 }
+
+func (s *applicationSuite) TestUnitsInfoBotSupported(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "UnitsInfo")
+			return nil
+		},
+	)
+	client := application.NewClient(apiCaller)
+	_, err := client.UnitsInfo(nil)
+	c.Assert(err, gc.ErrorMatches, "UnitsInfo for Application facade v0 not supported")
+	c.Assert(called, jc.IsFalse)
+}
+
+func apiForUnitsInfo(f basetesting.APICallerFunc) basetesting.BestVersionCaller {
+	return basetesting.BestVersionCaller{
+		BestVersion:   12,
+		APICallerFunc: f,
+	}
+}
+
+func (s *applicationSuite) TestUnitsInfoCallError(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "UnitsInfo")
+			return errors.New("boom")
+		},
+	)
+
+	client := application.NewClient(apiForUnitsInfo(apiCaller))
+	_, err := client.UnitsInfo(nil)
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *applicationSuite) TestUnitsInfo(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			called = true
+			c.Assert(request, gc.Equals, "UnitsInfo")
+			args, ok := a.(params.Entities)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(args, jc.DeepEquals, params.Entities{
+				Entities: []params.Entity{
+					{Tag: "unit-foo-0"},
+					{Tag: "unit-bar-1"},
+				}})
+
+			result, ok := response.(*params.UnitInfoResults)
+			c.Assert(ok, jc.IsTrue)
+			result.Results = []params.UnitInfoResult{
+				{Error: &params.Error{Message: "boom"}},
+				{Result: &params.UnitResult{
+					Tag:             "unit-bar-1",
+					WorkloadVersion: "666",
+					Machine:         "1",
+					OpenedPorts:     []string{"80"},
+					PublicAddress:   "10.0.0.1",
+					Charm:           "charm-bar",
+					Leader:          true,
+					RelationData: []params.EndpointRelationData{{
+						Endpoint:        "db",
+						CrossModel:      true,
+						RelatedEndpoint: "server",
+						ApplicationData: map[string]interface{}{"foo": "bar"},
+						UnitRelationData: map[string]params.RelationData{
+							"baz": {
+								InScope:  true,
+								UnitData: map[string]interface{}{"hello": "world"},
+							},
+						},
+					}},
+					ProviderId: "provider-id",
+					Address:    "192.168.1.1",
+				}},
+			}
+			return nil
+		},
+	)
+
+	client := application.NewClient(apiForUnitsInfo(apiCaller))
+	results, err := client.UnitsInfo(
+		[]names.UnitTag{
+			names.NewUnitTag("foo/0"),
+			names.NewUnitTag("bar/1"),
+		},
+	)
+	c.Check(called, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, []params.UnitInfoResult{
+		{Error: &params.Error{Message: "boom"}},
+		{Result: &params.UnitResult{
+			Tag:             "unit-bar-1",
+			WorkloadVersion: "666",
+			Machine:         "1",
+			OpenedPorts:     []string{"80"},
+			PublicAddress:   "10.0.0.1",
+			Charm:           "charm-bar",
+			Leader:          true,
+			RelationData: []params.EndpointRelationData{{
+				Endpoint:        "db",
+				CrossModel:      true,
+				RelatedEndpoint: "server",
+				ApplicationData: map[string]interface{}{"foo": "bar"},
+				UnitRelationData: map[string]params.RelationData{
+					"baz": {
+						InScope:  true,
+						UnitData: map[string]interface{}{"hello": "world"},
+					},
+				},
+			}},
+			ProviderId: "provider-id",
+			Address:    "192.168.1.1",
+		}},
+	})
+}
+
+func (s *applicationSuite) TestUnitssInfoResultMismatch(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, response interface{}) error {
+			c.Assert(request, gc.Equals, "UnitsInfo")
+
+			result, ok := response.(*params.UnitInfoResults)
+			c.Assert(ok, jc.IsTrue)
+			result.Results = []params.UnitInfoResult{
+				{}, {}, {},
+			}
+			return nil
+		},
+	)
+
+	client := application.NewClient(apiForUnitsInfo(apiCaller))
+	_, err := client.UnitsInfo(
+		[]names.UnitTag{
+			names.NewUnitTag("foo/0"),
+			names.NewUnitTag("bar/1"),
+		},
+	)
+	c.Assert(err, gc.ErrorMatches, "expected 2 results, got 3")
+}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -4,6 +4,7 @@
 package application_test
 
 import (
+	stderrors "errors"
 	"time"
 
 	"github.com/juju/charm/v7"
@@ -1653,9 +1654,9 @@ func (s *applicationSuite) TestUnitsInfo(c *gc.C) {
 	)
 	c.Check(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, gc.DeepEquals, []params.UnitInfoResult{
-		{Error: &params.Error{Message: "boom"}},
-		{Result: &params.UnitResult{
+	c.Assert(results, gc.DeepEquals, []application.UnitInfo{
+		{Error: stderrors.New("boom")},
+		{
 			Tag:             "unit-bar-1",
 			WorkloadVersion: "666",
 			Machine:         "1",
@@ -1663,12 +1664,12 @@ func (s *applicationSuite) TestUnitsInfo(c *gc.C) {
 			PublicAddress:   "10.0.0.1",
 			Charm:           "charm-bar",
 			Leader:          true,
-			RelationData: []params.EndpointRelationData{{
+			RelationData: []application.EndpointRelationData{{
 				Endpoint:        "db",
 				CrossModel:      true,
 				RelatedEndpoint: "server",
 				ApplicationData: map[string]interface{}{"foo": "bar"},
-				UnitRelationData: map[string]params.RelationData{
+				UnitRelationData: map[string]application.RelationData{
 					"baz": {
 						InScope:  true,
 						UnitData: map[string]interface{}{"hello": "world"},
@@ -1677,7 +1678,7 @@ func (s *applicationSuite) TestUnitsInfo(c *gc.C) {
 			}},
 			ProviderId: "provider-id",
 			Address:    "192.168.1.1",
-		}},
+		},
 	})
 }
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              2,
 	"AllWatcher":                   1,
 	"Annotations":                  2,
-	"Application":                  11,
+	"Application":                  12,
 	"ApplicationOffers":            2,
 	"ApplicationScaler":            1,
 	"Backups":                      2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -154,6 +154,7 @@ func AllFacades() *facade.Registry {
 	reg("Application", 9, application.NewFacadeV9)   // ApplicationInfo; generational config; Force on App, Relation and Unit Removal.
 	reg("Application", 10, application.NewFacadeV10) // --force and --no-wait parameters
 	reg("Application", 11, application.NewFacadeV11) // Get call returns the endpoint bindings
+	reg("Application", 12, application.NewFacadeV12) // Adds UnitsInfo()
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -256,7 +256,7 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		storageAccess,
 		ctx.Auth(),
 		blockChecker,
-		&modelShim{facadeModel},
+		&modelShim{facadeModel}, // modelShim wraps the AllPorts() API.
 		leadershipReader,
 		stateCharm,
 		DeployApplication,
@@ -2807,8 +2807,6 @@ func (api *APIBase) relationData(app Application, myUnit Unit) ([]params.Endpoin
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-
-		otherUnits = append(otherUnits, myUnit)
 		for _, u := range otherUnits {
 			ru, err := rel.Unit(u.Name())
 			if err != nil {

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -49,7 +49,7 @@ type applicationSuite struct {
 	jujutesting.JujuConnSuite
 	commontesting.BlockHelper
 
-	applicationAPI *application.APIv11
+	applicationAPI *application.APIv12
 	application    *state.Application
 	authorizer     *apiservertesting.FakeAuthorizer
 	repo           *mockRepo
@@ -113,7 +113,7 @@ func (s *applicationSuite) UploadCharmMultiSeries(c *gc.C, url, name string) (*c
 	return s.UploadCharm(c, url, name)
 }
 
-func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv11 {
+func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv12 {
 	resources := common.NewResources()
 	c.Assert(resources.RegisterNamed("dataDir", common.StringResource(c.MkDir())), jc.ErrorIsNil)
 	storageAccess, err := application.GetStorageState(s.State)
@@ -128,7 +128,8 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv11 {
 		storageAccess,
 		s.authorizer,
 		blockChecker,
-		model,
+		application.GetModel(model),
+		nil, // leadership not used in these tests.
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		pm,
@@ -137,7 +138,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv11 {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	return &application.APIv11{api}
+	return &application.APIv12{api}
 }
 
 func (s *applicationSuite) TestCharmConfig(c *gc.C) {
@@ -161,7 +162,9 @@ func (s *applicationSuite) TestCharmConfigV8(c *gc.C) {
 	api := &application.APIv8{
 		APIv9: &application.APIv9{
 			APIv10: &application.APIv10{
-				APIv11: s.applicationAPI,
+				APIv11: &application.APIv11{
+					s.applicationAPI,
+				},
 			},
 		},
 	}

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -15,6 +15,10 @@ func GetState(st *state.State) Backend {
 	return stateShim{st}
 }
 
-func SetModelType(api *APIv11, modelType state.ModelType) {
+func GetModel(m *state.Model) Model {
+	return modelShim{m}
+}
+
+func SetModelType(api *APIv12, modelType state.ModelType) {
 	api.modelType = modelType
 }

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -29,7 +29,7 @@ import (
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	applicationAPI *application.APIv11
+	applicationAPI *application.APIv12
 	authorizer     apiservertesting.FakeAuthorizer
 }
 
@@ -51,7 +51,8 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		storageAccess,
 		s.authorizer,
 		blockChecker,
-		model,
+		application.GetModel(model),
+		nil, // leadership not used in this suite.
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		&mockStoragePoolManager{},
@@ -60,12 +61,12 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.applicationAPI = &application.APIv11{api}
+	s.applicationAPI = &application.APIv12{api}
 }
 
 func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{&application.APIv9{&application.APIv10{s.applicationAPI}}}}}}}
+	v4 := &application.APIv4{&application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{&application.APIv9{&application.APIv10{&application.APIv11{s.applicationAPI}}}}}}}}
 	results, err := v4.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -85,7 +86,7 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 
 func (s *getSuite) TestClientApplicationGetSmokeTestV5(c *gc.C) {
 	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{&application.APIv9{&application.APIv10{s.applicationAPI}}}}}}
+	v5 := &application.APIv5{&application.APIv6{&application.APIv7{&application.APIv8{&application.APIv9{&application.APIv10{&application.APIv11{s.applicationAPI}}}}}}}
 	results, err := v5.Get(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
@@ -204,7 +205,8 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 		storageAccess,
 		s.authorizer,
 		blockChecker,
-		mod,
+		application.GetModel(mod),
+		nil, // leadership not used in this suite.
 		application.CharmToStateCharm,
 		application.DeployApplication,
 		&mockStoragePoolManager{},
@@ -213,7 +215,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	apiV8 := &application.APIv8{&application.APIv9{&application.APIv10{&application.APIv11{api}}}}
+	apiV8 := &application.APIv8{&application.APIv9{&application.APIv10{&application.APIv11{&application.APIv12{api}}}}}
 
 	results, err := apiV8.Get(params.ApplicationGet{ApplicationName: "dashboard4miner"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1658,7 +1658,7 @@
     },
     {
         "Name": "Application",
-        "Version": 11,
+        "Version": 12,
         "Schema": {
             "type": "object",
             "properties": {
@@ -1943,6 +1943,17 @@
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/ApplicationUnexpose"
+                        }
+                    }
+                },
+                "UnitsInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UnitInfoResults"
                         }
                     }
                 },
@@ -3182,6 +3193,45 @@
                         "units"
                     ]
                 },
+                "EndpointRelationData": {
+                    "type": "object",
+                    "properties": {
+                        "ApplicationData": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "cross-model": {
+                            "type": "boolean"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "related-endpoint": {
+                            "type": "string"
+                        },
+                        "unit-relation-data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/RelationData"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "endpoint",
+                        "cross-model",
+                        "related-endpoint",
+                        "ApplicationData",
+                        "unit-relation-data"
+                    ]
+                },
                 "Entities": {
                     "type": "object",
                     "properties": {
@@ -3323,6 +3373,28 @@
                     "required": [
                         "scope",
                         "directive"
+                    ]
+                },
+                "RelationData": {
+                    "type": "object",
+                    "properties": {
+                        "InScope": {
+                            "type": "boolean"
+                        },
+                        "UnitData": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "InScope",
+                        "UnitData"
                     ]
                 },
                 "RelationSuspendedArg": {
@@ -3582,6 +3654,81 @@
                         "life",
                         "space-tag",
                         "zones"
+                    ]
+                },
+                "UnitInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/UnitResult"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UnitInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UnitInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UnitResult": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "leader": {
+                            "type": "boolean"
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "opened-ports": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "public-address": {
+                            "type": "string"
+                        },
+                        "relation-data": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EndpointRelationData"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "workload-version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "workload-version",
+                        "opened-ports",
+                        "charm"
                     ]
                 },
                 "UnitsResolved": {

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -446,3 +446,45 @@ type ApplicationInfoResult struct {
 type ApplicationInfoResults struct {
 	Results []ApplicationInfoResult `json:"results"`
 }
+
+// RelationData holds information about a unit's relation.
+type RelationData struct {
+	InScope  bool                   `yaml:"in-scope"`
+	UnitData map[string]interface{} `yaml:"data"`
+}
+
+// EndpointRelationData holds information about a relation to a given endpoint.
+type EndpointRelationData struct {
+	Endpoint         string                  `json:"endpoint"`
+	CrossModel       bool                    `json:"cross-model"`
+	RelatedEndpoint  string                  `json:"related-endpoint"`
+	ApplicationData  map[string]interface{}  `yaml:"application-relation-data"`
+	UnitRelationData map[string]RelationData `json:"unit-relation-data"`
+}
+
+// UnitResult holds unit info.
+type UnitResult struct {
+	Tag             string                 `json:"tag"`
+	WorkloadVersion string                 `json:"workload-version"`
+	Machine         string                 `json:"machine,omitempty"`
+	OpenedPorts     []string               `json:"opened-ports"`
+	PublicAddress   string                 `json:"public-address,omitempty"`
+	Charm           string                 `json:"charm"`
+	Leader          bool                   `json:"leader,omitempty"`
+	RelationData    []EndpointRelationData `json:"relation-data,omitempty"`
+
+	// The following are for CAAS models.
+	ProviderId string `json:"provider-id,omitempty"`
+	Address    string `json:"address,omitempty"`
+}
+
+// UnitInfoResults holds an unit info result or a retrieval error.
+type UnitInfoResult struct {
+	Result *UnitResult `json:"result,omitempty"`
+	Error  *Error      `json:"error,omitempty"`
+}
+
+// UnitInfoResults holds units associated with entities.
+type UnitInfoResults struct {
+	Results []UnitInfoResult `json:"results"`
+}

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -289,6 +289,14 @@ func NewShowCommandForTest(api ApplicationsInfoAPI, store jujuclient.ClientStore
 	return modelcmd.Wrap(cmd)
 }
 
+func NewShowUnitCommandForTest(api UnitsInfoAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &showUnitCommand{newAPIFunc: func() (UnitsInfoAPI, error) {
+		return api, nil
+	}}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
 // RepoSuiteBaseSuite allows the patching of the supported juju suite for
 // each test.
 type RepoSuiteBaseSuite struct {

--- a/cmd/juju/application/show.go
+++ b/cmd/juju/application/show.go
@@ -24,11 +24,11 @@ The command takes deployed application names or aliases as an argument.
 The command does an exact search. It does not support wildcards.
 
 Examples:
-    $ juju show-application mysql
-    $ juju show-application mysql wordpress
+    juju show-application mysql
+    juju show-application mysql wordpress
 
-    $ juju show-application myapplication
-        where "myapplication" is the application name alias, see "juju help deploy" for more information
+    juju show-application myapplication
+      where "myapplication" is the application name alias, see "juju help deploy" for more information
 
 `
 

--- a/cmd/juju/application/showunit.go
+++ b/cmd/juju/application/showunit.go
@@ -1,0 +1,283 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
+	"github.com/juju/naturalsort"
+
+	"github.com/juju/juju/api/application"
+	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+const showUnitDoc = `
+The command takes deployed unit names as an argument.
+
+Optionally, relation data for only a specified endpoint
+or related unit may be shown, or just the application data. 
+
+Examples:
+    $ juju show-unit mysql/0
+    $ juju show-unit mysql/0 wordpress/1
+    $ juju show-unit mysql/0 --app
+    $ juju show-unit mysql/0 --endpoint db
+    $ juju show-unit mysql/0 --related-unit wordpress/2
+`
+
+// NewShowUnitCommand returns a command that displays unit info.
+func NewShowUnitCommand() cmd.Command {
+	s := &showUnitCommand{}
+	s.newAPIFunc = func() (UnitsInfoAPI, error) {
+		return s.newUnitAPI()
+	}
+	return modelcmd.Wrap(s)
+}
+
+type showUnitCommand struct {
+	modelcmd.ModelCommandBase
+
+	out         cmd.Output
+	units       []string
+	endpoint    string
+	relatedUnit string
+	appOnly     bool
+
+	newAPIFunc func() (UnitsInfoAPI, error)
+}
+
+// Info implements Command.Info.
+func (c *showUnitCommand) Info() *cmd.Info {
+	showCmd := &cmd.Info{
+		Name:    "show-unit",
+		Args:    "<unit name>",
+		Purpose: "Displays information about a unit.",
+		Doc:     showUnitDoc,
+	}
+	return jujucmd.Info(showCmd)
+}
+
+// Init implements Command.Init.
+func (c *showUnitCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.Errorf("an unit name must be supplied")
+	}
+	c.units = args
+	if c.relatedUnit != "" && !names.IsValidUnit(c.relatedUnit) {
+		return errors.NotValidf("related unit name %v", c.relatedUnit)
+	}
+	var invalid []string
+	for _, one := range c.units {
+		if !names.IsValidUnit(one) {
+			invalid = append(invalid, one)
+		}
+	}
+	if len(invalid) == 0 {
+		return nil
+	}
+	plural := "s"
+	if len(invalid) == 1 {
+		plural = ""
+	}
+	return errors.NotValidf(`unit name%v %v`, plural, strings.Join(invalid, `, `))
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *showUnitCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters.Formatters())
+	f.StringVar(&c.endpoint, "endpoint", "", "Only show relation data for the specified endpoint")
+	f.StringVar(&c.relatedUnit, "related-unit", "", "Only show relation data for the specified unit")
+	f.BoolVar(&c.appOnly, "app", false, "Only show application relation data")
+}
+
+// UnitsInfoAPI defines the API methods that show-unit command uses.
+type UnitsInfoAPI interface {
+	Close() error
+	BestAPIVersion() int
+	UnitsInfo([]names.UnitTag) ([]params.UnitInfoResult, error)
+}
+
+func (c *showUnitCommand) newUnitAPI() (UnitsInfoAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return application.NewClient(root), nil
+}
+
+// Info implements Command.Run.
+func (c *showUnitCommand) Run(ctx *cmd.Context) error {
+	client, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if v := client.BestAPIVersion(); v < 12 {
+		// old client does not support showing applications.
+		return errors.NotSupportedf("show unit on API server version %v", v)
+	}
+
+	tags, err := c.getUnitTags()
+	if err != nil {
+		return err
+	}
+
+	results, err := client.UnitsInfo(tags)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var errs params.ErrorResults
+	var valid []params.UnitResult
+	for _, result := range results {
+		if result.Error != nil {
+			errs.Results = append(errs.Results, params.ErrorResult{result.Error})
+			continue
+		}
+		valid = append(valid, *result.Result)
+	}
+	if len(errs.Results) > 0 {
+		return errs.Combine()
+	}
+
+	output, err := c.formatUnitInfos(valid)
+	if err != nil {
+		return err
+	}
+	return c.out.Write(ctx, output)
+}
+
+func (c *showUnitCommand) getUnitTags() ([]names.UnitTag, error) {
+	tags := make([]names.UnitTag, len(c.units))
+	for i, one := range c.units {
+		if !names.IsValidUnit(one) {
+			return nil, errors.Errorf("invalid unit name %v", one)
+		}
+		tags[i] = names.NewUnitTag(one)
+	}
+	return tags, nil
+}
+
+func (c *showUnitCommand) formatUnitInfos(all []params.UnitResult) (map[string]UnitInfo, error) {
+	if len(all) == 0 {
+		return nil, nil
+	}
+	output := make(map[string]UnitInfo)
+	for _, one := range all {
+		tag, info, err := c.createUnitInfo(one)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		output[tag.Id()] = info
+	}
+	return output, nil
+}
+
+type UnitRelationData struct {
+	InScope  bool                   `yaml:"in-scope" json:"in-scope"`
+	UnitData map[string]interface{} `yaml:"data" json:"data"`
+}
+
+type RelationData struct {
+	Endpoint                string                      `yaml:"endpoint" json:"endpoint"`
+	CrossModel              bool                        `yaml:"cross-model,omitempty" json:"cross-model,omitempty"`
+	RelatedEndpoint         string                      `yaml:"related-endpoint" json:"related-endpoint"`
+	ApplicationRelationData map[string]interface{}      `yaml:"application-data,omitempty" json:"application-data,omitempty"`
+	MyData                  UnitRelationData            `yaml:"local-unit,omitempty" json:"local-unit,omitempty"`
+	Data                    map[string]UnitRelationData `yaml:"related-units,omitempty" json:"related-units,omitempty"`
+}
+
+// ApplicationInfo defines the serialization behaviour of the application information.
+type UnitInfo struct {
+	WorkloadVersion string         `yaml:"workload-version,omitempty" json:"workload-version,omitempty"`
+	Machine         string         `yaml:"machine,omitempty" json:"machine,omitempty"`
+	OpenedPorts     []string       `yaml:"opened-ports" json:"opened-ports"`
+	PublicAddress   string         `yaml:"public-address,omitempty" json:"public-address,omitempty"`
+	Charm           string         `yaml:"charm" json:"charm"`
+	Leader          bool           `yaml:"leader" json:"leader"`
+	RelationData    []RelationData `yaml:"relation-info,omitempty" json:"relation-info,omitempty"`
+
+	// The following are for CAAS models.
+	ProviderId string `yaml:"provider-id,omitempty" json:"provider-id,omitempty"`
+	Address    string `yaml:"address,omitempty" json:"address,omitempty"`
+}
+
+func (c *showUnitCommand) createUnitInfo(details params.UnitResult) (names.UnitTag, UnitInfo, error) {
+	tag, err := names.ParseUnitTag(details.Tag)
+	if err != nil {
+		return names.UnitTag{}, UnitInfo{}, errors.Trace(err)
+	}
+
+	info := UnitInfo{
+		WorkloadVersion: details.WorkloadVersion,
+		Machine:         details.Machine,
+		OpenedPorts:     details.OpenedPorts,
+		PublicAddress:   details.PublicAddress,
+		Charm:           details.Charm,
+		Leader:          details.Leader,
+		ProviderId:      details.ProviderId,
+		Address:         details.Address,
+	}
+	for _, rdparams := range details.RelationData {
+		if c.endpoint != "" && rdparams.Endpoint != c.endpoint {
+			continue
+		}
+		rd := RelationData{
+			Endpoint:                rdparams.Endpoint,
+			RelatedEndpoint:         rdparams.RelatedEndpoint,
+			CrossModel:              rdparams.CrossModel,
+			ApplicationRelationData: make(map[string]interface{}),
+			Data:                    make(map[string]UnitRelationData),
+		}
+		for k, v := range rdparams.ApplicationData {
+			rd.ApplicationRelationData[k] = v
+		}
+		if c.appOnly {
+			info.RelationData = append(info.RelationData, rd)
+			continue
+		}
+		var unitNames []string
+		for remoteUnit := range rdparams.UnitRelationData {
+			if c.relatedUnit != "" && remoteUnit != c.relatedUnit {
+				continue
+			}
+			if remoteUnit == tag.Id() {
+				data := rdparams.UnitRelationData[remoteUnit]
+				urd := UnitRelationData{
+					InScope:  data.InScope,
+					UnitData: make(map[string]interface{}),
+				}
+				for k, v := range data.UnitData {
+					urd.UnitData[k] = v
+				}
+				rd.MyData = urd
+				continue
+			}
+			unitNames = append(unitNames, remoteUnit)
+		}
+		naturalsort.Sort(unitNames)
+		for _, remoteUnit := range unitNames {
+			data := rdparams.UnitRelationData[remoteUnit]
+			urd := UnitRelationData{
+				InScope:  data.InScope,
+				UnitData: make(map[string]interface{}),
+			}
+			for k, v := range data.UnitData {
+				urd.UnitData[k] = v
+			}
+			rd.Data[remoteUnit] = urd
+		}
+		info.RelationData = append(info.RelationData, rd)
+	}
+
+	return tag, info, nil
+}

--- a/cmd/juju/application/showunit_test.go
+++ b/cmd/juju/application/showunit_test.go
@@ -1,0 +1,405 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/application"
+	"github.com/juju/juju/jujuclient"
+	_ "github.com/juju/juju/provider/dummy"
+	jujutesting "github.com/juju/juju/testing"
+)
+
+type ShowUnitSuite struct {
+	jujutesting.FakeJujuXDGDataHomeSuite
+	store *jujuclient.MemStore
+
+	mockAPI *mockShowUnitAPI
+}
+
+var _ = gc.Suite(&ShowUnitSuite{})
+
+func (s *ShowUnitSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
+	s.store = jujuclient.NewMemStore()
+	s.store.CurrentControllerName = "testing"
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Models["testing"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{
+			"admin/controller": {},
+		},
+		CurrentModel: "admin/controller",
+	}
+	s.store.Accounts["testing"] = jujuclient.AccountDetails{
+		User: "admin",
+	}
+
+	s.mockAPI = &mockShowUnitAPI{
+		version:       12,
+		unitsInfoFunc: func([]names.UnitTag) ([]params.UnitInfoResult, error) { return nil, nil },
+	}
+}
+
+func (s *ShowUnitSuite) runShow(c *gc.C, args ...string) (*cmd.Context, error) {
+	return cmdtesting.RunCommand(c, application.NewShowUnitCommandForTest(s.mockAPI, s.store), args...)
+}
+
+type showUnitTest struct {
+	args   []string
+	err    string
+	stdout string
+	stderr string
+}
+
+func (s *ShowUnitSuite) assertRunShow(c *gc.C, t showUnitTest) {
+	context, err := s.runShow(c, t.args...)
+	if t.err == "" {
+		c.Assert(err, jc.ErrorIsNil)
+	} else {
+		c.Assert(err, gc.ErrorMatches, t.err)
+	}
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, t.stdout)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, t.stderr)
+}
+
+func (s *ShowUnitSuite) TestShowNoArguments(c *gc.C) {
+	msg := "an unit name must be supplied"
+	s.assertRunShow(c, showUnitTest{
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowUnitSuite) TestShowInvalidRelatedUnit(c *gc.C) {
+	msg := "related unit name so-42-far-not-good not valid"
+	s.assertRunShow(c, showUnitTest{
+		args:   []string{"--related-unit", "so-42-far-not-good", "wordpress/0"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowUnitSuite) TestShowInvalidName(c *gc.C) {
+	msg := "unit name so-42-far-not-good not valid"
+	s.assertRunShow(c, showUnitTest{
+		args:   []string{"so-42-far-not-good"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowUnitSuite) TestShowInvalidValidNames(c *gc.C) {
+	msg := "unit name so-42-far-not-good not valid"
+	s.assertRunShow(c, showUnitTest{
+		args:   []string{"so-42-far-not-good", "wordpress/0"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowUnitSuite) TestShowInvalidNames(c *gc.C) {
+	msg := "unit names so-42-far-not-good, oo not valid"
+	s.assertRunShow(c, showUnitTest{
+		args:   []string{"so-42-far-not-good", "oo"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowUnitSuite) TestShowInvalidAndValidNames(c *gc.C) {
+	msg := "unit names so-42-far-not-good, oo not valid"
+	s.assertRunShow(c, showUnitTest{
+		args:   []string{"so-42-far-not-good", "wordpress/0", "oo"},
+		err:    fmt.Sprintf("%v", msg),
+		stderr: fmt.Sprintf("ERROR %v\n", msg),
+	})
+}
+
+func (s *ShowUnitSuite) TestShowUnsupported(c *gc.C) {
+	s.mockAPI.version = 11
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0"},
+		err:  "show unit on API server version 11 not supported",
+	})
+}
+
+func (s *ShowUnitSuite) TestShowApiError(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Error: &params.Error{Message: "boom"}},
+		}, nil
+	}
+	msg := "boom"
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0"},
+		err:  fmt.Sprintf("%v", msg),
+	})
+}
+
+func (s *ShowUnitSuite) createTestUnitInfo(app string, otherEndpoint string) *params.UnitResult {
+	result := &params.UnitResult{
+		Tag:             fmt.Sprintf("unit-%v-0", app),
+		WorkloadVersion: "666",
+		Machine:         "0",
+		OpenedPorts:     []string{"100-102/ip"},
+		PublicAddress:   "10.0.0.1",
+		Charm:           fmt.Sprintf("charm-%v", app),
+		Leader:          true,
+		RelationData: []params.EndpointRelationData{{
+			Endpoint:        "db",
+			CrossModel:      true,
+			RelatedEndpoint: "server",
+			ApplicationData: map[string]interface{}{app: "setting"},
+			UnitRelationData: map[string]params.RelationData{
+				"mariadb/2": {
+					InScope:  true,
+					UnitData: map[string]interface{}{"mariadb/2": "mariadb/2-setting"},
+				},
+			},
+		}},
+		ProviderId: "provider-id",
+		Address:    "192.168.1.1",
+	}
+	if otherEndpoint != "" {
+		result.RelationData = append(result.RelationData, params.EndpointRelationData{
+			Endpoint:        otherEndpoint,
+			RelatedEndpoint: "common",
+		})
+		result.RelationData[0].UnitRelationData["mariadb/3"] = params.RelationData{
+			InScope:  true,
+			UnitData: map[string]interface{}{"mariadb/3": "mariadb/3-setting"},
+		}
+	}
+	return result
+}
+
+func (s *ShowUnitSuite) TestShow(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Result: s.createTestUnitInfo("wordpress", "")},
+		}, nil
+	}
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0"},
+		stdout: `
+wordpress/0:
+  workload-version: "666"
+  machine: "0"
+  opened-ports:
+  - 100-102/ip
+  public-address: 10.0.0.1
+  charm: charm-wordpress
+  leader: true
+  relation-info:
+  - endpoint: db
+    cross-model: true
+    related-endpoint: server
+    application-data:
+      wordpress: setting
+    related-units:
+      mariadb/2:
+        in-scope: true
+        data:
+          mariadb/2: mariadb/2-setting
+  provider-id: provider-id
+  address: 192.168.1.1
+`[1:],
+	})
+}
+
+func (s *ShowUnitSuite) TestShowAppOnly(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Result: s.createTestUnitInfo("wordpress", "")},
+		}, nil
+	}
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0", "--app"},
+		stdout: `
+wordpress/0:
+  workload-version: "666"
+  machine: "0"
+  opened-ports:
+  - 100-102/ip
+  public-address: 10.0.0.1
+  charm: charm-wordpress
+  leader: true
+  relation-info:
+  - endpoint: db
+    cross-model: true
+    related-endpoint: server
+    application-data:
+      wordpress: setting
+  provider-id: provider-id
+  address: 192.168.1.1
+`[1:],
+	})
+}
+
+func (s *ShowUnitSuite) TestShowEndpoint(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Result: s.createTestUnitInfo("wordpress", "db-shared")},
+		}, nil
+	}
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0", "--endpoint", "db-shared"},
+		stdout: `
+wordpress/0:
+  workload-version: "666"
+  machine: "0"
+  opened-ports:
+  - 100-102/ip
+  public-address: 10.0.0.1
+  charm: charm-wordpress
+  leader: true
+  relation-info:
+  - endpoint: db-shared
+    related-endpoint: common
+  provider-id: provider-id
+  address: 192.168.1.1
+`[1:],
+	})
+}
+
+func (s *ShowUnitSuite) TestShowOtherUnit(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Result: s.createTestUnitInfo("wordpress", "db-shared")},
+		}, nil
+	}
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0", "--related-unit", "mariadb/3", "--endpoint", "db"},
+		stdout: `
+wordpress/0:
+  workload-version: "666"
+  machine: "0"
+  opened-ports:
+  - 100-102/ip
+  public-address: 10.0.0.1
+  charm: charm-wordpress
+  leader: true
+  relation-info:
+  - endpoint: db
+    cross-model: true
+    related-endpoint: server
+    application-data:
+      wordpress: setting
+    related-units:
+      mariadb/3:
+        in-scope: true
+        data:
+          mariadb/3: mariadb/3-setting
+  provider-id: provider-id
+  address: 192.168.1.1
+`[1:],
+	})
+}
+
+func (s *ShowUnitSuite) TestShowJSON(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Result: s.createTestUnitInfo("wordpress", "")},
+		}, nil
+	}
+	s.assertRunShow(c, showUnitTest{
+		args:   []string{"wordpress/0", "--format", "json"},
+		stdout: `{"wordpress/0":{"workload-version":"666","machine":"0","opened-ports":["100-102/ip"],"public-address":"10.0.0.1","charm":"charm-wordpress","leader":true,"relation-info":[{"endpoint":"db","cross-model":true,"related-endpoint":"server","application-data":{"wordpress":"setting"},"local-unit":{"in-scope":false,"data":null},"related-units":{"mariadb/2":{"in-scope":true,"data":{"mariadb/2":"mariadb/2-setting"}}}}],"provider-id":"provider-id","address":"192.168.1.1"}}` + "\n",
+	})
+}
+
+func (s *ShowUnitSuite) TestShowMix(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Result: s.createTestUnitInfo("wordpress", "")},
+			{Error: &params.Error{Message: "boom"}},
+		}, nil
+	}
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0", "logging/0"},
+		err:  "boom",
+	})
+}
+
+func (s *ShowUnitSuite) TestShowMany(c *gc.C) {
+	s.mockAPI.unitsInfoFunc = func([]names.UnitTag) ([]params.UnitInfoResult, error) {
+		return []params.UnitInfoResult{
+			{Result: s.createTestUnitInfo("wordpress", "")},
+			{Result: s.createTestUnitInfo("logging", "")},
+		}, nil
+	}
+	s.assertRunShow(c, showUnitTest{
+		args: []string{"wordpress/0", "logging/0"},
+		stdout: `
+logging/0:
+  workload-version: "666"
+  machine: "0"
+  opened-ports:
+  - 100-102/ip
+  public-address: 10.0.0.1
+  charm: charm-logging
+  leader: true
+  relation-info:
+  - endpoint: db
+    cross-model: true
+    related-endpoint: server
+    application-data:
+      logging: setting
+    related-units:
+      mariadb/2:
+        in-scope: true
+        data:
+          mariadb/2: mariadb/2-setting
+  provider-id: provider-id
+  address: 192.168.1.1
+wordpress/0:
+  workload-version: "666"
+  machine: "0"
+  opened-ports:
+  - 100-102/ip
+  public-address: 10.0.0.1
+  charm: charm-wordpress
+  leader: true
+  relation-info:
+  - endpoint: db
+    cross-model: true
+    related-endpoint: server
+    application-data:
+      wordpress: setting
+    related-units:
+      mariadb/2:
+        in-scope: true
+        data:
+          mariadb/2: mariadb/2-setting
+  provider-id: provider-id
+  address: 192.168.1.1
+`[1:],
+	})
+}
+
+type mockShowUnitAPI struct {
+	version       int
+	unitsInfoFunc func([]names.UnitTag) ([]params.UnitInfoResult, error)
+}
+
+func (s mockShowUnitAPI) Close() error {
+	return nil
+}
+
+func (s mockShowUnitAPI) BestAPIVersion() int {
+	return s.version
+}
+
+func (s mockShowUnitAPI) UnitsInfo(tags []names.UnitTag) ([]params.UnitInfoResult, error) {
+	return s.unitsInfoFunc(tags)
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -425,6 +425,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(application.NewApplicationSetConstraintsCommand())
 	r.Register(application.NewBundleDiffCommand())
 	r.Register(application.NewShowApplicationCommand())
+	r.Register(application.NewShowUnitCommand())
 
 	// Operation protection commands
 	r.Register(block.NewDisableCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -634,6 +634,7 @@ var commandNames = []string{
 	"show-status-log",
 	"show-storage",
 	"show-space",
+	"show-unit",
 	"show-user",
 	"show-wallet",
 	"sla",

--- a/state/relation.go
+++ b/state/relation.go
@@ -617,7 +617,7 @@ func (r *Relation) Endpoints() []Endpoint {
 }
 
 // RelatedEndpoints returns the endpoints of the relation r with which
-// units of the named application will establish relations. If the service
+// units of the named application will establish relations. If the application
 // is not part of the relation r, an error will be returned.
 func (r *Relation) RelatedEndpoints(applicationname string) ([]Endpoint, error) {
 	local, err := r.Endpoint(applicationname)

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -46,6 +46,11 @@ func (ru *RelationUnit) Endpoint() Endpoint {
 	return ru.endpoint
 }
 
+// UnitName returns the name of the unit in the relation.
+func (ru *RelationUnit) UnitName() string {
+	return ru.unitName
+}
+
 // ErrCannotEnterScope indicates that a relation unit failed to enter its scope
 // due to either the unit or the relation not being Alive.
 var ErrCannotEnterScope = stderrors.New("cannot enter scope: unit or relation is not alive")

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1090,6 +1090,7 @@ func addRU(c *gc.C, app *state.Application, rel *state.Relation, principal *stat
 	}
 	ru, err := rel.Unit(u)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ru.UnitName(), gc.Equals, u.Name())
 	return u, ru
 }
 


### PR DESCRIPTION
### Checklist

 - [X] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
It we want to expose the new API, we'll need to update libjuju

----

## Description of change

Add a new show-unit command. There's 3 separate commits:
- apiserver facade / state implementation
- api client
- CLI command itself

This command adds a show option for units, like for machines, applications etc.
A key point is that you can use it to inspect unit relation data. Until now, you would have had to run 3 hook commands using juju exec to get the same result.

## QA steps

Deploy mediawiki related to a 3 unit mariadb
Deploy mediawiki related to a mariadb offer

Then you can try show-unit, eg

```
$ juju show-unit mediawiki/0
mediawiki/0:
  workload-version: 1.19.14
  machine: "0"
  opened-ports:
  - 80/tcp
  public-address: 10.169.54.195
  charm: cs:mediawiki-19
  leader: true
  relation-info:
  - endpoint: db
    cross-model: true
    related-endpoint: db
    application-data: {}
    related-units:
      mariadb/0:
        in-scope: true
        data:
          database: remote-7f82691643ef447f88f2b34d08a51b91
          egress-subnets: 10.169.54.226/32
          host: 10.169.54.226
          ingress-address: 10.169.54.226
          password: aemaevohbeiyohe
          private-address: 10.169.54.226
          slave: "False"
          user: riekoovahfuokah

$ juju show-unit mariadb/0
mariadb/0:
  workload-version: 10.1.40
  machine: "0"
  opened-ports: []
  public-address: 10.169.54.226
  charm: cs:trusty/mariadb-7
  leader: true
  relation-info:
  - endpoint: cluster
    related-endpoint: cluster
    application-data: {}
    local-unit:
      in-scope: true
      data:
        egress-subnets: 10.169.54.226/32
        ingress-address: 10.169.54.226
        private-address: 10.169.54.226
    related-units:
      mariadb/1:
        in-scope: false
        data: {}
      mariadb/2:
        in-scope: false
        data: {}
  - endpoint: db
    cross-model: true
    related-endpoint: db
    application-data: {}
    related-units:
      remote-7f82691643ef447f88f2b34d08a51b91/0:
        in-scope: true
        data:
          egress-subnets: 10.169.54.195/32
          ingress-address: 10.169.54.195
          private-address: 10.169.54.195
```

