### PR TITLE
Add extra logging, tweak timeout for user registration

### DIFF
--- a/acceptancetests/jujupy/backend.py
+++ b/acceptancetests/jujupy/backend.py
@@ -239,7 +239,8 @@ class JujuBackend:
         # timing command tacked on).
         command_string = ' '.join(quote(a) for a in args)
         with scoped_environ(env):
-            return pexpect.spawn(command_string)
+            log.debug('starting client interaction: {}'.format(command_string))
+            return pexpect.spawn(command_string, encoding='UTF-8', timeout=60)
 
     @contextmanager
     def juju_async(self, command, args, used_feature_flags,

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -23,6 +23,7 @@ import os
 import pexpect
 import re
 import shutil
+import six
 import subprocess
 import sys
 import time
@@ -1954,7 +1955,8 @@ class ModelClient:
         command.
 
         """
-        for row in output.split('\n'):
+        out_text = six.ensure_text(output)
+        for row in out_text.split('\n'):
             if 'juju register' in row:
                 command_string = row.strip().lstrip()
                 command_parts = command_string.split(' ')
@@ -2375,11 +2377,12 @@ def register_user_interactively(client, token, controller_name):
     """
     try:
         child = client.expect('register', (token), include_e=False)
-        child.expect('Enter a new password:')
+        child.logfile = sys.stdout
+        child.expect(u'Enter a new password:')
         child.sendline(client.env.user_name + '_password')
-        child.expect('Confirm password:')
+        child.expect(u'Confirm password:')
         child.sendline(client.env.user_name + '_password')
-        child.expect('Enter a name for this controller \[.*\]:')
+        child.expect(u'Enter a name for this controller \[.*\]:')
         child.sendline(controller_name)
         client._end_pexpect_session(child)
     except pexpect.TIMEOUT:

--- a/acceptancetests/substrate.py
+++ b/acceptancetests/substrate.py
@@ -16,6 +16,7 @@ from boto.exception import EC2ResponseError
 from dateutil import parser as date_parser
 
 import gce
+import six
 from utility import (
     temp_dir,
     until_timeout,
@@ -204,7 +205,8 @@ class AWSAccount:
                     try:
                         interface.delete()
                     except EC2ResponseError as e:
-                        if e.error_code not in (
+                        err_code = six.ensure_text(e.error_code)
+                        if err_code not in (
                                 'InvalidNetworkInterface.InUse',
                                 'InvalidNetworkInterfaceID.NotFound'):
                             raise
@@ -230,7 +232,9 @@ class AWSAccount:
                     if not deleted:
                         failures.append((sg_id, "Failed to delete"))
                 except EC2ResponseError as e:
-                    failures.append((sg_id, repr(e)))
+                    err_code = six.ensure_text(e.error_code)
+                    if err_code != 'InvalidGroup.NotFound':
+                        failures.append((sg_id, repr(e)))
 
         return failures
 


### PR DESCRIPTION
## Description of change

nw-cross-model-relations has been failing regularly. Many of the failures have been in the step to register a user on one of the controllers (timeout). Running the tests locally many times could not reproduce. This PR introduces several tweaks to either fix or diagnose:
- increase timeout to pexpect setup to 60s
- add stdout logger to pexpect interaction so we can see where it stops next time
- add some python3 compatibility tweaks (I ran the tests using python3)
- tweak the AWS sec group cleanup to ignore not found errors

## QA steps

run nw-cross-model-relations using python2 and python3
