### PR TITLE
[2.8] Enable relation-list tool to list remote (or peer) application

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -103,7 +103,7 @@ show_help() {
         # shellcheck disable=SC2086
         output="${output}\n    $(green ${test})|Runs the ${name} tests"
     done
-    echo "${output}" | column -t -s "|"
+    echo -e "${output}" | column -t -s "|"
 
     echo ""
     echo "Examples:"
@@ -124,7 +124,7 @@ show_help() {
     exit 1
 }
 
-while getopts "hH?:vVtAsaxrlpS" opt; do
+while getopts "hH?vVtAs:a:x:rl:p:S:" opt; do
     case "${opt}" in
     h|\?)
         show_help
@@ -134,52 +134,42 @@ while getopts "hH?:vVtAsaxrlpS" opt; do
         ;;
     v)
         VERBOSE=2
-        shift
         ;;
     V)
         VERBOSE=3
-        shift
         alias juju="juju --debug"
         ;;
     t)
         TEST_VERBOSE=3
-        shift
         alias juju="juju --debug"
         ;;
     A)
         RUN_ALL="true"
-        shift
         ;;
     s)
-        SKIP_LIST="${2}"
-        shift 2
+        SKIP_LIST="${OPTARG}"
         ;;
     a)
-        ARITFACT_FILE="${2}"
-        shift 2
+        ARITFACT_FILE="${OPTARG}"
         ;;
     x)
-        OUTPUT_FILE="${2}"
-        shift 2
+        OUTPUT_FILE="${OPTARG}"
         ;;
     r)
         export BOOTSTRAP_REUSE="true"
-        shift
         ;;
     l)
-        export BOOTSTRAP_REUSE_LOCAL="${2}"
+        export BOOTSTRAP_REUSE_LOCAL="${OPTARG}"
         export BOOTSTRAP_REUSE="true"
-        CLOUD=$(juju show-controller "${2}" --format=json | jq -r ".[\"${2}\"] | .details | .cloud")
-        export BOOTSTRAP_PROVIDER="${CLOUD}"
-        shift 2
+        CLOUD=$(juju show-controller "${OPTARG}" --format=json | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
+        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}')
+        export BOOTSTRAP_PROVIDER="${PROVIDER}"
         ;;
     p)
-        export BOOTSTRAP_PROVIDER="${2}"
-        shift 2
+        export BOOTSTRAP_PROVIDER="${OPTARG}"
         ;;
     S)
-        export BOOTSTRAP_SERIES="${2}"
-        shift 2
+        export BOOTSTRAP_SERIES="${OPTARG}"
         ;;
     *)
         echo "Unexpected argument ${opt}" >&2
@@ -188,7 +178,6 @@ while getopts "hH?:vVtAsaxrlpS" opt; do
 done
 
 shift $((OPTIND-1))
