### PR TITLE
[dev] Enable subnet discovery for LXD substrate

### DIFF
--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -1,0 +1,110 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs/context"
+)
+
+// Subnets returns basic information about subnets known by the provider for
+// the environment.
+func (e *environ) Subnets(ctx context.ProviderCallContext, inst instance.Id, subnetIDs []network.Id) ([]network.SubnetInfo, error) {
+	srv := e.server()
+
+	// All containers will have the same view on the LXD network. If an
+	// instance ID is provided, the best we can do is to also ensure the
+	// container actually exists at the cost of an additional API call.
+	if inst != instance.UnknownId {
+		contList, err := srv.FilterContainers(string(inst))
+		if err != nil {
+			return nil, errors.Trace(err)
+		} else if len(contList) == 0 {
+			return nil, errors.NotFoundf("container with instance ID %q", inst)
+		}
+	}
+
+	networkNames, err := srv.GetNetworkNames()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var keepList set.Strings
+	if len(subnetIDs) != 0 {
+		keepList = set.NewStrings()
+		for _, id := range subnetIDs {
+			keepList.Add(string(id))
+		}
+	}
+
+	var (
+		subnets         []network.SubnetInfo
+		uniqueSubnetIDs = set.NewStrings()
+	)
+	for _, networkName := range networkNames {
+		state, err := srv.GetNetworkState(networkName)
+		if err != nil {
+			return nil, errors.Annotatef(err, "querying lxd server for state of network %q", networkName)
+		}
+
+		// We are only interested in non-loopback networks that are up.
+		if state.Type == "loopback" || state.State != "up" {
+			continue
+		}
+
+		for _, stateAddr := range state.Addresses {
+			netAddr := network.NewProviderAddress(stateAddr.Address)
+			if netAddr.Scope == network.ScopeLinkLocal || netAddr.Scope == network.ScopeMachineLocal {
+				continue
+			}
+
+			subnetID, cidr, err := makeSubnetIDForNetwork(networkName, stateAddr.Address, stateAddr.Netmask)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			if uniqueSubnetIDs.Contains(subnetID) {
+				continue
+			} else if keepList != nil && !keepList.Contains(subnetID) {
+				continue
+			}
+
+			uniqueSubnetIDs.Add(subnetID)
+			subnets = append(subnets, makeSubnetInfo(network.Id(subnetID), makeNetworkID(networkName), cidr))
+		}
+	}
+
+	return subnets, nil
+}
+
+func makeNetworkID(networkName string) network.Id {
+	return network.Id(fmt.Sprintf("net-%s", networkName))
+}
+
+func makeSubnetIDForNetwork(networkName, address, mask string) (string, string, error) {
+	_, netCIDR, err := net.ParseCIDR(fmt.Sprintf("%s/%s", address, mask))
+	if err != nil {
+		return "", "", errors.Annotatef(err, "calculating CIDR for network %q", networkName)
+	}
+
+	cidr := netCIDR.String()
+	subnetID := fmt.Sprintf("subnet-%s-%s", networkName, cidr)
+	return subnetID, cidr, nil
+}
+
+func makeSubnetInfo(subnetID network.Id, networkID network.Id, cidr string) network.SubnetInfo {
+	return network.SubnetInfo{
+		ProviderId:        subnetID,
+		ProviderNetworkId: networkID,
+		CIDR:              cidr,
+		VLANTag:           0,
+	}
+}

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -6,12 +6,16 @@ package lxd
 import (
 	"fmt"
 	"net"
+	"sort"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
+	lxdapi "github.com/lxc/lxd/shared/api"
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 )
 
@@ -107,4 +111,171 @@ func makeSubnetInfo(subnetID network.Id, networkID network.Id, cidr string) netw
 		CIDR:              cidr,
 		VLANTag:           0,
 	}
