### PR TITLE
Merge 2.7 into 2.8

### DIFF
--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -194,25 +194,28 @@ func resolveNetworkInfoAddresses(
 	for i, info := range netInfoResult.Info {
 		for j, addr := range info.Addresses {
 			if ip := net.ParseIP(addr.Address); ip == nil {
-				resolvedAddr := addressForHost(addr.Address)
-				if resolvedAddr != "" {
-					addr.Hostname = addr.Address
-					addr.Address = resolvedAddr
-					netInfoResult.Info[i].Addresses[j] = addr
-				}
+				// If the address is not an IP, we assume it is a host name.
+				addr.Hostname = addr.Address
+				addr.Address = addressForHost(addr.Hostname)
+				netInfoResult.Info[i].Addresses[j] = addr
 			}
 		}
 	}
 
 	// Resolve addresses in IngressAddresses.
-	for i, addr := range netInfoResult.IngressAddresses {
-		if ip := net.ParseIP(addr); ip == nil {
-			resolvedAddr := addressForHost(addr)
-			if resolvedAddr != "" {
-				netInfoResult.IngressAddresses[i] = resolvedAddr
-			}
+	// This is slightly different to the addresses above in that we do not
+	// include anything that does not resolve to a usable address.
+	var newIngress []string
+	for _, addr := range netInfoResult.IngressAddresses {
+		if ip := net.ParseIP(addr); ip != nil {
+			newIngress = append(newIngress, addr)
+			continue
+		}
+		if ipAddr := addressForHost(addr); ipAddr != "" {
+			newIngress = append(newIngress, ipAddr)
 		}
 	}
+	netInfoResult.IngressAddresses = newIngress
 
 	return netInfoResult
 }
@@ -220,8 +223,36 @@ func resolveNetworkInfoAddresses(
 func resolveHostAddress(hostName string, lookupHost resolver) string {
 	resolved, err := lookupHost(hostName)
 	if err != nil {
-		logger.Warningf("The address %q is neither an IP address nor a resolvable hostname", hostName)
+		logger.Errorf("resolving %q: %v", hostName, err)
 		return ""
 	}
-	return resolved[0]
+
+	// We have seen examples of /etc/hosts entries like this:
+	//   127.0.1.1 hostname.fqdn hostname
+	//
+	// The default behaviour of net.LookupHost returns any IPs resolved via the
+	// hosts file *without* querying DNS. Given that these may include loopback
+	// addresses that are unusable by machines they might be advertised to,
+	// we avoid returning them.
+	for _, addr := range resolved {
+		if ip := net.ParseIP(addr); ip != nil && !ip.IsLoopback() {
+			return addr
+		}
+	}
+
+	if len(resolved) == 0 {
+		logger.Warningf("no addresses resolved for host %q", hostName)
+	} else {
+		// If we got results, but they were all filtered out, then we need to
+		// help out operators with some advice.
+		logger.Warningf(
+			"no usable addresses resolved for host %q\n\t"+
+				"resolved: %v\n\t"+
+				"consider editing the hosts file, or changing host resolution order via /etc/nsswitch.conf",
+			hostName,
+			resolved,
+		)
+	}
+
+	return ""
 }

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -26,7 +26,7 @@ var _ = gc.Suite(&NetworkGetSuite{})
 func (s *NetworkGetSuite) SetUpSuite(c *gc.C) {
 	s.ContextSuite.SetUpSuite(c)
 	lookupHost := func(host string) (addrs []string, err error) {
-		return []string{"10.3.3.3"}, nil
+		return []string{"127.0.1.1", "10.3.3.3"}, nil
 	}
 	testing.PatchValue(&jujuc.LookupHost, lookupHost)
 }
@@ -146,11 +146,10 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 
 func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
 	for i, t := range []struct {
-		summary  string
-		args     []string
-		code     int
-		out      string
-		checkctx func(*gc.C, *cmd.Context)
+		summary string
+		args    []string
+		code    int
+		out     string
 	}{{
 		summary: "no arguments",
 		code:    2,
@@ -287,27 +286,46 @@ ingress-addresses:
 - 10.3.3.3`[1:],
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
-		com := s.createCommand(c)
-		ctx := cmdtesting.Context(c)
-		code := cmd.Main(com, ctx, t.args)
-		c.Check(code, gc.Equals, t.code)
-		if code == 0 {
-			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-			expect := t.out
-			if expect != "" {
-				expect = expect + "\n"
-			}
-			c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
-		} else {
-			c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-			expect := fmt.Sprintf(`(.|\n)*ERROR %s\n`, t.out)
-			c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
+		s.testScenario(c, t.args, t.code, t.out)
+	}
+}
+
+func (s *NetworkGetSuite) TestNetworkGetLoopbackOnly(c *gc.C) {
+	lookupHost := func(host string) (addrs []string, err error) {
+		return []string{"127.0.1.1"}, nil
+	}
+	testing.PatchValue(&jujuc.LookupHost, lookupHost)
+
+	s.testScenario(c, []string{"resolvable-hostname"}, 0, `
+bind-addresses:
+- macaddress: "00:11:22:33:44:33"
+  interfacename: eth3
+  addresses:
+  - hostname: resolvable-hostname
+    address: ""
+    cidr: 10.33.1.8/24`[1:])
+}
+
+func (s *NetworkGetSuite) testScenario(c *gc.C, args []string, code int, out string) {
+	ctx := cmdtesting.Context(c)
+
+	c.Check(cmd.Main(s.createCommand(c), ctx, args), gc.Equals, code)
+
+	if code == 0 {
+		c.Check(bufferString(ctx.Stderr), gc.Equals, "")
+		expect := out
+		if expect != "" {
+			expect = expect + "\n"
 		}
+		c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
+	} else {
+		c.Check(bufferString(ctx.Stdout), gc.Equals, "")
+		expect := fmt.Sprintf(`(.|\n)*ERROR %s\n`, out)
+		c.Check(bufferString(ctx.Stderr), gc.Matches, expect)
 	}
 }
 
 func (s *NetworkGetSuite) TestHelp(c *gc.C) {
-
 	helpLine := `Usage: network-get [options] <binding-name> [--ingress-address] [--bind-address] [--egress-subnets]`
 
 	com := s.createCommand(c)


### PR DESCRIPTION
Merge 2.7 into 2.8 to bring forward:
- #11657 from manadart/2.7-update-gorilla-websocket
- #11638 from manadart/2.7-local-machine-addrs
- #11639 from SimonRichardson/unpin-machine-applications-on-destroy
- #11650 from manadart/2.7-pruner-test-kill
- #11660 from achilleasa/2.7-ensure-cert-leafs-are-at-least-384-bytes-long
- #11664 from ycliuhw/fix/OCI-fetch-2.7

Some of these are effectively no-ops. The material changes are:
- The logging instead of throwing or errors in #11639.
- #11638.
