### PR TITLE
Add comfile flags to rebuild-schema make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,9 +152,9 @@ rebuild-schema:
 ## rebuild-schema: Rebuild the schema for clients with the latest facades
 	@echo "Generating facade schema..."
 ifdef SCHEMA_PATH
-	@go run $(PROJECT)/generate/schemagen "$(SCHEMA_PATH)"
+	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen "$(SCHEMA_PATH)"
 else
-	@go run $(PROJECT)/generate/schemagen \
+	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen \
 		./apiserver/facades/schema.json
 endif
 


### PR DESCRIPTION
## Description of change

The rebuild-schema make target is failing om ppc due to https://go-review.googlesource.com/c/go/+/234105/

We added the -N compile flag to the core build target but also need it for rebuild-schema.

## QA steps

make rebuild-schema

