### PR TITLE
[2.7] Support KVM for focal hosts

### DIFF
--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -41,6 +41,19 @@ func ContainerFromInstance(inst instances.Instance) Container {
 	return kvm.container
 }
 
+// Patcher defines an interface that matches the PatchValue method on
+// CleanupSuite
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}
+
+// PatchGetHostSeries allows tests to override host series detection.
+func PatchGetHostSeries(p Patcher, fn func() (string, error)) {
+	p.PatchValue(&getHostSeries, func() (string, error) {
+		return fn()
+	})
+}
+
 // NewRunStub is a stub to fake shelling out to os.Exec or utils.RunCommand.
 func NewRunStub(output string, err error) *runStub {
 	return &runStub{output: output, err: err}

--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -158,10 +158,11 @@ func generateOSElement(p domainParams) OS {
 // generateFeaturesElement generates the appropriate features element based on
 // the architecture.
 func generateFeaturesElement(p domainParams) *Features {
+	f := new(Features)
 	if p.Arch() == arch.ARM64 {
-		return &Features{GIC: &GIC{Version: "host"}}
+		f.GIC = &GIC{Version: "host"}
 	}
-	return nil
+	return f
 }
 
 // generateCPU infor generates any model/fallback related settings. These are
@@ -235,11 +236,11 @@ type NVRAMCode struct {
 	Type     string `xml:"type,attr,omitempty"`
 }
 
-// Features is only generated for ARM64 at the time of this writing. This is
-// because GIC is required for ARM64.
-// See: https://libvirt.org/formatdomain.html#elementsFeatures
+// Features allows us to request one or more hypervisor features to be toggled
+// on/off. See: https://libvirt.org/formatdomain.html#elementsFeatures
 type Features struct {
-	GIC *GIC `xml:"gic,omitempty"`
+	GIC  *GIC   `xml:"gic,omitempty"`
+	ACPI string `xml:"acpi"`
 }
 
 // GIC is the Generic Interrupt Controller and is required to UEFI boot on

--- a/container/kvm/libvirt/domainxml_test.go
+++ b/container/kvm/libvirt/domainxml_test.go
@@ -30,6 +30,9 @@ var amd64DomainStr = `
     <os>
         <type>hvm</type>
     </os>
+    <features>
+        <acpi></acpi>
+    </features>
     <devices>
         <disk device="disk" type="file">
             <driver type="qcow2" name="qemu"></driver>
@@ -70,6 +73,7 @@ var arm64DomainStr = `
     </os>
     <features>
         <gic version="host"></gic>
+        <acpi></acpi>
     </features>
     <cpu mode="custom" match="exact">
         <model fallback="allow">cortex-a53</model>

--- a/packaging/dependency/kvm.go
+++ b/packaging/dependency/kvm.go
@@ -20,28 +20,37 @@ type kvmDependency struct {
 
 // PackageList implements packaging.Dependency.
 func (dep kvmDependency) PackageList(series string) ([]packaging.Package, error) {
+	if series == "centos7" || series == "opensuseleap" {
+		return nil, errors.NotSupportedf("installing kvm on series %q", series)
+	}
+
 	var pkgList []string
+	if dep.arch == arch.ARM64 {
+		// ARM64 doesn't support legacy BIOS so it requires Extensible Firmware
+		// Interface.
+		pkgList = append(pkgList, "qemu-efi")
+	}
+
+	pkgList = append(pkgList,
+		// `qemu-kvm` must be installed before `libvirt-bin` on trusty. It appears
+		// that upstart doesn't reload libvirtd if installed after, and we see
+		// errors related to `qemu-kvm` not being installed.
+		"qemu-kvm",
+		"qemu-utils",
+		"genisoimage",
+	)
 
 	switch series {
-	case "centos7", "opensuseleap":
-		return nil, errors.NotSupportedf("installing kvm on series %q", series)
+	case "precise", "trusty", "xenial", "bionic", "eoan":
+		pkgList = append(pkgList, "libvirt-bin")
 	default:
-		if dep.arch == arch.ARM64 {
-			// ARM64 doesn't support legacy BIOS so it requires Extensible Firmware
-			// Interface.
-			pkgList = append(pkgList, "qemu-efi")
-		}
-
+		// On focal+ virsh is provided by libvirt-clients; also we need
+		// to install the daemon package separately.
 		pkgList = append(pkgList,
-			// `qemu-kvm` must be installed before `libvirt-bin` on trusty. It appears
-			// that upstart doesn't reload libvirtd if installed after, and we see
-			// errors related to `qemu-kvm` not being installed.
-			"qemu-kvm",
-			"qemu-utils",
-			"genisoimage",
-			"libvirt-bin",
+			"libvirt-daemon-system",
+			"libvirt-clients",
 		)
-
-		return packaging.MakePackageList(packaging.AptPackageManager, "", pkgList...), nil
 	}
+
+	return packaging.MakePackageList(packaging.AptPackageManager, "", pkgList...), nil
 }


### PR DESCRIPTION
## Description of change

This PR back-ports a fix for https://bugs.launchpad.net/juju/+bug/1883575 by ensuring that the correct set of apt packages are installed for focal+ and that the format for the backing root image is explicitly passed as an argument to qemu-img calls.

In addition, this PR enables the `acpi` feature for KVM containers.

## QA steps

Bootstrap a controller and add two kvm-capable machines (I provisioned them using MAAS), one with a **bionic** image and one with a **focal** image.

Then run the following steps and make sure 'juju status' is happy.

```console
# Machine 0 is the bionic one; machine 1 is the focal one
$ juju deploy wordpress --to kvm:0 
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to kvm:1 --series focal --force

# Verify that the ACPI feature has been added to the VM definition by running (in both kvm machines)
$ virsh dumpxml `virsh list | grep juju | awk '{print $2}'` | grep '<features>' -A 2
  <features>
    <acpi/>
  </features>
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1883575
https://bugs.launchpad.net/juju/+bug/1883792