### PR TITLE
Remove corresponding instanceData when machine is removed.

### DIFF
--- a/state/machine.go
+++ b/state/machine.go
@@ -291,6 +291,16 @@ func getInstanceData(st *State, id string) (instanceData, error) {
 	return instData, nil
 }
 
+// removeInstanceDataOp returns the operation needed to remove the
+// instance data document associated with the given globalKey.
+func removeInstanceDataOp(globalKey string) txn.Op {
+	return txn.Op{
+		C:      instanceDataC,
+		Id:     globalKey,
+		Remove: true,
+	}
+}
+
 // AllInstanceData retrieves all instance data in the model
 // and provides a way to query hardware characteristics and
 // charm profiles by machine.
@@ -1085,6 +1095,7 @@ func (m *Machine) removeOps() ([]txn.Op, error) {
 		removeMachineBlockDevicesOp(m.Id()),
 		removeModelMachineRefOp(m.st, m.Id()),
 		removeSSHHostKeyOp(m.globalKey()),
+		removeInstanceDataOp(m.doc.DocID),
 	}
 	linkLayerDevicesOps, err := m.removeAllLinkLayerDevicesOps()
 	if err != nil {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -558,7 +558,14 @@ func (s *MachineSuite) TestDestroyFailsWhenNewContainerAdded(c *gc.C) {
 }
 
 func (s *MachineSuite) TestRemove(c *gc.C) {
-	err := s.State.SetSSHHostKeys(s.machine.MachineTag(), state.SSHHostKeys{"rsa", "dsa"})
+	arch := "amd64"
+	char := &instance.HardwareCharacteristics{
+		Arch: &arch,
+	}
+	err := s.machine.SetProvisioned("umbrella/0", "snowflake", "fake_nonce", char)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.SetSSHHostKeys(s.machine.MachineTag(), state.SSHHostKeys{"rsa", "dsa"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.Remove()


### PR DESCRIPTION
## Description of change

Found during test of a different bug, instanceDataDoc for a machine is not removed when the machine is removed.  The MachineSuite.TestRemoves checked that the hardware characteristic data was no longer there after a machine was removed, however the data wasn't set to begin with due to lack of machine.SetProvisioned().

## QA steps

```sh
juju bootstrap
juju add-machine
juju remove-machine 0
juju-db.bash
juju:PRIMARY> db.instanceData.find()
```

Only the instance data for the controller should be seen.