### PR TITLE
[dev] Discover OVS bridge devices

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -174,14 +174,15 @@ func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
 				mtu = uint(iface.MTU)
 			}
 			args := state.LinkLayerDeviceArgs{
-				Name:        iface.InterfaceName,
-				MTU:         mtu,
-				ProviderID:  iface.ProviderId,
-				Type:        corenetwork.LinkLayerDeviceType(iface.InterfaceType),
-				MACAddress:  iface.MACAddress,
-				IsAutoStart: !iface.NoAutoStart,
-				IsUp:        !iface.Disabled,
-				ParentName:  iface.ParentInterfaceName,
+				Name:            iface.InterfaceName,
+				MTU:             mtu,
+				ProviderID:      iface.ProviderId,
+				Type:            corenetwork.LinkLayerDeviceType(iface.InterfaceType),
+				MACAddress:      iface.MACAddress,
+				IsAutoStart:     !iface.NoAutoStart,
+				IsUp:            !iface.Disabled,
+				ParentName:      iface.ParentInterfaceName,
+				VirtualPortType: iface.VirtualPortType,
 			}
 			logger.Tracef("state device args for device: %+v", args)
 			devicesArgs = append(devicesArgs, args)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -18960,6 +18960,9 @@
                                 "$ref": "#/definitions/Address"
                             }
                         },
+                        "virtual-port-type": {
+                            "type": "string"
+                        },
                         "vlan-tag": {
                             "type": "integer"
                         }
@@ -22025,6 +22028,9 @@
                             "items": {
                                 "$ref": "#/definitions/Address"
                             }
+                        },
+                        "virtual-port-type": {
+                            "type": "string"
                         },
                         "vlan-tag": {
                             "type": "integer"
@@ -28414,6 +28420,9 @@
                             "items": {
                                 "$ref": "#/definitions/Address"
                             }
+                        },
+                        "virtual-port-type": {
+                            "type": "string"
                         },
                         "vlan-tag": {
                             "type": "integer"

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -190,6 +190,11 @@ type NetworkConfig struct {
 	// IsDefaultGateway marks an interface that is a default gateway for a machine.
 	IsDefaultGateway bool `json:"is-default-gateway,omitempty"`
 
+	// VirtualPortType provides additional information about the type of
+	// this device if it belongs to a virtual switch (e.g. when using
+	// open-vswitch).
+	VirtualPortType string `json:"virtual-port-type,omitempty"`
+
 	// NetworkOrigin represents the authoritative source of the NetworkConfig.
 	// It is expected that either the provider gave us this info or the
 	// machine gave us this info.
@@ -245,6 +250,7 @@ func NetworkConfigFromInterfaceInfo(interfaceInfos network.InterfaceInfos) []Net
 			GatewayAddress:   v.GatewayAddress.Value,
 			Routes:           routes,
 			IsDefaultGateway: v.IsDefaultGateway,
+			VirtualPortType:  string(v.VirtualPortType),
 			NetworkOrigin:    NetworkOrigin(v.Origin),
 		}
 	}
@@ -290,6 +296,7 @@ func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) network.InterfaceIn
 			GatewayAddress:      network.NewProviderAddress(v.GatewayAddress),
 			Routes:              routes,
 			IsDefaultGateway:    v.IsDefaultGateway,
+			VirtualPortType:     network.VirtualPortType(v.VirtualPortType),
 			Origin:              network.Origin(v.NetworkOrigin),
 		}
 

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -34,6 +34,14 @@ const (
 	BridgeInterface     InterfaceType = "bridge"
 )
 
