### PR TITLE
Adds upgrade worker to model agent

### DIFF
--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -39,7 +39,7 @@ func NewUpgraderFacade(st *state.State, resources facade.Resources, auth facade.
 		return nil, common.ErrPerm
 	}
 	switch tag.(type) {
-	case names.MachineTag, names.ControllerAgentTag, names.ApplicationTag:
+	case names.MachineTag, names.ControllerAgentTag, names.ApplicationTag, names.ModelTag:
 		return NewUpgraderAPI(st, resources, auth)
 	case names.UnitTag:
 		return NewUnitUpgraderAPI(st, resources, auth)
@@ -72,7 +72,7 @@ func NewUpgraderAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*UpgraderAPI, error) {
-	if !authorizer.AuthMachineAgent() && !authorizer.AuthApplicationAgent() {
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthApplicationAgent() && !authorizer.AuthModelAgent() {
 		return nil, common.ErrPerm
 	}
 	getCanReadWrite := func() (common.AuthFunc, error) {

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
-	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -43,7 +42,9 @@ func NewCAASOperatorUpgraderAPI(
 	authorizer facade.Authorizer,
 	broker caas.Upgrader,
 ) (*API, error) {
-	if !authorizer.AuthController() && !authorizer.AuthApplicationAgent() && !authorizer.AuthModelAgent() {
+	if !authorizer.AuthController() &&
+		!authorizer.AuthApplicationAgent() &&
+		!authorizer.AuthModelAgent() {
 		return nil, common.ErrPerm
 	}
 	return &API{
@@ -64,14 +65,9 @@ func (api *API) UpgradeOperator(arg params.KubernetesUpgradeArg) (params.ErrorRe
 	if !api.auth.AuthOwner(tag) {
 		return serverErr(common.ErrPerm), nil
 	}
-	appName := tag.Id()
 
-	// Nodes representing controllers really mean the controller operator.
-	if tag.Kind() == names.MachineTagKind || tag.Kind() == names.ControllerAgentTagKind {
-		appName = bootstrap.ControllerModelName
-	}
-	logger.Debugf("upgrading caas app %v", appName)
-	err = api.broker.Upgrade(appName, arg.Version)
+	logger.Debugf("upgrading caas agent for %s", tag)
+	err = api.broker.Upgrade(arg.AgentTag, arg.Version)
 	if err != nil {
 		return serverErr(err), nil
 	}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -43,7 +43,7 @@ func NewCAASOperatorUpgraderAPI(
 	authorizer facade.Authorizer,
 	broker caas.Upgrader,
 ) (*API, error) {
-	if !authorizer.AuthController() && !authorizer.AuthApplicationAgent() {
+	if !authorizer.AuthController() && !authorizer.AuthApplicationAgent() && !authorizer.AuthModelAgent() {
 		return nil, common.ErrPerm
 	}
 	return &API{

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
@@ -55,7 +55,7 @@ func (s *CAASProvisionerSuite) TestUpgradeOperator(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	s.broker.CheckCall(c, 0, "Upgrade", "app", vers)
+	s.broker.CheckCall(c, 0, "Upgrade", s.authorizer.Tag.String(), vers)
 }
 
 func (s *CAASProvisionerSuite) assertUpgradeController(c *gc.C, tag names.Tag) {
@@ -74,7 +74,7 @@ func (s *CAASProvisionerSuite) assertUpgradeController(c *gc.C, tag names.Tag) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	s.broker.CheckCall(c, 0, "Upgrade", "controller", vers)
+	s.broker.CheckCall(c, 0, "Upgrade", tag.String(), vers)
 }
 
 func (s *CAASProvisionerSuite) TestUpgradeLegacyController(c *gc.C) {

--- a/caas/kubernetes/provider/controller_upgrade.go
+++ b/caas/kubernetes/provider/controller_upgrade.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/names/v4"
+	"github.com/juju/version"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/juju/juju/environs/bootstrap"
+)
+
+type upgradeCAASControllerBridge struct {
+	clientFn    func() kubernetes.Interface
+	namespaceFn func() string
+}
+
+// UpgradeCAASControllerBroker describes the interface needed for upgrading
+// Juju Kubernetes controllers
+type UpgradeCAASControllerBroker interface {
+	// Client returns a Kubernetes client associated with the current broker's
+	// cluster
+	Client() kubernetes.Interface
+
+	// Namespace returns the targeted Kubernetes namespace for this broker
+	Namespace() string
+}
+
+func (u *upgradeCAASControllerBridge) Client() kubernetes.Interface {
+	return u.clientFn()
+}
+
+func (u *upgradeCAASControllerBridge) Namespace() string {
+	return u.namespaceFn()
+}
+
+func controllerUpgrade(appName string, vers version.Number, broker UpgradeCAASControllerBroker) error {
+	return upgradeStatefulSet(appName, "", vers, broker.Client().AppsV1().StatefulSets(broker.Namespace()))
+}
+
+func (k *kubernetesClient) upgradeController(agentTag names.Tag, vers version.Number) error {
+	broker := &upgradeCAASControllerBridge{
+		clientFn:    k.client,
+		namespaceFn: k.GetCurrentNamespace,
+	}
+	return controllerUpgrade(bootstrap.ControllerModelName, vers, broker)
+}

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -1,0 +1,97 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+// DummyUpgradeCAASController implements UpgradeCAASControllerBroker for the
+// purpose of testing.
+type dummyUpgradeCAASController struct {
+	client *fake.Clientset
+}
+
+type ControllerUpgraderSuite struct {
+	broker *dummyUpgradeCAASController
+}
+
+var _ = gc.Suite(&ControllerUpgraderSuite{})
+
+func (d *dummyUpgradeCAASController) Client() kubernetes.Interface {
+	return d.client
+}
+
+func (d *dummyUpgradeCAASController) Namespace() string {
+	return "test"
+}
+
+func (s *ControllerUpgraderSuite) SetUpTest(c *gc.C) {
+	s.broker = &dummyUpgradeCAASController{
+		client: fake.NewSimpleClientset(),
+	}
+}
+
+func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
+	var (
+		appName      = JujuControllerStackName
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+	_, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).Create(
+		&apps.StatefulSet{
+			ObjectMeta: meta.ObjectMeta{
+				Name: appName,
+			},
+			Spec: apps.StatefulSetSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						Containers: []core.Container{
+							{
+								Name:  "jujud",
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(controllerUpgrade(appName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
+
+	ss, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).
+		Get(appName, meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ss.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
+
+	c.Assert(ss.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Spec.Template.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+}
+
+func (s *ControllerUpgraderSuite) TestControllerDoesNotExist(c *gc.C) {
+	var (
+		appName = JujuControllerStackName
+	)
+	err := controllerUpgrade(appName, version.MustParse("9.9.9"), s.broker)
+	c.Assert(err, gc.NotNil)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}

--- a/caas/kubernetes/provider/modeloperator_upgrade.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/names/v4"
+	"github.com/juju/version"
+	"k8s.io/client-go/kubernetes"
+)
+
+type upgradeCAASModelOperatorBridge struct {
+	clientFn    func() kubernetes.Interface
+	namespaceFn func() string
+}
+
+type UpgradeCAASModelOperatorBroker interface {
+	// Client returns a Kubernetes client associated with the current broker's
+	// cluster
+	Client() kubernetes.Interface
+
+	// Namespace returns the targeted Kubernetes namespace for this broker
+	Namespace() string
+}
+
+func (u *upgradeCAASModelOperatorBridge) Client() kubernetes.Interface {
+	return u.clientFn()
+}
+
+func modelOperatorUpgrade(
+	operatorName string,
+	vers version.Number,
+	broker UpgradeCAASModelOperatorBroker) error {
+	return upgradeDeployment(operatorName, "", vers,
+		broker.Client().AppsV1().Deployments(broker.Namespace()))
+}
+
+func (u *upgradeCAASModelOperatorBridge) Namespace() string {
+	return u.namespaceFn()
+}
+
+func (k *kubernetesClient) upgradeModelOperator(agentTag names.Tag, vers version.Number) error {
+	broker := &upgradeCAASModelOperatorBridge{
+		clientFn:    k.client,
+		namespaceFn: k.GetCurrentNamespace,
+	}
+	return modelOperatorUpgrade(modelOperatorName, vers, broker)
+}

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+type dummyUpgradeCAASModel struct {
+	client *fake.Clientset
+}
+
+type modelUpgraderSuite struct {
+	broker *dummyUpgradeCAASModel
+}
+
+var _ = gc.Suite(&modelUpgraderSuite{})
+
+func (d *dummyUpgradeCAASModel) Client() kubernetes.Interface {
+	return d.client
+}
+
+func (d *dummyUpgradeCAASModel) Namespace() string {
+	return "test"
+}
+
+func (s *modelUpgraderSuite) SetUpTest(c *gc.C) {
+	s.broker = &dummyUpgradeCAASModel{
+		client: fake.NewSimpleClientset(),
+	}
+}
+
+func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
+	var (
+		operatorName = modelOperatorName
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).Create(
+		&apps.Deployment{
+			ObjectMeta: meta.ObjectMeta{
+				Name: operatorName,
+			},
+			Spec: apps.DeploymentSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						Containers: []core.Container{
+							{
+								Name:  "jujud",
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(modelOperatorUpgrade(operatorName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
+	de, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).
+		Get(operatorName, meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(de.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
+
+	c.Assert(de.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Spec.Template.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+}

--- a/caas/kubernetes/provider/operator_upgrade.go
+++ b/caas/kubernetes/provider/operator_upgrade.go
@@ -1,0 +1,224 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/version"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+type upgradeCAASOperatorBridge struct {
+	clientFn         func() kubernetes.Interface
+	clockFn          func() clock.Clock
+	deploymentNameFn func(string, bool) string
+	namespaceFn      func() string
+	operatorFn       func(string) (*caas.Operator, error)
+	operatorNameFn   func(string) string
+}
+
+type UpgradeCAASOperatorBroker interface {
+	// Clock provides the clock to use with this broker for time operations
+	Clock() clock.Clock
+
+	// Client returns a Kubernetes client associated with the current broker's
+	// cluster
+	Client() kubernetes.Interface
+
+	// Returns the deployment name use for the given application name, supports
+	// finding legacy deployment names if set to True.
+	DeploymentName(string, bool) string
+
+	Namespace() string
+
+	// Operator returns an Operator with current status and life details.
+	Operator(string) (*caas.Operator, error)
+
+	// OperatorName returns the operator name used for the operator deployment
+	// for the supplied application.
+	OperatorName(string) string
+}
+
+const applicationUpgradeTimeoutSeconds = time.Second * 30
+
+func (u *upgradeCAASOperatorBridge) Client() kubernetes.Interface {
+	return u.clientFn()
+}
+
+func (u *upgradeCAASOperatorBridge) Clock() clock.Clock {
+	return u.clockFn()
+}
+
+func (u *upgradeCAASOperatorBridge) DeploymentName(n string, l bool) string {
+	return u.deploymentNameFn(n, l)
+}
+
+func (u *upgradeCAASOperatorBridge) Operator(n string) (*caas.Operator, error) {
+	return u.operatorFn(n)
+}
+
+func (u *upgradeCAASOperatorBridge) OperatorName(n string) string {
+	return u.operatorNameFn(n)
+}
+
+func (u *upgradeCAASOperatorBridge) Namespace() string {
+	return u.namespaceFn()
+}
+
+func operatorInitUpgrade(appName, imagePath string, broker UpgradeCAASOperatorBroker) (func() (bool, error), error) {
+	deploymentName := broker.DeploymentName(appName, true)
+
+	var data []byte
+	var selector labels.Set
+	podChecker := func(appName string,
+		labelSet labels.Set,
+		broker UpgradeCAASOperatorBroker) func() (bool, error) {
+
+		return func() (done bool, err error) {
+			labelSelector := labelSetToSelector(labelSet).String()
+			podList, err := broker.Client().CoreV1().Pods(broker.Namespace()).
+				List(meta.ListOptions{
+					LabelSelector: labelSelector,
+				})
+			if k8serrors.IsNotFound(err) {
+				// Not found means not ready.
+				logger.Tracef("listing pod %q, not found yet", selector.String())
+				return false, nil
+			} else if err != nil {
+				return false, errors.Trace(err)
+			}
+			pod := podList.Items[0]
+			if pod.Status.Phase != core.PodRunning {
+				logger.Debugf(
+					"init container %q is still upgrade, current status -> %q",
+					appName, pod.Status.Phase)
+				return false, nil
+			}
+
+			index, found := findJujudContainer(pod.Spec.InitContainers)
+			if !found {
+				logger.Debugf("init container for app %q not found", appName)
+				return false, nil
+			}
+
+			return pod.Spec.InitContainers[index].Image == imagePath, nil
+		}
+	}
+
+	ssInterface := broker.Client().AppsV1().StatefulSets(broker.Namespace())
+	sResource, err := ssInterface.Get(deploymentName, meta.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, errors.Annotatef(err, "getting statefulset %q", deploymentName)
+	} else if err == nil {
+		selector = sResource.Spec.Selector.MatchLabels
+		if err := ensureJujuInitContainer(&sResource.Spec.Template.Spec, imagePath); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data, err = json.Marshal(apps.StatefulSet{Spec: sResource.Spec}); err != nil {
+			return nil, errors.Trace(err)
+		}
+		_, err = ssInterface.Patch(sResource.GetName(), types.StrategicMergePatchType, data)
+		return podChecker(deploymentName, selector, broker), errors.Trace(err)
+	}
+
+	deInterface := broker.Client().AppsV1().Deployments(broker.Namespace())
+	deResource, err := deInterface.Get(deploymentName, meta.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	} else if err == nil {
+		selector = deResource.Spec.Selector.MatchLabels
+		if err := ensureJujuInitContainer(&deResource.Spec.Template.Spec, imagePath); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data, err = json.Marshal(apps.Deployment{Spec: deResource.Spec}); err != nil {
+			return nil, errors.Trace(err)
+		}
+		_, err = deInterface.Patch(deResource.GetName(), types.StrategicMergePatchType, data)
+		return podChecker(deploymentName, selector, broker), errors.Trace(err)
+	}
+
+	dsInterface := broker.Client().AppsV1().DaemonSets(broker.Namespace())
+	dsResource, err := dsInterface.Get(deploymentName, meta.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	} else if err == nil {
+		selector = dsResource.Spec.Selector.MatchLabels
+		if err := ensureJujuInitContainer(&dsResource.Spec.Template.Spec, imagePath); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data, err = json.Marshal(apps.DaemonSet{Spec: dsResource.Spec}); err != nil {
+			return nil, errors.Trace(err)
+		}
+		_, err = dsInterface.Patch(dsResource.GetName(), types.StrategicMergePatchType, data)
+		return podChecker(deploymentName, selector, broker), errors.Trace(err)
+	}
+
+	return nil, errors.NotFoundf("deployment %q init containers", deploymentName)
+}
+
+func operatorUpgrade(appName string, vers version.Number, broker UpgradeCAASOperatorBroker) error {
+	operator, err := broker.Operator(appName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	operatorImagePath := podcfg.RebuildOldOperatorImagePath(operator.Config.OperatorImagePath, vers)
+	if len(operatorImagePath) == 0 {
+		// This should never happen.
+		return errors.NotValidf("no resource is upgradable for application %q", appName)
+	}
+
+	podChecker, err := operatorInitUpgrade(appName, operatorImagePath, broker)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	timeout := broker.Clock().After(applicationUpgradeTimeoutSeconds)
+	for {
+		select {
+		case <-timeout:
+			return errors.Timeoutf("timeout while waiting for the upgraded operator of %q ready", appName)
+		case <-broker.Clock().After(time.Second):
+			// TODO(caas): change to use k8s watcher to trigger the polling.
+			ready, err := podChecker()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if ready {
+				logger.Infof("init container has been upgraded to %q, now the operator for %q starts to upgrade", operatorImagePath, appName)
+				return errors.Trace(upgradeStatefulSet(
+					broker.OperatorName(appName),
+					operatorImagePath,
+					vers,
+					broker.Client().AppsV1().StatefulSets(broker.Namespace())))
+			}
+		}
+	}
+}
+
+func (k *kubernetesClient) upgradeOperator(agentTag names.Tag, vers version.Number) error {
+	broker := &upgradeCAASOperatorBridge{
+		clientFn:         k.client,
+		clockFn:          func() clock.Clock { return k.clock },
+		deploymentNameFn: k.deploymentName,
+		namespaceFn:      k.GetCurrentNamespace,
+		operatorFn:       k.Operator,
+		operatorNameFn:   k.operatorName,
+	}
+	return operatorUpgrade(agentTag.Id(), vers, broker)
+}

--- a/caas/kubernetes/provider/operator_upgrade_test.go
+++ b/caas/kubernetes/provider/operator_upgrade_test.go
@@ -1,0 +1,340 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+type DummyUpgradeCAASOperator struct {
+	client     *fake.Clientset
+	OperatorFn func(string) (*caas.Operator, error)
+}
+
+type OperatorUpgraderSuite struct {
+	broker *DummyUpgradeCAASOperator
+}
+
+var _ = gc.Suite(&OperatorUpgraderSuite{})
+
+func (d *DummyUpgradeCAASOperator) Client() kubernetes.Interface {
+	return d.client
+}
+
+func (d *DummyUpgradeCAASOperator) Clock() clock.Clock {
+	return testclock.NewClock(time.Time{})
+}
+
+func (d *DummyUpgradeCAASOperator) DeploymentName(n string, _ bool) string {
+	return n
+}
+
+func (d *DummyUpgradeCAASOperator) Namespace() string {
+	return "test"
+}
+
+func (d *DummyUpgradeCAASOperator) Operator(n string) (*caas.Operator, error) {
+	if d.OperatorFn == nil {
+		return nil, errors.NotImplementedf("Operator()")
+	}
+	return d.OperatorFn(n)
+}
+
+func (d *DummyUpgradeCAASOperator) OperatorName(n string) string {
+	return n
+}
+
+func (o *OperatorUpgraderSuite) SetUpTest(c *gc.C) {
+	o.broker = &DummyUpgradeCAASOperator{
+		client: fake.NewSimpleClientset(),
+	}
+}
+
+func (o *OperatorUpgraderSuite) TestStatefulSetInitUpgrade(c *gc.C) {
+	var (
+		appName      = "testinitss"
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := o.broker.Client().AppsV1().StatefulSets(o.broker.Namespace()).Create(
+		&apps.StatefulSet{
+			ObjectMeta: meta.ObjectMeta{
+				Name: o.broker.DeploymentName(appName, true),
+			},
+			Spec: apps.StatefulSetSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						InitContainers: []core.Container{
+							{
+								Name:  caas.InitContainerName,
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	podChecker, err := operatorInitUpgrade(appName, newImagePath, o.broker)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ss, err := o.broker.Client().AppsV1().StatefulSets(o.broker.Namespace()).
+		Get(o.broker.DeploymentName(appName, true), meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ss.Spec.Template.Spec.InitContainers[0].Image, gc.Equals, newImagePath)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Create(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodPending,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err := podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsFalse)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Update(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodRunning,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err = podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsTrue)
+}
+
+func (o *OperatorUpgraderSuite) TestDaemonSetInitUpgrade(c *gc.C) {
+	var (
+		appName      = "testinitds"
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := o.broker.Client().AppsV1().DaemonSets(o.broker.Namespace()).Create(
+		&apps.DaemonSet{
+			ObjectMeta: meta.ObjectMeta{
+				Name: o.broker.DeploymentName(appName, true),
+			},
+			Spec: apps.DaemonSetSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						InitContainers: []core.Container{
+							{
+								Name:  caas.InitContainerName,
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	podChecker, err := operatorInitUpgrade(appName, newImagePath, o.broker)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ds, err := o.broker.Client().AppsV1().DaemonSets(o.broker.Namespace()).
+		Get(o.broker.DeploymentName(appName, true), meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ds.Spec.Template.Spec.InitContainers[0].Image, gc.Equals, newImagePath)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Create(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodPending,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err := podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsFalse)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Update(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodRunning,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err = podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsTrue)
+}
+
+func (o *OperatorUpgraderSuite) TestDeploymentInitUpgrade(c *gc.C) {
+	var (
+		appName      = "testinitds"
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := o.broker.Client().AppsV1().Deployments(o.broker.Namespace()).Create(
+		&apps.Deployment{
+			ObjectMeta: meta.ObjectMeta{
+				Name: o.broker.DeploymentName(appName, true),
+			},
+			Spec: apps.DeploymentSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						InitContainers: []core.Container{
+							{
+								Name:  caas.InitContainerName,
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	podChecker, err := operatorInitUpgrade(appName, newImagePath, o.broker)
+	c.Assert(err, jc.ErrorIsNil)
+
+	de, err := o.broker.Client().AppsV1().Deployments(o.broker.Namespace()).
+		Get(o.broker.DeploymentName(appName, true), meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(de.Spec.Template.Spec.InitContainers[0].Image, gc.Equals, newImagePath)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Create(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodPending,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err := podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsFalse)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Update(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodRunning,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err = podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsTrue)
+}

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -4,222 +4,136 @@
 package provider
 
 import (
-	"encoding/json"
-	"fmt"
-	"time"
-
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 	"github.com/juju/version"
-	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
-	k8stypes "k8s.io/apimachinery/pkg/types"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appstyped "k8s.io/client-go/kubernetes/typed/apps/v1"
 
 	"github.com/juju/juju/cloudconfig/podcfg"
 	k8sannotations "github.com/juju/juju/core/annotations"
-	"github.com/juju/juju/core/status"
 )
 
-const applicationUpgradeTimeoutSeconds = 30
-
-// Upgrade sets the OCI image for the app's operator to the specified version.
-func (k *kubernetesClient) Upgrade(appName string, vers version.Number) error {
-
-	isController := appName == JujuControllerStackName
-	if isController {
-		// Upgrade the controller pod.
-		return errors.Trace(k.upgradeControllerOrOperator(appName, vers, ""))
-	}
-
-	operator, err := k.Operator(appName)
+func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
+	tag, err := names.ParseTag(agentTag)
 	if err != nil {
-		return errors.Trace(err)
-	}
-	operatorImagePath := podcfg.RebuildOldOperatorImagePath(operator.Config.OperatorImagePath, vers)
-	if len(operatorImagePath) == 0 {
-		// This should never happen.
-		return errors.NotValidf("no resource is upgradable for application %q", appName)
+		return errors.Annotate(err, "parsing agent tag to upgrade")
 	}
 
-	// To upgrade an application, we upgrade the Juju init container in the workload pod first then operator pod.
-	podChecker, err := k.upgradeJujuInitContainer(appName, operatorImagePath)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	logger.Infof("handling upgrade request for tag %q", tag)
 
-	timeout := k.clock.After(applicationUpgradeTimeoutSeconds * time.Second)
-	for {
-		select {
-		case <-timeout:
-			return errors.Timeoutf("timeout while waiting for the upgraded operator of %q ready", appName)
-		case <-k.clock.After(1 * time.Second):
-			// TODO(caas): change to use k8s watcher to trigger the polling.
-			ready, err := podChecker()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			if ready {
-				logger.Infof("init container has been upgraded to %q, now the operator for %q starts to upgrade", operatorImagePath, appName)
-				return errors.Trace(k.upgradeControllerOrOperator(k.operatorName(appName), vers, operatorImagePath))
-			}
-		}
+	switch tag.Kind() {
+	case names.MachineTagKind:
+	case names.ControllerAgentTagKind:
+		return k.upgradeController(tag, vers)
+	case names.ApplicationTagKind:
+		return k.upgradeOperator(tag, vers)
+	case names.ModelTagKind:
+		return k.upgradeModelOperator(tag, vers)
 	}
+	return errors.NotImplementedf("k8s upgrade for agent tag %q", agentTag)
 }
 
-func upgradeContainer(existingContainers []core.Container, imagePath string) {
-	index := findJujudContainer(existingContainers)
-	if index >= 0 {
-		c := existingContainers[index]
-		if imagePath != c.Image {
-			logger.Infof("upgrading from %q to %q", c.Image, imagePath)
-			c.Image = imagePath
-			existingContainers[index] = c
-		}
-	}
-}
-
-func findJujudContainer(containers []core.Container) (index int) {
-	index = -1
-	for i, c := range containers {
-		if podcfg.IsJujuOCIImage(c.Image) {
-			return i
-		}
-	}
-	return index
-}
-
-func (k *kubernetesClient) upgradeControllerOrOperator(name string, vers version.Number, imagePath string) error {
-	logger.Debugf("Upgrading %q", name)
-
-	api := k.client().AppsV1().StatefulSets(k.namespace)
-	existingStatefulSet, err := api.Get(name, v1.GetOptions{})
+func upgradeDeployment(name, imagePath string, vers version.Number, broker appstyped.DeploymentInterface) error {
+	de, err := broker.Get(name, meta.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		// We always expect that the controller or operator statefulset resource exist.
-		// So this should never happen unless it was deleted accidentally.
-		return errors.Annotatef(err, "getting the existing statefulset %q to upgrade", name)
+		return errors.NotFoundf(
+			"deployment %q", name)
+	} else if err != nil {
+		return errors.Annotatef(err,
+			"getting deployment to upgrade for name %q", name)
 	}
+
+	updatedTemplateSpec, err := upgradePodTemplateSpec(&de.Spec.Template, imagePath, vers)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "deployment %q", name)
 	}
-
-	if len(imagePath) == 0 {
-		jujudContainerIdx := findJujudContainer(existingStatefulSet.Spec.Template.Spec.Containers)
-		if jujudContainerIdx < 0 {
-			return errors.NotFoundf("jujud container in statefulset %q", existingStatefulSet.GetName())
-		}
-		imagePath = existingStatefulSet.Spec.Template.Spec.Containers[jujudContainerIdx].Image
-	}
-
-	upgradeContainer(existingStatefulSet.Spec.Template.Spec.Containers, imagePath)
+	de.Spec.Template = *updatedTemplateSpec
 
 	// update juju-version annotation.
 	// TODO(caas): consider how to upgrade to current annotations format safely.
 	// just ensure juju-version to current version for now.
-	existingStatefulSet.SetAnnotations(
-		k8sannotations.New(existingStatefulSet.GetAnnotations()).
+	de.SetAnnotations(
+		k8sannotations.New(de.GetAnnotations()).
 			Add(labelVersion, vers.String()).ToMap(),
 	)
-	existingStatefulSet.Spec.Template.SetAnnotations(
-		k8sannotations.New(existingStatefulSet.Spec.Template.GetAnnotations()).
+	de.Spec.Template.SetAnnotations(
+		k8sannotations.New(de.Spec.Template.GetAnnotations()).
 			Add(labelVersion, vers.String()).ToMap(),
 	)
 
-	_, err = api.Update(existingStatefulSet)
-	return errors.Trace(err)
+	if _, err := broker.Update(de); err != nil {
+		return errors.Annotatef(err, "updating deployment %q to %s",
+			name, vers)
+	}
+	return nil
 }
 
-func (k *kubernetesClient) selectPod(labelSet k8slabels.Set) (*core.Pod, error) {
-	labelSelector := labelSetToSelector(labelSet).String()
-	podList, err := k.client().CoreV1().Pods(k.namespace).List(v1.ListOptions{
-		LabelSelector: labelSelector,
-	})
+func upgradeStatefulSet(name, imagePath string, vers version.Number, broker appstyped.StatefulSetInterface) error {
+	ss, err := broker.Get(name, meta.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return errors.NotFoundf(
+			"statefulset %q", name)
+	} else if err != nil {
+		return errors.Annotatef(err,
+			"getting statefulset to upgrade for name %q", name)
+	}
+
+	updatedTemplateSpec, err := upgradePodTemplateSpec(&ss.Spec.Template, imagePath, vers)
 	if err != nil {
-		return nil, errors.Annotatef(err, "selecting pod with label %q", labelSelector)
+		return errors.Annotatef(err, "statefulset %q", name)
 	}
-	if len(podList.Items) == 0 {
-		return nil, errors.NotFoundf("pod for selector %q", labelSet)
+	ss.Spec.Template = *updatedTemplateSpec
+
+	// update juju-version annotation.
+	// TODO(caas): consider how to upgrade to current annotations format safely.
+	// just ensure juju-version to current version for now.
+	ss.SetAnnotations(
+		k8sannotations.New(ss.GetAnnotations()).
+			Add(labelVersion, vers.String()).ToMap(),
+	)
+	ss.Spec.Template.SetAnnotations(
+		k8sannotations.New(ss.Spec.Template.GetAnnotations()).
+			Add(labelVersion, vers.String()).ToMap(),
+	)
+
+	if _, err := broker.Update(ss); err != nil {
+		return errors.Annotatef(err, "updating statefulset %q to %s",
+			name, vers)
 	}
-	return &podList.Items[0], nil
+	return nil
 }
 
-func (k *kubernetesClient) upgradeJujuInitContainer(appName string, imagePath string) (podChecker func() (bool, error), err error) {
-	deploymentName := k.deploymentName(appName, true)
-
-	var data []byte
-	var selector k8slabels.Set
-	defer func() {
-		podChecker = func() (done bool, err error) {
-			pod, err := k.selectPod(selector)
-			if errors.IsNotFound(err) {
-				// Not found means not ready.
-				logger.Tracef("listing pod %q, not found yet", selector.String())
-				return false, nil
-			} else if err != nil {
-				return false, errors.Trace(err)
-			}
-			_, opStatus, _, err := k.getPODStatus(*pod, k.clock.Now())
-			if err != nil {
-				return false, errors.Trace(err)
-			}
-			index := findJujudContainer(pod.Spec.InitContainers)
-			msg := fmt.Sprintf("init container of %q is still upgrading, current status -> %q", appName, opStatus)
-			if index >= 0 {
-				msg += " | version -> " + pod.Spec.InitContainers[index].Image
-			}
-			defer func() {
-				if !done {
-					logger.Debugf(msg)
-				}
-			}()
-			return opStatus == status.Running && index >= 0 && pod.Spec.InitContainers[index].Image == imagePath, nil
-		}
-	}()
-	sResource, err := k.getStatefulSet(deploymentName)
-	if err != nil && !errors.IsNotFound(err) {
-		return podChecker, errors.Trace(err)
-	} else if err == nil {
-		selector = sResource.Spec.Selector.MatchLabels
-		if err := ensureJujuInitContainer(&sResource.Spec.Template.Spec, imagePath); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		if data, err = json.Marshal(apps.StatefulSet{Spec: sResource.Spec}); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		_, err = k.client().AppsV1().StatefulSets(k.namespace).Patch(sResource.GetName(), k8stypes.StrategicMergePatchType, data)
-		return podChecker, errors.Trace(err)
+func upgradePodTemplateSpec(
+	podTemplate *core.PodTemplateSpec,
+	imagePath string,
+	vers version.Number,
+) (*core.PodTemplateSpec, error) {
+	jujudContainerIdx, found := findJujudContainer(podTemplate.Spec.Containers)
+	if !found {
+		return nil, errors.NotFoundf("jujud container in pod spec")
 	}
 
-	deResource, err := k.getDeployment(deploymentName)
-	if err != nil && !errors.IsNotFound(err) {
-		return podChecker, errors.Trace(err)
-	} else if err == nil {
-		selector = deResource.Spec.Selector.MatchLabels
-		if err := ensureJujuInitContainer(&deResource.Spec.Template.Spec, imagePath); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		if data, err = json.Marshal(apps.Deployment{Spec: deResource.Spec}); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		_, err = k.client().AppsV1().Deployments(k.namespace).Patch(deResource.GetName(), k8stypes.StrategicMergePatchType, data)
-		return podChecker, errors.Trace(err)
+	if imagePath == "" {
+		imagePath = podcfg.RebuildOldOperatorImagePath(
+			podTemplate.Spec.Containers[jujudContainerIdx].Image, vers)
 	}
 
-	daResource, err := k.getDaemonSet(deploymentName)
-	if err != nil && !errors.IsNotFound(err) {
-		return podChecker, errors.Trace(err)
-	} else if err == nil {
-		selector = daResource.Spec.Selector.MatchLabels
-		if err := ensureJujuInitContainer(&daResource.Spec.Template.Spec, imagePath); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		if data, err = json.Marshal(apps.DaemonSet{Spec: daResource.Spec}); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		_, err = k.client().AppsV1().DaemonSets(k.namespace).Patch(daResource.GetName(), k8stypes.StrategicMergePatchType, data)
-		return podChecker, errors.Trace(err)
+	upgradedTemp := podTemplate.DeepCopy()
+
+	if upgradedTemp.Spec.Containers[jujudContainerIdx].Image != imagePath {
+		upgradedTemp.Spec.Containers[jujudContainerIdx].Image = imagePath
 	}
-	// TODO(caas): check here should error or not(operator charm does not have any workload. So it's probably ok if there is no init containers to upgrade).
-	return podChecker, nil
+	return upgradedTemp, nil
+}
+
+func findJujudContainer(containers []core.Container) (int, bool) {
+	for i, c := range containers {
+		if podcfg.IsJujuOCIImage(c.Image) {
+			return i, true
+		}
+	}
+	return -1, false
 }

--- a/caas/kubernetes/provider/upgrade_test.go
+++ b/caas/kubernetes/provider/upgrade_test.go
@@ -1,390 +1,57 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package provider
 
 import (
-	"encoding/json"
-	"time"
+	"fmt"
 
-	"github.com/golang/mock/gomock"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
-	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cloudconfig/podcfg"
 )
 
-func (s *K8sBrokerSuite) TestUpgradeController(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
+type UpgraderSuite struct {
+}
 
-	ss := apps.StatefulSet{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "controller",
-			Annotations: map[string]string{
-				"juju-version": "1.1.1",
-			},
-			Labels: map[string]string{"juju-operator": "controller"},
-		},
-		Spec: apps.StatefulSetSpec{
-			RevisionHistoryLimit: int32Ptr(0),
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						"juju-version": "1.1.1",
-					},
-				},
+var _ = gc.Suite(&UpgraderSuite{})
+
+func (u *UpgraderSuite) TestUpgradePodTemplateSpec(c *gc.C) {
+	tests := []struct {
+		ExpectedPodTemplateSpec core.PodTemplateSpec
+		PodTemplateSpec         core.PodTemplateSpec
+		ImagePath               string
+		Version                 version.Number
+	}{
+		{
+			ExpectedPodTemplateSpec: core.PodTemplateSpec{
 				Spec: core.PodSpec{
 					Containers: []core.Container{
-						{Image: "foo"},
-						{Image: "jujud-operator:1.1.1"},
+						{
+							Image: fmt.Sprintf("%s/%s:2.6.7", podcfg.JujudOCINamespace, podcfg.JujudOCIName),
+						},
 					},
 				},
 			},
-		},
-	}
-	updated := ss
-	updated.Annotations["juju-version"] = "6.6.6"
-	updated.Spec.Template.Annotations["juju-version"] = "6.6.6"
-	updated.Spec.Template.Spec.Containers[1].Image = "jujud-operator:6.6.6"
-	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("controller", v1.GetOptions{}).
-			Return(&ss, nil),
-		s.mockStatefulSets.EXPECT().Update(&updated).
-			Return(nil, nil),
-	)
-
-	err := s.broker.Upgrade("controller", version.MustParse("6.6.6"))
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *K8sBrokerSuite) assertUpgradeApplication(c *gc.C, shouldTimeout bool, adjustClock func(), assertCalls ...*gomock.Call) {
-	operatorSS := apps.StatefulSet{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "app-name-operator",
-			Annotations: map[string]string{
-				"juju-version":       "1.1.1",
-				"juju.io/controller": testing.ControllerTag.Id(),
-			},
-			Labels: map[string]string{"juju-app": "app-name"},
-		},
-		Spec: apps.StatefulSetSpec{
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						"juju-version": "1.1.1",
-					},
-				},
+			PodTemplateSpec: core.PodTemplateSpec{
 				Spec: core.PodSpec{
 					Containers: []core.Container{
-						{Image: "foo"},
-						{Name: "juju-operator", Image: "jujud-operator:1.1.1"},
+						{
+							Image: fmt.Sprintf("%s/%s:2.6.6", podcfg.JujudOCINamespace, podcfg.JujudOCIName),
+						},
 					},
 				},
 			},
+			Version: version.MustParse("2.6.7"),
 		},
 	}
 
-	opPodRuning := core.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "test-operator",
-		},
-		Spec: core.PodSpec{
-			Containers: []core.Container{
-				{Image: "foo"},
-				{Name: "juju-operator", Image: "jujud-operator:1.1.1"},
-			},
-		},
-		Status: core.PodStatus{
-			Phase:   core.PodRunning,
-			Message: "test message.",
-		},
-	}
-	opCm := core.ConfigMap{
-		Data: map[string]string{
-			"test-agent.conf": "agent-conf-data",
-			"operator.yaml":   "operator-info-data",
-		},
-	}
-
-	updatedOperatorSS := operatorSS
-	updatedOperatorSS.Annotations["juju-version"] = "6.6.6"
-	updatedOperatorSS.Spec.Template.Annotations["juju-version"] = "6.6.6"
-	updatedOperatorSS.Spec.Template.Spec.Containers[1].Image = "jujud-operator:6.6.6"
-
-	expectedAssertCalls := []*gomock.Call{
-		// check operator status.
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("app-name-operator", v1.GetOptions{}).
-			Return(&updatedOperatorSS, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{opPodRuning}}, nil),
-		s.mockConfigMaps.EXPECT().Get("app-name-operator-config", v1.GetOptions{}).
-			Return(&opCm, nil),
-
-		// handle legacy operator name.
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-	}
-	expectedAssertCalls = append(expectedAssertCalls, assertCalls...)
-	if !shouldTimeout {
-		expectedAssertCalls = append(expectedAssertCalls,
-			// handle legacy operator name.
-			s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
-				Return(nil, s.k8sNotFoundError()),
-			s.mockStatefulSets.EXPECT().Get("app-name-operator", v1.GetOptions{}).
-				Return(&operatorSS, nil),
-			// Upgrade operator.
-			s.mockStatefulSets.EXPECT().Update(&updatedOperatorSS).
-				DoAndReturn(func(in *apps.StatefulSet) (*apps.StatefulSet, error) {
-					return in, nil
-				}),
-		)
-	}
-	gomock.InOrder(
-		expectedAssertCalls...,
-	)
-
-	errChan := make(chan error)
-	go func() {
-		errChan <- s.broker.Upgrade("app-name", version.MustParse("6.6.6"))
-	}()
-
-	adjustClock()
-	select {
-	case err := <-errChan:
-		if shouldTimeout {
-			c.Assert(err, jc.Satisfies, errors.IsTimeout)
-		} else {
-			c.Assert(err, jc.ErrorIsNil)
-		}
-	case <-time.After(testing.LongWait):
-		c.Fatalf("timed out waiting for Upgrade return")
-	}
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationTimeoutFailed(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
-		Name:      "database-appuuid",
-		MountPath: "path/to/here",
-	})
-	workloadStatefulSet := unitStatefulSetArg(2, "workload-storage", podSpec)
-	expectedPatchSS := apps.StatefulSet{Spec: unitStatefulSetArg(2, "workload-storage", podSpec).Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchSS.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchSSData, err := json.Marshal(expectedPatchSS)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, true,
-		func() {
-			err := s.clock.WaitAdvance(30*time.Second, testing.ShortWait, 2)
-			c.Assert(err, jc.ErrorIsNil)
-		},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadStatefulSet, nil),
-		s.mockStatefulSets.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchSSData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{}}, nil),
-	)
-}
-
-var appPodRuning = core.Pod{
-	ObjectMeta: v1.ObjectMeta{
-		Name:   "app-name",
-		Labels: map[string]string{"juju-app": "app-name"},
-	},
-	Spec: core.PodSpec{
-		InitContainers: []core.Container{
-			{Name: "juju-operator", Image: "jujud-operator:6.6.6"},
-		},
-	},
-	Status: core.PodStatus{
-		Phase:   core.PodRunning,
-		Message: "test message.",
-	},
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationForStatefulApp(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
-		Name:      "database-appuuid",
-		MountPath: "path/to/here",
-	})
-	workloadStatefulSet := unitStatefulSetArg(2, "workload-storage", podSpec)
-	expectedPatchSS := apps.StatefulSet{Spec: unitStatefulSetArg(2, "workload-storage", podSpec).Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchSS.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchSSData, err := json.Marshal(expectedPatchSS)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, false, func() {
-		err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
+	for _, test := range tests {
+		podTempl, err := upgradePodTemplateSpec(&test.PodTemplateSpec, test.ImagePath, test.Version)
 		c.Assert(err, jc.ErrorIsNil)
-	},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadStatefulSet, nil),
-		s.mockStatefulSets.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchSSData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{appPodRuning}}, nil),
-	)
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationForStatelessApp(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-
-	workloadDeployment := &apps.Deployment{
-		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
-			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
-			}},
-		Spec: apps.DeploymentSpec{
-			Replicas: int32Ptr(1),
-			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
-			},
-			RevisionHistoryLimit: int32Ptr(0),
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{
-						"juju-app": "app-name",
-					},
-					Annotations: map[string]string{
-						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
-					},
-				},
-				Spec: podSpec,
-			},
-		},
+		c.Assert(test.ExpectedPodTemplateSpec.Spec.Containers[0].Image, gc.Equals, podTempl.Spec.Containers[0].Image)
 	}
-	expectedPatchDeployment := apps.Deployment{Spec: workloadDeployment.Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchDeployment.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchDeploymentData, err := json.Marshal(expectedPatchDeployment)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, false, func() {
-		err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
-		c.Assert(err, jc.ErrorIsNil)
-	},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadDeployment, nil),
-		s.mockDeployments.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchDeploymentData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{appPodRuning}}, nil),
-	)
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationForDaemonApp(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-
-	workloadDaemonSet := &apps.DaemonSet{
-		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
-			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
-			}},
-		Spec: apps.DaemonSetSpec{
-			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
-			},
-			RevisionHistoryLimit: int32Ptr(0),
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					GenerateName: "app-name-",
-					Labels:       map[string]string{"juju-app": "app-name"},
-					Annotations: map[string]string{
-						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-					},
-				},
-				Spec: podSpec,
-			},
-		},
-	}
-	expectedPatchDaemonSet := apps.DaemonSet{Spec: workloadDaemonSet.Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchDaemonSet.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchDaemonSetData, err := json.Marshal(expectedPatchDaemonSet)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, false, func() {
-		err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
-		c.Assert(err, jc.ErrorIsNil)
-	},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockDaemonSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadDaemonSet, nil),
-		s.mockDaemonSets.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchDaemonSetData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{appPodRuning}}, nil),
-	)
-}
-
-func (s *K8sBrokerSuite) TestUpgradeNothingToUpgrade(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("controller", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-	)
-
-	err := s.broker.Upgrade("controller", version.MustParse("6.6.6"))
-	c.Assert(err, gc.ErrorMatches, `getting the existing statefulset "controller" to upgrade:  "test" not found`)
 }

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	jujudOCINamespace = "jujusolutions"
-	jujudOCIName      = "jujud-operator"
-	jujudbOCIName     = "juju-db"
+	JujudOCINamespace = "jujusolutions"
+	JujudOCIName      = "jujud-operator"
+	JujudbOCIName     = "juju-db"
 )
 
 // GetControllerImagePath returns oci image path of jujud for a controller.
@@ -27,15 +27,15 @@ func (cfg *ControllerPodConfig) GetControllerImagePath() string {
 func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
 	imageRepo := cfg.Controller.Config.CAASImageRepo()
 	if imageRepo == "" {
-		imageRepo = jujudOCINamespace
+		imageRepo = JujudOCINamespace
 	}
 	v := jujudbVersion
-	return fmt.Sprintf("%s/%s:%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor)
+	return fmt.Sprintf("%s/%s:%d.%d", imageRepo, JujudbOCIName, v.Major, v.Minor)
 }
 
 // IsJujuOCIImage returns true if the image path is for a Juju operator.
 func IsJujuOCIImage(imagePath string) bool {
-	return strings.Contains(imagePath, jujudOCIName+":")
+	return strings.Contains(imagePath, JujudOCIName+":")
 }
 
 // GetJujuOCIImagePath returns the jujud oci image path.
@@ -78,8 +78,8 @@ func tagImagePath(path string, ver version.Number) string {
 
 func imageRepoToPath(imageRepo string, ver version.Number) string {
 	if imageRepo == "" {
-		imageRepo = jujudOCINamespace
+		imageRepo = JujudOCINamespace
 	}
-	path := fmt.Sprintf("%s/%s", imageRepo, jujudOCIName)
+	path := fmt.Sprintf("%s/%s", imageRepo, JujudOCIName)
 	return tagImagePath(path, ver)
 }

--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -7,20 +7,19 @@ run_deploy_microk8s() {
   bootstrap microk8s "${name}"
 
   microk8s.config > "${TEST_DIR}"/kube.conf
+  export KUBE_CONFIG="${TEST_DIR}"/kube.conf
 }
 
-test_deploy_admission() {
+test_controller_model_admission() {
   name=test-$(petname)
-
-  run_deploy_microk8s "${name}"
 
   namespace=controller-"${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 
-  kubectl --kubeconfig "${TEST_DIR}"/kube.conf apply -f - <<EOF
+  kubectl --kubeconfig "${KUBE_CONFIG}" apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: test
+  name: $name
   namespace: $namespace
   labels:
     juju-app: test-app
@@ -29,7 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: $namespace
-  name: test
+  name: $name
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -38,22 +37,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: role-grantor-binding
+  name: $name
   namespace: $namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: test
+  name: $name
 subjects:
   - kind: ServiceAccount
-    name: test
+    name: $name
     namespace: $namespace
 EOF
 
-  sa_secret=$(kubectl --kubeconfig "${TEST_DIR}"/kube.conf get sa -o json test -n "$namespace" | jq -r '.secrets[0].name')
-  bearer_token=$(kubectl --kubeconfig "${TEST_DIR}"/kube.conf get secret -o json "$sa_secret" -n "$namespace" | jq -r '.data.token' | base64 -d)
+  sa_secret=$(kubectl --kubeconfig "${KUBE_CONFIG}" get sa -o json "${name}" -n "$namespace" | jq -r '.secrets[0].name')
+  bearer_token=$(kubectl --kubeconfig "${KUBE_CONFIG}" get secret -o json "$sa_secret" -n "$namespace" | jq -r '.data.token' | base64 -d)
 
-  kubectl --kubeconfig "${TEST_DIR}"/kube.conf config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
+  kubectl --kubeconfig "${KUBE_CONFIG}" config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
 
 
   # Short sleep to let juju controller watchers catch up.
@@ -63,13 +62,79 @@ EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: test
+  name: $name
   namespace: $namespace
 data:
   test: test
 EOF
 
-juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" test -o=jsonpath='{.metadata.labels.juju-app}')
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
+  check_contains "${juju_app}" "test-app"
+
+  echo "$juju_app" | check test-app
+}
+
+test_new_model_admission() {
+  name=test-$(petname)
+
+  model_name=$(petname)
+  namespace=${model_name}
+
+  juju add-model "${model_name}"
+
+  kubectl --kubeconfig "${KUBE_CONFIG}" apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: $name
+  namespace: $namespace
+  labels:
+    juju-app: test-app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: $namespace
+  name: $name
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: $name
+  namespace: $namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: $name
+subjects:
+  - kind: ServiceAccount
+    name: $name
+    namespace: $namespace
+EOF
+
+  sa_secret=$(kubectl --kubeconfig "${KUBE_CONFIG}" get sa -o json "$name" -n "$namespace" | jq -r '.secrets[0].name')
+  bearer_token=$(kubectl --kubeconfig "${KUBE_CONFIG}" get secret -o json "$sa_secret" -n "$namespace" | jq -r '.data.token' | base64 -d)
+
+  kubectl --kubeconfig "${TEST_DIR}"/kube.conf config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
+
+  # Short sleep to let juju controller watchers catch up.
+  sleep 15
+
+ kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $name
+  namespace: $namespace
+data:
+  test: test
+EOF
+
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
   check_contains "${juju_app}" "test-app"
 
   echo "$juju_app" | check test-app

--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -9,5 +9,8 @@ test_caasadmission() {
     echo "==> Checking for dependencies"
     check_dependencies juju jq petname microk8s
 
-    test_deploy_admission
+    run_deploy_microk8s "$(petname)"
+
+    test_controller_model_admission
+    test_new_model_admission
 }

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -147,9 +147,15 @@ func (u *Upgrader) loop() error {
 		if err != nil {
 			return err
 		}
-		logger.Debugf("desired agent binary version: %v", wantVersion)
 
-		if wantVersion == jujuversion.Current {
+		haveVersion := jujuversion.Current
+		if wantVersion.Build == 0 {
+			haveVersion.Build = 0
+		} else {
+			haveVersion.Build = jujuversion.OfficialBuild
+		}
+
+		if wantVersion == haveVersion {
 			u.config.InitialUpgradeCheckComplete.Unlock()
 			continue
 		} else if !upgrader.AllowedTargetVersion(

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -107,7 +107,7 @@ func (u *Upgrader) loop() error {
 	// for a full minute; but after that we proceed regardless.
 	versionWatcher, err := u.upgraderClient.WatchAPIVersion(u.tag.String())
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "getting upgrader facade watch api version client")
 	}
 	logger.Infof("abort check blocked until version event received")
 	// TODO(fwereade): 2016-03-17 lp:1558657


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

*Please replace with a description about why this change is needed, along with a description of what changed?*

## QA steps

*Please replace with how we can verify that the change works?*

```sh
cd tests && ./main.sh caasadmission
```

2nd
```sh
export DOCKER_USERNAME=<your-dockerhub-username>
make install operator-image microk8s-operator-update push-operator-image
juju bootstrap microk8s
# Check that the model agent has come up in the controller namespace
juju add-model test
# Check that the model agent has come up in the test namespace

export JUJU_BUILD_NUMBER=1
make install operator-image microk8s-operator-update push-operator-image
juju upgrade-controller --agent-stream=develop --agent-version=2.8.1.1
# Wait for controller to restart and verify that the new controller that comes up has the new image and version. The model agent has the correct version and image.
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?*

## Bug reference

*Please add a link to any bugs that this change is related to.*
