### PR TITLE
Only create cinder volumes with AZ if it makes sense

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1463,7 +1463,7 @@
   version = "v0.2.3"
 
 [[projects]]
-  digest = "1:116113ad2ba26a24f3c81618696697566a4c54603f5bcb028759de859059fa55"
+  digest = "1:1b16e29ee3012a661a935328145e7c6aa4b12eedacdbe63faacc9e435343b4da"
   name = "gopkg.in/goose.v2"
   packages = [
     ".",
@@ -1489,7 +1489,7 @@
     "testservices/swiftservice",
   ]
   pruneopts = ""
-  revision = "f18d0f2f8f9bc5b5234a338670210c4bf4328ab4"
+  revision = "8cf841f2b8d72717b1e95338c3b7fc2e0533579f"
 
 [[projects]]
   digest = "1:445becf3878aa9bd50dfa972bd65f974ed2468c09350ab9ce28b1e4adce464df"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -493,7 +493,7 @@
 
 [[constraint]]
   name = "gopkg.in/goose.v2"
-  revision = "f18d0f2f8f9bc5b5234a338670210c4bf4328ab4"
+  revision = "8cf841f2b8d72717b1e95338c3b7fc2e0533579f"
 
 [[override]]
   name = "gopkg.in/httprequest.v1"

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
@@ -245,35 +246,15 @@ func (s *cinderVolumeSource) createVolume(
 		return nil, errors.Trace(err)
 	}
 
-	// If this volume is being attached to an instance, attempt to provision
-	// the storage in the same availability zone.
-	// This helps to avoid a situation with all storage residing in a single
-	// AZ that upon failure would effectively take down attached instances
-	// whatever zone they were in.
-	az := ""
-	if arg.Attachment != nil {
-		instanceID := arg.Attachment.InstanceId
-		if instanceID != "" {
-			aZones, err := s.zonedEnv.InstanceAvailabilityZoneNames(ctx, []instance.Id{instanceID})
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if len(aZones) > 0 {
-				az = aZones[0]
-			} else {
-				// All instances should have an availability zone.
-				// The default is "nova" so something is wrong if nothing
-				// is returned from this call.
-				logger.Warningf("no availability zone detected for instance %q", instanceID)
-			}
-		}
-	}
-
 	var metadata interface{}
 	if len(arg.ResourceTags) > 0 {
 		metadata = arg.ResourceTags
 	}
 