-
 [ "${1:-}" = "--" ] && shift
 
 export VERBOSE="${VERBOSE}"

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -1,0 +1,55 @@
+run_relation_list_app() {
+    echo
+
+    model_name="test-relation-list-app"
+    file="${TEST_DIR}/${model_name}.log"
+
+    ensure "${model_name}" "${file}"
+
+    # Deploy 2 departer instances
+    juju deploy wordpress
+    juju deploy mysql
+    juju relate wordpress mysql
+    wait_for "wordpress" "$(idle_condition "wordpress" 1 0)"
+    wait_for "mysql" "$(idle_condition "mysql" 0 0)"
+
+    # Figure out the right relation IDs to use for our hook tool invocations
+    db_rel_id=$(juju run --unit mysql/0 "relation-ids db" | cut -d':' -f2)
+    peer_rel_id=$(juju run --unit mysql/0 "relation-ids cluster" | cut -d':' -f2)
+
+    # Remove wordpress unit; the wordpress-mysql relation is still established
+    # but there are no units present in the wordpress side
+    juju remove-unit wordpress/0
+    sleep 5
+
+    got=$(juju run --unit mysql/0 "relation-list --app -r ${db_rel_id}")
+    if [ "${got}" != "wordpress" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected running 'relation-list --app' on mysql unit for non-peer relation to return 'wordpress'; got ${got}")
+      exit 1
+    fi
+
+    got=$(juju run --unit mysql/0 "relation-list --app -r ${peer_rel_id}")
+    if [ "${got}" != "mysql" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected running 'relation-list --app' on mysql unit for peer relation to return 'mysql'; got ${got}")
+      exit 1
+    fi
+
+    destroy_model "${model_name}"
+}
+
+test_relation_list_app() {
+    if [ "$(skip 'test_relation_list_app')" ]; then
+        echo "==> TEST SKIPPED: relation list app unit tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_relation_list_app"
+    )
+}

--- a/tests/suites/relations/task.sh
+++ b/tests/suites/relations/task.sh
@@ -15,6 +15,7 @@ test_relations() {
 
     test_relation_data_exchange
     test_relation_departing_unit
+    test_relation_list_app
 
     destroy_controller "test-relations"
 }

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -32,6 +32,10 @@ type Relation interface {
 
 	// Tag returns the relation tag.
 	Tag() names.RelationTag
+
+	// OtherApplication returns the name of the application on the other
+	// end of the relation (from this unit's perspective).
+	OtherApplication() string
 }
 
 type RelationUnit interface {
@@ -174,4 +178,10 @@ func (ctx *ContextRelation) Suspended() bool {
 // SetStatus sets the relation's status.
 func (ctx *ContextRelation) SetStatus(status relation.Status) error {
 	return errors.Trace(ctx.ru.Relation().SetStatus(status))
+}
+
+// RemoteApplicationName returns the application on the other end of this
+// relation from the perspective of this unit.
+func (ctx *ContextRelation) RemoteApplicationName() string {
+	return ctx.ru.Relation().OtherApplication()
 }

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -211,6 +211,11 @@ func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
 	c.Assert(relStatus.Status, gc.Equals, status.Suspended)
 }
 
+func (s *ContextRelationSuite) TestRemoteApplicationName(c *gc.C) {
+	ctx := context.NewContextRelation(s.relUnit, nil)
+	c.Assert(ctx.RemoteApplicationName(), gc.Equals, "u")
+}
+
 type relUnitShim struct {
 	*apiuniter.RelationUnit
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -317,6 +317,10 @@ type ContextRelation interface {
 
 	// SetStatus sets the relation's status.
 	SetStatus(relation.Status) error
+
+	// RemoteApplicationName returns the application on the other end of
+	// the relation from the perspective of this unit.
+	RemoteApplicationName() string
 }
 
 // ContextStorageAttachment expresses the capabilities of a hook with

--- a/worker/uniter/runner/jujuc/context_mock_test.go
+++ b/worker/uniter/runner/jujuc/context_mock_test.go
@@ -121,6 +121,20 @@ func (mr *MockContextRelationMockRecorder) ReadSettings(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSettings", reflect.TypeOf((*MockContextRelation)(nil).ReadSettings), arg0)
 }
 
+// RemoteApplicationName mocks base method
+func (m *MockContextRelation) RemoteApplicationName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoteApplicationName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RemoteApplicationName indicates an expected call of RemoteApplicationName
+func (mr *MockContextRelationMockRecorder) RemoteApplicationName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplicationName", reflect.TypeOf((*MockContextRelation)(nil).RemoteApplicationName))
+}
+
 // SetStatus mocks base method
 func (m *MockContextRelation) SetStatus(arg0 relation.Status) error {
 	m.ctrl.T.Helper()

--- a/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -28,6 +28,8 @@ type Relation struct {
 	RemoteApplicationSettings Settings
 	// LocalApplicationSettings is data for jujuc.ContextRelation
 	LocalApplicationSettings Settings
+	// RemoteApplicationName is data for jujuc.ContextRelation
+	RemoteApplicationName string
 }
 
 // Reset clears the Relation's settings.
@@ -154,4 +156,10 @@ func (r *ContextRelation) Suspended() bool {
 // SetStatus implements jujuc.ContextRelation.
 func (r *ContextRelation) SetStatus(status relation.Status) error {
 	return nil
+}
+
+// RemoteApplicationName implements jujuc.ContextRelation.
+func (r *ContextRelation) RemoteApplicationName() string {
+	r.stub.AddCall("RemoteApplicationName")
+	return r.info.RemoteApplicationName
 }

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -5,16 +5,15 @@
 package mocks
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
+	charm "github.com/juju/charm/v7"
 	params "github.com/juju/juju/apiserver/params"
 	application "github.com/juju/juju/core/application"
 	network "github.com/juju/juju/core/network"
 	jujuc "github.com/juju/juju/worker/uniter/runner/jujuc"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
+	time "time"
 )
 
 // MockContext is a mock of Context interface
@@ -172,10 +171,10 @@ func (mr *MockContextMockRecorder) Component(arg0 interface{}) *gomock.Call {
 }
 
 // ConfigSettings mocks base method
-func (m *MockContext) ConfigSettings() (charm_v6.Settings, error) {
+func (m *MockContext) ConfigSettings() (charm.Settings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigSettings")
-	ret0, _ := ret[0].(charm_v6.Settings)
+	ret0, _ := ret[0].(charm.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -609,7 +608,7 @@ func (mr *MockContextMockRecorder) SetUnitWorkloadVersion(arg0 interface{}) *gom
 }
 
 // Storage mocks base method
-func (m *MockContext) Storage(arg0 names_v3.StorageTag) (jujuc.ContextStorageAttachment, error) {
+func (m *MockContext) Storage(arg0 names.StorageTag) (jujuc.ContextStorageAttachment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Storage", arg0)
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
@@ -624,10 +623,10 @@ func (mr *MockContextMockRecorder) Storage(arg0 interface{}) *gomock.Call {
 }
 
 // StorageTags mocks base method
-func (m *MockContext) StorageTags() ([]names_v3.StorageTag, error) {
+func (m *MockContext) StorageTags() ([]names.StorageTag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageTags")
-	ret0, _ := ret[0].([]names_v3.StorageTag)
+	ret0, _ := ret[0].([]names.StorageTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/worker/uniter/runner/jujuc/relation-list.go
+++ b/worker/uniter/runner/jujuc/relation-list.go
@@ -16,10 +16,11 @@ import (
 // RelationListCommand implements the relation-list command.
 type RelationListCommand struct {
 	cmd.CommandBase
-	ctx             Context
-	RelationId      int
-	relationIdProxy gnuflag.Value
-	out             cmd.Output
+	ctx                   Context
+	RelationId            int
+	relationIdProxy       gnuflag.Value
+	ListRemoteApplication bool
+	out                   cmd.Output
 }
 
 func NewRelationListCommand(ctx Context) (cmd.Command, error) {
@@ -49,8 +50,9 @@ func (c *RelationListCommand) Info() *cmd.Info {
 
 func (c *RelationListCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters.Formatters())
-	f.Var(c.relationIdProxy, "r", "specify a relation by id")
+	f.Var(c.relationIdProxy, "r", "Specify a relation by id")
 	f.Var(c.relationIdProxy, "relation", "")
+	f.BoolVar(&c.ListRemoteApplication, "app", false, "List remote application instead of participating units")
 }
 
 func (c *RelationListCommand) Init(args []string) (err error) {
@@ -65,6 +67,11 @@ func (c *RelationListCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	if c.ListRemoteApplication {
+		return c.out.Write(ctx, r.RemoteApplicationName())
+	}
+
 	unitNames := r.UnitNames()
 	if unitNames == nil {
 		unitNames = []string{}

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -25,6 +25,7 @@ var relationListTests = []struct {
 	summary            string
 	relid              int
 	members0, members1 []string
+	remoteAppName      string
 	args               []string
 	code               int
 	out                string
@@ -104,13 +105,20 @@ var relationListTests = []struct {
 		relid:    1,
 		args:     []string{"--format", "yaml"},
 		out:      "- bar\n- baz\n- foo",
+	}, {
+		summary:       "remote application for relation",
+		members1:      []string{}, // relation established but all units removed
+		relid:         1,
+		remoteAppName: "galaxy",
+		args:          []string{"--app"},
+		out:           "galaxy",
 	},
 }
 
 func (s *RelationListSuite) TestRelationList(c *gc.C) {
 	for i, t := range relationListTests {
 		c.Logf("test %d: %s", i, t.summary)
-		hctx, info := s.newHookContext(t.relid, "", "")
+		hctx, info := s.newHookContext(t.relid, "", t.remoteAppName)
 		info.setRelations(0, t.members0)
 		info.setRelations(1, t.members1)
 		c.Logf("%#v %#v", info.rels[t.relid], t.members1)
@@ -143,12 +151,14 @@ Summary:
 list relation units
 
 Options:
+--app  (= false)
+    List remote application instead of participating units
 --format  (= smart)
     Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 -r, --relation  (= %s)
-    specify a relation by id
+    Specify a relation by id
 %s`[1:]
 
 	for relid, t := range map[int]struct {

--- a/worker/uniter/runner/jujuc/relation_test.go
+++ b/worker/uniter/runner/jujuc/relation_test.go
@@ -23,8 +23,8 @@ func (s *relationSuite) newHookContext(relid int, remote string, app string) (ju
 	settings := jujuctesting.Settings{
 		"private-address": "u-0.testing.invalid",
 	}
-	rInfo.setNextRelation("", s.Unit, settings) // peer0
-	rInfo.setNextRelation("", s.Unit, settings) // peer1
+	rInfo.setNextRelation("", s.Unit, app, settings) // peer0
+	rInfo.setNextRelation("", s.Unit, app, settings) // peer1
 	if relid >= 0 {
 		rInfo.SetAsRelationHook(relid, remote)
 		if app == "" {
@@ -52,7 +52,7 @@ func (ri *relationInfo) reset() {
 	ri.rels = nil
 }
 
-func (ri *relationInfo) setNextRelation(name, unit string, settings jujuctesting.Settings) int {
+func (ri *relationInfo) setNextRelation(name, unit, app string, settings jujuctesting.Settings) int {
 	if ri.rels == nil {
 		ri.rels = make(map[int]*jujuctesting.Relation)
 	}
@@ -65,6 +65,7 @@ func (ri *relationInfo) setNextRelation(name, unit string, settings jujuctesting
 		relation.UnitName = unit
 		relation.SetRelated(unit, settings)
 	}
+	relation.RemoteApplicationName = app
 	ri.rels[id] = relation
 	return id
 }
@@ -74,7 +75,7 @@ func (ri *relationInfo) addRelatedApplications(relname string, count int) {
 		ri.rels = make(map[int]*jujuctesting.Relation)
 	}
 	for i := 0; i < count; i++ {
-		ri.setNextRelation(relname, "", nil)
+		ri.setNextRelation(relname, "", ri.RemoteApplicationName, nil)
 	}
 }
 


### PR DESCRIPTION
## Description of change

Prior to this change, the relation-list tool only produces output when the remote relations has at least one unit present. This makes it hard for charm authors to introspect the remote application name when no units are available (e.g. they are still coming up or they have been explicitly removed without also removing the remote application).

This PR makes the relation-list tool more consistent with our other relation tools by adding a `--app` flag. If the charm specifies this flag as part of the tool invocation, the output will contain the remote application name (or the local application name if this is a peer relation).

## QA steps

```console
$ juju bootstrap lxd test --no-gui
$ juju deploy wordpress
$ juju deploy mysql
$ juju relate wordpress mysql

# Wait for both units to come up

# This is the normal output of relation-list
$ juju run --unit mysql/0 "relation-list -r 2"
wordpress/0

# Remove unit and wait for it to go away
$ juju remove-unit wordpress/0

# Relation list should now be empty
$ juju run --unit mysql/0 "relation-list -r 2"

# But we should still be able to grab the remote app name
$ juju run --unit mysql/0 "relation-list -r 2 --app"
wordpress

# This should also work for peer relations
$ juju run --unit mysql/0 "relation-list -r 0 --app"
mysql
```

## Documentation changes

@timClicks we need to update the docs for `relation-list` to mention `--app` (2.8+)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871480