### PR TITLE
[dev] Check networking method value before using OVS bridges and remove OVS-specific cleanup code for lxd

### DIFF
--- a/api/common/network.go
+++ b/api/common/network.go
@@ -128,18 +128,12 @@ func GetObservedNetworkConfig(source NetworkConfigSource) ([]params.NetworkConfi
 	nameToConfigs := make(map[string][]params.NetworkConfig)
 	sysClassNetPath := source.SysClassNetPath()
 	for _, nic := range interfaces {
-		nicType := network.ParseInterfaceType(sysClassNetPath, nic.Name)
-		// OVS bridges expose one of the internal ports as a device
-		// with the same name as the bridge. However, they are not
-		// detected as bridge devices so we need to manually force
-		// their type so they can be used by juju for containerized
-		// workloads.
 		virtualPortType := corenetwork.NonVirtualPort
 		if knownOVSBridges.Contains(nic.Name) {
-			nicType = corenetwork.BridgeInterface
 			virtualPortType = corenetwork.OvsPort
 		}
 
+		nicType := network.ParseInterfaceType(sysClassNetPath, nic.Name)
 		nicConfig := interfaceToNetworkConfig(nic, nicType, virtualPortType, corenetwork.OriginMachine)
 		if nicConfig.InterfaceName == defaultRouteDevice {
 			nicConfig.IsDefaultGateway = true

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -340,7 +340,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigForOVSDevices(c *gc.C) {
 		CIDR:            "10.100.19.0/24",
 		MTU:             1500,
 		InterfaceName:   "ovsbr0",
-		InterfaceType:   "bridge",
+		InterfaceType:   "ethernet",
 		ConfigType:      "static",
 		Address:         "10.100.19.123",
 		VirtualPortType: "openvswitch",

--- a/apiserver/facades/agent/provisioner/mocks/containerizer_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/containerizer_mock.go
@@ -5,12 +5,11 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/core/network"
 	containerizer "github.com/juju/juju/network/containerizer"
 	state "github.com/juju/juju/state"
+	reflect "reflect"
 )
 
 // MockLinkLayerDevice is a mock of LinkLayerDevice interface
@@ -38,6 +37,7 @@ func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 
 // Addresses mocks base method
 func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Addresses")
 	ret0, _ := ret[0].([]*state.Address)
 	ret1, _ := ret[1].(error)
@@ -46,11 +46,13 @@ func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 
 // Addresses indicates an expected call of Addresses
 func (mr *MockLinkLayerDeviceMockRecorder) Addresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*MockLinkLayerDevice)(nil).Addresses))
 }
 
 // EthernetDeviceForBridge mocks base method
 func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string) (state.LinkLayerDeviceArgs, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0)
 	ret0, _ := ret[0].(state.LinkLayerDeviceArgs)
 	ret1, _ := ret[1].(error)
@@ -59,11 +61,13 @@ func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string) (state.LinkLa
 
 // EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge
 func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0)
 }
 
 // IsAutoStart mocks base method
 func (m *MockLinkLayerDevice) IsAutoStart() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAutoStart")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -71,11 +75,13 @@ func (m *MockLinkLayerDevice) IsAutoStart() bool {
 
 // IsAutoStart indicates an expected call of IsAutoStart
 func (mr *MockLinkLayerDeviceMockRecorder) IsAutoStart() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAutoStart", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsAutoStart))
 }
 
 // IsUp mocks base method
 func (m *MockLinkLayerDevice) IsUp() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUp")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -83,11 +89,13 @@ func (m *MockLinkLayerDevice) IsUp() bool {
 
 // IsUp indicates an expected call of IsUp
 func (mr *MockLinkLayerDeviceMockRecorder) IsUp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUp", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsUp))
 }
 
 // MACAddress mocks base method
 func (m *MockLinkLayerDevice) MACAddress() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MACAddress")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -95,11 +103,13 @@ func (m *MockLinkLayerDevice) MACAddress() string {
 
 // MACAddress indicates an expected call of MACAddress
 func (mr *MockLinkLayerDeviceMockRecorder) MACAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MACAddress", reflect.TypeOf((*MockLinkLayerDevice)(nil).MACAddress))
 }
 
 // MTU mocks base method
 func (m *MockLinkLayerDevice) MTU() uint {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MTU")
 	ret0, _ := ret[0].(uint)
 	return ret0
@@ -107,11 +117,13 @@ func (m *MockLinkLayerDevice) MTU() uint {
 
 // MTU indicates an expected call of MTU
 func (mr *MockLinkLayerDeviceMockRecorder) MTU() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MTU", reflect.TypeOf((*MockLinkLayerDevice)(nil).MTU))
 }
 
 // Name mocks base method
 func (m *MockLinkLayerDevice) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -119,11 +131,13 @@ func (m *MockLinkLayerDevice) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
 }
 
 // ParentDevice mocks base method
 func (m *MockLinkLayerDevice) ParentDevice() (containerizer.LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentDevice")
 	ret0, _ := ret[0].(containerizer.LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -132,11 +146,13 @@ func (m *MockLinkLayerDevice) ParentDevice() (containerizer.LinkLayerDevice, err
 
 // ParentDevice indicates an expected call of ParentDevice
 func (mr *MockLinkLayerDeviceMockRecorder) ParentDevice() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentDevice", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentDevice))
 }
 
 // ParentName mocks base method
 func (m *MockLinkLayerDevice) ParentName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -144,11 +160,13 @@ func (m *MockLinkLayerDevice) ParentName() string {
 
 // ParentName indicates an expected call of ParentName
 func (mr *MockLinkLayerDeviceMockRecorder) ParentName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentName", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentName))
 }
 
 // Type mocks base method
 func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
 	ret0, _ := ret[0].(network.LinkLayerDeviceType)
 	return ret0
@@ -156,5 +174,20 @@ func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 
 // Type indicates an expected call of Type
 func (mr *MockLinkLayerDeviceMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLinkLayerDevice)(nil).Type))
