### PR TITLE
[dev] Detach veth device from OVS bridge when removing LXD container

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -44,6 +44,12 @@ type ContainerSpec struct {
 // MiB suffix for memory constraints. By default we use "MB".
 var minMiBVersion = &version.DottedVersion{Major: 3, Minor: 10}
 
+// maybeRemovePortsFromOvsBridge attempts to remove portName from all OVS
+// bridges it is attached to. This function is overridden by tests.
+var maybeRemovePortFromOvsBridge = func(portName string) error {
+	return corenetwork.MaybeRemovePortFromOvsBridge(portName)
+}
+
 // ApplyConstraints applies the input constraints as valid LXD container
 // configuration to the container spec.
 // Note that we pass these through as supplied. If an instance type constraint
@@ -322,6 +328,13 @@ func (s *Server) RemoveContainer(name string) error {
 		}
 	}
 
+	// Attempt to manually remove ports from the system's OVS bridges. If
+	// the container is not bridged via OVS this is a no-op. This step is
+	// required for lxd versions older than 4.2.
+	if err = maybeRemovePortsFromOvsBridge(state); err != nil {
+		return errors.Trace(err)
+	}
+
 	// LXD has issues deleting containers, even if they've been stopped. The
 	// general advice passed back from the LXD team is to retry it again, to
 	// see if this helps clean up the containers.
