### PR TITLE
Adds support for host pid support to pod spec.

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2451,6 +2451,7 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 				spec.Pod.ReadinessGates = k8sResources.Pod.ReadinessGates
 				spec.Pod.DNSPolicy = k8sResources.Pod.DNSPolicy
 				spec.Pod.HostNetwork = k8sResources.Pod.HostNetwork
+				spec.Pod.HostPID = k8sResources.Pod.HostPID
 			}
 			spec.ServiceAccounts = append(spec.ServiceAccounts, &k8sResources.K8sRBACResources)
 		}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -151,6 +151,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 				},
 				DNSPolicy:   core.DNSClusterFirst,
 				HostNetwork: true,
+				HostPID:     true,
 			},
 		},
 	}
@@ -196,6 +197,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 		},
 		DNSPolicy:                    core.DNSClusterFirst,
 		HostNetwork:                  true,
+		HostPID:                      true,
 		ServiceAccountName:           "app-name",
 		AutomountServiceAccountToken: boolPtr(true),
 		InitContainers:               initContainers(),

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -88,6 +88,7 @@ type PodSpec struct {
 	ReadinessGates                []core.PodReadinessGate  `json:"readinessGates,omitempty" yaml:"readinessGates,omitempty"`
 	DNSPolicy                     core.DNSPolicy           `json:"dnsPolicy,omitempty" yaml:"dnsPolicy,omitempty"`
 	HostNetwork                   bool                     `json:"hostNetwork,omitempty" yaml:"hostNetwork,omitempty"`
+	HostPID                       bool                     `json:"hostPID,omitempty" yaml:"hostPID,omitempty"`
 }
 
 // IsEmpty checks if PodSpec is empty or not.

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -202,6 +202,7 @@ kubernetesResources:
       - conditionType: PodScheduled
     dnsPolicy: ClusterFirstWithHostNet
     hostNetwork: true
+    hostPID: true
   secrets:
     - name: build-robot-secret
       type: Opaque
@@ -716,6 +717,7 @@ echo "do some stuff here for gitlab-init container"
 					},
 					DNSPolicy:   "ClusterFirstWithHostNet",
 					HostNetwork: true,
+					HostPID:     true,
 				},
 				Secrets: []k8sspecs.Secret{
 					{


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Adds the ability to set the HostPID attribute to a CAAS pod spec that will in turn control a Kubernetes pod attribute of the same name.

## QA steps

Run CAAS Kubernetes unit tests.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1883934