+}
+
+// VirtualPortType mocks base method
+func (m *MockLinkLayerDevice) VirtualPortType() network.VirtualPortType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VirtualPortType")
+	ret0, _ := ret[0].(network.VirtualPortType)
+	return ret0
+}
+
+// VirtualPortType indicates an expected call of VirtualPortType
+func (mr *MockLinkLayerDeviceMockRecorder) VirtualPortType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualPortType", reflect.TypeOf((*MockLinkLayerDevice)(nil).VirtualPortType))
 }

--- a/apiserver/facades/agent/provisioner/mocks/package_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/package_mock.go
@@ -5,10 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
+	charm "github.com/juju/charm/v7"
 	set "github.com/juju/collections/set"
 	provisioner "github.com/juju/juju/apiserver/facades/agent/provisioner"
 	constraints "github.com/juju/juju/core/constraints"
@@ -16,7 +14,8 @@ import (
 	network "github.com/juju/juju/network"
 	containerizer "github.com/juju/juju/network/containerizer"
 	state "github.com/juju/juju/state"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockMachine is a mock of Machine interface
@@ -44,6 +43,7 @@ func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 
 // AllAddresses mocks base method
 func (m *MockMachine) AllAddresses() ([]containerizer.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllAddresses")
 	ret0, _ := ret[0].([]containerizer.Address)
 	ret1, _ := ret[1].(error)
@@ -52,11 +52,13 @@ func (m *MockMachine) AllAddresses() ([]containerizer.Address, error) {
 
 // AllAddresses indicates an expected call of AllAddresses
 func (mr *MockMachineMockRecorder) AllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockMachine)(nil).AllAddresses))
 }
 
 // AllLinkLayerDevices mocks base method
 func (m *MockMachine) AllLinkLayerDevices() ([]containerizer.LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllLinkLayerDevices")
 	ret0, _ := ret[0].([]containerizer.LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -65,11 +67,13 @@ func (m *MockMachine) AllLinkLayerDevices() ([]containerizer.LinkLayerDevice, er
 
 // AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices
 func (mr *MockMachineMockRecorder) AllLinkLayerDevices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllLinkLayerDevices", reflect.TypeOf((*MockMachine)(nil).AllLinkLayerDevices))
 }
 
 // AllSpaces mocks base method
 func (m *MockMachine) AllSpaces() (set.Strings, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
 	ret0, _ := ret[0].(set.Strings)
 	ret1, _ := ret[1].(error)
@@ -78,11 +82,13 @@ func (m *MockMachine) AllSpaces() (set.Strings, error) {
 
 // AllSpaces indicates an expected call of AllSpaces
 func (mr *MockMachineMockRecorder) AllSpaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockMachine)(nil).AllSpaces))
 }
 
 // Constraints mocks base method
 func (m *MockMachine) Constraints() (constraints.Value, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Constraints")
 	ret0, _ := ret[0].(constraints.Value)
 	ret1, _ := ret[1].(error)
@@ -91,11 +97,13 @@ func (m *MockMachine) Constraints() (constraints.Value, error) {
 
 // Constraints indicates an expected call of Constraints
 func (mr *MockMachineMockRecorder) Constraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockMachine)(nil).Constraints))
 }
 
 // ContainerType mocks base method
 func (m *MockMachine) ContainerType() instance.ContainerType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
 	ret0, _ := ret[0].(instance.ContainerType)
 	return ret0
