### PR TITLE
Do not create juju-clean-shutdown.service for systemd

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -486,9 +486,6 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-quantal-amd64\.sha256
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
 set -xe
-install -D -m 644 /dev/null '/etc/systemd/system/juju-clean-shutdown\.service'
-printf '%s\\n' '\\n\[Unit\]\\n.*Stop all network interfaces.*WantedBy=final\.target\\n' > '/etc/systemd.*'
-/bin/systemctl enable '/etc/systemd/system/juju-clean-shutdown\.service'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 .*

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/service"
-	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
 )
 
@@ -221,12 +220,8 @@ func (w *unixConfigure) ConfigureBasic() error {
 func (w *unixConfigure) addCleanShutdownJob(initSystem string) {
 	switch initSystem {
 	case service.InitSystemUpstart:
-		path, contents := upstart.CleanShutdownJobPath, upstart.CleanShutdownJob
-		w.conf.AddRunTextFile(path, contents, 0644)
-	case service.InitSystemSystemd:
-		path, contents := systemd.CleanShutdownServicePath, systemd.CleanShutdownService
-		w.conf.AddRunTextFile(path, contents, 0644)
-		w.conf.AddScripts(fmt.Sprintf("/bin/systemctl enable '%s'", path))
+		p, contents := upstart.CleanShutdownJobPath, upstart.CleanShutdownJob
+		w.conf.AddRunTextFile(p, contents, 0644)
 	}
 }
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -409,8 +409,6 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(keys, jc.SameContents, []string{"output", "users", "runcmd", "ssh_keys"})
 	c.Assert(userDataMap["runcmd"], jc.DeepEquals, []interface{}{
 		"set -xe",
-		"install -D -m 644 /dev/null '/etc/systemd/system/juju-clean-shutdown.service'",
-		"printf '%s\\n' '\n[Unit]\nDescription=Stop all network interfaces on shutdown\nDefaultDependencies=false\nAfter=final.target\n\n[Service]\nType=oneshot\nExecStart=/sbin/ifdown -a -v --force\nStandardOutput=tty\nStandardError=tty\n\n[Install]\nWantedBy=final.target\n' > '/etc/systemd/system/juju-clean-shutdown.service'", "/bin/systemctl enable '/etc/systemd/system/juju-clean-shutdown.service'",
 		"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
 		"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
 	})

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -11,12 +11,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/juju/core/paths"
-
 	"github.com/coreos/go-systemd/v22/unit"
 	"github.com/juju/errors"
 	"github.com/juju/utils/shell"
 
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/service/common"
 )
 
@@ -344,26 +343,3 @@ func deserializeOptions(opts []*unit.UnitOption, renderer shell.Renderer) (commo
 	err := validate("<>", conf, renderer)
 	return conf, errors.Trace(err)
 }
-
-// CleanShutdownService is added to machines to ensure DHCP-assigned
-// IP addresses are released on shutdown, reboot, or halt. See bug
-// http://pad.lv/1348663 for more info.
-const CleanShutdownService = `
-[Unit]
-Description=Stop all network interfaces on shutdown
-DefaultDependencies=false
-After=final.target
-
-[Service]
-Type=oneshot
-ExecStart=/sbin/ifdown -a -v --force
-StandardOutput=tty
-StandardError=tty
-
-[Install]
-WantedBy=final.target
-`
-
-// CleanShutdownServicePath is the full file path where
-// CleanShutdownService is created.
-const CleanShutdownServicePath = "/etc/systemd/system/juju-clean-shutdown.service"


### PR DESCRIPTION
## Description of change

This patch removes the creation of the clean shutdown service on machines running systemd.

It doesn't even work for systems running netplan, and the original (venerable) issue addressed by its introduction appears not to require it any longer:
https://bugs.launchpad.net/juju-core/+bug/1348663

The removal is conservative in that Windows and Upstart-based operating systems remain untouched.

## QA steps

- Bootstrap to MAAS and add a machine.
- `juju add-machine lxd:0 --series trusty`.
- `juju add-machine lxd:0 --series xenial`.
- `juju add-machine lxd:0 --series bionic`.
- Wait for the containers to come up, then SSH to one and ensure that the `juju-clean-shutdown` service is absent.
- Navigate to the subnet for which MAAS is providing DHCP - something like ```http://<server>:5240/MAAS/#/subnet/<id>``` and observe the IPs assigned to each of the containers.
- One by one, remove the container machines and observe that the IPs are released, disappearing from the allocation list.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1878639
