### PR TITLE
Output a simplified yaml for model-config

### DIFF
--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -361,7 +361,7 @@ func (c *configCommand) handleIsKeyOfModel(attrs config.ConfigValues, ctx *cmd.C
 	if len(c.keys) == 1 {
 		key := c.keys[0]
 		if value, found := attrs[key]; found {
-			if c.out.Name() == "tabular" {
+			if !c.outputSimpleYAML && c.out.Name() == "tabular" {
 				// The user has not specified that they want
 				// YAML or JSON formatting, so we print out
 				// the value unadorned.
@@ -380,7 +380,7 @@ func (c *configCommand) handleIsKeyOfModel(attrs config.ConfigValues, ctx *cmd.C
 
 	// In tabular format, don't print "cloudinit-userdata" it can be very long,
 	// instead give instructions on how to print specifically.
-	if value, ok := attrs[config.CloudInitUserDataKey]; ok && c.out.Name() == "tabular" && value.Value.(string) != "" {
+	if value, ok := attrs[config.CloudInitUserDataKey]; ok && !c.outputSimpleYAML && c.out.Name() == "tabular" && value.Value.(string) != "" {
 		value.Value = "<value set, see juju model-config cloudinit-userdata>"
 		attrs["cloudinit-userdata"] = value
 	}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -162,7 +162,7 @@ while getopts "hH?vVtAs:a:x:rl:p:S:" opt; do
         export BOOTSTRAP_REUSE_LOCAL="${OPTARG}"
         export BOOTSTRAP_REUSE="true"
         CLOUD=$(juju show-controller "${OPTARG}" --format=json | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
-        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}')
+        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}' | head -n 1)
         export BOOTSTRAP_PROVIDER="${PROVIDER}"
         ;;
     p)

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -1,0 +1,48 @@
+run_model_config_isomorphic() {
+  echo
+
+  FILE=$(mktemp)
+
+  juju model-config --all > "${FILE}" && \
+    sed -i '/^agent\-version/d' "${FILE}" && \
+    juju model-config "${FILE}"
+}
+
+run_model_config_cloudinit_userdata() {
+  echo
+
+  FILE=$(mktemp)
+
+  cat << EOF > "${FILE}"
+cloudinit-userdata: |
+  packages:
+    - jq
+    - shellcheck
+EOF
+
+  cat "${FILE}"
+  juju model-config "${FILE}"
+  juju model-config --all cloudinit-userdata | grep -q "^cloudinit-userdata: |$"
+
+  # cloudinit-userdata is not present from the default yaml output
+  ! juju model-config cloudinit-userdata | grep -q "^cloudinit-userdata: |$"
+
+  # cloudinit-userdata is hidden in the normal output
+  juju model-config | grep -q "<value set, see juju model-config cloudinit-userdata>"
+}
+
+test_model_config() {
+  if [ "$(skip 'test_model_config')" ]; then
+    echo "==> TEST SKIPPED: model config"
+    return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    run "run_model_config_isomorphic"
+    run "run_model_config_cloudinit_userdata"
+  )
+}

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -15,6 +15,7 @@ test_cli() {
 
     test_display_clouds
     test_local_charms
+    test_model_config
 
     destroy_controller "test-cli"
 }


### PR DESCRIPTION
## Description of change

The following changes allow us to output a model-config yaml that can
also be consumed by model-config. The type is then isomorphic, as in we
don't lose any information through the usage of this command.

This doesn't break backward compatibility but introduces a new output
format: simple-yaml (better name?), that removes the superfluous
information that isn't required by the input for the command.

We could have attempted to parse the original yaml into the simplified
yaml, but we would have issues knowing if it really did conform to the
simplified yaml and would be very error-prone.

-----

The command is actually really simple if you supply `--all` or
`--format=simple-yaml` then it will output a nice neat version of the
yaml. All here, just redirects the previous yaml output to the simple
yaml output, killing two birds with one stone.

-----

The only thing to consider is that `agent-version` is not allowed to be
piped directly into model-config, so is required to be removed. This is
a damn shame and would have been better to have a flag on model-config,
something like --ignore-error.

To get around this, you can do:

```
juju model-config --all > output.yaml && \
    sed -i '/^agent\-version/d' output.yaml && \
    juju model-config ./output.yaml
```

## QA steps

#### Output then update

Output `model-config`, then update the `model-config`:

```sh
$ juju model-config --all > output.yaml && \
    sed -i '/^agent\-version/d' output.yaml && \
    juju model-config ./output.yaml
```

#### Output all

```sh
$ juju model-config --all         
agent-metadata-url: ""
agent-stream: released
agent-version: 2.8.1.1
apt-ftp-proxy: ""
apt-http-proxy: http://172.17.0.2:3142
apt-https-proxy: ""
apt-mirror: ""
apt-no-proxy: ""
automatically-retry-hooks: true
backup-dir: ""
cloudinit-userdata: |
  packages:
    - 'jq'
container-image-metadata-url: ""
container-image-stream: released
container-inherit-properties: ""
container-networking-method: local
default-series: bionic
default-space: ""
development: false
disable-network-management: false
egress-subnets: ""
enable-os-refresh-update: true
enable-os-upgrade: true
fan-config: ""
firewall-mode: instance
ftp-proxy: ""
http-proxy: ""
https-proxy: ""
ignore-machine-addresses: false
image-metadata-url: ""
image-stream: released
juju-ftp-proxy: ""
juju-http-proxy: ""
juju-https-proxy: ""
juju-no-proxy: 127.0.0.1,localhost,::1
logforward-enabled: false
logging-config: <root>=DEBUG
lxd-snap-channel: latest/stable
max-action-results-age: 336h
max-action-results-size: 5G
max-status-history-age: 336h
max-status-history-size: 5G
net-bond-reconfigure-delay: 17
no-proxy: 127.0.0.1,localhost,::1
provisioner-harvest-mode: destroyed
proxy-ssh: false
resource-tags: a=1 b=2
snap-http-proxy: ""
snap-https-proxy: ""
snap-store-assertions: ""
snap-store-proxy: ""
snap-store-proxy-url: ""
ssl-hostname-verification: true
storage-default-filesystem-source: lxd
test-mode: false
transmit-vendor-metrics: true
update-status-hook-interval: 5m
```

#### Output one

```sh
$ juju model-config --all cloudinit-userdata       
cloudinit-userdata: |
  packages:
    - 'jq'
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1879972