@@ -103,11 +111,13 @@ func (m *MockMachine) ContainerType() instance.ContainerType {
 
 // ContainerType indicates an expected call of ContainerType
 func (mr *MockMachineMockRecorder) ContainerType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMachine)(nil).ContainerType))
 }
 
 // Id mocks base method
 func (m *MockMachine) Id() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -115,11 +125,13 @@ func (m *MockMachine) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockMachineMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
 }
 
 // InstanceId mocks base method
 func (m *MockMachine) InstanceId() (instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
@@ -128,11 +140,13 @@ func (m *MockMachine) InstanceId() (instance.Id, error) {
 
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMachineMockRecorder) InstanceId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachine)(nil).InstanceId))
 }
 
 // IsManual mocks base method
 func (m *MockMachine) IsManual() (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsManual")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -141,23 +155,27 @@ func (m *MockMachine) IsManual() (bool, error) {
 
 // IsManual indicates an expected call of IsManual
 func (mr *MockMachineMockRecorder) IsManual() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManual", reflect.TypeOf((*MockMachine)(nil).IsManual))
 }
 
 // MachineTag mocks base method
-func (m *MockMachine) MachineTag() names_v3.MachineTag {
+func (m *MockMachine) MachineTag() names.MachineTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
-	ret0, _ := ret[0].(names_v3.MachineTag)
+	ret0, _ := ret[0].(names.MachineTag)
 	return ret0
 }
 
 // MachineTag indicates an expected call of MachineTag
 func (mr *MockMachineMockRecorder) MachineTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockMachine)(nil).MachineTag))
 }
 
 // Raw mocks base method
 func (m *MockMachine) Raw() *state.Machine {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Raw")
 	ret0, _ := ret[0].(*state.Machine)
 	return ret0
@@ -165,11 +183,13 @@ func (m *MockMachine) Raw() *state.Machine {
 
 // Raw indicates an expected call of Raw
 func (mr *MockMachineMockRecorder) Raw() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Raw", reflect.TypeOf((*MockMachine)(nil).Raw))
 }
 
 // RemoveAllAddresses mocks base method
 func (m *MockMachine) RemoveAllAddresses() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllAddresses")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -177,11 +197,13 @@ func (m *MockMachine) RemoveAllAddresses() error {
 
 // RemoveAllAddresses indicates an expected call of RemoveAllAddresses
 func (mr *MockMachineMockRecorder) RemoveAllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllAddresses", reflect.TypeOf((*MockMachine)(nil).RemoveAllAddresses))
 }
 
 // SetConstraints mocks base method
 func (m *MockMachine) SetConstraints(arg0 constraints.Value) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConstraints", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -189,11 +211,13 @@ func (m *MockMachine) SetConstraints(arg0 constraints.Value) error {
 
 // SetConstraints indicates an expected call of SetConstraints
 func (mr *MockMachineMockRecorder) SetConstraints(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConstraints", reflect.TypeOf((*MockMachine)(nil).SetConstraints), arg0)
 }
 
 // SetDevicesAddresses mocks base method
 func (m *MockMachine) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -205,11 +229,13 @@ func (m *MockMachine) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) 
 
 // SetDevicesAddresses indicates an expected call of SetDevicesAddresses
 func (mr *MockMachineMockRecorder) SetDevicesAddresses(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicesAddresses", reflect.TypeOf((*MockMachine)(nil).SetDevicesAddresses), arg0...)
 }
 
 // SetLinkLayerDevices mocks base method
 func (m *MockMachine) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -221,11 +247,13 @@ func (m *MockMachine) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) err
 
 // SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices
 func (mr *MockMachineMockRecorder) SetLinkLayerDevices(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkLayerDevices", reflect.TypeOf((*MockMachine)(nil).SetLinkLayerDevices), arg0...)
 }
 
 // SetParentLinkLayerDevicesBeforeTheirChildren mocks base method
 func (m *MockMachine) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetParentLinkLayerDevicesBeforeTheirChildren", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -233,11 +261,13 @@ func (m *MockMachine) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.
 
 // SetParentLinkLayerDevicesBeforeTheirChildren indicates an expected call of SetParentLinkLayerDevicesBeforeTheirChildren
 func (mr *MockMachineMockRecorder) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParentLinkLayerDevicesBeforeTheirChildren", reflect.TypeOf((*MockMachine)(nil).SetParentLinkLayerDevicesBeforeTheirChildren), arg0)
 }
 
 // Units mocks base method
 func (m *MockMachine) Units() ([]provisioner.Unit, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units")
 	ret0, _ := ret[0].([]provisioner.Unit)
 	ret1, _ := ret[1].(error)
@@ -246,6 +276,7 @@ func (m *MockMachine) Units() ([]provisioner.Unit, error) {
 
 // Units indicates an expected call of Units
 func (mr *MockMachineMockRecorder) Units() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockMachine)(nil).Units))
 }
 
