### PR TITLE
Change Errorf to Debugf in DetectCredentials.

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -151,12 +151,12 @@ func (p environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 
 	remoteCertCredentials, err := p.detectRemoteCredentials(certPEM, keyPEM)
 	if err != nil {
-		logger.Errorf("unable to detect remote LXC credentials: %s", err)
+		logger.Debugf("unable to detect remote LXC credentials: %s", err)
 	}
 
 	localCertCredentials, err := p.detectLocalCredentials(certPEM, keyPEM)
 	if err != nil {
-		logger.Errorf("unable to detect local LXC credentials: %s", err)
+		logger.Debugf("unable to detect local LXC credentials: %s", err)
 	}
 
 	authCredentials := make(map[string]cloud.Credential)


### PR DESCRIPTION

## Description of change

Having an error log message in DetectCredentials caused confusion with users attempting to autoload-credentials for clouds other than lxd.  Other juju commands still show the inability to get lxd creds as an error, such as bootstrap localhost when lxd is not installed.  The details on failure to find lxd credentials will still be seen with the --debug flag for autoload.



## QA steps

```console
# create a bionic vm, copy the pr juju over
$ sudo apt purge lxd
$ juju bootstrap localhost
ERROR Permission denied, are you in the lxd group?

Please configure LXD by running:
	$ newgrp lxd
	$ lxd init
$ ./juju autoload-credentials
This operation can be applied to both a copy on this client and to the one on a controller.
No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.

Looking for cloud and credential information on local client...
No cloud credentials found.
$ ./juju autoload-credentials --debug
.... 
16:07:01 DEBUG juju.container.lxd connection.go:170 LXD snap socket not found, falling back to debian socket: "/var/lib/lxd"
16:07:01 DEBUG juju.provider.lxd credentials.go:160 unable to detect local LXC credentials: failed to connect to local LXD: LXD socket not found; is LXD installed & running?

Please install LXD by running:
	$ sudo snap install lxd
and then configure it with:
	$ newgrp lxd
	$ lxd init

...
No cloud credentials found.
```

## Documentation changes

Add azure to list of clouds which can autoload-credentials.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1860717
