### PR TITLE
Link-Layer Device Update Rework

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -164,3 +164,8 @@ func (o *MachineLinkLayerOp) MarkProcessed(dev LinkLayerDevice) {
 func (o *MachineLinkLayerOp) IsProcessed(dev network.InterfaceInfo) bool {
 	return o.processed.Contains(dev.MACAddress)
 }
+
+// Done (state.ModelOperation) returns the result of running the operation.
+func (o *MachineLinkLayerOp) Done(err error) error {
+	return err
+}

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -9,6 +9,44 @@ import (
 	"github.com/juju/juju/state"
 )
 
+// machineShim wraps a state.Machine reference in order to
+// implement the LinkLayerMachine indirection.
+type machineShim struct {
+	*state.Machine
+}
+
+// AllLinkLayerDevices returns all layer-2 devices for the machine
+// as a slice of the LinkLayerDevice indirection.
+func (s machineShim) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
+	devList, err := s.Machine.AllLinkLayerDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]LinkLayerDevice, len(devList))
+	for i, dev := range devList {
+		out[i] = dev
+	}
+
+	return out, nil
+}
+
+// AllLinkLayerDevices returns all layer-3 addresses for the machine
+// as a slice of the LinkLayerAddress indirection.
+func (s machineShim) AllAddresses() ([]LinkLayerAddress, error) {
+	addrList, err := s.Machine.AllAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]LinkLayerAddress, len(addrList))
+	for i, addr := range addrList {
+		out[i] = addr
+	}
+
+	return out, nil
+}
+
 // NOTE: All of the following code is only tested with a feature test.
 
 // NewSubnetShim creates new subnet shim to be used by subnets and spaces Facades.

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -175,8 +175,3 @@ func (o *mergeMachineLinkLayerOp) processNewDevices() {
 		}
 	}
 }
-
-// Done (state.ModelOperation) returns the result of running the operation.
-func (o *mergeMachineLinkLayerOp) Done(err error) error {
-	return err
-}

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -153,7 +153,7 @@ func (s *ipAddressesStateSuite) TestDeviceMethodReturnsNotFoundErrorWhenMissing(
 	result, err := addresses[0].Device()
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, `device "eth0" on machine "0" not found`)
+	c.Assert(err, gc.ErrorMatches, `device with ID .+ not found`)
 }
 
 func (s *ipAddressesStateSuite) TestSubnetMethodReturnsSubnet(c *gc.C) {

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -215,6 +215,26 @@ func (dev *LinkLayerDevice) SetProviderIDOps(id network.Id) ([]txn.Op, error) {
 	}, nil
 }
 
+// RemoveOps returns transaction operations that will ensure that the
+// device is not present in the collection and that if set,
+// its provider ID is removed from the global register.
+// Note that this method eschews responsibility for removing device
+// addresses and for ensuring that this device has no children.
+// That responsibility lies with the caller.
+func (dev *LinkLayerDevice) RemoveOps() []txn.Op {
+	ops := []txn.Op{{
+		C:      linkLayerDevicesC,
+		Id:     dev.DocID(),
+		Remove: true,
+	}}
+
+	if dev.ProviderID() != "" {
+		ops = append(ops, dev.st.networkEntityGlobalKeyRemoveOp("linklayerdevice", dev.ProviderID()))
+	}
+
+	return ops
+}
+
 // Remove removes the device, if it exists. No error is returned when the device
 // was already removed. ErrParentDeviceHasChildren is returned if this device is
 // a parent to one or more existing devices and therefore cannot be removed.

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -49,10 +50,10 @@ type linkLayerDeviceDoc struct {
 	// IsUp is true when the device is up (enabled).
 	IsUp bool `bson:"is-up"`
 
-	// ParentName is the name of the parent device, which may be empty. When set
-	// the parent device must be on the same machine, unless the current device
-	// is inside a container, in which case ParentName can be a global key of a
-	// BridgeDevice on the host machine of the container.
+	// ParentName is the name of the parent device, which may be empty.
+	// When set, the parent device must be on the same machine unless the
+	// current device is inside a container, in which case it can be a global
+	// key of a bridge device on the container host.
 	ParentName string `bson:"parent-name"`
 }
 
