### PR TITLE
[dev] Switch to core/network type for ProviderInterfaceInfo

### DIFF
--- a/api/machineundertaker/undertaker.go
+++ b/api/machineundertaker/undertaker.go
@@ -83,7 +83,7 @@ func (api *API) GetProviderInterfaceInfo(machine names.MachineTag) ([]network.Pr
 	infos := make([]network.ProviderInterfaceInfo, len(item.Interfaces))
 	for i, info := range item.Interfaces {
 		infos[i].InterfaceName = info.InterfaceName
-		infos[i].MACAddress = info.MACAddress
+		infos[i].HardwareAddress = info.MACAddress
 		infos[i].ProviderId = network.Id(info.ProviderId)
 	}
 	return infos, nil

--- a/api/machineundertaker/undertaker.go
+++ b/api/machineundertaker/undertaker.go
@@ -9,9 +9,8 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/network"
 )
 
 // NewWatcherFunc exists to let us test WatchMachineRemovals.
@@ -85,7 +84,7 @@ func (api *API) GetProviderInterfaceInfo(machine names.MachineTag) ([]network.Pr
 	for i, info := range item.Interfaces {
 		infos[i].InterfaceName = info.InterfaceName
 		infos[i].MACAddress = info.MACAddress
-		infos[i].ProviderId = corenetwork.Id(info.ProviderId)
+		infos[i].ProviderId = network.Id(info.ProviderId)
 	}
 	return infos, nil
 }

--- a/api/machineundertaker/undertaker_test.go
+++ b/api/machineundertaker/undertaker_test.go
@@ -150,13 +150,13 @@ func (*undertakerSuite) TestGetInfo(c *gc.C) {
 	results, err := api.GetProviderInterfaceInfo(names.NewMachineTag("100"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, []network.ProviderInterfaceInfo{{
-		InterfaceName: "hamster huey",
-		MACAddress:    "calvin",
-		ProviderId:    "1234",
+		InterfaceName:   "hamster huey",
+		HardwareAddress: "calvin",
+		ProviderId:      "1234",
 	}, {
-		InterfaceName: "happy hamster hop",
-		MACAddress:    "hobbes",
-		ProviderId:    "1235",
+		InterfaceName:   "happy hamster hop",
+		HardwareAddress: "hobbes",
+		ProviderId:      "1235",
 	}})
 }
 

--- a/api/machineundertaker/undertaker_test.go
+++ b/api/machineundertaker/undertaker_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/juju/juju/api/machineundertaker"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 )
 

--- a/apiserver/facades/controller/machineundertaker/backend.go
+++ b/apiserver/facades/controller/machineundertaker/backend.go
@@ -4,7 +4,7 @@
 package machineundertaker
 
 import (
-	"github.com/juju/juju/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 )
 

--- a/apiserver/facades/controller/machineundertaker/undertaker.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )

--- a/apiserver/facades/controller/machineundertaker/undertaker.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker.go
@@ -94,7 +94,7 @@ func (m *API) GetMachineProviderInterfaceInfo(machines params.Entities) params.P
 		infos := make([]params.ProviderInterfaceInfo, len(interfaces))
 		for i, info := range interfaces {
 			infos[i].InterfaceName = info.InterfaceName
-			infos[i].MACAddress = info.MACAddress
+			infos[i].MACAddress = info.HardwareAddress
 			infos[i].ProviderId = string(info.ProviderId)
 		}
 

--- a/apiserver/facades/controller/machineundertaker/undertaker_test.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker_test.go
@@ -95,20 +95,20 @@ func (*undertakerSuite) TestGetMachineProviderInterfaceInfo(c *gc.C) {
 		"0": {
 			Stub: &testing.Stub{},
 			interfaceInfos: []network.ProviderInterfaceInfo{{
-				InterfaceName: "billy",
-				MACAddress:    "hexadecimal!",
-				ProviderId:    "a number",
+				InterfaceName:   "billy",
+				HardwareAddress: "hexadecimal!",
+				ProviderId:      "a number",
 			}, {
-				InterfaceName: "lily",
-				MACAddress:    "octal?",
-				ProviderId:    "different number",
+				InterfaceName:   "lily",
+				HardwareAddress: "octal?",
+				ProviderId:      "different number",
 			}}},
 		"2": {
 			Stub: &testing.Stub{},
 			interfaceInfos: []network.ProviderInterfaceInfo{{
-				InterfaceName: "gilly",
-				MACAddress:    "sexagesimal?!",
-				ProviderId:    "some number",
+				InterfaceName:   "gilly",
+				HardwareAddress: "sexagesimal?!",
+				ProviderId:      "some number",
 			}},
 		},
 	}

--- a/apiserver/facades/controller/machineundertaker/undertaker_test.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/machineundertaker"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 )
 

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -339,7 +339,8 @@ type ProviderInterfaceInfo struct {
 	// ProviderId is a provider-specific NIC id.
 	ProviderId Id
 
-	// MACAddress is the network interface's hardware MAC address
-	// (e.g. "aa:bb:cc:dd:ee:ff").
-	MACAddress string
+	// HardwareAddress is the network interface's hardware address. The
+	// contents of this field depend on the NIC type (a MAC address for an
+	// ethernet device, a GUID for an infiniband device etc.)
+	HardwareAddress string
 }

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	jsonschema "github.com/juju/jsonschema"
 	cloud "github.com/juju/juju/cloud"
@@ -17,10 +15,10 @@ import (
 	config "github.com/juju/juju/environs/config"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
-	network0 "github.com/juju/juju/network"
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockNetworkingEnviron is a mock of NetworkingEnviron interface
@@ -338,7 +336,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -8,9 +8,8 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/network"
 )
 
 // SupportsNetworking is a convenience helper to check if an environment
@@ -20,7 +19,7 @@ var SupportsNetworking = supportsNetworking
 
 // DefaultSpaceInfo should be passed into Networking.ProviderSpaceInfo
 // to get information about the default space.
-var DefaultSpaceInfo *corenetwork.SpaceInfo
+var DefaultSpaceInfo *network.SpaceInfo
 
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
@@ -28,8 +27,8 @@ type Networking interface {
 	// Subnets returns basic information about subnets known
 	// by the provider for the environment.
 	Subnets(
-		ctx context.ProviderCallContext, inst instance.Id, subnetIds []corenetwork.Id,
-	) ([]corenetwork.SubnetInfo, error)
+		ctx context.ProviderCallContext, inst instance.Id, subnetIds []network.Id,
+	) ([]network.SubnetInfo, error)
 
 	// SuperSubnets returns information about aggregated subnets - eg. global CIDR
 	// for EC2 VPC.
@@ -41,7 +40,7 @@ type Networking interface {
 	// but not all of the instances were found, the returned slice will
 	// have some nil slots, and an ErrPartialInstances error will be
 	// returned.
-	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]corenetwork.InterfaceInfos, error)
+	NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]network.InterfaceInfos, error)
 
 	// SupportsSpaces returns whether the current environment supports
 	// spaces. The returned error satisfies errors.IsNotSupported(),
