### PR TITLE
[dev] Use OVS bridges (if present) for KVM workloads

### DIFF
--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -41,6 +41,19 @@ func ContainerFromInstance(inst instances.Instance) Container {
 	return kvm.container
 }
 
+// Patcher defines an interface that matches the PatchValue method on
+// CleanupSuite
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}
+
+// PatchGetHostSeries allows tests to override host series detection.
+func PatchGetHostSeries(p Patcher, fn func() (string, error)) {
+	p.PatchValue(&getHostSeries, func() (string, error) {
+		return fn()
+	})
+}
+
 // NewRunStub is a stub to fake shelling out to os.Exec or utils.RunCommand.
 func NewRunStub(output string, err error) *runStub {
 	return &runStub{output: output, err: err}

--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -168,10 +168,11 @@ func generateOSElement(p domainParams) OS {
 // generateFeaturesElement generates the appropriate features element based on
 // the architecture.
 func generateFeaturesElement(p domainParams) *Features {
+	f := new(Features)
 	if p.Arch() == arch.ARM64 {
-		return &Features{GIC: &GIC{Version: "host"}}
+		f.GIC = &GIC{Version: "host"}
 	}
-	return nil
+	return f
 }
 
 // generateCPU infor generates any model/fallback related settings. These are
@@ -245,11 +246,11 @@ type NVRAMCode struct {
 	Type     string `xml:"type,attr,omitempty"`
 }
 
-// Features is only generated for ARM64 at the time of this writing. This is
-// because GIC is required for ARM64.
-// See: https://libvirt.org/formatdomain.html#elementsFeatures
+// Features allows us to request one or more hypervisor features to be toggled
+// on/off. See: https://libvirt.org/formatdomain.html#elementsFeatures
 type Features struct {
-	GIC *GIC `xml:"gic,omitempty"`
+	GIC  *GIC   `xml:"gic,omitempty"`
+	ACPI string `xml:"acpi"`
 }
 
 // GIC is the Generic Interrupt Controller and is required to UEFI boot on

--- a/container/kvm/libvirt/domainxml_test.go
+++ b/container/kvm/libvirt/domainxml_test.go
@@ -30,6 +30,9 @@ var amd64DomainStr = `
     <os>
         <type>hvm</type>
     </os>
+    <features>
+        <acpi></acpi>
+    </features>
     <devices>
         <disk device="disk" type="file">
             <driver type="qcow2" name="qemu"></driver>
@@ -70,6 +73,7 @@ var arm64DomainStr = `
     </os>
     <features>
         <gic version="host"></gic>
+        <acpi></acpi>
     </features>
     <cpu mode="custom" match="exact">
         <model fallback="allow">cortex-a53</model>
@@ -111,6 +115,9 @@ var amd64WithOvsBridgeDomainStr = `
     <os>
         <type>hvm</type>
     </os>
+    <features>
+        <acpi></acpi>
+    </features>
     <devices>
         <disk device="disk" type="file">
             <driver type="qcow2" name="qemu"></driver>

--- a/container/kvm/wrappedcmds.go
+++ b/container/kvm/wrappedcmds.go
@@ -56,6 +56,11 @@ var (
 	// first part is the opaque identifier we don't care about
 	// then the hostname, and lastly the status.
 	machineListPattern = regexp.MustCompile(`(?m)^\s+\d+\s+(?P<hostname>[-\w]+)\s+(?P<status>.+)\s*$`)
+
+	// Overridden by tests.
+	getHostSeries = func() (string, error) {
+		return series.HostSeries()
+	}
 )
 
 // CreateMachineParams Implements libvirt.domainParams.
@@ -459,20 +464,52 @@ func writeRootDisk(params CreateMachineParams) (string, error) {
 		guestBase,
 		backingFileName(params.Series, params.Arch()))
 
-	out, err := params.runCmd(
-		"",
-		"qemu-img",
+	cmdArgs := []string{
 		"create",
 		"-b", backingPath,
+	}
+
+	// On focal+ we must explicitly specify the format of the backing image
+	// as well (see LP1883575).
+	needsBackingImgFormat, err := mustSpecifyBackingImageFormat()
+	if err != nil {
+		return "", errors.Trace(err)
+	} else if needsBackingImgFormat {
+		// Contrary to their extension, the backing files fetched via
+		// simple stream are raw and not qcow2 images.
+		cmdArgs = append(cmdArgs, "-F", "raw")
+	}
+
+	cmdArgs = append(cmdArgs,
 		"-f", "qcow2",
 		imgPath,
-		fmt.Sprintf("%dG", params.RootDisk))
+		fmt.Sprintf("%dG", params.RootDisk),
+	)
+
+	out, err := params.runCmd("", "qemu-img", cmdArgs...)
 	logger.Debugf("create root image: %s", out)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
 
 	return imgPath, nil
+}
+
+// mustSpecifyBackingImageFormat returns true if the qemu-img command on the
+// host requests the backing image format to be explicitly provided as an
+// argument.
+func mustSpecifyBackingImageFormat() (bool, error) {
+	series, err := getHostSeries()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	switch series {
+	case "precise", "trusty", "xenial", "bionic", "eoan":
+		return false, nil
+	default: // focal+
+		return true, nil
+	}
 }
 
 // pool info parses and returns the output of `virsh pool-info <poolname>`.

--- a/container/kvm/wrappedcmds.go
+++ b/container/kvm/wrappedcmds.go
@@ -64,7 +64,6 @@ type CreateMachineParams struct {
 	Series            string
 	UserDataFile      string
 	NetworkConfigData string
-	NetworkBridge     string
 	Memory            uint64
 	CpuCores          uint64
 	RootDisk          uint64

--- a/packaging/dependency/kvm.go
+++ b/packaging/dependency/kvm.go
@@ -20,28 +20,37 @@ type kvmDependency struct {
 
 // PackageList implements packaging.Dependency.
 func (dep kvmDependency) PackageList(series string) ([]packaging.Package, error) {
+	if series == "centos7" || series == "opensuseleap" {
+		return nil, errors.NotSupportedf("installing kvm on series %q", series)
+	}
+
 	var pkgList []string
+	if dep.arch == arch.ARM64 {
+		// ARM64 doesn't support legacy BIOS so it requires Extensible Firmware
+		// Interface.
+		pkgList = append(pkgList, "qemu-efi")
+	}
+
+	pkgList = append(pkgList,
+		// `qemu-kvm` must be installed before `libvirt-bin` on trusty. It appears
+		// that upstart doesn't reload libvirtd if installed after, and we see
+		// errors related to `qemu-kvm` not being installed.
+		"qemu-kvm",
+		"qemu-utils",
+		"genisoimage",
+	)
 
 	switch series {
-	case "centos7", "opensuseleap":
-		return nil, errors.NotSupportedf("installing kvm on series %q", series)
+	case "precise", "trusty", "xenial", "bionic", "eoan":
+		pkgList = append(pkgList, "libvirt-bin")
 	default:
-		if dep.arch == arch.ARM64 {
-			// ARM64 doesn't support legacy BIOS so it requires Extensible Firmware
-			// Interface.
-			pkgList = append(pkgList, "qemu-efi")
-		}
-
+		// On focal+ virsh is provided by libvirt-clients; also we need
+		// to install the daemon package separately.
 		pkgList = append(pkgList,
-			// `qemu-kvm` must be installed before `libvirt-bin` on trusty. It appears
-			// that upstart doesn't reload libvirtd if installed after, and we see
-			// errors related to `qemu-kvm` not being installed.
-			"qemu-kvm",
-			"qemu-utils",
-			"genisoimage",
-			"libvirt-bin",
+			"libvirt-daemon-system",
+			"libvirt-clients",
 		)
-
-		return packaging.MakePackageList(packaging.AptPackageManager, "", pkgList...), nil
 	}
+
+	return packaging.MakePackageList(packaging.AptPackageManager, "", pkgList...), nil
 }

--- a/pki/tls/sni.go
+++ b/pki/tls/sni.go
@@ -20,7 +20,7 @@ type Logger interface {
 // supplied  authority that best matches the client hellow message.
 func AuthoritySNITLSGetter(authority pki.Authority, logger Logger) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-		logger.Debugf("recieved tls client hello for server name %s", hello.ServerName)
+		logger.Debugf("received tls client hello for server name %s", hello.ServerName)
 		var cert *tls.Certificate
 		authority.LeafRange(func(leaf pki.Leaf) bool {
 			if err := hello.SupportsCertificate(leaf.TLSCertificate()); err == nil {


### PR DESCRIPTION
## Description of change

This PR allows juju to use OVS bridges when deploying KVM workloads. The changes in this PR build on top of #11670 which allows the bridge policy to correctly detect and select OVS bridges in a space-aware way. 

When using OVS bridges as the parent for the KVM NICs juju must include an additional XML element called `<virtualport>` which allows KVM to set up the bridge correctly.

Finally, the PR includes an additional set of changes to make KVM workloads work with focal hosts and request the `acpi` feature for kvm instances.

## QA steps

Similar to #11670 you will need a MAAS instance. For the following set of tests, you need to provision the following set of instances:

| host | IP (for reference) | series | NIC count | Notes |
|------|------|-----|-----------|------|
| kvm-1| 10.0.0.2|bionic | 1 | controller |
| kvm-2| 10.0.0.3|bionic | 1 |  |
| kvm-3| 10.0.0.4|focal | 1 |  |

Set up an OVS bridge on kvm-2. ⚠️ Make sure you set up a root password first and access the `kvm-2` instance via `virsh console kvm-2` as the following steps will change the network config on the box and lock you out if using an SSH session.

```console
# Run these in a console in kvm-2
# (replace ens4 with the name of the NIC on your machine)
apt-get -y install openvswitch-switch iptraf-ng net-tools
ovs-vsctl add-br ovsbr0
ovs-vsctl add-port ovsbr0 ens4
ifconfig ens4 0
ip link set ovsbr0 state up && dhclient -v ovsbr0
ip route replace default via 10.0.0.1 dev ovsbr0

# Make a note of the IP assigned to ovsbr0 by dhclient
```

Then run the following on your dev machine (replace IPs with the ones MAAS provisioned your machines with):

```console
# Use kvm-1 as the controller
$ juju bootstrap manual/ubuntu@10.0.0.2 --no-gui 

# Add two machines; for kvm-2 use the IP assigned to ovsbr0
$ juju add-machine ssh:ubuntu@$ovsbr0-ip
$ juju add-machine ssh:ubuntu@10.0.0.4

$ juju deploy wordpress --to kvm:0 
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to kvm:1 --series focal --force

# Ensure that juju status is happy and that the wordpress container got an IP in the same subnet as the OVS bridge

# Verify that the ACPI feature has been added to the VM definition by running (in both kvm machines)
$ virsh dumpxml `virsh list | grep juju | awk '{print $2}'` | grep '<features>' -A 2
  <features>
    <acpi/>
  </features>
```

## Bug reference
This PR also includes a fix for https://bugs.launchpad.net/juju/+bug/1883575 and https://bugs.launchpad.net/juju/+bug/1883792