### PR TITLE
Add caas fields to allwatcher and cache.

### DIFF
--- a/core/cache/application_test.go
+++ b/core/cache/application_test.go
@@ -106,14 +106,16 @@ func (s *ApplicationSuite) TestStatusWhenUnsetNoUnits(c *gc.C) {
 	model := s.NewModel(cache.ModelChange{
 		Name: "test",
 	})
+	now := time.Now()
 	model.UpdateApplication(cache.ApplicationChange{
 		Name:   "app",
-		Status: s.status(status.Unset, time.Now()),
+		Status: s.status(status.Unset, now),
 	}, s.Manager)
 	app, err := model.Application("app")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(app.Status(), jc.DeepEquals, status.StatusInfo{
 		Status: status.Unknown,
+		Since:  &now,
 	})
 }
 
@@ -144,7 +146,7 @@ func (s *ApplicationSuite) TestStatusWhenUnsetWithUnits(c *gc.C) {
 	c.Assert(app.Status(), jc.DeepEquals, expected)
 }
 
-func (s *ApplicationSuite) TestStatusOperatorRunning(c *gc.C) {
+func (s *ApplicationSuite) TestDisplayStatusOperatorRunning(c *gc.C) {
 	model := s.NewModel(cache.ModelChange{
 		Name: "test",
 	})
@@ -156,10 +158,10 @@ func (s *ApplicationSuite) TestStatusOperatorRunning(c *gc.C) {
 	}, s.Manager)
 	app, err := model.Application("app")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(app.Status(), jc.DeepEquals, appStatus)
+	c.Assert(app.DisplayStatus(), jc.DeepEquals, appStatus)
 }
 
-func (s *ApplicationSuite) TestStatusOperatorActive(c *gc.C) {
+func (s *ApplicationSuite) TestDisplayStatusOperatorActive(c *gc.C) {
 	model := s.NewModel(cache.ModelChange{
 		Name: "test",
 	})
@@ -171,21 +173,22 @@ func (s *ApplicationSuite) TestStatusOperatorActive(c *gc.C) {
 	}, s.Manager)
 	app, err := model.Application("app")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(app.Status(), jc.DeepEquals, appStatus)
+	c.Assert(app.DisplayStatus(), jc.DeepEquals, appStatus)
 }
 