@@ -56,7 +55,7 @@ type Networking interface {
 	// Spaces returns a slice of network.SpaceInfo with info, including
 	// details of all associated subnets, about all spaces known to the
 	// provider that have subnets available.
-	Spaces(ctx context.ProviderCallContext) ([]corenetwork.SpaceInfo, error)
+	Spaces(ctx context.ProviderCallContext) ([]network.SpaceInfo, error)
 
 	// ProviderSpaceInfo returns the details of the space requested as
 	// a ProviderSpaceInfo. This will contain everything needed to
@@ -77,7 +76,7 @@ type Networking interface {
 	// authoritative. In that case the provider should collect up any
 	// other information needed to determine routability and include
 	// the passed-in space info in the ProviderSpaceInfo returned.
-	ProviderSpaceInfo(ctx context.ProviderCallContext, space *corenetwork.SpaceInfo) (*ProviderSpaceInfo, error)
+	ProviderSpaceInfo(ctx context.ProviderCallContext, space *network.SpaceInfo) (*ProviderSpaceInfo, error)
 
 	// AreSpacesRoutable returns whether the communication between the
 	// two spaces can use cloud-local addresses.
@@ -91,7 +90,7 @@ type Networking interface {
 	// AllocateContainerAddresses allocates a static address for each of the
 	// container NICs in preparedInfo, hosted by the hostInstanceID. Returns the
 	// network config including all allocated addresses on success.
-	AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo corenetwork.InterfaceInfos) (corenetwork.InterfaceInfos, error)
+	AllocateContainerAddresses(ctx context.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo network.InterfaceInfos) (network.InterfaceInfos, error)
 
 	// ReleaseContainerAddresses releases the previously allocated
 	// addresses matching the interface details passed in.
@@ -106,7 +105,7 @@ type Networking interface {
 	// - returns a subset based on public scope matching.
 	// The address `Value` is then returned to the client,
 	// which is just a string, so we do not actually leak a SpaceAddress.
-	SSHAddresses(ctx context.ProviderCallContext, addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddresses, error)
+	SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error)
 }
 
 // NetworkingEnviron combines the standard Environ interface with the
@@ -161,7 +160,7 @@ func SupportsContainerAddresses(ctx context.ProviderCallContext, env BootstrapEn
 // ProviderSpaceInfo contains all the information about a space needed
 // by another environ to decide whether it can be routed to.
 type ProviderSpaceInfo struct {
-	corenetwork.SpaceInfo
+	network.SpaceInfo
 
 	// Cloud type governs what attributes will exist in the
 	// provider-specific map.

--- a/environs/space/environs_mock_test.go
+++ b/environs/space/environs_mock_test.go
@@ -5,8 +5,6 @@
 package space
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
@@ -15,10 +13,10 @@ import (
 	config "github.com/juju/juju/environs/config"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
-	network0 "github.com/juju/juju/network"
 	storage "github.com/juju/juju/storage"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockBootstrapEnviron is a mock of BootstrapEnviron interface
@@ -256,7 +254,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names_v3.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(network.InterfaceInfos)
@@ -503,7 +501,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -5,9 +5,6 @@
 package testing
 
 import (
-	io "io"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	jsonschema "github.com/juju/jsonschema"
 	cloud "github.com/juju/juju/cloud"
@@ -23,6 +20,8 @@ import (
 	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
 	environschema "gopkg.in/juju/environschema.v1"
+	io "io"
+	reflect "reflect"
 )
 
 // MockEnvironProvider is a mock of EnvironProvider interface
@@ -1765,7 +1764,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/network/network.go
+++ b/network/network.go
@@ -72,23 +72,6 @@ type NetworkInfo struct {
 	Addresses []InterfaceAddress
 }
 
-// ProviderInterfaceInfo holds enough information to identify an
-// interface or link layer device to a provider so that it can be
-// queried or manipulated. Its initial purpose is to pass to
-// provider.ReleaseContainerAddresses.
-type ProviderInterfaceInfo struct {
-	// InterfaceName is the raw OS-specific network device name (e.g.
-	// "eth1", even for a VLAN eth1.42 virtual interface).
-	InterfaceName string
-
-	// ProviderId is a provider-specific NIC id.
-	ProviderId corenetwork.Id
-
-	// MACAddress is the network interface's hardware MAC address
-	// (e.g. "aa:bb:cc:dd:ee:ff").
-	MACAddress string
-}
-
 // DeviceToBridge gives the information about a particular device that
 // should be bridged.
 type DeviceToBridge struct {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1932,7 +1932,7 @@ func (e *environ) AllocateContainerAddresses(ctx context.ProviderCallContext, ho
 	return nil, errors.NotSupportedf("container address allocation")
 }
 
-func (e *environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
+func (e *environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []corenetwork.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container address allocation")
 }
 

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2267,7 +2267,7 @@ func (e *environ) AllocateContainerAddresses(ctx context.ProviderCallContext, ho
 	return nil, errors.NotSupportedf("container address allocation")
 }
 
-func (e *environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
+func (e *environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []corenetwork.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container address allocation")
 }
 

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/gce/google"
 )
 
@@ -346,7 +345,7 @@ func (e *environ) AllocateContainerAddresses(context.ProviderCallContext, instan
 }
 
 // ReleaseContainerAddresses implements environs.NetworkingEnviron.
-func (e *environ) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
+func (e *environ) ReleaseContainerAddresses(context.ProviderCallContext, []corenetwork.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container addresses")
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2257,20 +2257,20 @@ func (env *maasEnviron) allocateContainerAddresses2(ctx context.ProviderCallCont
 }
 
 func (env *maasEnviron) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []corenetwork.ProviderInterfaceInfo) error {
-	macAddresses := make([]string, len(interfaces))
+	hwAddresses := make([]string, len(interfaces))
 	for i, info := range interfaces {
-		macAddresses[i] = info.MACAddress
+		hwAddresses[i] = info.HardwareAddress
 	}
 	if !env.usingMAAS2() {
-		return env.releaseContainerAddresses1(ctx, macAddresses)
+		return env.releaseContainerAddresses1(ctx, hwAddresses)
 	}
-	return env.releaseContainerAddresses2(ctx, macAddresses)
+	return env.releaseContainerAddresses2(ctx, hwAddresses)
 }
 
-func (env *maasEnviron) releaseContainerAddresses1(ctx context.ProviderCallContext, macAddresses []string) error {
+func (env *maasEnviron) releaseContainerAddresses1(ctx context.ProviderCallContext, hwAddresses []string) error {
 	devicesAPI := env.getMAASClient().GetSubObject("devices")
 	values := url.Values{}
-	for _, address := range macAddresses {
+	for _, address := range hwAddresses {
 		values.Add("mac_address", address)
 	}
 	result, err := devicesAPI.CallGet("list", values)
@@ -2311,8 +2311,8 @@ func (env *maasEnviron) releaseContainerAddresses1(ctx context.ProviderCallConte
 	return nil
 }
 
-func (env *maasEnviron) releaseContainerAddresses2(ctx context.ProviderCallContext, macAddresses []string) error {
-	devices, err := env.maasController.Devices(gomaasapi.DevicesArgs{MACAddresses: macAddresses})
+func (env *maasEnviron) releaseContainerAddresses2(ctx context.ProviderCallContext, hwAddresses []string) error {
+	devices, err := env.maasController.Devices(gomaasapi.DevicesArgs{MACAddresses: hwAddresses})
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2256,7 +2256,7 @@ func (env *maasEnviron) allocateContainerAddresses2(ctx context.ProviderCallCont
 	return interfaces, nil
 }
 
-func (env *maasEnviron) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
+func (env *maasEnviron) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []corenetwork.ProviderInterfaceInfo) error {
 	macAddresses := make([]string, len(interfaces))
 	for i, info := range interfaces {
 		macAddresses[i] = info.MACAddress

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -999,9 +999,9 @@ func (s *environSuite) TestReleaseContainerAddresses(c *gc.C) {
 	env := s.makeEnviron()
 	err := env.ReleaseContainerAddresses(s.callCtx,
 		[]corenetwork.ProviderInterfaceInfo{
-			{MACAddress: "mac1"},
-			{MACAddress: "mac3"},
-			{MACAddress: "mac4"},
+			{HardwareAddress: "mac1"},
+			{HardwareAddress: "mac3"},
+			{HardwareAddress: "mac4"},
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1025,8 +1025,8 @@ func (s *environSuite) TestReleaseContainerAddresses_HandlesDupes(c *gc.C) {
 	env := s.makeEnviron()
 	err := env.ReleaseContainerAddresses(s.callCtx,
 		[]corenetwork.ProviderInterfaceInfo{
-			{MACAddress: "mac1"},
-			{MACAddress: "mac2"},
+			{HardwareAddress: "mac1"},
+			{HardwareAddress: "mac2"},
 		})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -36,7 +36,6 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
@@ -999,7 +998,7 @@ func (s *environSuite) TestReleaseContainerAddresses(c *gc.C) {
 
 	env := s.makeEnviron()
 	err := env.ReleaseContainerAddresses(s.callCtx,
-		[]network.ProviderInterfaceInfo{
+		[]corenetwork.ProviderInterfaceInfo{
 			{MACAddress: "mac1"},
 			{MACAddress: "mac3"},
 			{MACAddress: "mac4"},
@@ -1025,7 +1024,7 @@ func (s *environSuite) TestReleaseContainerAddresses_HandlesDupes(c *gc.C) {
 
 	env := s.makeEnviron()
 	err := env.ReleaseContainerAddresses(s.callCtx,
-		[]network.ProviderInterfaceInfo{
+		[]corenetwork.ProviderInterfaceInfo{
 			{MACAddress: "mac1"},
 			{MACAddress: "mac2"},
 		})

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -30,7 +30,6 @@ import (
 	envjujutesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -225,18 +224,18 @@ func (suite *maas2EnvironSuite) TestSpaces(c *gc.C) {
 	result, err := env.Spaces(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
-	c.Assert(result[0].Name, gc.Equals, corenetwork.SpaceName("freckles"))
-	c.Assert(result[0].ProviderId, gc.Equals, corenetwork.Id("4567"))
+	c.Assert(result[0].Name, gc.Equals, network.SpaceName("freckles"))
+	c.Assert(result[0].ProviderId, gc.Equals, network.Id("4567"))
 	subnets := result[0].Subnets
 	c.Assert(subnets, gc.HasLen, 2)
-	c.Assert(subnets[0].ProviderId, gc.Equals, corenetwork.Id("99"))
+	c.Assert(subnets[0].ProviderId, gc.Equals, network.Id("99"))
 	c.Assert(subnets[0].VLANTag, gc.Equals, 66)
 	c.Assert(subnets[0].CIDR, gc.Equals, "192.168.10.0/24")
-	c.Assert(subnets[0].ProviderSpaceId, gc.Equals, corenetwork.Id("4567"))
-	c.Assert(subnets[1].ProviderId, gc.Equals, corenetwork.Id("98"))
+	c.Assert(subnets[0].ProviderSpaceId, gc.Equals, network.Id("4567"))
+	c.Assert(subnets[1].ProviderId, gc.Equals, network.Id("98"))
 	c.Assert(subnets[1].VLANTag, gc.Equals, 67)
 	c.Assert(subnets[1].CIDR, gc.Equals, "192.168.11.0/24")
-	c.Assert(subnets[1].ProviderSpaceId, gc.Equals, corenetwork.Id("4567"))
+	c.Assert(subnets[1].ProviderSpaceId, gc.Equals, network.Id("4567"))
 }
 
 func (suite *maas2EnvironSuite) TestSpacesError(c *gc.C) {
@@ -810,7 +809,7 @@ func (suite *maas2EnvironSuite) TestSubnetsNoFilters(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	subnets, err := env.Subnets(suite.callCtx, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.SubnetInfo{
+	expected := []network.SubnetInfo{
 		{CIDR: "192.168.10.0/24", ProviderId: "99", VLANTag: 66, ProviderSpaceId: "5"},
 		{CIDR: "192.168.11.0/24", ProviderId: "100", VLANTag: 66, ProviderSpaceId: "6"},
 		{CIDR: "192.168.12.0/24", ProviderId: "101", VLANTag: 66, ProviderSpaceId: "7"},
@@ -833,9 +832,9 @@ func (suite *maas2EnvironSuite) TestSubnetsSubnetIds(c *gc.C) {
 		spaces: getFourSpaces(),
 	})
 	env := suite.makeEnviron(c, nil)
-	subnets, err := env.Subnets(suite.callCtx, "", []corenetwork.Id{"99", "100"})
+	subnets, err := env.Subnets(suite.callCtx, "", []network.Id{"99", "100"})
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.SubnetInfo{
+	expected := []network.SubnetInfo{
 		{CIDR: "192.168.10.0/24", ProviderId: "99", VLANTag: 66, ProviderSpaceId: "5"},
 		{CIDR: "192.168.11.0/24", ProviderId: "100", VLANTag: 66, ProviderSpaceId: "6"},
 	}
@@ -847,7 +846,7 @@ func (suite *maas2EnvironSuite) TestSubnetsSubnetIdsMissing(c *gc.C) {
 		spaces: getFourSpaces(),
 	})
 	env := suite.makeEnviron(c, nil)
-	_, err := env.Subnets(suite.callCtx, "", []corenetwork.Id{"99", "missing"})
+	_, err := env.Subnets(suite.callCtx, "", []network.Id{"99", "missing"})
 	msg := "failed to find the following subnets: missing"
 	c.Assert(err, gc.ErrorMatches, msg)
 }
@@ -885,7 +884,7 @@ func (suite *maas2EnvironSuite) TestSubnetsInstId(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	subnets, err := env.Subnets(suite.callCtx, "William Gibson", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []corenetwork.SubnetInfo{
+	expected := []network.SubnetInfo{
 		{CIDR: "192.168.10.0/24", ProviderId: "99", VLANTag: 66, ProviderSpaceId: "5"},
 		{CIDR: "192.168.11.0/24", ProviderId: "100", VLANTag: 0, ProviderSpaceId: "6"},
 		{CIDR: "192.168.12.0/24", ProviderId: "101", VLANTag: 2, ProviderSpaceId: "7"},
@@ -982,7 +981,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 	params := environs.StartInstanceParams{ControllerUUID: suite.controllerUUID}
 	result, err := jujutesting.StartInstanceWithParams(env, suite.callCtx, "1", params)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
 		CIDR:              "10.20.19.0/24",
@@ -997,12 +996,12 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("default", "10.20.19.103")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("default", "10.20.19.103")},
+		DNSServers:        network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 		DNSSearchDomains:  nil,
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
-		Origin:            corenetwork.OriginProvider,
+		GatewayAddress:    network.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:            network.OriginProvider,
 	}, {
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
@@ -1018,12 +1017,12 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("default", "10.20.19.104")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("default", "10.20.19.104")},
+		DNSServers:        network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 		DNSSearchDomains:  nil,
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
-		Origin:            corenetwork.OriginProvider,
+		GatewayAddress:    network.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:            network.OriginProvider,
 	}, {
 		DeviceIndex:         1,
 		MACAddress:          "52:54:00:70:9b:fe",
@@ -1040,12 +1039,12 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("admin", "10.50.19.103")},
+		Addresses:           network.ProviderAddresses{network.NewProviderAddressInSpace("admin", "10.50.19.103")},
 		DNSServers:          nil,
 		DNSSearchDomains:    nil,
 		MTU:                 1500,
-		GatewayAddress:      corenetwork.NewProviderAddressInSpace("admin", "10.50.19.2"),
-		Origin:              corenetwork.OriginProvider,
+		GatewayAddress:      network.NewProviderAddressInSpace("admin", "10.50.19.2"),
+		Origin:              network.OriginProvider,
 	}}
 	c.Assert(result.NetworkInfo, jc.DeepEquals, expected)
 }
@@ -1151,7 +1150,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := corenetwork.InterfaceInfos{{
+	prepared := network.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1159,7 +1158,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 	ignored := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "192.168.1.0/24",
@@ -1171,16 +1170,16 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("freckles", "192.168.1.127")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "192.168.1.127")},
+		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "192.168.1.1"),
-		Routes: []corenetwork.Route{{
+		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
+		Routes: []network.Route{{
 			DestinationCIDR: subnet1.CIDR(),
 			GatewayIP:       "192.168.1.1",
 			Metric:          100,
 		}},
-		Origin: corenetwork.OriginProvider,
+		Origin: network.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -1281,7 +1280,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := corenetwork.InterfaceInfos{{
+	prepared := network.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1289,7 +1288,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 	ignored := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "10.20.19.0/24",
@@ -1301,12 +1300,12 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.104")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "10.20.19.104")},
+		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.2"),
-		Routes:            []corenetwork.Route{},
-		Origin:            corenetwork.OriginProvider,
+		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
+		Routes:            []network.Route{},
+		Origin:            network.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -1376,7 +1375,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesStaticRoutesDenied
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := corenetwork.InterfaceInfos{{
+	prepared := network.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1522,7 +1521,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 	suite.injectController(controller)
 	env := suite.makeEnviron(c, nil)
 
-	prepared := corenetwork.InterfaceInfos{{
+	prepared := network.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:9b:ff",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1531,7 +1530,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		CIDR:          "192.168.1.0/24",
 		InterfaceName: "eth1",
 	}}
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "10.20.19.0/24",
@@ -1542,11 +1541,11 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.127")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "10.20.19.127")},
+		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.2"),
-		Origin:            corenetwork.OriginProvider,
+		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
+		Origin:            network.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		MACAddress:        "52:54:00:70:9b:f4",
@@ -1558,16 +1557,16 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("freckles", "192.168.1.127")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "192.168.1.127")},
+		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "192.168.1.1"),
-		Routes: []corenetwork.Route{{
+		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
+		Routes: []network.Route{{
 			DestinationCIDR: "10.20.19.0/24",
 			GatewayIP:       "192.168.1.1",
 			Metric:          100,
 		}},
-		Origin: corenetwork.OriginProvider,
+		Origin: network.OriginProvider,
 	}}
 	ignored := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
@@ -1575,9 +1574,9 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, expected)
 }
 
-func (suite *maas2EnvironSuite) assertAllocateContainerAddressesFails(c *gc.C, controller *fakeController, prepared corenetwork.InterfaceInfos, errorMatches string) {
+func (suite *maas2EnvironSuite) assertAllocateContainerAddressesFails(c *gc.C, controller *fakeController, prepared network.InterfaceInfos, errorMatches string) {
 	if prepared == nil {
-		prepared = corenetwork.InterfaceInfos{{}}
+		prepared = network.InterfaceInfos{{}}
 	}
 	suite.injectController(controller)
 	env := suite.makeEnviron(c, nil)
@@ -1640,7 +1639,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesMachinesError(c *g
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := corenetwork.InterfaceInfos{
+	prepared := network.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
@@ -1675,7 +1674,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDeviceError(
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := corenetwork.InterfaceInfos{
+	prepared := network.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
@@ -1754,14 +1753,14 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := corenetwork.InterfaceInfos{
+	prepared := network.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "", MACAddress: "DEADBEEF"},
 		{InterfaceName: "eth1", CIDR: "", MACAddress: "DEADBEEE"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
 	allocated, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(allocated, jc.DeepEquals, corenetwork.InterfaceInfos{{
+	c.Assert(allocated, jc.DeepEquals, network.InterfaceInfos{{
 		DeviceIndex:    0,
 		MACAddress:     "53:54:00:70:9b:ff",
 		ProviderId:     "93",
@@ -1773,7 +1772,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		NoAutoStart:    false,
 		ConfigType:     "manual",
 		MTU:            1500,
-		Origin:         corenetwork.OriginProvider,
+		Origin:         network.OriginProvider,
 	}, {
 		DeviceIndex:    1,
 		MACAddress:     "53:54:00:70:9b:f1",
@@ -1786,7 +1785,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		NoAutoStart:    false,
 		ConfigType:     "manual",
 		MTU:            1500,
-		Origin:         corenetwork.OriginProvider,
+		Origin:         network.OriginProvider,
 	}})
 }
 
@@ -1818,7 +1817,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateInterfaceErr
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := corenetwork.InterfaceInfos{
+	prepared := network.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
 		{InterfaceName: "eth1", CIDR: "10.20.20.0/24", MACAddress: "DEADBEEE"},
 	}
@@ -1868,7 +1867,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesLinkSubnetError(c 
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := corenetwork.InterfaceInfos{
+	prepared := network.InterfaceInfos{
 		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
 		{InterfaceName: "eth1", CIDR: "10.20.20.0/24", MACAddress: "DEADBEEE"},
 	}
@@ -1982,7 +1981,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := corenetwork.InterfaceInfos{{
+	prepared := network.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:9b:ff",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -1990,7 +1989,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 	containerTag := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), containerTag, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
 		CIDR:              "10.20.19.0/24",
@@ -2002,12 +2001,12 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("space-1", "10.20.19.105")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("space-1", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("space-1", "10.20.19.105")},
+		DNSServers:        network.NewProviderAddressesInSpace("space-1", "10.20.19.2", "10.20.19.3"),
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("space-1", "10.20.19.2"),
-		Routes:            []corenetwork.Route{},
-		Origin:            corenetwork.OriginProvider,
+		GatewayAddress:    network.NewProviderAddressInSpace("space-1", "10.20.19.2"),
+		Routes:            []network.Route{},
+		Origin:            network.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -2178,7 +2177,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	prepared := corenetwork.InterfaceInfos{{
+	prepared := network.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:88:aa",
 		CIDR:          "10.20.19.0/24",
 		InterfaceName: "eth0",
@@ -2190,7 +2189,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 	containerTag := names.NewMachineTag("1/lxd/0")
 	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), containerTag, prepared)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:88:aa",
 		CIDR:              "10.20.19.0/24",
@@ -2202,12 +2201,12 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.105")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "10.20.19.105")},
+		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "10.20.19.2"),
-		Routes:            []corenetwork.Route{},
-		Origin:            corenetwork.OriginProvider,
+		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
+		Routes:            []network.Route{},
+		Origin:            network.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		MACAddress:        "53:54:00:70:88:bb",
@@ -2220,12 +2219,12 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("freckles", "192.168.1.101")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("freckles", "192.168.1.2"),
+		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "192.168.1.101")},
+		DNSServers:        network.NewProviderAddressesInSpace("freckles", "192.168.1.2"),
 		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("freckles", "192.168.1.1"),
-		Routes:            []corenetwork.Route{},
-		Origin:            corenetwork.OriginProvider,
+		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
+		Routes:            []network.Route{},
+		Origin:            network.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -2465,9 +2465,9 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddresses(c *gc.C) {
 
 	env := suite.makeEnviron(c, controller)
 	err := env.ReleaseContainerAddresses(suite.callCtx, []network.ProviderInterfaceInfo{
-		{MACAddress: "will"},
-		{MACAddress: "dustin"},
-		{MACAddress: "eleven"},
+		{HardwareAddress: "will"},
+		{HardwareAddress: "dustin"},
+		{HardwareAddress: "eleven"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2487,8 +2487,8 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddresses_HandlesDupes(c *gc
 
 	env := suite.makeEnviron(c, controller)
 	err := env.ReleaseContainerAddresses(suite.callCtx, []network.ProviderInterfaceInfo{
-		{MACAddress: "will"},
-		{MACAddress: "eleven"},
+		{HardwareAddress: "will"},
+		{HardwareAddress: "eleven"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2503,7 +2503,7 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddresses_HandlesDupes(c *gc
 func (suite *maas2EnvironSuite) TestReleaseContainerAddressesErrorGettingDevices(c *gc.C) {
 	controller := newFakeControllerWithErrors(errors.New("Everything done broke"))
 	env := suite.makeEnviron(c, controller)
-	err := env.ReleaseContainerAddresses(suite.callCtx, []network.ProviderInterfaceInfo{{MACAddress: "anything"}})
+	err := env.ReleaseContainerAddresses(suite.callCtx, []network.ProviderInterfaceInfo{{HardwareAddress: "anything"}})
 	c.Assert(err, gc.ErrorMatches, "Everything done broke")
 }
 
@@ -2516,7 +2516,7 @@ func (suite *maas2EnvironSuite) TestReleaseContainerAddressesErrorDeletingDevice
 
 	env := suite.makeEnviron(c, controller)
 	err := env.ReleaseContainerAddresses(suite.callCtx, []network.ProviderInterfaceInfo{
-		{MACAddress: "eleven"},
+		{HardwareAddress: "eleven"},
 	})
 	c.Assert(err, gc.ErrorMatches, "deleting device hopper: don't delete me")
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2288,7 +2288,7 @@ func (e *Environ) AllocateContainerAddresses(ctx context.ProviderCallContext, ho
 }
 
 // ReleaseContainerAddresses is specified on environs.Networking.
-func (e *Environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
+func (e *Environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []corenetwork.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("release container address")
 }
 

--- a/provider/oracle/network/environ.go
+++ b/provider/oracle/network/environ.go
@@ -19,7 +19,6 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/network"
 	commonProvider "github.com/juju/juju/provider/oracle/common"
 )
 
@@ -334,7 +333,7 @@ func (e Environ) AllocateContainerAddresses(
 }
 
 // ReleaseContainerAddresses is defined on the environs.Networking interface.
-func (e Environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
+func (e Environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []corenetwork.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container")
 }
 

--- a/provider/oracle/network/environ_test.go
+++ b/provider/oracle/network/environ_test.go
@@ -18,7 +18,6 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	jujunetwork "github.com/juju/juju/network"
 	"github.com/juju/juju/provider/oracle"
 	"github.com/juju/juju/provider/oracle/network"
 	oracletesting "github.com/juju/juju/provider/oracle/testing"
@@ -134,7 +133,7 @@ func (e *environSuite) TestAllocateContainerAddress(c *gc.C) {
 }
 
 func (e *environSuite) TestReleaseContainerAddresses(c *gc.C) {
-	var i []jujunetwork.ProviderInterfaceInfo
+	var i []corenetwork.ProviderInterfaceInfo
 	err := e.netEnv.ReleaseContainerAddresses(e.callCtx, i)
 	c.Assert(err, gc.NotNil)
 	is := errors.IsNotSupported(err)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -498,13 +498,13 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllProviderInterfaceInfos(c *gc.
 	results, err := s.machine.AllProviderInterfaceInfos()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.SameContents, []corenetwork.ProviderInterfaceInfo{{
-		InterfaceName: "sara-lynn",
-		MACAddress:    "ab:cd:ef:01:23:45",
-		ProviderId:    "thing1",
+		InterfaceName:   "sara-lynn",
+		HardwareAddress: "ab:cd:ef:01:23:45",
+		ProviderId:      "thing1",
 	}, {
-		InterfaceName: "bojack",
-		MACAddress:    "ab:cd:ef:01:23:46",
-		ProviderId:    "thing2",
+		InterfaceName:   "bojack",
+		HardwareAddress: "ab:cd:ef:01:23:46",
+		ProviderId:      "thing2",
 	}})
 }
 

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -497,7 +497,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllProviderInterfaceInfos(c *gc.
 
 	results, err := s.machine.AllProviderInterfaceInfos()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.SameContents, []network.ProviderInterfaceInfo{{
+	c.Assert(results, jc.SameContents, []corenetwork.ProviderInterfaceInfo{{
 		InterfaceName: "sara-lynn",
 		MACAddress:    "ab:cd:ef:01:23:45",
 		ProviderId:    "thing1",

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -87,12 +87,12 @@ func (m *Machine) forEachLinkLayerDeviceDoc(
 // the link layer devices belonging to this machine. These can be used
 // to identify the devices when interacting with the provider
 // directly (for example, releasing container addresses).
-func (m *Machine) AllProviderInterfaceInfos() ([]network.ProviderInterfaceInfo, error) {
+func (m *Machine) AllProviderInterfaceInfos() ([]corenetwork.ProviderInterfaceInfo, error) {
 	devices, err := m.AllLinkLayerDevices()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	result := make([]network.ProviderInterfaceInfo, len(devices))
+	result := make([]corenetwork.ProviderInterfaceInfo, len(devices))
 	for i, device := range devices {
 		result[i].InterfaceName = device.Name()
 		result[i].MACAddress = device.MACAddress()

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -95,7 +95,7 @@ func (m *Machine) AllProviderInterfaceInfos() ([]corenetwork.ProviderInterfaceIn
 	result := make([]corenetwork.ProviderInterfaceInfo, len(devices))
 	for i, device := range devices {
 		result[i].InterfaceName = device.Name()
-		result[i].MACAddress = device.MACAddress()
+		result[i].HardwareAddress = device.MACAddress()
 		result[i].ProviderId = device.ProviderID()
 	}
 	return result, nil

--- a/worker/containerbroker/mocks/base_mock.go
+++ b/worker/containerbroker/mocks/base_mock.go
@@ -6,14 +6,13 @@ package mocks
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
+	base "github.com/juju/juju/api/base"
+	names "github.com/juju/names/v4"
+	httprequest "gopkg.in/httprequest.v1"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
-	base "github.com/juju/juju/api/base"
-	names_v3 "github.com/juju/names/v4"
-	httprequest_v1 "gopkg.in/httprequest.v1"
 )
 
 // MockAPICaller is a mock of APICaller interface
@@ -41,6 +40,7 @@ func (m *MockAPICaller) EXPECT() *MockAPICallerMockRecorder {
 
 // APICall mocks base method
 func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, arg5 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APICall", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -48,11 +48,13 @@ func (m *MockAPICaller) APICall(arg0 string, arg1 int, arg2, arg3 string, arg4, 
 
 // APICall indicates an expected call of APICall
 func (mr *MockAPICallerMockRecorder) APICall(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APICall", reflect.TypeOf((*MockAPICaller)(nil).APICall), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // BakeryClient mocks base method
 func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BakeryClient")
 	ret0, _ := ret[0].(base.MacaroonDischarger)
 	return ret0
@@ -60,11 +62,13 @@ func (m *MockAPICaller) BakeryClient() base.MacaroonDischarger {
 
 // BakeryClient indicates an expected call of BakeryClient
 func (mr *MockAPICallerMockRecorder) BakeryClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BakeryClient", reflect.TypeOf((*MockAPICaller)(nil).BakeryClient))
 }
 
 // BestFacadeVersion mocks base method
 func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BestFacadeVersion", arg0)
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -72,11 +76,13 @@ func (m *MockAPICaller) BestFacadeVersion(arg0 string) int {
 
 // BestFacadeVersion indicates an expected call of BestFacadeVersion
 func (mr *MockAPICallerMockRecorder) BestFacadeVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestFacadeVersion", reflect.TypeOf((*MockAPICaller)(nil).BestFacadeVersion), arg0)
 }
 
 // ConnectControllerStream mocks base method
 func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, arg2 http.Header) (base.Stream, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectControllerStream", arg0, arg1, arg2)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -85,11 +91,13 @@ func (m *MockAPICaller) ConnectControllerStream(arg0 string, arg1 url.Values, ar
 
 // ConnectControllerStream indicates an expected call of ConnectControllerStream
 func (mr *MockAPICallerMockRecorder) ConnectControllerStream(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectControllerStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectControllerStream), arg0, arg1, arg2)
 }
 
 // ConnectStream mocks base method
 func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectStream", arg0, arg1)
 	ret0, _ := ret[0].(base.Stream)
 	ret1, _ := ret[1].(error)
@@ -98,11 +106,13 @@ func (m *MockAPICaller) ConnectStream(arg0 string, arg1 url.Values) (base.Stream
 
 // ConnectStream indicates an expected call of ConnectStream
 func (mr *MockAPICallerMockRecorder) ConnectStream(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectStream", reflect.TypeOf((*MockAPICaller)(nil).ConnectStream), arg0, arg1)
 }
 
 // Context mocks base method
 func (m *MockAPICaller) Context() context.Context {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
 	return ret0
@@ -110,31 +120,36 @@ func (m *MockAPICaller) Context() context.Context {
 
 // Context indicates an expected call of Context
 func (mr *MockAPICallerMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPICaller)(nil).Context))
 }
 
 // HTTPClient mocks base method
-func (m *MockAPICaller) HTTPClient() (*httprequest_v1.Client, error) {
+func (m *MockAPICaller) HTTPClient() (*httprequest.Client, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*httprequest_v1.Client)
+	ret0, _ := ret[0].(*httprequest.Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HTTPClient indicates an expected call of HTTPClient
 func (mr *MockAPICallerMockRecorder) HTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HTTPClient", reflect.TypeOf((*MockAPICaller)(nil).HTTPClient))
 }
 
 // ModelTag mocks base method
-func (m *MockAPICaller) ModelTag() (names_v3.ModelTag, bool) {
+func (m *MockAPICaller) ModelTag() (names.ModelTag, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(names_v3.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // ModelTag indicates an expected call of ModelTag
 func (mr *MockAPICallerMockRecorder) ModelTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAPICaller)(nil).ModelTag))
 }

--- a/worker/containerbroker/mocks/dependency_mock.go
+++ b/worker/containerbroker/mocks/dependency_mock.go
@@ -34,6 +34,7 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 
 // Abort mocks base method
 func (m *MockContext) Abort() <-chan struct{} {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Abort")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
@@ -41,11 +42,13 @@ func (m *MockContext) Abort() <-chan struct{} {
 
 // Abort indicates an expected call of Abort
 func (mr *MockContextMockRecorder) Abort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockContext)(nil).Abort))
 }
 
 // Get mocks base method
 func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -53,5 +56,6 @@ func (m *MockContext) Get(arg0 string, arg1 interface{}) error {
 
 // Get indicates an expected call of Get
 func (mr *MockContextMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockContext)(nil).Get), arg0, arg1)
 }

--- a/worker/containerbroker/mocks/environs_mock.go
+++ b/worker/containerbroker/mocks/environs_mock.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
+	charm "github.com/juju/charm/v7"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
@@ -40,6 +40,7 @@ func (m *MockLXDProfiler) EXPECT() *MockLXDProfilerMockRecorder {
 
 // AssignLXDProfiles mocks base method
 func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignLXDProfiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -48,11 +49,13 @@ func (m *MockLXDProfiler) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []l
 
 // AssignLXDProfiles indicates an expected call of AssignLXDProfiles
 func (mr *MockLXDProfilerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignLXDProfiles", reflect.TypeOf((*MockLXDProfiler)(nil).AssignLXDProfiles), arg0, arg1, arg2)
 }
 
 // LXDProfileNames mocks base method
 func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -61,11 +64,13 @@ func (m *MockLXDProfiler) LXDProfileNames(arg0 string) ([]string, error) {
 
 // LXDProfileNames indicates an expected call of LXDProfileNames
 func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockLXDProfiler)(nil).LXDProfileNames), arg0)
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
+func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfile) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -73,6 +78,7 @@ func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDPr
 
 // MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile
 func (mr *MockLXDProfilerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfiler)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
@@ -101,6 +107,7 @@ func (m *MockInstanceBroker) EXPECT() *MockInstanceBrokerMockRecorder {
 
 // AllInstances mocks base method
 func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -109,11 +116,13 @@ func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]i
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllInstances), arg0)
 }
 
 // AllRunningInstances mocks base method
 func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -122,11 +131,13 @@ func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContex
 
 // AllRunningInstances indicates an expected call of AllRunningInstances
 func (mr *MockInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
 // MaintainInstance mocks base method
 func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -134,11 +145,13 @@ func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, 
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockInstanceBrokerMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockInstanceBroker)(nil).MaintainInstance), arg0, arg1)
 }
 
 // StartInstance mocks base method
 func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -147,11 +160,13 @@ func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockInstanceBrokerMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockInstanceBroker)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
 func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -163,6 +178,7 @@ func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockInstanceBrokerMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockInstanceBroker)(nil).StopInstances), varargs...)
 }

--- a/worker/containerbroker/mocks/machine_lock_mock.go
+++ b/worker/containerbroker/mocks/machine_lock_mock.go
@@ -35,6 +35,7 @@ func (m *MockLock) EXPECT() *MockLockMockRecorder {
 
 // Acquire mocks base method
 func (m *MockLock) Acquire(arg0 machinelock.Spec) (func(), error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Acquire", arg0)
 	ret0, _ := ret[0].(func())
 	ret1, _ := ret[1].(error)
@@ -43,11 +44,13 @@ func (m *MockLock) Acquire(arg0 machinelock.Spec) (func(), error) {
 
 // Acquire indicates an expected call of Acquire
 func (mr *MockLockMockRecorder) Acquire(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Acquire", reflect.TypeOf((*MockLock)(nil).Acquire), arg0)
 }
 
 // Report mocks base method
 func (m *MockLock) Report(arg0 ...machinelock.ReportOption) (string, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -60,5 +63,6 @@ func (m *MockLock) Report(arg0 ...machinelock.ReportOption) (string, error) {
 
 // Report indicates an expected call of Report
 func (mr *MockLockMockRecorder) Report(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockLock)(nil).Report), arg0...)
 }

--- a/worker/containerbroker/mocks/machine_mock.go
+++ b/worker/containerbroker/mocks/machine_mock.go
@@ -5,16 +5,15 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
 	life "github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockMachineProvisioner is a mock of MachineProvisioner interface
@@ -42,6 +41,7 @@ func (m *MockMachineProvisioner) EXPECT() *MockMachineProvisionerMockRecorder {
 
 // AvailabilityZone mocks base method
 func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZone")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -50,11 +50,13 @@ func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
 
 // AvailabilityZone indicates an expected call of AvailabilityZone
 func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone))
 }
 
 // DistributionGroup mocks base method
 func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DistributionGroup")
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
@@ -63,11 +65,13 @@ func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
 
 // DistributionGroup indicates an expected call of DistributionGroup
 func (mr *MockMachineProvisionerMockRecorder) DistributionGroup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup))
 }
 
 // EnsureDead mocks base method
 func (m *MockMachineProvisioner) EnsureDead() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureDead")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -75,11 +79,13 @@ func (m *MockMachineProvisioner) EnsureDead() error {
 
 // EnsureDead indicates an expected call of EnsureDead
 func (mr *MockMachineProvisionerMockRecorder) EnsureDead() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead))
 }
 
 // Id mocks base method
 func (m *MockMachineProvisioner) Id() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -87,11 +93,13 @@ func (m *MockMachineProvisioner) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockMachineProvisionerMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachineProvisioner)(nil).Id))
 }
 
 // InstanceId mocks base method
 func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
@@ -100,11 +108,13 @@ func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
 
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMachineProvisionerMockRecorder) InstanceId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId))
 }
 
 // InstanceStatus mocks base method
 func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceStatus")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -114,11 +124,13 @@ func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error)
 
 // InstanceStatus indicates an expected call of InstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) InstanceStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus))
 }
 
 // KeepInstance mocks base method
 func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KeepInstance")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -127,11 +139,13 @@ func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
 
 // KeepInstance indicates an expected call of KeepInstance
 func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance))
 }
 
 // Life mocks base method
 func (m *MockMachineProvisioner) Life() life.Value {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
 	ret0, _ := ret[0].(life.Value)
 	return ret0
@@ -139,23 +153,27 @@ func (m *MockMachineProvisioner) Life() life.Value {
 
 // Life indicates an expected call of Life
 func (mr *MockMachineProvisionerMockRecorder) Life() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockMachineProvisioner)(nil).Life))
 }
 
 // MachineTag mocks base method
-func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
+func (m *MockMachineProvisioner) MachineTag() names.MachineTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
-	ret0, _ := ret[0].(names_v3.MachineTag)
+	ret0, _ := ret[0].(names.MachineTag)
 	return ret0
 }
 
 // MachineTag indicates an expected call of MachineTag
 func (mr *MockMachineProvisionerMockRecorder) MachineTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockMachineProvisioner)(nil).MachineTag))
 }
 
 // MarkForRemoval mocks base method
 func (m *MockMachineProvisioner) MarkForRemoval() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarkForRemoval")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -163,11 +181,13 @@ func (m *MockMachineProvisioner) MarkForRemoval() error {
 
 // MarkForRemoval indicates an expected call of MarkForRemoval
 func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval))
 }
 
 // ModelAgentVersion mocks base method
 func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelAgentVersion")
 	ret0, _ := ret[0].(*version.Number)
 	ret1, _ := ret[1].(error)
@@ -176,11 +196,13 @@ func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
 
 // ModelAgentVersion indicates an expected call of ModelAgentVersion
 func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion))
 }
 
 // ProvisioningInfo mocks base method
 func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo")
 	ret0, _ := ret[0].(*params.ProvisioningInfoV10)
 	ret1, _ := ret[1].(error)
@@ -189,11 +211,13 @@ func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10
 
 // ProvisioningInfo indicates an expected call of ProvisioningInfo
 func (mr *MockMachineProvisionerMockRecorder) ProvisioningInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).ProvisioningInfo))
 }
 
 // Refresh mocks base method
 func (m *MockMachineProvisioner) Refresh() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -201,11 +225,13 @@ func (m *MockMachineProvisioner) Refresh() error {
 
 // Refresh indicates an expected call of Refresh
 func (mr *MockMachineProvisionerMockRecorder) Refresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMachineProvisioner)(nil).Refresh))
 }
 
 // Remove mocks base method
 func (m *MockMachineProvisioner) Remove() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -213,11 +239,13 @@ func (m *MockMachineProvisioner) Remove() error {
 
 // Remove indicates an expected call of Remove
 func (mr *MockMachineProvisionerMockRecorder) Remove() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove))
 }
 
 // SetCharmProfiles mocks base method
 func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -225,11 +253,13 @@ func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles
 func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0)
 }
 
 // SetInstanceInfo mocks base method
 func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 string, arg3 *instance.HardwareCharacteristics, arg4 []params.NetworkConfig, arg5 []params.Volume, arg6 map[string]params.VolumeAttachmentInfo, arg7 []string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -237,11 +267,13 @@ func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 st
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // SetInstanceStatus mocks base method
 func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -249,11 +281,13 @@ func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 stri
 
 // SetInstanceStatus indicates an expected call of SetInstanceStatus
 func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2)
 }
 
 // SetModificationStatus mocks base method
 func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -261,11 +295,13 @@ func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 
 
 // SetModificationStatus indicates an expected call of SetModificationStatus
 func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2)
 }
 
 // SetPassword mocks base method
 func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPassword", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -273,11 +309,13 @@ func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
 
 // SetPassword indicates an expected call of SetPassword
 func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0)
 }
 
 // SetStatus mocks base method
 func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -285,11 +323,13 @@ func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2
 
 // SetStatus indicates an expected call of SetStatus
 func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2)
 }
 
 // SetSupportedContainers mocks base method
 func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.ContainerType) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -301,11 +341,13 @@ func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.Contain
 
 // SetSupportedContainers indicates an expected call of SetSupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), arg0...)
 }
 
 // Status mocks base method
 func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