@@ -65,22 +66,6 @@ type LinkLayerDevice struct {
 
 func newLinkLayerDevice(st *State, doc linkLayerDeviceDoc) *LinkLayerDevice {
 	return &LinkLayerDevice{st: st, doc: doc}
-}
-
-// AllLinkLayerDevices returns all link layer devices in the model.
-func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
-	devicesCollection, closer := st.db().GetCollection(linkLayerDevicesC)
-	defer closer()
-
-	var sDocs []linkLayerDeviceDoc
-	err = devicesCollection.Find(nil).All(&sDocs)
-	if err != nil {
-		return nil, errors.Errorf("cannot get all link layer devices")
-	}
-	for _, d := range sDocs {
-		devices = append(devices, newLinkLayerDevice(st, d))
-	}
-	return devices, nil
 }
 
 // DocID returns the globally unique ID of the link-layer device, including the
@@ -139,56 +124,42 @@ func (dev *LinkLayerDevice) IsUp() bool {
 	return dev.doc.IsUp
 }
 
-// ParentName returns the name of this device's parent device, if set. The
-// parent device is almost always on the same machine as the child device, but
-// as a special case a child device on a container machine can have a parent
-// BridgeDevice on the container's host machine. In the last case ParentName()
-// returns the global key of the parent device, not just its name.
+// ParentName returns the name of this device's parent device if set.
+// The parent device is almost always on the same machine as the child device,
+// but as a special case a child device on a container machine can have a
+// parent bridge device on the container's host machine.
+// In this case the global key of the parent device is returned.
 func (dev *LinkLayerDevice) ParentName() string {
 	return dev.doc.ParentName
 }
 