+}
+
+// NetworkInterfaces returns a slice with the network interfaces that
+// correspond to the given instance IDs. If no instances where found, but there
+// was no other error, it will return ErrNoInstances. If some but not all of
+// the instances were found, the returned slice will have some nil slots, and
+// an ErrPartialInstances error will be returned.
+func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []instance.Id) ([]network.InterfaceInfos, error) {
+	var (
+		missing int
+		srv     = e.server()
+		res     = make([]network.InterfaceInfos, len(ids))
+	)
+
+	for instIdx, id := range ids {
+		container, state, err := getContainerDetails(srv, string(id))
+		if err != nil {
+			if errors.IsNotFound(err) {
+				missing++
+				continue
+			}
+			return nil, errors.Annotatef(err, "retrieving network interface info for instance %q", id)
+		} else if len(state.Network) == 0 {
+			continue
+		}
+
+		// Sort interfaces by name to ensure consistent device indexes
+		// across calls when we iterate the container's network map.
+		networkNames := make([]string, 0, len(state.Network))
+		for network := range state.Network {
+			networkNames = append(networkNames, network)
+		}
+		sort.Strings(networkNames)
+
+		var devIdx int
+		for _, networkName := range networkNames {
+			netInfo := state.Network[networkName]
+
+			// Ignore loopback devices
+			if detectInterfaceType(netInfo.Type) == network.LoopbackInterface {
+				continue
+			}
+
+			ni, err := makeInterfaceInfo(container, networkName, netInfo)
+			if err != nil {
+				return nil, errors.Annotatef(err, "retrieving network interface info for instane %q", id)
+			} else if len(ni.Addresses) == 0 {
+				continue
+			}
+
+			ni.DeviceIndex = devIdx
+			devIdx++
+			res[instIdx] = append(res[instIdx], ni)
+		}
+	}
+
+	if missing > 0 {
+		// Found at least one instance
+		if missing != len(res) {
+			return res, environs.ErrPartialInstances
+		}
+
+		return nil, environs.ErrNoInstances
+	}
+	return res, nil
+}
+
+func makeInterfaceInfo(container *lxdapi.Container, networkName string, netInfo lxdapi.ContainerStateNetwork) (network.InterfaceInfo, error) {
+	var ni = network.InterfaceInfo{
+		MACAddress:          netInfo.Hwaddr,
+		MTU:                 netInfo.Mtu,
+		InterfaceName:       networkName,
+		ParentInterfaceName: hostNetworkForGuestNetwork(container, networkName),
+		InterfaceType:       detectInterfaceType(netInfo.Type),
+		Origin:              network.OriginProvider,
+
+		// We cannot tell from the API response whether the interface
+		// uses a static or DHCP configuration; assume static unless
+		// this is a loopback device (see below).
+		ConfigType: network.ConfigStatic,
+	}
+
+	if ni.InterfaceType == network.LoopbackInterface {
+		ni.ConfigType = network.ConfigLoopback
+	}
+
+	if ni.ParentInterfaceName != "" {
+		ni.ProviderNetworkId = makeNetworkID(ni.ParentInterfaceName)
+	}
+
+	// Iterate the list of addresses assigned to this interface ignoring
+	// any link-local ones. The first non link-local address is treated as
+	// the primary address and is used to populate the interface CIDR and
+	// subnet ID fields.
+	for _, addr := range netInfo.Addresses {
+		netAddr := network.NewProviderAddress(addr.Address)
+		if netAddr.Scope == network.ScopeLinkLocal || netAddr.Scope == network.ScopeMachineLocal {
+			continue
+		}
+		ni.Addresses = append(ni.Addresses, netAddr)
+
+		if len(ni.Addresses) > 1 { // CIDR and subnetID already calculated
+			continue
+		}
+
+		// Use the parent bridge name to match the subnet IDs reported
+		// by the Subnets() method.
+		subnetID, cidr, err := makeSubnetIDForNetwork(ni.ParentInterfaceName, addr.Address, addr.Netmask)
+		if err != nil {
+			return network.InterfaceInfo{}, errors.Trace(err)
+		}
+
+		ni.CIDR = cidr
+		ni.ProviderSubnetId = network.Id(subnetID)
+		ni.ProviderId = network.Id(fmt.Sprintf("nic-%s", netInfo.Hwaddr))
+	}
+
+	return ni, nil
+}
+
+func detectInterfaceType(lxdIfaceType string) network.InterfaceType {
+	switch lxdIfaceType {
+	case "bridge":
+		return network.BridgeInterface
+	case "broadcast":
+		return network.EthernetInterface
+	case "loopback":
+		return network.LoopbackInterface
+	default:
+		return network.UnknownInterface
+	}
+}
+
+func hostNetworkForGuestNetwork(container *lxdapi.Container, network string) string {
+	if container.ExpandedDevices == nil {
+		return ""
+	}
+	devInfo, found := container.ExpandedDevices[network]
+	if !found {
+		return ""
+	}
+
+	return devInfo["network"]
+}
+
+func getContainerDetails(srv Server, containerID string) (*lxdapi.Container, *lxdapi.ContainerState, error) {
+	cont, _, err := srv.GetContainer(containerID)
+	if err != nil {
+		// Unfortunately the lxd client does not expose error
+		// codes so we need to match against a string here.
+		if strings.Contains(err.Error(), "not found") {
+			return nil, nil, errors.NotFoundf("container %q", containerID)
+		}
+		return nil, nil, errors.Trace(err)
+	}
+
+	state, _, err := srv.GetContainerState(containerID)
+	if err != nil {
+		// Unfortunately the lxd client does not expose error
+		// codes so we need to match against a string here.
+		if strings.Contains(err.Error(), "not found") {
+			return nil, nil, errors.NotFoundf("container %q", containerID)
+		}
+		return nil, nil, errors.Trace(err)
+	}
+
+	return cont, state, nil
 }

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 	"github.com/juju/utils/set"
 	lxdapi "github.com/lxc/lxd/shared/api"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 )
