### PR TITLE
Address Conversion Refactoring

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -7,12 +7,10 @@ import (
 	"net"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
@@ -222,35 +220,6 @@ func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
 	logger.Tracef("seen devices: %+v", seenDeviceNames.SortedValues())
 	logger.Tracef("network interface list transformed to state args:\n%+v\n%+v", devicesArgs, devicesAddrs)
 	return devicesArgs, devicesAddrs
-}
-
-// NetworkingEnvironFromModelConfig constructs and returns
-// environs.NetworkingEnviron using the given configGetter. Returns an error
-// satisfying errors.IsNotSupported() if the model config does not support
-// networking features.
-func NetworkingEnvironFromModelConfig(configGetter environs.EnvironConfigGetter) (environs.NetworkingEnviron, error) {
-	modelConfig, err := configGetter.ModelConfig()
-	if err != nil {
-		return nil, errors.Annotate(err, "failed to get model config")
-	}
-	cloudSpec, err := configGetter.CloudSpec()
-	if err != nil {
-		return nil, errors.Annotate(err, "failed to get cloudspec")
-	}
-	if cloudSpec.Type == cloud.CloudTypeCAAS {
-		return nil, errors.NotSupportedf("CAAS model %q networking", modelConfig.Name())
-	}
-
-	env, err := environs.GetEnviron(configGetter, environs.New)
-	if err != nil {
-		return nil, errors.Annotate(err, "failed to construct a model from config")
-	}
-	netEnviron, supported := environs.SupportsNetworking(env)
-	if !supported {
-		// " not supported" will be appended to the message below.
-		return nil, errors.NotSupportedf("model %q networking", modelConfig.Name())
-	}
-	return netEnviron, nil
 }
 
 // NetworkConfigSource defines the necessary calls to obtain the network

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -850,7 +850,7 @@ func (s *AddressSuite) TestSpaceAddressesToProviderAddresses(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *AddressSuite) TestIPToCIDRNotation(c *gc.C) {
+func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
 	type test struct {
 		IP   string
 		CIDR string
@@ -868,8 +868,8 @@ func (s *AddressSuite) TestIPToCIDRNotation(c *gc.C) {
 	}}
 
 	for i, t := range tests {
-		c.Logf("test %d: IPToCIDRNotation(%q, %q)", i, t.IP, t.CIDR)
-		got, err := network.IPToCIDRNotation(t.IP, t.CIDR)
+		c.Logf("test %d: ValueForCIDR(%q, %q)", i, t.IP, t.CIDR)
+		got, err := network.NewMachineAddress(t.IP).ValueForCIDR(t.CIDR)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(got, gc.Equals, t.exp)
 	}


### PR DESCRIPTION
## Description of change

This patch implements some modularisation of address conversion, and removal of redundant methods.
- Address value with subnet mask is implemented directly on `network.MachineAddress`.
- This is recruited by the `network.InterfaceInfos` method `CIDRAddress`, use of which should be phased out as per comment.
- Conversion of `network.InterfaceInfos` to state args now uses `ValueForCIDR` on the primary address. The extracted method here will be used for updating *all* device addresses in state in a following patch.

## QA steps

Chases presented here are mechanical only; unit tests remain green.

## Documentation changes

None.

## Bug reference

N/A
