### PR TITLE
[dev] Export virtual port type when migrating

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
-	github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a
+	github.com/juju/description/v2 v2.0.0-20200624110037-d88c95d27048
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c h1:m/Uo8B7nrH3K6n
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
-github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a h1:/ygBd+M6aG7v3SSUJYhwCc6dqKZCI467+eNaEYUAWXg=
-github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
+github.com/juju/description/v2 v2.0.0-20200624110037-d88c95d27048 h1:RrssxHrvsflbE6Sv3UhGT4pOArrfu4S6zqeyyHk/Mj8=
+github.com/juju/description/v2 v2.0.0-20200624110037-d88c95d27048/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1453,15 +1453,16 @@ func (e *exporter) linklayerdevices() error {
 	e.logger.Debugf("read %d ip devices", len(linklayerdevices))
 	for _, device := range linklayerdevices {
 		e.model.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
-			ProviderID:  string(device.ProviderID()),
-			MachineID:   device.MachineID(),
-			Name:        device.Name(),
-			MTU:         device.MTU(),
-			Type:        string(device.Type()),
-			MACAddress:  device.MACAddress(),
-			IsAutoStart: device.IsAutoStart(),
-			IsUp:        device.IsUp(),
-			ParentName:  device.ParentName(),
+			ProviderID:      string(device.ProviderID()),
+			MachineID:       device.MachineID(),
+			Name:            device.Name(),
+			MTU:             device.MTU(),
+			Type:            string(device.Type()),
+			MACAddress:      device.MACAddress(),
+			IsAutoStart:     device.IsAutoStart(),
+			IsUp:            device.IsUp(),
+			ParentName:      device.ParentName(),
+			VirtualPortType: string(device.VirtualPortType()),
 		})
 	}
 	return nil

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1169,8 +1169,9 @@ func (s *MigrationExportSuite) TestLinkLayerDevices(c *gc.C) {
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
 	})
 	deviceArgs := state.LinkLayerDeviceArgs{
-		Name: "foo",
-		Type: network.EthernetDevice,
+		Name:            "foo",
+		Type:            network.EthernetDevice,
+		VirtualPortType: network.OvsPort,
 	}
 	err := machine.SetLinkLayerDevices(deviceArgs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1183,6 +1184,7 @@ func (s *MigrationExportSuite) TestLinkLayerDevices(c *gc.C) {
 	device := devices[0]
 	c.Assert(device.Name(), gc.Equals, "foo")
 	c.Assert(device.Type(), gc.Equals, string(network.EthernetDevice))
+	c.Assert(device.VirtualPortType(), gc.Equals, "openvswitch", gc.Commentf("VirtualPortType was not exported correctly"))
 }
 
 func (s *MigrationExportSuite) TestLinkLayerDevicesSkipped(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1705,17 +1705,18 @@ func (i *importer) addLinkLayerDevice(device description.LinkLayerDevice) error 
 	localID := linkLayerDeviceGlobalKey(device.MachineID(), device.Name())
 	linkLayerDeviceDocID := i.st.docID(localID)
 	newDoc := &linkLayerDeviceDoc{
-		ModelUUID:   modelUUID,
-		DocID:       linkLayerDeviceDocID,
-		MachineID:   device.MachineID(),
-		ProviderID:  providerID,
-		Name:        device.Name(),
-		MTU:         device.MTU(),
-		Type:        network.LinkLayerDeviceType(device.Type()),
-		MACAddress:  device.MACAddress(),
-		IsAutoStart: device.IsAutoStart(),
-		IsUp:        device.IsUp(),
-		ParentName:  device.ParentName(),
+		ModelUUID:       modelUUID,
+		DocID:           linkLayerDeviceDocID,
+		MachineID:       device.MachineID(),
+		ProviderID:      providerID,
+		Name:            device.Name(),
+		MTU:             device.MTU(),
+		Type:            network.LinkLayerDeviceType(device.Type()),
+		MACAddress:      device.MACAddress(),
+		IsAutoStart:     device.IsAutoStart(),
+		IsUp:            device.IsUp(),
+		ParentName:      device.ParentName(),
+		VirtualPortType: network.VirtualPortType(device.VirtualPortType()),
 	}
 
 	ops := []txn.Op{{

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1486,8 +1486,9 @@ func (s *MigrationImportSuite) TestLinkLayerDevice(c *gc.C) {
 		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
 	})
 	deviceArgs := state.LinkLayerDeviceArgs{
-		Name: "foo",
-		Type: network.EthernetDevice,
+		Name:            "foo",
+		Type:            network.EthernetDevice,
+		VirtualPortType: network.OvsPort,
 	}
 	err := machine.SetLinkLayerDevices(deviceArgs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1499,6 +1500,7 @@ func (s *MigrationImportSuite) TestLinkLayerDevice(c *gc.C) {
 	device := devices[0]
 	c.Assert(device.Name(), gc.Equals, "foo")
 	c.Assert(device.Type(), gc.Equals, network.EthernetDevice)
+	c.Assert(device.VirtualPortType(), gc.Equals, network.OvsPort, gc.Commentf("VirtualPortType not migrated correctly"))
 }
 
 func (s *MigrationImportSuite) TestLinkLayerDeviceMigratesReferences(c *gc.C) {


### PR DESCRIPTION
## Description of change

Small follow-up PR to the OVS support work to export/import the `VirtualPortType` field for link layer devices when migrating models.
 
## QA steps

Not required.