@@ -315,11 +357,13 @@ func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
 
 // Status indicates an expected call of Status
 func (mr *MockMachineProvisionerMockRecorder) Status() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status))
 }
 
 // String mocks base method
 func (m *MockMachineProvisioner) String() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -327,11 +371,13 @@ func (m *MockMachineProvisioner) String() string {
 
 // String indicates an expected call of String
 func (mr *MockMachineProvisionerMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockMachineProvisioner)(nil).String))
 }
 
 // SupportedContainers mocks base method
 func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType, bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportedContainers")
 	ret0, _ := ret[0].([]instance.ContainerType)
 	ret1, _ := ret[1].(bool)
@@ -341,11 +387,13 @@ func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType
 
 // SupportedContainers indicates an expected call of SupportedContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportedContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers))
 }
 
 // SupportsNoContainers mocks base method
 func (m *MockMachineProvisioner) SupportsNoContainers() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsNoContainers")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -353,23 +401,27 @@ func (m *MockMachineProvisioner) SupportsNoContainers() error {
 
 // SupportsNoContainers indicates an expected call of SupportsNoContainers
 func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers))
 }
 
 // Tag mocks base method
-func (m *MockMachineProvisioner) Tag() names_v3.Tag {
+func (m *MockMachineProvisioner) Tag() names.Tag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
 // Tag indicates an expected call of Tag
 func (mr *MockMachineProvisionerMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockMachineProvisioner)(nil).Tag))
 }
 
 // WatchAllContainers mocks base method
 func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchAllContainers")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -378,11 +430,13 @@ func (m *MockMachineProvisioner) WatchAllContainers() (watcher.StringsWatcher, e
 
 // WatchAllContainers indicates an expected call of WatchAllContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchAllContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAllContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchAllContainers))
 }
 
 // WatchContainers mocks base method
 func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchContainers", arg0)
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
@@ -391,5 +445,6 @@ func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (w
 
 // WatchContainers indicates an expected call of WatchContainers
 func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0)
 }

