### PR TITLE
[2.8] Display channel when upgrading charm

### DIFF
--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -5,6 +5,7 @@ package application
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/juju/charm/v7"
@@ -361,6 +362,15 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 
 	if c.Channel == "" {
 		c.Channel = csclientparams.Channel(applicationInfo.Channel)
+	}
+
+	newURL, err := url.Parse(newRef)
+	if err != nil {
+		return errors.Trace(err)
+	} else if newURL.Scheme != "" && newURL.Scheme != "local" && c.Channel != "" {
+		// If not upgrading from a local path, display the channel we
+		// are pulling the charm from.
+		ctx.Infof("Looking up metadata for charm %v (channel: %s)", newRef, c.Channel)
 	}
 
 	chID, csMac, err := c.addCharm(addCharmParams{


### PR DESCRIPTION
## Description of change

 The channel from which the charm was fetched is recorded when the charm gets deployed and the operator has no means to query this information when they are trying to upgrade their charm.

This PR adds an info-level message to the juju CLI that includes the configured channel when upgrading to a charm that is hosted remotely.


## QA steps

```console
$ juju bootstrap lxd test --no-gui
$ juju deploy cs:~jameinel/ubuntu-lite-7

# The CLI now displays an info message with the configured channel for the upgrade
$ juju upgrade-charm ubuntu-lite --path cs:~jameinel/ubuntu-lite-7
Looking up metadata for charm cs:~jameinel/ubuntu-lite-7 (channel: stable)
ERROR already running specified charm "cs:~jameinel/ubuntu-lite-7"

$ juju upgrade-charm ubuntu-lite --path cs:~jameinel/ubuntu-lite-8 --channel edge
Looking up metadata for charm cs:~jameinel/ubuntu-lite-8 (channel: edge)
ERROR cannot resolve URL "cs:~jameinel/ubuntu-lite-8": charm or bundle not found

# Also, try it out with a *local* charm and ensure that the info message is not displayed as 
# it only makes sense for charms fetched from the store
```

## Documentation changes

@timClicks Do we need to update our `juju upgrade-charm` docs to include the above info message?

## Bug reference

https://bugs.launchpad.net/juju/+bug/1880973
