### PR TITLE
Move the derived status method into the core/status package.

### DIFF
--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -60,6 +60,7 @@ type ApplicationChange struct {
 	Config          map[string]interface{}
 	Subordinate     bool
 	Status          status.StatusInfo
+	OperatorStatus  status.StatusInfo // For CAAS applications.
 	WorkloadVersion string
 }
 

--- a/core/cache/charmconfigwatcher_test.go
+++ b/core/cache/charmconfigwatcher_test.go
@@ -162,7 +162,7 @@ func (s *charmConfigWatcherSuite) newWatcher(c *gc.C, unitName string, charmURL 
 // newStub model sets up a cached model containing a redis application
 // and a branch with 2 redis units tracking it.
 func (s *charmConfigWatcherSuite) newStubModel() *stubCharmConfigModel {
-	app := newApplication(s.Gauges, s.Hub, s.NewResident())
+	app := newApplication(nil, s.Gauges, s.Hub, s.NewResident())
 	app.setDetails(ApplicationChange{
 		Name:   "redis",
 		Config: map[string]interface{}{}},

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -245,6 +245,21 @@ func (m *Model) Units() map[string]Unit {
 	return units
 }
 
+// applicationUnits returns all units for the specified application.
+func (m *Model) applicationUnits(appName string) []Unit {
+	m.mu.Lock()
+
+	var result []Unit
+	for _, u := range m.units {
+		if u.details.Application == appName {
+			result = append(result, u.copy())
+		}
+	}
+
+	m.mu.Unlock()
+	return result
+}
+
 // Unit returns the unit with the input name.
 // If the unit is not found, a NotFoundError is returned.
 func (m *Model) Unit(unitName string) (Unit, error) {
@@ -335,7 +350,7 @@ func (m *Model) updateApplication(ch ApplicationChange, rm *residentManager) {
 
 	app, found := m.applications[ch.Name]
 	if !found {
-		app = newApplication(m.metrics, m.hub, rm.new())
+		app = newApplication(m, m.metrics, m.hub, rm.new())
 		m.applications[ch.Name] = app
 	}
 	app.setDetails(ch)

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -164,7 +164,8 @@ func (s *EntitySuite) NewModel(details ModelChange) *Model {
 }
 
 func (s *EntitySuite) NewApplication(details ApplicationChange) *Application {
-	a := newApplication(s.Gauges, s.Hub, s.NewResident())
+	m := s.NewModel(ModelChange{Name: "test"})
+	a := newApplication(m, m.metrics, m.hub, s.Manager.new())
 	a.setDetails(details)
 	return a
 }

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/settings"
+	"github.com/juju/juju/core/status"
 )
 
 // Unit represents a unit in a cached model.
@@ -76,7 +77,17 @@ func (u *Unit) Ports() []network.Port {
 	return u.details.Ports
 }
 
-// Config settings returns the effective charm configuration for this unit
+// AgentStatus returns the agent status of the unit.
+func (u *Unit) AgentStatus() status.StatusInfo {
+	return u.details.AgentStatus
+}
+
+// WorkloadStatus returns the workload status of the unit.
+func (u *Unit) WorkloadStatus() status.StatusInfo {
+	return u.details.WorkloadStatus
+}
+
+// ConfigSettings returns the effective charm configuration for this unit
 // taking into account whether it is tracking a model branch.
 func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	if u.details.CharmURL == "" {

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -192,6 +192,7 @@ type ApplicationInfo struct {
 	Config          map[string]interface{}
 	Subordinate     bool
 	Status          StatusInfo
+	OperatorStatus  StatusInfo // For CAAS models
 	WorkloadVersion string
 }
 

--- a/core/status/status_test.go
+++ b/core/status/status_test.go
@@ -3,6 +3,8 @@
 package status_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -96,5 +98,43 @@ func (s *StatusSuite) TestInvalidModelStatus(c *gc.C) {
 		status.Waiting,
 	} {
 		c.Assert(status.ValidModelStatus(v), jc.IsFalse, gc.Commentf("status %q is valid for a model", v))
+	}
+}
+
+func (s *StatusSuite) TestDerivedStatusEmpty(c *gc.C) {
+	info := status.DeriveStatus(nil)
+	c.Assert(info, jc.DeepEquals, status.StatusInfo{
+		Status: status.Unknown,
+	})
+}
+
+func (s *StatusSuite) TestDerivedStatusBringsAllDetails(c *gc.C) {
+	now := time.Now()
+	value := status.StatusInfo{
+		Status:  status.Active,
+		Message: "I'm active",
+		Data:    map[string]interface{}{"key": "value"},
+		Since:   &now,
+	}
+	info := status.DeriveStatus([]status.StatusInfo{value})
+	c.Assert(info, jc.DeepEquals, value)
+}
+
+func (s *StatusSuite) TestDerivedStatusPriority(c *gc.C) {
+	for _, t := range []struct{ status1, status2, expected status.Status }{
+		{status.Active, status.Waiting, status.Waiting},
+		{status.Maintenance, status.Waiting, status.Waiting},
+		{status.Active, status.Blocked, status.Blocked},
+		{status.Waiting, status.Blocked, status.Blocked},
+		{status.Maintenance, status.Blocked, status.Blocked},
+		{status.Maintenance, status.Error, status.Error},
+		{status.Blocked, status.Error, status.Error},
+		{status.Waiting, status.Error, status.Error},
+		{status.Active, status.Error, status.Error},
+	} {
+		value := status.DeriveStatus([]status.StatusInfo{
+			{Status: t.status1}, {Status: t.status2},
+		})
+		c.Check(value.Status, gc.Equals, t.expected)
 	}
 }


### PR DESCRIPTION
Add a Status method to the Application type in core/cache, and have
it use the derived status of the units if the application status
value is Unset.

This work is a prelude to a more efficient allwatcher handling of unit status values when no application status has been set.

