### PR TITLE
The instance mutator worker ignores manually provisioned machines

### DIFF
--- a/api/instancemutater/machine.go
+++ b/api/instancemutater/machine.go
@@ -188,6 +188,9 @@ func (m *Machine) WatchLXDProfileVerificationNeeded() (watcher.NotifyWatcher, er
 	}
 	result := results.Results[0]
 	if result.Error != nil {
+		if params.IsCodeNotSupported(result.Error) {
+			return nil, errors.NotSupportedf("watching LXD profiles on machine %q", m.tag.Id())
+		}
 		return nil, result.Error
 	}
 	return apiwatcher.NewNotifyWatcher(m.facade.RawAPICaller(), result), nil

--- a/api/instancemutater/machine_test.go
+++ b/api/instancemutater/machine_test.go
@@ -91,10 +91,20 @@ func (s *instanceMutaterMachineSuite) TestWatchLXDProfileVerificationNeededServe
 	defer s.setup(c).Finish()
 
 	api := s.machineForScenario(c,
-		s.expectWatchLXDProfileVerificationNeededWithError(errors.New("failed")),
+		s.expectWatchLXDProfileVerificationNeededWithError("", "failed"),
 	)
 	_, err := api.WatchLXDProfileVerificationNeeded()
 	c.Assert(err, gc.ErrorMatches, "failed")
+}
+
+func (s *instanceMutaterMachineSuite) TestWatchLXDProfileVerificationNeededNotSupported(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	api := s.machineForScenario(c,
+		s.expectWatchLXDProfileVerificationNeededWithError("not supported", "failed"),
+	)
+	_, err := api.WatchLXDProfileVerificationNeeded()
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *instanceMutaterMachineSuite) TestWatchContainers(c *gc.C) {
@@ -325,7 +335,7 @@ func (s *instanceMutaterMachineSuite) expectWatchLXDProfileVerificationNeeded() 
 	fExp.RawAPICaller().Return(s.apiCaller)
 }
 
