### PR TITLE
Fix intermittent cmd/status tests

### DIFF
--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/charm/v7"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -4984,6 +4985,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 	for _, s := range steps {
 		s.step(c, ctx)
 	}
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	return ctx
 }
 
@@ -5036,6 +5038,8 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 }
 
 func (s *StatusSuite) TestStatusWithFormatTabularValidModelUUID(c *gc.C) {
+	loggo.GetLogger("dummy.modelcache").SetLogLevel(loggo.TRACE)
+	loggo.GetLogger("juju.state.allwatcher").SetLogLevel(loggo.TRACE)
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
 

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/charm/v7"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -5038,8 +5037,6 @@ func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 }
 
 func (s *StatusSuite) TestStatusWithFormatTabularValidModelUUID(c *gc.C) {
-	loggo.GetLogger("dummy.modelcache").SetLogLevel(loggo.TRACE)
-	loggo.GetLogger("juju.state.allwatcher").SetLogLevel(loggo.TRACE)
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
 

--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	// HubWatcherIdleFunc allows tets to be able to get callbacks
+	// HubWatcherIdleFunc allows tests to be able to get callbacks
 	// when the hub watcher hasn't notified any watchers for a specified time.
 	HubWatcherIdleFunc func(string)
 


### PR DESCRIPTION
Since we are using the model cache now for application status, we need to make sure all the events have been processed before calling the status call.

However this wasn't actually the problem even though it is necessary.

The underlying problem was in the handling of the status updates in the all watcher code.

The existing implementation will accidentally overwrite an error status
if a workload status update comes in. Instead of trying to handle both
agent status and workload status updates in one method, made two, one
of which is very trivial.

There was already an existing test for a unit coming out of an error
state, but there was no test for the updating of workload status when
in an error state. That is the test that is added.

## QA steps

Running the tests using stress-race script.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1884918