### PR TITLE
Record the correct device link for Azure disks

### DIFF
--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -457,7 +457,7 @@ func (s *storageSuite) TestCreateVolumesLegacy(c *gc.C) {
 			Volume:  names.NewVolumeTag(volumeId),
 			Machine: names.NewMachineTag(machineId),
 			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
-				BusAddress: fmt.Sprintf("scsi@5:0.0.%d", lun),
+				DeviceLink: fmt.Sprintf("/dev/disk/azure/scsi1/lun%d", lun),
 			},
 		}
 	}


### PR DESCRIPTION
## Description of change

When provisioning Azure storage, we were making up a bus address to store with the block device entity in state. But it was wrong. We instead record the device link. This fixes the deployment of charms with storage.

## QA steps

bootstrap azure
juju deploy postgresql --storage pgdata=5G
juju status --storage

Also test with a bespoke charm with multiple storage defined to check that block devices are matched up correctly.
Also check that upgrading a broken deployment fixes storage.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1884018