### PR TITLE
Migrate Additional IP Address Fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
-	github.com/juju/description/v2 v2.0.0-20200514032006-b515a22fe74e
+	github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
@@ -106,7 +106,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c h1:m/Uo8B7nrH3K6n
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
-github.com/juju/description/v2 v2.0.0-20200514032006-b515a22fe74e h1:YewjT3e0KpdGM/3k5cJTAD7vPzKe9/PEd7qSlUwaxPY=
-github.com/juju/description/v2 v2.0.0-20200514032006-b515a22fe74e/go.mod h1:5CKxYQKZCqzv6+dokJVLL7bCCeFZHi1j3i2iLb/X7Z8=
+github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a h1:/ygBd+M6aG7v3SSUJYhwCc6dqKZCI467+eNaEYUAWXg=
+github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
@@ -633,8 +633,8 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200422194213-44a606286825 h1:dSChiwOTvzwbHFTMq2l6uRardHH7/E6SqEkqccinS/o=
 golang.org/x/crypto v0.0.0-20200422194213-44a606286825/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
-golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -194,7 +194,7 @@ func (st *State) exportImpl(cfg ExportConfig) (description.Model, error) {
 	if err := export.subnets(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := export.ipaddresses(); err != nil {
+	if err := export.ipAddresses(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := export.linklayerdevices(); err != nil {
@@ -1492,7 +1492,7 @@ func (e *exporter) subnets() error {
 	return nil
 }
 
-func (e *exporter) ipaddresses() error {
+func (e *exporter) ipAddresses() error {
 	if e.cfg.SkipIPAddresses {
 		return nil
 	}
@@ -1503,15 +1503,18 @@ func (e *exporter) ipaddresses() error {
 	e.logger.Debugf("read %d ip addresses", len(ipaddresses))
 	for _, addr := range ipaddresses {
 		e.model.AddIPAddress(description.IPAddressArgs{
-			ProviderID:       string(addr.ProviderID()),
-			DeviceName:       addr.DeviceName(),
-			MachineID:        addr.MachineID(),
-			SubnetCIDR:       addr.SubnetCIDR(),
-			ConfigMethod:     string(addr.ConfigMethod()),
-			Value:            addr.Value(),
-			DNSServers:       addr.DNSServers(),
-			DNSSearchDomains: addr.DNSSearchDomains(),
-			GatewayAddress:   addr.GatewayAddress(),
+			ProviderID:        string(addr.ProviderID()),
+			DeviceName:        addr.DeviceName(),
+			MachineID:         addr.MachineID(),
+			SubnetCIDR:        addr.SubnetCIDR(),
+			ConfigMethod:      string(addr.ConfigMethod()),
+			Value:             addr.Value(),
+			DNSServers:        addr.DNSServers(),
+			DNSSearchDomains:  addr.DNSSearchDomains(),
+			GatewayAddress:    addr.GatewayAddress(),
+			ProviderNetworkID: addr.ProviderNetworkID().String(),
+			ProviderSubnetID:  addr.ProviderSubnetID().String(),
+			Origin:            string(addr.Origin()),
 		})
 	}
 	return nil

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1322,13 +1322,16 @@ func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	err = machine.SetLinkLayerDevices(deviceArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	args := state.LinkLayerDeviceAddress{
-		DeviceName:       "foo",
-		ConfigMethod:     network.StaticAddress,
-		CIDRAddress:      "0.1.2.3/24",
-		ProviderID:       "bar",
-		DNSServers:       []string{"bam", "mam"},
-		DNSSearchDomains: []string{"weeee"},
-		GatewayAddress:   "0.1.2.1",
+		DeviceName:        "foo",
+		ConfigMethod:      network.StaticAddress,
+		CIDRAddress:       "0.1.2.3/24",
+		ProviderID:        "bar",
+		DNSServers:        []string{"bam", "mam"},
+		DNSSearchDomains:  []string{"weeee"},
+		GatewayAddress:    "0.1.2.1",
+		ProviderNetworkID: "p-net-id",
+		ProviderSubnetID:  "p-sub-id",
+		Origin:            network.OriginProvider,
 	}
 	err = machine.SetDevicesAddresses(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1348,6 +1351,10 @@ func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	c.Assert(addr.DNSServers(), jc.DeepEquals, []string{"bam", "mam"})
 	c.Assert(addr.DNSSearchDomains(), jc.DeepEquals, []string{"weeee"})
 	c.Assert(addr.GatewayAddress(), gc.Equals, "0.1.2.1")
+	c.Assert(addr.ProviderNetworkID(), gc.Equals, "p-net-id")
+	c.Assert(addr.ProviderSubnetID(), gc.Equals, "p-sub-id")
+	c.Assert(addr.Origin(), gc.Equals, string(network.OriginProvider))
+
 }
 
 func (s *MigrationExportSuite) TestIPAddressesSkipped(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -203,8 +203,8 @@ func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err
 	if err := restore.linklayerdevices(); err != nil {
 		return nil, nil, errors.Annotate(err, "linklayerdevices")
 	}
-	if err := restore.ipaddresses(); err != nil {
-		return nil, nil, errors.Annotate(err, "ipaddresses")
+	if err := restore.ipAddresses(); err != nil {
+		return nil, nil, errors.Annotate(err, "ipAddresses")
 	}
 	if err := restore.storage(); err != nil {
 		return nil, nil, errors.Annotate(err, "storage")
@@ -1796,16 +1796,16 @@ func (i *importer) addSubnet(id string, args network.SubnetInfo) error {
 	return nil
 }
 
-func (i *importer) ipaddresses() error {
-	i.logger.Debugf("importing ip addresses")
+func (i *importer) ipAddresses() error {
+	i.logger.Debugf("importing IP addresses")
 	for _, addr := range i.model.IPAddresses() {
 		err := i.addIPAddress(addr)
 		if err != nil {
-			i.logger.Errorf("error importing ip address %v: %s", addr, err)
+			i.logger.Errorf("error importing IP address %v: %s", addr, err)
 			return errors.Trace(err)
 		}
 	}
-	i.logger.Debugf("importing ip addresses succeeded")
+	i.logger.Debugf("importing IP addresses succeeded")
 	return nil
 }
 
@@ -1820,18 +1820,21 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 	modelUUID := i.st.ModelUUID()
 
 	newDoc := &ipAddressDoc{
-		DocID:            ipAddressDocID,
-		ModelUUID:        modelUUID,
-		ProviderID:       providerID,
-		DeviceName:       addr.DeviceName(),
-		MachineID:        addr.MachineID(),
-		SubnetCIDR:       subnetCIDR,
-		ConfigMethod:     network.AddressConfigMethod(addr.ConfigMethod()),
-		Value:            addressValue,
-		DNSServers:       addr.DNSServers(),
-		DNSSearchDomains: addr.DNSSearchDomains(),
-		GatewayAddress:   addr.GatewayAddress(),
-		IsDefaultGateway: addr.IsDefaultGateway(),
+		DocID:             ipAddressDocID,
+		ModelUUID:         modelUUID,
+		ProviderID:        providerID,
+		DeviceName:        addr.DeviceName(),
+		MachineID:         addr.MachineID(),
+		SubnetCIDR:        subnetCIDR,
+		ConfigMethod:      network.AddressConfigMethod(addr.ConfigMethod()),
+		Value:             addressValue,
+		DNSServers:        addr.DNSServers(),
+		DNSSearchDomains:  addr.DNSSearchDomains(),
+		GatewayAddress:    addr.GatewayAddress(),
+		IsDefaultGateway:  addr.IsDefaultGateway(),
+		ProviderNetworkID: addr.ProviderNetworkID(),
+		ProviderSubnetID:  addr.ProviderSubnetID(),
+		Origin:            network.Origin(addr.Origin()),
 	}
 
 	ops := []txn.Op{{

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1662,13 +1662,16 @@ func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {
 	err = machine.SetLinkLayerDevices(deviceArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	args := state.LinkLayerDeviceAddress{
-		DeviceName:       "foo",
-		ConfigMethod:     network.StaticAddress,
-		CIDRAddress:      "0.1.2.3/24",
-		ProviderID:       "bar",
-		DNSServers:       []string{"bam", "mam"},
-		DNSSearchDomains: []string{"weeee"},
-		GatewayAddress:   "0.1.2.1",
+		DeviceName:        "foo",
+		ConfigMethod:      network.StaticAddress,
+		CIDRAddress:       "0.1.2.3/24",
+		ProviderID:        "bar",
+		DNSServers:        []string{"bam", "mam"},
+		DNSSearchDomains:  []string{"weeee"},
+		GatewayAddress:    "0.1.2.1",
+		ProviderNetworkID: "p-net-id",
+		ProviderSubnetID:  "p-sub-id",
+		Origin:            network.OriginProvider,
 	}
 	err = machine.SetDevicesAddresses(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1688,6 +1691,9 @@ func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {
 	c.Assert(addr.DNSServers(), jc.DeepEquals, []string{"bam", "mam"})
 	c.Assert(addr.DNSSearchDomains(), jc.DeepEquals, []string{"weeee"})
 	c.Assert(addr.GatewayAddress(), gc.Equals, "0.1.2.1")
+	c.Assert(addr.ProviderNetworkID().String(), gc.Equals, "p-net-id")
+	c.Assert(addr.ProviderSubnetID().String(), gc.Equals, "p-sub-id")
+	c.Assert(addr.Origin(), gc.Equals, network.OriginProvider)
 }
 
 func (s *MigrationImportSuite) TestSSHHostKey(c *gc.C) {


### PR DESCRIPTION
## Description of change

This patch updates the _juju/description_ dependency, and ensures the following additional fields are migrated with IP Addresses:
- `ProviderNetworkID`
- `ProviderSubnetID`
- `Origin`

## QA steps

Regression:
- With this patch run `juju bootstrap lxd dst --no-gui && juju destroy-model default -y`.
- With 2.7 run `juju bootstrap lxd src --no-gui && juju add-machine`.
- After quiescence run `juju migrate default dst` and ensure success.

Success:
- Execute the steps above on AWS, but bootstrap all controllers with this patch.
- Check the IP addresses collection. The ens* devices should have fields populated for `provider-subnet-id` and `origin`.

## Documentation changes

None.

## Bug reference

N/A
