### PR TITLE
Lp 1882149

### DIFF
--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -145,7 +145,7 @@ func (c *removeUnitCommand) validateCAASRemoval() error {
 	if names.IsValidUnit(c.EntityNames[0]) {
 		msg := `
 k8s models do not support removing named units.
-Instead specify an application with --num-units (defaults to 1).
+Instead specify an application with --num-units.
 `[1:]
 		return errors.Errorf(msg)
 	}
@@ -156,9 +156,8 @@ Instead specify an application with --num-units (defaults to 1).
 		return errors.NotValidf("application name %q", c.EntityNames[0])
 	}
 	if c.NumUnits <= 0 {
-		return errors.NotValidf("removing %d units", c.NumUnits)
+		return errors.New("specify the number of units (> 0) to remove using --num-units")
 	}
-
 	return nil
 }
 

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -194,7 +194,7 @@ func (s *RemoveUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
 	s.store.Models["arthur"].Models["king/sword"] = m
 
 	_, err := s.runRemoveUnit(c, "some-application-name")
-	c.Assert(err, gc.ErrorMatches, "removing 0 units not valid")
+	c.Assert(err, gc.ErrorMatches, `specify the number of units \(> 0\) to remove using --num-units`)
 
 	_, err = s.runRemoveUnit(c, "some-application-name", "--destroy-storage")
 	c.Assert(err, gc.ErrorMatches, "k8s models only support --num-units")


### PR DESCRIPTION

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Just fix some error messages for remove-unit command;

## QA steps

```console
$ juju remove-unit mariadb-k8s/0
ERROR k8s models do not support removing named units.
Instead specify an application with --num-units.

$ juju remove-unit mariadb-k8s
ERROR specify the number of units (> 0) to remove using --num-units

$ juju remove-unit mariadb-k8s --num-units 1
scaling down to 2 units

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1882149