### PR TITLE
Add new line to juju config output

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -396,6 +396,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 	if err != nil {
 		return err
 	}
+
 	if len(c.keys) == 1 {
 		logger.Infof("format %v is ignored", c.out.Name())
 		key := c.keys[0]
@@ -408,11 +409,8 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 		}
 		v, ok := info["value"]
 		if !ok || v == nil {
-			// Note that unlike the output with a non-nil and non-empty value
-			// below, this output should never have a newline.
-			return nil
+			v = ""
 		}
-
 		_, err = fmt.Fprintln(ctx.Stdout, v)
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -408,13 +408,12 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 		}
 		v, ok := info["value"]
 		if !ok || v == nil {
-			// Note that unlike the output with a non-nil and non-empty value below, this
-			// output should never have a newline.
+			// Note that unlike the output with a non-nil and non-empty value
+			// below, this output should never have a newline.
 			return nil
 		}
-		// TODO (anastasiamac 2018-08-29) We want to have a new line after here (fmt.Fprintln).
-		// However, it will break all existing scripts and should be done as part of Juju 3.x work.
-		_, err := fmt.Fprint(ctx.Stdout, v)
+
+		_, err = fmt.Fprintln(ctx.Stdout, v)
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -196,7 +196,7 @@ func (s *configCommandSuite) TestGetCharmConfigKey(c *gc.C) {
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "title"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Nearly There")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Nearly There\n")
 }
 
 func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValue(c *gc.C) {
@@ -204,7 +204,7 @@ func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValue(c *gc.C) {
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
 func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
@@ -212,7 +212,7 @@ func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value", "--format", "json"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
 func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
@@ -221,7 +221,7 @@ func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
 		s.fake, s.store), ctx, []string{"dummy-application", "juju-external-hostname"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "ext-host")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "ext-host\n")
 }
 
 func (s *configCommandSuite) TestGetConfigKeyNotFound(c *gc.C) {

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -148,7 +148,7 @@ func (s *ApplicationConfigSuite) TestConfigNoValueSingleSetting(c *gc.C) {
 	// set value to be something so that we can check newline added
 	s.configCommandOutput(c, appName, "stremptydefault=a")
 	output := s.configCommandOutput(c, appName, "stremptydefault")
-	c.Assert(output, gc.Equals, "a")
+	c.Assert(output, gc.Equals, "a\n")
 }
 
 func (s *ApplicationConfigSuite) assertSameConfigOutput(c *gc.C, expectedValues settingsMap) {

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -143,7 +143,7 @@ func (s *ApplicationConfigSuite) TestConfigNoValueSingleSetting(c *gc.C) {
 	// use 'juju config foo' to see values
 	for option := range charm.Config().Options {
 		output := s.configCommandOutput(c, appName, option)
-		c.Assert(output, gc.Equals, "")
+		c.Assert(output, gc.Equals, "\n")
 	}
 	// set value to be something so that we can check newline added
 	s.configCommandOutput(c, appName, "stremptydefault=a")


### PR DESCRIPTION
## Description of change

The following adds the correct standard Unix newline after the output
of a config value. Originally it was missing, there was some debate about
adding it, as it _might_ breaks existing scripts, but @wallyworld has made
the decision to add fix it (which I think is right).

It should now be possible to correctly use `|` when using `juju config`.

The code is really simple, just force the usage of `fmt.Fprintln`, which
will do exactly what operators expect to happen.

## QA steps

```sh
juju deploy lxd test
juju deploy mediawiki
juju config mediawiki skin
```

Notice the newline is correctly added:
```sh
vector

```

Instead of
```sh
vector%
```

## Documentation changes

We should note this in the release docs @timClicks, that `juju config` correctly
follows Unix conventions.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1879809
