### PR TITLE
Validate ingress resource names;

### DIFF
--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -29,6 +29,9 @@ func (k *kubernetesClient) ensureIngressResources(
 	appName string, annotations k8sannotations.Annotation, ingSpecs []k8sspecs.K8sIngressSpec,
 ) (cleanUps []func(), err error) {
 	for _, v := range ingSpecs {
+		if v.Name == appName {
+			return cleanUps, errors.NotValidf("ingress name %q is reserved for juju expose", appName)
+		}
 		ing := &v1beta1.Ingress{
 			ObjectMeta: v1.ObjectMeta{
 				Name:        v.Name,


### PR DESCRIPTION

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Raise an error if charm has any ingress resources named to the application name because the application name is a reserved name for juju expose.

## QA steps

-  deploy a charm creates an ingress resource using the application name;

## Documentation changes

Maybe

## Bug reference

https://bugs.launchpad.net/juju/+bug/1884674
