### PR TITLE
Static link and strip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ PROJECT := github.com/juju/juju
 
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
-HOST_GOOS=$(shell GOOS= GOARCH= go env GOOS)
-HOST_GOARCH=$(shell GOOS= GOARCH= go env GOARCH)
+GOHOSTOS=$(shell go env GOHOSTOS)
+GOHOSTARCH=$(shell go env GOHOSTARCH)
+export CGO_ENABLED=0
 
 BUILD_DIR ?= $(PROJECT_DIR)/_build
 BIN_DIR = ${BUILD_DIR}/${GOOS}_${GOARCH}/bin
@@ -69,7 +70,7 @@ ifeq ($(shell echo "${GOARCH}" | sed -E 's/.*(ppc64le|ppc64).*/golang/'), golang
 else
 	COMPILE_FLAGS =
 endif
-    LINK_FLAGS = -ldflags "-s -w -X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) -X $(PROJECT)/version.build=$(JUJU_BUILD_NUMBER)"
+    LINK_FLAGS = -ldflags "-s -w -extldflags '-static' -X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) -X $(PROJECT)/version.build=$(JUJU_BUILD_NUMBER)"
 endif
 
 define DEPENDENCIES
@@ -241,7 +242,7 @@ push-release-operator-image: operator-image
 
 host-install:
 ## install juju for host os/architecture
-	GOOS=$(HOST_GOOS) GOARCH=$(HOST_GOARCH) make install
+	GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) make install
 
 microk8s-operator-update: host-install operator-image
 ## microk8s-operator-update: Push up the newly built operator image for use with microk8s

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,6 +53,8 @@ parts:
       github.com/juju/juju/version.build: ""
     # go-static is not supported by the standard go plugin.
     go-static: true
+    # go-strip is not supported by the standard go plugin.
+    go-strip: true
     override-build: |
       snapcraftctl build
 


### PR DESCRIPTION
## Description of change

- Snap'd bins now strip debug info.
- Makefile bins now build without CGO and are statically linked.

## QA steps

Check static linked bins
```
make build
ldd _build/`go env GOOS`_`go env GOARCH`/bin/jujud
du -h _build/`go env GOOS`_`go env GOARCH`/bin/*
```

Check stripped snap bins
```
snapcraft --use-lxd
sudo snap install juju_2.8.1_amd64.snap --dangerous --classic
which juju
ldd /snap/juju/current/bin/jujud
du -h /snap/juju/current/bin/*
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1883703
https://bugs.launchpad.net/juju/+bug/1875481
