### PR TITLE
Export Admin Facade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,9 @@ rebuild-schema:
 ## rebuild-schema: Rebuild the schema for clients with the latest facades
 	@echo "Generating facade schema..."
 ifdef SCHEMA_PATH
-	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen "$(SCHEMA_PATH)"
+	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
 else
-	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen \
+	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
 		./apiserver/facades/schema.json
 endif
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -849,6 +849,267 @@
         }
     },
     {
+        "Name": "Admin",
+        "Description": "admin is the only object that unlogged-in clients can access. It holds any\nmethods that are needed to log in.",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Login": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/LoginRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LoginResult"
+                        }
+                    },
+                    "description": "Login logs in with the provided credentials.  All subsequent requests on the\nconnection will act as the authenticated user."
+                },
+                "RedirectInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/RedirectInfoResult"
+                        }
+                    },
+                    "description": "RedirectInfo returns redirected host information for the model.\nIn Juju it always returns an error because the Juju controller\ndoes not multiplex controllers."
+                }
+            },
+            "definitions": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "AuthUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "controller-access": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "identity": {
+                            "type": "string"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model-access": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "display-name",
+                        "identity",
+                        "controller-access",
+                        "model-access"
+                    ]
+                },
+                "FacadeVersions": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "versions": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "versions"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "LoginRequest": {
+                    "type": "object",
+                    "properties": {
+                        "auth-tag": {
+                            "type": "string"
+                        },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
+                        "cli-args": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "macaroons": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Macaroon"
+                                }
+                            }
+                        },
+                        "nonce": {
+                            "type": "string"
+                        },
+                        "user-data": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-tag",
+                        "credentials",
+                        "nonce",
+                        "macaroons",
+                        "user-data"
+                    ]
+                },
+                "LoginResult": {
+                    "type": "object",
+                    "properties": {
+                        "bakery-discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        },
+                        "discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "discharge-required-error": {
+                            "type": "string"
+                        },
+                        "facades": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FacadeVersions"
+                            }
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "public-dns-name": {
+                            "type": "string"
+                        },
+                        "server-version": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        },
+                        "user-info": {
+                            "$ref": "#/definitions/AuthUserInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "RedirectInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers",
+                        "ca-cert"
+                    ]
+                }
+            }
+        }
+    },
+    {
         "Name": "Agent",
         "Description": "AgentAPIV2 implements the version 2 of the API provided to an agent.",
         "Version": 2,

--- a/generate/schemagen/gen/describeapi_mock.go
+++ b/generate/schemagen/gen/describeapi_mock.go
@@ -34,6 +34,20 @@ func (m *MockAPIServer) EXPECT() *MockAPIServerMockRecorder {
 	return m.recorder
 }
 
+// AdminFacadeDetails mocks base method
+func (m *MockAPIServer) AdminFacadeDetails() []facade.Details {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AdminFacadeDetails")
+	ret0, _ := ret[0].([]facade.Details)
+	return ret0
+}
+
+// AdminFacadeDetails indicates an expected call of AdminFacadeDetails
+func (mr *MockAPIServerMockRecorder) AdminFacadeDetails() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminFacadeDetails", reflect.TypeOf((*MockAPIServer)(nil).AdminFacadeDetails))
+}
+
 // AllFacades mocks base method
 func (m *MockAPIServer) AllFacades() Registry {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description of change

The following outputs the Admin facade so it makes it possible to login
via another source, other than using the local credentials.

The code is quite simple as we fall back to the facade.Type rather than
asking the registry for the information. We have to do this, as the
Admin facade details are outside of the registry and I'm not sure why
this is...


## QA steps


```sh
make rebuild-schema
```

## Bug reference

Fixes: https://bugs.launchpad.net/juju/+bug/1885324
