### PR TITLE
Add centos8

### DIFF
--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -92,6 +92,12 @@ var cloudinitDataVerifyTests = []cloudinitDataVerifyTest{
 		result:          expectedResult,
 	},
 	{
+		description:     "centos8 on centos8",
+		machineSeries:   "centos8",
+		containerSeries: "centos8",
+		result:          expectedResult,
+	},
+	{
 		description:     "win2012 on win2012",
 		machineSeries:   "win2012",
 		containerSeries: "win2012",

--- a/cmd/juju/application/setseries.go
+++ b/cmd/juju/application/setseries.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
-	"github.com/juju/utils/series"
+	"github.com/juju/os/series"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -14,9 +14,11 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
+	jujuos "github.com/juju/os"
 	"github.com/juju/os/series"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/ssh"
@@ -531,11 +533,20 @@ func (c *BootstrapCommand) populateTools(st *state.State, env environs.Bootstrap
 		if err != nil {
 			return errors.Trace(err)
 		}
-		osSeries := series.OSSupportedSeries(opSys)
-		for _, s := range osSeries {
-			toolsVersion := agentTools.Version
-			toolsVersion.Series = s
-			toolsVersions = append(toolsVersions, toolsVersion)
+		osTypes := set.NewInts(int(opSys))
+		// If a Linux OS, we'll include all Linux OS's.
+		if opSys.IsLinux() {
+			for _, osType := range []jujuos.OSType{jujuos.Ubuntu, jujuos.CentOS, jujuos.GenericLinux, jujuos.OpenSUSE} {
+				osTypes.Add(int(osType))
+			}
+		}
+		for _, osType := range osTypes.SortedValues() {
+			osSeries := series.OSSupportedSeries(jujuos.OSType(osType))
+			for _, s := range osSeries {
+				toolsVersion := agentTools.Version
+				toolsVersion.Series = s
+				toolsVersions = append(toolsVersions, toolsVersion)
+			}
 		}
 	} else {
 		// Tools were downloaded from an external source: don't clone.

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -713,7 +713,7 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 			c.Assert(err, jc.ErrorIsNil)
 			hostos, err := series.GetOSFromSeries(series.MustHostSeries())
 			c.Assert(err, jc.ErrorIsNil)
-			if os == hostos {
+			if os == hostos || os.IsLinux() && hostos.IsLinux() {
 				expectedSeries.Add(ser)
 			}
 		}

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/utils"
 
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
@@ -24,13 +23,12 @@ import (
 )
 
 func newToolsMetadataCommand() cmd.Command {
-	return modelcmd.Wrap(&toolsMetadataCommand{})
+	return &toolsMetadataCommand{}
 }
 
 // toolsMetadataCommand is used to generate simplestreams metadata for juju agents.
 type toolsMetadataCommand struct {
-	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
+	cmd.CommandBase
 	fetch       bool
 	metadataDir string
 	stream      string
@@ -44,8 +42,9 @@ generate-agents creates the simplestreams metadata for agents.
 This command works by scanning a directory for agent binary tarballs from which to generate
 simplestreams agent metadata. The working directory is specified using the -d argument
 (defaults to $JUJU_DATA or if not defined $XDG_DATA_HOME/juju or if that is not defined
-~/.local/share/juju). The working directory is expected to contain a named subdirectory
-containing agent binary tarballs, and is where the resulting metadata is written.
+~/.local/share/juju). The working directory path must contain a "tools" subdirectory.
+This "tools" directory is expected to contain a named subdirectory containing agent binary
+tarballs, and is where the resulting metadata is written.
 
 The stream for which metadata is generated is specified using the --stream parameter
 (default is "released"). Metadata can be generated for any supported stream - released,

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -121,9 +120,7 @@ var expectedOutputDirectoryTemplate = expectedOutputCommon + `
 `
 
 func newToolsMetadataCommandForTest() cmd.Command {
-	cmd := &toolsMetadataCommand{}
-	cmd.SetClientStore(jujuclienttesting.MinimalStore())
-	return modelcmd.Wrap(cmd)
+	return &toolsMetadataCommand{}
 }
 
 func (s *ToolsMetadataSuite) TestGenerateToDirectory(c *gc.C) {

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -8,13 +8,14 @@ import (
 	"path"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs"
+	jujuos "github.com/juju/os"
+	jujuseries "github.com/juju/os/series"
 	jujuarch "github.com/juju/utils/arch"
-	jujuos "github.com/juju/utils/os"
-	jujuseries "github.com/juju/utils/series"
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
+
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/environs"
 )
 
 // SourcedImage is the result of a successful image acquisition.
@@ -186,8 +187,15 @@ func seriesRemoteAliases(series, arch string) ([]string, error) {
 	case jujuos.Ubuntu:
 		return []string{path.Join(series, arch)}, nil
 	case jujuos.CentOS:
-		if series == "centos7" && arch == jujuarch.AMD64 {
-			return []string{"centos/7/amd64"}, nil
+		if arch == jujuarch.AMD64 {
+			switch series {
+			case "centos7":
+				return []string{"centos/7/amd64"}, nil
+			case "centos8":
+				return []string{"centos/8/amd64"}, nil
+			default:
+				return nil, errors.NotSupportedf("series %q", series)
+			}
 		}
 	case jujuos.OpenSUSE:
 		if series == "opensuseleap" && arch == jujuarch.AMD64 {

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -188,6 +188,9 @@ func (s *imageSuite) TestSeriesRemoteAliasesNotSupported(c *gc.C) {
 	_, err := lxd.SeriesRemoteAliases("centos7", "arm64")
 	c.Assert(err, gc.ErrorMatches, `series "centos7" not supported`)
 
+	_, err = lxd.SeriesRemoteAliases("centos8", "arm64")
+	c.Assert(err, gc.ErrorMatches, `series "centos8" not supported`)
+
 	_, err = lxd.SeriesRemoteAliases("opensuseleap", "s390x")
 	c.Assert(err, gc.ErrorMatches, `series "opensuseleap" not supported`)
 }

--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -6,8 +6,8 @@
 package lxd
 
 import (
+	"github.com/juju/os/series"
 	"github.com/juju/proxy"
-	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/container"
 )

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/os/series"
 	"github.com/juju/packaging/manager"
 	"github.com/juju/proxy"
-	"github.com/juju/utils/series"
 	"github.com/lxc/lxd/shared"
 
 	"github.com/juju/juju/container"

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -6,8 +6,8 @@ package lxd
 import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/os"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/os"
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"

--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -318,6 +318,7 @@ const (
 	Win81        SeriesName = "win81"
 	Win10        SeriesName = "win10"
 	Centos7      SeriesName = "centos7"
+	Centos8      SeriesName = "centos8"
 	OpenSUSELeap SeriesName = "opensuseleap"
 	GenericLinux SeriesName = "genericlinux"
 	Kubernetes   SeriesName = "kubernetes"
@@ -392,6 +393,11 @@ var nonUbuntuSeries = map[SeriesName]SeriesVersion{
 	Centos7: {
 		WorkloadType: OtherWorkloadType,
 		Version:      "centos7",
+		Supported:    true,
+	},
+	Centos8: {
+		WorkloadType: OtherWorkloadType,
+		Version:      "centos8",
 		Supported:    true,
 	},
 	OpenSUSELeap: {

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -41,7 +41,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -59,7 +59,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -77,7 +77,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -95,7 +95,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func makeTempFile(c *gc.C, content string) (*os.File, func()) {

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -65,7 +65,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNoConfigURL(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }
 
@@ -74,8 +74,8 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-image-metadata-url/", ""},
-		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"config-image-metadata-url/", "", false},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }
 
@@ -113,10 +113,10 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-image-metadata-url/", ""},
-		{"foobar/", ""},
-		{"betwixt/releases/", ""},
-		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"config-image-metadata-url/", "", false},
+		{"foobar/", "", false},
+		{"betwixt/releases/", "", false},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }
 
@@ -136,6 +136,6 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNonReleaseStream(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"http://cloud-images.ubuntu.com/daily/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/daily/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -652,8 +652,9 @@ func SignMetadata(fileName string, fileData []byte) (string, []byte, error) {
 
 // SourceDetails stored some details that need to be checked about data source.
 type SourceDetails struct {
-	URL string
-	Key string
+	URL           string
+	Key           string
+	RequireSigned bool
 }
 
 func AssertExpectedSources(c *gc.C, obtained []simplestreams.DataSource, dsDetails []SourceDetails) {
@@ -669,6 +670,7 @@ func AssertExpectedSources(c *gc.C, obtained []simplestreams.DataSource, dsDetai
 		expected := dsDetails[i]
 		c.Assert(url, gc.DeepEquals, expected.URL)
 		c.Assert(source.PublicSigningKey(), gc.DeepEquals, expected.Key)
+		c.Assert(source.RequireSigned(), gc.Equals, expected.RequireSigned)
 	}
 	c.Assert(obtained, gc.HasLen, len(dsDetails))
 }

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -43,12 +43,15 @@ const (
 
 	// IndexFileVersion is used to construct the streams index file.
 	IndexFileVersion = 2
+
+	// streamsAgentURL is the path to the default simplestreams agent metadata.
+	streamsAgentURL = "https://streams.canonical.com/juju/tools"
 )
 
 var currentStreamsVersion = StreamsVersionV1
 
 // This needs to be a var so we can override it for testing.
-var DefaultBaseURL = "https://streams.canonical.com/juju/tools"
+var DefaultBaseURL = streamsAgentURL
 
 const (
 	// Used to specify the released tools metadata.

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -109,7 +109,7 @@ func GetMetadataSources(env environs.BootstrapEnviron) ([]simplestreams.DataSour
 			PublicSigningKey:     keys.JujuPublicKey,
 			HostnameVerification: utils.VerifySSLHostnames,
 			Priority:             simplestreams.DEFAULT_CLOUD_DATA,
-			RequireSigned:        true,
+			RequireSigned:        DefaultBaseURL == streamsAgentURL,
 		}
 		if err := dataSourceConfig.Validate(); err != nil {
 			return nil, errors.Annotate(err, "simplestreams config validation failed")

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -62,7 +62,7 @@ func (s *URLsSuite) TestToolsURLsNoConfigURL(c *gc.C) {
 	env := s.env(c, "")
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey}})
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey, true}})
 }
 
 func (s *URLsSuite) TestToolsSources(c *gc.C) {
@@ -70,8 +70,8 @@ func (s *URLsSuite) TestToolsSources(c *gc.C) {
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-tools-metadata-url/", keys.JujuPublicKey},
-		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey},
+		{"config-tools-metadata-url/", keys.JujuPublicKey, false},
+		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey, true},
 	})
 }
 
@@ -103,9 +103,9 @@ func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-tools-metadata-url/", keys.JujuPublicKey},
-		{"betwixt/releases/", ""},
-		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey},
+		{"config-tools-metadata-url/", keys.JujuPublicKey, false},
+		{"betwixt/releases/", "", false},
+		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey, true},
 	})
 }
 

