### PR TITLE
Better error messages when deploying bundles

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1523,7 +1523,7 @@ func (s *FakeStoreStateSuite) setupCharmMaybeAddForce(c *gc.C, url, name, series
 	var err error
 	chDir, err = charm.ReadCharmDir(testcharms.RepoWithSeries(series).CharmDirPath(name))
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(errors.Cause(err)) {
 			c.Fatal(err)
 			return nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,8 @@ require (
 	github.com/joyent/gosign v0.0.0-20140524000734-0da0d5f13420
 	github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf
 	github.com/juju/bundlechanges v0.0.0-20200625095418-8b1912834d29
-	github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85
-	github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09
+	github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815
+	github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,12 @@ github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596 h1:HxkKL4WZ8j/2q63vn
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596/go.mod h1:/Hb24f6NaHMuxV/XeKR9v1QY8qCc0NanWAXQuv6+Ob0=
 github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85 h1:YgEB2tnlAwVftOnPUKTN4i6NDYZy0ztR5l/HdUuHS2Y=
 github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
+github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815 h1:3brl7UJ57uDUxKNWo/g60glFnD/vXu9WX4/rSi3/s7o=
+github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09 h1:PJQnY2Ahu3zsaU5chuBZR6z27dyCRwMTicZ/5jGO494=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
+github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e h1:pifiFWcyhxHsWMBv8PM5kmoeuWVul8p7vg/WZ2bioo8=
+github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=


### PR DESCRIPTION
## Description of change

This brings in the new charm and charmrepo changes around error
messages, when reading and parsing bundle files. The charm repo
highlights and identifies each file that went wrong, so the charmer can
see easily how something isn't quite right.

There is one problem and that is the sad reality of the code though, we
now have 3 different error types that we have to negotiate between...

 - std error
 - gopkg.in/errgo
 - github.com/juju/errors

Considering this is in fact a juju project, we should drop the errgo one
and be done with it. The code path itself has to marshal and unmarshal
the errors from std err -> juju/errors -> errgo -> juju/errors and each one has
different semantics. Not to mention we actually lose the stack trace
from the marshalling and unmarshalling, which is a damn shame.

## QA steps

```yaml
# ./tmp/bundle.yaml
series: bionic

applications:
    dummy:
        charm: ../testcharms/charm-repo/bionic/dummy
        num_units: 1
```

Apply this diff to your repo.

```diff
diff --git a/testcharms/charm-repo/bionic/dummy/config.yaml b/testcharms/charm-repo/bionic/dummy/config.yaml
index a164f0a19a..204abf7489 100644
--- a/testcharms/charm-repo/bionic/dummy/config.yaml
+++ b/testcharms/charm-repo/bionic/dummy/config.yaml
@@ -1,5 +1,5 @@
 options:
-  title: {default: My Title, description: A descriptive title used for the application., type: string}
+       title: {default: My Title, description: A descriptive title used for the application., type: string}
   outlook: {description: No default outlook., type: string}
   username: {default: admin001, description: The name of the initial account (given admin permissions)., type: string}
   skill-level: {description: A number indicating skill., type: int}
```

#### Test

```sh
juju bootstrap lxd test
juju deploy ./tmp/bundle.yaml
```

#### Expected outcome:

```sh
ERROR cannot deploy bundle: issue parsing "config.yaml" file: yaml: line 2: found character that cannot start any token
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1871711
