### PR TITLE
Handle series upgrade for machine upgraded out-of-band

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -109,7 +109,7 @@ var facadeVersions = map[string]int{
 	"UnitAssigner":                 1,
 	"Uniter":                       16,
 	"Upgrader":                     1,
-	"UpgradeSeries":                1,
+	"UpgradeSeries":                2,
 	"UpgradeSteps":                 2,
 	"UserManager":                  2,
 	"VolumeAttachmentsWatcher":     2,

--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -65,13 +65,29 @@ func (s *Client) MachineStatus() (model.UpgradeSeriesStatus, error) {
 	return "", errors.Trace(r.Error)
 }
 
+// CurrentSeries returns what Juju thinks the current series of the machine is.
+// Note that a machine could have been upgraded out-of-band by running
+// do-release-upgrade outside of the upgrade-series workflow,
+// making this value incorrect.
+func (s *Client) CurrentSeries() (string, error) {
+	series, err := s.series("CurrentSeries")
+	return series, errors.Trace(err)
+}
+
+// TargetSeries returns the series that a machine has been locked
+// for upgrading to.
 func (s *Client) TargetSeries() (string, error) {
+	series, err := s.series("TargetSeries")
+	return series, errors.Trace(err)
+}
+
+func (s *Client) series(methodName string) (string, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.authTag.String()}},
 	}
 
