### PR TITLE
Ensure Instance Poller Sets Address Provider IDs for Network and Subnet

### DIFF
--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -973,6 +973,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 	aExp.DeviceName().Return("eth0")
 	aExp.Value().Return("10.0.0.42")
 	aExp.SetProviderIDOps(network.Id("p-addr")).Return([]txn.Op{{C: "addr-provider-id"}}, nil)
+	aExp.SetProviderNetIDsOps(network.Id("p-net"), network.Id("p-sub")).Return([]txn.Op{{C: "addr-provider-net-ids"}})
 
 	s.st.SetMachineInfo(c, machineInfo{
 		id:               "1",
@@ -991,6 +992,8 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 					MACAddress:        "00:00:00:00:00:00",
 					ProviderId:        "p-dev",
 					ProviderAddressId: "p-addr",
+					ProviderNetworkId: "p-net",
+					ProviderSubnetId:  "p-sub",
 					Addresses:         []params.Address{{Value: "10.0.0.42"}},
 				}},
 			},
@@ -1008,6 +1011,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 				{C: "machine-alive"},
 				{C: "dev-provider-id"},
 				{C: "addr-provider-id"},
+				{C: "addr-provider-net-ids"},
 			}})
 		}
 	}

--- a/apiserver/facades/controller/instancepoller/package_mock_test.go
+++ b/apiserver/facades/controller/instancepoller/package_mock_test.go
@@ -325,6 +325,20 @@ func (mr *MockStateLinkLayerDeviceAddressMockRecorder) SetProviderIDOps(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProviderIDOps", reflect.TypeOf((*MockStateLinkLayerDeviceAddress)(nil).SetProviderIDOps), arg0)
 }
 