-func (s *instanceMutaterMachineSuite) expectWatchLXDProfileVerificationNeededWithError(err error) func() {
+func (s *instanceMutaterMachineSuite) expectWatchLXDProfileVerificationNeededWithError(code, message string) func() {
 	return func() {
 		args := params.Entities{
 			Entities: []params.Entity{
@@ -336,7 +346,8 @@ func (s *instanceMutaterMachineSuite) expectWatchLXDProfileVerificationNeededWit
 			Results: []params.NotifyWatchResult{
 				{
 					Error: &params.Error{
-						Message: err.Error(),
+						Code:    code,
+						Message: message,
 					},
 				},
 			},

--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -291,6 +291,9 @@ func (api *InstanceMutaterAPI) watchOneEntityApplication(canAccess common.AuthFu
 	if err != nil {
 		return result, err
 	}
+	if machine.IsManual() {
+		return result, errors.NotSupportedf("watching lxd profiles on manual machines")
+	}
 	watch, err := machine.WatchLXDProfileVerificationNeeded()
 	if err != nil {
 		return result, err

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -59,6 +59,7 @@ type ModelCache interface {
 // ModelCacheMachine represents a point of use Machine from the cache package.
 type ModelCacheMachine interface {
 	ContainerType() instance.ContainerType
+	IsManual() bool
 	WatchLXDProfileVerificationNeeded() (cache.NotifyWatcher, error)
 	WatchContainers() (cache.StringsWatcher, error)
 }

--- a/apiserver/facades/agent/instancemutater/mocks/modelcache_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/modelcache_mock.go
@@ -108,6 +108,18 @@ func (mr *MockModelCacheMachineMockRecorder) ContainerType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockModelCacheMachine)(nil).ContainerType))
 }
 
+// IsManual mocks base method
+func (m *MockModelCacheMachine) IsManual() bool {
+	ret := m.ctrl.Call(m, "IsManual")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsManual indicates an expected call of IsManual
+func (mr *MockModelCacheMachineMockRecorder) IsManual() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManual", reflect.TypeOf((*MockModelCacheMachine)(nil).IsManual))
+}
+
 // WatchContainers mocks base method
 func (m *MockModelCacheMachine) WatchContainers() (cache.StringsWatcher, error) {
 	ret := m.ctrl.Call(m, "WatchContainers")

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -107,6 +107,9 @@ func MachineChange(c *gc.C, modelUUID string, machine *state.Machine) cache.Mach
 	chProf, err := machine.CharmProfiles()
 	c.Assert(err, jc.ErrorIsNil)
 
+	isManual, err := machine.IsManual()
+	c.Assert(err, jc.ErrorIsNil)
+
 	sc, scKnown := machine.SupportedContainers()
 
 	return cache.MachineChange{
@@ -118,6 +121,7 @@ func MachineChange(c *gc.C, modelUUID string, machine *state.Machine) cache.Mach
 		Life:                     life.Value(machine.Life().String()),
 		Series:                   machine.Series(),
 		ContainerType:            string(machine.ContainerType()),
+		IsManual:                 isManual,
 		SupportedContainers:      sc,
 		SupportedContainersKnown: scKnown,
 		HardwareCharacteristics:  hwc,

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -183,6 +183,7 @@ type MachineChange struct {
 	Config                   map[string]interface{}
 	Series                   string
 	ContainerType            string
+	IsManual                 bool
 	SupportedContainers      []instance.ContainerType
 	SupportedContainersKnown bool
 	HardwareCharacteristics  *instance.HardwareCharacteristics

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -60,6 +60,11 @@ func (m *Machine) CharmProfiles() []string {
 	return m.details.CharmProfiles
 }
 
+// IsManual returns true if the machine was manually provisioned.
+func (m *Machine) IsManual() bool {
+	return m.details.IsManual
+}
+
 // ContainerType returns the cached container type hosting this machine.
 func (m *Machine) ContainerType() instance.ContainerType {
 	return instance.ContainerType(m.details.ContainerType)

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -221,12 +221,22 @@ func (m *backingMachine) updated(ctx *allWatcherContext) error {
 		wantsVote = err == nil && node.WantsVote()
 		hasVote = err == nil && node.HasVote()
 	}
+	modelId, _ := ctx.entityIDForGlobalKey(modelGlobalKey)
+	modelEntity := ctx.store.Get(modelId)
+	var providerType string
+	if modelEntity != nil {
+		modelInfo := modelEntity.(*multiwatcher.ModelInfo)
+		providerType, _ = modelInfo.Config["type"].(string)
+
+	}
+	isManual := isManualMachine(m.Id, m.Nonce, providerType)
 	info := &multiwatcher.MachineInfo{
 		ModelUUID:                m.ModelUUID,
 		Id:                       m.Id,
 		Life:                     multiwatcher.Life(m.Life.String()),
 		Series:                   m.Series,
 		ContainerType:            m.ContainerType,
+		IsManual:                 isManual,
 		Jobs:                     paramsJobsFromJobs(m.Jobs),
 		SupportedContainers:      m.SupportedContainers,
 		SupportedContainersKnown: m.SupportedContainersKnown,

--- a/state/machine.go
+++ b/state/machine.go
@@ -459,29 +459,35 @@ func (m *Machine) IsManager() bool {
 
 // IsManual returns true if the machine was manually provisioned.
 func (m *Machine) IsManual() (bool, error) {
+	// To avoid unnecessary db lookups, a little of the
+	// logic from isManualMachine() below is duplicated here
+	// so we can exit early if possible.
+	if strings.HasPrefix(m.doc.Nonce, manualMachinePrefix) {
+		return true, nil
+	}
+	if m.doc.Id != "0" {
+		return false, nil
+	}
+	modelSettings, err := readSettings(m.st.db(), settingsC, modelGlobalKey)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	providerRaw, _ := modelSettings.Get("type")
+	providerType, _ := providerRaw.(string)
+	return isManualMachine(m.doc.Id, m.doc.Nonce, providerType), nil
+}
+
+func isManualMachine(id, nonce, providerType string) bool {
 	// Apart from the bootstrap machine, manually provisioned
 	// machines have a nonce prefixed with "manual:". This is
 	// unique to manual provisioning.
-	if strings.HasPrefix(m.doc.Nonce, manualMachinePrefix) {
-		return true, nil
+	if strings.HasPrefix(nonce, manualMachinePrefix) {
+		return true
 	}
 	// The bootstrap machine uses BootstrapNonce, so in that
 	// case we need to check if its provider type is "manual".
 	// We also check for "null", which is an alias for manual.
-	if m.doc.Id == "0" {
-		model, err := m.st.Model()
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-
-		cfg, err := model.ModelConfig()
-		if err != nil {
-			return false, err
-		}
-		t := cfg.Type()
-		return t == "null" || t == "manual", nil
-	}
-	return false, nil
+	return id == "0" && (providerType == "null" || providerType == "manual")
 }
 
 // AgentTools returns the tools that the agent is currently running.

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -141,6 +141,7 @@ type MachineInfo struct {
 	Config                   map[string]interface{}            `json:"config,omitempty"`
 	Series                   string                            `json:"series"`
 	ContainerType            string                            `json:"container-type"`
+	IsManual                 bool                              `json:"-"` // internal use only
 	SupportedContainers      []instance.ContainerType          `json:"supported-containers"`
 	SupportedContainersKnown bool                              `json:"supported-containers-known"`
 	HardwareCharacteristics  *instance.HardwareCharacteristics `json:"hardware-characteristics,omitempty"`

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -304,6 +304,16 @@ func (s *workerEnvironSuite) TestCharmProfilingInfoError(c *gc.C) {
 	c.Assert(err, jc.Satisfies, params.IsCodeNotSupported)
 }
 
+func (s *workerEnvironSuite) TestMachineNotSupported(c *gc.C) {
+	defer s.setup(c, 1).Finish()
+
+	s.notifyMachines([][]string{{"0"}})
+	s.expectFacadeMachineTag(0)
+	s.machine[0].EXPECT().WatchLXDProfileVerificationNeeded().Return(nil, errors.NotSupportedf(""))
+	s.machine[0].EXPECT().CharmProfilingInfo().Times(0)
+	s.cleanKill(c, s.workerForScenario(c))
+}
+
 func (s *workerSuite) setup(c *gc.C, machineCount int) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -417,6 +417,7 @@ func (c *cacheWorker) translateMachine(d multiwatcher.Delta) interface{} {
 		Config:                   value.Config,
 		Series:                   value.Series,
 		ContainerType:            value.ContainerType,
+		IsManual:                 value.IsManual,
 		SupportedContainers:      value.SupportedContainers,
 		SupportedContainersKnown: value.SupportedContainersKnown,
 		HardwareCharacteristics:  value.HardwareCharacteristics,


### PR DESCRIPTION
## Description of change

When adding manually provisioned machines to juju, the worker which applies any lxd profiles needed by a charm should not mess with such machines - only lxd containers created by juju should have the profile updated. This prevents juju from trying to apply lxd profiles to any manual machine added to an lxd controller - it was incorrectly trying to apply a profile to a manually added kvm machine for example.
It does mean though the user is responsible for ensuring any lxd containers manually added are suitable for running any workloads deployed to those containers.

## QA steps

bootstrap lxd
juju add-machine ssh:somekvmcontainer
juju deploy somecharmwithalxdprofile --to id

check juju status for errors, previously for example
"cannot upgrade machine's lxd profile: 4: not found"

Also deploy a charm with a profile to a lxd controller and check it is applied.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1883178
