### PR TITLE
Instance Poller - Remove Provider IDs for Unobserved Link-Layer Devices

### DIFF
--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -914,8 +914,10 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigRelinquishUnseen(c *gc
 
 	// Hardware address not matched.
 	dev := instancepoller.NewMockLinkLayerDevice(ctrl)
-	dev.EXPECT().MACAddress().Return("01:01:01:01:01:01")
-	dev.EXPECT().Name().Return("eth0")
+	dExp := dev.EXPECT()
+	dExp.MACAddress().Return("01:01:01:01:01:01")
+	dExp.Name().Return("eth0")
+	dExp.SetProviderIDOps(network.Id("")).Return([]txn.Op{{C: "dev-provider-id"}}, nil)
 
 	// Address should be set back to machine origin.
 	addr := instancepoller.NewMockLinkLayerAddress(ctrl)
@@ -947,6 +949,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigRelinquishUnseen(c *gc
 			buildCalled = true
 			c.Check(call.Args, gc.DeepEquals, []interface{}{[]txn.Op{
 				{C: "machine-alive"},
+				{C: "dev-provider-id"},
 				{C: "address-origin-manual"},
 			}})
 		}
@@ -960,7 +963,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 
 	s.setDefaultSpaceInfo()
 
-	// Hardware address will match; prover ID will be set.
+	// Hardware address will match; provider ID will be set.
 	dev := instancepoller.NewMockLinkLayerDevice(ctrl)
 	dExp := dev.EXPECT()
 	dExp.MACAddress().Return("00:00:00:00:00:00").Times(2)

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -71,15 +71,18 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// Not all providers (such as AWS) have names for NIC devices.
 	incomingDev := o.Incoming().GetByHardwareAddress(dev.MACAddress())
 
+	var ops []txn.Op
+	var err error
+
 	// If this device was not observed by the provider,
 	// ensure that responsibility for the addresses is relinquished
 	// to the machine agent.
 	if incomingDev == nil {
-		return o.opsForDeviceOriginRelinquishment(dev), nil
+		ops, err = o.opsForDeviceOriginRelinquishment(dev)
+		return ops, errors.Trace(err)
 	}
 
 	// Warn the user that we will not change a provider ID that is already set.
-	// The ops generated for this scenario will be nil.
 	// TODO (manadart 2020-06-09): If this is seen in the wild, we should look
 	// into removing/reassigning provider IDs for devices.
 	providerID := dev.ProviderID()
@@ -88,11 +91,11 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 			"not changing provider ID for device %s from %q to %q",
 			dev.MACAddress(), providerID, incomingDev.ProviderId,
 		)
-	}
-
-	ops, err := dev.SetProviderIDOps(incomingDev.ProviderId)
-	if err != nil {
-		return nil, errors.Trace(err)
+	} else {
+		ops, err = dev.SetProviderIDOps(incomingDev.ProviderId)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	for _, addr := range o.DeviceAddresses(dev) {
@@ -108,14 +111,21 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 }
 
 // opsForDeviceOriginRelinquishment returns transaction operations required to
-// ensure that the origin for all addresses on the device is relinquished to
-// the machine.
-func (o *mergeMachineLinkLayerOp) opsForDeviceOriginRelinquishment(dev networkingcommon.LinkLayerDevice) []txn.Op {
-	var ops []txn.Op
+// ensure that a device has no provider ID and that the origin for all
+// addresses on the device is relinquished to the machine.
+func (o *mergeMachineLinkLayerOp) opsForDeviceOriginRelinquishment(
+	dev networkingcommon.LinkLayerDevice,
+) ([]txn.Op, error) {
+	ops, err := dev.SetProviderIDOps("")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	for _, addr := range o.DeviceAddresses(dev) {
 		ops = append(ops, addr.SetOriginOps(network.OriginMachine)...)
 	}
-	return ops
+
+	return ops, nil
 }
 
 func (o *mergeMachineLinkLayerOp) processExistingDeviceAddress(

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -659,6 +659,20 @@ func (s *linkLayerDevicesStateSuite) TestSetProviderIDOps(c *gc.C) {
 	dev2 := s.addNamedDevice(c, "bar")
 	_, err = dev2.SetProviderIDOps("p1")
 	c.Assert(err, gc.ErrorMatches, "provider IDs not unique: p1")
+
+	// Unset the ID.
+	ops, err = dev1.SetProviderIDOps("")
+	c.Assert(err, jc.ErrorIsNil)
+	state.RunTransaction(c, s.State, ops)
+
+	dev1, err = s.machine.LinkLayerDevice("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dev1.ProviderID().String(), gc.Equals, "")
+
+	// The global ID is unregistered, so we should be able to reset it.
+	ops, err = dev1.SetProviderIDOps("p1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ops, gc.Not(gc.HasLen), 0)
 }
 
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {


### PR DESCRIPTION
## Description of change

This patch ensures that when the instance-poller relinquishes responsibility for a link-layer device in state, it removes any provider ID from the device and from the global collection.

## QA steps

- Bootstrap to AWS.
- Connect to Mongo, copy one of the devices documents and insert it changing the `_id`, `name`, `providerid` and `mac-address` something like:
```javascript
db.linklayerdevices.insertOne({
        "_id" : "bdf5cc58-afb7-4ff8-8a8c-d7487e02970a:m#0#d#ens6",
        "name" : "ens6",
        "model-uuid" : "bdf5cc58-afb7-4ff8-8a8c-d7487e02970a",
        "mtu" : 9001,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "0a:99:77:5a:ed:c6",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "providerid" : "p-oneZ[O]R!"
})
```
- You can wait for the instance-poller to run, or SSH to the controller machine and execute `sudo systemctl restart jujud-machine-0`.
- After a while this document should have `providerid` unset.

## Documentation changes

None.

## Bug reference

N/A