-	err := s.facade.FacadeCall("TargetSeries", args, &results)
+	err := s.facade.FacadeCall(methodName, args, &results)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/api/upgradeseries/upgradeseries_test.go
+++ b/api/upgradeseries/upgradeseries_test.go
@@ -97,6 +97,25 @@ func (s *upgradeSeriesSuite) TestSetMachineStatus(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
+func (s *upgradeSeriesSuite) TestCurrentSeries(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	fCaller := mocks.NewMockFacadeCaller(ctrl)
+
+	resultSource := params.StringResults{
+		Results: []params.StringResult{{
+			Result: "xenial",
+		}},
+	}
+	fCaller.EXPECT().FacadeCall("CurrentSeries", s.args, gomock.Any()).SetArg(2, resultSource)
+
+	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
+	target, err := api.CurrentSeries()
+	c.Assert(err, gc.IsNil)
+	c.Check(target, gc.Equals, "xenial")
+}
+
 func (s *upgradeSeriesSuite) TestTargetSeries(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -343,7 +343,10 @@ func AllFacades() *facade.Registry {
 	reg("Uniter", 16, uniter.NewUniterAPI)
 
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
-	reg("UpgradeSeries", 1, upgradeseries.NewAPI)
+
+	reg("UpgradeSeries", 1, upgradeseries.NewAPIv1)
+	reg("UpgradeSeries", 2, upgradeseries.NewAPI) // Adds CurrentSeries.
+
 	reg("UpgradeSteps", 1, upgradesteps.NewFacadeV1)
 	reg("UpgradeSteps", 2, upgradesteps.NewFacadeV2)
 	reg("UserManager", 1, usermanager.NewUserManagerAPI)

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -78,7 +78,7 @@ func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusRes
 
 	results := make([]params.UpgradeSeriesStatusResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -106,7 +106,7 @@ func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.Er
 
 	results := make([]params.ErrorResult, len(args.Params))
 	for i, param := range args.Params {
-		machine, err := a.authAndMachine(param.Entity, canAccess)
+		machine, err := a.authAndGetMachine(param.Entity, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -135,7 +135,7 @@ func (a *API) CurrentSeries(args params.Entities) (params.StringResults, error) 
 
 	results := make([]params.StringResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -159,7 +159,7 @@ func (a *API) TargetSeries(args params.Entities) (params.StringResults, error) {
 
 	results := make([]params.StringResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -186,7 +186,7 @@ func (a *API) StartUnitCompletion(args params.UpgradeSeriesStartUnitCompletionPa
 		return params.ErrorResults{}, err
 	}
 	for i, entity := range args.Entities {
-		machine, err := a.authAndMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity, canAccess)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -213,7 +213,7 @@ func (a *API) FinishUpgradeSeries(args params.UpdateSeriesArgs) (params.ErrorRes
 		return params.ErrorResults{}, err
 	}
 	for i, arg := range args.Args {
-		machine, err := a.authAndMachine(arg.Entity, canAccess)
+		machine, err := a.authAndGetMachine(arg.Entity, canAccess)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -268,7 +268,7 @@ func (a *API) unitsInState(args params.Entities, status model.UpgradeSeriesStatu
 
 	results := make([]params.EntitiesResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -293,7 +293,7 @@ func (a *API) unitsInState(args params.Entities, status model.UpgradeSeriesStatu
 	return result, nil
 }
 
-func (a *API) authAndMachine(e params.Entity, canAccess common.AuthFunc) (common.UpgradeSeriesMachine, error) {
+func (a *API) authAndGetMachine(e params.Entity, canAccess common.AuthFunc) (common.UpgradeSeriesMachine, error) {
 	tag, err := names.ParseMachineTag(e.Tag)
 	if err != nil {
 		return nil, err

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -85,6 +85,18 @@ func (s *upgradeSeriesSuite) TestSetMachineStatus(c *gc.C) {
 	})
 }
 
+func (s *upgradeSeriesSuite) TestCurrentSeries(c *gc.C) {
+	defer s.arrangeTest(c).Finish()
+
+	s.machine.EXPECT().Series().Return("xenial")
+
+	results, err := s.api.CurrentSeries(s.entityArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.StringResults{
+		Results: []params.StringResult{{Result: "xenial"}},
+	})
+}
+
 func (s *upgradeSeriesSuite) TestUpgradeSeriesTarget(c *gc.C) {
 	defer s.arrangeTest(c).Finish()
 

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -86,7 +86,7 @@ func NewAPIv4(st *state.State, res facade.Resources, auth facade.Authorizer) (*A
 	return &APIv4{api}, nil
 }
 
-// NewAPIv5 is a wrapper that creates a V4 spaces API.
+// NewAPIv5 is a wrapper that creates a V5 spaces API.
 func NewAPIv5(st *state.State, res facade.Resources, auth facade.Authorizer) (*APIv5, error) {
 	api, err := NewAPI(st, res, auth)
 	if err != nil {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40897,7 +40897,7 @@
     {
         "Name": "UpgradeSeries",
         "Description": "API serves methods required by the machine agent upgrade-series worker.",
-        "Version": 1,
+        "Version": 2,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -40907,6 +40907,18 @@
         "Schema": {
             "type": "object",
             "properties": {
+                "CurrentSeries": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    },
+                    "description": "CurrentSeries returns what Juju thinks the current series of the machine is.\nNote that a machine could have been upgraded out-of-band by running\ndo-release-upgrade outside of the upgrade-series workflow,\nmaking this value incorrect."
+                },
                 "FinishUpgradeSeries": {
                     "type": "object",
                     "properties": {

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -285,7 +285,7 @@ func (s *agentConfSuite) TestCopyAgentBinaryOriginalAgentBinariesNotFound(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.manager.CopyAgentBinary(s.machineName, s.unitNames, s.dataDir, "xenial", "xenial", jujuVersion)
-	c.Assert(err, gc.ErrorMatches, "failed to copy tools: .* no such file or directory")
+	c.Assert(err, gc.ErrorMatches, "copying agent binaries: .* no such file or directory")
 }
 
 func (s *agentConfSuite) TestWriteSystemdAgents(c *gc.C) {

--- a/worker/upgradeseries/manifold.go
+++ b/worker/upgradeseries/manifold.go
@@ -63,24 +63,15 @@ func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) 
 		return nil, errors.Errorf("expected a machine tag, got %v", tag)
 	}
 
-	// Partially apply the NewFacade method and pass it as a factory.
-	// This is so the worker can use the API server in different contexts.
-	// TODO (manadart 2018-08-30): This behaviour is vestigial.
-	// We no longer need a factory and can pass a concrete facade.
-	newFacade := func(t names.Tag) Facade {
-		return config.NewFacade(apiCaller, t)
-	}
-
-	// Partially apply Upgrader factory function so we only need to request
+	// Partially apply the upgrader factory function so we only need to request
 	// using the getter for the target OS series.
 	newUpgrader := func(targetSeries string) (Upgrader, error) {
 		return NewUpgrader(targetSeries, service.NewServiceManagerWithDefaults(), config.Logger)
 	}
 
 	cfg := Config{
-		Tag:             tag,
 		Logger:          config.Logger,
-		FacadeFactory:   newFacade,
+		Facade:          config.NewFacade(apiCaller, tag),
 		Service:         &serviceAccess{},
 		UpgraderFactory: newUpgrader,
 	}

--- a/worker/upgradeseries/manifold.go
+++ b/worker/upgradeseries/manifold.go
@@ -64,9 +64,9 @@ func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) 
 	}
 
 	// Partially apply the upgrader factory function so we only need to request
-	// using the getter for the target OS series.
-	newUpgrader := func(targetSeries string) (Upgrader, error) {
-		return NewUpgrader(targetSeries, service.NewServiceManagerWithDefaults(), config.Logger)
+	// using the getter for the to/from OS series.
+	newUpgrader := func(currentSeries, targetSeries string) (Upgrader, error) {
+		return NewUpgrader(currentSeries, targetSeries, service.NewServiceManagerWithDefaults(), config.Logger)
 	}
 
 	cfg := Config{

--- a/worker/upgradeseries/mocks/package_mock.go
+++ b/worker/upgradeseries/mocks/package_mock.go
@@ -5,13 +5,12 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	model "github.com/juju/juju/core/model"
 	watcher "github.com/juju/juju/core/watcher"
 	upgradeseries "github.com/juju/juju/worker/upgradeseries"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockFacade is a mock of Facade interface
@@ -35,6 +34,21 @@ func NewMockFacade(ctrl *gomock.Controller) *MockFacade {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockFacade) EXPECT() *MockFacadeMockRecorder {
 	return m.recorder
+}
+
+// CurrentSeries mocks base method
+func (m *MockFacade) CurrentSeries() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentSeries")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CurrentSeries indicates an expected call of CurrentSeries
+func (mr *MockFacadeMockRecorder) CurrentSeries() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentSeries", reflect.TypeOf((*MockFacade)(nil).CurrentSeries))
 }
 
 // FinishUpgradeSeries mocks base method
@@ -125,10 +139,10 @@ func (mr *MockFacadeMockRecorder) TargetSeries() *gomock.Call {
 }
 
 // UnitsCompleted mocks base method
-func (m *MockFacade) UnitsCompleted() ([]names_v3.UnitTag, error) {
+func (m *MockFacade) UnitsCompleted() ([]names.UnitTag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitsCompleted")
-	ret0, _ := ret[0].([]names_v3.UnitTag)
+	ret0, _ := ret[0].([]names.UnitTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -140,10 +154,10 @@ func (mr *MockFacadeMockRecorder) UnitsCompleted() *gomock.Call {
 }
 
 // UnitsPrepared mocks base method
-func (m *MockFacade) UnitsPrepared() ([]names_v3.UnitTag, error) {
+func (m *MockFacade) UnitsPrepared() ([]names.UnitTag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitsPrepared")
-	ret0, _ := ret[0].([]names_v3.UnitTag)
+	ret0, _ := ret[0].([]names.UnitTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/worker/upgradeseries/shim.go
+++ b/worker/upgradeseries/shim.go
@@ -4,11 +4,12 @@
 package upgradeseries
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/upgradeseries"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/names/v4"
 )
 
 // Facade exposes the API surface required by the upgrade-series worker.

--- a/worker/upgradeseries/shim.go
+++ b/worker/upgradeseries/shim.go
@@ -19,6 +19,7 @@ type Facade interface {
 	MachineStatus() (model.UpgradeSeriesStatus, error)
 	UnitsPrepared() ([]names.UnitTag, error)
 	UnitsCompleted() ([]names.UnitTag, error)
+	CurrentSeries() (string, error)
 	TargetSeries() (string, error)
 
 	// Setters
@@ -29,7 +30,8 @@ type Facade interface {
 	UnpinMachineApplications() (map[string]error, error)
 }
 
-// NewFacade creates a *upgradeseries.Client and returns it as a Facade.
+// NewFacade creates a new upgrade-series client and returns its
+// reference as the facade indirection above.
 func NewFacade(apiCaller base.APICaller, tag names.Tag) Facade {
 	return upgradeseries.NewClient(apiCaller, tag)
 }

--- a/worker/upgradeseries/upgrader.go
+++ b/worker/upgradeseries/upgrader.go
@@ -29,10 +29,17 @@ type Upgrader interface {
 type upgrader struct {
 	logger Logger
 
+	// jujuCurrentSeries is what Juju thinks the
+	// current series of the machine is.
+	jujuCurrentSeries string
+
+	// fromSeries is the actual current series,
+	// determined directly from the machine.
 	fromSeries string
 	fromInit   string
-	toSeries   string
-	toInit     string
+
+	toSeries string
+	toInit   string
 
 	machineAgent string
 	unitAgents   []string
@@ -42,7 +49,9 @@ type upgrader struct {
 
 // NewUpgrader uses the input function to determine the series that should be
 // supported, and returns a reference to a new Upgrader that supports it.
-func NewUpgrader(toSeries string, manager service.SystemdServiceManager, logger Logger) (Upgrader, error) {
+func NewUpgrader(
+	currentSeries, toSeries string, manager service.SystemdServiceManager, logger Logger,
+) (Upgrader, error) {
 	fromSeries, err := hostSeries()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -58,12 +67,13 @@ func NewUpgrader(toSeries string, manager service.SystemdServiceManager, logger 
 	}
 
 	return &upgrader{
-		logger:     logger,
-		fromSeries: fromSeries,
-		fromInit:   fromInit,
-		toSeries:   toSeries,
-		toInit:     toInit,
-		manager:    manager,
+		logger:            logger,
+		jujuCurrentSeries: currentSeries,
+		fromSeries:        fromSeries,
+		fromInit:          fromInit,
+		toSeries:          toSeries,
+		toInit:            toInit,
+		manager:           manager,
 	}, nil
 }
 

--- a/worker/upgradeseries/upgrader.go
+++ b/worker/upgradeseries/upgrader.go
@@ -131,8 +131,12 @@ func (u *upgrader) ensureSystemdFiles() error {
 // right tools path for the target OS series, and that individual agents use
 // those files.
 func (u *upgrader) ensureAgentBinaries() error {
+	// Here we pass what Juju *thinks* the current series is, because that is
+	// where we expect the agent binaries to be.
+	// If was pass the machine-detected series for a machine upgraded outside
+	// of this workflow, the binaries will not be found.
 	if err := u.manager.CopyAgentBinary(
-		u.machineAgent, u.unitAgents, paths.NixDataDir, u.toSeries, u.fromSeries, version.Current); err != nil {
+		u.machineAgent, u.unitAgents, paths.NixDataDir, u.toSeries, u.jujuCurrentSeries, version.Current); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/worker/upgradeseries/upgrader_test.go
+++ b/worker/upgradeseries/upgrader_test.go
@@ -67,6 +67,24 @@ func (s *upgraderSuite) TestFromSystemdCopyToolsOnly(c *gc.C) {
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
 }
 
+func (s *upgraderSuite) TestFromSystemdCopyToolsForAlreadyUpgradedMachine(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	s.setupMocks(ctrl)
+
+	// Actual series is Bionic.
+	s.patchFrom("bionic")
+
+	// No systemd file changes; just the new tools for the target series.
+	s.manager.EXPECT().CopyAgentBinary(
+		s.machineService, s.unitServices, paths.NixDataDir, "bionic", "xenial", version.Current,
+	).Return(nil)
+
+	// Juju thinks the machine is Xenial.
+	upg := s.newUpgrader(c, "xenial", "bionic")
+	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
+}
+
 func (s *upgraderSuite) TestToSystemdServicesWritten(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/worker/upgradeseries/upgrader_test.go
+++ b/worker/upgradeseries/upgrader_test.go
@@ -47,7 +47,7 @@ func (s *upgraderSuite) TestNotToSystemdCopyToolsOnly(c *gc.C) {
 		s.machineService, s.unitServices, paths.NixDataDir, "trusty", "precise", version.Current,
 	).Return(nil)
 
-	upg := s.newUpgrader(c, "trusty")
+	upg := s.newUpgrader(c, "precise", "trusty")
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
 }
 
@@ -63,7 +63,7 @@ func (s *upgraderSuite) TestFromSystemdCopyToolsOnly(c *gc.C) {
 		s.machineService, s.unitServices, paths.NixDataDir, "bionic", "xenial", version.Current,
 	).Return(nil)
 
-	upg := s.newUpgrader(c, "bionic")
+	upg := s.newUpgrader(c, "xenial", "bionic")
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
 }
 
@@ -82,7 +82,7 @@ func (s *upgraderSuite) TestToSystemdServicesWritten(c *gc.C) {
 		s.machineService, s.unitServices, paths.NixDataDir, "xenial", "trusty", version.Current,
 	).Return(nil)
 
-	upg := s.newUpgrader(c, "xenial")
+	upg := s.newUpgrader(c, "trusty", "xenial")
 	c.Assert(upg.PerformUpgrade(), jc.ErrorIsNil)
 }
 
@@ -93,8 +93,8 @@ func (s *upgraderSuite) setupMocks(ctrl *gomock.Controller) {
 	s.manager.EXPECT().FindAgents(paths.NixDataDir).Return(s.machineService, s.unitServices, nil, nil)
 }
 
-func (s *upgraderSuite) newUpgrader(c *gc.C, toSeries string) upgradeseries.Upgrader {
-	upg, err := upgradeseries.NewUpgrader(toSeries, s.manager, s.logger)
+func (s *upgraderSuite) newUpgrader(c *gc.C, currentSeries, toSeries string) upgradeseries.Upgrader {
+	upg, err := upgradeseries.NewUpgrader(currentSeries, toSeries, s.manager, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 	return upg
 }

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/juju/os/series"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/service"
-	"github.com/juju/os/series"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/package_mock.go github.com/juju/juju/worker/upgradeseries Facade,Logger,AgentService,ServiceAccess,Upgrader
@@ -81,7 +81,6 @@ func (config Config) Validate() error {
 type upgradeSeriesWorker struct {
 	Facade
 
-	facadeFactory   func(names.Tag) Facade
 	catacomb        catacomb.Catacomb
 	logger          Logger
 	service         ServiceAccess
@@ -109,7 +108,6 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 	w := &upgradeSeriesWorker{
 		Facade:          config.FacadeFactory(config.Tag),
-		facadeFactory:   config.FacadeFactory,
 		logger:          config.Logger,
 		service:         config.Service,
 		upgraderFactory: config.UpgraderFactory,

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -195,13 +195,13 @@ func (w *upgradeSeriesWorker) handlePrepareStarted() error {
 		return nil
 	}
 
-	return errors.Trace(w.transitionPrepareComplete(unitServices))
+	return errors.Trace(w.transitionPrepareComplete())
 }
 
 // transitionPrepareComplete rewrites service unit files for unit agents running
 // on this machine so that they are compatible with the init system of the
 // series upgrade target.
-func (w *upgradeSeriesWorker) transitionPrepareComplete(unitServices map[string]string) error {
+func (w *upgradeSeriesWorker) transitionPrepareComplete() error {
 	w.logger.Infof("preparing service units for series upgrade")
 	toSeries, err := w.TargetSeries()
 	if err != nil {

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -32,15 +32,11 @@ type Logger interface {
 
 // Config is the configuration needed to construct an UpgradeSeries worker.
 type Config struct {
-	// FacadeFactory is used to acquire back-end state with
-	// the input tag context.
-	FacadeFactory func(names.Tag) Facade
+	// Facade is used to access back-end state.
+	Facade Facade
 
 	// Logger is the logger for this worker.
 	Logger Logger
-
-	// Tag is the current machine tag.
-	Tag names.Tag
 
 	// ServiceAccess provides access to the local init system.
 	Service ServiceAccess
@@ -56,15 +52,8 @@ func (config Config) Validate() error {
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
 	}
-	if config.Tag == nil {
-		return errors.NotValidf("nil machine tag")
-	}
-	k := config.Tag.Kind()
-	if k != names.MachineTagKind {
-		return errors.NotValidf("%q tag kind", k)
-	}
-	if config.FacadeFactory == nil {
-		return errors.NotValidf("nil FacadeFactory")
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
 	}
 	if config.Service == nil {
 		return errors.NotValidf("nil Service")
@@ -107,7 +96,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 	}
 
 	w := &upgradeSeriesWorker{
-		Facade:          config.FacadeFactory(config.Tag),
+		Facade:          config.Facade,
 		logger:          config.Logger,
 		service:         config.Service,
 		upgraderFactory: config.UpgraderFactory,

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -164,6 +164,7 @@ func (s *workerSuite) expectMachinePrepareStartedUnitFilesWrittenProgressPrepare
 
 	exp.MachineStatus().Return(model.UpgradeSeriesPrepareStarted, nil)
 	s.expectUnitsPrepared("wordpress/0", "mysql/0")
+	exp.CurrentSeries().Return("trusty", nil)
 	exp.TargetSeries().Return("xenial", nil)
 
 	s.upgrader.EXPECT().PerformUpgrade().Return(nil)
@@ -303,7 +304,7 @@ func (s *workerSuite) workerForScenario(c *gc.C, behaviours ...func()) worker.Wo
 		Logger:          s.logger,
 		Facade:          s.facade,
 		Service:         s.service,
-		UpgraderFactory: func(_ string) (upgradeseries.Upgrader, error) { return s.upgrader, nil },
+		UpgraderFactory: func(_, _ string) (upgradeseries.Upgrader, error) { return s.upgrader, nil },
 	}
 
 	for _, b := range behaviours {

--- a/worker/upgradeseries/worker_test.go
+++ b/worker/upgradeseries/worker_test.go
@@ -301,8 +301,7 @@ func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 func (s *workerSuite) workerForScenario(c *gc.C, behaviours ...func()) worker.Worker {
 	cfg := upgradeseries.Config{
 		Logger:          s.logger,
-		FacadeFactory:   func(_ names.Tag) upgradeseries.Facade { return s.facade },
-		Tag:             names.NewMachineTag("0"),
+		Facade:          s.facade,
 		Service:         s.service,
 		UpgraderFactory: func(_ string) (upgradeseries.Upgrader, error) { return s.upgrader, nil },
 	}


### PR DESCRIPTION
## Description of change

This patch handles the case where `do-release-upgrade` is run outside of the intended upgrade-series workflow.

In the example of upgrading a machine from Xenial to Bionic, with Juju still thinking the machine is running Xenial, we see:
- The series upgrade is able to be commenced for what appears to be a valid upgrade.
- When running, the worker detects Bionic on-machine for the "from" series.
- An error results when attempting to copy agent binaries not present for that series - they are in the Xenial location.

This patch still uses the locally determined series for detecting the init system, but for copying binaries we use the current machine series according to Juju's data.

## QA steps

- Bootstrap to LXD.
- Add 2 machines via `juju add-machine --series xenial`.
- `juju ssh 0` and run `do-release-upgrade`, confirming prompts as required.
- For each machine:
  - `juju upgrade-series [0|1] prepare bionic -y`. This should complete without error.
- Finish upgrade for the already upgraded host: `juju upgrade-series complete 0`.
- `juju ssh 1` and run `do-release-upgrade`, confirming prompts as required.
- `juju upgrade-series complete 1`.
- Check that the machines have been upgraded to Bionic via Juju status.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1870195
