### PR TITLE
Ensure all HA controllers use the same bakery public keys

### DIFF
--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -56,7 +56,8 @@ func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	key, err := bakery.GenerateKey()
+	bakeryConfig := st.NewBakeryConfig()
+	key, err := bakeryConfig.GetOffersThirdPartyKey()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,6 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN76APTgBEdHkR/PSbpeY4I8cWeEA=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges v0.0.0-20200425015902-9e5ed4306b93 h1:ccyisx1a8mxq30KtEVLqiC+TXZbet6jneurdvc9ATCA=
-github.com/juju/bundlechanges v0.0.0-20200425015902-9e5ed4306b93/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
 github.com/juju/bundlechanges v0.0.0-20200610103550-2c584a1d0a20 h1:kh7sWk+OrZj3yHAj2widz7S9+xKPkjpfKtMuvmRK6DI=
 github.com/juju/bundlechanges v0.0.0-20200610103550-2c584a1d0a20/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596 h1:HxkKL4WZ8j/2q63vngE6poi5p1I6KzsxC0v93bvpDBM=

--- a/state/bakerystorage.go
+++ b/state/bakerystorage.go
@@ -29,3 +29,11 @@ func (st *State) NewBakeryStorage() (bakerystorage.ExpirableStorage, error) {
 		},
 	})
 }
+
+// NewBakeryConfig returns a new bakerystorage.BakeryConfig instance.
+func (st *State) NewBakeryConfig() bakerystorage.BakeryConfig {
+	collectionGetter := func(collection string) (mongo.Collection, func()) {
+		return st.db().GetCollection(collection)
+	}
+	return bakerystorage.NewBakeryConfig(controllersC, collectionGetter)
+}

--- a/state/bakerystorage/config.go
+++ b/state/bakerystorage/config.go
@@ -1,0 +1,169 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bakerystorage
+
+import (
+	"encoding/json"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/mongo"
+)
+
+var logger = loggo.GetLogger("juju.state.bakerystorage")
+
+const (
+	// Key for bakery config attributes.
+	bakeryConfigKey = "bakeryConfig"
+)
+
+type collectionGetterFunc func(name string) (mongo.Collection, func())
+
+// BakeryConfig defines methods used to access bakery configuration.
+type BakeryConfig interface {
+	InitialiseBakeryConfigOp() (txn.Op, error)
+	GetLocalUsersKey() (*bakery.KeyPair, error)
+	GetLocalUsersThirdPartyKey() (*bakery.KeyPair, error)
+	GetExternalUsersThirdPartyKey() (*bakery.KeyPair, error)
+	GetOffersThirdPartyKey() (*bakery.KeyPair, error)
+}
+
+// NewBakeryConfig returns an instance used to access bakery configuration.
+func NewBakeryConfig(collection string, collectionGetter collectionGetterFunc) BakeryConfig {
+	return &bakeryConfig{
+		collection:       collection,
+		collectionGetter: collectionGetter,
+	}
+}
+
+type bakeryConfig struct {
+	collection       string
+	collectionGetter collectionGetterFunc
+}
+
+type bakeryConfigDoc struct {
+	LocalUsersKey              string `bson:"local-users-key"`
+	LocalUsersThirdPartyKey    string `bson:"local-users-thirdparty-key"`
+	ExternalUsersThirdPartyKey string `bson:"external-users-thirdparty-key"`
+	OffersThirdPartyKey        string `bson:"offers-thirdparty-key"`
+}
+
+// InitialiseBakeryConfigOp returns a txn.Op used to create the bakery config in state.
+func (b *bakeryConfig) InitialiseBakeryConfigOp() (txn.Op, error) {
+	localUsersThirdPartyKey, err := bakery.GenerateKey()
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	localUsersThirdPartyKeyBytes, err := json.Marshal(localUsersThirdPartyKey)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+
+	externalUsersThirdPartyKey, err := bakery.GenerateKey()
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	externalUsersThirdPartyKeyBytes, err := json.Marshal(externalUsersThirdPartyKey)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+
+	localUsersKey, err := bakery.GenerateKey()
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	localUsersKeyBytes, err := json.Marshal(localUsersKey)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+
+	offersThirdPartyKey, err := bakery.GenerateKey()
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+	offersThirdPartyKeyBytes, err := json.Marshal(offersThirdPartyKey)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
+
+	return txn.Op{
+		C:      b.collection,
+		Id:     bakeryConfigKey,
+		Assert: txn.DocMissing,
+		Insert: &bakeryConfigDoc{
+			LocalUsersKey:              string(localUsersKeyBytes),
+			LocalUsersThirdPartyKey:    string(localUsersThirdPartyKeyBytes),
+			ExternalUsersThirdPartyKey: string(externalUsersThirdPartyKeyBytes),
+			OffersThirdPartyKey:        string(offersThirdPartyKeyBytes),
+		},
+	}, nil
+}
+
+// GetLocalUsersKey returns the key pair used with the local users bakery.
+func (b *bakeryConfig) GetLocalUsersKey() (*bakery.KeyPair, error) {
+	doc, err := b.bakeryConfigDoc()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return b.deserialiseKey(doc.LocalUsersKey, "local users key")
+}
+
+// GetLocalUsersThirdPartyKey returns the third party key pair used with the local users bakery.
+func (b *bakeryConfig) GetLocalUsersThirdPartyKey() (*bakery.KeyPair, error) {
+	doc, err := b.bakeryConfigDoc()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return b.deserialiseKey(doc.LocalUsersThirdPartyKey, "local users third party key")
+}
+
+// GetExternalUsersThirdPartyKey returns the third party key pair used with the external users bakery.
+func (b *bakeryConfig) GetExternalUsersThirdPartyKey() (*bakery.KeyPair, error) {
+	doc, err := b.bakeryConfigDoc()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return b.deserialiseKey(doc.ExternalUsersThirdPartyKey, "external users third party key")
+}
+
+// GetOffersThirdPartyKey returns the key pair used with the cross model offers bakery.
+func (b *bakeryConfig) GetOffersThirdPartyKey() (*bakery.KeyPair, error) {
+	doc, err := b.bakeryConfigDoc()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return b.deserialiseKey(doc.OffersThirdPartyKey, "offers third party key")
+}
+
+func (b *bakeryConfig) deserialiseKey(data, label string) (*bakery.KeyPair, error) {
+	if data == "" {
+		return nil, errors.NotValidf("empty " + label)
+	}
+
+	var keyPair bakery.KeyPair
+	err := json.Unmarshal([]byte(data), &keyPair)
+	if err != nil {
+		err = errors.Trace(err)
+	}
+	logger.Debugf("using %s: %s", label, keyPair.Public.String())
+	return &keyPair, nil
+}
+
+func (b *bakeryConfig) bakeryConfigDoc() (*bakeryConfigDoc, error) {
+	var doc bakeryConfigDoc
+	controllers, closer := b.collectionGetter(b.collection)
+	defer closer()
+	err := controllers.FindId(bakeryConfigKey).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("bakery config")
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &doc, nil
+}