-func (dev *LinkLayerDevice) parentDeviceNameAndMachineID() (string, string) {
-	if dev.doc.ParentName == "" {
-		// No parent set, so no ID and name to return.
-		return "", ""
+// ParentID uses the rules for ParentName (above) to return the global ID of
+// this device's parent if it has one.
+func (dev *LinkLayerDevice) ParentID() string {
+	parent := dev.doc.ParentName
+	if parent == "" {
+		return ""
 	}
-	// In case ParentName is a global key, try getting the host machine ID from
-	// there first.
-	hostMachineID, parentDeviceName, err := parseLinkLayerDeviceParentNameAsGlobalKey(dev.doc.ParentName)
-	if err != nil {
-		// We validate the ParentName before setting it, so this case cannot
-		// happen and we're only logging the error.
-		logger.Errorf("%s has invalid parent: %v", dev, err)
-		return "", ""
+
+	prefix := dev.doc.ModelUUID + ":"
+	if strings.Contains(parent, "#") {
+		return prefix + parent
 	}
-	if hostMachineID == "" {
-		// Parent device is on the same machine and
-		// ParentName is not a global key.
-		return dev.doc.ParentName, dev.doc.MachineID
-	}
-	return parentDeviceName, hostMachineID
+
+	prefix = prefix + "m"
+	return strings.Join([]string{prefix, dev.doc.MachineID, "d", dev.doc.ParentName}, "#")
 }
 
 // ParentDevice returns the LinkLayerDevice corresponding to the parent device
 // of this device, if set. When no parent device name is set, it returns nil and
 // no error.
 func (dev *LinkLayerDevice) ParentDevice() (*LinkLayerDevice, error) {
-	if dev.doc.ParentName == "" {
+	if dev.ParentID() == "" {
 		return nil, nil
 	}
 
-	parentDeviceName, parentMachineID := dev.parentDeviceNameAndMachineID()
-	return dev.machineProxy(parentMachineID).LinkLayerDevice(parentDeviceName)
-}
-
-func (dev *LinkLayerDevice) parentDocID() string {
-	parentDeviceName, parentMachineID := dev.parentDeviceNameAndMachineID()
-	parentGlobalKey := linkLayerDeviceGlobalKey(parentMachineID, parentDeviceName)
-	if parentGlobalKey == "" {
-		return ""
-	}
-	return dev.st.docID(parentGlobalKey)
+	dev, err := dev.st.LinkLayerDevice(dev.ParentID())
+	return dev, errors.Trace(err)
 }
 
 // SetProviderIDOps returns the operations required to set the input
@@ -204,7 +175,7 @@ func (dev *LinkLayerDevice) SetProviderIDOps(id network.Id) ([]txn.Op, error) {
 	// If the incoming provider ID is not empty, we will only set it on the
 	// device if it is currently empty.
 	// TODO (manadart 2020-06-30): This is a preservation of prior behaviour
-	// and probably bears re-evaluation.
+	// and probably bares re-evaluation.
 	if id != "" && currentID != "" {
 		return nil, nil
 	}
@@ -244,12 +215,6 @@ func (dev *LinkLayerDevice) SetProviderIDOps(id network.Id) ([]txn.Op, error) {
 	}, nil
 }
 
-// machineProxy is a convenience wrapper for calling Machine.LinkLayerDevice()
-// or Machine.forEachLinkLayerDeviceDoc() from a *LinkLayerDevice and machineID.
-func (dev *LinkLayerDevice) machineProxy(machineID string) *Machine {
-	return &Machine{st: dev.st, doc: machineDoc{Id: machineID}}
-}
-
 // Remove removes the device, if it exists. No error is returned when the device
 // was already removed. ErrParentDeviceHasChildren is returned if this device is
 // a parent to one or more existing devices and therefore cannot be removed.
@@ -262,7 +227,7 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 				return nil, err
 			}
 		}
-		ops, err := removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.parentDocID())
+		ops, err := removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.ParentID())
 		if err != nil {
 			return nil, err
 		}
@@ -276,13 +241,42 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 }
 
 func (dev *LinkLayerDevice) errNoOperationsIfMissing() error {
-	_, err := dev.machineProxy(dev.doc.MachineID).LinkLayerDevice(dev.doc.Name)
+	_, err := dev.st.LinkLayerDevice(dev.DocID())
 	if errors.IsNotFound(err) {
 		return jujutxn.ErrNoOperations
-	} else if err != nil {
-		return errors.Trace(err)
 	}
-	return nil
+	return errors.Trace(err)
+}
+
+// AllLinkLayerDevices returns all link layer devices in the model.
+func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
+	devicesCollection, closer := st.db().GetCollection(linkLayerDevicesC)
+	defer closer()
+
+	var sDocs []linkLayerDeviceDoc
+	err = devicesCollection.Find(nil).All(&sDocs)
+	if err != nil {
+		return nil, errors.Errorf("cannot get all link layer devices")
+	}
+	for _, d := range sDocs {
+		devices = append(devices, newLinkLayerDevice(st, d))
+	}
+	return devices, nil
+}
+
+func (st *State) LinkLayerDevice(id string) (*LinkLayerDevice, error) {
+	linkLayerDevices, closer := st.db().GetCollection(linkLayerDevicesC)
+	defer closer()
+
+	var doc linkLayerDeviceDoc
+	err := linkLayerDevices.FindId(id).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("device with ID %q", id)
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "retrieving %q", id)
+	}
+
+	return newLinkLayerDevice(st, doc), nil
 }
 
 // removeLinkLayerDeviceOps returns the list of operations needed to remove the