+// VirtualPortType defines the list of known port types for virtual NICs.
+type VirtualPortType string
+
+const (
+	NonVirtualPort VirtualPortType = ""
+	OvsPort        VirtualPortType = "openvswitch"
+)
+
 // Route defines a single route to a subnet via a defined gateway.
 type Route struct {
 	// DestinationCIDR is the subnet that we want a controlled route to.
@@ -182,6 +190,11 @@ type InterfaceInfo struct {
 	// IsDefaultGateway is set if this device is a default gw on a machine.
 	IsDefaultGateway bool
 
+	// VirtualPortType provides additional information about the type of
+	// this device if it belongs to a virtual switch (e.g. when using
+	// open-vswitch).
+	VirtualPortType VirtualPortType
+
 	// Origin represents the authoritative source of the InterfaceInfo.
 	// It is expected that either the provider gave us this info or the
 	// machine gave us this info.
@@ -200,9 +213,10 @@ func (i *InterfaceInfo) ActualInterfaceName() string {
 }
 
 // IsVirtual returns true when the interface is a virtual device, as
-// opposed to a physical device (e.g. a VLAN or a network alias)
+// opposed to a physical device (e.g. a VLAN, network alias or OVS-managed
+// device).
 func (i *InterfaceInfo) IsVirtual() bool {
-	return i.VLANTag > 0
+	return i.VLANTag > 0 || i.VirtualPortType != NonVirtualPort
 }
 
 // IsVLAN returns true when the interface is a VLAN interface.

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -34,6 +34,7 @@ func (s *nicSuite) SetUpTest(_ *gc.C) {
 			GatewayIP:       "0.1.2.1",
 			Metric:          0,
 		}}},
+		{DeviceIndex: 42, InterfaceName: "ovsbr0", VirtualPortType: network.OvsPort},
 	}
 }
 