+// SetProviderNetIDsOps mocks base method
+func (m *MockStateLinkLayerDeviceAddress) SetProviderNetIDsOps(arg0, arg1 network.Id) []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetProviderNetIDsOps", arg0, arg1)
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// SetProviderNetIDsOps indicates an expected call of SetProviderNetIDsOps
+func (mr *MockStateLinkLayerDeviceAddressMockRecorder) SetProviderNetIDsOps(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProviderNetIDsOps", reflect.TypeOf((*MockStateLinkLayerDeviceAddress)(nil).SetProviderNetIDsOps), arg0, arg1)
+}
+
 // SubnetCIDR mocks base method
 func (m *MockStateLinkLayerDeviceAddress) SubnetCIDR() string {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/instancepoller/state.go
+++ b/apiserver/facades/controller/instancepoller/state.go
@@ -33,6 +33,10 @@ type StateLinkLayerDeviceAddress interface {
 	// SetProviderIDOps returns the operations required to set the input
 	// provider ID for the address.
 	SetProviderIDOps(id network.Id) ([]txn.Op, error)
+
+	// SetProviderNetIDsOps returns the transaction operations required to ensure
+	// that the input provider IDs are set against the address.
+	SetProviderNetIDsOps(networkID, subnetID network.Id) []txn.Op
 }
 
 // StateLinkLayerDevice represents a link layer device from state package.

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -26,9 +26,13 @@ type ipAddressDoc struct {
 	// ModelUUID. Empty when not supported by the provider.
 	ProviderID string `bson:"providerid,omitempty"`
 
-	// ProviderSubnetID is a provider-specific ID subnet ID this IP address.
+	// ProviderSubnetID is a provider-specific ID for this address's subnet.
 	// Empty when not supported by the provider.
 	ProviderSubnetID string `bson:"provider-subnet-id,omitempty"`
+
+	// ProviderNetworkID is a provider-specific ID for this address's network.
+	// Empty when not supported by the provider.
+	ProviderNetworkID string `bson:"provider-network-id,omitempty"`
 
 	// DeviceName is the name of the link-layer device this IP address is
 	// assigned to.
@@ -37,9 +41,9 @@ type ipAddressDoc struct {
 	// MachineID is the ID of the machine this IP address's device belongs to.
 	MachineID string `bson:"machine-id"`
 
-	// SubnetCIDR is the CIDR of the subnet this IP address belongs to. The CIDR
-	// will either match a known provider subnet or a machine-local subnet (like
-	// 10.0.3.0/24 or 127.0.0.0/8).
+	// SubnetCIDR is the CIDR of the subnet this IP address belongs to.
+	// The CIDR will either match a known provider subnet or a machine-local
+	// subnet (like 10.0.3.0/24 or 127.0.0.0/8).
 	SubnetCIDR string `bson:"subnet-cidr"`
 
 	// ConfigMethod is the method used to configure this IP address.
@@ -61,7 +65,8 @@ type ipAddressDoc struct {
 	// uses. Can be empty.
 	GatewayAddress string `bson:"gateway-address,omitempty"`
 
-	// IsDefaultGateway is set to true if that device/subnet is the default gw for the machine
+	// IsDefaultGateway is set to true if that device/subnet is the default
+	// gw for the machine.
 	IsDefaultGateway bool `bson:"is-default-gateway,omitempty"`
 
 	// Origin represents the authoritative source of the ipAddress.
@@ -104,6 +109,11 @@ func (addr *Address) ProviderID() network.Id {
 // ProviderSubnetID returns the provider-specific subnet ID, if set.
 func (addr *Address) ProviderSubnetID() network.Id {
 	return network.Id(addr.doc.ProviderSubnetID)
+}
+
+// ProviderNetworkID returns the provider-specific network ID, if set.
+func (addr *Address) ProviderNetworkID() network.Id {
+	return network.Id(addr.doc.ProviderNetworkID)
 }
 
 // MachineID returns the ID of the machine this IP address belongs to.

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -743,26 +743,25 @@ func (m *Machine) newIPAddressDocFromArgs(args *LinkLayerDeviceAddress) (*ipAddr
 
 	globalKey := ipAddressGlobalKey(m.doc.Id, args.DeviceName, addressValue)
 	ipAddressDocID := m.st.docID(globalKey)
-	providerID := string(args.ProviderID)
-	subnetID := string(args.ProviderSubnetID)
 
 	modelUUID := m.st.ModelUUID()
 
 	newDoc := &ipAddressDoc{
-		DocID:            ipAddressDocID,
-		ModelUUID:        modelUUID,
-		ProviderID:       providerID,
-		ProviderSubnetID: subnetID,
-		DeviceName:       args.DeviceName,
-		MachineID:        m.doc.Id,
-		SubnetCIDR:       subnetCIDR,
-		ConfigMethod:     args.ConfigMethod,
-		Value:            addressValue,
-		DNSServers:       args.DNSServers,
-		DNSSearchDomains: args.DNSSearchDomains,
-		GatewayAddress:   args.GatewayAddress,
-		IsDefaultGateway: args.IsDefaultGateway,
-		Origin:           args.Origin,
+		DocID:             ipAddressDocID,
+		ModelUUID:         modelUUID,
+		ProviderID:        args.ProviderID.String(),
+		ProviderNetworkID: args.ProviderNetworkID.String(),
+		ProviderSubnetID:  args.ProviderSubnetID.String(),
+		DeviceName:        args.DeviceName,
+		MachineID:         m.doc.Id,
+		SubnetCIDR:        subnetCIDR,
+		ConfigMethod:      args.ConfigMethod,
+		Value:             addressValue,
+		DNSServers:        args.DNSServers,
+		DNSSearchDomains:  args.DNSSearchDomains,
+		GatewayAddress:    args.GatewayAddress,
+		IsDefaultGateway:  args.IsDefaultGateway,
+		Origin:            args.Origin,
 	}
 	return newDoc, nil
 }
@@ -1164,11 +1163,8 @@ func (m *Machine) GetNetworkInfoForSpaces(spaces set.Strings) map[string]Machine
 				}},
 			}}
 		}
-		if err != nil {
-			r.Error = err
-		} else {
-			results[corenetwork.AlphaSpaceId] = r
-		}
+
+		results[corenetwork.AlphaSpaceId] = r
 	}
 
 	for _, id := range spaces.Values() {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -683,6 +683,7 @@ func (s *MigrationSuite) TestIPAddressDocFields(c *gc.C) {
 		"GatewayAddress",
 		"IsDefaultGateway",
 		"ProviderID",
+		"ProviderNetworkID",
 		"ProviderSubnetID",
 		"DNSServers",
 		"SubnetCIDR",


### PR DESCRIPTION
## Description of change

This patch ensures that the instance-poller populates provider IDs for network and subnet when it updates link-layer device addresses.

Provider network ID in particular was added to the `ip.addresses` collection.

## QA steps

- Bootstrap to AWS.
- Connect to Mongo and look at the `ip.addresses` collection. The address for the controller NIC should have a provider subnet ID.

## Documentation changes

None.

## Bug reference

N/A
