### PR TITLE
Handle new lines in a tabular format.

### DIFF
--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -4,6 +4,8 @@
 package action
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -182,7 +184,18 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 	tw := output.TabWriter(writer)
 	fmt.Fprintf(tw, "%s\t%s\n", "Action", "Description")
 	for _, value := range list {
-		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.TrimSpace(value.description))
+		scanner := bufio.NewScanner(bytes.NewBufferString(strings.TrimSpace(value.description)))
+		scanner.Split(bufio.ScanLines)
+
+		var lines []string
+		for scanner.Scan() {
+			var prefix string
+			if len(lines) > 0 {
+				prefix = "\t"
+			}
+			lines = append(lines, fmt.Sprintf("%s%s", prefix, scanner.Text()))
+		}
+		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.Join(lines, "\n"))
 	}
 	tw.Flush()
 	return nil


### PR DESCRIPTION
## Description of change

This change correctly handles newlines when the description contains
them. This is so we can keep tabular formatting and still have the nice
output.

It's not exactly complicated, but just scans over each line and inserts
a tab at the beginning of every line after the first one (it's already
tabbed).

## QA steps

```sh
juju bootstrap lxd test
juju deploy cs:percona-cluster-290
juju actions percona-cluster
```

Outputs the following:

```sh
Action                           Description
backup                           Full database backup
bootstrap-pxc                    Bootstrap this unit of Percona.
                                 *WARNING* This action will bootstrap this unit of Percona cluster. This
                                 should only occur in a recovery scenario. Make sure this unit has the
                                 highest sequence number in grastate.dat or data loss may occur.
                                 See upstream Percona documentation for context
                                 https://www.percona.com/blog/2014/09/01/galera-replication-how-to-recover-a-pxc-cluster/
complete-cluster-series-upgrade  Perform final operations post series upgrade. Inform all nodes in the
                                 cluster the upgrade is complete cluster wide. Update configuration with all
                                 peers for wsrep replication.
                                 This action should be performed on the current leader. Note the leader may
                                 have changed during the series upgrade process.
mysqldump                        MySQL dump of databases. Action will return mysqldump-file location of the
                                 requested backup in the results. If the databases parameter is unset all
                                 databases will be dumped. If the databases parameter is set only the
                                 databases specified will be dumped. Note it may be necessary to use the
                                 set-pxc-strict-mode action first to set either PERMISSIVE or MASTER to
                                 allow locking of tables for mysqldump to complete successfully.
                                 See https://www.percona.com/doc/percona-xtradb-cluster/LATEST/features/pxc-strict-mode.html
                                 for more detail.
notify-bootstrapped              No description
pause                            Pause the MySQL service.
resume                           Resume the MySQL service.
set-pxc-strict-mode              Set PXC strict mode.

```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871719