@@ -274,6 +305,7 @@ func (m *MockBridgePolicy) EXPECT() *MockBridgePolicyMockRecorder {
 
 // FindMissingBridgesForContainer mocks base method
 func (m *MockBridgePolicy) FindMissingBridgesForContainer(arg0 containerizer.Machine, arg1 containerizer.Container) ([]network.DeviceToBridge, int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindMissingBridgesForContainer", arg0, arg1)
 	ret0, _ := ret[0].([]network.DeviceToBridge)
 	ret1, _ := ret[1].(int)
@@ -283,11 +315,13 @@ func (m *MockBridgePolicy) FindMissingBridgesForContainer(arg0 containerizer.Mac
 
 // FindMissingBridgesForContainer indicates an expected call of FindMissingBridgesForContainer
 func (mr *MockBridgePolicyMockRecorder) FindMissingBridgesForContainer(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMissingBridgesForContainer", reflect.TypeOf((*MockBridgePolicy)(nil).FindMissingBridgesForContainer), arg0, arg1)
 }
 
 // PopulateContainerLinkLayerDevices mocks base method
 func (m *MockBridgePolicy) PopulateContainerLinkLayerDevices(arg0 containerizer.Machine, arg1 containerizer.Container) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PopulateContainerLinkLayerDevices", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -295,6 +329,7 @@ func (m *MockBridgePolicy) PopulateContainerLinkLayerDevices(arg0 containerizer.
 
 // PopulateContainerLinkLayerDevices indicates an expected call of PopulateContainerLinkLayerDevices
 func (mr *MockBridgePolicyMockRecorder) PopulateContainerLinkLayerDevices(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopulateContainerLinkLayerDevices", reflect.TypeOf((*MockBridgePolicy)(nil).PopulateContainerLinkLayerDevices), arg0, arg1)
 }
 
@@ -323,6 +358,7 @@ func (m *MockUnit) EXPECT() *MockUnitMockRecorder {
 
 // Application mocks base method
 func (m *MockUnit) Application() (provisioner.Application, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application")
 	ret0, _ := ret[0].(provisioner.Application)
 	ret1, _ := ret[1].(error)
@@ -331,11 +367,13 @@ func (m *MockUnit) Application() (provisioner.Application, error) {
 
 // Application indicates an expected call of Application
 func (mr *MockUnitMockRecorder) Application() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockUnit)(nil).Application))
 }
 
 // Name mocks base method
 func (m *MockUnit) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -343,6 +381,7 @@ func (m *MockUnit) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockUnitMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockUnit)(nil).Name))
 }
 
@@ -371,6 +410,7 @@ func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 
 // Charm mocks base method
 func (m *MockApplication) Charm() (provisioner.Charm, bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm")
 	ret0, _ := ret[0].(provisioner.Charm)
 	ret1, _ := ret[1].(bool)
@@ -380,11 +420,13 @@ func (m *MockApplication) Charm() (provisioner.Charm, bool, error) {
 
 // Charm indicates an expected call of Charm
 func (mr *MockApplicationMockRecorder) Charm() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockApplication)(nil).Charm))
 }
 
 // Name mocks base method
 func (m *MockApplication) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -392,6 +434,7 @@ func (m *MockApplication) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockApplicationMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockApplication)(nil).Name))
 }
 
@@ -419,19 +462,22 @@ func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 }
 
 // LXDProfile mocks base method
-func (m *MockCharm) LXDProfile() *charm_v6.LXDProfile {
+func (m *MockCharm) LXDProfile() *charm.LXDProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfile")
-	ret0, _ := ret[0].(*charm_v6.LXDProfile)
+	ret0, _ := ret[0].(*charm.LXDProfile)
 	return ret0
 }
 
 // LXDProfile indicates an expected call of LXDProfile
 func (mr *MockCharmMockRecorder) LXDProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfile", reflect.TypeOf((*MockCharm)(nil).LXDProfile))
 }
 
 // Revision mocks base method
 func (m *MockCharm) Revision() int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revision")
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -439,5 +485,6 @@ func (m *MockCharm) Revision() int {
 
 // Revision indicates an expected call of Revision
 func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }

--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -53,10 +53,6 @@ func PatchGetSnapManager(patcher patcher, mgr SnapManager) {
 	patcher.PatchValue(&getSnapManager, func() SnapManager { return mgr })
 }
 