+
+var _ environs.Networking = (*environ)(nil)
 
 // Subnets returns basic information about subnets known by the provider for
 // the environment.
@@ -278,4 +281,66 @@ func getContainerDetails(srv Server, containerID string) (*lxdapi.Container, *lx
 	}
 
 	return cont, state, nil
+}
+
+// SuperSubnets returns information about aggregated subnet.
+func (*environ) SuperSubnets(context.ProviderCallContext) ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
+}
+
+// SupportsSpaces returns whether the current environment supports
+// spaces. The returned error satisfies errors.IsNotSupported(),
+// unless a general API failure occurs.
+func (*environ) SupportsSpaces(context.ProviderCallContext) (bool, error) {
+	return true, nil
+}
+
+// SupportsSpaceDiscovery returns whether the current environment
+// supports discovering spaces from the provider. The returned error
+// satisfies errors.IsNotSupported(), unless a general API failure occurs.
+func (*environ) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// Spaces returns a slice of network.SpaceInfo with info, including
+// details of all associated subnets, about all spaces known to the
+// provider that have subnets available.
+func (*environ) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
+	return nil, errors.NotSupportedf("spaces")
+}
+
+// ProviderSpaceInfo returns the details of the space requested as
+// a ProviderSpaceInfo.
+func (*environ) ProviderSpaceInfo(context.ProviderCallContext, *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+	return nil, errors.NotSupportedf("spaces")
+}
+
+// AreSpacesRoutable returns whether the communication between the
+// two spaces can use cloud-local addaddresses.
+func (*environ) AreSpacesRoutable(context.ProviderCallContext, *environs.ProviderSpaceInfo, *environs.ProviderSpaceInfo) (bool, error) {
+	return false, errors.NotSupportedf("spaces")
+}
+
+// SupportsContainerAddresses returns true if the current environment is
+// able to allocate addaddresses for containers.
+func (*environ) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// AllocateContainerAddresses allocates a static addsubnetss for each of the
+// container NICs in preparedInfo, hosted by the hostInstanceID. Returns the
+// network config including all allocated addaddresses on success.
+func (*environ) AllocateContainerAddresses(context.ProviderCallContext, instance.Id, names.MachineTag, network.InterfaceInfos) (network.InterfaceInfos, error) {
+	return nil, errors.NotSupportedf("container address allocation")
+}
+
+// ReleaseContainerAddresses releases the previously allocated
+// addaddresses matching the interface details passed in.
+func (*environ) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
+	return errors.NotSupportedf("container address allocation")
+}
+
+// SSHAddresses filters the input addaddresses to those suitable for SSH use.
+func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
+	return addresses, nil
 }

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -7,6 +7,7 @@ import (
 	jujulxd "github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 
 	"github.com/golang/mock/gomock"
@@ -148,4 +149,195 @@ func (s *environNetSuite) TestSubnetsForKnownContainerAndSubnetFiltering(c *gc.C
 		},
 	}
 	c.Assert(subnets, gc.DeepEquals, expSubnets)