--- a/state/bakerystorage/config_test.go
+++ b/state/bakerystorage/config_test.go
@@ -1,0 +1,174 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bakerystorage
+
+import (
+	"encoding/json"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+	jujutesting "github.com/juju/juju/testing"
+)
+
+type ConfigSuite struct {
+	jujutesting.BaseSuite
+	testing.Stub
+
+	collectionGetter func(name string) (mongo.Collection, func())
+	collection       mockCollection
+	closeCollection  func()
+
+	bakeryDocResult bakeryConfigDoc
+}
+
+var _ = gc.Suite(&ConfigSuite{})
+
+func (s *ConfigSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.Stub.ResetCalls()
+	s.collection = mockCollection{
+		Stub: &s.Stub,
+		one: func(q *mockQuery, result *interface{}) error {
+			id := q.id.(string)
+			if id != "bakeryConfig" {
+				return mgo.ErrNotFound
+			}
+			*(*result).(*bakeryConfigDoc) = s.bakeryDocResult
+			return nil
+		},
+	}
+	s.closeCollection = func() {
+		s.AddCall("Close")
+		s.PopNoErr()
+	}
+	s.collectionGetter = func(collection string) (mongo.Collection, func()) {
+		s.AddCall("GetCollection", collection)
+		s.PopNoErr()
+		return &s.collection, s.closeCollection
+	}
+}
+
+func (s *ConfigSuite) TestInitialiseBakeryConfigOp(c *gc.C) {
+	bakeryConfig := NewBakeryConfig("test", s.collectionGetter)
+	op, err := bakeryConfig.InitialiseBakeryConfigOp()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.C, gc.Equals, "test")
+
+	doc, ok := op.Insert.(*bakeryConfigDoc)
+	c.Assert(ok, jc.IsTrue)
+	var key bakery.KeyPair
+	err = json.Unmarshal([]byte(doc.LocalUsersKey), &key)
+	c.Assert(err, jc.ErrorIsNil)
+	err = json.Unmarshal([]byte(doc.OffersThirdPartyKey), &key)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ConfigSuite) TestLocalUsersKey(c *gc.C) {
+	s.bakeryDocResult = bakeryConfigDoc{
+		LocalUsersKey:              `{"public":"XXy70HKjZ6SbrW0h6zb5xkQYzUAvarTDFrl4//7wgUo=","private":"AwHI3v9AQjbAzhZx0JBjqaPYhVJ5Ksi+PWog4rNwS9Y="}`,
+		LocalUsersThirdPartyKey:    "x",
+		ExternalUsersThirdPartyKey: "x",
+		OffersThirdPartyKey:        "x",
+	}
+	bakeryConfig := NewBakeryConfig("test", s.collectionGetter)
+	key, err := bakeryConfig.GetLocalUsersKey()
+	c.Assert(err, jc.ErrorIsNil)
+	keyBytes, err := json.Marshal(key)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.CheckCalls(c, []testing.StubCall{
+		{"GetCollection", []interface{}{"test"}},
+		{"FindId", []interface{}{"bakeryConfig"}},
+		{"One", []interface{}{&bakeryConfigDoc{
+			LocalUsersKey:              string(keyBytes),
+			LocalUsersThirdPartyKey:    "x",
+			ExternalUsersThirdPartyKey: "x",
+			OffersThirdPartyKey:        "x",
+		}}},
+		{"Close", nil},
+	})
+}
+
+func (s *ConfigSuite) TestLocalUsersThirdPartyKey(c *gc.C) {
+	s.bakeryDocResult = bakeryConfigDoc{
+		LocalUsersKey:              "x",
+		LocalUsersThirdPartyKey:    `{"public":"XXy70HKjZ6SbrW0h6zb5xkQYzUAvarTDFrl4//7wgUo=","private":"AwHI3v9AQjbAzhZx0JBjqaPYhVJ5Ksi+PWog4rNwS9Y="}`,
+		ExternalUsersThirdPartyKey: "x",
+		OffersThirdPartyKey:        "x",
+	}
+	bakeryConfig := NewBakeryConfig("test", s.collectionGetter)
+	key, err := bakeryConfig.GetLocalUsersThirdPartyKey()
+	c.Assert(err, jc.ErrorIsNil)
+	keyBytes, err := json.Marshal(key)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.CheckCalls(c, []testing.StubCall{
+		{"GetCollection", []interface{}{"test"}},
+		{"FindId", []interface{}{"bakeryConfig"}},
+		{"One", []interface{}{&bakeryConfigDoc{
+			LocalUsersKey:              "x",
+			LocalUsersThirdPartyKey:    string(keyBytes),
+			ExternalUsersThirdPartyKey: "x",
+			OffersThirdPartyKey:        "x",
+		}}},
+		{"Close", nil},
+	})
+}
+
+func (s *ConfigSuite) TestExternalUsersThirdPartyKey(c *gc.C) {
+	s.bakeryDocResult = bakeryConfigDoc{
+		LocalUsersKey:              "x",
+		LocalUsersThirdPartyKey:    "x",
+		ExternalUsersThirdPartyKey: `{"public":"XXy70HKjZ6SbrW0h6zb5xkQYzUAvarTDFrl4//7wgUo=","private":"AwHI3v9AQjbAzhZx0JBjqaPYhVJ5Ksi+PWog4rNwS9Y="}`,
+		OffersThirdPartyKey:        "x",
+	}
+	bakeryConfig := NewBakeryConfig("test", s.collectionGetter)
+	key, err := bakeryConfig.GetExternalUsersThirdPartyKey()
+	c.Assert(err, jc.ErrorIsNil)
+	keyBytes, err := json.Marshal(key)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.CheckCalls(c, []testing.StubCall{
+		{"GetCollection", []interface{}{"test"}},
+		{"FindId", []interface{}{"bakeryConfig"}},
+		{"One", []interface{}{&bakeryConfigDoc{
+			LocalUsersKey:              "x",
+			LocalUsersThirdPartyKey:    "x",
+			ExternalUsersThirdPartyKey: string(keyBytes),
+			OffersThirdPartyKey:        "x",
+		}}},
+		{"Close", nil},
+	})
+}
+
+func (s *ConfigSuite) TestOffersThirdPartyKey(c *gc.C) {
+	s.bakeryDocResult = bakeryConfigDoc{
+		LocalUsersKey:              "x",
+		LocalUsersThirdPartyKey:    "x",
+		ExternalUsersThirdPartyKey: "x",
+		OffersThirdPartyKey:        `{"public":"XXy70HKjZ6SbrW0h6zb5xkQYzUAvarTDFrl4//7wgUo=","private":"AwHI3v9AQjbAzhZx0JBjqaPYhVJ5Ksi+PWog4rNwS9Y="}`,
+	}
+	bakeryConfig := NewBakeryConfig("test", s.collectionGetter)
+	key, err := bakeryConfig.GetOffersThirdPartyKey()
+	c.Assert(err, jc.ErrorIsNil)
+	keyBytes, err := json.Marshal(key)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.CheckCalls(c, []testing.StubCall{
+		{"GetCollection", []interface{}{"test"}},
+		{"FindId", []interface{}{"bakeryConfig"}},
+		{"One", []interface{}{&bakeryConfigDoc{
+			LocalUsersKey:              "x",
+			LocalUsersThirdPartyKey:    "x",
+			ExternalUsersThirdPartyKey: "x",
+			OffersThirdPartyKey:        string(keyBytes),
+		}}},
+		{"Close", nil},
+	})
+}

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -218,6 +218,12 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 		userGlobalKey(userAccessID(args.ControllerModelArgs.Owner)),
 		permission.AdminAccess)
 
