### PR TITLE
Update name of snap package to install for cloud in add-k8s error output.

### DIFF
--- a/cmd/juju/caas/gke_test.go
+++ b/cmd/juju/caas/gke_test.go
@@ -274,5 +274,5 @@ func (s *gkeSuite) TestEnsureExecutableGcloudNotFound(c *gc.C) {
 			}, nil),
 	)
 	err := gke.ensureExecutable()
-	c.Assert(err, gc.ErrorMatches, "gcloud command not found, please 'snap install gcloud' then try again: ")
+	c.Assert(err, gc.ErrorMatches, "gcloud command not found, please 'snap install google-cloud-sdk --classic' then try again: ")
 }


### PR DESCRIPTION

## Description of change

Update name of snap package to install for cloud in add-k8s error output.

## QA steps

```console
# Assuming that the google-cloud-sdk snap is not installed locally.
$ juju add-k8s --credential company --gke --project=ubuntu-rickh gke-k8s
ERROR gcloud command not found, please 'snap install google-cloud-sdk --classic' then try again:
$ sudo snap install google-cloud-sdk --classic
google-cloud-sdk 299.0.0 from Cloud SDK (google-cloud-sdk✓) installed

# This will fail but not because gcloud is not installed.  That is okay for the purposes of this qa.
$ juju add-k8s --credential company --gke --project=ubuntu-rickh gke-k8s
ERROR ERROR: (gcloud.container.clusters.list) Your current active account [company] does not have any valid credentials
Please run:

  $ gcloud auth login

to obtain new credentials.

For service account, please activate it first:

  $ gcloud auth activate-service-account ACCOUNT

```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1884260