--- a/worker/containerbroker/mocks/state_mock.go
+++ b/worker/containerbroker/mocks/state_mock.go
@@ -5,14 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	provisioner "github.com/juju/juju/api/provisioner"
 	params "github.com/juju/juju/apiserver/params"
 	network "github.com/juju/juju/core/network"
 	network0 "github.com/juju/juju/network"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockState is a mock of State interface
@@ -40,6 +39,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 
 // ContainerConfig mocks base method
 func (m *MockState) ContainerConfig() (params.ContainerConfig, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerConfig")
 	ret0, _ := ret[0].(params.ContainerConfig)
 	ret1, _ := ret[1].(error)
@@ -48,11 +48,13 @@ func (m *MockState) ContainerConfig() (params.ContainerConfig, error) {
 
 // ContainerConfig indicates an expected call of ContainerConfig
 func (mr *MockStateMockRecorder) ContainerConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockState)(nil).ContainerConfig))
 }
 
 // ContainerManagerConfig mocks base method
 func (m *MockState) ContainerManagerConfig(arg0 params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerManagerConfig", arg0)
 	ret0, _ := ret[0].(params.ContainerManagerConfig)
 	ret1, _ := ret[1].(error)
@@ -61,11 +63,13 @@ func (m *MockState) ContainerManagerConfig(arg0 params.ContainerManagerConfigPar
 
 // ContainerManagerConfig indicates an expected call of ContainerManagerConfig
 func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockState)(nil).ContainerManagerConfig), arg0)
 }
 
 // GetContainerInterfaceInfo mocks base method