+	bakeryConfig := st.NewBakeryConfig()
+	initBakeryConfigOp, err := bakeryConfig.InitialiseBakeryConfigOp()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	ops = append(ops,
 		txn.Op{
 			C:      controllersC,
@@ -255,6 +261,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 			Assert: txn.DocMissing,
 			Insert: &hostedModelCountDoc{},
 		},
+		initBakeryConfigOp,
 		createSettingsOp(controllersC, ControllerSettingsGlobalKey, args.ControllerConfig),
 		createSettingsOp(globalSettingsC, cloudGlobalKey(args.Cloud.Name), args.ControllerInheritedConfig),
 	)

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -232,6 +232,17 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	// Check that the alpha space is created.
 	_, err = s.State.SpaceByName(network.AlphaSpaceName)
 	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that the bakery config is created.
+	bakeryConfig := s.State.NewBakeryConfig()
+	_, err = bakeryConfig.GetLocalUsersKey()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = bakeryConfig.GetLocalUsersThirdPartyKey()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = bakeryConfig.GetExternalUsersThirdPartyKey()
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = bakeryConfig.GetOffersThirdPartyKey()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *InitializeSuite) TestInitializeWithInvalidCredentialType(c *gc.C) {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2874,3 +2874,25 @@ func RemoveUnsupportedLinkLayer(pool *StatePool) error {
 
 	return nil
 }
+
+// AddBakeryConfig adds a bakery config doc to controllers collection
+// if it does not already exist.
+func AddBakeryConfig(pool *StatePool) error {
+	const bakeryConfigKey = "bakeryConfig"
+	st := pool.SystemState()
+	coll, closer := st.db().GetRawCollection(controllersC)
+	defer closer()
+
+	if n, err := coll.FindId(bakeryConfigKey).Count(); err != nil {
+		return errors.Trace(err)
+	} else if n > 0 {
+		return nil
+	}
+
+	bakeryConfig := st.NewBakeryConfig()
+	op, err := bakeryConfig.InitialiseBakeryConfigOp()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(st.runRawTransaction([]txn.Op{op}))
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -82,6 +82,7 @@ type StateBackend interface {
 	DropPresenceDatabase() error
 	DropLeasesCollection() error
 	RemoveUnsupportedLinkLayer() error
+	AddBakeryConfig() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -337,4 +338,8 @@ func (s stateBackend) DropLeasesCollection() error {
 
 func (s stateBackend) RemoveUnsupportedLinkLayer() error {
 	return state.RemoveUnsupportedLinkLayer(s.pool)
+}
+
+func (s stateBackend) AddBakeryConfig() error {
+	return state.AddBakeryConfig(s.pool)
 }

--- a/upgrades/sets_281_test.go
+++ b/upgrades/sets_281_test.go
@@ -30,3 +30,9 @@ func (s *steps281Suite) TestRemoveUnsupportedLinkLayer(c *gc.C) {
 	// Logic for step itself is tested in state package.
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps281Suite) AddBakeryConfig(c *gc.C) {
+	step := findStateStep(c, v281, "add bakery config")
+	// Logic for step itself is tested in state package.
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/steps_281.go
+++ b/upgrades/steps_281.go
@@ -22,5 +22,12 @@ func stateStepsFor281() []Step {
 				return context.State().RemoveUnsupportedLinkLayer()
 			},
 		},
+		&upgradeStep{
+			description: `add bakery config`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddBakeryConfig()
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Description of change

Add a new doc to the controllers collection to hold macaroon bakery config.
We store the 4 public keys used in various bakeries. This ensure that each controller uses the same public key, and avoids the issue where a discharge request ends up at a different controller and fails because a different key is in use.

## QA steps

Hard to test the actual issue, but can do a regression test to ensure macaroons work. There's unit tests to check that the same key is served each time it is asked for.

Deploy some HA controllers in 2.7.6
Upgrade to this PR, check controllers collection for bakery config.
Add a user and grant read on a model.
Login as that user and check the cookies jar to confirm macaroons are used.
Run juju status several times; restart the controller agents and repeat.
There will be prompts for password at times but login and status should work each time.
Check a cmr scenario also.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1856071
