### PR TITLE
Ensure dashboard is enabled on k8s bootstrap

### DIFF
--- a/caas/jujud-operator-dockerfile
+++ b/caas/jujud-operator-dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     python3-distutils \
     # below apt dependencies are required by controller pod.
     iproute2 \
+    curl \
     && pip3 install --upgrade pip setuptools \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /root/.cache

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/proxy"
 	"github.com/juju/version"
 
 	"github.com/juju/juju/agent"
@@ -39,6 +40,14 @@ type ControllerPodConfig struct {
 	// Bootstrap contains bootstrap-specific configuration. If this is set,
 	// Controller must also be set.
 	Bootstrap *BootstrapConfig
+
+	// DisableSSLHostnameVerification can be set to true to tell cloud-init
+	// that it shouldn't verify SSL certificates
+	DisableSSLHostnameVerification bool
+
+	// ProxySettings encapsulates all proxy-related settings used to access
+	// an outside network.
+	ProxySettings proxy.Settings
 
 	// Controller contains controller-specific configuration. If this is
 	// set, then the instance will be configured as a controller pod.
@@ -356,6 +365,8 @@ func NewBootstrapControllerPodConfig(
 // Bootstrap func, and that has set an agent-version (via finding the tools to,
 // use for bootstrap, or otherwise).
 func FinishControllerPodConfig(pcfg *ControllerPodConfig, cfg *config.Config, agentEnvironment map[string]string) {
+	pcfg.DisableSSLHostnameVerification = !cfg.SSLHostnameVerification()
+	pcfg.ProxySettings = cfg.JujuProxySettings()
 	if pcfg.AgentEnvironment == nil {
 		pcfg.AgentEnvironment = make(map[string]string)
 	}

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -101,7 +101,9 @@ func (*podcfgSuite) TestBootstrapConstraints(c *gc.C) {
 
 func (*podcfgSuite) TestFinishControllerPodConfig(c *gc.C) {
 	cfg := testing.CustomModelConfig(c, testing.Attrs{
-		"type": "kubernetes",
+		"type":                      "kubernetes",
+		"ssl-hostname-verification": false,
+		"juju-https-proxy":          "https-proxy",
 	})
 	podConfig, err := podcfg.NewBootstrapControllerPodConfig(
 		testing.FakeControllerConfig(),
@@ -109,12 +111,14 @@ func (*podcfgSuite) TestFinishControllerPodConfig(c *gc.C) {
 		"kubernetes",
 		constraints.Value{},
 	)
+	c.Assert(err, jc.ErrorIsNil)
 	podcfg.FinishControllerPodConfig(
 		podConfig,
 		cfg,
 		map[string]string{"foo": "bar"},
 	)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(podConfig.DisableSSLHostnameVerification, jc.IsTrue)
+	c.Assert(podConfig.ProxySettings.Https, gc.Equals, "https-proxy")
 	c.Assert(podConfig.AgentEnvironment, jc.DeepEquals, map[string]string{
 		"PROVIDER_TYPE": "kubernetes",
 		"foo":           "bar",

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -278,7 +278,7 @@ func bootstrapCAAS(
 	}
 	podConfig.JujuVersion = jujuVersion
 	podConfig.OfficialBuild = jujuversion.OfficialBuild
-	if err := finalizePodBootstrapConfig(podConfig, args, environ.Config()); err != nil {
+	if err := finalizePodBootstrapConfig(ctx, podConfig, args, environ.Config()); err != nil {
 		return errors.Annotate(err, "finalizing bootstrap instance config")
 	}
 	if err := result.CaasBootstrapFinalizer(ctx, podConfig, args.DialOpts); err != nil {
@@ -686,7 +686,7 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.RegionInheritedConfig = args.Cloud.RegionConfig
 	icfg.Bootstrap.HostedModelConfig = args.HostedModelConfig
 	icfg.Bootstrap.Timeout = args.DialOpts.Timeout
-	icfg.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, cfg.GUIStream(), vers.Major, vers.Minor, func(msg string) {
+	icfg.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, cfg.GUIStream(), vers.Major, vers.Minor, true, func(msg string) {
 		ctx.Infof(msg)
 	})
 	icfg.Bootstrap.JujuDbSnapPath = args.JujuDbSnapPath
@@ -695,6 +695,7 @@ func finalizeInstanceBootstrapConfig(
 }
 
 func finalizePodBootstrapConfig(
+	ctx environs.BootstrapContext,
 	pcfg *podcfg.ControllerPodConfig,
 	args BootstrapParams,
 	cfg *config.Config,
@@ -756,6 +757,11 @@ func finalizePodBootstrapConfig(
 		pcfg.AgentEnvironment[k] = v
 	}
 
+	vers, ok := cfg.AgentVersion()
+	if !ok {
+		return errors.New("controller model configuration has no agent-version")
+	}
+
 	pcfg.Bootstrap.ControllerModelConfig = cfg
 	pcfg.Bootstrap.ControllerCloud = args.Cloud
 	pcfg.Bootstrap.ControllerCloudRegion = args.CloudRegion
@@ -768,6 +774,9 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerServiceType = args.ControllerServiceType
 	pcfg.Bootstrap.ControllerExternalName = args.ControllerExternalName
 	pcfg.Bootstrap.ControllerExternalIPs = append([]string(nil), args.ControllerExternalIPs...)
+	pcfg.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, cfg.GUIStream(), vers.Major, vers.Minor, false, func(msg string) {
+		ctx.Infof(msg)
+	})
 	return nil
 }
 
@@ -1035,10 +1044,14 @@ func setPrivateMetadataSources(metadataDir string) ([]*imagemetadata.ImageMetada
 // non-empty, remote GUI archive info is retrieved from simplestreams using it
 // as the base URL. The given logProgress function is used to inform users
 // about errors or progress in setting up the Juju GUI.
-func guiArchive(dataSourceBaseURL, stream string, major, minor int, logProgress func(string)) *coretools.GUIArchive {
+func guiArchive(dataSourceBaseURL, stream string, major, minor int, allowLocal bool, logProgress func(string)) *coretools.GUIArchive {
 	// The environment variable is only used for development purposes.
 	path := os.Getenv("JUJU_GUI")
-	if path != "" {
+	if path != "" && !allowLocal {
+		// TODO(wallyworld) - support local archive on k8s controllers at bootstrap
+		// It can't be passed the same way as on IAAS as it's too large.
+		logProgress("Dashboard from local archive on bootstrap not supported")
+	} else if path != "" {
 		vers, err := guiVersion(path)
 		if err != nil {
 			logProgress(fmt.Sprintf("Cannot use Juju Dashboard at %q: %s", path, err))

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -76,6 +76,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 
+	s.PatchEnvironment("JUJU_GUI", "")
 	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	storageDir := c.MkDir()
 	s.PatchValue(&envtools.DefaultBaseURL, storageDir)
@@ -325,7 +326,7 @@ func (s *bootstrapSuite) assertFinalizePodBootstrapConfig(c *gc.C, serviceType, 
 		ControllerExternalIPs:      externalIps,
 		ExtraAgentValuesForTesting: map[string]string{"foo": "bar"},
 	}
-	err = bootstrap.FinalizePodBootstrapConfig(podConfig, params, modelCfg)
+	err = bootstrap.FinalizePodBootstrapConfig(envtesting.BootstrapContext(c), podConfig, params, modelCfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(podConfig.Bootstrap.ControllerModelConfig, jc.DeepEquals, modelCfg)
 	c.Assert(podConfig.Bootstrap.ControllerServiceType, gc.Equals, serviceType)


### PR DESCRIPTION
## Description of change

Ensure the dashboard is available when bootstrapping a k8s controller.

## QA steps

juju bootstrap microk8s
juju dashboard


## Bug reference

https://bugs.launchpad.net/bugs/1881206