+	az, err := s.availabilityZoneForVolume(ctx, arg.Tag.Id(), arg.Attachment)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	cinderVolume, err := s.storageAdapter.CreateVolume(cinder.CreateVolumeVolumeParams{
 		// The Cinder documentation incorrectly states the
 		// size parameter is in GB. It is actually GiB.
@@ -302,6 +283,60 @@ func (s *cinderVolumeSource) createVolume(
 	}
 	logger.Debugf("created volume: %+v", cinderVolume)
 	return &storage.Volume{Tag: arg.Tag, VolumeInfo: cinderToJujuVolumeInfo(cinderVolume)}, nil
+}
+
+func (s *cinderVolumeSource) availabilityZoneForVolume(
+	ctx context.ProviderCallContext, volName string, attachment *storage.VolumeAttachmentParams,
+) (string, error) {
+	// If this volume is being attached to an instance, attempt to provision
+	// the storage in the same availability zone.
+	// This helps to avoid a situation with all storage residing in a single
+	// AZ that upon failure would effectively take down attached instances
+	// whatever zone they were in.
+	// However, we first attempt to query the possible volume availability zones.
+	// If the API is old and does not support explicit volume AZs, or volumes can
+	// only be provisioned in say the default "nova" zone and the instance is in
+	// a different zone, we won't attempt to use the instance zone because that
+	// won't work and we'll get a 400 error back.
+	if attachment == nil || attachment.InstanceId == "" {
+		return "", nil
+	}
+
+	volumeZones, err := s.storageAdapter.ListVolumeAvailabilityZones()
+	if err != nil && !gooseerrors.IsNotImplemented(err) {
+		logger.Infof("block volume zones not supported, not using availability zone for volume %q", volName)
+		return "", errors.Trace(err)
+	}
+	vZones := set.NewStrings()
+	for _, vz := range volumeZones {
+		if vz.State.Available {
+			vZones.Add(vz.Name)
+		}
+	}
+	if vZones.Size() == 0 {
+		logger.Infof("no block volume zones defined, not using availability zone for volume %q", volName)
+		return "", nil
+	}
+	logger.Debugf("possible block volume zones: %v", vZones.SortedValues())
+	aZones, err := s.zonedEnv.InstanceAvailabilityZoneNames(ctx, []instance.Id{attachment.InstanceId})
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(aZones) == 0 {
+		// All instances should have an availability zone.
+		// The default is "nova" so something is wrong if nothing
+		// is returned from this call.
+		logger.Warningf("no availability zone detected for instance %q", attachment.InstanceId)
+		return "", nil
+	}
+	// Only choose an AZ from the instance if there's a matching volume AZ.
+	az := aZones[0]
+	if vZones.Contains(az) {
+		logger.Debugf("using availability zone %q to create cinder volume %q", az, volName)
+		return az, nil
+	}
+	logger.Warningf("no compatible availability zone detected for volume %q", volName)
+	return "", nil
 }
 
 // ListVolumes is specified on the storage.VolumeSource interface.
@@ -656,6 +691,7 @@ type OpenstackStorage interface {
 	DetachVolume(serverId, attachmentId string) error
 	ListVolumeAttachments(serverId string) ([]nova.VolumeAttachment, error)
 	SetVolumeMetadata(volumeId string, metadata map[string]string) (map[string]string, error)
+	ListVolumeAvailabilityZones() ([]cinder.AvailabilityZone, error)
 }
 
 type endpointResolver interface {

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -183,6 +183,12 @@ func (s *cinderVolumeSourceSuite) TestCreateVolume(c *gc.C) {
 				ID: mockVolId,
 			}, nil
 		},
+		listAvailabilityZones: func() ([]cinder.AvailabilityZone, error) {
+			return []cinder.AvailabilityZone{{
+				Name:  "zone-1",
+				State: cinder.AvailabilityZoneState{Available: true},
+			}}, nil
+		},
 		getVolume: func(volumeId string) (*cinder.Volume, error) {
 			var status string
 			getVolumeCalls++
@@ -236,6 +242,81 @@ func (s *cinderVolumeSourceSuite) TestCreateVolume(c *gc.C) {
 	// should have been 2 calls to GetVolume: twice initially
 	// to wait until the volume became available.
 	c.Check(getVolumeCalls, gc.Equals, 2)
+}
+
+func (s *cinderVolumeSourceSuite) TestCreateVolumeNoCompatibleZones(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	var created bool
+	mockAdapter := &mockAdapter{
+		createVolume: func(args cinder.CreateVolumeVolumeParams) (*cinder.Volume, error) {
+			created = true
+			c.Assert(args, jc.DeepEquals, cinder.CreateVolumeVolumeParams{
+				Size: 1,
+				Name: "juju-testmodel-volume-123",
+			})
+			return &cinder.Volume{
+				ID: mockVolId,
+			}, nil
+		},
+		listAvailabilityZones: func() ([]cinder.AvailabilityZone, error) {
+			return []cinder.AvailabilityZone{{
+				Name:  "nova",
+				State: cinder.AvailabilityZoneState{Available: true},
+			}}, nil
+		},
+		getVolume: func(volumeId string) (*cinder.Volume, error) {
+			return &cinder.Volume{
+				ID:     volumeId,
+				Size:   1,
+				Status: "available",
+			}, nil
+		},
+	}
+
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
+	_, err := volSource.CreateVolumes(s.callCtx, []storage.VolumeParams{{
+		Provider: openstack.CinderProviderType,
+		Tag:      mockVolumeTag,
+		Size:     1024,
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(created, jc.IsTrue)
+}
+
+func (s *cinderVolumeSourceSuite) TestCreateVolumeZonesNotSupported(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	var created bool
+	mockAdapter := &mockAdapter{
+		// listAvailabilityZones not implemented so we get a NotImplemented error.
+		createVolume: func(args cinder.CreateVolumeVolumeParams) (*cinder.Volume, error) {
+			created = true
+			c.Assert(args, jc.DeepEquals, cinder.CreateVolumeVolumeParams{
+				Size: 1,
+				Name: "juju-testmodel-volume-123",
+			})
+			return &cinder.Volume{
+				ID: mockVolId,
+			}, nil
+		},
+		getVolume: func(volumeId string) (*cinder.Volume, error) {
+			return &cinder.Volume{
+				ID:     volumeId,
+				Size:   1,
+				Status: "available",
+			}, nil
+		},
+	}
+
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
+	_, err := volSource.CreateVolumes(s.callCtx, []storage.VolumeParams{{
+		Provider: openstack.CinderProviderType,
+		Tag:      mockVolumeTag,
+		Size:     1024,
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(created, jc.IsTrue)
 }
 
 func (s *cinderVolumeSourceSuite) TestCreateVolumeVolumeType(c *gc.C) {
@@ -770,6 +851,7 @@ type mockAdapter struct {
 	detachVolume          func(string, string) error
 	listVolumeAttachments func(string) ([]nova.VolumeAttachment, error)
 	setVolumeMetadata     func(string, map[string]string) (map[string]string, error)
+	listAvailabilityZones func() ([]cinder.AvailabilityZone, error)
 }
 
 func (ma *mockAdapter) GetVolume(volumeId string) (*cinder.Volume, error) {
@@ -837,6 +919,14 @@ func (ma *mockAdapter) SetVolumeMetadata(volumeId string, metadata map[string]st
 		return ma.setVolumeMetadata(volumeId, metadata)
 	}
 	return nil, nil
+}
+
+func (ma *mockAdapter) ListVolumeAvailabilityZones() ([]cinder.AvailabilityZone, error) {
+	ma.MethodCall(ma, "ListAvailabilityZones")
+	if ma.listAvailabilityZones != nil {
+		return ma.listAvailabilityZones()
+	}
+	return nil, gooseerrors.NewNotImplementedf(nil, nil, "ListAvailabilityZones")
 }
 
 type testEndpointResolver struct {


### PR DESCRIPTION
## Description of change

We attempt to provision a cinder volume in the same AZ as the instance it's being attached to.
This isn't always possible - the volumes may have a different set of allowable AZ, or no AZ at all (just the default "nova").
So we first query the supported volume AZ and only if there's a match with the instance AZ do we then use that AZ when creating the volume.

Needs https://github.com/go-goose/goose/pull/87 to land first

## QA steps

on prodstack (via wendigo) which only has volume AZ "nova" and an old API
juju bootstrap
juju deploy postgresql --storage pgdata=cinder,1G
juju status --storage

## Bug reference

https://bugs.launchpad.net/juju/+bug/1885639
