### PR TITLE
Sets number passing of pod spec json to number

### DIFF
--- a/caas/kubernetes/provider/specs/container_env.go
+++ b/caas/kubernetes/provider/specs/container_env.go
@@ -235,6 +235,10 @@ func (cv configValue) to(name string) (envVars []core.EnvVar, envFromSources []c
 
 // JSON Unmarshal types - https://golang.org/pkg/encoding/json/#Unmarshal
 func stringify(i interface{}) (string, error) {
+	type stringer interface {
+		String() string
+	}
+
 	switch v := i.(type) {
 	case string:
 		return v, nil
@@ -243,6 +247,8 @@ func stringify(i interface{}) (string, error) {
 	case float64:
 		// All the numbers are float64 - https://golang.org/pkg/encoding/json/#Number
 		return fmt.Sprintf("%g", v), nil
+	case stringer:
+		return v.(stringer).String(), nil
 	default:
 		return "", errors.NotSupportedf("%v with type %T", i, i)
 	}

--- a/caas/kubernetes/provider/specs/decode.go
+++ b/caas/kubernetes/provider/specs/decode.go
@@ -82,6 +82,7 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	}
 	logger.Debugf("decoding stream as JSON")
 	decoder := json.NewDecoder(d.r)
+	decoder.UseNumber()
 	if d.strict {
 		decoder.DisallowUnknownFields()
 	}

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -5,6 +5,7 @@ package specs_test
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -75,6 +76,7 @@ containers:
       restricted: "yes"
       switch: on
       special: p@ssword's
+      number: 5242880
       my-resource-limit:
         resource:
           container-name: container1
@@ -421,6 +423,7 @@ echo "do some stuff here for gitlab container"
 					"switch":     true,
 					"brackets":   `["hello", "world"]`,
 					"special":    "p@ssword's",
+					"number":     json.Number("5242880"),
 					"my-resource-limit": map[string]interface{}{
 						"resource": map[string]interface{}{
 							"container-name": "container1",


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Numbers parsed by json encoder will be set to json.Number when they are destined for interface{} unmarshalling.

## QA steps

*Please replace with how we can verify that the change works?*

```sh
cd caas/kubernetes/provider/specs
go test .
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1881227
