### PR TITLE
Upgrade Step for Link-Layer Devices Named "unsupportedx"

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2821,15 +2821,15 @@ func AddOriginToIPAddresses(pool *StatePool) error {
 		}
 
 		// Set the origin to OriginProvider as the default ip address origin.
-		// The expectation is that the instancepoller will set all ip addresses
-		// that it knows about as a OriginProvier and anything it doesn't as a
-		// OriginMachine.
-		// The instancepoller will quiesce on the right value after the first
+		// The expectation is that the instance poller will set all IP
+		// addresses that it knows about to OriginProvider and anything it
+		// doesn't to OriginMachine.
+		// The instance poller will quiesce on the right value after the first
 		// run.
 		//
-		// The state of the network.Origin is a statemachine as follows:
+		// The state of the network.Origin is a state-machine as follows:
 		//
-		//     OriginProvier -> OriginMachine -> Dead
+		//     OriginProvider -> OriginMachine -> Deleted
 		//
 		ops = append(ops, txn.Op{
 			C:      ipAddressesC,
@@ -2848,4 +2848,8 @@ func AddOriginToIPAddresses(pool *StatePool) error {
 func DropPresenceDatabase(pool *StatePool) error {
 	st := pool.SystemState()
 	return st.session.DB("presence").DropDatabase()
+}
+
+func RemoveUnsupportedLinkLayer(pool *StatePool) error {
+	return nil
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -81,6 +81,7 @@ type StateBackend interface {
 	AddOriginToIPAddresses() error
 	DropPresenceDatabase() error
 	DropLeasesCollection() error
+	RemoveUnsupportedLinkLayer() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -332,4 +333,8 @@ func (s stateBackend) DropPresenceDatabase() error {
 
 func (s stateBackend) DropLeasesCollection() error {
 	return state.DropLeasesCollection(s.pool)
+}
+
+func (s stateBackend) RemoveUnsupportedLinkLayer() error {
+	return state.RemoveUnsupportedLinkLayer(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -41,6 +41,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.7.0"), stateStepsFor27()},
 		upgradeToVersion{version.MustParse("2.7.7"), stateStepsFor277()},
 		upgradeToVersion{version.MustParse("2.8.0"), stateStepsFor28()},
+		upgradeToVersion{version.MustParse("2.8.1"), stateStepsFor281()},
 	}
 	return steps
 }

--- a/upgrades/sets_281_test.go
+++ b/upgrades/sets_281_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v281 = version.MustParse("2.8.1")
+
+type steps281Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps281Suite{})
+
+func (s *steps281Suite) TestRemoveUnsupportedLinkLayer(c *gc.C) {
+	step := findStateStep(c, v281, `remove "unsupported" link-layer device data`)
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/sets_281_test.go
+++ b/upgrades/sets_281_test.go
@@ -20,6 +20,11 @@ type steps281Suite struct {
 
 var _ = gc.Suite(&steps281Suite{})
 
+func (s *steps281Suite) TestAddOriginToIPAddresses(c *gc.C) {
+	step := findStateStep(c, v281, "add origin to IP addresses")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 func (s *steps281Suite) TestRemoveUnsupportedLinkLayer(c *gc.C) {
 	step := findStateStep(c, v281, `remove "unsupported" link-layer device data`)
 	// Logic for step itself is tested in state package.

--- a/upgrades/steps_28.go
+++ b/upgrades/steps_28.go
@@ -51,7 +51,7 @@ func stateStepsFor28() []Step {
 			},
 		},
 		&upgradeStep{
-			description: "add origin to ip addresses",
+			description: "add origin to IP addresses",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return context.State().AddOriginToIPAddresses()

--- a/upgrades/steps_281.go
+++ b/upgrades/steps_281.go
@@ -6,6 +6,15 @@ package upgrades
 // stateStepsFor281 returns upgrade steps for Juju 2.8.1.
 func stateStepsFor281() []Step {
 	return []Step{
+		// This step occurs for the 2.8.0 upgrade, but is repeated here due to
+		// now-fixed issues that could have unset address origin since.
+		&upgradeStep{
+			description: "add origin to IP addresses",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddOriginToIPAddresses()
+			},
+		},
 		&upgradeStep{
 			description: `remove "unsupported" link-layer device data`,
 			targets:     []Target{DatabaseMaster},

--- a/upgrades/steps_281.go
+++ b/upgrades/steps_281.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor281 returns upgrade steps for Juju 2.8.1.
+func stateStepsFor281() []Step {
+	return []Step{
+		&upgradeStep{
+			description: `remove "unsupported" link-layer device data`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveUnsupportedLinkLayer()
+			},
+		},
+	}
+}

--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -49,7 +49,7 @@ func (s *steps28Suite) TestAddMachineIDToSubordinates(c *gc.C) {
 }
 
 func (s *steps28Suite) TestAddOriginToIPAddresses(c *gc.C) {
-	step := findStateStep(c, v280, "add origin to ip addresses")
+	step := findStateStep(c, v280, "add origin to IP addresses")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -631,6 +631,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.7.0",
 		"2.7.7",
 		"2.8.0",
+		"2.8.1",
 	})
 }
 


### PR DESCRIPTION
## Description of change

This patch adds an upgrade step for version 2.8.1 that removes link-layer data for devices sourced from the EC2 provider with names beginning with "unsupported".

Such devices and addresses duplicate correctly named data sourced directly from the machine, and prevent updates via the new instance-poller logic.

At the same time, the 2.8.0 step for updating address origin is repeated, as this version had a subsequently fixed issue whereby addresses could achieve an empty origin value, regressing the step.

## QA steps

- Bootstrap to AWS with any prior version; I used 2.7 edge.
- Connect to Mongo and observe entries in the `linklayerdevices` and `ip.addresses` collections with names beginning with "unsupported".
- With this patch, run `juju upgrade-controller --build-agent`.
- Check the collections again to ensure that the unsupported devices and addresses are absent.
- Note also the "provider" origin on docs in the `ip.addresses` collection, where it was absent before.

## Documentation changes

None

## Bug reference

N/A
