### PR TITLE
Charmhub API find client

### DIFF
--- a/api/charmhub/client.go
+++ b/api/charmhub/client.go
@@ -37,7 +37,7 @@ func newClientFromFacade(frontend base.ClientFacade, backend base.FacadeCaller) 
 // Info queries the charmhub API for information for a given name.
 func (c *Client) Info(name string) (InfoResponse, error) {
 	args := params.Entity{Tag: names.NewApplicationTag(name).String()}
-	var result params.CharmHubCharmInfoResult
+	var result params.CharmHubEntityInfoResult
 	if err := c.facade.FacadeCall("Info", args, &result); err != nil {
 		return InfoResponse{}, errors.Trace(err)
 	}
@@ -49,7 +49,7 @@ func (c *Client) Info(name string) (InfoResponse, error) {
 // given query.
 func (c *Client) Find(query string) ([]FindResponse, error) {
 	args := params.Query{Query: query}
-	var result params.CharmHubCharmFindResult
+	var result params.CharmHubEntityFindResult
 	if err := c.facade.FacadeCall("Find", args, &result); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/charmhub/client.go
+++ b/api/charmhub/client.go
@@ -34,6 +34,7 @@ func newClientFromFacade(frontend base.ClientFacade, backend base.FacadeCaller) 
 	}
 }
 
+// Info queries the charmhub API for information for a given name.
 func (c *Client) Info(name string) (InfoResponse, error) {
 	args := params.Entity{Tag: names.NewApplicationTag(name).String()}
 	var result params.CharmHubCharmInfoResult
@@ -42,4 +43,16 @@ func (c *Client) Info(name string) (InfoResponse, error) {
 	}
 
 	return convertCharmInfoResult(result.Result), nil
+}
+
+// Find queries the charmhub API finding potential charms or bundles for the
+// given query.
+func (c *Client) Find(query string) (FindResponse, error) {
+	args := params.Query{Query: query}
+	var result params.CharmHubCharmFindResult
+	if err := c.facade.FacadeCall("Find", args, &result); err != nil {
+		return FindResponse{}, errors.Trace(err)
+	}
+
+	return convertCharmFindResult(result.Result), nil
 }

--- a/api/charmhub/client.go
+++ b/api/charmhub/client.go
@@ -47,12 +47,12 @@ func (c *Client) Info(name string) (InfoResponse, error) {
 
 // Find queries the charmhub API finding potential charms or bundles for the
 // given query.
-func (c *Client) Find(query string) (FindResponse, error) {
+func (c *Client) Find(query string) ([]FindResponse, error) {
 	args := params.Query{Query: query}
 	var result params.CharmHubCharmFindResult
 	if err := c.facade.FacadeCall("Find", args, &result); err != nil {
-		return FindResponse{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
-	return convertCharmFindResult(result.Result), nil
+	return convertCharmFindResults(result.Results), nil
 }

--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -39,13 +39,13 @@ func (s charmHubSuite) TestFind(c *gc.C) {
 
 	arg := params.Query{Query: "wordpress"}
 	resultSource := params.CharmHubCharmFindResult{
-		Result: getParamsFindResponse(),
+		Results: getParamsFindResponses(),
 	}
 	s.facade.EXPECT().FacadeCall("Find", arg, gomock.Any()).SetArg(2, resultSource)
 
 	obtained, err := s.newClientFromFacadeForTest().Find("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
-	assertFindResponseSameContents(c, obtained, getFindResponse())
+	assertFindResponsesSameContents(c, obtained, getFindResponses())
 }
 
 func (s *charmHubSuite) newClientFromFacadeForTest() *Client {
@@ -73,16 +73,16 @@ func getInfoResponse() InfoResponse {
 	}
 }
 
-func getFindResponse() FindResponse {
+func getFindResponses() []FindResponse {
 	channelMaps, charm, defaultChannelMap := getChannelMapResponse()
-	return FindResponse{
+	return []FindResponse{{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
 		ChannelMap:     channelMaps,
 		Charm:          charm,
 		DefaultRelease: defaultChannelMap,
-	}
+	}}
 }
 
 func getChannelMapResponse() ([]ChannelMap, Charm, ChannelMap) {
@@ -174,13 +174,18 @@ func assertInfoResponseSameContents(c *gc.C, obtained, expected InfoResponse) {
 	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
 }
 
-func assertFindResponseSameContents(c *gc.C, obtained, expected FindResponse) {
-	c.Assert(obtained.Type, gc.Equals, expected.Type)
-	c.Assert(obtained.ID, gc.Equals, expected.ID)
-	c.Assert(obtained.Name, gc.Equals, expected.Name)
-	assertCharmSameContents(c, obtained.Charm, expected.Charm)
-	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
-	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
+func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse) {
+	c.Assert(obtained, gc.HasLen, 1)
+	c.Assert(expected, gc.HasLen, 1)
+
+	want := obtained[0]
+	got := expected[0]
+	c.Assert(want.Type, gc.Equals, got.Type)
+	c.Assert(want.ID, gc.Equals, got.ID)
+	c.Assert(want.Name, gc.Equals, got.Name)
+	assertCharmSameContents(c, want.Charm, got.Charm)
+	c.Assert(want.ChannelMap, gc.DeepEquals, got.ChannelMap)
+	c.Assert(want.DefaultRelease, gc.DeepEquals, got.DefaultRelease)
 }
 
 func assertCharmSameContents(c *gc.C, obtained, expected Charm) {
@@ -205,16 +210,16 @@ func getParamsInfoResponse() params.InfoResponse {
 	}
 }
 
-func getParamsFindResponse() params.FindResponse {
+func getParamsFindResponses() []params.FindResponse {
 	channelMaps, charm, defaultChannelMap := getParamsChannelMapResponse()
-	return params.FindResponse{
+	return []params.FindResponse{{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
 		ChannelMap:     channelMaps,
 		Charm:          charm,
 		DefaultRelease: defaultChannelMap,
-	}
+	}}
 }
 
 func getParamsChannelMapResponse() ([]params.ChannelMap, params.CharmHubCharm, params.ChannelMap) {

--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -74,12 +74,11 @@ func getInfoResponse() InfoResponse {
 }
 
 func getFindResponses() []FindResponse {
-	channelMaps, entity, defaultChannelMap := getChannelMapResponse()
+	_, entity, defaultChannelMap := getChannelMapResponse()
 	return []FindResponse{{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMaps,
 		Entity:         entity,
 		DefaultRelease: defaultChannelMap,
 	}}
@@ -184,7 +183,6 @@ func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse)
 	c.Assert(want.ID, gc.Equals, got.ID)
 	c.Assert(want.Name, gc.Equals, got.Name)
 	assertEntitySameContents(c, want.Entity, got.Entity)
-	c.Assert(want.ChannelMap, gc.DeepEquals, got.ChannelMap)
 	c.Assert(want.DefaultRelease, gc.DeepEquals, got.DefaultRelease)
 }
 
@@ -211,12 +209,11 @@ func getParamsInfoResponse() params.InfoResponse {
 }
 
 func getParamsFindResponses() []params.FindResponse {
-	channelMaps, entity, defaultChannelMap := getParamsChannelMapResponse()
+	_, entity, defaultChannelMap := getParamsChannelMapResponse()
 	return []params.FindResponse{{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMaps,
 		Entity:         entity,
 		DefaultRelease: defaultChannelMap,
 	}}

--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -34,6 +34,20 @@ func (s charmHubSuite) TestInfo(c *gc.C) {
 	assertInfoResponseSameContents(c, obtained, getInfoResponse())
 }
 
+func (s charmHubSuite) TestFind(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	arg := params.Query{Query: "wordpress"}
+	resultSource := params.CharmHubCharmFindResult{
+		Result: getParamsFindResponse(),
+	}
+	s.facade.EXPECT().FacadeCall("Find", arg, gomock.Any()).SetArg(2, resultSource)
+
+	obtained, err := s.newClientFromFacadeForTest().Find("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	assertFindResponseSameContents(c, obtained, getFindResponse())
+}
+
 func (s *charmHubSuite) newClientFromFacadeForTest() *Client {
 	return newClientFromFacade(s.client, s.facade)
 }
@@ -48,11 +62,31 @@ func (s *charmHubSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func getInfoResponse() InfoResponse {
+	channelMaps, charm, defaultChannelMap := getChannelMapResponse()
 	return InfoResponse{
-		Name: "wordpress",
-		Type: "object",
-		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []ChannelMap{{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMaps,
+		Charm:          charm,
+		DefaultRelease: defaultChannelMap,
+	}
+}
+
+func getFindResponse() FindResponse {
+	channelMaps, charm, defaultChannelMap := getChannelMapResponse()
+	return FindResponse{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMaps,
+		Charm:          charm,
+		DefaultRelease: defaultChannelMap,
+	}
+}
+
+func getChannelMapResponse() ([]ChannelMap, Charm, ChannelMap) {
+	return []ChannelMap{{
 			Channel: Channel{
 				Name: "latest/stable",
 				Platform: Platform{
@@ -79,8 +113,7 @@ func getInfoResponse() InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}},
-		Charm: Charm{
+		}}, Charm{
 			Categories: []Category{{
 				Featured: true,
 				Name:     "blog",
@@ -102,8 +135,7 @@ func getInfoResponse() InfoResponse {
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		},
-		DefaultRelease: ChannelMap{
+		}, ChannelMap{
 			Channel: Channel{
 				Name: "latest/stable",
 				Platform: Platform{
@@ -130,11 +162,19 @@ func getInfoResponse() InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		},
-	}
+		}
 }
 
 func assertInfoResponseSameContents(c *gc.C, obtained, expected InfoResponse) {
+	c.Assert(obtained.Type, gc.Equals, expected.Type)
+	c.Assert(obtained.ID, gc.Equals, expected.ID)
+	c.Assert(obtained.Name, gc.Equals, expected.Name)
+	assertCharmSameContents(c, obtained.Charm, expected.Charm)
+	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
+	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
+}
+
+func assertFindResponseSameContents(c *gc.C, obtained, expected FindResponse) {
 	c.Assert(obtained.Type, gc.Equals, expected.Type)
 	c.Assert(obtained.ID, gc.Equals, expected.ID)
 	c.Assert(obtained.Name, gc.Equals, expected.Name)
@@ -154,11 +194,31 @@ func assertCharmSameContents(c *gc.C, obtained, expected Charm) {
 }
 
 func getParamsInfoResponse() params.InfoResponse {
+	channelMaps, charm, defaultChannelMap := getParamsChannelMapResponse()
 	return params.InfoResponse{
-		Name: "wordpress",
-		Type: "object",
-		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []params.ChannelMap{{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMaps,
+		Charm:          charm,
+		DefaultRelease: defaultChannelMap,
+	}
+}
+
+func getParamsFindResponse() params.FindResponse {
+	channelMaps, charm, defaultChannelMap := getParamsChannelMapResponse()
+	return params.FindResponse{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMaps,
+		Charm:          charm,
+		DefaultRelease: defaultChannelMap,
+	}
+}
+
+func getParamsChannelMapResponse() ([]params.ChannelMap, params.CharmHubCharm, params.ChannelMap) {
+	return []params.ChannelMap{{
 			Channel: params.Channel{
 				Name: "latest/stable",
 				Platform: params.Platform{
@@ -185,8 +245,7 @@ func getParamsInfoResponse() params.InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}},
-		Charm: params.CharmHubCharm{
+		}}, params.CharmHubCharm{
 			Categories: []params.Category{{
 				Featured: true,
 				Name:     "blog",
@@ -208,8 +267,7 @@ func getParamsInfoResponse() params.InfoResponse {
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		},
-		DefaultRelease: params.ChannelMap{
+		}, params.ChannelMap{
 			Channel: params.Channel{
 				Name: "latest/stable",
 				Platform: params.Platform{
@@ -236,6 +294,5 @@ func getParamsInfoResponse() params.InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		},
-	}
+		}
 }

--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -24,7 +24,7 @@ func (s charmHubSuite) TestInfo(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	arg := params.Entity{Tag: names.NewApplicationTag("wordpress").String()}
-	resultSource := params.CharmHubCharmInfoResult{
+	resultSource := params.CharmHubEntityInfoResult{
 		Result: getParamsInfoResponse(),
 	}
 	s.facade.EXPECT().FacadeCall("Info", arg, gomock.Any()).SetArg(2, resultSource)
@@ -38,7 +38,7 @@ func (s charmHubSuite) TestFind(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	arg := params.Query{Query: "wordpress"}
-	resultSource := params.CharmHubCharmFindResult{
+	resultSource := params.CharmHubEntityFindResult{
 		Results: getParamsFindResponses(),
 	}
 	s.facade.EXPECT().FacadeCall("Find", arg, gomock.Any()).SetArg(2, resultSource)
@@ -62,30 +62,30 @@ func (s *charmHubSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func getInfoResponse() InfoResponse {
-	channelMaps, charm, defaultChannelMap := getChannelMapResponse()
+	channelMaps, entity, defaultChannelMap := getChannelMapResponse()
 	return InfoResponse{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
 		ChannelMap:     channelMaps,
-		Charm:          charm,
+		Entity:         entity,
 		DefaultRelease: defaultChannelMap,
 	}
 }
 
 func getFindResponses() []FindResponse {
-	channelMaps, charm, defaultChannelMap := getChannelMapResponse()
+	channelMaps, entity, defaultChannelMap := getChannelMapResponse()
 	return []FindResponse{{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
 		ChannelMap:     channelMaps,
-		Charm:          charm,
+		Entity:         entity,
 		DefaultRelease: defaultChannelMap,
 	}}
 }
 
-func getChannelMapResponse() ([]ChannelMap, Charm, ChannelMap) {
+func getChannelMapResponse() ([]ChannelMap, Entity, ChannelMap) {
 	return []ChannelMap{{
 			Channel: Channel{
 				Name: "latest/stable",
@@ -113,7 +113,7 @@ func getChannelMapResponse() ([]ChannelMap, Charm, ChannelMap) {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}}, Charm{
+		}}, Entity{
 			Categories: []Category{{
 				Featured: true,
 				Name:     "blog",
@@ -169,7 +169,7 @@ func assertInfoResponseSameContents(c *gc.C, obtained, expected InfoResponse) {
 	c.Assert(obtained.Type, gc.Equals, expected.Type)
 	c.Assert(obtained.ID, gc.Equals, expected.ID)
 	c.Assert(obtained.Name, gc.Equals, expected.Name)
-	assertCharmSameContents(c, obtained.Charm, expected.Charm)
+	assertEntitySameContents(c, obtained.Entity, expected.Entity)
 	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
 	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
 }
@@ -183,12 +183,12 @@ func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse)
 	c.Assert(want.Type, gc.Equals, got.Type)
 	c.Assert(want.ID, gc.Equals, got.ID)
 	c.Assert(want.Name, gc.Equals, got.Name)
-	assertCharmSameContents(c, want.Charm, got.Charm)
+	assertEntitySameContents(c, want.Entity, got.Entity)
 	c.Assert(want.ChannelMap, gc.DeepEquals, got.ChannelMap)
 	c.Assert(want.DefaultRelease, gc.DeepEquals, got.DefaultRelease)
 }
 
-func assertCharmSameContents(c *gc.C, obtained, expected Charm) {
+func assertEntitySameContents(c *gc.C, obtained, expected Entity) {
 	c.Assert(obtained.Categories, gc.DeepEquals, expected.Categories)
 	c.Assert(obtained.Description, gc.Equals, expected.Description)
 	c.Assert(obtained.License, gc.Equals, expected.License)
@@ -199,30 +199,30 @@ func assertCharmSameContents(c *gc.C, obtained, expected Charm) {
 }
 
 func getParamsInfoResponse() params.InfoResponse {
-	channelMaps, charm, defaultChannelMap := getParamsChannelMapResponse()
+	channelMaps, entity, defaultChannelMap := getParamsChannelMapResponse()
 	return params.InfoResponse{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
 		ChannelMap:     channelMaps,
-		Charm:          charm,
+		Entity:         entity,
 		DefaultRelease: defaultChannelMap,
 	}
 }
 
 func getParamsFindResponses() []params.FindResponse {
-	channelMaps, charm, defaultChannelMap := getParamsChannelMapResponse()
+	channelMaps, entity, defaultChannelMap := getParamsChannelMapResponse()
 	return []params.FindResponse{{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
 		ChannelMap:     channelMaps,
-		Charm:          charm,
+		Entity:         entity,
 		DefaultRelease: defaultChannelMap,
 	}}
 }
 
-func getParamsChannelMapResponse() ([]params.ChannelMap, params.CharmHubCharm, params.ChannelMap) {
+func getParamsChannelMapResponse() ([]params.ChannelMap, params.CharmHubEntity, params.ChannelMap) {
 	return []params.ChannelMap{{
 			Channel: params.Channel{
 				Name: "latest/stable",
@@ -250,7 +250,7 @@ func getParamsChannelMapResponse() ([]params.ChannelMap, params.CharmHubCharm, p
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}}, params.CharmHubCharm{
+		}}, params.CharmHubEntity{
 			Categories: []params.Category{{
 				Featured: true,
 				Name:     "blog",

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -18,6 +18,14 @@ func convertCharmInfoResult(info params.InfoResponse) InfoResponse {
 	}
 }
 
+func convertCharmFindResults(responses []params.FindResponse) []FindResponse {
+	results := make([]FindResponse, len(responses))
+	for i, resp := range responses {
+		results[i] = convertCharmFindResult(resp)
+	}
+	return results
+}
+
 func convertCharmFindResult(info params.FindResponse) FindResponse {
 	return FindResponse{
 		Type:           info.Type,

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -32,7 +32,6 @@ func convertCharmFindResult(info params.FindResponse) FindResponse {
 		ID:             info.ID,
 		Name:           info.Name,
 		Entity:         convertEntity(info.Entity),
-		ChannelMap:     convertChannelMap(info.ChannelMap),
 		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
 	}
 }
@@ -113,12 +112,11 @@ type InfoResponse struct {
 }
 
 type FindResponse struct {
-	Type           string       `json:"type"`
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
-	Entity         Entity       `json:"entity"`
-	ChannelMap     []ChannelMap `json:"channel-map"`
-	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+	Type           string     `json:"type"`
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	Entity         Entity     `json:"entity"`
+	DefaultRelease ChannelMap `json:"default-release,omitempty"`
 }
 
 type ChannelMap struct {

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -12,7 +12,7 @@ func convertCharmInfoResult(info params.InfoResponse) InfoResponse {
 		Type:           info.Type,
 		ID:             info.ID,
 		Name:           info.Name,
-		Charm:          convertCharm(info.Charm),
+		Entity:         convertEntity(info.Entity),
 		ChannelMap:     convertChannelMap(info.ChannelMap),
 		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
 	}
@@ -31,14 +31,14 @@ func convertCharmFindResult(info params.FindResponse) FindResponse {
 		Type:           info.Type,
 		ID:             info.ID,
 		Name:           info.Name,
-		Charm:          convertCharm(info.Charm),
+		Entity:         convertEntity(info.Entity),
 		ChannelMap:     convertChannelMap(info.ChannelMap),
 		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
 	}
 }
 
-func convertCharm(ch params.CharmHubCharm) Charm {
-	return Charm{
+func convertEntity(ch params.CharmHubEntity) Entity {
+	return Entity{
 		Categories:  convertCategories(ch.Categories),
 		Description: ch.Description,
 		License:     ch.License,
@@ -107,7 +107,7 @@ type InfoResponse struct {
 	Type           string       `json:"type"`
 	ID             string       `json:"id"`
 	Name           string       `json:"name"`
-	Charm          Charm        `json:"charm"`
+	Entity         Entity       `json:"entity"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
 }
@@ -116,7 +116,7 @@ type FindResponse struct {
 	Type           string       `json:"type"`
 	ID             string       `json:"id"`
 	Name           string       `json:"name"`
-	Charm          Charm        `json:"charm"`
+	Entity         Entity       `json:"entity"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
 }
@@ -154,7 +154,7 @@ type Download struct {
 	URL        string `json:"url"`
 }
 
-type Charm struct {
+type Entity struct {
 	Categories  []Category        `json:"categories"`
 	Description string            `json:"description"`
 	License     string            `json:"license"`

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -18,6 +18,17 @@ func convertCharmInfoResult(info params.InfoResponse) InfoResponse {
 	}
 }
 
+func convertCharmFindResult(info params.FindResponse) FindResponse {
+	return FindResponse{
+		Type:           info.Type,
+		ID:             info.ID,
+		Name:           info.Name,
+		Charm:          convertCharm(info.Charm),
+		ChannelMap:     convertChannelMap(info.ChannelMap),
+		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
+	}
+}
+
 func convertCharm(ch params.CharmHubCharm) Charm {
 	return Charm{
 		Categories:  convertCategories(ch.Categories),
@@ -81,7 +92,19 @@ func convertPlatforms(platforms []params.Platform) []Platform {
 	return result
 }
 
+// Although InfoResponse or FindResponse are similar, they will change once the
+// charmhub API has settled.
+
 type InfoResponse struct {
+	Type           string       `json:"type"`
+	ID             string       `json:"id"`
+	Name           string       `json:"name"`
+	Charm          Charm        `json:"charm"`
+	ChannelMap     []ChannelMap `json:"channel-map"`
+	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+}
+
+type FindResponse struct {
 	Type           string       `json:"type"`
 	ID             string       `json:"id"`
 	Name           string       `json:"name"`

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -19,52 +19,61 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.charmhub")
 
+// Client represents a charmhub Client for making queries to the charmhub API.
 type Client interface {
 	Info(ctx context.Context, name string) (transport.InfoResponse, error)
+	Find(ctx context.Context, query string) ([]transport.FindResponse, error)
 }
 
-// API provides the charmhub API facade for version 1.
+// CharmHubAPI API provides the charmhub API facade for version 1.
 type CharmHubAPI struct {
 	auth facade.Authorizer
 
 	// newClientFunc is for testing purposes to facilitate using mocks.
-	newClientFunc func(charmhub.Config) (Client, error)
+	client Client
 }
 
+// NewFacade creates a new CharmHubAPI facade.
 func NewFacade(ctx facade.Context) (*CharmHubAPI, error) {
 	auth := ctx.Auth()
-	newClientFunc := func(p charmhub.Config) (Client, error) {
-		return charmhub.NewClient(p)
+	client, err := charmhub.NewClient(charmhub.CharmhubConfig())
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return newCharmHubAPI(auth, newClientFunc)
+	return newCharmHubAPI(auth, client)
 }
 
-func newCharmHubAPI(authorizer facade.Authorizer, newClientFunc func(charmhub.Config) (Client, error)) (*CharmHubAPI, error) {
+func newCharmHubAPI(authorizer facade.Authorizer, client Client) (*CharmHubAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}
-	return &CharmHubAPI{auth: authorizer, newClientFunc: newClientFunc}, nil
+	return &CharmHubAPI{auth: authorizer, client: client}, nil
 }
 
+// Info queries the charmhub API with a given entity ID.
 func (api *CharmHubAPI) Info(arg params.Entity) (params.CharmHubCharmInfoResult, error) {
-	logger.Tracef("Info()")
+	logger.Tracef("Info(%v)", arg.Tag)
+
 	tag, err := names.ParseApplicationTag(arg.Tag)
 	if err != nil {
 		return params.CharmHubCharmInfoResult{}, errors.BadRequestf("arg value is empty")
 	}
-	// TODO: (hml) 2020-06-17
-	// Add model config value for charmhub-url to charmhub client New().
-	// once implemented.
-	// TODO: (hml) 2020-06-19
-	// PR Comment
-	// "I think it's fair to say we should cache this, as generating
-	// a new client for every info is wasteful. Lets tackle at a later point."
-	chClient, err := api.newClientFunc(charmhub.CharmhubConfig())
+	// TODO (stickupkid): Create a proper context to be used here.
+	info, err := api.client.Info(context.TODO(), tag.Id())
 	if err != nil {
-		return params.CharmHubCharmInfoResult{}, errors.Annotate(err, "could not get charm hub client")
+		return params.CharmHubCharmInfoResult{}, errors.Trace(err)
 	}
-	// TODO:
-	// Create a proper context to be used here.
-	info, err := chClient.Info(context.TODO(), tag.Id())
-	return params.CharmHubCharmInfoResult{Result: convertCharmInfoResult(info)}, err
+	return params.CharmHubCharmInfoResult{Result: convertCharmInfoResult(info)}, nil
+}
+
+// Find queries the charmhub API with a given entity ID.
+func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubCharmFindResult, error) {
+	logger.Tracef("Find(%v)", arg.Query)
+
+	// TODO (stickupkid): Create a proper context to be used here.
+	results, err := api.client.Find(context.TODO(), arg.Query)
+	if err != nil {
+		return params.CharmHubCharmFindResult{}, errors.Trace(err)
+	}
+	return params.CharmHubCharmFindResult{Results: convertCharmFindResults(results)}, nil
 }

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -51,29 +51,29 @@ func newCharmHubAPI(authorizer facade.Authorizer, client Client) (*CharmHubAPI, 
 }
 
 // Info queries the charmhub API with a given entity ID.
-func (api *CharmHubAPI) Info(arg params.Entity) (params.CharmHubCharmInfoResult, error) {
+func (api *CharmHubAPI) Info(arg params.Entity) (params.CharmHubEntityInfoResult, error) {
 	logger.Tracef("Info(%v)", arg.Tag)
 
 	tag, err := names.ParseApplicationTag(arg.Tag)
 	if err != nil {
-		return params.CharmHubCharmInfoResult{}, errors.BadRequestf("arg value is empty")
+		return params.CharmHubEntityInfoResult{}, errors.BadRequestf("arg value is empty")
 	}
 	// TODO (stickupkid): Create a proper context to be used here.
 	info, err := api.client.Info(context.TODO(), tag.Id())
 	if err != nil {
-		return params.CharmHubCharmInfoResult{}, errors.Trace(err)
+		return params.CharmHubEntityInfoResult{}, errors.Trace(err)
 	}
-	return params.CharmHubCharmInfoResult{Result: convertCharmInfoResult(info)}, nil
+	return params.CharmHubEntityInfoResult{Result: convertCharmInfoResult(info)}, nil
 }
 
 // Find queries the charmhub API with a given entity ID.
-func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubCharmFindResult, error) {
+func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubEntityFindResult, error) {
 	logger.Tracef("Find(%v)", arg.Query)
 
 	// TODO (stickupkid): Create a proper context to be used here.
 	results, err := api.client.Find(context.TODO(), arg.Query)
 	if err != nil {
-		return params.CharmHubCharmFindResult{}, errors.Trace(err)
+		return params.CharmHubEntityFindResult{}, errors.Trace(err)
 	}
-	return params.CharmHubCharmFindResult{Results: convertCharmFindResults(results)}, nil
+	return params.CharmHubEntityFindResult{Results: convertCharmFindResults(results)}, nil
 }

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -83,7 +83,6 @@ func assertFindResponseSameContents(c *gc.C, obtained, expected params.FindRespo
 	c.Assert(obtained.ID, gc.Equals, expected.ID)
 	c.Assert(obtained.Name, gc.Equals, expected.Name)
 	assertEntitySameContents(c, obtained.Entity, expected.Entity)
-	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
 	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
 }
 
@@ -110,12 +109,11 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 }
 
 func getCharmHubFindResponses() []transport.FindResponse {
-	channelMap, entity, defaultRelease := getCharmHubResponse()
+	_, entity, defaultRelease := getCharmHubResponse()
 	return []transport.FindResponse{{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
 		Entity:         entity,
 		DefaultRelease: defaultRelease,
 	}}
@@ -218,12 +216,11 @@ func getParamsInfoResponse() params.InfoResponse {
 }
 
 func getParamsFindResponse() params.FindResponse {
-	channelMap, entity, defaultRelease := getParamsResponse()
+	_, entity, defaultRelease := getParamsResponse()
 	return params.FindResponse{
 		Name:           "wordpress",
 		Type:           "object",
 		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
 		Entity:         entity,
 		DefaultRelease: defaultRelease,
 	}

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -13,7 +13,6 @@ import (
 
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/client/charmhub/mocks"
-	"github.com/juju/juju/charmhub"
 )
 
 var _ = gc.Suite(&charmHubAPISuite{})
@@ -35,9 +34,7 @@ func (s *charmHubAPISuite) TestInfo(c *gc.C) {
 
 func (s *charmHubAPISuite) newCharmHubAPIForTest(c *gc.C) *CharmHubAPI {
 	s.expectAuth()
-	api, err := newCharmHubAPI(s.authorizer, func(p charmhub.Config) (Client, error) {
-		return s.client, nil
-	})
+	api, err := newCharmHubAPI(s.authorizer, s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	return api
 }

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -32,6 +32,17 @@ func (s *charmHubAPISuite) TestInfo(c *gc.C) {
 	assertInfoResponseSameContents(c, obtained.Result, getParamsInfoResponse())
 }
 
+func (s *charmHubAPISuite) TestFind(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectFind()
+	arg := params.Query{Query: "wordpress"}
+	obtained, err := s.newCharmHubAPIForTest(c).Find(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(obtained.Results, gc.HasLen, 1)
+	assertFindResponseSameContents(c, obtained.Results[0], getParamsFindResponse())
+}
+
 func (s *charmHubAPISuite) newCharmHubAPIForTest(c *gc.C) *CharmHubAPI {
 	s.expectAuth()
 	api, err := newCharmHubAPI(s.authorizer, s.client)
@@ -54,16 +65,29 @@ func (s *charmHubAPISuite) expectInfo() {
 	s.client.EXPECT().Info(gomock.Any(), "wordpress").Return(getCharmHubInfoResponse(), nil)
 }
 
+func (s *charmHubAPISuite) expectFind() {
+	s.client.EXPECT().Find(gomock.Any(), "wordpress").Return(getCharmHubFindResponses(), nil)
+}
+
 func assertInfoResponseSameContents(c *gc.C, obtained, expected params.InfoResponse) {
 	c.Assert(obtained.Type, gc.Equals, expected.Type)
 	c.Assert(obtained.ID, gc.Equals, expected.ID)
 	c.Assert(obtained.Name, gc.Equals, expected.Name)
-	assertCharmSameContents(c, obtained.Charm, expected.Charm)
+	assertEntitySameContents(c, obtained.Entity, expected.Entity)
 	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
 	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
 }
 
-func assertCharmSameContents(c *gc.C, obtained, expected params.CharmHubCharm) {
+func assertFindResponseSameContents(c *gc.C, obtained, expected params.FindResponse) {
+	c.Assert(obtained.Type, gc.Equals, expected.Type)
+	c.Assert(obtained.ID, gc.Equals, expected.ID)
+	c.Assert(obtained.Name, gc.Equals, expected.Name)
+	assertEntitySameContents(c, obtained.Entity, expected.Entity)
+	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
+	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
+}
+
+func assertEntitySameContents(c *gc.C, obtained, expected params.CharmHubEntity) {
 	c.Assert(obtained.Categories, gc.DeepEquals, expected.Categories)
 	c.Assert(obtained.Description, gc.Equals, expected.Description)
 	c.Assert(obtained.License, gc.Equals, expected.License)
@@ -74,11 +98,31 @@ func assertCharmSameContents(c *gc.C, obtained, expected params.CharmHubCharm) {
 }
 
 func getCharmHubInfoResponse() transport.InfoResponse {
+	channelMap, entity, defaultRelease := getCharmHubResponse()
 	return transport.InfoResponse{
-		Name: "wordpress",
-		Type: "object",
-		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []transport.ChannelMap{{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMap,
+		Entity:         entity,
+		DefaultRelease: defaultRelease,
+	}
+}
+
+func getCharmHubFindResponses() []transport.FindResponse {
+	channelMap, entity, defaultRelease := getCharmHubResponse()
+	return []transport.FindResponse{{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMap,
+		Entity:         entity,
+		DefaultRelease: defaultRelease,
+	}}
+}
+
+func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.ChannelMap) {
+	return []transport.ChannelMap{{
 			Channel: transport.Channel{
 				Name: "latest/stable",
 				Platform: transport.Platform{
@@ -107,8 +151,7 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}},
-		Charm: transport.Charm{
+		}}, transport.Entity{
 			Categories: []transport.Category{{
 				Featured: true,
 				Name:     "blog",
@@ -130,8 +173,7 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		},
-		DefaultRelease: transport.ChannelMap{
+		}, transport.ChannelMap{
 			Channel: transport.Channel{
 				Name: "latest/stable",
 				Platform: transport.Platform{
@@ -160,16 +202,35 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		},
-	}
+		}
 }
 
 func getParamsInfoResponse() params.InfoResponse {
+	channelMap, entity, defaultRelease := getParamsResponse()
 	return params.InfoResponse{
-		Name: "wordpress",
-		Type: "object",
-		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []params.ChannelMap{{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMap,
+		Entity:         entity,
+		DefaultRelease: defaultRelease,
+	}
+}
+
+func getParamsFindResponse() params.FindResponse {
+	channelMap, entity, defaultRelease := getParamsResponse()
+	return params.FindResponse{
+		Name:           "wordpress",
+		Type:           "object",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMap,
+		Entity:         entity,
+		DefaultRelease: defaultRelease,
+	}
+}
+
+func getParamsResponse() ([]params.ChannelMap, params.CharmHubEntity, params.ChannelMap) {
+	return []params.ChannelMap{{
 			Channel: params.Channel{
 				Name: "latest/stable",
 				Platform: params.Platform{
@@ -196,8 +257,7 @@ func getParamsInfoResponse() params.InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}},
-		Charm: params.CharmHubCharm{
+		}}, params.CharmHubEntity{
 			Categories: []params.Category{{
 				Featured: true,
 				Name:     "blog",
@@ -219,8 +279,7 @@ func getParamsInfoResponse() params.InfoResponse {
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		},
-		DefaultRelease: params.ChannelMap{
+		}, params.ChannelMap{
 			Channel: params.Channel{
 				Name: "latest/stable",
 				Platform: params.Platform{
@@ -247,6 +306,5 @@ func getParamsInfoResponse() params.InfoResponse {
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		},
-	}
+		}
 }

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -19,6 +19,25 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 	}
 }
 
+func convertCharmFindResults(responses []transport.FindResponse) []params.FindResponse {
+	results := make([]params.FindResponse, len(responses))
+	for k, response := range responses {
+		results[k] = convertCharmFindResult(response)
+	}
+	return results
+}
+
+func convertCharmFindResult(resp transport.FindResponse) params.FindResponse {
+	return params.FindResponse{
+		Type:           resp.Type,
+		ID:             resp.ID,
+		Name:           resp.Name,
+		Charm:          convertCharm(resp.Charm),
+		ChannelMap:     convertChannelMap(resp.ChannelMap),
+		DefaultRelease: convertOneChannelMap(resp.DefaultRelease),
+	}
+}
+
 func convertCharm(ch transport.Charm) params.CharmHubCharm {
 	return params.CharmHubCharm{
 		Categories:  convertCategories(ch.Categories),

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -13,7 +13,7 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 		Type:           info.Type,
 		ID:             info.ID,
 		Name:           info.Name,
-		Charm:          convertCharm(info.Charm),
+		Entity:         convertEntity(info.Entity),
 		ChannelMap:     convertChannelMap(info.ChannelMap),
 		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
 	}
@@ -32,14 +32,14 @@ func convertCharmFindResult(resp transport.FindResponse) params.FindResponse {
 		Type:           resp.Type,
 		ID:             resp.ID,
 		Name:           resp.Name,
-		Charm:          convertCharm(resp.Charm),
+		Entity:         convertEntity(resp.Entity),
 		ChannelMap:     convertChannelMap(resp.ChannelMap),
 		DefaultRelease: convertOneChannelMap(resp.DefaultRelease),
 	}
 }
 
-func convertCharm(ch transport.Charm) params.CharmHubCharm {
-	return params.CharmHubCharm{
+func convertEntity(ch transport.Entity) params.CharmHubEntity {
+	return params.CharmHubEntity{
 		Categories:  convertCategories(ch.Categories),
 		Description: ch.Description,
 		License:     ch.License,

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -33,7 +33,6 @@ func convertCharmFindResult(resp transport.FindResponse) params.FindResponse {
 		ID:             resp.ID,
 		Name:           resp.Name,
 		Entity:         convertEntity(resp.Entity),
-		ChannelMap:     convertChannelMap(resp.ChannelMap),
 		DefaultRelease: convertOneChannelMap(resp.DefaultRelease),
 	}
 }

--- a/apiserver/facades/client/charmhub/mocks/package_mock.go
+++ b/apiserver/facades/client/charmhub/mocks/package_mock.go
@@ -34,6 +34,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// Find mocks base method
+func (m *MockClient) Find(arg0 context.Context, arg1 string) ([]transport.FindResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Find", arg0, arg1)
+	ret0, _ := ret[0].([]transport.FindResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Find indicates an expected call of Find
+func (mr *MockClientMockRecorder) Find(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockClient)(nil).Find), arg0, arg1)
+}
+
 // Info mocks base method
 func (m *MockClient) Info(arg0 context.Context, arg1 string) (transport.InfoResponse, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9239,7 +9239,7 @@
                             "$ref": "#/definitions/Query"
                         },
                         "Result": {
-                            "$ref": "#/definitions/CharmHubCharmFindResult"
+                            "$ref": "#/definitions/CharmHubEntityFindResult"
                         }
                     },
                     "description": "Find queries the charmhub API with a given entity ID."
@@ -9251,7 +9251,7 @@
                             "$ref": "#/definitions/Entity"
                         },
                         "Result": {
-                            "$ref": "#/definitions/CharmHubCharmInfoResult"
+                            "$ref": "#/definitions/CharmHubEntityInfoResult"
                         }
                     },
                     "description": "Info queries the charmhub API with a given entity ID."
@@ -9306,7 +9306,7 @@
                     },
                     "additionalProperties": false
                 },
-                "CharmHubCharm": {
+                "CharmHubEntity": {
                     "type": "object",
                     "properties": {
                         "categories": {
@@ -9356,7 +9356,7 @@
                         "used-by"
                     ]
                 },
-                "CharmHubCharmFindResult": {
+                "CharmHubEntityFindResult": {
                     "type": "object",
                     "properties": {
                         "errors": {
@@ -9375,7 +9375,7 @@
                         "errors"
                     ]
                 },
-                "CharmHubCharmInfoResult": {
+                "CharmHubEntityInfoResult": {
                     "type": "object",
                     "properties": {
                         "errors": {
@@ -9460,11 +9460,11 @@
                                 "$ref": "#/definitions/ChannelMap"
                             }
                         },
-                        "charm": {
-                            "$ref": "#/definitions/CharmHubCharm"
-                        },
                         "default-release": {
                             "$ref": "#/definitions/ChannelMap"
+                        },
+                        "entity": {
+                            "$ref": "#/definitions/CharmHubEntity"
                         },
                         "id": {
                             "type": "string"
@@ -9481,6 +9481,7 @@
                         "type",
                         "id",
                         "name",
+                        "entity",
                         "channel-map"
                     ]
                 },
@@ -9493,11 +9494,11 @@
                                 "$ref": "#/definitions/ChannelMap"
                             }
                         },
-                        "charm": {
-                            "$ref": "#/definitions/CharmHubCharm"
-                        },
                         "default-release": {
                             "$ref": "#/definitions/ChannelMap"
+                        },
+                        "entity": {
+                            "$ref": "#/definitions/CharmHubEntity"
                         },
                         "id": {
                             "type": "string"
@@ -9514,6 +9515,7 @@
                         "type",
                         "id",
                         "name",
+                        "entity",
                         "channel-map"
                     ]
                 },

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9454,12 +9454,6 @@
                 "FindResponse": {
                     "type": "object",
                     "properties": {
-                        "channel-map": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ChannelMap"
-                            }
-                        },
                         "default-release": {
                             "$ref": "#/definitions/ChannelMap"
                         },
@@ -9481,8 +9475,7 @@
                         "type",
                         "id",
                         "name",
-                        "entity",
-                        "channel-map"
+                        "entity"
                     ]
                 },
                 "InfoResponse": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9224,7 +9224,7 @@
     },
     {
         "Name": "CharmHub",
-        "Description": "API provides the charmhub API facade for version 1.",
+        "Description": "CharmHubAPI API provides the charmhub API facade for version 1.",
         "Version": 1,
         "AvailableTo": [
             "model-user"
@@ -9232,6 +9232,18 @@
         "Schema": {
             "type": "object",
             "properties": {
+                "Find": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Query"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmHubCharmFindResult"
+                        }
+                    },
+                    "description": "Find queries the charmhub API with a given entity ID."
+                },
                 "Info": {
                     "type": "object",
                     "properties": {
@@ -9241,7 +9253,8 @@
                         "Result": {
                             "$ref": "#/definitions/CharmHubCharmInfoResult"
                         }
-                    }
+                    },
+                    "description": "Info queries the charmhub API with a given entity ID."
                 }
             },
             "definitions": {
@@ -9343,6 +9356,25 @@
                         "used-by"
                     ]
                 },
+                "CharmHubCharmFindResult": {
+                    "type": "object",
+                    "properties": {
+                        "errors": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FindResponse"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result",
+                        "errors"
+                    ]
+                },
                 "CharmHubCharmInfoResult": {
                     "type": "object",
                     "properties": {
@@ -9419,6 +9451,39 @@
                         "error-list"
                     ]
                 },
+                "FindResponse": {
+                    "type": "object",
+                    "properties": {
+                        "channel-map": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ChannelMap"
+                            }
+                        },
+                        "charm": {
+                            "$ref": "#/definitions/CharmHubCharm"
+                        },
+                        "default-release": {
+                            "$ref": "#/definitions/ChannelMap"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "id",
+                        "name",
+                        "channel-map"
+                    ]
+                },
                 "InfoResponse": {
                     "type": "object",
                     "properties": {
@@ -9492,6 +9557,18 @@
                         "architecture",
                         "os",
                         "series"
+                    ]
+                },
+                "Query": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "query"
                     ]
                 },
                 "Revision": {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -36,7 +36,6 @@ type FindResponse struct {
 	ID             string         `json:"id"`
 	Name           string         `json:"name"`
 	Entity         CharmHubEntity `json:"entity"`
-	ChannelMap     []ChannelMap   `json:"channel-map"`
 	DefaultRelease ChannelMap     `json:"default-release,omitempty"`
 }
 

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -27,8 +27,8 @@ type InfoResponse struct {
 }
 
 type CharmHubCharmFindResult struct {
-	Result FindResponse  `json:"result"`
-	Errors ErrorResponse `json:"errors"`
+	Results []FindResponse `json:"result"`
+	Errors  ErrorResponse  `json:"errors"`
 }
 
 type FindResponse struct {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -3,14 +3,35 @@
 
 package params
 
+// Query holds the query information when attempting to find possible charms or
+// bundles for searching the charmhub.
+type Query struct {
+	Query string `json:"query"`
+}
+
 // TODO (hml) 2020-06-17
-// Create actual params.InfoResponse and params.ErrorResponse structs for use here.
+// Create actual params.InfoResponse and params.ErrorResponse structs for use
+// here.
 type CharmHubCharmInfoResult struct {
 	Result InfoResponse  `json:"result"`
 	Errors ErrorResponse `json:"errors"`
 }
 
 type InfoResponse struct {
+	Type           string        `json:"type"`
+	ID             string        `json:"id"`
+	Name           string        `json:"name"`
+	Charm          CharmHubCharm `json:"charm,omitempty"`
+	ChannelMap     []ChannelMap  `json:"channel-map"`
+	DefaultRelease ChannelMap    `json:"default-release,omitempty"`
+}
+
+type CharmHubCharmFindResult struct {
+	Result FindResponse  `json:"result"`
+	Errors ErrorResponse `json:"errors"`
+}
+
+type FindResponse struct {
 	Type           string        `json:"type"`
 	ID             string        `json:"id"`
 	Name           string        `json:"name"`

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -12,32 +12,32 @@ type Query struct {
 // TODO (hml) 2020-06-17
 // Create actual params.InfoResponse and params.ErrorResponse structs for use
 // here.
-type CharmHubCharmInfoResult struct {
+type CharmHubEntityInfoResult struct {
 	Result InfoResponse  `json:"result"`
 	Errors ErrorResponse `json:"errors"`
 }
 
 type InfoResponse struct {
-	Type           string        `json:"type"`
-	ID             string        `json:"id"`
-	Name           string        `json:"name"`
-	Charm          CharmHubCharm `json:"charm,omitempty"`
-	ChannelMap     []ChannelMap  `json:"channel-map"`
-	DefaultRelease ChannelMap    `json:"default-release,omitempty"`
+	Type           string         `json:"type"`
+	ID             string         `json:"id"`
+	Name           string         `json:"name"`
+	Entity         CharmHubEntity `json:"entity"`
+	ChannelMap     []ChannelMap   `json:"channel-map"`
+	DefaultRelease ChannelMap     `json:"default-release,omitempty"`
 }
 
-type CharmHubCharmFindResult struct {
+type CharmHubEntityFindResult struct {
 	Results []FindResponse `json:"result"`
 	Errors  ErrorResponse  `json:"errors"`
 }
 
 type FindResponse struct {
-	Type           string        `json:"type"`
-	ID             string        `json:"id"`
-	Name           string        `json:"name"`
-	Charm          CharmHubCharm `json:"charm,omitempty"`
-	ChannelMap     []ChannelMap  `json:"channel-map"`
-	DefaultRelease ChannelMap    `json:"default-release,omitempty"`
+	Type           string         `json:"type"`
+	ID             string         `json:"id"`
+	Name           string         `json:"name"`
+	Entity         CharmHubEntity `json:"entity"`
+	ChannelMap     []ChannelMap   `json:"channel-map"`
+	DefaultRelease ChannelMap     `json:"default-release,omitempty"`
 }
 
 type ChannelMap struct {
@@ -73,7 +73,7 @@ type Download struct {
 	URL        string `json:"url"`
 }
 
-type CharmHubCharm struct {
+type CharmHubEntity struct {
 	Categories  []Category        `json:"categories"`
 	Description string            `json:"description"`
 	License     string            `json:"license"`

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1319,7 +1319,8 @@ type WatchContainerStartArg struct {
 	Container string `json:"container,omitempty"`
 }
 
-// WatchContainerStartArgs holds the details to watch many containers for start events.
+// WatchContainerStartArgs holds the details to watch many containers for start
+// events.
 type WatchContainerStartArgs struct {
 	Args []WatchContainerStartArg `json:"args"`
 }

--- a/charmhub/client_integration_test.go
+++ b/charmhub/client_integration_test.go
@@ -31,3 +31,14 @@ func (s *ClientSuite) TestLiveInfoRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, "wordpress")
 }
+
+func (s *ClientSuite) TestLiveFindRequest(c *gc.C) {
+	config := charmhub.CharmhubConfig()
+
+	client, err := charmhub.NewClient(config)
+	c.Assert(err, jc.ErrorIsNil)
+
+	responses, err := client.Find(context.TODO(), "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(responses[0].Name, gc.Equals, "wordpress")
+}

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -81,36 +81,6 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 			Name: "wordpress",
 			Type: "object",
 			ID:   "charmCHARMcharmCHARMcharmCHARM01",
-			ChannelMap: []transport.ChannelMap{{
-				Channel: transport.Channel{
-					Name: "latest/stable",
-					Platform: transport.Platform{
-						Architecture: "all",
-						OS:           "ubuntu",
-						Series:       "bionic",
-					},
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-					Risk:       "stable",
-					Track:      "latest",
-				},
-				Revision: transport.Revision{
-					ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: transport.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Platforms: []transport.Platform{{
-						Architecture: "all",
-						OS:           "ubuntu",
-						Series:       "bionic",
-					}},
-					Revision: 16,
-					Version:  "1.0.3",
-				},
-			}},
 			Entity: transport.Entity{
 				Categories: []transport.Category{{
 					Featured: true,

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -111,7 +111,7 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					Version:  "1.0.3",
 				},
 			}},
-			Charm: transport.Charm{
+			Entity: transport.Entity{
 				Categories: []transport.Category{{
 					Featured: true,
 					Name:     "blog",

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -37,5 +37,6 @@ func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoRespo
 	if err := c.client.Get(ctx, path, &resp); err != nil {
 		return resp, errors.Trace(err)
 	}
+
 	return resp, nil
 }

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -37,6 +37,5 @@ func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoRespo
 	if err := c.client.Get(ctx, path, &resp); err != nil {
 		return resp, errors.Trace(err)
 	}
-
 	return resp, nil
 }

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -107,7 +107,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				Version:  "1.0.3",
 			},
 		}},
-		Charm: transport.Charm{
+		Entity: transport.Entity{
 			Categories: []transport.Category{{
 				Featured: true,
 				Name:     "blog",

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -41,7 +41,7 @@ type Download struct {
 	URL        string `json:"url"`
 }
 
-type Charm struct {
+type Entity struct {
 	Categories  []Category        `json:"categories"`
 	Description string            `json:"description"`
 	License     string            `json:"license"`

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -9,10 +9,9 @@ type FindResponses struct {
 }
 
 type FindResponse struct {
-	Type           string       `json:"type"`
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
-	Entity         Entity       `json:"charm"`
-	ChannelMap     []ChannelMap `json:"channel-map"`
-	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+	Type           string     `json:"type"`
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	Entity         Entity     `json:"charm"`
+	DefaultRelease ChannelMap `json:"default-release,omitempty"`
 }

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -9,9 +9,10 @@ type FindResponses struct {
 }
 
 type FindResponse struct {
-	Type           string     `json:"type"`
-	ID             string     `json:"id"`
-	Name           string     `json:"name"`
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// TODO (stickupkid): Swap this over to the new name if it ever happens.
 	Entity         Entity     `json:"charm"`
 	DefaultRelease ChannelMap `json:"default-release,omitempty"`
 }

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -12,7 +12,7 @@ type FindResponse struct {
 	Type           string       `json:"type"`
 	ID             string       `json:"id"`
 	Name           string       `json:"name"`
-	Charm          Charm        `json:"charm,omitempty"`
+	Entity         Entity       `json:"charm"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
 }

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -7,7 +7,7 @@ type InfoResponse struct {
 	Type           string       `json:"type"`
 	ID             string       `json:"id"`
 	Name           string       `json:"name"`
-	Charm          Charm        `json:"charm,omitempty"`
+	Entity         Entity       `json:"charm"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
 }

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -4,9 +4,10 @@
 package transport
 
 type InfoResponse struct {
-	Type           string       `json:"type"`
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// TODO (stickupkid): Swap this over to the new name if it ever happens.
 	Entity         Entity       `json:"charm"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -56,7 +56,7 @@ func (iw infoWriter) print(info interface{}) error {
 }
 
 func (iw infoWriter) publisher() string {
-	publisher, _ := iw.in.Charm.Publisher["display-name"]
+	publisher, _ := iw.in.Entity.Publisher["display-name"]
 	return publisher
 }
 
@@ -119,9 +119,9 @@ func (b bundleInfoWriter) Print() error {
 	out := &bundleInfoOutput{
 		Name:        b.in.Name,
 		ID:          b.in.ID,
-		Summary:     b.in.Charm.Summary,
+		Summary:     b.in.Entity.Summary,
 		Publisher:   b.publisher(),
-		Description: b.in.Charm.Description,
+		Description: b.in.Entity.Description,
 		Channels:    b.channels(),
 	}
 	return b.print(out)
@@ -155,12 +155,12 @@ func (c charmInfoWriter) Print() error {
 	out := &charmInfoOutput{
 		Name:        c.in.Name,
 		ID:          c.in.ID,
-		Summary:     c.in.Charm.Summary,
+		Summary:     c.in.Entity.Summary,
 		Publisher:   c.publisher(),
 		Supports:    c.supports(),
 		Tags:        c.tags(),
 		Subordinate: c.subordinate(),
-		Description: c.in.Charm.Description,
+		Description: c.in.Entity.Description,
 		Channels:    c.channels(),
 	}
 	if rels, err := c.relations(); err == nil {

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -133,7 +133,7 @@ func getBundleInfoResponse() charmhub.InfoResponse {
 					Version:  "1.0.3",
 				},
 			}},
-		Charm: charmhub.Charm{
+		Entity: charmhub.Entity{
 			Categories: []charmhub.Category{{
 				Featured: true,
 				Name:     "blog",
@@ -243,7 +243,7 @@ func getCharmInfoResponse() charmhub.InfoResponse {
 					Version:      "1.0.3",
 				},
 			}},
-		Charm: charmhub.Charm{
+		Entity: charmhub.Entity{
 			Categories: []charmhub.Category{{
 				Featured: true,
 				Name:     "blog",


### PR DESCRIPTION
## Description of change

This is a very mechanical change for adding the charmhub find client
methods to the existing charmhub client.

The find methods takes a new `params.Query` instead of a `params.Entity` as
you might want to utilize search queries that don't align to our strict
names tagging system.

For example, searching for `"word press"` (with a space) will return
`wordpress`, but would fail our names.ApplicationTag parsing. Additionally
searching for multiple things `"wordpress + mysql"` would hopefully be
clever enough to work that out as well.

Essentially we're allowing free form text in the search. We may want to
restrict the amount you can actually search for, but we don't restrict
input anywhere else and to be honest, we'll probably get it wrong.


## QA steps

```sh
go test -v ./api/charmhub/...
```
