### PR TITLE
Adding find methods to charmhub.

### DIFF
--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -14,12 +14,13 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub"
+	"github.com/juju/juju/charmhub/transport"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.charmhub")
 
 type Client interface {
-	Info(ctx context.Context, name string) (charmhub.InfoResponse, error)
+	Info(ctx context.Context, name string) (transport.InfoResponse, error)
 }
 
 // API provides the charmhub API facade for version 1.

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -6,6 +6,7 @@ package charmhub
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -75,15 +76,15 @@ func assertCharmSameContents(c *gc.C, obtained, expected params.CharmHubCharm) {
 	c.Assert(obtained.UsedBy, gc.DeepEquals, expected.UsedBy)
 }
 
-func getCharmHubInfoResponse() charmhub.InfoResponse {
-	return charmhub.InfoResponse{
+func getCharmHubInfoResponse() transport.InfoResponse {
+	return transport.InfoResponse{
 		Name: "wordpress",
 		Type: "object",
 		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []charmhub.ChannelMap{{
-			Channel: charmhub.Channel{
+		ChannelMap: []transport.ChannelMap{{
+			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: charmhub.Platform{
+				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",
@@ -92,16 +93,16 @@ func getCharmHubInfoResponse() charmhub.InfoResponse {
 				Risk:       "stable",
 				Track:      "latest",
 			},
-			Revision: charmhub.Revision{
+			Revision: transport.Revision{
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: charmhub.Download{
+				Download: transport.Download{
 					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []charmhub.Platform{{
+				Platforms: []transport.Platform{{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",
@@ -110,14 +111,14 @@ func getCharmHubInfoResponse() charmhub.InfoResponse {
 				Version:  "1.0.3",
 			},
 		}},
-		Charm: charmhub.Charm{
-			Categories: []charmhub.Category{{
+		Charm: transport.Charm{
+			Categories: []transport.Category{{
 				Featured: true,
 				Name:     "blog",
 			}},
 			Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
 			License:     "Apache-2.0",
-			Media: []charmhub.Media{{
+			Media: []transport.Media{{
 				Height: 256,
 				Type:   "icon",
 				URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
@@ -133,10 +134,10 @@ func getCharmHubInfoResponse() charmhub.InfoResponse {
 				"wordpress-site",
 			},
 		},
-		DefaultRelease: charmhub.ChannelMap{
-			Channel: charmhub.Channel{
+		DefaultRelease: transport.ChannelMap{
+			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: charmhub.Platform{
+				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",
@@ -145,16 +146,16 @@ func getCharmHubInfoResponse() charmhub.InfoResponse {
 				Risk:       "stable",
 				Track:      "latest",
 			},
-			Revision: charmhub.Revision{
+			Revision: transport.Revision{
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: charmhub.Download{
+				Download: transport.Download{
 					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []charmhub.Platform{{
+				Platforms: []transport.Platform{{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -5,10 +5,10 @@ package charmhub
 
 import (
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/charmhub"
+	"github.com/juju/juju/charmhub/transport"
 )
 
-func convertCharmInfoResult(info charmhub.InfoResponse) params.InfoResponse {
+func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 	return params.InfoResponse{
 		Type:           info.Type,
 		ID:             info.ID,
@@ -19,7 +19,7 @@ func convertCharmInfoResult(info charmhub.InfoResponse) params.InfoResponse {
 	}
 }
 
-func convertCharm(ch charmhub.Charm) params.CharmHubCharm {
+func convertCharm(ch transport.Charm) params.CharmHubCharm {
 	return params.CharmHubCharm{
 		Categories:  convertCategories(ch.Categories),
 		Description: ch.Description,
@@ -31,7 +31,7 @@ func convertCharm(ch charmhub.Charm) params.CharmHubCharm {
 	}
 }
 
-func convertCategories(categories []charmhub.Category) []params.Category {
+func convertCategories(categories []transport.Category) []params.Category {
 	result := make([]params.Category, len(categories))
 	for i, c := range categories {
 		result[i] = params.Category(c)
@@ -39,7 +39,7 @@ func convertCategories(categories []charmhub.Category) []params.Category {
 	return result
 }
 
-func convertMedia(media []charmhub.Media) []params.Media {
+func convertMedia(media []transport.Media) []params.Media {
 	result := make([]params.Media, len(media))
 	for i, m := range media {
 		result[i] = params.Media(m)
@@ -47,7 +47,7 @@ func convertMedia(media []charmhub.Media) []params.Media {
 	return result
 }
 
-func convertChannelMap(cms []charmhub.ChannelMap) []params.ChannelMap {
+func convertChannelMap(cms []transport.ChannelMap) []params.ChannelMap {
 	result := make([]params.ChannelMap, len(cms))
 	for i, cm := range cms {
 		result[i] = convertOneChannelMap(cm)
@@ -55,7 +55,7 @@ func convertChannelMap(cms []charmhub.ChannelMap) []params.ChannelMap {
 	return result
 }
 
-func convertOneChannelMap(defaultMap charmhub.ChannelMap) params.ChannelMap {
+func convertOneChannelMap(defaultMap transport.ChannelMap) params.ChannelMap {
 	return params.ChannelMap{
 		Channel: params.Channel{
 			Name:       defaultMap.Channel.Name,
@@ -74,7 +74,7 @@ func convertOneChannelMap(defaultMap charmhub.ChannelMap) params.ChannelMap {
 	}
 }
 
-func convertPlatforms(platforms []charmhub.Platform) []params.Platform {
+func convertPlatforms(platforms []transport.Platform) []params.Platform {
 	result := make([]params.Platform, len(platforms))
 	for i, p := range platforms {
 		result[i] = params.Platform(p)

--- a/apiserver/facades/client/charmhub/mocks/package_mock.go
+++ b/apiserver/facades/client/charmhub/mocks/package_mock.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	charmhub "github.com/juju/juju/charmhub"
+	transport "github.com/juju/juju/charmhub/transport"
 	reflect "reflect"
 )
 
@@ -35,10 +35,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Info mocks base method
-func (m *MockClient) Info(arg0 context.Context, arg1 string) (charmhub.InfoResponse, error) {
+func (m *MockClient) Info(arg0 context.Context, arg1 string) (transport.InfoResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Info", arg0, arg1)
-	ret0, _ := ret[0].(charmhub.InfoResponse)
+	ret0, _ := ret[0].(transport.InfoResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
+	charmhubpath "github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
 )
 
 // ServerURL holds the default location of the global charm hub.
@@ -66,14 +69,14 @@ func CharmhubConfig() Config {
 }
 
 // BasePath returns the base configuration path for speaking to the server API.
-func (c Config) BasePath() (Path, error) {
+func (c Config) BasePath() (charmhubpath.Path, error) {
 	baseURL := strings.TrimRight(c.URL, "/")
 	rawURL := fmt.Sprintf("%s/%s", baseURL, path.Join(c.Version, c.Entity))
 	url, err := url.Parse(rawURL)
 	if err != nil {
-		return Path{}, errors.Trace(err)
+		return charmhubpath.Path{}, errors.Trace(err)
 	}
-	return MakePath(url), nil
+	return charmhubpath.MakePath(url), nil
 }
 
 // Client represents the client side of a charm store.
@@ -110,11 +113,11 @@ func NewClient(config Config) (*Client, error) {
 }
 
 // Info returns charm info on the provided charm name from charmhub.
-func (c *Client) Info(ctx context.Context, name string) (InfoResponse, error) {
+func (c *Client) Info(ctx context.Context, name string) (transport.InfoResponse, error) {
 	return c.infoClient.Info(ctx, name)
 }
 
 // Find searches for a given charm for a given name from charmhub.
-func (c *Client) Find(ctx context.Context, name string) ([]FindResponse, error) {
+func (c *Client) Find(ctx context.Context, name string) ([]transport.FindResponse, error) {
 	return c.findClient.Find(ctx, name)
 }

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -99,11 +99,10 @@ func NewClient(config Config) (*Client, error) {
 		return nil, errors.Annotate(err, "constructing find path")
 	}
 
-	var (
-		httpClient   = DefaultHTTPTransport()
-		apiRequester = NewAPIRequester(httpClient)
-		restClient   = NewHTTPRESTClient(apiRequester)
-	)
+	httpClient := DefaultHTTPTransport()
+	apiRequester := NewAPIRequester(httpClient)
+	restClient := NewHTTPRESTClient(apiRequester)
+
 	return &Client{
 		infoClient: NewInfoClient(infoPath, restClient),
 		findClient: NewFindClient(findPath, restClient),
@@ -118,61 +117,4 @@ func (c *Client) Info(ctx context.Context, name string) (InfoResponse, error) {
 // Find searches for a given charm for a given name from charmhub.
 func (c *Client) Find(ctx context.Context, name string) ([]FindResponse, error) {
 	return c.findClient.Find(ctx, name)
-}
-
-type ChannelMap struct {
-	Channel  Channel  `json:"channel,omitempty"`
-	Revision Revision `json:"revision,omitempty"`
-}
-
-type Channel struct {
-	Name       string   `json:"name"`
-	Platform   Platform `json:"platform"`
-	ReleasedAt string   `json:"released-at"`
-	Risk       string   `json:"risk"`
-	Track      string   `json:"track"`
-}
-
-type Platform struct {
-	Architecture string `json:"architecture"`
-	OS           string `json:"os"`
-	Series       string `json:"series"`
-}
-
-type Revision struct {
-	ConfigYAML   string     `json:"config-yaml"`
-	CreatedAt    string     `json:"created-at"`
-	Download     Download   `json:"download"`
-	MetadataYAML string     `json:"metadata-yaml"`
-	Platforms    []Platform `json:"platforms"`
-	Revision     int        `json:"revision"`
-	Version      string     `json:"version"`
-}
-
-type Download struct {
-	HashSHA265 string `json:"hash-sha-265"`
-	Size       int    `json:"size"`
-	URL        string `json:"url"`
-}
-
-type Charm struct {
-	Categories  []Category        `json:"categories"`
-	Description string            `json:"description"`
-	License     string            `json:"license"`
-	Media       []Media           `json:"media"`
-	Publisher   map[string]string `json:"publisher"`
-	Summary     string            `json:"summary"`
-	UsedBy      []string          `json:"used-by"`
-}
-
-type Category struct {
-	Featured bool   `json:"featured"`
-	Name     string `json:"name"`
-}
-
-type Media struct {
-	Type   string `json:"type"`
-	URL    string `json:"url"`
-	Width  int    `json:"width,omitempty"`
-	Height int    `json:"height,omitempty"`
 }

--- a/charmhub/client_mock_test.go
+++ b/charmhub/client_mock_test.go
@@ -7,6 +7,7 @@ package charmhub
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
+	path "github.com/juju/juju/charmhub/path"
 	http "net/http"
 	reflect "reflect"
 )
@@ -73,7 +74,7 @@ func (m *MockRESTClient) EXPECT() *MockRESTClientMockRecorder {
 }
 
 // Get mocks base method
-func (m *MockRESTClient) Get(arg0 context.Context, arg1 Path, arg2 interface{}) error {
+func (m *MockRESTClient) Get(arg0 context.Context, arg1 path.Path, arg2 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/charmhub/client_test.go
+++ b/charmhub/client_test.go
@@ -9,35 +9,6 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-type PathSuite struct {
-	testing.IsolationSuite
-}
-
-var _ = gc.Suite(&PathSuite{})
-
-func (s *PathSuite) TestJoin(c *gc.C) {
-	rawURL := MustParseURL(c, "http://foobar/v1/path/")
-
-	path := MakePath(rawURL)
-	appPath, err := path.Join("entity", "app")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(appPath.String(), gc.Equals, "http://foobar/v1/path/entity/app")
-}
-
-func (s *PathSuite) TestJoinMultipleTimes(c *gc.C) {
-	rawURL := MustParseURL(c, "http://foobar/v1/path/")
-
-	path := MakePath(rawURL)
-	entityPath, err := path.Join("entity")
-	c.Assert(err, jc.ErrorIsNil)
-
-	appPath, err := entityPath.Join("app")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(appPath.String(), gc.Equals, "http://foobar/v1/path/entity/app")
-}
-
 type ConfigSuite struct {
 	testing.IsolationSuite
 }

--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"context"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// FindClient defines a client for info requests.
+type FindClient struct {
+	path   Path
+	client RESTClient
+}
+
+// NewFindClient creates a FindClient for requesting
+func NewFindClient(path Path, client RESTClient) *FindClient {
+	return &FindClient{
+		path:   path,
+		client: client,
+	}
+}
+
+// Find searches Charm Hub and provides results matching a string.
+func (c *FindClient) Find(ctx context.Context, query string) ([]FindResponse, error) {
+	path, err := c.path.Query("q", query)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var resp FindResponses
+	if err := c.client.Get(ctx, path, &resp); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if len(resp.ErrorList) > 0 {
+		var combined []string
+		for _, err := range resp.ErrorList {
+			if err.Message != "" {
+				combined = append(combined, err.Message)
+			}
+		}
+		return nil, errors.Errorf(strings.Join(combined, "\n"))
+	}
+
+	return resp.Results, nil
+}
+
+type FindResponses struct {
+	Results   []FindResponse `json:"results"`
+	ErrorList []APIError     `json:"error-list"`
+}
+
+type FindResponse struct {
+	Type           string       `json:"type"`
+	ID             string       `json:"id"`
+	Name           string       `json:"name"`
+	Charm          Charm        `json:"charm,omitempty"`
+	ChannelMap     []ChannelMap `json:"channel-map"`
+	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+}

--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -10,13 +10,14 @@ import (
 	"github.com/juju/errors"
 )
 
-// FindClient defines a client for info requests.
+// FindClient defines a client for querying information about a given charm or
+// bundle for a given charmhub store.
 type FindClient struct {
 	path   Path
 	client RESTClient
 }
 
-// NewFindClient creates a FindClient for requesting
+// NewFindClient creates a FindClient for querying charm or bundle information.
 func NewFindClient(path Path, client RESTClient) *FindClient {
 	return &FindClient{
 		path:   path,

--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -8,17 +8,19 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
 )
 
 // FindClient defines a client for querying information about a given charm or
 // bundle for a given charmhub store.
 type FindClient struct {
-	path   Path
+	path   path.Path
 	client RESTClient
 }
 
 // NewFindClient creates a FindClient for querying charm or bundle information.
-func NewFindClient(path Path, client RESTClient) *FindClient {
+func NewFindClient(path path.Path, client RESTClient) *FindClient {
 	return &FindClient{
 		path:   path,
 		client: client,
@@ -26,13 +28,13 @@ func NewFindClient(path Path, client RESTClient) *FindClient {
 }
 
 // Find searches Charm Hub and provides results matching a string.
-func (c *FindClient) Find(ctx context.Context, query string) ([]FindResponse, error) {
+func (c *FindClient) Find(ctx context.Context, query string) ([]transport.FindResponse, error) {
 	path, err := c.path.Query("q", query)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	var resp FindResponses
+	var resp transport.FindResponses
 	if err := c.client.Get(ctx, path, &resp); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -48,18 +50,4 @@ func (c *FindClient) Find(ctx context.Context, query string) ([]FindResponse, er
 	}
 
 	return resp.Results, nil
-}
-
-type FindResponses struct {
-	Results   []FindResponse `json:"results"`
-	ErrorList []APIError     `json:"error-list"`
-}
-
-type FindResponse struct {
-	Type           string       `json:"type"`
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
-	Charm          Charm        `json:"charm,omitempty"`
-	ChannelMap     []ChannelMap `json:"channel-map"`
-	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
 }

--- a/charmhub/find_integration_test.go
+++ b/charmhub/find_integration_test.go
@@ -15,25 +15,26 @@ import (
 	"github.com/juju/juju/charmhub"
 )
 
-type InfoClientSuite struct {
+type FindClientSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&InfoClientSuite{})
+var _ = gc.Suite(&FindClientSuite{})
 
-func (s *InfoClientSuite) TestLiveInfoRequest(c *gc.C) {
+func (s *FindClientSuite) TestLiveFindRequest(c *gc.C) {
 	config := charmhub.CharmhubConfig()
 	basePath, err := config.BasePath()
 	c.Assert(err, jc.ErrorIsNil)
 
-	infoPath, err := basePath.Join("info")
+	findPath, err := basePath.Join("find")
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := charmhub.NewAPIRequester(charmhub.DefaultHTTPTransport())
 	restClient := charmhub.NewHTTPRESTClient(apiRequester)
 
-	client := charmhub.NewInfoClient(infoPath, restClient)
-	response, err := client.Info(context.TODO(), "wordpress")
+	client := charmhub.NewFindClient(findPath, restClient)
+	responses, err := client.Find(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(response.Name, gc.Equals, "wordpress")
+	c.Assert(len(responses), jc.GreaterThan, 1)
+	c.Assert(responses[0].Name, gc.Equals, "wordpress")
 }

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	path "github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
 )
 
 type FindSuite struct {
@@ -27,7 +30,7 @@ func (s *FindSuite) TestFind(c *gc.C) {
 
 	baseURL := MustParseURL(c, "http://api.foo.bar")
 
-	path := MakePath(baseURL)
+	path := path.MakePath(baseURL)
 	name := "meshuggah"
 
 	restClient := NewMockRESTClient(ctrl)
@@ -46,7 +49,7 @@ func (s *FindSuite) TestFindFailure(c *gc.C) {
 
 	baseURL := MustParseURL(c, "http://api.foo.bar")
 
-	path := MakePath(baseURL)
+	path := path.MakePath(baseURL)
 	name := "meshuggah"
 
 	restClient := NewMockRESTClient(ctrl)
@@ -57,12 +60,12 @@ func (s *FindSuite) TestFindFailure(c *gc.C) {
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
-func (s *FindSuite) expectGet(c *gc.C, client *MockRESTClient, path Path, name string) {
-	namedPath, err := path.Query("q", name)
+func (s *FindSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, name string) {
+	namedPath, err := p.Query("q", name)
 	c.Assert(err, jc.ErrorIsNil)
 
-	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ Path, responses *FindResponses) {
-		responses.Results = []FindResponse{{
+	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, responses *transport.FindResponses) {
+		responses.Results = []transport.FindResponse{{
 			Name: name,
 		}}
 	}).Return(nil)
@@ -73,15 +76,15 @@ func (s *FindSuite) expectGetFailure(c *gc.C, client *MockRESTClient) {
 }
 
 func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
-	findResponses := FindResponses{
-		Results: []FindResponse{{
+	findResponses := transport.FindResponses{
+		Results: []transport.FindResponse{{
 			Name: "wordpress",
 			Type: "object",
 			ID:   "charmCHARMcharmCHARMcharmCHARM01",
-			ChannelMap: []ChannelMap{{
-				Channel: Channel{
+			ChannelMap: []transport.ChannelMap{{
+				Channel: transport.Channel{
 					Name: "latest/stable",
-					Platform: Platform{
+					Platform: transport.Platform{
 						Architecture: "all",
 						OS:           "ubuntu",
 						Series:       "bionic",
@@ -90,16 +93,16 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					Risk:       "stable",
 					Track:      "latest",
 				},
-				Revision: Revision{
+				Revision: transport.Revision{
 					ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: Download{
+					Download: transport.Download{
 						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 						Size:       12042240,
 						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 					},
 					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Platforms: []Platform{{
+					Platforms: []transport.Platform{{
 						Architecture: "all",
 						OS:           "ubuntu",
 						Series:       "bionic",
@@ -108,14 +111,14 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					Version:  "1.0.3",
 				},
 			}},
-			Charm: Charm{
-				Categories: []Category{{
+			Charm: transport.Charm{
+				Categories: []transport.Category{{
 					Featured: true,
 					Name:     "blog",
 				}},
 				Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
 				License:     "Apache-2.0",
-				Media: []Media{{
+				Media: []transport.Media{{
 					Height: 256,
 					Type:   "icon",
 					URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
@@ -131,10 +134,10 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					"wordpress-site",
 				},
 			},
-			DefaultRelease: ChannelMap{
-				Channel: Channel{
+			DefaultRelease: transport.ChannelMap{
+				Channel: transport.Channel{
 					Name: "latest/stable",
-					Platform: Platform{
+					Platform: transport.Platform{
 						Architecture: "all",
 						OS:           "ubuntu",
 						Series:       "bionic",
@@ -143,16 +146,16 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					Risk:       "stable",
 					Track:      "latest",
 				},
-				Revision: Revision{
+				Revision: transport.Revision{
 					ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: Download{
+					Download: transport.Download{
 						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 						Size:       12042240,
 						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 					},
 					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Platforms: []Platform{{
+					Platforms: []transport.Platform{{
 						Architecture: "all",
 						OS:           "ubuntu",
 						Series:       "bionic",
@@ -194,8 +197,8 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 }
 
 func (s *FindSuite) TestFindErrorPayload(c *gc.C) {
-	findResponses := FindResponses{
-		ErrorList: []APIError{{
+	findResponses := transport.FindResponses{
+		ErrorList: []transport.APIError{{
 			Code:    "some-error-code",
 			Message: "not found error code",
 		}},

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -1,0 +1,230 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package charmhub
+
+import (
+	"context"
+	"encoding/json"
+	http "net/http"
+	"net/http/httptest"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type FindSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FindSuite{})
+
+func (s *FindSuite) TestFind(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := MakePath(baseURL)
+	name := "meshuggah"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, path, name)
+
+	client := NewFindClient(path, restClient)
+	responses, err := client.Find(context.TODO(), name)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(responses), gc.Equals, 1)
+	c.Assert(responses[0].Name, gc.Equals, name)
+}
+
+func (s *FindSuite) TestFindFailure(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := MakePath(baseURL)
+	name := "meshuggah"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGetFailure(c, restClient)
+
+	client := NewFindClient(path, restClient)
+	_, err := client.Find(context.TODO(), name)
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
+}
+
+func (s *FindSuite) expectGet(c *gc.C, client *MockRESTClient, path Path, name string) {
+	namedPath, err := path.Query("q", name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ Path, responses *FindResponses) {
+		responses.Results = []FindResponse{{
+			Name: name,
+		}}
+	}).Return(nil)
+}
+
+func (s *FindSuite) expectGetFailure(c *gc.C, client *MockRESTClient) {
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("boom"))
+}
+
+func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
+	findResponses := FindResponses{
+		Results: []FindResponse{{
+			Name: "wordpress",
+			Type: "object",
+			ID:   "charmCHARMcharmCHARMcharmCHARM01",
+			ChannelMap: []ChannelMap{{
+				Channel: Channel{
+					Name: "latest/stable",
+					Platform: Platform{
+						Architecture: "all",
+						OS:           "ubuntu",
+						Series:       "bionic",
+					},
+					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+					Risk:       "stable",
+					Track:      "latest",
+				},
+				Revision: Revision{
+					ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
+					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
+					Download: Download{
+						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+						Size:       12042240,
+						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
+					},
+					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
+					Platforms: []Platform{{
+						Architecture: "all",
+						OS:           "ubuntu",
+						Series:       "bionic",
+					}},
+					Revision: 16,
+					Version:  "1.0.3",
+				},
+			}},
+			Charm: Charm{
+				Categories: []Category{{
+					Featured: true,
+					Name:     "blog",
+				}},
+				Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
+				License:     "Apache-2.0",
+				Media: []Media{{
+					Height: 256,
+					Type:   "icon",
+					URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
+					Width:  256,
+				}},
+				Publisher: map[string]string{
+					"display-name": "Wordress Charmers",
+				},
+				Summary: "WordPress is a full featured web blogging tool, this charm deploys it.",
+				UsedBy: []string{
+					"wordpress-everlast",
+					"wordpress-jorge",
+					"wordpress-site",
+				},
+			},
+			DefaultRelease: ChannelMap{
+				Channel: Channel{
+					Name: "latest/stable",
+					Platform: Platform{
+						Architecture: "all",
+						OS:           "ubuntu",
+						Series:       "bionic",
+					},
+					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+					Risk:       "stable",
+					Track:      "latest",
+				},
+				Revision: Revision{
+					ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
+					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
+					Download: Download{
+						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+						Size:       12042240,
+						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
+					},
+					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
+					Platforms: []Platform{{
+						Architecture: "all",
+						OS:           "ubuntu",
+						Series:       "bionic",
+					}},
+					Revision: 16,
+					Version:  "1.0.3",
+				},
+			},
+		}},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		err := json.NewEncoder(w).Encode(findResponses)
+		c.Assert(err, jc.ErrorIsNil)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := Config{
+		URL: server.URL,
+	}
+	basePath, err := config.BasePath()
+	c.Assert(err, jc.ErrorIsNil)
+
+	findPath, err := basePath.Join("find")
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiRequester := NewAPIRequester(DefaultHTTPTransport())
+	restClient := NewHTTPRESTClient(apiRequester)
+
+	client := NewFindClient(findPath, restClient)
+	responses, err := client.Find(context.TODO(), "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(responses, gc.DeepEquals, findResponses.Results)
+}
+
+func (s *FindSuite) TestFindErrorPayload(c *gc.C) {
+	findResponses := FindResponses{
+		ErrorList: []APIError{{
+			Code:    "some-error-code",
+			Message: "not found error code",
+		}},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		err := json.NewEncoder(w).Encode(findResponses)
+		c.Assert(err, jc.ErrorIsNil)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := Config{
+		URL: server.URL,
+	}
+	basePath, err := config.BasePath()
+	c.Assert(err, jc.ErrorIsNil)
+
+	findPath, err := basePath.Join("find")
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiRequester := NewAPIRequester(DefaultHTTPTransport())
+	restClient := NewHTTPRESTClient(apiRequester)
+
+	client := NewFindClient(findPath, restClient)
+	_, err = client.Find(context.TODO(), "wordpress")
+	c.Assert(err, gc.ErrorMatches, "not found error code")
+}

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
 	httprequest "gopkg.in/httprequest.v1"
 )
 
@@ -23,12 +25,6 @@ type Transport interface {
 // DefaultHTTPTransport creates a new HTTPTransport.
 func DefaultHTTPTransport() *http.Client {
 	return &http.Client{}
-}
-
-// APIError represents the error from the charmhub api.
-type APIError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
 }
 
 // APIRequester creates a wrapper around the transport to allow for better
@@ -65,7 +61,7 @@ func (t *APIRequester) Do(req *http.Request) (*http.Response, error) {
 		return nil, errors.Errorf(`expected "application/json" contentType from server: %v`, contentType)
 	}
 
-	var apiError APIError
+	var apiError transport.APIError
 	if err := json.Unmarshal(data, &apiError); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -76,7 +72,7 @@ func (t *APIRequester) Do(req *http.Request) (*http.Response, error) {
 // RESTClient defines a type for making requests to a server.
 type RESTClient interface {
 	// Get performs GET requests to a given Path.
-	Get(context.Context, Path, interface{}) error
+	Get(context.Context, path.Path, interface{}) error
 }
 
 // HTTPRESTClient represents a RESTClient that expects to interact with a
@@ -97,7 +93,7 @@ func NewHTTPRESTClient(transport Transport) *HTTPRESTClient {
 // parsing the result as JSON into the given result value, which should
 // be a pointer to the expected data, but may be nil if no result is
 // desired.
-func (c *HTTPRESTClient) Get(ctx context.Context, path Path, result interface{}) error {
+func (c *HTTPRESTClient) Get(ctx context.Context, path path.Path, result interface{}) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", path.String(), nil)
 	if err != nil {
 		return errors.Annotate(err, "can not make new request")

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -7,16 +7,18 @@ import (
 	"context"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
 )
 
 // InfoClient defines a client for info requests.
 type InfoClient struct {
-	path   Path
+	path   path.Path
 	client RESTClient
 }
 
 // NewInfoClient creates a InfoClient for requesting
-func NewInfoClient(path Path, client RESTClient) *InfoClient {
+func NewInfoClient(path path.Path, client RESTClient) *InfoClient {
 	return &InfoClient{
 		path:   path,
 		client: client,
@@ -25,8 +27,8 @@ func NewInfoClient(path Path, client RESTClient) *InfoClient {
 
 // Info requests the information of a given charm. If that charm doesn't exist
 // an error stating that fact will be returned.
-func (c *InfoClient) Info(ctx context.Context, name string) (InfoResponse, error) {
-	var resp InfoResponse
+func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoResponse, error) {
+	var resp transport.InfoResponse
 	path, err := c.path.Join(name)
 	if err != nil {
 		return resp, errors.Trace(err)
@@ -36,13 +38,4 @@ func (c *InfoClient) Info(ctx context.Context, name string) (InfoResponse, error
 		return resp, errors.Trace(err)
 	}
 	return resp, nil
-}
-
-type InfoResponse struct {
-	Type           string       `json:"type"`
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
-	Charm          Charm        `json:"charm,omitempty"`
-	ChannelMap     []ChannelMap `json:"channel-map"`
-	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
 }

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -23,16 +23,16 @@ func NewInfoClient(path Path, client RESTClient) *InfoClient {
 	}
 }
 
-// Get requests the information of a given charm. If that charm doesn't exist
+// Info requests the information of a given charm. If that charm doesn't exist
 // an error stating that fact will be returned.
-func (i *InfoClient) Get(ctx context.Context, name string) (InfoResponse, error) {
+func (c *InfoClient) Info(ctx context.Context, name string) (InfoResponse, error) {
 	var resp InfoResponse
-	path, err := i.path.Join(name)
+	path, err := c.path.Join(name)
 	if err != nil {
 		return resp, errors.Trace(err)
 	}
 
-	if err := i.client.Get(ctx, path, &resp); err != nil {
+	if err := c.client.Get(ctx, path, &resp); err != nil {
 		return resp, errors.Trace(err)
 	}
 	return resp, nil
@@ -45,61 +45,4 @@ type InfoResponse struct {
 	Charm          Charm        `json:"charm,omitempty"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
-}
-
-type ChannelMap struct {
-	Channel  Channel  `json:"channel,omitempty"`
-	Revision Revision `json:"revision,omitempty"`
-}
-
-type Channel struct {
-	Name       string   `json:"name"`
-	Platform   Platform `json:"platform"`
-	ReleasedAt string   `json:"released-at"`
-	Risk       string   `json:"risk"`
-	Track      string   `json:"track"`
-}
-
-type Platform struct {
-	Architecture string `json:"architecture"`
-	OS           string `json:"os"`
-	Series       string `json:"series"`
-}
-
-type Revision struct {
-	ConfigYAML   string     `json:"config-yaml"`
-	CreatedAt    string     `json:"created-at"`
-	Download     Download   `json:"download"`
-	MetadataYAML string     `json:"metadata-yaml"`
-	Platforms    []Platform `json:"platforms"`
-	Revision     int        `json:"revision"`
-	Version      string     `json:"version"`
-}
-
-type Download struct {
-	HashSHA265 string `json:"hash-sha-265"`
-	Size       int    `json:"size"`
-	URL        string `json:"url"`
-}
-
-type Charm struct {
-	Categories  []Category        `json:"categories"`
-	Description string            `json:"description"`
-	License     string            `json:"license"`
-	Media       []Media           `json:"media"`
-	Publisher   map[string]string `json:"publisher"`
-	Summary     string            `json:"summary"`
-	UsedBy      []string          `json:"used-by"`
-}
-
-type Category struct {
-	Featured bool   `json:"featured"`
-	Name     string `json:"name"`
-}
-
-type Media struct {
-	Type   string `json:"type"`
-	URL    string `json:"url"`
-	Width  int    `json:"width,omitempty"`
-	Height int    `json:"height,omitempty"`
 }

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -22,7 +22,7 @@ type InfoSuite struct {
 
 var _ = gc.Suite(&InfoSuite{})
 
-func (s *InfoSuite) TestGet(c *gc.C) {
+func (s *InfoSuite) TestInfo(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -35,12 +35,12 @@ func (s *InfoSuite) TestGet(c *gc.C) {
 	s.expectGet(c, restClient, path, name)
 
 	client := NewInfoClient(path, restClient)
-	response, err := client.Get(context.TODO(), name)
+	response, err := client.Info(context.TODO(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, name)
 }
 
-func (s *InfoSuite) TestGetFailure(c *gc.C) {
+func (s *InfoSuite) TestInfoFailure(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -53,7 +53,7 @@ func (s *InfoSuite) TestGetFailure(c *gc.C) {
 	s.expectGetFailure(c, restClient)
 
 	client := NewInfoClient(path, restClient)
-	_, err := client.Get(context.TODO(), name)
+	_, err := client.Info(context.TODO(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
@@ -184,7 +184,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 	restClient := NewHTTPRESTClient(apiRequester)
 
 	client := NewInfoClient(infoPath, restClient)
-	response, err := client.Get(context.TODO(), "wordpress")
+	response, err := client.Info(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response, gc.DeepEquals, infoResponse)
 }

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	path "github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -28,7 +30,7 @@ func (s *InfoSuite) TestInfo(c *gc.C) {
 
 	baseURL := MustParseURL(c, "http://api.foo.bar")
 
-	path := MakePath(baseURL)
+	path := path.MakePath(baseURL)
 	name := "meshuggah"
 
 	restClient := NewMockRESTClient(ctrl)
@@ -46,7 +48,7 @@ func (s *InfoSuite) TestInfoFailure(c *gc.C) {
 
 	baseURL := MustParseURL(c, "http://api.foo.bar")
 
-	path := MakePath(baseURL)
+	path := path.MakePath(baseURL)
 	name := "meshuggah"
 
 	restClient := NewMockRESTClient(ctrl)
@@ -57,11 +59,11 @@ func (s *InfoSuite) TestInfoFailure(c *gc.C) {
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
-func (s *InfoSuite) expectGet(c *gc.C, client *MockRESTClient, path Path, name string) {
-	namedPath, err := path.Join(name)
+func (s *InfoSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, name string) {
+	namedPath, err := p.Join(name)
 	c.Assert(err, jc.ErrorIsNil)
 
-	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ Path, response *InfoResponse) {
+	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, response *transport.InfoResponse) {
 		response.Name = name
 	}).Return(nil)
 }
@@ -71,14 +73,14 @@ func (s *InfoSuite) expectGetFailure(c *gc.C, client *MockRESTClient) {
 }
 
 func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
-	infoResponse := InfoResponse{
+	infoResponse := transport.InfoResponse{
 		Name: "wordpress",
 		Type: "object",
 		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []ChannelMap{{
-			Channel: Channel{
+		ChannelMap: []transport.ChannelMap{{
+			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: Platform{
+				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",
@@ -87,16 +89,16 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				Risk:       "stable",
 				Track:      "latest",
 			},
-			Revision: Revision{
+			Revision: transport.Revision{
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: Download{
+				Download: transport.Download{
 					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []Platform{{
+				Platforms: []transport.Platform{{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",
@@ -105,14 +107,14 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				Version:  "1.0.3",
 			},
 		}},
-		Charm: Charm{
-			Categories: []Category{{
+		Charm: transport.Charm{
+			Categories: []transport.Category{{
 				Featured: true,
 				Name:     "blog",
 			}},
 			Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
 			License:     "Apache-2.0",
-			Media: []Media{{
+			Media: []transport.Media{{
 				Height: 256,
 				Type:   "icon",
 				URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
@@ -128,10 +130,10 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				"wordpress-site",
 			},
 		},
-		DefaultRelease: ChannelMap{
-			Channel: Channel{
+		DefaultRelease: transport.ChannelMap{
+			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: Platform{
+				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",
@@ -140,16 +142,16 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				Risk:       "stable",
 				Track:      "latest",
 			},
-			Revision: Revision{
+			Revision: transport.Revision{
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: Download{
+				Download: transport.Download{
 					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []Platform{{
+				Platforms: []transport.Platform{{
 					Architecture: "all",
 					OS:           "ubuntu",
 					Series:       "bionic",

--- a/charmhub/package_test.go
+++ b/charmhub/package_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	path "github.com/juju/juju/charmhub/path"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -25,9 +26,9 @@ func MustParseURL(c *gc.C, path string) *url.URL {
 	return u
 }
 
-func MustMakePath(c *gc.C, path string) Path {
-	u := MustParseURL(c, path)
-	return MakePath(u)
+func MustMakePath(c *gc.C, p string) path.Path {
+	u := MustParseURL(c, p)
+	return path.MakePath(u)
 }
 
 type nopCloser struct {

--- a/charmhub/path.go
+++ b/charmhub/path.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// Path defines a absolute path for calling requests to the server.
+type Path struct {
+	base *url.URL
+}
+
+// MakePath creates a URL for queries to a server.
+func MakePath(base *url.URL) Path {
+	return Path{
+		base: base,
+	}
+}
+
+// Join will sum path names onto a base URL and ensure it constructs a URL
+// that is valid.
+// Example:
+//  - http://baseurl/name0/name1/
+//
+func (u Path) Join(names ...string) (Path, error) {
+	baseURL := u.String()
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
+
+	namedPath := path.Join(names...)
+	path, err := url.Parse(baseURL + namedPath)
+	if err != nil {
+		return Path{}, errors.Trace(err)
+	}
+	return MakePath(path), nil
+}
+
+// Query adds additional query parameters to the Path.
+// Example:
+//  - http://baseurl/name0/name1?q=value
+//
+func (u Path) Query(key string, value string) (Path, error) {
+	baseQuery, err := url.ParseQuery(u.base.RawQuery)
+	if err != nil {
+		return Path{}, errors.Trace(err)
+	}
+
+	baseQuery.Add(key, value)
+
+	newURL, err := url.Parse(u.base.String())
+	if err != nil {
+		return Path{}, errors.Trace(err)
+	}
+
+	newURL.RawQuery = baseQuery.Encode()
+
+	return MakePath(newURL), nil
+}
+
+// String returns a stringified version of the Path.
+// Under the hood this calls the url.URL#String method.
+func (u Path) String() string {
+	return u.base.String()
+}

--- a/charmhub/path/package_test.go
+++ b/charmhub/path/package_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package path
+
+import (
+	"net/url"
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+func MustParseURL(c *gc.C, path string) *url.URL {
+	u, err := url.Parse(path)
+	c.Assert(err, jc.ErrorIsNil)
+	return u
+}
+
+func MustMakePath(c *gc.C, path string) Path {
+	u := MustParseURL(c, path)
+	return MakePath(u)
+}

--- a/charmhub/path/path.go
+++ b/charmhub/path/path.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmhub
+package path
 
 import (
 	"net/url"

--- a/charmhub/path/path_test.go
+++ b/charmhub/path/path_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmhub
+package path
 
 import (
 	"github.com/juju/testing"

--- a/charmhub/path_test.go
+++ b/charmhub/path_test.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type PathSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&PathSuite{})
+
+func (s *PathSuite) TestJoin(c *gc.C) {
+	rawURL := MustParseURL(c, "http://foobar/v1/path/")
+
+	path := MakePath(rawURL)
+	appPath, err := path.Join("entity", "app")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(appPath.String(), gc.Equals, "http://foobar/v1/path/entity/app")
+}
+
+func (s *PathSuite) TestJoinMultipleTimes(c *gc.C) {
+	rawURL := MustParseURL(c, "http://foobar/v1/path/")
+
+	path := MakePath(rawURL)
+	entityPath, err := path.Join("entity")
+	c.Assert(err, jc.ErrorIsNil)
+
+	appPath, err := entityPath.Join("app")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(appPath.String(), gc.Equals, "http://foobar/v1/path/entity/app")
+}
+
+func (s *PathSuite) TestQuery(c *gc.C) {
+	rawURL := MustParseURL(c, "http://foobar/v1/path")
+
+	path := MakePath(rawURL)
+
+	newPath, err := path.Query("q", "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(path.String(), gc.Equals, "http://foobar/v1/path")
+	c.Assert(newPath.String(), gc.Equals, "http://foobar/v1/path?q=foo")
+}
+
+func (s *PathSuite) TestJoinQuery(c *gc.C) {
+	rawURL := MustParseURL(c, "http://foobar/v1/path")
+
+	path := MakePath(rawURL)
+	entityPath, err := path.Join("entity")
+	c.Assert(err, jc.ErrorIsNil)
+
+	appPath, err := entityPath.Join("app")
+	c.Assert(err, jc.ErrorIsNil)
+
+	newPath, err := appPath.Query("q", "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(appPath.String(), gc.Equals, "http://foobar/v1/path/entity/app")
+	c.Assert(newPath.String(), gc.Equals, "http://foobar/v1/path/entity/app?q=foo")
+}
+
+func (s *PathSuite) TestMultipleQueries(c *gc.C) {
+	rawURL := MustParseURL(c, "http://foobar/v1/path")
+
+	path := MakePath(rawURL)
+
+	newPath, err := path.Query("q", "foo1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	newPath, err = newPath.Query("q", "foo2")
+	c.Assert(err, jc.ErrorIsNil)
+
+	newPath, err = newPath.Query("x", "bar")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(path.String(), gc.Equals, "http://foobar/v1/path")
+	c.Assert(newPath.String(), gc.Equals, "http://foobar/v1/path?q=foo1&q=foo2&x=bar")
+}

--- a/charmhub/transport.go
+++ b/charmhub/transport.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+// The following contains all the common DTOs for a gathering information from
+// a given store.
+
+type ChannelMap struct {
+	Channel  Channel  `json:"channel,omitempty"`
+	Revision Revision `json:"revision,omitempty"`
+}
+
+type Channel struct {
+	Name       string   `json:"name"`
+	Platform   Platform `json:"platform"`
+	ReleasedAt string   `json:"released-at"`
+	Risk       string   `json:"risk"`
+	Track      string   `json:"track"`
+}
+
+type Platform struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+	Series       string `json:"series"`
+}
+
+type Revision struct {
+	ConfigYAML   string     `json:"config-yaml"`
+	CreatedAt    string     `json:"created-at"`
+	Download     Download   `json:"download"`
+	MetadataYAML string     `json:"metadata-yaml"`
+	Platforms    []Platform `json:"platforms"`
+	Revision     int        `json:"revision"`
+	Version      string     `json:"version"`
+}
+
+type Download struct {
+	HashSHA265 string `json:"hash-sha-265"`
+	Size       int    `json:"size"`
+	URL        string `json:"url"`
+}
+
+type Charm struct {
+	Categories  []Category        `json:"categories"`
+	Description string            `json:"description"`
+	License     string            `json:"license"`
+	Media       []Media           `json:"media"`
+	Publisher   map[string]string `json:"publisher"`
+	Summary     string            `json:"summary"`
+	UsedBy      []string          `json:"used-by"`
+}
+
+type Category struct {
+	Featured bool   `json:"featured"`
+	Name     string `json:"name"`
+}
+
+type Media struct {
+	Type   string `json:"type"`
+	URL    string `json:"url"`
+	Width  int    `json:"width,omitempty"`
+	Height int    `json:"height,omitempty"`
+}

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmhub
+package transport
 
 // The following contains all the common DTOs for a gathering information from
 // a given store.

--- a/charmhub/transport/error.go
+++ b/charmhub/transport/error.go
@@ -1,0 +1,10 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package transport
+
+// APIError represents the error from the charmhub api.
+type APIError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package transport
+
+type FindResponses struct {
+	Results   []FindResponse `json:"results"`
+	ErrorList []APIError     `json:"error-list"`
+}
+
+type FindResponse struct {
+	Type           string       `json:"type"`
+	ID             string       `json:"id"`
+	Name           string       `json:"name"`
+	Charm          Charm        `json:"charm,omitempty"`
+	ChannelMap     []ChannelMap `json:"channel-map"`
+	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+}

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -1,0 +1,13 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package transport
+
+type InfoResponse struct {
+	Type           string       `json:"type"`
+	ID             string       `json:"id"`
+	Name           string       `json:"name"`
+	Charm          Charm        `json:"charm,omitempty"`
+	ChannelMap     []ChannelMap `json:"channel-map"`
+	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+}


### PR DESCRIPTION
## Description of change

The following adds find client methods for hitting the find endpoint.
The find is rather dumb at the moment, as we don't currently pass in any
additional arguments (--narrow for example). Instead, we're doing a
purely dumb lookup against some canned responses. So attempting to test
how other queries will work seem rather fruitless, we should though wire
these up in the future.

The code itself is rather boring, it just uses the existing rest-client
to query the endpoint and marshalls it correctly based on the content
type.

----

Example API is https://api.snapcraft.io/v2/charms/find?q=wordpress

Although it also brings back `osm` charm as well. 

## QA steps

```sh
go test -v ./charmhub/... -check.v -tags="integration"
```
