### PR TITLE
Handle missing security groups

### DIFF
--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -903,7 +903,7 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointBadURL(c *gc.C) {
 		"north": map[string]string{"volumev2": "some %4"},
 	}}
 	url, err := openstack.GetVolumeEndpointURL(client, "north")
-	c.Assert(err, gc.ErrorMatches, `parse some %4: .*`)
+	c.Assert(err, gc.ErrorMatches, `parse ("?)some %4("?): .*`)
 	c.Assert(url, gc.IsNil)
 }
 

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -567,8 +567,8 @@ func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2)
 	// Due to parallelization of the provisioner, it's possible that we try
 	// to create the model security group a second time before the first time
 	// is complete causing failures.
-	// NOTE: This can block for ever (API timeouts). We should allow a mutex to
-	// timeout and fail with an error.
+	// TODO (stickupkid): This can block forever (API timeouts). We should allow
+	// a mutex to timeout and fail with an error.
 	c.ensureGroupMutex.Lock()
 	defer c.ensureGroupMutex.Unlock()
 

--- a/provider/openstack/legacy_firewaller.go
+++ b/provider/openstack/legacy_firewaller.go
@@ -32,7 +32,7 @@ type legacyNovaFirewaller struct {
 // other instances that might be running on the same OpenStack account.
 // In addition, a specific machine security group is created for each
 // machine, so that its firewall rules can be configured per machine.
-func (c *legacyNovaFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPort int) ([]string, error) {
+func (c *legacyNovaFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineID string, apiPort int) ([]string, error) {
 	jujuGroup, err := c.setUpGlobalGroup(ctx, c.jujuGroupName(controllerUUID), apiPort)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -40,7 +40,7 @@ func (c *legacyNovaFirewaller) SetUpGroups(ctx context.ProviderCallContext, cont
 	var machineGroup nova.SecurityGroup
 	switch c.environ.Config().FirewallMode() {
 	case config.FwInstance:
-		machineGroup, err = c.ensureGroup(ctx, c.machineGroupName(controllerUUID, machineId), nil)
+		machineGroup, err = c.ensureGroup(ctx, c.machineGroupName(controllerUUID, machineID), nil)
 	case config.FwGlobal:
 		machineGroup, err = c.ensureGroup(ctx, c.globalGroupName(controllerUUID), nil)
 	}
@@ -132,6 +132,7 @@ func (c *legacyNovaFirewaller) ensureGroup(ctx context.ProviderCallContext, name
 			// mean CIDR=0.0.0.0/0
 			rule.GroupId = &group.Id
 		}
+
 		groupRule, err := novaClient.CreateSecurityGroupRule(rule)
 		if err != nil && !gooseerrors.IsDuplicateValue(err) {
 			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
@@ -149,6 +150,7 @@ func (c *legacyNovaFirewaller) deleteSecurityGroups(ctx context.ProviderCallCont
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Annotate(err, "cannot list security groups")
 	}
+
 	for _, group := range securityGroups {
 		if match(group.Name) {
 			deleteSecurityGroup(ctx,
@@ -238,18 +240,18 @@ func (c *legacyNovaFirewaller) IngressRules(ctx context.ProviderCallContext) ([]
 }
 
 // OpenInstancePorts implements Firewaller interface.
-func (c *legacyNovaFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules []network.IngressRule) error {
-	return c.openInstancePorts(ctx, c.openPortsInGroup, machineId, rules)
+func (c *legacyNovaFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineID string, rules []network.IngressRule) error {
+	return c.openInstancePorts(ctx, c.openPortsInGroup, machineID, rules)
 }
 
 // CloseInstancePorts implements Firewaller interface.
-func (c *legacyNovaFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules []network.IngressRule) error {
-	return c.closeInstancePorts(ctx, c.closePortsInGroup, machineId, rules)
+func (c *legacyNovaFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineID string, rules []network.IngressRule) error {
+	return c.closeInstancePorts(ctx, c.closePortsInGroup, machineID, rules)
 }
 
 // InstanceIngressRules implements Firewaller interface.
-func (c *legacyNovaFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineId string) ([]network.IngressRule, error) {
-	return c.instanceIngressRules(ctx, c.ingressRulesInGroup, machineId)
+func (c *legacyNovaFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineID string) ([]network.IngressRule, error) {
+	return c.instanceIngressRules(ctx, c.ingressRulesInGroup, machineID)
 }
 
 func (c *legacyNovaFirewaller) matchingGroup(ctx context.ProviderCallContext, nameRegExp string) (nova.SecurityGroup, error) {


### PR DESCRIPTION
## Description of change

If a security group is missing or has been previously been removed then
we should output error messages to the operator. Just continue onwards
and remain silent.

The code is actually really simple and just checks for the error before
bubbling it up through the stack.

Fixes LP#1864564

## QA steps

It is expected that you've followed the setting up [microstack with juju](https://microstack.run/docs/juju).

```sh
juju bootstrap microstack test
juju deploy cs:~jameinel/ubuntu-lite-7
juju add-unit ubuntu-lite -n 1
```

Remove the new security group via microstack, openstack CLI.

```sh
juju remove-unit ubuntu-lite/1
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1864564