@@ -316,7 +310,9 @@ func removeLinkLayerDeviceOps(st *State, linkLayerDeviceDocID, parentDeviceDocID
 
 	var ops []txn.Op
 	if parentDeviceDocID != "" {
-		ops = append(ops, decrementDeviceNumChildrenOp(parentDeviceDocID))
+		localID, _ := st.strictLocalID(parentDeviceDocID)
+		ops = append(ops, decrementDeviceNumChildrenOp(localID))
+		//ops = append(ops, decrementDeviceNumChildrenOp(parentDeviceDocID))
 	}
 
 	addressesQuery := findAddressesQuery(machineID, deviceName)

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -320,8 +320,8 @@ func (addr *Address) Remove() error {
 	return errors.Annotatef(addr.st.db().RunTransaction(addr.RemoveOps()), "removing address %s", addr)
 }
 
-// RemoveOp returns a transaction operation that will ensure that the
-// device is not present in the collection, and that if set,
+// RemoveOps returns transaction operations that will ensure that the
+// address is not present in the collection and that if set,
 // its provider ID is removed from the global register.
 func (addr *Address) RemoveOps() []txn.Op {
 	ops := []txn.Op{{

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -314,28 +314,27 @@ func (addr *Address) SetProviderNetIDsOps(networkID, subnetID network.Id) []txn.
 	}}
 }
 
-// Remove removes the IP address, if it exists. No error is returned when the
-// address was already removed.
-func (addr *Address) Remove() (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot remove %s", addr)
-
-	removeOp := removeIPAddressDocOp(addr.doc.DocID)
-	ops := []txn.Op{removeOp}
-	if addr.ProviderID() != "" {
-		op := addr.st.networkEntityGlobalKeyRemoveOp("address", addr.ProviderID())
-		ops = append(ops, op)
-	}
-	return addr.st.db().RunTransaction(ops)
+// Remove removes the IP address if it exists.
+// No error is returned if the address was already removed.
+func (addr *Address) Remove() error {
+	return errors.Annotatef(addr.st.db().RunTransaction(addr.RemoveOps()), "removing address %s", addr)
 }
 
-// removeIPAddressDocOpOp returns an operation to remove the ipAddressDoc
-// matching the given ipAddressDocID, without asserting it still exists.
-func removeIPAddressDocOp(ipAddressDocID string) txn.Op {
-	return txn.Op{
+// RemoveOp returns a transaction operation that will ensure that the
+// device is not present in the collection, and that if set,
+// its provider ID is removed from the global register.
+func (addr *Address) RemoveOps() []txn.Op {
+	ops := []txn.Op{{
 		C:      ipAddressesC,
-		Id:     ipAddressDocID,
+		Id:     addr.doc.DocID,
 		Remove: true,
+	}}
+
+	if addr.ProviderID() != "" {
+		ops = append(ops, addr.st.networkEntityGlobalKeyRemoveOp("address", addr.ProviderID()))
 	}
+
+	return ops
 }
 
 // insertIPAddressDocOp returns an operation inserting the given newDoc,
@@ -434,12 +433,8 @@ func findAddressesQuery(machineID, deviceName string) bson.D {
 func (st *State) removeMatchingIPAddressesDocOps(findQuery bson.D) ([]txn.Op, error) {
 	var ops []txn.Op
 	callbackFunc := func(resultDoc *ipAddressDoc) {
-		ops = append(ops, removeIPAddressDocOp(resultDoc.DocID))
-		if resultDoc.ProviderID != "" {
-			addrID := network.Id(resultDoc.ProviderID)
-			op := st.networkEntityGlobalKeyRemoveOp("address", addrID)
-			ops = append(ops, op)
-		}
+		addr := &Address{st: st, doc: *resultDoc}
+		ops = append(ops, addr.RemoveOps()...)
 	}
 
 	err := st.forEachIPAddressDoc(findQuery, callbackFunc)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -167,7 +167,7 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithMissingParentSam
 		Type:       corenetwork.EthernetDevice,
 		ParentName: "br-eth0",
 	}
-	s.assertSetLinkLayerDevicesReturnsNotValidError(c, args, `ParentName not valid: device "br-eth0" on machine "0" not found`)
+	s.assertSetLinkLayerDevicesReturnsNotValidError(c, args, `ParentName not valid: device with ID .+ not found`)
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesNoParentSuccess(c *gc.C) {
@@ -340,7 +340,7 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesRefusesToAddParentAn
 	c.Assert(err, gc.ErrorMatches, `cannot set link-layer devices to machine "0": `+
 		`invalid device "child1": `+
 		`ParentName not valid: `+
-		`device "parent1" on machine "0" not found`,
+		`device with ID .+ not found`,
 	)
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
@@ -439,7 +439,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineLinkLayerDeviceReturnsNotFoundEr
 	result, err := s.machine.LinkLayerDevice("missing")
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, `device "missing" on machine "0" not found`)
+	c.Assert(err, gc.ErrorMatches, "device with ID .+ not found")
 }
 
 func (s *linkLayerDevicesStateSuite) TestMachineLinkLayerDeviceReturnsLinkLayerDevice(c *gc.C) {

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -675,6 +675,15 @@ func (s *linkLayerDevicesStateSuite) TestSetProviderIDOps(c *gc.C) {
 	c.Assert(ops, gc.Not(gc.HasLen), 0)
 }
 
+func (s *linkLayerDevicesStateSuite) TestRemoveOps(c *gc.C) {
+	dev := s.addNamedDevice(c, "eth0")
+
+	state.RunTransaction(c, s.State, dev.RemoveOps())
+
+	_, err := s.State.LinkLayerDevice(dev.DocID())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {
 	s.createSpaceAndSubnetWithProviderID(c, spaceName, CIDR, "")
 }

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -22,20 +22,8 @@ import (
 // error satisfying errors.IsNotFound() is returned when no such device exists
 // on the machine.
 func (m *Machine) LinkLayerDevice(name string) (*LinkLayerDevice, error) {
-	linkLayerDevices, closer := m.st.db().GetCollection(linkLayerDevicesC)
-	defer closer()
-
-	linkLayerDeviceDocID := m.linkLayerDeviceDocIDFromName(name)
-	deviceAsString := m.deviceAsStringFromName(name)
-
-	var doc linkLayerDeviceDoc
-	err := linkLayerDevices.FindId(linkLayerDeviceDocID).One(&doc)
-	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("%s", deviceAsString)
-	} else if err != nil {
-		return nil, errors.Annotatef(err, "cannot get %s", deviceAsString)
-	}
-	return newLinkLayerDevice(m.st, doc), nil
+	dev, err := m.st.LinkLayerDevice(m.linkLayerDeviceDocIDFromName(name))
+	return dev, errors.Trace(err)
 }
 
 func (m *Machine) linkLayerDeviceDocIDFromName(deviceName string) string {
@@ -44,10 +32,6 @@ func (m *Machine) linkLayerDeviceDocIDFromName(deviceName string) string {
 
 func (m *Machine) linkLayerDeviceGlobalKeyFromName(deviceName string) string {
 	return linkLayerDeviceGlobalKey(m.doc.Id, deviceName)
-}
-
-func (m *Machine) deviceAsStringFromName(deviceName string) string {
-	return fmt.Sprintf("device %q on machine %q", deviceName, m.doc.Id)
 }
 
 // AllLinkLayerDevices returns all exiting link-layer devices of the machine.


### PR DESCRIPTION
## Description of change

This patch is preparatory work for ongoing refactoring of link-layer device updates. It includes the following:
- Relocate of the `Done` method to the common base for link-layer device model operations.
- Addition of `machineShim` to the common networking API so that slices of indirections for devices and addresses can be returned.
- Addition of `RemoveOps` methods for devices and addresses that will be used in the device update model operation.
- Simplification of link-layer device retrieval and corresponding removal of the `machineProxy` convolution.

## QA steps

Tests cover the changes. Bootstrap anything, add a machine, and check that there are no errors for updating link-layer devices.

## Documentation changes

None.

## Bug reference

N/A