-func PatchMaybeRemovePortFromOvsBridge(patcher patcher, fn func(string) error) {
-	patcher.PatchValue(&maybeRemovePortFromOvsBridge, fn)
-}
-
 func GetImageSources(mgr container.Manager) ([]ServerSpec, error) {
 	return mgr.(*containerManager).getImageSources()
 }

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -53,9 +53,6 @@ var _ = gc.Suite(&managerSuite{})
 func (s *managerSuite) patch() {
 	lxd.PatchConnectRemote(s, map[string]lxdclient.ImageServer{"cloud-images.ubuntu.com": s.cSvr})
 	lxd.PatchGenerateVirtualMACAddress(s)
-	lxd.PatchMaybeRemovePortFromOvsBridge(s, func(string) error {
-		return nil
-	})
 }
 
 func (s *managerSuite) makeManager(c *gc.C) {
@@ -186,16 +183,8 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 	c.Check(instanceStatus.Status, gc.Equals, status.Running)
 	c.Check(*hc.AvailabilityZone, gc.Equals, "test-availability-zone")
 
-	var triedToRemoveFromOvsBridge bool
-	lxd.PatchMaybeRemovePortFromOvsBridge(s, func(portName string) error {
-		c.Assert(portName, gc.Equals, "1lxd2-0", gc.Commentf("expected manager to attempt removal of device 1lxd2-0 from OVS bridge"))
-		triedToRemoveFromOvsBridge = true
-		return nil
-	})
-
 	err = s.manager.DestroyContainer(instanceId)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(triedToRemoveFromOvsBridge, jc.IsTrue, gc.Commentf("expected manager to attempt removal of all bridged devices from OVS bridges"))
 }
 
 func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {

--- a/core/network/ovs.go
+++ b/core/network/ovs.go
@@ -52,23 +52,6 @@ func OvsManagedBridges() (set.Strings, error) {
 	return ovsBridges, nil
 }
 
-// MaybeRemovePortFromOvsBridge attempts to remove portName from any openvswitch
-// bridge that it is attached to. If portName does not exist, this is a no-op.
-func MaybeRemovePortFromOvsBridge(portName string) error {
-	haveOvsCli, err := ovsToolsAvailable()
-	if err != nil {
-		return errors.Trace(err)
-	} else if !haveOvsCli { // nothing to do if the tools are missing
-		return nil
-	}
-
-	logger.Debugf("remove port from all OVS bridges: ovs-vsctl --if-exists del-port %s", portName)
-	if _, err = getCommandOutput(exec.Command("ovs-vsctl", "--if-exists", "del-port", portName)); err != nil {
-		return errors.Annotate(err, "deleting port from ovs-managed bridge via ovs-vsctl")
-	}
-	return nil
-}
-
 func ovsToolsAvailable() (bool, error) {
 	if _, err := exec.LookPath("ovs-vsctl"); err != nil {
 		// OVS tools not installed

--- a/core/network/ovs_test.go
+++ b/core/network/ovs_test.go
@@ -73,17 +73,3 @@ func (s *ovsSuite) TestMissingOvsTools(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ovsIfaces, gc.HasLen, 0, gc.Commentf("expected ovs-managed bridge list to be empty"))
 }
-
-func (s *ovsSuite) TestRemovePortFromOvsBridge(c *gc.C) {
-	// Patch output for "ovs-vsctl del-port" and make sure exec.LookPath can
-	// detect it in the path
-	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
-	expArgs := []string{"ovs-vsctl", "--if-exists", "del-port", "the-port"}
-	s.PatchValue(&getCommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
-		c.Assert(cmd.Args, gc.DeepEquals, expArgs, gc.Commentf("expected ovs-vsctl to be invoked with args: %v", expArgs))
-		return []byte("\n"), nil
-	})
-
-	err := MaybeRemovePortFromOvsBridge("the-port")
-	c.Assert(err, jc.ErrorIsNil)
-}

--- a/network/containerizer/bridgepolicy_mock_test.go
+++ b/network/containerizer/bridgepolicy_mock_test.go
@@ -5,14 +5,13 @@
 package containerizer
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	set "github.com/juju/collections/set"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
+	reflect "reflect"
 )
 
 // MockContainer is a mock of Container interface
@@ -40,6 +39,7 @@ func (m *MockContainer) EXPECT() *MockContainerMockRecorder {
 
 // AllAddresses mocks base method
 func (m *MockContainer) AllAddresses() ([]Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllAddresses")
 	ret0, _ := ret[0].([]Address)
 	ret1, _ := ret[1].(error)
@@ -48,11 +48,13 @@ func (m *MockContainer) AllAddresses() ([]Address, error) {
 
 // AllAddresses indicates an expected call of AllAddresses
 func (mr *MockContainerMockRecorder) AllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockContainer)(nil).AllAddresses))
 }
 
 // AllLinkLayerDevices mocks base method
 func (m *MockContainer) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllLinkLayerDevices")
 	ret0, _ := ret[0].([]LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -61,11 +63,13 @@ func (m *MockContainer) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
 
 // AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices
 func (mr *MockContainerMockRecorder) AllLinkLayerDevices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllLinkLayerDevices", reflect.TypeOf((*MockContainer)(nil).AllLinkLayerDevices))
 }
 
 // AllSpaces mocks base method
 func (m *MockContainer) AllSpaces() (set.Strings, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
 	ret0, _ := ret[0].(set.Strings)
 	ret1, _ := ret[1].(error)
@@ -74,11 +78,13 @@ func (m *MockContainer) AllSpaces() (set.Strings, error) {
 
 // AllSpaces indicates an expected call of AllSpaces
 func (mr *MockContainerMockRecorder) AllSpaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockContainer)(nil).AllSpaces))
 }
 
 // Constraints mocks base method
 func (m *MockContainer) Constraints() (constraints.Value, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Constraints")
 	ret0, _ := ret[0].(constraints.Value)
 	ret1, _ := ret[1].(error)
@@ -87,11 +93,13 @@ func (m *MockContainer) Constraints() (constraints.Value, error) {
 
 // Constraints indicates an expected call of Constraints
 func (mr *MockContainerMockRecorder) Constraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockContainer)(nil).Constraints))
 }
 
 // ContainerType mocks base method
 func (m *MockContainer) ContainerType() instance.ContainerType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
 	ret0, _ := ret[0].(instance.ContainerType)
 	return ret0
