### PR TITLE
Do not set controller link-layer data out-of-band

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -66,7 +66,7 @@ var facadeVersions = map[string]int{
 	"MachineActions":               1,
 	"MachineManager":               6,
 	"MachineUndertaker":            1,
-	"Machiner":                     3,
+	"Machiner":                     4,
 	"MeterStatus":                  2,
 	"MetricsAdder":                 2,
 	"MetricsDebug":                 2,

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -34,11 +34,11 @@ func (m *Machine) Life() life.Value {
 
 // Refresh updates the cached local copy of the machine's data.
 func (m *Machine) Refresh() error {
-	life, err := m.st.machineLife(m.tag)
+	l, err := m.st.machineLife(m.tag)
 	if err != nil {
 		return err
 	}
-	m.life = life
+	m.life = l
 	return nil
 }
 
@@ -123,20 +123,6 @@ func (m *Machine) SetObservedNetworkConfig(netConfig []params.NetworkConfig) err
 		return errors.Trace(err)
 	}
 	return nil
-}
-
-// SetProviderNetworkConfig sets the machine network config as seen by the
-// provider.
-func (m *Machine) SetProviderNetworkConfig() error {
-	var result params.ErrorResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: m.tag.String()}},
-	}
-	err := m.st.facade.FacadeCall("SetProviderNetworkConfig", args, &result)
-	if err != nil {
-		return err
-	}
-	return result.OneError()
 }
 
 // RecordAgentStartTime updates the start time for the agent running on the

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -243,7 +243,8 @@ func AllFacades() *facade.Registry {
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
 	reg("Machiner", 1, machine.NewMachinerAPIV1)
 	reg("Machiner", 2, machine.NewMachinerAPIV2) // Adds RecordAgentStartTime.
-	reg("Machiner", 3, machine.NewMachinerAPI)   // Relies on agent-set origin in SetObservedNetworkConfig.
+	reg("Machiner", 3, machine.NewMachinerAPIV3) // Relies on agent-set origin in SetObservedNetworkConfig.
+	reg("Machiner", 4, machine.NewMachinerAPI)   // Removes SetProviderNetworkConfig.
 
 	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacadeV1)
 	reg("MeterStatus", 2, meterstatus.NewMeterStatusFacade)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -22321,7 +22321,7 @@
     {
         "Name": "Machiner",
         "Description": "MachinerAPI implements the API used by the machiner worker.",
-        "Version": 3,
+        "Version": 4,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent"
@@ -22423,18 +22423,6 @@
                         }
                     },
                     "description": "SetObservedNetworkConfig reads the network config for the machine identified\nby the input args. This config is merged with the new network config supplied\nin the same args and updated if it has changed."
-                },
-                "SetProviderNetworkConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ErrorResults"
-                        }
-                    },
-                    "description": "SetProviderNetworkConfig sets the provider supplied network configuration\ncontained in the input args against each machine supplied with said args."
                 },
                 "SetStatus": {
                     "type": "object",
@@ -28212,18 +28200,6 @@
                         }
                     },
                     "description": "SetPasswords sets the given password for each supplied entity, if possible."
-                },
-                "SetProviderNetworkConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ErrorResults"
-                        }
-                    },
-                    "description": "SetProviderNetworkConfig sets the provider supplied network configuration\ncontained in the input args against each machine supplied with said args."
                 },
                 "SetStatus": {
                     "type": "object",


### PR DESCRIPTION
## Description of change

This patch accompanies #11683.

It removes the logic whereby the machine agent, if running on a controller, sets link-layer device information from the provider before starting the various workers.

There is no need for this step to be performed. The machiner worker will populate device information as soon as it starts, then the instance-poller will decorate this with provider data.

In the case of AWS, it fixes a bug whereby we had duplicated devices due to device names being unsupported by the provider, and filled with a placeholder such as _unsupported0_ by Juju.

This was the only usage of `SetProviderNetworkConfig` from the common networking API. It is now removed, and that method stubbed for old versions of the `machiner` API, which embeds it. Stubbing it (allowing removal of the common logic) is safe - for new bootstraps, QA verifies this. For upgrades, the controller machine agent has already used it to set link-layer data.

## QA steps

On a variety of substrates:
- Bootstrap and deploy a workload; check that it settles without error. 
- ```juju enable-ha``` and check that the controllers arrive at a healthy state.
- Connect to Mongo and see that the `linklayerdevices` collection has the devices we expect.

I tried LXD, MAAS, AWS.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1855263
