### PR TITLE
[2.8] Filter non live relations from relation ids output

### DIFF
--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -36,6 +37,9 @@ type Relation interface {
 	// OtherApplication returns the name of the application on the other
 	// end of the relation (from this unit's perspective).
 	OtherApplication() string
+
+	// Life returns the relation's current life state.
+	Life() life.Value
 }
 
 type RelationUnit interface {
@@ -184,4 +188,9 @@ func (ctx *ContextRelation) SetStatus(status relation.Status) error {
 // relation from the perspective of this unit.
 func (ctx *ContextRelation) RemoteApplicationName() string {
 	return ctx.ru.Relation().OtherApplication()
+}
+
+// Life returns the relation's current life state.
+func (ctx *ContextRelation) Life() life.Value {
+	return ctx.ru.Relation().Life()
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/storage"
@@ -321,6 +322,9 @@ type ContextRelation interface {
 	// RemoteApplicationName returns the application on the other end of
 	// the relation from the perspective of this unit.
 	RemoteApplicationName() string
+
+	// Life returns the relation's current life state.
+	Life() life.Value
 }
 
 // ContextStorageAttachment expresses the capabilities of a hook with

--- a/worker/uniter/runner/jujuc/context_mock_test.go
+++ b/worker/uniter/runner/jujuc/context_mock_test.go
@@ -7,6 +7,7 @@ package jujuc
 import (
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
+	life "github.com/juju/juju/core/life"
 	relation "github.com/juju/juju/core/relation"
 	reflect "reflect"
 )
@@ -75,6 +76,20 @@ func (m *MockContextRelation) Id() int {
 func (mr *MockContextRelationMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockContextRelation)(nil).Id))
+}
+
+// Life mocks base method
+func (m *MockContextRelation) Life() life.Value {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Life")
+	ret0, _ := ret[0].(life.Value)
+	return ret0
+}
+
+// Life indicates an expected call of Life
+func (mr *MockContextRelationMockRecorder) Life() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockContextRelation)(nil).Life))
 }
 
 // Name mocks base method

--- a/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -30,6 +31,8 @@ type Relation struct {
 	LocalApplicationSettings Settings
 	// RemoteApplicationName is data for jujuc.ContextRelation
 	RemoteApplicationName string
+	// The current life value.
+	Life life.Value
 }
 
 // Reset clears the Relation's settings.
@@ -85,6 +88,14 @@ func (r *ContextRelation) FakeId() string {
 	r.stub.NextErr()
 
 	return fmt.Sprintf("%s:%d", r.info.Name, r.info.Id)
+}
+
+// Life implements jujuc.ContextRelation.
+func (r *ContextRelation) Life() life.Value {
+	r.stub.AddCall("Life")
+	r.stub.NextErr()
+
+	return r.info.Life
 }
 
 // Settings implements jujuc.ContextRelation.

--- a/worker/uniter/runner/jujuc/jujuctesting/relations.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -32,12 +33,17 @@ func (r *Relations) SetRelation(id int, relCtx jujuc.ContextRelation) {
 
 // SetNewRelation adds the relation to the set of known relations.
 func (r *Relations) SetNewRelation(id int, name string, stub *testing.Stub) *Relation {
+	return r.SetNewRelationWithLife(id, name, life.Alive, stub)
+}
+
+func (r *Relations) SetNewRelationWithLife(id int, name string, life life.Value, stub *testing.Stub) *Relation {
 	if name == "" {
 		name = fmt.Sprintf("relation-%d", id)
 	}
 	rel := &Relation{
 		Id:   id,
 		Name: name,
+		Life: life,
 	}
 	relCtx := &ContextRelation{info: rel}
 	relCtx.stub = stub

--- a/worker/uniter/runner/jujuc/relation-ids.go
+++ b/worker/uniter/runner/jujuc/relation-ids.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/gnuflag"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/core/life"
 )
 
 // RelationIdsCommand implements the relation-ids command.
@@ -73,7 +74,7 @@ func (c *RelationIdsCommand) Run(ctx *cmd.Context) error {
 	}
 	for _, id := range ids {
 		r, err := c.ctx.Relation(id)
-		if err == nil && r.Name() == c.Name {
+		if err == nil && r.Name() == c.Name && r.Life() != life.Dead {
 			result = append(result, r.FakeId())
 		} else if err != nil && !errors.IsNotFound(err) {
 			return errors.Trace(err)


### PR DESCRIPTION
## Description of change

This PR provides a stop gap fix for https://bugs.launchpad.net/juju/+bug/1870013 by filtering the output of the `relation-ids` hook tool to exclude relations that are in a `Dead` state.

Note that this PR _does not address the underlying issue_ (correctly populate the hook context for network-get) but rather prevents the manifestation of the linked bug for workflows that iterate the output of `relation-ids` to obtain additional relation information (e.g. via network-get).

## QA steps

```console
$ juju bootstrap lxd test
$ juju deploy mysql
$ juju deploy wordpress
$ juju deploy statusnet
$ juju relate mysql wordpress
$ juju relate mysql statusnet

$ juju run --unit mysql/0 "relation-ids db"
db:2
db:3

# Remove relation and wait a bit for the removal to be ACK'd
$ juju remove-relation mysql wordpress
$ juju run --unit mysql/0 "relation-ids db"
db:3

# The non-patched 2.8 juju includes the deleted relation in the above command output thus causing the bug to manifest
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1870013