@@ -99,11 +107,13 @@ func (m *MockContainer) ContainerType() instance.ContainerType {
 
 // ContainerType indicates an expected call of ContainerType
 func (mr *MockContainerMockRecorder) ContainerType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockContainer)(nil).ContainerType))
 }
 
 // Id mocks base method
 func (m *MockContainer) Id() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -111,11 +121,13 @@ func (m *MockContainer) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockContainerMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockContainer)(nil).Id))
 }
 
 // Raw mocks base method
 func (m *MockContainer) Raw() *state.Machine {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Raw")
 	ret0, _ := ret[0].(*state.Machine)
 	return ret0
@@ -123,11 +135,13 @@ func (m *MockContainer) Raw() *state.Machine {
 
 // Raw indicates an expected call of Raw
 func (mr *MockContainerMockRecorder) Raw() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Raw", reflect.TypeOf((*MockContainer)(nil).Raw))
 }
 
 // RemoveAllAddresses mocks base method
 func (m *MockContainer) RemoveAllAddresses() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllAddresses")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -135,11 +149,13 @@ func (m *MockContainer) RemoveAllAddresses() error {
 
 // RemoveAllAddresses indicates an expected call of RemoveAllAddresses
 func (mr *MockContainerMockRecorder) RemoveAllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllAddresses", reflect.TypeOf((*MockContainer)(nil).RemoveAllAddresses))
 }
 
 // SetConstraints mocks base method
 func (m *MockContainer) SetConstraints(arg0 constraints.Value) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConstraints", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -147,11 +163,13 @@ func (m *MockContainer) SetConstraints(arg0 constraints.Value) error {
 
 // SetConstraints indicates an expected call of SetConstraints
 func (mr *MockContainerMockRecorder) SetConstraints(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConstraints", reflect.TypeOf((*MockContainer)(nil).SetConstraints), arg0)
 }
 
 // SetDevicesAddresses mocks base method
 func (m *MockContainer) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -163,11 +181,13 @@ func (m *MockContainer) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress
 
 // SetDevicesAddresses indicates an expected call of SetDevicesAddresses
 func (mr *MockContainerMockRecorder) SetDevicesAddresses(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicesAddresses", reflect.TypeOf((*MockContainer)(nil).SetDevicesAddresses), arg0...)
 }
 
 // SetLinkLayerDevices mocks base method
 func (m *MockContainer) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -179,11 +199,13 @@ func (m *MockContainer) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) e
 
 // SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices
 func (mr *MockContainerMockRecorder) SetLinkLayerDevices(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkLayerDevices", reflect.TypeOf((*MockContainer)(nil).SetLinkLayerDevices), arg0...)
 }
 
 // SetParentLinkLayerDevicesBeforeTheirChildren mocks base method
 func (m *MockContainer) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetParentLinkLayerDevicesBeforeTheirChildren", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -191,6 +213,7 @@ func (m *MockContainer) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []stat
 
 // SetParentLinkLayerDevicesBeforeTheirChildren indicates an expected call of SetParentLinkLayerDevicesBeforeTheirChildren
 func (mr *MockContainerMockRecorder) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParentLinkLayerDevicesBeforeTheirChildren", reflect.TypeOf((*MockContainer)(nil).SetParentLinkLayerDevicesBeforeTheirChildren), arg0)
 }
 
@@ -219,6 +242,7 @@ func (m *MockAddress) EXPECT() *MockAddressMockRecorder {
 
 // DeviceName mocks base method
 func (m *MockAddress) DeviceName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeviceName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -226,11 +250,13 @@ func (m *MockAddress) DeviceName() string {
 
 // DeviceName indicates an expected call of DeviceName
 func (mr *MockAddressMockRecorder) DeviceName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeviceName", reflect.TypeOf((*MockAddress)(nil).DeviceName))
 }
 
 // Subnet mocks base method
 func (m *MockAddress) Subnet() (Subnet, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnet")
 	ret0, _ := ret[0].(Subnet)
 	ret1, _ := ret[1].(error)
@@ -239,6 +265,7 @@ func (m *MockAddress) Subnet() (Subnet, error) {
 
 // Subnet indicates an expected call of Subnet
 func (mr *MockAddressMockRecorder) Subnet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockAddress)(nil).Subnet))
 }
 
@@ -267,6 +294,7 @@ func (m *MockSubnet) EXPECT() *MockSubnetMockRecorder {
 
 // SpaceID mocks base method
 func (m *MockSubnet) SpaceID() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpaceID")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -274,6 +302,7 @@ func (m *MockSubnet) SpaceID() string {
 
 // SpaceID indicates an expected call of SpaceID
 func (mr *MockSubnetMockRecorder) SpaceID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceID", reflect.TypeOf((*MockSubnet)(nil).SpaceID))
 }
 