-func (s *ApplicationSuite) TestStatusOperatorWaiting(c *gc.C) {
+func (s *ApplicationSuite) TestDisplayStatusOperatorWaiting(c *gc.C) {
 	model := s.NewModel(cache.ModelChange{
 		Name: "test",
 	})
 	expected := s.status(status.Waiting, time.Now())
+	expected.Message = status.MessageInitializingAgent
 	model.UpdateApplication(cache.ApplicationChange{
 		Name:           "app",
 		Status:         s.status(status.Active, time.Now()),
 		OperatorStatus: expected}, s.Manager)
 	app, err := model.Application("app")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(app.Status(), jc.DeepEquals, expected)
+	c.Assert(app.DisplayStatus(), jc.DeepEquals, expected)
 }
 
 func (s *ApplicationSuite) TestUnitsSorted(c *gc.C) {

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/settings"
@@ -27,6 +28,7 @@ type ControllerConfigChange struct {
 type ModelChange struct {
 	ModelUUID       string
 	Name            string
+	Type            model.ModelType
 	Life            life.Value
 	Owner           string // tag maybe?
 	IsController    bool
@@ -46,6 +48,14 @@ type RemoveModel struct {
 	ModelUUID string
 }
 
+// PodSpec is used to determine whether or not a CAAS application
+// has called the command to set the pod spec.
+type PodSpec struct {
+	Spec    string
+	Raw     bool
+	Counter int
+}
+
 // ApplicationChange represents either a new application, or a change
 // to an existing application in a model.
 type ApplicationChange struct {
@@ -62,6 +72,7 @@ type ApplicationChange struct {
 	Status          status.StatusInfo
 	OperatorStatus  status.StatusInfo // For CAAS applications.
 	WorkloadVersion string
+	PodSpec         *PodSpec // For CAAS applications.
 }
 
 // copy returns a deep copy of the ApplicationChange.
@@ -150,8 +161,10 @@ type UnitChange struct {
 	PortRanges     []network.PortRange
 	Principal      string
 	Subordinate    bool
-	WorkloadStatus status.StatusInfo
-	AgentStatus    status.StatusInfo
+
+	WorkloadStatus  status.StatusInfo
+	AgentStatus     status.StatusInfo
+	ContainerStatus status.StatusInfo // For CAAS models.
 }
 
 // copy returns a deep copy of the UnitChange.

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/pubsub"
 
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 )
@@ -89,6 +90,13 @@ type Model struct {
 	// subscribers have handled the call. We only record the last one
 	// as the tests want to know that a set of changes have been applied.
 	lastSummaryPublish <-chan struct{}
+}
+
+// Type returns the model type for this model, either "iaas" or "caas".
+func (m *Model) Type() model.ModelType {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.details.Type
 }
 
 // Config returns the current model config.

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -189,6 +189,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/instance",
 		"core/life",
 		"core/lxdprofile",
+		"core/model",
 		"core/network",
 		"core/permission",
 		"core/settings",

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/settings"
 	"github.com/juju/juju/core/status"
@@ -85,6 +86,21 @@ func (u *Unit) AgentStatus() status.StatusInfo {
 // WorkloadStatus returns the workload status of the unit.
 func (u *Unit) WorkloadStatus() status.StatusInfo {
 	return u.details.WorkloadStatus
+}
+
+// DisplayWorkloadStatus returns the workload status of the unit.
+// For CAAS models, the cloud container status is used over the unit
+// if the cloud container status in certain circumstances.
+func (u *Unit) DisplayWorkloadStatus() status.StatusInfo {
+	if u.model.Type() == model.IAAS {
+		return u.details.WorkloadStatus
+	}
+	app, err := u.model.Application(u.Application())
+	if err != nil {
+		return u.details.WorkloadStatus
+	}
+	return status.UnitDisplayStatus(
+		u.details.WorkloadStatus, u.details.ContainerStatus, app.ExpectsWorkload())
 }
 
 // ConfigSettings returns the effective charm configuration for this unit

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -177,6 +177,14 @@ func NewStatusInfo(s status.StatusInfo, err error) StatusInfo {
 	}
 }
 
+// PodSpec is used to determine whether or not a CAAS application
+// has called the command to set the pod spec.
+type PodSpec struct {
+	Spec    string
+	Raw     bool
+	Counter int
+}
+
 // ApplicationInfo holds the information about an application that is tracked
 // by multiwatcherStore.
 type ApplicationInfo struct {
@@ -192,8 +200,9 @@ type ApplicationInfo struct {
 	Config          map[string]interface{}
 	Subordinate     bool
 	Status          StatusInfo
-	OperatorStatus  StatusInfo // For CAAS models
+	OperatorStatus  StatusInfo // For CAAS models.
 	WorkloadVersion string
+	PodSpec         *PodSpec // For CAAS models.
 }
 
 // EntityID returns a unique identifier for an application across
@@ -364,8 +373,9 @@ type UnitInfo struct {
 	Principal      string
 	Subordinate    bool
 	// Workload and agent state are modelled separately.
-	WorkloadStatus StatusInfo
-	AgentStatus    StatusInfo
+	WorkloadStatus  StatusInfo
+	AgentStatus     StatusInfo
+	ContainerStatus StatusInfo // For CAAS models.
 }
 
 // EntityID returns a unique identifier for a unit across

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -124,6 +124,28 @@ func (s *internalStateSuite) newState(c *gc.C) *State {
 	return st
 }
 
+func (s *internalStateSuite) newCAASState(c *gc.C) *State {
+	s.modelCount++
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": fmt.Sprintf("testmodel%d", s.modelCount),
+		"uuid": utils.MustNewUUID().String(),
+	})
+	_, st, err := s.controller.NewModel(ModelArgs{
+		Type:        ModelTypeCAAS,
+		CloudName:   "dummy",
+		CloudRegion: "dummy-region",
+		Config:      cfg,
+		Owner:       s.owner,
+		StorageProviderRegistry: storage.ChainedProviderRegistry{
+			dummy.StorageProviders(),
+			provider.CommonStorageProviders(),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { st.Close() })
+	return st
+}
+
 type internalStatePolicy struct{}
 
 func (internalStatePolicy) Prechecker() (environs.InstancePrechecker, error) {

--- a/state/podspec_ops.go
+++ b/state/podspec_ops.go
@@ -68,14 +68,14 @@ func (op *setPodSpecOperation) buildTxn(_ int) ([]txn.Op, error) {
 	}
 
 	var prereqOps []txn.Op
-	appTagID := op.appTag.Id()
-	app, err := op.m.State().Application(appTagID)
+	appName := op.appTag.Id()
+	app, err := op.m.State().Application(appName)
 	if err != nil {
 		return nil, errors.Annotate(err, "setting pod spec")
 	}
 	if app.Life() != Alive {
 		return nil, errors.Annotate(
-			errors.Errorf("application %s not alive", app.String()),
+			errors.Errorf("application %s not alive", appName),
 			"setting pod spec",
 		)
 	}
@@ -97,7 +97,7 @@ func (op *setPodSpecOperation) buildTxn(_ int) ([]txn.Op, error) {
 
 	sop := txn.Op{
 		C:  podSpecsC,
-		Id: applicationGlobalKey(appTagID),
+		Id: applicationGlobalKey(appName),
 	}
 	existing, err := op.m.podInfo(op.appTag)
 	if err == nil {

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -410,6 +410,7 @@ func (c *cacheWorker) translateModel(d multiwatcher.Delta) interface{} {
 	return cache.ModelChange{
 		ModelUUID:       value.ModelUUID,
 		Name:            value.Name,
+		Type:            value.Type,
 		Life:            value.Life,
 		Owner:           value.Owner,
 		IsController:    value.IsController,
@@ -441,6 +442,15 @@ func (c *cacheWorker) translateApplication(d multiwatcher.Delta) interface{} {
 		return nil
 	}
 
+	var podSpec *cache.PodSpec
+	if spec := value.PodSpec; spec != nil {
+		podSpec = &cache.PodSpec{
+			Spec:    spec.Spec,
+			Raw:     spec.Raw,
+			Counter: spec.Counter,
+		}
+	}
+
 	return cache.ApplicationChange{
 		ModelUUID:       value.ModelUUID,
 		Name:            value.Name,
@@ -453,7 +463,9 @@ func (c *cacheWorker) translateApplication(d multiwatcher.Delta) interface{} {
 		Config:          value.Config,
 		Subordinate:     value.Subordinate,
 		Status:          coreStatus(value.Status),
+		OperatorStatus:  coreStatus(value.OperatorStatus),
 		WorkloadVersion: value.WorkloadVersion,
+		PodSpec:         podSpec,
 	}
 }
 
@@ -527,8 +539,10 @@ func (c *cacheWorker) translateUnit(d multiwatcher.Delta) interface{} {
 		PortRanges:     value.PortRanges,
 		Principal:      value.Principal,
 		Subordinate:    value.Subordinate,
-		WorkloadStatus: coreStatus(value.WorkloadStatus),
-		AgentStatus:    coreStatus(value.AgentStatus),
+
+		WorkloadStatus:  coreStatus(value.WorkloadStatus),
+		AgentStatus:     coreStatus(value.AgentStatus),
+		ContainerStatus: coreStatus(value.ContainerStatus),
 	}
 }
 


### PR DESCRIPTION
In order to be able to correctly derive an application status in the cache for a CAAS model,
additional data needs to be passed in. Both the podSpec and container status for the units
need to be available.

A drive-by in this branch was chaning the loggers used in the allwatcher package to all use
the allWatcherLogger not the standard state package logger. This is really useful when 
debugging the low level watcher tests.

In order to correctly handle the status changes in the allwatcher, the method to determine
the parent had to be refactored to return the suffix as an additional parameter. This is then
used in the statusDoc updated method to update the correct status value.

## QA steps

Just the unit tests.