-func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) (network.InterfaceInfos, error) {
+func (m *MockState) GetContainerInterfaceInfo(arg0 names.MachineTag) (network.InterfaceInfos, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
@@ -74,11 +78,13 @@ func (m *MockState) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) (network
 
 // GetContainerInterfaceInfo indicates an expected call of GetContainerInterfaceInfo
 func (mr *MockStateMockRecorder) GetContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).GetContainerInterfaceInfo), arg0)
 }
 
 // GetContainerProfileInfo mocks base method
-func (m *MockState) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+func (m *MockState) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
@@ -87,11 +93,13 @@ func (m *MockState) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*provis
 
 // GetContainerProfileInfo indicates an expected call of GetContainerProfileInfo
 func (mr *MockStateMockRecorder) GetContainerProfileInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockState)(nil).GetContainerProfileInfo), arg0)
 }
 
 // HostChangesForContainer mocks base method
-func (m *MockState) HostChangesForContainer(arg0 names_v3.MachineTag) ([]network0.DeviceToBridge, int, error) {
+func (m *MockState) HostChangesForContainer(arg0 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
@@ -101,11 +109,13 @@ func (m *MockState) HostChangesForContainer(arg0 names_v3.MachineTag) ([]network
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer
 func (mr *MockStateMockRecorder) HostChangesForContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockState)(nil).HostChangesForContainer), arg0)
 }
 
 // Machines mocks base method