@@ -302,6 +331,7 @@ func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 
 // Addresses mocks base method
 func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Addresses")
 	ret0, _ := ret[0].([]*state.Address)
 	ret1, _ := ret[1].(error)
@@ -310,11 +340,13 @@ func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 
 // Addresses indicates an expected call of Addresses
 func (mr *MockLinkLayerDeviceMockRecorder) Addresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*MockLinkLayerDevice)(nil).Addresses))
 }
 
 // EthernetDeviceForBridge mocks base method
 func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string) (state.LinkLayerDeviceArgs, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0)
 	ret0, _ := ret[0].(state.LinkLayerDeviceArgs)
 	ret1, _ := ret[1].(error)
@@ -323,11 +355,13 @@ func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string) (state.LinkLa
 
 // EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge
 func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0)
 }
 
 // IsAutoStart mocks base method
 func (m *MockLinkLayerDevice) IsAutoStart() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAutoStart")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -335,11 +369,13 @@ func (m *MockLinkLayerDevice) IsAutoStart() bool {
 
 // IsAutoStart indicates an expected call of IsAutoStart
 func (mr *MockLinkLayerDeviceMockRecorder) IsAutoStart() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAutoStart", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsAutoStart))
 }
 
 // IsUp mocks base method
 func (m *MockLinkLayerDevice) IsUp() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUp")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -347,11 +383,13 @@ func (m *MockLinkLayerDevice) IsUp() bool {
 
 // IsUp indicates an expected call of IsUp
 func (mr *MockLinkLayerDeviceMockRecorder) IsUp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUp", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsUp))
 }
 
 // MACAddress mocks base method
 func (m *MockLinkLayerDevice) MACAddress() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MACAddress")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -359,11 +397,13 @@ func (m *MockLinkLayerDevice) MACAddress() string {
 
 // MACAddress indicates an expected call of MACAddress
 func (mr *MockLinkLayerDeviceMockRecorder) MACAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MACAddress", reflect.TypeOf((*MockLinkLayerDevice)(nil).MACAddress))
 }
 
 // MTU mocks base method
 func (m *MockLinkLayerDevice) MTU() uint {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MTU")
 	ret0, _ := ret[0].(uint)
 	return ret0
@@ -371,11 +411,13 @@ func (m *MockLinkLayerDevice) MTU() uint {
 
 // MTU indicates an expected call of MTU
 func (mr *MockLinkLayerDeviceMockRecorder) MTU() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MTU", reflect.TypeOf((*MockLinkLayerDevice)(nil).MTU))
 }
 
 // Name mocks base method
 func (m *MockLinkLayerDevice) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -383,11 +425,13 @@ func (m *MockLinkLayerDevice) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
 }
 
 // ParentDevice mocks base method
 func (m *MockLinkLayerDevice) ParentDevice() (LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentDevice")
 	ret0, _ := ret[0].(LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -396,11 +440,13 @@ func (m *MockLinkLayerDevice) ParentDevice() (LinkLayerDevice, error) {
 
 // ParentDevice indicates an expected call of ParentDevice
 func (mr *MockLinkLayerDeviceMockRecorder) ParentDevice() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentDevice", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentDevice))
 }
 
 // ParentName mocks base method
 func (m *MockLinkLayerDevice) ParentName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -408,11 +454,13 @@ func (m *MockLinkLayerDevice) ParentName() string {
 
 // ParentName indicates an expected call of ParentName
 func (mr *MockLinkLayerDeviceMockRecorder) ParentName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentName", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentName))
 }
 
 // Type mocks base method
 func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
 	ret0, _ := ret[0].(network.LinkLayerDeviceType)
 	return ret0
@@ -420,5 +468,20 @@ func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 
 // Type indicates an expected call of Type
 func (mr *MockLinkLayerDeviceMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLinkLayerDevice)(nil).Type))
+}
+
+// VirtualPortType mocks base method
+func (m *MockLinkLayerDevice) VirtualPortType() network.VirtualPortType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VirtualPortType")
+	ret0, _ := ret[0].(network.VirtualPortType)
+	return ret0
+}
+
+// VirtualPortType indicates an expected call of VirtualPortType
+func (mr *MockLinkLayerDeviceMockRecorder) VirtualPortType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualPortType", reflect.TypeOf((*MockLinkLayerDevice)(nil).VirtualPortType))
 }

