### PR TITLE
Deterministic bundle changes with dry-run

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -483,8 +483,7 @@
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "9c9a93fa5758432ec07279ca9ece5c686008a802"
-  source = "github.com/SimonRichardson/bundlechanges"
+  revision = "6fa9a5bcf8d4ec654391174c8fe8ab032f0fd0c4"
 
 [[projects]]
   digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -479,11 +479,12 @@
   revision = "b99631de12cf04a906c1d4e4ec54fb86eae5863d"
 
 [[projects]]
-  digest = "1:9544af6faffc74ab333f16af6a5083af589efaf817465ee9d32318b354184d9a"
+  digest = "1:0a665becb192f6be720b9356da6356e71a9d769420117ecc3e7957188a791a99"
   name = "github.com/juju/bundlechanges"
   packages = ["."]
   pruneopts = ""
-  revision = "b5d1e3bdcff216029591bdd2fa013fd0dd3d8b3e"
+  revision = "9c9a93fa5758432ec07279ca9ece5c686008a802"
+  source = "github.com/SimonRichardson/bundlechanges"
 
 [[projects]]
   digest = "1:f720ea29e073a9a7109a5080f32753292dc8616a22a905876d425cc64c21bd8d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,8 +59,9 @@
   source = "github.com/juju/raft-boltdb"
 
 [[constraint]]
-  revision = "b5d1e3bdcff216029591bdd2fa013fd0dd3d8b3e"
+  revision = "9c9a93fa5758432ec07279ca9ece5c686008a802"
   name = "github.com/juju/bundlechanges"
+  source = "github.com/SimonRichardson/bundlechanges"
 
 [[constraint]]
   revision = "518c591d8576f28b31d46e90ee00536418690345"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,9 +59,8 @@
   source = "github.com/juju/raft-boltdb"
 
 [[constraint]]
-  revision = "9c9a93fa5758432ec07279ca9ece5c686008a802"
+  revision = "6fa9a5bcf8d4ec654391174c8fe8ab032f0fd0c4"
   name = "github.com/juju/bundlechanges"
-  source = "github.com/SimonRichardson/bundlechanges"
 
 [[constraint]]
   revision = "518c591d8576f28b31d46e90ee00536418690345"


### PR DESCRIPTION
## Description of change

The following brings in the process bundle machine changes from
bundlechanges package. The gopkg still refers to my personal repo until
it's approved correctly, once that's done I'll update it here.


## QA steps

It might be worth testing this without the changes first and then the changes
to see the difference.

```yaml
# repro.yaml
series: bionic
machines:
  "0":
    series: bionic
  "1":
    series: bionic
  "2":
    series: bionic
  "10":
    series: bionic
  "11":
    series: bionic
  "12":
    series: bionic

applications:
    ubuntu:
      num_units: 6
      charm: ubuntu
      to:
      - 0
      - 1
      - 2
      - 10
      - 11
      - 12
    memcached:
      num_units: 3
      charm: cs:memcached
      to:
      - 10
      - 11
      - 12
```

```yaml
# repro2.yaml
series: bionic
machines:
  "0":
    series: bionic
  "1":
    series: bionic
  "2":
    series: bionic
  "10":
    series: bionic
  "11":
    series: bionic
  "12":
    series: bionic
  "20":
    series: bionic
  "21":
    series: bionic
  "22":
    series: bionic

applications:
    ubuntu:
      num_units: 6
      charm: ubuntu
      to:
      - 0
      - 1
      - 2
      - 10
      - 11
      - 12
    memcached:
      num_units: 6
      charm: cs:memcached
      to:
      - 10
      - 11
      - 12
      - 20
      - 21
      - 22
```

```sh
juju bootstrap lxd test
juju deploy ./repro.yaml

# Run the following command multiple times, to see it change the 
# output for released 2.7 vs this patch.
juju deploy --dry-run ./repro2.yaml
```

You should see the following output every time:

```sh
Resolving charm: cs:memcached
Resolving charm: ubuntu
Changes to deploy bundle:
- add new machine 6 (bundle machine 20)
- add new machine 7 (bundle machine 21)
- add new machine 8 (bundle machine 22)
- add unit memcached/3 to new machine 6
- add unit memcached/4 to new machine 7
- add unit memcached/5 to new machine 8
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1883645
