### PR TITLE
Add go mod sum check

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,13 +16,15 @@ jobs:
 
     - name: Install Dependencies
       run: |
+        echo "::set-env name=GOPATH::$(go env GOPATH)"
+        echo "::add-path::$(go env GOPATH)/bin"
+
         GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
         GO111MODULE=off go get -u github.com/tsenart/deadcode
         GO111MODULE=off go get -u golang.org/x/lint/golint
         GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
         GO111MODULE=off go get -u github.com/mdempsky/unconvert
         GO111MODULE=off go get -u github.com/gordonklaus/ineffassign
-        echo "##[add-path]${GOPATH}/bin"
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/state/bakerystorage/config.go
+++ b/state/bakerystorage/config.go
@@ -148,7 +148,7 @@ func (b *bakeryConfig) deserialiseKey(data, label string) (*bakery.KeyPair, erro
 	var keyPair bakery.KeyPair
 	err := json.Unmarshal([]byte(data), &keyPair)
 	if err != nil {
-		err = errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	logger.Debugf("using %s: %s", label, keyPair.Public.String())
 	return &keyPair, nil

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -98,6 +98,16 @@ run_go_fmt() {
   fi
 }
 
+run_go_tidy() {
+  CUR_SHA=$(git show HEAD:go.sum | shasum -a 1 | awk '{ print $1 }')
+  go mod tidy 2>&1
+  NEW_SHA=$(cat go.sum | shasum -a 1 | awk '{ print $1 }')
+  if [ "${CUR_SHA}" != "${NEW_SHA}" ]; then
+      (>&2 echo "\\nError: go mod sum is out of sync. Run 'go mod tidy' and commit source.")
+      exit 1
+  fi
+}
+
 test_static_analysis_go() {
   if [ "$(skip 'test_static_analysis_go')" ]; then
       echo "==> TEST SKIPPED: static go analysis"
@@ -173,5 +183,6 @@ test_static_analysis_go() {
 
     ## go fmt
     run "run_go_fmt" "${FILES}"
+    run "run_go_tidy"
   )
 }


### PR DESCRIPTION
## Description of change

To prevent our go sum becoming bloated, we should ensure that people run
`go mod tidy` on it to ensure we remove the dead weight.

## QA steps

```sh
make static-analysis
```