@@ -47,6 +48,7 @@ func (s *nicSuite) TestIsVirtual(c *gc.C) {
 	c.Check(s.info[0].IsVirtual(), jc.IsTrue)
 	c.Check(s.info[1].IsVirtual(), jc.IsFalse)
 	c.Check(s.info[2].IsVirtual(), jc.IsTrue)
+	c.Check(s.info[9].IsVirtual(), jc.IsTrue, gc.Commentf("expected NIC with OVS virtual port type to be treated as virtual"))
 }
 
 func (s *nicSuite) TestIsVLAN(c *gc.C) {

--- a/core/network/ovs.go
+++ b/core/network/ovs.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
+
+// Overridden by tests
+var getCommandOutput = func(cmd *exec.Cmd) ([]byte, error) { return cmd.Output() }
+
+// OvsManagedBridges returns a filtered version of ifaceList that only contains
+// bridge interfaces managed by openvswitch.
+func OvsManagedBridges(ifaceList InterfaceInfos) (InterfaceInfos, error) {
+	if _, err := exec.LookPath("ovs-vsctl"); err != nil {
+		// ovs tools not installed; nothing to do
+		if execErr, isExecErr := err.(*exec.Error); isExecErr && execErr.Unwrap() == exec.ErrNotFound {
+			return nil, nil
+		}
+
+		return nil, errors.Annotate(err, "ovsManagedBridges: looking for ovs-vsctl")
+	}
+
+	// Query list of ovs-managed device names
+	res, err := getCommandOutput(exec.Command("ovs-vsctl", "list-br"))
+	if err != nil {
+		return nil, errors.Annotate(err, "querying ovs-managed bridges via ovs-vsctl")
+	}
+
+	ovsBridges := set.NewStrings()
+	for _, iface := range strings.Split(string(res), "\n") {
+		if iface = strings.TrimSpace(iface); iface != "" {
+			ovsBridges.Add(iface)
+		}
+	}
+
+	return ifaceList.Filter(func(iface InterfaceInfo) bool {
+		return ovsBridges.Contains(iface.InterfaceName)
+	}), nil
+}

--- a/core/network/ovs_internal_test.go
+++ b/core/network/ovs_internal_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package broker
+package network
 
 import (
 	"os/exec"
@@ -9,25 +9,23 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/core/network"
 )
 
-type brokerSuite struct {
+type ovsSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&brokerSuite{})
+var _ = gc.Suite(&ovsSuite{})
 
-func (s *brokerSuite) SetUpSuite(c *gc.C) {
+func (s *ovsSuite) SetUpSuite(c *gc.C) {
 	s.IsolationSuite.SetUpSuite(c)
 }
 
-func (s *brokerSuite) SetUpTest(c *gc.C) {
+func (s *ovsSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 }
 
-func (s *brokerSuite) TestExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestExistingOVSManagedBridges(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -36,20 +34,20 @@ func (s *brokerSuite) TestExistingOVSManagedBridges(c *gc.C) {
 		return []byte("ovsbr1" + "\n"), nil
 	})
 
-	ifaces := network.InterfaceInfos{
+	ifaces := InterfaceInfos{
 		{InterfaceName: "eth0"},
 		{InterfaceName: "eth1"},
 		{InterfaceName: "lxdbr0"},
 		{InterfaceName: "ovsbr1"},
 	}
 
-	ovsIfaces, err := ovsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridges(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 1, gc.Commentf("expected ovs-managed bridge list to contain a single entry"))
 	c.Assert(ovsIfaces[0].InterfaceName, gc.Equals, "ovsbr1", gc.Commentf("expected ovs-managed bridge list to contain iface 'ovsbr1'"))
 }
 
-func (s *brokerSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -58,20 +56,20 @@ func (s *brokerSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
 		return []byte("\n"), nil
 	})
 
-	ifaces := network.InterfaceInfos{
+	ifaces := InterfaceInfos{
 		{InterfaceName: "eth0"},
 		{InterfaceName: "eth1"},
 		{InterfaceName: "lxdbr0"},
 	}
 
-	ovsIfaces, err := ovsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridges(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }
 
-func (s *brokerSuite) TestMissingOVSTools(c *gc.C) {
-	ifaces := network.InterfaceInfos{{InterfaceName: "eth0"}}
-	ovsIfaces, err := ovsManagedBridges(ifaces)
+func (s *ovsSuite) TestMissingOVSTools(c *gc.C) {
+	ifaces := InterfaceInfos{{InterfaceName: "eth0"}}
+	ovsIfaces, err := OvsManagedBridges(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }

--- a/core/network/ovs_test.go
+++ b/core/network/ovs_test.go
@@ -25,7 +25,7 @@ func (s *ovsSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 }
 
-func (s *ovsSuite) TestExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestExistingOVSManagedBridgeInterfaces(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -41,13 +41,13 @@ func (s *ovsSuite) TestExistingOVSManagedBridges(c *gc.C) {
 		{InterfaceName: "ovsbr1"},
 	}
 
-	ovsIfaces, err := OvsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridgeInterfaces(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 1, gc.Commentf("expected ovs-managed bridge list to contain a single entry"))
 	c.Assert(ovsIfaces[0].InterfaceName, gc.Equals, "ovsbr1", gc.Commentf("expected ovs-managed bridge list to contain iface 'ovsbr1'"))
 }
 
-func (s *ovsSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
+func (s *ovsSuite) TestNonExistingOVSManagedBridgeInterfaces(c *gc.C) {
 	// Patch output for "ovs-vsctl list-br" and make sure exec.LookPath can
 	// detect it in the path
 	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
@@ -62,14 +62,14 @@ func (s *ovsSuite) TestNonExistingOVSManagedBridges(c *gc.C) {
 		{InterfaceName: "lxdbr0"},
 	}
 
-	ovsIfaces, err := OvsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridgeInterfaces(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }
 
 func (s *ovsSuite) TestMissingOVSTools(c *gc.C) {
 	ifaces := InterfaceInfos{{InterfaceName: "eth0"}}
-	ovsIfaces, err := OvsManagedBridges(ifaces)
+	ovsIfaces, err := OvsManagedBridgeInterfaces(ifaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -54,6 +54,10 @@ type linkLayerDeviceDoc struct {
 	// is inside a container, in which case ParentName can be a global key of a
 	// BridgeDevice on the host machine of the container.
 	ParentName string `bson:"parent-name"`
+
+	// If this is device is part of a virtual switch, this field indicates
+	// the type of switch (e.g. an OVS bridge ) this port belongs to.
+	VirtualPortType network.VirtualPortType `bson:"virtual-port-type"`
 }
 
 // LinkLayerDevice represents the state of a link-layer network device for a
@@ -146,6 +150,12 @@ func (dev *LinkLayerDevice) IsUp() bool {
 // returns the global key of the parent device, not just its name.
 func (dev *LinkLayerDevice) ParentName() string {
 	return dev.doc.ParentName
+}
+
+// VirtualPortType returns the type of virtual port for the device if managed
+// by a virtual switch.
+func (dev *LinkLayerDevice) VirtualPortType() network.VirtualPortType {
+	return dev.doc.VirtualPortType
 }
 
 func (dev *LinkLayerDevice) parentDeviceNameAndMachineID() (string, string) {
@@ -347,6 +357,9 @@ func updateLinkLayerDeviceDocOp(existingDoc, newDoc *linkLayerDeviceDoc) (txn.Op
 	}
 	if existingDoc.ParentName != newDoc.ParentName {
 		changes["parent-name"] = newDoc.ParentName
+	}
+	if existingDoc.VirtualPortType != newDoc.VirtualPortType {
+		changes["virtual-port-type"] = newDoc.VirtualPortType
 	}
 
 	var updates bson.D

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -608,6 +608,21 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesNoop(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithVirtualPort(c *gc.C) {
+	args := state.LinkLayerDeviceArgs{
+		Name:            "foo",
+		Type:            corenetwork.EthernetDevice,
+		VirtualPortType: corenetwork.OvsPort,
+	}
+	err := s.machine.SetLinkLayerDevices(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	devs, err := s.machine.AllLinkLayerDevices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(devs, gc.HasLen, 1)
+	c.Assert(devs[0].VirtualPortType(), gc.Equals, corenetwork.OvsPort, gc.Commentf("virtual port type field was not persisted"))
+}
+
 func (s *linkLayerDevicesStateSuite) removeDeviceAndAssertSuccess(c *gc.C, givenDevice *state.LinkLayerDevice) {
 	err := givenDevice.Remove()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -163,6 +163,10 @@ type LinkLayerDeviceArgs struct {
 	// key of a BridgeDevice on the host machine of the container. Traffic
 	// originating from a device egresses from its parent device.
 	ParentName string
+
+	// If this is device is part of a virtual switch, this field indicates
+	// the type of switch (e.g. an OVS bridge ) this port belongs to.
+	VirtualPortType corenetwork.VirtualPortType
 }
 
 // SetLinkLayerDevices sets link-layer devices on the machine, adding or
@@ -406,17 +410,18 @@ func (m *Machine) newLinkLayerDeviceDocFromArgs(args *LinkLayerDeviceArgs) *link
 	modelUUID := m.st.ModelUUID()
 
 	return &linkLayerDeviceDoc{
-		DocID:       linkLayerDeviceDocID,
-		Name:        args.Name,
-		ModelUUID:   modelUUID,
-		MTU:         args.MTU,
-		ProviderID:  providerID,
-		MachineID:   m.doc.Id,
-		Type:        args.Type,
-		MACAddress:  args.MACAddress,
-		IsAutoStart: args.IsAutoStart,
-		IsUp:        args.IsUp,
-		ParentName:  args.ParentName,
+		DocID:           linkLayerDeviceDocID,
+		Name:            args.Name,
+		ModelUUID:       modelUUID,
+		MTU:             args.MTU,
+		ProviderID:      providerID,
+		MachineID:       m.doc.Id,
+		Type:            args.Type,
+		MACAddress:      args.MACAddress,
+		IsAutoStart:     args.IsAutoStart,
+		IsUp:            args.IsUp,
+		ParentName:      args.ParentName,
+		VirtualPortType: args.VirtualPortType,
 	}
 }
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -708,6 +708,7 @@ func (s *MigrationSuite) TestLinkLayerDeviceDocFields(c *gc.C) {
 		"IsAutoStart",
 		"IsUp",
 		"ParentName",
+		"VirtualPortType",
 	)
 	s.AssertExportedFields(c, linkLayerDeviceDoc{}, migrated.Union(ignored))
 }


### PR DESCRIPTION
## Description of change

This PR includes a much better implementation for the changes proposed in https://github.com/juju/juju/pull/11670. It allows for OVS devices to be discovered by the machiner and persisted to the `linklayerdevices` collection. This allows the space-aware bridge policy code to make use of the known OVS bridges and assign them to container workloads.

This works out of the box for LXD but KVM needs additional configuration (coming up in a followup PR) to make use of the bridge.

While testing the changes from this PR, I noticed that while the veth devices for LXD containers get added to the correct bridge, they don't get removed when the container goes away; ovs-vsctl output looks as follows once the container has been removed:

```console
ovs-vsctl show
430499db-d52f-4173-8e9f-3eec229c7b25
    Bridge "ovsbr0"
        Port "ovsbr0"
            Interface "ovsbr0"
                type: internal
        Port "ens4"
            Interface "ens4"
        Port "veth4PESPA"
            Interface "veth4PESPA"
                error: "could not open network device veth4PESPA (No such device)"
    ovs_version: "2.9.5"
```

This will be tackled in a separate PR as it is not directly related to these changes.

## QA steps

Some of the QA steps require access to a MAAS instance which can provision dual-NIC machines. For my local testing, I opted to set up a virtual maas (https://discourse.juju.is/t/local-maas-development-setup/1319) and provision machines via KVM.

For the following test you will need to provision two machines which are then used as manual provisioning targets by juju:
- Machine A (single NIC) which will host the controller.
- Machine B (single NIC) which will run the lxd workloads for the QA steps.

⚠️ **Important** ⚠️ : before setting up the OVS bridge using the steps below make sure to ssh into the box, set a root password and ensure that you can access the machine's console via `virsh console $machine-name`. The OVS bridge steps will temporarily kill networking and you need to be logged in to the machine to see which IP gets assigned to the bridge device!

To set up an OVS bridge, access the dual-NIC machine via the console and type the following commands (remember to replace ensX with the names of the NICs on your machine!)

```console
# ssh into kvm-1 
apt-get -y install openvswitch-switch iptraf-ng net-tools
ovs-vsctl add-br ovsbr0
ovs-vsctl add-port ovsbr0 ens4
ifconfig ens4 0

ip link set ovsbr0 up && dhclient -v ovsbr0
# Note the IP assigned to ovsbr0

ip route delete 10.0.0.0/24 dev ens4
ip route replace default via 10.0.0.1 dev ovsbr0

# Connect over ssh to the ovsbr0 IP fire up 'iptraf-ng' and monitor the ovsbr0 device
# Then from the console, run something like 'curl canonical.com' and verify that the packets flow through the device
```

## # QA scenario 1: OVS bridge with single interface

```console
# Bootstrap controller on machine 1
$ juju bootstrap manual/ubuntu@10.0.0.1 --no-gui

# Add a machine and deploy an lxd workload to it
$ juju add-machine ssh:ubuntu@$ip-assigned-to-ovsbr0
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to lxd:0

# ssh to the machine you just added and verify that the veth device used by lxd has been added to the switch by running:
$ ovs-vsctl show

# Check that ovsbr0 is the parent of eth0 veth device used by the lxd container
$ lxc profile show default
```

### QA scenario 2: OVS bridge with bonded interfaces

For this step you will need a **dual-NIC** machine. The bond (balanced-slb mode although you can use balanced-tcp if you have a router that supports LACP) can be set up as follows (remember to replace ensX with the names of the NICs on your machine!):

```console
# ssh into kvm-1 
apt-get -y install openvswitch-switch iptraf-ng net-tools
ovs-vsctl add-br ovsbr0
ovs-vsctl add-bond ovsbr0 bond0 ens4 ens7
ovs-vsctl set port bond0 bond_mode=balance-slb
ip addr flush dev ens4
ip addr flush dev ens7
ip link set ens4 up
ip link set ens7 up

ip link set ovsbr0 up && dhclient -v ovsbr0
# Note the IP assigned to ovsbr0

# Check that both links are enabled
ovs-appctl bond/show bond0

# Use curl to verify connectivity
```

Follow the same steps as the previous test to add the machine and deploy an lxd workload.