### PR TITLE
Rewrite juju scp help

### DIFF
--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -17,62 +17,97 @@ import (
 )
 
 var usageSCPSummary = `
-Transfers files to/from a Juju machine.`[1:]
+Securely transfer files within a model.`[1:]
 
 var usageSCPDetails = `
-The source or destination arguments may either be a local path or a remote
-location. The syntax for a remote location is:
+Transfer files to, from and between Juju machine(s), unit(s) and the 
+Juju client.
 
-    [<user>@]<target>:[<path>]
+The basic syntax for the command requires the location of 1 or more source 
+files or directories and their intended destination:
 
-If the user is not specified, "ubuntu" is used. If <path> is not specified, it
-defaults to the home directory of the remote user account.
+    <source> <destination>
 
-The <target> may be either a 'unit name' or a 'machine id'. These can be
-obtained from the output of "juju status".
+The <source> and <destination> arguments may either be a path to a local file
+or a remote location. Here is a fuller syntax diagram:
 
-Options specific to scp can be provided after a "--". Refer to the scp(1) man
-page for an explanation of those options. The "-r" option to recursively copy a
-directory is particularly useful.
+    # <source>                 <destination>
+    [[<user>@]<target>:]<path> [<user>@]<target>:[<path>]
 
-The SSH host keys of the target are verified. The --no-host-key-checks option
-can be used to disable these checks. Use of this option is not recommended as
-it opens up the possibility of a man-in-the-middle attack.
+<user> is a user account that exists on the remote host. Juju defaults to the 
+"ubuntu" user when this is omitted.
+
+<target> may be either a unit or machine. Units are specified in form 
+'<application-name>/<n>', e.g. postgresql/0 or haproxy/2. Machines are 
+specified in form '<n>', e.g. 0 or 12. The units and machines in your model can
+be obtained from the output of "juju status".
+
+<path> is a file path. Local relative paths are resolved relative to the 
+current working directory. Remote relative paths are resolved relative to the
+home directory of the remote user account. 
+
+
+Providing arguments directly to scp
+
+Send arguments directly to the underlying scp utility for full control by
+adding two hyphens to the argument list and adding arguments to the right
+(-- <arg> [...]). Common arguments to scp include
+
+ - "-r" recursively copy files from a directory
+ - "-3" use the client as a proxy for transfers between machines
+ - "-C" enable SSH compression
+
+
+Transfers between machines
+
+Machines do not have SSH connectivity to each other by default. Within a Juju
+model, all communication is facilitated by the Juju controller. To transfer
+files between machines, you can use the -3 option to scp, e.g. add "-- -3"
+to the command-line arguments.
+
+
+Security considerations
+
+To enable transfers to/from machines that do not have internet access, you can use
+the Juju controller as a proxy with the --proxy option.  
+
+The SSH host keys of the target are verified by default. To disable this, add
+ --no-host-key-checks option. Using this option is strongly discouraged.
+
 
 Examples:
 
-Copy file /var/log/syslog from machine 2 to the client's current working
-directory:
+    # Copy the config of a Charmed Kubernetes cluster to ~/.kube/config
+    juju scp kubernetes-master/0:config ~/.kube/config
 
+    # Copy file /var/log/syslog from machine 2 to the client's 
+    # current working directory:
     juju scp 2:/var/log/syslog .
 
-Recursively copy the /var/log/mongodb directory from a mongodb unit to the
-client's local remote-logs directory:
-
+    # Recursively copy the /var/log/mongodb directory from the
+    # mongodb/0 unit to the client's local remote-logs directory:
     juju scp -- -r mongodb/0:/var/log/mongodb/ remote-logs
 
-Copy foo.txt from the client's current working directory to an apache2 unit of
-model "prod". Proxy the SSH connection through the controller and turn on scp
-compression:
-
+    # Copy foo.txt from the client's current working directory to a
+    # the apache2/1 unit model "prod" (-m prod). Proxy the SSH connection 
+    # through the controller (--proxy) and enable compression (-- -C):
     juju scp -m prod --proxy -- -C foo.txt apache2/1:
 
-Copy multiple files from the client's current working directory to machine 2:
-
+    # Copy multiple files from the client's current working directory to 
+    # the /home/ubuntu directory of machine 2:
     juju scp file1 file2 2:
 
-Copy multiple files from the bob user account on machine 3 to the client's
-current working directory:
-
+    # Copy multiple files from machine 3 as user "bob" to the client's
+    # current working directory:
     juju scp bob@3:'file1 file2' .
 
-Copy file.dat from machine 0 to the machine hosting unit foo/0 (-3
-causes the transfer to be made via the client):
-
+    # Copy file.dat from machine 0 to the machine hosting unit foo/0 
+    # (-- -3):
     juju scp -- -3 0:file.dat foo/0:
 
 See also: 
-    ssh`
+	ssh
+`
 
 func newSCPCommand(hostChecker jujussh.ReachableChecker) cmd.Command {
 	c := new(scpCommand)


### PR DESCRIPTION
Expands the details section to be more readable for readers scanning the text in a hurry. It adds more specific advice for the standard invocation, passing args to `scp` and transfers between machines.

Migrates the examples to the style used by the Kubernetes docs.

Adds extra example for using juju scp to extract k8s config from a Charmed Kubernetes cluster.