-func (m *MockState) Machines(arg0 ...names_v3.MachineTag) ([]provisioner.MachineResult, error) {
+func (m *MockState) Machines(arg0 ...names.MachineTag) ([]provisioner.MachineResult, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -118,11 +128,13 @@ func (m *MockState) Machines(arg0 ...names_v3.MachineTag) ([]provisioner.Machine
 
 // Machines indicates an expected call of Machines
 func (mr *MockStateMockRecorder) Machines(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machines", reflect.TypeOf((*MockState)(nil).Machines), arg0...)
 }
 
 // PrepareContainerInterfaceInfo mocks base method
-func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) (network.InterfaceInfos, error) {
+func (m *MockState) PrepareContainerInterfaceInfo(arg0 names.MachineTag) (network.InterfaceInfos, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
 	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
@@ -131,11 +143,13 @@ func (m *MockState) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) (net
 
 // PrepareContainerInterfaceInfo indicates an expected call of PrepareContainerInterfaceInfo
 func (mr *MockStateMockRecorder) PrepareContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).PrepareContainerInterfaceInfo), arg0)
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockState) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error {
+func (m *MockState) ReleaseContainerAddresses(arg0 names.MachineTag) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -143,11 +157,13 @@ func (m *MockState) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error {
 
 // ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses
 func (mr *MockStateMockRecorder) ReleaseContainerAddresses(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockState)(nil).ReleaseContainerAddresses), arg0)
 }
 
 // SetHostMachineNetworkConfig mocks base method