+}
+
+func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	srv := NewMockServer(ctrl)
+	srv.EXPECT().GetContainer("woot").Return(&lxdapi.Container{
+		ExpandedDevices: map[string]map[string]string{
+			"eth0": map[string]string{
+				"name":    "eth0",
+				"network": "lxdbr0",
+				"type":    "nic",
+			},
+			"eth1": map[string]string{
+				"name":    "eth1",
+				"network": "ovsbr0",
+				"type":    "nic",
+			},
+		},
+	}, "etag", nil)
+	srv.EXPECT().GetContainerState("woot").Return(&lxdapi.ContainerState{
+		Network: map[string]lxdapi.ContainerStateNetwork{
+			"eth0": lxdapi.ContainerStateNetwork{
+				Type:   "broadcast",
+				State:  "up",
+				Mtu:    1500,
+				Hwaddr: "00:16:3e:19:29:cb",
+				Addresses: []lxdapi.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "10.55.158.99",
+						Netmask: "24",
+						Scope:   "global",
+					},
+					{
+						Family:  "inet6",
+						Address: "fe80::216:3eff:fe19:29cb",
+						Netmask: "64",
+						Scope:   "link", // should be ignored as it is link-local
+					},
+				},
+			},
+			"lo": lxdapi.ContainerStateNetwork{
+				Type:   "loopback", // skipped as this is a loopback device
+				State:  "up",
+				Mtu:    1500,
+				Hwaddr: "00:16:3e:19:39:39",
+				Addresses: []lxdapi.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "127.0.0.1",
+						Netmask: "8",
+						Scope:   "local",
+					},
+				},
+			},
+			"eth1": lxdapi.ContainerStateNetwork{
+				Type:   "broadcast",
+				State:  "up",
+				Mtu:    1500,
+				Hwaddr: "00:16:3e:fe:fe:fe",
+				Addresses: []lxdapi.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "10.42.42.99",
+						Netmask: "24",
+						Scope:   "global",
+					},
+				},
+			},
+		},
+	}, "etag", nil)
+
+	env := s.NewEnviron(c, srv, nil).(*environ)
+
+	ctx := context.NewCloudCallContext()
+	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot"})
+	c.Assert(err, jc.ErrorIsNil)
+	expInfos := []network.InterfaceInfos{
+		network.InterfaceInfos{
+			{
+				DeviceIndex:         0,
+				MACAddress:          "00:16:3e:19:29:cb",
+				MTU:                 1500,
+				InterfaceName:       "eth0",
+				ParentInterfaceName: "lxdbr0",
+				InterfaceType:       network.EthernetInterface,
+				Origin:              network.OriginProvider,
+				ConfigType:          network.ConfigStatic,
+				CIDR:                "10.55.158.0/24",
+				ProviderId:          "nic-00:16:3e:19:29:cb",
+				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
+				ProviderNetworkId:   "net-lxdbr0",
+				Addresses:           network.NewProviderAddresses("10.55.158.99"),
+			},
+			{
+				DeviceIndex:         1,
+				MACAddress:          "00:16:3e:fe:fe:fe",
+				MTU:                 1500,
+				InterfaceName:       "eth1",
+				ParentInterfaceName: "ovsbr0",
+				InterfaceType:       network.EthernetInterface,
+				Origin:              network.OriginProvider,
+				ConfigType:          network.ConfigStatic,
+				CIDR:                "10.42.42.0/24",
+				ProviderId:          "nic-00:16:3e:fe:fe:fe",
+				ProviderSubnetId:    "subnet-ovsbr0-10.42.42.0/24",
+				ProviderNetworkId:   "net-ovsbr0",
+				Addresses:           network.NewProviderAddresses("10.42.42.99"),
+			},
+		},
+	}
+	c.Assert(infos, gc.DeepEquals, expInfos)
+}
+
+func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	srv := NewMockServer(ctrl)
+	srv.EXPECT().GetContainer("woot").Return(&lxdapi.Container{
+		ExpandedDevices: map[string]map[string]string{
+			"eth0": map[string]string{
+				"name":    "eth0",
+				"network": "lxdbr0",
+				"type":    "nic",
+			},
+		},
+	}, "etag", nil)
+	srv.EXPECT().GetContainer("unknown").Return(nil, "", errors.New("not found"))
+	srv.EXPECT().GetContainerState("woot").Return(&lxdapi.ContainerState{
+		Network: map[string]lxdapi.ContainerStateNetwork{
+			"eth0": lxdapi.ContainerStateNetwork{
+				Type:   "broadcast",
+				State:  "up",
+				Mtu:    1500,
+				Hwaddr: "00:16:3e:19:29:cb",
+				Addresses: []lxdapi.ContainerStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "10.55.158.99",
+						Netmask: "24",
+						Scope:   "global",
+					},
+				},
+			},
+		},
+	}, "etag", nil)
+
+	env := s.NewEnviron(c, srv, nil).(*environ)
+
+	ctx := context.NewCloudCallContext()
+	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot", "unknown"})
+	c.Assert(err, gc.Equals, environs.ErrPartialInstances, gc.Commentf("expected a partial instances error to be returned if some of the instances were not found"))
+	expInfos := []network.InterfaceInfos{
+		network.InterfaceInfos{
+			{
+				DeviceIndex:         0,
+				MACAddress:          "00:16:3e:19:29:cb",
+				MTU:                 1500,
+				InterfaceName:       "eth0",
+				ParentInterfaceName: "lxdbr0",
+				InterfaceType:       network.EthernetInterface,
+				Origin:              network.OriginProvider,
+				ConfigType:          network.ConfigStatic,
+				CIDR:                "10.55.158.0/24",
+				ProviderId:          "nic-00:16:3e:19:29:cb",
+				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
+				ProviderNetworkId:   "net-lxdbr0",
+				Addresses:           network.NewProviderAddresses("10.55.158.99"),
+			},
+		},
+		nil, // slot for second instance is nil as the container was not found
+	}
+	c.Assert(infos, gc.DeepEquals, expInfos)
+}
+
+func (s *environNetSuite) TestNetworkInterfacesNoResults(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	srv := NewMockServer(ctrl)
+	srv.EXPECT().GetContainer("unknown1").Return(nil, "", errors.New("not found"))
+	srv.EXPECT().GetContainer("unknown2").Return(nil, "", errors.New("not found"))
+
+	env := s.NewEnviron(c, srv, nil).(*environ)
+
+	ctx := context.NewCloudCallContext()
+	_, err := env.NetworkInterfaces(ctx, []instance.Id{"unknown1", "unknown2"})
+	c.Assert(err, gc.Equals, environs.ErrNoInstances, gc.Commentf("expected a no instances error to be returned if none of the requested instances exists"))
 }

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -1,0 +1,151 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	jujulxd "github.com/juju/juju/container/lxd"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs/context"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	lxdapi "github.com/lxc/lxd/shared/api"
+	gc "gopkg.in/check.v1"
+)
+
+type environNetSuite struct {
+	EnvironSuite
+}
+
+var _ = gc.Suite(&environNetSuite{})
+
+func (s *environNetSuite) TestSubnetsForUnknownContainer(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	srv := NewMockServer(ctrl)
+	srv.EXPECT().FilterContainers("bogus").Return(nil, nil)
+
+	env := s.NewEnviron(c, srv, nil).(*environ)
+
+	ctx := context.NewCloudCallContext()
+	_, err := env.Subnets(ctx, instance.Id("bogus"), nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *environNetSuite) TestSubnetsForKnownContainer(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	srv := NewMockServer(ctrl)
+	srv.EXPECT().FilterContainers("woot").Return([]jujulxd.Container{
+		jujulxd.Container{},
+	}, nil)
+	srv.EXPECT().GetNetworkNames().Return([]string{"lo", "ovs-system", "lxdbr0"}, nil)
+	srv.EXPECT().GetNetworkState("lo").Return(&lxdapi.NetworkState{
+		Type:  "loopback", // should be filtered out because it's loopback
+		State: "up",
+	}, nil)
+	srv.EXPECT().GetNetworkState("ovs-system").Return(&lxdapi.NetworkState{
+		Type:  "broadcast",
+		State: "down", // should be filtered out because it's down
+	}, nil)
+	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
+		Type:  "broadcast",
+		State: "up",
+		Addresses: []lxdapi.NetworkStateAddress{
+			{
+				Family:  "inet",
+				Address: "10.55.158.1",
+				Netmask: "24",
+				Scope:   "global",
+			},
+			{
+				Family:  "inet",
+				Address: "10.42.42.1",
+				Netmask: "24",
+				Scope:   "global",
+			},
+			{
+				Family:  "inet6",
+				Address: "fe80::c876:d1ff:fe9c:fa46",
+				Netmask: "64",
+				Scope:   "link", // ignored because it has link scope
+			},
+		},
+	}, nil)
+
+	env := s.NewEnviron(c, srv, nil).(*environ)
+
+	ctx := context.NewCloudCallContext()
+	subnets, err := env.Subnets(ctx, instance.Id("woot"), nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expSubnets := []network.SubnetInfo{
+		{
+			CIDR:              "10.55.158.0/24",
+			ProviderId:        "subnet-lxdbr0-10.55.158.0/24",
+			ProviderNetworkId: "net-lxdbr0",
+		},
+		{
+			CIDR:              "10.42.42.0/24",
+			ProviderId:        "subnet-lxdbr0-10.42.42.0/24",
+			ProviderNetworkId: "net-lxdbr0",
+		},
+	}
+	c.Assert(subnets, gc.DeepEquals, expSubnets)
+}
+
+func (s *environNetSuite) TestSubnetsForKnownContainerAndSubnetFiltering(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	srv := NewMockServer(ctrl)
+	srv.EXPECT().FilterContainers("woot").Return([]jujulxd.Container{
+		jujulxd.Container{},
+	}, nil)
+	srv.EXPECT().GetNetworkNames().Return([]string{"lxdbr0"}, nil)
+	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
+		Type:  "broadcast",
+		State: "up",
+		Addresses: []lxdapi.NetworkStateAddress{
+			{
+				Family:  "inet",
+				Address: "10.55.158.1",
+				Netmask: "24",
+				Scope:   "global",
+			},
+			{
+				Family:  "inet",
+				Address: "10.42.42.1",
+				Netmask: "24",
+				Scope:   "global",
+			},
+			{
+				Family:  "inet6",
+				Address: "fe80::c876:d1ff:fe9c:fa46",
+				Netmask: "64",
+				Scope:   "link", // ignored because it has link scope
+			},
+		},
+	}, nil)
+
+	env := s.NewEnviron(c, srv, nil).(*environ)
+
+	// Filter list so we only get a single subnet
+	ctx := context.NewCloudCallContext()
+	subnets, err := env.Subnets(ctx, instance.Id("woot"), []network.Id{"subnet-lxdbr0-10.55.158.0/24"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expSubnets := []network.SubnetInfo{
+		{
+			CIDR:              "10.55.158.0/24",
+			ProviderId:        "subnet-lxdbr0-10.55.158.0/24",
+			ProviderNetworkId: "net-lxdbr0",
+		},
+	}
+	c.Assert(subnets, gc.DeepEquals, expSubnets)
+}

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -43,7 +43,7 @@ func (s *environNetSuite) TestSubnetsForKnownContainer(c *gc.C) {
 
 	srv := NewMockServer(ctrl)
 	srv.EXPECT().FilterContainers("woot").Return([]jujulxd.Container{
-		jujulxd.Container{},
+		{},
 	}, nil)
 	srv.EXPECT().GetNetworkNames().Return([]string{"lo", "ovs-system", "lxdbr0"}, nil)
 	srv.EXPECT().GetNetworkState("lo").Return(&lxdapi.NetworkState{
@@ -106,7 +106,7 @@ func (s *environNetSuite) TestSubnetsForKnownContainerAndSubnetFiltering(c *gc.C
 
 	srv := NewMockServer(ctrl)
 	srv.EXPECT().FilterContainers("woot").Return([]jujulxd.Container{
-		jujulxd.Container{},
+		{},
 	}, nil)
 	srv.EXPECT().GetNetworkNames().Return([]string{"lxdbr0"}, nil)
 	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
@@ -158,12 +158,12 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 	srv := NewMockServer(ctrl)
 	srv.EXPECT().GetContainer("woot").Return(&lxdapi.Container{
 		ExpandedDevices: map[string]map[string]string{
-			"eth0": map[string]string{
+			"eth0": {
 				"name":    "eth0",
 				"network": "lxdbr0",
 				"type":    "nic",
 			},
-			"eth1": map[string]string{
+			"eth1": {
 				"name":    "eth1",
 				"network": "ovsbr0",
 				"type":    "nic",
@@ -172,7 +172,7 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 	}, "etag", nil)
 	srv.EXPECT().GetContainerState("woot").Return(&lxdapi.ContainerState{
 		Network: map[string]lxdapi.ContainerStateNetwork{
-			"eth0": lxdapi.ContainerStateNetwork{
+			"eth0": {
 				Type:   "broadcast",
 				State:  "up",
 				Mtu:    1500,
@@ -192,7 +192,7 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 					},
 				},
 			},
-			"lo": lxdapi.ContainerStateNetwork{
+			"lo": {
 				Type:   "loopback", // skipped as this is a loopback device
 				State:  "up",
 				Mtu:    1500,
@@ -206,7 +206,7 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 					},
 				},
 			},
-			"eth1": lxdapi.ContainerStateNetwork{
+			"eth1": {
 				Type:   "broadcast",
 				State:  "up",
 				Mtu:    1500,
@@ -229,7 +229,7 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot"})
 	c.Assert(err, jc.ErrorIsNil)
 	expInfos := []network.InterfaceInfos{
-		network.InterfaceInfos{
+		{
 			{
 				DeviceIndex:         0,
 				MACAddress:          "00:16:3e:19:29:cb",
@@ -272,7 +272,7 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 	srv := NewMockServer(ctrl)
 	srv.EXPECT().GetContainer("woot").Return(&lxdapi.Container{
 		ExpandedDevices: map[string]map[string]string{
-			"eth0": map[string]string{
+			"eth0": {
 				"name":    "eth0",
 				"network": "lxdbr0",
 				"type":    "nic",
@@ -282,7 +282,7 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 	srv.EXPECT().GetContainer("unknown").Return(nil, "", errors.New("not found"))
 	srv.EXPECT().GetContainerState("woot").Return(&lxdapi.ContainerState{
 		Network: map[string]lxdapi.ContainerStateNetwork{
-			"eth0": lxdapi.ContainerStateNetwork{
+			"eth0": {
 				Type:   "broadcast",
 				State:  "up",
 				Mtu:    1500,
@@ -305,7 +305,7 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot", "unknown"})
 	c.Assert(err, gc.Equals, environs.ErrPartialInstances, gc.Commentf("expected a partial instances error to be returned if some of the instances were not found"))
 	expInfos := []network.InterfaceInfos{
-		network.InterfaceInfos{
+		{
 			{
 				DeviceIndex:         0,
 				MACAddress:          "00:16:3e:19:29:cb",

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -79,6 +79,8 @@ type Server interface {
 	Name() string
 	GetNetworkNames() ([]string, error)
 	GetNetworkState(name string) (*lxdapi.NetworkState, error)
+	GetContainer(name string) (*lxdapi.Container, string, error)
+	GetContainerState(name string) (*lxdapi.ContainerState, string, error)
 }
 
 // ServerFactory creates a new factory for creating servers that are required

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -77,6 +77,8 @@ type Server interface {
 	UseTargetServer(name string) (*lxd.Server, error)
 	GetClusterMembers() (members []lxdapi.ClusterMember, err error)
 	Name() string
+	GetNetworkNames() ([]string, error)
+	GetNetworkState(name string) (*lxdapi.NetworkState, error)
 }
 
 // ServerFactory creates a new factory for creating servers that are required

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -317,6 +317,22 @@ func (mr *MockServerMockRecorder) GetConnectionInfo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionInfo", reflect.TypeOf((*MockServer)(nil).GetConnectionInfo))
 }
 
+// GetContainer mocks base method
+func (m *MockServer) GetContainer(arg0 string) (*api.Container, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainer", arg0)
+	ret0, _ := ret[0].(*api.Container)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetContainer indicates an expected call of GetContainer
+func (mr *MockServerMockRecorder) GetContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainer", reflect.TypeOf((*MockServer)(nil).GetContainer), arg0)
+}
+
 // GetContainerProfiles mocks base method
 func (m *MockServer) GetContainerProfiles(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -330,6 +346,22 @@ func (m *MockServer) GetContainerProfiles(arg0 string) ([]string, error) {
 func (mr *MockServerMockRecorder) GetContainerProfiles(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfiles", reflect.TypeOf((*MockServer)(nil).GetContainerProfiles), arg0)
+}
+
+// GetContainerState mocks base method
+func (m *MockServer) GetContainerState(arg0 string) (*api.ContainerState, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerState", arg0)
+	ret0, _ := ret[0].(*api.ContainerState)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetContainerState indicates an expected call of GetContainerState
+func (mr *MockServerMockRecorder) GetContainerState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerState", reflect.TypeOf((*MockServer)(nil).GetContainerState), arg0)
 }
 
 // GetNICsFromProfile mocks base method

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -5,14 +5,13 @@
 package lxd
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	lxd "github.com/juju/juju/container/lxd"
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
 	lxd1 "github.com/lxc/lxd/client"
 	api "github.com/lxc/lxd/shared/api"
+	reflect "reflect"
 )
 
 // MockServer is a mock of Server interface
@@ -346,6 +345,36 @@ func (m *MockServer) GetNICsFromProfile(arg0 string) (map[string]map[string]stri
 func (mr *MockServerMockRecorder) GetNICsFromProfile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNICsFromProfile", reflect.TypeOf((*MockServer)(nil).GetNICsFromProfile), arg0)
+}
+
+// GetNetworkNames mocks base method
+func (m *MockServer) GetNetworkNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetworkNames indicates an expected call of GetNetworkNames
+func (mr *MockServerMockRecorder) GetNetworkNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkNames", reflect.TypeOf((*MockServer)(nil).GetNetworkNames))
+}
+
+// GetNetworkState mocks base method
+func (m *MockServer) GetNetworkState(arg0 string) (*api.NetworkState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworkState", arg0)
+	ret0, _ := ret[0].(*api.NetworkState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetworkState indicates an expected call of GetNetworkState
+func (mr *MockServerMockRecorder) GetNetworkState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkState", reflect.TypeOf((*MockServer)(nil).GetNetworkState), arg0)
 }
 
 // GetProfile mocks base method

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -714,6 +714,14 @@ func (*StubClient) GetNetworkState(string) (*api.NetworkState, error) {
 	panic("this stub is deprecated; use mocks instead")
 }
 
+func (*StubClient) GetContainer(string) (*api.Container, string, error) {
+	panic("this stub is deprecated; use mocks instead")
+}
+
+func (*StubClient) GetContainerState(string) (*api.ContainerState, string, error) {
+	panic("this stub is deprecated; use mocks instead")
+}
+
 // TODO (manadart 2018-07-20): This exists to satisfy the testing stub
 // interface. It is temporary, pending replacement with mocks and
 // should not be called in tests.

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -428,6 +428,8 @@ type StubClient struct {
 	ServerCert         string
 	ServerHostArch     string
 	ServerVer          string
+	NetworkNames       []string
+	NetworkState       map[string]api.NetworkState
 }
 
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
@@ -704,6 +706,14 @@ func (conn *StubClient) Name() string {
 	return "server"
 }
 
+func (*StubClient) GetNetworkNames() ([]string, error) {
+	panic("this stub is deprecated; use mocks instead")
+}
+
+func (*StubClient) GetNetworkState(string) (*api.NetworkState, error) {
+	panic("this stub is deprecated; use mocks instead")
+}
+
 // TODO (manadart 2018-07-20): This exists to satisfy the testing stub
 // interface. It is temporary, pending replacement with mocks and
 // should not be called in tests.
@@ -738,7 +748,7 @@ type EnvironSuite struct {
 	testing.BaseSuite
 }
 
-func (s *EnvironSuite) NewEnviron(c *gc.C, svr Server, cfgEdit map[string]interface{}) environs.Environ {
+func (s *EnvironSuite) NewEnviron(c *gc.C, srv Server, cfgEdit map[string]interface{}) environs.Environ {
 	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -755,13 +765,13 @@ func (s *EnvironSuite) NewEnviron(c *gc.C, svr Server, cfgEdit map[string]interf
 	c.Assert(err, jc.ErrorIsNil)
 
 	return &environ{
-		serverUnlocked: svr,
+		serverUnlocked: srv,
 		ecfgUnlocked:   eCfg,
 		namespace:      namespace,
 	}
 }
 
-func (s *EnvironSuite) NewEnvironWithServerFactory(c *gc.C, svr ServerFactory, cfgEdit map[string]interface{}) environs.Environ {
+func (s *EnvironSuite) NewEnvironWithServerFactory(c *gc.C, srv ServerFactory, cfgEdit map[string]interface{}) environs.Environ {
 	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -778,7 +788,7 @@ func (s *EnvironSuite) NewEnvironWithServerFactory(c *gc.C, svr ServerFactory, c
 	c.Assert(err, jc.ErrorIsNil)
 
 	provid := environProvider{
-		serverFactory: svr,
+		serverFactory: srv,
 	}
 
 	return &environ{


### PR DESCRIPTION
## Description of change

This PR provides an implementation of the `environs.Networking` interface for the LXD provider. This change facilitates subnet discovery on LXD clouds, a pre-requisite for allowing charms to target specific endpoints (and by extension specific subnets) when opening/closing ports.

As an extra bonus, the `NetworkInterfaces` implementation makes an extra LXD API call and uses the obtained information to populate the `ParentInterfaceName` field of the `NetworkInfo` struct with the NIC on the LXD host that serves as a bridge.

The following naming conventions are used for generating provider-specific IDs:
- Network ID: `net-$network_name` (e.g. `net-lxdbr0`)
- Subnet ID: `subnet-$network_name-CIDR` (e.g. `subnet-lxdbr0-10.55.158.0/24`)
- NIC ID: `nic-$hw_ddr` (e.g. `nic-00:16:3e:19:29:cb`)

## QA steps

```console
$ juju bootstrap lxd test

# Juju subnets should now show you a list of discovered subnets (output on your machine will be different)
# matching the ones on the LXD host
$ juju subnets
subnets:
...
  10.55.158.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.55.158.0/24
    provider-network-id: net-lxdbr0
    status: in-use
    space: alpha
    zones: []
...

# Then, connect to mongo and inspect the contents of the linklayerdevices collection
> db.linklayerdevices.find().pretty()

# Ensure that non-loopback devices include a providerid and parent value and that their origin is set to provider
```