### PR TITLE
Upgrade charmhelpers to include the linux_distribution missing fix fo…

### DIFF
--- a/caas/jujud-operator-requirements.txt
+++ b/caas/jujud-operator-requirements.txt
@@ -1,4 +1,4 @@
 pip>=7.0.0,<8.2.0
-charmhelpers>=0.4.0,<1.0.0
+charmhelpers>=0.20.15,<1.0.0
 charms.reactive>=0.1.0,<2.0.0
 kubernetes==10.0.*


### PR DESCRIPTION
## Description of change

Upgrade charmhelpers because current version breaks on python3.8 which is the python version on ubuntu 20.04. 

```
application-db1: 11:17:25 DEBUG unit.db1/0.install Traceback (most recent call last):
application-db1: 11:17:25 DEBUG unit.db1/0.install   File "/var/lib/juju/agents/unit-db1-0/charm/hooks/install", line 8, in <module>
application-db1: 11:17:25 DEBUG unit.db1/0.install     caas_base.init_config_states()
application-db1: 11:17:25 DEBUG unit.db1/0.install   File "lib/charms/layer/caas_base.py", line 31, in init_config_states
application-db1: 11:17:25 DEBUG unit.db1/0.install     from charms.reactive import set_state
application-db1: 11:17:25 DEBUG unit.db1/0.install   File "lib/charms/reactive/__init__.py", line 22, in <module>
application-db1: 11:17:25 DEBUG unit.db1/0.install     from .endpoints import *  # noqa
application-db1: 11:17:25 DEBUG unit.db1/0.install   File "lib/charms/reactive/endpoints.py", line 23, in <module>
application-db1: 11:17:25 DEBUG unit.db1/0.install     from charms.reactive.helpers import data_changed
application-db1: 11:17:25 DEBUG unit.db1/0.install   File "lib/charms/reactive/helpers.py", line 21, in <module>
application-db1: 11:17:25 DEBUG unit.db1/0.install     from charmhelpers.core import host
application-db1: 11:17:25 DEBUG unit.db1/0.install   File "lib/charmhelpers/core/host.py", line 41, in <module>
application-db1: 11:17:25 DEBUG unit.db1/0.install     __platform__ = get_platform()
application-db1: 11:17:25 DEBUG unit.db1/0.install   File "lib/charmhelpers/osplatform.py", line 13, in get_platform
application-db1: 11:17:25 DEBUG unit.db1/0.install     tuple_platform = platform.linux_distribution()
application-db1: 11:17:25 DEBUG unit.db1/0.install AttributeError: module 'platform' has no attribute 'linux_distribution'
application-db1: 11:17:25 TRACE juju.worker.uniter.context checking for reboot request
application-db1: 11:17:25 ERROR juju.worker.uniter.operation hook "install" (via explicit, bespoke hook script) failed: exit status 1
```

Note: we will need rebuild the CI test charm to include the latest charmhelpers lib as well.

## QA steps

deploy CAAS workload to see if install hook failed;

## Documentation changes

No

## Bug reference

None