-func (m *MockState) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg1 []params.NetworkConfig) error {
+func (m *MockState) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []params.NetworkConfig) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -155,5 +171,6 @@ func (m *MockState) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg1 [
 
 // SetHostMachineNetworkConfig indicates an expected call of SetHostMachineNetworkConfig
 func (mr *MockStateMockRecorder) SetHostMachineNetworkConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockState)(nil).SetHostMachineNetworkConfig), arg0, arg1)
 }

--- a/worker/containerbroker/mocks/worker_mock.go
+++ b/worker/containerbroker/mocks/worker_mock.go
@@ -34,16 +34,19 @@ func (m *MockWorker) EXPECT() *MockWorkerMockRecorder {
 
 // Kill mocks base method
 func (m *MockWorker) Kill() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
 // Kill indicates an expected call of Kill
 func (mr *MockWorkerMockRecorder) Kill() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockWorker)(nil).Kill))
 }
 
 // Wait mocks base method
 func (m *MockWorker) Wait() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -51,5 +54,6 @@ func (m *MockWorker) Wait() error {
 
 // Wait indicates an expected call of Wait
 func (mr *MockWorkerMockRecorder) Wait() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockWorker)(nil).Wait))
 }

--- a/worker/machineundertaker/undertaker.go
+++ b/worker/machineundertaker/undertaker.go
@@ -8,10 +8,10 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/worker/v2"
 
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/common"
 )
 

--- a/worker/machineundertaker/undertaker_test.go
+++ b/worker/machineundertaker/undertaker_test.go
@@ -14,10 +14,10 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker/machineundertaker"
 )
 


### PR DESCRIPTION
## Description of change

This is a mechanical change that removes `ProviderInterfaceInfo` from the `network` package and changes all references to it to use the same type from the `core/network` package. This allows us to drop a redundant import for types such as `environ.Networking`.

In addition, the `MACAddress` field of this type has been renamed to the more generic `HardwareAddress` to cater for devices that use different address naming conventions (e.g. infiniband uses GUIDs instead of MAC addresses).

## QA steps

Bootstrap a controller on each one of the modified providers.