### PR TITLE
Handle idle condition correctly

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -313,8 +313,8 @@ introspect_controller() {
         return
     fi
 
-    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_reports.log"
-    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.log"
+    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_reports.log" 2>/dev/null
+    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.log" 2>/dev/null
 }
 
 remove_controller_offers() {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -212,7 +212,7 @@ destroy_model() {
         return
     fi
 
-    output="${TEST_DIR}/${name}-destroy.txt"
+    output="${TEST_DIR}/${name}-destroy.log"
 
     echo "====> Destroying juju model ${name}"
     echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
@@ -248,7 +248,7 @@ destroy_controller() {
         fi
         echo "====> Destroying model ($(green "${name}"))"
 
-        output="${TEST_DIR}/${name}-destroy-model.txt"
+        output="${TEST_DIR}/${name}-destroy-model.log"
         echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
 
         echo "====> Destroyed model ($(green "${name}"))"
@@ -270,7 +270,7 @@ destroy_controller() {
 
     set_verbosity
 
-    output="${TEST_DIR}/${name}-destroy-controller.txt"
+    output="${TEST_DIR}/${name}-destroy-controller.log"
 
     echo "====> Destroying juju ($(green "${name}"))"
     echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
@@ -313,8 +313,8 @@ introspect_controller() {
         return
     fi
 
-    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_reports.txt"
-    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.txt"
+    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" > "${TEST_DIR}/${name}-juju_engine_reports.log"
+    echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" > "${TEST_DIR}/${name}-juju_goroutines.log"
 }
 
 remove_controller_offers() {
@@ -329,7 +329,7 @@ remove_controller_offers() {
             echo "${OUT}" | while read -r offer; do
                 if [ -n "${offer}" ]; then
                     juju remove-offer --force -y -c "${name}" "${offer}"
-                    echo "${offer}" >> "${TEST_DIR}/${name}-juju_removed_offers.txt"
+                    echo "${offer}" >> "${TEST_DIR}/${name}-juju_removed_offers.log"
                 fi
             done
         done

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -40,7 +40,9 @@ idle_condition() {
     app_index=${2:-0}
     unit_index=${3:-0}
 
-    echo ".applications | select(.[\"$name\"] | .units | .[\"$name/$unit_index\"] | .[\"juju-status\"] | .current == \"idle\") | keys[$app_index]"
+    path=".[\"$name\"] | .units | .[\"$name/$unit_index\"]"
+
+    echo ".applications | select(($path | .[\"juju-status\"] | .current == \"idle\") and ($path | .[\"workload-status\"] | .current != \"error\")) | keys[$app_index]"
 }
 
 idle_subordinate_condition() {
@@ -52,8 +54,10 @@ idle_subordinate_condition() {
     unit_index=${4:-0}
     parent_index=${5:-0}
 
+    path=".[\"$parent\"] | .units | .[\"$parent/$parent_index\"] | .subordinates | .[\"$name/$unit_index\"]"
+
     # Print the *subordinate* name if it has an idle status in parent application
-    echo ".applications | select(.[\"$parent\"] | .units | .[\"$parent/$parent_index\"] | .subordinates | .[\"$name/$unit_index\"] | .[\"juju-status\"] | .current == \"idle\") | \"$name\""
+    echo ".applications | select(($path | .[\"juju-status\"] | .current == \"idle\") and ($path | .[\"workload-status\"] | .current != \"error\")) | \"$name\""
 }
 
 active_condition() {

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -46,13 +46,12 @@ idle_condition() {
 }
 
 idle_subordinate_condition() {
-    local name parent app_index unit_index parent_index
+    local name parent unit_index parent_index
 
     name=${1}
     parent=${2}
-    app_index=${3:-0}
-    unit_index=${4:-0}
-    parent_index=${5:-0}
+    unit_index=${3:-0}
+    parent_index=${4:-0}
 
     path=".[\"$parent\"] | .units | .[\"$parent/$parent_index\"] | .subordinates | .[\"$name/$unit_index\"]"
 

--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -3,7 +3,7 @@ run_charmrevisionupdater() {
     echo
 
     model_name="test-charmrevisionupdater"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 

--- a/tests/suites/agents/task.sh
+++ b/tests/suites/agents/task.sh
@@ -9,7 +9,7 @@ test_agents() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-agents.txt"
+    file="${TEST_DIR}/test-agents.log"
 
     JUJU_AGENT_TESTING_OPTIONS=CHARM_REVISION_UPDATE_INTERVAL=15s \
     bootstrap "test-agents" "${file}"

--- a/tests/suites/appdata/appdata.sh
+++ b/tests/suites/appdata/appdata.sh
@@ -1,7 +1,7 @@
 run_appdata_basic() {
     echo
 
-    file="${TEST_DIR}/appdata-basic.txt"
+    file="${TEST_DIR}/appdata-basic.log"
 
     ensure "appdata-basic" "${file}"
 

--- a/tests/suites/appdata/task.sh
+++ b/tests/suites/appdata/task.sh
@@ -9,7 +9,7 @@ test_appdata() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-appdata.txt"
+    file="${TEST_DIR}/test-appdata.log"
 
     bootstrap "test-appdata" "${file}"
 

--- a/tests/suites/branches/active_branch.sh
+++ b/tests/suites/branches/active_branch.sh
@@ -2,7 +2,7 @@
 run_indicate_active_branch_no_active() {
   echo
 
-  file="${TEST_DIR}/indicate-active-branch-no-active.txt"
+  file="${TEST_DIR}/indicate-active-branch-no-active.log"
 
   ensure "indicate-active-branch-no-active" "${file}"
 
@@ -24,7 +24,7 @@ run_indicate_active_branch_no_active() {
 run_indicate_active_branch_active() {
   echo
 
-  file="${TEST_DIR}/indicate-active-branch-active.txt"
+  file="${TEST_DIR}/indicate-active-branch-active.log"
 
   ensure "indicate-active-branch-active" "${file}"
 

--- a/tests/suites/branches/branches.sh
+++ b/tests/suites/branches/branches.sh
@@ -3,7 +3,7 @@ run_branch() {
     echo
 
     # The following ensures that a bootstrap juju exists
-    file="${TEST_DIR}/test-branches.txt"
+    file="${TEST_DIR}/test-branches.log"
     ensure "branches" "${file}"
 
     juju branch | check 'Active branch is "master"'

--- a/tests/suites/branches/task.sh
+++ b/tests/suites/branches/task.sh
@@ -9,7 +9,7 @@ test_branches() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-branch.txt"
+    file="${TEST_DIR}/test-branch.log"
 
     export JUJU_DEV_FEATURE_FLAGS=generations
 

--- a/tests/suites/cli/local_charms.sh
+++ b/tests/suites/cli/local_charms.sh
@@ -2,7 +2,7 @@
 run_deploy_local_charm_revision() {
   echo
 
-  file="${TEST_DIR}/local-charm-deploy-git.txt"
+  file="${TEST_DIR}/local-charm-deploy-git.log"
 
   ensure "local-charm-deploy" "${file}"
 
@@ -33,7 +33,7 @@ run_deploy_local_charm_revision() {
 run_deploy_local_charm_revision_no_vcs() {
   echo
 
-  file="${TEST_DIR}/local-charm-deploy-no-vcs.txt"
+  file="${TEST_DIR}/local-charm-deploy-no-vcs.log"
 
   ensure "local-charm-deploy-no-vcs" "${file}"
 
@@ -55,7 +55,7 @@ run_deploy_local_charm_revision_no_vcs() {
 run_deploy_local_charm_revision_no_vcs_but_version_file() {
   echo
 
-  file="${TEST_DIR}/local-charm-deploy-version-file.txt"
+  file="${TEST_DIR}/local-charm-deploy-version-file.log"
 
   ensure "local-charm-deploy-version-file" "${file}"
 
@@ -90,7 +90,7 @@ run_deploy_local_charm_revision_no_vcs_but_version_file() {
 run_deploy_local_charm_revision_relative_path() {
   echo
 
-  file="${TEST_DIR}/local-charm-deploy-relative-path.txt"
+  file="${TEST_DIR}/local-charm-deploy-relative-path.log"
 
   ensure "relative-path" "${file}"
 
@@ -130,7 +130,7 @@ run_deploy_local_charm_revision_relative_path() {
 run_deploy_local_charm_revision_invalid_git() {
   echo
 
-  file="${TEST_DIR}/local-charm-deploy-wrong-git.txt"
+  file="${TEST_DIR}/local-charm-deploy-wrong-git.log"
   ensure "local-charm-deploy-wrong-git" "${file}"
 
   TMP_CHARM_GIT=$(mktemp -d -t ci-XXXXXXXXXX)

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -9,7 +9,7 @@ test_cli() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-cli.txt"
+    file="${TEST_DIR}/test-cli.log"
 
     bootstrap "test-cli" "${file}"
 

--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -6,7 +6,7 @@ cat_mongo_service() {
 run_mongo_memory_profile() {
     echo
 
-    file="${TEST_DIR}/mongo_memory_profile.txt"
+    file="${TEST_DIR}/mongo_memory_profile.log"
 
     ensure "mongo-memory-profile" "${file}"
 

--- a/tests/suites/controller/task.sh
+++ b/tests/suites/controller/task.sh
@@ -9,7 +9,7 @@ test_controller() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-controller.txt"
+    file="${TEST_DIR}/test-controller.log"
 
     bootstrap "test-controller" "${file}"
 

--- a/tests/suites/deploy/charms/lxd-profile-alt/lxd-profile.yaml
+++ b/tests/suites/deploy/charms/lxd-profile-alt/lxd-profile.yaml
@@ -3,6 +3,6 @@ description: lxd profile for testing
 config:
   security.nesting: "true"
   security.privileged: "true"
-  linux.kernel_modules: nbd,ip_tables,ip6_tables
+  linux.kernel_modules: ip_tables,ip6_tables
   environment.http_proxy: ""
 

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -1,7 +1,7 @@
 run_deploy_bundle() {
     echo
 
-    file="${TEST_DIR}/test-bundles-deploy.txt"
+    file="${TEST_DIR}/test-bundles-deploy.log"
 
     ensure "test-bundles-deploy" "${file}"
 
@@ -15,7 +15,7 @@ run_deploy_bundle() {
 run_deploy_cmr_bundle() {
     echo
 
-    file="${TEST_DIR}/test-cmr-bundles-deploy.txt"
+    file="${TEST_DIR}/test-cmr-bundles-deploy.log"
 
     ensure "test-cmr-bundles-deploy" "${file}"
 
@@ -40,7 +40,7 @@ run_deploy_cmr_bundle() {
 run_deploy_exported_bundle() {
     echo
 
-    file="${TEST_DIR}/test-export-bundles-deploy.txt"
+    file="${TEST_DIR}/test-export-bundles-deploy.log"
 
     ensure "test-export-bundles-deploy" "${file}"
 
@@ -58,7 +58,7 @@ run_deploy_exported_bundle() {
 run_deploy_trusted_bundle() {
     echo
 
-    file="${TEST_DIR}/test-trusted-bundles-deploy.txt"
+    file="${TEST_DIR}/test-trusted-bundles-deploy.log"
 
     ensure "test-trusted-bundles-deploy" "${file}"
 
@@ -80,7 +80,7 @@ run_deploy_lxd_profile_bundle_openstack() {
     echo
 
     model_name="test-deploy-lxd-profile-bundle-o7k"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 
@@ -113,7 +113,7 @@ run_deploy_lxd_profile_bundle() {
     echo
 
     model_name="test-deploy-lxd-profile-bundle"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -31,6 +31,8 @@ run_deploy_cmr_bundle() {
     sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" > "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
     juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 
+    wait_for "wordpress" "$(idle_condition "wordpress")"
+
     destroy_model "test-cmr-bundles-deploy"
     destroy_model "other"
 }
@@ -92,8 +94,8 @@ run_deploy_lxd_profile_bundle_openstack() {
     wait_for "neutron-api" "$(idle_condition "neutron-api" 4)"
     wait_for "neutron-gateway" "$(idle_condition "neutron-gateway" 5)"
     wait_for "nova-compute" "$(idle_condition "nova-compute" 8)"
-    wait_for "lxd" "$(idle_subordinate_condition "lxd" "nova-compute" 2)"
-    wait_for "neutron-openvswitch" "$(idle_subordinate_condition "neutron-openvswitch" "nova-compute" 6)"
+    wait_for "lxd" "$(idle_subordinate_condition "lxd" "nova-compute")"
+    wait_for "neutron-openvswitch" "$(idle_subordinate_condition "neutron-openvswitch" "nova-compute")"
     wait_for "nova-cloud-controller" "$(idle_condition "nova-cloud-controller" 7)"
 
     lxd_profile_name="juju-${model_name}-neutron-openvswitch"

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -1,7 +1,7 @@
 run_deploy_charm() {
     echo
 
-    file="${TEST_DIR}/test-deploy-charm.txt"
+    file="${TEST_DIR}/test-deploy-charm.log"
 
     ensure "test-deploy-charm" "${file}"
 
@@ -14,7 +14,7 @@ run_deploy_charm() {
 run_deploy_lxd_profile_charm() {
     echo
 
-    file="${TEST_DIR}/test-deploy-lxd-profile.txt"
+    file="${TEST_DIR}/test-deploy-lxd-profile.log"
 
     ensure "test-deploy-lxd-profile" "${file}"
 
@@ -29,7 +29,7 @@ run_deploy_lxd_profile_charm() {
 run_deploy_lxd_profile_charm_container() {
     echo
 
-    file="${TEST_DIR}/test-deploy-lxd-profile.txt"
+    file="${TEST_DIR}/test-deploy-lxd-profile.log"
 
     ensure "test-deploy-lxd-profile-container" "${file}"
 
@@ -45,7 +45,7 @@ run_deploy_lxd_profile_charm_container() {
 run_deploy_local_lxd_profile_charm() {
     echo
 
-    file="${TEST_DIR}/test-deploy-local-lxd-profile.txt"
+    file="${TEST_DIR}/test-deploy-local-lxd-profile.log"
 
     ensure "test-deploy-local-lxd-profile" "${file}"
 
@@ -89,7 +89,7 @@ run_deploy_lxd_to_machine() {
     echo
 
     model_name="test-deploy-lxd-machine"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 
@@ -146,7 +146,7 @@ run_deploy_lxd_to_container() {
     echo
 
     model_name="test-deploy-lxd-container"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 
@@ -156,7 +156,7 @@ run_deploy_lxd_to_container() {
     wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 
     INST_ID=$(juju status --format=json | jq -r ".machines | .[\"0\"] | .[\"instance-id\"]")
-    OUT=$(lxc exec ${INST_ID} -- sh -c "lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-0\"")
+    OUT=$(lxc exec "${INST_ID}" -- sh -c "lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-0\"")
     echo "${OUT}" | grep "linux.kernel_modules: nbd,ip_tables,ip6_tables"
 
     juju upgrade-charm "lxd-profile-alt" --path "${charm}"
@@ -168,7 +168,7 @@ run_deploy_lxd_to_container() {
 
     attempt=0
     while true; do
-        OUT=$(lxc exec ${INST_ID} -- sh -c "lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-1\"" || echo 'NOT FOUND')
+        OUT=$(lxc exec "${INST_ID}" -- sh -c "lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-1\"" || echo 'NOT FOUND')
         if echo "${OUT}" | grep -q "linux.kernel_modules: nbd,ip_tables,ip6_tables"; then
             break
         fi
@@ -184,7 +184,7 @@ run_deploy_lxd_to_container() {
     # Ensure that the old one is removed
     attempt=0
     while true; do
-        OUT=$(lxc exec ${INST_ID} -- sh -c "lxc profile list" || echo 'NOT FOUND')
+        OUT=$(lxc exec "${INST_ID}" -- sh -c "lxc profile list" || echo 'NOT FOUND')
         if echo "${OUT}" | grep -v "juju-test-deploy-lxd-container-lxd-profile-alt-0"; then
             break
         fi
@@ -210,17 +210,18 @@ test_deploy_charms() {
         cd .. || exit
 
         run "run_deploy_charm"
-        run "run_deploy_lxd_to_container"
         run "run_deploy_lxd_profile_charm_container"
 
         case "${BOOTSTRAP_PROVIDER:-}" in
             "lxd")
                 run "run_deploy_lxd_to_machine"
+                run "run_deploy_lxd_to_container"
                 run "run_deploy_lxd_profile_charm"
                 run "run_deploy_local_lxd_profile_charm"
                 ;;
             "localhost")
                 run "run_deploy_lxd_to_machine"
+                run "run_deploy_lxd_to_container"
                 run "run_deploy_lxd_profile_charm"
                 run "run_deploy_local_lxd_profile_charm"
                 ;;

--- a/tests/suites/deploy/export_overlay.sh
+++ b/tests/suites/deploy/export_overlay.sh
@@ -1,7 +1,7 @@
 run_cmr_bundles_export_overlay() {
     echo
 
-    file="${TEST_DIR}/test-cmr-bundles-export-overlay.txt"
+    file="${TEST_DIR}/test-cmr-bundles-export-overlay.log"
 
     ensure "cmr-bundles-test-export-overlay" "${file}"
 
@@ -16,13 +16,13 @@ run_cmr_bundles_export_overlay() {
 
     juju add-model test1
 
-    echo -n 'my-include' > example.txt
+    echo -n 'my-include' > example.log
     cat > overlay.yaml << EOT
 applications:
   wordpress:
     annotations:
-      raw: include-file://example.txt
-      enc: include-base64://example.txt
+      raw: include-file://example.log
+      enc: include-base64://example.log
 EOT
 
     juju deploy ./testcharms/charm-repo/bundle/multi-doc-overlays --overlay overlay.yaml

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -9,7 +9,7 @@ test_deploy() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-deploy-ctl.txt"
+    file="${TEST_DIR}/test-deploy-ctl.log"
 
     bootstrap "test-deploy-ctl" "${file}"
 

--- a/tests/suites/examples/example.sh
+++ b/tests/suites/examples/example.sh
@@ -3,7 +3,7 @@ run_example1() {
     echo
 
     # The following ensures that a bootstrap juju exists
-    file="${TEST_DIR}/test-example1.txt"
+    file="${TEST_DIR}/test-example1.log"
     ensure "example1" "${file}"
 
     # Run your checks here
@@ -16,7 +16,7 @@ run_example1() {
 run_example2() {
     echo
 
-    file="${TEST_DIR}/test-example2.txt"
+    file="${TEST_DIR}/test-example2.log"
     ensure "example2" "${file}"
 
     echo "Hello example 2!" | check "Hello example 2!"

--- a/tests/suites/examples/other.sh
+++ b/tests/suites/examples/other.sh
@@ -1,7 +1,7 @@
 run_other() {
     echo
 
-    file="${TEST_DIR}/test-other.txt"
+    file="${TEST_DIR}/test-other.log"
     ensure "other" "${file}"
 
     echo "Hello other!"

--- a/tests/suites/examples/task.sh
+++ b/tests/suites/examples/task.sh
@@ -9,7 +9,7 @@ test_examples() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-example.txt"
+    file="${TEST_DIR}/test-example.log"
 
     bootstrap "test-example" "${file}"
 

--- a/tests/suites/hooks/dispatch.sh
+++ b/tests/suites/hooks/dispatch.sh
@@ -3,7 +3,7 @@ run_hook_dispatching_script() {
     echo
 
     model_name="test-hook-dispatching"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -2,7 +2,7 @@ run_start_hook_fires_after_reboot() {
     echo
 
     model_name="test-start-hook-fires-after-reboot"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 
@@ -60,7 +60,7 @@ run_reboot_monitor_state_cleanup() {
     echo
 
     model_name="test-reboot-monitor-state-cleanup"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 

--- a/tests/suites/hooks/task.sh
+++ b/tests/suites/hooks/task.sh
@@ -9,7 +9,7 @@ test_hooks() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-hooks.txt"
+    file="${TEST_DIR}/test-hooks.log"
 
     bootstrap "test-hooks" "${file}"
 

--- a/tests/suites/hooktools/state_tools.sh
+++ b/tests/suites/hooktools/state_tools.sh
@@ -2,7 +2,7 @@ run_state_delete_get_set() {
     echo
 
     model_name="test-state-delete-get-set"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 
@@ -30,7 +30,7 @@ run_state_set_clash_uniter_state() {
     echo
 
     model_name="test-state-set-clash-uniter-state"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 

--- a/tests/suites/hooktools/task.sh
+++ b/tests/suites/hooktools/task.sh
@@ -9,7 +9,7 @@ test_hooktools() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-hooktools.txt"
+    file="${TEST_DIR}/test-hooktools.log"
 
     bootstrap "test-hooktools" "${file}"
 

--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -3,7 +3,7 @@ test_log_permissions() {
   echo
 
   # The following ensures that a bootstrap juju exists
-  file="${TEST_DIR}/test_log_permissions.txt"
+  file="${TEST_DIR}/test_log_permissions.log"
   ensure "correct-log" "${file}"
 
   juju deploy postgresql

--- a/tests/suites/machine/task.sh
+++ b/tests/suites/machine/task.sh
@@ -7,7 +7,7 @@ test_machine() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-machine.txt"
+    file="${TEST_DIR}/test-machine.log"
 
     bootstrap "test-machine" "${file}"
 

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -41,7 +41,7 @@ manual_deploy() {
 
     juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
 
-    file="${TEST_DIR}/test-${name}.txt"
+    file="${TEST_DIR}/test-${name}.log"
 
     bootstrap "${cloud_name}" "test-${name}" "${file}"
 

--- a/tests/suites/model/model_migration.sh
+++ b/tests/suites/model/model_migration.sh
@@ -5,7 +5,7 @@ run_model_migration() {
     echo
 
     # The following ensures that a bootstrap juju exists.
-    file="${TEST_DIR}/test-model-migration.txt"
+    file="${TEST_DIR}/test-model-migration.log"
     ensure "model-migration" "${file}"
 
     # Ensure we have another controller available.
@@ -41,7 +41,7 @@ run_model_migration_saas_common() {
     echo
 
     # The following ensures that a bootstrap juju exists.
-    file="${TEST_DIR}/test-model-migration-saas-common.txt"
+    file="${TEST_DIR}/test-model-migration-saas-common.log"
     ensure "model-migration-saas" "${file}"
 
     # Ensure we have another controller available.
@@ -100,7 +100,7 @@ run_model_migration_saas_external() {
     echo
 
     # The following ensures that a bootstrap juju exists.
-    file="${TEST_DIR}/test-model-migration-saas-external.txt"
+    file="${TEST_DIR}/test-model-migration-saas-external.log"
     ensure "model-migration-saas" "${file}"
 
     # Ensure we have controllers for the consuming model
@@ -161,7 +161,7 @@ run_model_migration_saas_consumer() {
     echo
 
     # The following ensures that a bootstrap juju exists.
-    file="${TEST_DIR}/test-model-migration-saas-consumer.txt"
+    file="${TEST_DIR}/test-model-migration-saas-consumer.log"
     ensure "model-migration-saas" "${file}"
 
     # Ensure we have controllers for the consuming model
@@ -247,7 +247,7 @@ bootstrap_alt_controller() {
     START_TIME=$(date +%s)
     echo "====> Bootstrapping ${name}"
 
-    file="${TEST_DIR}/${name}.txt"
+    file="${TEST_DIR}/${name}.log"
     juju_bootstrap "${BOOTSTRAP_PROVIDER}" "${name}" "misc" "${file}"
 
     END_TIME=$(date +%s)

--- a/tests/suites/model/task.sh
+++ b/tests/suites/model/task.sh
@@ -9,7 +9,7 @@ test_model() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-models.txt"
+    file="${TEST_DIR}/test-models.log"
 
     bootstrap "test-models" "${file}"
 

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -2,7 +2,7 @@ run_relation_data_exchange() {
     echo
 
     model_name="test-relation-data-exchange"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 

--- a/tests/suites/relations/relation_departing_unit.sh
+++ b/tests/suites/relations/relation_departing_unit.sh
@@ -2,7 +2,7 @@ run_relation_departing_unit() {
     echo
 
     model_name="test-relation-departing-unit"
-    file="${TEST_DIR}/${model_name}.txt"
+    file="${TEST_DIR}/${model_name}.log"
 
     ensure "${model_name}" "${file}"
 

--- a/tests/suites/relations/task.sh
+++ b/tests/suites/relations/task.sh
@@ -9,7 +9,7 @@ test_relations() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-relations.txt"
+    file="${TEST_DIR}/test-relations.log"
 
     bootstrap "test-relations" "${file}"
 

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -9,7 +9,7 @@ test_smoke() {
     echo "==> Checking for dependencies"
     check_dependencies juju
 
-    file="${TEST_DIR}/test-smoke.txt"
+    file="${TEST_DIR}/test-smoke.log"
 
     bootstrap "test-smoke" "${file}"
 

--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -1,7 +1,7 @@
 run_juju_bind() {
     echo
 
-    file="${TEST_DIR}/test-juju-bind.txt"
+    file="${TEST_DIR}/test-juju-bind.log"
 
     ensure "spaces-juju-bind" "${file}"
 

--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -16,7 +16,7 @@ test_spaces_ec2() {
     hotplug_nic_id=$(setup_nic_for_space_tests)
     echo "[+] created secondary NIC with ID ${hotplug_nic_id}"
 
-    file="${TEST_DIR}/test-spaces-ec2.txt"
+    file="${TEST_DIR}/test-spaces-ec2.log"
 
     bootstrap "test-spaces-ec2" "${file}"
 

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -1,7 +1,7 @@
 run_upgrade_charm_with_bind() {
     echo
 
-    file="${TEST_DIR}/test-upgrade-charm-with-bind-ec2.txt"
+    file="${TEST_DIR}/test-upgrade-charm-with-bind-ec2.log"
 
     ensure "spaces-upgrade-charm-with-bind-ec2" "${file}"
 


### PR DESCRIPTION
## Description of change

Whilst testing I noticed that we can be both idle and in an error
condition. That is clearly wrong. Instead, we should ensure that the
error state is correctly handled by the wait_for condition.

The code is really simple, check for both idle and not an error.

## QA steps

```sh
cd tests && ./main.sh deploy
```

## Bug reference

Found whilst testing https://github.com/juju/juju/pull/11701, which is in response to https://bugs.launchpad.net/juju/+bug/1876849