--- a/featuretests/tools_test.go
+++ b/featuretests/tools_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200424054733-9a8294627524
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os v0.0.0-20200323101341-8e16ce76f45e
+	github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b h1:Ow9ltIspVQvDdG
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
-github.com/juju/os v0.0.0-20200323101341-8e16ce76f45e h1:atxWn8Xx0oEjyYxd6RmV0O2vA+imhCfDvNHKkFAcnzM=
-github.com/juju/os v0.0.0-20200323101341-8e16ce76f45e/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
+github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsyQXD3ufLXa8pzcnj7JhLk=
+github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=
@@ -411,6 +411,7 @@ github.com/juju/usso v0.0.0-20160401104424-68a59c96c178/go.mod h1:sHjHrlB/5phHrK
 github.com/juju/utils v0.0.0-20160526025251-ffea6ead0c37/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20161003233226-28c01ec2ad93/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
+github.com/juju/utils v0.0.0-20180517015153-d2ddf8edc7dc/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180619112806-c746c6e86f4f/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180808125547-9dfc6dbfb02b/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
@@ -700,6 +701,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/packaging/dependency/kvm.go
+++ b/packaging/dependency/kvm.go
@@ -20,7 +20,7 @@ type kvmDependency struct {
 
 // PackageList implements packaging.Dependency.
 func (dep kvmDependency) PackageList(series string) ([]packaging.Package, error) {
-	if series == "centos7" || series == "opensuseleap" {
+	if series == "centos7" || series == "centos8" || series == "opensuseleap" {
 		return nil, errors.NotSupportedf("installing kvm on series %q", series)
 	}
 

--- a/packaging/dependency/lxd.go
+++ b/packaging/dependency/lxd.go
@@ -29,7 +29,7 @@ func (dep lxdDependency) PackageList(series string) ([]packaging.Package, error)
 	var pkg packaging.Package
 
 	switch series {
-	case "centos7", "opensuseleap", "precise":
+	case "centos7", "centos8", "opensuseleap", "precise":
 		return nil, errors.NotSupportedf("LXD containers on series %q", series)
 	case "trusty", "xenial", "bionic", blankSeries:
 		pkg.Name = "lxd"

--- a/packaging/dependency/mongo.go
+++ b/packaging/dependency/mongo.go
@@ -38,7 +38,7 @@ func (dep mongoDependency) PackageList(series string) ([]packaging.Package, erro
 	}
 
 	switch series {
-	case "centos7", "opensuseleap", "precise":
+	case "centos7", "centos8", "opensuseleap", "precise":
 		return nil, errors.NotSupportedf("installing mongo on series %q", series)
 	case "trusty":
 		aptPkgList = append(aptPkgList, "juju-mongodb")

--- a/packaging/manager_test.go
+++ b/packaging/manager_test.go
@@ -21,15 +21,17 @@ func (s *DependencyManagerTestSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DependencyManagerTestSuite) TestInstallWithCentos(c *gc.C) {
-	s.assertInstallCallsCorrectBinary(c, assertParams{
-		series:       "centos7",
-		pkg:          "foo",
-		pm:           packaging.YumPackageManager,
-		expPkgBinary: "yum",
-		expArgs: []string{
-			"--assumeyes", "--debuglevel=1", "install", "foo",
-		},
-	})
+	for _, series := range []string{"centos7", "centos8"} {
+		s.assertInstallCallsCorrectBinary(c, assertParams{
+			series:       series,
+			pkg:          "foo",
+			pm:           packaging.YumPackageManager,
+			expPkgBinary: "yum",
+			expArgs: []string{
+				"--assumeyes", "--debuglevel=1", "install", "foo",
+			},
+		})
+	}
 }
 
 func (s *DependencyManagerTestSuite) TestInstallWithOpenSuse(c *gc.C) {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -713,13 +713,19 @@ func (s *environSuite) testStartInstanceWindows(
 }
 
 func (s *environSuite) TestStartInstanceCentOS(c *gc.C) {
+	for _, series := range []string{"centos7", "centos8"} {
+		s.assertStartInstanceCentOS(c, series)
+	}
+}
+
+func (s *environSuite) assertStartInstanceCentOS(c *gc.C, series string) {
 	// Starting a CentOS VM, we should not expect an image query.
 	s.PatchValue(&s.ubuntuServerSKUs, nil)
 
 	env := s.openEnviron(c)
 	s.sender = s.startInstanceSenders(false)
 	s.requests = nil
-	args := makeStartInstanceParams(c, s.controllerUUID, "centos7")
+	args := makeStartInstanceParams(c, s.controllerUUID, series)
 	_, err := env.StartInstance(s.callCtx, args)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -94,7 +94,7 @@ func SeriesImage(
 		publisher = centOSPublisher
 		offering = centOSOffering
 		switch series {
-		case "centos7":
+		case "centos7", "centos8":
 			sku = "7.3"
 		default:
 			return nil, errors.NotSupportedf("deploying %s", series)

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -86,7 +86,9 @@ func (s *imageutilsSuite) TestSeriesImageWindows(c *gc.C) {
 }
 
 func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
-	s.assertImageId(c, "centos7", "released", "OpenLogic:CentOS:7.3:latest")
+	for _, series := range []string{"centos7", "centos8"} {
+		s.assertImageId(c, series, "released", "OpenLogic:CentOS:7.3:latest")
+	}
 }
 
 func (s *imageutilsSuite) TestSeriesImageGenericLinux(c *gc.C) {

--- a/provider/common/disk_test.go
+++ b/provider/common/disk_test.go
@@ -21,6 +21,7 @@ func (s *DiskSuite) TestMinRootDiskSizeGiB(c *gc.C) {
 		{"trusty", 8},
 		{"win2012r2", 40},
 		{"centos7", 8},
+		{"centos8", 8},
 		{"opensuseleap", 8},
 		{"fake-series", 8},
 	}

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -29,9 +29,9 @@ func (*ErrorsSuite) TestWrapZoneIndependentError(c *gc.C) {
 
 	stack := errors.ErrorStack(wrapped)
 	c.Assert(stack, gc.Matches, `
-.*github.com/juju/juju/provider/common/errors_test.go:.*: foo
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/juju/juju/provider/common/errors_test.go:.*: foo
+.*/juju/juju/provider/common/errors_test.go:.*: bar
+.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
@@ -46,9 +46,9 @@ func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
 
 	stack := errors.ErrorStack(err)
 	c.Assert(stack, gc.Matches, `
-.*github.com/juju/juju/provider/common/errors_test.go:.*: foo
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/juju/juju/provider/common/errors_test.go:.*: foo
+.*/juju/juju/provider/common/errors_test.go:.*: bar
+.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialNew(c *gc.C) {

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/os"
+	jujuseries "github.com/juju/os/series"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/os"
-	jujuseries "github.com/juju/utils/series"
 	"github.com/juju/version"
 	"github.com/kr/pretty"
 

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -13,8 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	// jujuos "github.com/juju/utils/os"
-	"github.com/juju/utils/series"
+	"github.com/juju/os/series"
 
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -132,6 +132,10 @@ var discoveryTests = []discoveryTest{{
 	series:   "centos7",
 	expected: service.InitSystemSystemd,
 }, {
+	os:       jujuos.CentOS,
+	series:   "centos8",
+	expected: service.InitSystemSystemd,
+}, {
 	os:       jujuos.OpenSUSE,
 	series:   "opensuseleap",
 	expected: service.InitSystemSystemd,

--- a/upgrades/steps_24.go
+++ b/upgrades/steps_24.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/series"
+	"github.com/juju/os/series"
 
 	"github.com/juju/juju/service"
 )

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -37,7 +37,7 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 			if s != "n/a" {
 				// There is no lsb_release command on CentOS.
 				if current_os == os.CentOS {
-					c.Check(s, gc.Matches, `centos7`)
+					c.Check(s, gc.Matches, `centos7|centos8`)
 				}
 			}
 		}


### PR DESCRIPTION
## Description of change

Add support for centos8 workloads.

To aid testing, fixes were done to the agent simplestreams metadata plugin tools and infrastructure.
The `juju metadata generate-tools` command was fixed to run without needing a controller.
At bootstrap, bespoke agent metadata no longer needs to be signed.
The bespoke agent metadata at bootstrap now includes generated metadata for all linux series. 

## QA steps

The real test is only done when the release jobs generate proper agent binaries for centos8.
We can check that the core parts are wired up using fake metadata.
Create some agent tarballs eg, juju-2.8.0-centos8-amd64.tgz, juju-2.8.0-bionic-amd64.tgz
Run juju metadata generate-tools --stream proposed to create the simplestreams metadata
Bootstrap with this metadata, eg juju bootstrap --metadata-source=~/simplestreams --config agent-stream=proposed ...
Add a centos8 machine, eg juju add-machine --series centos8

If the controller is LXD, you'll need to get a centos8 image locally, aliased to juju/centos8/amd64
If the controller is Azure, it will start a centos8 machine
The centos images seem to lack cloud-init or something as the agent doesn't start, but it's the same for centos7.
The key point is that juju handles centos8 as a supported series.

Check also that juju metadata add-image 1234 --series centos8 works


## Bug reference

https://bugs.launchpad.net/bugs/1881451
