### PR TITLE
[2.8] forward-port of LP1882573 and other drive-by fixes

### DIFF
--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -75,6 +75,11 @@ func NewContainerManager(cfg container.ManagerConfig, svr *Server) (container.Ma
 	imageMetaDataURL := cfg.PopValue(config.ContainerImageMetadataURLKey)
 	imageStream := cfg.PopValue(config.ContainerImageStreamKey)
 
+	// This value is also popped by the provisioner worker; the following
+	// dummy pop operation ensures that we don't get a spurious warning
+	// for it when calling WarnAboutUnused() below.
+	_ = cfg.PopValue(config.LXDSnapChannel)
+
 	cfg.WarnAboutUnused()
 	return &containerManager{
 		server:           svr,

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/joyent/gosdc v0.0.0-20140524000815-2f11feadd2d9
 	github.com/joyent/gosign v0.0.0-20140524000734-0da0d5f13420
 	github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf
-	github.com/juju/bundlechanges v0.0.0-20200425015902-9e5ed4306b93
+	github.com/juju/bundlechanges v0.0.0-20200610103550-2c584a1d0a20
 	github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85
 	github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN7
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/bundlechanges v0.0.0-20200425015902-9e5ed4306b93 h1:ccyisx1a8mxq30KtEVLqiC+TXZbet6jneurdvc9ATCA=
 github.com/juju/bundlechanges v0.0.0-20200425015902-9e5ed4306b93/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
+github.com/juju/bundlechanges v0.0.0-20200610103550-2c584a1d0a20 h1:kh7sWk+OrZj3yHAj2widz7S9+xKPkjpfKtMuvmRK6DI=
+github.com/juju/bundlechanges v0.0.0-20200610103550-2c584a1d0a20/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596 h1:HxkKL4WZ8j/2q63vngE6poi5p1I6KzsxC0v93bvpDBM=
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596/go.mod h1:/Hb24f6NaHMuxV/XeKR9v1QY8qCc0NanWAXQuv6+Ob0=
 github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85 h1:YgEB2tnlAwVftOnPUKTN4i6NDYZy0ztR5l/HdUuHS2Y=


### PR DESCRIPTION
## Description of change

This PR forward-ports the fix from https://github.com/juju/juju/pull/11692 to 2.8.

In addition, it includes a small drive-by fix for a spurious warning emitted by the lxd container manager wrt 'lxd-snap-channel' not being used (it actually is used but from the provisioner worker)

## QA steps

Same as https://github.com/juju/juju/pull/11692

## Bug reference

https://bugs.launchpad.net/juju/+bug/1882573