--- a/network/containerizer/shim.go
+++ b/network/containerizer/shim.go
@@ -30,6 +30,7 @@ type LinkLayerDevice interface {
 	ParentDevice() (LinkLayerDevice, error)
 	EthernetDeviceForBridge(name string) (state.LinkLayerDeviceArgs, error)
 	Addresses() ([]*state.Address, error)
+	VirtualPortType() network.VirtualPortType
 
 	// These are recruited in tests. See comment on Machine below.
 	MTU() uint

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -473,7 +473,7 @@ func (dev *LinkLayerDevice) RemoveAddresses() error {
 // device with the input name and this device as its parent.
 // If the device is not a bridge, an error is returned.
 func (dev *LinkLayerDevice) EthernetDeviceForBridge(name string) (LinkLayerDeviceArgs, error) {
-	if dev.Type() != network.BridgeDevice {
+	if !dev.isBridge() {
 		return LinkLayerDeviceArgs{}, errors.Errorf("device must be a Bridge Device, receiver has type %q", dev.Type())
 	}
 	return LinkLayerDeviceArgs{
@@ -485,4 +485,18 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(name string) (LinkLayerDevic
 		IsAutoStart: true,
 		ParentName:  dev.globalKey(),
 	}, nil
+}
+
+func (dev *LinkLayerDevice) isBridge() bool {
+	if dev.Type() == network.BridgeDevice {
+		return true
+	}
+
+	// OVS bridges expose their internal port as a plain NIC with the
+	// same name as the bridge.
+	if dev.VirtualPortType() == network.OvsPort {
+		return true
+	}
+
+	return false
 }

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -366,7 +366,7 @@ func (m *Machine) verifyHostMachineParentDeviceExistsAndIsABridgeDevice(hostMach
 		return errors.Trace(err)
 	}
 
-	if parentDevice.Type() != corenetwork.BridgeDevice {
+	if !parentDevice.isBridge() {
 		errorMessage := fmt.Sprintf(
 			"parent device %q on host machine %q must be of type %q, not type %q",
 			parentDeviceName, hostMachineID, corenetwork.BridgeDevice, parentDevice.Type(),


### PR DESCRIPTION
## Description of change

This PR attempts to address two issues that got introduced by the recent OVS work:
- Automatically (always) using OVS bridges for container workloads.
- Attempting to remove the lxd veth interfaces from OVS bridges at container removal time.

As far as the first issue is concerned, we should only evaluate OVS bridges as potential bridge targets (always subject to any operator-provider constraints) when the container networking method has been set to `provider`. In all other cases, juju should never try to override any setup that the operator might have already performed (e.g. editing their lxd profile to change the default bridge). To this end, the bridge policy examines the configured container networking method and forces the type of OVS bridges (any link layer device with an `openvswitch` VirtualPort type) to bridge so that `PopulateContainerLinkLayerDevices` can make use of them.

For the second issue:  the version of lxd that ships with bionic (as an apt package) fails to automatically remove veth devices if they are attached to an OVS bridge instead of the default lxd bridge. In an attempt to address this problem, we introduced extra logic into the container removal code (in #11716) to effectively run (when the OVS cli tools are present) `ovs-vsctl --if-exists del-port X` for each veth device.

This command requires to be executed as root and works as expected when we deploy an lxd workload in an already provisioned machine as the agent runs as root. On the other hand, if we bootstrap a local lxd cloud, it is actually the juju CLI that runs the above command which obviously fails (and bubbles up as annoying user-facing error) as the CLI is not running as root. _Not to mention that the command would have no effect when using a remote lxd server_.

Given that this issue has been fixed in newer versions of juju and there is not really much we can do to fix this for local/remote lxd clouds, this cleanup logic has now been removed. If a bug is raised on this matter, we can advise them to:
- either use the manual cleanup command, or
- upgrade to a newer lxd version

## QA steps

Follow the instructions from #11714 to provision some manual machines using bionic images (referred to below as kvm-1, kvm-2) and set up an OVS bridge on one of them.

```console
# Use kvm-1 as the controller
$ juju bootstrap manual/ubuntu@10.0.0.2 --no-gui 

# Add the kvm-2 machine using the IP assigned to ovsbr0
$ juju add-machine ssh:ubuntu@$ovsbr0-ip

$ juju deploy wordpress --to lxd:0 
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to kvm:0 

# Wait for both units to deploy and then check that we are using the default lxd/kvm bridges 
# and that a NIC is attached to each one:
$ juju ssh 0
$ sudo brctl show
bridge name     bridge id               STP enabled     interfaces
lxdbr0          8000.000000000000       no          0lxd0-0
virbr0          8000.5254006ffef7       yes             virbr0-nic

# Then remove the applications, change the container networking method and re-deploy
$ juju remove-application wordpress
$ juju remove-application ubuntu-lite
$ juju model-config container-networking-method=provider
$ juju deploy wordpress --to lxd:0 
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to kvm:0 

# SSH back to the machine and check that the NICs are attached to the OVS bridge
$ sudo ovs-vctl show
46a8b8f1-b430-432f-9bd0-e609cb767f65
    Bridge "ovsbr0"
        Port "vnet0"
            Interface "vnet0"
        Port "ens4"
            Interface "ens4"
        Port "ovsbr0"
            Interface "ovsbr0"
                type: internal
        Port "0lxd0-0"
            Interface "0lxd0-0"
    ovs_version: "2.9.5"

# Finally check that you can bootstrap and clean up a local lxd cloud with no error
juju bootstrap lxd test
juju kill-controller lxd -t0 -y
```