### PR TITLE
Network health integration test

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -46,14 +46,13 @@ idle_condition() {
 }
 
 idle_subordinate_condition() {
-    local name parent unit_index parent_index
+    local name parent unit_index
 
     name=${1}
     parent=${2}
     unit_index=${3:-0}
-    parent_index=${4:-0}
 
-    path=".[\"$parent\"] | .units | .[\"$parent/$parent_index\"] | .subordinates | .[\"$name/$unit_index\"]"
+    path=".[\"$parent\"] | .units | .[] | .subordinates | .[\"$name/$unit_index\"]"
 
     # Print the *subordinate* name if it has an idle status in parent application
     echo ".applications | select(($path | .[\"juju-status\"] | .current == \"idle\") and ($path | .[\"workload-status\"] | .current != \"error\")) | \"$name\""

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -1,26 +1,79 @@
 run_network_health() {
-  echo
+    echo
 
-  file="${TEST_DIR}/network-health.txt"
+    file="${TEST_DIR}/network-health.txt"
 
-  ensure "network-health" "${file}"
+    ensure "network-health" "${file}"
 
-  # Deploy/relate charms and run connection tests.
+    # Deploy some applications for different series.
+    juju deploy mongodb --series xenial
+    juju deploy ubuntu -n 2 --series bionic
 
-  destroy_model "network-health"
+    # Now the testing charm for each series.
+    # TODO (manadart 2020-06-08): This charm needs updating with Focal support.
+    juju deploy '~juju-qa/network-health' network-health-xenial --series xenial
+    juju deploy '~juju-qa/network-health' network-health-bionic --series bionic
+
+    juju expose network-health-xenial
+    juju expose network-health-bionic
+
+    juju add-relation network-health-xenial mongodb
+    juju add-relation network-health-bionic ubuntu
+
+    wait_for "mongodb" "$(idle_condition "mongodb")"
+    wait_for "ubuntu" "$(idle_condition "ubuntu" 3 0)"
+    wait_for "ubuntu" "$(idle_condition "ubuntu" 3 1)"
+    wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "mongodb")"
+    wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu" 0)"
+    wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu" 1)"
+
+    check_default_routes
+    check_accessibility
+
+    destroy_model "network-health"
+}
+
+check_default_routes() {
+    echo "[+] checking default routes"
+
+    for machine in $(juju machines --format=json | jq -r ".machines | keys | .[]"); do
+        default=$(juju run --machine "$machine" -- ip route show | grep default)
+        if [ -z "$default" ]; then
+            echo "No default route detected for machine ${machine}"
+            exit 1
+        fi
+    done
+}
+
+check_accessibility() {
+    echo "[+] checking neighbour connectivity and external access"
+
+    for net_health_unit in "network-health-xenial/0" "network-health-bionic/0"  "network-health-bionic/1"; do
+        ip="$(juju show-unit $net_health_unit --format json | jq -r ".[\"$net_health_unit\"] | .[\"public-address\"]")"
+
+        curl_cmd="curl 2>/dev/null ${ip}:8039"
+
+        # Check that each of the principles can access the subordinate.
+        for principle_unit in "mongodb/0" "ubuntu/0" "ubuntu/1"; do
+            check_contains "$(juju run --unit $principle_unit "$curl_cmd")" "pass"
+        done
+
+        # Check that the exposed subordinate is accessible externally.
+        check_contains "$($curl_cmd)" "pass"
+    done
 }
 
 test_network_health() {
-  if [ "$(skip 'test_active_branch_output')" ]; then
-    echo "==> TEST SKIPPED: test_network_health"
-    return
-  fi
+    if [ "$(skip 'test_network_health')" ]; then
+        echo "==> TEST SKIPPED: test_network_health"
+        return
+    fi
 
-  (
-    set_verbosity
+    (
+        set_verbosity
 
-    cd .. || exit
+        cd .. || exit
 
-    run "run_network_health"
-  )
+        run "run_network_health"
+    )
 }

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -1,0 +1,26 @@
+run_network_health() {
+  echo
+
+  file="${TEST_DIR}/network-health.txt"
+
+  ensure "network-health" "${file}"
+
+  # Deploy/relate charms and run connection tests.
+
+  destroy_model "network-health"
+}
+
+test_network_health() {
+  if [ "$(skip 'test_active_branch_output')" ]; then
+    echo "==> TEST SKIPPED: test_network_health"
+    return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    run "run_network_health"
+  )
+}

--- a/tests/suites/network/task.sh
+++ b/tests/suites/network/task.sh
@@ -1,0 +1,19 @@
+test_network() {
+    if [ "$(skip 'test_network')" ]; then
+        echo "==> TEST SKIPPED: network tests"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju
+
+    file="${TEST_DIR}/test-network.txt"
+
+    bootstrap "test-network" "${file}"
+
+    test_network_health
+
+    destroy_controller "test-network"
+}


### PR DESCRIPTION
## Description of change

This patch adds an integration test suite that will ultimately replace the current network health acceptance tests.

## QA steps

```sh
cd tests
BOOTSTRAP_PROVIDER=aws ./main.sh -v network
```

## Documentation changes

None.

## Bug reference

N/A
