### PR TITLE
Add start-timeout for fetch-oci service;

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ apps:
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
+    start-timeout: 1m
     stop-timeout: 35s
 
 parts:


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

add start timeout for fetch-oci service;

```console
error: cannot perform the following tasks:
- Run hook connect-plug-peers of snap "juju" (run hook "connect-plug-peers": error: cannot communicate with server: timeout exceeded while waiting for response)
```