@@ -349,6 +362,25 @@ func (s *Server) RemoveContainer(name string) error {
 	}
 	if err := retry.Call(retryArgs); err != nil {
 		return errors.Trace(errors.Cause(err))
+	}
+	return nil
+}
+
+// maybeRemovePortsFromOvsBridge attempts to remove the container virtual
+// ethernet devices from the OVS bridge they were attached to as LXD seems
+// unable to do this automatically. If none of the container devices were
+// attached to an OVS bridge, or the system does not support OVS, then this is
+// a no-op.
+func maybeRemovePortsFromOvsBridge(containerState *api.ContainerState) error {
+	for _, nic := range containerState.Network {
+		// We are only interested in NICs for which juju has explicitly
+		// specified a host interface name
+		if nic.HostName == "" {
+			continue
+		}
+		if err := maybeRemovePortFromOvsBridge(nic.HostName); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	return nil

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -61,11 +61,11 @@ func VerifyNICsWithConfigFile(svr *Server, nics map[string]device, reader func(s
 	return svr.verifyNICsWithConfigFile(nics, reader)
 }
 
-func NetworkDevicesFromConfig(mgr container.Manager, netConfig *container.NetworkConfig) (
+func NetworkDevicesFromConfig(mgr container.Manager, netConfig *container.NetworkConfig, machineID string) (
 	map[string]device, []string, error,
 ) {
 	cMgr := mgr.(*containerManager)
-	return cMgr.networkDevicesFromConfig(netConfig)
+	return cMgr.networkDevicesFromConfig(netConfig, machineID)
 }
 
 func NewTestingServer(svr lxdclient.ContainerServer, clock clock.Clock) (*Server, error) {

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -53,6 +53,10 @@ func PatchGetSnapManager(patcher patcher, mgr SnapManager) {
 	patcher.PatchValue(&getSnapManager, func() SnapManager { return mgr })
 }
 
+func PatchMaybeRemovePortFromOvsBridge(patcher patcher, fn func(string) error) {
+	patcher.PatchValue(&maybeRemovePortFromOvsBridge, fn)
+}
+
 func GetImageSources(mgr container.Manager) ([]ServerSpec, error) {
 	return mgr.(*containerManager).getImageSources()
 }

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -345,7 +345,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C
 	s.makeManager(c)
 	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Interfaces: interfaces,
-	})
+	}, "0/lxd/0")
 
 	c.Assert(err, gc.ErrorMatches, "parent interface name is empty")
 	c.Assert(result, gc.IsNil)
@@ -364,11 +364,12 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 
 	expected := map[string]map[string]string{
 		"eth0": {
-			"hwaddr":  "aa:bb:cc:dd:ee:f0",
-			"name":    "eth0",
-			"nictype": "bridged",
-			"parent":  "br-eth0",
-			"type":    "nic",
+			"hwaddr":    "aa:bb:cc:dd:ee:f0",
+			"name":      "eth0",
+			"nictype":   "bridged",
+			"parent":    "br-eth0",
+			"type":      "nic",
+			"host_name": "1lxd2-0",
 		},
 	}
 
@@ -376,7 +377,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 	result, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Device:     "lxdbr0",
 		Interfaces: interfaces,
-	})
+	}, "1/lxd/2")
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, expected)
@@ -397,7 +398,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigUnknownCIDR(c *gc.C) {
 	_, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Device:     "lxdbr0",
 		Interfaces: interfaces,
-	})
+	}, "1/lxd/2")
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(unknown, gc.DeepEquals, []string{"br-eth0"})
@@ -410,7 +411,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigNoInputGetsProfileNICs(c *gc.
 	s.cSvr.EXPECT().GetProfile("default").Return(defaultLegacyProfileWithNIC(), lxdtesting.ETag, nil)
 
 	s.makeManager(c)
-	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{})
+	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{}, "1/lxd/2")
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := map[string]map[string]string{
@@ -419,6 +420,8 @@ func (s *managerSuite) TestNetworkDevicesFromConfigNoInputGetsProfileNICs(c *gc.
 			"type":    "nic",
 			"nictype": "bridged",
 			"hwaddr":  "00:16:3e:00:00:00",
+			// NOTE: the host name will not be set because we get
+			// the NICs from the default profile.
 		},
 	}
 

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -467,13 +467,15 @@ func sortInterfacesByName(interfaces corenetwork.InterfaceInfos) {
 // unsupported protocols.
 const errIPV6NotSupported = `socket: address family not supported by protocol`
 
-// DevicesFromInterfaceInfo uses the input interface info collection to create a
-// map of network device configuration in the LXD format.
-// Names for any networks without a known CIDR are returned in a slice.
-func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos) (map[string]device, []string, error) {
+// DevicesFromInterfaceInfo uses the input interface info collection to create
+// a map of network device configuration in the LXD format. Names for any
+// networks without a known CIDR are returned in a slice. The machineID arg is
+// used for generating predictable host interface names for the container's
+// ethernet devices.
+func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos, machineID string) (map[string]device, []string, error) {
 	nics := make(map[string]device, len(interfaces))
 	var unknown []string
-
+	var nicCount int
 	for _, v := range interfaces {
 		if v.InterfaceType == corenetwork.LoopbackInterface {
 			continue
@@ -487,7 +489,9 @@ func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos) (map[string
 		if v.CIDR == "" {
 			unknown = append(unknown, v.ParentInterfaceName)
 		}
-		nics[v.InterfaceName] = newNICDevice(v.InterfaceName, v.ParentInterfaceName, v.MACAddress, v.MTU)
+		hostIfaceName := makeHostInterfaceName(machineID, nicCount)
+		nics[v.InterfaceName] = newNICDevice(v.InterfaceName, v.ParentInterfaceName, hostIfaceName, v.MACAddress, v.MTU)
+		nicCount++
 	}
 
 	return nics, unknown, nil
@@ -498,13 +502,18 @@ func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos) (map[string
 // TODO (manadart 2018-06-21) We want to support nictype=macvlan too.
 // This will involve interrogating the parent device, via the server if it is
 // LXD managed, or via the container.NetworkConfig.DeviceType that this is
-// being generated from.
-func newNICDevice(deviceName, parentDevice, hwAddr string, mtu int) device {
+// being generated from. If the hostIfaceName argument is not empty, LXD will
+// use its value as the name of the container's virtual eth device on the host.
+// Otherwise, the host interface will be assigned a random unique value by LXD.
+func newNICDevice(deviceName, parentDevice, hostIfaceName, hwAddr string, mtu int) device {
 	device := map[string]string{
 		"type":    "nic",
 		"nictype": nicTypeBridged,
 		"name":    deviceName,
 		"parent":  parentDevice,
+	}
+	if hostIfaceName != "" {
+		device["host_name"] = hostIfaceName
 	}
 	if hwAddr != "" {
 		device["hwaddr"] = hwAddr
@@ -513,4 +522,13 @@ func newNICDevice(deviceName, parentDevice, hwAddr string, mtu int) device {
 		device["mtu"] = fmt.Sprintf("%v", mtu)
 	}
 	return device
+}
+
+// makeHostInterfaceName constructs and return a suitable name for the host
+// NIC that represents a virtual ethernet device attached to a container.
+func makeHostInterfaceName(machineID string, nicIndex int) string {
+	// Remove the slashes to make the final device name easier to parse,
+	// e.g. 0lxd1-1.
+	machineID = strings.Replace(machineID, "/", "", -1)
+	return fmt.Sprintf("%s-%d", machineID, nicIndex)
 }

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -660,7 +660,7 @@ func (s *networkSuite) TestEnableHTTPSListenerWithErrors(c *gc.C) {
 }
 
 func (s *networkSuite) TestNewNICDeviceWithoutMACAddressOrMTUGreaterThanZero(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "", 0)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "", "", 0)
 	expected := map[string]string{
 		"name":    "eth1",
 		"nictype": "bridged",
@@ -671,7 +671,7 @@ func (s *networkSuite) TestNewNICDeviceWithoutMACAddressOrMTUGreaterThanZero(c *
 }
 
 func (s *networkSuite) TestNewNICDeviceWithMACAddressButNoMTU(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "aa:bb:cc:dd:ee:f0", 0)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "", "aa:bb:cc:dd:ee:f0", 0)
 	expected := map[string]string{
 		"hwaddr":  "aa:bb:cc:dd:ee:f0",
 		"name":    "eth1",
@@ -683,7 +683,7 @@ func (s *networkSuite) TestNewNICDeviceWithMACAddressButNoMTU(c *gc.C) {
 }
 
 func (s *networkSuite) TestNewNICDeviceWithoutMACAddressButMTUGreaterThanZero(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "", 1492)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "", "", 1492)
 	expected := map[string]string{
 		"mtu":     "1492",
 		"name":    "eth1",
@@ -695,7 +695,7 @@ func (s *networkSuite) TestNewNICDeviceWithoutMACAddressButMTUGreaterThanZero(c 
 }
 
 func (s *networkSuite) TestNewNICDeviceWithMACAddressAndMTUGreaterThanZero(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "aa:bb:cc:dd:ee:f0", 9000)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "", "aa:bb:cc:dd:ee:f0", 9000)
 	expected := map[string]string{
 		"hwaddr":  "aa:bb:cc:dd:ee:f0",
 		"mtu":     "9000",
@@ -703,6 +703,18 @@ func (s *networkSuite) TestNewNICDeviceWithMACAddressAndMTUGreaterThanZero(c *gc
 		"nictype": "bridged",
 		"parent":  "br-eth1",
 		"type":    "nic",
+	}
+	c.Assert(device, gc.DeepEquals, expected)
+}
+
+func (s *networkSuite) TestNewNICDeviceWithAssignedHostNICName(c *gc.C) {
+	device := lxd.NewNICDevice("eth1", "br-eth1", "1lxd2-0", "", 0)
+	expected := map[string]string{
+		"name":      "eth1",
+		"nictype":   "bridged",
+		"parent":    "br-eth1",
+		"type":      "nic",
+		"host_name": "1lxd2-0",
 	}
 	c.Assert(device, gc.DeepEquals, expected)
 }


### PR DESCRIPTION
## Description of change

When bridging the virtual ethernet device from an LXD container to an OVS bridge on the host, LXD correctly attaches the device to the bridge but does not remove it when the container gets destroyed (lxd<4.2; bionic). As a result, running `ovs-vsctl show` yields the following output:

```console
$ ovs-vsctl show
430499db-d52f-4173-8e9f-3eec229c7b25
    Bridge "ovsbr0"
        Port "ovsbr0"
            Interface "ovsbr0"
                type: internal
        Port "ens4"
            Interface "ens4"
        Port "veth4PESPA"
            Interface "veth4PESPA"
                error: "could not open network device veth4PESPA (No such device)"
    ovs_version: "2.9.5"
```

In order to fix this, we need to make a call to `ovs-vsctl del-port --if-exists X` during container cleanup. However, this requires that juju is aware of the host device name for each virtual ethernet device belonging to the container that goes away. By default, LXD assigns a random name but it is possible to provide a user-defined name instead.

To this end, juju will now assign predictable device names to LXD veth devices using the following pattern `$machineID-$device_index` (where `$machineID` is the container machine ID with the slashes removed, e.g. `0/lxd/1` becomes `0lxd1`). 

This change allows us to properly clean up the veth devices (if not using OVS, these are all no-ops) and as a bonus makes it easier to identify devices in `ip a` output as well as inside the mongo documents.

## QA steps

Follow the instructions from https://github.com/juju/juju/pull/11714 to provision some manual machines using bionic images (referred to below as kvm-1, kvm-2, kvm-3) and set up an OVS bridge on **one** of them.

```sh
# Use kvm-1 as the controller
$ juju bootstrap manual/ubuntu@10.0.0.2 --no-gui 

# Add two machines; for kvm-2 use the IP assigned to ovsbr0
$ juju add-machine ssh:ubuntu@$ovsbr0-ip
$ juju add-machine ssh:ubuntu@10.0.0.4

$ juju deploy wordpress --to lxd:0 
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to lxd:1 

# Run ovs-vsctl on kvm-2 (the one with the OVS bridge) and check that the veth is attached and named correctly
$ ovs-vsctl show
430499db-d52f-4173-8e9f-3eec229c7b25
    Bridge "ovsbr0"
        Port "ovsbr0"
            Interface "ovsbr0"
                type: internal
        Port "ens4"
            Interface "ens4"
        Port "0lxd0-0"                     <--- look for this
            Interface "0lxd0-0"
    ovs_version: "2.9.5"

# Teardown the controllers and ensure that the device is removed from the OVS bridge
$ juju remove-application wordpress
$ juju remove-application ubuntu-lite

$ ovs-vsctl show
430499db-d52f-4173-8e9f-3eec229c7b25
    Bridge "ovsbr0"
        Port "ovsbr0"
            Interface "ovsbr0"
                type: internal
        Port "ens4"
            Interface "ens4"
    ovs_version: "2.9.5"
```